### PR TITLE
feature/separate-wal-storage

### DIFF
--- a/packages/apps/ferretdb/templates/postgres.yaml
+++ b/packages/apps/ferretdb/templates/postgres.yaml
@@ -6,19 +6,18 @@ metadata:
 spec:
   instances: {{ .Values.replicas }}
   enableSuperuserAccess: true
-
   minSyncReplicas: {{ .Values.quorum.minSyncReplicas }}
   maxSyncReplicas: {{ .Values.quorum.maxSyncReplicas }}
 
   monitoring:
     enablePodMonitor: true
-
   storage:
     size: {{ required ".Values.size is required" .Values.size }}
     {{- with .Values.storageClass }}
     storageClass: {{ . }}
     {{- end }}
-
+  walStorage:
+    size: 1Gi
   inheritedMetadata:
     labels:
       policy.cozystack.io/allow-to-apiserver: "true"

--- a/packages/apps/postgres/Chart.yaml
+++ b/packages/apps/postgres/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/postgres/templates/db.yaml
+++ b/packages/apps/postgres/templates/db.yaml
@@ -16,16 +16,15 @@ spec:
 
   minSyncReplicas: {{ .Values.quorum.minSyncReplicas }}
   maxSyncReplicas: {{ .Values.quorum.maxSyncReplicas }}
-
   monitoring:
     enablePodMonitor: true
-
   storage:
     size: {{ required ".Values.size is required" .Values.size }}
     {{- with .Values.storageClass }}
     storageClass: {{ . }}
     {{- end }}
-
+  walStorage:
+    size: {{ .Values.walSize | default "1Gi" }}
   inheritedMetadata:
     labels:
       policy.cozystack.io/allow-to-apiserver: "true"

--- a/packages/apps/postgres/values.yaml
+++ b/packages/apps/postgres/values.yaml
@@ -7,6 +7,7 @@
 ##
 external: false
 size: 10Gi
+walSize: 1Gi
 replicas: 2
 storageClass: ""
 

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -67,7 +67,8 @@ postgres 0.6.0 2a4768a
 postgres 0.6.2 54fd61c
 postgres 0.7.0 dc9d8bb
 postgres 0.7.1 175a65f
-postgres 0.8.0 HEAD
+postgres 0.8.0 cb7b8158
+postgres 0.8.1 HEAD
 rabbitmq 0.1.0 f642698
 rabbitmq 0.2.0 5ca8823
 rabbitmq 0.3.0 9e33dc0

--- a/packages/core/installer/values.yaml
+++ b/packages/core/installer/values.yaml
@@ -1,2 +1,2 @@
 cozystack:
-  image: ghcr.io/aenix-io/cozystack/cozystack:v0.23.1@sha256:dfa803a3e02ec9ea221029d361aa9d7aef0b5eb0a36d66c949b265d4ac4fc114
+  image: kklinch0/cozystack:22.0.56@sha256:b6b7c0caf72480e05b84b5512f54eed8541ee19d406975ce0f70a85e88035266

--- a/packages/extra/monitoring/templates/alerta/alerta-db.yaml
+++ b/packages/extra/monitoring/templates/alerta/alerta-db.yaml
@@ -10,10 +10,10 @@ spec:
     {{- with .Values.alerta.storageClassName }}
     storageClass: {{ . }}
     {{- end }}
-
+  walStorage:
+    size: 1Gi
   monitoring:
     enablePodMonitor: true
-
   inheritedMetadata:
     labels:
       policy.cozystack.io/allow-to-apiserver: "true"

--- a/packages/extra/monitoring/templates/grafana/db.yaml
+++ b/packages/extra/monitoring/templates/grafana/db.yaml
@@ -6,10 +6,10 @@ spec:
   instances: 2
   storage:
     size: {{ .Values.grafana.db.size }}
-
+  walStorage:
+    size: 1Gi
   monitoring:
     enablePodMonitor: true
-
   inheritedMetadata:
     labels:
       policy.cozystack.io/allow-to-apiserver: "true"

--- a/packages/system/keycloak/templates/db.yaml
+++ b/packages/system/keycloak/templates/db.yaml
@@ -6,10 +6,10 @@ spec:
   instances: 2
   storage:
     size: 20Gi
-
+  walStorage:
+    size: 1Gi
   monitoring:
     enablePodMonitor: true
-
   inheritedMetadata:
     labels:
       policy.cozystack.io/allow-to-apiserver: "true"

--- a/packages/system/seaweedfs/templates/database.yaml
+++ b/packages/system/seaweedfs/templates/database.yaml
@@ -7,10 +7,10 @@ spec:
   instances: 2
   storage:
     size: 10Gi
-
+  walStorage:
+    size: 1Gi
   monitoring:
     enablePodMonitor: true
-
   inheritedMetadata:
     labels:
       policy.cozystack.io/allow-to-apiserver: "true"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added dedicated Write-Ahead Log (WAL) storage configuration for PostgreSQL clusters across multiple services
  - WAL storage size set to 1Gi by default

- **Version Updates**
  - Updated PostgreSQL Helm chart version from 0.8.0 to 0.8.1

- **Infrastructure Changes**
  - Updated Cozystack component image reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->