### PR TITLE
Add guard against empty cloudInit in vm-instance app

### DIFF
--- a/packages/apps/virtual-machine/README.md
+++ b/packages/apps/virtual-machine/README.md
@@ -36,24 +36,23 @@ virtctl ssh <user>@<vm>
 
 ### Common parameters
 
-| Name                      | Description                                                                                                | Value            |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------- |
-| `external`                | Enable external access from outside the cluster                                                            | `false`          |
-| `externalMethod`          | specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList` | `WholeIP`        |
-| `externalPorts`           | Specify ports to forward from outside the cluster                                                          | `[]`             |
-| `running`                 | Determines if the virtual machine should be running                                                        | `true`           |
-| `instanceType`            | Virtual Machine instance type                                                                              | `u1.medium`      |
-| `instanceProfile`         | Virtual Machine prefferences profile                                                                       | `ubuntu`         |
-| `systemDisk.image`        | The base image for the virtual machine. Allowed values: `ubuntu`, `cirros`, `alpine`, `fedora` and `talos` | `ubuntu`         |
-| `systemDisk.storage`      | The size of the disk allocated for the virtual machine                                                     | `5Gi`            |
-| `systemDisk.storageClass` | StorageClass used to store the data                                                                        | `replicated`     |
-| `gpus`                    | List of GPUs to attach                                                                                     | `[]`             |
-| `resources.cpu`           | The number of CPU cores allocated to the virtual machine                                                   | `""`             |
-| `resources.memory`        | The amount of memory allocated to the virtual machine                                                      | `""`             |
-| `sshKeys`                 | List of SSH public keys for authentication. Can be a single key or a list of keys.                         | `[]`             |
-| `cloudInit`               | cloud-init user data config. See cloud-init documentation for more details.                                | `#cloud-config
-` |
-| `cloudInitSeed`           | A seed string to generate an SMBIOS UUID for the VM.                                                       | `""`             |
+| Name                      | Description                                                                                                | Value        |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------ |
+| `external`                | Enable external access from outside the cluster                                                            | `false`      |
+| `externalMethod`          | specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList` | `WholeIP`    |
+| `externalPorts`           | Specify ports to forward from outside the cluster                                                          | `[]`         |
+| `running`                 | Determines if the virtual machine should be running                                                        | `true`       |
+| `instanceType`            | Virtual Machine instance type                                                                              | `u1.medium`  |
+| `instanceProfile`         | Virtual Machine preferences profile                                                                        | `ubuntu`     |
+| `systemDisk.image`        | The base image for the virtual machine. Allowed values: `ubuntu`, `cirros`, `alpine`, `fedora` and `talos` | `ubuntu`     |
+| `systemDisk.storage`      | The size of the disk allocated for the virtual machine                                                     | `5Gi`        |
+| `systemDisk.storageClass` | StorageClass used to store the data                                                                        | `replicated` |
+| `gpus`                    | List of GPUs to attach                                                                                     | `[]`         |
+| `resources.cpu`           | The number of CPU cores allocated to the virtual machine                                                   | `""`         |
+| `resources.memory`        | The amount of memory allocated to the virtual machine                                                      | `""`         |
+| `sshKeys`                 | List of SSH public keys for authentication. Can be a single key or a list of keys.                         | `[]`         |
+| `cloudInit`               | cloud-init user data config. See cloud-init documentation for more details.                                | `""`         |
+| `cloudInitSeed`           | A seed string to generate an SMBIOS UUID for the VM.                                                       | `""`         |
 
 ## U Series
 

--- a/packages/apps/virtual-machine/templates/vm.yaml
+++ b/packages/apps/virtual-machine/templates/vm.yaml
@@ -98,6 +98,7 @@ spec:
             secret:
               secretName: {{ include "virtual-machine.fullname" $ }}-ssh-keys
           propagationMethod:
+            # keys will be injected into metadata part of cloud-init disk
             noCloud: {}
       {{- end }}
       terminationGracePeriodSeconds: 30
@@ -108,8 +109,14 @@ spec:
       {{- if or .Values.sshKeys .Values.cloudInit }}
       - name: cloudinitdisk
         cloudInitNoCloud:
+        {{- if .Values.cloudInit }}
           secretRef:
             name: {{ include "virtual-machine.fullname" . }}-cloud-init
+        {{- else }}
+          userData: |
+            #cloud-config
+            final_message: Cloud-init user-data was left blank intentionally.
+        {{- end }}
       {{- end }}
       networks:
       - name: default

--- a/packages/apps/virtual-machine/values.schema.json
+++ b/packages/apps/virtual-machine/values.schema.json
@@ -88,7 +88,7 @@
     },
     "instanceProfile": {
       "type": "string",
-      "description": "Virtual Machine prefferences profile",
+      "description": "Virtual Machine preferences profile",
       "default": "ubuntu",
       "optional": true,
       "enum": [
@@ -198,7 +198,7 @@
     "cloudInit": {
       "type": "string",
       "description": "cloud-init user data config. See cloud-init documentation for more details.",
-      "default": "#cloud-config\n"
+      "default": ""
     },
     "cloudInitSeed": {
       "type": "string",

--- a/packages/apps/virtual-machine/values.yaml
+++ b/packages/apps/virtual-machine/values.yaml
@@ -12,7 +12,7 @@ externalPorts:
 running: true
 
 ## @param instanceType Virtual Machine instance type
-## @param instanceProfile Virtual Machine prefferences profile
+## @param instanceProfile Virtual Machine preferences profile
 ##
 instanceType: "u1.medium"
 instanceProfile: ubuntu
@@ -55,8 +55,7 @@ sshKeys: []
 ##   password: ubuntu
 ##   chpasswd: { expire: False }
 ##
-cloudInit: |
-  #cloud-config
+cloudInit: ""
 
 ## @param cloudInitSeed A seed string to generate an SMBIOS UUID for the VM.
 cloudInitSeed: ""

--- a/packages/apps/vm-instance/README.md
+++ b/packages/apps/vm-instance/README.md
@@ -36,22 +36,21 @@ virtctl ssh <user>@<vm>
 
 ### Common parameters
 
-| Name               | Description                                                                                                | Value            |
-| ------------------ | ---------------------------------------------------------------------------------------------------------- | ---------------- |
-| `external`         | Enable external access from outside the cluster                                                            | `false`          |
-| `externalMethod`   | specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList` | `WholeIP`        |
-| `externalPorts`    | Specify ports to forward from outside the cluster                                                          | `[]`             |
-| `running`          | Determines if the virtual machine should be running                                                        | `true`           |
-| `instanceType`     | Virtual Machine instance type                                                                              | `u1.medium`      |
-| `instanceProfile`  | Virtual Machine prefferences profile                                                                       | `ubuntu`         |
-| `disks`            | List of disks to attach                                                                                    | `[]`             |
-| `gpus`             | List of GPUs to attach                                                                                     | `[]`             |
-| `resources.cpu`    | The number of CPU cores allocated to the virtual machine                                                   | `""`             |
-| `resources.memory` | The amount of memory allocated to the virtual machine                                                      | `""`             |
-| `sshKeys`          | List of SSH public keys for authentication. Can be a single key or a list of keys.                         | `[]`             |
-| `cloudInit`        | cloud-init user data config. See cloud-init documentation for more details.                                | `#cloud-config
-` |
-| `cloudInitSeed`    | A seed string to generate an SMBIOS UUID for the VM.                                                       | `""`             |
+| Name               | Description                                                                                                | Value       |
+| ------------------ | ---------------------------------------------------------------------------------------------------------- | ----------- |
+| `external`         | Enable external access from outside the cluster                                                            | `false`     |
+| `externalMethod`   | specify method to passthrough the traffic to the virtual machine. Allowed values: `WholeIP` and `PortList` | `WholeIP`   |
+| `externalPorts`    | Specify ports to forward from outside the cluster                                                          | `[]`        |
+| `running`          | Determines if the virtual machine should be running                                                        | `true`      |
+| `instanceType`     | Virtual Machine instance type                                                                              | `u1.medium` |
+| `instanceProfile`  | Virtual Machine preferences profile                                                                        | `ubuntu`    |
+| `disks`            | List of disks to attach                                                                                    | `[]`        |
+| `gpus`             | List of GPUs to attach                                                                                     | `[]`        |
+| `resources.cpu`    | The number of CPU cores allocated to the virtual machine                                                   | `""`        |
+| `resources.memory` | The amount of memory allocated to the virtual machine                                                      | `""`        |
+| `sshKeys`          | List of SSH public keys for authentication. Can be a single key or a list of keys.                         | `[]`        |
+| `cloudInit`        | cloud-init user data config. See cloud-init documentation for more details.                                | `""`        |
+| `cloudInitSeed`    | A seed string to generate an SMBIOS UUID for the VM.                                                       | `""`        |
 
 ## U Series
 

--- a/packages/apps/vm-instance/templates/vm.yaml
+++ b/packages/apps/vm-instance/templates/vm.yaml
@@ -1,8 +1,8 @@
 {{- if and .Values.instanceType (not (lookup "instancetype.kubevirt.io/v1beta1" "VirtualMachineClusterInstancetype" "" .Values.instanceType)) }}
-{{-   fail (printf "Specified instancetype not exists in cluster: %s" .Values.instanceType) }}
+{{-   fail (printf "Specified instanceType does not exist in the cluster: %s" .Values.instanceType) }}
 {{- end }}
 {{- if and .Values.instanceProfile (not (lookup "instancetype.kubevirt.io/v1beta1" "VirtualMachineClusterPreference" "" .Values.instanceProfile)) }}
-{{-   fail (printf "Specified profile not exists in cluster: %s" .Values.instanceProfile) }}
+{{-   fail (printf "Specified instanceProfile does not exist in the cluster: %s" .Values.instanceProfile) }}
 {{- end }}
 
 apiVersion: kubevirt.io/v1
@@ -83,6 +83,7 @@ spec:
             secret:
               secretName: {{ include "virtual-machine.fullname" $ }}-ssh-keys
           propagationMethod:
+            # keys will be injected into metadata part of cloud-init disk
             noCloud: {}
       {{- end }}
       terminationGracePeriodSeconds: 30
@@ -95,8 +96,14 @@ spec:
       {{- if or .Values.sshKeys .Values.cloudInit }}
       - name: cloudinitdisk
         cloudInitNoCloud:
+        {{- if .Values.cloudInit }}
           secretRef:
             name: {{ include "virtual-machine.fullname" . }}-cloud-init
+        {{- else }}
+          userData: |
+            #cloud-config
+            final_message: Cloud-init user-data was left blank intentionally.
+        {{- end }}
       {{- end }}
       networks:
       - name: default

--- a/packages/apps/vm-instance/values.schema.json
+++ b/packages/apps/vm-instance/values.schema.json
@@ -88,7 +88,7 @@
     },
     "instanceProfile": {
       "type": "string",
-      "description": "Virtual Machine prefferences profile",
+      "description": "Virtual Machine preferences profile",
       "default": "ubuntu",
       "optional": true,
       "enum": [
@@ -179,7 +179,7 @@
     "cloudInit": {
       "type": "string",
       "description": "cloud-init user data config. See cloud-init documentation for more details.",
-      "default": "#cloud-config\n"
+      "default": ""
     },
     "cloudInitSeed": {
       "type": "string",

--- a/packages/apps/vm-instance/values.yaml
+++ b/packages/apps/vm-instance/values.yaml
@@ -12,7 +12,7 @@ externalPorts:
 running: true
 
 ## @param instanceType Virtual Machine instance type
-## @param instanceProfile Virtual Machine prefferences profile
+## @param instanceProfile Virtual Machine preferences profile
 ##
 instanceType: "u1.medium"
 instanceProfile: ubuntu
@@ -53,8 +53,7 @@ sshKeys: []
 ##   password: ubuntu
 ##   chpasswd: { expire: False }
 ##
-cloudInit: |
-  #cloud-config
+cloudInit: ""
 
 ## @param cloudInitSeed A seed string to generate an SMBIOS UUID for the VM.
 cloudInitSeed: ""


### PR DESCRIPTION
Prevent the VM resource from referencing a non-existent secret when `sshKeys` are set and `cloudInit` is set to empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved cloud-init configuration handling with conditional logic and clearer error messaging when expected configuration values are missing.

- **Documentation**
  - Refined virtual machine configuration guides by reformatting parameter tables and correcting typographical errors in parameter descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->