### PR TITLE
kube-ovn: Fix flush ip xfrm policy rule error

### DIFF
--- a/packages/system/kubeovn/images/kubeovn/Dockerfile
+++ b/packages/system/kubeovn/images/kubeovn/Dockerfile
@@ -51,4 +51,5 @@ WORKDIR /kube-ovn
 RUN setcap CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SYS_ADMIN+eip /usr/lib/openvswitch-switch/ovs-vswitchd \
  && setcap CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SYS_ADMIN+eip /usr/sbin/xtables-legacy-multi \
  && setcap CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SYS_ADMIN+eip /usr/sbin/xtables-nft-multi \
- && setcap CAP_NET_ADMIN,CAP_NET_RAW,CAP_NET_BIND_SERVICE,CAP_SYS_ADMIN+eip /usr/sbin/ipset
+ && setcap CAP_NET_ADMIN,CAP_NET_RAW,CAP_NET_BIND_SERVICE,CAP_SYS_ADMIN+eip /usr/sbin/ipset \
+ && setcap CAP_NET_ADMIN,CAP_NET_RAW,CAP_SYS_ADMIN+eip /usr/bin/ip


### PR DESCRIPTION
Fix error:

```
E0310 22:22:18.208943  124771 ipsec.go:376] flush ip xfrm policy rule error: fork/exec /usr/sbin/ip: operation not permitted, output:
E0310 22:22:18.208977  124771 ipsec.go:399] flush ip xfrm rules error: fork/exec /usr/sbin/ip: operation not permitted
```


Upstream bug: https://github.com/kubeovn/kube-ovn/issues/4526#issuecomment-2521200770