### PR TITLE
Fix conflict of deploying KubeVirt Instancetypes

### DIFF
--- a/packages/system/kubevirt-instancetypes/Makefile
+++ b/packages/system/kubevirt-instancetypes/Makefile
@@ -1,4 +1,4 @@
-export NAME=kubevirt-common-instancetypes
+export NAME=kubevirt-instancetypes
 export NAMESPACE=cozy-kubevirt
 
 include ../../../scripts/package.mk

--- a/packages/system/kubevirt/templates/kubevirt-cr.yaml
+++ b/packages/system/kubevirt/templates/kubevirt-cr.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   certificateRotateStrategy: {}
   configuration:
+    commonInstancetypesDeployment:
+      enabled: false
     developerConfiguration:
       featureGates:
       - HotplugVolumes


### PR DESCRIPTION
We have common-instance-types deployed by kubevirt-operator and separate helm-chart.
In this case operator always overrides the resource by default ones.

This PR disables common-instance-types deployment for kubevirt-operator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package’s internal identifier to enhance consistency across integration points.

- **New Features**
  - Introduced a new configuration option that enables a deployment toggle for managing instance types (disabled by default).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->