### PR TITLE
Add missing permissions to the Linstor plunger.

### DIFF
--- a/packages/system/linstor/templates/satellites-plunger.yaml
+++ b/packages/system/linstor/templates/satellites-plunger.yaml
@@ -16,8 +16,12 @@ spec:
         - "/scripts/plunger-satellite.sh"
         securityContext:
           capabilities:
+            add:
+            - NET_ADMIN
+            - SYS_ADMIN
             drop:
             - ALL
+          privileged: true
           # make some room for live debugging
           readOnlyRootFilesystem: false
         volumeMounts:


### PR DESCRIPTION
The Linstor satellite creates problems with admin privileges, so the plunger needs the same privileges to fix those problems.

Also, use the native `losetup`. The Linstor image has a wrapper with an additional function that we do not need here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the management of unused loop devices with clearer feedback and refined error handling.
  
- **New Features**
  - Enhanced container configuration by adding elevated system permissions, allowing the container to perform higher-level operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->