### PR TITLE
Update Flux Operator to 0.18.0

### DIFF
--- a/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.17.0
+appVersion: v0.18.0
 description: 'A Helm chart for deploying the Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.17.0
+version: 0.18.0

--- a/packages/system/fluxcd-operator/charts/flux-operator/README.md
+++ b/packages/system/fluxcd-operator/charts/flux-operator/README.md
@@ -1,6 +1,6 @@
 # flux-operator
 
-![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.17.0](https://img.shields.io/badge/AppVersion-v0.17.0-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.18.0](https://img.shields.io/badge/AppVersion-v0.18.0-informational?style=flat-square)
 
 The [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator) provides a
 declarative API for the installation and upgrade of CNCF [Flux](https://fluxcd.io) and the
@@ -46,11 +46,13 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | marketplace | object | `{"account":"","license":"","type":""}` | Marketplace settings. |
 | multitenancy | object | `{"defaultServiceAccount":"flux-operator","enabled":false}` | Enable [multitenancy lockdown](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for the ResourceSet APIs. |
 | nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` | Pod Node Selector settings. |
 | podSecurityContext | object | `{}` | Pod security context settings. |
 | priorityClassName | string | `""` | Pod priority class name. Recommended value is system-cluster-critical. |
 | rbac.create | bool | `true` | Grant the cluster-admin role to the flux-operator service account (required for the Flux Instance deployment). |
 | rbac.createAggregation | bool | `true` | Grant the Kubernetes view, edit and admin roles access to ResourceSet APIs. |
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":8081},"initialDelaySeconds":5,"periodSeconds":10}` | Container readiness probe settings. |
+| reporting | object | `{"interval":"5m"}` | Flux [reporting](https://fluxcd.control-plane.io/operator/fluxreport/) settings. |
 | resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Container resources requests and limits settings. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context settings. The default is compliant with the pod security restricted profile. |
 | serviceAccount | object | `{"automount":true,"create":true,"name":""}` | Pod service account settings. The name of the service account defaults to the release name. |

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/deployment.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/deployment.yaml
@@ -61,6 +61,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: REPORTING_INTERVAL
+              value: {{ .Values.reporting.interval }}
             {{- with .Values.marketplace.type }}
             - name: MARKETPLACE_TYPE
               value: {{ . }}
@@ -108,3 +110,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
@@ -194,6 +194,12 @@
         "nameOverride": {
             "type": "string"
         },
+        "nodeSelector": {
+            "properties": {},
+            "type": [
+                "object"
+            ]
+        },
         "podSecurityContext": {
             "default": {
                 "fsGroup": 1337
@@ -244,6 +250,17 @@
                     "type": "integer"
                 }
             },
+            "type": "object"
+        },
+        "reporting": {
+            "properties": {
+                "interval": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "interval"
+            ],
             "type": "object"
         },
         "resources": {

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
@@ -8,6 +8,10 @@ multitenancy:
   enabled: false
   defaultServiceAccount: "flux-operator" # @schema required: true
 
+# -- Flux [reporting](https://fluxcd.control-plane.io/operator/fluxreport/) settings.
+reporting:
+  interval: 5m # @schema required: true
+
 # -- Install and upgrade the custom resource definitions.
 installCRDs: true # @schema default: true
 
@@ -95,6 +99,9 @@ affinity: # @schema default: {"nodeAffinity":{"requiredDuringSchedulingIgnoredDu
 
 # -- Pod tolerations settings.
 tolerations: [ ] # @schema item: object ; uniqueItems: true
+
+# -- Pod Node Selector settings.
+nodeSelector: { } # @schema type: object
 
 # -- If `true`, the container ports (`8080` and `8081`) are exposed on the host network.
 hostNetwork: false # @schema default: false

--- a/packages/system/fluxcd/charts/flux-instance/Chart.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.17.0
+appVersion: v0.18.0
 description: 'A Helm chart for deploying a Flux instance managed by Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.17.0
+version: 0.18.0

--- a/packages/system/fluxcd/charts/flux-instance/README.md
+++ b/packages/system/fluxcd/charts/flux-instance/README.md
@@ -1,6 +1,6 @@
 # flux-instance
 
-![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.17.0](https://img.shields.io/badge/AppVersion-v0.17.0-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.18.0](https://img.shields.io/badge/AppVersion-v0.18.0-informational?style=flat-square)
 
 This chart is a thin wrapper around the `FluxInstance` custom resource, which is
 used by the [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator)


### PR DESCRIPTION
Released early this week

https://github.com/controlplaneio-fluxcd/flux-operator/releases/tag/v0.18.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upgraded the charts to version 0.18.0.
  - Added options for custom pod scheduling using node selectors.
  - Introduced a reporting configuration with a customizable interval through an environment variable.

- **Documentation**
  - Updated release information and configuration details to reflect the new options and version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->