### PR TITLE
Remove workaround for ZFS tools.

### DIFF
--- a/packages/system/linstor/templates/satellites-plunger.yaml
+++ b/packages/system/linstor/templates/satellites-plunger.yaml
@@ -25,8 +25,6 @@ spec:
           # make some room for live debugging
           readOnlyRootFilesystem: false
         volumeMounts:
-        - mountPath: /run
-          name: host-run
         - mountPath: /dev
           name: dev
         - mountPath: /var/lib/drbd

--- a/packages/system/linstor/templates/satellites-talos.yaml
+++ b/packages/system/linstor/templates/satellites-talos.yaml
@@ -22,11 +22,6 @@ spec:
               $patch: delete
             - name: drbd-module-loader
               $patch: delete
-            containers:
-            - name: linstor-satellite
-              volumeMounts:
-              - mountPath: /run
-                name: host-run
             volumes:
             - name: run-systemd-system
               $patch: delete
@@ -45,8 +40,4 @@ spec:
             - name: etc-lvm-archive
               hostPath:
                 path: /var/etc/lvm/archive
-                type: DirectoryOrCreate
-            - name: host-run
-              hostPath:
-                path: /run
                 type: DirectoryOrCreate


### PR DESCRIPTION
The mounting of /run parts was fixed in a consistent way upstream.

fixes #699