### PR TITLE
Fix typo in VirtualPodAutoscaler Makefile

### DIFF
--- a/packages/system/vertical-pod-autoscaler/Makefile
+++ b/packages/system/vertical-pod-autoscaler/Makefile
@@ -1,11 +1,11 @@
-export NAME=victoria-metrics-operator
+export NAME=vertical-pod-autoscaler
 export NAMESPACE=cozy-$(NAME)
 
 include ../../../scripts/package.mk
 
 update:
 	rm -rf charts
-	# VictoriaMetrics operator
+	# VirtualPodAutoscaler operator
 	helm repo add cowboysysop https://cowboysysop.github.io/charts/
 	helm repo update cowboysysop
 	helm pull cowboysysop/vertical-pod-autoscaler --untar --untardir charts


### PR DESCRIPTION
Makefile was copied from VictoriaMetrics Operator, some lines were not changed.

Follow-up to #676
Resolves #705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the operator naming to align with the Vertical Pod Autoscaler identity for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->