### PR TITLE
[linstor] Plunger: detach also / devices

### DIFF
--- a/packages/system/linstor/hack/plunger/plunger-satellite.sh
+++ b/packages/system/linstor/hack/plunger/plunger-satellite.sh
@@ -22,7 +22,7 @@ while true; do
   # the `/` path could not be a backing file for a loop device, so it's a good indicator of a stuck loop device
   # TODO describe the issue in more detail
   # Using the direct /usr/sbin/losetup as the linstor-satellite image has own wrapper in /usr/local
-  stale_loopbacks=$(/usr/sbin/losetup --json | jq -r '.[][] | select(."back-file" == "/ (deleted)").name')
+  stale_loopbacks=$(/usr/sbin/losetup --json | jq -r '.[][] | select(."back-file" == "/" or ."back-file" == "/ (deleted)").name' )
   for stale_device in $stale_loopbacks; do (
     echo "Detaching stuck loop device ${stale_device}"
     set -x


### PR DESCRIPTION
I just noticed that many devices are still attached to `/`, they are not deleted but still blocking DRBD operations

Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved detection of inactive loop devices by broadening the filtering criteria, ensuring more accurate identification in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->