### PR TITLE
Enable Cilium host firewall

### DIFF
--- a/packages/system/cilium/values.yaml
+++ b/packages/system/cilium/values.yaml
@@ -1,5 +1,7 @@
 cilium:
   kubeProxyReplacement: true
+  hostFirewall:
+    enabled: true
   hubble:
     enabled: false
   externalIPs:

--- a/packages/system/linstor/templates/networkpolicy.yaml
+++ b/packages/system/linstor/templates/networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: restrict-drbd-reactor
+spec:
+  ingressDeny:
+  - fromEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "9942"
+  ingress:
+  - fromEntities:
+    - world
+    - host
+    - cluster
+  nodeSelector:
+    matchLabels: {}

--- a/packages/system/monitoring-agents/templates/networkpolicy.yaml
+++ b/packages/system/monitoring-agents/templates/networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: restrict-node-exporter
+spec:
+  ingressDeny:
+  - fromEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "9100"
+  ingress:
+  - fromEntities:
+    - world
+    - host
+    - cluster
+  nodeSelector:
+    matchLabels: {}


### PR DESCRIPTION
This commit enables Cilium's host firewall feature and makes use of it to deny external connections to two exporters running as daemonset pods in the host network namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Host firewall is now enabled by default, adding an extra layer of security.
  - Enhanced network traffic management with new policies:
    - One policy tightens access to critical service ports.
    - Another secures monitoring endpoints by restricting unauthorized external access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->