### PR TITLE
Enable Cilium host firewall

### DIFF
--- a/packages/system/cilium/templates/networkpolicy.yaml
+++ b/packages/system/cilium/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: restrict-system-components
+spec:
+  ingressDeny:
+  - fromEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "2379"  # etcd
+      - port: "2380"  # etcd
+      - port: "3367"  # linstor
+      - port: "7473"  # frr-metrics (metallb)
+      - port: "8123"  # cozy assets server
+      - port: "9443"  # kube-rbac-proxy
+      - port: "10250" # kubelet
+      - port: "10257" # kube-controller-manager
+      - port: "10259" # kube-scheduler
+  ingress:
+  - fromEntities:
+    - world
+    - host
+    - cluster
+  nodeSelector:
+    matchLabels: {}

--- a/packages/system/cilium/values.yaml
+++ b/packages/system/cilium/values.yaml
@@ -1,5 +1,7 @@
 cilium:
   kubeProxyReplacement: true
+  hostFirewall:
+    enabled: true
   hubble:
     enabled: false
   externalIPs:

--- a/packages/system/linstor/templates/networkpolicy.yaml
+++ b/packages/system/linstor/templates/networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: restrict-drbd-reactor
+spec:
+  ingressDeny:
+  - fromEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "9942"
+  ingress:
+  - fromEntities:
+    - world
+    - host
+    - cluster
+  nodeSelector:
+    matchLabels: {}

--- a/packages/system/monitoring-agents/templates/networkpolicy.yaml
+++ b/packages/system/monitoring-agents/templates/networkpolicy.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumClusterwideNetworkPolicy
+metadata:
+  name: restrict-node-exporter
+spec:
+  ingressDeny:
+  - fromEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: "9100"
+  ingress:
+  - fromEntities:
+    - world
+    - host
+    - cluster
+  nodeSelector:
+    matchLabels: {}


### PR DESCRIPTION
This commit enables Cilium's host firewall feature and makes use of it to deny external connections to two exporters running as daemonset pods in the host network namespace.