### PR TITLE
[linstor] fix reloader patch

### DIFF
--- a/packages/core/installer/values.yaml
+++ b/packages/core/installer/values.yaml
@@ -1,2 +1,2 @@
 cozystack:
-  image: ghcr.io/cozystack/cozystack/installer:v0.29.0@sha256:9dfdd5ce52251155695243e0800e7730e70d7c7dcd96b44dbff51b5ce2c40b0b
+  image: ghcr.io/cozystack/cozystack/installer:v0.29.0@sha256:577adae2245eee6f3b5037c1c6218ade4e0a091ff7f44b6cb0c1b598c418c5a3

--- a/packages/system/linstor/templates/cluster.yaml
+++ b/packages/system/linstor/templates/cluster.yaml
@@ -44,13 +44,24 @@ spec:
             name: linstor-plunger
             defaultMode: 0755
   patches:
-  - target:
-      group: apps
-      version: v1
-      kind: Deployment
-    patch: |
-      apiVersion: apps/v1
-      kind: Deployment
-      metadata:
-        annotations:
-          secret.reloader.stakater.com/auto: "true"
+    - target:
+        kind: Deployment
+        name: linstor-controller
+      patch: |-
+        - op: add
+          path: /metadata/annotations/reloader.stakater.com~1auto
+          value: "true"
+    - target:
+        kind: Deployment
+        name: linstor-csi-controller
+      patch: |-
+        - op: add
+          path: /metadata/annotations/reloader.stakater.com~1auto
+          value: "true"
+    - target:
+        kind: DaemonSet
+        name: linstor-csi-node
+      patch: |-
+        - op: add
+          path: /metadata/annotations/reloader.stakater.com~1auto
+          value: "true"

--- a/packages/system/linstor/templates/satellites-reloader.yaml
+++ b/packages/system/linstor/templates/satellites-reloader.yaml
@@ -4,15 +4,10 @@ metadata:
   name: cozystack-reloader
 spec:
   patches:
-  - target:
-      group: apps
-      version: v1
-      kind: DaemonSet
-      name: linstor-satellite
-    patch: |
-      apiVersion: apps/v1
-      kind: DaemonSet
-      metadata:
+    - target:
+        kind: DaemonSet
         name: linstor-satellite
-        annotations:
-          secret.reloader.stakater.com/auto: "true"
+      patch: |-
+        - op: add
+          path: /metadata/annotations/reloader.stakater.com~1auto
+          value: "true"


### PR DESCRIPTION
this PR fixes problem

```
* admission webhook "vlinstorcluster.kb.io" denied the request: LinstorCluster.piraeus.io "linstorcluster" is invalid: spec.patches.0.patch: Invalid value: "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  annotations:\n    secret.reloader.stakater.com/auto: \"true\"\n": Failed to parse patch as either Strategic Merge Patch (missing metadata.name in object {{apps/v1 Deployment} {{ } map[] map[secret.reloader.stakater.com/auto:true]}}) or JSON Patch (json: cannot unmarshal object into Go value of type jsonpatch.Patch)
```

used solution from
- https://github.com/piraeusdatastore/piraeus-operator/issues/701#issuecomment-2377702085