### PR TITLE
kubevirt for able to run CX or RT type of instances.

### DIFF
--- a/packages/system/kubevirt/templates/kubevirt-cr.yaml
+++ b/packages/system/kubevirt/templates/kubevirt-cr.yaml
@@ -15,6 +15,7 @@ spec:
       - ExpandDisks
       - LiveMigration
       - AutoResourceLimitsGate
+      - CPUManager
     evictionStrategy: LiveMigrate
   customizeComponents: {}
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Without this, kubevirt does not recognize that cpu-manager is being used on the node and does not change the label "cpumanager=false" on nodes, which prevents the starting of instances with types CX or RT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the CPUManager feature to enhance CPU resource management for virtual machines in KubeVirt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->