### PR TITLE
[e2e] Add mirror.gcr.io as default mirror for docker.io

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -113,6 +113,11 @@ machine:
         - usermode_helper=disabled
     - name: zfs
     - name: spl
+  registries:
+    mirrors:
+      docker.io:
+        endpoints:
+        - https://mirror.gcr.io
   files:
   - content: |
       [plugins]


### PR DESCRIPTION

related issues:
- https://github.com/cozystack/talm/pull/48
- https://github.com/cozystack/website/pull/154
- https://github.com/cozystack/cozystack/pull/782


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced additional configuration options that enable using Docker image mirrors. This enhancement can improve image retrieval performance and provide redundancy while maintaining the existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->