### PR TITLE
[ci] Fix release branch matching

### DIFF
--- a/.github/workflows/pull-requests-release.yaml
+++ b/.github/workflows/pull-requests-release.yaml
@@ -51,10 +51,10 @@ jobs:
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;
-            const match = branch.match(/^release-(v\d+\.\d+\.\d+(?:[-\w\.]+)?)$/);
+            const match = branch.match(/^release-(\d+\.\d+\.\d+(?:[-\w\.]+)?)$/);
   
             if (!match) {
-              core.setFailed(`Branch '${branch}' does not match expected format 'release-vX.Y.Z[-suffix]'`);
+              core.setFailed(`Branch '${branch}' does not match expected format 'release-X.Y.Z[-suffix]'`);
             } else {
               const tag = match[1];
               core.setOutput('tag', tag);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the branch naming convention for release management to remove the 'v' prefix.
  - Revised the displayed error messages to match the new format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->