### PR TITLE
[kubevirt] Enable VMExport feature

### DIFF
--- a/packages/extra/ingress/Chart.yaml
+++ b/packages/extra/ingress/Chart.yaml
@@ -3,4 +3,4 @@ name: ingress
 description: NGINX Ingress Controller
 icon: /logos/ingress-nginx.svg
 type: application
-version: 1.4.0
+version: 1.5.0

--- a/packages/extra/ingress/README.md
+++ b/packages/extra/ingress/README.md
@@ -4,12 +4,13 @@
 
 ### Common parameters
 
-| Name             | Description                                                       | Value   |
-| ---------------- | ----------------------------------------------------------------- | ------- |
-| `replicas`       | Number of ingress-nginx replicas                                  | `2`     |
-| `externalIPs`    | List of externalIPs for service.                                  | `[]`    |
-| `whitelist`      | List of client networks                                           | `[]`    |
-| `clouflareProxy` | Restoring original visitor IPs when Cloudflare proxied is enabled | `false` |
-| `dashboard`      | Should ingress serve Cozystack service dashboard                  | `false` |
-| `cdiUploadProxy` | Should ingress serve CDI upload proxy                             | `false` |
+| Name              | Description                                                       | Value   |
+| ----------------- | ----------------------------------------------------------------- | ------- |
+| `replicas`        | Number of ingress-nginx replicas                                  | `2`     |
+| `externalIPs`     | List of externalIPs for service.                                  | `[]`    |
+| `whitelist`       | List of client networks                                           | `[]`    |
+| `clouflareProxy`  | Restoring original visitor IPs when Cloudflare proxied is enabled | `false` |
+| `dashboard`       | Should ingress serve Cozystack service dashboard                  | `false` |
+| `cdiUploadProxy`  | Should ingress serve CDI upload proxy                             | `false` |
+| `virtExportProxy` | Should ingress serve KubeVirt export proxy                        | `false` |
 

--- a/packages/extra/ingress/values.schema.json
+++ b/packages/extra/ingress/values.schema.json
@@ -35,6 +35,11 @@
             "type": "boolean",
             "description": "Should ingress serve CDI upload proxy",
             "default": false
+        },
+        "virtExportProxy": {
+            "type": "boolean",
+            "description": "Should ingress serve KubeVirt export proxy",
+            "default": false
         }
     }
 }

--- a/packages/extra/ingress/values.yaml
+++ b/packages/extra/ingress/values.yaml
@@ -30,3 +30,6 @@ dashboard: false
 
 ## @param cdiUploadProxy Should ingress serve CDI upload proxy
 cdiUploadProxy: false
+
+## @param virtExportProxy Should ingress serve KubeVirt export proxy
+virtExportProxy: false

--- a/packages/extra/ingress/vm-exportproxy.yaml
+++ b/packages/extra/ingress/vm-exportproxy.yaml
@@ -1,0 +1,37 @@
+{{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
+{{- $issuerType := (index $cozyConfig.data "clusterissuer") | default "http01" }}
+
+{{- $myNS := lookup "v1" "Namespace" "" .Release.Namespace }}
+{{- $host := index $myNS.metadata.annotations "namespace.cozystack.io/host" }}
+
+{{- if .Values.virtExportProxy }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/backend-protocol: HTTPS
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    {{- if eq $issuerType "cloudflare" }} 
+    {{- else }}
+    acme.cert-manager.io/http01-ingress-class: {{ .Release.Namespace }}
+    {{- end }}
+  name: virt-exportproxy-{{ .Release.Namespace }}
+  namespace: cozy-kubevirt
+spec:
+  ingressClassName: {{ .Release.Namespace }}
+  rules:
+  - host: virt-exportproxy.{{ $host }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: virt-exportproxy
+            port:
+              number: 443
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    virt-exportproxy.{{ $host }}
+    secretName: virt-exportproxy-{{ .Release.Namespace }}-tls
+{{- end }}

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -16,7 +16,8 @@ ingress 1.0.0 d7cfa53c
 ingress 1.1.0 5bbc488e
 ingress 1.2.0 28fca4ef
 ingress 1.3.0 fde4bcfa
-ingress 1.4.0 HEAD
+ingress 1.4.0 fd240701
+ingress 1.5.0 HEAD
 monitoring 1.0.0 d7cfa53c
 monitoring 1.1.0 25221fdc
 monitoring 1.2.0 f81be075

--- a/packages/system/kubevirt/templates/kubevirt-cr.yaml
+++ b/packages/system/kubevirt/templates/kubevirt-cr.yaml
@@ -17,6 +17,7 @@ spec:
       - AutoResourceLimitsGate
       - CPUManager
       - GPU
+      - VMExport
     evictionStrategy: LiveMigrate
   customizeComponents: {}
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option to control the virtual export proxy service (default disabled).
  - Deployed a dedicated ingress configuration to support flexible routing for the virtual export proxy.
  - Enabled a feature toggle for VM export capabilities in KubeVirt deployments.
- **Documentation**
  - Updated user documentation to include details about the new virtual export proxy parameter.
- **Chores**
  - Upgraded the associated ingress component from version 1.4.0 to 1.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->