### PR TITLE
Revert "Release v0.30.2"

### DIFF
--- a/packages/apps/kubernetes/images/cluster-autoscaler.tag
+++ b/packages/apps/kubernetes/images/cluster-autoscaler.tag
@@ -1,1 +1,1 @@
-ghcr.io/cozystack/cozystack/cluster-autoscaler:0.18.0@sha256:85371c6aabf5a7fea2214556deac930c600e362f92673464fe2443784e2869c3
+ghcr.io/cozystack/cozystack/cluster-autoscaler:0.17.1@sha256:85371c6aabf5a7fea2214556deac930c600e362f92673464fe2443784e2869c3

--- a/packages/apps/kubernetes/images/kubevirt-cloud-provider.tag
+++ b/packages/apps/kubernetes/images/kubevirt-cloud-provider.tag
@@ -1,1 +1,1 @@
-ghcr.io/cozystack/cozystack/kubevirt-cloud-provider:0.18.0@sha256:795d8e1ef4b2b0df2aa1e09d96cd13476ebb545b4bf4b5779b7547a70ef64cf9
+ghcr.io/cozystack/cozystack/kubevirt-cloud-provider:0.17.1@sha256:795d8e1ef4b2b0df2aa1e09d96cd13476ebb545b4bf4b5779b7547a70ef64cf9

--- a/packages/apps/kubernetes/images/kubevirt-csi-driver.tag
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver.tag
@@ -1,1 +1,1 @@
-ghcr.io/cozystack/cozystack/kubevirt-csi-driver:0.18.0@sha256:6f9091c3e7e4951c5e43fdafd505705fcc9f1ead290ee3ae42e97e9ec2b87b20
+ghcr.io/cozystack/cozystack/kubevirt-csi-driver:0.17.1@sha256:d1346d59224e6d2d07f1551af918ed31e57ba84b750122c1aeceaf9b33dd2271

--- a/packages/core/installer/values.yaml
+++ b/packages/core/installer/values.yaml
@@ -1,2 +1,2 @@
 cozystack:
-  image: ghcr.io/cozystack/cozystack/installer:v0.30.2@sha256:59996588b5d59b5593fb34442b2f2ed8ef466d138b229a8d37beb6f70141a690
+  image: ghcr.io/cozystack/cozystack/installer:v0.30.1@sha256:29b975e1485efa98965d292d772efc11966724fef2f9b70612e398dff0eded5b

--- a/packages/core/testing/values.yaml
+++ b/packages/core/testing/values.yaml
@@ -1,2 +1,2 @@
 e2e:
-  image: ghcr.io/cozystack/cozystack/e2e-sandbox:v0.30.2@sha256:31273d6b42dc88c2be2ff9ba64564d1b12e70ae8a5480953341b0d113ac7d4bd
+  image: ghcr.io/cozystack/cozystack/e2e-sandbox:v0.30.1@sha256:04dcc6161e9bdb4d30538e3706bb29c93c1d615c6f3d940f9af64d3dda2f491e

--- a/packages/extra/bootbox/images/matchbox.tag
+++ b/packages/extra/bootbox/images/matchbox.tag
@@ -1,1 +1,1 @@
-ghcr.io/cozystack/cozystack/matchbox:v0.30.2@sha256:307d382f75f1dcb39820c73b93b2ce576cdb6d58032679bda7d926999c677900
+ghcr.io/cozystack/cozystack/matchbox:v0.30.1@sha256:a30e58f07c702e693f9bc052c3ef6eab443e1db8bcc86689199b2db6af14ebb7

--- a/packages/extra/monitoring/images/grafana.tag
+++ b/packages/extra/monitoring/images/grafana.tag
@@ -1,1 +1,1 @@
-ghcr.io/cozystack/cozystack/grafana:1.9.2@sha256:c63978e1ed0304e8518b31ddee56c4e8115541b997d8efbe1c0a74da57140399
+ghcr.io/cozystack/cozystack/grafana:1.9.2@sha256:fb48d37f1a9386e0023df9ac067ec2e03953b7b8c9d6abf2d12716e084f846a4

--- a/packages/system/bucket/images/s3manager.tag
+++ b/packages/system/bucket/images/s3manager.tag
@@ -1,1 +1,1 @@
-ghcr.io/cozystack/cozystack/s3manager:v0.5.0@sha256:a47d2743d01bff0ce60aa745fdff54f9b7184dff8679b11ab4ecd08ac663012b
+ghcr.io/cozystack/cozystack/s3manager:v0.5.0@sha256:3537d3baaf96d576148e6df17552f2ead2b7a55ba122ef542a2e99bde896d218

--- a/packages/system/cozystack-api/values.yaml
+++ b/packages/system/cozystack-api/values.yaml
@@ -1,2 +1,2 @@
 cozystackAPI:
-  image: ghcr.io/cozystack/cozystack/cozystack-api:v0.30.2@sha256:7ef370dc8aeac0a6b2a50b7d949f070eb21d267ba0a70e7fc7c1564bfe6d4f83
+  image: ghcr.io/cozystack/cozystack/cozystack-api:v0.30.1@sha256:7ef370dc8aeac0a6b2a50b7d949f070eb21d267ba0a70e7fc7c1564bfe6d4f83

--- a/packages/system/cozystack-controller/values.yaml
+++ b/packages/system/cozystack-controller/values.yaml
@@ -1,5 +1,5 @@
 cozystackController:
-  image: ghcr.io/cozystack/cozystack/cozystack-controller:v0.30.2@sha256:5b87a8ea0dcde1671f44532c1ee6db11a5dd922d1a009078ecf6495ec193e52a
+  image: ghcr.io/cozystack/cozystack/cozystack-controller:v0.30.1@sha256:5b87a8ea0dcde1671f44532c1ee6db11a5dd922d1a009078ecf6495ec193e52a
   debug: false
   disableTelemetry: false
-  cozystackVersion: "v0.30.2"
+  cozystackVersion: "v0.30.1"

--- a/packages/system/dashboard/charts/kubeapps/templates/dashboard/configmap.yaml
+++ b/packages/system/dashboard/charts/kubeapps/templates/dashboard/configmap.yaml
@@ -76,7 +76,7 @@ data:
       "kubeappsNamespace": {{ .Release.Namespace | quote }},
       "helmGlobalNamespace": {{ include "kubeapps.helmGlobalPackagingNamespace" . | quote }},
       "carvelGlobalNamespace": {{ .Values.kubeappsapis.pluginConfig.kappController.packages.v1alpha1.globalPackagingNamespace | quote }},
-      "appVersion": "v0.30.2",
+      "appVersion": "v0.30.1",
       "authProxyEnabled": {{ .Values.authProxy.enabled }},
       "oauthLoginURI": {{ .Values.authProxy.oauthLoginURI | quote }},
       "oauthLogoutURI": {{ .Values.authProxy.oauthLogoutURI | quote }},

--- a/packages/system/dashboard/values.yaml
+++ b/packages/system/dashboard/values.yaml
@@ -18,14 +18,14 @@ kubeapps:
     image:
       registry: ghcr.io/cozystack/cozystack
       repository: dashboard
-      tag: v0.30.2
+      tag: v0.30.1
       digest: "sha256:a83fe4654f547469cfa469a02bda1273c54bca103a41eb007fdb2e18a7a91e93"
   kubeappsapis:
     image:
       registry: ghcr.io/cozystack/cozystack
       repository: kubeapps-apis
-      tag: v0.30.2
-      digest: "sha256:3b5805b56f2fb9fd25f4aa389cdfbbb28a3f2efb02245c52085a45d1dc62bf92"
+      tag: v0.30.1
+      digest: "sha256:5019c8fc4a5d4437cae32a635303ceebcb489c582092fd4bcfc04353b4582233"
     pluginConfig:
       flux:
         packages:

--- a/packages/system/kamaji/values.yaml
+++ b/packages/system/kamaji/values.yaml
@@ -3,7 +3,7 @@ kamaji:
     deploy: false
   image:
     pullPolicy: IfNotPresent
-    tag: v0.30.2@sha256:e04f68e4cc5b023ed39ce2242b32aee51f97235371602239d0c4a9cea97c8d0d
+    tag: v0.30.1@sha256:e6be608afa1aba23309d419cba5406a70fc510dcab8cb399fcd2064c1b48f10e
     repository: ghcr.io/cozystack/cozystack/kamaji
   resources:
     limits:

--- a/packages/system/kubeovn-webhook/values.yaml
+++ b/packages/system/kubeovn-webhook/values.yaml
@@ -1,3 +1,3 @@
 portSecurity: true
 routes: ""
-image: ghcr.io/cozystack/cozystack/kubeovn-webhook:v0.30.2@sha256:fa14fa7a0ffa628eb079ddcf6ce41d75b43de92e50f489422f8fb15c4dab2dbf
+image: ghcr.io/cozystack/cozystack/kubeovn-webhook:v0.30.1@sha256:fa14fa7a0ffa628eb079ddcf6ce41d75b43de92e50f489422f8fb15c4dab2dbf

--- a/packages/system/kubeovn/values.yaml
+++ b/packages/system/kubeovn/values.yaml
@@ -22,4 +22,4 @@ global:
   images:
     kubeovn:
       repository: kubeovn
-      tag: v1.13.8@sha256:071a93df2dce484b347bbace75934ca9e1743668bfe6f1161ba307dee204767d
+      tag: v1.13.8@sha256:385329464045cdf5e01364e9f2293edc71065a0910576a8e26ea9ac7097aae71


### PR DESCRIPTION
Reverts cozystack/cozystack#813

The patch-release branch `release-0.30.2` should not have been merged with `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Rolled back several container image versions and tags across multiple components to earlier releases.
  - Updated image digests for certain components without changing their version tags.
  - Adjusted configuration files to reflect previous version numbers where applicable.
  - No changes to configuration structure or public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->