### PR TITLE
[platform] Hash tenant config and store in configmap

### DIFF
--- a/packages/apps/tenant/templates/configuration-hash.yaml
+++ b/packages/apps/tenant/templates/configuration-hash.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cozy-tenant-configuration-hash
+  namespace: {{ include "tenant.name" . }}
+data:
+  cozyTenantConfigurationHash: {{ sha256sum (toJson .Values) | quote }}

--- a/packages/core/platform/templates/apps.yaml
+++ b/packages/core/platform/templates/apps.yaml
@@ -54,6 +54,12 @@ spec:
         namespace: cozy-public
   values:
     host: "{{ $host }}"
+  valuesFrom:
+  - kind: ConfigMap
+    name: "cozy-system-configuration-hash"
+    valuesKey: "cozyTenantConfigurationHash"
+    targetPath: "cozyTenantConfigurationHash"
+    optional: true
   dependsOn:
   {{- range $x := $bundle.releases }}
   {{- if has $x.name (list "cilium" "kubeovn") }}

--- a/packages/core/platform/templates/configuration-hash.yaml
+++ b/packages/core/platform/templates/configuration-hash.yaml
@@ -1,0 +1,14 @@
+{{- $rootTenantConfiguration := dict "values" .Values }}
+{{- $cozyConfig     := index (lookup "v1" "ConfigMap" "cozy-system" "cozystack"           ) "data" }}
+{{- $cozyScheduling := index (lookup "v1" "ConfigMap" "cozy-system" "cozystack-scheduling") "data" }}
+{{- $cozyBranding   := index (lookup "v1" "ConfigMap" "cozy-system" "cozystack-branding"  ) "data" }}
+{{- $_ := set $rootTenantConfiguration "config" $cozyConfig }}
+{{- $_ := set $rootTenantConfiguration "scheduling" $cozyScheduling }}
+{{- $_ := set $rootTenantConfiguration "branding" $cozyBranding }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cozy-system-configuration-hash
+  namespace: tenant-root
+data:
+  cozyTenantConfigurationHash: {{ sha256sum (toJson $rootTenantConfiguration) | quote }}

--- a/pkg/apis/apps/v1alpha1/types.go
+++ b/pkg/apis/apps/v1alpha1/types.go
@@ -21,6 +21,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	CozySystemConfigurationHashConfigMapName = "cozy-system-configuration-hash"
+	CozyTenantConfigurationHashConfigMapName = "cozy-tenant-configuration-hash"
+	CozyTenantConfigurationHashKey           = "cozyTenantConfigurationHash"
+)
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ApplicationList is a list of Application objects.

--- a/pkg/registry/apps/application/rest.go
+++ b/pkg/registry/apps/application/rest.go
@@ -988,6 +988,18 @@ func (r *REST) convertApplicationToHelmRelease(app *appsv1alpha1.Application) (*
 		},
 	}
 
+	valuesFromConfigMap := appsv1alpha1.CozyTenantConfigurationHashConfigMapName
+	if helmRelease.Name == "tenant-root" && helmRelease.Namespace == "tenant-root" {
+		valuesFromConfigMap = appsv1alpha1.CozySystemConfigurationHashConfigMapName
+	}
+	helmRelease.Spec.ValuesFrom = []helmv2.ValuesReference{{
+		Kind:       "ConfigMap",
+		Name:       valuesFromConfigMap,
+		ValuesKey:  appsv1alpha1.CozyTenantConfigurationHashKey,
+		TargetPath: appsv1alpha1.CozyTenantConfigurationHashKey,
+		Optional:   true,
+	}}
+
 	return helmRelease, nil
 }
 


### PR DESCRIPTION
Every tenant now creates a configmap in its __tenant__ namespace with a sha256 of its values. Tenants (and eventually all other apps), watch the configmap in their __release__ namespace, by referencing it in the valuesFrom part of the HelmRelease. `tenant-root` is an exception, since it is the only tenant where the release namespace is the same as the tenant namespace. It references a different configmap in its valesFrom, created and reconciled by the cozystack installer script. Part of #802.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced ConfigMaps that provide SHA256 hashes representing aggregated tenant and system configurations for improved configuration tracking.
  - Configuration hashes are now injected into application releases, including a special system configuration hash for the root tenant.

- **Chores**
  - Added new constants for configuration hash naming to improve consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->