### PR TITLE
[monitoring] fix vpa for vmagent delete resources

### DIFF
--- a/packages/system/monitoring-agents/templates/vmagent.yaml
+++ b/packages/system/monitoring-agents/templates/vmagent.yaml
@@ -20,12 +20,8 @@ spec:
   additionalScrapeConfigs:
     name: additional-scrape-configs
     key: prometheus-additional.yaml
-  resources:
-    limits:
-      memory: 1024Mi
-    requests:
-      cpu: 50m
-      memory: 768Mi
+  resources: {}
+  configReloaderResources: {}
   #statefulMode: true
   #statefulStorage:
   #  volumeClaimTemplate:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated resource allocation settings for monitoring agents by removing predefined CPU and memory limits.
  - Added an option to specify separate resource settings for the config reloader component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->