### PR TITLE
[platform]: add VerticalPodAutoscaler for Cozystack dashboard

### DIFF
--- a/packages/core/platform/bundles/paas-full.yaml
+++ b/packages/core/platform/bundles/paas-full.yaml
@@ -270,7 +270,10 @@ releases:
             {{- end }}
     {{- end }}
     {{- end }}
+      frontend:
+        resourcesPreset: "none"
       dashboard:
+        resourcesPreset: "none"
         {{- $cozystackBranding:= lookup "v1" "ConfigMap" "cozy-system" "cozystack-branding" }}
         {{- $branding := dig "data" "branding" "" $cozystackBranding }}
         {{- if $branding }}

--- a/packages/core/platform/bundles/paas-hosted.yaml
+++ b/packages/core/platform/bundles/paas-hosted.yaml
@@ -168,7 +168,10 @@ releases:
             {{- end }}
     {{- end }}
     {{- end }}
+      frontend:
+        resourcesPreset: "none"
       dashboard:
+        resourcesPreset: "none"
         {{- $cozystackBranding:= lookup "v1" "ConfigMap" "cozy-system" "cozystack-branding" }}
         {{- $branding := dig "data" "branding" "" $cozystackBranding }}
         {{- if $branding }}

--- a/packages/system/dashboard/templates/vpa.yaml
+++ b/packages/system/dashboard/templates/vpa.yaml
@@ -1,0 +1,80 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: dashboard-internal-dashboard
+  namespace: cozy-dashboard
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: dashboard-internal-dashboard
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+    - containerName: dashboard
+      controlledResources: ["cpu", "memory"]
+      minAllowed:
+        cpu: 50m
+        memory: 64Mi
+      maxAllowed:
+        cpu: 500m
+        memory: 512Mi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: dashboard-internal-kubeappsapis
+  namespace: cozy-dashboard
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: dashboard-internal-kubeappsapis
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+      - containerName: kubeappsapis
+        controlledResources: ["cpu", "memory"]
+        minAllowed:
+          cpu: 50m
+          memory: 100Mi
+        maxAllowed:
+          cpu: 1000m
+          memory: 1Gi
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: dashboard-vpa
+  namespace: cozy-dashboard
+spec:
+  targetRef:
+    apiVersion: "apps/v1"
+    kind: Deployment
+    name: dashboard
+  updatePolicy:
+    updateMode: "Auto"
+  resourcePolicy:
+    containerPolicies:
+    - containerName: nginx
+      controlledResources: ["cpu", "memory"]
+      minAllowed:
+        cpu: "50m"
+        memory: "64Mi"
+      maxAllowed:
+        cpu: "500m"
+        memory: "512Mi"
+    {{- $dashboardKCconfig := lookup "v1" "ConfigMap" "cozy-dashboard" "kubeapps-auth-config" }}
+    {{- $dashboardKCValues := dig "data" "values.yaml" "" $dashboardKCconfig }}
+    {{- if $dashboardKCValues }}
+    - containerName: auth-proxy
+      controlledResources: ["cpu", "memory"]
+      minAllowed:
+        cpu: "50m"
+        memory: "64Mi"
+      maxAllowed:
+        cpu: "500m"
+        memory: "512Mi"
+    {{- end }}

--- a/packages/system/dashboard/values.yaml
+++ b/packages/system/dashboard/values.yaml
@@ -15,12 +15,14 @@ kubeapps:
     flux:
       enabled: true
   dashboard:
+    resourcesPreset: "none"
     image:
       registry: ghcr.io/cozystack/cozystack
       repository: dashboard
       tag: v0.30.2
       digest: "sha256:a83fe4654f547469cfa469a02bda1273c54bca103a41eb007fdb2e18a7a91e93"
   kubeappsapis:
+    resourcesPreset: "none"
     image:
       registry: ghcr.io/cozystack/cozystack
       repository: kubeapps-apis

--- a/packages/system/keycloak-configure/templates/configure-kk.yaml
+++ b/packages/system/keycloak-configure/templates/configure-kk.yaml
@@ -216,6 +216,7 @@ data:
   values.yaml: |
     kubeapps:
       authProxy:
+        resourcesPreset: "none"
         enabled: true
         provider: "oidc"
         clientID: "kubeapps"

--- a/scripts/migrations/10
+++ b/scripts/migrations/10
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Migration 10 --> 11
+
+# Force reconcile hr keycloak-configure
+if kubectl get helmrelease keycloak-configure -n cozy-keycloak; then
+  kubectl delete po -l app=source-controller -n cozy-fluxcd
+  timestamp=$(date --rfc-3339=ns)
+  kubectl annotate helmrelease keycloak-configure -n cozy-keycloak \
+    reconcile.fluxcd.io/forceAt="$timestamp" \
+    reconcile.fluxcd.io/requestedAt="$timestamp" \
+    --overwrite
+fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automated resource management for dashboard components using Kubernetes VerticalPodAutoscaler, enabling dynamic adjustment of CPU and memory resources.
- **Chores**
  - Updated configuration to explicitly set resource presets to "none" for dashboard, frontend, and related components.
  - Added a migration script to ensure Keycloak configuration is properly reconciled in managed environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->