### PR TITLE
[dx] automatically detect version for migrations in installer.sh

### DIFF
--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -3,7 +3,7 @@ set -o pipefail
 set -e
 
 BUNDLE=$(set -x; kubectl get configmap -n cozy-system cozystack -o 'go-template={{index .data "bundle-name"}}')
-VERSION=12
+VERSION=$(find scripts/migrations -mindepth 1 -maxdepth 1 -type f | sort -V | awk -F/ 'END {print $NF+1}')
 
 run_migrations() {
   if ! kubectl get configmap -n cozy-system cozystack-version; then


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated migration versioning to automatically determine the next version based on existing migration scripts, removing the need for manual updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->