### PR TITLE
[ci] Fix checkout and improve error output for gen_versions_map.sh

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/hack/gen_versions_map.sh
+++ b/hack/gen_versions_map.sh
@@ -31,7 +31,7 @@ resolved_miss_map=$(
 
     # if commit is not HEAD, check if it's valid
     if [ "$commit" != "HEAD" ]; then
-      if [ "$(git show "${commit}:./${chart}/Chart.yaml" 2>/dev/null | awk '$1 == "version:" {print $2}')" != "${version}" ]; then
+      if [ "$(git show "${commit}:./${chart}/Chart.yaml" | awk '$1 == "version:" {print $2}')" != "${version}" ]; then
         echo "Commit $commit for $chart $version is not valid" >&2
         exit 1
       fi
@@ -44,7 +44,7 @@ resolved_miss_map=$(
     # if commit is HEAD, but version is not found in HEAD, check all tags
     found_tag=""
     for tag in $search_commits; do
-      if [ "$(git show "${tag}:./${chart}/Chart.yaml" 2>/dev/null | awk '$1 == "version:" {print $2}')" = "${version}" ]; then
+      if [ "$(git show "${tag}:./${chart}/Chart.yaml" | awk '$1 == "version:" {print $2}')" = "${version}" ]; then
         found_tag=$(git rev-parse --short "${tag}")
         break
       fi


### PR DESCRIPTION
Third attempt to fix https://github.com/cozystack/cozystack/pull/842 and https://github.com/cozystack/cozystack/pull/836

tested in https://github.com/cozystack/cozystack/actions/runs/14599981710/job/40955508728?pr=808

Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved GitHub Actions workflow to fetch full git history and tags during pre-commit checks.
- **Refactor**
	- Updated script behavior to display error messages when version extraction from git fails, making troubleshooting easier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->