### PR TITLE
Update LINSTOR to v1.31.0

### DIFF
--- a/packages/system/piraeus-operator/charts/piraeus/Chart.yaml
+++ b/packages/system/piraeus-operator/charts/piraeus/Chart.yaml
@@ -3,8 +3,8 @@ name: piraeus
 description: |
   The Piraeus Operator manages software defined storage clusters using LINSTOR in Kubernetes.
 type: application
-version: 2.7.1
-appVersion: "v2.7.1"
+version: 2.8.1
+appVersion: "v2.8.1"
 maintainers:
   - name: Piraeus Datastore
     url: https://piraeus.io

--- a/packages/system/piraeus-operator/charts/piraeus/templates/config.yaml
+++ b/packages/system/piraeus-operator/charts/piraeus/templates/config.yaml
@@ -17,20 +17,19 @@ data:
     #   quay.io/piraeusdatastore/piraeus-server:v1.24.2
     components:
       linstor-controller:
-        tag: v1.29.2
+        tag: v1.31.0
         image: piraeus-server
       linstor-satellite:
-        # Pin with digest to ensure we pull the version with downgraded thin-send-recv
-        tag: v1.29.2
+        tag: v1.31.0
         image: piraeus-server
       linstor-csi:
-        tag: v1.6.4
+        tag: v1.7.1
         image: piraeus-csi
       drbd-reactor:
-        tag: v1.6.0
+        tag: v1.8.0
         image: drbd-reactor
       ha-controller:
-        tag: v1.2.3
+        tag: v1.3.0
         image: piraeus-ha-controller
       drbd-shutdown-guard:
         tag: v1.0.0
@@ -39,7 +38,7 @@ data:
         tag: v0.11
         image: ktls-utils
       drbd-module-loader:
-        tag: v9.2.12
+        tag: v9.2.13
         # The special "match" attribute is used to select an image based on the node's reported OS.
         # The operator will first check the k8s node's ".status.nodeInfo.osImage" field, and compare it against the list
         # here. If one matches, that specific image name will be used instead of the fallback image.
@@ -90,25 +89,25 @@ data:
     base: registry.k8s.io/sig-storage
     components:
       csi-attacher:
-        tag: v4.7.0
+        tag: v4.8.1
         image: csi-attacher
       csi-livenessprobe:
-        tag: v2.14.0
+        tag: v2.15.0
         image: livenessprobe
       csi-provisioner:
-        tag: v5.1.0
+        tag: v5.2.0
         image: csi-provisioner
       csi-snapshotter:
-        tag: v8.1.0
+        tag: v8.2.1
         image: csi-snapshotter
       csi-resizer:
-        tag: v1.12.0
+        tag: v1.13.2
         image: csi-resizer
       csi-external-health-monitor-controller:
-        tag: v0.13.0
+        tag: v0.14.0
         image: csi-external-health-monitor-controller
       csi-node-driver-registrar:
-        tag: v2.12.0
+        tag: v2.13.0
         image: csi-node-driver-registrar
   {{- range $idx, $value := .Values.imageConfigOverride }}
   {{ add $idx 1 }}_helm_override.yaml: |


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Helm chart version and container image tags for Piraeus Operator and related components to newer releases. This includes updates for controller, satellite, CSI, DRBD, and sig-storage images. No other configuration changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->