### PR TITLE
[platform] make apps and extra application load hash tenant config

### DIFF
--- a/packages/apps/bucket/Chart.yaml
+++ b/packages/apps/bucket/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/bucket/Makefile
+++ b/packages/apps/bucket/Makefile
@@ -1,4 +1,4 @@
 include ../../../scripts/package.mk
 
 generate:
-	readme-generator -v values.yaml -s values.schema.json -r README.md
+	#readme-generator -v values.yaml -s values.schema.json -r README.md

--- a/packages/apps/bucket/templates/helmrelease.yaml
+++ b/packages/apps/bucket/templates/helmrelease.yaml
@@ -16,3 +16,9 @@ spec:
   timeout: 5m0s
   values:
     bucketName: {{ .Release.Name }}
+  valuesFrom:
+  - kind: ConfigMap
+    name: cozy-tenant-configuration-hash
+    optional: true
+    targetPath: cozyTenantConfigurationHash
+    valuesKey: cozyTenantConfigurationHash

--- a/packages/apps/nats/Chart.yaml
+++ b/packages/apps/nats/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/nats/templates/nats.yaml
+++ b/packages/apps/nats/templates/nats.yaml
@@ -95,3 +95,9 @@ spec:
           spec:
             type: LoadBalancer
       {{- end }}
+  valuesFrom:
+  - kind: ConfigMap
+    name: cozy-tenant-configuration-hash
+    optional: true
+    targetPath: cozyTenantConfigurationHash
+    valuesKey: cozyTenantConfigurationHash

--- a/packages/apps/tenant/Chart.yaml
+++ b/packages/apps/tenant/Chart.yaml
@@ -4,4 +4,4 @@ description: Separated tenant namespace
 icon: /logos/tenant.svg
 
 type: application
-version: 1.9.1
+version: 1.10.0

--- a/packages/apps/tenant/templates/etcd.yaml
+++ b/packages/apps/tenant/templates/etcd.yaml
@@ -22,4 +22,10 @@ spec:
       version: "*"
   interval: 1m0s
   timeout: 5m0s
+  valuesFrom:
+  - kind: ConfigMap
+    name: cozy-tenant-configuration-hash
+    optional: true
+    targetPath: cozyTenantConfigurationHash
+    valuesKey: cozyTenantConfigurationHash
 {{- end }}

--- a/packages/apps/tenant/templates/info.yaml
+++ b/packages/apps/tenant/templates/info.yaml
@@ -24,4 +24,10 @@ spec:
       version: "*"
   interval: 1m0s
   timeout: 5m0s
+  valuesFrom:
+  - kind: ConfigMap
+    name: cozy-tenant-configuration-hash
+    optional: true
+    targetPath: cozyTenantConfigurationHash
+    valuesKey: cozyTenantConfigurationHash
 {{- end }}

--- a/packages/apps/tenant/templates/ingress.yaml
+++ b/packages/apps/tenant/templates/ingress.yaml
@@ -23,4 +23,10 @@ spec:
   interval: 1m0s
   timeout: 5m0s
   values: {}
+  valuesFrom:
+  - kind: ConfigMap
+    name: cozy-tenant-configuration-hash
+    optional: true
+    targetPath: cozyTenantConfigurationHash
+    valuesKey: cozyTenantConfigurationHash
 {{- end }}

--- a/packages/apps/tenant/templates/monitoring.yaml
+++ b/packages/apps/tenant/templates/monitoring.yaml
@@ -44,6 +44,10 @@ spec:
         resources: {}
       vmstorage:
         resources: {}
-    oncall:
-      enabled: false
+  valuesFrom:
+  - kind: ConfigMap
+    name: cozy-tenant-configuration-hash
+    optional: true
+    targetPath: cozyTenantConfigurationHash
+    valuesKey: cozyTenantConfigurationHash
 {{- end }}

--- a/packages/apps/tenant/templates/seaweedfs.yaml
+++ b/packages/apps/tenant/templates/seaweedfs.yaml
@@ -22,4 +22,10 @@ spec:
       version: "*"
   interval: 1m0s
   timeout: 5m0s
+  valuesFrom:
+  - kind: ConfigMap
+    name: cozy-tenant-configuration-hash
+    optional: true
+    targetPath: cozyTenantConfigurationHash
+    valuesKey: cozyTenantConfigurationHash
 {{- end }}

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -1,4 +1,5 @@
-bucket 0.1.0 HEAD
+bucket 0.1.0 721c12a7
+bucket 0.2.0 HEAD
 clickhouse 0.1.0 f7eaab0a
 clickhouse 0.2.0 53f2365e
 clickhouse 0.2.1 dfbc210b
@@ -75,7 +76,8 @@ nats 0.3.0 78366f19
 nats 0.3.1 c62a83a7
 nats 0.4.0 898374b5
 nats 0.4.1 8267072d
-nats 0.5.0 HEAD
+nats 0.5.0 721c12a7
+nats 0.6.0 HEAD
 postgres 0.1.0 263e47be
 postgres 0.2.0 53f2365e
 postgres 0.2.1 d7cfa53c
@@ -130,7 +132,8 @@ tenant 1.6.8 bc95159a
 tenant 1.7.0 24fa7222
 tenant 1.8.0 160e4e2a
 tenant 1.9.0 728743db
-tenant 1.9.1 HEAD
+tenant 1.9.1 721c12a7
+tenant 1.10.0 HEAD
 virtual-machine 0.1.4 f2015d65
 virtual-machine 0.1.5 263e47be
 virtual-machine 0.2.0 c0685f43

--- a/packages/extra/ingress/Chart.yaml
+++ b/packages/extra/ingress/Chart.yaml
@@ -3,4 +3,4 @@ name: ingress
 description: NGINX Ingress Controller
 icon: /logos/ingress-nginx.svg
 type: application
-version: 1.4.0
+version: 1.5.0

--- a/packages/extra/ingress/templates/nginx-ingress.yaml
+++ b/packages/extra/ingress/templates/nginx-ingress.yaml
@@ -51,3 +51,9 @@ spec:
           server-snippet: "real_ip_header CF-Connecting-IP;"
           {{- end }}
         {{- end }}
+  valuesFrom:
+  - kind: ConfigMap
+    name: cozy-tenant-configuration-hash
+    optional: true
+    targetPath: cozyTenantConfigurationHash
+    valuesKey: cozyTenantConfigurationHash

--- a/packages/extra/seaweedfs/Chart.yaml
+++ b/packages/extra/seaweedfs/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -82,6 +82,12 @@ spec:
           limits:
             cpu: "500m"
             memory: "512Mi"
+  valuesFrom:
+  - kind: ConfigMap
+    name: cozy-tenant-configuration-hash
+    optional: true
+    targetPath: cozyTenantConfigurationHash
+    valuesKey: cozyTenantConfigurationHash
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: WorkloadMonitor

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -16,7 +16,8 @@ ingress 1.0.0 d7cfa53c
 ingress 1.1.0 5bbc488e
 ingress 1.2.0 28fca4ef
 ingress 1.3.0 fde4bcfa
-ingress 1.4.0 HEAD
+ingress 1.4.0 721c12a7
+ingress 1.5.0 HEAD
 monitoring 1.0.0 d7cfa53c
 monitoring 1.1.0 25221fdc
 monitoring 1.2.0 f81be075
@@ -40,4 +41,5 @@ seaweedfs 0.1.0 71514249
 seaweedfs 0.2.0 5fb9cfe3
 seaweedfs 0.2.1 fde4bcfa
 seaweedfs 0.3.0 45a7416c
-seaweedfs 0.4.0 HEAD
+seaweedfs 0.4.0 721c12a7
+seaweedfs 0.5.0 HEAD


### PR DESCRIPTION
As part of #802 and https://github.com/cozystack/cozystack/pull/818

Add default `valuesFrom` to apps and extra helm releases installed by default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled dynamic configuration for multiple components by allowing them to optionally consume values from a shared ConfigMap.
- **Chores**
  - Updated the tenant app version to 1.10.0 and adjusted version mappings accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->