### PR TITLE
[tenant] Fix networkpolicy for accessing externalIPs from the cluster

### DIFF
--- a/packages/apps/tenant/Chart.yaml
+++ b/packages/apps/tenant/Chart.yaml
@@ -4,4 +4,4 @@ description: Separated tenant namespace
 icon: /logos/tenant.svg
 
 type: application
-version: 1.9.1
+version: 1.9.2

--- a/packages/apps/tenant/templates/networkpolicy.yaml
+++ b/packages/apps/tenant/templates/networkpolicy.yaml
@@ -24,6 +24,7 @@ spec:
   ingress:
   - fromEntities:
       - world
+      - cluster
   egress:
   - toEntities:
       - world

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -130,7 +130,8 @@ tenant 1.6.8 bc95159a
 tenant 1.7.0 24fa7222
 tenant 1.8.0 160e4e2a
 tenant 1.9.0 728743db
-tenant 1.9.1 HEAD
+tenant 1.9.1 721c12a7
+tenant 1.9.2 HEAD
 virtual-machine 0.1.4 f2015d65
 virtual-machine 0.1.5 263e47be
 virtual-machine 0.2.0 c0685f43


### PR DESCRIPTION
This PR fixes an issue with accessing external IPs of cluster from cluster itself

```
Policy verdict log: flow 0x6c9bf32e local EP ID 1155, remote ID remote-node, proto 6, ingress, action deny, auth: disabled, match none, 172.27.88.13:46124 -> 10.244.4.174:30274 tcp SYN
xx drop (Policy denied) flow 0x6c9bf32e to endpoint 1155, ifindex 247, file bpf_lxc.c:2181, , identity remote-node->56986: 172.27.88.13:46124 -> 10.244.4.174:30274 tcp SYN
```

related doc: https://docs.cilium.io/en/stable/security/policy/language/#entities-based


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded network access for the tenant application to allow connections from both external sources and within the cluster.

- **Chores**
	- Updated the tenant application to version 1.9.2.
	- Adjusted version mappings to reflect the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->