### PR TITLE
[platform] delete extra dependencies for piraeus operator

### DIFF
--- a/packages/core/platform/bundles/distro-full.yaml
+++ b/packages/core/platform/bundles/distro-full.yaml
@@ -161,7 +161,7 @@ releases:
   releaseName: piraeus-operator
   chart: cozy-piraeus-operator
   namespace: cozy-linstor
-  dependsOn: [cilium,cert-manager,victoria-metrics-operator]
+  dependsOn: [cilium,cert-manager]
 
 - name: snapshot-controller
   releaseName: snapshot-controller

--- a/packages/system/linstor/templates/podscrape.yaml
+++ b/packages/system/linstor/templates/podscrape.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "operator.victoriametrics.com/v1beta1" }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMPodScrape
 metadata:
@@ -42,3 +43,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: linstor-controller
+{{- end }}

--- a/packages/system/piraeus-operator/templates/alerts.yaml
+++ b/packages/system/piraeus-operator/templates/alerts.yaml
@@ -1,7 +1,8 @@
 {{- $files := .Files.Glob "alerts/*.yaml" -}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
 {{- range $path, $file := $files }}
 ---
 # from: {{ $path }}
 {{ toString $file }}
-
+{{- end }}
 {{- end -}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated dependency configuration so that piraeus-operator no longer depends on victoria-metrics-operator.
- **Refactor**
	- Improved compatibility by ensuring certain resources (VMPodScrape and alert definitions) are only rendered if the required API versions are available in the Kubernetes cluster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->