### PR TITLE
[virtual-machine] Fix: Add GPU names to virtual machines spec

### DIFF
--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -143,7 +143,8 @@ virtual-machine 0.7.1 0ab39f20
 virtual-machine 0.8.0 3fa4dd3a
 virtual-machine 0.8.1 93c46161
 virtual-machine 0.8.2 de19450f
-virtual-machine 0.9.0 HEAD
+virtual-machine 0.9.0 721c12a7
+virtual-machine 0.9.1 HEAD
 vm-disk 0.1.0 d971f2ff
 vm-disk 0.1.1 HEAD
 vm-instance 0.1.0 1ec10165
@@ -153,7 +154,8 @@ vm-instance 0.4.0 e23286a3
 vm-instance 0.4.1 0ab39f20
 vm-instance 0.5.0 3fa4dd3a
 vm-instance 0.5.1 de19450f
-vm-instance 0.6.0 HEAD
+vm-instance 0.6.0 721c12a7
+vm-instance 0.6.1 HEAD
 vpn 0.1.0 263e47be
 vpn 0.2.0 53f2365e
 vpn 0.3.0 6c5cf5bf

--- a/packages/apps/virtual-machine/Chart.yaml
+++ b/packages/apps/virtual-machine/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.0
+version: 0.9.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/virtual-machine/templates/vm.yaml
+++ b/packages/apps/virtual-machine/templates/vm.yaml
@@ -74,7 +74,8 @@ spec:
           {{- if .Values.gpus }}
           gpus:
           {{- range $i, $gpu := .Values.gpus }}
-          - deviceName: {{ $gpu.name }}
+          - name: gpu{{ add $i 1 }}
+            deviceName: {{ $gpu.name }}
           {{- end }}
           {{- end }}
           disks:

--- a/packages/apps/vm-instance/Chart.yaml
+++ b/packages/apps/vm-instance/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/vm-instance/templates/vm.yaml
+++ b/packages/apps/vm-instance/templates/vm.yaml
@@ -46,7 +46,8 @@ spec:
           {{- if .Values.gpus }}
           gpus:
           {{- range $i, $gpu := .Values.gpus }}
-          - deviceName: {{ $gpu.name }}
+          - name: gpu{{ add $i 1 }}
+            deviceName: {{ $gpu.name }}
           {{- end }}
           {{- end }}
           disks:


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Each GPU device entry now includes a unique identifier alongside its device name in both VirtualMachine and VM Instance templates.

- **Configuration**
  - The default GPU configuration now includes a specific GPU entry by default, instead of being empty.

- **Version Updates**
  - Chart versions for VirtualMachine and VM Instance applications have been incremented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->