### PR TITLE
Suppress wget progress bar

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -60,7 +60,7 @@ done
 
 # Prepare system drive
 if [ ! -f nocloud-amd64.raw ]; then
-  wget https://github.com/cozystack/cozystack/releases/latest/download/nocloud-amd64.raw.xz -O nocloud-amd64.raw.xz
+  wget https://github.com/cozystack/cozystack/releases/latest/download/nocloud-amd64.raw.xz -O nocloud-amd64.raw.xz --show-progress --output-file /dev/stdout --progress=dot:giga 2>/dev/null
   rm -f nocloud-amd64.raw
   xz --decompress nocloud-amd64.raw.xz
 fi


### PR DESCRIPTION
In our CI wget spams thousands of lines of the progress bar into the output, making it hard to read. Turns out, it doesn't have an option to just remove the progress bar, but explicitly directing wget's log to stdout and invoking --show-progress sends that to stderr which we redirect to dev/null. The downloaded size is still reported at regular intervals, but --progress=dot:giga shortens that to one line per 32M which is manageable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved file download process to display clearer progress updates during downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->