### PR TITLE
[kubernetes] Update tenant Kubernetes to v1.32

### DIFF
--- a/packages/apps/kubernetes/Makefile
+++ b/packages/apps/kubernetes/Makefile
@@ -1,4 +1,4 @@
-UBUNTU_CONTAINER_DISK_TAG = v1.30.1
+KUBERNETES_VERSION = v1.32
 KUBERNETES_PKG_TAG = $(shell awk '$$1 == "version:" {print $$2}' Chart.yaml)
 
 include ../../../scripts/common-envs.mk
@@ -12,8 +12,9 @@ image: image-ubuntu-container-disk image-kubevirt-cloud-provider image-kubevirt-
 image-ubuntu-container-disk:
 	docker buildx build --platform linux/amd64 --build-arg ARCH=amd64 images/ubuntu-container-disk \
 		--provenance false \
-		--tag $(REGISTRY)/ubuntu-container-disk:$(call settag,$(UBUNTU_CONTAINER_DISK_TAG)) \
-		--tag $(REGISTRY)/ubuntu-container-disk:$(call settag,$(UBUNTU_CONTAINER_DISK_TAG)-$(TAG)) \
+		--build-arg KUBERNETES_VERSION=${KUBERNETES_VERSION} \
+		--tag $(REGISTRY)/ubuntu-container-disk:$(call settag,$(KUBERNETES_VERSION)) \
+		--tag $(REGISTRY)/ubuntu-container-disk:$(call settag,$(KUBERNETES_VERSION)-$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/ubuntu-container-disk:latest \
 		--cache-to type=inline \
 		--metadata-file images/ubuntu-container-disk.json \

--- a/packages/apps/kubernetes/images/ubuntu-container-disk/Dockerfile
+++ b/packages/apps/kubernetes/images/ubuntu-container-disk/Dockerfile
@@ -1,3 +1,4 @@
+# TODO: Here we use ubuntu:22.04, as guestfish has some network issues running in ubuntu:24.04
 FROM ubuntu:22.04 as guestfish
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -5,6 +6,7 @@ RUN apt-get update \
  && apt-get -y install \
      libguestfs-tools \
      linux-image-generic \
+     wget \
      make \
      bash-completion \
  && apt-get clean
@@ -13,7 +15,10 @@ WORKDIR /build
 
 FROM guestfish as builder
 
-RUN wget -O image.img https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+# noble is a code name for the Ubuntu 24.04 LTS release
+RUN wget -O image.img https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img --show-progress --output-file /dev/stdout --progress=dot:giga 2>/dev/null
+
+ARG KUBERNETES_VERSION
 
 RUN qemu-img resize image.img 5G \
  && eval "$(guestfish --listen --network)" \
@@ -26,8 +31,8 @@ RUN qemu-img resize image.img 5G \
  && guestfish --remote sh "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg" \
  && guestfish --remote sh 'echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list' \
 # kubernetes repo
- && guestfish --remote sh "curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg" \
- && guestfish --remote sh "echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list" \
+ && guestfish --remote sh "curl -fsSL https://pkgs.k8s.io/core:/stable:/${KUBERNETES_VERSION}/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg" \
+ && guestfish --remote sh "echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBERNETES_VERSION}/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list" \
 # install containerd
  && guestfish --remote command "apt-get update -y" \
  && guestfish --remote command "apt-get install -y containerd.io" \

--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -283,7 +283,7 @@ spec:
         kind: KubevirtMachineTemplate
         name: {{ $.Release.Name }}-{{ $groupName }}-{{ $kubevirtmachinetemplateHash }}
         namespace: {{ $.Release.Namespace }}
-      version: v1.30.1
+      version: v1.32.3
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineHealthCheck

--- a/packages/apps/kubernetes/templates/helmreleases/delete.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/delete.yaml
@@ -20,7 +20,7 @@ spec:
           effect: "NoSchedule"
       containers:
         - name: kubectl
-          image: docker.io/clastix/kubectl:v1.30.1
+          image: docker.io/clastix/kubectl:v1.32
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
This PR also updates ubuntu-container-disk image to latest 24.04 LTS (Noble Numbat)

Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Kubernetes version references from v1.30.1 to v1.32 in build and deployment configurations.
	- Changed the base image for Ubuntu container disk to Ubuntu 24.04.
	- Made the Kubernetes version configurable during build processes.
	- Updated the kubectl container image in pre-delete jobs to use the latest tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->