### PR TITLE
[fluxcd] update to flux-operator 0.19.0

### DIFF
--- a/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.18.0
+appVersion: v0.19.0
 description: 'A Helm chart for deploying the Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.18.0
+version: 0.19.0

--- a/packages/system/fluxcd-operator/charts/flux-operator/README.md
+++ b/packages/system/fluxcd-operator/charts/flux-operator/README.md
@@ -1,6 +1,6 @@
 # flux-operator
 
-![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.18.0](https://img.shields.io/badge/AppVersion-v0.18.0-informational?style=flat-square)
+![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.19.0](https://img.shields.io/badge/AppVersion-v0.19.0-informational?style=flat-square)
 
 The [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator) provides a
 declarative API for the installation and upgrade of CNCF [Flux](https://fluxcd.io) and the
@@ -33,6 +33,7 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]}]}]}}}` | Pod affinity and anti-affinity settings. |
+| apiPriority | object | `{"enabled":false,"extraServiceAccounts":[],"level":"workload-high"}` | Kubernetes [API priority and fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/) settings. |
 | commonAnnotations | object | `{}` | Common annotations to add to all deployed objects including pods. |
 | commonLabels | object | `{}` | Common labels to add to all deployed objects including pods. |
 | extraArgs | list | `[]` | Container extra arguments. |

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/admin-clusterrole.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/admin-clusterrole.yaml
@@ -18,6 +18,6 @@ roleRef:
   name: cluster-admin
 subjects:
   - kind: ServiceAccount
-    name: {{ include "flux-operator.fullname" . }}
+    name: {{ include "flux-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
@@ -878,6 +878,18 @@ spec:
                 required:
                 - name
                 type: object
+              skip:
+                description: Skip defines whether we need to skip input provider response
+                  updates.
+                properties:
+                  labels:
+                    description: |-
+                      Labels specifies list of labels to skip input provider response when any of the label conditions matched.
+                      When prefixed with !, input provider response will be skipped if it does not have this label.
+                    items:
+                      type: string
+                    type: array
+                type: object
               type:
                 description: Type specifies the type of the input provider.
                 enum:

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/flowschema.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/flowschema.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.apiPriority.enabled }}
+apiVersion: flowcontrol.apiserver.k8s.io/v1
+kind: FlowSchema
+metadata:
+  name: {{ include "flux-operator.fullname" . }}
+  annotations:
+    apf.kubernetes.io/autoupdate-spec: "false"
+spec:
+  distinguisherMethod:
+    type: ByUser
+  matchingPrecedence: 950
+  priorityLevelConfiguration:
+    name: {{ .Values.apiPriority.level }}
+  rules:
+    - nonResourceRules:
+        - nonResourceURLs:
+            - '*'
+          verbs:
+            - '*'
+      resourceRules:
+        - apiGroups:
+            - '*'
+          clusterScope: true
+          namespaces:
+            - '*'
+          resources:
+            - '*'
+          verbs:
+            - '*'
+      subjects:
+        - kind: ServiceAccount
+          serviceAccount:
+            name: {{ include "flux-operator.serviceAccountName" . }}
+            namespace: {{ .Release.Namespace }}
+        {{- range .Values.apiPriority.extraServiceAccounts }}
+        - kind: ServiceAccount
+          serviceAccount:
+            name: {{ .name }}
+            namespace: {{ .namespace }}
+        {{- end }}
+{{- end }}

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
@@ -63,6 +63,25 @@
             },
             "type": "object"
         },
+        "apiPriority": {
+            "default": {
+                "enabled": false,
+                "extraServiceAccounts": [],
+                "level": "workload-high"
+            },
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "extraServiceAccounts": {
+                    "type": "array"
+                },
+                "level": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "commonAnnotations": {
             "properties": {},
             "type": "object"

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
@@ -33,6 +33,16 @@ image:
 # Recommended value is system-cluster-critical.
 priorityClassName: "" # @schema default: "system-cluster-critical"
 
+# -- Kubernetes [API priority and fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/) settings.
+apiPriority: # @schema default: {"enabled":false,"level":"workload-high","extraServiceAccounts":[]}
+  enabled: false
+  level: workload-high
+  extraServiceAccounts: []
+#    - name: kustomize-controller
+#      namespace: flux-system
+#    - name: helm-controller
+#      namespace: flux-system
+
 # -- Container resources requests and limits settings.
 resources: # @schema required: true
   limits:

--- a/packages/system/fluxcd/charts/flux-instance/Chart.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.18.0
+appVersion: v0.19.0
 description: 'A Helm chart for deploying a Flux instance managed by Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.18.0
+version: 0.19.0

--- a/packages/system/fluxcd/charts/flux-instance/README.md
+++ b/packages/system/fluxcd/charts/flux-instance/README.md
@@ -1,6 +1,6 @@
 # flux-instance
 
-![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.18.0](https://img.shields.io/badge/AppVersion-v0.18.0-informational?style=flat-square)
+![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.19.0](https://img.shields.io/badge/AppVersion-v0.19.0-informational?style=flat-square)
 
 This chart is a thin wrapper around the `FluxInstance` custom resource, which is
 used by the [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configurable API priority and fairness settings for the Flux Operator, allowing prioritization of API requests and inclusion of extra service accounts.
  - Added support for a new `skip` field in the `ResourceSetInputProvider` CRD to control update skipping based on label conditions.

- **Bug Fixes**
  - Updated service account reference in admin ClusterRoleBinding to use the dedicated service account name for improved accuracy.

- **Documentation**
  - Updated Helm chart and app version numbers to 0.19.0 in documentation and metadata.
  - Added documentation for the new `apiPriority` configuration option in the Flux Operator Helm chart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->