### PR TITLE
[ci] Create long‑lived maintenance branch after release published

### DIFF
--- a/.github/workflows/pull-requests-release.yaml
+++ b/.github/workflows/pull-requests-release.yaml
@@ -76,6 +76,36 @@ jobs:
           git tag -f ${{ steps.get_tag.outputs.tag }} ${{ github.sha }}
           git push -f origin ${{ steps.get_tag.outputs.tag }}
 
+      # Ensure maintenance branch release-X.Y
+      - name: Ensure maintenance branch release-X.Y
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ steps.get_tag.outputs.tag }}';  // e.g. v0.1.3 or v0.1.3-rc3
+            const match = tag.match(/^v(\d+)\.(\d+)\.\d+(?:[-\w\.]+)?$/);
+            if (!match) {
+              core.setFailed(`❌ tag '${tag}' must match 'vX.Y.Z' or 'vX.Y.Z-suffix'`);
+              return;
+            }
+            const line = `${match[1]}.${match[2]}`;
+            const branch = `release-${line}`;
+            try {
+              await github.rest.repos.getBranch({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                branch
+              });
+              console.log(`Branch '${branch}' already exists`);
+            } catch (_) {
+              await github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo:  context.repo.repo,
+                ref:   `refs/heads/${branch}`,
+                sha:   context.sha
+              });
+              console.log(`✅ Branch '${branch}' created at ${context.sha}`);
+            }
+
       # Get the latest published release
       - name: Get the latest published release
         id: latest_release

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -178,32 +178,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Ensure long‑lived maintenance branch release‑X.Y
-      - name: Ensure maintenance branch release‑${{ steps.tag.outputs.line }}
-        if: |
-          steps.check_release.outputs.skip == 'false' &&
-          steps.get_base.outputs.branch == 'main'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const branch = `release-${'${{ steps.tag.outputs.line }}'}`;
-            try {
-              await github.rest.repos.getBranch({
-                owner: context.repo.owner,
-                repo:  context.repo.repo,
-                branch
-              });
-              console.log(`Branch '${branch}' already exists`);
-            } catch (_) {
-              await github.rest.git.createRef({
-                owner: context.repo.owner,
-                repo:  context.repo.repo,
-                ref:   `refs/heads/${branch}`,
-                sha:   context.sha
-              });
-              console.log(`Branch '${branch}' created at ${context.sha}`);
-            }
-
       # Create release‑X.Y.Z branch and push (force‑update)
       - name: Create release branch
         if: steps.check_release.outputs.skip == 'false'


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated release workflows to ensure maintenance branches are created during release finalization instead of during tag creation.
	- Removed maintenance branch creation from the tag workflow and added it to the release finalization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->