### PR TITLE
[ci] increase the time for waiting helm releases

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -231,7 +231,7 @@ timeout 60 sh -c 'until kubectl get hr -A | grep cozy; do sleep 1; done'
 
 sleep 5
 
-kubectl get hr -A | awk 'NR>1 {print "kubectl wait --timeout=15m --for=condition=ready -n " $1 " hr/" $2 " &"} END{print "wait"}' | sh -x
+kubectl get hr -A | awk 'NR>1 {print "kubectl wait --timeout=20m --for=condition=ready -n " $1 " hr/" $2 " &"} END{print "wait"}' | sh -x
 
 # Wait for Cluster-API providers
 timeout 60 sh -c 'until kubectl get deploy -n cozy-cluster-api capi-controller-manager capi-kamaji-controller-manager capi-kubeadm-bootstrap-controller-manager capi-operator-cluster-api-operator capk-controller-manager; do sleep 1; done'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Increased the timeout duration for waiting on Cluster-API provider deployments to improve reliability during environment setup.
  - Extended the wait time for HelmRelease resources to become ready from 15 to 20 minutes for enhanced deployment stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->