### PR TITLE
[ci] Use dots in release candidtate versions, as per SemVer

### DIFF
--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -3,7 +3,9 @@ name: Versioned Tag
 on:
   push:
     tags:
-      - 'v*.*.*' # vX.Y.Z or vX.Y.Z-rcN
+      - 'v*.*.*' # vX.Y.Z
+      - 'v*.*.*-rc.*' # vX.Y.Z-rc.N
+
 
 concurrency:
   group: tags-${{ github.workflow }}-${{ github.ref }}
@@ -46,18 +48,18 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const ref = context.ref.replace('refs/tags/', '');           // e.g. v0.31.5-rc1
-            const m = ref.match(/^v(\d+\.\d+\.\d+)(-rc\d+)?$/);
+            const ref = context.ref.replace('refs/tags/', '');           // e.g. v0.31.5-rc.1
+            const m = ref.match(/^v(\d+\.\d+\.\d+)(-rc\.\d+)?$/);        // ['0.31.5', '-rc.1']
             if (!m) {
-              core.setFailed(`❌ tag '${ref}' must match 'vX.Y.Z' or 'vX.Y.Z-rcN'`);
+              core.setFailed(`❌ tag '${ref}' must match 'vX.Y.Z' or 'vX.Y.Z-rc.N'`);
               return;
             }
-            const version = m[1] + (m[2] ?? '');                         // 0.31.5‑rc1
+            const version = m[1] + (m[2] ?? '');                         // 0.31.5‑rc.1
             const isRc    = Boolean(m[2]);
             const [maj, min] = m[1].split('.');
-            core.setOutput('tag',     ref);
-            core.setOutput('version', version);
-            core.setOutput('is_rc',   isRc);
+            core.setOutput('tag',     ref);                              // v0.31.5-rc.1
+            core.setOutput('version', version);                          // 0.31.5-rc.1
+            core.setOutput('is_rc',   isRc);                             // true
             core.setOutput('line',    `${maj}.${min}`);                  // 0.31
 
       # Detect base branch (main or release‑X.Y) the tag was pushed from


### PR DESCRIPTION
Before: 0.31.0-rc1
After:  0.31.0-rc.1

Why this matters: we want to do things the right way from the start.
Version patten affects how versions are parsed and sorted.
For example, we have release candidates number 9 and 10:

* In 'rc.9' and 'rc.10', the numeric parts are compared as numbers,
  so 9 comes before 10.
* In 'rc9' and 'rc10', versions are compared lexicographically,
  so 10 comes before 9, which is wrong.

Reference: SemVer items 9–11. https://semver.org/#spec-item-9
Signed-off-by: Nick Volynkin <nick.volynkin@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow to recognize and process release candidate tags with a dot separator (e.g., vX.Y.Z-rc.N).
  - Improved tag validation and error messaging to reflect the new tag format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->