### PR TITLE
[ci] automatically trigger tests in releasing PR

### DIFF
--- a/.github/workflows/pull-requests-release.yaml
+++ b/.github/workflows/pull-requests-release.yaml
@@ -3,6 +3,11 @@ name: Releasing PR
 on:
   pull_request:
     types: [labeled, opened, synchronize, reopened, closed]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to test"
+        required: true
 
 concurrency:
   group: pull-requests-release-${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -16,15 +21,19 @@ jobs:
       contents: read
       packages: write
 
-    # Run only when the PR carries the "release" label and not closed.
+    # Run only when the PR carries the "release" label and not closed or via workflow_dispatch
     if: |
-      contains(github.event.pull_request.labels.*.name, 'release') &&
-      github.event.action != 'closed'
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'release') &&
+       github.event.action != 'closed')
+      || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          # for workflow_dispatch take a specific SHA, otherwise — head.sha PR
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.sha }}
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -222,3 +222,25 @@ jobs:
             } else {
               console.log(`PR already exists from ${head} to ${base}`);
             }
+
+      # Run tests
+      - name: Trigger release-verify tests
+        if: steps.check_release.outputs.skip == 'false'
+        uses: actions/github-script@v7
+        env:
+          GH_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
+          DISPATCH_REF:   ${{ steps.get_base.outputs.branch }}  # main or release-X.Y
+          DISPATCH_SHA:   ${{ github.sha }}                     # commit for tests
+        with:
+          github-token: ${{ env.GH_TOKEN }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner:       context.repo.owner,
+              repo:        context.repo.repo,
+              workflow_id: '.github/workflows/pull-requests-release.yaml',
+              ref:         process.env.DISPATCH_REF,
+              inputs: {
+                sha: process.env.DISPATCH_SHA
+              }
+            });
+            console.log(`🔔 verify-job triggered on ${process.env.DISPATCH_SHA}`);


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to manually trigger the release verification workflow with a specific commit SHA.
  - The release verification workflow now supports both pull request events and manual triggers.
- **Chores**
  - Automated triggering of release verification tests from the tags workflow when a new release is detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->