### PR TITLE
[e2e] Fix device_ownership_from_security_context CRI

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -60,7 +60,8 @@ done
 
 # Prepare system drive
 if [ ! -f nocloud-amd64.raw ]; then
-  wget https://github.com/cozystack/cozystack/releases/latest/download/nocloud-amd64.raw.xz -O nocloud-amd64.raw.xz --show-progress --output-file /dev/stdout --progress=dot:giga 2>/dev/null
+  wget https://github.com/cozystack/cozystack/releases/latest/download/nocloud-amd64.raw.xz \
+    -O nocloud-amd64.raw.xz --show-progress --output-file /dev/stdout --progress=dot:giga 2>/dev/null
   rm -f nocloud-amd64.raw
   xz --decompress nocloud-amd64.raw.xz
 fi
@@ -85,7 +86,8 @@ done
 # Start VMs
 for i in 1 2 3; do
   qemu-system-x86_64 -machine type=pc,accel=kvm -cpu host -smp 8 -m 16384 \
-    -device virtio-net,netdev=net0,mac=52:54:00:12:34:5$i -netdev tap,id=net0,ifname=cozy-srv$i,script=no,downscript=no \
+    -device virtio-net,netdev=net0,mac=52:54:00:12:34:5$i \
+    -netdev tap,id=net0,ifname=cozy-srv$i,script=no,downscript=no \
     -drive file=srv$i/system.img,if=virtio,format=raw \
     -drive file=srv$i/seed.img,if=virtio,format=raw \
     -drive file=srv$i/data.img,if=virtio,format=raw \
@@ -121,7 +123,7 @@ machine:
   files:
   - content: |
       [plugins]
-        [plugins."io.containerd.grpc.v1.cri"]
+        [plugins."io.containerd.cri.v1.runtime"]
           device_ownership_from_security_context = true      
     path: /etc/cri/conf.d/20-customization.part
     op: create


### PR DESCRIPTION
Currently, you can't create VMDisk or VMInstance. The importer pod in Error state with logs 

`kubectl -n tenant-root logs importer-prime-84b44042-c0ac-4e52-8fbd-a0313f4701a6`

```
I0422 07:37:02.928787       1 importer.go:107] Starting importer
E0422 07:37:02.929473       1 importer.go:137] exit status 1, blockdev: cannot open /dev/cdi-block-volume: Permission denied

kubevirt.io/containerized-data-importer/pkg/util.GetAvailableSpaceBlock
        pkg/util/file.go:135
kubevirt.io/containerized-data-importer/pkg/util.GetAvailableSpaceByVolumeMode
        pkg/util/util.go:99
main.main
        cmd/cdi-importer/importer.go:135
runtime.main
        GOROOT/src/runtime/proc.go:271
runtime.goexit
        src/runtime/asm_amd64.s:1695
```

This change solves the issue with importer pod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved formatting of script commands for better readability.
  - Updated container runtime configuration for enhanced customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->