### PR TITLE
Revert "[ci] automatically trigger tests in releasing PR"

### DIFF
--- a/.github/workflows/pull-requests-release.yaml
+++ b/.github/workflows/pull-requests-release.yaml
@@ -3,11 +3,6 @@ name: Releasing PR
 on:
   pull_request:
     types: [labeled, opened, synchronize, reopened, closed]
-  workflow_dispatch:
-    inputs:
-      sha:
-        description: "Commit SHA to test"
-        required: true
 
 concurrency:
   group: pull-requests-release-${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -21,19 +16,15 @@ jobs:
       contents: read
       packages: write
 
-    # Run only when the PR carries the "release" label and not closed or via workflow_dispatch
+    # Run only when the PR carries the "release" label and not closed.
     if: |
-      (github.event_name == 'pull_request' &&
-       contains(github.event.pull_request.labels.*.name, 'release') &&
-       github.event.action != 'closed')
-      || github.event_name == 'workflow_dispatch'
+      contains(github.event.pull_request.labels.*.name, 'release') &&
+      github.event.action != 'closed'
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # for workflow_dispatch take a specific SHA, otherwise — head.sha PR
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || inputs.sha }}
           fetch-depth: 0
           fetch-tags: true
 

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -225,25 +225,3 @@ jobs:
             } else {
               console.log(`PR already exists from ${head} to ${base}`);
             }
-
-      # Run tests
-      - name: Trigger release-verify tests
-        if: steps.check_release.outputs.skip == 'false'
-        uses: actions/github-script@v7
-        env:
-          GH_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
-          DISPATCH_REF:   ${{ steps.get_base.outputs.branch }}  # main or release-X.Y
-          DISPATCH_SHA:   ${{ github.sha }}                     # commit for tests
-        with:
-          github-token: ${{ env.GH_TOKEN }}
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner:       context.repo.owner,
-              repo:        context.repo.repo,
-              workflow_id: 'pull-requests-release.yaml',
-              ref:         process.env.DISPATCH_REF,
-              inputs: {
-                sha: process.env.DISPATCH_SHA
-              }
-            });
-            console.log(`🔔 verify-job triggered on ${process.env.DISPATCH_SHA}`);


### PR DESCRIPTION
Revert https://github.com/cozystack/cozystack/pull/894 due to fact this logic does not trigger checks in pull requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed support for manually triggering the pull request release workflow.
  - Simplified release workflow to run automatically only on labeled pull requests.
  - Eliminated the step in the tags workflow that triggered release verification via manual dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->