### PR TITLE
Make kubevirt's CPU allocation ratio configurable

### DIFF
--- a/packages/core/platform/bundles/paas-full.yaml
+++ b/packages/core/platform/bundles/paas-full.yaml
@@ -134,6 +134,11 @@ releases:
   namespace: cozy-kubevirt
   privileged: true
   dependsOn: [cilium,kubeovn,kubevirt-operator]
+  {{- $cpuAllocationRatio := index $cozyConfig.data "cpu-allocation-ratio" }}
+  {{- if $cpuAllocationRatio }}
+  values:
+    cpuAllocationRatio: {{ $cpuAllocationRatio }}
+  {{- end }}
 
 - name: kubevirt-instancetypes
   releaseName: kubevirt-instancetypes

--- a/packages/system/kubevirt/templates/kubevirt-cr.yaml
+++ b/packages/system/kubevirt/templates/kubevirt-cr.yaml
@@ -10,6 +10,9 @@ spec:
     commonInstancetypesDeployment:
       enabled: false
     developerConfiguration:
+      {{- if .Values.cpuAllocationRatio }}
+      cpuAllocationRatio: {{ .Values.cpuAllocationRatio }}
+      {{- end }}
       featureGates:
       - HotplugVolumes
       - ExpandDisks


### PR DESCRIPTION
Kubevirt's default cpu-to-vcpu ration is 1:10, which might be a bit extreme for some users. This patch introduces a new key in the Cozystack configmap, "cpu-allocation-ratio" where admins of Cozystack can specify an alternative value, if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for optionally configuring a CPU allocation ratio for KubeVirt deployments when the relevant setting is provided.
- **Chores**
	- Improved configuration flexibility for KubeVirt by allowing dynamic injection of CPU allocation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->