### PR TITLE
[519] Cross-arch builds: builders variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ build-deps:
 	@tar --version | grep -q GNU || (echo "GNU tar is required" && exit 1)
 	@sed --version | grep -q GNU || (echo "GNU sed is required" && exit 1)
 	@awk --version | grep -q GNU || (echo "GNU awk is required" && exit 1)
-	@docker info --format=json | jq -r '"v0.13.0\n\(.ClientInfo.Plugins[] | select(.Name == "buildx") | .Version)"' | sort -CV || (echo "docker buildx plugin version >=0.13.0 is required" && exit 1)
 
 build: build-deps
 	make -C packages/apps/http-cache image

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ build-deps:
 	@tar --version | grep -q GNU || (echo "GNU tar is required" && exit 1)
 	@sed --version | grep -q GNU || (echo "GNU sed is required" && exit 1)
 	@awk --version | grep -q GNU || (echo "GNU awk is required" && exit 1)
+	@docker info --format=json | jq -r '"v0.13.0\n\(.ClientInfo.Plugins[] | select(.Name == "buildx") | .Version)"' | sort -CV || (echo "docker buildx plugin version >=0.13.0 is required" && exit 1)
 
 build: build-deps
 	make -C packages/apps/http-cache image

--- a/packages/system/cozystack-controller/Makefile
+++ b/packages/system/cozystack-controller/Makefile
@@ -9,6 +9,7 @@ image: image-cozystack-controller update-version
 image-cozystack-controller:
 	docker buildx build -f images/cozystack-controller/Dockerfile ../../.. \
 		--provenance false \
+		--builder=$(BUILDER) \
 		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/cozystack-controller:$(call settag,$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/cozystack-controller:latest \

--- a/packages/system/cozystack-controller/Makefile
+++ b/packages/system/cozystack-controller/Makefile
@@ -9,6 +9,7 @@ image: image-cozystack-controller update-version
 image-cozystack-controller:
 	docker buildx build -f images/cozystack-controller/Dockerfile ../../.. \
 		--provenance false \
+		--platform=$(PLATFORM)
 		--tag $(REGISTRY)/cozystack-controller:$(call settag,$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/cozystack-controller:latest \
 		--cache-to type=inline \

--- a/packages/system/cozystack-controller/Makefile
+++ b/packages/system/cozystack-controller/Makefile
@@ -9,7 +9,7 @@ image: image-cozystack-controller update-version
 image-cozystack-controller:
 	docker buildx build -f images/cozystack-controller/Dockerfile ../../.. \
 		--provenance false \
-		--platform=$(PLATFORM)
+		--platform=$(PLATFORM) \
 		--tag $(REGISTRY)/cozystack-controller:$(call settag,$(TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/cozystack-controller:latest \
 		--cache-to type=inline \

--- a/scripts/common-envs.mk
+++ b/scripts/common-envs.mk
@@ -16,6 +16,9 @@ ifeq ($(COZYSTACK_VERSION),)
 endif
 
 # Get the name of the default docker buildx builder
-BUILDER ?= $(shell docker buildx inspect --bootstrap | head -n2 | awk '/^Name:/{print $$NF}')
+BUILDER ?= $(shell jq -r '.Name' ~/.docker/buildx/current)
 # Get platforms supported by the builder
+# TODO: figure out how to get runners status dynamically, in json
+# PLATFORM ?= $(shell jq -r '.Nodes[] | .Platforms | map(.os + "/" + .architecture) | join(",")' ~/.docker/buildx/instances/$(BUILDER))
 PLATFORM ?= $(shell docker buildx inspect --bootstrap $(BUILDER) | egrep '^Platforms:' | egrep -o 'linux/amd64|linux/arm64' | sort -u | xargs | sed 's/ /,/g')
+

--- a/scripts/common-envs.mk
+++ b/scripts/common-envs.mk
@@ -15,15 +15,7 @@ ifeq ($(COZYSTACK_VERSION),)
     COZYSTACK_VERSION = $(patsubst v%,%,$(shell git describe --tags))
 endif
 
-# Calculate PLATFORM based on current docker daemon arch
-ifndef PLATFORM
-  DOCKER_DAEMON_ARCH := $(shell docker info --format='{{.Architecture}}')
-  ifeq ($(DOCKER_DAEMON_ARCH),x86_64)
-      PLATFORM := linux/amd64
-  else ifeq ($(DOCKER_DAEMON_ARCH),aarch64)
-      PLATFORM := linux/arm64
-  else
-      $(error Unsupported architecture: "$(DOCKER_DAEMON_ARCH)")
-  endif
-  undefine DOCKER_DAEMON_ARCH
-endif
+# Get the name of the default docker buildx builder
+BUILDER ?= $(shell docker buildx inspect | head -n2 | awk '/^Name:/{print $$NF}')
+# Get platforms supported by the builder
+PLATFORM ?= $(shell docker buildx inspect $(BUILDER) | egrep '^Platforms:' | egrep -o 'linux/amd64|linux/arm64' | sort -u | xargs | sed 's/ /,/g')

--- a/scripts/common-envs.mk
+++ b/scripts/common-envs.mk
@@ -16,6 +16,6 @@ ifeq ($(COZYSTACK_VERSION),)
 endif
 
 # Get the name of the default docker buildx builder
-BUILDER ?= $(shell docker buildx inspect | head -n2 | awk '/^Name:/{print $$NF}')
+BUILDER ?= $(shell docker buildx inspect --bootstrap | head -n2 | awk '/^Name:/{print $$NF}')
 # Get platforms supported by the builder
-PLATFORM ?= $(shell docker buildx inspect $(BUILDER) | egrep '^Platforms:' | egrep -o 'linux/amd64|linux/arm64' | sort -u | xargs | sed 's/ /,/g')
+PLATFORM ?= $(shell docker buildx inspect --bootstrap $(BUILDER) | egrep '^Platforms:' | egrep -o 'linux/amd64|linux/arm64' | sort -u | xargs | sed 's/ /,/g')

--- a/scripts/common-envs.mk
+++ b/scripts/common-envs.mk
@@ -14,3 +14,16 @@ ifeq ($(COZYSTACK_VERSION),)
     $(shell git fetch upstream --tags)
     COZYSTACK_VERSION = $(patsubst v%,%,$(shell git describe --tags))
 endif
+
+# Calculate PLATFORM based on current docker daemon arch
+ifndef PLATFORM
+  DOCKER_DAEMON_ARCH := $(shell docker info --format='{{.Architecture}}')
+  ifeq ($(DOCKER_DAEMON_ARCH),x86_64)
+      PLATFORM := linux/amd64
+  else ifeq ($(DOCKER_DAEMON_ARCH),aarch64)
+      PLATFORM := linux/arm64
+  else
+      $(error Unsupported architecture: "$(DOCKER_DAEMON_ARCH)")
+  endif
+  undefine DOCKER_DAEMON_ARCH
+endif


### PR DESCRIPTION
Added PLATFORM variable to `common-envs.mk`: if not defined, it is calculated based on docker daemon arch.
May be overridden by e.g. `make -e PLATFORM='linux/arm64' ...`
Added the variable to a single Dockerfile for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved Docker build process to automatically detect and use the current builder and supported platforms, enhancing consistency and flexibility for multi-platform builds. No changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->