### PR TITLE
Update kube-ovn to latest version

### DIFF
--- a/packages/system/kubeovn/charts/kube-ovn/Chart.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/Chart.yaml
@@ -15,12 +15,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v1.13.10
+version: v1.13.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.13.10"
+appVersion: "1.13.11"
 
 kubeVersion: ">= 1.23.0-0"

--- a/packages/system/kubeovn/charts/kube-ovn/templates/controller-deploy.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/controller-deploy.yaml
@@ -83,6 +83,9 @@ spec:
           - --node-switch={{ .Values.networking.NODE_SUBNET }}
           - --node-switch-cidr={{ index $cozyConfig.data "ipv4-join-cidr" }}
           - --service-cluster-ip-range={{ index $cozyConfig.data "ipv4-svc-cidr" }}
+          {{- if .Values.global.logVerbosity }}
+          - --v={{ .Values.global.logVerbosity }}
+          {{- end }}
           - --network-type={{- .Values.networking.NETWORK_TYPE }}
           - --default-provider-name={{ .Values.networking.vlan.PROVIDER_NAME }}
           - --default-interface-name={{- .Values.networking.vlan.VLAN_INTERFACE_NAME }}

--- a/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
@@ -35,11 +35,7 @@ spec:
         command:
           - sh
           - -xec
-          - {{ if not .Values.DISABLE_MODULES_MANAGEMENT -}}
-            iptables -V
-            {{- else -}}
-            echo "nothing to do"
-            {{- end }}
+          - iptables -V
         securityContext:
           allowPrivilegeEscalation: true
           capabilities:
@@ -93,6 +89,9 @@ spec:
           - --node-switch={{ .Values.networking.NODE_SUBNET }}
           - --encap-checksum=true
           - --service-cluster-ip-range={{ index $cozyConfig.data "ipv4-svc-cidr" }}
+          {{- if .Values.global.logVerbosity }}
+          - --v={{ .Values.global.logVerbosity }}
+          {{- end }}
           {{- if eq .Values.networking.NETWORK_TYPE "vlan" }}
           - --iface=
           {{- else}}
@@ -125,9 +124,6 @@ spec:
               - NET_RAW
               - SYS_ADMIN
               - SYS_PTRACE
-              {{- if not .Values.DISABLE_MODULES_MANAGEMENT }}
-              - SYS_MODULE
-              {{- end }}
               - SYS_NICE
         env:
           - name: ENABLE_SSL

--- a/packages/system/kubeovn/charts/kube-ovn/templates/ovsovn-ds.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/templates/ovsovn-ds.yaml
@@ -49,8 +49,9 @@ spec:
             - -xec
             - |
               chown -R nobody: /var/run/ovn /var/log/ovn /etc/openvswitch /var/run/openvswitch /var/log/openvswitch
-              {{- if not .Values.DISABLE_MODULES_MANAGEMENT }}
               iptables -V
+              {{- if not .Values.DISABLE_MODULES_MANAGEMENT }}
+              /usr/share/openvswitch/scripts/ovs-ctl load-kmod
               {{- else }}
               ln -sf /bin/true /usr/local/sbin/modprobe
               ln -sf /bin/true /usr/local/sbin/modinfo
@@ -64,6 +65,9 @@ spec:
             privileged: true
             runAsUser: 0
           volumeMounts:
+            - mountPath: /lib/modules
+              name: host-modules
+              readOnly: true
             - mountPath: /usr/local/sbin
               name: usr-local-sbin
             - mountPath: /var/log/ovn
@@ -96,9 +100,7 @@ spec:
               add:
                 - NET_ADMIN
                 - NET_BIND_SERVICE
-                {{- if not .Values.DISABLE_MODULES_MANAGEMENT }}
-                - SYS_MODULE
-                {{- end }}
+                - NET_RAW
                 - SYS_NICE
                 - SYS_ADMIN
           env:

--- a/packages/system/kubeovn/charts/kube-ovn/values.yaml
+++ b/packages/system/kubeovn/charts/kube-ovn/values.yaml
@@ -10,7 +10,7 @@ global:
       repository: kube-ovn
       dpdkRepository: kube-ovn-dpdk
       vpcRepository: vpc-nat-gateway
-      tag: v1.13.10
+      tag: v1.13.11
       support_arm: true
       thirdparty: true
 

--- a/packages/system/kubeovn/images/kubeovn/Dockerfile
+++ b/packages/system/kubeovn/images/kubeovn/Dockerfile
@@ -1,9 +1,2 @@
-ARG VERSION=v1.13.10
+ARG VERSION=v1.13.11
 FROM kubeovn/kube-ovn:${VERSION}
-
-# Fix https://github.com/kubeovn/kube-ovn/issues/4526
-RUN setcap CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SYS_ADMIN+eip /usr/lib/openvswitch-switch/ovs-vswitchd \
- && setcap CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SYS_ADMIN+eip /usr/sbin/xtables-legacy-multi \
- && setcap CAP_NET_ADMIN,CAP_NET_BIND_SERVICE,CAP_SYS_ADMIN+eip /usr/sbin/xtables-nft-multi \
- && setcap CAP_NET_ADMIN,CAP_NET_RAW,CAP_NET_BIND_SERVICE,CAP_SYS_ADMIN+eip /usr/sbin/ipset \
- && setcap CAP_NET_ADMIN,CAP_NET_RAW,CAP_SYS_ADMIN+eip /usr/bin/ip

--- a/packages/system/kubeovn/patches/cozyconfig.diff
+++ b/packages/system/kubeovn/patches/cozyconfig.diff
@@ -3,7 +3,7 @@ diff --git a/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml b/
 index d9a9a67..b2e12dd 100644
 --- a/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
 +++ b/packages/system/kubeovn/charts/kube-ovn/templates/ovncni-ds.yaml
-@@ -51,18 +51,12 @@ spec:
+@@ -51,18 +51,15 @@ spec:
            - bash
            - /kube-ovn/start-cniserver.sh
          args:
@@ -21,6 +21,9 @@ index d9a9a67..b2e12dd 100644
 -          {{ .Values.ipv6.SVC_CIDR }}
 -          {{- end }}
 +          - --service-cluster-ip-range={{ index $cozyConfig.data "ipv4-svc-cidr" }}
++          {{- if .Values.global.logVerbosity }}
++          - --v={{ .Values.global.logVerbosity }}
++          {{- end }}
            {{- if eq .Values.networking.NETWORK_TYPE "vlan" }}
            - --iface=
            {{- else}}
@@ -28,7 +31,7 @@ diff --git a/packages/system/kubeovn/charts/kube-ovn/templates/controller-deploy
 index 0e69494..756eb7c 100644
 --- a/packages/system/kubeovn/charts/kube-ovn/templates/controller-deploy.yaml
 +++ b/packages/system/kubeovn/charts/kube-ovn/templates/controller-deploy.yaml
-@@ -52,46 +52,19 @@ spec:
+@@ -52,46 +52,22 @@ spec:
            image: {{ .Values.global.registry.address }}/{{ .Values.global.images.kubeovn.repository }}:{{ .Values.global.images.kubeovn.tag }}
            imagePullPolicy: {{ .Values.image.pullPolicy }}
            args:
@@ -77,6 +80,9 @@ index 0e69494..756eb7c 100644
 -          {{- end }}
 +          - --node-switch-cidr={{ index $cozyConfig.data "ipv4-join-cidr" }}
 +          - --service-cluster-ip-range={{ index $cozyConfig.data "ipv4-svc-cidr" }}
++          {{- if .Values.global.logVerbosity }}
++          - --v={{ .Values.global.logVerbosity }}
++          {{- end }}
            - --network-type={{- .Values.networking.NETWORK_TYPE }}
            - --default-provider-name={{ .Values.networking.vlan.PROVIDER_NAME }}
            - --default-interface-name={{- .Values.networking.vlan.VLAN_INTERFACE_NAME }}


### PR DESCRIPTION
This commit bumps kube-ovn to 1.13.11 and uses the upstream image instead of building our own, now that the fixes necessary for kube-ovn to work properly in Talos have been released in the upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configurable log verbosity in Kube-OVN components via a new optional log verbosity flag.

- **Improvements**
  - Centralized network configuration by dynamically retrieving key values from an external ConfigMap, simplifying management.
  - Updated container image and chart versions to 1.13.11.
  - Adjusted container security capabilities and init container logic for improved consistency and reliability.

- **Bug Fixes**
  - Fixed issues related to conditional capability and command execution in container startup routines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->