### PR TITLE
[metallb] Build patched image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ build: build-deps
 	make -C packages/system/kubeovn image
 	make -C packages/system/kubeovn-webhook image
 	make -C packages/system/dashboard image
+	make -C packages/system/metallb image
 	make -C packages/system/kamaji image
 	make -C packages/system/bucket image
 	make -C packages/core/testing image

--- a/packages/system/metallb/Makefile
+++ b/packages/system/metallb/Makefile
@@ -1,6 +1,7 @@
 export NAME=metallb
 export NAMESPACE=cozy-$(NAME)
 
+include ../../../scripts/common-envs.mk
 include ../../../scripts/package.mk
 
 update:
@@ -9,3 +10,25 @@ update:
 	helm repo update metallb
 	helm pull metallb/metallb --untar --untardir charts
 	rm -rf charts/metallb/charts/frr-k8s
+
+image-controller image-speaker:
+	$(eval TARGET := $(subst image-,,$@))
+	$(eval VERSION := $(shell yq '.appVersion' charts/metallb/Chart.yaml))
+	docker buildx build images/metallb \
+		--provenance false \
+		--target $(TARGET) \
+		--build-arg VERSION=$(VERSION) \
+		--tag $(REGISTRY)/metallb-$(TARGET):$(VERSION) \
+		--cache-from type=registry,ref=$(REGISTRY)/metallb-$(TARGET):latest \
+		--cache-to type=inline \
+		--metadata-file images/$(TARGET).json \
+		--push=$(PUSH) \
+		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack"
+		--load=1
+	REPOSITORY="$(REGISTRY)/metallb-$(TARGET)" \
+		yq -i '.metallb.$(TARGET).image.repository = strenv(REPOSITORY)' values.yaml
+	TAG=$(VERSION)@$$(yq e '."containerimage.digest"' images/$(TARGET).json -o json -r) \
+		yq -i '.metallb.$(TARGET).image.tag = strenv(TAG)' values.yaml
+	rm -f images/$(TARGET).json
+
+image: image-controller image-speaker

--- a/packages/system/metallb/charts/metallb/Chart.lock
+++ b/packages/system/metallb/charts/metallb/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: crds
   repository: ""
-  version: 0.14.8
+  version: 0.14.9
 - name: frr-k8s
   repository: https://metallb.github.io/frr-k8s
-  version: 0.0.14
-digest: sha256:8dff488902a5b504a491bbd1a9ab0983a877ff214e163ed74106c73c939a9aa3
-generated: "2024-07-23T15:22:40.589621+03:00"
+  version: 0.0.16
+digest: sha256:20d9a53af12c82d35168e7524ae337341b2c7cb43e2169545185f750a718466e
+generated: "2024-12-17T15:39:32.082324414+01:00"

--- a/packages/system/metallb/charts/metallb/Chart.yaml
+++ b/packages/system/metallb/charts/metallb/Chart.yaml
@@ -1,14 +1,14 @@
 apiVersion: v2
-appVersion: v0.14.8
+appVersion: v0.14.9
 dependencies:
 - condition: crds.enabled
   name: crds
   repository: ""
-  version: 0.14.8
+  version: 0.14.9
 - condition: frrk8s.enabled
   name: frr-k8s
   repository: https://metallb.github.io/frr-k8s
-  version: 0.0.14
+  version: 0.0.16
 description: A network load-balancer implementation for Kubernetes using standard
   routing protocols
 home: https://metallb.universe.tf
@@ -18,4 +18,4 @@ name: metallb
 sources:
 - https://github.com/metallb/metallb
 type: application
-version: 0.14.8
+version: 0.14.9

--- a/packages/system/metallb/charts/metallb/README.md
+++ b/packages/system/metallb/charts/metallb/README.md
@@ -17,7 +17,7 @@ Kubernetes: `>= 1.19.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 |  | crds | 0.0.0 |
-| https://metallb.github.io/frr-k8s | frr-k8s | 0.0.14 |
+| https://metallb.github.io/frr-k8s | frr-k8s | 0.0.16 |
 
 ## Values
 
@@ -79,17 +79,17 @@ Kubernetes: `>= 1.19.0-0`
 | prometheus.podMonitor.relabelings | list | `[]` |  |
 | prometheus.prometheusRule.additionalLabels | object | `{}` |  |
 | prometheus.prometheusRule.addressPoolExhausted.enabled | bool | `true` |  |
-| prometheus.prometheusRule.addressPoolExhausted.labels.severity | string | `"alert"` |  |
+| prometheus.prometheusRule.addressPoolExhausted.labels.severity | string | `"critical"` |  |
 | prometheus.prometheusRule.addressPoolUsage.enabled | bool | `true` |  |
 | prometheus.prometheusRule.addressPoolUsage.thresholds[0].labels.severity | string | `"warning"` |  |
 | prometheus.prometheusRule.addressPoolUsage.thresholds[0].percent | int | `75` |  |
 | prometheus.prometheusRule.addressPoolUsage.thresholds[1].labels.severity | string | `"warning"` |  |
 | prometheus.prometheusRule.addressPoolUsage.thresholds[1].percent | int | `85` |  |
-| prometheus.prometheusRule.addressPoolUsage.thresholds[2].labels.severity | string | `"alert"` |  |
+| prometheus.prometheusRule.addressPoolUsage.thresholds[2].labels.severity | string | `"critical"` |  |
 | prometheus.prometheusRule.addressPoolUsage.thresholds[2].percent | int | `95` |  |
 | prometheus.prometheusRule.annotations | object | `{}` |  |
 | prometheus.prometheusRule.bgpSessionDown.enabled | bool | `true` |  |
-| prometheus.prometheusRule.bgpSessionDown.labels.severity | string | `"alert"` |  |
+| prometheus.prometheusRule.bgpSessionDown.labels.severity | string | `"critical"` |  |
 | prometheus.prometheusRule.configNotLoaded.enabled | bool | `true` |  |
 | prometheus.prometheusRule.configNotLoaded.labels.severity | string | `"warning"` |  |
 | prometheus.prometheusRule.enabled | bool | `false` |  |

--- a/packages/system/metallb/charts/metallb/charts/crds/Chart.yaml
+++ b/packages/system/metallb/charts/metallb/charts/crds/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.14.8
+appVersion: v0.14.9
 description: MetalLB CRDs
 home: https://metallb.universe.tf
 icon: https://metallb.universe.tf/images/logo/metallb-white.png
@@ -7,4 +7,4 @@ name: crds
 sources:
 - https://github.com/metallb/metallb
 type: application
-version: 0.14.8
+version: 0.14.9

--- a/packages/system/metallb/charts/metallb/charts/crds/templates/crds.yaml
+++ b/packages/system/metallb/charts/metallb/charts/crds/templates/crds.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: bfdprofiles.metallb.io
 spec:
   group: metallb.io
@@ -123,7 +123,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: bgpadvertisements.metallb.io
 spec:
   group: metallb.io
@@ -329,7 +329,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: bgppeers.metallb.io
 spec:
   conversion:
@@ -365,6 +365,8 @@ spec:
         - jsonPath: .spec.ebgpMultiHop
           name: Multi Hops
           type: string
+      deprecated: true
+      deprecationWarning: v1beta1 is deprecated, please use v1beta2
       name: v1beta1
       schema:
         openAPIV3Schema:
@@ -526,15 +528,26 @@ spec:
                   default: false
                   description: To set if we want to disable MP BGP that will separate IPv4 and IPv6 route exchanges into distinct BGP sessions.
                   type: boolean
+                dynamicASN:
+                  description: |-
+                    DynamicASN detects the AS number to use for the remote end of the session
+                    without explicitly setting it via the ASN field. Limited to:
+                    internal - if the neighbor's ASN is different than MyASN connection is denied.
+                    external - if the neighbor's ASN is the same as MyASN the connection is denied.
+                    ASN and DynamicASN are mutually exclusive and one of them must be specified.
+                  enum:
+                    - internal
+                    - external
+                  type: string
                 ebgpMultiHop:
                   description: To set if the BGPPeer is multi-hops away. Needed for FRR mode only.
                   type: boolean
                 enableGracefulRestart:
                   description: |-
-                    EnableGracefulRestart allows BGP peer to continue to forward data packets along
-                    known routes while the routing protocol information is being restored.
-                    This field is immutable because it requires restart of the BGP session
-                    Supported for FRR mode only.
+                    EnableGracefulRestart allows BGP peer to continue to forward data packets
+                    along known routes while the routing protocol information is being
+                    restored. This field is immutable because it requires restart of the BGP
+                    session. Supported for FRR mode only.
                   type: boolean
                   x-kubernetes-validations:
                     - message: EnableGracefulRestart cannot be changed after creation
@@ -622,7 +635,9 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 peerASN:
-                  description: AS number to expect from the remote end of the session.
+                  description: |-
+                    AS number to expect from the remote end of the session.
+                    ASN and DynamicASN are mutually exclusive and one of them must be specified.
                   format: int32
                   maximum: 4294967295
                   minimum: 0
@@ -649,7 +664,6 @@ spec:
                   type: string
               required:
                 - myASN
-                - peerASN
                 - peerAddress
               type: object
             status:
@@ -665,7 +679,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: communities.metallb.io
 spec:
   group: metallb.io
@@ -730,7 +744,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: ipaddresspools.metallb.io
 spec:
   group: metallb.io
@@ -940,7 +954,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: l2advertisements.metallb.io
 spec:
   group: metallb.io
@@ -1120,7 +1134,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.16.3
   name: servicel2statuses.metallb.io
 spec:
   group: metallb.io

--- a/packages/system/metallb/charts/metallb/templates/controller.yaml
+++ b/packages/system/metallb/charts/metallb/templates/controller.yaml
@@ -84,7 +84,7 @@ spec:
         - name: METALLB_DEPLOYMENT
           value: {{ template "metallb.fullname" . }}-controller
         {{- end }}
-        {{- if .Values.speaker.frr.enabled }}
+        {{- if and .Values.speaker.enabled .Values.speaker.frr.enabled }}
         - name: METALLB_BGP_TYPE
           value: frr
         {{- end }}

--- a/packages/system/metallb/charts/metallb/templates/podmonitor.yaml
+++ b/packages/system/metallb/charts/metallb/templates/podmonitor.yaml
@@ -36,6 +36,7 @@ spec:
     relabelings:
 {{- toYaml .Values.prometheus.podMonitor.relabelings | nindent 4 }}
 {{- end }}
+{{- if .Values.speaker.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
@@ -73,6 +74,7 @@ spec:
 {{- if .Values.prometheus.podMonitor.relabelings }}
     relabelings:
 {{- toYaml .Values.prometheus.podMonitor.relabelings | nindent 4 }}
+{{- end }}
 {{- end }}
 ---
 {{- if .Values.prometheus.rbacPrometheus }}

--- a/packages/system/metallb/charts/metallb/templates/prometheusrules.yaml
+++ b/packages/system/metallb/charts/metallb/templates/prometheusrules.yaml
@@ -19,8 +19,8 @@ spec:
     {{- if .Values.prometheus.prometheusRule.staleConfig.enabled }}
     - alert: MetalLBStaleConfig
       annotations:
-        message: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod
-          }} has a stale config for > 1 minute'`}}
+        summary: {{`'Stale config on {{ $labels.pod }}'`}}
+        description: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod }} has a stale config for > 1 minute'`}}
       expr: metallb_k8s_client_config_stale_bool{job=~"{{ template "metallb.fullname" . }}.*"} == 1
       for: 1m
       {{- with .Values.prometheus.prometheusRule.staleConfig.labels }}
@@ -31,8 +31,8 @@ spec:
     {{- if .Values.prometheus.prometheusRule.configNotLoaded.enabled }}
     - alert: MetalLBConfigNotLoaded
       annotations:
-        message: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod
-          }} has not loaded for > 1 minute'`}}
+        summary: {{`'Config on {{ $labels.pod }} has not been loaded'`}}
+        description: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod }} has not loaded for > 1 minute'`}}
       expr: metallb_k8s_client_config_loaded_bool{job=~"{{ template "metallb.fullname" . }}.*"} == 0
       for: 1m
       {{- with .Values.prometheus.prometheusRule.configNotLoaded.labels }}
@@ -43,8 +43,8 @@ spec:
     {{- if .Values.prometheus.prometheusRule.addressPoolExhausted.enabled }}
     - alert: MetalLBAddressPoolExhausted
       annotations:
-        message: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod
-          }} has exhausted address pool {{ $labels.pool }} for > 1 minute'`}}
+        summary: {{`'Exhausted address pool on {{ $labels.pod }}'`}}
+        description: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod }} has exhausted address pool {{ $labels.pool }} for > 1 minute'`}}
       expr: metallb_allocator_addresses_in_use_total >= on(pool) metallb_allocator_addresses_total
       for: 1m
       {{- with .Values.prometheus.prometheusRule.addressPoolExhausted.labels }}
@@ -57,8 +57,8 @@ spec:
     {{- range .Values.prometheus.prometheusRule.addressPoolUsage.thresholds }}
     - alert: MetalLBAddressPoolUsage{{ .percent }}Percent
       annotations:
-        message: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod
-          }} has address pool {{ $labels.pool }} past `}}{{ .percent }}{{`% usage for > 1 minute'`}}
+        summary: {{`'Exhausted address pool on {{ $labels.pod }}'`}}
+        message: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod }} has address pool {{ $labels.pool }} past `}}{{ .percent }}{{`% usage for > 1 minute'`}}
       expr: ( metallb_allocator_addresses_in_use_total / on(pool) metallb_allocator_addresses_total ) * 100 > {{ .percent }}
       {{- with .labels }}
       labels:
@@ -69,8 +69,8 @@ spec:
     {{- if .Values.prometheus.prometheusRule.bgpSessionDown.enabled }}
     - alert: MetalLBBGPSessionDown
       annotations:
-        message: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod
-          }} has BGP session {{ $labels.peer }} down for > 1 minute'`}}
+        summary:  {{`'BGP session down on {{ $labels.pod }}'`}}
+        message: {{`'{{ $labels.job }} - MetalLB {{ $labels.container }} on {{ $labels.pod }} has BGP session {{ $labels.peer }} down for > 1 minute'`}}
       expr: metallb_bgp_session_up{job=~"{{ template "metallb.fullname" . }}.*"} == 0
       for: 1m
       {{- with .Values.prometheus.prometheusRule.bgpSessionDown.labels }}

--- a/packages/system/metallb/charts/metallb/templates/rbac.yaml
+++ b/packages/system/metallb/charts/metallb/templates/rbac.yaml
@@ -19,11 +19,11 @@ rules:
   resources: ["events"]
   verbs: ["create", "patch"]
 - apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  resources: ["validatingwebhookconfigurations"]
   resourceNames: ["metallb-webhook-configuration"]
   verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 - apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+  resources: ["validatingwebhookconfigurations"]
   verbs: ["list", "watch"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
@@ -41,6 +41,7 @@ rules:
   resources: ["subjectaccessreviews"]
   verbs: ["create"]
 {{- end }}
+{{- if .Values.speaker.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -72,7 +73,7 @@ rules:
 {{- if or .Values.frrk8s.enabled .Values.frrk8s.external }}
 - apiGroups: ["frrk8s.metallb.io"]
   resources: ["frrconfigurations"]
-  verbs: ["get", "list", "watch","create","update"]
+  verbs: ["get", "list", "watch","create","update","delete"]
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -109,6 +110,7 @@ rules:
 - apiGroups: ["metallb.io"]
   resources: ["communities"]
   verbs: ["get", "list", "watch"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -117,7 +119,7 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "metallb.labels" . | nindent 4 }}
 rules:
-{{- if .Values.speaker.memberlist.enabled }}
+{{- if and .Values.speaker.enabled .Values.speaker.memberlist.enabled }}
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create", "get", "list", "watch"]
@@ -166,6 +168,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ template "metallb.fullname" . }}:controller
+{{- if .Values.speaker.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -195,6 +198,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "metallb.speaker.serviceAccountName" . }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/packages/system/metallb/charts/metallb/templates/service-accounts.yaml
+++ b/packages/system/metallb/charts/metallb/templates/service-accounts.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
-{{- if .Values.speaker.serviceAccount.create }}
+{{- if and .Values.speaker.enabled .Values.speaker.serviceAccount.create }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/packages/system/metallb/charts/metallb/templates/servicemonitor.yaml
+++ b/packages/system/metallb/charts/metallb/templates/servicemonitor.yaml
@@ -1,4 +1,9 @@
+{{- if and .Values.prometheus.serviceMonitor.enabled .Values.prometheus.podMonitor.enabled }}
+{{- fail "prometheus.serviceMonitor.enabled and prometheus.podMonitor.enabled cannot both be set" }}
+{{- end }}
+
 {{- if .Values.prometheus.serviceMonitor.enabled }}
+{{- if .Values.speaker.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -89,6 +94,7 @@ spec:
 {{- end }}
   sessionAffinity: None
   type: ClusterIP
+{{- end }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -97,7 +103,6 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "metallb.labels" . | nindent 4 }}
-    app.kubernetes.io/component: speaker
     {{- if .Values.prometheus.serviceMonitor.controller.additionalLabels }}
 {{ toYaml .Values.prometheus.serviceMonitor.controller.additionalLabels | indent 4 }}
     {{- end }}

--- a/packages/system/metallb/charts/metallb/values.yaml
+++ b/packages/system/metallb/charts/metallb/values.yaml
@@ -42,7 +42,7 @@ prometheus:
   # certificate to be used.
   controllerMetricsTLSSecret: ""
 
-  # prometheus doens't have the permission to scrape all namespaces so we give it permission to scrape metallb's one
+  # prometheus doesn't have the permission to scrape all namespaces so we give it permission to scrape metallb's one
   rbacPrometheus: true
 
   # the service account used by prometheus
@@ -64,7 +64,7 @@ prometheus:
     # enable support for Prometheus Operator
     enabled: false
 
-    # optional additionnal labels for podMonitors
+    # optional additional labels for podMonitors
     additionalLabels: {}
 
     # optional annotations for podMonitors
@@ -143,7 +143,7 @@ prometheus:
     # enable alertmanager alerts
     enabled: false
 
-    # optional additionnal labels for prometheusRules
+    # optional additional labels for prometheusRules
     additionalLabels: {}
 
     # optional annotations for prometheusRules
@@ -165,7 +165,7 @@ prometheus:
     addressPoolExhausted:
       enabled: true
       labels:
-        severity: alert
+        severity: critical
 
     addressPoolUsage:
       enabled: true
@@ -178,13 +178,13 @@ prometheus:
             severity: warning
         - percent: 95
           labels:
-            severity: alert
+            severity: critical
 
     # MetalLBBGPSessionDown
     bgpSessionDown:
       enabled: true
       labels:
-        severity: alert
+        severity: critical
 
     extraAlerts: []
 

--- a/packages/system/metallb/images/metallb/Dockerfile
+++ b/packages/system/metallb/images/metallb/Dockerfile
@@ -1,0 +1,87 @@
+# syntax=docker/dockerfile:1.2
+
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.22.7 AS builder
+
+ARG VERSION
+ARG GIT_COMMIT=dev
+ARG GIT_BRANCH=dev
+ARG TARGETARCH
+ARG TARGETOS
+ARG TARGETPLATFORM
+
+WORKDIR /go/go.universe.tf/metallb
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    curl -sSL https://github.com/metallb/metallb/archive/refs/tags/${VERSION}.tar.gz \
+    | tar -xzvf- --strip=1 
+
+RUN curl -sSLO https://github.com/metallb/metallb/pull/2726.diff && \
+    git apply 2726.diff
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download -x
+
+RUN case ${TARGETPLATFORM} in \
+    "linux/arm/v6") export VARIANT="6" ;; \
+    "linux/arm/v7") export VARIANT="7" ;; \
+    *) export VARIANT="" ;; \
+    esac && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=$VARIANT \
+    go build -v -o /build/controller \
+    -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' \
+      -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+    ./controller \
+    && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=$VARIANT \
+    go build -v -o /build/frr-metrics \
+    -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' \
+      -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+    frr-tools/metrics/exporter.go \
+    && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=$VARIANT \
+    go build -v -o /build/cp-tool \
+    -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' \
+      -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+    frr-tools/cp-tool/cp-tool.go \
+    && \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=$VARIANT \
+    go build -v -o /build/speaker \
+    -ldflags "-X 'go.universe.tf/metallb/internal/version.gitCommit=${GIT_COMMIT}' \
+      -X 'go.universe.tf/metallb/internal/version.gitBranch=${GIT_BRANCH}'" \
+    ./speaker
+
+FROM gcr.io/distroless/static:latest as controller
+
+COPY --from=builder /build/controller /controller
+
+LABEL org.opencontainers.image.authors="metallb" \
+    org.opencontainers.image.url="https://github.com/metallb/metallb" \
+    org.opencontainers.image.documentation="https://metallb.universe.tf" \
+    org.opencontainers.image.source="https://github.com/cozystack/cozystack" \
+    org.opencontainers.image.vendor="metallb" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.description="Metallb Controller" \
+    org.opencontainers.image.title="controller" \
+    org.opencontainers.image.base.name="gcr.io/distroless/static:latest"
+
+ENTRYPOINT ["/controller"]
+
+FROM gcr.io/distroless/static:latest as speaker
+
+COPY --from=builder /build/cp-tool /cp-tool
+COPY --from=builder /build/speaker /speaker
+COPY --from=builder /build/frr-metrics /frr-metrics
+COPY --from=builder /go/go.universe.tf/metallb/frr-tools/reloader/frr-reloader.sh /frr-reloader.sh
+
+LABEL org.opencontainers.image.authors="metallb" \
+  org.opencontainers.image.url="https://github.com/metallb/metallb" \
+  org.opencontainers.image.documentation="https://metallb.universe.tf" \
+  org.opencontainers.image.source="https://github.com/cozystack/cozystack" \
+  org.opencontainers.image.vendor="metallb" \
+  org.opencontainers.image.licenses="Apache-2.0" \
+  org.opencontainers.image.description="Metallb speaker" \
+  org.opencontainers.image.title="speaker" \
+  org.opencontainers.image.base.name="gcr.io/distroless/static:latest"
+
+ENTRYPOINT ["/speaker"]

--- a/packages/system/metallb/values.yaml
+++ b/packages/system/metallb/values.yaml
@@ -2,5 +2,12 @@ metallb:
   crds:
     enabled: true
 
-  #speaker:
-  #  tolerateMaster: false
+  controller:
+    image:
+      repository: ghcr.io/cozystack/cozystack/metallb/controller
+      tag: v0.14.9@sha256:c86418d1072d6037341d731917d11a2f281fb17559d5bb650962512f9894fd50
+
+  speaker:
+    image:
+      repository: ghcr.io/cozystack/cozystack/metallb/speaker
+      tag: v0.14.9@sha256:60fddc8fd6c125180186db31990993b4ebea5023ad410bf08ca9537a956e8279


### PR DESCRIPTION
Since it's taking a while for metallb/metallb#2726 to get released, the binaries with the fix are recompiled in-tree. Workaround for #909.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for dynamic ASN assignment in BGP peer resources, allowing selection between "internal" and "external" options.
  - Introduced multi-stage Dockerfile for streamlined, reproducible builds of controller and speaker images.
  - Added conditional creation of monitoring and RBAC resources based on component enablement.
  - Added new image build targets for MetalLB components with automated image tagging and metadata updates.

- **Improvements**
  - Updated Helm chart and CRD versions to v0.14.9.
  - Enhanced alert annotations and severity levels for Prometheus rules.
  - Refined configuration defaults for container images and resource creation logic.
  - Improved documentation and corrected typographical errors in configuration files.
  - Updated environment variable conditions and tightened resource creation logic for speaker components.

- **Bug Fixes**
  - Tightened conditions for creating service accounts and RBAC resources to prevent unnecessary resource creation.
  - Added validation to prevent simultaneous enabling of conflicting monitoring options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->