### PR TITLE
Revert "Downgrade CAPI operator"

### DIFF
--- a/packages/system/capi-operator/Makefile
+++ b/packages/system/capi-operator/Makefile
@@ -3,7 +3,7 @@ export NAMESPACE=cozy-cluster-api
 export REPO_NAME=capi-operator
 export REPO_URL=https://kubernetes-sigs.github.io/cluster-api-operator
 export CHART_NAME=cluster-api-operator 
-export CHART_VERSION=^0.18
+export CHART_VERSION=^0.19
 
 include ../../../scripts/package.mk
 

--- a/packages/system/capi-operator/charts/cluster-api-operator/Chart.yaml
+++ b/packages/system/capi-operator/charts/cluster-api-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.18.1
+appVersion: 0.19.0
 description: Cluster API Operator
 name: cluster-api-operator
 type: application
-version: 0.18.1
+version: 0.19.0

--- a/packages/system/capi-operator/charts/cluster-api-operator/templates/addon.yaml
+++ b/packages/system/capi-operator/charts/cluster-api-operator/templates/addon.yaml
@@ -1,26 +1,8 @@
 # Addon provider
-{{- if .Values.addon }}
-{{- $addons := split ";" .Values.addon }}
-{{- $addonNamespace := "" }}
-{{- $addonName := "" }}
-{{- $addonVersion := "" }}
-{{- range $addon := $addons }}
-{{- $addonArgs := split ":" $addon }}
-{{- $addonArgsLen :=  len $addonArgs }}
-{{-  if eq $addonArgsLen 3 }}
-  {{- $addonNamespace = $addonArgs._0 }}
-  {{- $addonName = $addonArgs._1 }}
-  {{- $addonVersion = $addonArgs._2 }}
-{{-  else if eq $addonArgsLen 2 }}
-  {{- $addonNamespace = print $addonArgs._0 "-addon-system" }}
-  {{- $addonName = $addonArgs._0 }}
-  {{- $addonVersion = $addonArgs._1 }}
-{{-  else if eq $addonArgsLen 1 }}
-  {{- $addonNamespace = print $addonArgs._0 "-addon-system" }}
-  {{- $addonName = $addonArgs._0 }}
-{{- else }}
-  {{- fail "addon provider argument should have the following format helm:v1.0.0 or mynamespace:helm:v1.0.0" }}
-{{- end }}
+{{- range $name, $addon := $.Values.addon }}
+  {{- $addonNamespace := default ( printf "%s-%s" $name "addon-system" ) (get $addon "namespace") }}
+  {{- $addonName := $name }}
+  {{- $addonVersion := get $addon "version" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -56,5 +38,24 @@ spec:
 {{- if $.Values.secretNamespace }}
   secretNamespace: {{ $.Values.secretNamespace }}
 {{- end }}
+{{- if $addon.manifestPatches }}
+  manifestPatches: {{ toYaml $addon.manifestPatches | nindent 4 }}
 {{- end }}
+{{- if $addon.additionalManifests }}
+  additionalManifests:
+    name: {{ $addon.additionalManifests.name }}
+    {{- if $addon.additionalManifests.namespace }}
+    namespace: {{ $addon.additionalManifests.namespace }}
+    {{- end }} {{/* if $addon.additionalManifests.namespace */}}
 {{- end }}
+{{- if $addon.additionalManifests }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $addon.additionalManifests.name }}
+  namespace: {{ default $addonNamespace $addon.additionalManifests.namespace }}
+data:
+  manifests: {{- toYaml $addon.additionalManifests.manifests | nindent 4 }}
+{{- end }}
+{{- end }} {{/* range $name, $addon := .Values.addon */}}

--- a/packages/system/capi-operator/charts/cluster-api-operator/templates/bootstrap.yaml
+++ b/packages/system/capi-operator/charts/cluster-api-operator/templates/bootstrap.yaml
@@ -1,26 +1,8 @@
 # Bootstrap provider
-{{- if .Values.bootstrap }}
-{{- $bootstraps := split ";" .Values.bootstrap }}
-{{- $bootstrapNamespace := "" }}
-{{- $bootstrapName := "" }}
-{{- $bootstrapVersion := "" }}
-{{- range $bootstrap := $bootstraps }}
-{{- $bootstrapArgs := split ":" $bootstrap }}
-{{- $bootstrapArgsLen :=  len $bootstrapArgs }}
-{{-  if eq $bootstrapArgsLen 3 }}
-  {{- $bootstrapNamespace = $bootstrapArgs._0 }}
-  {{- $bootstrapName = $bootstrapArgs._1 }}
-  {{- $bootstrapVersion = $bootstrapArgs._2 }}
-{{-  else if eq $bootstrapArgsLen 2 }}
-  {{- $bootstrapNamespace = print $bootstrapArgs._0 "-bootstrap-system" }}
-  {{- $bootstrapName = $bootstrapArgs._0 }}
-  {{- $bootstrapVersion = $bootstrapArgs._1 }}
-{{-  else if eq $bootstrapArgsLen 1 }}
-  {{- $bootstrapNamespace = print $bootstrapArgs._0 "-bootstrap-system" }}
-  {{- $bootstrapName = $bootstrapArgs._0 }}
-{{- else }}
-  {{- fail "bootstrap provider argument should have the following format kubeadm:v1.0.0 or mynamespace:kubeadm:v1.0.0" }}
-{{- end }}
+{{- range $name, $bootstrap := $.Values.bootstrap }}
+  {{- $bootstrapNamespace := default ( printf "%s-%s" $name "bootstrap-system" ) (get $bootstrap "namespace") }}
+  {{- $bootstrapName := $name }}
+  {{- $bootstrapVersion := get $bootstrap "version" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -57,5 +39,24 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
+{{- if $bootstrap.manifestPatches }}
+  manifestPatches: {{ toYaml $bootstrap.manifestPatches | nindent 4 }}
 {{- end }}
+{{- if $bootstrap.additionalManifests }}
+  additionalManifests:
+    name: {{ $bootstrap.additionalManifests.name }}
+    {{- if $bootstrap.additionalManifests.namespace }}
+    namespace: {{ $bootstrap.additionalManifests.namespace }}
+    {{- end }} {{/* if $bootstrap.additionalManifests.namespace */}}
 {{- end }}
+{{- if $bootstrap.additionalManifests }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $bootstrap.additionalManifests.name }}
+  namespace: {{ default $bootstrapNamespace $bootstrap.additionalManifests.namespace }}
+data:
+  manifests: {{- toYaml $bootstrap.additionalManifests.manifests | nindent 4 }}
+{{- end }}
+{{- end }} {{/* range $name, $bootstrap := .Values.bootstrap */}}

--- a/packages/system/capi-operator/charts/cluster-api-operator/templates/control-plane.yaml
+++ b/packages/system/capi-operator/charts/cluster-api-operator/templates/control-plane.yaml
@@ -1,26 +1,8 @@
 # Control plane provider
-{{- if .Values.controlPlane }}
-{{- $controlPlanes := split ";" .Values.controlPlane }}
-{{- $controlPlaneNamespace := "" }}
-{{- $controlPlaneName := "" }}
-{{- $controlPlaneVersion := "" }}
-{{- range $controlPlane := $controlPlanes }}
-{{- $controlPlaneArgs := split ":" $controlPlane }}
-{{- $controlPlaneArgsLen :=  len $controlPlaneArgs }}
-{{-  if eq $controlPlaneArgsLen 3 }}
-  {{- $controlPlaneNamespace = $controlPlaneArgs._0 }}
-  {{- $controlPlaneName = $controlPlaneArgs._1 }}
-  {{- $controlPlaneVersion = $controlPlaneArgs._2 }}
-{{-  else if eq $controlPlaneArgsLen 2 }}
-  {{- $controlPlaneNamespace = print $controlPlaneArgs._0 "-control-plane-system" }}
-  {{- $controlPlaneName = $controlPlaneArgs._0 }}
-  {{- $controlPlaneVersion = $controlPlaneArgs._1 }}
-{{-  else if eq $controlPlaneArgsLen 1 }}
-  {{- $controlPlaneNamespace = print $controlPlaneArgs._0 "-control-plane-system" }}
-  {{- $controlPlaneName = $controlPlaneArgs._0 }}
-{{- else }}
-  {{- fail "controlplane provider argument should have the following format kubeadm:v1.0.0 or mynamespace:kubeadm:v1.0.0" }}
-{{-  end }}
+{{- range $name, $controlPlane := $.Values.controlPlane }}
+  {{- $controlPlaneNamespace := default ( printf "%s-%s" $name "control-plane-system" ) (get $controlPlane "namespace") }}
+  {{- $controlPlaneName := $name }}
+  {{- $controlPlaneVersion := get $controlPlane "version" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -70,5 +52,24 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
+{{- if $controlPlane.manifestPatches }}
+  manifestPatches: {{ toYaml $controlPlane.manifestPatches | nindent 4 }}
 {{- end }}
+{{- if $controlPlane.additionalManifests }}
+  additionalManifests:
+    name: {{ $controlPlane.additionalManifests.name }}
+    {{- if $controlPlane.additionalManifests.namespace }}
+    namespace: {{ $controlPlane.additionalManifests.namespace }}
+    {{- end }} {{/* if $controlPlane.additionalManifests.namespace */}}
 {{- end }}
+{{- if $controlPlane.additionalManifests }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $controlPlane.additionalManifests.name }}
+  namespace: {{ default $controlPlaneNamespace $controlPlane.additionalManifests.namespace }}
+data:
+  manifests: {{- toYaml $controlPlane.additionalManifests.manifests | nindent 4 }}
+{{- end }}
+{{- end }} {{/* range $name, $controlPlane := .Values.controlPlane */}}

--- a/packages/system/capi-operator/charts/cluster-api-operator/templates/core.yaml
+++ b/packages/system/capi-operator/charts/cluster-api-operator/templates/core.yaml
@@ -1,25 +1,8 @@
 # Core provider
-{{- if .Values.core }}
-{{- $coreArgs := split ":" .Values.core }}
-{{- $coreArgsLen :=  len $coreArgs }}
-{{- $coreVersion := "" }}
-{{- $coreNamespace := "" }}
-{{- $coreName := "" }}
-{{- $coreVersion := "" }}
-{{-  if eq $coreArgsLen 3 }}
-  {{- $coreNamespace = $coreArgs._0 }}
-  {{- $coreName = $coreArgs._1 }}
-  {{- $coreVersion = $coreArgs._2 }}
-{{-  else if eq $coreArgsLen 2 }}
-  {{- $coreNamespace = "capi-system" }}
-  {{- $coreName = $coreArgs._0 }}
-  {{- $coreVersion = $coreArgs._1 }}
-{{-  else if eq $coreArgsLen 1 }}
-  {{- $coreNamespace = "capi-system" }}
-  {{- $coreName = $coreArgs._0 }}
-{{- else }}
-  {{- fail "core provider argument should have the following format cluster-api:v1.0.0 or mynamespace:cluster-api:v1.0.0" }}
-{{-  end }}
+{{- range $name, $core := $.Values.core }}
+  {{- $coreNamespace := default "capi-system" (get $core "namespace") }}
+  {{- $coreName := $name }}
+  {{- $coreVersion := get $core "version" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -65,4 +48,24 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
+{{- if $core.manifestPatches }}
+  manifestPatches: {{ toYaml $core.manifestPatches | nindent 4 }}
 {{- end }}
+{{- if $core.additionalManifests }}
+  additionalManifests:
+    name: {{ $core.additionalManifests.name }}
+    {{- if $core.additionalManifests.namespace }}
+    namespace: {{ $core.additionalManifests.namespace }}
+    {{- end }}
+{{- end }}
+{{- if $core.additionalManifests }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $core.additionalManifests.name }}
+  namespace: {{ default $coreNamespace $core.additionalManifests.namespace }}
+data:
+  manifests: {{- toYaml $core.additionalManifests.manifests | nindent 4 }}
+{{- end }}
+{{- end }} {{/* range $name, $core := .Values.core */}}

--- a/packages/system/capi-operator/charts/cluster-api-operator/templates/infra.yaml
+++ b/packages/system/capi-operator/charts/cluster-api-operator/templates/infra.yaml
@@ -1,26 +1,8 @@
 # Infrastructure providers
-{{- if .Values.infrastructure }}
-{{- $infrastructures := split ";" .Values.infrastructure }}
-{{- $infrastructureNamespace := "" }}
-{{- $infrastructureName := "" }}
-{{- $infrastructureVersion := "" }}
-{{- range $infrastructure := $infrastructures }}
-{{- $infrastructureArgs := split ":" $infrastructure }}
-{{- $infrastructureArgsLen := len $infrastructureArgs }}
-{{-  if eq $infrastructureArgsLen 3 }}
-  {{- $infrastructureNamespace = $infrastructureArgs._0 }}
-  {{- $infrastructureName = $infrastructureArgs._1 }}
-  {{- $infrastructureVersion = $infrastructureArgs._2 }}
-{{-  else if eq $infrastructureArgsLen 2 }}
-  {{- $infrastructureNamespace = print $infrastructureArgs._0 "-infrastructure-system" }}
-  {{- $infrastructureName = $infrastructureArgs._0 }}
-  {{- $infrastructureVersion = $infrastructureArgs._1 }}
-{{-  else if eq $infrastructureArgsLen 1 }}
-  {{- $infrastructureNamespace = print $infrastructureArgs._0 "-infrastructure-system" }}
-  {{- $infrastructureName = $infrastructureArgs._0 }}
-{{- else }}
-  {{- fail "infrastructure provider argument should have the following format aws:v1.0.0 or mynamespace:aws:v1.0.0" }}
-{{- end }}
+{{- range $name, $infra := $.Values.infrastructure }}
+  {{- $infrastructureNamespace := default ( printf "%s-%s" $name "infrastructure-system" ) (get $infra "namespace") }}
+  {{- $infrastructureName := $name }}
+  {{- $infrastructureVersion := get $infra "version" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -83,5 +65,24 @@ spec:
 {{- if $.Values.additionalDeployments }}
   additionalDeployments: {{ toYaml $.Values.additionalDeployments | nindent 4 }}
 {{- end }}
+{{- if $infra.manifestPatches }}
+  manifestPatches: {{- toYaml $infra.manifestPatches | nindent 4 }}
+{{- end }} {{/* if $infra.manifestPatches */}}
+{{- if $infra.additionalManifests }}
+  additionalManifests:
+    name: {{ $infra.additionalManifests.name }}
+    {{- if $infra.additionalManifests.namespace }}
+    namespace: {{ $infra.additionalManifests.namespace }}
+    {{- end }} {{/* if $infra.additionalManifests.namespace */}}
+{{- end }} {{/* if $infra.additionalManifests */}}
+{{- if $infra.additionalManifests }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $infra.additionalManifests.name }}
+  namespace: {{ default $infrastructureNamespace $infra.additionalManifests.namespace }}
+data:
+  manifests: {{- toYaml $infra.additionalManifests.manifests | nindent 4 }}
 {{- end }}
-{{- end }}
+{{- end }} {{/* range $name, $infra := .Values.infrastructure */}}

--- a/packages/system/capi-operator/charts/cluster-api-operator/templates/ipam.yaml
+++ b/packages/system/capi-operator/charts/cluster-api-operator/templates/ipam.yaml
@@ -1,26 +1,8 @@
 # IPAM providers
-{{- if .Values.ipam }}
-{{- $ipams := split ";" .Values.ipam }}
-{{- $ipamNamespace := "" }}
-{{- $ipamName := "" }}
-{{- $ipamVersion := "" }}
-{{- range $ipam := $ipams }}
-{{- $ipamArgs := split ":" $ipam }}
-{{- $ipamArgsLen := len $ipamArgs }}
-{{-  if eq $ipamArgsLen 3 }}
-  {{- $ipamNamespace = $ipamArgs._0 }}
-  {{- $ipamName = $ipamArgs._1 }}
-  {{- $ipamVersion = $ipamArgs._2 }}
-{{-  else if eq $ipamArgsLen 2 }}
-  {{- $ipamNamespace = print $ipamArgs._0 "-ipam-system" }}
-  {{- $ipamName = $ipamArgs._0 }}
-  {{- $ipamVersion = $ipamArgs._1 }}
-{{-  else if eq $ipamArgsLen 1 }}
-  {{- $ipamNamespace = print $ipamArgs._0 "-ipam-system" }}
-  {{- $ipamName = $ipamArgs._0 }}
-{{- else }}
-  {{- fail "ipam provider argument should have the following format in-cluster:v1.0.0 or mynamespace:in-cluster:v1.0.0" }}
-{{- end }}
+{{- range $name, $ipam := $.Values.ipam }}
+  {{- $ipamNamespace := default ( printf "%s-%s" $name "ipam-system" ) (get $ipam "namespace") }}
+  {{- $ipamName := $name }}
+  {{- $ipamVersion := get $ipam "version" }}
 ---
 apiVersion: v1
 kind: Namespace
@@ -70,8 +52,27 @@ spec:
     namespace: {{ $.Values.configSecret.namespace }}
     {{- end }}
 {{- end }}
+{{- if $ipam.manifestPatches }}
+  manifestPatches: {{ toYaml $ipam.manifestPatches | nindent 4 }}
+{{- end }}
 {{- if $.Values.additionalDeployments }}
   additionalDeployments: {{ toYaml $.Values.additionalDeployments | nindent 4 }}
 {{- end }}
+{{- if $ipam.additionalManifests }}
+  additionalManifests:
+    name: {{ $ipam.additionalManifests.name }}
+    {{- if $ipam.additionalManifests.namespace }}
+    namespace: {{ $ipam.additionalManifests.namespace }}
+    {{- end }} {{/* if $ipam.additionalManifests.namespace */}}
 {{- end }}
+{{- if $ipam.additionalManifests }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $ipam.additionalManifests.name }}
+  namespace: {{ default $ipamNamespace $ipam.additionalManifests.namespace }}
+data:
+  manifests: {{- toYaml $ipam.additionalManifests.manifests | nindent 4 }}
 {{- end }}
+{{- end }} {{/* range $name, $ipam := .Values.ipam */}}

--- a/packages/system/capi-operator/charts/cluster-api-operator/templates/operator-components.yaml
+++ b/packages/system/capi-operator/charts/cluster-api-operator/templates/operator-components.yaml
@@ -1305,6 +1305,13 @@ spec:
                       description: Manager defines the properties that can be enabled
                         on the controller manager for the additional provider deployment.
                       properties:
+                        additionalArgs:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            AdditionalArgs is a map of additional options that will be passed
+                            in as container args to the provider's controller manager.
+                          type: object
                         cacheNamespace:
                           description: |-
                             CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -2836,6 +2843,13 @@ spec:
                 description: Manager defines the properties that can be enabled on
                   the controller manager for the provider.
                 properties:
+                  additionalArgs:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      AdditionalArgs is a map of additional options that will be passed
+                      in as container args to the provider's controller manager.
+                    type: object
                   cacheNamespace:
                     description: |-
                       CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -3048,27 +3062,32 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        Last time the condition transitioned from one status to another.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        A human readable message indicating details about the transition.
+                        message is a human readable message indicating details about the transition.
                         This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        The reason for the condition's last transition in CamelCase.
+                        reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -3078,6 +3097,8 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -4711,27 +4732,32 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        Last time the condition transitioned from one status to another.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        A human readable message indicating details about the transition.
+                        message is a human readable message indicating details about the transition.
                         This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        The reason for the condition's last transition in CamelCase.
+                        reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -4741,6 +4767,8 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -6043,6 +6071,13 @@ spec:
                       description: Manager defines the properties that can be enabled
                         on the controller manager for the additional provider deployment.
                       properties:
+                        additionalArgs:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            AdditionalArgs is a map of additional options that will be passed
+                            in as container args to the provider's controller manager.
+                          type: object
                         cacheNamespace:
                           description: |-
                             CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -7574,6 +7609,13 @@ spec:
                 description: Manager defines the properties that can be enabled on
                   the controller manager for the provider.
                 properties:
+                  additionalArgs:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      AdditionalArgs is a map of additional options that will be passed
+                      in as container args to the provider's controller manager.
+                    type: object
                   cacheNamespace:
                     description: |-
                       CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -7786,27 +7828,32 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        Last time the condition transitioned from one status to another.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        A human readable message indicating details about the transition.
+                        message is a human readable message indicating details about the transition.
                         This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        The reason for the condition's last transition in CamelCase.
+                        reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -7816,6 +7863,8 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -9450,27 +9499,32 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        Last time the condition transitioned from one status to another.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        A human readable message indicating details about the transition.
+                        message is a human readable message indicating details about the transition.
                         This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        The reason for the condition's last transition in CamelCase.
+                        reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -9480,6 +9534,8 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -10783,6 +10839,13 @@ spec:
                       description: Manager defines the properties that can be enabled
                         on the controller manager for the additional provider deployment.
                       properties:
+                        additionalArgs:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            AdditionalArgs is a map of additional options that will be passed
+                            in as container args to the provider's controller manager.
+                          type: object
                         cacheNamespace:
                           description: |-
                             CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -12314,6 +12377,13 @@ spec:
                 description: Manager defines the properties that can be enabled on
                   the controller manager for the provider.
                 properties:
+                  additionalArgs:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      AdditionalArgs is a map of additional options that will be passed
+                      in as container args to the provider's controller manager.
+                    type: object
                   cacheNamespace:
                     description: |-
                       CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -12527,27 +12597,32 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        Last time the condition transitioned from one status to another.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        A human readable message indicating details about the transition.
+                        message is a human readable message indicating details about the transition.
                         This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        The reason for the condition's last transition in CamelCase.
+                        reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -12557,6 +12632,8 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -14190,27 +14267,32 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        Last time the condition transitioned from one status to another.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        A human readable message indicating details about the transition.
+                        message is a human readable message indicating details about the transition.
                         This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        The reason for the condition's last transition in CamelCase.
+                        reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -14220,6 +14302,8 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -15522,6 +15606,13 @@ spec:
                       description: Manager defines the properties that can be enabled
                         on the controller manager for the additional provider deployment.
                       properties:
+                        additionalArgs:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            AdditionalArgs is a map of additional options that will be passed
+                            in as container args to the provider's controller manager.
+                          type: object
                         cacheNamespace:
                           description: |-
                             CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -17053,6 +17144,13 @@ spec:
                 description: Manager defines the properties that can be enabled on
                   the controller manager for the provider.
                 properties:
+                  additionalArgs:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      AdditionalArgs is a map of additional options that will be passed
+                      in as container args to the provider's controller manager.
+                    type: object
                   cacheNamespace:
                     description: |-
                       CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -17265,27 +17363,32 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        Last time the condition transitioned from one status to another.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        A human readable message indicating details about the transition.
+                        message is a human readable message indicating details about the transition.
                         This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        The reason for the condition's last transition in CamelCase.
+                        reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -17295,6 +17398,8 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -18929,27 +19034,32 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        Last time the condition transitioned from one status to another.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        A human readable message indicating details about the transition.
+                        message is a human readable message indicating details about the transition.
                         This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        The reason for the condition's last transition in CamelCase.
+                        reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -18959,6 +19069,8 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -20262,6 +20374,13 @@ spec:
                       description: Manager defines the properties that can be enabled
                         on the controller manager for the additional provider deployment.
                       properties:
+                        additionalArgs:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            AdditionalArgs is a map of additional options that will be passed
+                            in as container args to the provider's controller manager.
+                          type: object
                         cacheNamespace:
                           description: |-
                             CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -21793,6 +21912,13 @@ spec:
                 description: Manager defines the properties that can be enabled on
                   the controller manager for the provider.
                 properties:
+                  additionalArgs:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      AdditionalArgs is a map of additional options that will be passed
+                      in as container args to the provider's controller manager.
+                    type: object
                   cacheNamespace:
                     description: |-
                       CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -22006,27 +22132,32 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        Last time the condition transitioned from one status to another.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        A human readable message indicating details about the transition.
+                        message is a human readable message indicating details about the transition.
                         This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        The reason for the condition's last transition in CamelCase.
+                        reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -22036,6 +22167,8 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -23371,6 +23504,13 @@ spec:
                       description: Manager defines the properties that can be enabled
                         on the controller manager for the additional provider deployment.
                       properties:
+                        additionalArgs:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            AdditionalArgs is a map of additional options that will be passed
+                            in as container args to the provider's controller manager.
+                          type: object
                         cacheNamespace:
                           description: |-
                             CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -24902,6 +25042,13 @@ spec:
                 description: Manager defines the properties that can be enabled on
                   the controller manager for the provider.
                 properties:
+                  additionalArgs:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      AdditionalArgs is a map of additional options that will be passed
+                      in as container args to the provider's controller manager.
+                    type: object
                   cacheNamespace:
                     description: |-
                       CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -25114,27 +25261,32 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        Last time the condition transitioned from one status to another.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        A human readable message indicating details about the transition.
+                        message is a human readable message indicating details about the transition.
                         This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        The reason for the condition's last transition in CamelCase.
+                        reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -25144,6 +25296,8 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime
@@ -26481,6 +26635,13 @@ spec:
                       description: Manager defines the properties that can be enabled
                         on the controller manager for the additional provider deployment.
                       properties:
+                        additionalArgs:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            AdditionalArgs is a map of additional options that will be passed
+                            in as container args to the provider's controller manager.
+                          type: object
                         cacheNamespace:
                           description: |-
                             CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -28012,6 +28173,13 @@ spec:
                 description: Manager defines the properties that can be enabled on
                   the controller manager for the provider.
                 properties:
+                  additionalArgs:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      AdditionalArgs is a map of additional options that will be passed
+                      in as container args to the provider's controller manager.
+                    type: object
                   cacheNamespace:
                     description: |-
                       CacheNamespace if specified restricts the manager's cache to watch objects in
@@ -28225,27 +28393,32 @@ spec:
                   properties:
                     lastTransitionTime:
                       description: |-
-                        Last time the condition transitioned from one status to another.
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
                         This should be when the underlying condition changed. If that is not known, then using the time when
                         the API field changed is acceptable.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        A human readable message indicating details about the transition.
+                        message is a human readable message indicating details about the transition.
                         This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
                       type: string
                     reason:
                       description: |-
-                        The reason for the condition's last transition in CamelCase.
+                        reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
                         This field may be empty.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                     severity:
                       description: |-
                         severity provides an explicit classification of Reason code, so the users or machines can immediately
                         understand the current situation and act accordingly.
                         The Severity field MUST be set only when Status=False.
+                      maxLength: 32
                       type: string
                     status:
                       description: status of the condition, one of True, False, Unknown.
@@ -28255,6 +28428,8 @@ spec:
                         type of condition in CamelCase or in foo.example.com/CamelCase.
                         Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
                         can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
                       type: string
                   required:
                   - lastTransitionTime

--- a/packages/system/capi-operator/charts/cluster-api-operator/values.schema.json
+++ b/packages/system/capi-operator/charts/cluster-api-operator/values.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "core": {
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "bootstrap": {
+      "type": "object",
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "controlPlane": {
+      "type": "object",
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "infrastructure": {
+      "type": "object",
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "addon": {
+      "type": "object",
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    },
+    "ipam": {
+      "type": "object",
+      "oneOf": [
+        { "type": "object" },
+        { "type": "null" }
+      ]
+    }
+  }
+}

--- a/packages/system/capi-operator/charts/cluster-api-operator/values.yaml
+++ b/packages/system/capi-operator/charts/cluster-api-operator/values.yaml
@@ -1,12 +1,30 @@
 ---
 # ---
 # Cluster API provider options
-core: ""
-bootstrap: ""
-controlPlane: ""
-infrastructure: ""
-ipam: ""
-addon: ""
+core: {}
+# cluster-api: {}  # Name, required
+#   namespace: ""  # Optional
+#   version: ""    # Optional
+bootstrap: {}
+# kubeadm: {}      # Name, required
+#   namespace: ""  # Optional
+#   version: ""    # Optional
+controlPlane: {}
+# kubeadm: {}      # Name, required
+#   namespace: ""  # Optional
+#   version: ""    # Optional
+infrastructure: {}
+# docker: {}  # Name, required
+#   namespace: ""  # Optional
+#   version: ""    # Optional
+addon: {}
+# helm: {}         # Name, required
+#   namespace: ""  # Optional
+#   version: ""    # Optional
+ipam: {}
+# in-cluster: {}   # Name, required
+#   namespace: ""  # Optional
+#   version: ""    # Optional
 manager.featureGates: {}
 fetchConfig: {}
 # ---
@@ -21,7 +39,7 @@ leaderElection:
 image:
   manager:
     repository: registry.k8s.io/capi-operator/cluster-api-operator
-    tag: v0.18.1
+    tag: v0.19.0
     pullPolicy: IfNotPresent
 env:
   manager: []


### PR DESCRIPTION
Reverts cozystack/cozystack#942

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for specifying manifest patches and additional manifests for all provider types, enabling more flexible customization.
  - Introduced an optional property to pass additional arguments to provider controller managers.
  - Added a JSON schema for validating chart values.

- **Enhancements**
  - Provider configuration now uses structured maps instead of strings, simplifying customization and reducing errors.
  - Improved validation and descriptions for condition fields in resource schemas.

- **Updates**
  - Upgraded Cluster API Operator chart and app versions to 0.19.0.
  - Updated default image tag for the manager container to v0.19.0.

- **Documentation**
  - Added example configurations in the values file for easier setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->