### PR TITLE
[cluster-api] Update capi-providers

### DIFF
--- a/packages/system/capi-providers/templates/providers.yaml
+++ b/packages/system/capi-providers/templates/providers.yaml
@@ -5,7 +5,7 @@ metadata:
   name: cluster-api
 spec:
   # https://github.com/kubernetes-sigs/cluster-api
-  version: v1.10.0
+  version: v1.10.1
 ---
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: ControlPlaneProvider
@@ -13,7 +13,7 @@ metadata:
   name: kamaji
 spec:
   # https://github.com/clastix/cluster-api-control-plane-provider-kamaji
-  version: v0.14.2
+  version: v0.15.1
   deployment:
     containers:
     - name: manager
@@ -31,7 +31,7 @@ metadata:
   name: kubeadm
 spec:
   # https://github.com/kubernetes-sigs/cluster-api
-  version: v1.10.0
+  version: v1.10.1
 ---
 apiVersion: operator.cluster.x-k8s.io/v1alpha2
 kind: InfrastructureProvider


### PR DESCRIPTION
v0.10.1 version fixes Bootstrap: Make joinConfiguration.discovery.bootstrapToken.token optional (https://github.com/kubernetes-sigs/cluster-api/pull/12136)

ref https://github.com/cozystack/cozystack/issues/939 and https://github.com/clastix/cluster-api-control-plane-provider-kamaji/issues/212

fixes https://github.com/cozystack/cozystack/issues/939

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the versions of cluster-api CoreProvider and kubeadm BootstrapProvider from v1.10.0 to v1.10.1.
  - Updated the version of kamaji ControlPlaneProvider from v0.14.2 to v0.15.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->