### PR TITLE
Update Kamaji to edge-25.4.1

### DIFF
--- a/packages/system/kamaji/charts/kamaji/crds/kamaji.clastix.io_datastores.yaml
+++ b/packages/system/kamaji/charts/kamaji/crds/kamaji.clastix.io_datastores.yaml
@@ -120,6 +120,9 @@ spec:
                     - PostgreSQL
                     - NATS
                   type: string
+                  x-kubernetes-validations:
+                    - message: Datastore driver is immutable
+                      rule: self == oldSelf
                 endpoints:
                   description: |-
                     List of the endpoints to connect to the shared datastore.
@@ -263,6 +266,21 @@ spec:
                 - driver
                 - endpoints
               type: object
+              x-kubernetes-validations:
+                - message: certificateAuthority privateKey must have secretReference or content when driver is etcd
+                  rule: '(self.driver == "etcd") ? (self.tlsConfig != null && (has(self.tlsConfig.certificateAuthority.privateKey.secretReference) || has(self.tlsConfig.certificateAuthority.privateKey.content))) : true'
+                - message: clientCertificate must have secretReference or content when driver is etcd
+                  rule: '(self.driver == "etcd") ? (self.tlsConfig != null && (has(self.tlsConfig.clientCertificate.certificate.secretReference) || has(self.tlsConfig.clientCertificate.certificate.content))) : true'
+                - message: clientCertificate privateKey must have secretReference or content when driver is etcd
+                  rule: '(self.driver == "etcd") ? (self.tlsConfig != null && (has(self.tlsConfig.clientCertificate.privateKey.secretReference) || has(self.tlsConfig.clientCertificate.privateKey.content))) : true'
+                - message: When driver is not etcd and tlsConfig exists, clientCertificate must be null or contain valid content
+                  rule: '(self.driver != "etcd" && has(self.tlsConfig) && has(self.tlsConfig.clientCertificate)) ? (((has(self.tlsConfig.clientCertificate.certificate.secretReference) || has(self.tlsConfig.clientCertificate.certificate.content)))) : true'
+                - message: When driver is not etcd and basicAuth exists, username must have secretReference or content
+                  rule: '(self.driver != "etcd" && has(self.basicAuth)) ? ((has(self.basicAuth.username.secretReference) || has(self.basicAuth.username.content))) : true'
+                - message: When driver is not etcd and basicAuth exists, password must have secretReference or content
+                  rule: '(self.driver != "etcd" && has(self.basicAuth)) ? ((has(self.basicAuth.password.secretReference) || has(self.basicAuth.password.content))) : true'
+                - message: When driver is not etcd, either tlsConfig or basicAuth must be provided
+                  rule: '(self.driver != "etcd") ? (has(self.tlsConfig) || has(self.basicAuth)) : true'
             status:
               description: DataStoreStatus defines the observed state of DataStore.
               properties:

--- a/packages/system/kamaji/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/packages/system/kamaji/charts/kamaji/crds/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -427,7 +427,7 @@ spec:
                                   Values defined by an Env with a duplicate key will take precedence.
                                   Cannot be updated.
                                 items:
-                                  description: EnvFromSource represents the source of a set of ConfigMaps
+                                  description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                                   properties:
                                     configMapRef:
                                       description: The ConfigMap to select from
@@ -447,7 +447,7 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
-                                      description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                      description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
                                       type: string
                                     secretRef:
                                       description: The Secret to select from
@@ -696,6 +696,12 @@ spec:
                                           - port
                                         type: object
                                     type: object
+                                  stopSignal:
+                                    description: |-
+                                      StopSignal defines which signal will be sent to a container when it is being stopped.
+                                      If not specified, the default is defined by the container runtime in use.
+                                      StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                    type: string
                                 type: object
                               livenessProbe:
                                 description: |-
@@ -1792,7 +1798,7 @@ spec:
                                   Values defined by an Env with a duplicate key will take precedence.
                                   Cannot be updated.
                                 items:
-                                  description: EnvFromSource represents the source of a set of ConfigMaps
+                                  description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
                                   properties:
                                     configMapRef:
                                       description: The ConfigMap to select from
@@ -1812,7 +1818,7 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     prefix:
-                                      description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                      description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
                                       type: string
                                     secretRef:
                                       description: The Secret to select from
@@ -2061,6 +2067,12 @@ spec:
                                           - port
                                         type: object
                                     type: object
+                                  stopSignal:
+                                    description: |-
+                                      StopSignal defines which signal will be sent to a container when it is being stopped.
+                                      If not specified, the default is defined by the container runtime in use.
+                                      StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                    type: string
                                 type: object
                               livenessProbe:
                                 description: |-
@@ -4087,7 +4099,7 @@ spec:
                                   The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                   The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
                                   The volume will be mounted read-only (ro) and non-executable files (noexec).
-                                  Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                                  Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                   The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                                 properties:
                                   pullPolicy:
@@ -5173,7 +5185,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                               Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -5188,7 +5199,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                               Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -5349,7 +5359,6 @@ spec:
                                           pod labels will be ignored. The default value is empty.
                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                         items:
                                           type: string
                                         type: array
@@ -5364,7 +5373,6 @@ spec:
                                           pod labels will be ignored. The default value is empty.
                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                         items:
                                           type: string
                                         type: array
@@ -5518,7 +5526,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                               Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -5533,7 +5540,6 @@ spec:
                                               pod labels will be ignored. The default value is empty.
                                               The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                               Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                              This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                             items:
                                               type: string
                                             type: array
@@ -5694,7 +5700,6 @@ spec:
                                           pod labels will be ignored. The default value is empty.
                                           The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                           Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                         items:
                                           type: string
                                         type: array
@@ -5709,7 +5714,6 @@ spec:
                                           pod labels will be ignored. The default value is empty.
                                           The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                           Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                          This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                         items:
                                           type: string
                                         type: array
@@ -6339,7 +6343,6 @@ spec:
                                   - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                                   If this value is nil, the behavior is equivalent to the Honor policy.
-                                  This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                 type: string
                               nodeTaintsPolicy:
                                 description: |-
@@ -6350,7 +6353,6 @@ spec:
                                   - Ignore: node taints are ignored. All nodes are included.
 
                                   If this value is nil, the behavior is equivalent to the Ignore policy.
-                                  This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                                 type: string
                               topologyKey:
                                 description: |-
@@ -7071,7 +7073,7 @@ spec:
                       description: KubernetesDeploymentStatus defines the status for the Tenant Control Plane Deployment in the management cluster.
                       properties:
                         availableReplicas:
-                          description: Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.
+                          description: Total number of available non-terminating pods (ready for at least minReadySeconds) targeted by this deployment.
                           format: int32
                           type: integer
                         collisionCount:
@@ -7129,16 +7131,24 @@ spec:
                           format: int64
                           type: integer
                         readyReplicas:
-                          description: readyReplicas is the number of pods targeted by this Deployment with a Ready Condition.
+                          description: Total number of non-terminating pods targeted by this Deployment with a Ready Condition.
                           format: int32
                           type: integer
                         replicas:
-                          description: Total number of non-terminated pods targeted by this deployment (their labels match the selector).
+                          description: Total number of non-terminating pods targeted by this deployment (their labels match the selector).
                           format: int32
                           type: integer
                         selector:
                           description: Selector is the label selector used to group the Tenant Control Plane Pods used by the scale subresource.
                           type: string
+                        terminatingReplicas:
+                          description: |-
+                            Total number of terminating pods targeted by this deployment. Terminating pods have a non-null
+                            .metadata.deletionTimestamp and have not yet reached the Failed or Succeeded .status.phase.
+
+                            This is an alpha field. Enable DeploymentReplicaSetTerminatingReplicas to be able to use this field.
+                          format: int32
+                          type: integer
                         unavailableReplicas:
                           description: |-
                             Total number of unavailable pods targeted by this deployment. This is the total number of
@@ -7147,7 +7157,7 @@ spec:
                           format: int32
                           type: integer
                         updatedReplicas:
-                          description: Total number of non-terminated pods targeted by this deployment that have the desired template spec.
+                          description: Total number of non-terminating pods targeted by this deployment that have the desired template spec.
                           format: int32
                           type: integer
                       required:
@@ -7379,6 +7389,7 @@ spec:
                             - Migrating
                             - Ready
                             - NotReady
+                            - Sleeping
                           type: string
                         version:
                           description: Version is the running Kubernetes version of the Tenant Control Plane.

--- a/packages/system/kamaji/charts/kamaji/templates/controller.yaml
+++ b/packages/system/kamaji/charts/kamaji/templates/controller.yaml
@@ -19,10 +19,6 @@ spec:
       labels:
         {{- include "kamaji.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "kamaji.serviceAccountName" . }}

--- a/packages/system/kamaji/charts/kamaji/templates/rbac.yaml
+++ b/packages/system/kamaji/charts/kamaji/templates/rbac.yaml
@@ -9,6 +9,10 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   namespace: {{ .Release.Namespace }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/packages/system/kamaji/images/kamaji/Dockerfile
+++ b/packages/system/kamaji/images/kamaji/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
-FROM golang:1.23 as builder
+FROM golang:1.24 as builder
 
-ARG VERSION=edge-25.3.2
+ARG VERSION=edge-25.4.1
 ARG TARGETOS TARGETARCH
 
 WORKDIR /workspace

--- a/packages/system/kamaji/values.yaml
+++ b/packages/system/kamaji/values.yaml
@@ -3,7 +3,7 @@ kamaji:
     deploy: false
   image:
     pullPolicy: IfNotPresent
-    tag: v0.31.0-rc.1@sha256:3ae6f1b2e42dcb9dcfbf8213029eb731197ccdbf27fdc30539d975caf32184d4
+    tag: latest@sha256:f6a33408df8d3c4223005392bcd8bae9d8c02fd73e2540bbaa911dedb7880ea8
     repository: ghcr.io/cozystack/cozystack/kamaji
   resources:
     limits:


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new validation rules to enforce stricter configuration requirements for datastore drivers and authentication fields.
  - Introduced a new field to specify stop signals for containers and a new status field to track terminating pods.
  - Added a new "Sleeping" status for version reporting.

- **Improvements**
  - Updated and clarified field descriptions for environment variable sources, volume types, and deployment status.
  - Removed outdated beta feature gate notes from documentation.

- **Bug Fixes**
  - Improved handling and validation of sensitive configuration fields based on driver type.

- **Chores**
  - Updated Go base image and Kamaji version in the Dockerfile.
  - Changed Kamaji image tag to use the latest version.

- **Refactor**
  - Moved imagePullSecrets configuration from the deployment to the ServiceAccount manifest for better management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->