### PR TITLE
[kubernetes] fix regression: return port specification

### DIFF
--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -150,7 +150,7 @@ spec:
     ingress:
       extraAnnotations:
         nginx.ingress.kubernetes.io/ssl-passthrough: "true"
-      hostname: {{ .Values.host | default (printf "%s.%s" .Release.Name $host) }}
+      hostname: {{ .Values.host | default (printf "%s.%s" .Release.Name $host) }}:443
       className: "{{ $ingress }}"
   deployment:
     podAdditionalMetadata:


### PR DESCRIPTION
This PR fixes regression from https://github.com/cozystack/cozystack/pull/867

We have updated Kamaji, removed workaround, but didn't return the port specification

Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated network configuration to explicitly include port 443 in hostnames for ingress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->