### PR TITLE
[ingress] avoid invalid externalIPs when config value is empty

### DIFF
--- a/packages/extra/ingress/templates/nginx-ingress.yaml
+++ b/packages/extra/ingress/templates/nginx-ingress.yaml
@@ -34,7 +34,7 @@ spec:
           enabled: false
         {{- end }}
         service:
-          {{- if and (eq $exposeIngress .Release.Namespace) $exposeExternalIPs }}
+          {{- if and (ne $exposeExternalIPs "") (eq $exposeIngress .Release.Namespace) }}
           externalIPs:
             {{- toYaml (splitList "," $exposeExternalIPs) | nindent 12 }}
           type: ClusterIP


### PR DESCRIPTION
Fix regression introduced by https://github.com/cozystack/cozystack/pull/929#discussion_r2090992853

becasue of `splitList "," "" == [""]`

Signed-off-by: Andrei Kvapil <kvapss@gmail.com>
