### PR TITLE
Revert "[ingress] avoid invalid externalIPs when config value is empty"

### DIFF
--- a/packages/extra/ingress/templates/nginx-ingress.yaml
+++ b/packages/extra/ingress/templates/nginx-ingress.yaml
@@ -34,7 +34,7 @@ spec:
           enabled: false
         {{- end }}
         service:
-          {{- if and (ne $exposeExternalIPs "") (eq $exposeIngress .Release.Namespace) }}
+          {{- if and (eq $exposeIngress .Release.Namespace) $exposeExternalIPs }}
           externalIPs:
             {{- toYaml (splitList "," $exposeExternalIPs) | nindent 12 }}
           type: ClusterIP


### PR DESCRIPTION
Reverts cozystack/cozystack#957. This was already fixed by https://github.com/cozystack/cozystack/pull/952