### PR TITLE
[e2e] Return genisoimage to the e2e-test Dockerfile

### DIFF
--- a/packages/core/testing/images/e2e-sandbox/Dockerfile
+++ b/packages/core/testing/images/e2e-sandbox/Dockerfile
@@ -8,7 +8,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN apt update -q
-RUN apt install -yq --no-install-recommends ca-certificates qemu-kvm qemu-utils iproute2 iptables wget xz-utils netcat curl jq make git
+RUN apt install -yq --no-install-recommends genisoimage ca-certificates qemu-kvm qemu-utils iproute2 iptables wget xz-utils netcat curl jq make git
 RUN curl -sSL "https://github.com/siderolabs/talos/releases/download/v${TALOSCTL_VERSION}/talosctl-${TARGETOS}-${TARGETARCH}" -o /usr/local/bin/talosctl \
  && chmod +x /usr/local/bin/talosctl
 RUN curl -sSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl" -o /usr/local/bin/kubectl \


### PR DESCRIPTION
commit 7a7512da308eeb8559577bb9f901bebf04f29269 removed genisoimage package installation from Dockerfile which leds to test fail due to the fact that genisoimage is missing and runner enable to create image. [issue reference](https://github.com/cozystack/cozystack/actions/runs/15084476654/job/42406141954).
restored genisoimage package installation in Dockerfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added the ability to create ISO images within the container environment by including the genisoimage package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->