### PR TITLE
[kubernetes] Fix Ingress-NGINX depends on Cert-Manager

### DIFF
--- a/packages/apps/kubernetes/Chart.yaml
+++ b/packages/apps/kubernetes/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.0
+version: 0.20.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/kubernetes/templates/helmreleases/ingress-nginx.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/ingress-nginx.yaml
@@ -6,6 +6,11 @@ ingress-nginx:
     hostNetwork: true
     service:
       enabled: false
+    {{- if not .Values.addons.certManager.enabled }}
+    admissionWebhooks:
+      certManager:
+        enabled: false
+    {{- end }}
   nodeSelector:
     node-role.kubernetes.io/ingress-nginx: ""
 {{- end }}

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -64,7 +64,8 @@ kubernetes 0.17.0 1fbbfcd0
 kubernetes 0.17.1 fd240701
 kubernetes 0.18.0 721c12a7
 kubernetes 0.19.0 93bdf411
-kubernetes 0.20.0 HEAD
+kubernetes 0.20.0 609e7ede
+kubernetes 0.20.1 HEAD
 mysql 0.1.0 263e47be
 mysql 0.2.0 c24a103f
 mysql 0.3.0 53f2365e


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration to automatically disable admission webhooks for cert-manager when the cert-manager addon is not enabled, preventing unnecessary webhook setup.

- **Chores**
  - Updated Kubernetes chart version to 0.20.1.
  - Updated version mapping for the Kubernetes package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->