### PR TITLE
[apps] Add `topologySpreadConstraints` for managed PostgreSQL and tenant Kubernetes clusters.

### DIFF
--- a/packages/apps/ferretdb/templates/postgres.yaml
+++ b/packages/apps/ferretdb/templates/postgres.yaml
@@ -11,6 +11,9 @@ spec:
   {{- $rawConstraints := get $configMap.data "globalAppTopologySpreadConstraints" }}
   {{- if $rawConstraints }}
   {{- $rawConstraints | fromYaml | toYaml | nindent 2 }}
+    labelSelector:
+      matchLabels:
+        cnpg.io/cluster: {{ .Release.Name }}-postgres
   {{- end }}
   {{- end }}
   minSyncReplicas: {{ .Values.quorum.minSyncReplicas }}

--- a/packages/apps/kubernetes/Chart.yaml
+++ b/packages/apps/kubernetes/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.20.1
+version: 0.21.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -31,6 +31,16 @@ spec:
             {{- end }}
             cluster.x-k8s.io/deployment-name: {{ $.Release.Name }}-{{ .groupName }}
         spec:
+          {{- $configMap := lookup "v1" "ConfigMap" "cozy-system" "cozystack-scheduling" }}
+          {{- if $configMap }}
+          {{- $rawConstraints := get $configMap.data "globalAppTopologySpreadConstraints" }}
+          {{- if $rawConstraints }}
+          {{- $rawConstraints | fromYaml | toYaml | nindent 10 }}
+            labelSelector:
+              matchLabels:
+                cluster.x-k8s.io/cluster-name: {{ $.Release.Name }}
+          {{- end }}
+          {{- end }}
           domain:
             {{- if and .group.resources .group.resources.cpu }}
             cpu:

--- a/packages/apps/postgres/Chart.yaml
+++ b/packages/apps/postgres/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.11.0
+version: 0.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/postgres/templates/db.yaml
+++ b/packages/apps/postgres/templates/db.yaml
@@ -17,6 +17,9 @@ spec:
   {{- $rawConstraints := get $configMap.data "globalAppTopologySpreadConstraints" }}
   {{- if $rawConstraints }}
   {{- $rawConstraints | fromYaml | toYaml | nindent 2 }}
+    labelSelector:
+      matchLabels:
+        cnpg.io/cluster: {{ .Release.Name }}
   {{- end }}
   {{- end }}
   postgresql:

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -65,7 +65,8 @@ kubernetes 0.17.1 fd240701
 kubernetes 0.18.0 721c12a7
 kubernetes 0.19.0 93bdf411
 kubernetes 0.20.0 609e7ede
-kubernetes 0.20.1 HEAD
+kubernetes 0.20.1 f9f8bb2f
+kubernetes 0.21.0 HEAD
 mysql 0.1.0 263e47be
 mysql 0.2.0 c24a103f
 mysql 0.3.0 53f2365e
@@ -99,7 +100,8 @@ postgres 0.8.0 4e68e65c
 postgres 0.9.0 8267072d
 postgres 0.10.0 721c12a7
 postgres 0.10.1 93bdf411
-postgres 0.11.0 HEAD
+postgres 0.11.0 f9f8bb2f
+postgres 0.12.0 HEAD
 rabbitmq 0.1.0 263e47be
 rabbitmq 0.2.0 53f2365e
 rabbitmq 0.3.0 6c5cf5bf

--- a/packages/extra/monitoring/Chart.yaml
+++ b/packages/extra/monitoring/Chart.yaml
@@ -3,4 +3,4 @@ name: monitoring
 description: Monitoring and observability stack
 icon: /logos/monitoring.svg
 type: application
-version: 1.9.2
+version: 1.10.0

--- a/packages/extra/monitoring/templates/alerta/alerta-db.yaml
+++ b/packages/extra/monitoring/templates/alerta/alerta-db.yaml
@@ -10,6 +10,9 @@ spec:
   {{- $rawConstraints := get $configMap.data "globalAppTopologySpreadConstraints" }}
   {{- if $rawConstraints }}
   {{- $rawConstraints | fromYaml | toYaml | nindent 2 }}
+    labelSelector:
+      matchLabels:
+        cnpg.io/cluster: alerta-db
   {{- end }}
   {{- end }}
   storage:

--- a/packages/extra/monitoring/templates/grafana/db.yaml
+++ b/packages/extra/monitoring/templates/grafana/db.yaml
@@ -11,6 +11,9 @@ spec:
   {{- $rawConstraints := get $configMap.data "globalAppTopologySpreadConstraints" }}
   {{- if $rawConstraints }}
   {{- $rawConstraints | fromYaml | toYaml | nindent 2 }}
+    labelSelector:
+      matchLabels:
+        cnpg.io/cluster: grafana-db
   {{- end }}
   {{- end }}
   monitoring:

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -38,7 +38,8 @@ monitoring 1.8.0 8c460528
 monitoring 1.8.1 8267072d
 monitoring 1.9.0 45a7416c
 monitoring 1.9.1 fd240701
-monitoring 1.9.2 HEAD
+monitoring 1.9.2 f9f8bb2f
+monitoring 1.10.0 HEAD
 seaweedfs 0.1.0 71514249
 seaweedfs 0.2.0 5fb9cfe3
 seaweedfs 0.2.1 fde4bcfa

--- a/packages/system/keycloak/templates/db.yaml
+++ b/packages/system/keycloak/templates/db.yaml
@@ -11,6 +11,9 @@ spec:
   {{- $rawConstraints := get $configMap.data "globalAppTopologySpreadConstraints" }}
   {{- if $rawConstraints }}
   {{- $rawConstraints | fromYaml | toYaml | nindent 2 }}
+    labelSelector:
+      matchLabels:
+        cnpg.io/cluster: keycloak-db
   {{- end }}
   {{- end }}
   monitoring:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for injecting custom topology spread constraints into virtual machine templates, PostgreSQL clusters, and monitoring components based on a ConfigMap in the cluster.

- **Chores**
  - Updated chart versions for Kubernetes (0.21.0), Postgres (0.12.0), and Monitoring (1.10.0).
  - Updated version mappings for Kubernetes, Postgres, and Monitoring packages.
  - Increased memory allocation for QEMU virtual machine tests from 8 GB to 14 GB.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->