### PR TITLE
[dx] fix version_map generator to exclude duplicates

### DIFF
--- a/hack/gen_versions_map.sh
+++ b/hack/gen_versions_map.sh
@@ -61,4 +61,4 @@ resolved_miss_map=$(
   done < $miss_map
 )
 
-printf "%s\n" "$new_map" "$resolved_miss_map" | sort -k1,1 -k2,2 -V | awk '$1' > "$file"
+printf "%s\n" "$new_map" "$resolved_miss_map" | sort -k1,1 -k2,2 -V | awk '!seen[$1, $2]++' > "$file"


### PR DESCRIPTION
This PR fixes duplicates generation in version_map:
![](https://github.com/user-attachments/assets/bfcafc87-9d81-430e-b961-7b0bd8867a24)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Bug Fixes**
	- Improved deduplication in the generated versions map to ensure only unique chart-version pairs are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->