### PR TITLE
[virtual-machine] fix: specify ports even for wholeIP mode

### DIFF
--- a/packages/apps/virtual-machine/templates/service.yaml
+++ b/packages/apps/virtual-machine/templates/service.yaml
@@ -17,7 +17,7 @@ spec:
   selector:
     {{- include "virtual-machine.selectorLabels" . | nindent 4 }}
   ports:
-    {{- if eq .Values.externalMethod "WholeIP" }}
+    {{- if and (eq .Values.externalMethod "WholeIP") (not .Values.externalPorts) }}
     - port: 65535
     {{- else }}
     {{- range .Values.externalPorts }}

--- a/packages/apps/vm-instance/templates/service.yaml
+++ b/packages/apps/vm-instance/templates/service.yaml
@@ -17,7 +17,7 @@ spec:
   selector:
     {{- include "virtual-machine.selectorLabels" . | nindent 4 }}
   ports:
-    {{- if eq .Values.externalMethod "WholeIP" }}
+    {{- if and (eq .Values.externalMethod "WholeIP") (not .Values.externalPorts) }}
     - port: 65535
     {{- else }}
     {{- range .Values.externalPorts }}


### PR DESCRIPTION
There is an issue with wholeIP services: internal communication from pods doesn't work as expected.

Cilium intercepts pod-to-pod traffic, preventing cozy-proxy from rewriting the source IP in return packets.

This PR allows Cilium to handle specified ports, enabling hairpin traffic to work correctly at least for these cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved service port configuration to ensure explicit port definitions are respected when using the "WholeIP" method. Now, custom external ports will not be overridden, providing more accurate and expected service exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->