### PR TITLE
Update Flux operator to 0.21.0, Flux to 2.6.0

### DIFF
--- a/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.20.0
+appVersion: v0.21.0
 description: 'A Helm chart for deploying the Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.20.0
+version: 0.21.0

--- a/packages/system/fluxcd-operator/charts/flux-operator/README.md
+++ b/packages/system/fluxcd-operator/charts/flux-operator/README.md
@@ -1,6 +1,6 @@
 # flux-operator
 
-![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.20.0](https://img.shields.io/badge/AppVersion-v0.20.0-informational?style=flat-square)
+![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.21.0](https://img.shields.io/badge/AppVersion-v0.21.0-informational?style=flat-square)
 
 The [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator) provides a
 declarative API for the installation and upgrade of CNCF [Flux](https://fluxcd.io) and the

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
@@ -484,6 +484,9 @@ spec:
                 type: string
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: the only accepted name for a FluxInstance is 'flux'
+          rule: self.metadata.name == 'flux'
     served: true
     storage: true
     subresources:
@@ -553,6 +556,22 @@ spec:
           spec:
             description: FluxReportSpec defines the observed state of a Flux installation.
             properties:
+              cluster:
+                description: Cluster is the version information of the Kubernetes
+                  cluster.
+                properties:
+                  nodes:
+                    description: Nodes is the number of nodes in the Kubernetes cluster.
+                    type: integer
+                  platform:
+                    description: Platform is the os/arch of the Kubernetes control
+                      plane.
+                    type: string
+                  serverVersion:
+                    description: ServerVersion is the version of the Kubernetes API
+                      server.
+                    type: string
+                type: object
               components:
                 description: ComponentsStatus is the status of the Flux controller
                   deployments.
@@ -748,6 +767,9 @@ spec:
                 type: string
             type: object
         type: object
+        x-kubernetes-validations:
+        - message: the only accepted name for a FluxReport is 'flux'
+          rule: self.metadata.name == 'flux'
     served: true
     storage: true
     subresources:
@@ -893,6 +915,7 @@ spec:
               type:
                 description: Type specifies the type of the input provider.
                 enum:
+                - Static
                 - GitHubBranch
                 - GitHubPullRequest
                 - GitLabBranch
@@ -902,12 +925,16 @@ spec:
                 description: |-
                   URL specifies the HTTP/S address of the input provider API.
                   When connecting to a Git provider, the URL should point to the repository address.
-                pattern: ^(http|https)://.*$
+                pattern: ^((http|https)://.*){0,1}$
                 type: string
             required:
             - type
-            - url
             type: object
+            x-kubernetes-validations:
+            - message: spec.url must be empty when spec.type is 'Static'
+              rule: self.type != 'Static' || !has(self.url)
+            - message: spec.url must not be empty when spec.type is not 'Static'
+              rule: self.type == 'Static' || has(self.url)
           status:
             description: ResourceSetInputProviderStatus defines the observed state
               of ResourceSetInputProvider.
@@ -1136,12 +1163,68 @@ spec:
                       - ResourceSetInputProvider
                       type: string
                     name:
-                      description: Name of the input provider resource.
+                      description: |-
+                        Name of the input provider resource. Cannot be set
+                        when the Selector field is set.
                       type: string
+                    selector:
+                      description: |-
+                        Selector is a label selector to filter the input provider resources
+                        as an alternative to the Name field.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
                   required:
                   - kind
-                  - name
                   type: object
+                  x-kubernetes-validations:
+                  - message: at least one of name or selector must be set for input
+                      provider references
+                    rule: has(self.name) || has(self.selector)
+                  - message: cannot set both name and selector for input provider
+                      references
+                    rule: '!has(self.name) || !has(self.selector)'
                 type: array
               resources:
                 description: Resources contains the list of Kubernetes resources to

--- a/packages/system/fluxcd/charts/flux-instance/Chart.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.20.0
+appVersion: v0.21.0
 description: 'A Helm chart for deploying a Flux instance managed by Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.20.0
+version: 0.21.0

--- a/packages/system/fluxcd/charts/flux-instance/README.md
+++ b/packages/system/fluxcd/charts/flux-instance/README.md
@@ -1,6 +1,6 @@
 # flux-instance
 
-![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.20.0](https://img.shields.io/badge/AppVersion-v0.20.0-informational?style=flat-square)
+![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.21.0](https://img.shields.io/badge/AppVersion-v0.21.0-informational?style=flat-square)
 
 This chart is a thin wrapper around the `FluxInstance` custom resource, which is
 used by the [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator)

--- a/packages/system/fluxcd/values.yaml
+++ b/packages/system/fluxcd/values.yaml
@@ -5,7 +5,7 @@ flux-instance:
       domain: cozy.local # -- default value is overriden in patches
     distribution:
       artifact: ""
-      version: 2.5.x
+      version: 2.6.x
       registry: ghcr.io/fluxcd
     components:
       - source-controller


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced resource validation for FluxInstance and FluxReport, enforcing specific resource names.
  - Added Kubernetes cluster version details to FluxReport.
  - Introduced a new static input provider type with conditional URL requirements.
  - Improved input provider referencing in ResourceSet to support label selectors with mutual exclusivity validation.

- **Chores**
  - Updated Helm chart versions and documentation badges to 0.21.0.
  - Updated FluxCD distribution version to 2.6.x.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->