### PR TITLE
Fixed Gateway API manifest

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/gateway-api-crds.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/gateway-api-crds.yaml
@@ -17,6 +17,7 @@ spec:
         kind: HelmRepository
         name: cozystack-system
         namespace: cozy-system
+      version: '>= 0.0.0-0'
   kubeConfig:
     secretRef:
       name: {{ .Release.Name }}-admin-kubeconfig


### PR DESCRIPTION
In current version of Cozystack, flux's HelmRelease will refuse to install cozy-gateway-api-crds when gatewayAPI enabled, complaining version '*'not found and breaking install of entire kubernetes app. This patch adds working version match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to allow compatibility with all available versions of the gateway-api-crds chart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->