### PR TITLE
[platform] Introduce cluster-domain option and unhardcode cozy.local

### DIFF
--- a/packages/apps/clickhouse/Chart.yaml
+++ b/packages/apps/clickhouse/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.1
+version: 0.9.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/clickhouse/templates/clickhouse.yaml
+++ b/packages/apps/clickhouse/templates/clickhouse.yaml
@@ -1,3 +1,5 @@
+{{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
+{{- $clusterDomain := (index $cozyConfig.data "cluster-domain") | default "cozy.local" }}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-credentials" .Release.Name) }}
 {{- $passwords := dict }}
 {{- $users := .Values.users }}
@@ -32,7 +34,7 @@ kind: "ClickHouseInstallation"
 metadata:
   name: "{{ .Release.Name }}"
 spec:
-  namespaceDomainPattern:  "%s.svc.cozy.local"
+  namespaceDomainPattern:  "%s.svc.{{ $clusterDomain }}"
   defaults:
     templates:
       dataVolumeClaimTemplate: data-volume-template

--- a/packages/apps/kubernetes/Chart.yaml
+++ b/packages/apps/kubernetes/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.23.0
+version: 0.23.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/kubernetes/templates/helmreleases/vertical-pod-autoscaler.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/vertical-pod-autoscaler.yaml
@@ -1,4 +1,6 @@
 {{- define "cozystack.defaultVPAValues" -}}
+{{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
+{{- $clusterDomain := (index $cozyConfig.data "cluster-domain") | default "cozy.local" }}
 {{- $myNS := lookup "v1" "Namespace" "" .Release.Namespace }}
 {{- $targetTenant := index $myNS.metadata.annotations "namespace.cozystack.io/monitoring" }}
 vertical-pod-autoscaler:
@@ -13,7 +15,7 @@ vertical-pod-autoscaler:
       metric-for-pod-labels: kube_pod_labels{job="kube-state-metrics", tenant="{{ .Release.Namespace }}", cluster="{{ .Release.Name }}"}[8d]
       pod-name-label: pod
       pod-namespace-label: namespace
-      prometheus-address: http://vmselect-shortterm.{{ $targetTenant }}.svc.cozy.local:8481/select/0/prometheus/
+      prometheus-address: http://vmselect-shortterm.{{ $targetTenant }}.svc.{{ $clusterDomain }}:8481/select/0/prometheus/
       prometheus-cadvisor-job-name: cadvisor
     resources:
       limits:

--- a/packages/apps/nats/Chart.yaml
+++ b/packages/apps/nats/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/nats/templates/nats.yaml
+++ b/packages/apps/nats/templates/nats.yaml
@@ -1,3 +1,5 @@
+{{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
+{{- $clusterDomain := (index $cozyConfig.data "cluster-domain") | default "cozy.local" }}
 {{- $passwords := dict }}
 {{- range $user, $u := .Values.users }}
   {{- if $u.password }}
@@ -51,6 +53,9 @@ spec:
                 {{- end }}
       fullnameOverride: {{ .Release.Name }}
       config:
+        cluster:
+          routeURLs:
+            k8sClusterDomain: {{ $clusterDomain }}
         {{- if or (gt (len $passwords) 0) (gt (len .Values.config.merge) 0) }}
         merge:
           {{- if gt (len $passwords) 0 }}

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -10,7 +10,7 @@ clickhouse 0.6.1 c62a83a7
 clickhouse 0.6.2 8267072d
 clickhouse 0.7.0 93bdf411
 clickhouse 0.9.0 6130f43d
-clickhouse 0.9.1 HEAD
+clickhouse 0.9.2 HEAD
 ferretdb 0.1.0 e9716091
 ferretdb 0.1.1 91b0499a
 ferretdb 0.2.0 6c5cf5bf
@@ -71,7 +71,7 @@ kubernetes 0.19.0 93bdf411
 kubernetes 0.20.0 609e7ede
 kubernetes 0.20.1 f9f8bb2f
 kubernetes 0.21.0 6130f43d
-kubernetes 0.23.0 HEAD
+kubernetes 0.23.1 HEAD
 mysql 0.1.0 263e47be
 mysql 0.2.0 c24a103f
 mysql 0.3.0 53f2365e
@@ -90,7 +90,8 @@ nats 0.3.1 c62a83a7
 nats 0.4.0 898374b5
 nats 0.4.1 8267072d
 nats 0.5.0 93bdf411
-nats 0.6.0 HEAD
+nats 0.6.0 6130f43d
+nats 0.6.1 HEAD
 postgres 0.1.0 263e47be
 postgres 0.2.0 53f2365e
 postgres 0.2.1 d7cfa53c

--- a/packages/core/platform/bundles/distro-full.yaml
+++ b/packages/core/platform/bundles/distro-full.yaml
@@ -1,4 +1,5 @@
 {{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
+{{- $clusterDomain := (index $cozyConfig.data "cluster-domain") | default "cozy.local" }}
 
 releases:
 - name: fluxcd-operator
@@ -13,6 +14,11 @@ releases:
   chart: cozy-fluxcd
   namespace: cozy-fluxcd
   dependsOn: [fluxcd-operator,cilium]
+  values:
+    flux-instance:
+      instance:
+        cluster:
+          domain: {{ $clusterDomain }}
 
 - name: cilium
   releaseName: cilium
@@ -121,6 +127,9 @@ releases:
   namespace: cozy-mariadb-operator
   optional: true
   dependsOn: [cilium,cert-manager,victoria-metrics-operator]
+  values:
+    mariadb-operator:
+      clusterName: {{ $clusterDomain }}
 
 - name: postgres-operator
   releaseName: postgres-operator
@@ -135,6 +144,9 @@ releases:
   namespace: cozy-kafka-operator
   optional: true
   dependsOn: [cilium,victoria-metrics-operator]
+  values:
+    strimzi-kafka-operator:
+      kubernetesServiceDnsDomain: {{ $clusterDomain }}
 
 - name: clickhouse-operator
   releaseName: clickhouse-operator

--- a/packages/core/platform/bundles/distro-hosted.yaml
+++ b/packages/core/platform/bundles/distro-hosted.yaml
@@ -1,4 +1,5 @@
 {{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
+{{- $clusterDomain := (index $cozyConfig.data "cluster-domain") | default "cozy.local" }}
 
 releases:
 - name: fluxcd-operator
@@ -13,6 +14,11 @@ releases:
   chart: cozy-fluxcd
   namespace: cozy-fluxcd
   dependsOn: [fluxcd-operator]
+  values:
+    flux-instance:
+      instance:
+        cluster:
+          domain: {{ $clusterDomain }}
 
 - name: cert-manager-crds
   releaseName: cert-manager-crds
@@ -83,6 +89,9 @@ releases:
   namespace: cozy-mariadb-operator
   optional: true
   dependsOn: [victoria-metrics-operator]
+  values:
+    mariadb-operator:
+      clusterName: {{ $clusterDomain }}
 
 - name: postgres-operator
   releaseName: postgres-operator
@@ -97,6 +106,9 @@ releases:
   namespace: cozy-kafka-operator
   optional: true
   dependsOn: [victoria-metrics-operator]
+  values:
+    strimzi-kafka-operator:
+      kubernetesServiceDnsDomain: {{ $clusterDomain }}
 
 - name: clickhouse-operator
   releaseName: clickhouse-operator

--- a/packages/core/platform/bundles/paas-full.yaml
+++ b/packages/core/platform/bundles/paas-full.yaml
@@ -1,4 +1,5 @@
 {{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
+{{- $clusterDomain := (index $cozyConfig.data "cluster-domain") | default "cozy.local" }}
 {{- $oidcEnabled := index $cozyConfig.data "oidc-enabled" }}
 {{- $host := index $cozyConfig.data "root-host" }}
 {{- if not $host }}
@@ -22,6 +23,11 @@ releases:
   chart: cozy-fluxcd
   namespace: cozy-fluxcd
   dependsOn: [fluxcd-operator,cilium,kubeovn]
+  values:
+    flux-instance:
+      instance:
+        cluster:
+          domain: {{ $clusterDomain }}
 
 - name: cilium
   releaseName: cilium
@@ -193,6 +199,9 @@ releases:
   chart: cozy-mariadb-operator
   namespace: cozy-mariadb-operator
   dependsOn: [cilium,kubeovn,cert-manager,victoria-metrics-operator]
+  values:
+    mariadb-operator:
+      clusterName: {{ $clusterDomain }}
 
 - name: postgres-operator
   releaseName: postgres-operator
@@ -205,6 +214,9 @@ releases:
   chart: cozy-kafka-operator
   namespace: cozy-kafka-operator
   dependsOn: [cilium,kubeovn,victoria-metrics-operator]
+  values:
+    strimzi-kafka-operator:
+      kubernetesServiceDnsDomain: {{ $clusterDomain }}
 
 - name: clickhouse-operator
   releaseName: clickhouse-operator
@@ -370,6 +382,11 @@ releases:
   namespace: cozy-vertical-pod-autoscaler
   privileged: true
   dependsOn: [monitoring-agents]
+  values:
+    vertical-pod-autoscaler:
+      recommender:
+        extraArgs:
+          prometheus-address: http://vmselect-shortterm.tenant-root.svc.{{ $clusterDomain }}:8481/select/0/prometheus/
 
 - name: vertical-pod-autoscaler-crds
   releaseName: vertical-pod-autoscaler-crds

--- a/packages/core/platform/bundles/paas-hosted.yaml
+++ b/packages/core/platform/bundles/paas-hosted.yaml
@@ -1,4 +1,5 @@
 {{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
+{{- $clusterDomain := (index $cozyConfig.data "cluster-domain") | default "cozy.local" }}
 {{- $oidcEnabled := index $cozyConfig.data "oidc-enabled" }}
 {{- $host := index $cozyConfig.data "root-host" }}
 {{- if not $host }}
@@ -22,6 +23,11 @@ releases:
   chart: cozy-fluxcd
   namespace: cozy-fluxcd
   dependsOn: [fluxcd-operator]
+  values:
+    flux-instance:
+      instance:
+        cluster:
+          domain: {{ $clusterDomain }}
 
 - name: cert-manager-crds
   releaseName: cert-manager-crds
@@ -92,6 +98,9 @@ releases:
   chart: cozy-mariadb-operator
   namespace: cozy-mariadb-operator
   dependsOn: [cert-manager,victoria-metrics-operator]
+  values:
+    mariadb-operator:
+      clusterName: {{ $clusterDomain }}
 
 - name: postgres-operator
   releaseName: postgres-operator
@@ -104,6 +113,9 @@ releases:
   chart: cozy-kafka-operator
   namespace: cozy-kafka-operator
   dependsOn: [victoria-metrics-operator]
+  values:
+    strimzi-kafka-operator:
+      kubernetesServiceDnsDomain: {{ $clusterDomain }}
 
 - name: clickhouse-operator
   releaseName: clickhouse-operator
@@ -206,6 +218,11 @@ releases:
   namespace: cozy-vertical-pod-autoscaler
   privileged: true
   dependsOn: [monitoring-agents]
+  values:
+    vertical-pod-autoscaler:
+      recommender:
+        extraArgs:
+          prometheus-address: http://vmselect-shortterm.tenant-root.svc.{{ $clusterDomain }}:8481/select/0/prometheus/
 
 - name: vertical-pod-autoscaler-crds
   releaseName: vertical-pod-autoscaler-crds

--- a/packages/system/keycloak/templates/sts.yaml
+++ b/packages/system/keycloak/templates/sts.yaml
@@ -1,5 +1,6 @@
 {{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
 {{- $host := index $cozyConfig.data "root-host" }}
+{{- $clusterDomain := (index $cozyConfig.data "cluster-domain") | default "cozy.local" }}
 
 {{- $existingPassword := lookup "v1" "Secret" "cozy-keycloak" (printf "%s-credentials" .Release.Name) }}
 {{- $password := randAlphaNum 16 -}}
@@ -113,7 +114,7 @@ spec:
             - name: KC_HOSTNAME
               value: https://keycloak.{{ $host }}
             - name: JAVA_OPTS_APPEND
-              value: "-Djgroups.dns.query=keycloak-headless.cozy-keycloak.svc.cozy.local"
+              value: "-Djgroups.dns.query=keycloak-headless.cozy-keycloak.svc.{{ $clusterDomain }}"
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dynamic cluster domain configuration is now propagated to multiple components, allowing them to use the cluster domain value from a central ConfigMap instead of a hardcoded value.
  - The cluster domain is now injected into ClickHouse, Kubernetes, NATS, Keycloak, and various operator releases for improved flexibility and consistency.

- **Chores**
  - Updated chart versions for ClickHouse, Kubernetes, and NATS applications.
  - Refreshed version references in the versions map to reflect the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->