### PR TITLE
[kafka] specify mimimal working resource presets

### DIFF
--- a/packages/apps/kafka/Chart.yaml
+++ b/packages/apps/kafka/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/kafka/README.md
+++ b/packages/apps/kafka/README.md
@@ -14,9 +14,9 @@
 | `zookeeper.replicas`        | Number of ZooKeeper replicas                                                                                                                                                                                      | `3`     |
 | `zookeeper.storageClass`    | StorageClass used to store the ZooKeeper data                                                                                                                                                                     | `""`    |
 | `kafka.resources`           | Resources                                                                                                                                                                                                         | `{}`    |
-| `kafka.resourcesPreset`     | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`  |
+| `kafka.resourcesPreset`     | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `small` |
 | `zookeeper.resources`       | Resources                                                                                                                                                                                                         | `{}`    |
-| `zookeeper.resourcesPreset` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `nano`  |
+| `zookeeper.resourcesPreset` | Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production). | `micro` |
 
 ### Configuration parameters
 

--- a/packages/apps/kafka/values.schema.json
+++ b/packages/apps/kafka/values.schema.json
@@ -33,7 +33,7 @@
                 "resourcesPreset": {
                     "type": "string",
                     "description": "Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production).",
-                    "default": "nano"
+                    "default": "small"
                 }
             }
         },
@@ -63,7 +63,7 @@
                 "resourcesPreset": {
                     "type": "string",
                     "description": "Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production).",
-                    "default": "nano"
+                    "default": "micro"
                 }
             }
         },

--- a/packages/apps/kafka/values.yaml
+++ b/packages/apps/kafka/values.yaml
@@ -25,7 +25,7 @@ kafka:
   #     memory: 512Mi
   
   ## @param kafka.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production).
-  resourcesPreset: "nano"
+  resourcesPreset: "small"
 
 zookeeper:
   size: 5Gi
@@ -42,7 +42,7 @@ zookeeper:
   #     memory: 512Mi
   
   ## @param zookeeper.resourcesPreset Set container resources according to one common preset (allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge). This is ignored if resources is set (resources is recommended for production).
-  resourcesPreset: "nano"
+  resourcesPreset: "micro"
 
 ## @section Configuration parameters
 

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -39,7 +39,8 @@ kafka 0.3.2 93c46161
 kafka 0.3.3 8267072d
 kafka 0.4.0 85ec09b8
 kafka 0.5.0 93bdf411
-kafka 0.6.0 HEAD
+kafka 0.6.0 6130f43d
+kafka 0.6.1 HEAD
 kubernetes 0.1.0 263e47be
 kubernetes 0.2.0 53f2365e
 kubernetes 0.3.0 007d414f


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated default resource presets for Kafka (now "small") and ZooKeeper (now "micro") to provide improved baseline resources.
- **Documentation**
  - Updated documentation to reflect new default resource presets for Kafka and ZooKeeper.
- **Chores**
  - Incremented Kafka chart version to 0.6.1 and updated version mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->