### PR TITLE
[dashboard] Cumulative update

### DIFF
--- a/packages/core/platform/templates/_helpers.tpl
+++ b/packages/core/platform/templates/_helpers.tpl
@@ -69,4 +69,10 @@ kubeapps:
       .appview-first-row section[aria-labelledby="access-urls-title"] {
         width: 100%;
       }
+      .header-version {
+        display: none;
+      }
+      .label.label-info-secondary {
+        display: none;
+      }
 {{- end }}

--- a/packages/system/dashboard/images/dashboard/Dockerfile
+++ b/packages/system/dashboard/images/dashboard/Dockerfile
@@ -1,7 +1,7 @@
 FROM bitnami/node:20.15.1 AS build
 WORKDIR /app
 
-ARG COMMIT_REF=190ea544aeb0be74bb6d1aa4bb474910559e7ecd
+ARG COMMIT_REF=d89e721fcb3130de6027251b1befb0208fdbeb85
 RUN wget -O- https://github.com/cozystack/kubeapps/archive/${COMMIT_REF}.tar.gz | tar xzf - --strip-components=2 kubeapps-${COMMIT_REF}/dashboard
 
 RUN yarn install --frozen-lockfile

--- a/packages/system/dashboard/images/kubeapps-apis/Dockerfile
+++ b/packages/system/dashboard/images/kubeapps-apis/Dockerfile
@@ -4,7 +4,7 @@
 # syntax = docker/dockerfile:1
 
 FROM alpine AS source
-ARG COMMIT_REF=dd02680d796c962b8dcc4e5ea70960a846c1acdc
+ARG COMMIT_REF=d89e721fcb3130de6027251b1befb0208fdbeb85
 RUN apk add --no-cache patch
 WORKDIR /source
 RUN wget -O- https://github.com/cozystack/kubeapps/archive/${COMMIT_REF}.tar.gz | tar xzf - --strip-components=1

--- a/packages/system/dashboard/values.yaml
+++ b/packages/system/dashboard/values.yaml
@@ -32,6 +32,8 @@ kubeapps:
           memory: 256Mi
   kubeappsapis:
     resourcesPreset: "none"
+    qps: "250.0"
+    burst: "500"
     image:
       registry: ghcr.io/cozystack/cozystack
       repository: kubeapps-apis


### PR DESCRIPTION
This PR includes fixes and updates for cozystack dashboard:

### [fix client rate limiter](https://github.com/cozystack/kubeapps/commit/b1467cecc1fc1f570e7a1da97b8597b4ee6f110f)

fixes the error `client rate limiter Wait returned an error: context canceled`
The QPS and Burst options were set after the kubernetes client initalized and had no effect

The limits are also increased fivefold:

```diff
-         - --kube-api-qps=50.0
-         - --kube-api-burst=100
+         - --kube-api-qps=250.0
+         - --kube-api-burst=500
```


### [fix relative urls](https://github.com/cozystack/kubeapps/commit/e2153e26ddbb78c1b0ddcd47c4dcf9e38834a8ac)

Fixes regression introduced in https://github.com/cozystack/cozystack/pull/935 which suddenly removed previus workaround https://github.com/cozystack/cozystack/pull/102

Now the proper fix prepared.

Related to upstream issue https://github.com/vmware-tanzu/kubeapps/issues/7740 

### [remove version selector](https://github.com/cozystack/kubeapps/commit/f412a6aba4a1589785fc46ac459f9ab99582ef5b)

from both package insallation page and upgrading page
<img width="505" alt="Screenshot 2025-06-10 at 1 47 10" src="https://github.com/user-attachments/assets/36068264-2878-4b82-a159-6c911f1c1eef" />

now it always will default to the latest package version

### [always fetch details from the latest version](https://github.com/cozystack/kubeapps/commit/741a7ddb9326d5916917991617ea624d9a5edc01)

If old package version installed it will display information from the latest package in repository. This and previus fix actually remove the need for having versions_map logic and pack multiple charts for the release. But informs user about newer versions and allows to perform upgrade on demand in specific time:

<img width="423" alt="Screenshot 2025-06-10 at 1 52 53" src="https://github.com/user-attachments/assets/dd571c9f-c2bc-403f-9aa0-3d8853600241" />

### [Remove plugin name from header]https://github.com/cozystack/kubeapps/commit/ffc0b0246b513aadb179532054f9e55618abb487

We always use flux though

<img width="386" alt="Screenshot 2025-06-10 at 1 55 39" src="https://github.com/user-attachments/assets/df6f52b5-82ab-4e7a-a973-2a82eb38ebfb" />

### [Fix switching context from app view](https://github.com/cozystack/kubeapps/commit/d89e721fcb3130de6027251b1befb0208fdbeb85)

Fixes the error message while swtiching tenant from the application view

```
An error occurred while fetching the application: Unable to get installed package.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new configuration options for API request rate limits in the dashboard settings.

- **Style**
  - Updated dashboard appearance to hide version information and specific label elements.

- **Chores**
  - Updated internal references to the latest version of the dashboard source code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->