### PR TITLE
Wrap cert-manager CRDs in conditional

### DIFF
--- a/packages/apps/kubernetes/Chart.yaml
+++ b/packages/apps/kubernetes/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.24.0
+version: 0.24.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/kubernetes/templates/helmreleases/cert-manager-crds.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/cert-manager-crds.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.addons.certManager.enabled }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -53,4 +54,5 @@ metadata:
 stringData:
   values: |
     {{- toYaml .Values.addons.certManager.valuesOverride | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -45,7 +45,8 @@ kafka 0.5.0 93bdf411
 kafka 0.6.0 6130f43d
 kafka 0.6.1 632224a3
 kafka 0.7.0 HEAD
-kubernetes 0.24.0 HEAD
+kubernetes 0.24.0 62cb694d
+kubernetes 0.24.1 HEAD
 mysql 0.1.0 263e47be
 mysql 0.2.0 c24a103f
 mysql 0.3.0 53f2365e


### PR DESCRIPTION
There's no point in installing the CRDs if cert-manager itself is disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - cert-manager CRDs are now only installed when the cert-manager addon is enabled, providing more control over addon management.

- **Chores**
  - Updated the Kubernetes chart version to 0.24.1.
  - Adjusted version mapping to reflect the new chart version and associated commit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->