### PR TITLE
Make VMAgent extraArgs tunable

### DIFF
--- a/packages/system/monitoring-agents/templates/vmagent.yaml
+++ b/packages/system/monitoring-agents/templates/vmagent.yaml
@@ -1,3 +1,7 @@
+{{- define "monitoring-agents.vmagent.defaultExtraArgs" }}
+promscrape.streamParse: "true"
+promscrape.maxScrapeSize: 32MB
+{{- end }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMAgent
 metadata:
@@ -8,8 +12,7 @@ spec:
     cluster: {{ .Values.vmagent.externalLabels.cluster }}
     tenant: {{ .Values.vmagent.externalLabels.tenant }}
   extraArgs:
-    promscrape.streamParse: "true"
-    promscrape.maxScrapeSize: 32MB
+    {{- toYaml (deepCopy .Values.vmagent.extraArgs | mergeOverwrite (fromYaml (include "monitoring-agents.vmagent.defaultExtraArgs" .))) | nindent 4 }}
   remoteWrite:
   {{- range .Values.vmagent.remoteWrite.urls }}
   - url: {{ . | quote }}

--- a/packages/system/monitoring-agents/values.yaml
+++ b/packages/system/monitoring-agents/values.yaml
@@ -309,6 +309,7 @@ vmagent:
     urls:
       - http://vminsert-shortterm.tenant-root.svc:8480/insert/0/prometheus
       - http://vminsert-longterm.tenant-root.svc:8480/insert/0/prometheus
+  extraArgs: {}
 
 fluent-bit:
   rbac:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved flexibility for VMAgent configuration by allowing users to override default extra arguments through Helm values.

- **Chores**
  - Centralized default argument definitions for VMAgent to simplify configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->