### PR TITLE
Setup systemd timer to tear down sandbox

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -87,6 +87,12 @@ jobs:
       - name: Set sandbox ID
         run: echo "SANDBOX_NAME=cozy-e2e-sandbox-$(echo "${GITHUB_REPOSITORY}:${GITHUB_WORKFLOW}:${GITHUB_REF}" | sha256sum | cut -c1-10)" >> $GITHUB_ENV
 
+      - name: Delete sandbox in 24h
+        run: sudo systemd-run
+          --on-calendar="$(date -d 'now + 24 hours' '+%Y-%m-%d %H:%M:%S')"
+          --unit=teardown-$SANDBOX_NAME
+          /usr/bin/docker rm -f $SANDBOX_NAME
+
       - name: Prepare environment
         run: make SANDBOX_NAME=$SANDBOX_NAME prepare-env
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated scheduling to delete sandboxes 24 hours after creation in pull request workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->