### PR TITLE
[tests] increase disk space for vms

### DIFF
--- a/hack/e2e-cluster.bats
+++ b/hack/e2e-cluster.bats
@@ -87,7 +87,7 @@ EOF
   for i in 1 2 3; do
     cp nocloud-amd64.raw srv${i}/system.img
     qemu-img resize srv${i}/system.img 50G
-    qemu-img create srv${i}/data.img 100G
+    qemu-img create srv${i}/data.img 200G
   done
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the disk size for VM data images from 100GB to 200GB in end-to-end cluster tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->