### PR TITLE
[virtual-machines] Introduce golden disks functionality

### DIFF
--- a/hack/cdi_golden_image_create.sh
+++ b/hack/cdi_golden_image_create.sh
@@ -16,7 +16,7 @@ kubectl create -f - <<EOF
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: DataVolume
 metadata:
-  name: "goldenimage-$name"
+  name: "vm-image-$name"
   namespace: cozy-public
   annotations:
     cdi.kubevirt.io/storage.bind.immediate.requested: "true"

--- a/hack/cdi_golden_image_create.sh
+++ b/hack/cdi_golden_image_create.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+name="$1"
+url="$2"
+
+if [ -z "$name" ] || [ -z "$url" ]; then
+  echo "Usage: <name> <url>"
+  echo "Example: 'ubuntu' 'https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img'"
+  exit 1
+fi
+
+#### create DV ubuntu source for CDI image cloning
+kubectl create -f - <<EOF
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: "goldenimage-$name"
+  namespace: cozy-public
+  annotations:
+    cdi.kubevirt.io/storage.bind.immediate.requested: "true"
+spec:
+  source:
+    http:
+      url: "$url"
+  storage:
+    resources:
+      requests:
+        storage: 5Gi
+    storageClassName: replicated
+EOF

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -149,7 +149,7 @@ vm-disk 0.1.0 d971f2ff
 vm-disk 0.1.1 6130f43d
 vm-disk 0.1.2 632224a3
 vm-disk 0.2.0 4369b031
-vm-disk 0.2.1 HEAD
+vm-disk 0.3.0 HEAD
 vm-instance 0.1.0 1ec10165
 vm-instance 0.2.0 84f3ccc0
 vm-instance 0.3.0 4e68e65c

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -148,7 +148,8 @@ virtual-machine 0.12.0 HEAD
 vm-disk 0.1.0 d971f2ff
 vm-disk 0.1.1 6130f43d
 vm-disk 0.1.2 632224a3
-vm-disk 0.2.0 HEAD
+vm-disk 0.2.0 4369b031
+vm-disk 0.2.1 HEAD
 vm-instance 0.1.0 1ec10165
 vm-instance 0.2.0 84f3ccc0
 vm-instance 0.3.0 4e68e65c

--- a/packages/apps/virtual-machine/Chart.yaml
+++ b/packages/apps/virtual-machine/Chart.yaml
@@ -23,4 +23,4 @@ version: 0.12.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.11.0
+appVersion: 0.12.0

--- a/packages/apps/virtual-machine/templates/vm.yaml
+++ b/packages/apps/virtual-machine/templates/vm.yaml
@@ -39,6 +39,13 @@ spec:
         storageClassName: {{ . }}
         {{- end }}
       source:
+        {{- $goldenImageName := .Values.systemDisk.image }}
+        {{- $dv := lookup "cdi.kubevirt.io/v1beta1" "DataVolume" "cozy-public" (printf "goldenimage-%s" $goldenImageName) }}
+        {{- if $dv }}
+        pvc:
+          name: goldenimage-{{ $goldenImageName }}
+          namespace: cozy-public
+        {{- else }}
         http:
           {{- if eq .Values.systemDisk.image "cirros" }}
           url: https://download.cirros-cloud.net/0.6.2/cirros-0.6.2-x86_64-disk.img
@@ -51,6 +58,7 @@ spec:
           {{- else if eq .Values.systemDisk.image "talos" }}
           url: https://github.com/siderolabs/talos/releases/download/v1.7.6/nocloud-amd64.raw.xz
           {{- end }}
+        {{- end }}
 
   template:
     metadata:

--- a/packages/apps/virtual-machine/templates/vm.yaml
+++ b/packages/apps/virtual-machine/templates/vm.yaml
@@ -39,11 +39,10 @@ spec:
         storageClassName: {{ . }}
         {{- end }}
       source:
-        {{- $goldenImageName := .Values.systemDisk.image }}
-        {{- $dv := lookup "cdi.kubevirt.io/v1beta1" "DataVolume" "cozy-public" (printf "goldenimage-%s" $goldenImageName) }}
+        {{- $dv := lookup "cdi.kubevirt.io/v1beta1" "DataVolume" "cozy-public" (printf "vm-image-%s" .Values.systemDisk.image) }}
         {{- if $dv }}
         pvc:
-          name: goldenimage-{{ $goldenImageName }}
+          name: vm-image-{{ .Values.systemDisk.image }}
           namespace: cozy-public
         {{- else }}
         http:

--- a/packages/apps/vm-disk/Chart.yaml
+++ b/packages/apps/vm-disk/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/vm-disk/Chart.yaml
+++ b/packages/apps/vm-disk/Chart.yaml
@@ -16,10 +16,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 0.2.0
+appVersion: 0.3.0

--- a/packages/apps/vm-disk/templates/dv.yaml
+++ b/packages/apps/vm-disk/templates/dv.yaml
@@ -20,11 +20,10 @@ spec:
     {{- fail "Exactly one type of source is expected!" }}
   {{- end }}
   source:
-    {{- $goldenImageName := .Values.source.image }}
-    {{- if $goldenImageName }}
-    {{- $dv := lookup "cdi.kubevirt.io/v1beta1" "DataVolume" "cozy-public" (printf "goldenimage-%s" $goldenImageName) }}
+    {{- if hasKey .Values.source "image" }}
+    {{- $dv := lookup "cdi.kubevirt.io/v1beta1" "DataVolume" "cozy-public" (printf "vm-image-%s" .Values.source.image.name) }}
     pvc:
-      name: goldenimage-{{ $goldenImageName }}
+      name: vm-image-{{ required "A valid .Values.source.image.name entry required!" .Values.source.image.name }}
       namespace: cozy-public
     {{- else if hasKey .Values.source "http" }}
     http:

--- a/packages/apps/vm-disk/templates/dv.yaml
+++ b/packages/apps/vm-disk/templates/dv.yaml
@@ -20,7 +20,13 @@ spec:
     {{- fail "Exactly one type of source is expected!" }}
   {{- end }}
   source:
-    {{- if hasKey .Values.source "http" }}
+    {{- $goldenImageName := .Values.source.image }}
+    {{- if $goldenImageName }}
+    {{- $dv := lookup "cdi.kubevirt.io/v1beta1" "DataVolume" "cozy-public" (printf "goldenimage-%s" $goldenImageName) }}
+    pvc:
+      name: goldenimage-{{ $goldenImageName }}
+      namespace: cozy-public
+    {{- else if hasKey .Values.source "http" }}
     http:
       url: {{ required "A valid .Values.source.http.url entry required!" .Values.source.http.url }}
     {{- else if hasKey .Values.source "upload" }}

--- a/packages/apps/vm-disk/values.yaml
+++ b/packages/apps/vm-disk/values.yaml
@@ -1,6 +1,10 @@
 ## @section Common parameters
 
-## @param source The source image location used to create a disk
+## @param source The golden image disk name to use
+## Example using golden image:
+## source:
+##   image: ubuntu
+##
 ## Example upload local image:
 ## source:
 ##   upload: {}

--- a/packages/apps/vm-disk/values.yaml
+++ b/packages/apps/vm-disk/values.yaml
@@ -1,9 +1,10 @@
 ## @section Common parameters
 
-## @param source The golden image disk name to use
+## @param source The source image location used to create a disk
 ## Example using golden image:
 ## source:
-##   image: ubuntu
+##   image:
+##     name: ubuntu
 ##
 ## Example upload local image:
 ## source:

--- a/packages/system/kubevirt-cdi/templates/cdi-cr.yaml
+++ b/packages/system/kubevirt-cdi/templates/cdi-cr.yaml
@@ -3,6 +3,7 @@ kind: CDI
 metadata:
   name: cdi
 spec:
+  cloneStrategyOverride: copy
   config:
     {{- with .Values.uploadProxyURL }}
     uploadProxyURLOverride: {{ quote . }}
@@ -20,3 +21,26 @@ spec:
   workload:
     nodeSelector:
       kubernetes.io/os: linux
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cdi-copy-dv
+rules:
+- apiGroups: ["cdi.kubevirt.io"]
+  resources: ["datavolumes/source"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cdi-clone-dv
+  namespace: cozy-public
+subjects:
+- kind: Group
+  name: system:serviceaccounts
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cdi-copy-dv
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Use Golden Images to speed up VM / VMI deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using pre-imported "golden image" disks for virtual machines, enabling faster provisioning by referencing existing images instead of downloading via HTTP.
  * Introduced a script to automate the import of golden images into the system.

* **Improvements**
  * Updated documentation and configuration to clarify and demonstrate how to use golden images.
  * Enhanced permission settings to support secure cloning of data volumes.

* **Versioning**
  * Updated vm-disk package to version 0.3.0.
  * Updated virtual-machine app version to 0.12.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->