### PR TITLE
Create LoadBalancer service for single-node MySQL

### DIFF
--- a/packages/apps/mysql/Chart.yaml
+++ b/packages/apps/mysql/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.1
+version: 0.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/mysql/templates/mariadb.yaml
+++ b/packages/apps/mysql/templates/mariadb.yaml
@@ -61,7 +61,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/instance: {{ $.Release.Name }}
-
+    {{- if and .Values.external (eq (int .Values.replicas) 1) }}
+    type: LoadBalancer
+    {{- end }}
   storage:
     size: {{ .Values.size }}
     resizeInUseVolumes: true
@@ -70,7 +72,7 @@ spec:
     storageClassName: {{ . }}
     {{- end }}
 
-  {{- if .Values.external }}
+  {{- if and .Values.external (gt (int .Values.replicas) 1) }}
   primaryService:
     type: LoadBalancer
   {{- end }}

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -63,7 +63,8 @@ mysql 0.6.0 93bdf411
 mysql 0.7.0 6130f43d
 mysql 0.7.1 632224a3
 mysql 0.8.0 62cb694d
-mysql 0.8.1 HEAD
+mysql 0.8.1 4369b031
+mysql 0.8.2 HEAD
 nats 0.1.0 e9716091
 nats 0.2.0 6c5cf5bf
 nats 0.3.0 78366f19


### PR DESCRIPTION
## Changelog
```
[mysql] Bugfix: external=true did not work for MySQL deployed with a single replica,
since the MariaDB operator does not create separate primary and secondary services for a single-node DB.
A special condition is added to make the "all-node" service a LoadBalancer if external=true and replicas=1.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of external service exposure for MySQL deployments, with refined logic for LoadBalancer configuration based on the number of replicas.
- **Chores**
  - Updated MySQL chart version to 0.8.2.
  - Adjusted version mapping to reflect the latest changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Resolves https://github.com/cozystack/cozystack/issues/1095