### PR TITLE
[maintenance] Add a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- Thank you for making a contribution! Here are some tips for you:
+- Start the PR title with the [label] of Cozystack component:
+  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
+  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
+  - For development and maintenance: [tests], [ci], [docs], [maintenance].
+- If it's a work in progress, consider creating this PR as a draft.
+- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
+- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
+-->
+
+## What this PR does
+
+
+### Release note
+
+<!--  Write a release note:
+- Explain what has changed internally and for users.
+- Start with the same [label] as in the PR title
+- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
+-->
+
+```release-note
+[]
+```


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs],  
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Adds a PR template that will be used for all new pull requests.
It promotes some good practices and has a designated space for a release note that we can later compile to form a changelog.

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[maintenance] Add a pull request template for promoting good practices and automating release notes generation.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new pull request template to guide contributors on formatting PR titles, labeling, and writing release notes. The template also encourages marking work-in-progress PRs as drafts and provides sections for PR descriptions and release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->