### PR TITLE
[ci] Use Nexus as a pull-through cache for CI

### DIFF
--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -141,7 +141,25 @@ machine:
     mirrors:
       docker.io:
         endpoints:
-        - https://mirror.gcr.io
+        - https://dockerio.nexus.lllamnyp.su
+      cr.fluentbit.io:
+        endpoints:
+        - https://fluentbit.nexus.lllamnyp.su
+      docker-registry3.mariadb.com:
+        endpoints:
+        - https://mariadb.nexus.lllamnyp.su
+      gcr.io:
+        endpoints:
+        - https://gcr.nexus.lllamnyp.su
+      ghcr.io:
+        endpoints:
+        - https://ghcr.nexus.lllamnyp.su
+      quay.io:
+        endpoints:
+        - https://quay.nexus.lllamnyp.su
+      registry.k8s.io:
+        endpoints:
+        - https://k8s.nexus.lllamnyp.su
   files:
   - content: |
       [plugins]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated registry mirror endpoints for improved cluster configuration, adding multiple new mirrors for various registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->