### PR TITLE
[docs] Add backup and restore instructions for PostgreSQL 

### DIFF
--- a/packages/apps/postgres/Chart.yaml
+++ b/packages/apps/postgres/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.17.0
+version: 0.17.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/postgres/README.md
+++ b/packages/apps/postgres/README.md
@@ -11,31 +11,56 @@ This managed service is controlled by the CloudNativePG operator, ensuring effic
 - Docs: <https://cloudnative-pg.io/docs/>
 - Github: <https://github.com/cloudnative-pg/cloudnative-pg>
 
-## HowTos
+## Operations
+
+### How to enable backups
+
+To back up a PostgreSQL application, an external S3-compatible storage is required.
+
+To start regular backups, update the application, setting `backup.enabled` to `true`, and fill in the path and credentials to an  `backup.*`:
+
+```yaml
+## @param backup.enabled Enable regular backups
+## @param backup.schedule Cron schedule for automated backups
+## @param backup.retentionPolicy Retention policy
+## @param backup.destinationPath Path to store the backup (i.e. s3://bucket/path/to/folder)
+## @param backup.endpointURL S3 Endpoint used to upload data to the cloud
+## @param backup.s3AccessKey Access key for S3, used for authentication
+## @param backup.s3SecretKey Secret key for S3, used for authentication
+backup:
+  enabled: false
+  retentionPolicy: 30d
+  destinationPath: s3://bucket/path/to/folder/
+  endpointURL: http://minio-gateway-service:9000
+  schedule: "0 2 * * * *"
+  s3AccessKey: oobaiRus9pah8PhohL1ThaeTa4UVa7gu
+  s3SecretKey: ju3eum4dekeich9ahM1te8waeGai0oog
+```
+
+### How to recover a backup
+
+CloudNativePG supports point-in-time-recovery.
+Recovering a backup is done by creating a new database instance and restoring the data in it.
+
+Create a new PostgreSQL application with a different name, but identical configuration.
+Set `bootstrap.enabled` to `true` and fill in the name of the database instance to recover from and the recovery time:
+
+```yaml
+## @param bootstrap.enabled Restore database cluster from a backup
+## @param bootstrap.recoveryTime Timestamp (PITR) up to which recovery will proceed, expressed in RFC 3339 format. If left empty, will restore latest
+## @param bootstrap.oldName Name of database cluster before deleting
+##
+bootstrap:
+  enabled: false
+  recoveryTime: ""  # leave empty for latest or exact timestamp; example: 2020-11-26 15:22:00.00000+00
+  oldName: "<previous-postgres-instance>"
+```
 
 ### How to switch primary/secondary replica
 
 See:
 
 - <https://cloudnative-pg.io/documentation/1.15/rolling_update/#manual-updates-supervised>
-
-### How to restore backup
-
-find snapshot:
-
-```bash
-restic -r s3:s3.example.org/postgres-backups/database_name snapshots
-```
-
-restore:
-
-```bash
-restic -r s3:s3.example.org/postgres-backups/database_name restore latest --target /tmp/
-```
-
-more details:
-
-- <https://blog.aenix.io/restic-effective-backup-from-stdin-4bc1e8f083c1>
 
 ## Parameters
 
@@ -60,23 +85,23 @@ more details:
 
 ### Backup parameters
 
-| Name                     | Description                                                          | Value                               |
-| ------------------------ | -------------------------------------------------------------------- | ----------------------------------- |
-| `backup.enabled`         | Enable pereiodic backups                                             | `false`                             |
-| `backup.schedule`        | Cron schedule for automated backups                                  | `0 2 * * * *`                       |
-| `backup.retentionPolicy` | The retention policy                                                 | `30d`                               |
-| `backup.destinationPath` | The path where to store the backup (i.e. s3://bucket/path/to/folder) | `s3://BUCKET_NAME/`                 |
-| `backup.endpointURL`     | Endpoint to be used to upload data to the cloud                      | `http://minio-gateway-service:9000` |
-| `backup.s3AccessKey`     | The access key for S3, used for authentication                       | `oobaiRus9pah8PhohL1ThaeTa4UVa7gu`  |
-| `backup.s3SecretKey`     | The secret key for S3, used for authentication                       | `ju3eum4dekeich9ahM1te8waeGai0oog`  |
+| Name                     | Description                                                | Value                               |
+| ------------------------ | ---------------------------------------------------------- | ----------------------------------- |
+| `backup.enabled`         | Enable regular backups                                     | `false`                             |
+| `backup.schedule`        | Cron schedule for automated backups                        | `0 2 * * * *`                       |
+| `backup.retentionPolicy` | Retention policy                                           | `30d`                               |
+| `backup.destinationPath` | Path to store the backup (i.e. s3://bucket/path/to/folder) | `s3://bucket/path/to/folder/`       |
+| `backup.endpointURL`     | S3 Endpoint used to upload data to the cloud               | `http://minio-gateway-service:9000` |
+| `backup.s3AccessKey`     | Access key for S3, used for authentication                 | `oobaiRus9pah8PhohL1ThaeTa4UVa7gu`  |
+| `backup.s3SecretKey`     | Secret key for S3, used for authentication                 | `ju3eum4dekeich9ahM1te8waeGai0oog`  |
 
 ### Bootstrap parameters
 
 | Name                     | Description                                                                                                                             | Value   |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `bootstrap.enabled`      | Restore cluster from backup                                                                                                             | `false` |
-| `bootstrap.recoveryTime` | Time stamp up to which recovery will proceed, expressed in RFC 3339 format, if empty, will restore latest                               | `""`    |
-| `bootstrap.oldName`      | Name of cluster before deleting                                                                                                         | `""`    |
+| `bootstrap.enabled`      | Restore database cluster from a backup                                                                                                  | `false` |
+| `bootstrap.recoveryTime` | Timestamp (PITR) up to which recovery will proceed, expressed in RFC 3339 format. If left empty, will restore latest                    | `""`    |
+| `bootstrap.oldName`      | Name of database cluster before deleting                                                                                                | `""`    |
 | `resources`              | Explicit CPU and memory configuration for each PostgreSQL replica. When left empty, the preset defined in `resourcesPreset` is applied. | `{}`    |
 | `resourcesPreset`        | Default sizing preset used when `resources` is omitted. Allowed values: none, nano, micro, small, medium, large, xlarge, 2xlarge.       | `micro` |
 

--- a/packages/apps/postgres/values.schema.json
+++ b/packages/apps/postgres/values.schema.json
@@ -62,7 +62,7 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "description": "Enable pereiodic backups",
+                    "description": "Enable regular backups",
                     "default": false
                 },
                 "schedule": {
@@ -72,27 +72,27 @@
                 },
                 "retentionPolicy": {
                     "type": "string",
-                    "description": "The retention policy",
+                    "description": "Retention policy",
                     "default": "30d"
                 },
                 "destinationPath": {
                     "type": "string",
-                    "description": "The path where to store the backup (i.e. s3://bucket/path/to/folder)",
-                    "default": "s3://BUCKET_NAME/"
+                    "description": "Path to store the backup (i.e. s3://bucket/path/to/folder)",
+                    "default": "s3://bucket/path/to/folder/"
                 },
                 "endpointURL": {
                     "type": "string",
-                    "description": "Endpoint to be used to upload data to the cloud",
+                    "description": "S3 Endpoint used to upload data to the cloud",
                     "default": "http://minio-gateway-service:9000"
                 },
                 "s3AccessKey": {
                     "type": "string",
-                    "description": "The access key for S3, used for authentication",
+                    "description": "Access key for S3, used for authentication",
                     "default": "oobaiRus9pah8PhohL1ThaeTa4UVa7gu"
                 },
                 "s3SecretKey": {
                     "type": "string",
-                    "description": "The secret key for S3, used for authentication",
+                    "description": "Secret key for S3, used for authentication",
                     "default": "ju3eum4dekeich9ahM1te8waeGai0oog"
                 }
             }
@@ -102,17 +102,17 @@
             "properties": {
                 "enabled": {
                     "type": "boolean",
-                    "description": "Restore cluster from backup",
+                    "description": "Restore database cluster from a backup",
                     "default": false
                 },
                 "recoveryTime": {
                     "type": "string",
-                    "description": "Time stamp up to which recovery will proceed, expressed in RFC 3339 format, if empty, will restore latest",
+                    "description": "Timestamp (PITR) up to which recovery will proceed, expressed in RFC 3339 format. If left empty, will restore latest",
                     "default": ""
                 },
                 "oldName": {
                     "type": "string",
-                    "description": "Name of cluster before deleting",
+                    "description": "Name of database cluster before deleting",
                     "default": ""
                 }
             }

--- a/packages/apps/postgres/values.yaml
+++ b/packages/apps/postgres/values.yaml
@@ -59,17 +59,17 @@ databases: {}
 
 ## @section Backup parameters
 
-## @param backup.enabled Enable pereiodic backups
+## @param backup.enabled Enable regular backups
 ## @param backup.schedule Cron schedule for automated backups
-## @param backup.retentionPolicy The retention policy
-## @param backup.destinationPath The path where to store the backup (i.e. s3://bucket/path/to/folder)
-## @param backup.endpointURL Endpoint to be used to upload data to the cloud
-## @param backup.s3AccessKey The access key for S3, used for authentication
-## @param backup.s3SecretKey The secret key for S3, used for authentication
+## @param backup.retentionPolicy Retention policy
+## @param backup.destinationPath Path to store the backup (i.e. s3://bucket/path/to/folder)
+## @param backup.endpointURL S3 Endpoint used to upload data to the cloud
+## @param backup.s3AccessKey Access key for S3, used for authentication
+## @param backup.s3SecretKey Secret key for S3, used for authentication
 backup:
   enabled: false
   retentionPolicy: 30d
-  destinationPath: s3://BUCKET_NAME/
+  destinationPath: s3://bucket/path/to/folder/
   endpointURL: http://minio-gateway-service:9000
   schedule: "0 2 * * * *"
   s3AccessKey: oobaiRus9pah8PhohL1ThaeTa4UVa7gu
@@ -77,9 +77,9 @@ backup:
 
 ## @section Bootstrap parameters
 
-## @param bootstrap.enabled Restore cluster from backup
-## @param bootstrap.recoveryTime Time stamp up to which recovery will proceed, expressed in RFC 3339 format, if empty, will restore latest
-## @param bootstrap.oldName Name of cluster before deleting
+## @param bootstrap.enabled Restore database cluster from a backup
+## @param bootstrap.recoveryTime Timestamp (PITR) up to which recovery will proceed, expressed in RFC 3339 format. If left empty, will restore latest
+## @param bootstrap.oldName Name of database cluster before deleting
 ##
 bootstrap:
   enabled: false

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -103,7 +103,8 @@ postgres 0.12.1 632224a3
 postgres 0.14.0 62cb694d
 postgres 0.15.1 4369b031
 postgres 0.16.0 70f82667
-postgres 0.17.0 HEAD
+postgres 0.17.0 acd4663a
+postgres 0.17.1 HEAD
 rabbitmq 0.1.0 263e47be
 rabbitmq 0.2.0 53f2365e
 rabbitmq 0.3.0 6c5cf5bf


### PR DESCRIPTION
## What this PR does

Rephrase the descriptions for backup and restore variables

### Release note

```release-note
[docs] Add backup and restore instructions for PostgreSQL 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated PostgreSQL backup restore instructions to use a YAML configuration approach for bootstrapping from a backup, replacing previous shell command examples.
  * Clarified and restructured backup and recovery documentation, including detailed configuration examples for enabling backups with S3-compatible storage.
  * Improved descriptions and default values for backup-related configuration parameters for better clarity and consistency.

* **Chores**
  * Incremented the PostgreSQL app chart version.
  * Updated version mapping for the PostgreSQL package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->