### PR TITLE
bugfix make keycloak deletable

### DIFF
--- a/packages/core/platform/bundles/paas-full.yaml
+++ b/packages/core/platform/bundles/paas-full.yaml
@@ -354,7 +354,7 @@ releases:
   optional: true
   dependsOn: [cilium,kubeovn]
 
-{{- if $oidcEnabled }}
+{{- if eq $oidcEnabled "true" }}
 - name: keycloak
   releaseName: keycloak
   chart: cozy-keycloak

--- a/packages/core/platform/bundles/paas-hosted.yaml
+++ b/packages/core/platform/bundles/paas-hosted.yaml
@@ -182,7 +182,7 @@ releases:
   dependsOn: []
   {{- end }}
 
-{{- if $oidcEnabled }}
+{{- if eq $oidcEnabled "true" }}
 - name: keycloak
   releaseName: keycloak
   chart: cozy-keycloak


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
- make Keycloak deletable 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically removes Keycloak-related resources and Helm releases when OIDC is disabled in configuration.
  * Deletes the associated namespace after resource cleanup.

* **Bug Fixes**
  * Improved logic to ensure Keycloak resources are only deployed when OIDC is explicitly enabled.

* **Chores**
  * Minor cleanup of internal comments and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->