### PR TITLE
Update Flux Operator (0.24.0)

### DIFF
--- a/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.23.0
+appVersion: v0.24.0
 description: 'A Helm chart for deploying the Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.23.0
+version: 0.24.0

--- a/packages/system/fluxcd-operator/charts/flux-operator/README.md
+++ b/packages/system/fluxcd-operator/charts/flux-operator/README.md
@@ -1,6 +1,6 @@
 # flux-operator
 
-![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.23.0](https://img.shields.io/badge/AppVersion-v0.23.0-informational?style=flat-square)
+![Version: 0.24.0](https://img.shields.io/badge/Version-0.24.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.24.0](https://img.shields.io/badge/AppVersion-v0.24.0-informational?style=flat-square)
 
 The [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator) provides a
 declarative API for the installation and upgrade of CNCF [Flux](https://fluxcd.io) and the
@@ -38,6 +38,8 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | commonLabels | object | `{}` | Common labels to add to all deployed objects including pods. |
 | extraArgs | list | `[]` | Container extra arguments. |
 | extraEnvs | list | `[]` | Container extra environment variables. |
+| extraVolumeMounts | list | `[]` | Container extra volume mounts. |
+| extraVolumes | list | `[]` | Pod extra volumes. |
 | fullnameOverride | string | `""` |  |
 | hostNetwork | bool | `false` | If `true`, the container ports (`8080` and `8081`) are exposed on the host network. |
 | image | object | `{"imagePullPolicy":"IfNotPresent","pullSecrets":[],"repository":"ghcr.io/controlplaneio-fluxcd/flux-operator","tag":""}` | Container image settings. The image tag defaults to the chart appVersion. |

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
@@ -586,6 +586,9 @@ spec:
                     description: ServerVersion is the version of the Kubernetes API
                       server.
                     type: string
+                required:
+                - platform
+                - serverVersion
                 type: object
               components:
                 description: ComponentsStatus is the status of the Flux controller
@@ -636,6 +639,23 @@ spec:
                 required:
                 - entitlement
                 - status
+                type: object
+              operator:
+                description: Operator is the version information of the Flux Operator.
+                properties:
+                  apiVersion:
+                    description: APIVersion is the API version of the Flux Operator.
+                    type: string
+                  platform:
+                    description: Platform is the os/arch of Flux Operator.
+                    type: string
+                  version:
+                    description: Version is the version number of Flux Operator.
+                    type: string
+                required:
+                - apiVersion
+                - platform
+                - version
                 type: object
               reconcilers:
                 description: |-
@@ -858,8 +878,10 @@ spec:
                   - a PEM-encoded CA certificate (`ca.crt`)
                   - a PEM-encoded client certificate (`tls.crt`) and private key (`tls.key`)
 
-                  When connecting to a Git provider that uses self-signed certificates, the CA certificate
+                  When connecting to a Git or OCI provider that uses self-signed certificates, the CA certificate
                   must be set in the Secret under the 'ca.crt' key to establish the trust relationship.
+                  When connecting to an OCI provider that supports client certificates (mTLS), the client certificate
+                  and private key must be set in the Secret under the 'tls.crt' and 'tls.key' keys, respectively.
                 properties:
                   name:
                     description: Name of the referent.
@@ -884,9 +906,19 @@ spec:
                       ExcludeBranch specifies the regular expression to filter the branches
                       that the input provider should exclude.
                     type: string
+                  excludeTag:
+                    description: |-
+                      ExcludeTag specifies the regular expression to filter the tags
+                      that the input provider should exclude.
+                    type: string
                   includeBranch:
                     description: |-
                       IncludeBranch specifies the regular expression to filter the branches
+                      that the input provider should include.
+                    type: string
+                  includeTag:
+                    description: |-
+                      IncludeTag specifies the regular expression to filter the tags
                       that the input provider should include.
                     type: string
                   labels:
@@ -896,13 +928,17 @@ spec:
                       type: string
                     type: array
                   limit:
+                    default: 100
                     description: |-
                       Limit specifies the maximum number of input sets to return.
                       When not set, the default limit is 100.
                     type: integer
                   semver:
-                    description: Semver specifies the semantic version range to filter
-                      and order the tags.
+                    description: |-
+                      Semver specifies a semantic version range to filter and sort the tags.
+                      If this field is not specified, the tags will be sorted in reverse
+                      alphabetical order.
+                      Supported only for tags at the moment.
                     type: string
                 type: object
               schedule:
@@ -933,10 +969,12 @@ spec:
               secretRef:
                 description: |-
                   SecretRef specifies the Kubernetes Secret containing the basic-auth credentials
-                  to access the input provider. The secret must contain the keys
-                  'username' and 'password'.
-                  When connecting to a Git provider, the password should be a personal access token
+                  to access the input provider.
+                  When connecting to a Git provider, the secret must contain the keys
+                  'username' and 'password', and the password should be a personal access token
                   that grants read-only access to the repository.
+                  When connecting to an OCI provider, the secret must contain a Kubernetes
+                  Image Pull Secret, as if created by `kubectl create secret docker-registry`.
                 properties:
                   name:
                     description: Name of the referent.
@@ -944,6 +982,14 @@ spec:
                 required:
                 - name
                 type: object
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName specifies the name of the Kubernetes ServiceAccount
+                  used for authentication with AWS, Azure or GCP services through
+                  workload identity federation features. If not specified, the
+                  authentication for these cloud providers will use the ServiceAccount
+                  of the operator (or any other environment authentication configuration).
+                type: string
               skip:
                 description: Skip defines whether we need to skip input provider response
                   updates.
@@ -966,12 +1012,20 @@ spec:
                 - GitLabBranch
                 - GitLabTag
                 - GitLabMergeRequest
+                - AzureDevOpsBranch
+                - AzureDevOpsTag
+                - AzureDevOpsPullRequest
+                - OCIArtifactTag
+                - ACRArtifactTag
+                - ECRArtifactTag
+                - GARArtifactTag
                 type: string
               url:
                 description: |-
-                  URL specifies the HTTP/S address of the input provider API.
+                  URL specifies the HTTP/S or OCI address of the input provider API.
                   When connecting to a Git provider, the URL should point to the repository address.
-                pattern: ^((http|https)://.*){0,1}$
+                  When connecting to an OCI provider, the URL should point to the OCI repository address.
+                pattern: ^((http|https|oci)://.*){0,1}$
                 type: string
             required:
             - type
@@ -981,6 +1035,27 @@ spec:
               rule: self.type != 'Static' || !has(self.url)
             - message: spec.url must not be empty when spec.type is not 'Static'
               rule: self.type == 'Static' || has(self.url)
+            - message: spec.url must start with 'http://' or 'https://' when spec.type
+                is a Git provider
+              rule: '!self.type.startsWith(''Git'') || self.url.startsWith(''http'')'
+            - message: spec.url must start with 'http://' or 'https://' when spec.type
+                is a Git provider
+              rule: '!self.type.startsWith(''AzureDevOps'') || self.url.startsWith(''http'')'
+            - message: spec.url must start with 'oci://' when spec.type is an OCI
+                provider
+              rule: '!self.type.endsWith(''ArtifactTag'') || self.url.startsWith(''oci'')'
+            - message: cannot specify spec.serviceAccountName when spec.type is not
+                one of AzureDevOps* or *ArtifactTag
+              rule: '!has(self.serviceAccountName) || self.type.startsWith(''AzureDevOps'')
+                || self.type.endsWith(''ArtifactTag'')'
+            - message: cannot specify spec.certSecretRef when spec.type is one of
+                Static, AzureDevOps*, ACRArtifactTag, ECRArtifactTag or GARArtifactTag
+              rule: '!has(self.certSecretRef) || !(self.url == ''Static'' || self.type.startsWith(''AzureDevOps'')
+                || (self.type.endsWith(''ArtifactTag'') && self.type != ''OCIArtifactTag''))'
+            - message: cannot specify spec.secretRef when spec.type is one of Static,
+                ACRArtifactTag, ECRArtifactTag or GARArtifactTag
+              rule: '!has(self.secretRef) || !(self.url == ''Static'' || (self.type.endsWith(''ArtifactTag'')
+                && self.type != ''OCIArtifactTag''))'
           status:
             description: ResourceSetInputProviderStatus defines the observed state
               of ResourceSetInputProvider.

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/deployment.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/deployment.yaml
@@ -99,9 +99,15 @@ spec:
           volumeMounts:
             - name: temp
               mountPath: /tmp
+            {{- if .Values.extraVolumeMounts }}
+              {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
         - name: temp
           emptyDir: {}
+        {{- if .Values.extraVolumes }}
+          {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
@@ -116,11 +116,17 @@ nodeSelector: { } # @schema type: object
 # -- If `true`, the container ports (`8080` and `8081`) are exposed on the host network.
 hostNetwork: false # @schema default: false
 
+# -- Pod extra volumes.
+extraVolumes: [ ] # @schema item: object ; uniqueItems: true
+
 # -- Container extra environment variables.
 extraEnvs: [ ] # @schema item: object ; uniqueItems: true
 
 # -- Container extra arguments.
 extraArgs: [ ] # @schema item: string ; uniqueItems: true
+
+# -- Container extra volume mounts.
+extraVolumeMounts: [ ] # @schema item: object ; uniqueItems: true
 
 # -- Container logging level flag.
 logLevel: "info" # @schema enum:[debug,info,error]

--- a/packages/system/fluxcd/charts/flux-instance/Chart.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.23.0
+appVersion: v0.24.0
 description: 'A Helm chart for deploying a Flux instance managed by Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.23.0
+version: 0.24.0

--- a/packages/system/fluxcd/charts/flux-instance/README.md
+++ b/packages/system/fluxcd/charts/flux-instance/README.md
@@ -1,6 +1,6 @@
 # flux-instance
 
-![Version: 0.23.0](https://img.shields.io/badge/Version-0.23.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.23.0](https://img.shields.io/badge/AppVersion-v0.23.0-informational?style=flat-square)
+![Version: 0.24.0](https://img.shields.io/badge/Version-0.24.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.24.0](https://img.shields.io/badge/AppVersion-v0.24.0-informational?style=flat-square)
 
 This chart is a thin wrapper around the `FluxInstance` custom resource, which is
 used by the [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator)


### PR DESCRIPTION
This PR updates Flux Operator to 0.24.0 - some changes have been undertaken to make upgrading Flux on any version of the flux-operator more reliable - these are related to `spec.distribution.artifact` which I think you have already seen

https://fluxcd.control-plane.io/operator/fluxinstance/#distribution-artifact

May be relevant to air-gapped environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying extra pod volumes and container volume mounts via new configuration options in the Helm chart.
  * Extended CRD schemas to support additional provider types, new filtering options, and enhanced validation and authentication fields.
  * Introduced new fields for improved authentication and workload identity federation in CRDs.

* **Documentation**
  * Updated README files to document new configuration options and reflect the latest chart versions.

* **Chores**
  * Bumped Helm chart and app versions to 0.24.0 for both operator and instance charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->