### PR TITLE
[docs] Fix a typo in preset resource tables in the README's

### DIFF
--- a/packages/apps/clickhouse/README.md
+++ b/packages/apps/clickhouse/README.md
@@ -75,6 +75,6 @@ This setting is ignored if the corresponding `resources` value is set.
 | `micro`     | `500m` | `256Mi` |
 | `small`     | `1`    | `512Mi` |
 | `medium`    | `1`    | `1Gi`   |
-| `large`     | `3`    | `2Gi`   |
+| `large`     | `2`    | `2Gi`   |
 | `xlarge`    | `4`    | `4Gi`   |
 | `2xlarge`   | `8`    | `8Gi`   |

--- a/packages/apps/ferretdb/README.md
+++ b/packages/apps/ferretdb/README.md
@@ -62,6 +62,6 @@ This setting is ignored if the corresponding `resources` value is set.
 | `micro`     | `500m` | `256Mi` |
 | `small`     | `1`    | `512Mi` |
 | `medium`    | `1`    | `1Gi`   |
-| `large`     | `3`    | `2Gi`   |
+| `large`     | `2`    | `2Gi`   |
 | `xlarge`    | `4`    | `4Gi`   |
 | `2xlarge`   | `8`    | `8Gi`   |

--- a/packages/apps/http-cache/README.md
+++ b/packages/apps/http-cache/README.md
@@ -100,7 +100,7 @@ This setting is ignored if the corresponding `resources` value is set.
 | `micro`     | `500m` | `256Mi` |
 | `small`     | `1`    | `512Mi` |
 | `medium`    | `1`    | `1Gi`   |
-| `large`     | `3`    | `2Gi`   |
+| `large`     | `2`    | `2Gi`   |
 | `xlarge`    | `4`    | `4Gi`   |
 | `2xlarge`   | `8`    | `8Gi`   |
 

--- a/packages/apps/kafka/README.md
+++ b/packages/apps/kafka/README.md
@@ -46,7 +46,7 @@ This setting is ignored if the corresponding `resources` value is set.
 | `micro`     | `500m` | `256Mi` |
 | `small`     | `1`    | `512Mi` |
 | `medium`    | `1`    | `1Gi`   |
-| `large`     | `3`    | `2Gi`   |
+| `large`     | `2`    | `2Gi`   |
 | `xlarge`    | `4`    | `4Gi`   |
 | `2xlarge`   | `8`    | `8Gi`   |
 

--- a/packages/apps/kubernetes/README.md
+++ b/packages/apps/kubernetes/README.md
@@ -146,7 +146,7 @@ This setting is ignored if the corresponding `resources` value is set.
 | `micro`     | `500m` | `256Mi` |
 | `small`     | `1`    | `512Mi` |
 | `medium`    | `1`    | `1Gi`   |
-| `large`     | `3`    | `2Gi`   |
+| `large`     | `2`    | `2Gi`   |
 | `xlarge`    | `4`    | `4Gi`   |
 | `2xlarge`   | `8`    | `8Gi`   |
 

--- a/packages/apps/mysql/README.md
+++ b/packages/apps/mysql/README.md
@@ -119,7 +119,7 @@ This setting is ignored if the corresponding `resources` value is set.
 | `micro`     | `500m` | `256Mi` |
 | `small`     | `1`    | `512Mi` |
 | `medium`    | `1`    | `1Gi`   |
-| `large`     | `3`    | `2Gi`   |
+| `large`     | `2`    | `2Gi`   |
 | `xlarge`    | `4`    | `4Gi`   |
 | `2xlarge`   | `8`    | `8Gi`   |
 

--- a/packages/apps/nats/README.md
+++ b/packages/apps/nats/README.md
@@ -42,7 +42,7 @@ This setting is ignored if the corresponding `resources` value is set.
 | `micro`     | `500m` | `256Mi` |
 | `small`     | `1`    | `512Mi` |
 | `medium`    | `1`    | `1Gi`   |
-| `large`     | `3`    | `2Gi`   |
+| `large`     | `2`    | `2Gi`   |
 | `xlarge`    | `4`    | `4Gi`   |
 | `2xlarge`   | `8`    | `8Gi`   |
 

--- a/packages/apps/postgres/README.md
+++ b/packages/apps/postgres/README.md
@@ -103,7 +103,7 @@ This setting is ignored if the corresponding `resources` value is set.
 | `micro`     | `500m` | `256Mi` |
 | `small`     | `1`    | `512Mi` |
 | `medium`    | `1`    | `1Gi`   |
-| `large`     | `3`    | `2Gi`   |
+| `large`     | `2`    | `2Gi`   |
 | `xlarge`    | `4`    | `4Gi`   |
 | `2xlarge`   | `8`    | `8Gi`   |
 

--- a/packages/apps/redis/README.md
+++ b/packages/apps/redis/README.md
@@ -45,6 +45,6 @@ This setting is ignored if the corresponding `resources` value is set.
 | `micro`     | `500m` | `256Mi` |
 | `small`     | `1`    | `512Mi` |
 | `medium`    | `1`    | `1Gi`   |
-| `large`     | `3`    | `2Gi`   |
+| `large`     | `2`    | `2Gi`   |
 | `xlarge`    | `4`    | `4Gi`   |
 | `2xlarge`   | `8`    | `8Gi`   |

--- a/packages/apps/tcp-balancer/README.md
+++ b/packages/apps/tcp-balancer/README.md
@@ -52,6 +52,6 @@ This setting is ignored if the corresponding `resources` value is set.
 | `micro`     | `500m` | `256Mi` |
 | `small`     | `1`    | `512Mi` |
 | `medium`    | `1`    | `1Gi`   |
-| `large`     | `3`    | `2Gi`   |
+| `large`     | `2`    | `2Gi`   |
 | `xlarge`    | `4`    | `4Gi`   |
 | `2xlarge`   | `8`    | `8Gi`   |

--- a/packages/apps/vpn/README.md
+++ b/packages/apps/vpn/README.md
@@ -56,7 +56,7 @@ This setting is ignored if the corresponding `resources` value is set.
 | `micro`     | `500m` | `256Mi` |
 | `small`     | `1`    | `512Mi` |
 | `medium`    | `1`    | `1Gi`   |
-| `large`     | `3`    | `2Gi`   |
+| `large`     | `2`    | `2Gi`   |
 | `xlarge`    | `4`    | `4Gi`   |
 | `2xlarge`   | `8`    | `8Gi`   |
 


### PR DESCRIPTION
Signed-off-by: Nick Volynkin <nick.volynkin@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation across multiple applications to reflect a change in the CPU allocation for the "large" resource preset from 3 CPUs to 2 CPUs. Memory allocation for this preset remains unchanged at 2Gi. No other documentation changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->