### PR TITLE
fix add vm job resources

### DIFF
--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -170,7 +170,8 @@ virtual-machine 0.10.0 6130f43d
 virtual-machine 0.10.2 632224a3
 virtual-machine 0.11.0 4369b031
 virtual-machine 0.12.0 acd4663a
-virtual-machine 0.12.1 HEAD
+virtual-machine 0.12.1 909208ba
+virtual-machine 0.12.2 HEAD
 vm-disk 0.1.0 d971f2ff
 vm-disk 0.1.1 6130f43d
 vm-disk 0.1.2 632224a3
@@ -188,7 +189,8 @@ vm-instance 0.7.0 6130f43d
 vm-instance 0.7.2 632224a3
 vm-instance 0.8.0 4369b031
 vm-instance 0.9.0 acd4663a
-vm-instance 0.10.0 HEAD
+vm-instance 0.10.0 909208ba
+vm-instance 0.10.1 HEAD
 vpn 0.1.0 263e47be
 vpn 0.2.0 53f2365e
 vpn 0.3.0 6c5cf5bf

--- a/packages/apps/virtual-machine/Chart.yaml
+++ b/packages/apps/virtual-machine/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.12.1
+version: 0.12.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/virtual-machine/templates/vm-update-hook.yaml
+++ b/packages/apps/virtual-machine/templates/vm-update-hook.yaml
@@ -52,6 +52,13 @@ spec:
       containers:
         - name: update-resources
           image: bitnami/kubectl:latest
+          resources:
+            requests:
+              memory: "16Mi"
+              cpu: "10m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
           command: ["sh", "-exc"]
           args:
             - |

--- a/packages/apps/vm-instance/Chart.yaml
+++ b/packages/apps/vm-instance/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/vm-instance/templates/vm-update-hook.yaml
+++ b/packages/apps/vm-instance/templates/vm-update-hook.yaml
@@ -42,6 +42,13 @@ spec:
       containers:
         - name: update-resources
           image: bitnami/kubectl:latest
+          resources:
+            requests:
+              memory: "16Mi"
+              cpu: "10m"
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
           command: ["sh", "-exc"]
           args:
             - |


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
- add resources for vm and vmi jobs
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit CPU and memory resource requests and limits for update jobs in both virtual-machine and vm-instance applications to improve resource management.

* **Chores**
  * Updated version mappings and chart versions for virtual-machine (to 0.12.2) and vm-instance (to 0.10.1).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->