### PR TITLE
[ci] Refactor testing logic

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -264,8 +264,7 @@ jobs:
       - uses: actions/checkout@v4
       - id: set
         run: |
-          apps=$(find hack/e2e-apps -maxdepth 1 -mindepth 1 -name '*.bats' | \
-            awk -F/ '{sub(/\..+/, "", $NF); print $NF}' | jq -R . | jq -cs .)
+          apps=$(ls hack/e2e-apps/*.bats | cut -f3 -d/ | cut -f1 -d. | jq -R | jq -cs)
           echo "matrix={\"app\":$apps}" >> "$GITHUB_OUTPUT"
 
   test_apps:

--- a/hack/e2e-apps/clickhouse.bats
+++ b/hack/e2e-apps/clickhouse.bats
@@ -38,4 +38,5 @@ EOF
   timeout 100 sh -ec "until kubectl -n tenant-test get svc chi-clickhouse-$name-clickhouse-0-0 -o jsonpath='{.spec.ports[*].port}' | grep -q '9000 8123 9009'; do sleep 10; done"
   timeout 80 sh -ec "until kubectl -n tenant-test get sts chi-clickhouse-$name-clickhouse-0-1 ; do sleep 10; done"
   kubectl -n tenant-test wait statefulset.apps/chi-clickhouse-$name-clickhouse-0-1 --timeout=140s --for=jsonpath='{.status.replicas}'=1
+  kubectl -n tenant-test delete clickhouse $name
 }

--- a/hack/e2e-apps/kubernetes-latest.bats
+++ b/hack/e2e-apps/kubernetes-latest.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+@test "Create a tenant Kubernetes control plane with latest version" {
+  . hack/e2e-apps/run-kubernetes.sh
+  run_kubernetes_test 'keys | sort_by(.) | .[-1]' 'test-latest-version' '59991'
+}

--- a/hack/e2e-apps/kubernetes-previous.bats
+++ b/hack/e2e-apps/kubernetes-previous.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+@test "Create a tenant Kubernetes control plane with previous version" {
+  . hack/e2e-apps/run-kubernetes.sh
+  run_kubernetes_test 'keys | sort_by(.) | .[-2]' 'test-previous-version' '59992'
+}

--- a/hack/e2e-apps/run-kubernetes.sh
+++ b/hack/e2e-apps/run-kubernetes.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env bats
-
 run_kubernetes_test() {
     local version_expr="$1"
     local test_name="$2"
@@ -103,11 +101,4 @@ EOF
   # Clean up by deleting the Kubernetes resource
   kubectl -n tenant-test delete kuberneteses.apps.cozystack.io $test_name
 
-}
-
-@test "Create a tenant Kubernetes control plane with latest version" {
-  run_kubernetes_test 'keys | sort_by(.) | .[-1]' 'test-latest-version' '59991'
-}
-@test "Create a tenant Kubernetes control plane with previous version" {
-  run_kubernetes_test 'keys | sort_by(.) | .[-2]' 'test-previous-version' '59992'
 }


### PR DESCRIPTION
* Simplify test discovery logic in workflow.
* Delete Clickhouse after successful test.
* Separate two k8s tests into separate jobs.

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new end-to-end tests for creating tenant Kubernetes control planes with the latest and previous versions.
* **Bug Fixes**
  * Updated test script to include deletion of ClickHouse resources after test completion.
* **Chores**
  * Simplified the process for generating test app names in the workflow.
  * Refactored test helper scripts by removing embedded test cases for improved modularity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->