### PR TITLE
[platform] Autodetect RobotLB

### DIFF
--- a/packages/apps/ferretdb/templates/external-svc.yaml
+++ b/packages/apps/ferretdb/templates/external-svc.yaml
@@ -8,7 +8,9 @@ spec:
   type: {{ ternary "LoadBalancer" "ClusterIP" .Values.external }}
   {{- if .Values.external }}
   externalTrafficPolicy: Local
+    {{- if (include "cozy-lib.network.disableLoadBalancerNodePorts" $ | fromYaml) }}
   allocateLoadBalancerNodePorts: false
+    {{- end }}
   {{- end }}
   ports:
   - name: ferretdb

--- a/packages/apps/http-cache/templates/haproxy/service.yaml
+++ b/packages/apps/http-cache/templates/haproxy/service.yaml
@@ -10,7 +10,9 @@ spec:
   type: {{ ternary "LoadBalancer" "ClusterIP" .Values.external }}
   {{- if .Values.external }}
   externalTrafficPolicy: Local
+    {{- if (include "cozy-lib.network.disableLoadBalancerNodePorts" $ | fromYaml) }}
   allocateLoadBalancerNodePorts: false
+    {{- end }}
   {{- end }}
   selector:
     app: {{ .Release.Name }}-haproxy

--- a/packages/apps/postgres/templates/external-svc.yaml
+++ b/packages/apps/postgres/templates/external-svc.yaml
@@ -7,7 +7,9 @@ spec:
   type: {{ ternary "LoadBalancer" "ClusterIP" .Values.external }}
   {{- if .Values.external }}
   externalTrafficPolicy: Local
+    {{- if (include "cozy-lib.network.disableLoadBalancerNodePorts" $ | fromYaml) }}
   allocateLoadBalancerNodePorts: false
+    {{- end }}
   {{- end }}
   ports:
   - name: postgres

--- a/packages/apps/redis/templates/service.yaml
+++ b/packages/apps/redis/templates/service.yaml
@@ -11,7 +11,9 @@ spec:
   type: {{ ternary "LoadBalancer" "ClusterIP" .Values.external }}
   {{- if .Values.external }}
   externalTrafficPolicy: Local
+    {{- if (include "cozy-lib.network.disableLoadBalancerNodePorts" $ | fromYaml) }}
   allocateLoadBalancerNodePorts: false
+    {{- end }}
   {{- end }}
   selector:
     app.kubernetes.io/component: redis

--- a/packages/apps/tcp-balancer/templates/service.yaml
+++ b/packages/apps/tcp-balancer/templates/service.yaml
@@ -10,7 +10,9 @@ spec:
   type: {{ ternary "LoadBalancer" "ClusterIP" .Values.external }}
   {{- if .Values.external }}
   externalTrafficPolicy: Local
+    {{- if (include "cozy-lib.network.disableLoadBalancerNodePorts" $ | fromYaml) }}
   allocateLoadBalancerNodePorts: false
+    {{- end }}
   {{- end }}
   selector:
     app: {{ .Release.Name }}-haproxy

--- a/packages/apps/virtual-machine/templates/service.yaml
+++ b/packages/apps/virtual-machine/templates/service.yaml
@@ -13,7 +13,9 @@ metadata:
 spec:
   type: {{ ternary "LoadBalancer" "ClusterIP" .Values.external }}
   externalTrafficPolicy: Local
+    {{- if (include "cozy-lib.network.disableLoadBalancerNodePorts" $ | fromYaml) }}
   allocateLoadBalancerNodePorts: false
+    {{- end }}
   selector:
     {{- include "virtual-machine.selectorLabels" . | nindent 4 }}
   ports:

--- a/packages/apps/vm-instance/templates/service.yaml
+++ b/packages/apps/vm-instance/templates/service.yaml
@@ -13,7 +13,9 @@ metadata:
 spec:
   type: {{ ternary "LoadBalancer" "ClusterIP" .Values.external }}
   externalTrafficPolicy: Local
+    {{- if (include "cozy-lib.network.disableLoadBalancerNodePorts" $ | fromYaml) }}
   allocateLoadBalancerNodePorts: false
+    {{- end }}
   selector:
     {{- include "virtual-machine.selectorLabels" . | nindent 4 }}
   ports:

--- a/packages/library/cozy-lib/templates/_network.tpl
+++ b/packages/library/cozy-lib/templates/_network.tpl
@@ -1,0 +1,23 @@
+{{- define "cozy-lib.network.defaultDisableLoadBalancerNodePorts" }}
+{{/* Default behavior prior to introduction */}}
+{{-   `true` }}
+{{- end }}
+
+{{/* 
+Invoke as {{ include "cozy-lib.network.disableLoadBalancerNodePorts" $ }}.
+Detects whether the current load balancer class requires nodeports to function
+correctly. Currently just checks if Hetzner's RobotLB is enabled, which does
+require nodeports, and so, returns `false`. Otherwise assumes that metallb is
+in use and returns `true`.
+*/}}
+
+{{- define "cozy-lib.network.disableLoadBalancerNodePorts" }}
+{{-   include "cozy-lib.loadCozyConfig" (list "" .) }}
+{{-   $cozyConfig := index . 1 "cozyConfig" }}
+{{-   if not $cozyConfig }}
+{{-     include "cozy-lib.network.defaultDisableLoadBalancerNodePorts" . }}
+{{-   else }}
+{{-     $enabledComponents := splitList "," ((index $cozyConfig.data "bundle-enable") | default "") }}
+{{-     not (has "robotlb" $enabledComponents) }}
+{{-   end }}
+{{- end }}


### PR DESCRIPTION
If running in Hetzner and using Hetzner's cloud load balancers, node ports need to be allocated for the load balancer to function correctly. Therefore if RobotLB is enabled, we probably need to assign node ports.

Release note:
[platform] Autodetect if node ports should be assigned to load balancer services.

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[platform] Autodetect RobotLB
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added conditional control to disable load balancer node ports for external services including PostgreSQL, Redis, HAProxy, and others based on configuration.
* **Chores**
  * Introduced new configuration options to flexibly manage network-related service settings across multiple applications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->