### PR TITLE
[seaweedfs] add tests

### DIFF
--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -13,24 +13,33 @@ spec: {}
 EOF
 
   # Wait for the bucket to be ready
-  sleep 5
   kubectl -n tenant-test wait hr bucket-test --timeout=100s --for=condition=ready
 
   # Get and decode credentials
   kubectl get secret bucket-test -ojsonpath='{.data.BucketInfo}' -n tenant-test | base64 -d > bucket-test-credentials.json
-
-  # Start port-forwarding
-  bash -c 'timeout 100s kubectl port-forward service/seaweedfs-s3 -n tenant-test 8333:8333 > /dev/null 2>&1 &'
 
   # Get credentials from the secret
   ACCESS_KEY=$(jq -r '.spec.secretS3.accessKeyID' bucket-test-credentials.json)
   SECRET_KEY=$(jq -r '.spec.secretS3.accessSecretKey' bucket-test-credentials.json)
   BUCKET_NAME=$(jq -r '.spec.bucketName' bucket-test-credentials.json)
 
+  # Start port-forwarding
+  bash -c 'timeout 100s kubectl port-forward service/seaweedfs-s3 -n tenant-test 8333:8333 > /dev/null 2>&1 &'
+
+  # Wait for port-forward to be ready
+  timeout 30 sh -ec 'until nc -z localhost 8333; do sleep 1; done'
+
+  # Set up MinIO alias with error handling
   mc alias set local https://localhost:8333 $ACCESS_KEY $SECRET_KEY --insecure
-  mc cp bucket-test-credentials.json $BUCKET_NAME/bucket-test-credentials.json
-  mc ls $BUCKET_NAME
-  mc rm bucket-test-credentials.json $BUCKET_NAME/bucket-test-credentials.json
+
+  # Upload file to bucket
+  mc cp bucket-test-credentials.json local/$BUCKET_NAME/bucket-test-credentials.json
+
+  # Verify file was uploaded
+  mc ls local/$BUCKET_NAME | grep bucket-test-credentials.json
+
+  # Clean up uploaded file
+  mc rm local/$BUCKET_NAME/bucket-test-credentials.json
 
   kubectl -n tenant-test delete bucket.apps.cozystack.io test
 }

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -16,7 +16,7 @@ EOF
   kubectl -n tenant-test wait hr bucket-test --timeout=100s --for=condition=ready
 
   # Wait for credentials to be ready
-  timeout 60 bash -c "
+  timeout 180 bash -c "
       until kubectl get secret bucket-test -ojsonpath='{.data.BucketInfo}' -n tenant-test >/dev/null 2>&1; do
         sleep 2
       done

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -16,6 +16,13 @@ EOF
   kubectl -n tenant-test wait hr bucket-${name} --timeout=100s --for=condition=ready
   kubectl -n tenant-test wait bucketclaims.objectstorage.k8s.io bucket-${name} --timeout=300s --for=jsonpath='{.status.bucketReady}'
 
+
+  # Wait for credentials to be ready
+  timeout 180 bash -c "
+      until kubectl get secret bucket-${name} -ojsonpath='{.data.BucketInfo}' -n tenant-test >/dev/null 2>&1; do
+        sleep 2
+      done
+  "
   # Get and decode credentials
   kubectl -n tenant-test get secret bucket-${name} -ojsonpath='{.data.BucketInfo}' | base64 -d > bucket-test-credentials.json
 

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -15,14 +15,8 @@ EOF
   # Wait for the bucket to be ready
   kubectl -n tenant-test wait hr bucket-${name} --timeout=100s --for=condition=ready
   kubectl -n tenant-test wait bucketclaims.objectstorage.k8s.io bucket-${name} --timeout=300s --for=jsonpath='{.status.bucketReady}'
+  kubectl -n tenant-test wait bucketaccesses.objectstorage.k8s.io bucket-${name} --timeout=300s --for=jsonpath='{.status.accessGranted}'
 
-
-  # Wait for credentials to be ready
-  timeout 180 bash -c "
-      until kubectl get secret bucket-${name} -ojsonpath='{.data.BucketInfo}' -n tenant-test >/dev/null 2>&1; do
-        sleep 2
-      done
-  "
   # Get and decode credentials
   kubectl -n tenant-test get secret bucket-${name} -ojsonpath='{.data.BucketInfo}' | base64 -d > bucket-test-credentials.json
 

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -16,7 +16,7 @@ EOF
   kubectl -n tenant-test wait hr bucket-test --timeout=100s --for=condition=ready
 
   # Get and decode credentials
-  kubectl get secret bucket-test -ojsonpath='{.data.BucketInfo}' -n tenant-test | base64 -d > bucket-test-credentials.json
+  kubectl get secret bucket-test wait -ojsonpath='{.data.BucketInfo}' --timeout=100s -n tenant-test | base64 -d > bucket-test-credentials.json
 
   # Get credentials from the secret
   ACCESS_KEY=$(jq -r '.spec.secretS3.accessKeyID' bucket-test-credentials.json)

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+@test "Create and Verify Seeweedfs Bucket" {
+  # Create the bucket resource
+  name='test'
+  kubectl apply -f - <<EOF
+apiVersion: apps.cozystack.io/v1alpha1
+kind: Bucket
+metadata:
+  name: test
+  namespace: tenant-test
+spec: {}
+EOF
+
+  # Wait for the bucket to be ready
+  sleep 5
+  kubectl -n tenant-test wait hr bucket-test --timeout=100s --for=condition=ready
+
+  # Get and decode credentials
+  kubectl get secret bucket-test -ojsonpath='{.data.BucketInfo}' -n tenant-test | base64 -d > bucket-test-credentials.json
+
+  # Start port-forwarding
+  bash -c 'timeout 100s kubectl port-forward service/seaweedfs-s3 -n tenant-test 8333:8333 > /dev/null 2>&1 &'
+
+  # Get credentials from the secret
+  ACCESS_KEY=$(jq -r '.spec.secretS3.accessKeyID' bucket-test-credentials.json)
+  SECRET_KEY=$(jq -r '.spec.secretS3.accessSecretKey' bucket-test-credentials.json)
+  BUCKET_NAME=$(jq -r '.spec.bucketName' bucket-test-credentials.json)
+
+  mc alias set local https://localhost:8333 $ACCESS_KEY $SECRET_KEY --insecure
+  mc cp bucket-test-credentials.json $BUCKET_NAME/bucket-test-credentials.json
+  mc ls $BUCKET_NAME
+  mc rm bucket-test-credentials.json $BUCKET_NAME/bucket-test-credentials.json
+
+  kubectl -n tenant-test delete bucket.apps.cozystack.io test
+}

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -26,7 +26,7 @@ EOF
   BUCKET_NAME=$(jq -r '.spec.bucketName' bucket-test-credentials.json)
 
   # Start port-forwarding
-  bash -c 'timeout 100s kubectl port-forward service/seaweedfs-s3 -n tenant-test 8333:8333 > /dev/null 2>&1 &'
+  bash -c 'timeout 100s kubectl port-forward service/seaweedfs-s3 -n tenant-root 8333:8333 > /dev/null 2>&1 &'
 
   # Wait for port-forward to be ready
   timeout 30 sh -ec 'until nc -z localhost 8333; do sleep 1; done'

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -123,7 +123,7 @@ EOF
 
 @test "Configure Tenant and wait for applications" {
   # Patch root tenant and wait for its releases
-  kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true}}'
+  kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true, "seaweedfs":true}}'
 
   timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring tenant-root >/dev/null 2>&1; do sleep 1; done'
   kubectl wait hr/etcd hr/ingress hr/tenant-root -n tenant-root --timeout=2m --for=condition=ready

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -126,7 +126,7 @@ EOF
   kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true, "seaweedfs":true}}'
 
   timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring tenant-root >/dev/null 2>&1; do sleep 1; done'
-  kubectl wait hr/etcd hr/ingress hr/seaweedfs hr/seaweedfs-system hr/tenant-root -n tenant-root --timeout=4m --for=condition=ready
+  kubectl wait hr/etcd hr/ingress hr/seaweedfs hr/seaweedfs-system hr/tenant-root -n tenant-root --timeout=8m --for=condition=ready
 
   if ! kubectl wait hr/monitoring -n tenant-root --timeout=2m --for=condition=ready; then
     flux reconcile hr monitoring -n tenant-root --force

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -126,7 +126,7 @@ EOF
   kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true, "seaweedfs":true}}'
 
   timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring tenant-root >/dev/null 2>&1; do sleep 1; done'
-  kubectl wait hr/etcd hr/ingress hr/tenant-root -n tenant-root --timeout=2m --for=condition=ready
+  kubectl wait hr/etcd hr/ingress hr/seaweedfs hr/tenant-root -n tenant-root --timeout=2m --for=condition=ready
 
   if ! kubectl wait hr/monitoring -n tenant-root --timeout=2m --for=condition=ready; then
     flux reconcile hr monitoring -n tenant-root --force

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -126,7 +126,7 @@ EOF
   kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true, "seaweedfs":true}}'
 
   timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring tenant-root >/dev/null 2>&1; do sleep 1; done'
-  kubectl wait hr/etcd hr/ingress hr/seaweedfs hr/tenant-root -n tenant-root --timeout=2m --for=condition=ready
+  kubectl wait hr/etcd hr/ingress hr/seaweedfs hr/seaweedfs-system hr/tenant-root -n tenant-root --timeout=4m --for=condition=ready
 
   if ! kubectl wait hr/monitoring -n tenant-root --timeout=2m --for=condition=ready; then
     flux reconcile hr monitoring -n tenant-root --force

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -126,7 +126,7 @@ EOF
   kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true, "seaweedfs":true}}'
 
   timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring tenant-root >/dev/null 2>&1; do sleep 1; done'
-  kubectl wait hr/etcd hr/ingress hr/seaweedfs hr/seaweedfs-system hr/tenant-root -n tenant-root --timeout=8m --for=condition=ready
+  kubectl wait hr/etcd hr/ingress hr/seaweedfs hr/tenant-root -n tenant-root --timeout=4m --for=condition=ready
 
   if ! kubectl wait hr/monitoring -n tenant-root --timeout=2m --for=condition=ready; then
     flux reconcile hr monitoring -n tenant-root --force

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -123,10 +123,10 @@ EOF
 
 @test "Configure Tenant and wait for applications" {
   # Patch root tenant and wait for its releases
-  kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true, "seaweedfs": true}}'
+  kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true}}'
 
-  timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring seaweedfs tenant-root >/dev/null 2>&1; do sleep 1; done'
-  kubectl wait hr/etcd hr/ingress hr/tenant-root hr/seaweedfs -n tenant-root --timeout=4m --for=condition=ready
+  timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring tenant-root >/dev/null 2>&1; do sleep 1; done'
+  kubectl wait hr/etcd hr/ingress hr/tenant-root -n tenant-root --timeout=4m --for=condition=ready
 
   if ! kubectl wait hr/monitoring -n tenant-root --timeout=2m --for=condition=ready; then
     flux reconcile hr monitoring -n tenant-root --force
@@ -182,8 +182,9 @@ spec:
   isolated: true
   monitoring: false
   resourceQuotas: {}
-  seaweedfs: false
+  seaweedfs: true
 EOF
   kubectl wait hr/tenant-test -n tenant-root --timeout=1m --for=condition=ready
   kubectl wait namespace tenant-test --timeout=20s --for=jsonpath='{.status.phase}'=Active
+  kubectl wait hr/seaweedfs -n tenant-test --timeout=4m --for=condition=ready
 }

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -123,10 +123,10 @@ EOF
 
 @test "Configure Tenant and wait for applications" {
   # Patch root tenant and wait for its releases
-  kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true}}'
+  kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true, "seaweedfs": true}}'
 
-  timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring tenant-root >/dev/null 2>&1; do sleep 1; done'
-  kubectl wait hr/etcd hr/ingress hr/tenant-root -n tenant-root --timeout=4m --for=condition=ready
+  timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring seaweedfs tenant-root >/dev/null 2>&1; do sleep 1; done'
+  kubectl wait hr/etcd hr/ingress hr/tenant-root hr/seaweedfs -n tenant-root --timeout=4m --for=condition=ready
 
   if ! kubectl wait hr/monitoring -n tenant-root --timeout=2m --for=condition=ready; then
     flux reconcile hr monitoring -n tenant-root --force
@@ -182,9 +182,8 @@ spec:
   isolated: true
   monitoring: false
   resourceQuotas: {}
-  seaweedfs: true
+  seaweedfs: false
 EOF
   kubectl wait hr/tenant-test -n tenant-root --timeout=1m --for=condition=ready
   kubectl wait namespace tenant-test --timeout=20s --for=jsonpath='{.status.phase}'=Active
-  kubectl wait hr/seaweedfs -n tenant-test --timeout=4m --for=condition=ready
 }

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -182,8 +182,9 @@ spec:
   isolated: true
   monitoring: false
   resourceQuotas: {}
-  seaweedfs: false
+  seaweedfs: true
 EOF
   kubectl wait hr/tenant-test -n tenant-root --timeout=1m --for=condition=ready
   kubectl wait namespace tenant-test --timeout=20s --for=jsonpath='{.status.phase}'=Active
+  kubectl wait hr/seaweedfs -n tenant-test --timeout=4m --for=condition=ready
 }

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -123,10 +123,10 @@ EOF
 
 @test "Configure Tenant and wait for applications" {
   # Patch root tenant and wait for its releases
-  kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true, "seaweedfs":true}}'
+  kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true}}'
 
   timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring tenant-root >/dev/null 2>&1; do sleep 1; done'
-  kubectl wait hr/etcd hr/ingress hr/seaweedfs hr/tenant-root -n tenant-root --timeout=4m --for=condition=ready
+  kubectl wait hr/etcd hr/ingress hr/tenant-root -n tenant-root --timeout=4m --for=condition=ready
 
   if ! kubectl wait hr/monitoring -n tenant-root --timeout=2m --for=condition=ready; then
     flux reconcile hr monitoring -n tenant-root --force

--- a/packages/core/testing/images/e2e-sandbox/Dockerfile
+++ b/packages/core/testing/images/e2e-sandbox/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_${TA
  && chmod +x /usr/local/bin/yq
 RUN curl -sSL "https://fluxcd.io/install.sh" | bash
 RUN curl -sSL "https://github.com/cozystack/cozypkg/raw/refs/heads/main/hack/install.sh" | sh -s -- -v "${COZYPKG_VERSION}"
-RUN curl https://dl.min.io/client/mc/release/linux-amd64/mc --create-dirs -o  /usr/local/bin/mc \
+RUN curl https://dl.min.io/client/mc/release/${TARGETOS}-${TARGETARCH}/mc --create-dirs -o  /usr/local/bin/mc \
 && chmod +x /usr/local/bin/mc
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/packages/core/testing/images/e2e-sandbox/Dockerfile
+++ b/packages/core/testing/images/e2e-sandbox/Dockerfile
@@ -9,7 +9,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN apt update -q
-RUN apt install -yq --no-install-recommends awscli psmisc genisoimage ca-certificates qemu-kvm qemu-utils iproute2 iptables wget xz-utils netcat curl jq make git
+RUN apt install -yq --no-install-recommends psmisc genisoimage ca-certificates qemu-kvm qemu-utils iproute2 iptables wget xz-utils netcat curl jq make git
 RUN curl -sSL "https://github.com/siderolabs/talos/releases/download/v${TALOSCTL_VERSION}/talosctl-${TARGETOS}-${TARGETARCH}" -o /usr/local/bin/talosctl \
  && chmod +x /usr/local/bin/talosctl
 RUN curl -sSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl" -o /usr/local/bin/kubectl \

--- a/packages/core/testing/images/e2e-sandbox/Dockerfile
+++ b/packages/core/testing/images/e2e-sandbox/Dockerfile
@@ -9,7 +9,7 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN apt update -q
-RUN apt install -yq --no-install-recommends psmisc genisoimage ca-certificates qemu-kvm qemu-utils iproute2 iptables wget xz-utils netcat curl jq make git
+RUN apt install -yq --no-install-recommends awscli psmisc genisoimage ca-certificates qemu-kvm qemu-utils iproute2 iptables wget xz-utils netcat curl jq make git
 RUN curl -sSL "https://github.com/siderolabs/talos/releases/download/v${TALOSCTL_VERSION}/talosctl-${TARGETOS}-${TARGETARCH}" -o /usr/local/bin/talosctl \
  && chmod +x /usr/local/bin/talosctl
 RUN curl -sSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl" -o /usr/local/bin/kubectl \
@@ -19,6 +19,7 @@ RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_${TA
  && chmod +x /usr/local/bin/yq
 RUN curl -sSL "https://fluxcd.io/install.sh" | bash
 RUN curl -sSL "https://github.com/cozystack/cozypkg/raw/refs/heads/main/hack/install.sh" | sh -s -- -v "${COZYPKG_VERSION}"
-
+RUN curl https://dl.min.io/client/mc/release/linux-amd64/mc --create-dirs -o  /usr/local/bin/mc \
+&& chmod +x /usr/local/bin/mc
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does
Add tests for seaweedfs buckets

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced automated end-to-end testing for SeaweedFS bucket creation and verification in Kubernetes environments.

* **Chores**
  * Added MinIO client installation to the test environment for improved S3 compatibility testing.
  * Enabled SeaweedFS support in tenant configuration for end-to-end tests with extended HelmRelease timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->