### PR TITLE
Update Flux Operator to 0.27.0

### DIFF
--- a/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.24.1
+appVersion: v0.27.0
 description: 'A Helm chart for deploying the Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.24.1
+version: 0.27.0

--- a/packages/system/fluxcd-operator/charts/flux-operator/README.md
+++ b/packages/system/fluxcd-operator/charts/flux-operator/README.md
@@ -1,6 +1,6 @@
 # flux-operator
 
-![Version: 0.24.1](https://img.shields.io/badge/Version-0.24.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.24.1](https://img.shields.io/badge/AppVersion-v0.24.1-informational?style=flat-square)
+![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.27.0](https://img.shields.io/badge/AppVersion-v0.27.0-informational?style=flat-square)
 
 The [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator) provides a
 declarative API for the installation and upgrade of CNCF [Flux](https://fluxcd.io) and the
@@ -56,7 +56,7 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | rbac.createAggregation | bool | `true` | Grant the Kubernetes view, edit and admin roles access to ResourceSet APIs. |
 | readinessProbe | object | `{"httpGet":{"path":"/readyz","port":8081},"initialDelaySeconds":5,"periodSeconds":10}` | Container readiness probe settings. |
 | reporting | object | `{"interval":"5m"}` | Flux [reporting](https://fluxcd.control-plane.io/operator/fluxreport/) settings. |
-| resources | object | `{"limits":{"cpu":"1000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Container resources requests and limits settings. |
+| resources | object | `{"limits":{"cpu":"2000m","memory":"1Gi"},"requests":{"cpu":"100m","memory":"64Mi"}}` | Container resources requests and limits settings. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"seccompProfile":{"type":"RuntimeDefault"}}` | Container security context settings. The default is compliant with the pod security restricted profile. |
 | serviceAccount | object | `{"automount":true,"create":true,"name":""}` | Pod service account settings. The name of the service account defaults to the release name. |
 | serviceMonitor | object | `{"create":false,"interval":"60s","labels":{},"scrapeTimeout":"30s"}` | Prometheus Operator scraping settings. |

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
@@ -85,6 +85,16 @@ spec:
                       required for object-level workload identity.
                       This feature is only available in Flux v2.6.0 and later.
                     type: boolean
+                  size:
+                    description: |-
+                      Size defines the vertical scaling profile of the Flux controllers.
+                      The size is used to determine the concurrency and CPU/Memory limits for the Flux controllers.
+                      Accepted values are: 'small', 'medium' and 'large'.
+                    enum:
+                    - small
+                    - medium
+                    - large
+                    type: string
                   tenantDefaultServiceAccount:
                     description: |-
                       TenantDefaultServiceAccount is the name of the service account

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
@@ -1,5 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "object",
+    "required": [
+        "resources",
+        "securityContext"
+    ],
     "properties": {
         "affinity": {
             "default": {
@@ -21,16 +26,23 @@
                     }
                 }
             },
+            "type": "object",
             "properties": {
                 "nodeAffinity": {
+                    "type": "object",
                     "properties": {
                         "requiredDuringSchedulingIgnoredDuringExecution": {
+                            "type": "object",
                             "properties": {
                                 "nodeSelectorTerms": {
+                                    "type": "array",
                                     "items": {
+                                        "type": "object",
                                         "properties": {
                                             "matchExpressions": {
+                                                "type": "array",
                                                 "items": {
+                                                    "type": "object",
                                                     "properties": {
                                                         "key": {
                                                             "type": "string"
@@ -39,29 +51,22 @@
                                                             "type": "string"
                                                         },
                                                         "values": {
+                                                            "type": "array",
                                                             "items": {
                                                                 "type": "string"
-                                                            },
-                                                            "type": "array"
+                                                            }
                                                         }
-                                                    },
-                                                    "type": "object"
-                                                },
-                                                "type": "array"
+                                                    }
+                                                }
                                             }
-                                        },
-                                        "type": "object"
-                                    },
-                                    "type": "array"
+                                        }
+                                    }
                                 }
-                            },
-                            "type": "object"
+                            }
                         }
-                    },
-                    "type": "object"
+                    }
                 }
-            },
-            "type": "object"
+            }
         },
         "apiPriority": {
             "default": {
@@ -69,6 +74,7 @@
                 "extraServiceAccounts": [],
                 "level": "workload-high"
             },
+            "type": "object",
             "properties": {
                 "enabled": {
                     "type": "boolean"
@@ -79,30 +85,41 @@
                 "level": {
                     "type": "string"
                 }
-            },
-            "type": "object"
+            }
         },
         "commonAnnotations": {
-            "properties": {},
             "type": "object"
         },
         "commonLabels": {
-            "properties": {},
             "type": "object"
         },
         "extraArgs": {
+            "type": "array",
+            "uniqueItems": true,
             "items": {
                 "type": "string"
-            },
-            "type": "array",
-            "uniqueItems": true
+            }
         },
         "extraEnvs": {
+            "type": "array",
+            "uniqueItems": true,
             "items": {
                 "type": "object"
-            },
+            }
+        },
+        "extraVolumeMounts": {
             "type": "array",
-            "uniqueItems": true
+            "uniqueItems": true,
+            "items": {
+                "type": "object"
+            }
+        },
+        "extraVolumes": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "object"
+            }
         },
         "fullnameOverride": {
             "type": "string"
@@ -112,21 +129,25 @@
             "type": "boolean"
         },
         "image": {
+            "type": "object",
+            "required": [
+                "repository"
+            ],
             "properties": {
                 "imagePullPolicy": {
+                    "type": "string",
                     "enum": [
                         "IfNotPresent",
                         "Always",
                         "Never"
-                    ],
-                    "type": "string"
+                    ]
                 },
                 "pullSecrets": {
+                    "type": "array",
+                    "uniqueItems": true,
                     "items": {
                         "type": "object"
-                    },
-                    "type": "array",
-                    "uniqueItems": true
+                    }
                 },
                 "repository": {
                     "type": "string"
@@ -134,11 +155,7 @@
                 "tag": {
                     "type": "string"
                 }
-            },
-            "required": [
-                "repository"
-            ],
-            "type": "object"
+            }
         },
         "installCRDs": {
             "default": true,
@@ -153,8 +170,10 @@
                 "initialDelaySeconds": 15,
                 "periodSeconds": 20
             },
+            "type": "object",
             "properties": {
                 "httpGet": {
+                    "type": "object",
                     "properties": {
                         "path": {
                             "type": "string"
@@ -162,8 +181,7 @@
                         "port": {
                             "type": "integer"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "initialDelaySeconds": {
                     "type": "integer"
@@ -171,18 +189,18 @@
                 "periodSeconds": {
                     "type": "integer"
                 }
-            },
-            "type": "object"
+            }
         },
         "logLevel": {
+            "type": "string",
             "enum": [
                 "debug",
                 "info",
                 "error"
-            ],
-            "type": "string"
+            ]
         },
         "marketplace": {
+            "type": "object",
             "properties": {
                 "account": {
                     "type": "string"
@@ -193,10 +211,13 @@
                 "type": {
                     "type": "string"
                 }
-            },
-            "type": "object"
+            }
         },
         "multitenancy": {
+            "type": "object",
+            "required": [
+                "defaultServiceAccount"
+            ],
             "properties": {
                 "defaultServiceAccount": {
                     "type": "string"
@@ -204,26 +225,18 @@
                 "enabled": {
                     "type": "boolean"
                 }
-            },
-            "required": [
-                "defaultServiceAccount"
-            ],
-            "type": "object"
+            }
         },
         "nameOverride": {
             "type": "string"
         },
         "nodeSelector": {
-            "properties": {},
-            "type": [
-                "object"
-            ]
+            "type": "object"
         },
         "podSecurityContext": {
             "default": {
                 "fsGroup": 1337
             },
-            "properties": {},
             "type": "object"
         },
         "priorityClassName": {
@@ -231,6 +244,7 @@
             "type": "string"
         },
         "rbac": {
+            "type": "object",
             "properties": {
                 "create": {
                     "type": "boolean"
@@ -238,8 +252,7 @@
                 "createAggregation": {
                     "type": "boolean"
                 }
-            },
-            "type": "object"
+            }
         },
         "readinessProbe": {
             "default": {
@@ -250,8 +263,10 @@
                 "initialDelaySeconds": 5,
                 "periodSeconds": 10
             },
+            "type": "object",
             "properties": {
                 "httpGet": {
+                    "type": "object",
                     "properties": {
                         "path": {
                             "type": "string"
@@ -259,8 +274,7 @@
                         "port": {
                             "type": "integer"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "initialDelaySeconds": {
                     "type": "integer"
@@ -268,23 +282,24 @@
                 "periodSeconds": {
                     "type": "integer"
                 }
-            },
-            "type": "object"
+            }
         },
         "reporting": {
+            "type": "object",
+            "required": [
+                "interval"
+            ],
             "properties": {
                 "interval": {
                     "type": "string"
                 }
-            },
-            "required": [
-                "interval"
-            ],
-            "type": "object"
+            }
         },
         "resources": {
+            "type": "object",
             "properties": {
                 "limits": {
+                    "type": "object",
                     "properties": {
                         "cpu": {
                             "type": "string"
@@ -292,14 +307,14 @@
                         "memory": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "requests": {
                     "default": {
                         "cpu": "100m",
                         "memory": "64Mi"
                     },
+                    "type": "object",
                     "properties": {
                         "cpu": {
                             "type": "string"
@@ -307,13 +322,12 @@
                         "memory": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 }
-            },
-            "type": "object"
+            }
         },
         "securityContext": {
+            "type": "object",
             "properties": {
                 "allowPrivilegeEscalation": {
                     "default": false,
@@ -325,16 +339,16 @@
                             "ALL"
                         ]
                     },
+                    "type": "object",
                     "properties": {
                         "drop": {
+                            "type": "array",
+                            "uniqueItems": true,
                             "items": {
                                 "type": "string"
-                            },
-                            "type": "array",
-                            "uniqueItems": true
+                            }
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "readOnlyRootFilesystem": {
                     "default": true,
@@ -348,15 +362,14 @@
                     "default": {
                         "type": "RuntimeDefault"
                     },
+                    "type": "object",
                     "properties": {
                         "type": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 }
-            },
-            "type": "object"
+            }
         },
         "serviceAccount": {
             "default": {
@@ -364,6 +377,7 @@
                 "create": true,
                 "name": ""
             },
+            "type": "object",
             "properties": {
                 "automount": {
                     "type": "boolean"
@@ -374,8 +388,7 @@
                 "name": {
                     "type": "string"
                 }
-            },
-            "type": "object"
+            }
         },
         "serviceMonitor": {
             "default": {
@@ -383,6 +396,7 @@
                 "interval": "60s",
                 "scrapeTimeout": "30s"
             },
+            "type": "object",
             "properties": {
                 "create": {
                     "type": "boolean"
@@ -391,26 +405,19 @@
                     "type": "string"
                 },
                 "labels": {
-                    "properties": {},
                     "type": "object"
                 },
                 "scrapeTimeout": {
                     "type": "string"
                 }
-            },
-            "type": "object"
+            }
         },
         "tolerations": {
+            "type": "array",
+            "uniqueItems": true,
             "items": {
                 "type": "object"
-            },
-            "type": "array",
-            "uniqueItems": true
+            }
         }
-    },
-    "required": [
-        "resources",
-        "securityContext"
-    ],
-    "type": "object"
+    }
 }

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
@@ -46,7 +46,7 @@ apiPriority: # @schema default: {"enabled":false,"level":"workload-high","extraS
 # -- Container resources requests and limits settings.
 resources: # @schema required: true
   limits:
-    cpu: 1000m
+    cpu: 2000m
     memory: 1Gi
   requests: # @schema default: {"cpu":"100m","memory":"64Mi"}
     cpu: 100m

--- a/packages/system/fluxcd/charts/flux-instance/Chart.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.24.1
+appVersion: v0.27.0
 description: 'A Helm chart for deploying a Flux instance managed by Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.24.1
+version: 0.27.0

--- a/packages/system/fluxcd/charts/flux-instance/README.md
+++ b/packages/system/fluxcd/charts/flux-instance/README.md
@@ -1,6 +1,6 @@
 # flux-instance
 
-![Version: 0.24.1](https://img.shields.io/badge/Version-0.24.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.24.1](https://img.shields.io/badge/AppVersion-v0.24.1-informational?style=flat-square)
+![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.27.0](https://img.shields.io/badge/AppVersion-v0.27.0-informational?style=flat-square)
 
 This chart is a thin wrapper around the `FluxInstance` custom resource, which is
 used by the [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator)
@@ -37,7 +37,9 @@ helm -n flux-system uninstall flux
 | commonAnnotations | object | `{}` | Common annotations to add to all deployed objects including pods. |
 | commonLabels | object | `{}` | Common labels to add to all deployed objects including pods. |
 | fullnameOverride | string | `"flux"` |  |
-| instance.cluster | object | `{"domain":"cluster.local","multitenant":false,"networkPolicy":true,"tenantDefaultServiceAccount":"default","type":"kubernetes"}` | Cluster https://fluxcd.control-plane.io/operator/fluxinstance/#cluster-configuration |
+| healthcheck.enabled | bool | `false` | Enable post-install and post-upgrade health checks. |
+| healthcheck.timeout | string | `"5m"` | Health check timeout in Go duration format. |
+| instance.cluster | object | `{"domain":"cluster.local","multitenant":false,"networkPolicy":true,"size":"","tenantDefaultServiceAccount":"default","type":"kubernetes"}` | Cluster https://fluxcd.control-plane.io/operator/fluxinstance/#cluster-configuration |
 | instance.commonMetadata | object | `{"annotations":{},"labels":{}}` | Common metadata https://fluxcd.control-plane.io/operator/fluxinstance/#common-metadata |
 | instance.components | list | `["source-controller","kustomize-controller","helm-controller","notification-controller"]` | Components https://fluxcd.control-plane.io/operator/fluxinstance/#components-configuration |
 | instance.distribution | object | `{"artifact":"oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:latest","artifactPullSecret":"","imagePullSecret":"","registry":"ghcr.io/fluxcd","version":"2.x"}` | Distribution https://fluxcd.control-plane.io/operator/fluxinstance/#distribution-configuration |

--- a/packages/system/fluxcd/charts/flux-instance/templates/healthcheck.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/templates/healthcheck.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.healthcheck.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-healthcheck"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      {{- with .Values.healthcheck.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Values.healthcheck.serviceAccount.name }}
+      {{- with .Values.healthcheck.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.healthcheck.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
+      containers:
+        - name: healthcheck
+          image: "{{ .Values.healthcheck.image.repository }}:{{ .Values.healthcheck.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: "{{ .Values.healthcheck.image.imagePullPolicy }}"
+          args:
+            - wait
+            - instance
+            - {{ include "flux-instance.fullname" . }}
+            - --namespace={{ .Release.Namespace }}
+            - --timeout={{ .Values.healthcheck.timeout }}
+            {{- range .Values.healthcheck.extraArgs }}
+            - {{ . }}
+            {{- end }}
+          {{- with .Values.healthcheck.envs }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.healthcheck.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.healthcheck.resources | nindent 12 }}
+          {{- with .Values.healthcheck.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.healthcheck.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.healthcheck.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.healthcheck.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.healthcheck.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/packages/system/fluxcd/charts/flux-instance/templates/instance.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/templates/instance.yaml
@@ -24,7 +24,12 @@ spec:
     imagePullSecret: {{ .Values.instance.distribution.imagePullSecret }}
     {{- end }}
   components: {{ .Values.instance.components | toYaml | nindent 4 }}
-  cluster: {{ .Values.instance.cluster | toYaml | nindent 4 }}
+  cluster:
+    {{- range $key, $value := .Values.instance.cluster }}
+    {{- if not (and (kindIs "string" $value) (eq $value "")) }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+    {{- end }}
   {{- if or .Values.instance.commonMetadata.annotations  .Values.instance.commonMetadata.labels }}
   commonMetadata:
     {{- with .Values.instance.commonMetadata.annotations }}

--- a/packages/system/fluxcd/charts/flux-instance/templates/serviceaccount.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.healthcheck.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.healthcheck.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "flux-instance.labels" . | nindent 4 }}
+    {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.healthcheck.serviceAccount.automount }}
+{{- end }}

--- a/packages/system/fluxcd/charts/flux-instance/values.schema.json
+++ b/packages/system/fluxcd/charts/flux-instance/values.schema.json
@@ -1,20 +1,275 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "type": "object",
     "properties": {
         "commonAnnotations": {
-            "properties": {},
             "type": "object"
         },
         "commonLabels": {
-            "properties": {},
             "type": "object"
         },
         "fullnameOverride": {
             "type": "string"
         },
+        "healthcheck": {
+            "type": "object",
+            "required": [
+                "resources",
+                "securityContext"
+            ],
+            "properties": {
+                "affinity": {
+                    "default": {
+                        "nodeAffinity": {
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                "nodeSelectorTerms": [
+                                    {
+                                        "matchExpressions": [
+                                            {
+                                                "key": "kubernetes.io/os",
+                                                "operator": "In",
+                                                "values": [
+                                                    "linux"
+                                                ]
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "type": "object",
+                    "properties": {
+                        "nodeAffinity": {
+                            "type": "object",
+                            "properties": {
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nodeSelectorTerms": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "envs": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "extraArgs": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "hostNetwork": {
+                    "default": false,
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "required": [
+                        "repository"
+                    ],
+                    "properties": {
+                        "imagePullPolicy": {
+                            "type": "string",
+                            "enum": [
+                                "IfNotPresent",
+                                "Always",
+                                "Never"
+                            ]
+                        },
+                        "pullSecrets": {
+                            "type": "array",
+                            "uniqueItems": true,
+                            "items": {
+                                "type": "object"
+                            }
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podSecurityContext": {
+                    "default": {
+                        "fsGroup": 1337
+                    },
+                    "type": "object"
+                },
+                "resources": {
+                    "type": "object",
+                    "properties": {
+                        "limits": {
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "requests": {
+                            "default": {
+                                "cpu": "100m",
+                                "memory": "64Mi"
+                            },
+                            "type": "object",
+                            "properties": {
+                                "cpu": {
+                                    "type": "string"
+                                },
+                                "memory": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "securityContext": {
+                    "type": "object",
+                    "properties": {
+                        "allowPrivilegeEscalation": {
+                            "default": false,
+                            "type": "boolean"
+                        },
+                        "capabilities": {
+                            "default": {
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "type": "object",
+                            "properties": {
+                                "drop": {
+                                    "type": "array",
+                                    "uniqueItems": true,
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "readOnlyRootFilesystem": {
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "runAsNonRoot": {
+                            "default": true,
+                            "type": "boolean"
+                        },
+                        "seccompProfile": {
+                            "default": {
+                                "type": "RuntimeDefault"
+                            },
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "default": {
+                        "automount": true,
+                        "create": false,
+                        "name": "flux-operator"
+                    },
+                    "type": "object",
+                    "properties": {
+                        "automount": {
+                            "type": "boolean"
+                        },
+                        "create": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "timeout": {
+                    "default": "5m",
+                    "type": "string"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "volumeMounts": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "volumes": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "object"
+                    }
+                }
+            }
+        },
         "instance": {
+            "type": "object",
+            "required": [
+                "distribution",
+                "cluster"
+            ],
             "properties": {
                 "cluster": {
+                    "type": "object",
                     "properties": {
                         "domain": {
                             "type": "string"
@@ -25,37 +280,46 @@
                         "networkPolicy": {
                             "type": "boolean"
                         },
+                        "size": {
+                            "type": "string",
+                            "enum": [
+                                "",
+                                "small",
+                                "medium",
+                                "large"
+                            ]
+                        },
                         "tenantDefaultServiceAccount": {
                             "type": "string"
                         },
                         "type": {
+                            "type": "string",
                             "enum": [
                                 "kubernetes",
                                 "openshift",
                                 "aws",
                                 "azure",
                                 "gcp"
-                            ],
-                            "type": "string"
+                            ]
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "commonMetadata": {
+                    "type": "object",
                     "properties": {
                         "annotations": {
-                            "properties": {},
                             "type": "object"
                         },
                         "labels": {
-                            "properties": {},
                             "type": "object"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "components": {
+                    "type": "array",
+                    "uniqueItems": true,
                     "items": {
+                        "type": "string",
                         "enum": [
                             "source-controller",
                             "kustomize-controller",
@@ -63,13 +327,15 @@
                             "notification-controller",
                             "image-reflector-controller",
                             "image-automation-controller"
-                        ],
-                        "type": "string"
-                    },
-                    "type": "array",
-                    "uniqueItems": true
+                        ]
+                    }
                 },
                 "distribution": {
+                    "type": "object",
+                    "required": [
+                        "version",
+                        "registry"
+                    ],
                     "properties": {
                         "artifact": {
                             "type": "string"
@@ -86,39 +352,35 @@
                         "version": {
                             "type": "string"
                         }
-                    },
-                    "required": [
-                        "version",
-                        "registry"
-                    ],
-                    "type": "object"
+                    }
                 },
                 "kustomize": {
+                    "type": "object",
                     "properties": {
                         "patches": {
+                            "type": "array",
                             "items": {
                                 "type": "object"
-                            },
-                            "type": "array"
+                            }
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "sharding": {
+                    "type": "object",
                     "properties": {
                         "key": {
                             "type": "string"
                         },
                         "shards": {
+                            "type": "array",
                             "items": {
                                 "type": "string"
-                            },
-                            "type": "array"
+                            }
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "storage": {
+                    "type": "object",
                     "properties": {
                         "class": {
                             "type": "string"
@@ -126,21 +388,21 @@
                         "size": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 },
                 "sync": {
+                    "type": "object",
                     "properties": {
                         "interval": {
                             "type": "string"
                         },
                         "kind": {
+                            "type": "string",
                             "enum": [
                                 "GitRepository",
                                 "OCIRepository",
                                 "Bucket"
-                            ],
-                            "type": "string"
+                            ]
                         },
                         "name": {
                             "type": "string"
@@ -160,19 +422,12 @@
                         "url": {
                             "type": "string"
                         }
-                    },
-                    "type": "object"
+                    }
                 }
-            },
-            "required": [
-                "distribution",
-                "cluster"
-            ],
-            "type": "object"
+            }
         },
         "nameOverride": {
             "type": "string"
         }
-    },
-    "type": "object"
+    }
 }

--- a/packages/system/fluxcd/charts/flux-instance/values.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/values.yaml
@@ -20,6 +20,7 @@ instance:
   # -- Cluster https://fluxcd.control-plane.io/operator/fluxinstance/#cluster-configuration
   cluster: # @schema required: true
     type: kubernetes # @schema enum:[kubernetes,openshift,aws,azure,gcp]
+    size: "" # @schema enum:['',small,medium,large]
     domain: "cluster.local"
     networkPolicy: true
     multitenant: false
@@ -35,7 +36,7 @@ instance:
   # -- Sharding https://fluxcd.control-plane.io/operator/fluxinstance/#sharding-configuration
   sharding: # @schema required: false
     key: "sharding.fluxcd.io/key"
-    shards: [] # @schema item: string
+    shards: [ ] # @schema item: string
   # -- Sync https://fluxcd.control-plane.io/operator/fluxinstance/#sync-configuration
   sync: # @schema required: false
     interval: 1m
@@ -48,10 +49,101 @@ instance:
     provider: ""
   kustomize: # @schema required: false
     # -- Kustomize patches https://fluxcd.control-plane.io/operator/fluxinstance/#kustomize-patches
-    patches: [] # @schema item: object
+    patches: [ ] # @schema item: object
 
 # -- Common annotations to add to all deployed objects including pods.
 commonAnnotations: { }
 
 # -- Common labels to add to all deployed objects including pods.
 commonLabels: { }
+
+# Healthcheck job settings.
+healthcheck:
+  # -- Enable post-install and post-upgrade health checks.
+  enabled: false
+  # -- Health check timeout in Go duration format.
+  timeout: 5m # @schema default: "5m"
+
+  # Container image settings.
+  # The image tag defaults to the chart appVersion.
+  # @ignore
+  image:
+    repository: ghcr.io/controlplaneio-fluxcd/flux-operator-cli # @schema required: true
+    tag: ""
+    pullSecrets: [ ] # @schema item: object ; uniqueItems: true
+    imagePullPolicy: IfNotPresent # @schema enum:[IfNotPresent, Always, Never]
+
+  # Container resources requests and limits settings.
+  # @ignore
+  resources: # @schema required: true
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests: # @schema default: {"cpu":"100m","memory":"64Mi"}
+      cpu: 100m
+      memory: 64Mi
+
+  # Pod service account settings.
+  # The name of the service account defaults to the release name.
+  # @ignore
+  serviceAccount: # @schema default: {"create":false,"automount":true,"name":"flux-operator"}
+    create: false
+    automount: true
+    name: "flux-operator"
+
+  # Pod security context settings.
+  # @ignore
+  podSecurityContext: { } # @schema default: {"fsGroup":1337}
+
+  # Container security context settings.
+  # The default is compliant with the pod security restricted profile.
+  # @ignore
+  securityContext: # @schema required: true
+    runAsNonRoot: true # @schema default: true
+    readOnlyRootFilesystem: true # @schema default: true
+    allowPrivilegeEscalation: false # @schema default: false
+    capabilities: # @schema default: {"drop":["ALL"]}
+      drop: # @schema item: string ; uniqueItems: true
+        - "ALL"
+    seccompProfile: # @schema default: {"type":"RuntimeDefault"}
+      type: "RuntimeDefault"
+
+  # Pod affinity and anti-affinity settings.
+  # @ignore
+  affinity: # @schema default: {"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"kubernetes.io/os","operator":"In","values":["linux"]}]}]}}}
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+
+  # Pod tolerations settings.
+  # @ignore
+  tolerations: [ ] # @schema item: object ; uniqueItems: true
+
+  # Pod Node Selector settings.
+  # @ignore
+  nodeSelector: { } # @schema type: object
+
+  # If `true`, the container ports (`8080` and `8081`) are exposed on the host network.
+  # @ignore
+  hostNetwork: false # @schema default: false
+
+  # Pod extra volumes.
+  # @ignore
+  volumes: [ ] # @schema item: object ; uniqueItems: true
+
+  # Container extra volume mounts.
+  # @ignore
+  volumeMounts: [ ] # @schema item: object ; uniqueItems: true
+
+  # Container extra environment variables.
+  # @ignore
+  envs: [ ] # @schema item: object ; uniqueItems: true
+
+  # Container extra arguments.
+  # @ignore
+  extraArgs: [ ] # @schema item: string ; uniqueItems: true


### PR DESCRIPTION
New Flux Operator from this morning

Changelogs:
* 0.25.0 https://github.com/controlplaneio-fluxcd/flux-operator/releases/tag/v0.25.0
* 0.26.0 https://github.com/controlplaneio-fluxcd/flux-operator/releases/tag/v0.26.0
* 0.27.0 https://github.com/controlplaneio-fluxcd/flux-operator/releases/tag/v0.27.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable healthcheck feature for post-install and post-upgrade verification, including a dedicated healthcheck job and service account options.
  * Added an optional `size` field to cluster configuration, allowing selection of vertical scaling profiles (`small`, `medium`, `large`).

* **Enhancements**
  * Increased default CPU resource limits for the Flux Operator from 1 CPU to 2 CPUs.
  * Improved configuration schemas with explicit typing and validation for greater clarity and reliability.

* **Documentation**
  * Updated documentation to reflect new configuration options, version numbers, and enhanced resource settings.

* **Bug Fixes**
  * Template rendering now omits empty string values in cluster configuration, resulting in cleaner manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->