### PR TITLE
[fix] Disable VPA for VPA

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/vertical-pod-autoscaler.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/vertical-pod-autoscaler.yaml
@@ -3,8 +3,8 @@
 {{- $clusterDomain := (index $cozyConfig.data "cluster-domain") | default "cozy.local" }}
 {{- $myNS := lookup "v1" "Namespace" "" .Release.Namespace }}
 {{- $targetTenant := index $myNS.metadata.annotations "namespace.cozystack.io/monitoring" }}
+vpaForVPA: false
 vertical-pod-autoscaler:
-  vpaForVPA: false
   recommender:
     extraArgs:
       container-name-label: container


### PR DESCRIPTION
The earlier PR was erroneously merged without including an amendment to the existing commits, so now this amendment must be included as a separate patch. See #1301 for details.

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration structure by moving the `vpaForVPA` setting to a top-level key in the default values for Vertical Pod Autoscaler. No changes to configuration values or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->