### PR TITLE
controller add sleep before annotate hr

### DIFF
--- a/internal/controller/system_helm_reconciler.go
+++ b/internal/controller/system_helm_reconciler.go
@@ -33,6 +33,7 @@ const requestedAt = "reconcile.fluxcd.io/requestedAt"
 
 func (r *CozystackConfigReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx)
+	time.Sleep(2 * time.Second)
 
 	digest, err := r.computeDigest(ctx)
 	if err != nil {

--- a/internal/controller/tenant_helm_reconciler.go
+++ b/internal/controller/tenant_helm_reconciler.go
@@ -26,6 +26,7 @@ type TenantHelmReconciler struct {
 
 func (r *TenantHelmReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+	time.Sleep(2 * time.Second)
 
 	hr := &helmv2.HelmRelease{}
 	if err := r.Get(ctx, req.NamespacedName, hr); err != nil {


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
- controller add sleep before annotate hr
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - None.
- Chores
  - Introduced a fixed 2-second delay at the start of reconciliation for system and tenant Helm operations. This may slightly increase the time before reconciliation actions begin, impacting perceived responsiveness during sync cycles. No other behavior or outcomes are changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->