### PR TITLE
[cozy-lib] Fix malformed retrieval of cozyConfig

### DIFF
--- a/packages/library/cozy-lib/templates/_network.tpl
+++ b/packages/library/cozy-lib/templates/_network.tpl
@@ -13,7 +13,7 @@ in use and returns `true`.
 
 {{- define "cozy-lib.network.disableLoadBalancerNodePorts" }}
 {{-   include "cozy-lib.loadCozyConfig" (list "" .) }}
-{{-   $cozyConfig := index . 1 "cozyConfig" }}
+{{-   $cozyConfig := index . "cozyConfig" }}
 {{-   if not $cozyConfig }}
 {{-     include "cozy-lib.network.defaultDisableLoadBalancerNodePorts" . }}
 {{-   else }}


### PR DESCRIPTION
A malformed access to the global context was preventing some helm charts from rendering correctly.

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

This patch fixes the issue.

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[cozy-lib] Fix malformed retrieval of cozyConfig in cozy-lib template.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected configuration lookup for the network setting that controls disabling LoadBalancer node ports, ensuring defaults are applied when config is absent and behavior reflects enabled components.
* **Refactor**
  * Simplified configuration retrieval path to use the root context for more reliable evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->