### PR TITLE
fix seaweedfs s3 liveness probe scheme

### DIFF
--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -84,6 +84,8 @@ seaweedfs:
     enableAuth: false
     readinessProbe:
       scheme: HTTPS
+    livenessProbe:
+      scheme: HTTPS
     logs:
       type: ""
     ingress:


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
fix seaweedfs s3 liveness probe scheme
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a liveness check for the SeaweedFS S3 endpoint (HTTPS). This improves health monitoring and enables automatic recovery if the service becomes unresponsive, enhancing stability and uptime while reducing manual intervention. Readiness behavior remains unchanged. No user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->