### PR TITLE
Fix missing cozy-lib.resources.flatten template

### DIFF
--- a/packages/library/cozy-lib/templates/_resources.tpl
+++ b/packages/library/cozy-lib/templates/_resources.tpl
@@ -172,3 +172,15 @@
 {{-   $xmsMi := min (div $memoryLimitInt 4194304) (div $memoryRequestInt 1048576) }}
 {{-   printf `-Xms%dm -Xmx%dm` $xmsMi $xmxMi }}
 {{- end }}
+
+{{- define "cozy-lib.resources.flatten" -}}
+{{- $out := dict -}}
+{{- $res := include "cozy-lib.resources.sanitize" . | fromYaml -}}
+{{- range $section, $values := $res }}
+  {{- range $k, $v := $values }}
+    {{- $key := printf "%s.%s" $section $k }}
+    {{- $_ := set $out $key $v }}
+  {{- end }}
+{{- end }}
+{{- dict "resourceQuotas" $out | toYaml }}
+{{- end }}


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```