### PR TITLE
Update SeaweedFS to v3.97 to enable SSE support

### DIFF
--- a/packages/system/seaweedfs/charts/seaweedfs/Chart.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: SeaweedFS
 name: seaweedfs
-appVersion: "3.96"
+appVersion: "3.97"
 # Dev note: Trigger a helm chart release by `git tag -a helm-<version>`
-version: 4.0.396
+version: 4.0.397

--- a/packages/system/seaweedfs/charts/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/values.yaml
@@ -358,7 +358,7 @@ volume:
   # This will automatically create a job for patching Kubernetes resources if the dataDirs type is 'persistentVolumeClaim' and the size has changed.
   resizeHook:
     enabled: true
-    image: bitnami/kubectl
+    image: alpine/k8s:1.28.4
 
   # idx can be defined by:
   #


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[seaweedfs] Update SeaweedFS to v3.97 to enable SSE support
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated SeaweedFS chart to version 4.0.397 and app version to 3.97.
  * Changed the image used for volume resize operations to alpine/k8s:1.28.4, replacing bitnami/kubectl.
  * This affects the resize hook used to patch Kubernetes resources during capacity changes for PVC-based deployments.
  * No other functional changes included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->