### PR TITLE
Get rid of bitnami images

### DIFF
--- a/packages/apps/virtual-machine/templates/vm-update-hook.yaml
+++ b/packages/apps/virtual-machine/templates/vm-update-hook.yaml
@@ -51,7 +51,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: update-resources
-          image: bitnami/kubectl:latest
+          image: docker.io/alpine/k8s:1.33.4
           resources:
             requests:
               memory: "16Mi"

--- a/packages/apps/vm-disk/templates/pvc-resize-hook.yaml
+++ b/packages/apps/vm-disk/templates/pvc-resize-hook.yaml
@@ -19,7 +19,7 @@ spec:
       backoffLimit: 1
       containers:
         - name: resize
-          image: bitnami/kubectl
+          image: docker.io/alpine/k8s:1.33.4
           command: ["sh", "-xec"]
           args:
             - |

--- a/packages/apps/vm-instance/templates/vm-update-hook.yaml
+++ b/packages/apps/vm-instance/templates/vm-update-hook.yaml
@@ -41,7 +41,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: update-resources
-          image: bitnami/kubectl:latest
+          image: docker.io/alpine/k8s:1.33.4
           resources:
             requests:
               memory: "16Mi"

--- a/packages/extra/etcd/templates/hook/job.yaml
+++ b/packages/extra/etcd/templates/hook/job.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: etcd-hook
       containers:
         - name: kubectl
-          image: bitnami/kubectl:latest
+          image: docker.io/alpine/k8s:1.33.4
           command:
           - sh
           args:

--- a/packages/system/dashboard/values.yaml
+++ b/packages/system/dashboard/values.yaml
@@ -21,7 +21,18 @@ kubeapps:
       repository: dashboard
       tag: v0.36.0-alpha.1
       digest: "sha256:54906b3d2492c8603a347a5938b6db36e5ed5c4149111cae1804ac9110361947"
+  frontend:
+    image:
+      repository: bitnamilegacy/nginx
+  authProxy:
+    image:
+      repository: bitnamilegacy/oauth2-proxy
   redis:
+    image:
+      repository: bitnamilegacy/redis
+    kubectl:
+      image:
+        repository: bitnamilegacy/kubectl
     master:
       resourcesPreset: "none"
       resources:

--- a/packages/system/seaweedfs/templates/hook.yaml
+++ b/packages/system/seaweedfs/templates/hook.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: seaweedfs-hook
       containers:
         - name: kubectl
-          image: bitnami/kubectl:latest
+          image: docker.io/alpine/k8s:1.33.4
           command:
           - sh
           args:

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -21,6 +21,8 @@ seaweedfs:
       type: ""
   volume:
     replicas: 2
+    resizeHook:
+      image: docker.io/alpine/k8s:1.33.4
     # minimum free disk space(in percents). If free disk space lower this value - all volumes marks as ReadOnly
     minFreeSpacePercent: 5
     dataDirs:

--- a/packages/system/velero/values.yaml
+++ b/packages/system/velero/values.yaml
@@ -13,3 +13,7 @@ velero:
     volumeSnapshotLocation: null
     namespace: cozy-velero
     features: EnableCSI
+  kubectl:
+    image:
+      repository: docker.io/alpine/k8s
+      tag: 1.33.4

--- a/packages/system/vertical-pod-autoscaler/values.yaml
+++ b/packages/system/vertical-pod-autoscaler/values.yaml
@@ -4,6 +4,11 @@ vertical-pod-autoscaler:
   crds:
     enabled: false
 
+    image:
+      registry: docker.io
+      repository: alpine/k8s
+      tag: 1.33.4
+
   updater:
     resources:
       limits:


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

This PR removes bitnami images from all charts. Bitnami has deprecated their free images, see details here:
- https://github.com/bitnami/charts/issues/35164

Also dashboard has moved helper images to `bitnamilegacy`, we will fully replace it by our new dashboard soon:
- https://github.com/cozystack/cozystack/pull/1269

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
Get rid of bitnami images
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added configurable image overrides for Kubeapps components (frontend, auth proxy, Redis, kubectl).
  * Introduced image settings for Velero’s kubectl helper.
  * Added image configuration for Vertical Pod Autoscaler components.
  * Added a configurable resize hook image for SeaweedFS volumes.

* Chores
  * Standardized kubectl-related images to alpine/k8s:1.33.4 across multiple operational hooks (VM update, PVC resize, etcd maintenance, SeaweedFS pre-upgrade), with no behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->