### PR TITLE
[virtual-machine] Fix vm update hook

### DIFF
--- a/packages/apps/virtual-machine/templates/vm-update-hook.yaml
+++ b/packages/apps/virtual-machine/templates/vm-update-hook.yaml
@@ -64,14 +64,14 @@ spec:
             - |
               {{- if $needUpdateType }}
               echo "Patching VirtualMachine for instancetype update..."
-              kubectl patch virtualmachine {{ $vmName }} -n {{ $namespace }} \
+              kubectl patch virtualmachines.kubevirt.io {{ $vmName }} -n {{ $namespace }} \
                 --type merge \
                 -p '{"spec":{"instancetype":{"name": "{{ $instanceType }}", "revisionName": null}}}'
               {{- end }}
               
               {{- if $needUpdateProfile }}
               echo "Patching VirtualMachine for preference update..."
-              kubectl patch virtualmachine {{ $vmName }} -n {{ $namespace }} \
+              kubectl patch virtualmachines.kubevirt.io {{ $vmName }} -n {{ $namespace }} \
                 --type merge \
                 -p '{"spec":{"preference":{"name": "{{ $instanceProfile }}", "revisionName": null}}}'
               {{- end }}

--- a/packages/apps/vm-instance/templates/vm-update-hook.yaml
+++ b/packages/apps/vm-instance/templates/vm-update-hook.yaml
@@ -54,14 +54,14 @@ spec:
             - |
               {{- if $needUpdateType }}
               echo "Patching VirtualMachine for instancetype update..."
-              kubectl patch virtualmachine {{ $vmName }} -n {{ $namespace }} \
+              kubectl patch virtualmachines.kubevirt.io {{ $vmName }} -n {{ $namespace }} \
                 --type merge \
                 -p '{"spec":{"instancetype":{"name": "{{ $instanceType }}", "revisionName": null}}}'
               {{- end }}
               
               {{- if $needUpdateProfile }}
               echo "Patching VirtualMachine for preference update..."
-              kubectl patch virtualmachine {{ $vmName }} -n {{ $namespace }} \
+              kubectl patch virtualmachines.kubevirt.io {{ $vmName }} -n {{ $namespace }} \
                 --type merge \
                 -p '{"spec":{"preference":{"name": "{{ $instanceProfile }}", "revisionName": null}}}'
               {{- end }}


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Fix regression introduced by https://github.com/cozystack/cozystack/pull/1169, now we have correct singular names for virtualmachines which are conflictiing with KubeVirt ones.

Solution: explicitly specify apiversion

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[virtual-machine] Fix vm update hook
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of VM update hooks by targeting the correct API resource, preventing occasional patch failures when updating instancetype and preference.
  * Ensures VM updates apply consistently across environments without changing existing behavior.

* **Chores**
  * Aligned resource references with fully qualified API names to enhance compatibility with current cluster configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->