### PR TITLE
[platform] Fix boolean override bug in Helm merge — ConfigMap values now correctly take precedence over bundle defaults

### DIFF
--- a/packages/core/platform/templates/helmreleases.yaml
+++ b/packages/core/platform/templates/helmreleases.yaml
@@ -77,7 +77,7 @@ spec:
   {{-   $values = merge . $values }}
   {{- end }}
   {{- with index $cozyConfig.data (printf "values-%s" $x.name) }}
-  {{-   $values = merge (fromYaml .) $values }}
+  {{-   $values = mergeOverwrite $values (fromYaml .) }}
   {{- end }}
   {{- with $values }}
   values:


### PR DESCRIPTION
## What this PR does

Fixes a bug where boolean values from bundle files could not be properly overridden by `values-<component>` entries in ConfigMaps.  

The root cause is a Helm merge function limitation: when merging boolean values, `true` from the first map is not overwritten by `false` from the second map. This caused ConfigMap overrides to be ignored in certain cases.  

This PR switches to `mergeOverwrite`, ensuring that ConfigMap values always take precedence over bundle defaults, as intended.  

### Example
- **Bundle:** `autoDirectNodeRoutes: true`  
- **ConfigMap (values-cilium):** `autoDirectNodeRoutes: false`  
- **Before:** result = `true` (incorrect)  
- **After:** result = `false` (correct)  

With this change, users can reliably override any component configuration using the `values-<component>` pattern in the Cozystack ConfigMap.  

---

## Release note

```release-note
[platform] Fix boolean override bug in Helm merge — ConfigMap values now correctly take precedence over bundle defaults


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Fixed per-release value merging so release-specific settings reliably take precedence over accumulated defaults.
  - Resolved cases where release overrides were ignored or only partially applied during deploys and upgrades.
  - Made merge behavior deterministic and predictable across environments, reducing configuration surprises.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->