### PR TITLE
make seaweedfs and nginx resources configurable

### DIFF
--- a/packages/extra/ingress/Chart.yaml
+++ b/packages/extra/ingress/Chart.yaml
@@ -3,4 +3,4 @@ name: ingress
 description: NGINX Ingress Controller
 icon: /logos/ingress-nginx.svg
 type: application
-version: 1.8.0
+version: 1.9.0

--- a/packages/extra/ingress/README.md
+++ b/packages/extra/ingress/README.md
@@ -4,9 +4,13 @@
 
 ### Common parameters
 
-| Name             | Description                                                       | Type        | Value   |
-| ---------------- | ----------------------------------------------------------------- | ----------- | ------- |
-| `replicas`       | Number of ingress-nginx replicas                                  | `int`       | `2`     |
-| `whitelist`      | List of client networks                                           | `[]*string` | `[]`    |
-| `clouflareProxy` | Restoring original visitor IPs when Cloudflare proxied is enabled | `bool`      | `false` |
+| Name               | Description                                                                                                                                | Type        | Value   |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------- | ------- |
+| `replicas`         | Number of ingress-nginx replicas                                                                                                           | `int`       | `2`     |
+| `whitelist`        | List of client networks                                                                                                                    | `[]*string` | `[]`    |
+| `clouflareProxy`   | Restoring original visitor IPs when Cloudflare proxied is enabled                                                                          | `bool`      | `false` |
+| `resources`        | Explicit CPU and memory configuration for each ingress-nginx replica. When left empty, the preset defined in `resourcesPreset` is applied. | `*object`   | `{}`    |
+| `resources.cpu`    | CPU available to each replica                                                                                                              | `*quantity` | `null`  |
+| `resources.memory` | Memory (RAM) available to each replica                                                                                                     | `*quantity` | `null`  |
+| `resourcesPreset`  | Default sizing preset used when `resources` is omitted. Allowed values: `nano`, `micro`, `small`, `medium`, `large`, `xlarge`, `2xlarge`.  | `string`    | `micro` |
 

--- a/packages/extra/ingress/templates/nginx-ingress.yaml
+++ b/packages/extra/ingress/templates/nginx-ingress.yaml
@@ -29,6 +29,7 @@ spec:
       controller:
         replicaCount: {{ .Values.replicas }}
         ingressClass: {{ .Release.Namespace }}
+        resources: {{- include "cozy-lib.resources.defaultingSanitize" (list .Values.resourcesPreset .Values.resources $) | nindent 10 }}
         ingressClassResource:
           name: {{ .Release.Namespace }}
           controllerValue: k8s.io/ingress-nginx-{{ .Release.Namespace }}

--- a/packages/extra/ingress/values.schema.json
+++ b/packages/extra/ingress/values.schema.json
@@ -12,6 +12,53 @@
       "type": "integer",
       "default": 2
     },
+    "resources": {
+      "description": "Explicit CPU and memory configuration for each ingress-nginx replica. When left empty, the preset defined in `resourcesPreset` is applied.",
+      "type": "object",
+      "default": {},
+      "properties": {
+        "cpu": {
+          "description": "CPU available to each replica",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "x-kubernetes-int-or-string": true
+        },
+        "memory": {
+          "description": "Memory (RAM) available to each replica",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "x-kubernetes-int-or-string": true
+        }
+      }
+    },
+    "resourcesPreset": {
+      "description": "Default sizing preset used when `resources` is omitted. Allowed values: `nano`, `micro`, `small`, `medium`, `large`, `xlarge`, `2xlarge`.",
+      "type": "string",
+      "default": "micro",
+      "enum": [
+        "nano",
+        "micro",
+        "small",
+        "medium",
+        "large",
+        "xlarge",
+        "2xlarge"
+      ]
+    },
     "whitelist": {
       "description": "List of client networks",
       "type": "array",

--- a/packages/extra/ingress/values.yaml
+++ b/packages/extra/ingress/values.yaml
@@ -13,3 +13,13 @@ whitelist: []
 
 ## @param clouflareProxy {bool} Restoring original visitor IPs when Cloudflare proxied is enabled
 clouflareProxy: false
+
+## @param resources {*resources} Explicit CPU and memory configuration for each ingress-nginx replica. When left empty, the preset defined in `resourcesPreset` is applied.
+## @field resources.cpu {*quantity} CPU available to each replica
+## @field resources.memory {*quantity} Memory (RAM) available to each replica
+resources: {}
+  # resources:
+  #   cpu: 4000m
+  #   memory: 4Gi
+## @param resourcesPreset {string enum:"nano,micro,small,medium,large,xlarge,2xlarge"} Default sizing preset used when `resources` is omitted. Allowed values: `nano`, `micro`, `small`, `medium`, `large`, `xlarge`, `2xlarge`.
+resourcesPreset: "micro"

--- a/packages/extra/seaweedfs/Chart.yaml
+++ b/packages/extra/seaweedfs/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/extra/seaweedfs/README.md
+++ b/packages/extra/seaweedfs/README.md
@@ -20,3 +20,22 @@
 | `filer.grpcPort`       | The port used to access the filer service externally.                                                  | `*int`              | `443`    |
 | `filer.whitelist`      | A list of IP addresses or CIDR ranges that are allowed to access the filer service.                    | `[]*string`         | `[]`     |
 
+
+### Vertical Pod Autoscaler parameters
+
+| Name                           | Description                                                         | Type     | Value                                                                                                                               |
+| ------------------------------ | ------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `vpa`                          | Vertical Pod Autoscaler configuration for each SeaweedFS component. | `object` | `{"filer":{"maxAllowed":{},"minAllowed":{}},"master":{"maxAllowed":{},"minAllowed":{}},"volume":{"maxAllowed":{},"minAllowed":{}}}` |
+| `vpa.filer.minAllowed.cpu`     | Minimum CPU request for filer pods                                  | `string` | `""`                                                                                                                                |
+| `vpa.filer.minAllowed.memory`  | Minimum memory request for filer pods                               | `string` | `""`                                                                                                                                |
+| `vpa.filer.maxAllowed.cpu`     | Maximum CPU limit for filer pods                                    | `string` | `""`                                                                                                                                |
+| `vpa.filer.maxAllowed.memory`  | Maximum memory limit for filer pods                                 | `string` | `""`                                                                                                                                |
+| `vpa.master.minAllowed.cpu`    | Minimum CPU request for master pods                                 | `string` | `""`                                                                                                                                |
+| `vpa.master.minAllowed.memory` | Minimum memory request for master pods                              | `string` | `""`                                                                                                                                |
+| `vpa.master.maxAllowed.cpu`    | Maximum CPU limit for master pods                                   | `string` | `""`                                                                                                                                |
+| `vpa.master.maxAllowed.memory` | Maximum memory limit for master pods                                | `string` | `""`                                                                                                                                |
+| `vpa.volume.minAllowed.cpu`    | Minimum CPU request for volume pods                                 | `string` | `""`                                                                                                                                |
+| `vpa.volume.minAllowed.memory` | Minimum memory request for volume pods                              | `string` | `""`                                                                                                                                |
+| `vpa.volume.maxAllowed.cpu`    | Maximum CPU limit for volume pods                                   | `string` | `""`                                                                                                                                |
+| `vpa.volume.maxAllowed.memory` | Maximum memory limit for volume pods                                | `string` | `""`                                                                                                                                |
+

--- a/packages/extra/seaweedfs/README.md
+++ b/packages/extra/seaweedfs/README.md
@@ -13,8 +13,8 @@
 | `size`                 | Persistent Volume size                                                                                 | `quantity`          | `10Gi`   |
 | `storageClass`         | StorageClass used to store the data                                                                    | `*string`           | `""`     |
 | `zones`                | A map of zones for MultiZone topology. Each zone can have its own number of replicas and size.         | `map[string]object` | `{...}`  |
-| `zones[name].replicas` | Number of replicas in the zone                                                                         | `int`               | `0`      |
-| `zones[name].size`     | Zone storage size                                                                                      | `quantity`          | `""`     |
+| `zones[name].replicas` | Number of replicas in the zone                                                                         | `*int`              | `null`   |
+| `zones[name].size`     | Zone storage size                                                                                      | `*quantity`         | `null`   |
 | `filer`                | Filer service configuration                                                                            | `*object`           | `{}`     |
 | `filer.grpcHost`       | The hostname used to expose or access the filer service externally.                                    | `*string`           | `""`     |
 | `filer.grpcPort`       | The port used to access the filer service externally.                                                  | `*int`              | `443`    |
@@ -23,19 +23,35 @@
 
 ### Vertical Pod Autoscaler parameters
 
-| Name                           | Description                                                         | Type     | Value                                                                                                                               |
-| ------------------------------ | ------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `vpa`                          | Vertical Pod Autoscaler configuration for each SeaweedFS component. | `object` | `{"filer":{"maxAllowed":{},"minAllowed":{}},"master":{"maxAllowed":{},"minAllowed":{}},"volume":{"maxAllowed":{},"minAllowed":{}}}` |
-| `vpa.filer.minAllowed.cpu`     | Minimum CPU request for filer pods                                  | `string` | `""`                                                                                                                                |
-| `vpa.filer.minAllowed.memory`  | Minimum memory request for filer pods                               | `string` | `""`                                                                                                                                |
-| `vpa.filer.maxAllowed.cpu`     | Maximum CPU limit for filer pods                                    | `string` | `""`                                                                                                                                |
-| `vpa.filer.maxAllowed.memory`  | Maximum memory limit for filer pods                                 | `string` | `""`                                                                                                                                |
-| `vpa.master.minAllowed.cpu`    | Minimum CPU request for master pods                                 | `string` | `""`                                                                                                                                |
-| `vpa.master.minAllowed.memory` | Minimum memory request for master pods                              | `string` | `""`                                                                                                                                |
-| `vpa.master.maxAllowed.cpu`    | Maximum CPU limit for master pods                                   | `string` | `""`                                                                                                                                |
-| `vpa.master.maxAllowed.memory` | Maximum memory limit for master pods                                | `string` | `""`                                                                                                                                |
-| `vpa.volume.minAllowed.cpu`    | Minimum CPU request for volume pods                                 | `string` | `""`                                                                                                                                |
-| `vpa.volume.minAllowed.memory` | Minimum memory request for volume pods                              | `string` | `""`                                                                                                                                |
-| `vpa.volume.maxAllowed.cpu`    | Maximum CPU limit for volume pods                                   | `string` | `""`                                                                                                                                |
-| `vpa.volume.maxAllowed.memory` | Maximum memory limit for volume pods                                | `string` | `""`                                                                                                                                |
+| Name                           | Description                                                         | Type        | Value  |
+| ------------------------------ | ------------------------------------------------------------------- | ----------- | ------ |
+| `vpa`                          | Vertical Pod Autoscaler configuration for each SeaweedFS component. | `object`    | `{}`   |
+| `vpa.master`                   | VPA configuration for the master servers                            | `object`    | `{}`   |
+| `vpa.master.minAllowed`        | Minimum resource requests                                           | `*object`   | `null` |
+| `vpa.master.minAllowed.cpu`    | Minimum CPU request                                                 | `*quantity` | `null` |
+| `vpa.master.minAllowed.memory` | Minimum memory request                                              | `*quantity` | `null` |
+| `vpa.master.maxAllowed`        | Maximum resource requests                                           | `*object`   | `null` |
+| `vpa.master.maxAllowed.cpu`    | Minimum CPU request                                                 | `*quantity` | `null` |
+| `vpa.master.maxAllowed.memory` | Minimum memory request                                              | `*quantity` | `null` |
+| `vpa.filer`                    | VPA configuration for the filer server                              | `object`    | `{}`   |
+| `vpa.filer.minAllowed`         | Minimum resource requests                                           | `*object`   | `null` |
+| `vpa.filer.minAllowed.cpu`     | Minimum CPU request                                                 | `*quantity` | `null` |
+| `vpa.filer.minAllowed.memory`  | Minimum memory request                                              | `*quantity` | `null` |
+| `vpa.filer.maxAllowed`         | Maximum resource requests                                           | `*object`   | `null` |
+| `vpa.filer.maxAllowed.cpu`     | Minimum CPU request                                                 | `*quantity` | `null` |
+| `vpa.filer.maxAllowed.memory`  | Minimum memory request                                              | `*quantity` | `null` |
+| `vpa.volume`                   | VPA configuration for the volume servers                            | `object`    | `{}`   |
+| `vpa.volume.minAllowed`        | Minimum resource requests                                           | `*object`   | `null` |
+| `vpa.volume.minAllowed.cpu`    | Minimum CPU request                                                 | `*quantity` | `null` |
+| `vpa.volume.minAllowed.memory` | Minimum memory request                                              | `*quantity` | `null` |
+| `vpa.volume.maxAllowed`        | Maximum resource requests                                           | `*object`   | `null` |
+| `vpa.volume.maxAllowed.cpu`    | Minimum CPU request                                                 | `*quantity` | `null` |
+| `vpa.volume.maxAllowed.memory` | Minimum memory request                                              | `*quantity` | `null` |
+| `vpa.s3`                       | VPA configuration for the S3 gateway                                | `object`    | `{}`   |
+| `vpa.s3.minAllowed`            | Minimum resource requests                                           | `*object`   | `null` |
+| `vpa.s3.minAllowed.cpu`        | Minimum CPU request                                                 | `*quantity` | `null` |
+| `vpa.s3.minAllowed.memory`     | Minimum memory request                                              | `*quantity` | `null` |
+| `vpa.s3.maxAllowed`            | Maximum resource requests                                           | `*object`   | `null` |
+| `vpa.s3.maxAllowed.cpu`        | Minimum CPU request                                                 | `*quantity` | `null` |
+| `vpa.s3.maxAllowed.memory`     | Minimum memory request                                              | `*quantity` | `null` |
 

--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -150,6 +150,13 @@ spec:
             - hosts:
               - {{ .Values.host | default (printf "s3.%s" $host) }}
               secretName: {{ .Release.Name }}-s3-ingress-tls
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
       cosi:
         driverName: "{{ .Release.Namespace }}.seaweedfs.objectstorage.k8s.io"
         bucketClassName: "{{ .Release.Namespace }}"

--- a/packages/extra/seaweedfs/templates/vpa.yaml
+++ b/packages/extra/seaweedfs/templates/vpa.yaml
@@ -1,4 +1,5 @@
 {{- if not (eq .Values.topology "Client") }}
+# --- Filer ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -14,14 +15,15 @@ spec:
     containerPolicies:
       - containerName: seaweedfs
         minAllowed:
-          cpu: 25m
-          memory: 64Mi
+          cpu: {{ default "25m" .Values.vpa.filer.minAllowed.cpu }}
+          memory: {{ default "64Mi" .Values.vpa.filer.minAllowed.memory }}
         maxAllowed:
-          cpu: "1"
-          memory: 2048Mi
+          cpu: {{ default "1" .Values.vpa.filer.maxAllowed.cpu }}
+          memory: {{ default "2048Mi" .Values.vpa.filer.maxAllowed.memory }}
 
 ---
 
+# --- Master ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -37,14 +39,42 @@ spec:
     containerPolicies:
       - containerName: seaweedfs
         minAllowed:
-          cpu: 25m
-          memory: 64Mi
+          cpu: {{ default "25m" .Values.vpa.master.minAllowed.cpu }}
+          memory: {{ default "64Mi" .Values.vpa.master.minAllowed.memory }}
         maxAllowed:
-          cpu: "1"
-          memory: 2048Mi
+          cpu: {{ default "1" .Values.vpa.master.maxAllowed.cpu }}
+          memory: {{ default "2048Mi" .Values.vpa.master.maxAllowed.memory }}
 
 ---
 
+# --- Volume ---
+{{- if .Values.zones }}
+  {{- if gt (len .Values.zones) 0 }}
+    {{- range $zoneName, $zoneSpec := .Values.zones }}
+---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ $.Release.Name }}-volume-{{ $zoneName }}
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ $.Release.Name }}-volume-{{ $zoneName }}
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+      - containerName: seaweedfs
+        minAllowed:
+          cpu: {{ default "25m" $.Values.vpa.volume.minAllowed.cpu }}
+          memory: {{ default "64Mi" $.Values.vpa.volume.minAllowed.memory }}
+        maxAllowed:
+          cpu: {{ default "1" $.Values.vpa.volume.maxAllowed.cpu }}
+          memory: {{ default "2048Mi" $.Values.vpa.volume.maxAllowed.memory }}
+    {{- end }}
+  {{- else }}
+---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:
@@ -60,9 +90,11 @@ spec:
     containerPolicies:
       - containerName: seaweedfs
         minAllowed:
-          cpu: 25m
-          memory: 64Mi
+          cpu: {{ default "25m" .Values.vpa.volume.minAllowed.cpu }}
+          memory: {{ default "64Mi" .Values.vpa.volume.minAllowed.memory }}
         maxAllowed:
-          cpu: "1"
-          memory: 2048Mi
+          cpu: {{ default "1" .Values.vpa.volume.maxAllowed.cpu }}
+          memory: {{ default "2048Mi" .Values.vpa.volume.maxAllowed.memory }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/packages/extra/seaweedfs/templates/vpa.yaml
+++ b/packages/extra/seaweedfs/templates/vpa.yaml
@@ -15,11 +15,35 @@ spec:
     containerPolicies:
       - containerName: seaweedfs
         minAllowed:
-          cpu: {{ default "25m" .Values.vpa.filer.minAllowed.cpu }}
-          memory: {{ default "64Mi" .Values.vpa.filer.minAllowed.memory }}
+          cpu: {{ dig "filer" "minAllowed" "cpu" "25m" .Values.vpa }}
+          memory: {{ dig "filer" "minAllowed" "memory" "64Mi" .Values.vpa }}
         maxAllowed:
-          cpu: {{ default "1" .Values.vpa.filer.maxAllowed.cpu }}
-          memory: {{ default "2048Mi" .Values.vpa.filer.maxAllowed.memory }}
+          cpu: {{ dig "filer" "maxAllowed" "cpu" "1" .Values.vpa }}
+          memory: {{ dig "filer" "maxAllowed" "memory" "2048Mi" .Values.vpa }}
+
+---
+
+# --- S3 ---
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}-s3
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}-s3
+  updatePolicy:
+    updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+      - containerName: seaweedfs
+        minAllowed:
+          cpu: {{ dig "s3" "minAllowed" "cpu" "25m" .Values.vpa }}
+          memory: {{ dig "s3" "minAllowed" "memory" "64Mi" .Values.vpa }}
+        maxAllowed:
+          cpu: {{ dig "s3" "maxAllowed" "cpu" "1" .Values.vpa }}
+          memory: {{ dig "s3" "maxAllowed" "memory" "2048Mi" .Values.vpa }}
 
 ---
 
@@ -39,18 +63,17 @@ spec:
     containerPolicies:
       - containerName: seaweedfs
         minAllowed:
-          cpu: {{ default "25m" .Values.vpa.master.minAllowed.cpu }}
-          memory: {{ default "64Mi" .Values.vpa.master.minAllowed.memory }}
+          cpu: {{ dig "master" "minAllowed" "cpu" "25m" .Values.vpa }}
+          memory: {{ dig "master" "minAllowed" "memory" "64Mi" .Values.vpa }}
         maxAllowed:
-          cpu: {{ default "1" .Values.vpa.master.maxAllowed.cpu }}
-          memory: {{ default "2048Mi" .Values.vpa.master.maxAllowed.memory }}
+          cpu: {{ dig "master" "maxAllowed" "cpu" "1" .Values.vpa }}
+          memory: {{ dig "master" "maxAllowed" "memory" "2048Mi" .Values.vpa }}
 
 ---
 
 # --- Volume ---
-{{- if .Values.zones }}
-  {{- if gt (len .Values.zones) 0 }}
-    {{- range $zoneName, $zoneSpec := .Values.zones }}
+{{- if and .Values.zones (gt (len .Values.zones) 0) }}
+  {{- range $zoneName, $zoneSpec := .Values.zones }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -67,13 +90,13 @@ spec:
     containerPolicies:
       - containerName: seaweedfs
         minAllowed:
-          cpu: {{ default "25m" $.Values.vpa.volume.minAllowed.cpu }}
-          memory: {{ default "64Mi" $.Values.vpa.volume.minAllowed.memory }}
+          cpu: {{ dig "volume" "minAllowed" "cpu" "25m" $.Values.vpa }}
+          memory: {{ dig "volume" "minAllowed" "memory" "64Mi" $.Values.vpa }}
         maxAllowed:
-          cpu: {{ default "1" $.Values.vpa.volume.maxAllowed.cpu }}
-          memory: {{ default "2048Mi" $.Values.vpa.volume.maxAllowed.memory }}
-    {{- end }}
-  {{- else }}
+          cpu: {{ dig "volume" "maxAllowed" "cpu" "1" $.Values.vpa }}
+          memory: {{ dig "volume" "maxAllowed" "memory" "2048Mi" $.Values.vpa }}
+  {{- end }}
+{{- else }}
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -90,11 +113,10 @@ spec:
     containerPolicies:
       - containerName: seaweedfs
         minAllowed:
-          cpu: {{ default "25m" .Values.vpa.volume.minAllowed.cpu }}
-          memory: {{ default "64Mi" .Values.vpa.volume.minAllowed.memory }}
+          cpu: {{ dig "volume" "minAllowed" "cpu" "25m" .Values.vpa }}
+          memory: {{ dig "volume" "minAllowed" "memory" "64Mi" .Values.vpa }}
         maxAllowed:
-          cpu: {{ default "1" .Values.vpa.volume.maxAllowed.cpu }}
-          memory: {{ default "2048Mi" .Values.vpa.volume.maxAllowed.memory }}
-  {{- end }}
+          cpu: {{ dig "volume" "maxAllowed" "cpu" "1" .Values.vpa }}
+          memory: {{ dig "volume" "maxAllowed" "memory" "2048Mi" .Values.vpa }}
 {{- end }}
 {{- end }}

--- a/packages/extra/seaweedfs/values.schema.json
+++ b/packages/extra/seaweedfs/values.schema.json
@@ -10,23 +10,22 @@
         "grpcPort": 443,
         "whitelist": {}
       },
+      "required": [
+        "maxAllowed",
+        "minAllowed"
+      ],
       "properties": {
-        "grpcHost": {
-          "description": "The hostname used to expose or access the filer service externally.",
-          "type": "string"
+        "maxAllowed": {
+          "description": "Maximum allowed CPU and memory for filer pods",
+          "type": "object",
+          "default": {},
+          "x-kubernetes-preserve-unknown-fields": true
         },
-        "grpcPort": {
-          "description": "The port used to access the filer service externally.",
-          "type": "integer",
-          "default": 443
-        },
-        "whitelist": {
-          "description": "A list of IP addresses or CIDR ranges that are allowed to access the filer service.",
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "string"
-          }
+        "minAllowed": {
+          "description": "Minimum allowed CPU and memory for filer pods",
+          "type": "object",
+          "default": {},
+          "x-kubernetes-preserve-unknown-fields": true
         }
       }
     },
@@ -71,6 +70,25 @@
         "MultiZone",
         "Client"
       ]
+    },
+    "vpa": {
+      "description": "Vertical Pod Autoscaler configuration for each SeaweedFS component.",
+      "type": "object",
+      "default": {
+        "filer": {
+          "maxAllowed": {},
+          "minAllowed": {}
+        },
+        "master": {
+          "maxAllowed": {},
+          "minAllowed": {}
+        },
+        "volume": {
+          "maxAllowed": {},
+          "minAllowed": {}
+        }
+      },
+      "x-kubernetes-preserve-unknown-fields": true
     },
     "zones": {
       "description": "A map of zones for MultiZone topology. Each zone can have its own number of replicas and size.",

--- a/packages/extra/seaweedfs/values.schema.json
+++ b/packages/extra/seaweedfs/values.schema.json
@@ -10,22 +10,23 @@
         "grpcPort": 443,
         "whitelist": {}
       },
-      "required": [
-        "maxAllowed",
-        "minAllowed"
-      ],
       "properties": {
-        "maxAllowed": {
-          "description": "Maximum allowed CPU and memory for filer pods",
-          "type": "object",
-          "default": {},
-          "x-kubernetes-preserve-unknown-fields": true
+        "grpcHost": {
+          "description": "The hostname used to expose or access the filer service externally.",
+          "type": "string"
         },
-        "minAllowed": {
-          "description": "Minimum allowed CPU and memory for filer pods",
-          "type": "object",
-          "default": {},
-          "x-kubernetes-preserve-unknown-fields": true
+        "grpcPort": {
+          "description": "The port used to access the filer service externally.",
+          "type": "integer",
+          "default": 443
+        },
+        "whitelist": {
+          "description": "A list of IP addresses or CIDR ranges that are allowed to access the filer service.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
         }
       }
     },
@@ -83,12 +84,327 @@
           "maxAllowed": {},
           "minAllowed": {}
         },
+        "s3": {
+          "maxAllowed": {},
+          "minAllowed": {}
+        },
         "volume": {
           "maxAllowed": {},
           "minAllowed": {}
         }
       },
-      "x-kubernetes-preserve-unknown-fields": true
+      "required": [
+        "filer",
+        "master",
+        "s3",
+        "volume"
+      ],
+      "properties": {
+        "filer": {
+          "description": "VPA configuration for the filer server",
+          "type": "object",
+          "default": {
+            "maxAllowed": {},
+            "minAllowed": {}
+          },
+          "properties": {
+            "maxAllowed": {
+              "description": "Maximum resource requests",
+              "type": "object",
+              "default": {},
+              "properties": {
+                "cpu": {
+                  "description": "Minimum CPU request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                },
+                "memory": {
+                  "description": "Minimum memory request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            },
+            "minAllowed": {
+              "description": "Minimum resource requests",
+              "type": "object",
+              "default": {},
+              "properties": {
+                "cpu": {
+                  "description": "Minimum CPU request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                },
+                "memory": {
+                  "description": "Minimum memory request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            }
+          }
+        },
+        "master": {
+          "description": "VPA configuration for the master servers",
+          "type": "object",
+          "default": {
+            "maxAllowed": {},
+            "minAllowed": {}
+          },
+          "properties": {
+            "maxAllowed": {
+              "description": "Maximum resource requests",
+              "type": "object",
+              "default": {},
+              "properties": {
+                "cpu": {
+                  "description": "Minimum CPU request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                },
+                "memory": {
+                  "description": "Minimum memory request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            },
+            "minAllowed": {
+              "description": "Minimum resource requests",
+              "type": "object",
+              "default": {},
+              "properties": {
+                "cpu": {
+                  "description": "Minimum CPU request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                },
+                "memory": {
+                  "description": "Minimum memory request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            }
+          }
+        },
+        "s3": {
+          "description": "VPA configuration for the S3 gateway",
+          "type": "object",
+          "default": {
+            "maxAllowed": {},
+            "minAllowed": {}
+          },
+          "properties": {
+            "maxAllowed": {
+              "description": "Maximum resource requests",
+              "type": "object",
+              "default": {},
+              "properties": {
+                "cpu": {
+                  "description": "Minimum CPU request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                },
+                "memory": {
+                  "description": "Minimum memory request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            },
+            "minAllowed": {
+              "description": "Minimum resource requests",
+              "type": "object",
+              "default": {},
+              "properties": {
+                "cpu": {
+                  "description": "Minimum CPU request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                },
+                "memory": {
+                  "description": "Minimum memory request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            }
+          }
+        },
+        "volume": {
+          "description": "VPA configuration for the volume servers",
+          "type": "object",
+          "default": {
+            "maxAllowed": {},
+            "minAllowed": {}
+          },
+          "properties": {
+            "maxAllowed": {
+              "description": "Maximum resource requests",
+              "type": "object",
+              "default": {},
+              "properties": {
+                "cpu": {
+                  "description": "Minimum CPU request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                },
+                "memory": {
+                  "description": "Minimum memory request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            },
+            "minAllowed": {
+              "description": "Minimum resource requests",
+              "type": "object",
+              "default": {},
+              "properties": {
+                "cpu": {
+                  "description": "Minimum CPU request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                },
+                "memory": {
+                  "description": "Minimum memory request",
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "anyOf": [
+                    {
+                      "type": "integer"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "zones": {
       "description": "A map of zones for MultiZone topology. Each zone can have its own number of replicas and size.",
@@ -96,10 +412,6 @@
       "default": {},
       "additionalProperties": {
         "type": "object",
-        "required": [
-          "replicas",
-          "size"
-        ],
         "properties": {
           "replicas": {
             "description": "Number of replicas in the zone",

--- a/packages/extra/seaweedfs/values.yaml
+++ b/packages/extra/seaweedfs/values.yaml
@@ -43,3 +43,63 @@ filer:
   grpcHost: ""
   grpcPort: 443
   whitelist: []
+
+## @section Vertical Pod Autoscaler parameters
+
+## @param vpa {object} Vertical Pod Autoscaler configuration for each SeaweedFS component.
+## @param vpa.filer {object} VPA configuration for the filer StatefulSet
+## @param vpa.filer.minAllowed {object} Minimum allowed CPU and memory for filer pods
+## @field vpa.filer.minAllowed.cpu {string} Minimum CPU request for filer pods
+## @field vpa.filer.minAllowed.memory {string} Minimum memory request for filer pods
+## @param vpa.filer.maxAllowed {object} Maximum allowed CPU and memory for filer pods
+## @field vpa.filer.maxAllowed.cpu {string} Maximum CPU limit for filer pods
+## @field vpa.filer.maxAllowed.memory {string} Maximum memory limit for filer pods
+## @param vpa.master {object} VPA configuration for the master StatefulSet
+## @param vpa.master.minAllowed {object} Minimum allowed CPU and memory for master pods
+## @field vpa.master.minAllowed.cpu {string} Minimum CPU request for master pods
+## @field vpa.master.minAllowed.memory {string} Minimum memory request for master pods
+## @param vpa.master.maxAllowed {object} Maximum allowed CPU and memory for master pods
+## @field vpa.master.maxAllowed.cpu {string} Maximum CPU limit for master pods
+## @field vpa.master.maxAllowed.memory {string} Maximum memory limit for master pods
+## @param vpa.volume {object} VPA configuration for the volume StatefulSets
+## @param vpa.volume.minAllowed {object} Minimum allowed CPU and memory for volume pods
+## @field vpa.volume.minAllowed.cpu {string} Minimum CPU request for volume pods
+## @field vpa.volume.minAllowed.memory {string} Minimum memory request for volume pods
+## @param vpa.volume.maxAllowed {object} Maximum allowed CPU and memory for volume pods
+## @field vpa.volume.maxAllowed.cpu {string} Maximum CPU limit for volume pods
+## @field vpa.volume.maxAllowed.memory {string} Maximum memory limit for volume pods
+
+## Example:
+## vpa:
+##   filer:
+##     minAllowed:
+##       cpu: 25m
+##       memory: 64Mi
+##     maxAllowed:
+##       cpu: "1"
+##       memory: 2048Mi
+##   master:
+##     minAllowed:
+##       cpu: 25m
+##       memory: 64Mi
+##     maxAllowed:
+##       cpu: "1"
+##       memory: 2048Mi
+##   volume:
+##     minAllowed:
+##       cpu: 25m
+##       memory: 64Mi
+##     maxAllowed:
+##       cpu: "1"
+##       memory: 2048Mi
+
+vpa:
+  filer:
+    minAllowed: {}
+    maxAllowed: {}
+  master:
+    minAllowed: {}
+    maxAllowed: {}
+  volume:
+    minAllowed: {}
+    maxAllowed: {}

--- a/packages/extra/seaweedfs/values.yaml
+++ b/packages/extra/seaweedfs/values.yaml
@@ -19,8 +19,8 @@ size: 10Gi
 storageClass: ""
 
 ## @param zones {map[string]zone} A map of zones for MultiZone topology. Each zone can have its own number of replicas and size.
-## @field zone.replicas {int} Number of replicas in the zone
-## @field zone.size {quantity} Zone storage size
+## @field zone.replicas {*int} Number of replicas in the zone
+## @field zone.size {*quantity} Zone storage size
 ## Example:
 ## zones:
 ##   dc1:
@@ -46,28 +46,15 @@ filer:
 
 ## @section Vertical Pod Autoscaler parameters
 
-## @param vpa {object} Vertical Pod Autoscaler configuration for each SeaweedFS component.
-## @param vpa.filer {object} VPA configuration for the filer StatefulSet
-## @param vpa.filer.minAllowed {object} Minimum allowed CPU and memory for filer pods
-## @field vpa.filer.minAllowed.cpu {string} Minimum CPU request for filer pods
-## @field vpa.filer.minAllowed.memory {string} Minimum memory request for filer pods
-## @param vpa.filer.maxAllowed {object} Maximum allowed CPU and memory for filer pods
-## @field vpa.filer.maxAllowed.cpu {string} Maximum CPU limit for filer pods
-## @field vpa.filer.maxAllowed.memory {string} Maximum memory limit for filer pods
-## @param vpa.master {object} VPA configuration for the master StatefulSet
-## @param vpa.master.minAllowed {object} Minimum allowed CPU and memory for master pods
-## @field vpa.master.minAllowed.cpu {string} Minimum CPU request for master pods
-## @field vpa.master.minAllowed.memory {string} Minimum memory request for master pods
-## @param vpa.master.maxAllowed {object} Maximum allowed CPU and memory for master pods
-## @field vpa.master.maxAllowed.cpu {string} Maximum CPU limit for master pods
-## @field vpa.master.maxAllowed.memory {string} Maximum memory limit for master pods
-## @param vpa.volume {object} VPA configuration for the volume StatefulSets
-## @param vpa.volume.minAllowed {object} Minimum allowed CPU and memory for volume pods
-## @field vpa.volume.minAllowed.cpu {string} Minimum CPU request for volume pods
-## @field vpa.volume.minAllowed.memory {string} Minimum memory request for volume pods
-## @param vpa.volume.maxAllowed {object} Maximum allowed CPU and memory for volume pods
-## @field vpa.volume.maxAllowed.cpu {string} Maximum CPU limit for volume pods
-## @field vpa.volume.maxAllowed.memory {string} Maximum memory limit for volume pods
+## @param vpa {vpa} Vertical Pod Autoscaler configuration for each SeaweedFS component.
+## @field vpa.master {vpaConfig} VPA configuration for the master servers
+## @field vpa.filer {vpaConfig} VPA configuration for the filer server
+## @field vpa.volume {vpaConfig} VPA configuration for the volume servers
+## @field vpa.s3 {vpaConfig} VPA configuration for the S3 gateway
+## @field vpaConfig.minAllowed {*vpaResourceConfig} Minimum resource requests
+## @field vpaConfig.maxAllowed {*vpaResourceConfig} Maximum resource requests
+## @field vpaResourceConfig.cpu {*quantity} Minimum CPU request
+## @field vpaResourceConfig.memory {*quantity} Minimum memory request
 
 ## Example:
 ## vpa:
@@ -95,6 +82,9 @@ filer:
 
 vpa:
   filer:
+    minAllowed: {}
+    maxAllowed: {}
+  s3:
     minAllowed: {}
     maxAllowed: {}
   master:

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -30,7 +30,8 @@ ingress 1.4.0 fd240701
 ingress 1.5.0 93bdf411
 ingress 1.6.0 632224a3
 ingress 1.7.0 c02a3818
-ingress 1.8.0 HEAD
+ingress 1.8.0 8f1975d1
+ingress 1.9.0 HEAD
 monitoring 1.0.0 d7cfa53c
 monitoring 1.1.0 25221fdc
 monitoring 1.2.0 f81be075
@@ -63,4 +64,5 @@ seaweedfs 0.3.0 45a7416c
 seaweedfs 0.4.0 632224a3
 seaweedfs 0.4.1 8c86905b
 seaweedfs 0.5.0 9584e5f5
-seaweedfs 0.6.0 HEAD
+seaweedfs 0.6.0 8f1975d1
+seaweedfs 0.7.0 HEAD

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -70,6 +70,7 @@ seaweedfs:
           key: password
           name: seaweedfs-db-app
     s3:
+      replicas: 2
       enabled: true
       port: 8333
       httpsPort: 0
@@ -109,13 +110,6 @@ seaweedfs:
         - hosts:
             - seaweedfs.demo.cozystack.io
           secretName: seaweedfs-s3-ingress-tls
-    resources:
-      limits:
-        cpu: "2"
-        memory: "2Gi"
-      requests:
-        cpu: "500m"
-        memory: "1Gi"
   cosi:
     enabled: true
     podLabels:


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
- make seaweedfs and nginx resources configurable
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ingress: per-replica CPU/memory via resources or resourcesPreset (nano→2xlarge) with sane defaults; controller resources injected.
  * SeaweedFS: expanded VPA support (filer, master, volume, and new s3); generates per-zone VPAs when zones exist; added S3 and cosi resource defaults.

* **Documentation**
  * Updated Ingress and SeaweedFS READMEs and values/examples for resources and VPA options.

* **Chores**
  * Bumped chart versions: Ingress → 1.9.0, SeaweedFS → 0.7.0; system S3 replicas defaulted to 2; version mappings anchored to specific SHAs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->