### PR TITLE
[kubeovn] Fix service scrape for plunger

### DIFF
--- a/packages/system/monitoring-agents/templates/kube-ovn-plunger-scrape.yaml
+++ b/packages/system/monitoring-agents/templates/kube-ovn-plunger-scrape.yaml
@@ -1,42 +1,23 @@
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: coredns
-  namespace: kube-system
-  labels:
-    app: coredns
-spec:
-  clusterIP: None
-  ports:
-    - name: http-metrics
-      port: 9153
-      protocol: TCP
-      targetPort: 9153
-  selector:
-    k8s-app: kube-dns
----
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
 metadata:
-  name: coredns
+  name: kubeovn-plunger
   namespace: cozy-monitoring
 spec:
   selector:
     matchLabels:
-      app: coredns
+      app.kubernetes.io/name: kube-ovn-plunger
+      app.kubernetes.io/instance: kubeovn-plunger
   namespaceSelector:
     matchNames:
-      - "kube-system"
+    - "cozy-kubeovn"
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    port: http-metrics
+  - port: metrics
     relabelConfigs:
     - action: labeldrop
-      regex: (endpoint|namespace|pod|container)
-    - replacement: kube-dns
+      regex: (endpoint|pod|container)
+    - replacement: kubeovn-plunger
       targetLabel: job
-    - sourceLabels: [__meta_kubernetes_pod_node_name]
-      targetLabel: node
     - targetLabel: tier
       replacement: cluster


### PR DESCRIPTION
## What this PR does

This patch delivers changes to the monitoring config of Kube-OVN plunger, which were accidentally omitted in its release, leading to a duplicate service, broken monitoring agents' helm release and not actually scraping the plunger.

### Release note

```release-note
[kubeovn-plunger] Fix the VMServiceScrape object for collecting the
plunger's metrics.
```