### PR TITLE
[cozystack-controller] Clusterwide read perms

### DIFF
--- a/packages/system/cozystack-controller/templates/rbac.yaml
+++ b/packages/system/cozystack-controller/templates/rbac.yaml
@@ -3,9 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cozystack-controller
 rules:
-- apiGroups: [""]
-  resources: ["configmaps", "pods", "namespaces", "nodes", "services", "persistentvolumes", "persistentvolumeclaims"]
-  verbs: ["get", "watch", "list"]
 - apiGroups: ['cozystack.io']
   resources: ['*']
   verbs: ['*']
@@ -15,6 +12,6 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "list", "watch", "patch", "update"]
-- apiGroups: ["apps"]
-  resources: ["deployments"]
+- apiGroups: ['*']
+  resources: ['*']
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## What this PR does

In an earlier patch the Cozystack controller now reads arbitrary objects in the cluster to establish the lineage of any created pod, service, pvc, or secret. These objects may be created by various other controllers, so in general, the controller now requires read permissions on arbitrary objects in the cluster.

### Release note

```release-note
[cozystack-controler] Fix an RBAC error that prevented the workload
labelling feature from working.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated controller permissions to comprehensively cover cozystack.io resources and broaden read access across Kubernetes API groups, improving operational coverage.
  * Maintains existing Helm and namespace-related access patterns.

* **Notes**
  * No user-facing changes or actions required. Existing workloads continue to operate as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->