### PR TITLE
[ci] Get REGISTRY from vars, not secrets

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -1,7 +1,7 @@
 name: Pull Request
 
 env:
-  REGISTRY: ${{ secrets.OCIR_REPO }}
+  REGISTRY: ${{ vars.OCIR_REPO }}
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
## What this PR does

This patch sources the REGISTRY env var from GitHub actions variables instead of secrets, so pull requests from forked repos work correctly.

### Release note

```release-note
[ci] Source the REGISTRY env var from actions' variables, not secrets,
so external pull requests can work.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration to source the container registry setting from organization variables instead of secrets, improving maintainability and visibility of build settings.
  * No impact to application features, functionality, or performance; builds and deployments continue to operate as before.
  * No action required from users or admins; this is an internal workflow refinement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->