### PR TITLE
[cozystack-controller] Implement cache for CozystackResourceDefinitions

### DIFF
--- a/internal/shared/crdmem/memory.go
+++ b/internal/shared/crdmem/memory.go
@@ -1,0 +1,99 @@
+package crdmem
+
+import (
+	"context"
+	"sync"
+
+	cozyv1alpha1 "github.com/cozystack/cozystack/api/v1alpha1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Memory struct {
+	mu        sync.RWMutex
+	data      map[string]cozyv1alpha1.CozystackResourceDefinition
+	primed    bool
+	primeOnce sync.Once
+}
+
+func New() *Memory {
+	return &Memory{data: make(map[string]cozyv1alpha1.CozystackResourceDefinition)}
+}
+
+var (
+	global     *Memory
+	globalOnce sync.Once
+)
+
+func Global() *Memory {
+	globalOnce.Do(func() { global = New() })
+	return global
+}
+
+func (m *Memory) Upsert(obj *cozyv1alpha1.CozystackResourceDefinition) {
+	if obj == nil {
+		return
+	}
+	m.mu.Lock()
+	m.data[obj.Name] = *obj.DeepCopy()
+	m.mu.Unlock()
+}
+
+func (m *Memory) Delete(name string) {
+	m.mu.Lock()
+	delete(m.data, name)
+	m.mu.Unlock()
+}
+
+func (m *Memory) Snapshot() []cozyv1alpha1.CozystackResourceDefinition {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]cozyv1alpha1.CozystackResourceDefinition, 0, len(m.data))
+	for _, v := range m.data {
+		out = append(out, v)
+	}
+	return out
+}
+
+func (m *Memory) IsPrimed() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.primed
+}
+
+type runnable func(context.Context) error
+
+func (r runnable) Start(ctx context.Context) error { return r(ctx) }
+
+func (m *Memory) EnsurePrimingWithManager(mgr ctrl.Manager) error {
+	var errOut error
+	m.primeOnce.Do(func() {
+		errOut = mgr.Add(runnable(func(ctx context.Context) error {
+			if ok := mgr.GetCache().WaitForCacheSync(ctx); !ok {
+				return nil
+			}
+			var list cozyv1alpha1.CozystackResourceDefinitionList
+			if err := mgr.GetClient().List(ctx, &list); err == nil {
+				for i := range list.Items {
+					m.Upsert(&list.Items[i])
+				}
+				m.mu.Lock()
+				m.primed = true
+				m.mu.Unlock()
+			}
+			return nil
+		}))
+	})
+	return errOut
+}
+
+func (m *Memory) ListFromCacheOrAPI(ctx context.Context, c client.Client) ([]cozyv1alpha1.CozystackResourceDefinition, error) {
+	if m.IsPrimed() {
+		return m.Snapshot(), nil
+	}
+	var list cozyv1alpha1.CozystackResourceDefinitionList
+	if err := c.List(ctx, &list); err != nil {
+		return nil, err
+	}
+	return list.Items, nil
+}


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

This PR introduces shared cache for CozystackResourceDefinitions and warbs it up before making decidion on restart cozystack-api server.

Reastart logic was also updated to trigger restart only if consistent hash from the configuration has been changed.

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[cozystack-controller] Implement cache for CozystackResourceDefinitions
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Smarter, hash-based restarts for the API component, triggered only when configuration truly changes.
  - Debounced restart behavior to avoid rapid, repeated restarts during bursts of updates.

- Performance
  - Introduces an internal in-memory configuration cache to speed up evaluations and reduce API calls.
  - Cache is primed at startup for faster, more responsive operations.

- Bug Fixes
  - Eliminates unnecessary restarts when there are no effective config changes, improving stability and reducing disruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->