### PR TITLE
[platform] Mark some secrets as non-user-facing

### DIFF
--- a/packages/apps/clickhouse/Chart.yaml
+++ b/packages/apps/clickhouse/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.13.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/clickhouse/templates/backup-script.yaml
+++ b/packages/apps/clickhouse/templates/backup-script.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-backup-script
+  labels:
+    apps.cozystack.io/tenantresource: "false"
 stringData:
   backup.sh: |
     #!/bin/sh

--- a/packages/apps/mysql/Chart.yaml
+++ b/packages/apps/mysql/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.10.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/mysql/templates/backup-script.yaml
+++ b/packages/apps/mysql/templates/backup-script.yaml
@@ -4,6 +4,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-backup-script
+  labels:
+    apps.cozystack.io/tenantresource: "false"
 stringData:
   backup.sh: |
     #!/bin/sh

--- a/packages/apps/postgres/Chart.yaml
+++ b/packages/apps/postgres/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.0
+version: 0.18.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/postgres/templates/init-script.yaml
+++ b/packages/apps/postgres/templates/init-script.yaml
@@ -30,6 +30,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-init-script
+  labels:
+    apps.cozystack.io/tenantresource: "false"
 stringData:
   init.sh: |
     #!/bin/bash

--- a/packages/apps/tenant/Chart.yaml
+++ b/packages/apps/tenant/Chart.yaml
@@ -4,4 +4,4 @@ description: Separated tenant namespace
 icon: /logos/tenant.svg
 
 type: application
-version: 1.14.0
+version: 1.14.1

--- a/packages/apps/tenant/templates/tenant.yaml
+++ b/packages/apps/tenant/templates/tenant.yaml
@@ -5,17 +5,7 @@ metadata:
   name: {{ include "tenant.name" . }}
   namespace: {{ include "tenant.name" . }}
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "tenant.name" . }}
-  namespace: {{ include "tenant.name" . }}
-  annotations:
-    kubernetes.io/service-account.name: {{ include "tenant.name" . }}
-type: kubernetes.io/service-account-token
----
 # == default role ==
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -17,7 +17,8 @@ clickhouse 0.10.1 4369b031
 clickhouse 0.11.0 08cb7c0f
 clickhouse 0.11.1 0e47e1e8
 clickhouse 0.12.0 c02a3818
-clickhouse 0.13.0 HEAD
+clickhouse 0.13.0 53fbe7c2
+clickhouse 0.13.1 HEAD
 ferretdb 0.1.0 e9716091
 ferretdb 0.1.1 91b0499a
 ferretdb 0.2.0 6c5cf5bf
@@ -88,7 +89,8 @@ mysql 0.8.0 62cb694d
 mysql 0.8.1 4369b031
 mysql 0.9.0 08cb7c0f
 mysql 0.9.1 c02a3818
-mysql 0.10.0 HEAD
+mysql 0.10.0 53fbe7c2
+mysql 0.10.1 HEAD
 nats 0.1.0 e9716091
 nats 0.2.0 6c5cf5bf
 nats 0.3.0 78366f19
@@ -127,7 +129,8 @@ postgres 0.16.0 70f82667
 postgres 0.17.0 acd4663a
 postgres 0.17.1 08cb7c0f
 postgres 0.17.3 c02a3818
-postgres 0.18.0 HEAD
+postgres 0.18.0 53fbe7c2
+postgres 0.18.1 HEAD
 rabbitmq 0.1.0 263e47be
 rabbitmq 0.2.0 53f2365e
 rabbitmq 0.3.0 6c5cf5bf
@@ -167,7 +170,8 @@ tcp-balancer 0.5.0 08cb7c0f
 tcp-balancer 0.5.1 c02a3818
 tcp-balancer 0.6.0 HEAD
 tenant 1.13.0 8f1975d1
-tenant 1.14.0 HEAD
+tenant 1.14.0 53fbe7c2
+tenant 1.14.1 HEAD
 virtual-machine 0.14.0 HEAD
 vm-disk 0.1.0 d971f2ff
 vm-disk 0.1.1 6130f43d
@@ -187,4 +191,5 @@ vpn 0.6.1 62cb694d
 vpn 0.6.2 4369b031
 vpn 0.7.0 08cb7c0f
 vpn 0.7.1 c02a3818
-vpn 0.8.0 HEAD
+vpn 0.8.0 53fbe7c2
+vpn 0.8.1 HEAD

--- a/packages/apps/vpn/Chart.yaml
+++ b/packages/apps/vpn/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/vpn/templates/secret.yaml
+++ b/packages/apps/vpn/templates/secret.yaml
@@ -22,6 +22,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}-vpn
+  labels:
+    apps.cozystack.io/tenantresource: "false"
 type: Opaque
 stringData:
   shadowbox_server_config.json: |

--- a/packages/apps/vpn/templates/tls.yaml
+++ b/packages/apps/vpn/templates/tls.yaml
@@ -14,7 +14,7 @@ data:
   tls.key: {{ index $existingSecret.data "tls.key" }}
   {{- else }}
   {{- with genSignedCert $cn nil nil 3650 $ca }}
-  cacert: {{ b64enc $ca.Cert }}
+  ca.crt: {{ b64enc $ca.Cert }}
   tls.crt: {{ b64enc .Cert }}
   tls.key: {{ b64enc .Key }}
   {{- end }}

--- a/packages/extra/info/Chart.yaml
+++ b/packages/extra/info/Chart.yaml
@@ -3,4 +3,4 @@ name: info
 description: Info
 icon: /logos/info.svg
 type: application
-version: 1.2.0
+version: 1.2.1

--- a/packages/extra/info/templates/serviceaccount.yaml
+++ b/packages/extra/info/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: {{ .Release.Namespace }}
+type: kubernetes.io/service-account-token

--- a/packages/extra/monitoring/Chart.yaml
+++ b/packages/extra/monitoring/Chart.yaml
@@ -3,4 +3,4 @@ name: monitoring
 description: Monitoring and observability stack
 icon: /logos/monitoring.svg
 type: application
-version: 1.13.1
+version: 1.13.2

--- a/packages/extra/monitoring/templates/alerta/alerta.yaml
+++ b/packages/extra/monitoring/templates/alerta/alerta.yaml
@@ -192,6 +192,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: alertmanager
+  labels:
+    apps.cozystack.io/tenantresource: "false"
 type: Opaque
 stringData:
   alertmanager.yaml: |

--- a/packages/extra/versions_map
+++ b/packages/extra/versions_map
@@ -21,7 +21,8 @@ etcd 2.10.1 HEAD
 info 1.0.0 93bdf411
 info 1.0.1 632224a3
 info 1.1.0 c02a3818
-info 1.2.0 HEAD
+info 1.2.0 53fbe7c2
+info 1.2.1 HEAD
 ingress 1.0.0 d7cfa53c
 ingress 1.1.0 5bbc488e
 ingress 1.2.0 28fca4ef
@@ -57,7 +58,8 @@ monitoring 1.11.0 4369b031
 monitoring 1.12.0 0e47e1e8
 monitoring 1.12.1 c02a3818
 monitoring 1.13.0 87b23161
-monitoring 1.13.1 HEAD
+monitoring 1.13.1 53fbe7c2
+monitoring 1.13.2 HEAD
 seaweedfs 0.1.0 71514249
 seaweedfs 0.2.0 5fb9cfe3
 seaweedfs 0.2.1 fde4bcfa


### PR DESCRIPTION
## What this PR does

Some k8s secrets created when deploying managed applications are unhelpful to the end user or are outright not meant to be shown, because they contain internal credentials not meant to be presented to the user. This patch adds an `apps.cozystack.io/tenantresource=false` label to such resources which will be later used to filter out such secrets in the web UI.

### Release note

```release-note
[platform] Mark non-user-facing secrets as such to avoid clutter in the
dashboard and leaking internal credentials.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic creation of a ServiceAccount token Secret via the Info add-on.

* **Improvements**
  * VPN TLS Secret CA field standardized to ca.crt for consistency.

* **Removals**
  * Removed the explicit ServiceAccount token Secret from the Tenant app (token now managed by Info).

* **Chores**
  * Added non-functional metadata labels to several Secrets.
  * Bumped chart/package metadata versions and updated version mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->