### PR TITLE
[platform] Add secret selectors to CozyRDs

### DIFF
--- a/packages/apps/postgres/Chart.yaml
+++ b/packages/apps/postgres/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.18.0
+version: 0.18.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/packages/apps/postgres/templates/db.yaml
+++ b/packages/apps/postgres/templates/db.yaml
@@ -78,7 +78,7 @@ spec:
     labels:
       policy.cozystack.io/allow-to-apiserver: "true"
       app.kubernetes.io/name: postgres.apps.cozystack.io
-      app.kubernets.io/instance: {{ $.Release.Name }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: WorkloadMonitor
@@ -91,5 +91,5 @@ spec:
   type: postgres
   selector:
     app.kubernetes.io/name: postgres.apps.cozystack.io
-    app.kubernets.io/instance: {{ $.Release.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
   version: {{ $.Chart.Version }}

--- a/packages/apps/versions_map
+++ b/packages/apps/versions_map
@@ -127,7 +127,8 @@ postgres 0.16.0 70f82667
 postgres 0.17.0 acd4663a
 postgres 0.17.1 08cb7c0f
 postgres 0.17.3 c02a3818
-postgres 0.18.0 HEAD
+postgres 0.18.0 53fbe7c2
+postgres 0.18.1 HEAD
 rabbitmq 0.1.0 263e47be
 rabbitmq 0.2.0 53f2365e
 rabbitmq 0.3.0 6c5cf5bf

--- a/packages/system/cozystack-api/templates/cozystack-resource-definitions.yaml
+++ b/packages/system/cozystack-api/templates/cozystack-resource-definitions.yaml
@@ -19,6 +19,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -41,6 +46,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -63,6 +73,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -85,6 +100,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -107,6 +127,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -129,6 +154,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -151,6 +181,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -173,6 +208,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -195,6 +235,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -217,6 +262,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -239,6 +289,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -261,6 +316,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -283,6 +343,13 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    - matchLabels:
+        cnpg.io/userType: superuser
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -305,6 +372,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -327,6 +399,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -349,6 +426,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -371,6 +453,11 @@ spec:
         kind: HelmRepository
         name: cozystack-apps
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -393,6 +480,11 @@ spec:
         kind: HelmRepository
         name: cozystack-extra
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -415,6 +507,11 @@ spec:
         kind: HelmRepository
         name: cozystack-extra
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -437,6 +534,11 @@ spec:
         kind: HelmRepository
         name: cozystack-extra
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -459,6 +561,11 @@ spec:
         kind: HelmRepository
         name: cozystack-extra
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -481,6 +588,11 @@ spec:
         kind: HelmRepository
         name: cozystack-extra
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]
 ---
 apiVersion: cozystack.io/v1alpha1
 kind: CozystackResourceDefinition
@@ -503,3 +615,8 @@ spec:
         kind: HelmRepository
         name: cozystack-extra
         namespace: cozy-public
+  secrets:
+    exclude:
+    - matchLabels:
+        apps.cozystack.io/tenantresource: "false"
+    include: [{}]


### PR DESCRIPTION
## What this PR does

This patch populates existing CozystackResourceDefinitions with minimal working examples of secret selectors to take advantage of the newest revision of the ancestor tracking webhook.

### Release note

```release-note
[platform] Specify secret selectors for existing managed apps in their
respective CozystackResourceDefinitions, which provides the last bit of
information necessary for the lineage webhook to correctly mark secrets
as user-facing or not.
```