### PR TITLE
[cozystack-api] Specify tenantmodules labels

### DIFF
--- a/packages/apps/tenant/templates/etcd.yaml
+++ b/packages/apps/tenant/templates/etcd.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "tenant.name" . }}
   labels:
     cozystack.io/ui: "true"
+    internal.cozystack.io/tenantmodule: "true"
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:

--- a/packages/apps/tenant/templates/info.yaml
+++ b/packages/apps/tenant/templates/info.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: {{ include "tenant.name" . }}
   labels:
     cozystack.io/ui: "true"
+    internal.cozystack.io/tenantmodule: "true"
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:

--- a/packages/apps/tenant/templates/ingress.yaml
+++ b/packages/apps/tenant/templates/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "tenant.name" . }}
   labels:
     cozystack.io/ui: "true"
+    internal.cozystack.io/tenantmodule: "true"
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:

--- a/packages/apps/tenant/templates/monitoring.yaml
+++ b/packages/apps/tenant/templates/monitoring.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "tenant.name" . }}
   labels:
     cozystack.io/ui: "true"
+    internal.cozystack.io/tenantmodule: "true"
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:

--- a/packages/apps/tenant/templates/seaweedfs.yaml
+++ b/packages/apps/tenant/templates/seaweedfs.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "tenant.name" . }}
   labels:
     cozystack.io/ui: "true"
+    internal.cozystack.io/tenantmodule: "true"
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:

--- a/packages/system/cozystack-api/templates/cozystack-resource-definitions/etcd.yaml
+++ b/packages/system/cozystack-api/templates/cozystack-resource-definitions/etcd.yaml
@@ -13,6 +13,7 @@ spec:
     prefix: ""
     labels:
       cozystack.io/ui: "true"
+      internal.cozystack.io/tenantmodule: "true"
     chart:
       name: etcd
       sourceRef:

--- a/packages/system/cozystack-api/templates/cozystack-resource-definitions/info.yaml
+++ b/packages/system/cozystack-api/templates/cozystack-resource-definitions/info.yaml
@@ -13,6 +13,7 @@ spec:
     prefix: ""
     labels:
       cozystack.io/ui: "true"
+      internal.cozystack.io/tenantmodule: "true"
     chart:
       name: info
       sourceRef:

--- a/packages/system/cozystack-api/templates/cozystack-resource-definitions/ingress.yaml
+++ b/packages/system/cozystack-api/templates/cozystack-resource-definitions/ingress.yaml
@@ -13,6 +13,7 @@ spec:
     prefix: ""
     labels:
       cozystack.io/ui: "true"
+      internal.cozystack.io/tenantmodule: "true"
     chart:
       name: ingress
       sourceRef:

--- a/packages/system/cozystack-api/templates/cozystack-resource-definitions/monitoring.yaml
+++ b/packages/system/cozystack-api/templates/cozystack-resource-definitions/monitoring.yaml
@@ -13,6 +13,7 @@ spec:
     prefix: ""
     labels:
       cozystack.io/ui: "true"
+      internal.cozystack.io/tenantmodule: "true"
     chart:
       name: monitoring
       sourceRef:

--- a/packages/system/cozystack-api/templates/cozystack-resource-definitions/seaweedfs.yaml
+++ b/packages/system/cozystack-api/templates/cozystack-resource-definitions/seaweedfs.yaml
@@ -13,6 +13,7 @@ spec:
     prefix: ""
     labels:
       cozystack.io/ui: "true"
+      internal.cozystack.io/tenantmodule: "true"
     chart:
       name: seaweedfs
       sourceRef:


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Tenant components are now consistently tagged as modules, enabling clearer grouping, filtering, and management in dashboards and APIs.
  - Improves discoverability and automation by making module scope explicit across tenant services.

- Chores
  - Standardized an internal module label across tenant releases and system resource definitions (etcd, ingress, monitoring, SeaweedFS, info) for consistency.
  - Metadata-only update with no runtime behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->