### PR TITLE
Flux Operator 0.29.0

### DIFF
--- a/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.28.0
+appVersion: v0.29.0
 description: 'A Helm chart for deploying the Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.28.0
+version: 0.29.0

--- a/packages/system/fluxcd-operator/charts/flux-operator/README.md
+++ b/packages/system/fluxcd-operator/charts/flux-operator/README.md
@@ -1,6 +1,6 @@
 # flux-operator
 
-![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.0](https://img.shields.io/badge/AppVersion-v0.28.0-informational?style=flat-square)
+![Version: 0.29.0](https://img.shields.io/badge/Version-0.29.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
 
 The [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator) provides a
 declarative API for the installation and upgrade of CNCF [Flux](https://fluxcd.io) and the
@@ -47,7 +47,7 @@ see the Flux Operator [documentation](https://fluxcd.control-plane.io/operator/)
 | livenessProbe | object | `{"httpGet":{"path":"/healthz","port":8081},"initialDelaySeconds":15,"periodSeconds":20}` | Container liveness probe settings. |
 | logLevel | string | `"info"` | Container logging level flag. |
 | marketplace | object | `{"account":"","license":"","type":""}` | Marketplace settings. |
-| multitenancy | object | `{"defaultServiceAccount":"flux-operator","enabled":false}` | Enable [multitenancy lockdown](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for the ResourceSet APIs. |
+| multitenancy | object | `{"defaultServiceAccount":"flux-operator","defaultWorkloadIdentityServiceAccount":"flux-operator","enabled":false,"enabledForWorkloadIdentity":false}` | Enable [multitenancy lockdown](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for the ResourceSet APIs. |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Pod Node Selector settings. |
 | podSecurityContext | object | `{}` | Pod security context settings. |

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
@@ -73,6 +73,12 @@ spec:
                     description: Multitenant enables the multitenancy lockdown. Defaults
                       to false.
                     type: boolean
+                  multitenantWorkloadIdentity:
+                    default: false
+                    description: |-
+                      MultitenantWorkloadIdentity enables the multitenancy lockdown for
+                      workload identity. Defaults to false.
+                    type: boolean
                   networkPolicy:
                     default: true
                     description: |-
@@ -95,10 +101,29 @@ spec:
                     - medium
                     - large
                     type: string
+                  tenantDefaultDecryptionServiceAccount:
+                    description: |-
+                      TenantDefaultDecryptionServiceAccount is the name of the service account
+                      to use as default for kustomize-controller SOPS decryption when the
+                      multitenant lockdown for workload identity is enabled. Defaults to the
+                      'default' service account from the tenant namespace.
+                    type: string
+                  tenantDefaultKubeConfigServiceAccount:
+                    description: |-
+                      TenantDefaultKubeConfigServiceAccount is the name of the service account
+                      to use as default for kustomize-controller and helm-controller remote
+                      cluster access via spec.kubeConfig.configMapRef when the multitenant
+                      lockdown for workload identity is enabled. Defaults to the 'default'
+                      service account from the tenant namespace.
+                    type: string
                   tenantDefaultServiceAccount:
                     description: |-
                       TenantDefaultServiceAccount is the name of the service account
-                      to use as default when the multitenant lockdown is enabled.
+                      to use as default when the multitenant lockdown is enabled, for
+                      kustomize-controller and helm-controller.
+                      This field will also be used for multitenant workload identity
+                      lockdown for source-controller, notification-controller,
+                      image-reflector-controller and image-automation-controller.
                       Defaults to the 'default' service account from the tenant namespace.
                     type: string
                   type:
@@ -114,6 +139,11 @@ spec:
                     - gcp
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: .objectLevelWorkloadIdentity must be set to true when .multitenantWorkloadIdentity
+                    is set to true
+                  rule: (has(self.objectLevelWorkloadIdentity) && self.objectLevelWorkloadIdentity)
+                    || !has(self.multitenantWorkloadIdentity) || !self.multitenantWorkloadIdentity
               commonMetadata:
                 description: |-
                   CommonMetadata specifies the common labels and annotations that are
@@ -572,7 +602,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
@@ -875,7 +905,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
@@ -1243,7 +1273,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
     helm.sh/resource-policy: keep
   labels:
     app.kubernetes.io/instance: '{{ .Release.Name }}'
@@ -1351,6 +1381,34 @@ spec:
                   - name
                   type: object
                 type: array
+              inputStrategy:
+                description: |-
+                  InputStrategy defines how the inputs are combined when multiple
+                  input provider objects are used. Defaults to flattening all inputs
+                  from all providers into a single list of input sets.
+                properties:
+                  name:
+                    description: |-
+                      Name defines how the inputs are combined when multiple
+                      input provider objects are used. Supported values are:
+                      - Flatten: all inputs sets from all input provider objects are
+                        flattened into a single list of input sets.
+                      - Permute: all inputs sets from all input provider objects are
+                        combined using a Cartesian product, resulting in a list of input sets
+                        that contains every possible combination of input values.
+                        For example, if provider A has inputs [{x: 1}, {x: 2}] and provider B has
+                        inputs [{y: "a"}, {y: "b"}], the resulting input sets will be:
+                        [{x: 1, y: "a"}, {x: 1, y: "b"}, {x: 2, y: "a"}, {x: 2, y: "b"}].
+                        This strategy can lead to a large number of input sets and should be
+                        used with caution. Users should use filtering features from
+                        ResourceSetInputProvider to limit the amount of exported inputs.
+                    enum:
+                    - Flatten
+                    - Permute
+                    type: string
+                required:
+                - name
+                type: object
               inputs:
                 description: Inputs contains the list of ResourceSet inputs.
                 items:
@@ -1374,6 +1432,8 @@ spec:
                       description: |-
                         APIVersion of the input provider resource.
                         When not set, the APIVersion of the ResourceSet is used.
+                      enum:
+                      - fluxcd.controlplane.io/v1
                       type: string
                     kind:
                       description: Kind of the input provider resource.
@@ -1433,8 +1493,6 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-map-type: atomic
-                  required:
-                  - kind
                   type: object
                   x-kubernetes-validations:
                   - message: at least one of name or selector must be set for input

--- a/packages/system/fluxcd-operator/charts/flux-operator/templates/deployment.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/templates/deployment.yaml
@@ -53,6 +53,9 @@ spec:
             {{- if .Values.multitenancy.enabled }}
             - --default-service-account={{ .Values.multitenancy.defaultServiceAccount }}
             {{- end }}
+            {{- if .Values.multitenancy.enabledForWorkloadIdentity }}
+            - --default-workload-identity-service-account={{ .Values.multitenancy.defaultWorkloadIdentityServiceAccount }}
+            {{- end }}
             {{- range .Values.extraArgs }}
             - {{ . }}
             {{- end }}

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.schema.json
@@ -216,13 +216,20 @@
         "multitenancy": {
             "type": "object",
             "required": [
-                "defaultServiceAccount"
+                "defaultServiceAccount",
+                "defaultWorkloadIdentityServiceAccount"
             ],
             "properties": {
                 "defaultServiceAccount": {
                     "type": "string"
                 },
+                "defaultWorkloadIdentityServiceAccount": {
+                    "type": "string"
+                },
                 "enabled": {
+                    "type": "boolean"
+                },
+                "enabledForWorkloadIdentity": {
                     "type": "boolean"
                 }
             }

--- a/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
+++ b/packages/system/fluxcd-operator/charts/flux-operator/values.yaml
@@ -6,7 +6,9 @@ fullnameOverride: ""
 # -- Enable [multitenancy lockdown](https://fluxcd.control-plane.io/operator/resourceset/#role-based-access-control) for the ResourceSet APIs.
 multitenancy:
   enabled: false
+  enabledForWorkloadIdentity: false
   defaultServiceAccount: "flux-operator" # @schema required: true
+  defaultWorkloadIdentityServiceAccount: "flux-operator" # @schema required: true
 
 # -- Flux [reporting](https://fluxcd.control-plane.io/operator/fluxreport/) settings.
 reporting:

--- a/packages/system/fluxcd/charts/flux-instance/Chart.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/Chart.yaml
@@ -8,7 +8,7 @@ annotations:
     - name: Upstream Project
       url: https://github.com/controlplaneio-fluxcd/flux-operator
 apiVersion: v2
-appVersion: v0.28.0
+appVersion: v0.29.0
 description: 'A Helm chart for deploying a Flux instance managed by Flux Operator. '
 home: https://github.com/controlplaneio-fluxcd
 icon: https://raw.githubusercontent.com/cncf/artwork/main/projects/flux/icon/color/flux-icon-color.png
@@ -25,4 +25,4 @@ sources:
 - https://github.com/controlplaneio-fluxcd/flux-operator
 - https://github.com/controlplaneio-fluxcd/charts
 type: application
-version: 0.28.0
+version: 0.29.0

--- a/packages/system/fluxcd/charts/flux-instance/README.md
+++ b/packages/system/fluxcd/charts/flux-instance/README.md
@@ -1,6 +1,6 @@
 # flux-instance
 
-![Version: 0.28.0](https://img.shields.io/badge/Version-0.28.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.0](https://img.shields.io/badge/AppVersion-v0.28.0-informational?style=flat-square)
+![Version: 0.29.0](https://img.shields.io/badge/Version-0.29.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
 
 This chart is a thin wrapper around the `FluxInstance` custom resource, which is
 used by the [Flux Operator](https://github.com/controlplaneio-fluxcd/flux-operator)


### PR DESCRIPTION
Release tag:

* https://github.com/controlplaneio-fluxcd/flux-operator/releases/tag/v0.29.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added multitenancy workload identity support, including enablement toggle and default workload identity service account.
  - FluxInstance gains fields for multitenant workload identity and default service accounts, plus schema validations for safer configs.
  - ResourceSet introduces input strategy (Flatten/Permute) and enhanced input provider references and validations.

- Documentation
  - Updated README to reflect new multitenancy settings and version badges.

- Chores
  - Bumped Helm chart versions/appVersions to 0.29.0 across related charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->