### PR TITLE
feature/make info app unconditionally

### DIFF
--- a/packages/apps/tenant/templates/info.yaml
+++ b/packages/apps/tenant/templates/info.yaml
@@ -1,6 +1,3 @@
-{{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
-{{- $oidcEnabled := index $cozyConfig.data "oidc-enabled" }}
-{{- if eq $oidcEnabled "true" }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -30,4 +27,3 @@ spec:
     force: true
     remediation:
       retries: -1
-{{- end }}

--- a/packages/extra/info/templates/dashboard-resourcemap.yaml
+++ b/packages/extra/info/templates/dashboard-resourcemap.yaml
@@ -1,3 +1,5 @@
+{{- $cozyConfig := lookup "v1" "ConfigMap" "cozy-system" "cozystack" }}
+{{- $oidcEnabled := index $cozyConfig.data "oidc-enabled" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -8,7 +10,11 @@ rules:
   resources:
   - secrets
   resourceNames:
-  - kubeconfig-{{ .Release.Namespace }}
+  - {{- if eq $oidcEnabled "true" -}}
+    kubeconfig-{{ .Release.Namespace }}
+    {{- else -}}
+    tenant-{{ .Release.Namespace }}
+    {{- end }}
   verbs: ["get", "list", "watch"]
 ---
 kind: RoleBinding
@@ -16,7 +22,13 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-dashboard-resources
 subjects:
+{{- if eq $oidcEnabled "true" }}
 {{ include "cozy-lib.rbac.subjectsForTenantAndAccessLevel" (list "view" .Release.Namespace) }}
+{{- else }}
+- kind: ServiceAccount
+  name: tenant-{{ .Release.Namespace }}
+  namespace: tenant-{{ .Release.Namespace }}
+{{- end }}
 roleRef:
   kind: Role
   name: {{ .Release.Name }}-dashboard-resources


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
- make info app unconditionally
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Dashboard resource mapping now adapts to the OIDC setting, switching resource names and RBAC subjects accordingly for OIDC and non-OIDC environments.
- Bug Fixes
  - Helm release is now consistently deployed without being gated by the OIDC flag, ensuring reliable rollout across environments.
- Refactor
  - Introduced configuration-driven branching for resource names and access subjects in the dashboard, improving alignment with environment settings and reducing manual adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->