### PR TITLE
Fix migration to v0.37.0

### DIFF
--- a/packages/apps/virtual-machine/templates/secret.yaml
+++ b/packages/apps/virtual-machine/templates/secret.yaml
@@ -11,12 +11,10 @@ stringData:
 {{- end }}
 {{- if or .Values.cloudInit .Values.sshKeys }}
 ---
-apiVersion: core.cozystack.io/v1alpha1
-kind: TenantSecret
+apiVersion: v1
+kind: Secret
 metadata:
   name: {{ include "virtual-machine.fullname" . }}-cloud-init
-  labels:
-    apps.cozystack.io/virtual-machine: {{ .Release.Name }}
 stringData:
   userdata: |
     {{- if .Values.cloudInit }}

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -89,8 +89,8 @@ kubectl get hr -A -o go-template='{{ range .items }}{{ if .spec.suspend }}{{ .sp
   esac
 done
 
-# TODO: Update all Cozystack managed charts to latest version
-# kubectl get hr -A -l cozystack.io/ui=true --no-headers | awk '{print "kubectl patch helmrelease -n " $1 " " $2 " --type=merge -p '\''{\"spec\":{\"chart\":{\"spec\":{\"version\":\"*\"}}}}'\'' "}' | sh -x
+# Update all Cozystack managed charts to latest version
+kubectl get hr -A -l cozystack.io/ui=true --no-headers | awk '{print "kubectl patch helmrelease -n " $1 " " $2 " --type=merge -p '\''{\"spec\":{\"chart\":{\"spec\":{\"version\":\">= 0.0.0-0\"}}}}'\'' "}' | sh -x
 
 # Reconcile platform chart
 trap 'exit' INT TERM

--- a/scripts/migrations/20
+++ b/scripts/migrations/20
@@ -4,10 +4,9 @@
 set -euo pipefail
 
 kubectl delete ingresses.networking.k8s.io --all -n cozy-dashboard --ignore-not-found
-kubectl delete cozystackresourcedefinitions --all-namespaces --all --ignore-not-found
 kubectl delete crd cozystackresourcedefinitions.cozystack.io --ignore-not-found
 
-timestamp=$(date --rfc-3339=ns)
+timestamp=$(date --rfc-3339=ns || date)
 # Make sure webhook is upgraded first, then run migration
 cozypkg -C packages/system/cozystack-controller -n cozy-system reconcile cozystack-controller --force --with-source
 kubectl wait hr/cozystack-controller -n cozy-system --timeout=4m --for=condition=ready || exit 1
@@ -20,7 +19,7 @@ kubectl get namespace -o custom-columns=NAME:.metadata.name --no-headers |
     kubectl annotate \
       pods,services,pvc,secrets,ingresses.networking.k8s.io,workloadmonitors.cozystack.io \
       -n "$namespace" --all \
-      migration.cozystack.io="$timestamp" --overwrite)
+      migration.cozystack.io="$timestamp" --overwrite || true)
   done
 # Stamp version
 kubectl create configmap -n cozy-system cozystack-version \


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended deletion of platform resource definitions during migrations.
  * Made timestamp generation resilient to environment differences to avoid script failures.
  * Made annotation steps tolerate failures so migrations continue if overwrite fails.

* **Chores**
  * Re-enabled automatic chart update path and added periodic reconciliation to keep platform components up to date.

* **Refactor**
  * Switched VM cloud-init to use native Kubernetes Secret for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->