### PR TITLE
[seaweedfs] Fix timeout while uploading hude files

### DIFF
--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
@@ -152,7 +152,10 @@ spec:
               {{- if .Values.s3.auditLogConfig }}
               -auditLogConfig=/etc/sw/s3_auditLogConfig.json \
               {{- end }}
-              -filer={{ template "seaweedfs.name" . }}-filer-client.{{ .Release.Namespace }}:{{ .Values.filer.port }}
+              -filer={{ template "seaweedfs.name" . }}-filer-client.{{ .Release.Namespace }}:{{ .Values.filer.port }} \
+              {{- range .Values.s3.extraArgs }}
+              {{ . }} \
+              {{- end }}
           volumeMounts:
             {{- if or (eq .Values.s3.logs.type "hostPath") (eq .Values.s3.logs.type "emptyDir") }}
             - name: logs

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -84,6 +84,8 @@ seaweedfs:
       auditLogConfig: {}
   s3:
     enabled: true
+    extraArgs:
+    - -idleTimeout=60
     enableAuth: false
     readinessProbe:
       scheme: HTTPS


### PR DESCRIPTION
Signed-off-by: Andrei Kvapil <kvapss@gmail.com>

<!-- Thank you for making a contribution! Here are some tips for you:
- Start the PR title with the [label] of Cozystack component:
  - For system components: [platform], [system], [linstor], [cilium], [kube-ovn], [dashboard], [cluster-api], etc.
  - For managed apps: [apps], [tenant], [kubernetes], [postgres], [virtual-machine] etc.
  - For development and maintenance: [tests], [ci], [docs], [maintenance].
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

related to https://github.com/seaweedfs/seaweedfs/pull/7294

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same [label] as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
[]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow supplying extra S3 server startup arguments via configuration, enabling custom runtime flags for the S3 service.

* **Chores**
  * Set default S3 idle timeout to 60 seconds for improved default connection handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->