### PR TITLE
[controller, api] Select ingresses and services

### DIFF
--- a/api/v1alpha1/cozystackresourcedefinitions_types.go
+++ b/api/v1alpha1/cozystackresourcedefinitions_types.go
@@ -52,6 +52,10 @@ type CozystackResourceDefinitionSpec struct {
 
 	// Secret selectors
 	Secrets CozystackResourceDefinitionResources `json:"secrets,omitempty"`
+	// Service selectors
+	Services CozystackResourceDefinitionResources `json:"services,omitempty"`
+	// Ingress selectors
+	Ingresses CozystackResourceDefinitionResources `json:"ingresses,omitempty"`
 
 	// Dashboard configuration for this resource
 	Dashboard *CozystackResourceDefinitionDashboard `json:"dashboard,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -237,6 +237,8 @@ func (in *CozystackResourceDefinitionSpec) DeepCopyInto(out *CozystackResourceDe
 	out.Application = in.Application
 	in.Release.DeepCopyInto(&out.Release)
 	in.Secrets.DeepCopyInto(&out.Secrets)
+	in.Services.DeepCopyInto(&out.Services)
+	in.Ingresses.DeepCopyInto(&out.Ingresses)
 	if in.Dashboard != nil {
 		in, out := &in.Dashboard, &out.Dashboard
 		*out = new(CozystackResourceDefinitionDashboard)

--- a/internal/lineagecontrollerwebhook/matcher.go
+++ b/internal/lineagecontrollerwebhook/matcher.go
@@ -62,12 +62,12 @@ func matchResourceToSelectorArray(ctx context.Context, name string, templateCont
 	return false
 }
 
-func matchResourceToExcludeInclude(ctx context.Context, name string, templateContext, l map[string]string, ex, in []*cozyv1alpha1.CozystackResourceDefinitionResourceSelector) bool {
-	if matchResourceToSelectorArray(ctx, name, templateContext, l, ex) {
+func matchResourceToExcludeInclude(ctx context.Context, name string, templateContext, l map[string]string, resources *cozyv1alpha1.CozystackResourceDefinitionResources) bool {
+	if resources == nil {
 		return false
 	}
-	if matchResourceToSelectorArray(ctx, name, templateContext, l, in) {
-		return true
+	if matchResourceToSelectorArray(ctx, name, templateContext, l, resources.Exclude) {
+		return false
 	}
-	return false
+	return matchResourceToSelectorArray(ctx, name, templateContext, l, resources.Include)
 }

--- a/packages/apps/virtual-machine/templates/service.yaml
+++ b/packages/apps/virtual-machine/templates/service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   name: {{ include "virtual-machine.fullname" . }}
   labels:
+    apps.cozystack.io/user-service: "true"
     {{- include "virtual-machine.labels" . | nindent 4 }}
   annotations:
     networking.cozystack.io/wholeIP: "true"

--- a/packages/apps/vm-instance/templates/service.yaml
+++ b/packages/apps/vm-instance/templates/service.yaml
@@ -5,6 +5,7 @@ kind: Service
 metadata:
   name: {{ include "virtual-machine.fullname" . }}
   labels:
+    apps.cozystack.io/user-service: "true"
     {{- include "virtual-machine.labels" . | nindent 4 }}
   annotations:
     networking.cozystack.io/wholeIP: "true"

--- a/packages/system/cozystack-api/cozyrds/bootbox.yaml
+++ b/packages/system/cozystack-api/cozyrds/bootbox.yaml
@@ -31,3 +31,13 @@ spec:
   secrets:
     exclude: []
     include: []
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - bootbox
+  ingresses:
+    exclude: []
+    include:
+      - resourceNames:
+          - bootbox

--- a/packages/system/cozystack-api/cozyrds/bucket.yaml
+++ b/packages/system/cozystack-api/cozyrds/bucket.yaml
@@ -35,3 +35,8 @@ spec:
       - resourceNames:
           - bucket-{{ .name }}
           - bucket-{{ .name }}-credentials
+  ingresses:
+    exclude: []
+    include:
+      - resourceNames:
+          - bucket-{{ .name }}-ui

--- a/packages/system/cozystack-api/cozyrds/clickhouse.yaml
+++ b/packages/system/cozystack-api/cozyrds/clickhouse.yaml
@@ -32,3 +32,8 @@ spec:
     include:
       - resourceNames:
           - clickhouse-{{ .name }}-credentials
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - chendpoint-clickhouse-{{ .name }}

--- a/packages/system/cozystack-api/cozyrds/etcd.yaml
+++ b/packages/system/cozystack-api/cozyrds/etcd.yaml
@@ -32,3 +32,8 @@ spec:
   secrets:
     exclude: []
     include: []
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - etcd

--- a/packages/system/cozystack-api/cozyrds/ferretdb.yaml
+++ b/packages/system/cozystack-api/cozyrds/ferretdb.yaml
@@ -33,3 +33,8 @@ spec:
     include:
       - resourceNames:
           - ferretdb-{{ .name }}-credentials
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - ferretdb-{{ .name }}

--- a/packages/system/cozystack-api/cozyrds/ingress.yaml
+++ b/packages/system/cozystack-api/cozyrds/ingress.yaml
@@ -32,3 +32,8 @@ spec:
   secrets:
     exclude: []
     include: []
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - "{{ slice .namespace 7 }}-ingress-controller"

--- a/packages/system/cozystack-api/cozyrds/kafka.yaml
+++ b/packages/system/cozystack-api/cozyrds/kafka.yaml
@@ -33,3 +33,8 @@ spec:
     include:
       - resourceNames:
           - kafka-{{ .name }}-clients-ca
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - kafka-{{ .name }}-kafka-bootstrap

--- a/packages/system/cozystack-api/cozyrds/kubernetes.yaml
+++ b/packages/system/cozystack-api/cozyrds/kubernetes.yaml
@@ -34,3 +34,13 @@ spec:
     include:
       - resourceNames:
           - kubernetes-{{ .name }}-admin-kubeconfig
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - kubernetes-{{ .name }}
+  ingresses:
+    exclude: []
+    include:
+      - resourceNames:
+          - kubernetes-{{ .name }}

--- a/packages/system/cozystack-api/cozyrds/monitoring.yaml
+++ b/packages/system/cozystack-api/cozyrds/monitoring.yaml
@@ -34,3 +34,15 @@ spec:
     include:
       - resourceNames:
           - grafana-admin-password
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - grafana-service
+          - alerta
+  ingresses:
+    exclude: []
+    include:
+      - resourceNames:
+          - grafana-ingress
+          - alerta

--- a/packages/system/cozystack-api/cozyrds/mysql.yaml
+++ b/packages/system/cozystack-api/cozyrds/mysql.yaml
@@ -33,3 +33,9 @@ spec:
     include:
       - resourceNames:
           - mysql-{{ .name }}-credentials
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - mysql-{{ .name }}-primary
+          - mysql-{{ .name }}-secondary

--- a/packages/system/cozystack-api/cozyrds/nats.yaml
+++ b/packages/system/cozystack-api/cozyrds/nats.yaml
@@ -33,3 +33,8 @@ spec:
     include:
       - resourceNames:
           - nats-{{ .name }}-credentials
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - nats-{{ .name }}

--- a/packages/system/cozystack-api/cozyrds/postgres.yaml
+++ b/packages/system/cozystack-api/cozyrds/postgres.yaml
@@ -41,3 +41,11 @@ spec:
     include:
       - resourceNames:
           - postgres-{{ .name }}-credentials
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - postgres-{{ .name }}-r
+          - postgres-{{ .name }}-ro
+          - postgres-{{ .name }}-rw
+          - postgres-{{ .name }}-external-write

--- a/packages/system/cozystack-api/cozyrds/rabbitmq.yaml
+++ b/packages/system/cozystack-api/cozyrds/rabbitmq.yaml
@@ -35,3 +35,8 @@ spec:
           - rabbitmq-{{ .name }}-default-user
       - matchLabels:
           apps.cozystack.io/user-secret: "true"
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - rabbitmq-{{ .name }}

--- a/packages/system/cozystack-api/cozyrds/redis.yaml
+++ b/packages/system/cozystack-api/cozyrds/redis.yaml
@@ -33,3 +33,11 @@ spec:
     include:
       - resourceNames:
           - redis-{{ .name }}-auth
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - rfs-redis-{{ .name }}
+          - rfrm-redis-{{ .name }}
+          - rfrs-redis-{{ .name }}
+          - redis-{{ .name }}-external-lb

--- a/packages/system/cozystack-api/cozyrds/seaweedfs.yaml
+++ b/packages/system/cozystack-api/cozyrds/seaweedfs.yaml
@@ -32,3 +32,13 @@ spec:
   secrets:
     exclude: []
     include: []
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - seaweedfs-{{ .name }}-s3
+  ingresses:
+    exclude: []
+    include:
+      - resourceNames:
+          - ingress-seaweedfs-{{ .name }}-s3

--- a/packages/system/cozystack-api/cozyrds/vm-instance.yaml
+++ b/packages/system/cozystack-api/cozyrds/vm-instance.yaml
@@ -32,3 +32,8 @@ spec:
   secrets:
     exclude: []
     include: []
+  services:
+    exclude: []
+    include:
+      - matchLabels:
+          apps.cozystack.io/user-service: "true"

--- a/packages/system/cozystack-api/cozyrds/vpn.yaml
+++ b/packages/system/cozystack-api/cozyrds/vpn.yaml
@@ -33,3 +33,8 @@ spec:
     include:
       - resourceNames:
           - vpn-{{ .name }}-urls
+  services:
+    exclude: []
+    include:
+      - resourceNames:
+          - vpn-{{ .name }}-vpn

--- a/packages/system/cozystack-controller/crds/cozystack.io_cozystackresourcedefinitions.yaml
+++ b/packages/system/cozystack-controller/crds/cozystack.io_cozystackresourcedefinitions.yaml
@@ -126,6 +126,173 @@ spec:
                 - plural
                 - singular
                 type: object
+              ingresses:
+                description: Ingress selectors
+                properties:
+                  exclude:
+                    description: |-
+                      Exclude contains an array of resource selectors that target resources.
+                      If a resource matches the selector in any of the elements in the array, it is
+                      hidden from the user, regardless of the matches in the include array.
+                    items:
+                      description: |-
+                        CozystackResourceDefinitionResourceSelector extends metav1.LabelSelector with resourceNames support.
+                        A resource matches this selector only if it satisfies ALL criteria:
+                        - Label selector conditions (matchExpressions and matchLabels)
+                        - AND has a name that matches one of the names in resourceNames (if specified)
+
+                        The resourceNames field supports Go templates with the following variables available:
+                        - {{ .name }}: The name of the managing application (from apps.cozystack.io/application.name)
+                        - {{ .kind }}: The lowercased kind of the managing application (from apps.cozystack.io/application.kind)
+                        - {{ .namespace }}: The namespace of the resource being processed
+
+                        Example YAML:
+                          secrets:
+                            include:
+                            - matchExpressions:
+                              - key: badlabel
+                                operator: DoesNotExist
+                              matchLabels:
+                                goodlabel: goodvalue
+                              resourceNames:
+                              - "{{ .name }}-secret"
+                              - "{{ .kind }}-{{ .name }}-tls"
+                              - "specificname"
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                        resourceNames:
+                          description: |-
+                            ResourceNames is a list of resource names to match
+                            If specified, the resource must have one of these exact names to match the selector
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  include:
+                    description: |-
+                      Include contains an array of resource selectors that target resources.
+                      If a resource matches the selector in any of the elements in the array, and
+                      matches none of the selectors in the exclude array that resource is marked
+                      as a tenant resource and is visible to users.
+                    items:
+                      description: |-
+                        CozystackResourceDefinitionResourceSelector extends metav1.LabelSelector with resourceNames support.
+                        A resource matches this selector only if it satisfies ALL criteria:
+                        - Label selector conditions (matchExpressions and matchLabels)
+                        - AND has a name that matches one of the names in resourceNames (if specified)
+
+                        The resourceNames field supports Go templates with the following variables available:
+                        - {{ .name }}: The name of the managing application (from apps.cozystack.io/application.name)
+                        - {{ .kind }}: The lowercased kind of the managing application (from apps.cozystack.io/application.kind)
+                        - {{ .namespace }}: The namespace of the resource being processed
+
+                        Example YAML:
+                          secrets:
+                            include:
+                            - matchExpressions:
+                              - key: badlabel
+                                operator: DoesNotExist
+                              matchLabels:
+                                goodlabel: goodvalue
+                              resourceNames:
+                              - "{{ .name }}-secret"
+                              - "{{ .kind }}-{{ .name }}-tls"
+                              - "specificname"
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                        resourceNames:
+                          description: |-
+                            ResourceNames is a list of resource names to match
+                            If specified, the resource must have one of these exact names to match the selector
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                type: object
               release:
                 description: Release configuration
                 properties:
@@ -172,6 +339,173 @@ spec:
                 type: object
               secrets:
                 description: Secret selectors
+                properties:
+                  exclude:
+                    description: |-
+                      Exclude contains an array of resource selectors that target resources.
+                      If a resource matches the selector in any of the elements in the array, it is
+                      hidden from the user, regardless of the matches in the include array.
+                    items:
+                      description: |-
+                        CozystackResourceDefinitionResourceSelector extends metav1.LabelSelector with resourceNames support.
+                        A resource matches this selector only if it satisfies ALL criteria:
+                        - Label selector conditions (matchExpressions and matchLabels)
+                        - AND has a name that matches one of the names in resourceNames (if specified)
+
+                        The resourceNames field supports Go templates with the following variables available:
+                        - {{ .name }}: The name of the managing application (from apps.cozystack.io/application.name)
+                        - {{ .kind }}: The lowercased kind of the managing application (from apps.cozystack.io/application.kind)
+                        - {{ .namespace }}: The namespace of the resource being processed
+
+                        Example YAML:
+                          secrets:
+                            include:
+                            - matchExpressions:
+                              - key: badlabel
+                                operator: DoesNotExist
+                              matchLabels:
+                                goodlabel: goodvalue
+                              resourceNames:
+                              - "{{ .name }}-secret"
+                              - "{{ .kind }}-{{ .name }}-tls"
+                              - "specificname"
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                        resourceNames:
+                          description: |-
+                            ResourceNames is a list of resource names to match
+                            If specified, the resource must have one of these exact names to match the selector
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                  include:
+                    description: |-
+                      Include contains an array of resource selectors that target resources.
+                      If a resource matches the selector in any of the elements in the array, and
+                      matches none of the selectors in the exclude array that resource is marked
+                      as a tenant resource and is visible to users.
+                    items:
+                      description: |-
+                        CozystackResourceDefinitionResourceSelector extends metav1.LabelSelector with resourceNames support.
+                        A resource matches this selector only if it satisfies ALL criteria:
+                        - Label selector conditions (matchExpressions and matchLabels)
+                        - AND has a name that matches one of the names in resourceNames (if specified)
+
+                        The resourceNames field supports Go templates with the following variables available:
+                        - {{ .name }}: The name of the managing application (from apps.cozystack.io/application.name)
+                        - {{ .kind }}: The lowercased kind of the managing application (from apps.cozystack.io/application.kind)
+                        - {{ .namespace }}: The namespace of the resource being processed
+
+                        Example YAML:
+                          secrets:
+                            include:
+                            - matchExpressions:
+                              - key: badlabel
+                                operator: DoesNotExist
+                              matchLabels:
+                                goodlabel: goodvalue
+                              resourceNames:
+                              - "{{ .name }}-secret"
+                              - "{{ .kind }}-{{ .name }}-tls"
+                              - "specificname"
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                        resourceNames:
+                          description: |-
+                            ResourceNames is a list of resource names to match
+                            If specified, the resource must have one of these exact names to match the selector
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                type: object
+              services:
+                description: Service selectors
                 properties:
                   exclude:
                     description: |-


### PR DESCRIPTION
## What this PR does

This patch extends the resource-selecting function of the webhook to also apply selectors to ingresses and services, like has been already done for secrets. The Cozystack resource definitions have been upgraded to contain two more fields: `ingresses` and `services` and populated with counterparts of the legacy selectors from the dashboard roles.

### Release note

```release-note
[controller, api] Enable marking ingresses and services as user-facing
and implement selectors for existing CozystackResourceDefinitions.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CRD and API now support selecting Services and Ingresses alongside Secrets.
  * Lineage/labeling logic updated to evaluate Services and Ingresses when computing tenant/resource labels.
  * System resource definitions updated to expose Service/Ingress selectors across many system apps (Bucket, Bootbox, ClickHouse, etcd, Ferretdb, Ingress, Kafka, Kubernetes, Monitoring, MySQL, NATS, Postgres, RabbitMQ, Redis, SeaweedFS, VM Instance, VPN).
  * VM service templates add apps.cozystack.io/user-service: "true" label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->