### PR TITLE
[seaweedfs] Record bucket disk usage

### DIFF
--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -30,6 +30,21 @@ seaweedfs:
         type: "persistentVolumeClaim"
         size: "10Gi"
         maxVolumes: 0
+    sidecars: |-
+      - name: exporter
+        image: mdoubez/filestat_exporter:latest
+        ports:
+        - containerPort: 9943
+          name: filemetrics
+        args:
+        - "-config.file"
+        - "none"
+        - "-path.cwd"
+        - "/data1"
+        - "bucket-*.dat"
+        volumeMounts:
+        - mountPath: /data1/
+          name: data1
   filer:
     replicas: 2
     #  replication type is XYZ:


### PR DESCRIPTION
## What this PR does

This patch adds a sidecar to the SeaweedFS volume statefulset with the filestat exporter which records file metrics about the bucket-* files. This provides a way to meter the object storage disk usage.

### Release note

```release-note
[seaweedfs] Measure and record the disk size of S3 buckets.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced monitoring capabilities for storage volumes to improve system observability and metrics collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->