### PR TITLE
[velero] Add velero image build with race condition fix patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ build: build-deps
 	make -C packages/system/dashboard image
 	make -C packages/system/metallb image
 	make -C packages/system/kamaji image
+	make -C packages/system/velero image
 	make -C packages/system/bucket image
 	make -C packages/system/objectstorage-controller image
 	make -C packages/core/testing image

--- a/packages/system/velero/Makefile
+++ b/packages/system/velero/Makefile
@@ -1,6 +1,7 @@
 export NAME=velero
 export NAMESPACE=cozy-$(NAME)
 
+include ../../../scripts/common-envs.mk
 include ../../../scripts/package.mk
 
 update:
@@ -9,3 +10,18 @@ update:
 	helm repo add tanzu https://vmware-tanzu.github.io/helm-charts
 	helm repo update tanzu
 	helm pull tanzu/velero --untar --untardir charts
+	tag=$$(yq .image.tag charts/velero/values.yaml) && \
+	sed -i "/ARG VERSION/ s|=.*|=$${tag}|g" images/velero/Dockerfile
+
+image:
+	docker buildx build images/velero \
+		--tag $(REGISTRY)/velero:$(call settag,$(TAG)) \
+		--cache-from type=registry,ref=$(REGISTRY)/velero:latest \
+		--cache-to type=inline \
+		--metadata-file images/velero.json \
+		$(BUILDX_ARGS)
+	REPOSITORY="$(REGISTRY)/velero" \
+		yq -i '.velero.image.repository = strenv(REPOSITORY)' values.yaml
+	TAG=$(TAG)@$$(yq e '."containerimage.digest"' images/velero.json -o json -r) \
+		yq -i '.velero.image.tag = strenv(TAG)' values.yaml
+	rm -f images/velero.json

--- a/packages/system/velero/charts/velero/Chart.yaml
+++ b/packages/system/velero/charts/velero/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.17.0
+appVersion: 1.17.1
 description: A Helm chart for velero
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
@@ -14,4 +14,4 @@ maintainers:
 name: velero
 sources:
 - https://github.com/vmware-tanzu/velero
-version: 11.0.0
+version: 11.2.0

--- a/packages/system/velero/charts/velero/templates/podmonitor.yaml
+++ b/packages/system/velero/charts/velero/templates/podmonitor.yaml
@@ -32,13 +32,22 @@ spec:
     {{- end }}
   podMetricsEndpoints:
   - port: http-monitoring
-    interval: {{ .Values.metrics.scrapeInterval }}
-    scrapeTimeout: {{ .Values.metrics.scrapeTimeout }}
-    {{- if .Values.metrics.nodeAgentPodMonitor.scheme }}
-    scheme: {{ .Values.metrics.nodeAgentPodMonitor.scheme }}
+    {{- with .Values.metrics.scrapeInterval }}
+    interval: {{ . }}
     {{- end }}
-    {{- if .Values.metrics.nodeAgentPodMonitor.tlsConfig }}
-    tlsConfig:
-      {{- toYaml .Values.metrics.nodeAgentPodMonitor.tlsConfig | nindent 6 }}
+    {{- with .Values.metrics.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.nodeAgentPodMonitor.scheme }}
+    scheme: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.nodeAgentPodMonitor.metricRelabelings }}
+    metricRelabelings: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.nodeAgentPodMonitor.relabelings }}
+    relabelings: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.nodeAgentPodMonitor.tlsConfig }}
+    tlsConfig: {{ toYaml . | nindent 6 }}
     {{- end }}
 {{- end }}

--- a/packages/system/velero/charts/velero/templates/servicemonitor.yaml
+++ b/packages/system/velero/charts/velero/templates/servicemonitor.yaml
@@ -28,19 +28,22 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   endpoints:
   - port: http-monitoring
-    interval: {{ .Values.metrics.scrapeInterval }}
-    scrapeTimeout: {{ .Values.metrics.scrapeTimeout }}
-    {{- if .Values.metrics.serviceMonitor.scheme }}
-    scheme: {{ .Values.metrics.serviceMonitor.scheme }}
+    {{- with .Values.metrics.scrapeInterval }}
+    interval: {{ . }}
     {{- end }}
-    {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
-    metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- with .Values.metrics.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
     {{- end }}
-    {{- if .Values.metrics.serviceMonitor.relabelings }}
-    relabelings: {{ toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
+    {{- with .Values.metrics.serviceMonitor.scheme }}
+    scheme: {{ . }}
     {{- end }}
-    {{- if .Values.metrics.serviceMonitor.tlsConfig }}
-    tlsConfig:
-      {{- toYaml .Values.metrics.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.relabelings }}
+    relabelings: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.tlsConfig }}
+    tlsConfig: {{ toYaml . | nindent 6 }}
     {{- end }}
 {{- end }}

--- a/packages/system/velero/charts/velero/values.schema.json
+++ b/packages/system/velero/charts/velero/values.schema.json
@@ -293,8 +293,6 @@
             },
             "required": [
                 "enabled",
-                "scrapeInterval",
-                "scrapeTimeout",
                 "service",
                 "podAnnotations",
                 "serviceMonitor",

--- a/packages/system/velero/charts/velero/values.yaml
+++ b/packages/system/velero/charts/velero/values.yaml
@@ -27,7 +27,7 @@ namespace:
 # enabling node-agent). Required.
 image:
   repository: velero/velero
-  tag: v1.17.0
+  tag: v1.17.1
   # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
   # If used, it will take precedence over the image.tag.
   # digest:
@@ -130,7 +130,7 @@ dnsPolicy: ClusterFirst
 # If the value is a string then it is evaluated as a template.
 initContainers:
   # - name: velero-plugin-for-aws
-  #   image: velero/velero-plugin-for-aws:v1.13.0
+  #   image: velero/velero-plugin-for-aws:v1.13.1
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
@@ -282,11 +282,16 @@ metrics:
     enabled: false
     annotations: {}
     additionalLabels: {}
-    # ServiceMonitor namespace. Default to Velero namespace.
+    # metrics.nodeAgentPodMonitor.metricRelabelings Specify Metric Relabelings to add to the scrape endpoint
+    # ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    # metricRelabelings: []
+    # metrics.nodeAgentPodMonitor.relabelings [array] Prometheus relabeling rules
+    # relabelings: []
+    # PodMonitor namespace. Default to Velero namespace.
     # namespace:
-    # ServiceMonitor connection scheme. Defaults to HTTP.
+    # PodMonitor connection scheme. Defaults to HTTP.
     # scheme: ""
-    # ServiceMonitor connection tlsConfig. Defaults to {}.
+    # PodMonitor connection tlsConfig. Defaults to {}.
     # tlsConfig: {}
 
   prometheusRule:
@@ -316,14 +321,14 @@ metrics:
     #     severity: critical
     # - alert: VeleroNoNewBackup
     #   annotations:
-    #     message: Velero backup {{ $labels.schedule }} has not run successfuly in the last 30h
+    #     message: Velero backup {{ $labels.schedule }} has not run successfully in the last 25h
     #   expr: |-
     #     (
-    #     rate(velero_backup_last_successful_timestamp{schedule!=""}[15m]) <=bool 0
+    #     (time() - velero_backup_last_successful_timestamp{schedule!=""}) >bool (25 * 3600)
     #     or
     #     absent(velero_backup_last_successful_timestamp{schedule!=""})
     #     ) == 1
-    #   for: 30h
+    #   for: 1h
     #   labels:
     #     severity: critical
     # - alert: VeleroBackupPartialFailures
@@ -784,7 +789,7 @@ schedules: {}
 #       velero.io/plugin-config: ""
 #       velero.io/pod-volume-restore: RestoreItemAction
 #     data:
-#       image: velero/velero:v1.17.0
+#       image: velero/velero:v1.17.1
 #       cpuRequest: 200m
 #       memRequest: 128Mi
 #       cpuLimit: 200m

--- a/packages/system/velero/images/velero/Dockerfile
+++ b/packages/system/velero/images/velero/Dockerfile
@@ -1,0 +1,49 @@
+# Build the velero binary
+FROM golang:1.24-bookworm AS builder
+
+ARG VERSION=v1.17.1
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
+ARG GOPROXY=https://proxy.golang.org
+
+ENV CGO_ENABLED=0 \
+    GO111MODULE=on \
+    GOPROXY=${GOPROXY} \
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH} \
+    GOARM=${TARGETVARIANT}
+
+WORKDIR /workspace
+
+RUN curl -sSL https://github.com/vmware-tanzu/velero/archive/refs/tags/${VERSION}.tar.gz | tar -xzvf- --strip=1
+
+COPY patches /patches
+RUN git apply /patches/*.diff || true
+
+RUN mkdir -p /output && \
+    export GOARM=$( echo "${GOARM}" | cut -c2-) && \
+    GIT_SHA=$(git rev-parse HEAD 2>/dev/null || echo "unknown") && \
+    go build -o /output/velero \
+    -ldflags "-X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=${VERSION}" \
+    ./cmd/velero && \
+    go build -o /output/velero-restore-helper \
+    -ldflags "-X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=${VERSION}" \
+    ./cmd/velero-restore-helper && \
+    go build -o /output/velero-helper \
+    -ldflags "-X github.com/vmware-tanzu/velero/pkg/buildinfo.Version=${VERSION}" \
+    ./cmd/velero-helper && \
+    go clean -modcache -cache
+
+# Velero image packing section
+# Use paketobuildpacks/run-jammy-tiny which includes shell for update-crds job
+FROM paketobuildpacks/run-jammy-tiny:latest
+
+COPY --from=builder /output/velero /velero
+COPY --from=builder /output/velero-restore-helper /velero-restore-helper
+COPY --from=builder /output/velero-helper /velero-helper
+
+USER cnb:cnb
+
+ENTRYPOINT ["/velero"]
+

--- a/packages/system/velero/images/velero/patches/9447.diff
+++ b/packages/system/velero/images/velero/patches/9447.diff
@@ -1,0 +1,303 @@
+diff --git a/changelogs/unreleased/9447-kvaps b/changelogs/unreleased/9447-kvaps
+new file mode 100644
+index 0000000000..869e43baaf
+--- /dev/null
++++ b/changelogs/unreleased/9447-kvaps
+@@ -0,0 +1 @@
++Fix race condition: check concurrent limit before GetExposed
+diff --git a/pkg/controller/data_download_controller.go b/pkg/controller/data_download_controller.go
+index b3f2044d9b..e05c9db141 100644
+--- a/pkg/controller/data_download_controller.go
++++ b/pkg/controller/data_download_controller.go
+@@ -315,10 +315,23 @@ func (r *DataDownloadReconciler) Reconcile(ctx context.Context, req ctrl.Request
+ 			return ctrl.Result{}, nil
+ 		}
+ 
++		// Reserve a slot atomically BEFORE doing expensive GetExposed operation
++		// This prevents race condition where multiple tasks waste time on GetExposed
++		// when the concurrent limit is already reached
++		if err := r.dataPathMgr.ReserveSlot(dd.Name); err != nil {
++			if err == datapath.ConcurrentLimitExceed {
++				log.Debug("Data path concurrent limit reached, requeue later")
++				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
++			}
++			return r.errorOut(ctx, dd, err, "error reserving data path slot", log)
++		}
++
+ 		result, err := r.restoreExposer.GetExposed(ctx, getDataDownloadOwnerObject(dd), r.client, r.nodeName, dd.Spec.OperationTimeout.Duration)
+ 		if err != nil {
++			r.dataPathMgr.ReleaseReservation(dd.Name)
+ 			return r.errorOut(ctx, dd, err, "restore exposer is not ready", log)
+ 		} else if result == nil {
++			r.dataPathMgr.ReleaseReservation(dd.Name)
+ 			return r.errorOut(ctx, dd, errors.New("no expose result is available for the current node"), "exposed snapshot is not ready", log)
+ 		}
+ 
+@@ -335,6 +348,7 @@ func (r *DataDownloadReconciler) Reconcile(ctx context.Context, req ctrl.Request
+ 		asyncBR, err = r.dataPathMgr.CreateMicroServiceBRWatcher(ctx, r.client, r.kubeClient, r.mgr, datapath.TaskTypeRestore,
+ 			dd.Name, dd.Namespace, result.ByPod.HostingPod.Name, result.ByPod.HostingContainer, dd.Name, callbacks, false, log)
+ 		if err != nil {
++			r.dataPathMgr.ReleaseReservation(dd.Name)
+ 			if err == datapath.ConcurrentLimitExceed {
+ 				log.Debug("Data path instance is concurrent limited requeue later")
+ 				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
+@@ -343,6 +357,8 @@ func (r *DataDownloadReconciler) Reconcile(ctx context.Context, req ctrl.Request
+ 			}
+ 		}
+ 
++		// Reservation is automatically completed in CreateMicroServiceBRWatcher
++
+ 		if err := r.initCancelableDataPath(ctx, asyncBR, result, log); err != nil {
+ 			log.WithError(err).Errorf("Failed to init cancelable data path for %s", dd.Name)
+ 
+diff --git a/pkg/controller/data_upload_controller.go b/pkg/controller/data_upload_controller.go
+index e2f8787ed9..9e94502ce8 100644
+--- a/pkg/controller/data_upload_controller.go
++++ b/pkg/controller/data_upload_controller.go
+@@ -319,15 +319,30 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request)
+ 			log.Info("Cancellable data path is already started")
+ 			return ctrl.Result{}, nil
+ 		}
++
++		// Reserve a slot atomically BEFORE doing expensive GetExposed operation
++		// This prevents race condition where multiple tasks waste time on GetExposed
++		// when the concurrent limit is already reached
++		if err := r.dataPathMgr.ReserveSlot(du.Name); err != nil {
++			if err == datapath.ConcurrentLimitExceed {
++				log.Debug("Data path concurrent limit reached, requeue later")
++				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
++			}
++			return r.errorOut(ctx, du, err, "error reserving data path slot", log)
++		}
++
+ 		waitExposePara := r.setupWaitExposePara(du)
+ 		res, err := ep.GetExposed(ctx, getOwnerObject(du), du.Spec.OperationTimeout.Duration, waitExposePara)
+ 		if err != nil {
++			r.dataPathMgr.ReleaseReservation(du.Name)
+ 			return r.errorOut(ctx, du, err, "exposed snapshot is not ready", log)
+ 		} else if res == nil {
++			r.dataPathMgr.ReleaseReservation(du.Name)
+ 			return r.errorOut(ctx, du, errors.New("no expose result is available for the current node"), "exposed snapshot is not ready", log)
+ 		}
+ 
+ 		if res.ByPod.NodeOS == nil {
++			r.dataPathMgr.ReleaseReservation(du.Name)
+ 			return r.errorOut(ctx, du, errors.New("unsupported ambiguous node OS"), "invalid expose result", log)
+ 		}
+ 
+@@ -344,6 +359,7 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request)
+ 		asyncBR, err = r.dataPathMgr.CreateMicroServiceBRWatcher(ctx, r.client, r.kubeClient, r.mgr, datapath.TaskTypeBackup,
+ 			du.Name, du.Namespace, res.ByPod.HostingPod.Name, res.ByPod.HostingContainer, du.Name, callbacks, false, log)
+ 		if err != nil {
++			r.dataPathMgr.ReleaseReservation(du.Name)
+ 			if err == datapath.ConcurrentLimitExceed {
+ 				log.Debug("Data path instance is concurrent limited requeue later")
+ 				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
+@@ -352,6 +368,8 @@ func (r *DataUploadReconciler) Reconcile(ctx context.Context, req ctrl.Request)
+ 			}
+ 		}
+ 
++		// Reservation is automatically completed in CreateMicroServiceBRWatcher
++
+ 		if err := r.initCancelableDataPath(ctx, asyncBR, res, log); err != nil {
+ 			log.WithError(err).Errorf("Failed to init cancelable data path for %s", du.Name)
+ 
+diff --git a/pkg/controller/pod_volume_backup_controller.go b/pkg/controller/pod_volume_backup_controller.go
+index aceaab7805..1efdadc557 100644
+--- a/pkg/controller/pod_volume_backup_controller.go
++++ b/pkg/controller/pod_volume_backup_controller.go
+@@ -269,10 +269,23 @@ func (r *PodVolumeBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
+ 			return ctrl.Result{}, nil
+ 		}
+ 
++		// Reserve a slot atomically BEFORE doing expensive GetExposed operation
++		// This prevents race condition where multiple tasks waste time on GetExposed
++		// when the concurrent limit is already reached
++		if err := r.dataPathMgr.ReserveSlot(pvb.Name); err != nil {
++			if err == datapath.ConcurrentLimitExceed {
++				log.Debug("Data path concurrent limit reached, requeue later")
++				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
++			}
++			return r.errorOut(ctx, pvb, err, "error reserving data path slot", log)
++		}
++
+ 		res, err := r.exposer.GetExposed(ctx, getPVBOwnerObject(pvb), r.client, r.nodeName, r.resourceTimeout)
+ 		if err != nil {
++			r.dataPathMgr.ReleaseReservation(pvb.Name)
+ 			return r.errorOut(ctx, pvb, err, "exposed PVB is not ready", log)
+ 		} else if res == nil {
++			r.dataPathMgr.ReleaseReservation(pvb.Name)
+ 			return r.errorOut(ctx, pvb, errors.New("no expose result is available for the current node"), "exposed PVB is not ready", log)
+ 		}
+ 
+@@ -288,6 +301,7 @@ func (r *PodVolumeBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
+ 		asyncBR, err = r.dataPathMgr.CreateMicroServiceBRWatcher(ctx, r.client, r.kubeClient, r.mgr, datapath.TaskTypeBackup,
+ 			pvb.Name, pvb.Namespace, res.ByPod.HostingPod.Name, res.ByPod.HostingContainer, pvb.Name, callbacks, false, log)
+ 		if err != nil {
++			r.dataPathMgr.ReleaseReservation(pvb.Name)
+ 			if err == datapath.ConcurrentLimitExceed {
+ 				log.Debug("Data path instance is concurrent limited requeue later")
+ 				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
+@@ -296,6 +310,8 @@ func (r *PodVolumeBackupReconciler) Reconcile(ctx context.Context, req ctrl.Requ
+ 			}
+ 		}
+ 
++		// Reservation is automatically completed in CreateMicroServiceBRWatcher
++
+ 		r.metrics.RegisterPodVolumeBackupEnqueue(r.nodeName)
+ 
+ 		if err := r.initCancelableDataPath(ctx, asyncBR, res, log); err != nil {
+diff --git a/pkg/controller/pod_volume_restore_controller.go b/pkg/controller/pod_volume_restore_controller.go
+index 87b2353f52..dda2ba22f8 100644
+--- a/pkg/controller/pod_volume_restore_controller.go
++++ b/pkg/controller/pod_volume_restore_controller.go
+@@ -282,10 +282,23 @@ func (r *PodVolumeRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Req
+ 			return ctrl.Result{}, nil
+ 		}
+ 
++		// Reserve a slot atomically BEFORE doing expensive GetExposed operation
++		// This prevents race condition where multiple tasks waste time on GetExposed
++		// when the concurrent limit is already reached
++		if err := r.dataPathMgr.ReserveSlot(pvr.Name); err != nil {
++			if err == datapath.ConcurrentLimitExceed {
++				log.Debug("Data path concurrent limit reached, requeue later")
++				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
++			}
++			return r.errorOut(ctx, pvr, err, "error reserving data path slot", log)
++		}
++
+ 		res, err := r.exposer.GetExposed(ctx, getPVROwnerObject(pvr), r.client, r.nodeName, r.resourceTimeout)
+ 		if err != nil {
++			r.dataPathMgr.ReleaseReservation(pvr.Name)
+ 			return r.errorOut(ctx, pvr, err, "exposed PVR is not ready", log)
+ 		} else if res == nil {
++			r.dataPathMgr.ReleaseReservation(pvr.Name)
+ 			return r.errorOut(ctx, pvr, errors.New("no expose result is available for the current node"), "exposed PVR is not ready", log)
+ 		}
+ 
+@@ -301,6 +314,7 @@ func (r *PodVolumeRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Req
+ 		asyncBR, err = r.dataPathMgr.CreateMicroServiceBRWatcher(ctx, r.client, r.kubeClient, r.mgr, datapath.TaskTypeRestore,
+ 			pvr.Name, pvr.Namespace, res.ByPod.HostingPod.Name, res.ByPod.HostingContainer, pvr.Name, callbacks, false, log)
+ 		if err != nil {
++			r.dataPathMgr.ReleaseReservation(pvr.Name)
+ 			if err == datapath.ConcurrentLimitExceed {
+ 				log.Debug("Data path instance is concurrent limited requeue later")
+ 				return ctrl.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
+@@ -309,6 +323,8 @@ func (r *PodVolumeRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Req
+ 			}
+ 		}
+ 
++		// Reservation is automatically completed in CreateMicroServiceBRWatcher
++
+ 		if err := r.initCancelableDataPath(ctx, asyncBR, res, log); err != nil {
+ 			log.WithError(err).Errorf("Failed to init cancelable data path for %s", pvr.Name)
+ 
+diff --git a/pkg/datapath/manager.go b/pkg/datapath/manager.go
+index 0b790a5cc9..c0db04001c 100644
+--- a/pkg/datapath/manager.go
++++ b/pkg/datapath/manager.go
+@@ -32,9 +32,10 @@ var FSBRCreator = newFileSystemBR
+ var MicroServiceBRWatcherCreator = newMicroServiceBRWatcher
+ 
+ type Manager struct {
+-	cocurrentNum int
+-	trackerLock  sync.Mutex
+-	tracker      map[string]AsyncBR
++	cocurrentNum   int
++	trackerLock    sync.Mutex
++	tracker        map[string]AsyncBR
++	reservations   map[string]bool // Track reserved slots before GetExposed completes
+ }
+ 
+ // NewManager creates the data path manager to manage concurrent data path instances
+@@ -42,6 +43,7 @@ func NewManager(cocurrentNum int) *Manager {
+ 	return &Manager{
+ 		cocurrentNum: cocurrentNum,
+ 		tracker:      map[string]AsyncBR{},
++		reservations: map[string]bool{},
+ 	}
+ }
+ 
+@@ -66,13 +68,21 @@ func (m *Manager) CreateMicroServiceBRWatcher(ctx context.Context, client client
+ 	defer m.trackerLock.Unlock()
+ 
+ 	if !resume {
+-		if len(m.tracker) >= m.cocurrentNum {
+-			return nil, ConcurrentLimitExceed
++		// For resume, we skip the limit check
++		// For new tasks, check if we have space (either already reserved or have available slots)
++		_, alreadyReserved := m.reservations[taskName]
++		if !alreadyReserved {
++			if (len(m.tracker) + len(m.reservations)) >= m.cocurrentNum {
++				return nil, ConcurrentLimitExceed
++			}
+ 		}
+ 	}
+ 
+ 	m.tracker[taskName] = MicroServiceBRWatcherCreator(client, kubeClient, mgr, taskType, taskName, namespace, podName, containerName, associatedObject, callbacks, log)
+ 
++	// Release reservation if it exists (it will be replaced by actual AsyncBR in tracker)
++	delete(m.reservations, taskName)
++
+ 	return m.tracker[taskName], nil
+ }
+ 
+@@ -95,3 +105,58 @@ func (m *Manager) GetAsyncBR(jobName string) AsyncBR {
+ 		return nil
+ 	}
+ }
++
++// CanAcceptNewTask checks if a new task can be accepted based on the concurrent limit.
++// This is a lightweight check that doesn't create any resources.
++func (m *Manager) CanAcceptNewTask(resume bool) bool {
++	m.trackerLock.Lock()
++	defer m.trackerLock.Unlock()
++
++	if resume {
++		return true
++	}
++
++	// Count both active tasks and reserved slots
++	return (len(m.tracker) + len(m.reservations)) < m.cocurrentNum
++}
++
++// ReserveSlot reserves a slot in the tracker before expensive operations (like GetExposed).
++// Returns ConcurrentLimitExceed if no slots are available.
++// Must be paired with either CompleteReservation or ReleaseReservation.
++func (m *Manager) ReserveSlot(taskName string) error {
++	m.trackerLock.Lock()
++	defer m.trackerLock.Unlock()
++
++	// Check if already reserved or in tracker
++	if _, exists := m.tracker[taskName]; exists {
++		return nil // Already active
++	}
++	if m.reservations[taskName] {
++		return nil // Already reserved
++	}
++
++	// Check if we can accept a new reservation
++	if (len(m.tracker) + len(m.reservations)) >= m.cocurrentNum {
++		return ConcurrentLimitExceed
++	}
++
++	m.reservations[taskName] = true
++	return nil
++}
++
++// CompleteReservation completes a reservation by replacing it with the actual AsyncBR.
++// Should be called after successful GetExposed and CreateMicroServiceBRWatcher.
++func (m *Manager) CompleteReservation(taskName string) {
++	m.trackerLock.Lock()
++	defer m.trackerLock.Unlock()
++
++	delete(m.reservations, taskName)
++}
++
++// ReleaseReservation releases a reserved slot if GetExposed or subsequent operations fail.
++func (m *Manager) ReleaseReservation(taskName string) {
++	m.trackerLock.Lock()
++	defer m.trackerLock.Unlock()
++
++	delete(m.reservations, taskName)
++}

--- a/packages/system/velero/values.yaml
+++ b/packages/system/velero/values.yaml
@@ -1,4 +1,8 @@
 velero:
+  image:
+    repository: ghcr.io/cozystack/cozystack/velero
+    tag: latest@sha256:ddf488ed2e281a0cecc5b4969fd84d3905f1e565e3c83aae8015f337a311415c
+    pullPolicy: IfNotPresent
   initContainers:
     - name: velero-plugin-for-aws
       image: velero/velero-plugin-for-aws:v1.12.1


### PR DESCRIPTION
## What this PR does

Adds velero image build infrastructure similar to kamaji, including:
- Dockerfile for building velero with patches
- Patch from PR https://github.com/vmware-tanzu/velero/pull/9447 to fix race condition in data path controllers
- Makefile targets for building and updating velero image
- Integration into main build process

Changes:
- Added `packages/system/velero/images/velero/Dockerfile` - builds velero binary with patch applied
- Added `packages/system/velero/images/velero/patches/9447.diff` - race condition fix patch
- Updated `packages/system/velero/Makefile` - added `image` target and improved `update` target
- Updated `packages/system/velero/values.yaml` - added image configuration
- Updated main `Makefile` - added velero to build targets

The patch fixes a race condition where multiple tasks waste time on expensive `GetExposed` operations when the concurrent limit is already reached. The fix checks the concurrent limit before performing the expensive operation.

### Release note

```release-note
[velero] Add custom velero image build with race condition fix patch
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Velero image build and a new multi-stage Velero runtime image for releases.
  * Made metrics fields (interval/timeout) optional and added relabeling placeholders for metrics configuration.

* **Bug Fixes**
  * Fixed a race condition in concurrent task handling to prevent dropped operations under load.

* **Chores**
  * Bumped Velero to v1.17.1 and chart to 11.2.0; updated related plugin tags and monitoring alerts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->