### PR TITLE
[talos] Set cpu frequency scheduler to performance

### DIFF
--- a/packages/core/talos/hack/gen-profiles.sh
+++ b/packages/core/talos/hack/gen-profiles.sh
@@ -33,28 +33,47 @@ for extension in $EXTENSIONS; do
   export "$extension_var=$image"
 done
 
+customizationDefinition=$(cat <<EOF
+customization:
+  extraKernelArgs:
+    - cpufreq.default_governor=performance
+    - amd_pstate=active
+    - intel_idle.max_cstate=0
+EOF
+)
 for profile in $PROFILES; do
   echo "writing profile images/talos/profiles/$profile.yaml"
   case "$profile" in
-    initramfs|kernel|iso)
+    iso)
+      customization=$customizationDefinition
       image_options="{}"
       out_format="raw"
       platform="metal"
       kind="$profile"
       ;;
+    initramfs|kernel)
+      customization=
+      image_options="{}"
+      out_format="raw"
+      platform="metal"
+      kind="$profile"
+      ;; 
     installer)
+      customization=$customizationDefinition
       image_options="{}"
       out_format="raw"
       platform="metal"
       kind="installer"
       ;;
     metal)
+      customization=$customizationDefinition
       image_options="{ diskSize: 1306525696, diskFormat: raw }"
       out_format=".xz"
       platform="metal"
       kind="image"
       ;;
     nocloud)
+      customization=$customizationDefinition
       image_options="{ diskSize: 1306525696, diskFormat: raw }"
       out_format=".xz"
       platform="nocloud"
@@ -73,6 +92,7 @@ arch: amd64
 platform: ${platform}
 secureboot: false
 version: ${TALOS_VERSION}
+${customization}
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz

--- a/packages/core/talos/images/talos/profiles/initramfs.yaml
+++ b/packages/core/talos/images/talos/profiles/initramfs.yaml
@@ -4,6 +4,7 @@ arch: amd64
 platform: metal
 secureboot: false
 version: v1.12.1
+
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz

--- a/packages/core/talos/images/talos/profiles/installer.yaml
+++ b/packages/core/talos/images/talos/profiles/installer.yaml
@@ -4,6 +4,11 @@ arch: amd64
 platform: metal
 secureboot: false
 version: v1.12.1
+customization:
+  extraKernelArgs:
+    - cpufreq.default_governor=performance
+    - amd_pstate=active
+    - intel_idle.max_cstate=0
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz

--- a/packages/core/talos/images/talos/profiles/iso.yaml
+++ b/packages/core/talos/images/talos/profiles/iso.yaml
@@ -4,6 +4,11 @@ arch: amd64
 platform: metal
 secureboot: false
 version: v1.12.1
+customization:
+  extraKernelArgs:
+    - cpufreq.default_governor=performance
+    - amd_pstate=active
+    - intel_idle.max_cstate=0
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz

--- a/packages/core/talos/images/talos/profiles/kernel.yaml
+++ b/packages/core/talos/images/talos/profiles/kernel.yaml
@@ -4,6 +4,7 @@ arch: amd64
 platform: metal
 secureboot: false
 version: v1.12.1
+
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz

--- a/packages/core/talos/images/talos/profiles/metal.yaml
+++ b/packages/core/talos/images/talos/profiles/metal.yaml
@@ -4,6 +4,11 @@ arch: amd64
 platform: metal
 secureboot: false
 version: v1.12.1
+customization:
+  extraKernelArgs:
+    - cpufreq.default_governor=performance
+    - amd_pstate=active
+    - intel_idle.max_cstate=0
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz

--- a/packages/core/talos/images/talos/profiles/nocloud.yaml
+++ b/packages/core/talos/images/talos/profiles/nocloud.yaml
@@ -4,6 +4,11 @@ arch: amd64
 platform: nocloud
 secureboot: false
 version: v1.12.1
+customization:
+  extraKernelArgs:
+    - cpufreq.default_governor=performance
+    - amd_pstate=active
+    - intel_idle.max_cstate=0
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz


### PR DESCRIPTION
## What this PR does
Sets default cpu frequency scheduler to performance.
Disables cpu energy saving options.

### Release note
```release-note
Default cpu frequency scheduler set to performance.
Cpu energy saving options disabled.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added kernel boot parameters to installable and image profiles (ISO, installer, metal, nocloud) to favor performance-oriented CPU governor and adjust idle handling, improving runtime performance and responsiveness.
  * Initramfs/kernel-style profiles remain unchanged (no extra boot parameters applied).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->