### PR TITLE
fix(ingress-nginx): always pass --enable-metrics flag explicitly

### DIFF
--- a/packages/system/ingress-nginx/charts/ingress-nginx/templates/_params.tpl
+++ b/packages/system/ingress-nginx/charts/ingress-nginx/templates/_params.tpl
@@ -54,9 +54,7 @@
 {{- if .Values.controller.watchIngressWithoutClass }}
 - --watch-ingress-without-class=true
 {{- end }}
-{{- if not .Values.controller.metrics.enabled }}
 - --enable-metrics={{ .Values.controller.metrics.enabled }}
-{{- end }}
 {{- if .Values.controller.enableTopologyAwareRouting }}
 - --enable-topology-aware-routing=true
 {{- end }}


### PR DESCRIPTION
## Summary

- Fix conditional logic for `--enable-metrics` flag in ingress-nginx controller params template
- The flag is now always passed explicitly using the value from `controller.metrics.enabled`

## Problem

The previous logic only passed `--enable-metrics=false` when metrics were disabled, but omitted the flag entirely when `metrics.enabled: true`. The custom protobuf-exporter controller image does not default to enabling per-request Prometheus metrics, so without the explicit flag, counters like `nginx_ingress_controller_requests` (with `ingress`, `service`, `status` labels) are not exposed. Only process-level metrics are available on `:10254/metrics`.

## Test plan

- [ ] Deploy ingress-nginx with `controller.metrics.enabled: true` and verify `nginx_ingress_controller_requests` metric appears on `:10254/metrics` after sending a request through an Ingress
- [ ] Deploy with `controller.metrics.enabled: false` and verify `--enable-metrics=false` is still passed correctly