### PR TITLE
[mariadb] fix: always enable replication for consistent service naming

### DIFF
--- a/packages/apps/mariadb/templates/backup-cronjob.yaml
+++ b/packages/apps/mariadb/templates/backup-cronjob.yaml
@@ -14,9 +14,6 @@ spec:
     spec:
       backoffLimit: 2
       template:
-        spec:
-          restartPolicy: OnFailure
-      template:
         metadata:
           annotations:
             checksum/config: {{ include (print $.Template.BasePath "/backup-script.yaml") . | sha256sum }}

--- a/packages/apps/mariadb/templates/backup-cronjob.yaml
+++ b/packages/apps/mariadb/templates/backup-cronjob.yaml
@@ -41,7 +41,7 @@ spec:
                   name: {{ .Release.Name }}
                   key: root-password
             - name: MYSQL_HOST
-              value: {{ .Release.Name }}-secondary
+              value: "{{ .Release.Name }}-{{ if eq (int .Values.replicas) 1 }}primary{{ else }}secondary{{ end }}"
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/packages/apps/mariadb/templates/mariadb.yaml
+++ b/packages/apps/mariadb/templates/mariadb.yaml
@@ -29,13 +29,11 @@ spec:
             - {{ .Release.Name }}
         topologyKey: "kubernetes.io/hostname"
 
-  {{- if gt (int .Values.replicas) 1 }}
   replication:
     enabled: true
     #primary:
     #  podIndex: 0
     #  automaticFailover: true
-  {{- end }}
 
   podMetadata:
     labels:
@@ -65,9 +63,6 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/instance: {{ $.Release.Name }}
-    {{- if and .Values.external (eq (int .Values.replicas) 1) }}
-    type: LoadBalancer
-    {{- end }}
   storage:
     size: {{ .Values.size }}
     resizeInUseVolumes: true
@@ -76,7 +71,7 @@ spec:
     storageClassName: {{ . }}
     {{- end }}
 
-  {{- if and .Values.external (gt (int .Values.replicas) 1) }}
+  {{- if .Values.external }}
   primaryService:
     type: LoadBalancer
   {{- end }}


### PR DESCRIPTION
## What this PR does

Enables replication unconditionally in the MariaDB CR, regardless of replica count.

Previously, single-replica MariaDB instances created a general service (`mariadb-<name>`) without `-primary`/`-secondary` suffixes. This caused:
- Dashboard not displaying the service (both dashboard-resourcemap RBAC and the ApplicationDefinition expect `-primary`/`-secondary`)
- Backup CronJob referencing non-existent `<name>-secondary` service

Also removes a duplicate `template` key in the backup-cronjob YAML that was silently ignored by the parser.

**BREAKING CHANGE:** Single-replica MariaDB instances will now expose services as `<name>-primary` and `<name>-secondary` instead of the bare `<name>`. Applications connecting via the old service DNS name must update their connection strings.

### Release note

```release-note
[mariadb] BREAKING: MariaDB now always enables replication, creating -primary/-secondary services even for single-replica instances. This fixes dashboard visibility and backup functionality for single-replica setups. Existing single-replica users must update connection strings from `<name>` to `<name>-primary`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed a redundant backup job restart policy that could cause conflicting behavior.
  * Ensured replication is consistently enabled across all deployment sizes.
  * Made external service LoadBalancer settings apply more predictably for external deployments.
  * Adjusted database host selection so single-replica deployments target the primary instance, improving connection correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->