### PR TITLE
[dashboard] Fix cluster-view ClusterRoleBinding namespace

### DIFF
--- a/packages/system/dashboard/templates/clusterrolebinding-cluster-view.yaml
+++ b/packages/system/dashboard/templates/clusterrolebinding-cluster-view.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: incloud-web-web
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ .Release.Namespace | quote }}

--- a/packages/system/dashboard/templates/clusterrolebinding-cluster-view.yaml
+++ b/packages/system/dashboard/templates/clusterrolebinding-cluster-view.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: incloud-web-web
-    namespace: incloud-web
+    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
## What this PR does

Fixes the dashboard `incloud-web-cluster-view` `ClusterRoleBinding` so it points at the ServiceAccount in the Helm release namespace instead of the non-existent hardcoded `incloud-web` namespace.

This restores the dashboard backend's `view` permissions and fixes the Administration -> External IPs page.

Fixes #2174

### Validation

- rendered `packages/system/dashboard` with `-n cozy-dashboard --set-json '_cluster={"branding":{}}'`
- verified `incloud-web-cluster-view` renders `subjects[0].namespace: cozy-dashboard`

### Release note

```release-note
[dashboard] Fix the dashboard cluster-view ClusterRoleBinding to use the Helm release namespace, restoring External IPs visibility in the dashboard.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster role binding updated to use the Helm release namespace at runtime instead of a hardcoded namespace.
  * Ensures correct service-account permissions across deployments, improving multi-environment consistency and reducing upgrade/configuration issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->