### PR TITLE
[clickhouse] Fix duplicate template key in backup CronJob and wrong cluster domain variable

### DIFF
--- a/packages/apps/clickhouse/templates/backup-cronjob.yaml
+++ b/packages/apps/clickhouse/templates/backup-cronjob.yaml
@@ -14,9 +14,6 @@ spec:
     spec:
       backoffLimit: 2
       template:
-        spec:
-          restartPolicy: OnFailure
-      template:
         metadata:
           annotations:
             checksum/config: {{ include (print $.Template.BasePath "/backup-script.yaml") . | sha256sum }}

--- a/packages/apps/clickhouse/templates/clickhouse.yaml
+++ b/packages/apps/clickhouse/templates/clickhouse.yaml
@@ -96,7 +96,7 @@ spec:
         {{- $replicas := int .Values.clickhouseKeeper.replicas }}
         {{- $release := .Release.Name }}
         {{- $namespace := .Release.Namespace }}
-        {{- $clusterDomain := .Values.clusterDomain }}
+        {{- $clusterDomain := (index .Values._cluster "cluster-domain") | default "cozy.local" }}
         {{- range $i := until $replicas }}
         - host: "chk-{{ $release }}-keeper-cluster1-0-{{ $i }}.{{ $namespace }}.svc.{{ $clusterDomain }}"
           port: 2181


### PR DESCRIPTION
## Summary

- Removes the duplicate `template` mapping key in `backup-cronjob.yaml` that caused a YAML unmarshal error when deploying ClickHouse with backup enabled (same class of bug as #2293 but in the ClickHouse chart)
- Replaces the non-existent `.Values.clusterDomain` with the correct `(index .Values._cluster "cluster-domain") | default "cozy.local"` in `clickhouse.yaml`, fixing malformed ClickHouse Keeper ZooKeeper node hostnames

Fixes #2333

## Test plan

- [ ] `helm template` renders `backup-cronjob.yaml` without YAML unmarshal errors when `backup.enabled=true`
- [ ] `helm template` renders `clickhouse.yaml` with correct Keeper FQDN hostnames (e.g. `*.svc.cozy.local` instead of `*.svc.`)
- [ ] Deploy ClickHouse with backup enabled and verify CronJob is created
- [ ] Deploy ClickHouse with Keeper enabled and verify connectivity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted backup job restart configuration for improved failure handling during scheduled backups
  * Enhanced ZooKeeper node hostname resolution with support for flexible cluster domain configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->