### PR TITLE
[workloadmonitor] Fix nil pointer dereference on PVC and persist Operational status

### DIFF
--- a/internal/controller/workloadmonitor_controller.go
+++ b/internal/controller/workloadmonitor_controller.go
@@ -181,7 +181,7 @@ func (r *WorkloadMonitorReconciler) reconcilePVCForMonitor(
 
 	for resourceName, resourceQuantity := range pvc.Status.Capacity {
 		storageClass := "default"
-		if pvc.Spec.StorageClassName != nil || *pvc.Spec.StorageClassName == "" {
+		if pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName != "" {
 			storageClass = *pvc.Spec.StorageClassName
 		}
 		resourceLabel := fmt.Sprintf("%s.storageclass.storage.k8s.io/requests.%s", storageClass, resourceName.String())
@@ -389,9 +389,9 @@ func (r *WorkloadMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		fresh.Status.AvailableReplicas = availableReplicas
 
 		// Default to operational = true, but check MinReplicas if set
-		monitor.Status.Operational = pointer.Bool(true)
-		if monitor.Spec.MinReplicas != nil && availableReplicas < *monitor.Spec.MinReplicas {
-			monitor.Status.Operational = pointer.Bool(false)
+		fresh.Status.Operational = pointer.Bool(true)
+		if fresh.Spec.MinReplicas != nil && availableReplicas < *fresh.Spec.MinReplicas {
+			fresh.Status.Operational = pointer.Bool(false)
 		}
 		return r.Status().Update(ctx, fresh)
 	})


### PR DESCRIPTION
## Summary

- Fixes a nil pointer dereference panic in `reconcilePVCForMonitor` when a PVC uses the cluster default StorageClass (no explicit `storageClassName` in the PVC spec). The condition `!= nil || ... == ""` was changed to `!= nil && ... != ""`.
- Fixes `Operational` status never being persisted: the retry callback was setting the field on the stale `monitor` object instead of the re-fetched `fresh` object that gets written back to the API server.

Fixes #2335

## Test plan

- [ ] Verify the controller no longer panics when reconciling a PVC that has a nil `StorageClassName`
- [ ] Verify the controller correctly assigns `"default"` as the storage class label for PVCs without an explicit class
- [ ] Verify `WorkloadMonitor.status.operational` is correctly set to `true` or `false` based on `minReplicas` vs `availableReplicas`
- [ ] Run existing unit tests: `go test ./internal/controller/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected PVC storage class selection logic to properly respect user-configured storage class names during provisioning, preventing unintended overrides.
  * Enhanced WorkloadMonitor operational status computation to ensure accurate status updates are preserved during concurrent modifications and conflict resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->