### PR TITLE
[tenant] Move namespace.cozystack.io/host from label to annotation

### DIFF
--- a/packages/apps/tenant/templates/namespace.yaml
+++ b/packages/apps/tenant/templates/namespace.yaml
@@ -63,11 +63,12 @@ metadata:
     namespace.cozystack.io/ingress: {{ $ingress | quote }}
     namespace.cozystack.io/monitoring: {{ $monitoring | quote }}
     namespace.cozystack.io/seaweedfs: {{ $seaweedfs | quote }}
-    namespace.cozystack.io/host: {{ $computedHost | quote }}
     {{- with $schedulingClass }}
     scheduler.cozystack.io/scheduling-class: {{ . | quote }}
     {{- end }}
     alpha.kubevirt.io/auto-memory-limits-ratio: "1.0"
+  annotations:
+    namespace.cozystack.io/host: {{ $computedHost | quote }}
   ownerReferences:
   - apiVersion: v1
     blockOwnerDeletion: true


### PR DESCRIPTION
## What this PR does

Moves `namespace.cozystack.io/host` from a namespace **label** to an **annotation** on tenant namespaces.

Kubernetes label values are limited to 63 characters. With typical domain names (e.g., `cozystack.example.com` = 21 chars), tenant names are effectively capped at ~41 characters. Since this value is not used as a label selector anywhere in the codebase (confirmed via grep), moving it to an annotation removes this constraint without breaking any existing functionality.

The host value remains available in the `cozystack-values` Secret as before.

Fixes #2002

### Release note

```release-note
[tenant] Move namespace.cozystack.io/host from namespace label to annotation to remove the 63-character tenant name constraint.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated namespace manifest structure to reorganize host information storage, moving from labels to annotations classification. This change preserves all computed host values and maintains compatibility with existing deployments while improving metadata categorization for namespace resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->