### PR TITLE
[redis] Expose maxmemory-policy configuration

### DIFF
--- a/packages/apps/redis/templates/redisfailover.yaml
+++ b/packages/apps/redis/templates/redisfailover.yaml
@@ -64,6 +64,7 @@ spec:
       - appendonly no
       - save ""
       {{- end }}
+      - maxmemory-policy {{ .Values.maxmemoryPolicy }}
   {{- if .Values.authEnabled }}
   auth:
     secretPath: {{ .Release.Name }}-auth

--- a/packages/apps/redis/values.schema.json
+++ b/packages/apps/redis/values.schema.json
@@ -87,6 +87,21 @@
         "v7"
       ]
     },
+    "maxmemoryPolicy": {
+      "description": "Eviction policy used when Redis reaches its memory limit.",
+      "type": "string",
+      "default": "noeviction",
+      "enum": [
+        "noeviction",
+        "allkeys-lru",
+        "allkeys-lfu",
+        "volatile-lru",
+        "volatile-lfu",
+        "allkeys-random",
+        "volatile-random",
+        "volatile-ttl"
+      ]
+    },
     "authEnabled": {
       "description": "Enable password generation.",
       "type": "boolean",

--- a/packages/apps/redis/values.yaml
+++ b/packages/apps/redis/values.yaml
@@ -44,5 +44,18 @@ version: v8
 ## @section Application-specific parameters
 ##
 
+## @enum {string} MaxmemoryPolicy - Redis eviction policy when maxmemory is reached.
+## @value noeviction
+## @value allkeys-lru
+## @value allkeys-lfu
+## @value volatile-lru
+## @value volatile-lfu
+## @value allkeys-random
+## @value volatile-random
+## @value volatile-ttl
+
+## @param {MaxmemoryPolicy} maxmemoryPolicy="noeviction" - Eviction policy used when Redis reaches its memory limit.
+maxmemoryPolicy: "noeviction"
+
 ## @param {bool} authEnabled - Enable password generation.
 authEnabled: true


### PR DESCRIPTION
## What this PR does

Adds a `maxmemoryPolicy` parameter to the Redis chart that allows users to configure the eviction policy used when Redis reaches its memory limit. The value is passed through to `spec.redis.customConfig` in the RedisFailover CR as `maxmemory-policy <value>`.

**Default**: `noeviction` (matches the upstream Redis default, so no behavioral change for existing deployments).

**Supported values**: `noeviction`, `allkeys-lru`, `allkeys-lfu`, `volatile-lru`, `volatile-lfu`, `allkeys-random`, `volatile-random`, `volatile-ttl`.

Changes:
- `values.yaml`: new `maxmemoryPolicy` field with JSDoc annotations
- `values.schema.json`: schema entry with enum validation
- `templates/redisfailover.yaml`: passes value into `customConfig`

The Spotahome Redis Operator already supports arbitrary `customConfig` entries, so no operator changes are needed.

Fixes #2154

### Release note

```release-note
[redis] Add maxmemoryPolicy parameter to configure the Redis eviction policy (default: noeviction).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis memory eviction policy configuration option. Select from eight eviction strategies—including noeviction (default), allkeys-lru, allkeys-lfu, volatile-lru, volatile-lfu, allkeys-random, volatile-random, and volatile-ttl—to control how Redis manages memory when capacity is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->