### PR TITLE
[redis] Auto-set maxmemory from resource limits

### DIFF
--- a/packages/apps/redis/templates/redisfailover.yaml
+++ b/packages/apps/redis/templates/redisfailover.yaml
@@ -64,6 +64,13 @@ spec:
       - appendonly no
       - save ""
       {{- end }}
+      {{- if .Values.maxmemory }}
+      - maxmemory {{ .Values.maxmemory }}
+      {{- else }}
+      {{- $resolved := include "cozy-lib.resources.defaultingSanitize" (list .Values.resourcesPreset .Values.resources $) | fromYaml }}
+      {{- $memLimitBytes := include "cozy-lib.resources.toFloat" $resolved.limits.memory | float64 | int64 }}
+      - maxmemory {{ div (mul $memLimitBytes 4) 5 }}
+      {{- end }}
   {{- if .Values.authEnabled }}
   auth:
     secretPath: {{ .Release.Name }}-auth

--- a/packages/apps/redis/values.schema.json
+++ b/packages/apps/redis/values.schema.json
@@ -87,6 +87,11 @@
         "v7"
       ]
     },
+    "maxmemory": {
+      "description": "Override the auto-computed maxmemory (bytes). When omitted, maxmemory is set to 80% of the memory resource limit.",
+      "type": "string",
+      "default": ""
+    },
     "authEnabled": {
       "description": "Enable password generation.",
       "type": "boolean",

--- a/packages/apps/redis/values.yaml
+++ b/packages/apps/redis/values.yaml
@@ -44,5 +44,8 @@ version: v8
 ## @section Application-specific parameters
 ##
 
+## @param {string} [maxmemory] - Override the auto-computed maxmemory (bytes). When omitted, maxmemory is set to 80% of the memory resource limit.
+maxmemory: ""
+
 ## @param {bool} authEnabled - Enable password generation.
 authEnabled: true


### PR DESCRIPTION
## What this PR does

Automatically sets Redis `maxmemory` to 80% of the pod's memory resource limit. This prevents OOM kills by ensuring Redis respects its container memory budget, leaving 20% headroom for replication buffers, the exporter sidecar, and Redis internal overhead.

**How it works:**
- Resolves the effective memory limit from either the explicit `resources.memory` parameter or the selected `resourcesPreset` using the existing `cozy-lib.resources.defaultingSanitize` and `toFloat` helpers
- Computes `maxmemory` as `memoryLimitBytes * 4 / 5` (integer arithmetic, equivalent to 80%)
- Injects the value into `spec.redis.customConfig` as `maxmemory <bytes>`

**Override:** Users can set an explicit `maxmemory` value (in bytes) to bypass the auto-computation.

**Examples by preset:**
| Preset | Memory Limit | Computed maxmemory |
|--------|-------------|-------------------|
| nano | 128Mi | ~102Mi |
| micro | 256Mi | ~204Mi |
| small | 512Mi | ~409Mi |
| medium | 1Gi | ~819Mi |
| large | 2Gi | ~1.6Gi |

Fixes #2155

### Release note

```release-note
[redis] Automatically set maxmemory to 80% of the memory resource limit to prevent OOM kills. Override with the new maxmemory parameter.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable `maxmemory` parameter for Redis memory limit management
  * When not specified, memory limit automatically defaults to 80% of allocated resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->