### PR TITLE
[redis] Expose persistence mode configuration (RDB/AOF)

### DIFF
--- a/packages/apps/redis/templates/redisfailover.yaml
+++ b/packages/apps/redis/templates/redisfailover.yaml
@@ -60,9 +60,17 @@ spec:
     customConfig:
       - tcp-keepalive 0
       - loglevel notice
-      {{- if not .Values.size }}
+      {{- $persistenceMode := .Values.persistenceMode | default "rdb" }}
+      {{- if or (not .Values.size) (eq $persistenceMode "none") }}
       - appendonly no
       - save ""
+      {{- else if eq $persistenceMode "aof" }}
+      - save ""
+      - appendonly yes
+      - appendfsync everysec
+      {{- else if eq $persistenceMode "both" }}
+      - appendonly yes
+      - appendfsync everysec
       {{- end }}
   {{- if .Values.authEnabled }}
   auth:

--- a/packages/apps/redis/values.schema.json
+++ b/packages/apps/redis/values.schema.json
@@ -87,6 +87,17 @@
         "v7"
       ]
     },
+    "persistenceMode": {
+      "description": "Persistence strategy. rdb uses periodic snapshots, aof uses append-only file, both enables both, none disables persistence.",
+      "type": "string",
+      "default": "rdb",
+      "enum": [
+        "rdb",
+        "aof",
+        "both",
+        "none"
+      ]
+    },
     "authEnabled": {
       "description": "Enable password generation.",
       "type": "boolean",

--- a/packages/apps/redis/values.yaml
+++ b/packages/apps/redis/values.yaml
@@ -44,5 +44,14 @@ version: v8
 ## @section Application-specific parameters
 ##
 
+## @enum {string} PersistenceMode - Redis data persistence strategy.
+## @value rdb
+## @value aof
+## @value both
+## @value none
+
+## @param {PersistenceMode} persistenceMode="rdb" - Persistence strategy. rdb uses periodic snapshots (operator defaults), aof uses append-only file with everysec fsync, both enables both strategies, none disables persistence entirely.
+persistenceMode: "rdb"
+
 ## @param {bool} authEnabled - Enable password generation.
 authEnabled: true


### PR DESCRIPTION
## What this PR does

Adds a `persistenceMode` parameter to the Redis chart that lets users choose their data persistence strategy. The value controls which `customConfig` entries are injected into the RedisFailover CR.

| Mode | Description | customConfig entries |
|------|-------------|---------------------|
| `rdb` (default) | Periodic RDB snapshots | (none — uses operator defaults) |
| `aof` | Append-only file | `save ""`, `appendonly yes`, `appendfsync everysec` |
| `both` | RDB + AOF | `appendonly yes`, `appendfsync everysec` |
| `none` | No persistence | `appendonly no`, `save ""` |

**Backward compatibility**: The default `rdb` mode produces identical output to the current chart. When `size` is empty (no PVC), persistence is always disabled regardless of the mode, matching current behavior.

Changes:
- `values.yaml`: new `persistenceMode` field with JSDoc annotations
- `values.schema.json`: schema entry with enum validation
- `templates/redisfailover.yaml`: mode-based persistence config logic

Fixes #2156

### Release note

```release-note
[redis] Add persistenceMode parameter (rdb/aof/both/none) to configure the Redis data persistence strategy.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redis persistence strategy is now configurable. Users can select from RDB (default), AOF, both, or no persistence to match their operational requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->