### PR TITLE
feat(postgres): add ClusterImageCatalog for system components

### DIFF
--- a/packages/system/harbor/templates/database.yaml
+++ b/packages/system/harbor/templates/database.yaml
@@ -5,7 +5,11 @@ metadata:
   name: {{ .Values.harbor.fullnameOverride }}-db
 spec:
   instances: {{ .Values.db.replicas }}
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    name: postgresql-bookworm
+    major: 17
   storage:
     size: {{ .Values.db.size }}
     {{- with .Values.db.storageClass }}

--- a/packages/system/keycloak/templates/db.yaml
+++ b/packages/system/keycloak/templates/db.yaml
@@ -4,7 +4,11 @@ metadata:
   name: keycloak-db
 spec:
   instances: 2
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    name: postgresql-bookworm
+    major: 17
   storage:
     size: 20Gi
   {{- if .Values._cluster.scheduling }}

--- a/packages/system/monitoring/templates/alerta/alerta-db.yaml
+++ b/packages/system/monitoring/templates/alerta/alerta-db.yaml
@@ -5,7 +5,11 @@ metadata:
   name: alerta-db
 spec:
   instances: 2
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    name: postgresql-bookworm
+    major: 17
   {{- if .Values._cluster.scheduling }}
   {{- $rawConstraints := get .Values._cluster.scheduling "globalAppTopologySpreadConstraints" }}
   {{- if $rawConstraints }}

--- a/packages/system/monitoring/templates/grafana/db.yaml
+++ b/packages/system/monitoring/templates/grafana/db.yaml
@@ -4,7 +4,11 @@ metadata:
   name: grafana-db
 spec:
   instances: 2
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    name: postgresql-bookworm
+    major: 17
   storage:
     size: {{ .Values.grafana.db.size }}
   {{- if .Values._cluster.scheduling }}

--- a/packages/system/postgres-operator/Makefile
+++ b/packages/system/postgres-operator/Makefile
@@ -9,3 +9,15 @@ update:
 	helm repo update cnpg
 	helm pull cnpg/cloudnative-pg --untar --untardir charts --version 0.26.1
 	rm -rf charts/cloudnative-pg/charts
+
+update-image-catalogs:
+	@echo "Downloading PostgreSQL image catalogs from CNPG artifacts..."
+	@curl -sSL https://raw.githubusercontent.com/cloudnative-pg/artifacts/main/image-catalogs/catalog-standard-bookworm.yaml \
+		| sed 's/postgresql-standard-bookworm/postgresql-bookworm/' \
+		| awk '/major: 18/,/image:/ {next} {print}' \
+		> templates/image-catalog-bookworm.yaml
+	@curl -sSL https://raw.githubusercontent.com/cloudnative-pg/artifacts/main/image-catalogs/catalog-standard-trixie.yaml \
+		| sed 's/postgresql-standard-trixie/postgresql-trixie/' \
+		| awk '/major: 18/,/image:/ {next} {print}' \
+		> templates/image-catalog-trixie.yaml
+	@echo "Updated image catalogs (PostgreSQL 13-17, excluded v18)"

--- a/packages/system/postgres-operator/Makefile
+++ b/packages/system/postgres-operator/Makefile
@@ -13,11 +13,9 @@ update:
 update-image-catalogs:
 	@echo "Downloading PostgreSQL image catalogs from CNPG artifacts..."
 	@curl -sSL https://raw.githubusercontent.com/cloudnative-pg/artifacts/main/image-catalogs/catalog-standard-bookworm.yaml \
-		| sed 's/postgresql-standard-bookworm/postgresql-bookworm/' \
-		| awk '/major: 18/,/image:/ {next} {print}' \
+		| yq '.metadata.name = "postgresql-bookworm" | del(.spec.images[] | select(.major == 13 or .major == 18))' \
 		> templates/image-catalog-bookworm.yaml
 	@curl -sSL https://raw.githubusercontent.com/cloudnative-pg/artifacts/main/image-catalogs/catalog-standard-trixie.yaml \
-		| sed 's/postgresql-standard-trixie/postgresql-trixie/' \
-		| awk '/major: 18/,/image:/ {next} {print}' \
+		| yq '.metadata.name = "postgresql-trixie" | del(.spec.images[] | select(.major == 13 or .major == 18))' \
 		> templates/image-catalog-trixie.yaml
-	@echo "Updated image catalogs (PostgreSQL 13-17, excluded v18)"
+	@echo "Updated image catalogs (PostgreSQL 14-17, excluded v13 EOL and v18)"

--- a/packages/system/postgres-operator/templates/image-catalog-bookworm.yaml
+++ b/packages/system/postgres-operator/templates/image-catalog-bookworm.yaml
@@ -6,17 +6,15 @@ metadata:
     images.cnpg.io/family: postgresql
     images.cnpg.io/type: standard
     images.cnpg.io/os: bookworm
-    images.cnpg.io/date: '20260406'
+    images.cnpg.io/date: '20260427'
     images.cnpg.io/publisher: cnpg.io
 spec:
   images:
-  - major: 13
-    image: ghcr.io/cloudnative-pg/postgresql:13.22-202511100817-standard-bookworm@sha256:e65cbf9ba18d313acde4bcdc1bc8eb636b0e005f83f23b44aba3f957ecca1e66
-  - major: 14
-    image: ghcr.io/cloudnative-pg/postgresql:14.22-202604060836-standard-bookworm@sha256:520831b1115377aedf2370f565da88688b5df89f55478130be88e5dabc54d71b
-  - major: 15
-    image: ghcr.io/cloudnative-pg/postgresql:15.17-202604060834-standard-bookworm@sha256:147e208ec48768a5db6b008015a91d8c65859ab5201f96a3240b4b20d54a462b
-  - major: 16
-    image: ghcr.io/cloudnative-pg/postgresql:16.13-202604060836-standard-bookworm@sha256:ad1312a89f2c85f507647e6cb47401fc5265c17dd38b4d5bc511b1ce47e98989
-  - major: 17
-    image: ghcr.io/cloudnative-pg/postgresql:17.9-202604060836-standard-bookworm@sha256:22b5b918265328349d2e99e1d0bfe8851712b92a32739962b852b1428a33874a
+    - major: 14
+      image: ghcr.io/cloudnative-pg/postgresql:14.22-202604270853-standard-bookworm@sha256:efdda2e4f4d53ddba1ba478c19738dbc63eb3eee697a6beb4f13c5f2cd68856d
+    - major: 15
+      image: ghcr.io/cloudnative-pg/postgresql:15.17-202604270853-standard-bookworm@sha256:b5c9affb267dcee0eaa366bd9987ca7b2429bf8d0bce23f8820533cf697f202d
+    - major: 16
+      image: ghcr.io/cloudnative-pg/postgresql:16.13-202604270853-standard-bookworm@sha256:5e2da2bd8acb33498a155ae0e3d07e277a1ca87ba31ed1d7b668033a84752df4
+    - major: 17
+      image: ghcr.io/cloudnative-pg/postgresql:17.9-202604270853-standard-bookworm@sha256:b054e25c4a813e1c8cf996058bcf9b0e5609e7958e459d42b8e1b5cf55baabd8

--- a/packages/system/postgres-operator/templates/image-catalog-bookworm.yaml
+++ b/packages/system/postgres-operator/templates/image-catalog-bookworm.yaml
@@ -1,0 +1,22 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: postgresql-bookworm
+  labels:
+    images.cnpg.io/family: postgresql
+    images.cnpg.io/type: standard
+    images.cnpg.io/os: bookworm
+    images.cnpg.io/date: '20260406'
+    images.cnpg.io/publisher: cnpg.io
+spec:
+  images:
+  - major: 13
+    image: ghcr.io/cloudnative-pg/postgresql:13.22-202511100817-standard-bookworm@sha256:e65cbf9ba18d313acde4bcdc1bc8eb636b0e005f83f23b44aba3f957ecca1e66
+  - major: 14
+    image: ghcr.io/cloudnative-pg/postgresql:14.22-202604060836-standard-bookworm@sha256:520831b1115377aedf2370f565da88688b5df89f55478130be88e5dabc54d71b
+  - major: 15
+    image: ghcr.io/cloudnative-pg/postgresql:15.17-202604060834-standard-bookworm@sha256:147e208ec48768a5db6b008015a91d8c65859ab5201f96a3240b4b20d54a462b
+  - major: 16
+    image: ghcr.io/cloudnative-pg/postgresql:16.13-202604060836-standard-bookworm@sha256:ad1312a89f2c85f507647e6cb47401fc5265c17dd38b4d5bc511b1ce47e98989
+  - major: 17
+    image: ghcr.io/cloudnative-pg/postgresql:17.9-202604060836-standard-bookworm@sha256:22b5b918265328349d2e99e1d0bfe8851712b92a32739962b852b1428a33874a

--- a/packages/system/postgres-operator/templates/image-catalog-trixie.yaml
+++ b/packages/system/postgres-operator/templates/image-catalog-trixie.yaml
@@ -6,17 +6,15 @@ metadata:
     images.cnpg.io/family: postgresql
     images.cnpg.io/type: standard
     images.cnpg.io/os: trixie
-    images.cnpg.io/date: '20260406'
+    images.cnpg.io/date: '20260427'
     images.cnpg.io/publisher: cnpg.io
 spec:
   images:
-  - major: 13
-    image: ghcr.io/cloudnative-pg/postgresql:13.22-202511100817-standard-trixie@sha256:8252529362b12a451a18cb19fdec9174ea09709102a7e6cf2e2b24d140dbd181
-  - major: 14
-    image: ghcr.io/cloudnative-pg/postgresql:14.22-202604060836-standard-trixie@sha256:8194f92a5da760127aa85b277bfaf71dfed59b22e0bf8f1f38d4893c8aebedd1
-  - major: 15
-    image: ghcr.io/cloudnative-pg/postgresql:15.17-202604060834-standard-trixie@sha256:021f860ac34f52689a966f4427d8bf48f89508aadf7fd60286ae9dbfe32f1f3a
-  - major: 16
-    image: ghcr.io/cloudnative-pg/postgresql:16.13-202604060836-standard-trixie@sha256:af4ccb6f3fad2ca86e53ea53264bd36d3de3facc208db936cf571bc5e264589c
-  - major: 17
-    image: ghcr.io/cloudnative-pg/postgresql:17.9-202604060836-standard-trixie@sha256:eba37bfc4b6cb1f1b3a869cab42ec1833519bbeb8cceacd1859b4faeca01fa4d
+    - major: 14
+      image: ghcr.io/cloudnative-pg/postgresql:14.22-202604270853-standard-trixie@sha256:1b953fa17f1edf1ef890bf6d40c3e1aa5823e6ed5f2b3d09fa4833db91408a1d
+    - major: 15
+      image: ghcr.io/cloudnative-pg/postgresql:15.17-202604270853-standard-trixie@sha256:5a43217bb39f2f2adc98474ae92c4624b881d260cc217f2d29b696cc4c9e6156
+    - major: 16
+      image: ghcr.io/cloudnative-pg/postgresql:16.13-202604270853-standard-trixie@sha256:26bd9ec26d086649538834949be24c29921a33b1c78999b44b5401fc4a6e8d13
+    - major: 17
+      image: ghcr.io/cloudnative-pg/postgresql:17.9-202604270853-standard-trixie@sha256:09cd71195163dfe51564e8845dc6eb58808bb0117a5756255d4e66be5a48c780

--- a/packages/system/postgres-operator/templates/image-catalog-trixie.yaml
+++ b/packages/system/postgres-operator/templates/image-catalog-trixie.yaml
@@ -1,0 +1,22 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ClusterImageCatalog
+metadata:
+  name: postgresql-trixie
+  labels:
+    images.cnpg.io/family: postgresql
+    images.cnpg.io/type: standard
+    images.cnpg.io/os: trixie
+    images.cnpg.io/date: '20260406'
+    images.cnpg.io/publisher: cnpg.io
+spec:
+  images:
+  - major: 13
+    image: ghcr.io/cloudnative-pg/postgresql:13.22-202511100817-standard-trixie@sha256:8252529362b12a451a18cb19fdec9174ea09709102a7e6cf2e2b24d140dbd181
+  - major: 14
+    image: ghcr.io/cloudnative-pg/postgresql:14.22-202604060836-standard-trixie@sha256:8194f92a5da760127aa85b277bfaf71dfed59b22e0bf8f1f38d4893c8aebedd1
+  - major: 15
+    image: ghcr.io/cloudnative-pg/postgresql:15.17-202604060834-standard-trixie@sha256:021f860ac34f52689a966f4427d8bf48f89508aadf7fd60286ae9dbfe32f1f3a
+  - major: 16
+    image: ghcr.io/cloudnative-pg/postgresql:16.13-202604060836-standard-trixie@sha256:af4ccb6f3fad2ca86e53ea53264bd36d3de3facc208db936cf571bc5e264589c
+  - major: 17
+    image: ghcr.io/cloudnative-pg/postgresql:17.9-202604060836-standard-trixie@sha256:eba37bfc4b6cb1f1b3a869cab42ec1833519bbeb8cceacd1859b4faeca01fa4d

--- a/packages/system/seaweedfs/templates/database.yaml
+++ b/packages/system/seaweedfs/templates/database.yaml
@@ -5,7 +5,11 @@ metadata:
   name: seaweedfs-db
 spec:
   instances: {{ .Values.db.replicas }}
-  imageName: ghcr.io/cloudnative-pg/postgresql:17.7
+  imageCatalogRef:
+    apiGroup: postgresql.cnpg.io
+    kind: ClusterImageCatalog
+    name: postgresql-bookworm
+    major: 17
   storage:
     size: {{ .Values.db.size }}
     {{- with .Values.db.storageClass }}


### PR DESCRIPTION
## Summary

Protects system PostgreSQL databases from automatic major version upgrades by introducing centralized ClusterImageCatalog resources based on official CNPG artifacts.

## Background

CloudNativePG operator v1.26+ automatically triggers major version upgrades when `imageName` changes in the Cluster spec. Legacy tag `17.7` is deprecated and pointed to `system` images which are also deprecated.

## Solution

Deploy two shared `ClusterImageCatalog` resources (bookworm and trixie) with postgres-operator using **standard** image type from CNPG official artifacts. Standard images provide more extensions than minimal (includes pgaudit, etc.) while system images are deprecated.

## Image Types Comparison

Based on [CNPG postgres-containers](https://github.com/cloudnative-pg/postgres-containers):

- **minimal**: Barebones PostgreSQL on Debian + PGDG packages
- **standard**: minimal + pgaudit + additional extensions ✅ **We use this**
- **system**: standard + Barman Cloud binaries (deprecated) ❌

## Changes

**ClusterImageCatalog resources:**
- `postgresql-bookworm` - Standard images on Debian bookworm (PostgreSQL 13-17)
- `postgresql-trixie` - Standard images on Debian trixie (PostgreSQL 13-17)
- PostgreSQL 18 **excluded** to prevent auto-upgrades
- SHA256-pinned images for reproducibility

**System databases updated:**
- keycloak/templates/db.yaml → `postgresql-bookworm` major 17
- harbor/templates/database.yaml → `postgresql-bookworm` major 17
- monitoring/templates/grafana/db.yaml → `postgresql-bookworm` major 17
- monitoring/templates/alerta/alerta-db.yaml → `postgresql-bookworm` major 17
- seaweedfs/templates/database.yaml → `postgresql-bookworm` major 17

**Makefile automation:**
- Added `make update-image-catalogs` target
- Downloads latest catalogs from https://github.com/cloudnative-pg/artifacts
- Automatically excludes PostgreSQL 18
- Renames to cozystack naming convention

## Benefits

- **No manual migrations** - catalogs deploy with operator, templates update via OCIRepo
- **Standard images** - more extensions than minimal, system images deprecated
- **Dual OS support** - bookworm (stable) and trixie (testing) available
- **Automated updates** - `make update-image-catalogs` syncs with upstream
- **Version control** - PostgreSQL 18 excluded, prevents accidental upgrades
- **Upstream alignment** - based on official CNPG image catalog format

## Usage

Update catalogs when CNPG releases new PostgreSQL versions:

```bash
cd packages/system/postgres-operator
make update-image-catalogs
```

## Test Plan

- [ ] Verify both ClusterImageCatalog resources deploy with postgres-operator
- [ ] Confirm existing databases continue running on PostgreSQL 17
- [ ] Check CNPG operator respects imageCatalogRef and does not trigger upgrades
- [ ] Validate `make update-image-catalogs` correctly downloads and filters catalogs
- [ ] Test trixie catalog works for clusters that need newer Debian base

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized PostgreSQL image catalogs and a helper task to refresh them, enabling standardized, pinned image selection across supported major versions.
* **Chores**
  * Migrated multiple platform database deployments to resolve PostgreSQL images via the new catalogs instead of fixed image tags, improving consistency and upgrade flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->