### PR TITLE
docs: update SECURITY.md — add Private Vulnerability Reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,12 @@ We welcome many types of contributions including:
 The best way to reach us with a question when contributing is to drop a line in
 our [Telegram channel](https://t.me/cozystack), or start a new GitHub discussion.
 
+## Reporting Security Vulnerabilities
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+Please use [GitHub Private Vulnerability Reporting](https://github.com/cozystack/cozystack/security/advisories/new) or email **cncf-cozystack-security@lists.cncf.io**. See [SECURITY.md](SECURITY.md) for full details.
+
 ## Raising Issues
 
 When raising issues, please specify the following:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,10 +26,15 @@ Supported versions may change over time as new release lines are cut. The author
 
 Please do **not** report security vulnerabilities through public GitHub issues, discussions, pull requests, Telegram, Slack, or other public community channels.
 
-At the moment, this repository does not publish a dedicated private security mailbox in-tree. If you need to report a vulnerability:
+The preferred way to report a vulnerability is through **GitHub Private Vulnerability Reporting**:
 
-1. Contact one of the project maintainers listed in `CODEOWNERS` using an existing private channel you already have.
-2. If you do not already have a private maintainer contact, use a public community channel only to request a private contact path, without disclosing any vulnerability details.
+1. Go to the **Security** tab of the affected repository (or use [this link for the main repository](https://github.com/cozystack/cozystack/security/advisories/new)).
+2. Click **"Report a vulnerability"** and fill in the details.
+3. The report will be visible only to the repository maintainers.
+
+If you cannot use GitHub Private Vulnerability Reporting, you may contact a project maintainer listed in `CODEOWNERS` through an existing private channel. If you do not already have a private maintainer contact, use a public community channel only to request a private contact path, without disclosing any vulnerability details.
+
+A dedicated security email address is being set up and will be published here when available.
 
 Please do not include exploit details, credentials, tokens, private keys, customer data, or other sensitive material in any public message.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,9 +32,9 @@ The preferred way to report a vulnerability is through **GitHub Private Vulnerab
 2. Click **"Report a vulnerability"** and fill in the details.
 3. The report will be visible only to the repository maintainers.
 
-If you cannot use GitHub Private Vulnerability Reporting, you may contact a project maintainer listed in `CODEOWNERS` through an existing private channel. If you do not already have a private maintainer contact, use a public community channel only to request a private contact path, without disclosing any vulnerability details.
+Alternatively, you can email the security team directly at **cncf-cozystack-security@lists.cncf.io**. This is a private mailing list monitored by project maintainers.
 
-A dedicated security email address is being set up and will be published here when available.
+If neither GitHub nor email works for you, you may contact a project maintainer listed in `CODEOWNERS` through an existing private channel. If you do not already have a private maintainer contact, use a public community channel only to request a private contact path, without disclosing any vulnerability details.
 
 Please do not include exploit details, credentials, tokens, private keys, customer data, or other sensitive material in any public message.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -82,6 +82,11 @@ Security is part of the normal Cozystack development and release process. Curren
 - automated pull request checks, including pre-commit validation, unit tests, builds, and end-to-end testing
 - release automation with patch releases, release branches, and backport workflows
 - ongoing maintenance of packaged dependencies and platform integrations across supported release lines
+- automated vulnerability scanning of all organization repositories and container images using Trivy
+- GitHub Private Vulnerability Reporting enabled on all public repositories
+- GitHub Secret Scanning and Push Protection enabled on all repositories
+- two-factor authentication required for all organization members
+- monthly public security summaries covering triaged findings
 
 Because Cozystack is an integration-heavy platform, some vulnerabilities may require coordination across multiple repositories or with upstream maintainers before a public fix can be released.
 


### PR DESCRIPTION
## Summary

- Add GitHub Private Vulnerability Reporting (PVR) as the primary channel for reporting vulnerabilities
- PVR has been enabled on all repositories in the cozystack organization
- Keep CODEOWNERS/private channel as a fallback method
- Note that a dedicated security email is being set up (pending CNCF)

## Context

As part of the security pipeline initiative, PVR and Secret Scanning have been enabled org-wide. This updates SECURITY.md to reflect that reporters now have a standard, obvious way to privately report vulnerabilities directly on GitHub.

## Changes

- `SECURITY.md`: Replace "no mailbox available" section with PVR as primary reporting method

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated security and contribution guidance: use GitHub Private Vulnerability Reporting (Security tab) or the security email for private reports; do not disclose vulnerabilities in public issues. Retained private maintainer fallback and guidance to request a private contact if needed. Added published project security practices: automated vulnerability and secret scanning, mandatory 2FA, private reporting enabled, and monthly public security summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->