### PR TITLE
[ci] Add upgrade test job to release pipeline

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - oracle-vm-24cpu-96gb-x86-64

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -317,7 +317,9 @@ jobs:
             echo "Attempt $attempt failed, retrying..."
           done
 
-      # Run the upgrade test: install previous version -> upgrade -> validate
+      # Run the upgrade test: install previous version -> upgrade -> validate.
+      # STRICT_BASELINE=1 makes Phase 1 fail fast on reconcile errors — the CI
+      # sandbox is always pristine, so any baseline failure is a real bug.
       - name: Run upgrade test
         env:
           RELEASE_TAG: ${{ steps.tag.outputs.tag }}
@@ -326,6 +328,7 @@ jobs:
           make -C packages/core/testing \
             SANDBOX_NAME=$SANDBOX_NAME \
             UPGRADE_TARGET_TAG="${RELEASE_TAG}" \
+            STRICT_BASELINE=1 \
             upgrade-cozystack
 
       # Collect debug information (always runs)
@@ -353,11 +356,11 @@ jobs:
   generate-changelog:
     name: Generate Changelog
     runs-on: [self-hosted]
-    needs: [prepare-release]
+    needs: [prepare-release, upgrade-test]
     permissions:
       contents: write
       pull-requests: write
-    if: needs.prepare-release.result == 'success'
+    if: needs.prepare-release.result == 'success' && needs.upgrade-test.result == 'success'
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -518,8 +521,8 @@ jobs:
   update-website-docs:
     name: Update Website Docs
     runs-on: [self-hosted]
-    needs: [generate-changelog, prepare-release]
-    if: needs.generate-changelog.result == 'success' && needs.prepare-release.outputs.skip != 'true'
+    needs: [generate-changelog, prepare-release, upgrade-test]
+    if: needs.generate-changelog.result == 'success' && needs.prepare-release.outputs.skip != 'true' && needs.upgrade-test.result == 'success'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -238,6 +238,118 @@ jobs:
               console.log(`PR already exists from ${head} to ${base}`);
             }
 
+  upgrade-test:
+    name: Upgrade Test
+    runs-on: [oracle-vm-24cpu-96gb-x86-64]
+    timeout-minutes: 150
+    needs: [prepare-release]
+    if: needs.prepare-release.outputs.skip != 'true'
+    permissions:
+      contents: read
+      packages: read
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.COZYSTACK_CI_APP_ID }}
+          private-key: ${{ secrets.COZYSTACK_CI_PRIVATE_KEY }}
+          owner: cozystack
+
+      - name: Parse tag
+        id: tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      # Checkout the release branch which has built image digests
+      - name: Checkout release branch
+        uses: actions/checkout@v4
+        with:
+          ref: release-${{ steps.tag.outputs.version }}
+          fetch-depth: 0
+          fetch-tags: true
+          token: ${{ steps.app-token.outputs.token }}
+
+      # Download the Talos nocloud image from the draft release
+      - name: Download Talos image from draft release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          mkdir -p _out/assets
+          # Find draft release and its nocloud asset
+          ASSET_URL=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate -q \
+            ".[] | select(.tag_name==\"${RELEASE_TAG}\" and .draft) | .assets[] | select(.name==\"nocloud-amd64.raw.xz\") | .url")
+          if [ -z "$ASSET_URL" ]; then
+            echo "nocloud-amd64.raw.xz not found in draft release for ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+          curl -sSL \
+            -H "Authorization: token ${GH_TOKEN}" \
+            -H "Accept: application/octet-stream" \
+            -o _out/assets/nocloud-amd64.raw.xz \
+            "$ASSET_URL"
+          ls -lh _out/assets/nocloud-amd64.raw.xz
+
+      - name: Set sandbox ID
+        run: echo "SANDBOX_NAME=cozy-upgrade-sandbox-$(echo "${GITHUB_REPOSITORY}:upgrade:${GITHUB_REF}" | sha256sum | cut -c1-10)" >> $GITHUB_ENV
+
+      # Prepare environment (create sandbox container, provision Talos cluster)
+      - name: Prepare workspace
+        run: |
+          rm -rf /tmp/$SANDBOX_NAME
+          cp -r "${GITHUB_WORKSPACE}" /tmp/$SANDBOX_NAME
+
+      - name: Prepare environment
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          attempt=0
+          until make SANDBOX_NAME=$SANDBOX_NAME prepare-env; do
+            attempt=$((attempt + 1))
+            if [ $attempt -ge 3 ]; then
+              echo "Attempt $attempt failed, exiting..."
+              exit 1
+            fi
+            echo "Attempt $attempt failed, retrying..."
+          done
+
+      # Run the upgrade test: install previous version -> upgrade -> validate
+      - name: Run upgrade test
+        env:
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          make -C packages/core/testing \
+            SANDBOX_NAME=$SANDBOX_NAME \
+            UPGRADE_TARGET_TAG="${RELEASE_TAG}" \
+            upgrade-cozystack
+
+      # Collect debug information (always runs)
+      - name: Collect report
+        if: always()
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME collect-report || true
+
+      - name: Upload upgrade test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: upgrade-test-report
+          path: /tmp/${{ env.SANDBOX_NAME }}/_out/cozyreport.tgz
+
+      - name: Tear down sandbox
+        if: always()
+        run: make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME delete || true
+
+      - name: Remove workspace
+        if: always()
+        run: rm -rf /tmp/$SANDBOX_NAME
+
   generate-changelog:
     name: Generate Changelog
     runs-on: [self-hosted]

--- a/hack/e2e-upgrade-cozystack.bats
+++ b/hack/e2e-upgrade-cozystack.bats
@@ -1,0 +1,494 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Cozystack upgrade test (Bats)
+#
+# Installs the previous stable minor release, deploys representative
+# workloads, upgrades to the current version, and validates that
+# existing workloads survive.
+#
+# Expects:
+#   - A provisioned Talos cluster (e2e-prepare-cluster.bats already ran)
+#   - UPGRADE_TARGET_TAG env var set to the current release tag (e.g. v0.43.0)
+#     Falls back to `git describe --tags --exact-match` if unset.
+# -----------------------------------------------------------------------------
+
+STATE_DIR="/tmp/upgrade-test"
+
+# ---------------------------------------------------------------------------
+# Helper: resolve the latest stable release from the previous minor line
+# ---------------------------------------------------------------------------
+find_previous_release() {
+  local current_tag="${UPGRADE_TARGET_TAG:-}"
+  if [ -z "$current_tag" ]; then
+    current_tag=$(git describe --tags --exact-match --match 'v*' 2>/dev/null || true)
+  fi
+  if [ -z "$current_tag" ]; then
+    echo "ERROR: Cannot determine current tag. Set UPGRADE_TARGET_TAG." >&2
+    return 1
+  fi
+
+  # v0.43.0-rc.1 → major=0, minor=43
+  local version="${current_tag#v}"
+  local major minor
+  major=$(echo "$version" | cut -d. -f1)
+  minor=$(echo "$version" | cut -d. -f2)
+
+  if [ "$minor" -eq 0 ]; then
+    echo "ERROR: No previous minor version exists (current minor is 0)" >&2
+    return 1
+  fi
+
+  local prev_minor=$((minor - 1))
+
+  # Latest stable (non-prerelease) tag from the previous minor line
+  local prev_release
+  prev_release=$(git tag -l "v${major}.${prev_minor}.*" --sort=-v:refname \
+    | grep -v -E '-(rc|alpha|beta)\.' | head -1)
+
+  if [ -z "$prev_release" ]; then
+    echo "ERROR: No stable release found for v${major}.${prev_minor}.*" >&2
+    return 1
+  fi
+
+  echo "$prev_release"
+}
+
+# ===================================================================
+# Phase 1: Install the previous stable release
+# ===================================================================
+
+@test "Determine previous stable release" {
+  mkdir -p "$STATE_DIR"
+  PREV_RELEASE=$(find_previous_release)
+  echo "Previous release: $PREV_RELEASE"
+  echo "$PREV_RELEASE" > "$STATE_DIR/prev-release"
+}
+
+@test "Extract and install previous version of Cozystack" {
+  PREV_RELEASE=$(cat "$STATE_DIR/prev-release")
+
+  # Extract installer chart from the previous release tag
+  local prev_installer="$STATE_DIR/prev-installer"
+  rm -rf "$prev_installer"
+  mkdir -p "$prev_installer/templates"
+
+  git show "${PREV_RELEASE}:packages/core/installer/Chart.yaml" \
+    > "$prev_installer/Chart.yaml"
+  git show "${PREV_RELEASE}:packages/core/installer/values.yaml" \
+    > "$prev_installer/values.yaml"
+  git show "${PREV_RELEASE}:packages/core/installer/templates/cozystack-operator.yaml" \
+    > "$prev_installer/templates/cozystack-operator.yaml"
+
+  echo "Operator image (previous): $(yq '.cozystackOperator.image' "$prev_installer/values.yaml")"
+
+  # Install previous version via Helm (same mechanism users use)
+  helm upgrade installer "$prev_installer" \
+    --install \
+    --namespace cozy-system \
+    --create-namespace \
+    --wait \
+    --timeout 2m
+
+  # Verify the operator deployment is available
+  kubectl wait deployment/cozystack-operator -n cozy-system \
+    --timeout=2m --for=condition=Available
+
+  # Wait for operator to install CRDs
+  timeout 120 sh -ec 'until kubectl wait crd/packages.cozystack.io --for=condition=Established --timeout=10s 2>/dev/null; do sleep 2; done'
+  timeout 120 sh -ec 'until kubectl wait crd/packagesources.cozystack.io --for=condition=Established --timeout=10s 2>/dev/null; do sleep 2; done'
+
+  # Wait for operator to create the platform PackageSource
+  timeout 120 sh -ec 'until kubectl get packagesource cozystack.cozystack-platform >/dev/null 2>&1; do sleep 2; done'
+}
+
+@test "Create platform Package and wait for previous version to stabilize" {
+  kubectl apply -f - <<EOF
+apiVersion: cozystack.io/v1alpha1
+kind: Package
+metadata:
+  name: cozystack.cozystack-platform
+spec:
+  variant: isp-full
+  components:
+    platform:
+      values:
+        networking:
+          podCIDR: "10.244.0.0/16"
+          podGateway: "10.244.0.1"
+          serviceCIDR: "10.96.0.0/16"
+          joinCIDR: "100.64.0.0/16"
+        publishing:
+          host: "example.org"
+          apiServerEndpoint: "https://192.168.123.10:6443"
+EOF
+
+  # Wait until HelmReleases appear & reconcile
+  timeout 180 sh -ec 'until [ $(kubectl get hr -A --no-headers 2>/dev/null | wc -l) -gt 10 ]; do sleep 1; done'
+  sleep 5
+  kubectl get hr -A \
+    | awk 'NR>1 {print "kubectl wait --timeout=15m --for=condition=ready -n "$1" hr/"$2" &"} END {print "wait"}' \
+    | sh -ex
+
+  if kubectl get hr -A | grep -v " True " | grep -v NAME; then
+    kubectl get hr -A
+    echo "Some HelmReleases failed to reconcile (previous version)" >&2
+  fi
+}
+
+@test "Wait for LINSTOR and configure storage (pre-upgrade)" {
+  kubectl wait deployment/linstor-controller -n cozy-linstor \
+    --timeout=5m --for=condition=available
+  timeout 60 sh -ec 'until [ $(kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor node list | grep -c Online) -eq 3 ]; do sleep 1; done'
+
+  created_pools=$(kubectl exec -n cozy-linstor deploy/linstor-controller -- \
+    linstor sp l -s data --pastable | awk '$2 == "data" {printf " " $4} END{printf " "}')
+  for node in srv1 srv2 srv3; do
+    case $created_pools in
+      *" $node "*) echo "Storage pool 'data' already exists on node $node"; continue;;
+    esac
+    kubectl exec -n cozy-linstor deploy/linstor-controller -- \
+      linstor ps cdp zfs ${node} /dev/vdc --pool-name data --storage-pool data
+  done
+
+  kubectl apply -f - <<'EOF'
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: linstor.csi.linbit.com
+parameters:
+  linstor.csi.linbit.com/storagePool: "data"
+  linstor.csi.linbit.com/layerList: "storage"
+  linstor.csi.linbit.com/allowRemoteVolumeAccess: "false"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: replicated
+provisioner: linstor.csi.linbit.com
+parameters:
+  linstor.csi.linbit.com/storagePool: "data"
+  linstor.csi.linbit.com/autoPlace: "3"
+  linstor.csi.linbit.com/layerList: "drbd storage"
+  linstor.csi.linbit.com/allowRemoteVolumeAccess: "true"
+  property.linstor.csi.linbit.com/DrbdOptions/auto-quorum: suspend-io
+  property.linstor.csi.linbit.com/DrbdOptions/Resource/on-no-data-accessible: suspend-io
+  property.linstor.csi.linbit.com/DrbdOptions/Resource/on-suspended-primary-outdated: force-secondary
+  property.linstor.csi.linbit.com/DrbdOptions/Net/rr-conflict: retry-connect
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+EOF
+}
+
+@test "Wait for MetalLB and configure address pool (pre-upgrade)" {
+  kubectl apply -f - <<'EOF'
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: cozystack
+  namespace: cozy-metallb
+spec:
+  ipAddressPools: [cozystack]
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: cozystack
+  namespace: cozy-metallb
+spec:
+  addresses: [192.168.123.200-192.168.123.250]
+  autoAssign: true
+  avoidBuggyIPs: false
+EOF
+}
+
+@test "Check Cozystack API service (pre-upgrade)" {
+  kubectl wait --for=condition=Available \
+    apiservices/v1alpha1.apps.cozystack.io \
+    apiservices/v1alpha1.core.cozystack.io \
+    --timeout=2m
+}
+
+@test "Create test tenant" {
+  # Patch root tenant — enable only what's needed for tenant creation
+  kubectl patch tenants/root -n tenant-root --type merge \
+    -p '{"spec":{"host":"example.org","ingress":false,"monitoring":false,"etcd":true,"isolated":true,"seaweedfs":false}}'
+
+  timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd tenant-root >/dev/null 2>&1; do sleep 1; done'
+  kubectl wait hr/etcd hr/tenant-root -n tenant-root --timeout=4m --for=condition=ready
+
+  # Create an isolated test tenant with resource quotas
+  kubectl -n tenant-root get tenants.apps.cozystack.io test 2>/dev/null ||
+  kubectl apply -f - <<EOF
+apiVersion: apps.cozystack.io/v1alpha1
+kind: Tenant
+metadata:
+  name: test
+  namespace: tenant-root
+spec:
+  etcd: false
+  host: ""
+  ingress: false
+  isolated: true
+  monitoring: false
+  resourceQuotas:
+    cpu: "60"
+    memory: "128Gi"
+    storage: "100Gi"
+  seaweedfs: false
+EOF
+  kubectl wait hr/tenant-test -n tenant-root --timeout=2m --for=condition=ready
+  kubectl wait namespace tenant-test --timeout=20s --for=jsonpath='{.status.phase}'=Active
+}
+
+# ===================================================================
+# Phase 2: Deploy workloads and seed test data
+# ===================================================================
+
+@test "Deploy PostgreSQL with test data" {
+  local name='upgrade-pg'
+
+  kubectl -n tenant-test delete postgreses.apps.cozystack.io "$name" --ignore-not-found --timeout=2m || true
+
+  kubectl apply -f - <<EOF
+apiVersion: apps.cozystack.io/v1alpha1
+kind: Postgres
+metadata:
+  name: $name
+  namespace: tenant-test
+spec:
+  external: false
+  size: 10Gi
+  replicas: 2
+  storageClass: ""
+  postgresql:
+    parameters:
+      max_connections: 100
+  quorum:
+    minSyncReplicas: 0
+    maxSyncReplicas: 0
+  users:
+    upgradeuser:
+      password: upgrade-test-pw
+  databases:
+    upgradedb:
+      roles:
+        admin:
+        - upgradeuser
+  backup:
+    enabled: false
+    s3Region: us-east-1
+    s3Bucket: s3.example.org/postgres-backups
+    schedule: "0 2 * * *"
+    cleanupStrategy: "--keep-last=3"
+    s3AccessKey: placeholder
+    s3SecretKey: placeholder
+    resticPassword: placeholder
+  resources: {}
+  resourcesPreset: "nano"
+EOF
+
+  sleep 5
+  kubectl -n tenant-test wait hr "postgres-$name" --timeout=120s --for=condition=ready
+  kubectl -n tenant-test wait "job.batch/postgres-${name}-init-job" --timeout=60s --for=condition=Complete
+
+  # Wait for RW endpoint to have an address
+  timeout 60 sh -ec "until kubectl -n tenant-test get endpoints postgres-${name}-rw -o jsonpath='{.subsets[*].addresses[*].ip}' | grep -q '[0-9]'; do sleep 5; done"
+
+  # Seed test data: create a table and insert 3 known rows
+  local pg_pod
+  pg_pod=$(kubectl get pods -n tenant-test \
+    -l "cnpg.io/cluster=postgres-${name}" \
+    --field-selector=status.phase=Running \
+    -o jsonpath='{.items[0].metadata.name}')
+
+  kubectl exec -n tenant-test "$pg_pod" -- \
+    psql -U postgres -d upgradedb -c "
+      CREATE TABLE IF NOT EXISTS upgrade_canary (
+        id serial PRIMARY KEY,
+        data text NOT NULL,
+        created_at timestamptz DEFAULT now()
+      );
+      INSERT INTO upgrade_canary (data) VALUES
+        ('pre-upgrade-row-1'),
+        ('pre-upgrade-row-2'),
+        ('pre-upgrade-row-3');
+    "
+
+  # Verify seed data
+  local count
+  count=$(kubectl exec -n tenant-test "$pg_pod" -- \
+    psql -U postgres -d upgradedb -t -A -c "SELECT count(*) FROM upgrade_canary;")
+  echo "Pre-upgrade row count: $count"
+  [ "$count" -eq 3 ]
+
+  echo "upgrade-pg" > "$STATE_DIR/pg-instance-name"
+}
+
+@test "Record pre-upgrade state" {
+  mkdir -p "$STATE_DIR"
+
+  # Snapshot HelmRelease count
+  kubectl get hr -A --no-headers | wc -l > "$STATE_DIR/pre-hr-count"
+  echo "Pre-upgrade HelmRelease count: $(cat "$STATE_DIR/pre-hr-count")"
+
+  # Snapshot pod state (for debugging if upgrade breaks things)
+  kubectl get pods -A --no-headers > "$STATE_DIR/pre-pods"
+  echo "Pre-upgrade pod count: $(wc -l < "$STATE_DIR/pre-pods")"
+}
+
+# ===================================================================
+# Phase 3: Upgrade to the current version
+# ===================================================================
+
+@test "Upgrade Cozystack to current version" {
+  PREV_RELEASE=$(cat "$STATE_DIR/prev-release")
+  echo "Upgrading from $PREV_RELEASE to current version"
+  echo "Operator image (current): $(yq '.cozystackOperator.image' packages/core/installer/values.yaml)"
+
+  helm upgrade installer packages/core/installer \
+    --install \
+    --namespace cozy-system \
+    --wait \
+    --timeout 2m
+
+  # Verify the new operator is available
+  kubectl wait deployment/cozystack-operator -n cozy-system \
+    --timeout=2m --for=condition=Available
+
+  # CRDs may be updated — wait for them to be established
+  timeout 120 sh -ec 'until kubectl wait crd/packages.cozystack.io --for=condition=Established --timeout=10s 2>/dev/null; do sleep 2; done'
+}
+
+# ===================================================================
+# Phase 4: Post-upgrade validation
+# ===================================================================
+
+@test "Wait for all HelmReleases to reconcile after upgrade" {
+  # Give Flux time to detect the new package source and start reconciling
+  sleep 10
+
+  # Wait for all HelmReleases to become Ready (generous timeout for full reconciliation)
+  local max_wait=900  # 15 minutes
+  local interval=10
+  local elapsed=0
+
+  while [ $elapsed -lt $max_wait ]; do
+    local not_ready
+    not_ready=$(kubectl get hr -A --no-headers 2>/dev/null | grep -v " True " | wc -l)
+    if [ "$not_ready" -eq 0 ]; then
+      echo "All HelmReleases are Ready after ${elapsed}s"
+      break
+    fi
+    echo "Waiting for $not_ready HelmReleases to reconcile (${elapsed}s / ${max_wait}s)..."
+    sleep "$interval"
+    elapsed=$((elapsed + interval))
+  done
+
+  # Final check: fail if any HR is still not ready
+  if kubectl get hr -A --no-headers | grep -v " True "; then
+    echo "HelmReleases still not ready after ${max_wait}s:" >&2
+    kubectl get hr -A >&2
+    exit 1
+  fi
+}
+
+@test "Verify no CrashLoopBackOff pods after upgrade" {
+  # Allow a brief settling period for pods to restart
+  sleep 10
+
+  local crashloop_pods
+  crashloop_pods=$(kubectl get pods -A --no-headers 2>/dev/null \
+    | grep -i "CrashLoopBackOff" || true)
+
+  if [ -n "$crashloop_pods" ]; then
+    echo "CrashLoopBackOff pods detected after upgrade:" >&2
+    echo "$crashloop_pods" >&2
+    exit 1
+  fi
+
+  echo "No CrashLoopBackOff pods found"
+}
+
+@test "Verify all PersistentVolumes are Bound after upgrade" {
+  local unbound_pvs
+  unbound_pvs=$(kubectl get pv --no-headers 2>/dev/null \
+    | grep -v "Bound" || true)
+
+  if [ -n "$unbound_pvs" ]; then
+    echo "Unbound PersistentVolumes detected after upgrade:" >&2
+    echo "$unbound_pvs" >&2
+    exit 1
+  fi
+
+  echo "All PersistentVolumes are Bound"
+}
+
+@test "Verify PostgreSQL data survived upgrade" {
+  local name
+  name=$(cat "$STATE_DIR/pg-instance-name")
+
+  # Wait for the PostgreSQL pods to stabilize after upgrade
+  timeout 120 sh -ec "until kubectl -n tenant-test get endpoints postgres-${name}-rw -o jsonpath='{.subsets[*].addresses[*].ip}' | grep -q '[0-9]'; do sleep 5; done"
+
+  local pg_pod
+  pg_pod=$(kubectl get pods -n tenant-test \
+    -l "cnpg.io/cluster=postgres-${name}" \
+    --field-selector=status.phase=Running \
+    -o jsonpath='{.items[0].metadata.name}')
+
+  # Check that the 3 pre-upgrade rows are still there
+  local count
+  count=$(kubectl exec -n tenant-test "$pg_pod" -- \
+    psql -U postgres -d upgradedb -t -A -c "SELECT count(*) FROM upgrade_canary;")
+  echo "Post-upgrade row count: $count"
+  [ "$count" -eq 3 ]
+
+  # Verify actual data values
+  local data
+  data=$(kubectl exec -n tenant-test "$pg_pod" -- \
+    psql -U postgres -d upgradedb -t -A -c "SELECT data FROM upgrade_canary ORDER BY id;")
+  echo "Post-upgrade data:"
+  echo "$data"
+  echo "$data" | grep -q "pre-upgrade-row-1"
+  echo "$data" | grep -q "pre-upgrade-row-2"
+  echo "$data" | grep -q "pre-upgrade-row-3"
+
+  echo "PostgreSQL data integrity verified"
+}
+
+@test "Verify Cozystack API available after upgrade" {
+  kubectl wait --for=condition=Available \
+    apiservices/v1alpha1.apps.cozystack.io \
+    apiservices/v1alpha1.core.cozystack.io \
+    --timeout=2m
+
+  echo "Cozystack API is available after upgrade"
+}
+
+@test "Verify platform pods are healthy after upgrade" {
+  # Check that key system namespaces have no unhealthy pods
+  local failed=false
+  for ns in cozy-system cozy-fluxcd cozy-linstor cozy-metallb; do
+    local not_running
+    not_running=$(kubectl get pods -n "$ns" --no-headers 2>/dev/null \
+      | grep -v -E "(Running|Completed|Succeeded)" || true)
+    if [ -n "$not_running" ]; then
+      echo "Unhealthy pods in $ns:" >&2
+      echo "$not_running" >&2
+      failed=true
+    fi
+  done
+
+  if [ "$failed" = true ]; then
+    exit 1
+  fi
+
+  echo "All platform pods are healthy after upgrade"
+}

--- a/hack/e2e-upgrade-cozystack.bats
+++ b/hack/e2e-upgrade-cozystack.bats
@@ -40,10 +40,11 @@ find_previous_release() {
 
   local prev_minor=$((minor - 1))
 
-  # Latest stable (non-prerelease) tag from the previous minor line
+  # Latest stable (non-prerelease) tag from the previous minor line.
+  # Per SemVer, any tag containing a hyphen is a pre-release.
   local prev_release
   prev_release=$(git tag -l "v${major}.${prev_minor}.*" --sort=-v:refname \
-    | grep -v -E '-(rc|alpha|beta)\.' | head -1)
+    | grep -v -- '-' | head -1)
 
   if [ -z "$prev_release" ]; then
     echo "ERROR: No stable release found for v${major}.${prev_minor}.*" >&2
@@ -112,16 +113,25 @@ spec:
           apiServerEndpoint: "https://192.168.123.10:6443"
 EOF
 
-  # Wait until HelmReleases appear & reconcile
+  # Wait until HelmReleases appear & reconcile. The 10-release floor is a
+  # conservative signal that the operator has started creating HRs for the
+  # isp-full variant (which produces many more); below 10 means the operator
+  # isn't reconciling yet.
   timeout 180 sh -ec 'until [ $(kubectl get hr -A --no-headers 2>/dev/null | wc -l) -gt 10 ]; do sleep 1; done'
   sleep 5
   kubectl get hr -A \
     | awk 'NR>1 {print "kubectl wait --timeout=15m --for=condition=ready -n "$1" hr/"$2" &"} END {print "wait"}' \
     | sh -ex
 
+  # Fail fast on a broken baseline when STRICT_BASELINE=1 (CI). On long-lived
+  # dev clusters, leave as a warning so pre-existing noise doesn't block runs.
   if kubectl get hr -A | grep -v " True " | grep -v NAME; then
     kubectl get hr -A
-    echo "Some HelmReleases failed to reconcile (previous version)" >&2
+    if [ "${STRICT_BASELINE:-0}" = "1" ]; then
+      echo "ERROR: HelmReleases failed to reconcile (previous version)" >&2
+      exit 1
+    fi
+    echo "WARNING: Some HelmReleases not reconciled (previous version); continuing with tolerant baseline" >&2
   fi
 }
 
@@ -297,6 +307,7 @@ EOF
     -l "cnpg.io/cluster=postgres-${name}" \
     --field-selector=status.phase=Running \
     -o jsonpath='{.items[0].metadata.name}')
+  [ -n "$pg_pod" ] || { echo "No running PostgreSQL pod found for postgres-${name}" >&2; exit 1; }
 
   kubectl exec -n tenant-test "$pg_pod" -- \
     psql -U postgres -d upgradedb -c "
@@ -321,6 +332,252 @@ EOF
   echo "upgrade-pg" > "$STATE_DIR/pg-instance-name"
 }
 
+@test "Deploy MariaDB with test data" {
+  local name='upgrade-mariadb'
+
+  kubectl -n tenant-test delete mariadbs.apps.cozystack.io "$name" --ignore-not-found --timeout=2m || true
+
+  kubectl apply -f - <<EOF
+apiVersion: apps.cozystack.io/v1alpha1
+kind: MariaDB
+metadata:
+  name: $name
+  namespace: tenant-test
+spec:
+  external: false
+  size: 10Gi
+  replicas: 2
+  storageClass: ""
+  users:
+    upgradeuser:
+      maxUserConnections: 100
+      password: upgrade-test-pw
+  databases:
+    upgradedb:
+      roles:
+        admin:
+        - upgradeuser
+  backup:
+    enabled: false
+    s3Region: us-east-1
+    s3Bucket: s3.example.org/mariadb-backups
+    schedule: "0 2 * * *"
+    cleanupStrategy: "--keep-last=3"
+    s3AccessKey: placeholder
+    s3SecretKey: placeholder
+    resticPassword: placeholder
+  resources: {}
+  resourcesPreset: "nano"
+EOF
+
+  sleep 5
+  kubectl -n tenant-test wait hr "mariadb-$name" --timeout=120s --for=condition=ready
+  kubectl -n tenant-test wait statefulset.apps/mariadb-$name --timeout=5m --for=jsonpath='{.status.readyReplicas}'=2
+  timeout 60 sh -ec "until kubectl -n tenant-test get endpoints mariadb-${name} -o jsonpath='{.subsets[*].addresses[*].ip}' | grep -q '[0-9]'; do sleep 5; done"
+
+  local my_pod
+  my_pod=$(kubectl get pods -n tenant-test \
+    -l "app.kubernetes.io/instance=mariadb-${name}" \
+    --field-selector=status.phase=Running \
+    -o jsonpath='{.items[0].metadata.name}')
+  [ -n "$my_pod" ] || { echo "No running MariaDB pod found for mariadb-${name}" >&2; exit 1; }
+
+  # Seed 3 known rows via the primary service (handles replica topology)
+  local root_pw
+  root_pw=$(kubectl get secret mariadb-${name}-credentials -n tenant-test \
+    -o jsonpath='{.data.root}' | base64 -d)
+  kubectl exec -n tenant-test "$my_pod" -- \
+    env MYSQL_PWD="$root_pw" mysql -h "mariadb-${name}-primary" -u root upgradedb -e "
+      CREATE TABLE IF NOT EXISTS upgrade_canary (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        data VARCHAR(64) NOT NULL
+      );
+      INSERT INTO upgrade_canary (data) VALUES
+        ('mariadb-pre-upgrade-row-1'),
+        ('mariadb-pre-upgrade-row-2'),
+        ('mariadb-pre-upgrade-row-3');
+    "
+
+  local count
+  count=$(kubectl exec -n tenant-test "$my_pod" -- \
+    env MYSQL_PWD="$root_pw" mysql -h "mariadb-${name}-primary" -u root -N -B upgradedb -e "SELECT count(*) FROM upgrade_canary;")
+  echo "MariaDB pre-upgrade row count: $count"
+  [ "$count" -eq 3 ]
+
+  echo "upgrade-mariadb" > "$STATE_DIR/mariadb-instance-name"
+}
+
+@test "Deploy Kafka cluster" {
+  local name='upgrade-kafka'
+
+  kubectl -n tenant-test delete kafkas.apps.cozystack.io "$name" --ignore-not-found --timeout=2m || true
+  kubectl -n tenant-test wait kafkas.apps.cozystack.io "$name" --for=delete --timeout=2m 2>/dev/null || true
+
+  kubectl apply -f - <<EOF
+apiVersion: apps.cozystack.io/v1alpha1
+kind: Kafka
+metadata:
+  name: $name
+  namespace: tenant-test
+spec:
+  external: false
+  kafka:
+    size: 5Gi
+    replicas: 2
+    storageClass: ""
+    resources: {}
+    resourcesPreset: "nano"
+  zookeeper:
+    size: 5Gi
+    replicas: 2
+    storageClass: ""
+    resources: {}
+    resourcesPreset: "nano"
+  topics:
+    - name: upgradeCanary
+      partitions: 1
+      replicas: 2
+      config:
+        min.insync.replicas: 1
+EOF
+
+  sleep 5
+  kubectl -n tenant-test wait hr "kafka-$name" --timeout=60s --for=condition=ready
+  kubectl -n tenant-test wait kafka "$name" --timeout=5m --for=condition=ready
+
+  # Record the Kafka CR generation so we can check it survives untouched
+  kubectl get kafka -n tenant-test "$name" \
+    -o jsonpath='{.metadata.uid}' > "$STATE_DIR/kafka-uid"
+  echo "$name" > "$STATE_DIR/kafka-instance-name"
+}
+
+@test "Deploy VirtualMachine" {
+  local name='upgrade-vm'
+
+  kubectl -n tenant-test delete vminstances.apps.cozystack.io "$name" --ignore-not-found --timeout=2m || true
+  kubectl -n tenant-test delete vmdisks.apps.cozystack.io "$name" --ignore-not-found --timeout=2m || true
+
+  kubectl apply -f - <<EOF
+apiVersion: apps.cozystack.io/v1alpha1
+kind: VMDisk
+metadata:
+  name: $name
+  namespace: tenant-test
+spec:
+  source:
+    http:
+      url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
+  optical: false
+  storage: 5Gi
+  storageClass: replicated
+---
+apiVersion: apps.cozystack.io/v1alpha1
+kind: VMInstance
+metadata:
+  name: $name
+  namespace: tenant-test
+spec:
+  external: false
+  running: true
+  instanceType: "u1.medium"
+  instanceProfile: ubuntu
+  disks:
+    - name: $name
+  gpus: []
+  sshKeys: []
+  cloudInit: |
+    #cloud-config
+    users:
+      - name: cozy
+        shell: /bin/bash
+  cloudInitSeed: ""
+EOF
+
+  kubectl -n tenant-test wait hr "vm-disk-$name" --timeout=30s --for=condition=ready
+  kubectl -n tenant-test wait dv "vm-disk-$name" --timeout=5m --for=condition=ready
+  kubectl -n tenant-test wait pvc "vm-disk-$name" --timeout=3m --for=jsonpath='{.status.phase}'=Bound
+  kubectl -n tenant-test wait hr "vm-instance-$name" --timeout=60s --for=condition=ready
+  kubectl -n tenant-test wait vm "vm-instance-$name" --timeout=2m --for=condition=Ready
+
+  # Record VMI UID so we can verify the instance itself survives (not just a recreate)
+  kubectl get vmi -n tenant-test "vm-instance-$name" \
+    -o jsonpath='{.metadata.uid}' > "$STATE_DIR/vm-uid"
+  echo "$name" > "$STATE_DIR/vm-instance-name"
+}
+
+@test "Deploy tenant Kubernetes cluster" {
+  local name='upgrade-k8s'
+  local k8s_version
+  k8s_version=$(yq 'keys | sort_by(.) | .[-1]' packages/apps/kubernetes/files/versions.yaml)
+
+  kubectl -n tenant-test delete kuberneteses.apps.cozystack.io "$name" --ignore-not-found --wait=false 2>/dev/null || true
+  kubectl -n tenant-test wait kuberneteses.apps.cozystack.io "$name" --for=delete --timeout=2m 2>/dev/null || true
+
+  kubectl apply -f - <<EOF
+apiVersion: apps.cozystack.io/v1alpha1
+kind: Kubernetes
+metadata:
+  name: $name
+  namespace: tenant-test
+spec:
+  addons:
+    certManager:
+      enabled: false
+      valuesOverride: {}
+    cilium:
+      valuesOverride: {}
+    fluxcd:
+      enabled: false
+      valuesOverride: {}
+    gatewayAPI:
+      enabled: false
+    gpuOperator:
+      enabled: false
+      valuesOverride: {}
+    ingressNginx:
+      enabled: false
+      hosts: []
+      valuesOverride: {}
+    monitoringAgents:
+      enabled: false
+      valuesOverride: {}
+    verticalPodAutoscaler:
+      valuesOverride: {}
+  controlPlane:
+    apiServer:
+      resources: {}
+      resourcesPreset: small
+    controllerManager:
+      resources: {}
+      resourcesPreset: micro
+    konnectivity:
+      server:
+        resources: {}
+        resourcesPreset: micro
+    replicas: 2
+    scheduler:
+      resources: {}
+      resourcesPreset: micro
+  host: ""
+  nodeGroups: {}
+  storageClass: replicated
+  version: "${k8s_version}"
+EOF
+
+  # Wait for the Kamaji control plane to spin up. We skip waiting for the
+  # tenant-node-dependent add-ons (nodeGroups is empty) — just verifying the
+  # control plane CR survives the upgrade is enough to catch CRD breakage.
+  timeout 120 sh -ec 'until kubectl get kamajicontrolplane -n tenant-test "kubernetes-'"$name"'" >/dev/null 2>&1; do sleep 2; done'
+  kubectl wait --for=condition=TenantControlPlaneCreated \
+    kamajicontrolplane -n tenant-test "kubernetes-$name" --timeout=5m
+  kubectl wait tcp -n tenant-test "kubernetes-$name" \
+    --timeout=5m --for=jsonpath='{.status.kubernetesResources.version.status}'=Ready
+
+  kubectl get tcp -n tenant-test "kubernetes-$name" \
+    -o jsonpath='{.metadata.uid}' > "$STATE_DIR/k8s-tcp-uid"
+  echo "$name" > "$STATE_DIR/k8s-instance-name"
+}
+
 @test "Record pre-upgrade state" {
   mkdir -p "$STATE_DIR"
 
@@ -338,9 +595,12 @@ EOF
   kubectl get pv --no-headers 2>/dev/null \
     | awk '$5 != "Bound" {print $1}' | sort > "$STATE_DIR/pre-unbound-pvs"
 
-  # Pre-upgrade cozystack migration version (for post-upgrade assertion)
-  kubectl get cm cozystack-version -n cozy-system -o jsonpath='{.data.version}' \
-    > "$STATE_DIR/pre-cozystack-version" 2>/dev/null || echo "0" > "$STATE_DIR/pre-cozystack-version"
+  # Pre-upgrade cozystack migration version (for post-upgrade assertion).
+  # Coalesce missing CM, kubectl failure, and empty stdout all to "0".
+  local previous_version
+  previous_version=$(kubectl get cm cozystack-version -n cozy-system \
+    -o jsonpath='{.data.version}' 2>/dev/null || true)
+  echo "${previous_version:-0}" > "$STATE_DIR/pre-cozystack-version"
 
   # Snapshot pod state (for debugging if upgrade breaks things)
   kubectl get pods -A --no-headers > "$STATE_DIR/pre-pods"
@@ -360,13 +620,15 @@ EOF
   local current_version="${current_tag#v}"
   echo "Upgrading from $PREV_RELEASE to $current_tag (oci://ghcr.io/cozystack/cozystack/cozy-installer:${current_version})"
 
-  # Pull the published OCI chart — same mechanism users run during upgrades
+  # Pull the published OCI chart — same mechanism users run during upgrades.
+  # Timeout is generous: the installer renders cozystack-migration-hook as a
+  # pre-upgrade Job (backoffLimit=3), and helm --wait blocks on it.
   helm upgrade cozystack \
     oci://ghcr.io/cozystack/cozystack/cozy-installer \
     --version "${current_version}" \
     --namespace cozy-system \
     --wait \
-    --timeout 2m
+    --timeout 10m
 
   # Verify the new operator is available
   kubectl wait deployment/cozystack-operator -n cozy-system \
@@ -485,6 +747,7 @@ EOF
     -l "cnpg.io/cluster=postgres-${name}" \
     --field-selector=status.phase=Running \
     -o jsonpath='{.items[0].metadata.name}')
+  [ -n "$pg_pod" ] || { echo "No running PostgreSQL pod found for postgres-${name} after upgrade" >&2; exit 1; }
 
   # Check that the 3 pre-upgrade rows are still there
   local count
@@ -504,6 +767,101 @@ EOF
   echo "$data" | grep -q "pre-upgrade-row-3"
 
   echo "PostgreSQL data integrity verified"
+}
+
+@test "Verify MariaDB data survived upgrade" {
+  local name
+  name=$(cat "$STATE_DIR/mariadb-instance-name")
+
+  # Wait for MariaDB to stabilize after upgrade
+  timeout 180 sh -ec "until kubectl -n tenant-test get endpoints mariadb-${name} -o jsonpath='{.subsets[*].addresses[*].ip}' | grep -q '[0-9]'; do sleep 5; done"
+  kubectl -n tenant-test wait statefulset.apps/mariadb-$name --timeout=5m --for=jsonpath='{.status.readyReplicas}'=2
+
+  local my_pod
+  my_pod=$(kubectl get pods -n tenant-test \
+    -l "app.kubernetes.io/instance=mariadb-${name}" \
+    --field-selector=status.phase=Running \
+    -o jsonpath='{.items[0].metadata.name}')
+  [ -n "$my_pod" ] || { echo "No running MariaDB pod found for mariadb-${name} after upgrade" >&2; exit 1; }
+
+  local root_pw
+  root_pw=$(kubectl get secret mariadb-${name}-credentials -n tenant-test \
+    -o jsonpath='{.data.root}' | base64 -d)
+
+  local count
+  count=$(kubectl exec -n tenant-test "$my_pod" -- \
+    env MYSQL_PWD="$root_pw" mysql -h "mariadb-${name}-primary" -u root -N -B upgradedb -e "SELECT count(*) FROM upgrade_canary;")
+  echo "MariaDB post-upgrade row count: $count"
+  [ "$count" -eq 3 ]
+
+  local data
+  data=$(kubectl exec -n tenant-test "$my_pod" -- \
+    env MYSQL_PWD="$root_pw" mysql -h "mariadb-${name}-primary" -u root -N -B upgradedb -e "SELECT data FROM upgrade_canary ORDER BY id;")
+  echo "MariaDB post-upgrade data:"
+  echo "$data"
+  echo "$data" | grep -q "mariadb-pre-upgrade-row-1"
+  echo "$data" | grep -q "mariadb-pre-upgrade-row-2"
+  echo "$data" | grep -q "mariadb-pre-upgrade-row-3"
+
+  echo "MariaDB data integrity verified"
+}
+
+@test "Verify Kafka cluster survived upgrade" {
+  local name
+  name=$(cat "$STATE_DIR/kafka-instance-name")
+  local pre_uid
+  pre_uid=$(cat "$STATE_DIR/kafka-uid")
+
+  kubectl -n tenant-test wait kafka "$name" --timeout=10m --for=condition=ready
+
+  local post_uid
+  post_uid=$(kubectl get kafka -n tenant-test "$name" -o jsonpath='{.metadata.uid}')
+  [ "$pre_uid" = "$post_uid" ] || { echo "Kafka UID changed during upgrade: $pre_uid → $post_uid" >&2; exit 1; }
+
+  # Topic should still be present on the broker — check via the Strimzi KafkaTopic CR
+  kubectl get kafkatopic -n tenant-test \
+    -l "strimzi.io/cluster=kafka-${name}" \
+    -o jsonpath='{.items[*].spec.topicName}' | grep -qw 'upgradeCanary'
+
+  echo "Kafka cluster and topic survived upgrade"
+}
+
+@test "Verify VirtualMachine survived upgrade" {
+  local name
+  name=$(cat "$STATE_DIR/vm-instance-name")
+  local pre_uid
+  pre_uid=$(cat "$STATE_DIR/vm-uid")
+
+  kubectl -n tenant-test wait vm "vm-instance-$name" --timeout=5m --for=condition=Ready
+
+  local post_uid
+  post_uid=$(kubectl get vmi -n tenant-test "vm-instance-$name" \
+    -o jsonpath='{.metadata.uid}')
+  [ "$pre_uid" = "$post_uid" ] || { echo "VMI UID changed during upgrade: $pre_uid → $post_uid" >&2; exit 1; }
+
+  local phase
+  phase=$(kubectl get vmi -n tenant-test "vm-instance-$name" \
+    -o jsonpath='{.status.phase}')
+  [ "$phase" = "Running" ] || { echo "VMI phase is $phase, expected Running" >&2; exit 1; }
+
+  echo "VirtualMachine survived upgrade (same UID, still Running)"
+}
+
+@test "Verify tenant Kubernetes cluster survived upgrade" {
+  local name
+  name=$(cat "$STATE_DIR/k8s-instance-name")
+  local pre_uid
+  pre_uid=$(cat "$STATE_DIR/k8s-tcp-uid")
+
+  kubectl wait tcp -n tenant-test "kubernetes-$name" \
+    --timeout=10m --for=jsonpath='{.status.kubernetesResources.version.status}'=Ready
+
+  local post_uid
+  post_uid=$(kubectl get tcp -n tenant-test "kubernetes-$name" \
+    -o jsonpath='{.metadata.uid}')
+  [ "$pre_uid" = "$post_uid" ] || { echo "TenantControlPlane UID changed during upgrade: $pre_uid → $post_uid" >&2; exit 1; }
+
+  echo "Tenant Kubernetes control plane survived upgrade"
 }
 
 @test "Verify Cozystack API available after upgrade" {

--- a/hack/e2e-upgrade-cozystack.bats
+++ b/hack/e2e-upgrade-cozystack.bats
@@ -64,26 +64,16 @@ find_previous_release() {
   echo "$PREV_RELEASE" > "$STATE_DIR/prev-release"
 }
 
-@test "Extract and install previous version of Cozystack" {
+@test "Install previous version of Cozystack from OCI" {
   PREV_RELEASE=$(cat "$STATE_DIR/prev-release")
+  local prev_version="${PREV_RELEASE#v}"
 
-  # Extract installer chart from the previous release tag
-  local prev_installer="$STATE_DIR/prev-installer"
-  rm -rf "$prev_installer"
-  mkdir -p "$prev_installer/templates"
+  echo "Installing Cozystack ${PREV_RELEASE} from oci://ghcr.io/cozystack/cozystack/cozy-installer"
 
-  git show "${PREV_RELEASE}:packages/core/installer/Chart.yaml" \
-    > "$prev_installer/Chart.yaml"
-  git show "${PREV_RELEASE}:packages/core/installer/values.yaml" \
-    > "$prev_installer/values.yaml"
-  git show "${PREV_RELEASE}:packages/core/installer/templates/cozystack-operator.yaml" \
-    > "$prev_installer/templates/cozystack-operator.yaml"
-
-  echo "Operator image (previous): $(yq '.cozystackOperator.image' "$prev_installer/values.yaml")"
-
-  # Install previous version via Helm (same mechanism users use)
-  helm upgrade installer "$prev_installer" \
-    --install \
+  # Install the same way end users do — pull the published OCI chart
+  helm upgrade --install cozystack \
+    oci://ghcr.io/cozystack/cozystack/cozy-installer \
+    --version "${prev_version}" \
     --namespace cozy-system \
     --create-namespace \
     --wait \
@@ -338,6 +328,20 @@ EOF
   kubectl get hr -A --no-headers | wc -l > "$STATE_DIR/pre-hr-count"
   echo "Pre-upgrade HelmRelease count: $(cat "$STATE_DIR/pre-hr-count")"
 
+  # Baseline sets for post-upgrade delta comparison. In the CI sandbox these
+  # are empty (clean start); on long-lived clusters they capture pre-existing
+  # noise so we only fail on upgrade-caused regressions.
+  kubectl get hr -A --no-headers 2>/dev/null \
+    | awk '$4 != "True" {print $1"/"$2}' | sort > "$STATE_DIR/pre-hr-not-ready"
+  kubectl get pods -A --no-headers 2>/dev/null \
+    | awk '/CrashLoopBackOff/ {print $1"/"$2}' | sort > "$STATE_DIR/pre-crashloop-pods"
+  kubectl get pv --no-headers 2>/dev/null \
+    | awk '$5 != "Bound" {print $1}' | sort > "$STATE_DIR/pre-unbound-pvs"
+
+  # Pre-upgrade cozystack migration version (for post-upgrade assertion)
+  kubectl get cm cozystack-version -n cozy-system -o jsonpath='{.data.version}' \
+    > "$STATE_DIR/pre-cozystack-version" 2>/dev/null || echo "0" > "$STATE_DIR/pre-cozystack-version"
+
   # Snapshot pod state (for debugging if upgrade breaks things)
   kubectl get pods -A --no-headers > "$STATE_DIR/pre-pods"
   echo "Pre-upgrade pod count: $(wc -l < "$STATE_DIR/pre-pods")"
@@ -349,11 +353,17 @@ EOF
 
 @test "Upgrade Cozystack to current version" {
   PREV_RELEASE=$(cat "$STATE_DIR/prev-release")
-  echo "Upgrading from $PREV_RELEASE to current version"
-  echo "Operator image (current): $(yq '.cozystackOperator.image' packages/core/installer/values.yaml)"
+  local current_tag="${UPGRADE_TARGET_TAG:-}"
+  if [ -z "$current_tag" ]; then
+    current_tag=$(git describe --tags --exact-match --match 'v*' 2>/dev/null)
+  fi
+  local current_version="${current_tag#v}"
+  echo "Upgrading from $PREV_RELEASE to $current_tag (oci://ghcr.io/cozystack/cozystack/cozy-installer:${current_version})"
 
-  helm upgrade installer packages/core/installer \
-    --install \
+  # Pull the published OCI chart — same mechanism users run during upgrades
+  helm upgrade cozystack \
+    oci://ghcr.io/cozystack/cozystack/cozy-installer \
+    --version "${current_version}" \
     --namespace cozy-system \
     --wait \
     --timeout 2m
@@ -370,64 +380,97 @@ EOF
 # Phase 4: Post-upgrade validation
 # ===================================================================
 
-@test "Wait for all HelmReleases to reconcile after upgrade" {
+@test "Wait for HelmReleases to reconcile after upgrade (no new failures)" {
   # Give Flux time to detect the new package source and start reconciling
   sleep 10
 
-  # Wait for all HelmReleases to become Ready (generous timeout for full reconciliation)
   local max_wait=900  # 15 minutes
   local interval=10
   local elapsed=0
+  local pre_not_ready="$STATE_DIR/pre-hr-not-ready"
 
+  # Wait until no HRs are newly not-ready (i.e., not present in the pre-upgrade baseline)
   while [ $elapsed -lt $max_wait ]; do
-    local not_ready
-    not_ready=$(kubectl get hr -A --no-headers 2>/dev/null | grep -v " True " | wc -l)
-    if [ "$not_ready" -eq 0 ]; then
-      echo "All HelmReleases are Ready after ${elapsed}s"
+    local new_not_ready
+    new_not_ready=$(comm -23 \
+      <(kubectl get hr -A --no-headers 2>/dev/null | awk '$4 != "True" {print $1"/"$2}' | sort) \
+      "$pre_not_ready")
+    if [ -z "$new_not_ready" ]; then
+      echo "No HelmReleases newly not-ready after ${elapsed}s"
       break
     fi
-    echo "Waiting for $not_ready HelmReleases to reconcile (${elapsed}s / ${max_wait}s)..."
+    local count
+    count=$(printf '%s\n' "$new_not_ready" | grep -c . || true)
+    echo "Waiting for $count newly not-ready HelmReleases (${elapsed}s / ${max_wait}s)..."
     sleep "$interval"
     elapsed=$((elapsed + interval))
   done
 
-  # Final check: fail if any HR is still not ready
-  if kubectl get hr -A --no-headers | grep -v " True "; then
-    echo "HelmReleases still not ready after ${max_wait}s:" >&2
+  # Final check: fail only on HRs that weren't already failing pre-upgrade
+  local new_not_ready
+  new_not_ready=$(comm -23 \
+    <(kubectl get hr -A --no-headers 2>/dev/null | awk '$4 != "True" {print $1"/"$2}' | sort) \
+    "$pre_not_ready")
+  if [ -n "$new_not_ready" ]; then
+    echo "HelmReleases newly not-ready after upgrade:" >&2
+    echo "$new_not_ready" >&2
     kubectl get hr -A >&2
     exit 1
   fi
 }
 
-@test "Verify no CrashLoopBackOff pods after upgrade" {
+@test "Verify migration state after upgrade" {
+  local expected actual previous
+  # Target version from the upgraded platform chart
+  expected=$(yq '.migrations.targetVersion' packages/core/platform/values.yaml)
+  actual=$(kubectl get cm cozystack-version -n cozy-system -o jsonpath='{.data.version}')
+  previous=$(cat "$STATE_DIR/pre-cozystack-version")
+
+  echo "cozystack-version: pre=$previous post=$actual chart_target=$expected"
+
+  # Version must match what the new platform chart expects (catches silent skips / wrong image)
+  [ "$actual" = "$expected" ]
+  # Version must not regress
+  [ "$actual" -ge "$previous" ]
+
+  # If a migration was required, verify the Job completed successfully
+  if [ "$previous" -lt "$expected" ]; then
+    kubectl wait job/cozystack-migration-hook -n cozy-system \
+      --for=condition=Complete --timeout=5m
+  fi
+}
+
+@test "Verify no new CrashLoopBackOff pods after upgrade" {
   # Allow a brief settling period for pods to restart
   sleep 10
 
-  local crashloop_pods
-  crashloop_pods=$(kubectl get pods -A --no-headers 2>/dev/null \
-    | grep -i "CrashLoopBackOff" || true)
+  local new_crashloop
+  new_crashloop=$(comm -23 \
+    <(kubectl get pods -A --no-headers 2>/dev/null | awk '/CrashLoopBackOff/ {print $1"/"$2}' | sort) \
+    "$STATE_DIR/pre-crashloop-pods")
 
-  if [ -n "$crashloop_pods" ]; then
-    echo "CrashLoopBackOff pods detected after upgrade:" >&2
-    echo "$crashloop_pods" >&2
+  if [ -n "$new_crashloop" ]; then
+    echo "New CrashLoopBackOff pods detected after upgrade:" >&2
+    echo "$new_crashloop" >&2
     exit 1
   fi
 
-  echo "No CrashLoopBackOff pods found"
+  echo "No new CrashLoopBackOff pods"
 }
 
-@test "Verify all PersistentVolumes are Bound after upgrade" {
-  local unbound_pvs
-  unbound_pvs=$(kubectl get pv --no-headers 2>/dev/null \
-    | grep -v "Bound" || true)
+@test "Verify no new unbound PersistentVolumes after upgrade" {
+  local new_unbound
+  new_unbound=$(comm -23 \
+    <(kubectl get pv --no-headers 2>/dev/null | awk '$5 != "Bound" {print $1}' | sort) \
+    "$STATE_DIR/pre-unbound-pvs")
 
-  if [ -n "$unbound_pvs" ]; then
-    echo "Unbound PersistentVolumes detected after upgrade:" >&2
-    echo "$unbound_pvs" >&2
+  if [ -n "$new_unbound" ]; then
+    echo "New unbound PersistentVolumes detected after upgrade:" >&2
+    echo "$new_unbound" >&2
     exit 1
   fi
 
-  echo "All PersistentVolumes are Bound"
+  echo "No new unbound PersistentVolumes"
 }
 
 @test "Verify PostgreSQL data survived upgrade" {

--- a/packages/core/testing/Makefile
+++ b/packages/core/testing/Makefile
@@ -43,9 +43,11 @@ test-apps-%:
 	docker exec "${SANDBOX_NAME}" sh -c 'cd /workspace && hack/cozytest.sh hack/e2e-apps/$*.bats'
 
 UPGRADE_TARGET_TAG ?=
+STRICT_BASELINE ?=
 upgrade-cozystack: ## Run the upgrade test (previous minor → current version)
 	docker exec \
 		$(if $(UPGRADE_TARGET_TAG),-e UPGRADE_TARGET_TAG="$(UPGRADE_TARGET_TAG)") \
+		$(if $(STRICT_BASELINE),-e STRICT_BASELINE="$(STRICT_BASELINE)") \
 		"${SANDBOX_NAME}" sh -c 'cd /workspace && hack/cozytest.sh hack/e2e-upgrade-cozystack.bats'
 
 collect-report: ## Collect the test report from the sandbox.

--- a/packages/core/testing/Makefile
+++ b/packages/core/testing/Makefile
@@ -42,6 +42,12 @@ test-openapi:
 test-apps-%:
 	docker exec "${SANDBOX_NAME}" sh -c 'cd /workspace && hack/cozytest.sh hack/e2e-apps/$*.bats'
 
+UPGRADE_TARGET_TAG ?=
+upgrade-cozystack: ## Run the upgrade test (previous minor → current version)
+	docker exec \
+		$(if $(UPGRADE_TARGET_TAG),-e UPGRADE_TARGET_TAG="$(UPGRADE_TARGET_TAG)") \
+		"${SANDBOX_NAME}" sh -c 'cd /workspace && hack/cozytest.sh hack/e2e-upgrade-cozystack.bats'
+
 collect-report: ## Collect the test report from the sandbox.
 	docker exec "${SANDBOX_NAME}" sh -c 'cd /workspace && hack/cozyreport.sh cozyreport'
 	mkdir -p ../../../_out


### PR DESCRIPTION
## What this PR does

Adds automated upgrade testing that runs on every tag push as part of the release pipeline. Tests the most common upgrade path: **previous latest minor release → current version**.

### New files

- **`hack/e2e-upgrade-cozystack.bats`** — 15-step BATS test script covering install → workloads → upgrade → validate
- **`packages/core/testing/Makefile`** — `upgrade-cozystack` target
- **`.github/workflows/tags.yaml`** — `upgrade-test` job (runs in parallel with changelog generation)

### How it works

1. Provisions a 3-node Talos cluster (reuses existing `e2e-prepare-cluster.bats`)
2. Determines the previous stable minor release via `git tag`
3. Extracts the previous version's installer chart from the git tag (`git show`)
4. Installs previous version via `helm upgrade` (same mechanism users use)
5. Deploys PostgreSQL with 3 canary rows as test data
6. Upgrades to the current version (`helm upgrade installer packages/core/installer`)
7. Validates post-upgrade health:
   - All HelmReleases reach `Ready=True`
   - No `CrashLoopBackOff` pods
   - All PersistentVolumes remain `Bound`
   - PostgreSQL data intact (row count + value check)
   - Cozystack API available
   - Platform system pods healthy

### Design decisions

- Tests platform upgrade only (uses new Talos image, which is backwards-compatible)
- Self-contained script — doesn't depend on `e2e-install-cozystack.bats`
- Runs on `oracle-vm-24cpu-96gb-x86-64` runner with 150-minute timeout
- Always cleans up sandbox on completion/failure

### Release note

```release-note
Added automated upgrade testing to the release pipeline. Every tag push now tests upgrading from the previous minor release, validating HelmRelease reconciliation, pod health, data integrity, and API availability.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive end-to-end upgrade test suite validating minor-version upgrades, infrastructure stability, workload/data preservation, storage behavior, and post-upgrade health checks.
* **Chores**
  * New CI job runs the upgrade validation and gates changelog/website updates on its success.
* **Chores**
  * Added Makefile targets to invoke the upgrade test and a configuration tweak to CI runner recognition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->