### PR TITLE
[tests] Add BATS E2E coverage for vm-disk source.disk and source.image

### DIFF
--- a/hack/e2e-apps/vm-disk.bats
+++ b/hack/e2e-apps/vm-disk.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+# Tests for vm-disk source types: source.image and source.disk.
+# Existing source.http coverage lives in vminstance.bats.
+
+@test "Create a VM Disk from source.image (golden image clone)" {
+  name='test-image-src'
+  kubectl -n tenant-test delete vmdisks.apps.cozystack.io $name --ignore-not-found --timeout=2m || true
+  kubectl apply -f - <<EOF
+apiVersion: apps.cozystack.io/v1alpha1
+kind: VMDisk
+metadata:
+  name: $name
+  namespace: tenant-test
+spec:
+  source:
+    image:
+      name: alpine-3.21
+  optical: false
+  storage: 5Gi
+  storageClass: replicated
+EOF
+  sleep 5
+  kubectl -n tenant-test wait hr vm-disk-$name --timeout=5s --for=condition=ready
+  kubectl -n tenant-test wait dv vm-disk-$name --timeout=250s --for=condition=ready
+  kubectl -n tenant-test wait pvc vm-disk-$name --timeout=200s --for=jsonpath='{.status.phase}'=Bound
+  kubectl -n tenant-test delete vmdisks.apps.cozystack.io $name
+}
+
+@test "Create a VM Disk from source.disk (PVC clone)" {
+  base='test-disk-base'
+  clone='test-disk-clone'
+
+  # Ensure both resources are absent before starting
+  kubectl -n tenant-test delete vmdisks.apps.cozystack.io $clone --ignore-not-found --timeout=2m || true
+  kubectl -n tenant-test delete vmdisks.apps.cozystack.io $base --ignore-not-found --timeout=2m || true
+
+  # Create the base disk via source.http (fast URL re-used from vminstance.bats)
+  kubectl apply -f - <<EOF
+apiVersion: apps.cozystack.io/v1alpha1
+kind: VMDisk
+metadata:
+  name: $base
+  namespace: tenant-test
+spec:
+  source:
+    http:
+      url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
+  optical: false
+  storage: 5Gi
+  storageClass: replicated
+EOF
+  sleep 5
+  kubectl -n tenant-test wait hr vm-disk-$base --timeout=5s --for=condition=ready
+  kubectl -n tenant-test wait dv vm-disk-$base --timeout=250s --for=condition=ready
+  kubectl -n tenant-test wait pvc vm-disk-$base --timeout=200s --for=jsonpath='{.status.phase}'=Bound
+
+  # Now clone the base disk using source.disk
+  kubectl apply -f - <<EOF
+apiVersion: apps.cozystack.io/v1alpha1
+kind: VMDisk
+metadata:
+  name: $clone
+  namespace: tenant-test
+spec:
+  source:
+    disk:
+      name: $base
+  optical: false
+  storage: 5Gi
+  storageClass: replicated
+EOF
+  sleep 5
+  kubectl -n tenant-test wait hr vm-disk-$clone --timeout=5s --for=condition=ready
+  kubectl -n tenant-test wait dv vm-disk-$clone --timeout=250s --for=condition=ready
+  kubectl -n tenant-test wait pvc vm-disk-$clone --timeout=200s --for=jsonpath='{.status.phase}'=Bound
+
+  # Cleanup both
+  kubectl -n tenant-test delete vmdisks.apps.cozystack.io $clone
+  kubectl -n tenant-test delete vmdisks.apps.cozystack.io $base
+}

--- a/hack/e2e-apps/vm-disk.bats
+++ b/hack/e2e-apps/vm-disk.bats
@@ -3,6 +3,10 @@
 # Tests for vm-disk source types: source.image and source.disk.
 # Existing source.http coverage lives in vminstance.bats.
 
+teardown() {
+  kubectl -n tenant-test delete vmdisks.apps.cozystack.io test-image-src test-disk-clone test-disk-base --ignore-not-found --timeout=2m || true
+}
+
 @test "Create a VM Disk from source.image (golden image clone)" {
   name='test-image-src'
   kubectl -n tenant-test delete vmdisks.apps.cozystack.io $name --ignore-not-found --timeout=2m || true
@@ -21,10 +25,9 @@ spec:
   storageClass: replicated
 EOF
   sleep 5
-  kubectl -n tenant-test wait hr vm-disk-$name --timeout=5s --for=condition=ready
+  kubectl -n tenant-test wait hr vm-disk-$name --timeout=30s --for=condition=ready
   kubectl -n tenant-test wait dv vm-disk-$name --timeout=250s --for=condition=ready
   kubectl -n tenant-test wait pvc vm-disk-$name --timeout=200s --for=jsonpath='{.status.phase}'=Bound
-  kubectl -n tenant-test delete vmdisks.apps.cozystack.io $name
 }
 
 @test "Create a VM Disk from source.disk (PVC clone)" {
@@ -35,8 +38,8 @@ EOF
   kubectl -n tenant-test delete vmdisks.apps.cozystack.io $clone --ignore-not-found --timeout=2m || true
   kubectl -n tenant-test delete vmdisks.apps.cozystack.io $base --ignore-not-found --timeout=2m || true
 
-  # Create the base disk via source.http. Alpine is ~50MB vs Ubuntu noble's ~600MB,
-  # which keeps this test fast; the assertion here is the clone step, not the HTTP import.
+  # Create the base disk from a golden image. The assertion here is the clone
+  # step (source.disk), not the base provisioning method.
   kubectl apply -f - <<EOF
 apiVersion: apps.cozystack.io/v1alpha1
 kind: VMDisk
@@ -45,14 +48,14 @@ metadata:
   namespace: tenant-test
 spec:
   source:
-    http:
-      url: https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/cloud/nocloud_alpine-3.21.6-x86_64-bios-cloudinit-r0.qcow2
+    image:
+      name: alpine-3.21
   optical: false
   storage: 5Gi
   storageClass: replicated
 EOF
   sleep 5
-  kubectl -n tenant-test wait hr vm-disk-$base --timeout=5s --for=condition=ready
+  kubectl -n tenant-test wait hr vm-disk-$base --timeout=30s --for=condition=ready
   kubectl -n tenant-test wait dv vm-disk-$base --timeout=250s --for=condition=ready
   kubectl -n tenant-test wait pvc vm-disk-$base --timeout=200s --for=jsonpath='{.status.phase}'=Bound
 
@@ -72,11 +75,7 @@ spec:
   storageClass: replicated
 EOF
   sleep 5
-  kubectl -n tenant-test wait hr vm-disk-$clone --timeout=5s --for=condition=ready
+  kubectl -n tenant-test wait hr vm-disk-$clone --timeout=30s --for=condition=ready
   kubectl -n tenant-test wait dv vm-disk-$clone --timeout=250s --for=condition=ready
   kubectl -n tenant-test wait pvc vm-disk-$clone --timeout=200s --for=jsonpath='{.status.phase}'=Bound
-
-  # Cleanup both
-  kubectl -n tenant-test delete vmdisks.apps.cozystack.io $clone
-  kubectl -n tenant-test delete vmdisks.apps.cozystack.io $base
 }

--- a/hack/e2e-apps/vm-disk.bats
+++ b/hack/e2e-apps/vm-disk.bats
@@ -35,7 +35,8 @@ EOF
   kubectl -n tenant-test delete vmdisks.apps.cozystack.io $clone --ignore-not-found --timeout=2m || true
   kubectl -n tenant-test delete vmdisks.apps.cozystack.io $base --ignore-not-found --timeout=2m || true
 
-  # Create the base disk via source.http (fast URL re-used from vminstance.bats)
+  # Create the base disk via source.http. Alpine is ~50MB vs Ubuntu noble's ~600MB,
+  # which keeps this test fast; the assertion here is the clone step, not the HTTP import.
   kubectl apply -f - <<EOF
 apiVersion: apps.cozystack.io/v1alpha1
 kind: VMDisk
@@ -45,7 +46,7 @@ metadata:
 spec:
   source:
     http:
-      url: https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
+      url: https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/cloud/nocloud_alpine-3.21.6-x86_64-bios-cloudinit-r0.qcow2
   optical: false
   storage: 5Gi
   storageClass: replicated


### PR DESCRIPTION
## What this PR does

Follow-up to #2258 per @lexfrei's non-blocking review comment: adds BATS E2E coverage for the new vm-disk `source.disk` and `source.image` clone paths. Existing coverage only exercised `source.http` (in `vminstance.bats`).

New file: `hack/e2e-apps/vm-disk.bats` with two `@test` cases:

- **`source.image`** — creates a VMDisk cloning from the `alpine-3.21` golden image in `cozy-public` (smallest image in the default collection), waits for the DataVolume to reach `Succeeded` and the PVC to be `Bound`, then cleans up.
- **`source.disk`** — first creates a base disk via `source.http`, waits for it to be ready, then creates a clone via `source.disk`, waits for the clone DV and PVC, and cleans up both.

The file passes the `cozytest.sh` awk-transform + `bash -n` syntax check. Full E2E requires a cluster and was not run locally.

### Release note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for VMDisk provisioning: image-based disk creation (golden image) and disk cloning from an existing PVC.
  * Tests validate readiness of associated resources and that the created PVCs reach a Bound state.
  * Includes automated test cleanup to remove created test artifacts after execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->