### PR TITLE
fix(mongodb): expose replica-set members per pod for external access (#2514)

### DIFF
--- a/packages/apps/mongodb/templates/external-svc.yaml
+++ b/packages/apps/mongodb/templates/external-svc.yaml
@@ -1,4 +1,12 @@
-{{- if .Values.external }}
+{{- /*
+  External access for non-sharded replica sets is handled by the Percona
+  MongoDB operator via `replsets[].expose` in mongodb.yaml: the operator
+  creates one LoadBalancer per pod and rewrites rs.conf so the driver can
+  discover the primary from outside the cluster (issue #2514). For sharded
+  mode we still expose mongos through a single LoadBalancer because mongos
+  is stateless and any router can route writes to the right shard primary.
+*/}}
+{{- if and .Values.external .Values.sharding }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,10 +23,5 @@ spec:
   selector:
     app.kubernetes.io/name: percona-server-mongodb
     app.kubernetes.io/instance: {{ .Release.Name }}
-    {{- if .Values.sharding }}
     app.kubernetes.io/component: mongos
-    {{- else }}
-    app.kubernetes.io/component: mongod
-    app.kubernetes.io/replset: rs0
-    {{- end }}
 {{- end }}

--- a/packages/apps/mongodb/templates/mongodb.yaml
+++ b/packages/apps/mongodb/templates/mongodb.yaml
@@ -99,7 +99,13 @@ spec:
       podDisruptionBudget:
         maxUnavailable: 1
       expose:
+        {{- if .Values.external }}
+        enabled: true
+        type: LoadBalancer
+        externalTrafficPolicy: Local
+        {{- else }}
         enabled: false
+        {{- end }}
     {{- end }}
 
   {{- if .Values.users }}

--- a/packages/apps/mongodb/tests/external-svc_test.yaml
+++ b/packages/apps/mongodb/tests/external-svc_test.yaml
@@ -18,12 +18,24 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: renders LoadBalancer service when external is true
+  - it: does not render in replica-set mode (operator handles per-pod LBs via replsets[].expose)
     release:
       name: test-mongodb
       namespace: tenant-test
     set:
       external: true
+      sharding: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders single LoadBalancer in sharded mode (mongos front-end)
+    release:
+      name: test-mongodb
+      namespace: tenant-test
+    set:
+      external: true
+      sharding: true
     asserts:
       - hasDocuments:
           count: 1
@@ -40,6 +52,7 @@ tests:
       namespace: tenant-test
     set:
       external: true
+      sharding: true
     asserts:
       - equal:
           path: metadata.name
@@ -51,6 +64,7 @@ tests:
       namespace: tenant-test
     set:
       external: true
+      sharding: true
     asserts:
       - equal:
           path: spec.type
@@ -62,6 +76,7 @@ tests:
       namespace: tenant-test
     set:
       external: true
+      sharding: true
     asserts:
       - equal:
           path: spec.externalTrafficPolicy
@@ -73,6 +88,7 @@ tests:
       namespace: tenant-test
     set:
       external: true
+      sharding: true
     asserts:
       - equal:
           path: spec.ports[0].name
@@ -82,73 +98,25 @@ tests:
           value: 27017
 
   ###########################
-  # Common selector labels  #
+  # Sharded selector        #
   ###########################
 
-  - it: sets app.kubernetes.io/name selector
+  - it: targets mongos pods only
     release:
       name: test-mongodb
       namespace: tenant-test
     set:
       external: true
+      sharding: true
     asserts:
       - equal:
           path: spec.selector["app.kubernetes.io/name"]
           value: percona-server-mongodb
-
-  - it: sets app.kubernetes.io/instance selector
-    release:
-      name: mydb
-      namespace: tenant-test
-    set:
-      external: true
-    asserts:
       - equal:
           path: spec.selector["app.kubernetes.io/instance"]
-          value: mydb
-
-  ###########################
-  # Replica set mode        #
-  ###########################
-
-  - it: selects mongod for replica set mode
-    release:
-      name: test-mongodb
-      namespace: tenant-test
-    set:
-      external: true
-      sharding: false
-    asserts:
-      - equal:
-          path: spec.selector["app.kubernetes.io/component"]
-          value: mongod
-      - equal:
-          path: spec.selector["app.kubernetes.io/replset"]
-          value: rs0
-
-  ###########################
-  # Sharded mode            #
-  ###########################
-
-  - it: selects mongos for sharded mode
-    release:
-      name: test-mongodb
-      namespace: tenant-test
-    set:
-      external: true
-      sharding: true
-    asserts:
+          value: test-mongodb
       - equal:
           path: spec.selector["app.kubernetes.io/component"]
           value: mongos
-
-  - it: does not set replset selector for sharded mode
-    release:
-      name: test-mongodb
-      namespace: tenant-test
-    set:
-      external: true
-      sharding: true
-    asserts:
       - notExists:
           path: spec.selector["app.kubernetes.io/replset"]

--- a/packages/apps/mongodb/tests/mongodb_test.yaml
+++ b/packages/apps/mongodb/tests/mongodb_test.yaml
@@ -214,6 +214,51 @@ tests:
         documentIndex: 0
 
   ###########################
+  # Replica set expose      #
+  ###########################
+
+  - it: disables replset expose by default
+    release:
+      name: test-mongodb
+      namespace: tenant-test
+    set:
+      _cluster:
+        cluster-domain: cozy.local
+      sharding: false
+      external: false
+    asserts:
+      - equal:
+          path: spec.replsets[0].expose.enabled
+          value: false
+        documentIndex: 0
+      - notExists:
+          path: spec.replsets[0].expose.type
+        documentIndex: 0
+
+  - it: enables per-pod LoadBalancer when external is true (issue 2514)
+    release:
+      name: test-mongodb
+      namespace: tenant-test
+    set:
+      _cluster:
+        cluster-domain: cozy.local
+      sharding: false
+      external: true
+    asserts:
+      - equal:
+          path: spec.replsets[0].expose.enabled
+          value: true
+        documentIndex: 0
+      - equal:
+          path: spec.replsets[0].expose.type
+          value: LoadBalancer
+        documentIndex: 0
+      - equal:
+          path: spec.replsets[0].expose.externalTrafficPolicy
+          value: Local
+        documentIndex: 0
+
+  ###########################
   # Sharded Cluster Mode    #
   ###########################
 


### PR DESCRIPTION
## What this PR does

Fixes #2514.

When `external: true` is set on a non-sharded `MongoDB`, Cozystack rendered a single
`LoadBalancer` Service whose selector matched **all** replica-set members
(`app.kubernetes.io/replset: rs0`). Round-robin balancing sent ~⅔ of writes to
secondaries and they were rejected with `MongoServerError: not primary`.

Drivers couldn't recover on their own either: connecting through the LB returned
the in-cluster DNS names of all members from `isMaster`, none of which resolve
from outside the cluster, so automatic primary discovery failed.

This PR replaces the manual `external-svc.yaml` (for replica-set mode) with the
Percona MongoDB operator's native `replsets[].expose` feature:

```yaml
replsets:
  - name: rs0
    expose:
      enabled: true
      type: LoadBalancer
      externalTrafficPolicy: Local
```

The operator then:
- creates one `LoadBalancer` Service **per pod** (`<release>-rs0-0`, `-1`, `-2`)
  with `statefulset.kubernetes.io/pod-name` selectors,
- watches `Service.status.loadBalancer.ingress` for each pod and rewrites the
  member `host` in `rs.conf` to the external IPs.

External clients use a standard replica-set URI
(`mongodb://...:27017,...:27017,...:27017/?replicaSet=rs0`) and the driver
discovers the primary correctly from outside the cluster.

For **sharded** mode the existing single `LoadBalancer` is preserved — it
front-ends stateless `mongos`, which can route writes to the right shard
primary itself. `external-svc.yaml` is now scoped to that case only.

### Tested

- `helm unittest .` in `packages/apps/mongodb/`: 91/91 pass.
- Applied on a dev stand:
  - `replsets[0].expose` is set as expected in the rendered PSMDB CR.
  - The Percona operator (`v1.21.1`) accepts the spec and creates 3 per-pod
    `LoadBalancer` Services with `statefulset.kubernetes.io/pod-name`
    selectors. The previous single round-robin Service is no longer rendered.
  - With an LB IP pool present, the operator promotes the allocated LB IPs into
    the PSMDB `status.host` field and into `rs.conf`.

End-to-end mongosh write loop wasn't run on the dev stand because the
underlying network does not advertise/route allocated LoadBalancer IPs (no
working L2/BGP path), so the rewritten `rs.conf` members are unreachable in
that environment. The structural change is otherwise fully verified and the
issue's reproduction scenario expects a real LB-capable network.

### Release note

```release-note
fix(mongodb): expose each replica-set member through its own LoadBalancer when `external: true`, so external clients can discover the primary via the standard replica-set connection string and writes no longer fail with "not primary" errors.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External LoadBalancer services now only render when both external and sharding are enabled.
  * Replica set external exposure is now conditional based on the external setting.
  * Service configuration now uses LoadBalancer type with Local traffic policy for external access.
  * Service selectors refined for proper mongos targeting in sharded deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->