### PR TITLE
fix(mongodb): reclaim PVCs and operator secrets on uninstall

### DIFF
--- a/packages/apps/mongodb/README.md
+++ b/packages/apps/mongodb/README.md
@@ -37,10 +37,11 @@ Run `helm upgrade` after MongoDB is ready to populate the credentials secret wit
 
 ### Data lifecycle
 
-When the MongoDB release is uninstalled, the operator reclaims:
+When the MongoDB release is uninstalled, all storage and credentials are reclaimed:
 
 - All PVCs backing the replica set storage (via the `percona.com/delete-psmdb-pvc` finalizer on the `PerconaServerMongoDB` CR).
-- Operator-managed user secrets associated with the cluster.
+- Internal operator-managed secrets (e.g. `internal-<release>-users`) are deleted as part of the same finalizer flow.
+- Helm-managed secrets (`<release>-credentials`, `<release>-user-*`, `<release>-s3-creds`) are removed by the standard `helm uninstall`.
 
 If you need to retain data, take a backup before deletion. Refer to the [Percona Operator for MongoDB documentation](https://docs.percona.com/percona-operator-for-mongodb/) for backup/restore workflows.
 

--- a/packages/apps/mongodb/README.md
+++ b/packages/apps/mongodb/README.md
@@ -35,6 +35,15 @@ When `external: true` is enabled:
 On first install, the credentials secret will be empty until the Percona operator initializes the cluster.
 Run `helm upgrade` after MongoDB is ready to populate the credentials secret with the actual password.
 
+### Data lifecycle
+
+When the MongoDB release is uninstalled, the operator reclaims:
+
+- All PVCs backing the replica set storage (via the `percona.com/delete-psmdb-pvc` finalizer on the `PerconaServerMongoDB` CR).
+- Operator-managed user secrets associated with the cluster.
+
+If you need to retain data, take a backup before deletion. Refer to the [Percona Operator for MongoDB documentation](https://docs.percona.com/percona-operator-for-mongodb/) for backup/restore workflows.
+
 ## Parameters
 
 ### Common parameters

--- a/packages/apps/mongodb/README.md
+++ b/packages/apps/mongodb/README.md
@@ -37,18 +37,36 @@ Run `helm upgrade` after MongoDB is ready to populate the credentials secret wit
 
 ### Data lifecycle
 
-When the MongoDB release is uninstalled, all storage and credentials are reclaimed:
+When the MongoDB release is uninstalled, the operator finalizers reclaim release-scoped resources:
 
-- All PVCs backing the replica set storage (via the `percona.com/delete-psmdb-pvc` finalizer on the `PerconaServerMongoDB` CR).
-- Operator-managed secrets deleted as part of the same finalizer flow:
+**Reclaimed by the `percona.com/delete-psmdb-pvc` finalizer:**
+
+- All PVCs backing the replica set storage. Whether the underlying PersistentVolume and on-disk data are actually deleted depends on the StorageClass `reclaimPolicy` (`Delete` removes them, `Retain` leaves them for manual cleanup).
+- Operator-managed secrets:
+  - `<release>-percona-server-mongodb-users` — operator users credentials
   - `internal-<release>` — internal operator state
-  - `internal-<release>-users` — operator-managed user credentials
+  - `internal-<release>-users` — operator-internal users data
   - `<release>-mongodb-encryption-key` — at-rest encryption key
-  - `percona-server-mongodb-users` — global operator users secret (shared default name; if a tenant has a Secret with this exact name in the namespace, it will also be deleted)
-- Helm-managed secrets removed by the standard `helm uninstall`:
-  - `<release>-credentials` — connection string for application code
-  - `<release>-user-<username>` — per-user passwords
-  - `<release>-s3-creds` — backup destination credentials (if backups are configured)
+
+**Reclaimed by `helm uninstall`:**
+
+- `<release>-credentials` — connection string for application code
+- `<release>-user-<username>` — per-user passwords
+- `<release>-s3-creds` — backup destination credentials (if backups are configured)
+
+**Not reclaimed automatically:**
+
+- TLS secrets `<release>-ssl` and `<release>-ssl-internal` (issued by cert-manager) remain in the namespace after uninstall. Delete them manually if no longer needed.
+
+**Recovery from a stuck deletion:**
+
+If the `psmdb-operator` is uninstalled before MongoDB CRs are deleted, the finalizers cannot run and the `PerconaServerMongoDB` CR hangs in `Terminating`. To recover, clear the finalizers manually:
+
+```bash
+kubectl --namespace <namespace> patch psmdb <release> --type merge --patch '{"metadata":{"finalizers":[]}}'
+```
+
+Note that this skips the operator-driven cleanup — PVCs and operator-managed secrets will remain orphaned and must be removed manually.
 
 If you need to retain data, take a backup before deletion. Refer to the [Percona Operator for MongoDB documentation](https://docs.percona.com/percona-operator-for-mongodb/) for backup/restore workflows.
 

--- a/packages/apps/mongodb/README.md
+++ b/packages/apps/mongodb/README.md
@@ -70,6 +70,33 @@ Note that this skips the operator-driven cleanup — PVCs and operator-managed s
 
 If you need to retain data, take a backup before deletion. Refer to the [Percona Operator for MongoDB documentation](https://docs.percona.com/percona-operator-for-mongodb/) for backup/restore workflows.
 
+### Upgrading from earlier versions
+
+Earlier versions of this chart referenced a namespace-shared system users secret (`percona-server-mongodb-users`). Upgrading to a release that scopes this secret per CR (`<release>-percona-server-mongodb-users`) triggers a password rotation for the operator-managed system users. The rotation is performed in place by the Percona operator via `db.changeUserPassword()` against the running mongod (operator log: `Secret data changed. Updating users...`); pods are not restarted and the cluster stays available.
+
+**Rotated automatically on upgrade:**
+
+- The five operator-managed system accounts: `databaseAdmin`, `userAdmin`, `backup`, `clusterAdmin`, `clusterMonitor`.
+- Secret `<release>-percona-server-mongodb-users` (newly created, per-CR) and `internal-<release>-users` receive the new values.
+- Secret `<release>-credentials` is regenerated; its `password` and `uri` keys reflect the new `databaseAdmin` password.
+
+**Not affected:**
+
+- Custom users defined under `users:` in chart values. Their `<release>-user-<name>` secrets are not touched.
+- The at-rest encryption key (`<release>-mongodb-encryption-key`) and replica set keyfile (`<release>-mongodb-keyfile`) are unchanged, so on-disk data remains readable.
+
+**Action required after upgrade:**
+
+Workloads that mount `<release>-credentials` keep using the cached old password until they re-read the secret. Restart those pods, or run a controller such as [Reloader](https://github.com/stakater/Reloader) to roll them automatically. Without this, application connections fail with authentication errors once their existing sessions expire.
+
+**Orphaned legacy secret:**
+
+The previous namespace-shared secret `percona-server-mongodb-users` is no longer referenced by any MongoDB CR after upgrade, but the operator does not garbage-collect it. If multiple MongoDB releases in the same namespace previously shared it, all of them rotate to their own per-CR secrets — passwords are no longer shared across CRs in the namespace, which is the intended outcome. Confirm no other consumers reference it, then remove it manually:
+
+```bash
+kubectl --namespace <namespace> delete secret percona-server-mongodb-users
+```
+
 ## Parameters
 
 ### Common parameters

--- a/packages/apps/mongodb/README.md
+++ b/packages/apps/mongodb/README.md
@@ -40,8 +40,15 @@ Run `helm upgrade` after MongoDB is ready to populate the credentials secret wit
 When the MongoDB release is uninstalled, all storage and credentials are reclaimed:
 
 - All PVCs backing the replica set storage (via the `percona.com/delete-psmdb-pvc` finalizer on the `PerconaServerMongoDB` CR).
-- Internal operator-managed secrets (e.g. `internal-<release>-users`) are deleted as part of the same finalizer flow.
-- Helm-managed secrets (`<release>-credentials`, `<release>-user-*`, `<release>-s3-creds`) are removed by the standard `helm uninstall`.
+- Operator-managed secrets deleted as part of the same finalizer flow:
+  - `internal-<release>` — internal operator state
+  - `internal-<release>-users` — operator-managed user credentials
+  - `<release>-mongodb-encryption-key` — at-rest encryption key
+  - `percona-server-mongodb-users` — global operator users secret (shared default name; if a tenant has a Secret with this exact name in the namespace, it will also be deleted)
+- Helm-managed secrets removed by the standard `helm uninstall`:
+  - `<release>-credentials` — connection string for application code
+  - `<release>-user-<username>` — per-user passwords
+  - `<release>-s3-creds` — backup destination credentials (if backups are configured)
 
 If you need to retain data, take a backup before deletion. Refer to the [Percona Operator for MongoDB documentation](https://docs.percona.com/percona-operator-for-mongodb/) for backup/restore workflows.
 

--- a/packages/apps/mongodb/templates/mongodb.yaml
+++ b/packages/apps/mongodb/templates/mongodb.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   crVersion: 1.21.1
   clusterServiceDNSSuffix: svc.{{ $clusterDomain }}
+  secrets:
+    users: {{ .Release.Name }}-percona-server-mongodb-users
   pause: false
   unmanaged: false
   image: percona/percona-server-mongodb:{{ include "mongodb.versionMap" $ }}

--- a/packages/apps/mongodb/templates/mongodb.yaml
+++ b/packages/apps/mongodb/templates/mongodb.yaml
@@ -5,6 +5,7 @@ kind: PerconaServerMongoDB
 metadata:
   name: {{ .Release.Name }}
   finalizers:
+    - percona.com/delete-psmdb-pods-in-order
     - percona.com/delete-psmdb-pvc
 spec:
   crVersion: 1.21.1

--- a/packages/apps/mongodb/templates/mongodb.yaml
+++ b/packages/apps/mongodb/templates/mongodb.yaml
@@ -4,6 +4,8 @@ apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB
 metadata:
   name: {{ .Release.Name }}
+  finalizers:
+    - percona.com/delete-psmdb-pvc
 spec:
   crVersion: 1.21.1
   clusterServiceDNSSuffix: svc.{{ $clusterDomain }}

--- a/packages/apps/mongodb/tests/mongodb_test.yaml
+++ b/packages/apps/mongodb/tests/mongodb_test.yaml
@@ -39,6 +39,23 @@ tests:
         documentIndex: 0
 
   ##################
+  # Finalizers     #
+  ##################
+
+  - it: sets delete-psmdb-pvc finalizer for automatic PVC cleanup
+    release:
+      name: test-mongodb
+      namespace: tenant-test
+    set:
+      _cluster:
+        cluster-domain: cozy.local
+    asserts:
+      - contains:
+          path: metadata.finalizers
+          content: percona.com/delete-psmdb-pvc
+        documentIndex: 0
+
+  ##################
   # CR Version     #
   ##################
 

--- a/packages/apps/mongodb/tests/mongodb_test.yaml
+++ b/packages/apps/mongodb/tests/mongodb_test.yaml
@@ -42,7 +42,7 @@ tests:
   # Finalizers     #
   ##################
 
-  - it: sets delete-psmdb-pvc finalizer for automatic PVC cleanup
+  - it: renders percona.com/delete-psmdb-pvc finalizer on PSMDB CR
     release:
       name: test-mongodb
       namespace: tenant-test
@@ -53,6 +53,11 @@ tests:
       - contains:
           path: metadata.finalizers
           content: percona.com/delete-psmdb-pvc
+        documentIndex: 0
+      - equal:
+          path: metadata.finalizers
+          value:
+            - percona.com/delete-psmdb-pvc
         documentIndex: 0
 
   ##################

--- a/packages/apps/mongodb/tests/mongodb_test.yaml
+++ b/packages/apps/mongodb/tests/mongodb_test.yaml
@@ -54,6 +54,10 @@ tests:
           path: metadata.finalizers
           content: percona.com/delete-psmdb-pvc
         documentIndex: 0
+      - contains:
+          path: metadata.finalizers
+          content: percona.com/delete-psmdb-pods-in-order
+        documentIndex: 0
 
   - it: renders percona.com/delete-psmdb-pvc finalizer in sharded mode
     release:
@@ -75,6 +79,10 @@ tests:
       - contains:
           path: metadata.finalizers
           content: percona.com/delete-psmdb-pvc
+        documentIndex: 0
+      - contains:
+          path: metadata.finalizers
+          content: percona.com/delete-psmdb-pods-in-order
         documentIndex: 0
 
   ##################

--- a/packages/apps/mongodb/tests/mongodb_test.yaml
+++ b/packages/apps/mongodb/tests/mongodb_test.yaml
@@ -86,6 +86,23 @@ tests:
         documentIndex: 0
 
   ##################
+  # Secrets        #
+  ##################
+
+  - it: scopes users secret name to the release for namespace isolation
+    release:
+      name: test-mongodb
+      namespace: tenant-test
+    set:
+      _cluster:
+        cluster-domain: cozy.local
+    asserts:
+      - equal:
+          path: spec.secrets.users
+          value: test-mongodb-percona-server-mongodb-users
+        documentIndex: 0
+
+  ##################
   # CR Version     #
   ##################
 

--- a/packages/apps/mongodb/tests/mongodb_test.yaml
+++ b/packages/apps/mongodb/tests/mongodb_test.yaml
@@ -42,7 +42,7 @@ tests:
   # Finalizers     #
   ##################
 
-  - it: renders percona.com/delete-psmdb-pvc finalizer on PSMDB CR
+  - it: renders Percona finalizers on PSMDB CR
     release:
       name: test-mongodb
       namespace: tenant-test
@@ -59,7 +59,7 @@ tests:
           content: percona.com/delete-psmdb-pods-in-order
         documentIndex: 0
 
-  - it: renders percona.com/delete-psmdb-pvc finalizer in sharded mode
+  - it: renders Percona finalizers in sharded mode
     release:
       name: test-mongodb
       namespace: tenant-test

--- a/packages/apps/mongodb/tests/mongodb_test.yaml
+++ b/packages/apps/mongodb/tests/mongodb_test.yaml
@@ -54,10 +54,27 @@ tests:
           path: metadata.finalizers
           content: percona.com/delete-psmdb-pvc
         documentIndex: 0
-      - equal:
+
+  - it: renders percona.com/delete-psmdb-pvc finalizer in sharded mode
+    release:
+      name: test-mongodb
+      namespace: tenant-test
+    set:
+      _cluster:
+        cluster-domain: cozy.local
+      sharding: true
+      shardingConfig:
+        configServers: 3
+        configServerSize: 3Gi
+        mongos: 2
+        shards:
+          - name: rs0
+            replicas: 3
+            size: 10Gi
+    asserts:
+      - contains:
           path: metadata.finalizers
-          value:
-            - percona.com/delete-psmdb-pvc
+          content: percona.com/delete-psmdb-pvc
         documentIndex: 0
 
   ##################


### PR DESCRIPTION
## What this PR does

Adds the upstream Percona finalizer pair to the `PerconaServerMongoDB` custom resource so the operator performs an ordered shutdown and reclaims persistent storage when a MongoDB release is uninstalled. Previously, deleting a MongoDB application left PVCs and operator-managed secrets orphaned in the tenant namespace, requiring manual cleanup before the same release name could be reused.

The finalizers added on the CR:

- `percona.com/delete-psmdb-pods-in-order` — ensures the primary is shut down last for graceful cluster termination.
- `percona.com/delete-psmdb-pvc` — instructs the operator to delete PVCs and operator-managed secrets when the CR is removed.

Coverage applies to all replica sets in both replicaset and sharded modes, including the config server in sharded deployments.

### Behavior change

Users who previously relied on orphaned PVCs as an implicit "soft delete" for data recovery should be aware that uninstalling a MongoDB release now removes the underlying storage and operator-managed credentials. The README's new "Data lifecycle" section enumerates exactly which resources are reclaimed by the operator versus by the standard `helm uninstall`. Take a backup before deletion if data retention is required.

This resolves cozystack/cozystack#2513.

### Screenshots

Not applicable — no UI changes.

### Release note

```release-note
fix(mongodb): reclaim PVCs and operator-managed secrets on uninstall via Percona finalizers.

WARNING: upgrading scopes the admin credentials secret per release instead of the namespace-shared default. This triggers an in-place rotation of the five operator-managed admin passwords on first reconcile. Pods are not restarted; application user passwords are unaffected. Workloads consuming `<release>-credentials` must be restarted to pick up the new admin passwords.
```

### Out of scope / follow-up

- Bats integration test would require a live cluster with the Percona MongoDB operator and belongs in the `hack/e2e-*.bats` family — left as a follow-up.
- Issue #2513 mentions considering similar treatment for PostgreSQL/MariaDB/Redis/ClickHouse. Each operator has a different cleanup mechanism; that work is intentionally out of scope here and should be tracked per-app.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded uninstall and upgrade guidance: which secrets/pvc remain, cert-manager TLS secrets must be deleted manually, remediation for orphaned legacy secret, and recovery steps for stuck deletions when the operator is removed before CRs.

* **New Features**
  * Added deletion finalizers to enforce controlled teardown.
  * User credentials secret now uses a deterministic, release-scoped name.

* **Tests**
  * Added chart tests for finalizer behavior (sharded/non‑sharded) and release-scoped users secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->