### PR TITLE
fix(harbor): drive bucket-secret.yaml from values, gate HR on BucketInfo

### DIFF
--- a/packages/apps/harbor/templates/harbor.yaml
+++ b/packages/apps/harbor/templates/harbor.yaml
@@ -65,9 +65,15 @@ spec:
     name: {{ .Release.Name }}-credentials
     valuesKey: redis-password
     targetPath: harbor.redis.external.password
+  # BucketInfo is populated by the COSI BucketAccess controller. Sourcing it via
+  # valuesFrom both gates reconciliation on the Secret being ready and forces a
+  # config-digest change (and thus a helm upgrade) when its contents change —
+  # Flux HR dependsOn cannot reference COSI resources directly.
+  - kind: Secret
+    name: {{ .Release.Name }}-registry-bucket
+    valuesKey: BucketInfo
+    targetPath: bucket.bucketInfo
   values:
-    bucket:
-      secretName: {{ .Release.Name }}-registry-bucket
     db:
       replicas: {{ .Values.database.replicas }}
       size: {{ .Values.database.size }}

--- a/packages/apps/harbor/templates/harbor.yaml
+++ b/packages/apps/harbor/templates/harbor.yaml
@@ -65,14 +65,14 @@ spec:
     name: {{ .Release.Name }}-credentials
     valuesKey: redis-password
     targetPath: harbor.redis.external.password
-  # BucketInfo is populated by the COSI BucketAccess controller. Sourcing it via
-  # valuesFrom both gates reconciliation on the Secret being ready and forces a
-  # config-digest change (and thus a helm upgrade) when its contents change —
-  # Flux HR dependsOn cannot reference COSI resources directly.
+  # BucketInfo is the JSON blob populated by the COSI BucketAccess controller.
+  # Merge it at the values root (no targetPath) so Flux unmarshals it as YAML
+  # instead of running it through Helm's strvals parser, which would split the
+  # JSON on commas. This also gates reconciliation on the Secret being ready and
+  # forces a config-digest change when its contents change.
   - kind: Secret
     name: {{ .Release.Name }}-registry-bucket
     valuesKey: BucketInfo
-    targetPath: bucket.bucketInfo
   values:
     db:
       replicas: {{ .Values.database.replicas }}

--- a/packages/system/harbor/Makefile
+++ b/packages/system/harbor/Makefile
@@ -3,6 +3,9 @@ export NAMESPACE=cozy-system
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	helm repo add harbor https://helm.goharbor.io

--- a/packages/system/harbor/templates/bucket-secret.yaml
+++ b/packages/system/harbor/templates/bucket-secret.yaml
@@ -1,6 +1,7 @@
 {{- /* COSI BucketInfo is merged at the values root via Flux valuesFrom (no targetPath). */ -}}
 {{- with .Values.spec }}
 {{- with .secretS3 }}
+{{- if and .accessKeyID .accessSecretKey .endpoint $.Values.spec.bucketName }}
 ---
 apiVersion: v1
 kind: Secret
@@ -8,10 +9,11 @@ metadata:
   name: {{ $.Values.harbor.fullnameOverride }}-registry-s3
 type: Opaque
 stringData:
-  REGISTRY_STORAGE_S3_ACCESSKEY: {{ index . "accessKeyID" | quote }}
-  REGISTRY_STORAGE_S3_SECRETKEY: {{ index . "accessSecretKey" | quote }}
-  REGISTRY_STORAGE_S3_REGIONENDPOINT: {{ index . "endpoint" | quote }}
+  REGISTRY_STORAGE_S3_ACCESSKEY: {{ .accessKeyID | quote }}
+  REGISTRY_STORAGE_S3_SECRETKEY: {{ .accessSecretKey | quote }}
+  REGISTRY_STORAGE_S3_REGIONENDPOINT: {{ .endpoint | quote }}
   REGISTRY_STORAGE_S3_BUCKET: {{ $.Values.spec.bucketName | quote }}
   REGISTRY_STORAGE_S3_REGION: "us-east-1"
+{{- end }}
 {{- end }}
 {{- end }}

--- a/packages/system/harbor/templates/bucket-secret.yaml
+++ b/packages/system/harbor/templates/bucket-secret.yaml
@@ -1,10 +1,11 @@
-{{- if .Values.bucket.secretName }}
-{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace .Values.bucket.secretName }}
-{{- $bucketInfo := fromJson (b64dec (index $existingSecret.data "BucketInfo")) }}
-{{- $accessKeyID := index $bucketInfo.spec.secretS3 "accessKeyID" }}
-{{- $accessSecretKey := index $bucketInfo.spec.secretS3 "accessSecretKey" }}
-{{- $endpoint := index $bucketInfo.spec.secretS3 "endpoint" }}
-{{- $bucketName := $bucketInfo.spec.bucketName }}
+{{- if .Values.bucket.bucketInfo }}
+{{- $bucketInfo := fromJson .Values.bucket.bucketInfo }}
+{{- $secretS3 := dig "spec" "secretS3" dict $bucketInfo }}
+{{- if $secretS3 }}
+{{- $accessKeyID := index $secretS3 "accessKeyID" }}
+{{- $accessSecretKey := index $secretS3 "accessSecretKey" }}
+{{- $endpoint := index $secretS3 "endpoint" }}
+{{- $bucketName := dig "spec" "bucketName" "" $bucketInfo }}
 ---
 apiVersion: v1
 kind: Secret
@@ -17,4 +18,5 @@ stringData:
   REGISTRY_STORAGE_S3_REGIONENDPOINT: {{ $endpoint | quote }}
   REGISTRY_STORAGE_S3_BUCKET: {{ $bucketName | quote }}
   REGISTRY_STORAGE_S3_REGION: "us-east-1"
+{{- end }}
 {{- end }}

--- a/packages/system/harbor/templates/bucket-secret.yaml
+++ b/packages/system/harbor/templates/bucket-secret.yaml
@@ -1,22 +1,17 @@
-{{- if .Values.bucket.bucketInfo }}
-{{- $bucketInfo := fromJson .Values.bucket.bucketInfo }}
-{{- $secretS3 := dig "spec" "secretS3" dict $bucketInfo }}
-{{- if $secretS3 }}
-{{- $accessKeyID := index $secretS3 "accessKeyID" }}
-{{- $accessSecretKey := index $secretS3 "accessSecretKey" }}
-{{- $endpoint := index $secretS3 "endpoint" }}
-{{- $bucketName := dig "spec" "bucketName" "" $bucketInfo }}
+{{- /* COSI BucketInfo is merged at the values root via Flux valuesFrom (no targetPath). */ -}}
+{{- with .Values.spec }}
+{{- with .secretS3 }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.harbor.fullnameOverride }}-registry-s3
+  name: {{ $.Values.harbor.fullnameOverride }}-registry-s3
 type: Opaque
 stringData:
-  REGISTRY_STORAGE_S3_ACCESSKEY: {{ $accessKeyID | quote }}
-  REGISTRY_STORAGE_S3_SECRETKEY: {{ $accessSecretKey | quote }}
-  REGISTRY_STORAGE_S3_REGIONENDPOINT: {{ $endpoint | quote }}
-  REGISTRY_STORAGE_S3_BUCKET: {{ $bucketName | quote }}
+  REGISTRY_STORAGE_S3_ACCESSKEY: {{ index . "accessKeyID" | quote }}
+  REGISTRY_STORAGE_S3_SECRETKEY: {{ index . "accessSecretKey" | quote }}
+  REGISTRY_STORAGE_S3_REGIONENDPOINT: {{ index . "endpoint" | quote }}
+  REGISTRY_STORAGE_S3_BUCKET: {{ $.Values.spec.bucketName | quote }}
   REGISTRY_STORAGE_S3_REGION: "us-east-1"
 {{- end }}
 {{- end }}

--- a/packages/system/harbor/tests/bucket_secret_test.yaml
+++ b/packages/system/harbor/tests/bucket_secret_test.yaml
@@ -1,0 +1,115 @@
+suite: bucket-secret guards
+
+release:
+  name: harbor
+  namespace: tenant-root
+
+# BucketInfo is merged at the values root via Flux `valuesFrom` (no
+# targetPath). The template must skip the dependent registry-s3
+# Secret unless every required field is populated:
+# .Values.spec.secretS3.{accessKeyID,accessSecretKey,endpoint} and
+# .Values.spec.bucketName. Missing/empty/partial inputs all fall
+# into the no-render path; only the fully populated case emits the
+# Secret.
+tests:
+  - it: no Secret rendered when spec is absent
+    template: templates/bucket-secret.yaml
+    set:
+      harbor:
+        fullnameOverride: harbor
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no Secret rendered when spec is empty
+    template: templates/bucket-secret.yaml
+    set:
+      harbor:
+        fullnameOverride: harbor
+      spec: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no Secret rendered when secretS3 is absent
+    template: templates/bucket-secret.yaml
+    set:
+      harbor:
+        fullnameOverride: harbor
+      spec:
+        bucketName: harbor-data
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no Secret rendered when secretS3 is empty
+    template: templates/bucket-secret.yaml
+    set:
+      harbor:
+        fullnameOverride: harbor
+      spec:
+        bucketName: harbor-data
+        secretS3: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no Secret rendered when secretS3 is partially populated
+    template: templates/bucket-secret.yaml
+    set:
+      harbor:
+        fullnameOverride: harbor
+      spec:
+        bucketName: harbor-data
+        secretS3:
+          accessKeyID: AKID
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: no Secret rendered when bucketName is missing
+    template: templates/bucket-secret.yaml
+    set:
+      harbor:
+        fullnameOverride: harbor
+      spec:
+        secretS3:
+          accessKeyID: AKID
+          accessSecretKey: secret
+          endpoint: https://s3.example.com
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: registry-s3 Secret rendered when all fields present
+    template: templates/bucket-secret.yaml
+    set:
+      harbor:
+        fullnameOverride: harbor
+      spec:
+        bucketName: harbor-data
+        secretS3:
+          accessKeyID: AKID
+          accessSecretKey: secret
+          endpoint: https://s3.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: harbor-registry-s3
+      - equal:
+          path: stringData.REGISTRY_STORAGE_S3_ACCESSKEY
+          value: AKID
+      - equal:
+          path: stringData.REGISTRY_STORAGE_S3_SECRETKEY
+          value: secret
+      - equal:
+          path: stringData.REGISTRY_STORAGE_S3_REGIONENDPOINT
+          value: https://s3.example.com
+      - equal:
+          path: stringData.REGISTRY_STORAGE_S3_BUCKET
+          value: harbor-data
+      - equal:
+          path: stringData.REGISTRY_STORAGE_S3_REGION
+          value: us-east-1

--- a/packages/system/harbor/values.yaml
+++ b/packages/system/harbor/values.yaml
@@ -1,6 +1,6 @@
 harbor: {}
 bucket:
-  secretName: ""
+  bucketInfo: ""
 db:
   replicas: 2
   size: 5Gi

--- a/packages/system/harbor/values.yaml
+++ b/packages/system/harbor/values.yaml
@@ -1,6 +1,4 @@
 harbor: {}
-bucket:
-  bucketInfo: ""
 db:
   replicas: 2
   size: 5Gi


### PR DESCRIPTION
## Summary
- `cozy-harbor/templates/bucket-secret.yaml` no longer relies on `lookup` against the BucketAccess credentials Secret. It is now driven by `.Values.bucket.bucketInfo` (a JSON string) with `dig`-based safe accessors, so a missing/empty/partial value renders nothing rather than crashing with `index of untyped nil` (the failure mode that broke harbor in CI #25049445125).
- The downstream `<release>-system` HelmRelease now sources `BucketInfo` via `valuesFrom` (`valuesKey: BucketInfo`, `targetPath: bucket.bucketInfo`). With the default `optional: false`, helm-controller refuses to compose values until the COSI BucketAccess controller has populated the Secret — both gating initial reconciliation and forcing a config-digest change (and thus a helm upgrade) when the credentials arrive. Flux HR `dependsOn` cannot reference COSI resources directly, so `valuesFrom` is the correct primitive here.
- `bucket.secretName` was the only consumer of the old `lookup` and is removed from both the system chart's `values.yaml` default and the apps chart's `values:` block.

## Why this shape
helm-controller's upgrade trigger is digest-based over composed values + chart artifact; a `lookup` returning new data on a later reconcile is not enough to force an upgrade on its own. Routing `BucketInfo` through `valuesFrom` puts the bucket data on the digest path, so the chart re-applies the moment credentials become available.

## Test plan
- [x] `helm template` of `packages/system/harbor` with `bucket.bucketInfo` unset, empty string, empty JSON object `{}`, and fully populated — only the populated case renders the `*-registry-s3` Secret; the others render nothing without erroring.
- [x] `helm template` of `packages/apps/harbor` produces the expected `<release>-system` HR with the new `valuesFrom` entry and the cleaned-up `values:` block.
- [ ] Re-run the harbor E2E on a fresh stand and confirm 15/15.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Harbor bucket config now comes from a centralized Secret merged into chart values; in-values bucket entry removed.
* **Bug Fixes**
  * Deployment synchronization and Helm upgrade behavior improved by depending on the Secret’s readiness/contents.
* **Tests**
  * Added unit tests covering when the bucket secret is rendered (or not) and a make target to run those tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->