### PR TITLE
ci(workflows): add SSH breakpoint on E2E failure for debug PRs

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -313,6 +313,17 @@ jobs:
           name: image-list
           path: /tmp/${{ env.SANDBOX_NAME }}/_out/images.txt
 
+      # ▸ Open an SSH breakpoint to the failing sandbox (opt-in via `debug` label).
+      #   Maintainers can SSH into the live runner, inspect Talos/Cozystack state
+      #   and resume the workflow with `breakpoint resume`. Times out after 30m.
+      - name: Breakpoint on E2E failure
+        if: failure() && contains(github.event.pull_request.labels.*.name, 'debug')
+        uses: namespacelabs/breakpoint-action@v0
+        with:
+          duration: 30m
+          endpoint: 158.101.126.45:5000
+          authorized-users: kvaps, gecube, kingdonb, lllamnyp, aobort, tym83, klinch0, nbykov0, matthieu-robin, mattia-eleuteri
+
       # ▸ Tear down environment (always runs)
       - name: Tear down sandbox
         if: always()

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -313,11 +313,11 @@ jobs:
           name: image-list
           path: /tmp/${{ env.SANDBOX_NAME }}/_out/images.txt
 
-      # ▸ Open an SSH breakpoint to the failing sandbox (opt-in via `debug` label).
-      #   Maintainers can SSH into the live runner, inspect Talos/Cozystack state
-      #   and resume the workflow with `breakpoint resume`. Times out after 30m.
+      # ▸ Open an SSH breakpoint to the failing sandbox so maintainers can attach
+      #   to the live runner, inspect Talos/Cozystack state and resume with
+      #   `breakpoint resume`. Times out after 30m.
       - name: Breakpoint on E2E failure
-        if: failure() && contains(github.event.pull_request.labels.*.name, 'debug')
+        if: failure()
         uses: namespacelabs/breakpoint-action@v0
         with:
           duration: 30m

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -316,8 +316,13 @@ jobs:
       # ▸ Open an SSH breakpoint to the failing sandbox so maintainers can attach
       #   to the live runner, inspect Talos/Cozystack state and resume with
       #   `breakpoint resume`. Times out after 30m.
+      #   Gated by the BREAKPOINT_ENABLED secret — in fork PRs the secret is
+      #   not exposed, so the step is skipped and forks cannot reach the
+      #   self-hosted rendezvous server.
       - name: Breakpoint on E2E failure
-        if: failure()
+        if: failure() && env.BREAKPOINT_ENABLED == 'true'
+        env:
+          BREAKPOINT_ENABLED: ${{ secrets.BREAKPOINT_ENABLED }}
         uses: namespacelabs/breakpoint-action@v0
         with:
           duration: 30m

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -316,17 +316,15 @@ jobs:
       # ▸ Open an SSH breakpoint to the failing sandbox so maintainers can attach
       #   to the live runner, inspect Talos/Cozystack state and resume with
       #   `breakpoint resume`. Times out after 30m.
-      #   Gated by the BREAKPOINT_ENABLED secret — in fork PRs the secret is
-      #   not exposed, so the step is skipped and forks cannot reach the
-      #   self-hosted rendezvous server.
+      #   Configured via the BREAKPOINT_ENDPOINT repository variable — in fork
+      #   PRs repository variables are not exposed, so the step is skipped and
+      #   forks cannot reach the self-hosted rendezvous server.
       - name: Breakpoint on E2E failure
-        if: failure() && env.BREAKPOINT_ENABLED == 'true'
-        env:
-          BREAKPOINT_ENABLED: ${{ secrets.BREAKPOINT_ENABLED }}
+        if: failure() && vars.BREAKPOINT_ENDPOINT != ''
         uses: namespacelabs/breakpoint-action@v0
         with:
           duration: 30m
-          endpoint: 158.101.126.45:5000
+          endpoint: ${{ vars.BREAKPOINT_ENDPOINT }}
           authorized-users: kvaps, gecube, kingdonb, lllamnyp, aobort, tym83, klinch0, nbykov0, matthieu-robin, mattia-eleuteri
 
       # ▸ Tear down environment (always runs)

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -163,6 +163,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      checks: write
     needs: ["build", "resolve_assets"]
     if: ${{ always() && (needs.build.result == 'success' || needs.resolve_assets.result == 'success') }}
 
@@ -312,6 +313,55 @@ jobs:
         with:
           name: image-list
           path: /tmp/${{ env.SANDBOX_NAME }}/_out/images.txt
+
+      # ▸ Open an SSH breakpoint to the failing sandbox so maintainers can attach,
+      #   inspect Talos/Cozystack state and resume with `breakpoint resume`.
+      #
+      #   Gated by the `debug` or `release` label (release PRs are bot-created,
+      #   so their presence implies maintainer authorship). authorized-users is
+      #   kept as a second defense layer at the breakpoint level.
+      #
+      #   Uses cozystack/breakpoint-action (fork of namespacelabs/breakpoint-action)
+      #   pinned by SHA. The fork adds: pause-idle mode (initial grace period for
+      #   the first SSH connection, idle-aware exit afterwards), endpoint output
+      #   and ::notice:: annotation, and a dedicated Check Run "Breakpoint Open"
+      #   that carries the SSH endpoint in output.summary while the breakpoint is
+      #   paused (conclusion=failure → standard ✗ in `gh pr checks`; updated to
+      #   conclusion=success when the breakpoint exits).
+      #
+      #   Configured via the BREAKPOINT_ENDPOINT repository variable — in fork
+      #   PRs repository variables are not exposed, so the step is skipped and
+      #   forks cannot reach the self-hosted rendezvous server.
+      - name: Breakpoint on E2E failure
+        if: |
+          failure() &&
+          vars.BREAKPOINT_ENDPOINT != '' &&
+          (contains(github.event.pull_request.labels.*.name, 'debug')
+            || contains(github.event.pull_request.labels.*.name, 'release'))
+        # cozystack/breakpoint-action v2-cozy.1
+        # mode: pause-idle defaults: grace-period=20m, idle-timeout=10m
+        uses: cozystack/breakpoint-action@a6f3a6f87be398ad63b6577351e3398e53f578e4
+        with:
+          mode: pause-idle
+          endpoint: ${{ vars.BREAKPOINT_ENDPOINT }}
+          authorized-users: kvaps, gecube, kingdonb, lllamnyp, aobort, tym83, klinch0, nbykov0, matthieu-robin, mattia-eleuteri
+          check-run-name: "Breakpoint Open"
+          github-token: ${{ github.token }}
+          check-run-summary-template: |
+            ## 🔴 SSH breakpoint open — paused for debug
+
+            ```
+            {endpoint}
+            ```
+
+            Enter the e2e sandbox after SSH:
+            ```
+            docker exec -ti $(docker ps --filter name=cozy-e2e-sandbox -q | head -1) bash
+            export KUBECONFIG=/workspace/kubeconfig
+            ```
+
+            Resume from inside: `breakpoint resume`. Otherwise the breakpoint
+            exits 10 minutes after the last SSH session disconnects.
 
       # ▸ Tear down environment (always runs)
       - name: Tear down sandbox

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -344,7 +344,7 @@ jobs:
         with:
           mode: pause-idle
           endpoint: ${{ vars.BREAKPOINT_ENDPOINT }}
-          authorized-users: kvaps, gecube, kingdonb, lllamnyp, aobort, tym83, klinch0, nbykov0, matthieu-robin, mattia-eleuteri
+          authorized-users: androndo, Arsolitt, IvanHunters, kvaps, lexfrei, lllamnyp, mattia-eleuteri, matthieu-robin, myasnikovdaniil, sircthulhu, tym83
           check-run-name: "Breakpoint Open"
           github-token: ${{ github.token }}
           check-run-summary-template: |


### PR DESCRIPTION
## What this PR does

Adds a `namespacelabs/breakpoint-action` step at the end of the E2E job
that opens an SSH endpoint to the failing sandbox so maintainers can
inspect Talos and Cozystack state before teardown.

The step runs whenever an earlier step in the E2E job fails. Idle
breakpoints time out after 30 minutes; maintainers can release the
sandbox sooner by running `breakpoint resume` from the SSH session.

The breakpoint connects to the project's self-hosted rendezvous server
at `158.101.126.45:5000`. Authorized users are the maintainers listed
in `MAINTAINERS.md`; SSH public keys are pulled from each maintainer's
GitHub profile by the action.

Inspired by [squat/kilo's CI setup](https://github.com/squat/kilo/blob/main/.github/workflows/ci.yml).


### Screenshots
<img width="713" height="55" alt="Screenshot 2026-05-14 at 20 57 43" src="https://github.com/user-attachments/assets/fc1b76b1-1eb0-4f52-976f-f469e71222b4" />

<img width="1404" height="956" alt="Screenshot 2026-05-14 at 20 58 27" src="https://github.com/user-attachments/assets/87194312-57c3-40ec-af58-262c9bba990f" />



### Release note

```release-note
ci(workflows): open SSH breakpoint to the runner on E2E failure
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now selects runner conditionally for PRs with specific labels (self-hosted vs cloud).
  * CI job permissions expanded to allow creating/updating check runs.
  * Added a conditional "Breakpoint on E2E failure" step that can open an SSH-accessible breakpoint and publishes a "Breakpoint Open" check with endpoint and attach/resume instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2535?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->