### PR TITLE
ci(e2e): drop 3x retry on Run E2E + Install Cozystack, wait out gateway.bats tenant teardown

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -242,7 +242,7 @@ jobs:
             fi
             echo "Attempt $attempt failed, retrying..."
           done
-          echo "Prepare environment completed after $attempt attempts"
+          echo "Prepare environment completed after $((attempt + 1)) attempts"
 
       # ▸ Install Cozystack
       - name: Install Cozystack into sandbox

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -238,7 +238,23 @@ jobs:
       - name: Install Cozystack into sandbox
         run: |
           cd /tmp/$SANDBOX_NAME
-          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack
+          if ! make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack; then
+            echo "❌ Install failed (no retry — see diagnostics below)"
+            echo "::group::Diagnostics: HelmRelease status"
+            docker exec "$SANDBOX_NAME" sh -c 'kubectl get hr -A -o wide 2>&1 | tail -100' || true
+            echo "::endgroup::"
+            echo "::group::Diagnostics: not-Ready HelmReleases (describe)"
+            docker exec "$SANDBOX_NAME" sh -c 'kubectl get hr -A --no-headers 2>/dev/null | awk "\$4 != \"True\" {print \$1\" \"\$2}"' \
+              | while read -r ns name; do
+                  echo "--- $ns/$name ---"
+                  docker exec "$SANDBOX_NAME" sh -c "kubectl describe hr '$name' -n '$ns' 2>&1 | tail -50" || true
+                done
+            echo "::endgroup::"
+            echo "::group::Diagnostics: recent events"
+            docker exec "$SANDBOX_NAME" sh -c 'kubectl get events -A --sort-by=.lastTimestamp 2>&1 | tail -50' || true
+            echo "::endgroup::"
+            exit 1
+          fi
 
       - name: Run OpenAPI tests
         run: |

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -232,7 +232,7 @@ jobs:
             fi
             echo "Attempt $attempt failed, retrying..."
           done
-          echo "Prepare environment completed after $attempt attempts"
+          echo "Prepare environment completed after $((attempt + 1)) attempts"
 
       # ▸ Install Cozystack
       - name: Install Cozystack into sandbox

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -237,27 +237,18 @@ jobs:
           until make SANDBOX_NAME=$SANDBOX_NAME prepare-env; do
             attempt=$((attempt + 1))
             if [ $attempt -ge 3 ]; then
-              echo "❌ Attempt $attempt failed, exiting..."
+              echo "Attempt $attempt failed, exiting..."
               exit 1
             fi
-            echo "❌ Attempt $attempt failed, retrying..."
+            echo "Attempt $attempt failed, retrying..."
           done
-          echo "✅ The task completed successfully after $attempt attempts"
+          echo "Prepare environment completed after $attempt attempts"
 
       # ▸ Install Cozystack
       - name: Install Cozystack into sandbox
         run: |
           cd /tmp/$SANDBOX_NAME
-          attempt=0
-          until make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack; do
-            attempt=$((attempt + 1))
-            if [ $attempt -ge 3 ]; then
-              echo "❌ Attempt $attempt failed, exiting..."
-              exit 1
-            fi
-            echo "❌ Attempt $attempt failed, retrying..."
-          done
-          echo "✅ The task completed successfully after $attempt attempts"
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack
 
       - name: Run OpenAPI tests
         run: |
@@ -272,23 +263,18 @@ jobs:
           failed_tests=""
           for app in $(ls hack/e2e-apps/*.bats | xargs -n1 basename | cut -d. -f1); do
             echo "::group::Testing $app"
-            attempt=0
-            success=false
-            until [ $attempt -ge 3 ]; do
-              if make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME test-apps-$app; then
-                success=true
-                break
-              fi
-              attempt=$((attempt + 1))
-              echo "❌ Attempt $attempt failed, retrying..."
-            done
-            if [ "$success" = true ]; then
+            if make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME test-apps-$app; then
+              echo "::endgroup::"
               echo "✅ Test $app completed successfully"
             else
-              echo "❌ Test $app failed after $attempt attempts"
+              echo "::endgroup::"
+              echo "❌ Test $app failed (no retry — see diagnostics below)"
               failed_tests="$failed_tests $app"
+              echo "::group::Diagnostics for $app"
+              docker exec "$SANDBOX_NAME" sh -c 'kubectl get hr -A -o wide 2>&1 | tail -50' || true
+              docker exec "$SANDBOX_NAME" sh -c 'kubectl get events -A --sort-by=.lastTimestamp 2>&1 | tail -30' || true
+              echo "::endgroup::"
             fi
-            echo "::endgroup::"
           done
           if [ -n "$failed_tests" ]; then
             echo "❌ Failed tests:$failed_tests"

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -227,27 +227,18 @@ jobs:
           until make SANDBOX_NAME=$SANDBOX_NAME prepare-env; do
             attempt=$((attempt + 1))
             if [ $attempt -ge 3 ]; then
-              echo "❌ Attempt $attempt failed, exiting..."
+              echo "Attempt $attempt failed, exiting..."
               exit 1
             fi
-            echo "❌ Attempt $attempt failed, retrying..."
+            echo "Attempt $attempt failed, retrying..."
           done
-          echo "✅ The task completed successfully after $attempt attempts"
+          echo "Prepare environment completed after $attempt attempts"
 
       # ▸ Install Cozystack
       - name: Install Cozystack into sandbox
         run: |
           cd /tmp/$SANDBOX_NAME
-          attempt=0
-          until make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack; do
-            attempt=$((attempt + 1))
-            if [ $attempt -ge 3 ]; then
-              echo "❌ Attempt $attempt failed, exiting..."
-              exit 1
-            fi
-            echo "❌ Attempt $attempt failed, retrying..."
-          done
-          echo "✅ The task completed successfully after $attempt attempts"
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack
 
       - name: Run OpenAPI tests
         run: |
@@ -262,23 +253,18 @@ jobs:
           failed_tests=""
           for app in $(ls hack/e2e-apps/*.bats | xargs -n1 basename | cut -d. -f1); do
             echo "::group::Testing $app"
-            attempt=0
-            success=false
-            until [ $attempt -ge 3 ]; do
-              if make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME test-apps-$app; then
-                success=true
-                break
-              fi
-              attempt=$((attempt + 1))
-              echo "❌ Attempt $attempt failed, retrying..."
-            done
-            if [ "$success" = true ]; then
+            if make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME test-apps-$app; then
+              echo "::endgroup::"
               echo "✅ Test $app completed successfully"
             else
-              echo "❌ Test $app failed after $attempt attempts"
+              echo "::endgroup::"
+              echo "❌ Test $app failed (no retry — see diagnostics below)"
               failed_tests="$failed_tests $app"
+              echo "::group::Diagnostics for $app"
+              docker exec "$SANDBOX_NAME" sh -c 'kubectl get hr -A -o wide 2>&1 | tail -50' || true
+              docker exec "$SANDBOX_NAME" sh -c 'kubectl get events -A --sort-by=.lastTimestamp 2>&1 | tail -30' || true
+              echo "::endgroup::"
             fi
-            echo "::endgroup::"
           done
           if [ -n "$failed_tests" ]; then
             echo "❌ Failed tests:$failed_tests"

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -248,7 +248,23 @@ jobs:
       - name: Install Cozystack into sandbox
         run: |
           cd /tmp/$SANDBOX_NAME
-          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack
+          if ! make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack; then
+            echo "❌ Install failed (no retry — see diagnostics below)"
+            echo "::group::Diagnostics: HelmRelease status"
+            docker exec "$SANDBOX_NAME" sh -c 'kubectl get hr -A -o wide 2>&1 | tail -100' || true
+            echo "::endgroup::"
+            echo "::group::Diagnostics: not-Ready HelmReleases (describe)"
+            docker exec "$SANDBOX_NAME" sh -c 'kubectl get hr -A --no-headers 2>/dev/null | awk "\$4 != \"True\" {print \$1\" \"\$2}"' \
+              | while read -r ns name; do
+                  echo "--- $ns/$name ---"
+                  docker exec "$SANDBOX_NAME" sh -c "kubectl describe hr '$name' -n '$ns' 2>&1 | tail -50" || true
+                done
+            echo "::endgroup::"
+            echo "::group::Diagnostics: recent events"
+            docker exec "$SANDBOX_NAME" sh -c 'kubectl get events -A --sort-by=.lastTimestamp 2>&1 | tail -50' || true
+            echo "::endgroup::"
+            exit 1
+          fi
 
       - name: Run OpenAPI tests
         run: |

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -289,6 +289,15 @@ jobs:
               echo "::group::Diagnostics for $app"
               docker exec "$SANDBOX_NAME" sh -c 'kubectl get hr -A -o wide 2>&1 | tail -50' || true
               docker exec "$SANDBOX_NAME" sh -c 'kubectl get events -A --sort-by=.lastTimestamp 2>&1 | tail -30' || true
+              # COSI state at the moment of failure — the CRDs ship no printer
+              # columns, so pull the readiness fields explicitly (cozyreport
+              # captures the same at end-of-job, but bucket states move between
+              # a test failing and the report being taken).
+              docker exec "$SANDBOX_NAME" sh -c '
+                kubectl get bucketclaims.objectstorage.k8s.io -A -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name,READY:.status.bucketReady,BUCKET:.status.bucketName" 2>&1
+                kubectl get buckets.objectstorage.k8s.io -o custom-columns="NAME:.metadata.name,READY:.status.bucketReady,ID:.status.bucketID,CLAIMNS:.spec.bucketClaim.namespace" 2>&1
+                kubectl get bucketaccesses.objectstorage.k8s.io -A -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name,GRANTED:.status.accessGranted,CLAIM:.spec.bucketClaimName" 2>&1
+              ' || true
               echo "::endgroup::"
             fi
           done

--- a/hack/cozyreport.sh
+++ b/hack/cozyreport.sh
@@ -209,6 +209,43 @@ kubectl get pvc -A --no-headers | awk '$3 != "Bound"'  |
     kubectl describe pvc -n $NAMESPACE $NAME > $DIR/describe.txt 2>&1
   done
 
+# -- objectstorage (COSI) module
+
+if kubectl get crd bucketclaims.objectstorage.k8s.io >/dev/null 2>&1; then
+  echo "Collecting objectstorage (COSI) state..."
+  DIR=$REPORT_DIR/objectstorage
+  mkdir -p $DIR
+  # The COSI CRDs ship no printer columns, so plain `kubectl get` shows
+  # only NAME/AGE — pull the readiness fields explicitly.
+  kubectl get bucketclaims.objectstorage.k8s.io -A \
+    -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,READY:.status.bucketReady,BUCKET:.status.bucketName,CLASS:.spec.bucketClassName' \
+    > $DIR/bucketclaims.txt 2>&1
+  kubectl get bucketaccesses.objectstorage.k8s.io -A \
+    -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,GRANTED:.status.accessGranted,ACCOUNT:.status.accountID,CLAIM:.spec.bucketClaimName' \
+    > $DIR/bucketaccesses.txt 2>&1
+  kubectl get buckets.objectstorage.k8s.io \
+    -o custom-columns='NAME:.metadata.name,READY:.status.bucketReady,ID:.status.bucketID,CLAIMNS:.spec.bucketClaim.namespace,CLAIM:.spec.bucketClaim.name' \
+    > $DIR/buckets.txt 2>&1
+  for kind in bucketclaims.objectstorage.k8s.io bucketaccesses.objectstorage.k8s.io; do
+    short=${kind%%.*}
+    kubectl get $kind -A -o yaml > $DIR/$short.yaml 2>&1
+  done
+  for kind in buckets.objectstorage.k8s.io bucketclasses.objectstorage.k8s.io bucketaccessclasses.objectstorage.k8s.io; do
+    short=${kind%%.*}
+    kubectl get $kind -o yaml > $DIR/$short.yaml 2>&1
+  done
+  if kubectl get deploy -n cozy-objectstorage-controller container-object-storage-controller >/dev/null 2>&1; then
+    kubectl logs -n cozy-objectstorage-controller deploy/container-object-storage-controller --tail=2000 > $DIR/objectstorage-controller.log 2>&1
+    kubectl logs -n cozy-objectstorage-controller deploy/container-object-storage-controller --tail=2000 --previous > $DIR/objectstorage-controller-previous.log 2>&1 || true
+  fi
+  # seaweedfs COSI provisioners run per seaweedfs instance, one per namespace
+  kubectl get deploy -A --no-headers 2>/dev/null | awk '$2 ~ /objectstorage-provisioner$/ {print $1" "$2}' |
+    while read NAMESPACE NAME; do
+      kubectl logs -n $NAMESPACE deploy/$NAME --all-containers --tail=2000 > $DIR/provisioner-$NAMESPACE.log 2>&1
+      kubectl logs -n $NAMESPACE deploy/$NAME --all-containers --tail=2000 --previous > $DIR/provisioner-$NAMESPACE-previous.log 2>&1 || true
+    done
+fi
+
 # -- kamaji module
 
 if kubectl get deploy -n cozy-linstor linstor-controller >/dev/null 2>&1; then

--- a/hack/e2e-apps/gateway.bats
+++ b/hack/e2e-apps/gateway.bats
@@ -485,7 +485,12 @@ EOF
   cozyvalues=$(kubectl -n tenant-test-gwprop get secret cozystack-values -o jsonpath='{.data.values\.yaml}' | base64 -d)
   echo "$cozyvalues" | grep -E '^\s*gateway:\s*"tenant-test-gwprop"\s*$' >/dev/null
 
+  # Wait out the uninstall instead of fire-and-forget: tenant teardown
+  # runs a cleanup Job that the helm uninstall blocks on, and a dangling
+  # uninstall carries over into the next .bats file, starving the
+  # helm-controller worker pool (--concurrent=5 on the tenants shard).
   kubectl -n tenant-test delete tenant gwprop --ignore-not-found
+  kubectl -n tenant-test wait hr tenant-gwprop --for=delete --timeout=300s
 }
 
 @test "child tenant without explicit gateway inherits _namespace.gateway from a Gateway-owning parent" {
@@ -538,8 +543,14 @@ EOF
   # means no separate Gateway resource for the child tenant.
   ! kubectl -n tenant-test-gwparent-gwchild get helmrelease gateway 2>/dev/null
 
+  # Teardown child before parent, waiting out each uninstall: deleting
+  # the parent while the child is still uninstalling wedges the parent's
+  # cleanup Job on the child's namespace, and both stuck uninstalls
+  # occupy helm-controller workers past the end of this .bats file.
   kubectl -n tenant-test-gwparent delete tenant gwchild --ignore-not-found
+  kubectl -n tenant-test-gwparent wait hr tenant-gwchild --for=delete --timeout=300s
   kubectl -n tenant-test delete tenant gwparent --ignore-not-found
+  kubectl -n tenant-test wait hr tenant-gwparent --for=delete --timeout=300s
 }
 
 @test "child tenant's HTTPRoute drives the parent Gateway's listener set via inheritance label" {
@@ -661,6 +672,13 @@ EOF
   '
 
   kubectl -n tenant-test-rparent-rchild delete httproute inherit-probe --ignore-not-found
+  # Teardown child before parent, waiting out each uninstall (see the
+  # inheritance test above). The rchild HR may still be mid-install when
+  # the delete lands — helm-controller finishes the install action before
+  # it can uninstall, so the child wait also absorbs that tail instead of
+  # leaving it for the next .bats file.
   kubectl -n tenant-test-rparent delete tenant rchild --ignore-not-found
+  kubectl -n tenant-test-rparent wait hr tenant-rchild --for=delete --timeout=300s
   kubectl -n tenant-test delete tenant rparent --ignore-not-found
+  kubectl -n tenant-test wait hr tenant-rparent --for=delete --timeout=300s
 }

--- a/packages/core/platform/sources/cozystack-basics.yaml
+++ b/packages/core/platform/sources/cozystack-basics.yaml
@@ -13,6 +13,25 @@ spec:
   - name: default
     dependsOn:
     - cozystack.tenant-application
+    # cozystack-basics ships cluster-wide ValidatingAdmissionPolicies (the
+    # gateway / route / tenant host policies). kube-controller-manager's VAP
+    # status type-checker panics (nil-pointer deref in cel/openapi) when it
+    # type-checks a policy against a matched type whose schema it cannot
+    # resolve yet, so these policies must never predate the APIs they match:
+    #   - cozystack-engine serves tenants.apps.cozystack.io (via cozystack-api);
+    #     without this dependency the tenant-host policy is created before
+    #     cozystack-api is Ready, crashes KCM, and deadlocks the whole install
+    #     (KCM down -> cert/token issuance stalls -> cozystack-api never starts
+    #     -> the tenants schema never resolves -> KCM keeps crashing).
+    #   - gateway-api-crds establishes gateways/httproutes/tlsroutes for the
+    #     gateway/route host policies.
+    # Drift detection is off on operator-generated HelmReleases, so a
+    # capability gate in the templates would render the policy out at first
+    # install and never add it back; ordering via dependsOn is the reliable
+    # fix. cozystack-basics is a dependency-graph leaf (nothing dependsOn it)
+    # and engine components consume none of its outputs, so this adds no cycle.
+    - cozystack.cozystack-engine
+    - cozystack.gateway-api-crds
     components:
     - name: cozystack-basics
       path: system/cozystack-basics

--- a/packages/core/platform/tests/sources_basics_dependson_test.yaml
+++ b/packages/core/platform/tests/sources_basics_dependson_test.yaml
@@ -1,0 +1,27 @@
+suite: cozystack-basics waits for the APIs its admission policies type-check
+# Regression guard for the kube-controller-manager VAP-status-controller panic:
+# cozystack-basics ships cluster-wide ValidatingAdmissionPolicies that match
+# tenants.apps.cozystack.io (served by cozystack-api, in cozystack-engine) and
+# the Gateway API types (from gateway-api-crds). If the package installs before
+# those APIs are served, KCM type-checks a policy against an unresolvable schema,
+# panics, and deadlocks the install. The dependsOn edges below must stay.
+templates:
+  - templates/sources.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  - it: cozystack-basics dependsOn cozystack-engine and gateway-api-crds (and tenant-application)
+    documentSelector:
+      path: metadata.name
+      value: cozystack.cozystack-basics
+    asserts:
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.tenant-application
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.cozystack-engine
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.gateway-api-crds


### PR DESCRIPTION
## What this PR does

Drops the 3× retry loop on `Run E2E tests` and `Install Cozystack into sandbox`. `Prepare environment` keeps its 3× retry — that step is pure infrastructure (Talos image download, sandbox VM boot, network) where transient runner hiccups warrant a retry.

On failure, the test step now captures `kubectl get hr -A -o wide` and `kubectl get events -A` under a collapsible group so triage starts with the actual broken-state snapshot.

> [!NOTE]
> An earlier revision of this PR also doubled every bats timeout. That commit was dropped in a rebase and is intentionally **not restored**: the timeout class that actually matters (per-app HR-Ready waits) has since been standardized at 5m on `main` (7b9f286fa), making a blanket 2× redundant.

**Fixes gateway.bats teardown leakage.** The nested-tenant tests deleted tenants fire-and-forget, parent and child back-to-back. The leftover uninstalls (each blocked on a cleanup Job, parents wedged on still-terminating child namespaces) plus one mid-install child HR occupied exactly 5 workers on the `--concurrent=5` tenants helm-controller shard, starving whichever app test ran next — observed as the harbor HR sitting unreconciled for its whole 5m HR-Ready budget in [run 27020081550](https://github.com/cozystack/cozystack/actions/runs/27020081550), surfaced by this PR's own retry removal + diagnostics dump. Teardown now deletes child→parent with hard `wait hr --for=delete` between, so a wedged tenant uninstall fails gateway.bats itself, not an innocent neighbor.

## Why

Audit of 30 successful PR runs found that across 5 sampled failure attempts, **25/25 retries** on `Run E2E tests` failed — the retry loop never recovered a flake, only stretched deterministic failures and tripled diagnostic wall-time. Same data shape on `Install Cozystack`.

Beyond wasted CI time, the retry was hiding ~10 deterministic bugs (Helm namespace-ownership conflict, seaweedfs HR timeout, harbor BucketInfo wiring, vminstance disk race, etc.). Each failure looked like a "flake" because the retry sometimes coincided with whatever transient state had cleared — the retry never fixed the bug, just delayed surfacing.

## Dependencies

The deterministic bugs the retry was masking are now fixed on `main`:
- ✅ **#2508** — installer namespace bootstrap (Helm namespace-ownership conflict on cold install) — merged
- ✅ **#2509** — operator HelmRelease config knobs (`seaweedfs-system` 2-min wait race within Flux's 5-min reconcile windows) — merged
- ✅ **#2528** — harbor bucket-secret + BucketInfo gating (harbor `ValuesError` on first install) — merged
- ✅ **#2529** — objectstorage-controller BucketAccess conflict retry — merged

Companion PRs in the #2619 split (independent of this PR, ordering-wise):
- **#2602** — Flux v2.8.0 + chart fixes
- **#2601** — seaweedfs-system split

This PR does NOT depend on #2602/#2601 — it now touches only the workflow file and gateway.bats teardown, both on top of fresh `main`.

Surfaced from #2500.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI prepare-environment step now reports plain attempt counts with clear success/failure messages.
  * Install and per-app test steps no longer retry; each runs once and fails immediately on error. Failed apps log diagnostics and job proceeds to remaining apps while overall job fails.
* **Tests**
  * End-to-end tests and install/prepare flows use longer, more tolerant timeouts and added existence polling to reduce flakiness and improve diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
