### PR TITLE
feat(ci): test-impact analysis E2E (default-on) + release E2E workflow

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -249,18 +249,51 @@ jobs:
           done
           echo "✅ The task completed successfully after $attempt attempts"
 
+      # Test Impact Analysis (TIA): walk the PackageSource graph for the PR
+      # diff and select only the bats files affected. Runs by default; opt
+      # out via the `full-e2e` label to run the full suite.
+      # `skip=true` means nothing to test (docs-only PR).
+      - name: Select E2E tests
+        id: select
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'full-e2e') }}
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          git diff --name-only "origin/${BASE_REF}...HEAD" > /tmp/changed.txt
+          apps=$(./hack/select-e2e.sh /tmp/changed.txt)
+          echo "Selected apps: ${apps:-<none>}"
+          echo "apps=${apps}" >> $GITHUB_OUTPUT
+          if [ -z "${apps}" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run OpenAPI tests
         run: |
           cd /tmp/$SANDBOX_NAME
           make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME test-openapi
 
-      # ▸ Run E2E tests
+      # Run E2E tests. With `full-e2e` label the selector is skipped, its
+      # outputs are empty, the != 'true' guard lets this step run, and the
+      # full bats list is used. Without the label, the selector decides;
+      # an empty selection (docs-only) skips this step entirely.
       - name: Run E2E tests
         id: e2e_tests
+        if: ${{ steps.select.outputs.skip != 'true' }}
+        env:
+          SELECTED_APPS: ${{ steps.select.outputs.apps }}
+          FULL_E2E: ${{ contains(github.event.pull_request.labels.*.name, 'full-e2e') }}
         run: |
           cd /tmp/$SANDBOX_NAME
+          if [ "$FULL_E2E" = "true" ] || [ -z "$SELECTED_APPS" ]; then
+            apps_list=$(ls hack/e2e-apps/*.bats | xargs -n1 basename | cut -d. -f1)
+          else
+            apps_list="$SELECTED_APPS"
+          fi
           failed_tests=""
-          for app in $(ls hack/e2e-apps/*.bats | xargs -n1 basename | cut -d. -f1); do
+          for app in $apps_list; do
             echo "::group::Testing $app"
             attempt=0
             success=false

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -177,8 +177,12 @@ jobs:
           owner: cozystack
 
       # ▸ Checkout and prepare the codebase
+      # fetch-depth: 0 is required by the "Select E2E tests" step so that
+      # `git diff origin/${BASE_REF}...HEAD` can resolve the base ref.
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       # ▸ Regular PR path – download artefacts produced by the *build* job
       - name: "Download Talos image (regular PR)"

--- a/.github/workflows/release-e2e.yaml
+++ b/.github/workflows/release-e2e.yaml
@@ -1,0 +1,159 @@
+name: Release E2E
+
+# Runs the full E2E suite against the tagged commit. Independent of the
+# release publish flow (`tags.yaml`) — a failure here is an alarm, not a
+# release blocker. PR-time E2E runs Test Impact Analysis by default, so
+# tags are the only place the full suite is exercised against shipped code.
+
+env:
+  # TODO: unhardcode this
+  REGISTRY: iad.ocir.io/idyksih5sir9/cozystack
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+      - 'v*.*.*-rc.*'
+      - 'v*.*.*-beta.*'
+      - 'v*.*.*-alpha.*'
+
+concurrency:
+  group: release-e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build (release E2E)
+    runs-on: [self-hosted]
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Login to registry
+        uses: docker/login-action@v3
+        with:
+          registry: iad.ocir.io
+          username: ${{ secrets.OCI_REGISTRY_USERNAME }}
+          password: ${{ secrets.OCI_REGISTRY_PASSWORD }}
+
+      - name: Build images
+        run: make build PUSH=1
+
+      - name: Build Talos image
+        run: make -C packages/core/talos build
+
+      - name: Upload Talos image
+        uses: actions/upload-artifact@v4
+        with:
+          name: talos-image
+          path: _out/assets/nocloud-amd64.raw.xz
+          retention-days: 1
+
+  e2e:
+    name: Release E2E (full suite)
+    runs-on: [self-hosted]
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: read
+    needs: ["build"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download Talos image
+        uses: actions/download-artifact@v4
+        with:
+          name: talos-image
+          path: _out/assets
+
+      - name: Set sandbox ID
+        run: echo "SANDBOX_NAME=cozy-e2e-release-$(echo "${GITHUB_REPOSITORY}:${GITHUB_REF}" | sha256sum | cut -c1-10)" >> $GITHUB_ENV
+
+      - name: Prepare workspace
+        env:
+          WORKSPACE: ${{ github.workspace }}
+        run: |
+          rm -rf /tmp/$SANDBOX_NAME
+          cp -r "$WORKSPACE" /tmp/$SANDBOX_NAME
+
+      - name: Prepare environment
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          attempt=0
+          until make SANDBOX_NAME=$SANDBOX_NAME prepare-env; do
+            attempt=$((attempt + 1))
+            if [ $attempt -ge 3 ]; then
+              echo "❌ Attempt $attempt failed, exiting..."
+              exit 1
+            fi
+            echo "❌ Attempt $attempt failed, retrying..."
+          done
+          echo "✅ The task completed successfully after $attempt attempts"
+
+      - name: Install Cozystack into sandbox
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack
+
+      - name: Run OpenAPI tests
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME test-openapi
+
+      # Always full suite — release E2E intentionally does not honour the
+      # `full-e2e` / TIA mechanism used by PR runs.
+      - name: Run E2E tests (full suite)
+        id: e2e_tests
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          failed_tests=""
+          for app in $(ls hack/e2e-apps/*.bats | xargs -n1 basename | cut -d. -f1); do
+            echo "::group::Testing $app"
+            if make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME test-apps-$app; then
+              echo "::endgroup::"
+              echo "✅ Test $app completed successfully"
+            else
+              echo "::endgroup::"
+              echo "❌ Test $app failed"
+              failed_tests="$failed_tests $app"
+              echo "::group::Diagnostics for $app"
+              kubectl get hr -A -o wide 2>&1 | tail -50 || true
+              kubectl get events -A --sort-by=.lastTimestamp 2>&1 | tail -50 || true
+              echo "::endgroup::"
+            fi
+          done
+          if [ -n "$failed_tests" ]; then
+            echo "❌ Failed tests:$failed_tests"
+            exit 1
+          fi
+          echo "✅ All E2E tests passed"
+
+      - name: Collect report
+        if: always()
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME collect-report || true
+
+      - name: Upload cozyreport.tgz
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cozyreport-${{ github.ref_name }}
+          path: /tmp/${{ env.SANDBOX_NAME }}/_out/cozyreport.tgz
+
+      - name: Tear down sandbox
+        if: always()
+        run: make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME delete || true
+
+      - name: Remove workspace
+        if: always()
+        run: rm -rf /tmp/$SANDBOX_NAME

--- a/hack/select-e2e.sh
+++ b/hack/select-e2e.sh
@@ -39,22 +39,12 @@ app_to_bats() {
 
 # yq: path -> PackageSource name
 build_owners_index() {
-  for f in "$SOURCES_DIR"/*.yaml; do
-    src=$(yq -r '.metadata.name' "$f")
-    yq -r '.spec.variants[]?.components[]?.path // ""' "$f" | while read -r path; do
-      if [ -n "$path" ]; then echo "$path	$src"; fi
-    done
-  done
+  yq -rN '.metadata.name as $n | .spec.variants[]?.components[]?.path | select(. != null and . != "") | . + "\t" + $n' "$SOURCES_DIR"/*.yaml
 }
 
 # yq: PackageSource name -> sources that depend on it (reverse of dependsOn)
 build_reverse_deps() {
-  for f in "$SOURCES_DIR"/*.yaml; do
-    src=$(yq -r '.metadata.name' "$f")
-    yq -r '.spec.variants[]?.dependsOn[]? // ""' "$f" | while read -r dep; do
-      if [ -n "$dep" ]; then echo "$dep	$src"; fi
-    done
-  done
+  yq -rN '.metadata.name as $n | .spec.variants[]?.dependsOn[]? | select(. != null and . != "") | . + "\t" + $n' "$SOURCES_DIR"/*.yaml
 }
 
 OWNERS=$(build_owners_index | sort -u)
@@ -104,7 +94,7 @@ while IFS= read -r file; do
 done < "$CHANGED"
 
 if [ "$trigger_full" = 1 ]; then
-  echo "$all_apps" | tr '\n' ' '
+  echo "$all_apps" | paste -sd ' ' -
   exit 0
 fi
 
@@ -141,7 +131,7 @@ final="$final $selected_apps"
 
 # Deduplicate; intersect with available bats files.
 final_apps=$(echo "$final" | tr ' ' '\n' | sort -u | grep -v '^$' | while read -r app; do
-  if echo "$all_apps" | grep -qw "$app"; then
+  if echo "$all_apps" | grep -Fxq "$app"; then
     echo "$app"
   fi
 done | paste -sd ' ' -)
@@ -150,7 +140,7 @@ done | paste -sd ' ' -)
 # silently skip E2E. Fall back to full suite so a path inside the graph is
 # never silently dropped.
 if [ -z "$final_apps" ]; then
-  echo "$all_apps" | tr '\n' ' '
+  echo "$all_apps" | paste -sd ' ' -
   exit 0
 fi
 

--- a/hack/select-e2e.sh
+++ b/hack/select-e2e.sh
@@ -1,0 +1,157 @@
+#!/bin/sh
+# Read a list of changed files (one per line) and emit space-separated app
+# names whose bats files in hack/e2e-apps/ should run.
+#
+# Usage: hack/select-e2e.sh <changed-files> [<sources-dir>]
+# Defaults: sources-dir = packages/core/platform/sources
+#
+# Output:
+#   - empty       no E2E impact (docs / dashboards / *.md only)
+#   - <app names> selected per the PackageSource dependency graph
+#   - full list   any path that affects all tests, OR an unrecognised
+#                 packages/* path, OR a per-app source whose graph has
+#                 no *-application descendants (conservative fallback)
+set -eu
+
+CHANGED="${1:?missing changed-files arg}"
+SOURCES_DIR="${2:-packages/core/platform/sources}"
+
+# Anything matching this pattern triggers the full bats suite. Per-app bats
+# (hack/e2e-apps/<name>.bats) are matched BEFORE this so editing one bats
+# file doesn't escalate to the full suite.
+full_suite_pattern='^(packages/library/|packages/core/|api/|cmd/|internal/|hack/[^/]+\.sh$|hack/[^/]+\.bats$|hack/e2e-apps/[^/]+\.sh$|Makefile$|\.github/workflows/(pull-requests|release-e2e)\.yaml$)'
+
+# All known per-app bats files
+all_apps=$(ls hack/e2e-apps/*.bats 2>/dev/null | xargs -n1 basename | sed 's/\.bats$//')
+
+# PackageSource name -> bats name(s). Most *-application sources map by
+# stripping the suffix; explicit overrides for the few that don't.
+app_to_bats() {
+  case "$1" in
+    postgres-application) echo postgres ;;
+    vm-instance-application) echo vminstance ;;
+    kubernetes-application) echo "kubernetes-latest kubernetes-previous" ;;
+    external-dns) echo external-dns ;;
+    *-application) echo "${1%-application}" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+# yq: path -> PackageSource name
+build_owners_index() {
+  for f in "$SOURCES_DIR"/*.yaml; do
+    src=$(yq -r '.metadata.name' "$f")
+    yq -r '.spec.variants[]?.components[]?.path // ""' "$f" | while read -r path; do
+      if [ -n "$path" ]; then echo "$path	$src"; fi
+    done
+  done
+}
+
+# yq: PackageSource name -> sources that depend on it (reverse of dependsOn)
+build_reverse_deps() {
+  for f in "$SOURCES_DIR"/*.yaml; do
+    src=$(yq -r '.metadata.name' "$f")
+    yq -r '.spec.variants[]?.dependsOn[]? // ""' "$f" | while read -r dep; do
+      if [ -n "$dep" ]; then echo "$dep	$src"; fi
+    done
+  done
+}
+
+OWNERS=$(build_owners_index | sort -u)
+REVERSE=$(build_reverse_deps | sort -u)
+
+trigger_full=0
+trigger_any=0
+selected_sources=""
+selected_apps=""
+
+while IFS= read -r file; do
+  [ -z "$file" ] && continue
+
+  # 1. Skip: docs, dashboards, *.md
+  if echo "$file" | grep -qE '^(docs/|dashboards/)' || echo "$file" | grep -qE '\.md$'; then
+    continue
+  fi
+
+  # 2. Per-app bats first — editing one bats file selects only that app.
+  if echo "$file" | grep -qE '^hack/e2e-apps/[^/]+\.bats$'; then
+    app=$(basename "$file" .bats)
+    selected_apps="$selected_apps $app"
+    trigger_any=1
+    continue
+  fi
+
+  # 3. Full-suite trigger
+  if echo "$file" | grep -qE "$full_suite_pattern"; then
+    trigger_full=1
+    continue
+  fi
+
+  # 4. Component change: lookup in PackageSource graph
+  rel=$(echo "$file" | sed -nE 's,^packages/(apps|system|extra)/([^/]+)/.*,\1/\2,p')
+  if [ -n "$rel" ]; then
+    src=$(echo "$OWNERS" | awk -v p="$rel" -F'\t' '$1==p {print $2}')
+    if [ -n "$src" ]; then
+      selected_sources="$selected_sources $src"
+      trigger_any=1
+    else
+      # Inside packages/ but no graph entry — be conservative.
+      trigger_full=1
+    fi
+  fi
+  # Anything else (e.g. unrelated workflow files, top-level configs) is
+  # silently ignored.
+done < "$CHANGED"
+
+if [ "$trigger_full" = 1 ]; then
+  echo "$all_apps" | tr '\n' ' '
+  exit 0
+fi
+
+if [ "$trigger_any" = 0 ]; then
+  exit 0  # nothing to run
+fi
+
+# Transitive closure: walk reverse-deps from each selected source.
+all_sources="$selected_sources"
+while :; do
+  new=""
+  for s in $all_sources; do
+    deps=$(echo "$REVERSE" | awk -v src="$s" -F'\t' '$1==src {print $2}')
+    for d in $deps; do
+      case " $all_sources " in *" $d "*) ;; *) new="$new $d";; esac
+    done
+  done
+  [ -z "$new" ] && break
+  all_sources="$all_sources $new"
+done
+
+# Filter to *-application sources, then map to bats names.
+final=""
+for s in $all_sources; do
+  app=${s#cozystack.}
+  case "$app" in
+    *-application) final="$final $(app_to_bats "$app")" ;;
+    external-dns) final="$final external-dns" ;;
+  esac
+done
+
+# Add directly-selected apps from per-app bats edits.
+final="$final $selected_apps"
+
+# Deduplicate; intersect with available bats files.
+final_apps=$(echo "$final" | tr ' ' '\n' | sort -u | grep -v '^$' | while read -r app; do
+  if echo "$all_apps" | grep -qw "$app"; then
+    echo "$app"
+  fi
+done | paste -sd ' ' -)
+
+# Safety net: a system source with no *-application descendants would otherwise
+# silently skip E2E. Fall back to full suite so a path inside the graph is
+# never silently dropped.
+if [ -z "$final_apps" ]; then
+  echo "$all_apps" | tr '\n' ' '
+  exit 0
+fi
+
+echo "$final_apps"

--- a/hack/select-e2e_test.bats
+++ b/hack/select-e2e_test.bats
@@ -1,90 +1,121 @@
 #!/usr/bin/env bats
-
-setup() {
-  TMPDIR=$(mktemp -d)
-  cp -r packages/core/platform/sources $TMPDIR/sources
-}
+# -----------------------------------------------------------------------------
+# Unit tests for hack/select-e2e.sh
+#
+# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
+# own line; there is no bats `run` or `$status`. Each test runs as a shell
+# function under `set -eu -x`, so assertions are direct shell tests that exit
+# non-zero on failure. setup()/teardown() are not honored — each test creates
+# and cleans its own scratch dir.
+#
+# Run with: hack/cozytest.sh hack/select-e2e_test.bats
+# -----------------------------------------------------------------------------
 
 @test "single app diff selects only that bats" {
-  echo "packages/apps/postgres/values.yaml" > $TMPDIR/diff
-  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
-  [ "$status" -eq 0 ]
-  [ "$output" = "postgres" ]
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    echo "packages/apps/postgres/values.yaml" > "$tmp/diff"
+    output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources")
+    [ "$output" = "postgres" ]
 }
 
 @test "operator diff selects all dependent app bats" {
-  # postgres-operator is depended on by postgres-application, harbor-application
-  # (Harbor uses postgres as its backing DB), and monitoring-application (Grafana
-  # DB). monitoring isn't in hack/e2e-apps/ so it's filtered out by the selector.
-  echo "packages/system/postgres-operator/values.yaml" > $TMPDIR/diff
-  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
-  [ "$status" -eq 0 ]
-  echo "$output" | grep -wq postgres
-  echo "$output" | grep -wq harbor
-  # Must NOT trigger full suite — confirm an unrelated bats is absent
-  ! echo "$output" | grep -wq kafka
+    # postgres-operator is depended on by postgres-application, harbor-application
+    # (Harbor uses postgres as its backing DB), and monitoring-application (Grafana
+    # DB). monitoring isn't in hack/e2e-apps/ so it's filtered out by the selector.
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    echo "packages/system/postgres-operator/values.yaml" > "$tmp/diff"
+    output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources")
+    echo "$output" | grep -wq postgres
+    echo "$output" | grep -wq harbor
+    if echo "$output" | grep -wq kafka; then
+        echo "operator diff must not trigger full suite; got: $output" >&2
+        exit 1
+    fi
 }
 
 @test "networking change triggers full suite" {
-  echo "packages/system/cilium/values.yaml" > $TMPDIR/diff
-  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
-  [ "$status" -eq 0 ]
-  # Full suite means more than 5 bats files
-  [ "$(echo $output | wc -w)" -gt 5 ]
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    echo "packages/system/cilium/values.yaml" > "$tmp/diff"
+    output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources")
+    # Full suite means more than 5 bats files
+    [ "$(echo "$output" | wc -w)" -gt 5 ]
 }
 
 @test "library change triggers full suite" {
-  echo "packages/library/cozy-lib/templates/_helpers.tpl" > $TMPDIR/diff
-  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
-  [ "$(echo $output | wc -w)" -gt 5 ]
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    echo "packages/library/cozy-lib/templates/_helpers.tpl" > "$tmp/diff"
+    output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources")
+    [ "$(echo "$output" | wc -w)" -gt 5 ]
 }
 
 @test "docs-only diff selects nothing" {
-  echo "docs/README.md" > $TMPDIR/diff
-  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    echo "docs/README.md" > "$tmp/diff"
+    output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources")
+    [ -z "$output" ]
 }
 
 @test "kubernetes-application maps to two bats files" {
-  echo "packages/apps/kubernetes/values.yaml" > $TMPDIR/diff
-  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
-  echo $output | grep -q "kubernetes-latest"
-  echo $output | grep -q "kubernetes-previous"
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    echo "packages/apps/kubernetes/values.yaml" > "$tmp/diff"
+    output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources")
+    echo "$output" | grep -q "kubernetes-latest"
+    echo "$output" | grep -q "kubernetes-previous"
 }
 
 @test "dashboards-only diff selects nothing (path is plural)" {
-  echo "dashboards/gpu/gpu-fleet.json" > $TMPDIR/diff
-  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
-  [ "$status" -eq 0 ]
-  [ -z "$output" ]
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    echo "dashboards/gpu/gpu-fleet.json" > "$tmp/diff"
+    output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources")
+    [ -z "$output" ]
 }
 
 @test "shared E2E helper script triggers full suite" {
-  echo "hack/e2e-apps/run-kubernetes.sh" > $TMPDIR/diff
-  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
-  [ "$(echo $output | wc -w)" -gt 5 ]
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    echo "hack/e2e-apps/run-kubernetes.sh" > "$tmp/diff"
+    output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources")
+    [ "$(echo "$output" | wc -w)" -gt 5 ]
 }
 
 @test "install bats triggers full suite" {
-  echo "hack/e2e-install-cozystack.bats" > $TMPDIR/diff
-  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
-  [ "$(echo $output | wc -w)" -gt 5 ]
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    echo "hack/e2e-install-cozystack.bats" > "$tmp/diff"
+    output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources")
+    [ "$(echo "$output" | wc -w)" -gt 5 ]
 }
 
 @test "per-app bats edit selects only that app, never escalates" {
-  echo "hack/e2e-apps/redis.bats" > $TMPDIR/diff
-  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
-  [ "$status" -eq 0 ]
-  [ "$output" = "redis" ]
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    echo "hack/e2e-apps/redis.bats" > "$tmp/diff"
+    output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources")
+    [ "$output" = "redis" ]
 }
 
 @test "release-e2e workflow change triggers full suite" {
-  echo ".github/workflows/release-e2e.yaml" > $TMPDIR/diff
-  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
-  [ "$(echo $output | wc -w)" -gt 5 ]
-}
-
-teardown() {
-  rm -rf $TMPDIR
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    echo ".github/workflows/release-e2e.yaml" > "$tmp/diff"
+    output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources")
+    [ "$(echo "$output" | wc -w)" -gt 5 ]
 }

--- a/hack/select-e2e_test.bats
+++ b/hack/select-e2e_test.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+setup() {
+  TMPDIR=$(mktemp -d)
+  cp -r packages/core/platform/sources $TMPDIR/sources
+}
+
+@test "single app diff selects only that bats" {
+  echo "packages/apps/postgres/values.yaml" > $TMPDIR/diff
+  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
+  [ "$status" -eq 0 ]
+  [ "$output" = "postgres" ]
+}
+
+@test "operator diff selects all dependent app bats" {
+  # postgres-operator is depended on by postgres-application, harbor-application
+  # (Harbor uses postgres as its backing DB), and monitoring-application (Grafana
+  # DB). monitoring isn't in hack/e2e-apps/ so it's filtered out by the selector.
+  echo "packages/system/postgres-operator/values.yaml" > $TMPDIR/diff
+  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -wq postgres
+  echo "$output" | grep -wq harbor
+  # Must NOT trigger full suite — confirm an unrelated bats is absent
+  ! echo "$output" | grep -wq kafka
+}
+
+@test "networking change triggers full suite" {
+  echo "packages/system/cilium/values.yaml" > $TMPDIR/diff
+  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
+  [ "$status" -eq 0 ]
+  # Full suite means more than 5 bats files
+  [ "$(echo $output | wc -w)" -gt 5 ]
+}
+
+@test "library change triggers full suite" {
+  echo "packages/library/cozy-lib/templates/_helpers.tpl" > $TMPDIR/diff
+  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
+  [ "$(echo $output | wc -w)" -gt 5 ]
+}
+
+@test "docs-only diff selects nothing" {
+  echo "docs/README.md" > $TMPDIR/diff
+  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "kubernetes-application maps to two bats files" {
+  echo "packages/apps/kubernetes/values.yaml" > $TMPDIR/diff
+  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
+  echo $output | grep -q "kubernetes-latest"
+  echo $output | grep -q "kubernetes-previous"
+}
+
+@test "dashboards-only diff selects nothing (path is plural)" {
+  echo "dashboards/gpu/gpu-fleet.json" > $TMPDIR/diff
+  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "shared E2E helper script triggers full suite" {
+  echo "hack/e2e-apps/run-kubernetes.sh" > $TMPDIR/diff
+  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
+  [ "$(echo $output | wc -w)" -gt 5 ]
+}
+
+@test "install bats triggers full suite" {
+  echo "hack/e2e-install-cozystack.bats" > $TMPDIR/diff
+  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
+  [ "$(echo $output | wc -w)" -gt 5 ]
+}
+
+@test "per-app bats edit selects only that app, never escalates" {
+  echo "hack/e2e-apps/redis.bats" > $TMPDIR/diff
+  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
+  [ "$status" -eq 0 ]
+  [ "$output" = "redis" ]
+}
+
+@test "release-e2e workflow change triggers full suite" {
+  echo ".github/workflows/release-e2e.yaml" > $TMPDIR/diff
+  run hack/select-e2e.sh $TMPDIR/diff $TMPDIR/sources
+  [ "$(echo $output | wc -w)" -gt 5 ]
+}
+
+teardown() {
+  rm -rf $TMPDIR
+}


### PR DESCRIPTION
## What this PR does

Adds **test-impact analysis (TIA)** to the PR E2E workflow so that only bats files affected by the diff are exercised, and a **release-time E2E workflow** that runs the full suite on every release tag to keep coverage on the shipped code.

### 1. Test-impact analysis selector — `hack/select-e2e.sh`

Reads `packages/core/platform/sources/*.yaml` (the PackageSource dependency graph) and emits the bats files affected by a PR diff. The walk is the same one `cozypkg dot` renders.

| Input | Output |
|---|---|
| `packages/apps/postgres/values.yaml` | `postgres` |
| `packages/system/postgres-operator/...` | `postgres harbor` (transitive) |
| `packages/system/cilium/...` | full suite (cilium has many transitive `*-application` dependents) |
| `packages/library/cozy-lib/...` | full suite (library affects everything) |
| `hack/e2e-install-cozystack.bats` | full suite (shared install affects all apps) |
| `hack/e2e-apps/redis.bats` | `redis` (per-app edit, never escalates) |
| `docs/agents/contributing.md` | (empty — no E2E impact) |
| `dashboards/gpu/gpu-fleet.json` | (empty) |

Conservative fallbacks:
- An unrecognised `packages/*` path or a system source with no `*-application` descendants escalates to the full suite, so a path inside the graph is never silently dropped.
- Per-app bats edits are matched **before** the full-suite trigger, so editing one bats file selects only that app rather than escalating.

### 2. Default-on TIA + `full-e2e` opt-out — `pull-requests.yaml`

- The `Select E2E tests` step runs by default and produces `apps` + `skip` outputs.
- `Run E2E tests` runs unless `skip=true` (docs / dashboards / `*.md` only).
- Adding the `full-e2e` label skips the selector step (output empty) and falls through to the unchanged full-bats-list path — the safety hatch when reviewers want the full suite on a PR.

### 3. `release-e2e.yaml` — full E2E on every release tag

Triggered on `v*.*.*`, `v*.*.*-rc.*`, `v*.*.*-beta.*`, `v*.*.*-alpha.*`. Builds images + Talos image, then runs the full suite. Independent of `tags.yaml`'s release publish flow — failure here is an alarm, not a release blocker.

This closes the coverage gap left by making PR runs default to TIA: the full suite is now exercised at tag-cut time against the shipped code.

## Tests

`hack/select-e2e_test.bats` covers 11 cases — single app, transitive operator, networking/library full-suite, docs/dashboards skip, `kubernetes-application` two-bats mapping, shared E2E helper, install bats, per-app bats no-escalation, release-e2e workflow change.

YAML parse verified for both new workflow files.

## Workflow injection safety

All `${{ }}` contexts that could carry untrusted data (`github.base_ref`, label arrays) flow through env vars, never directly into shell text. `github.workspace` is also indirected through `WORKSPACE` env in the release workflow.

### Release note

```
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs a Test Impact Analysis to pick only affected apps, reducing E2E runtime.
  * Added a release-level E2E workflow that runs full acceptance tests for version tags with deterministic sandboxing, artifact capture, conditional retries, teardown, and report upload.
  * E2E jobs accept selected-apps metadata and support conditional full-suite overrides.

* **Tests**
  * New test suite validates selection logic, operator expansion, full-suite escalation, and docs-only/no-op behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
