### PR TITLE
chore: address review followups from #2509 and #2553

### DIFF
--- a/cmd/cozystack-operator/main.go
+++ b/cmd/cozystack-operator/main.go
@@ -150,7 +150,7 @@ func main() {
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	parseFlag := func(flagName, raw string) time.Duration {
-		d, err := parsePositiveDuration(flagName, raw)
+		d, err := parsePositiveDuration(flagName, raw, helmReleaseMinDuration)
 		if err != nil {
 			setupLog.Error(err, "invalid duration flag")
 			os.Exit(1)
@@ -439,17 +439,28 @@ func installPlatformSourceResource(ctx context.Context, k8sClient client.Client,
 	return nil
 }
 
+// helmReleaseMinDuration is the lower bound enforced on every HelmRelease
+// duration flag. time.ParseDuration accepts values like "1ms" that would
+// thrash the Flux controller (or the apiserver, for retry-interval) without
+// usefully changing behaviour. 15s matches the smallest interval that has
+// ever been observed to be useful in practice.
+const helmReleaseMinDuration = 15 * time.Second
+
 // parsePositiveDuration parses raw as a time.Duration and rejects malformed
-// or non-positive values. Flux HelmRelease fields (Interval, Timeout,
-// RetryInterval) require strictly positive durations, so a misconfigured
-// flag must fail fast at startup rather than propagating into every HR.
-func parsePositiveDuration(flagName, raw string) (time.Duration, error) {
+// values, non-positive values, and values below min. Flux HelmRelease fields
+// (Interval, Timeout, RetryInterval) require strictly positive durations, so
+// a misconfigured flag must fail fast at startup rather than propagating into
+// every HR. Pass min=0 to disable the lower-bound check.
+func parsePositiveDuration(flagName, raw string, min time.Duration) (time.Duration, error) {
 	d, err := time.ParseDuration(raw)
 	if err != nil {
 		return 0, fmt.Errorf("invalid duration for %s=%q: %w", flagName, raw, err)
 	}
 	if d <= 0 {
 		return 0, fmt.Errorf("%s must be > 0 (got %q)", flagName, raw)
+	}
+	if min > 0 && d < min {
+		return 0, fmt.Errorf("%s must be >= %s (got %q)", flagName, min, raw)
 	}
 	return d, nil
 }

--- a/cmd/cozystack-operator/main_test.go
+++ b/cmd/cozystack-operator/main_test.go
@@ -578,21 +578,26 @@ func TestParsePositiveDuration(t *testing.T) {
 	tests := []struct {
 		name    string
 		raw     string
+		min     time.Duration
 		want    time.Duration
 		wantErr bool
 	}{
-		{name: "valid seconds", raw: "30s", want: 30 * time.Second},
-		{name: "valid minutes", raw: "5m", want: 5 * time.Minute},
-		{name: "valid compound", raw: "1h30m", want: 90 * time.Minute},
+		{name: "valid seconds, no min", raw: "30s", want: 30 * time.Second},
+		{name: "valid minutes, no min", raw: "5m", want: 5 * time.Minute},
+		{name: "valid compound, no min", raw: "1h30m", want: 90 * time.Minute},
 		{name: "zero rejected", raw: "0s", wantErr: true},
 		{name: "negative rejected", raw: "-5m", wantErr: true},
 		{name: "malformed rejected", raw: "5x", wantErr: true},
 		{name: "empty rejected", raw: "", wantErr: true},
+		{name: "above min accepted", raw: "30s", min: 15 * time.Second, want: 30 * time.Second},
+		{name: "at min accepted", raw: "15s", min: 15 * time.Second, want: 15 * time.Second},
+		{name: "below min rejected", raw: "1ms", min: 15 * time.Second, wantErr: true},
+		{name: "below min rejected (sub-second)", raw: "100ms", min: 15 * time.Second, wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parsePositiveDuration("--test-flag", tt.raw)
+			got, err := parsePositiveDuration("--test-flag", tt.raw, tt.min)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatalf("expected error for %q, got nil", tt.raw)

--- a/hack/cozyreport-summary.sh
+++ b/hack/cozyreport-summary.sh
@@ -1,14 +1,14 @@
-#!/bin/sh
+#!/bin/bash
 # Emit a human-readable summary of "what is broken" to a single file.
 # Reads the live cluster (not the report dir) so it can use kubectl JSONPath.
 # Usage: cozyreport-summary.sh > summary.txt
-set -eu
-# pipefail surfaces a failed kubectl in `kubectl ... | awk ...` chains as a
-# missing section instead of a silently-empty one. POSIX sh does not
-# guarantee `set -o pipefail`, but every shell cozystack ships with (dash,
-# bash, busybox ash) supports it; the call site wraps this script in
-# `|| true` so a hard exit here still produces a (truncated) summary.txt.
-set -o pipefail 2>/dev/null || true
+#
+# bash, not /bin/sh: we rely on `set -o pipefail` to surface failed kubectl
+# calls in `kubectl ... | awk ...` chains as missing sections instead of
+# silently-empty ones, and the e2e-sandbox image's /bin/sh (Ubuntu dash)
+# does not implement pipefail. The call site wraps this script in `|| true`
+# so a hard pipeline failure still produces a (truncated) summary.txt.
+set -euo pipefail
 
 echo "# Cozystack E2E Diagnostic Summary"
 echo "Generated: $(date -Iseconds)"

--- a/hack/cozyreport-summary.sh
+++ b/hack/cozyreport-summary.sh
@@ -3,6 +3,12 @@
 # Reads the live cluster (not the report dir) so it can use kubectl JSONPath.
 # Usage: cozyreport-summary.sh > summary.txt
 set -eu
+# pipefail surfaces a failed kubectl in `kubectl ... | awk ...` chains as a
+# missing section instead of a silently-empty one. POSIX sh does not
+# guarantee `set -o pipefail`, but every shell cozystack ships with (dash,
+# bash, busybox ash) supports it; the call site wraps this script in
+# `|| true` so a hard exit here still produces a (truncated) summary.txt.
+set -o pipefail 2>/dev/null || true
 
 echo "# Cozystack E2E Diagnostic Summary"
 echo "Generated: $(date -Iseconds)"

--- a/hack/cozyreport-summary.sh
+++ b/hack/cozyreport-summary.sh
@@ -38,8 +38,24 @@ echo
 
 echo "## Recent OOMKilled events (last 20)"
 echo
+# Catches kernel-OOM events emitted by kubelet at the node level. Misses
+# cgroup-only container kills that exit 137 without escalating to a node
+# OOMKilling event — those show up in the container-state section below.
 kubectl get events -A --field-selector reason=OOMKilling --sort-by=.lastTimestamp 2>/dev/null \
   | tail -20
+echo
+
+echo "## Containers with OOMKilled lastState"
+echo
+# Complements the OOMKilling-event section above. Container statuses retain
+# the lastState even when no node-level OOMKilling event was emitted (e.g.
+# cgroup-only kills with no kernel memory-pressure broadcast), so this
+# catches the silent-restart cases. Use go-template (not jsonpath) so the
+# inner range can still reach pod-level metadata via the outer-scope $pod.
+kubectl get pod -A -o go-template='{{range .items}}{{$pod := .}}{{range .status.containerStatuses}}{{if and .lastState.terminated (eq .lastState.terminated.reason "OOMKilled")}}  {{$pod.metadata.namespace}}/{{$pod.metadata.name}} container={{.name}} exitCode={{.lastState.terminated.exitCode}} finishedAt={{.lastState.terminated.finishedAt}}
+{{end}}{{end}}{{range .status.initContainerStatuses}}{{if and .lastState.terminated (eq .lastState.terminated.reason "OOMKilled")}}  {{$pod.metadata.namespace}}/{{$pod.metadata.name}} initContainer={{.name}} exitCode={{.lastState.terminated.exitCode}} finishedAt={{.lastState.terminated.finishedAt}}
+{{end}}{{end}}{{end}}' 2>/dev/null \
+  | head -40
 echo
 
 echo "## Recent Warning events (top 30)"

--- a/hack/cozyreport.sh
+++ b/hack/cozyreport.sh
@@ -3,7 +3,7 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPORT_DATE=$(date +%Y-%m-%d_%H-%M-%S)
 REPORT_NAME=${1:-cozyreport-$REPORT_DATE}
 REPORT_PDIR=$(mktemp -d)
-REPORT_DIR=$REPORT_PDIR/$REPORT_NAME
+REPORT_DIR="$REPORT_PDIR/$REPORT_NAME"
 
 # -- check dependencies
 command -V kubectl >/dev/null || exit $?
@@ -11,237 +11,237 @@ command -V tar >/dev/null || exit $?
 
 # -- cozystack module
 echo "Collecting Cozystack information..."
-mkdir -p $REPORT_DIR/cozystack
-kubectl get deploy -n cozy-system cozystack -o jsonpath='{.spec.template.spec.containers[0].image}' > $REPORT_DIR/cozystack/image.txt 2>&1
+mkdir -p "$REPORT_DIR/cozystack"
+kubectl get deploy -n cozy-system cozystack -o jsonpath='{.spec.template.spec.containers[0].image}' > "$REPORT_DIR/cozystack/image.txt" 2>&1
 if kubectl get deploy -n cozy-system cozystack-operator >/dev/null 2>&1; then
-  kubectl logs -n cozy-system deploy/cozystack-operator --tail=2000 > $REPORT_DIR/cozystack/operator.log 2>&1
-  kubectl logs -n cozy-system deploy/cozystack-operator --tail=2000 --previous > $REPORT_DIR/cozystack/operator-previous.log 2>&1 || true
+  kubectl logs -n cozy-system deploy/cozystack-operator --tail=2000 > "$REPORT_DIR/cozystack/operator.log" 2>&1
+  kubectl logs -n cozy-system deploy/cozystack-operator --tail=2000 --previous > "$REPORT_DIR/cozystack/operator-previous.log" 2>&1 || true
 fi
 kubectl get cm -n cozy-system --no-headers | awk '$1 ~ /^cozystack/' |
   while read NAME _; do
-    DIR=$REPORT_DIR/cozystack/configs
-    mkdir -p $DIR
-    kubectl get cm -n cozy-system $NAME -o yaml > $DIR/$NAME.yaml 2>&1
+    DIR="$REPORT_DIR/cozystack/configs"
+    mkdir -p "$DIR"
+    kubectl get cm -n cozy-system "$NAME" -o yaml > "$DIR/$NAME.yaml" 2>&1
   done
 
 # -- flux module
 echo "Collecting Flux controller state..."
-mkdir -p $REPORT_DIR/flux
+mkdir -p "$REPORT_DIR/flux"
 for ctrl in helm-controller source-controller notification-controller kustomize-controller; do
-  if kubectl get deploy -n cozy-fluxcd $ctrl >/dev/null 2>&1; then
-    kubectl logs -n cozy-fluxcd deploy/$ctrl --tail=2000 > $REPORT_DIR/flux/$ctrl.log 2>&1
-    kubectl logs -n cozy-fluxcd deploy/$ctrl --tail=2000 --previous > $REPORT_DIR/flux/$ctrl-previous.log 2>&1 || true
+  if kubectl get deploy -n cozy-fluxcd "$ctrl" >/dev/null 2>&1; then
+    kubectl logs -n cozy-fluxcd "deploy/$ctrl" --tail=2000 > "$REPORT_DIR/flux/$ctrl.log" 2>&1
+    kubectl logs -n cozy-fluxcd "deploy/$ctrl" --tail=2000 --previous > "$REPORT_DIR/flux/$ctrl-previous.log" 2>&1 || true
   fi
 done
 
 echo "Collecting Flux sources..."
 for kind in helmrepositories.source.toolkit.fluxcd.io ocirepositories.source.toolkit.fluxcd.io gitrepositories.source.toolkit.fluxcd.io externalartifacts.source.toolkit.fluxcd.io; do
   short=${kind%%.*}
-  kubectl get $kind -A > $REPORT_DIR/flux/$short.txt 2>&1
-  kubectl get $kind -A -o yaml > $REPORT_DIR/flux/$short.yaml 2>&1
+  kubectl get "$kind" -A > "$REPORT_DIR/flux/$short.txt" 2>&1
+  kubectl get "$kind" -A -o yaml > "$REPORT_DIR/flux/$short.yaml" 2>&1
 done
 
 # -- cert-manager module
 if kubectl get crd certificates.cert-manager.io >/dev/null 2>&1; then
   echo "Collecting cert-manager state..."
-  DIR=$REPORT_DIR/cert-manager
-  mkdir -p $DIR
-  kubectl get certificates.cert-manager.io -A > $DIR/certificates.txt 2>&1
-  kubectl get certificaterequests.cert-manager.io -A > $DIR/certificaterequests.txt 2>&1
-  kubectl get orders.acme.cert-manager.io -A > $DIR/orders.txt 2>&1
-  kubectl get challenges.acme.cert-manager.io -A > $DIR/challenges.txt 2>&1
+  DIR="$REPORT_DIR/cert-manager"
+  mkdir -p "$DIR"
+  kubectl get certificates.cert-manager.io -A > "$DIR/certificates.txt" 2>&1
+  kubectl get certificaterequests.cert-manager.io -A > "$DIR/certificaterequests.txt" 2>&1
+  kubectl get orders.acme.cert-manager.io -A > "$DIR/orders.txt" 2>&1
+  kubectl get challenges.acme.cert-manager.io -A > "$DIR/challenges.txt" 2>&1
   # Per non-Ready cert: full yaml + describe
   kubectl get certificates.cert-manager.io -A --no-headers 2>/dev/null | awk '$3 != "True"' | \
     while read NAMESPACE NAME _; do
-      cdir=$DIR/certificates/$NAMESPACE/$NAME
-      mkdir -p $cdir
-      kubectl get certificates.cert-manager.io -n $NAMESPACE $NAME -o yaml > $cdir/cert.yaml 2>&1
-      kubectl describe certificates.cert-manager.io -n $NAMESPACE $NAME > $cdir/describe.txt 2>&1
+      cdir="$DIR/certificates/$NAMESPACE/$NAME"
+      mkdir -p "$cdir"
+      kubectl get certificates.cert-manager.io -n "$NAMESPACE" "$NAME" -o yaml > "$cdir/cert.yaml" 2>&1
+      kubectl describe certificates.cert-manager.io -n "$NAMESPACE" "$NAME" > "$cdir/describe.txt" 2>&1
     done
   if kubectl get deploy -n cozy-cert-manager cert-manager >/dev/null 2>&1; then
-    kubectl logs -n cozy-cert-manager deploy/cert-manager --tail=2000 > $DIR/cert-manager.log 2>&1
-    kubectl logs -n cozy-cert-manager deploy/cert-manager-webhook --tail=2000 > $DIR/cert-manager-webhook.log 2>&1
+    kubectl logs -n cozy-cert-manager deploy/cert-manager --tail=2000 > "$DIR/cert-manager.log" 2>&1
+    kubectl logs -n cozy-cert-manager deploy/cert-manager-webhook --tail=2000 > "$DIR/cert-manager-webhook.log" 2>&1
   fi
 fi
 
 # -- kubernetes module
 
 echo "Collecting Kubernetes information..."
-mkdir -p $REPORT_DIR/kubernetes
-kubectl version > $REPORT_DIR/kubernetes/version.txt 2>&1
+mkdir -p "$REPORT_DIR/kubernetes"
+kubectl version > "$REPORT_DIR/kubernetes/version.txt" 2>&1
 
 echo "Collecting nodes..."
-kubectl get nodes -o wide > $REPORT_DIR/kubernetes/nodes.txt 2>&1
+kubectl get nodes -o wide > "$REPORT_DIR/kubernetes/nodes.txt" 2>&1
 kubectl get nodes --no-headers | awk '$2 != "Ready"' |
   while read NAME _; do
-    DIR=$REPORT_DIR/kubernetes/nodes/$NAME
-    mkdir -p $DIR
-    kubectl get node $NAME -o yaml > $DIR/node.yaml 2>&1
-    kubectl describe node $NAME > $DIR/describe.txt 2>&1
+    DIR="$REPORT_DIR/kubernetes/nodes/$NAME"
+    mkdir -p "$DIR"
+    kubectl get node "$NAME" -o yaml > "$DIR/node.yaml" 2>&1
+    kubectl describe node "$NAME" > "$DIR/describe.txt" 2>&1
   done
 
 echo "Collecting namespaces..."
-kubectl get ns -o wide > $REPORT_DIR/kubernetes/namespaces.txt 2>&1
+kubectl get ns -o wide > "$REPORT_DIR/kubernetes/namespaces.txt" 2>&1
 kubectl get ns --no-headers | awk '$2 != "Active"' |
   while read NAME _; do
-    DIR=$REPORT_DIR/kubernetes/namespaces/$NAME
-    mkdir -p $DIR
-    kubectl get ns $NAME -o yaml > $DIR/namespace.yaml 2>&1
-    kubectl describe ns $NAME > $DIR/describe.txt 2>&1
+    DIR="$REPORT_DIR/kubernetes/namespaces/$NAME"
+    mkdir -p "$DIR"
+    kubectl get ns "$NAME" -o yaml > "$DIR/namespace.yaml" 2>&1
+    kubectl describe ns "$NAME" > "$DIR/describe.txt" 2>&1
   done
 
 echo "Collecting events..."
-kubectl get events -A --sort-by=.lastTimestamp > $REPORT_DIR/kubernetes/events.txt 2>&1
+kubectl get events -A --sort-by=.lastTimestamp > "$REPORT_DIR/kubernetes/events.txt" 2>&1
 # Filter to warning-class and recent for quick triage
 kubectl get events -A --sort-by=.lastTimestamp \
   -o jsonpath='{range .items[?(@.type!="Normal")]}{.lastTimestamp}{"\t"}{.involvedObject.namespace}/{.involvedObject.kind}/{.involvedObject.name}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}' \
-  > $REPORT_DIR/kubernetes/events-warnings.txt 2>&1
+  > "$REPORT_DIR/kubernetes/events-warnings.txt" 2>&1
 
 echo "Collecting helmreleases..."
-kubectl get hr -A > $REPORT_DIR/kubernetes/helmreleases.txt 2>&1
+kubectl get hr -A > "$REPORT_DIR/kubernetes/helmreleases.txt" 2>&1
 kubectl get hr -A --no-headers | awk '$4 != "True"' | \
   while read NAMESPACE NAME _; do
-    DIR=$REPORT_DIR/kubernetes/helmreleases/$NAMESPACE/$NAME
-    mkdir -p $DIR
-    kubectl get hr -n $NAMESPACE $NAME -o yaml > $DIR/hr.yaml 2>&1
-    kubectl describe hr -n $NAMESPACE $NAME > $DIR/describe.txt 2>&1
+    DIR="$REPORT_DIR/kubernetes/helmreleases/$NAMESPACE/$NAME"
+    mkdir -p "$DIR"
+    kubectl get hr -n "$NAMESPACE" "$NAME" -o yaml > "$DIR/hr.yaml" 2>&1
+    kubectl describe hr -n "$NAMESPACE" "$NAME" > "$DIR/describe.txt" 2>&1
     # Helm storage secrets: latest revision per release.
-    kubectl get secret -n $NAMESPACE -l owner=helm,name=$NAME --sort-by='.metadata.creationTimestamp' --no-headers 2>/dev/null | \
+    kubectl get secret -n "$NAMESPACE" -l "owner=helm,name=$NAME" --sort-by='.metadata.creationTimestamp' --no-headers 2>/dev/null | \
       tail -1 | awk '{print $1}' | while read SECRET; do
         [ -z "$SECRET" ] && continue
-        kubectl get secret -n $NAMESPACE $SECRET -o jsonpath='{.data.release}' 2>/dev/null \
-          | base64 -d | base64 -d | gzip -d > $DIR/helm-release.json 2>&1 || true
+        kubectl get secret -n "$NAMESPACE" "$SECRET" -o jsonpath='{.data.release}' 2>/dev/null \
+          | base64 -d | base64 -d | gzip -d > "$DIR/helm-release.json" 2>&1 || true
       done
   done
 
 echo "Collecting packages..."
-kubectl get packages > $REPORT_DIR/kubernetes/packages.txt 2>&1
+kubectl get packages > "$REPORT_DIR/kubernetes/packages.txt" 2>&1
 kubectl get packages --no-headers | awk '$3 != "True"' | \
   while read NAME _; do
-    DIR=$REPORT_DIR/kubernetes/packages/$NAME
-    mkdir -p $DIR
-    kubectl get package $NAME -o yaml > $DIR/package.yaml 2>&1
-    kubectl describe package $NAME > $DIR/describe.txt 2>&1
+    DIR="$REPORT_DIR/kubernetes/packages/$NAME"
+    mkdir -p "$DIR"
+    kubectl get package "$NAME" -o yaml > "$DIR/package.yaml" 2>&1
+    kubectl describe package "$NAME" > "$DIR/describe.txt" 2>&1
   done
 
 echo "Collecting packagesources..."
-kubectl get packagesources > $REPORT_DIR/kubernetes/packagesources.txt 2>&1
+kubectl get packagesources > "$REPORT_DIR/kubernetes/packagesources.txt" 2>&1
 kubectl get packagesources --no-headers | awk '$3 != "True"' | \
   while read NAME _; do
-    DIR=$REPORT_DIR/kubernetes/packagesources/$NAME
-    mkdir -p $DIR
-    kubectl get packagesource $NAME -o yaml > $DIR/packagesource.yaml 2>&1
-    kubectl describe packagesource $NAME > $DIR/describe.txt 2>&1
+    DIR="$REPORT_DIR/kubernetes/packagesources/$NAME"
+    mkdir -p "$DIR"
+    kubectl get packagesource "$NAME" -o yaml > "$DIR/packagesource.yaml" 2>&1
+    kubectl describe packagesource "$NAME" > "$DIR/describe.txt" 2>&1
   done
 
 echo "Collecting cozystack apps..."
-DIR=$REPORT_DIR/cozystack-apps
-mkdir -p $DIR
+DIR="$REPORT_DIR/cozystack-apps"
+mkdir -p "$DIR"
 for kind in applications.apps.cozystack.io applicationdefinitions.apps.cozystack.io tenants.apps.cozystack.io; do
   short=${kind%%.*}
-  if kubectl get crd $kind >/dev/null 2>&1; then
-    kubectl get $kind -A > $DIR/$short.txt 2>&1
-    kubectl get $kind -A -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status!="True")]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null | \
+  if kubectl get crd "$kind" >/dev/null 2>&1; then
+    kubectl get "$kind" -A > "$DIR/$short.txt" 2>&1
+    kubectl get "$kind" -A -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status!="True")]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null | \
       while read NAMESPACE NAME; do
         [ -z "$NAMESPACE" ] && continue
-        d=$DIR/$short/$NAMESPACE/$NAME
-        mkdir -p $d
-        kubectl get $kind -n $NAMESPACE $NAME -o yaml > $d/$short.yaml 2>&1
-        kubectl describe $kind -n $NAMESPACE $NAME > $d/describe.txt 2>&1
+        d="$DIR/$short/$NAMESPACE/$NAME"
+        mkdir -p "$d"
+        kubectl get "$kind" -n "$NAMESPACE" "$NAME" -o yaml > "$d/$short.yaml" 2>&1
+        kubectl describe "$kind" -n "$NAMESPACE" "$NAME" > "$d/describe.txt" 2>&1
       done
   fi
 done
 
 echo "Collecting pods..."
-kubectl get pod -A -o wide > $REPORT_DIR/kubernetes/pods.txt 2>&1
+kubectl get pod -A -o wide > "$REPORT_DIR/kubernetes/pods.txt" 2>&1
 kubectl get pod -A --no-headers | awk '$4 !~ /Running|Succeeded|Completed/' |
   while read NAMESPACE NAME _ STATE _; do
-    DIR=$REPORT_DIR/kubernetes/pods/$NAMESPACE/$NAME
-    mkdir -p $DIR
-    CONTAINERS=$(kubectl get pod -o jsonpath='{.spec.containers[*].name} {.spec.initContainers[*].name}' -n $NAMESPACE $NAME)
-    kubectl get pod -n $NAMESPACE $NAME -o yaml > $DIR/pod.yaml 2>&1
-    kubectl describe pod -n $NAMESPACE $NAME > $DIR/describe.txt 2>&1
+    DIR="$REPORT_DIR/kubernetes/pods/$NAMESPACE/$NAME"
+    mkdir -p "$DIR"
+    CONTAINERS=$(kubectl get pod -o jsonpath='{.spec.containers[*].name} {.spec.initContainers[*].name}' -n "$NAMESPACE" "$NAME")
+    kubectl get pod -n "$NAMESPACE" "$NAME" -o yaml > "$DIR/pod.yaml" 2>&1
+    kubectl describe pod -n "$NAMESPACE" "$NAME" > "$DIR/describe.txt" 2>&1
     if [ "$STATE" != "Pending" ]; then
       for CONTAINER in $CONTAINERS; do
-        kubectl logs -n $NAMESPACE $NAME $CONTAINER > $DIR/logs-$CONTAINER.txt 2>&1
-        kubectl logs -n $NAMESPACE $NAME $CONTAINER --previous > $DIR/logs-$CONTAINER-previous.txt 2>&1
+        kubectl logs -n "$NAMESPACE" "$NAME" "$CONTAINER" > "$DIR/logs-$CONTAINER.txt" 2>&1
+        kubectl logs -n "$NAMESPACE" "$NAME" "$CONTAINER" --previous > "$DIR/logs-$CONTAINER-previous.txt" 2>&1
       done
     fi
   done
 
 echo "Collecting virtualmachines..."
-kubectl get vm -A > $REPORT_DIR/kubernetes/vms.txt 2>&1
+kubectl get vm -A > "$REPORT_DIR/kubernetes/vms.txt" 2>&1
 kubectl get vm -A --no-headers | awk '$5 != "True"' |
   while read NAMESPACE NAME _; do
-    DIR=$REPORT_DIR/kubernetes/vm/$NAMESPACE/$NAME
-    mkdir -p $DIR
-    kubectl get vm -n $NAMESPACE $NAME -o yaml > $DIR/vm.yaml 2>&1
-    kubectl describe vm -n $NAMESPACE $NAME > $DIR/describe.txt 2>&1
+    DIR="$REPORT_DIR/kubernetes/vm/$NAMESPACE/$NAME"
+    mkdir -p "$DIR"
+    kubectl get vm -n "$NAMESPACE" "$NAME" -o yaml > "$DIR/vm.yaml" 2>&1
+    kubectl describe vm -n "$NAMESPACE" "$NAME" > "$DIR/describe.txt" 2>&1
   done
 
 echo "Collecting virtualmachine instances..."
-kubectl get vmi -A > $REPORT_DIR/kubernetes/vmis.txt 2>&1
+kubectl get vmi -A > "$REPORT_DIR/kubernetes/vmis.txt" 2>&1
 kubectl get vmi -A --no-headers | awk '$4 != "Running"' |
   while read NAMESPACE NAME _; do
-    DIR=$REPORT_DIR/kubernetes/vmi/$NAMESPACE/$NAME
-    mkdir -p $DIR
-    kubectl get vmi -n $NAMESPACE $NAME -o yaml > $DIR/vmi.yaml 2>&1
-    kubectl describe vmi -n $NAMESPACE $NAME > $DIR/describe.txt 2>&1
+    DIR="$REPORT_DIR/kubernetes/vmi/$NAMESPACE/$NAME"
+    mkdir -p "$DIR"
+    kubectl get vmi -n "$NAMESPACE" "$NAME" -o yaml > "$DIR/vmi.yaml" 2>&1
+    kubectl describe vmi -n "$NAMESPACE" "$NAME" > "$DIR/describe.txt" 2>&1
   done
 
 echo "Collecting services..."
-kubectl get svc -A > $REPORT_DIR/kubernetes/services.txt 2>&1
+kubectl get svc -A > "$REPORT_DIR/kubernetes/services.txt" 2>&1
 kubectl get svc -A --no-headers | awk '$4 == "<pending>"' |
   while read NAMESPACE NAME _; do
-    DIR=$REPORT_DIR/kubernetes/services/$NAMESPACE/$NAME
-    mkdir -p $DIR
-    kubectl get svc -n $NAMESPACE $NAME -o yaml > $DIR/service.yaml 2>&1
-    kubectl describe svc -n $NAMESPACE $NAME > $DIR/describe.txt 2>&1
+    DIR="$REPORT_DIR/kubernetes/services/$NAMESPACE/$NAME"
+    mkdir -p "$DIR"
+    kubectl get svc -n "$NAMESPACE" "$NAME" -o yaml > "$DIR/service.yaml" 2>&1
+    kubectl describe svc -n "$NAMESPACE" "$NAME" > "$DIR/describe.txt" 2>&1
   done
 
 echo "Collecting pvcs..."
-kubectl get pvc -A > $REPORT_DIR/kubernetes/pvcs.txt 2>&1
+kubectl get pvc -A > "$REPORT_DIR/kubernetes/pvcs.txt" 2>&1
 kubectl get pvc -A --no-headers | awk '$3 != "Bound"'  |
   while read NAMESPACE NAME _; do
-    DIR=$REPORT_DIR/kubernetes/pvc/$NAMESPACE/$NAME
-    mkdir -p $DIR
-    kubectl get pvc -n $NAMESPACE $NAME -o yaml > $DIR/pvc.yaml 2>&1
-    kubectl describe pvc -n $NAMESPACE $NAME > $DIR/describe.txt 2>&1
+    DIR="$REPORT_DIR/kubernetes/pvc/$NAMESPACE/$NAME"
+    mkdir -p "$DIR"
+    kubectl get pvc -n "$NAMESPACE" "$NAME" -o yaml > "$DIR/pvc.yaml" 2>&1
+    kubectl describe pvc -n "$NAMESPACE" "$NAME" > "$DIR/describe.txt" 2>&1
   done
 
 # -- kamaji module
 
 if kubectl get deploy -n cozy-linstor linstor-controller >/dev/null 2>&1; then
   echo "Collecting kamaji resources..."
-  DIR=$REPORT_DIR/kamaji
-  mkdir -p $DIR
-  kubectl logs -n cozy-kamaji deployment/kamaji > $DIR/kamaji-controller.log 2>&1
-  kubectl get kamajicontrolplanes.controlplane.cluster.x-k8s.io -A > $DIR/kamajicontrolplanes.txt 2>&1
-  kubectl get kamajicontrolplanes.controlplane.cluster.x-k8s.io -A -o yaml > $DIR/kamajicontrolplanes.yaml 2>&1
-  kubectl get tenantcontrolplanes.kamaji.clastix.io -A > $DIR/tenantcontrolplanes.txt 2>&1
-  kubectl get tenantcontrolplanes.kamaji.clastix.io -A -o yaml > $DIR/tenantcontrolplanes.yaml 2>&1
+  DIR="$REPORT_DIR/kamaji"
+  mkdir -p "$DIR"
+  kubectl logs -n cozy-kamaji deployment/kamaji > "$DIR/kamaji-controller.log" 2>&1
+  kubectl get kamajicontrolplanes.controlplane.cluster.x-k8s.io -A > "$DIR/kamajicontrolplanes.txt" 2>&1
+  kubectl get kamajicontrolplanes.controlplane.cluster.x-k8s.io -A -o yaml > "$DIR/kamajicontrolplanes.yaml" 2>&1
+  kubectl get tenantcontrolplanes.kamaji.clastix.io -A > "$DIR/tenantcontrolplanes.txt" 2>&1
+  kubectl get tenantcontrolplanes.kamaji.clastix.io -A -o yaml > "$DIR/tenantcontrolplanes.yaml" 2>&1
 fi
 
 # -- linstor module
 
 if kubectl get deploy -n cozy-linstor linstor-controller >/dev/null 2>&1; then
   echo "Collecting linstor resources..."
-  DIR=$REPORT_DIR/linstor
-  mkdir -p $DIR
-  kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor --no-color n l > $DIR/nodes.txt 2>&1
-  kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor --no-color sp l > $DIR/storage-pools.txt 2>&1
-  kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor --no-color r l > $DIR/resources.txt 2>&1
+  DIR="$REPORT_DIR/linstor"
+  mkdir -p "$DIR"
+  kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor --no-color n l > "$DIR/nodes.txt" 2>&1
+  kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor --no-color sp l > "$DIR/storage-pools.txt" 2>&1
+  kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor --no-color r l > "$DIR/resources.txt" 2>&1
 fi
 
 # -- sandbox-host module
 
 echo "Collecting sandbox host context..."
-DIR=$REPORT_DIR/sandbox-host
-mkdir -p $DIR
-df -h > $DIR/df.txt 2>&1
-free -m > $DIR/free.txt 2>&1
-ps auxww > $DIR/ps.txt 2>&1
-dmesg | tail -200 > $DIR/dmesg.txt 2>&1 || true
+DIR="$REPORT_DIR/sandbox-host"
+mkdir -p "$DIR"
+df -h > "$DIR/df.txt" 2>&1
+free -m > "$DIR/free.txt" 2>&1
+ps auxww > "$DIR/ps.txt" 2>&1
+dmesg | tail -200 > "$DIR/dmesg.txt" 2>&1 || true
 if [ -f /workspace/talosconfig ]; then
   NODES=$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.addresses[?(@.type=="InternalIP")].address}{"\n"}{end}' 2>/dev/null)
   for node in ${NODES:-192.168.123.11 192.168.123.12 192.168.123.13}; do
@@ -258,8 +258,8 @@ echo "Generating summary..."
 "$SCRIPT_DIR/cozyreport-summary.sh" > "$REPORT_DIR/summary.txt" 2>&1 || true
 
 echo "Creating archive..."
-tar -czf $REPORT_NAME.tgz -C $REPORT_PDIR .
+tar -czf "$REPORT_NAME.tgz" -C "$REPORT_PDIR" .
 echo "Report created: $REPORT_NAME.tgz"
 
 echo "Cleaning up..."
-rm -rf $REPORT_PDIR
+rm -rf "$REPORT_PDIR"

--- a/hack/cozyreport.sh
+++ b/hack/cozyreport.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+# Best-effort diagnostic collection: deliberately runs without `set -e` so
+# one failed `kubectl` (missing CRD, RBAC denial, transient API timeout)
+# does not abort the rest of the report. Errors are captured into the
+# per-section output files via `2>&1`. The companion cozyreport-summary.sh
+# is fail-fast (`set -eu`) because it is wrapped in `|| true` at the call
+# site below — any change to either policy should be made deliberately.
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPORT_DATE=$(date +%Y-%m-%d_%H-%M-%S)
 REPORT_NAME=${1:-cozyreport-$REPORT_DATE}


### PR DESCRIPTION
## Summary
Address inline review followups left from #2509 (HelmRelease knobs) and #2553 (cozyreport).

**Operator (#2509 followup):**
- `cmd/cozystack-operator/main.go`: extend `parsePositiveDuration` with a `min` parameter and pass `helmReleaseMinDuration` (15s) at every HR-flag call site, so `--helmrelease-install-timeout=1ms` (and similar) fail fast at startup instead of producing a HelmRelease that thrashes the controller. Tests cover at-min, above-min, and below-min (including sub-second).

**cozyreport (#2553 followups):**
- `hack/cozyreport.sh`: consistent variable quoting across all loops; one-line comment at the top documenting the deliberate absence of `set -e` (best-effort diagnostic collection — a single failed kubectl must not abort the rest of the report).
- `hack/cozyreport-summary.sh`: enable `set -o pipefail` so failed kubectl calls in `kubectl ... | awk ...` chains surface as missing sections instead of silently-empty ones. Switched shebang to `/bin/bash` because the e2e-sandbox image's `/bin/sh` (Ubuntu dash, both 22.04 and 24.04) does not implement pipefail; bash is already installed in the image.
- `hack/cozyreport-summary.sh`: surface container-state `OOMKilled` (via `lastState.terminated.reason`) using a go-template — catches cgroup-only kills that exit 137 without escalating to a node-level `OOMKilling` event.

## Test plan
- [ ] `go test ./cmd/cozystack-operator/...` passes (TestParsePositiveDuration covers at-min, above-min, below-min, sub-second)
- [ ] Run an operator with `--helmrelease-install-timeout=1ms` and confirm it exits at startup with `must be >= 15s`
- [ ] `bash -n hack/cozyreport-summary.sh` and `sh -n hack/cozyreport.sh` syntax-clean
- [ ] Run `hack/cozyreport.sh` against an e2e cluster; confirm `summary.txt` contains the new `## Containers with OOMKilled lastState` section
- [ ] Simulate a failed kubectl in a pipeline (e.g., a missing CRD) and confirm `summary.txt` is truncated at the failure instead of producing a complete-but-empty section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended duration parsing tests to validate minimum-bound constraints.

* **Chores**
  * Enhanced reporting scripts with improved error handling and reliability.
  * Added detailed OOMKilled container state reporting in diagnostics.
  * Integrated Talos log collection support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->