### PR TITLE
fix(migrations): add missing application.group label in migration 29

### DIFF
--- a/packages/core/platform/images/migrations/migrations/29
+++ b/packages/core/platform/images/migrations/migrations/29
@@ -403,7 +403,7 @@ metadata:
     sharding.fluxcd.io/key: tenants
     apps.cozystack.io/application.kind: VMDisk
     apps.cozystack.io/application.group: apps.cozystack.io
-    apps.cozystack.io/application.name: ${INSTANCE}
+    apps.cozystack.io/application.name: vm-disk
 spec:
   suspend: true
   chartRef:
@@ -482,7 +482,7 @@ metadata:
     sharding.fluxcd.io/key: tenants
     apps.cozystack.io/application.kind: VMInstance
     apps.cozystack.io/application.group: apps.cozystack.io
-    apps.cozystack.io/application.name: ${INSTANCE}
+    apps.cozystack.io/application.name: vm-instance
 spec:
   suspend: true
   chartRef:

--- a/packages/core/platform/images/migrations/migrations/29
+++ b/packages/core/platform/images/migrations/migrations/29
@@ -402,7 +402,8 @@ metadata:
   labels:
     sharding.fluxcd.io/key: tenants
     apps.cozystack.io/application.kind: VMDisk
-    apps.cozystack.io/application.name: vm-disk
+    apps.cozystack.io/application.group: apps.cozystack.io
+    apps.cozystack.io/application.name: ${INSTANCE}
 spec:
   suspend: true
   chartRef:
@@ -480,7 +481,8 @@ metadata:
   labels:
     sharding.fluxcd.io/key: tenants
     apps.cozystack.io/application.kind: VMInstance
-    apps.cozystack.io/application.name: vm-instance
+    apps.cozystack.io/application.group: apps.cozystack.io
+    apps.cozystack.io/application.name: ${INSTANCE}
 spec:
   suspend: true
   chartRef:


### PR DESCRIPTION
## What this PR does

Migration 29 (`virtual-machine` → `vm-disk` + `vm-instance`) creates HelmReleases without the `apps.cozystack.io/application.group` label. This label is required by the Cozystack API server as a mandatory selector to synthesize VMDisk and VMInstance resources. Without it, HelmReleases are invisible to the API and the portal — resources appear to "disappear" even though DataVolumes and PVCs remain intact.

Additionally, `application.name` was set to the chart name (`vm-disk` / `vm-instance`) instead of the instance name, which is inconsistent with the operator and migration 22.

**Root cause**: The `application.group` label was introduced to the Cozystack API after migration 29 was written, creating a gap that only surfaces on clusters that ran this migration.

**Fix**:
- Add `apps.cozystack.io/application.group: apps.cozystack.io` to both vm-disk and vm-instance HelmRelease templates
- Fix `apps.cozystack.io/application.name` to use `${INSTANCE}` (the instance name) instead of the chart name

### Screenshots

No UI changes.

### Release note

```release-note
fix(migrations): migration 29 now correctly sets application.group and application.name labels on vm-disk and vm-instance HelmReleases, preventing VMDisk/VMInstance resources from disappearing from the API and portal after migration
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated migration process with enhanced resource labeling for system components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->