### PR TITLE
feat(keycloak): support extraEnv values and userProfile customization

### DIFF
--- a/packages/system/keycloak-configure/templates/configure-kk.yaml
+++ b/packages/system/keycloak-configure/templates/configure-kk.yaml
@@ -45,6 +45,10 @@ spec:
   smtp:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.userProfile }}
+  userProfileConfig:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   sessions:
     ssoSessionSettings:
       idleTimeout: 86400

--- a/packages/system/keycloak-configure/values.yaml
+++ b/packages/system/keycloak-configure/values.yaml
@@ -37,3 +37,21 @@
 #         # configMapKeyRef:
 #         #   name: "configmap-name"
 #         #   key: "key"
+
+# Declarative User Profile configuration mirrored into
+# ClusterKeycloakRealm.spec.userProfileConfig. Use this to define
+# custom user attributes that should be required at registration or
+# managed via the account console.
+# userProfile:
+#   unmanagedAttributePolicy: ENABLED
+#   attributes:
+#     - name: publicOfferAccepted
+#       displayName: "Public offer accepted"
+#       required:
+#         roles: [user]
+#       permissions:
+#         view: [user, admin]
+#         edit: [user, admin]
+#       validations:
+#         pattern:
+#           pattern: "^true$"

--- a/packages/system/keycloak-configure/values.yaml
+++ b/packages/system/keycloak-configure/values.yaml
@@ -45,13 +45,12 @@
 # userProfile:
 #   unmanagedAttributePolicy: ENABLED
 #   attributes:
-#     - name: publicOfferAccepted
-#       displayName: "Public offer accepted"
-#       required:
-#         roles: [user]
+#     - name: department
+#       displayName: "Department"
 #       permissions:
 #         view: [user, admin]
-#         edit: [user, admin]
+#         edit: [admin]
 #       validations:
-#         pattern:
-#           pattern: "^true$"
+#         length:
+#           min: 1
+#           max: 255

--- a/packages/system/keycloak/templates/sts.yaml
+++ b/packages/system/keycloak/templates/sts.yaml
@@ -172,6 +172,9 @@ spec:
               value: https://{{ $ingressHost }}
             - name: JAVA_OPTS_APPEND
               value: "-Djgroups.dns.query=keycloak-headless.cozy-keycloak.svc.{{ $clusterDomain }}"
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- if .Values.themes }}
           volumeMounts:
             - name: themes

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -32,5 +32,10 @@ imagePullSecrets: []
 # Each entry is appended verbatim to the container's env list and
 # supports the full corev1.EnvVar schema (value, valueFrom, ...).
 extraEnv: []
-# - name: DOCS_BASE_URL
-#   value: "https://docs.example.com"
+# - name: MY_VAR
+#   value: "some-value"
+# - name: MY_SECRET_VAR
+#   valueFrom:
+#     secretKeyRef:
+#       name: my-secret
+#       key: my-key

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -24,3 +24,13 @@ themes: []
 
 imagePullSecrets: []
 # - name: my-registry-secret
+
+# Extra environment variables to inject into the Keycloak container.
+# Useful for passing runtime values that custom themes read via
+# kcContext.properties (Keycloakify themes, FTL templates with
+# ${env.NAME} substitution, etc.).
+# Each entry is appended verbatim to the container's env list and
+# supports the full corev1.EnvVar schema (value, valueFrom, ...).
+extraEnv: []
+# - name: DOCS_BASE_URL
+#   value: "https://docs.example.com"


### PR DESCRIPTION
## What this PR does

Two related quality-of-life additions to the Keycloak system component:

1. **`keycloak` chart now accepts `extraEnv`.** Operators can append extra
   `EnvVar` entries to the Keycloak StatefulSet container without forking the
   chart. Useful when a custom theme needs runtime configuration via
   `kcContext.properties`, or when an extension expects environment variables.

2. **`keycloak-configure` chart now exposes a top-level `userProfile` value**
   that is mirrored verbatim into `ClusterKeycloakRealm.spec.userProfileConfig`.
   This lets operators declare custom user-profile attributes (required
   fields, validators, permissions, ...) declaratively, alongside the existing
   `login` and `smtp` blocks.

Both values default to empty, so existing deployments are unaffected.

### Release note

```release-note
feat(keycloak): support extraEnv values and userProfile customization
```