### PR TITLE
[kubernetes] Add CPU/memory limits to csi-resizer sidecar

### DIFF
--- a/packages/apps/kubernetes/templates/csi/deploy.yaml
+++ b/packages/apps/kubernetes/templates/csi/deploy.yaml
@@ -224,9 +224,12 @@ spec:
               name: kubeconfig
               readOnly: true
           resources:
+            limits:
+              cpu: 512m
+              memory: 512Mi
             requests:
-              cpu: 10m
-              memory: 20Mi
+              cpu: 125m
+              memory: 128Mi
           securityContext:
             capabilities:
               drop:


### PR DESCRIPTION
## Summary

- The `csi-resizer` container in `packages/apps/kubernetes/templates/csi/deploy.yaml` was the only sidecar in the `kcsi-controller` Deployment without `resources.limits`, which triggers a "no CPU limit" conformance warning.
- Aligned it with the other six CSI sidecars in the same Deployment: `limits` `cpu: 512m` / `memory: 512Mi` and `requests` `cpu: 125m` / `memory: 128Mi`.
- No other files touched; vendored charts and other CSI drivers (`nfs-driver`, `piraeus-operator`) are out of scope for this PR.

## Test plan

- [ ] `make -C packages/apps/kubernetes show NAME=test NAMESPACE=test` renders the Deployment with the new `limits` block
- [ ] Re-run the conformance/lint tool that originally flagged the warning — `csi-resizer has no CPU limit` should be gone
- [ ] CI passes

### Release note

\`\`\`release-note
Set CPU and memory limits on the csi-resizer sidecar of the kubevirt-csi controller to align with the other CSI sidecars and clear the "no CPU limit" conformance warning.
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource allocation for the CSI resizer component, increasing CPU and memory requests to improve performance and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2614)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->