### PR TITLE
test(e2e): silence helm-template render in install-cozystack trace

### DIFF
--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -18,17 +18,22 @@
   # actually pulls (skips configmap fields and CRD examples that happen to
   # contain an `image:` key). Add a chart here when a new peer-sensitive
   # workload is found.
-  # Capture each render into a variable first: bats does not enable
-  # `pipefail`, so a `helm template` failure inside a brace-grouped pipe
-  # would be silently masked by yq's exit code, the script would receive
-  # empty stdin, and the test would pass while pre-pull was skipped.
-  # Assigning to a variable lets `set -e` trigger on a render failure.
-  kubeovn_manifests=$(helm template packages/system/kubeovn)
-  linstor_manifests=$(helm template packages/system/linstor)
-  printf '%s\n%s\n' "$kubeovn_manifests" "$linstor_manifests" | yq -N '
+  # Stage each render to a file: bats does not enable `pipefail`, so a
+  # direct `helm template | yq` pipe would let yq's exit code mask a
+  # helm-template failure and the test would pass while pre-pull was
+  # skipped. Writing to a file makes `set -e` trip on a render failure
+  # without using `var=$(helm template ...)` captures, which `set -x`
+  # would expand into the trace and balloon CI logs.
+  local kubeovn_yaml linstor_yaml
+  kubeovn_yaml=$(mktemp)
+  linstor_yaml=$(mktemp)
+  helm template packages/system/kubeovn > "$kubeovn_yaml"
+  helm template packages/system/linstor > "$linstor_yaml"
+  cat "$kubeovn_yaml" "$linstor_yaml" | yq -N '
       (..|select(has("containers"))|.containers[]|.image),
       (..|select(has("initContainers"))|.initContainers[]|.image)
     ' | hack/e2e-prepull-images.sh
+  rm -f "$kubeovn_yaml" "$linstor_yaml"
 }
 
 @test "Install Cozystack" {

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -18,19 +18,26 @@
   # actually pulls (skips configmap fields and CRD examples that happen to
   # contain an `image:` key). Add a chart here when a new peer-sensitive
   # workload is found.
-  # Stream each render through a brace group instead of `var=$(helm ...)`:
-  # `set -x` would expand captured output into the trace and balloon CI
-  # logs, but rendered YAML flowing through a pipe stays out of stderr.
-  # `pipefail` makes a helm-template or yq failure trip `set -e` instead
-  # of being masked by the downstream prepull exit code.
-  set -o pipefail
-  {
-    helm template packages/system/kubeovn
-    helm template packages/system/linstor
-  } | yq -N '
+  # Stage each render AND the yq filter through tmp files instead of
+  # piping. Two constraints stack here: `set -x` would expand any
+  # `var=$(helm ...)` capture into the trace and balloon CI logs, and
+  # `set -o pipefail` is unavailable because hack/cozytest.sh runs under
+  # /bin/sh which is dash on Ubuntu CI. Redirection keeps each step as a
+  # standalone command — set -e catches a failure at any stage (helm
+  # render, yq filter, prepull) without needing pipefail and without
+  # leaking rendered YAML into the trace.
+  local kubeovn_yaml linstor_yaml images_list
+  kubeovn_yaml=$(mktemp)
+  linstor_yaml=$(mktemp)
+  images_list=$(mktemp)
+  helm template packages/system/kubeovn > "$kubeovn_yaml"
+  helm template packages/system/linstor > "$linstor_yaml"
+  yq -N '
       (..|select(has("containers"))|.containers[]|.image),
       (..|select(has("initContainers"))|.initContainers[]|.image)
-    ' | hack/e2e-prepull-images.sh
+    ' "$kubeovn_yaml" "$linstor_yaml" > "$images_list"
+  hack/e2e-prepull-images.sh < "$images_list"
+  rm -f "$kubeovn_yaml" "$linstor_yaml" "$images_list"
 }
 
 @test "Install Cozystack" {

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -18,22 +18,19 @@
   # actually pulls (skips configmap fields and CRD examples that happen to
   # contain an `image:` key). Add a chart here when a new peer-sensitive
   # workload is found.
-  # Stage each render to a file: bats does not enable `pipefail`, so a
-  # direct `helm template | yq` pipe would let yq's exit code mask a
-  # helm-template failure and the test would pass while pre-pull was
-  # skipped. Writing to a file makes `set -e` trip on a render failure
-  # without using `var=$(helm template ...)` captures, which `set -x`
-  # would expand into the trace and balloon CI logs.
-  local kubeovn_yaml linstor_yaml
-  kubeovn_yaml=$(mktemp)
-  linstor_yaml=$(mktemp)
-  helm template packages/system/kubeovn > "$kubeovn_yaml"
-  helm template packages/system/linstor > "$linstor_yaml"
-  cat "$kubeovn_yaml" "$linstor_yaml" | yq -N '
+  # Stream each render through a brace group instead of `var=$(helm ...)`:
+  # `set -x` would expand captured output into the trace and balloon CI
+  # logs, but rendered YAML flowing through a pipe stays out of stderr.
+  # `pipefail` makes a helm-template or yq failure trip `set -e` instead
+  # of being masked by the downstream prepull exit code.
+  set -o pipefail
+  {
+    helm template packages/system/kubeovn
+    helm template packages/system/linstor
+  } | yq -N '
       (..|select(has("containers"))|.containers[]|.image),
       (..|select(has("initContainers"))|.initContainers[]|.image)
     ' | hack/e2e-prepull-images.sh
-  rm -f "$kubeovn_yaml" "$linstor_yaml"
 }
 
 @test "Install Cozystack" {


### PR DESCRIPTION
## What this PR does

Trims the `Install Cozystack into sandbox` CI step from ~40k log lines back down to a normal size.

The `Pre-pull platform images` bats test was capturing each rendered chart into a shell variable so a render failure would trip `set -e`:

```sh
kubeovn_manifests=$(helm template packages/system/kubeovn)
linstor_manifests=$(helm template packages/system/linstor)
printf '%s\n%s\n' "$kubeovn_manifests" "$linstor_manifests" | yq ... | hack/e2e-prepull-images.sh
```

`hack/cozytest.sh` runs every bats test under `set -x`, and bash expands captured command output into the trace as `+ var=<entire stdout>`. The kubeovn and linstor renders are several thousand lines each, and the `printf` line re-expands both variables, so the same YAML was being dumped to the log three times.

This PR stages each render to a tmp file instead:

```sh
helm template packages/system/kubeovn > "$kubeovn_yaml"
helm template packages/system/linstor > "$linstor_yaml"
cat "$kubeovn_yaml" "$linstor_yaml" | yq ... | hack/e2e-prepull-images.sh
```

The original safety property is preserved — `helm template ... > file` is a simple command whose exit code still triggers `set -e` on failure, exactly like `var=$(helm template ...)` did. The trace now shows the command line, not its rendered output.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved image pre-pull test to render charts into temporary files, consolidate results, and feed them deterministically into the image pre-pull check.
  * Made failure handling more reliable so rendering or parsing errors now cause the test to fail predictably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->