### PR TITLE
[cert-manager] Set resources requests/limits on cert-manager pods

### DIFF
--- a/packages/system/cert-manager/values.yaml
+++ b/packages/system/cert-manager/values.yaml
@@ -1,0 +1,32 @@
+cert-manager:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 50m
+      memory: 128Mi
+  webhook:
+    resources:
+      limits:
+        cpu: 200m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 32Mi
+  cainjector:
+    resources:
+      limits:
+        cpu: 200m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 32Mi
+  startupapicheck:
+    resources:
+      limits:
+        cpu: 100m
+        memory: 64Mi
+      requests:
+        cpu: 10m
+        memory: 16Mi


### PR DESCRIPTION
## Summary

The upstream cert-manager chart ships with `resources: {}` for all four workloads, which triggers `no CPU limit` (and `no memory limit`) conformance warnings on every pod.

Override `packages/system/cert-manager/values.yaml` (previously empty) to set sane requests/limits sized to each component's role:

| Component | requests cpu/mem | limits cpu/mem | Notes |
|---|---|---|---|
| controller | 50m / 128Mi | 500m / 512Mi | Main workload — issues and renews certs |
| webhook | 10m / 32Mi | 200m / 128Mi | Admission webhook, short-lived requests |
| cainjector | 10m / 32Mi | 200m / 128Mi | CA bundle injection, light watch loop |
| startupapicheck | 10m / 16Mi | 100m / 64Mi | One-shot Job at install time |

Requests for `cainjector` (`10m` cpu / `32Mi` mem) match the example in the upstream values.yaml comment.

## Test plan

- [ ] `helm template . --namespace cert-manager` from `packages/system/cert-manager/` renders a `resources` block on all four pods (verified locally for controller, webhook, cainjector and the startupapicheck Job)
- [ ] Re-run the conformance/lint tool that originally flagged the warnings on `cert-manager-cainjector` — should be clean on the other three pods too
- [ ] CI passes

### Release note

\`\`\`release-note
Set CPU/memory requests and limits on cert-manager controller, webhook, cainjector and startupapicheck pods to clear "no CPU limit" conformance warnings.
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added resource allocation configuration for cert-manager deployment, specifying CPU and memory requests and limits for improved system stability and resource management across core components.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2616)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->