### PR TITLE
[cilium] Set resources requests/limits on cilium-agent

### DIFF
--- a/packages/system/cilium/values.yaml
+++ b/packages/system/cilium/values.yaml
@@ -20,6 +20,13 @@ cilium:
   envoy:
     enabled: false
   rollOutCiliumPods: true
+  resources:
+    limits:
+      cpu: 4000m
+      memory: 4Gi
+    requests:
+      cpu: 100m
+      memory: 512Mi
   operator:
     rollOutPods: true
     replicas: 1


### PR DESCRIPTION
## Summary

The upstream cilium chart ships with `resources: {}` for the `cilium-agent` DaemonSet container, which triggers a `no CPU limit` conformance warning on every node.

Override `packages/system/cilium/values.yaml` to set the sizing recommended by the upstream `values.yaml` comment:

- `limits` : `cpu: 4000m`, `memory: 4Gi`
- `requests` : `cpu: 100m`, `memory: 512Mi`

The agent runs the datapath for every pod on the node, so generous limits leave headroom for traffic bursts while keeping a modest baseline request.

## Test plan

- [ ] `helm template . --namespace kube-system` from `packages/system/cilium/` renders a `resources` block on the `cilium-agent` container of the DaemonSet (verified locally)
- [ ] Re-run the conformance/lint tool — the `cilium-agent has no CPU limit` warning should be gone
- [ ] CI passes

### Release note

\`\`\`release-note
Set CPU/memory requests and limits on the cilium-agent DaemonSet to clear the "no CPU limit" conformance warning. Values follow the upstream chart's recommended sizing (limits 4000m/4Gi, requests 100m/512Mi).
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource allocation configuration with specified CPU and memory requests and limits for improved resource management and system stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2617)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->