### PR TITLE
[goldpinger] Set resources requests/limits on goldpinger DaemonSet

### DIFF
--- a/packages/system/goldpinger/values.yaml
+++ b/packages/system/goldpinger/values.yaml
@@ -3,3 +3,10 @@ goldpinger:
     enabled: true
   prometheusRule:
     enabled: true
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi


### PR DESCRIPTION
## Summary

The upstream Bloomberg goldpinger chart ships with `resources: {}`, which triggers a `no CPU limit` conformance warning on the `goldpinger-daemon` container running on every node.

Override `packages/system/goldpinger/values.yaml` to set:

- `limits` : `cpu: 200m`, `memory: 256Mi`
- `requests` : `cpu: 50m`, `memory: 64Mi`

Comfortable margin for the ping-mesh fan-out on larger clusters while keeping a small baseline request so the DaemonSet schedules everywhere.

## Test plan

- [ ] `helm template . --namespace cozy-goldpinger` from `packages/system/goldpinger/` renders the `resources` block on the `goldpinger-daemon` container of the DaemonSet (verified locally)
- [ ] Re-run the conformance/lint tool — the `goldpinger has no CPU limit` warning should be gone
- [ ] CI passes

### Release note

\`\`\`release-note
Set CPU/memory requests and limits on the goldpinger DaemonSet to clear the "no CPU limit" conformance warning.
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes resource requirements for the goldpinger component, defining CPU limits (200m), memory limits (256Mi), CPU requests (50m), and memory requests (64Mi).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2623)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->