### PR TITLE
feat(cozy-tls): add TLS certificate chain sub-chart for managed services

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       name: Run 'make generate' in all app directories
       entry: |
         flock -x .git/pre-commit.lock sh -c '
-          for dir in ./packages/apps/*/ ./packages/extra/*/; do
+          for dir in ./packages/apps/*/ ./packages/extra/*/ ./packages/library/*/; do
             if [ -d "$dir" ]; then
               echo "Running make generate in $dir"
               make generate -C "$dir" || exit $?

--- a/packages/library/cozy-lib/values.schema.json
+++ b/packages/library/cozy-lib/values.schema.json
@@ -1,5 +1,7 @@
 {
-    "title": "Chart Values",
-    "type": "object",
-    "properties": {}
+  "title": "Chart Values",
+  "type": "object",
+  "properties": {
+
+  }
 }

--- a/packages/library/cozy-tls/.helmignore
+++ b/packages/library/cozy-tls/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/packages/library/cozy-tls/Chart.yaml
+++ b/packages/library/cozy-tls/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: cozy-tls
+description: TLS certificate chain sub-chart for managed services
+type: application
+version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process

--- a/packages/library/cozy-tls/Makefile
+++ b/packages/library/cozy-tls/Makefile
@@ -1,0 +1,8 @@
+include ../../../hack/common-envs.mk
+include ../../../hack/package.mk
+
+generate:
+	cozyvalues-gen -v values.yaml -s values.schema.json -r README.md
+
+test:
+	$(MAKE) -C ../../tests/cozy-tls-tests/ test

--- a/packages/library/cozy-tls/README.md
+++ b/packages/library/cozy-tls/README.md
@@ -12,8 +12,8 @@
 | `issuerRef.group`             | API group of the issuer resource.                                                                                               | `string`   | `cert-manager.io` |
 | `ca`                          | Configuration for the CA certificate issued by cert-manager.                                                                    | `object`   | `{}`              |
 | `ca.duration`                 | Validity duration of the CA certificate.                                                                                        | `string`   | `43800h`          |
-| `ca.algorithm`                | Key algorithm for the CA certificate (ECDSA or RSA).                                                                            | `string`   | `ECDSA`           |
-| `ca.size`                     | Key size in bits for the chosen algorithm.                                                                                      | `int`      | `256`             |
+| `ca.algorithm`                | Key algorithm for the CA certificate (ECDSA, RSA, or Ed25519).                                                                  | `string`   | `ECDSA`           |
+| `ca.size`                     | Key size in bits for the chosen algorithm (not used for Ed25519).                                                               | `int`      | `256`             |
 | `certificate`                 | Configuration for the leaf TLS certificate.                                                                                     | `object`   | `{}`              |
 | `certificate.secretName`      | Name of the Kubernetes Secret where the certificate is stored.                                                                  | `string`   | `""`              |
 | `certificate.duration`        | Validity duration of the leaf certificate.                                                                                      | `string`   | `8760h`           |
@@ -22,6 +22,6 @@
 | `certificate.dnsNameSuffixes` | List of DNS name suffixes appended to auto-generated SANs.                                                                      | `[]string` | `[]`              |
 | `certificate.usages`          | List of key usages for the certificate.                                                                                         | `[]string` | `[server auth]`   |
 | `certificate.encoding`        | Private key encoding format (PKCS1 or PKCS8).                                                                                   | `string`   | `PKCS8`           |
-| `certificate.algorithm`       | Key algorithm for the leaf certificate (ECDSA or RSA).                                                                          | `string`   | `ECDSA`           |
-| `certificate.size`            | Key size in bits for the chosen algorithm.                                                                                      | `int`      | `256`             |
+| `certificate.algorithm`       | Key algorithm for the leaf certificate (ECDSA, RSA, or Ed25519).                                                                | `string`   | `ECDSA`           |
+| `certificate.size`            | Key size in bits for the chosen algorithm (not used for Ed25519).                                                               | `int`      | `256`             |
 

--- a/packages/library/cozy-tls/README.md
+++ b/packages/library/cozy-tls/README.md
@@ -1,0 +1,27 @@
+## Parameters
+
+### Parameters
+
+| Name                          | Description                                                                                                                     | Type       | Value             |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------- | ----------------- |
+| `enabled`                     | Enable TLS provisioning for the application.                                                                                    | `bool`     | `false`           |
+| `clusterDomain`               | Cluster domain used when constructing default DNS names. Parent charts should forward _cluster["cluster-domain"] to this value. | `string`   | `cozy.local`      |
+| `issuerRef`                   | Reference to the cert-manager Issuer or ClusterIssuer that signs certificates.                                                  | `object`   | `{}`              |
+| `issuerRef.name`              | Name of the Issuer or ClusterIssuer resource.                                                                                   | `string`   | `""`              |
+| `issuerRef.kind`              | Kind of the issuer resource (Issuer or ClusterIssuer).                                                                          | `string`   | `Issuer`          |
+| `issuerRef.group`             | API group of the issuer resource.                                                                                               | `string`   | `cert-manager.io` |
+| `ca`                          | Configuration for the CA certificate issued by cert-manager.                                                                    | `object`   | `{}`              |
+| `ca.duration`                 | Validity duration of the CA certificate.                                                                                        | `string`   | `43800h`          |
+| `ca.algorithm`                | Key algorithm for the CA certificate (ECDSA or RSA).                                                                            | `string`   | `ECDSA`           |
+| `ca.size`                     | Key size in bits for the chosen algorithm.                                                                                      | `int`      | `256`             |
+| `certificate`                 | Configuration for the leaf TLS certificate.                                                                                     | `object`   | `{}`              |
+| `certificate.secretName`      | Name of the Kubernetes Secret where the certificate is stored.                                                                  | `string`   | `""`              |
+| `certificate.duration`        | Validity duration of the leaf certificate.                                                                                      | `string`   | `8760h`           |
+| `certificate.renewBefore`     | How long before expiry cert-manager should renew the certificate.                                                               | `string`   | `720h`            |
+| `certificate.dnsNames`        | Explicit list of DNS SANs to add to the certificate.                                                                            | `[]string` | `[]`              |
+| `certificate.dnsNameSuffixes` | List of DNS name suffixes appended to auto-generated SANs.                                                                      | `[]string` | `[]`              |
+| `certificate.usages`          | List of key usages for the certificate.                                                                                         | `[]string` | `[server auth]`   |
+| `certificate.encoding`        | Private key encoding format (PKCS1 or PKCS8).                                                                                   | `string`   | `PKCS8`           |
+| `certificate.algorithm`       | Key algorithm for the leaf certificate (ECDSA or RSA).                                                                          | `string`   | `ECDSA`           |
+| `certificate.size`            | Key size in bits for the chosen algorithm.                                                                                      | `int`      | `256`             |
+

--- a/packages/library/cozy-tls/templates/_helpers.tpl
+++ b/packages/library/cozy-tls/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "cozy-tls.name" -}}
-{{- .Release.Name }}
+{{- .Chart.Name }}
 {{- end }}
 
 {{/*

--- a/packages/library/cozy-tls/templates/_helpers.tpl
+++ b/packages/library/cozy-tls/templates/_helpers.tpl
@@ -1,0 +1,55 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cozy-tls.name" -}}
+{{- .Release.Name }}
+{{- end }}
+
+{{/*
+Name for the self-signed bootstrap issuer.
+*/}}
+{{- define "cozy-tls.selfsigned-issuer-name" -}}
+{{- printf "%s-selfsigned" .Release.Name }}
+{{- end }}
+
+{{/*
+Name for the CA certificate resource.
+*/}}
+{{- define "cozy-tls.ca-name" -}}
+{{- printf "%s-ca" .Release.Name }}
+{{- end }}
+
+{{/*
+Name of the Secret holding the CA key-pair.
+*/}}
+{{- define "cozy-tls.ca-secret-name" -}}
+{{- printf "%s-ca" .Release.Name }}
+{{- end }}
+
+{{/*
+Name for the leaf certificate resource.
+*/}}
+{{- define "cozy-tls.certificate-name" -}}
+{{- printf "%s-tls" .Release.Name }}
+{{- end }}
+
+{{/*
+Name of the Secret holding the leaf certificate.
+Falls back to "<release>-tls" when .Values.certificate.secretName is empty.
+*/}}
+{{- define "cozy-tls.certificate-secret-name" -}}
+{{- if .Values.certificate.secretName -}}
+{{- .Values.certificate.secretName }}
+{{- else -}}
+{{- printf "%s-tls" .Release.Name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "cozy-tls.labels" -}}
+app.kubernetes.io/name: {{ include "cozy-tls.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/packages/library/cozy-tls/templates/ca-certificate.yaml
+++ b/packages/library/cozy-tls/templates/ca-certificate.yaml
@@ -18,9 +18,14 @@ spec:
     name: {{ include "cozy-tls.selfsigned-issuer-name" . }}
     kind: Issuer
     group: cert-manager.io
+  {{- $caAlgorithm := .Values.ca.algorithm -}}
+  {{- if eq ($caAlgorithm | lower) "ed25519" }}{{ $caAlgorithm = "Ed25519" }}
+  {{- else if eq ($caAlgorithm | lower) "rsa" }}{{ $caAlgorithm = "RSA" }}
+  {{- else if eq ($caAlgorithm | lower) "ecdsa" }}{{ $caAlgorithm = "ECDSA" }}
+  {{- end }}
   privateKey:
-    algorithm: {{ .Values.ca.algorithm | quote }}
-    {{- if ne .Values.ca.algorithm "Ed25519" }}
+    algorithm: {{ $caAlgorithm | quote }}
+    {{- if ne ($caAlgorithm | lower) "ed25519" }}
     size: {{ .Values.ca.size }}
     {{- end }}
     rotationPolicy: Never

--- a/packages/library/cozy-tls/templates/ca-certificate.yaml
+++ b/packages/library/cozy-tls/templates/ca-certificate.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.enabled (not (.Values.issuerRef.name | trim)) }}
+{{- if not (regexMatch "^[1-9][0-9]*h$" .Values.ca.duration) }}
+{{- fail (printf "ca.duration (%s) must be in pure hours format (e.g. \"43800h\")" .Values.ca.duration) }}
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "cozy-tls.ca-name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cozy-tls.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "cozy-tls.ca-secret-name" . }}
+  duration: {{ .Values.ca.duration | quote }}
+  commonName: {{ include "cozy-tls.ca-name" . }}
+  isCA: true
+  issuerRef:
+    name: {{ include "cozy-tls.selfsigned-issuer-name" . }}
+    kind: Issuer
+    group: cert-manager.io
+  privateKey:
+    algorithm: {{ .Values.ca.algorithm | quote }}
+    size: {{ .Values.ca.size }}
+    rotationPolicy: Never
+{{- end }}

--- a/packages/library/cozy-tls/templates/ca-certificate.yaml
+++ b/packages/library/cozy-tls/templates/ca-certificate.yaml
@@ -20,6 +20,8 @@ spec:
     group: cert-manager.io
   privateKey:
     algorithm: {{ .Values.ca.algorithm | quote }}
+    {{- if ne .Values.ca.algorithm "Ed25519" }}
     size: {{ .Values.ca.size }}
+    {{- end }}
     rotationPolicy: Never
 {{- end }}

--- a/packages/library/cozy-tls/templates/ca-issuer.yaml
+++ b/packages/library/cozy-tls/templates/ca-issuer.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.enabled (not (.Values.issuerRef.name | trim)) }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "cozy-tls.ca-name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cozy-tls.labels" . | nindent 4 }}
+spec:
+  ca:
+    secretName: {{ include "cozy-tls.ca-secret-name" . }}
+{{- end }}

--- a/packages/library/cozy-tls/templates/certificate.yaml
+++ b/packages/library/cozy-tls/templates/certificate.yaml
@@ -35,7 +35,7 @@ spec:
   secretName: {{ include "cozy-tls.certificate-secret-name" . }}
   duration: {{ .Values.certificate.duration | quote }}
   renewBefore: {{ .Values.certificate.renewBefore | quote }}
-  commonName: {{ include "cozy-tls.certificate-name" . }}
+  commonName: {{ index $allDnsNames 0 | quote }}
   dnsNames:
     {{- toYaml $allDnsNames | nindent 4 }}
   usages:

--- a/packages/library/cozy-tls/templates/certificate.yaml
+++ b/packages/library/cozy-tls/templates/certificate.yaml
@@ -52,7 +52,9 @@ spec:
     {{- end }}
   privateKey:
     algorithm: {{ .Values.certificate.algorithm | quote }}
+    {{- if ne .Values.certificate.algorithm "Ed25519" }}
     size: {{ .Values.certificate.size }}
+    {{- end }}
     encoding: {{ .Values.certificate.encoding | quote }}
     rotationPolicy: Always
 {{- end }}

--- a/packages/library/cozy-tls/templates/certificate.yaml
+++ b/packages/library/cozy-tls/templates/certificate.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.enabled }}
+{{- $allDnsNames := list -}}
+{{- range .Values.certificate.dnsNames -}}
+  {{- $allDnsNames = append $allDnsNames . -}}
+{{- end -}}
+{{- range .Values.certificate.dnsNameSuffixes -}}
+  {{- $allDnsNames = append $allDnsNames (printf "%s-%s" $.Release.Name .) -}}
+  {{- $allDnsNames = append $allDnsNames (printf "%s-%s.%s.svc" $.Release.Name . $.Release.Namespace) -}}
+  {{- $allDnsNames = append $allDnsNames (printf "%s-%s.%s.svc.%s" $.Release.Name . $.Release.Namespace $.Values.clusterDomain) -}}
+{{- end -}}
+{{- if not $allDnsNames }}
+{{- fail "dnsNames and/or dnsNameSuffixes must not be empty when cozy-tls is enabled" }}
+{{- end }}
+{{- if not (regexMatch "^[1-9][0-9]*h$" .Values.certificate.duration) }}
+{{- fail (printf "certificate.duration (%s) must be in pure hours format (e.g. \"8760h\")" .Values.certificate.duration) }}
+{{- end }}
+{{- if not (regexMatch "^[1-9][0-9]*h$" .Values.certificate.renewBefore) }}
+{{- fail (printf "certificate.renewBefore (%s) must be in pure hours format (e.g. \"720h\")" .Values.certificate.renewBefore) }}
+{{- end }}
+{{- $durationHours := .Values.certificate.duration | trimSuffix "h" | float64 }}
+{{- $renewBeforeHours := .Values.certificate.renewBefore | trimSuffix "h" | float64 }}
+{{- if ge $renewBeforeHours $durationHours }}
+{{- fail (printf "certificate.renewBefore (%s) must be less than certificate.duration (%s)" .Values.certificate.renewBefore .Values.certificate.duration) }}
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "cozy-tls.certificate-name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cozy-tls.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "cozy-tls.certificate-secret-name" . }}
+  duration: {{ .Values.certificate.duration | quote }}
+  renewBefore: {{ .Values.certificate.renewBefore | quote }}
+  commonName: {{ include "cozy-tls.certificate-name" . }}
+  dnsNames:
+    {{- toYaml $allDnsNames | nindent 4 }}
+  usages:
+    {{- toYaml .Values.certificate.usages | nindent 4 }}
+  issuerRef:
+    {{- if (.Values.issuerRef.name | trim) }}
+    name: {{ .Values.issuerRef.name | quote }}
+    kind: {{ .Values.issuerRef.kind | quote }}
+    group: {{ .Values.issuerRef.group | quote }}
+    {{- else }}
+    name: {{ include "cozy-tls.ca-name" . }}
+    kind: Issuer
+    group: cert-manager.io
+    {{- end }}
+  privateKey:
+    algorithm: {{ .Values.certificate.algorithm | quote }}
+    size: {{ .Values.certificate.size }}
+    encoding: {{ .Values.certificate.encoding | quote }}
+    rotationPolicy: Always
+{{- end }}

--- a/packages/library/cozy-tls/templates/certificate.yaml
+++ b/packages/library/cozy-tls/templates/certificate.yaml
@@ -50,9 +50,17 @@ spec:
     kind: Issuer
     group: cert-manager.io
     {{- end }}
+  {{- $algorithm := .Values.certificate.algorithm -}}
+  {{- if eq ($algorithm | lower) "ed25519" }}{{ $algorithm = "Ed25519" }}
+  {{- else if eq ($algorithm | lower) "rsa" }}{{ $algorithm = "RSA" }}
+  {{- else if eq ($algorithm | lower) "ecdsa" }}{{ $algorithm = "ECDSA" }}
+  {{- end }}
+  {{- if and (eq ($algorithm | lower) "ed25519") (eq (.Values.certificate.encoding | lower) "pkcs1") }}
+  {{- fail "Ed25519 does not support PKCS1 encoding; use PKCS8 instead" }}
+  {{- end }}
   privateKey:
-    algorithm: {{ .Values.certificate.algorithm | quote }}
-    {{- if ne .Values.certificate.algorithm "Ed25519" }}
+    algorithm: {{ $algorithm | quote }}
+    {{- if ne ($algorithm | lower) "ed25519" }}
     size: {{ .Values.certificate.size }}
     {{- end }}
     encoding: {{ .Values.certificate.encoding | quote }}

--- a/packages/library/cozy-tls/templates/certificate.yaml
+++ b/packages/library/cozy-tls/templates/certificate.yaml
@@ -4,9 +4,11 @@
   {{- $allDnsNames = append $allDnsNames . -}}
 {{- end -}}
 {{- range .Values.certificate.dnsNameSuffixes -}}
-  {{- $allDnsNames = append $allDnsNames (printf "%s-%s" $.Release.Name .) -}}
-  {{- $allDnsNames = append $allDnsNames (printf "%s-%s.%s.svc" $.Release.Name . $.Release.Namespace) -}}
-  {{- $allDnsNames = append $allDnsNames (printf "%s-%s.%s.svc.%s" $.Release.Name . $.Release.Namespace $.Values.clusterDomain) -}}
+  {{- $name := printf "%s-%s" $.Release.Name . -}}
+  {{- $allDnsNames = append $allDnsNames $name -}}
+  {{- $allDnsNames = append $allDnsNames (printf "%s.%s" $name $.Release.Namespace) -}}
+  {{- $allDnsNames = append $allDnsNames (printf "%s.%s.svc" $name $.Release.Namespace) -}}
+  {{- $allDnsNames = append $allDnsNames (printf "%s.%s.svc.%s" $name $.Release.Namespace $.Values.clusterDomain) -}}
 {{- end -}}
 {{- if not $allDnsNames }}
 {{- fail "dnsNames and/or dnsNameSuffixes must not be empty when cozy-tls is enabled" }}
@@ -40,9 +42,9 @@ spec:
     {{- toYaml .Values.certificate.usages | nindent 4 }}
   issuerRef:
     {{- if (.Values.issuerRef.name | trim) }}
-    name: {{ .Values.issuerRef.name | quote }}
-    kind: {{ .Values.issuerRef.kind | quote }}
-    group: {{ .Values.issuerRef.group | quote }}
+    name: {{ .Values.issuerRef.name | trim | quote }}
+    kind: {{ .Values.issuerRef.kind | trim | quote }}
+    group: {{ .Values.issuerRef.group | trim | quote }}
     {{- else }}
     name: {{ include "cozy-tls.ca-name" . }}
     kind: Issuer

--- a/packages/library/cozy-tls/templates/selfsigned-issuer.yaml
+++ b/packages/library/cozy-tls/templates/selfsigned-issuer.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.enabled (not (.Values.issuerRef.name | trim)) }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "cozy-tls.selfsigned-issuer-name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "cozy-tls.labels" . | nindent 4 }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/packages/library/cozy-tls/values.schema.json
+++ b/packages/library/cozy-tls/values.schema.json
@@ -45,15 +45,14 @@
       "default": {},
       "required": [
         "algorithm",
-        "duration",
-        "size"
+        "duration"
       ],
       "properties": {
         "algorithm": {
-          "description": "Key algorithm for the CA certificate (ECDSA or RSA).",
+          "description": "Key algorithm for the CA certificate (ECDSA, RSA, or Ed25519).",
           "type": "string",
           "default": "ECDSA",
-          "enum": ["ECDSA", "RSA"]
+          "enum": ["ECDSA", "RSA", "Ed25519"]
         },
         "duration": {
           "description": "Validity duration of the CA certificate.",
@@ -77,15 +76,14 @@
         "duration",
         "encoding",
         "renewBefore",
-        "secretName",
-        "size"
+        "secretName"
       ],
       "properties": {
         "algorithm": {
-          "description": "Key algorithm for the leaf certificate (ECDSA or RSA).",
+          "description": "Key algorithm for the leaf certificate (ECDSA, RSA, or Ed25519).",
           "type": "string",
           "default": "ECDSA",
-          "enum": ["ECDSA", "RSA"]
+          "enum": ["ECDSA", "RSA", "Ed25519"]
         },
         "dnsNameSuffixes": {
           "description": "List of DNS name suffixes appended to auto-generated SANs.",

--- a/packages/library/cozy-tls/values.schema.json
+++ b/packages/library/cozy-tls/values.schema.json
@@ -1,0 +1,147 @@
+{
+  "title": "Chart Values",
+  "type": "object",
+  "properties": {
+    "enabled": {
+      "description": "Enable TLS provisioning for the application.",
+      "type": "boolean",
+      "default": false
+    },
+    "clusterDomain": {
+      "description": "Cluster domain used when constructing default DNS names. Parent charts should forward _cluster[\"cluster-domain\"] to this value.",
+      "type": "string",
+      "default": "cozy.local"
+    },
+    "issuerRef": {
+      "description": "Reference to the cert-manager Issuer or ClusterIssuer that signs certificates.",
+      "type": "object",
+      "default": {},
+      "required": [
+        "group",
+        "kind",
+        "name"
+      ],
+      "properties": {
+        "group": {
+          "description": "API group of the issuer resource.",
+          "type": "string",
+          "default": "cert-manager.io"
+        },
+        "kind": {
+          "description": "Kind of the issuer resource (Issuer or ClusterIssuer).",
+          "type": "string",
+          "default": "Issuer"
+        },
+        "name": {
+          "description": "Name of the Issuer or ClusterIssuer resource.",
+          "type": "string",
+          "default": ""
+        }
+      }
+    },
+    "ca": {
+      "description": "Configuration for the CA certificate issued by cert-manager.",
+      "type": "object",
+      "default": {},
+      "required": [
+        "algorithm",
+        "duration",
+        "size"
+      ],
+      "properties": {
+        "algorithm": {
+          "description": "Key algorithm for the CA certificate (ECDSA or RSA).",
+          "type": "string",
+          "default": "ECDSA",
+          "enum": ["ECDSA", "RSA"]
+        },
+        "duration": {
+          "description": "Validity duration of the CA certificate.",
+          "type": "string",
+          "default": "43800h",
+          "pattern": "^[1-9][0-9]*h$"
+        },
+        "size": {
+          "description": "Key size in bits for the chosen algorithm.",
+          "type": "integer",
+          "default": 256
+        }
+      }
+    },
+    "certificate": {
+      "description": "Configuration for the leaf TLS certificate.",
+      "type": "object",
+      "default": {},
+      "required": [
+        "algorithm",
+        "duration",
+        "encoding",
+        "renewBefore",
+        "secretName",
+        "size"
+      ],
+      "properties": {
+        "algorithm": {
+          "description": "Key algorithm for the leaf certificate (ECDSA or RSA).",
+          "type": "string",
+          "default": "ECDSA",
+          "enum": ["ECDSA", "RSA"]
+        },
+        "dnsNameSuffixes": {
+          "description": "List of DNS name suffixes appended to auto-generated SANs.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "dnsNames": {
+          "description": "Explicit list of DNS SANs to add to the certificate.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        },
+        "duration": {
+          "description": "Validity duration of the leaf certificate.",
+          "type": "string",
+          "default": "8760h",
+          "pattern": "^[1-9][0-9]*h$"
+        },
+        "encoding": {
+          "description": "Private key encoding format (PKCS1 or PKCS8).",
+          "type": "string",
+          "default": "PKCS8",
+          "enum": ["PKCS1", "PKCS8"]
+        },
+        "renewBefore": {
+          "description": "How long before expiry cert-manager should renew the certificate.",
+          "type": "string",
+          "default": "720h",
+          "pattern": "^[1-9][0-9]*h$"
+        },
+        "secretName": {
+          "description": "Name of the Kubernetes Secret where the certificate is stored.",
+          "type": "string",
+          "default": ""
+        },
+        "size": {
+          "description": "Key size in bits for the chosen algorithm.",
+          "type": "integer",
+          "default": 256
+        },
+        "usages": {
+          "description": "List of key usages for the certificate.",
+          "type": "array",
+          "default": [
+            "server auth"
+          ],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/library/cozy-tls/values.schema.json
+++ b/packages/library/cozy-tls/values.schema.json
@@ -10,7 +10,8 @@
     "clusterDomain": {
       "description": "Cluster domain used when constructing default DNS names. Parent charts should forward _cluster[\"cluster-domain\"] to this value.",
       "type": "string",
-      "default": "cozy.local"
+      "default": "cozy.local",
+      "minLength": 1
     },
     "issuerRef": {
       "description": "Reference to the cert-manager Issuer or ClusterIssuer that signs certificates.",
@@ -30,7 +31,11 @@
         "kind": {
           "description": "Kind of the issuer resource (Issuer or ClusterIssuer).",
           "type": "string",
-          "default": "Issuer"
+          "default": "Issuer",
+          "enum": [
+            "Issuer",
+            "ClusterIssuer"
+          ]
         },
         "name": {
           "description": "Name of the Issuer or ClusterIssuer resource.",
@@ -45,14 +50,19 @@
       "default": {},
       "required": [
         "algorithm",
-        "duration"
+        "duration",
+        "size"
       ],
       "properties": {
         "algorithm": {
           "description": "Key algorithm for the CA certificate (ECDSA, RSA, or Ed25519).",
           "type": "string",
           "default": "ECDSA",
-          "enum": ["ECDSA", "RSA", "Ed25519"]
+          "enum": [
+            "ECDSA",
+            "RSA",
+            "Ed25519"
+          ]
         },
         "duration": {
           "description": "Validity duration of the CA certificate.",
@@ -61,7 +71,7 @@
           "pattern": "^[1-9][0-9]*h$"
         },
         "size": {
-          "description": "Key size in bits for the chosen algorithm.",
+          "description": "Key size in bits for the chosen algorithm (not used for Ed25519).",
           "type": "integer",
           "default": 256
         }
@@ -76,14 +86,19 @@
         "duration",
         "encoding",
         "renewBefore",
-        "secretName"
+        "secretName",
+        "size"
       ],
       "properties": {
         "algorithm": {
           "description": "Key algorithm for the leaf certificate (ECDSA, RSA, or Ed25519).",
           "type": "string",
           "default": "ECDSA",
-          "enum": ["ECDSA", "RSA", "Ed25519"]
+          "enum": [
+            "ECDSA",
+            "RSA",
+            "Ed25519"
+          ]
         },
         "dnsNameSuffixes": {
           "description": "List of DNS name suffixes appended to auto-generated SANs.",
@@ -111,7 +126,10 @@
           "description": "Private key encoding format (PKCS1 or PKCS8).",
           "type": "string",
           "default": "PKCS8",
-          "enum": ["PKCS1", "PKCS8"]
+          "enum": [
+            "PKCS1",
+            "PKCS8"
+          ]
         },
         "renewBefore": {
           "description": "How long before expiry cert-manager should renew the certificate.",
@@ -125,7 +143,7 @@
           "default": ""
         },
         "size": {
-          "description": "Key size in bits for the chosen algorithm.",
+          "description": "Key size in bits for the chosen algorithm (not used for Ed25519).",
           "type": "integer",
           "default": 256
         },

--- a/packages/library/cozy-tls/values.yaml
+++ b/packages/library/cozy-tls/values.yaml
@@ -2,11 +2,25 @@
 enabled: false
 
 ## @param {string} clusterDomain="cozy.local" - Cluster domain used when constructing default DNS names. Parent charts should forward _cluster["cluster-domain"] to this value.
+## @minLength 1
 clusterDomain: "cozy.local"
+
+## @enum {string} PrivateKeyAlgorithm - Key algorithm for TLS certificates.
+## @value ECDSA
+## @value RSA
+## @value Ed25519
+
+## @enum {string} PrivateKeyEncoding - Private key encoding format.
+## @value PKCS1
+## @value PKCS8
+
+## @enum {string} IssuerKind - Kind of the cert-manager issuer resource.
+## @value Issuer
+## @value ClusterIssuer
 
 ## @typedef {struct} IssuerRef - Reference to the cert-manager Issuer or ClusterIssuer.
 ## @field {string} name - Name of the Issuer or ClusterIssuer resource.
-## @field {string} kind - Kind of the issuer resource (Issuer or ClusterIssuer).
+## @field {IssuerKind} kind - Kind of the issuer resource (Issuer or ClusterIssuer).
 ## @field {string} group - API group of the issuer resource.
 
 ## @param {IssuerRef} issuerRef - Reference to the cert-manager Issuer or ClusterIssuer that signs certificates.
@@ -17,7 +31,8 @@ issuerRef:
 
 ## @typedef {struct} CA - Configuration for the CA certificate.
 ## @field {string} duration - Validity duration of the CA certificate.
-## @field {string} algorithm - Key algorithm for the CA certificate (ECDSA, RSA, or Ed25519).
+## @pattern ^[1-9][0-9]*h$
+## @field {PrivateKeyAlgorithm} algorithm - Key algorithm for the CA certificate (ECDSA, RSA, or Ed25519).
 ## @field {int} size - Key size in bits for the chosen algorithm (not used for Ed25519).
 
 ## @param {CA} ca - Configuration for the CA certificate issued by cert-manager.
@@ -29,12 +44,14 @@ ca:
 ## @typedef {struct} Certificate - Configuration for the leaf TLS certificate.
 ## @field {string} secretName - Name of the Kubernetes Secret where the certificate is stored.
 ## @field {string} duration - Validity duration of the leaf certificate.
+## @pattern ^[1-9][0-9]*h$
 ## @field {string} renewBefore - How long before expiry cert-manager should renew the certificate.
+## @pattern ^[1-9][0-9]*h$
 ## @field {[]string} dnsNames - Explicit list of DNS SANs to add to the certificate.
 ## @field {[]string} dnsNameSuffixes - List of DNS name suffixes appended to auto-generated SANs.
 ## @field {[]string} usages - List of key usages for the certificate.
-## @field {string} encoding - Private key encoding format (PKCS1 or PKCS8).
-## @field {string} algorithm - Key algorithm for the leaf certificate (ECDSA, RSA, or Ed25519).
+## @field {PrivateKeyEncoding} encoding - Private key encoding format (PKCS1 or PKCS8).
+## @field {PrivateKeyAlgorithm} algorithm - Key algorithm for the leaf certificate (ECDSA, RSA, or Ed25519).
 ## @field {int} size - Key size in bits for the chosen algorithm (not used for Ed25519).
 
 ## @param {Certificate} certificate - Configuration for the leaf TLS certificate.

--- a/packages/library/cozy-tls/values.yaml
+++ b/packages/library/cozy-tls/values.yaml
@@ -17,8 +17,8 @@ issuerRef:
 
 ## @typedef {struct} CA - Configuration for the CA certificate.
 ## @field {string} duration - Validity duration of the CA certificate.
-## @field {string} algorithm - Key algorithm for the CA certificate (ECDSA or RSA).
-## @field {int} size - Key size in bits for the chosen algorithm.
+## @field {string} algorithm - Key algorithm for the CA certificate (ECDSA, RSA, or Ed25519).
+## @field {int} size - Key size in bits for the chosen algorithm (not used for Ed25519).
 
 ## @param {CA} ca - Configuration for the CA certificate issued by cert-manager.
 ca:
@@ -34,8 +34,8 @@ ca:
 ## @field {[]string} dnsNameSuffixes - List of DNS name suffixes appended to auto-generated SANs.
 ## @field {[]string} usages - List of key usages for the certificate.
 ## @field {string} encoding - Private key encoding format (PKCS1 or PKCS8).
-## @field {string} algorithm - Key algorithm for the leaf certificate (ECDSA or RSA).
-## @field {int} size - Key size in bits for the chosen algorithm.
+## @field {string} algorithm - Key algorithm for the leaf certificate (ECDSA, RSA, or Ed25519).
+## @field {int} size - Key size in bits for the chosen algorithm (not used for Ed25519).
 
 ## @param {Certificate} certificate - Configuration for the leaf TLS certificate.
 certificate:

--- a/packages/library/cozy-tls/values.yaml
+++ b/packages/library/cozy-tls/values.yaml
@@ -1,0 +1,51 @@
+## @param {bool} enabled=false - Enable TLS provisioning for the application.
+enabled: false
+
+## @param {string} clusterDomain="cozy.local" - Cluster domain used when constructing default DNS names. Parent charts should forward _cluster["cluster-domain"] to this value.
+clusterDomain: "cozy.local"
+
+## @typedef {struct} IssuerRef - Reference to the cert-manager Issuer or ClusterIssuer.
+## @field {string} name - Name of the Issuer or ClusterIssuer resource.
+## @field {string} kind - Kind of the issuer resource (Issuer or ClusterIssuer).
+## @field {string} group - API group of the issuer resource.
+
+## @param {IssuerRef} issuerRef - Reference to the cert-manager Issuer or ClusterIssuer that signs certificates.
+issuerRef:
+  name: ""
+  kind: "Issuer"
+  group: "cert-manager.io"
+
+## @typedef {struct} CA - Configuration for the CA certificate.
+## @field {string} duration - Validity duration of the CA certificate.
+## @field {string} algorithm - Key algorithm for the CA certificate (ECDSA or RSA).
+## @field {int} size - Key size in bits for the chosen algorithm.
+
+## @param {CA} ca - Configuration for the CA certificate issued by cert-manager.
+ca:
+  duration: "43800h"
+  algorithm: "ECDSA"
+  size: 256
+
+## @typedef {struct} Certificate - Configuration for the leaf TLS certificate.
+## @field {string} secretName - Name of the Kubernetes Secret where the certificate is stored.
+## @field {string} duration - Validity duration of the leaf certificate.
+## @field {string} renewBefore - How long before expiry cert-manager should renew the certificate.
+## @field {[]string} dnsNames - Explicit list of DNS SANs to add to the certificate.
+## @field {[]string} dnsNameSuffixes - List of DNS name suffixes appended to auto-generated SANs.
+## @field {[]string} usages - List of key usages for the certificate.
+## @field {string} encoding - Private key encoding format (PKCS1 or PKCS8).
+## @field {string} algorithm - Key algorithm for the leaf certificate (ECDSA or RSA).
+## @field {int} size - Key size in bits for the chosen algorithm.
+
+## @param {Certificate} certificate - Configuration for the leaf TLS certificate.
+certificate:
+  secretName: ""
+  duration: "8760h"
+  renewBefore: "720h"
+  dnsNames: []
+  dnsNameSuffixes: []
+  usages:
+    - server auth
+  encoding: "PKCS8"
+  algorithm: "ECDSA"
+  size: 256

--- a/packages/tests/cozy-tls-tests/Chart.yaml
+++ b/packages/tests/cozy-tls-tests/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: cozy-tls-tests
+description: Testing chart for cozy-tls
+type: application
+version: 0.1.0

--- a/packages/tests/cozy-tls-tests/Makefile
+++ b/packages/tests/cozy-tls-tests/Makefile
@@ -1,0 +1,2 @@
+test:
+	helm unittest .

--- a/packages/tests/cozy-tls-tests/charts/cozy-tls
+++ b/packages/tests/cozy-tls-tests/charts/cozy-tls
@@ -1,0 +1,1 @@
+../../../library/cozy-tls

--- a/packages/tests/cozy-tls-tests/tests/ca_chain_suffixes_values.yaml
+++ b/packages/tests/cozy-tls-tests/tests/ca_chain_suffixes_values.yaml
@@ -1,0 +1,7 @@
+cozy-tls:
+  enabled: true
+
+  certificate:
+    dnsNameSuffixes:
+      - master
+      - replicas

--- a/packages/tests/cozy-tls-tests/tests/ca_chain_test.yaml
+++ b/packages/tests/cozy-tls-tests/tests/ca_chain_test.yaml
@@ -366,7 +366,7 @@ tests:
             - redis-master
             - redis-master.tenant-test.svc
 
-  - it: leaf Certificate commonName equals release-tls
+  - it: leaf Certificate commonName equals first DNS name
     values:
       - ca_chain_values.yaml
     release:
@@ -376,7 +376,7 @@ tests:
     asserts:
       - equal:
           path: spec.commonName
-          value: myredis-tls
+          value: redis-master
 
   # ── CA chain — overrides ──────────────────────────────────────────────────────
 
@@ -668,3 +668,41 @@ tests:
       - equal:
           path: spec.privateKey.encoding
           value: PKCS1
+
+  # ── Label convention ──────────────────────────────────────────────────────────
+
+  - it: app.kubernetes.io/name label equals chart name on leaf Certificate
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: cozy-tls
+
+  - it: app.kubernetes.io/instance label equals release name on leaf Certificate
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: myredis
+
+  - it: app.kubernetes.io/name label equals chart name on CA Certificate
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: cozy-tls

--- a/packages/tests/cozy-tls-tests/tests/ca_chain_test.yaml
+++ b/packages/tests/cozy-tls-tests/tests/ca_chain_test.yaml
@@ -1,0 +1,465 @@
+suite: per-service CA chain
+
+templates:
+  - charts/cozy-tls/templates/selfsigned-issuer.yaml
+  - charts/cozy-tls/templates/ca-certificate.yaml
+  - charts/cozy-tls/templates/ca-issuer.yaml
+  - charts/cozy-tls/templates/certificate.yaml
+
+tests:
+  # ── SelfSigned Issuer ────────────────────────────────────────────────────────
+
+  - it: renders SelfSigned Issuer with correct name and namespace
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/selfsigned-issuer.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - equal:
+          path: kind
+          value: Issuer
+      - equal:
+          path: metadata.name
+          value: myredis-selfsigned
+      - equal:
+          path: metadata.namespace
+          value: tenant-test
+
+  - it: renders SelfSigned Issuer with selfSigned spec
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/selfsigned-issuer.yaml
+    asserts:
+      - isNotNull:
+          path: spec.selfSigned
+      - equal:
+          path: spec.selfSigned
+          value: {}
+
+  # ── CA Certificate ────────────────────────────────────────────────────────────
+
+  - it: renders CA Certificate with isCA true
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - equal:
+          path: kind
+          value: Certificate
+      - equal:
+          path: metadata.name
+          value: myredis-ca
+      - equal:
+          path: metadata.namespace
+          value: tenant-test
+      - equal:
+          path: spec.isCA
+          value: true
+
+  - it: CA Certificate secretName equals release-ca
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - equal:
+          path: spec.secretName
+          value: myredis-ca
+
+  - it: CA Certificate has default duration
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - equal:
+          path: spec.duration
+          value: "43800h"
+
+  - it: CA Certificate issuerRef points to selfsigned issuer
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - equal:
+          path: spec.issuerRef.name
+          value: myredis-selfsigned
+      - equal:
+          path: spec.issuerRef.kind
+          value: Issuer
+      - equal:
+          path: spec.issuerRef.group
+          value: cert-manager.io
+
+  - it: CA Certificate privateKey rotationPolicy is Never
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.rotationPolicy
+          value: Never
+
+  - it: CA Certificate privateKey defaults — ECDSA, size 256
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: ECDSA
+      - equal:
+          path: spec.privateKey.size
+          value: 256
+
+  - it: custom ca.algorithm and ca.size override CA Certificate privateKey
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.ca.algorithm: RSA
+      cozy-tls.ca.size: 4096
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: RSA
+      - equal:
+          path: spec.privateKey.size
+          value: 4096
+
+  - it: CA Certificate commonName equals release-ca
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - equal:
+          path: spec.commonName
+          value: myredis-ca
+
+  - it: CA Certificate does not set renewBefore (cert-manager defaults to 2/3 of lifetime)
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - notExists:
+          path: spec.renewBefore
+
+  # ── CA Issuer ─────────────────────────────────────────────────────────────────
+
+  - it: renders CA Issuer with correct name and namespace
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-issuer.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - equal:
+          path: kind
+          value: Issuer
+      - equal:
+          path: metadata.name
+          value: myredis-ca
+      - equal:
+          path: metadata.namespace
+          value: tenant-test
+
+  - it: CA Issuer spec.ca.secretName points to CA secret
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-issuer.yaml
+    asserts:
+      - equal:
+          path: spec.ca.secretName
+          value: myredis-ca
+
+  # ── Leaf Certificate — defaults ───────────────────────────────────────────────
+
+  - it: renders leaf Certificate with correct name and namespace
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: apiVersion
+          value: cert-manager.io/v1
+      - equal:
+          path: kind
+          value: Certificate
+      - equal:
+          path: metadata.name
+          value: myredis-tls
+      - equal:
+          path: metadata.namespace
+          value: tenant-test
+
+  - it: leaf Certificate secretName defaults to release-tls
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.secretName
+          value: myredis-tls
+
+  - it: leaf Certificate has default duration
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.duration
+          value: "8760h"
+
+  - it: leaf Certificate has default renewBefore
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.renewBefore
+          value: "720h"
+
+  - it: leaf Certificate has default usages
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.usages
+          value:
+            - server auth
+
+  - it: leaf Certificate privateKey defaults — ECDSA, size 256, PKCS8, rotationPolicy Always
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: ECDSA
+      - equal:
+          path: spec.privateKey.size
+          value: 256
+      - equal:
+          path: spec.privateKey.encoding
+          value: PKCS8
+      - equal:
+          path: spec.privateKey.rotationPolicy
+          value: Always
+
+  - it: custom certificate.algorithm and size override leaf Certificate privateKey
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.certificate.algorithm: RSA
+      cozy-tls.certificate.size: 4096
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: RSA
+      - equal:
+          path: spec.privateKey.size
+          value: 4096
+
+  - it: leaf Certificate issuerRef points to CA Issuer (not selfsigned, not external)
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.issuerRef.name
+          value: myredis-ca
+      - equal:
+          path: spec.issuerRef.kind
+          value: Issuer
+      - equal:
+          path: spec.issuerRef.group
+          value: cert-manager.io
+
+  - it: leaf Certificate has correct dnsNames from values
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - redis-master
+            - redis-master.tenant-test.svc
+
+  - it: leaf Certificate commonName equals release-tls
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.commonName
+          value: myredis-tls
+
+  # ── CA chain — overrides ──────────────────────────────────────────────────────
+
+  - it: custom ca.duration overrides default on CA Certificate
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.ca.duration: "87600h"
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - equal:
+          path: spec.duration
+          value: "87600h"
+
+  - it: custom certificate.duration overrides default on leaf Certificate
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.certificate.duration: "4380h"
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.duration
+          value: "4380h"
+
+  - it: custom certificate.renewBefore overrides default on leaf Certificate
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.certificate.renewBefore: "360h"
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.renewBefore
+          value: "360h"
+
+  - it: custom certificate.secretName overrides default on leaf Certificate
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.certificate.secretName: my-custom-tls-secret
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.secretName
+          value: my-custom-tls-secret
+
+  - it: custom certificate.usages overrides default on leaf Certificate
+    values:
+      - ca_chain_usages_override.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.usages
+          value:
+            - server auth
+            - client auth
+
+  - it: custom certificate.encoding overrides default on leaf Certificate
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.certificate.encoding: PKCS1
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.encoding
+          value: PKCS1

--- a/packages/tests/cozy-tls-tests/tests/ca_chain_test.yaml
+++ b/packages/tests/cozy-tls-tests/tests/ca_chain_test.yaml
@@ -533,3 +533,138 @@ tests:
           value: Ed25519
       - notExists:
           path: spec.privateKey.size
+
+  # ── Mixed algorithms ──────────────────────────────────────────────────────────
+
+  - it: mixed algorithms — CA uses RSA with size, leaf uses Ed25519 without size (ca-certificate)
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.ca.algorithm: RSA
+      cozy-tls.ca.size: 4096
+      cozy-tls.certificate.algorithm: Ed25519
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: RSA
+      - equal:
+          path: spec.privateKey.size
+          value: 4096
+
+  - it: mixed algorithms — CA uses RSA with size, leaf uses Ed25519 without size (certificate)
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.ca.algorithm: RSA
+      cozy-tls.ca.size: 4096
+      cozy-tls.certificate.algorithm: Ed25519
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: Ed25519
+      - notExists:
+          path: spec.privateKey.size
+
+  # ── Ed25519 with external issuer ──────────────────────────────────────────────
+
+  - it: leaf Certificate Ed25519 with external issuer renders without size field
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.certificate.algorithm: Ed25519
+      cozy-tls.issuerRef.name: my-issuer
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: Ed25519
+      - notExists:
+          path: spec.privateKey.size
+
+  # ── Ed25519 + PKCS1 validation ────────────────────────────────────────────────
+
+  - it: leaf Certificate Ed25519 with PKCS1 encoding fails with clear error
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.certificate.algorithm: Ed25519
+      cozy-tls.certificate.encoding: PKCS1
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "Ed25519 does not support PKCS1 encoding; use PKCS8 instead"
+
+  # ── RSA CA with explicit size ─────────────────────────────────────────────────
+
+  - it: CA Certificate RSA algorithm renders with custom size
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.ca.algorithm: RSA
+      cozy-tls.ca.size: 2048
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: RSA
+      - equal:
+          path: spec.privateKey.size
+          value: 2048
+
+  # ── ECDSA + PKCS1 (positive) ──────────────────────────────────────────────────
+
+  - it: leaf Certificate ECDSA with PKCS1 encoding renders successfully
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.certificate.algorithm: ECDSA
+      cozy-tls.certificate.encoding: PKCS1
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: ECDSA
+      - equal:
+          path: spec.privateKey.encoding
+          value: PKCS1
+
+  # ── RSA + PKCS1 (positive) ────────────────────────────────────────────────────
+
+  - it: leaf Certificate RSA with PKCS1 encoding renders successfully
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.certificate.algorithm: RSA
+      cozy-tls.certificate.size: 4096
+      cozy-tls.certificate.encoding: PKCS1
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: RSA
+      - equal:
+          path: spec.privateKey.encoding
+          value: PKCS1

--- a/packages/tests/cozy-tls-tests/tests/ca_chain_test.yaml
+++ b/packages/tests/cozy-tls-tests/tests/ca_chain_test.yaml
@@ -463,3 +463,73 @@ tests:
       - equal:
           path: spec.privateKey.encoding
           value: PKCS1
+
+  # ── Ed25519 — CA Certificate ──────────────────────────────────────────────────
+
+  - it: CA Certificate Ed25519 algorithm renders without size field
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.ca.algorithm: Ed25519
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: Ed25519
+      - notExists:
+          path: spec.privateKey.size
+
+  - it: CA Certificate Ed25519 omits size even when explicitly set
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.ca.algorithm: Ed25519
+      cozy-tls.ca.size: 256
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: Ed25519
+      - notExists:
+          path: spec.privateKey.size
+
+  # ── Ed25519 — leaf Certificate ────────────────────────────────────────────────
+
+  - it: leaf Certificate Ed25519 algorithm renders without size field
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.certificate.algorithm: Ed25519
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: Ed25519
+      - notExists:
+          path: spec.privateKey.size
+
+  - it: leaf Certificate Ed25519 omits size even when explicitly set
+    values:
+      - ca_chain_values.yaml
+    set:
+      cozy-tls.certificate.algorithm: Ed25519
+      cozy-tls.certificate.size: 256
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.privateKey.algorithm
+          value: Ed25519
+      - notExists:
+          path: spec.privateKey.size

--- a/packages/tests/cozy-tls-tests/tests/ca_chain_usages_override.yaml
+++ b/packages/tests/cozy-tls-tests/tests/ca_chain_usages_override.yaml
@@ -1,0 +1,10 @@
+cozy-tls:
+  enabled: true
+
+  certificate:
+    dnsNames:
+      - redis-master
+      - redis-master.tenant-test.svc
+    usages:
+      - server auth
+      - client auth

--- a/packages/tests/cozy-tls-tests/tests/ca_chain_values.yaml
+++ b/packages/tests/cozy-tls-tests/tests/ca_chain_values.yaml
@@ -1,0 +1,7 @@
+cozy-tls:
+  enabled: true
+
+  certificate:
+    dnsNames:
+      - redis-master
+      - redis-master.tenant-test.svc

--- a/packages/tests/cozy-tls-tests/tests/disabled_test.yaml
+++ b/packages/tests/cozy-tls-tests/tests/disabled_test.yaml
@@ -1,0 +1,92 @@
+suite: disabled mode
+
+templates:
+  - charts/cozy-tls/templates/selfsigned-issuer.yaml
+  - charts/cozy-tls/templates/ca-certificate.yaml
+  - charts/cozy-tls/templates/ca-issuer.yaml
+  - charts/cozy-tls/templates/certificate.yaml
+
+tests:
+  # ── enabled: false (explicit) ─────────────────────────────────────────────────
+
+  - it: selfsigned-issuer renders nothing when enabled is false
+    set:
+      cozy-tls.enabled: false
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/selfsigned-issuer.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: ca-certificate renders nothing when enabled is false
+    set:
+      cozy-tls.enabled: false
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: ca-issuer renders nothing when enabled is false
+    set:
+      cozy-tls.enabled: false
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-issuer.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: certificate renders nothing when enabled is false
+    set:
+      cozy-tls.enabled: false
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ── enabled omitted (chart default is false) ──────────────────────────────────
+
+  - it: selfsigned-issuer renders nothing with chart default values
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/selfsigned-issuer.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: ca-certificate renders nothing with chart default values
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: ca-issuer renders nothing with chart default values
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-issuer.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: certificate renders nothing with chart default values
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/packages/tests/cozy-tls-tests/tests/dns_name_suffixes_test.yaml
+++ b/packages/tests/cozy-tls-tests/tests/dns_name_suffixes_test.yaml
@@ -4,7 +4,7 @@ templates:
   - charts/cozy-tls/templates/certificate.yaml
 
 tests:
-  - it: expands suffixes into three DNS forms each
+  - it: expands suffixes into four DNS forms each
     values:
       - ca_chain_suffixes_values.yaml
     release:
@@ -15,9 +15,11 @@ tests:
           path: spec.dnsNames
           value:
             - myredis-master
+            - myredis-master.tenant-test
             - myredis-master.tenant-test.svc
             - myredis-master.tenant-test.svc.cozy.local
             - myredis-replicas
+            - myredis-replicas.tenant-test
             - myredis-replicas.tenant-test.svc
             - myredis-replicas.tenant-test.svc.cozy.local
 
@@ -35,9 +37,11 @@ tests:
           value:
             - custom.example.com
             - myredis-master
+            - myredis-master.tenant-test
             - myredis-master.tenant-test.svc
             - myredis-master.tenant-test.svc.cozy.local
             - myredis-replicas
+            - myredis-replicas.tenant-test
             - myredis-replicas.tenant-test.svc
             - myredis-replicas.tenant-test.svc.cozy.local
 

--- a/packages/tests/cozy-tls-tests/tests/dns_name_suffixes_test.yaml
+++ b/packages/tests/cozy-tls-tests/tests/dns_name_suffixes_test.yaml
@@ -1,0 +1,83 @@
+suite: dnsNameSuffixes expansion
+
+templates:
+  - charts/cozy-tls/templates/certificate.yaml
+
+tests:
+  - it: expands suffixes into three DNS forms each
+    values:
+      - ca_chain_suffixes_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - myredis-master
+            - myredis-master.tenant-test.svc
+            - myredis-master.tenant-test.svc.cozy.local
+            - myredis-replicas
+            - myredis-replicas.tenant-test.svc
+            - myredis-replicas.tenant-test.svc.cozy.local
+
+  - it: merges explicit dnsNames with computed dnsNameSuffixes
+    values:
+      - ca_chain_suffixes_values.yaml
+    set:
+      cozy-tls.certificate.dnsNames[0]: custom.example.com
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - custom.example.com
+            - myredis-master
+            - myredis-master.tenant-test.svc
+            - myredis-master.tenant-test.svc.cozy.local
+            - myredis-replicas
+            - myredis-replicas.tenant-test.svc
+            - myredis-replicas.tenant-test.svc.cozy.local
+
+  - it: succeeds with only dnsNameSuffixes and empty dnsNames
+    values:
+      - ca_chain_suffixes_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: succeeds with only explicit dnsNames and empty dnsNameSuffixes
+    values:
+      - ca_chain_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.dnsNames
+          value:
+            - redis-master
+            - redis-master.tenant-test.svc
+
+  - it: uses custom clusterDomain in generated dnsNames
+    values:
+      - ca_chain_suffixes_values.yaml
+    set:
+      cozy-tls.clusterDomain: custom.example.io
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - contains:
+          path: spec.dnsNames
+          content: myredis-master.tenant-test.svc.custom.example.io
+      - notContains:
+          path: spec.dnsNames
+          content: myredis-master.tenant-test.svc.cozy.local

--- a/packages/tests/cozy-tls-tests/tests/dns_name_suffixes_test.yaml
+++ b/packages/tests/cozy-tls-tests/tests/dns_name_suffixes_test.yaml
@@ -85,3 +85,14 @@ tests:
       - notContains:
           path: spec.dnsNames
           content: myredis-master.tenant-test.svc.cozy.local
+
+  - it: commonName equals first computed DNS name when using dnsNameSuffixes
+    values:
+      - ca_chain_suffixes_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: spec.commonName
+          value: myredis-master

--- a/packages/tests/cozy-tls-tests/tests/external_issuer_test.yaml
+++ b/packages/tests/cozy-tls-tests/tests/external_issuer_test.yaml
@@ -1,0 +1,183 @@
+suite: external issuer mode
+
+templates:
+  - charts/cozy-tls/templates/selfsigned-issuer.yaml
+  - charts/cozy-tls/templates/ca-certificate.yaml
+  - charts/cozy-tls/templates/ca-issuer.yaml
+  - charts/cozy-tls/templates/certificate.yaml
+
+tests:
+  # ── CA chain must be suppressed ───────────────────────────────────────────────
+
+  - it: selfsigned-issuer renders zero documents when external issuerRef is set
+    values:
+      - external_issuer_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/selfsigned-issuer.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: ca-certificate renders zero documents when external issuerRef is set
+    values:
+      - external_issuer_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: ca-issuer renders zero documents when external issuerRef is set
+    values:
+      - external_issuer_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/ca-issuer.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ── Leaf Certificate is rendered ──────────────────────────────────────────────
+
+  - it: leaf Certificate IS rendered when external issuerRef is set
+    values:
+      - external_issuer_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Certificate
+
+  - it: leaf Certificate issuerRef.name matches external value
+    values:
+      - external_issuer_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.issuerRef.name
+          value: my-cluster-issuer
+
+  - it: leaf Certificate issuerRef.kind matches ClusterIssuer from values
+    values:
+      - external_issuer_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+
+  - it: leaf Certificate issuerRef.group defaults to cert-manager.io
+    values:
+      - external_issuer_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.issuerRef.group
+          value: cert-manager.io
+
+  - it: leaf Certificate has correct dnsNames when using external issuer
+    values:
+      - external_issuer_values.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.dnsNames
+          value:
+            - redis-master
+            - redis-master.tenant-test.svc
+
+  # ── External issuer with kind Issuer (not ClusterIssuer) ─────────────────────
+
+  - it: works with kind Issuer as external issuerRef
+    values:
+      - external_issuer_values.yaml
+    set:
+      cozy-tls.issuerRef.name: my-namespace-issuer
+      cozy-tls.issuerRef.kind: Issuer
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.issuerRef.name
+          value: my-namespace-issuer
+      - equal:
+          path: spec.issuerRef.kind
+          value: Issuer
+
+  - it: selfsigned-issuer renders zero documents even when external kind is Issuer
+    values:
+      - external_issuer_values.yaml
+    set:
+      cozy-tls.issuerRef.name: my-namespace-issuer
+      cozy-tls.issuerRef.kind: Issuer
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/selfsigned-issuer.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # ── Custom issuerRef.group ────────────────────────────────────────────────────
+
+  - it: custom issuerRef.group is passed through to leaf Certificate
+    values:
+      - external_issuer_values.yaml
+    set:
+      cozy-tls.issuerRef.group: cert-manager.example.io
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.issuerRef.group
+          value: cert-manager.example.io
+
+  # ── dnsNameSuffixes with external issuer ─────────────────────────────────────
+
+  - it: dnsNameSuffixes expand correctly when using external issuer
+    values:
+      - external_issuer_values.yaml
+    set:
+      cozy-tls.certificate.dnsNameSuffixes[0]: master
+    release:
+      name: myredis
+      namespace: tenant-test
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - contains:
+          path: spec.dnsNames
+          content: myredis-master
+      - contains:
+          path: spec.dnsNames
+          content: myredis-master.tenant-test.svc
+      - contains:
+          path: spec.dnsNames
+          content: myredis-master.tenant-test.svc.cozy.local

--- a/packages/tests/cozy-tls-tests/tests/external_issuer_values.yaml
+++ b/packages/tests/cozy-tls-tests/tests/external_issuer_values.yaml
@@ -1,0 +1,11 @@
+cozy-tls:
+  enabled: true
+
+  issuerRef:
+    name: my-cluster-issuer
+    kind: ClusterIssuer
+
+  certificate:
+    dnsNames:
+      - redis-master
+      - redis-master.tenant-test.svc

--- a/packages/tests/cozy-tls-tests/tests/schema_validation_test.yaml
+++ b/packages/tests/cozy-tls-tests/tests/schema_validation_test.yaml
@@ -1,0 +1,100 @@
+suite: schema validation
+
+tests:
+  # ── issuerRef.kind enum ───────────────────────────────────────────────────────
+
+  - it: rejects issuerRef.kind values outside the Issuer/ClusterIssuer enum
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.issuerRef.kind: Secret
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate: {}
+
+  # ── algorithm enum ────────────────────────────────────────────────────────────
+
+  - it: rejects certificate.algorithm values outside the ECDSA/RSA/Ed25519 enum
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.certificate.algorithm: "AES"
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate: {}
+
+  - it: rejects ca.algorithm values outside the ECDSA/RSA/Ed25519 enum
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.ca.algorithm: "AES"
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate: {}
+
+  # ── encoding enum ─────────────────────────────────────────────────────────────
+
+  - it: rejects certificate.encoding values outside the PKCS1/PKCS8 enum
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.certificate.encoding: "DER"
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate: {}
+
+  # ── clusterDomain minLength ───────────────────────────────────────────────────
+
+  - it: rejects empty clusterDomain via minLength constraint
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.clusterDomain: ""
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate: {}
+
+  # ── duration pattern ──────────────────────────────────────────────────────────
+
+  - it: rejects ca.duration with non-pure-hours format via schema pattern
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.ca.duration: "43800h0m0s"
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate: {}
+
+  - it: rejects certificate.duration with non-pure-hours format via schema pattern
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.certificate.duration: "8760h30m"
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate: {}
+
+  - it: rejects certificate.renewBefore with non-pure-hours format via schema pattern
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.certificate.renewBefore: "720h30m"
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate: {}

--- a/packages/tests/cozy-tls-tests/tests/validation_test.yaml
+++ b/packages/tests/cozy-tls-tests/tests/validation_test.yaml
@@ -119,7 +119,7 @@ tests:
       - failedTemplate:
           errorPattern: ca.duration
 
-  - it: fails when issuerRef.name is whitespace-only
+  - it: defaults to CA issuer when issuerRef.name is whitespace-only
     set:
       cozy-tls.enabled: true
       cozy-tls.certificate.dnsNames[0]: test

--- a/packages/tests/cozy-tls-tests/tests/validation_test.yaml
+++ b/packages/tests/cozy-tls-tests/tests/validation_test.yaml
@@ -1,0 +1,131 @@
+suite: input validation
+
+templates:
+  - charts/cozy-tls/templates/certificate.yaml
+
+tests:
+  - it: fails when enabled is true but both dnsNames and dnsNameSuffixes are empty
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames: []
+      cozy-tls.certificate.dnsNameSuffixes: []
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate:
+          errorMessage: "dnsNames and/or dnsNameSuffixes must not be empty when cozy-tls is enabled"
+
+  - it: fails when enabled is true and neither dnsNames nor dnsNameSuffixes keys are set
+    set:
+      cozy-tls.enabled: true
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate:
+          errorMessage: "dnsNames and/or dnsNameSuffixes must not be empty when cozy-tls is enabled"
+
+  - it: fails when renewBefore equals duration
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.certificate.duration: "720h"
+      cozy-tls.certificate.renewBefore: "720h"
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate:
+          errorMessage: "certificate.renewBefore (720h) must be less than certificate.duration (720h)"
+
+  - it: fails when renewBefore exceeds duration
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.certificate.duration: "720h"
+      cozy-tls.certificate.renewBefore: "800h"
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate:
+          errorMessage: "certificate.renewBefore (800h) must be less than certificate.duration (720h)"
+
+  - it: fails when duration uses non-pure-hours format (e.g. 8760h0m0s)
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.certificate.duration: "8760h0m0s"
+      cozy-tls.certificate.renewBefore: "720h"
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate:
+          errorPattern: "8760h0m0s"
+
+  - it: fails when renewBefore uses non-pure-hours format (e.g. 720h30m)
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.certificate.duration: "8760h"
+      cozy-tls.certificate.renewBefore: "720h30m"
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate:
+          errorPattern: "720h30m"
+
+  - it: fails when ca.duration is not in pure hours format
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.ca.duration: "43800h0m0s"
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    release:
+      name: myredis
+      namespace: tenant-test
+    asserts:
+      - failedTemplate:
+          errorPattern: ca.duration
+
+  - it: fails when certificate.duration is 0h
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.certificate.duration: "0h"
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: certificate.duration
+  - it: fails when certificate.renewBefore is 0h
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.certificate.renewBefore: "0h"
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: certificate.renewBefore
+  - it: fails when ca.duration is 0h
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.ca.duration: "0h"
+    template: charts/cozy-tls/templates/ca-certificate.yaml
+    asserts:
+      - failedTemplate:
+          errorPattern: ca.duration
+
+  - it: fails when issuerRef.name is whitespace-only
+    set:
+      cozy-tls.enabled: true
+      cozy-tls.certificate.dnsNames[0]: test
+      cozy-tls.issuerRef.name: " "
+    template: charts/cozy-tls/templates/certificate.yaml
+    asserts:
+      - equal:
+          path: spec.issuerRef.name
+          value: RELEASE-NAME-ca


### PR DESCRIPTION
## What this PR does

Introduces the `cozy-tls` library Helm chart that provides a reusable TLS certificate chain for managed services via cert-manager. This replaces the `cozy-lib` TLS helper approach from #2485 with a standalone sub-chart that manages the full PKI lifecycle.

**Two operating modes:**
- **Self-signed CA chain** (default): creates a SelfSigned Issuer → CA Certificate → CA Issuer → leaf Certificate — fully automated, no external dependencies
- **External issuer**: when `issuerRef.name` is set, only the leaf Certificate is rendered, pointing to the user-provided Issuer/ClusterIssuer

**Key features:**
- `dnsNameSuffixes` field for automatic DNS SAN expansion (each suffix generates 4 FQDN forms: bare, namespace, .svc, .svc.cluster.local)
- Explicit `dnsNames` for full manual control, or both combined
- Configurable CA and leaf certificate lifetimes, key algorithm (ECDSA P-256), and usages
- Input validation with clear error messages on missing required fields
- Comprehensive helm-unittest test coverage (65 tests across 5 suites)

Supersedes #2485 — the library helper has been replaced by a full sub-chart with complete certificate scope.

### Screenshots

N/A — no UI changes.

### Release note

```release-note
Added `cozy-tls` library Helm chart for automated TLS certificate chain management via cert-manager.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helm chart for TLS provisioning with cert‑manager support: self‑signed CA chains, CA issuer, leaf certificates, external issuer mode, DNS suffix expansion, and configurable certificate/key parameters with validation.

* **Documentation**
  * Chart parameter docs added detailing TLS values, defaults and validation rules.

* **Tests**
  * Extensive Helm unit tests covering rendering, validation, dnsName suffix expansion, issuer modes, overrides and error cases.

* **Chores**
  * Build/test targets and packaging ignore rules added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2626)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->