### PR TITLE
[external-dns] Set resources requests/limits on external-dns container

### DIFF
--- a/packages/system/external-dns/values.yaml
+++ b/packages/system/external-dns/values.yaml
@@ -21,3 +21,11 @@ external-dns:
   # -- Specify the DNS provider (e.g., "aws", "google", "azure", etc.)
   provider:
     name: ""
+
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 64Mi


### PR DESCRIPTION
## Summary

The upstream external-dns chart ships with `resources: {}`, which triggers a `no CPU limit` conformance warning on the `external-dns` Deployment.

Override `packages/system/external-dns/values.yaml` to set:

- `limits` : `cpu: 100m`, `memory: 128Mi`
- `requests` : `cpu: 10m`, `memory: 64Mi`

Modest sizing for a controller that just watches Service / Ingress objects and pushes DNS records to the provider.

## Test plan

- [ ] `helm template . --namespace cozy-external-dns` from `packages/system/external-dns/` renders a `resources` block on the `external-dns` container of the Deployment (verified locally)
- [ ] Re-run the conformance/lint tool — the `external-dns has no CPU limit` warning should be gone
- [ ] CI passes

### Release note

\`\`\`release-note
Set CPU/memory requests and limits on the external-dns Deployment to clear the "no CPU limit" conformance warning.
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ExternalDNS resource allocation with optimized CPU and memory limits and requests for improved resource efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2629)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->