### PR TITLE
[reloader] Set resources requests/limits on reloader container

### DIFF
--- a/packages/system/reloader/values.yaml
+++ b/packages/system/reloader/values.yaml
@@ -1,3 +1,11 @@
 reloader:
   reloader:
     reloadStrategy: annotations
+    deployment:
+      resources:
+        limits:
+          cpu: 100m
+          memory: 512Mi
+        requests:
+          cpu: 10m
+          memory: 128Mi


### PR DESCRIPTION
## Summary

The upstream Stakater reloader chart ships with `resources: {}`, which triggers a `no CPU limit` conformance warning on the `reloader` Deployment.

Override `packages/system/reloader/values.yaml` at `reloader.reloader.deployment.resources` with the exact values from the chart's own commented example:

- `limits` : `cpu: 100m`, `memory: 512Mi`
- `requests` : `cpu: 10m`, `memory: 128Mi`

Reloader is a light controller that watches ConfigMap / Secret changes and triggers workload restarts — small CPU envelope with enough memory to track many objects in clusters with lots of namespaces.

## Test plan

- [ ] `helm template . --namespace cozy-reloader` from `packages/system/reloader/` renders a `resources` block on the `reloader-reloader` container of the Deployment (verified locally)
- [ ] Re-run the conformance/lint tool — the `reloader-reloader has no CPU limit` warning should be gone
- [ ] CI passes

### Release note

\`\`\`release-note
Set CPU/memory requests and limits on the reloader Deployment to clear the "no CPU limit" conformance warning. Values follow the upstream chart's commented example (limits 100m/512Mi, requests 10m/128Mi).
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resource allocation configuration to define CPU and memory parameters for system component deployments, enhancing infrastructure stability and resource optimization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2631)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->