### PR TITLE
[monitoring-agents] Set resources requests/limits on kube-state-metrics

### DIFF
--- a/packages/system/monitoring-agents/values.yaml
+++ b/packages/system/monitoring-agents/values.yaml
@@ -4,6 +4,13 @@ global:
 kube-state-metrics:
   extraArgs:
     - --metric-labels-allowlist=pods=[*],deployments=[*]
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
   rbac:
     extraRules:
       - apiGroups:


### PR DESCRIPTION
## Summary

The upstream kube-state-metrics chart ships with `resources: {}`, which triggers a `no CPU limit` conformance warning on the `monitoring-agents-kube-state-metrics` Deployment.

Override `packages/system/monitoring-agents/values.yaml` at `kube-state-metrics.resources` :

- `limits` : `cpu: 200m`, `memory: 256Mi`
- `requests` : `cpu: 50m`, `memory: 64Mi`

These are slightly above the upstream commented example (`limits 100m/64Mi`) because the cozystack wrapper adds Flux CRD scraping via `customResourceState` and wildcard `pods=[*],deployments=[*]` label allowlists — both of which increase memory pressure. The 200m CPU headroom is intentional: [a known upstream issue](https://github.com/kubernetes/kube-state-metrics/issues/461) is that **CPU limits too low cause memory to balloon** because internal queues can't drain fast enough.

## Test plan

- [ ] `helm template . --namespace cozy-monitoring` from `packages/system/monitoring-agents/` renders a `resources` block on the `kube-state-metrics` container of the `monitoring-agents-kube-state-metrics` Deployment (verified locally)
- [ ] Re-run the conformance/lint tool — the `kube-state-metrics has no CPU limit` warning should be gone
- [ ] CI passes

### Release note

\`\`\`release-note
Set CPU/memory requests and limits on the kube-state-metrics Deployment to clear the "no CPU limit" conformance warning. Values are slightly above the upstream example to account for the additional Flux CRD scraping configured in the cozystack wrapper.
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured resource constraints for monitoring agents to optimize system performance and stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2632)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->