### PR TITLE
[snapshot-controller] Set resources requests/limits on controller and webhook

### DIFF
--- a/packages/system/snapshot-controller/values.yaml
+++ b/packages/system/snapshot-controller/values.yaml
@@ -2,6 +2,13 @@ snapshot-controller:
   controller:
     replicaCount: 2
     revisionHistoryLimit: 10
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
   webhook:
     replicaCount: 2
     revisionHistoryLimit: 10
@@ -11,3 +18,10 @@ snapshot-controller:
       certManagerIssuerRef:
         name: selfsigned-cluster-issuer
         kind: ClusterIssuer
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 32Mi


### PR DESCRIPTION
## Summary

The [piraeusdatastore snapshot-controller chart](https://github.com/piraeusdatastore/helm-charts/blob/main/charts/snapshot-controller/values.yaml) (which deploys [kubernetes-csi/external-snapshotter](https://github.com/kubernetes-csi/external-snapshotter)) ships with `resources: {}` for **both** the controller and the validation webhook, triggering `no CPU limit` conformance warnings on the two Deployments in `cozy-snapshot-controller`.

Upstream doesn't publish official sizing either — manifests in the kubernetes-csi repo and the OpenShift fork both leave resources unset. Sized based on a [production reference](https://oneuptime.com/blog/post/2026-02-09-csi-snapshot-controller/view):

| Container | requests cpu/mem | limits cpu/mem |
|---|---|---|
| `snapshot-controller` | 100m / 128Mi | 500m / 512Mi |
| `snapshot-validation-webhook` | 10m / 32Mi | 100m / 128Mi |

Webhook stays light (HTTP admission validation, same sizing as cert-manager-webhook in #2616); controller gets the production-recommended envelope.

## Test plan

- [ ] `helm template . --namespace cozy-snapshot-controller` from `packages/system/snapshot-controller/` renders `resources` blocks on both `snapshot-controller` and `snapshot-validation-webhook` Deployments (verified locally)
- [ ] Re-run the conformance/lint tool — both `no CPU limit` warnings should be gone
- [ ] CI passes

### Release note

\`\`\`release-note
Set CPU/memory requests and limits on the snapshot-controller and snapshot-validation-webhook Deployments to clear "no CPU limit" conformance warnings.
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CPU and memory resource limits and requests for the snapshot-controller to enable proper resource allocation across the system.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2633)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->