### PR TITLE
[monitoring-agents] Set resources requests/limits on prometheus-node-exporter

### DIFF
--- a/packages/system/monitoring-agents/values.yaml
+++ b/packages/system/monitoring-agents/values.yaml
@@ -1,6 +1,15 @@
 global:
   target: cozy-monitoring
 
+prometheus-node-exporter:
+  resources:
+    limits:
+      cpu: 250m
+      memory: 180Mi
+    requests:
+      cpu: 100m
+      memory: 180Mi
+
 kube-state-metrics:
   extraArgs:
     - --metric-labels-allowlist=pods=[*],deployments=[*]


### PR DESCRIPTION
## Summary

The upstream prometheus-community node-exporter chart ships with `resources: {}`, which triggers a `no CPU limit` conformance warning on the `monitoring-agents-prometheus-node-exporter` DaemonSet.

Override `packages/system/monitoring-agents/values.yaml` at `prometheus-node-exporter.resources`. Values copied verbatim from the upstream [kube-prometheus reference manifests](https://github.com/prometheus-operator/kube-prometheus/blob/main/manifests/nodeExporter-daemonset.yaml):

- `limits` : `cpu: 250m`, `memory: 180Mi`
- `requests` : `cpu: 100m`, `memory: 180Mi`

`memory request == memory limit` gives **Guaranteed QoS** for memory, which is what kube-prometheus does on purpose: it keeps node-exporter out of the OOM-killer queue under node memory pressure. Important because node-exporter is the source of truth for node-level metrics (losing it makes the cluster blind to host issues).

## Test plan

- [ ] `helm template . --namespace cozy-monitoring` from `packages/system/monitoring-agents/` renders the `resources` block on the `node-exporter` container of the DaemonSet (verified locally)
- [ ] Re-run the conformance/lint tool — the `node-exporter has no CPU limit` warning should be gone
- [ ] CI passes

### Release note

\`\`\`release-note
Set CPU/memory requests and limits on the prometheus-node-exporter DaemonSet to clear the "no CPU limit" conformance warning. Values match the upstream kube-prometheus reference (limits 250m/180Mi, requests 100m/180Mi, memory request == limit for Guaranteed QoS).
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Kubernetes resource configuration for the monitoring agent, specifying CPU and memory limits and requests to optimize resource utilization in the monitoring infrastructure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2635)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->