### PR TITLE
[monitoring-agents] Set resources requests/limits on fluent-bit

### DIFF
--- a/packages/system/monitoring-agents/values.yaml
+++ b/packages/system/monitoring-agents/values.yaml
@@ -287,6 +287,13 @@ vmagent:
 fluent-bit:
   rbac:
     eventsAccess: true
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
   readinessProbe:
     httpGet:
       path: /


### PR DESCRIPTION
## Summary

The upstream fluent-bit chart ships with `resources: {}`, which triggers a `no CPU limit` conformance warning on the `monitoring-agents-fluent-bit` DaemonSet.

Override `packages/system/monitoring-agents/values.yaml` at `fluent-bit.resources` with the conservative production profile:

- `limits` : `cpu: 200m`, `memory: 256Mi`
- `requests` : `cpu: 50m`, `memory: 64Mi`

fluent-bit itself bounds buffer memory via `Mem_Buf_Limit 5MB` on the INPUT (already configured in this chart), so the memory envelope here mostly absorbs Lua / parser overhead and short bursts during log spikes. Larger or noisier clusters can override these values further.

## Test plan

- [ ] `helm template . --namespace cozy-monitoring` from `packages/system/monitoring-agents/` renders a `resources` block on the `fluent-bit` container of the DaemonSet (verified locally)
- [ ] Re-run the conformance/lint tool — the `fluent-bit has no CPU limit` warning should be gone
- [ ] CI passes

### Release note

\`\`\`release-note
Set CPU/memory requests and limits on the fluent-bit DaemonSet to clear the "no CPU limit" conformance warning.
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured explicit Kubernetes resource requests and limits for the monitoring component to optimize resource allocation and ensure stable system performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2636)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->