### PR TITLE
[keycloak-operator] Add CPU limit to keycloak-operator container

### DIFF
--- a/packages/system/keycloak-operator/values.yaml
+++ b/packages/system/keycloak-operator/values.yaml
@@ -6,6 +6,7 @@ keycloak-operator:
   clusterReconciliationEnabled: true
   resources:
     limits:
+      cpu: 200m
       memory: 512Mi
     requests:
       cpu: 50m


### PR DESCRIPTION
## Summary

The package `values.yaml` already overrode the upstream chart with `memory: 512Mi` limit and cpu/memory requests, but kept `limits.cpu` unset — the upstream [epam/edp-keycloak-operator chart](https://github.com/epam/edp-keycloak-operator/blob/master/deploy-templates/values.yaml) never defined it either. This triggers a `no CPU limit` conformance warning.

Add `limits.cpu: 200m` :

- `limits` : `cpu: 200m` (new), `memory: 512Mi` (existing)
- `requests` : `cpu: 50m`, `memory: 64Mi` (existing, aligned with upstream)

Modest envelope for a lightweight Go controller that reconciles Keycloak CRDs (KeycloakClient, KeycloakRealm, etc.) — consistent with other Go operators sized in this series (external-dns in #2629, reloader in #2631).

## Test plan

- [ ] `helm template . --namespace cozy-keycloak` from `packages/system/keycloak-operator/` renders a complete `resources` block (with `limits.cpu`) on the `keycloak-operator` container (verified locally)
- [ ] Re-run the conformance/lint tool — the `keycloak-operator has no CPU limit` warning should be gone
- [ ] CI passes

### Release note

\`\`\`release-note
Add a CPU limit to the keycloak-operator container to clear the "no CPU limit" conformance warning.
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Keycloak operator container resource limits to include CPU constraints, enhancing resource management and system stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2637)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->