### PR TITLE
fix(linstor): bump linstor-scheduler chart to 0.2.4 / appVersion v0.3.4

### DIFF
--- a/packages/system/linstor-scheduler/charts/linstor-scheduler/Chart.yaml
+++ b/packages/system/linstor-scheduler/charts/linstor-scheduler/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.3.2
+appVersion: v0.3.4
 deprecated: true
 description: 'Deploys a new kubernetes scheduler, configured to take advantage of
   storage system information. If a Pod is using a LINSTOR volume, the scheduler will
@@ -16,4 +16,4 @@ name: linstor-scheduler
 sources:
 - https://github.com/piraeusdatastore/linstor-scheduler-extender
 type: application
-version: 0.2.3
+version: 0.2.4


### PR DESCRIPTION
## What this PR does

Bumps the vendored `linstor-scheduler` chart from `0.2.3` / appVersion `v0.3.2` to `0.2.4` / appVersion `v0.3.4`.

This picks up [`linstor-scheduler-extender` v0.3.4](https://github.com/piraeusdatastore/linstor-scheduler-extender/releases/tag/v0.3.4), which fixes scheduling of pods backed by storage-only (non-DRBD) LINSTOR resources:

- The scheduler driver previously hard-required `Volumes[0].State.DiskState == "UpToDate"`, but that field is only populated by LINSTOR when a DRBD layer is present.
- For storage-only resources (single-replica ZFS / LVM, no DRBD), `DiskState` is an empty string. The scheduler treated that as "not UpToDate" and rejected every candidate node, leaving the pod stuck `Pending` with `Resource <name> is not UpToDate on node <node>, skipping (is )`.
- v0.3.4 (via [extender PR #20](https://github.com/piraeusdatastore/linstor-scheduler-extender/pull/20)) walks the resource's layer tree and only enforces the `UpToDate` check when a DRBD layer is actually present.

The corresponding upstream chart bump was merged in [piraeusdatastore/helm-charts#81](https://github.com/piraeusdatastore/helm-charts/pull/81).

Only `Chart.yaml` changes (appVersion + version); template files are intentionally untouched to preserve the cozystack-specific admission webhook / cert-manager additions in `charts/linstor-scheduler/templates/` that are not present upstream.

### Release note

```release-note
fix(linstor): bump linstor-scheduler chart to 0.2.4 / appVersion v0.3.4 to pick up the non-DRBD scheduling fix so pods backed by storage-only LINSTOR resources are no longer stuck Pending.
```
