### PR TITLE
fix(vm-instance): emit empty disk object so KubeVirt accepts disks without bus

### DIFF
--- a/packages/apps/vm-instance/templates/vm.yaml
+++ b/packages/apps/vm-instance/templates/vm.yaml
@@ -67,14 +67,14 @@ spec:
           - name: disk-{{ $disk.name }}
             {{- $dv := lookup "cdi.kubevirt.io/v1beta1" "DataVolume" $.Release.Namespace (printf "vm-disk-%s" $disk.name) }}
             {{- if $dv }}
-            {{- if and (hasKey $dv.metadata.annotations "vm-disk.cozystack.io/optical") (eq (index $dv.metadata.annotations "vm-disk.cozystack.io/optical") "true") }}
-            cdrom:
+            {{- $isOptical := and (hasKey $dv.metadata.annotations "vm-disk.cozystack.io/optical") (eq (index $dv.metadata.annotations "vm-disk.cozystack.io/optical") "true") }}
+            {{- $deviceKey := ternary "cdrom" "disk" $isOptical }}
+            {{- if $disk.bus }}
+            {{ $deviceKey }}:
+              bus: {{ $disk.bus }}
             {{- else }}
-            disk:
+            {{ $deviceKey }}: {}
             {{- end }}
-              {{- with $disk.bus }}
-              bus: {{ . }}
-              {{- end }}
             bootOrder: {{ add $i 1 }}
             {{- else }}
             {{-   fail (printf "Specified disk not exists in cluster: %s" .name) }}


### PR DESCRIPTION
## Problem

A VMInstance with disks whose `bus` field is unset (the schema default — `bus` is optional, no default value) fails to deploy. The KubeVirt admission webhook rejects the rendered VirtualMachine with:

```
admission webhook "virtualmachines-mutator.kubevirt.io" denied the request:
spec.template.spec.domain.devices.disks.disk in body must be of type object: "null"
```

### Root cause

`packages/apps/vm-instance/templates/vm.yaml` renders the disk entry as:

```yaml
- name: disk-foo
  disk:                  # ← no value
  bootOrder: 1
```

YAML parses `disk:` (no value) as `disk: null`. KubeVirt's `DiskTarget` schema requires an object, so the mutator rejects it.

The template only attached a child (`bus: …`) when `$disk.bus` was non-empty, so the empty-bus path produced a key with no value.

### Reproduction

On dev10:

```yaml
spec:
  disks:
  - name: test-ui
```

→ `kubectl get vminstance test -n tenant-root` shows `InstallFailed` with the exact admission-webhook message above.

## Fix

Restructure the disk loop so the `disk` / `cdrom` value is always a valid object:

- `bus` set → `disk: { bus: <x> }`
- `bus` empty → `disk: {}`

This mirrors how the same template already renders `cloudinitdisk`. Both the `disk` and `cdrom` branches get the fix.

## Verification

`helm install --dry-run=server` against dev10 (KubeVirt v1.6.3) with `disks: [{ name: test-ui }]` (no bus):

- **Before fix:** rendered `disk: null` — admission webhook rejects on real install.
- **After fix:** rendered `disk: {}` — install succeeds; `dry-run=server` returns the full manifest, no admission error.

`helm install --dry-run=server` with `disks: [{ name: test-ui, bus: sata }]`:

- **After fix:** rendered `disk:\n  bus: sata` — install succeeds.

### Release note

\`\`\`release-note
fix(vm-instance): emit "disk: {}" instead of "disk: null" so VMInstances with disks lacking an explicit bus type are accepted by the KubeVirt admission webhook.
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized VM disk device configuration handling to improve code maintainability and reliability in disk type selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2643)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->