### PR TITLE
feat(platform): add kuberture as optional system package

### DIFF
--- a/hack/e2e-apps/kuberture.bats
+++ b/hack/e2e-apps/kuberture.bats
@@ -1,0 +1,251 @@
+#!/usr/bin/env bats
+
+# Smoke-test the kuberture system addon: a Package CR for cozystack.kuberture
+# with config.outputs configured must materialise an HR in cozy-kuberture,
+# the controller Deployment must roll out, and the controller must create the
+# configured headless Services with the right external-dns annotations
+# (hostname/target/ttl) reflecting the IPs from default/kubernetes
+# EndpointSlice. Two outputs with different annotationPrefix values exercise
+# the cozystack-relevant property: a single kuberture instance can address
+# multiple external-dns instances from one platform-level package.
+#
+# cozytest.sh is plain POSIX shell — no `[[ ... ]]`, no bats `run` helper,
+# no FD 3, and `teardown()` is never auto-invoked. Cleanup is inlined at the
+# end of the @test body and runs on the success path only; the e2e Makefile's
+# sandbox teardown handles the failure case.
+
+# Shared cleanup so the inline success-path call at the end of the @test
+# body and the teardown hook (alive only under upstream bats) cannot
+# drift apart.
+_cleanup() {
+  # Probe Pods and their RBAC live outside the chart and need explicit
+  # teardown — the Package delete cascade does not own them. The
+  # ClusterRole/ClusterRoleBinding are cluster-scoped and would otherwise
+  # leak across e2e re-runs on the same sandbox cluster.
+  kubectl delete --namespace cozy-kuberture --ignore-not-found pod/kuberture-e2e-edns-public pod/kuberture-e2e-edns-internal 2>/dev/null || true
+  kubectl delete --namespace cozy-kuberture --ignore-not-found sa/kuberture-e2e-edns-probe 2>/dev/null || true
+  kubectl delete --ignore-not-found clusterrolebinding/kuberture-e2e-edns-probe clusterrole/kuberture-e2e-edns-probe 2>/dev/null || true
+  kubectl delete package.cozystack.io cozystack.kuberture --ignore-not-found --wait=true --timeout=180s 2>/dev/null || true
+}
+
+teardown() {
+  # Dead code under cozytest.sh — the runner never invokes it. Kept so
+  # the file still works under upstream bats (e.g. for local debugging
+  # via `bats hack/e2e-apps/kuberture.bats`).
+  _cleanup
+}
+
+@test "Platform-level kuberture publishes default/kubernetes EndpointSlice as annotated headless Services for multiple external-dns instances" {
+  pub_host=kuberture-e2e-public.cozystack.test
+  int_host=kuberture-e2e-internal.cozystack.test
+  pub_prefix=external-dns.alpha.kubernetes.io/
+  int_prefix=kuberture-e2e-internal-dns.io/
+
+  kubectl apply --filename - <<EOF
+apiVersion: cozystack.io/v1alpha1
+kind: Package
+metadata:
+  name: cozystack.kuberture
+spec:
+  variant: default
+  components:
+    kuberture:
+      values:
+        kuberture:
+          config:
+            outputs:
+              - name: public
+                hostname:
+                  - ${pub_host}
+                annotationPrefix: ${pub_prefix}
+                serviceName: kuberture-e2e-public
+                addressSource: endpointslice
+                recordTTL: 60
+              - name: internal
+                hostname:
+                  - ${int_host}
+                annotationPrefix: ${int_prefix}
+                serviceName: kuberture-e2e-internal
+                addressSource: endpointslice
+                recordTTL: 300
+EOF
+
+  # The cozystack operator materialises the namespace + HR from the Package;
+  # kubectl wait errors immediately if the object is not present yet, so loop
+  # until it appears before waiting on its condition.
+  timeout 180 sh -ec 'until kubectl get namespace cozy-kuberture >/dev/null 2>&1; do sleep 2; done'
+  timeout 180 sh -ec 'until kubectl --namespace cozy-kuberture get hr kuberture >/dev/null 2>&1; do sleep 2; done'
+  kubectl --namespace cozy-kuberture wait hr kuberture --timeout=300s --for=condition=ready
+
+  # Controller rollout. Use kubectl wait so the readiness check is anchored on
+  # the Available condition and not on a substring match of the replica count.
+  kubectl --namespace cozy-kuberture wait deployment kuberture --for=condition=available --timeout=180s
+
+  # The output Services are created reactively after the controller observes
+  # default/kubernetes EndpointSlice. Wait for both to appear.
+  for svc in kuberture-e2e-public kuberture-e2e-internal; do
+    timeout 120 sh -ec "until kubectl --namespace cozy-kuberture get service ${svc} >/dev/null 2>&1; do sleep 3; done"
+  done
+
+  # Both Services must be headless and carry external-dns annotations under
+  # their configured prefix. The `target` annotation must be non-empty —
+  # the actual IPs come from default/kubernetes EndpointSlice and depend on
+  # the cluster, so we only assert presence.
+  pub_json=$(kubectl --namespace cozy-kuberture get service kuberture-e2e-public --output json)
+  int_json=$(kubectl --namespace cozy-kuberture get service kuberture-e2e-internal --output json)
+
+  test "$(echo "${pub_json}" | jq --raw-output '.spec.clusterIP')" = "None"
+  test "$(echo "${int_json}" | jq --raw-output '.spec.clusterIP')" = "None"
+
+  test "$(echo "${pub_json}" | jq --raw-output --arg k "${pub_prefix}hostname" '.metadata.annotations[$k]')" = "${pub_host}"
+  test "$(echo "${int_json}" | jq --raw-output --arg k "${int_prefix}hostname" '.metadata.annotations[$k]')" = "${int_host}"
+
+  pub_target=$(echo "${pub_json}" | jq --raw-output --arg k "${pub_prefix}target" '.metadata.annotations[$k] // ""')
+  int_target=$(echo "${int_json}" | jq --raw-output --arg k "${int_prefix}target" '.metadata.annotations[$k] // ""')
+  test -n "${pub_target}"
+  test -n "${int_target}"
+
+  test "$(echo "${pub_json}" | jq --raw-output --arg k "${pub_prefix}ttl" '.metadata.annotations[$k]')" = "60"
+  test "$(echo "${int_json}" | jq --raw-output --arg k "${int_prefix}ttl" '.metadata.annotations[$k]')" = "300"
+
+  # The cross-prefix assertion proves the per-output isolation: the public
+  # Service must NOT carry the internal prefix's annotation, and vice versa.
+  test "$(echo "${pub_json}" | jq --raw-output --arg k "${int_prefix}hostname" '.metadata.annotations[$k] // "absent"')" = "absent"
+  test "$(echo "${int_json}" | jq --raw-output --arg k "${pub_prefix}hostname" '.metadata.annotations[$k] // "absent"')" = "absent"
+
+  # Routing proof: run two short-lived external-dns probes, each with a
+  # distinct --annotation-prefix, and verify each one picks up exactly its
+  # matching Service. This is the upstream Split Horizon DNS pattern from
+  # kubernetes-sigs/external-dns docs/advanced/split-horizon. inmemory
+  # provider + noop registry + --once means each probe runs one sync cycle
+  # against the live Services in cozy-kuberture, logs what it would publish,
+  # and exits — the logs are the assertion surface.
+  # external-dns 0.20 needs cluster-wide read on services/endpoints/nodes/
+  # namespaces even when `--namespace` narrows the source scope (informer
+  # cache initialisation reads cluster-wide before applying the filter).
+  # A namespace-scoped Role surfaces as a Pod crash without an obvious
+  # error in the bats log, so use ClusterRole + ClusterRoleBinding here.
+  kubectl apply --filename - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kuberture-e2e-edns-probe
+  namespace: cozy-kuberture
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kuberture-e2e-edns-probe
+rules:
+  - apiGroups: [""]
+    resources: ["services", "endpoints", "pods", "nodes", "namespaces"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuberture-e2e-edns-probe
+subjects:
+  - kind: ServiceAccount
+    name: kuberture-e2e-edns-probe
+    namespace: cozy-kuberture
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kuberture-e2e-edns-probe
+EOF
+
+  # One Pod per probe — explicit instead of eval-indirection. cozytest.sh runs
+  # the body under a POSIX `sh` (not bash) and `${probe}_prefix` indirection
+  # via eval is brittle (a name mismatch produces "parameter not set" with no
+  # useful diagnostic). Two near-identical blocks read more clearly here.
+  kubectl apply --filename - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kuberture-e2e-edns-public
+  namespace: cozy-kuberture
+spec:
+  serviceAccountName: kuberture-e2e-edns-probe
+  restartPolicy: Never
+  containers:
+    - name: edns
+      image: registry.k8s.io/external-dns/external-dns:v0.20.0
+      args:
+        - --source=service
+        - --namespace=cozy-kuberture
+        - --provider=inmemory
+        - --inmemory-zone=cozystack.test
+        - --registry=noop
+        - --once
+        - --interval=10s
+        - --annotation-prefix=${pub_prefix}
+        - --domain-filter=cozystack.test
+        - --log-level=info
+        - --log-format=text
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kuberture-e2e-edns-internal
+  namespace: cozy-kuberture
+spec:
+  serviceAccountName: kuberture-e2e-edns-probe
+  restartPolicy: Never
+  containers:
+    - name: edns
+      image: registry.k8s.io/external-dns/external-dns:v0.20.0
+      args:
+        - --source=service
+        - --namespace=cozy-kuberture
+        - --provider=inmemory
+        - --inmemory-zone=cozystack.test
+        - --registry=noop
+        - --once
+        - --interval=10s
+        - --annotation-prefix=${int_prefix}
+        - --domain-filter=cozystack.test
+        - --log-level=info
+        - --log-format=text
+EOF
+
+  for probe in public internal; do
+    timeout 180 sh -ec "until kubectl --namespace cozy-kuberture get pod kuberture-e2e-edns-${probe} -o jsonpath='{.status.phase}' 2>/dev/null | grep -E '^(Succeeded|Failed)$' >/dev/null; do sleep 3; done"
+    phase=$(kubectl --namespace cozy-kuberture get pod kuberture-e2e-edns-${probe} -o jsonpath='{.status.phase}')
+    if [ "${phase}" != "Succeeded" ]; then
+      # Dump enough context to diagnose the failure from the bats log alone
+      # (the e2e sandbox is destroyed before the run artefacts ship, so
+      # post-mortem kubectl access on the cluster is not available).
+      echo "==== probe ${probe} failed: phase=${phase}; describe ===="
+      kubectl --namespace cozy-kuberture describe pod kuberture-e2e-edns-${probe} || true
+      echo "==== probe ${probe} logs (current container) ===="
+      kubectl --namespace cozy-kuberture logs pod/kuberture-e2e-edns-${probe} || true
+      echo "==== probe ${probe} logs (previous container, if any) ===="
+      kubectl --namespace cozy-kuberture logs pod/kuberture-e2e-edns-${probe} --previous || true
+      exit 1
+    fi
+  done
+
+  pub_logs=$(kubectl --namespace cozy-kuberture logs pod/kuberture-e2e-edns-public)
+  int_logs=$(kubectl --namespace cozy-kuberture logs pod/kuberture-e2e-edns-internal)
+
+  # The probe that reads the default external-dns prefix must see
+  # kuberture-e2e-public.cozystack.test (kuberture-e2e-public Service carries
+  # external-dns.alpha.kubernetes.io/hostname=...) and must NOT see the
+  # internal hostname (kuberture-e2e-internal carries only the internal prefix).
+  echo "${pub_logs}" | grep -F "${pub_host}" >/dev/null
+  ! echo "${pub_logs}" | grep -F "${int_host}" >/dev/null
+
+  # And the inverse for the internal-prefix probe.
+  echo "${int_logs}" | grep -F "${int_host}" >/dev/null
+  ! echo "${int_logs}" | grep -F "${pub_host}" >/dev/null
+
+  # _cleanup deletes the probe Pods, their SA, the ClusterRole+ClusterRoleBinding,
+  # and finally the Package CR. Inlined here for the success path so a re-run
+  # within the same e2e session starts clean; failure path is covered by the
+  # sandbox teardown.
+  _cleanup
+}

--- a/packages/core/platform/sources/kuberture.yaml
+++ b/packages/core/platform/sources/kuberture.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: cozystack.io/v1alpha1
+kind: PackageSource
+metadata:
+  name: cozystack.kuberture
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: cozystack-packages
+    namespace: cozy-system
+    path: /
+  variants:
+  - name: default
+    # Install-order dependencies only:
+    # - cozystack.networking: CNI must be reconciled before the controller pod schedules.
+    # - cozystack.prometheus-operator-crds: the chart enables ServiceMonitor by
+    #   default; the CRD must exist before the manifest is applied.
+    #
+    # external-dns is intentionally NOT listed here. Kuberture creates
+    # annotated headless Services regardless of whether external-dns is
+    # installed — external-dns is a downstream consumer of those annotations,
+    # not a runtime prerequisite. Operators who want DNS records actually
+    # published enable an external-dns instance separately
+    # (cozystack.external-dns for the cluster-wide platform instance, which
+    # is the one that watches cozy-kuberture; cozystack.external-dns-application
+    # is tenant-namespaced and will not see Services outside its tenant).
+    dependsOn:
+    - cozystack.networking
+    - cozystack.prometheus-operator-crds
+    components:
+    - name: kuberture
+      path: system/kuberture
+      install:
+        namespace: cozy-kuberture
+        releaseName: kuberture

--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -210,6 +210,7 @@
 {{include "cozystack.platform.package.optional.default" (list "cozystack.telepresence" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.external-dns" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.external-dns-application" $) }}
+{{include "cozystack.platform.package.optional.default" (list "cozystack.kuberture" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.external-secrets-operator" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.velero" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.linstor-gui" $) }}

--- a/packages/system/kuberture/Chart.yaml
+++ b/packages/system/kuberture/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: cozy-kuberture
+version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process

--- a/packages/system/kuberture/Makefile
+++ b/packages/system/kuberture/Makefile
@@ -1,0 +1,48 @@
+export NAME=kuberture
+export NAMESPACE=cozy-$(NAME)
+
+include ../../../hack/package.mk
+
+# Pin the upstream kuberture chart by version AND OCI manifest digest.
+#
+# KUBERTURE_CHART_DIGEST below is the digest of the OCI **chart**
+# manifest at ghcr.io/lexfrei/kuberture/charts/kuberture — it pins
+# the contents of the helm chart artefact (templates, values.yaml,
+# Chart.yaml). It is NOT the digest of the controller container
+# image. The controller image digest lives in the shim
+# values.yaml at packages/system/kuberture/values.yaml under
+# kuberture.image.tag (pinning ghcr.io/lexfrei/kuberture); both
+# digests advance in lockstep with the upstream release.
+#
+# Bump together with the image tag+digest in values.yaml. The
+# digest pin closes the supply-chain hole that a tag-only pull
+# would leave — OCI registries can republish under the same tag,
+# but the manifest digest is immutable. To bump:
+#   crane manifest ghcr.io/lexfrei/kuberture/charts/kuberture:<new-tag> | sha256sum
+#   crane digest ghcr.io/lexfrei/kuberture:<new-tag>
+# (or `oras manifest fetch ...`) and update KUBERTURE_CHART_DIGEST
+# below plus kuberture.image.tag in values.yaml.
+KUBERTURE_CHART_VERSION ?= 0.1.1
+KUBERTURE_CHART_DIGEST ?= sha256:1356710b05fcf2dff93d3c723b923b653c74ca2a69360cef0dc1fcd9f595fa95
+
+test:
+	helm unittest .
+
+update:
+	rm -rf charts
+	mkdir -p charts
+	# Pull by digest, then verify Chart.yaml records the expected
+	# version. A digest mismatch (someone bumped DIGEST without
+	# bumping VERSION, or vice versa) trips the assert and aborts.
+	helm pull oci://ghcr.io/lexfrei/kuberture/charts/kuberture@$(KUBERTURE_CHART_DIGEST) --untar --untardir charts
+	@actual_version=$$(awk '/^version:/ {print $$2}' charts/kuberture/Chart.yaml | tr -d '"'); \
+	if [ "$$actual_version" != "$(KUBERTURE_CHART_VERSION)" ]; then \
+	  echo "ERROR: pulled chart Chart.yaml version=$$actual_version but Makefile KUBERTURE_CHART_VERSION=$(KUBERTURE_CHART_VERSION). Bump both in lockstep."; \
+	  exit 1; \
+	fi
+	# Drop vendored upstream helm-unittest fixtures: cozystack ships
+	# its own unittest coverage at tests/ targeting the shim values
+	# overrides, and the upstream fixtures are not reviewed code in
+	# this repo. Until the kuberture chart gains a .helmignore the
+	# fixtures ride along in the OCI tarball.
+	rm -rf charts/kuberture/tests

--- a/packages/system/kuberture/README.md
+++ b/packages/system/kuberture/README.md
@@ -1,0 +1,103 @@
+# kuberture
+
+Cozystack system package for [kuberture](https://github.com/lexfrei/kuberture) — a controller that translates the `default/kubernetes` EndpointSlice into annotated headless Services, so that `external-dns` (which cannot use EndpointSlice as a source) can publish the Kubernetes API endpoint to DNS.
+
+```text
+EndpointSlice (kubernetes) → kuberture → headless Service(s) with annotations → external-dns → DNS
+```
+
+## Status
+
+Optional. Disabled by default. Enable by adding `cozystack.kuberture` to `bundles.enabledPackages` in the platform HelmRelease values.
+
+The package ships no usable default beyond enabling ServiceMonitor: kuberture's deployment template fails fast if `config.outputs` is empty. The operator must declare at least one output describing the DNS name(s) they want published. The package itself cannot infer a sensible default hostname; that is intentional — a placeholder default would silently roll out and produce DNS records pointing at the wrong target.
+
+## Targeting an external-dns instance
+
+Each `config.outputs[*].annotationPrefix` selects which external-dns instance picks up that output's headless Service. The prefix is the namespace used for the `hostname`/`target`/`ttl` annotations that the controller writes onto the Service. An external-dns instance configured with a matching annotation prefix consumes those Services; an instance configured with a different prefix ignores them.
+
+`annotationPrefix` rules:
+
+- Omit the field entirely to inherit the controller default `external-dns.alpha.kubernetes.io/` (the prefix the platform-level system external-dns watches by default).
+- Set the field to a non-empty string ending in `/` to match a custom-prefixed external-dns instance (e.g. one started with `--annotation-prefix=<your-prefix>/`).
+- The empty string `""` is rejected by the chart's values schema — omission is the only zero-prefix path.
+
+The platform-level system external-dns watches services cluster-wide (`namespaced: false`) and is the consumer for kuberture output Services in `cozy-kuberture`. Tenant-scoped external-dns instances (delivered through `cozystack.external-dns-application`) run `namespaced: true` and will not pick up Services outside their tenant namespace.
+
+## Example: single external-dns instance
+
+The simplest case — publish the API endpoint under one DNS name, consumed by the platform external-dns:
+
+```yaml
+apiVersion: cozystack.io/v1alpha1
+kind: Package
+metadata:
+  name: cozystack.kuberture
+spec:
+  variant: default
+  components:
+    kuberture:
+      values:
+        kuberture:
+          config:
+            outputs:
+              - name: api
+                hostname:
+                  - api.k8s.example.com
+                serviceName: kuberture-api
+                addressSource: endpointslice
+                recordTTL: 60
+```
+
+`annotationPrefix` is omitted, so the controller uses the default `external-dns.alpha.kubernetes.io/`. `recordTTL` is set explicitly here for symmetry with the multi-instance example below; omit it to inherit the controller default.
+
+## Example: routing to multiple external-dns instances
+
+A single kuberture install can serve any number of external-dns instances by varying `annotationPrefix` per output. Two outputs — one targeting the platform external-dns, one targeting a custom-prefixed instance scoped to internal DNS:
+
+```yaml
+apiVersion: cozystack.io/v1alpha1
+kind: Package
+metadata:
+  name: cozystack.kuberture
+spec:
+  variant: default
+  components:
+    kuberture:
+      values:
+        kuberture:
+          config:
+            outputs:
+              - name: public
+                hostname:
+                  - api.k8s.example.com
+                serviceName: kuberture-public
+                addressSource: endpointslice
+              - name: internal
+                hostname:
+                  - api-internal.k8s.example.internal
+                annotationPrefix: internal-dns.example.com/
+                serviceName: kuberture-internal
+                addressSource: endpointslice
+```
+
+Each output renders its own headless Service in `cozy-kuberture`, carrying only its own prefix's annotations. The platform external-dns (default `--annotation-prefix=external-dns.alpha.kubernetes.io/`) reads only `kuberture-public`. A second external-dns instance started with `--annotation-prefix=internal-dns.example.com/` rebuilds every `hostname`/`target`/`ttl` annotation key under that prefix on startup and therefore reads only `kuberture-internal`. This is the upstream-documented [Split Horizon DNS pattern](https://kubernetes-sigs.github.io/external-dns/v0.20.0/docs/advanced/split-horizon/) — no cross-pollution between outputs because each external-dns ignores annotations under any prefix other than its own.
+
+## Address resolution
+
+`addressSource` picks where each output gets its target IPs:
+
+- `endpointslice` (default in the examples above) — read addresses directly from the `default/kubernetes` EndpointSlice. Use this when the EndpointSlice IPs are the addresses you want in DNS.
+- `node-internal` / `node-external` / `node-public` — resolve each EndpointSlice endpoint to a Node and emit the node's `InternalIP` / `ExternalIP` / a public IP. Use these when the EndpointSlice carries internal IPs but external-dns must publish the node's external IP (cloud-hosted control plane behind a LoadBalancer, etc.).
+
+## Dependencies
+
+The package declares no `dependsOn` on external-dns: kuberture creates annotated Services regardless of whether an external-dns instance exists to consume them. External-dns is a downstream reader of those annotations, not a runtime prerequisite. Operators who want DNS records actually published install external-dns separately (`cozystack.external-dns` for the cluster-wide platform instance).
+
+## NetworkPolicy
+
+The chart's `networkPolicy.enabled` defaults to `false`. Cozystack tenant isolation with Cilium does not require a NetworkPolicy on system packages running in dedicated platform namespaces (`cozy-kuberture` here); the controller only reads EndpointSlices and Nodes cluster-wide and writes Services in its own namespace. Operators running stricter zero-trust models can override `kuberture.networkPolicy.enabled: true` in their HelmRelease values to gate the controller's metrics/health ports.
+
+## Vendoring
+
+The chart is pulled from `oci://ghcr.io/lexfrei/kuberture/charts/kuberture` and the controller image from `ghcr.io/lexfrei/kuberture`. Both are in the maintainer's personal namespace and are intentionally not mirrored under `ghcr.io/cozystack/*` — air-gapped operators must mirror the chart and the controller image into their internal registry and override `kuberture.image.repository` accordingly. The chart version and OCI manifest digest are pinned in [`Makefile`](./Makefile); the controller image tag and image digest are pinned in [`values.yaml`](./values.yaml). All four pins advance in lockstep when bumping; see the in-file comments for the bump procedure.

--- a/packages/system/kuberture/charts/kuberture/Chart.yaml
+++ b/packages/system/kuberture/charts/kuberture/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+appVersion: 0.1.1
+description: Kubernetes EndpointSlice to DNS controller for external-dns
+home: https://github.com/lexfrei/kuberture
+maintainers:
+- email: f@lex.la
+  name: Aleksei Sviridkin
+name: kuberture
+sources:
+- https://github.com/lexfrei/kuberture
+type: application
+version: 0.1.1

--- a/packages/system/kuberture/charts/kuberture/templates/NOTES.txt
+++ b/packages/system/kuberture/charts/kuberture/templates/NOTES.txt
@@ -1,0 +1,20 @@
+kuberture has been installed.
+
+Controller watches EndpointSlice "{{ .Values.config.source.serviceName }}" in namespace "{{ .Values.config.source.namespace }}".
+
+Configured outputs:
+{{- range .Values.config.outputs }}
+  - {{ .name }}: {{ .hostname | join ", " }} -> {{ .serviceName }}
+{{- end }}
+
+Verify the deployment:
+
+  kubectl get deployment {{ include "kuberture.fullname" . }} --namespace {{ .Release.Namespace }}
+
+Check controller logs:
+
+  kubectl logs deployment/{{ include "kuberture.fullname" . }} --namespace {{ .Release.Namespace }}
+
+Check created headless Services:
+
+  kubectl get services --selector app.kubernetes.io/managed-by=kuberture

--- a/packages/system/kuberture/charts/kuberture/templates/_helpers.tpl
+++ b/packages/system/kuberture/charts/kuberture/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kuberture.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kuberture.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kuberture.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "kuberture.labels" -}}
+helm.sh/chart: {{ include "kuberture.chart" . }}
+{{ include "kuberture.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "kuberture.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kuberture.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "kuberture.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kuberture.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/packages/system/kuberture/charts/kuberture/templates/clusterrole.yaml
+++ b/packages/system/kuberture/charts/kuberture/templates/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kuberture.fullname" . }}
+  labels:
+    {{- include "kuberture.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]

--- a/packages/system/kuberture/charts/kuberture/templates/clusterrolebinding.yaml
+++ b/packages/system/kuberture/charts/kuberture/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "kuberture.fullname" . }}
+  labels:
+    {{- include "kuberture.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "kuberture.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kuberture.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/packages/system/kuberture/charts/kuberture/templates/configmap.yaml
+++ b/packages/system/kuberture/charts/kuberture/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kuberture.fullname" . }}
+  labels:
+    {{- include "kuberture.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml .Values.config | nindent 4 }}

--- a/packages/system/kuberture/charts/kuberture/templates/deployment.yaml
+++ b/packages/system/kuberture/charts/kuberture/templates/deployment.yaml
@@ -1,0 +1,125 @@
+{{- if not .Values.config.outputs }}
+{{- fail "config.outputs must contain at least one output entry" }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kuberture.fullname" . }}
+  labels:
+    {{- include "kuberture.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    {{- if gt (int .Values.replicaCount) 1 }}
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+    {{- else }}
+    type: Recreate
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "kuberture.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "kuberture.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kuberture.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--config"
+            - "/etc/kuberture/config.yaml"
+          env:
+            - name: KUBERTURE_INSTANCE
+              value: {{ include "kuberture.fullname" . | quote }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - name: metrics
+              containerPort: {{ last (splitList ":" .Values.config.metricsBindAddress) | int }}
+              protocol: TCP
+            - name: health
+              containerPort: {{ last (splitList ":" .Values.config.healthProbeBindAddress) | int }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            failureThreshold: 30
+            periodSeconds: 2
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kuberture
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "kuberture.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- else if gt (int .Values.replicaCount) 1 }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    {{- include "kuberture.selectorLabels" . | nindent 20 }}
+                topologyKey: kubernetes.io/hostname
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/packages/system/kuberture/charts/kuberture/templates/networkpolicy.yaml
+++ b/packages/system/kuberture/charts/kuberture/templates/networkpolicy.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "kuberture.fullname" . }}
+  labels:
+    {{- include "kuberture.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "kuberture.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - ports:
+        - port: {{ last (splitList ":" .Values.config.metricsBindAddress) | int }}
+          protocol: TCP
+        - port: {{ last (splitList ":" .Values.config.healthProbeBindAddress) | int }}
+          protocol: TCP
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+        - port: 443
+          protocol: TCP
+        - port: 6443
+          protocol: TCP
+{{- end }}

--- a/packages/system/kuberture/charts/kuberture/templates/pdb.yaml
+++ b/packages/system/kuberture/charts/kuberture/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kuberture.fullname" . }}
+  labels:
+    {{- include "kuberture.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "kuberture.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/packages/system/kuberture/charts/kuberture/templates/role.yaml
+++ b/packages/system/kuberture/charts/kuberture/templates/role.yaml
@@ -1,0 +1,22 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "kuberture.fullname" . }}
+  labels:
+    {{- include "kuberture.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]

--- a/packages/system/kuberture/charts/kuberture/templates/rolebinding.yaml
+++ b/packages/system/kuberture/charts/kuberture/templates/rolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kuberture.fullname" . }}
+  labels:
+    {{- include "kuberture.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "kuberture.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "kuberture.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/packages/system/kuberture/charts/kuberture/templates/service.yaml
+++ b/packages/system/kuberture/charts/kuberture/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kuberture.fullname" . }}
+  labels:
+    {{- include "kuberture.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "kuberture.selectorLabels" . | nindent 4 }}

--- a/packages/system/kuberture/charts/kuberture/templates/serviceaccount.yaml
+++ b/packages/system/kuberture/charts/kuberture/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kuberture.serviceAccountName" . }}
+  labels:
+    {{- include "kuberture.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: true
+{{- end }}

--- a/packages/system/kuberture/charts/kuberture/templates/servicemonitor.yaml
+++ b/packages/system/kuberture/charts/kuberture/templates/servicemonitor.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "kuberture.fullname" . }}
+  labels:
+    {{- include "kuberture.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "kuberture.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/packages/system/kuberture/charts/kuberture/values.schema.json
+++ b/packages/system/kuberture/charts/kuberture/values.schema.json
@@ -1,0 +1,206 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["config"],
+  "properties": {
+    "replicaCount": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 1
+    },
+    "revisionHistoryLimit": {
+      "type": "integer",
+      "minimum": 0,
+      "default": 3
+    },
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": ["Always", "IfNotPresent", "Never"]
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "serviceAccount": {
+      "type": "object",
+      "properties": {
+        "create": {
+          "type": "boolean"
+        },
+        "annotations": {
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "config": {
+      "type": "object",
+      "required": ["outputs"],
+      "properties": {
+        "source": {
+          "type": "object",
+          "properties": {
+            "namespace": {
+              "type": "string",
+              "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
+            },
+            "serviceName": {
+              "type": "string",
+              "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
+            }
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "hostname", "serviceName"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "hostname": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "annotationPrefix": {
+                "type": "string",
+                "pattern": "/$"
+              },
+              "serviceName": {
+                "type": "string",
+                "pattern": "^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$"
+              },
+              "recordTTL": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 86400
+              },
+              "addressSource": {
+                "type": "string",
+                "enum": ["endpointslice", "node-internal", "node-external", "node-public"]
+              },
+              "addressType": {
+                "type": "string",
+                "enum": ["IPv4", "IPv6"]
+              }
+            }
+          }
+        },
+        "metricsBindAddress": {
+          "type": "string"
+        },
+        "healthProbeBindAddress": {
+          "type": "string"
+        }
+      }
+    },
+    "resources": {
+      "type": "object",
+      "properties": {
+        "requests": {
+          "type": "object"
+        },
+        "limits": {
+          "type": "object"
+        }
+      }
+    },
+    "pdb": {
+      "type": "object",
+      "properties": {
+        "minAvailable": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 1
+        }
+      }
+    },
+    "networkPolicy": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        }
+      }
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
+    "affinity": {
+      "type": "object"
+    },
+    "podAnnotations": {
+      "type": "object"
+    },
+    "podLabels": {
+      "type": "object"
+    },
+    "service": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      }
+    },
+    "serviceMonitor": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "interval": {
+          "type": "string"
+        },
+        "scrapeTimeout": {
+          "type": "string"
+        },
+        "additionalLabels": {
+          "type": "object"
+        }
+      }
+    }
+  }
+}

--- a/packages/system/kuberture/charts/kuberture/values.yaml
+++ b/packages/system/kuberture/charts/kuberture/values.yaml
@@ -1,0 +1,54 @@
+replicaCount: 1
+revisionHistoryLimit: 3
+
+image:
+  repository: ghcr.io/lexfrei/kuberture
+  tag: "0.1.1"
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: ""
+
+config:
+  source:
+    namespace: default
+    serviceName: kubernetes
+  outputs: []
+  metricsBindAddress: ":8080"
+  healthProbeBindAddress: ":8081"
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    memory: 64Mi
+
+pdb:
+  minAvailable: 1
+
+networkPolicy:
+  enabled: false
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+podAnnotations: {}
+podLabels: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  scrapeTimeout: 10s
+  additionalLabels: {}

--- a/packages/system/kuberture/tests/kuberture_test.yaml
+++ b/packages/system/kuberture/tests/kuberture_test.yaml
@@ -1,0 +1,162 @@
+suite: cozystack-managed kuberture shim
+release:
+  name: kuberture
+  namespace: cozy-kuberture
+
+tests:
+  - it: fails fast when operator does not declare any output
+    template: charts/kuberture/templates/deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: config.outputs must contain at least one output entry
+
+  - it: enables ServiceMonitor by default so the platform Prometheus scrapes metrics
+    template: charts/kuberture/templates/servicemonitor.yaml
+    set:
+      kuberture.config.outputs:
+        - name: public
+          hostname: [api.example.com]
+          annotationPrefix: external-dns.alpha.kubernetes.io/
+          serviceName: kuberture-public
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: metadata.name
+          value: kuberture
+
+  - it: keeps source pinned to default/kubernetes EndpointSlice unless overridden
+    template: charts/kuberture/templates/configmap.yaml
+    set:
+      kuberture.config.outputs:
+        - name: public
+          hostname: [api.example.com]
+          annotationPrefix: external-dns.alpha.kubernetes.io/
+          serviceName: kuberture-public
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'source:\s+namespace: default\s+serviceName: kubernetes'
+
+  - it: renders every operator-supplied output with its annotationPrefix so each external-dns instance is addressable
+    template: charts/kuberture/templates/configmap.yaml
+    set:
+      kuberture.config.outputs:
+        - name: public
+          hostname: [api.example.com]
+          annotationPrefix: external-dns.alpha.kubernetes.io/
+          serviceName: kuberture-public
+        - name: internal
+          hostname: [api.internal.example]
+          annotationPrefix: internal-dns.io/
+          serviceName: kuberture-internal
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'annotationPrefix: external-dns\.alpha\.kubernetes\.io/'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'annotationPrefix: internal-dns\.io/'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'serviceName: kuberture-public'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'serviceName: kuberture-internal'
+
+  - it: rejects an empty annotationPrefix at install time so the comment about omission is the only documented zero-prefix path
+    template: charts/kuberture/templates/configmap.yaml
+    set:
+      kuberture.config.outputs:
+        - name: public
+          hostname: [api.example.com]
+          annotationPrefix: ""
+          serviceName: kuberture-public
+    asserts:
+      - failedTemplate:
+          errorPattern: "annotationPrefix.*does not match pattern '/\\$'"
+
+  - it: omits annotationPrefix from the rendered config when the operator omits it so the controller applies its default
+    template: charts/kuberture/templates/configmap.yaml
+    set:
+      kuberture.config.outputs:
+        - name: public
+          hostname: [api.example.com]
+          serviceName: kuberture-public
+    asserts:
+      - notMatchRegex:
+          path: data["config.yaml"]
+          pattern: 'annotationPrefix:'
+
+  - it: mounts the rendered ConfigMap into the controller so config changes propagate
+    template: charts/kuberture/templates/deployment.yaml
+    set:
+      kuberture.config.outputs:
+        - name: public
+          hostname: [api.example.com]
+          annotationPrefix: external-dns.alpha.kubernetes.io/
+          serviceName: kuberture-public
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: kuberture
+
+  - it: pins the controller image to a tag+sha256 digest so an upstream tag republish cannot silently swap the binary
+    template: charts/kuberture/templates/deployment.yaml
+    set:
+      kuberture.config.outputs:
+        - name: public
+          hostname: [api.example.com]
+          annotationPrefix: external-dns.alpha.kubernetes.io/
+          serviceName: kuberture-public
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/lexfrei/kuberture:[^@]+@sha256:[0-9a-f]{64}$'
+
+  - it: keeps the controller Role permitting full Service lifecycle on its release namespace so the operator can reconcile output Services
+    template: charts/kuberture/templates/role.yaml
+    set:
+      kuberture.config.outputs:
+        - name: public
+          hostname: [api.example.com]
+          annotationPrefix: external-dns.alpha.kubernetes.io/
+          serviceName: kuberture-public
+    asserts:
+      - isKind:
+          of: Role
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["services"]
+            verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+  - it: pins the container metrics port to the value derived from config.metricsBindAddress so a future schema tightening or upstream refactor cannot silently break Prometheus scraping
+    # The vendored chart derives containerPort via `last (splitList ":"
+    # .Values.config.metricsBindAddress) | int`, which renders the integer
+    # part after the final colon. The chart's values.schema.json validates
+    # metricsBindAddress only as a free-form string today; tracked as an
+    # upstream tightening request — for cozystack the right move is to pin
+    # the current contract here so an upstream refactor that changes the
+    # derivation (or our own future override of metricsBindAddress) is
+    # surfaced by a failing test.
+    template: charts/kuberture/templates/deployment.yaml
+    set:
+      kuberture.config.outputs:
+        - name: public
+          hostname: [api.example.com]
+          annotationPrefix: external-dns.alpha.kubernetes.io/
+          serviceName: kuberture-public
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: metrics
+            containerPort: 8080
+            protocol: TCP

--- a/packages/system/kuberture/values.yaml
+++ b/packages/system/kuberture/values.yaml
@@ -1,0 +1,25 @@
+kuberture:
+  image:
+    # Pulled directly from the upstream lexfrei/kuberture registry; this
+    # package is intentionally not mirrored under ghcr.io/cozystack/*.
+    # Air-gapped operators must mirror both this image and the OCI chart
+    # at oci://ghcr.io/lexfrei/kuberture/charts/kuberture separately. Bump
+    # the tag+digest here together with KUBERTURE_CHART_VERSION and
+    # KUBERTURE_CHART_DIGEST in the Makefile (resolve the new image digest
+    # with `crane digest ghcr.io/lexfrei/kuberture:<new-tag>`).
+    tag: 0.1.1@sha256:4f265331d65f6e5afc1bf6325e7ab62f2004fc75c0587978e41321f816105fbf
+
+  # Cozystack ships a Prometheus stack by default; surface kuberture's metrics.
+  serviceMonitor:
+    enabled: true
+
+  # Operators populate `config.outputs` per HelmRelease to bind the kubernetes
+  # control-plane EndpointSlice to one or more external-dns instances. Each
+  # output picks its target external-dns by `annotationPrefix`: omit the
+  # field entirely to inherit the controller default
+  # `external-dns.alpha.kubernetes.io/` (consumed by the platform external-dns),
+  # or set it to a non-empty value ending in `/` to match a custom-prefixed
+  # instance. The empty string `""` is rejected by the chart's values schema
+  # — omission and explicit value are the only two forms.
+  config:
+    outputs: []


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Adds [kuberture](https://github.com/lexfrei/kuberture) as an optional system package. Kuberture is a small controller that translates the `default/kubernetes` EndpointSlice into headless Services with external-dns-style annotations, closing the gap that external-dns cannot use EndpointSlice as a source directly:

```text
EndpointSlice (kubernetes) → kuberture → headless Service(s) with annotations → external-dns → DNS
```

The package is opt-in via `bundles.enabledPackages: [cozystack.kuberture]`. Operators populate `config.outputs` per HelmRelease — each output targets a specific external-dns instance by its `annotationPrefix`, so a single kuberture install can serve multiple external-dns instances (e.g. one publishing to the public zone, another to an internal corporate prefix) simultaneously.

The vendored chart at `packages/system/kuberture/charts/kuberture/` is pulled from `oci://ghcr.io/lexfrei/kuberture/charts/kuberture` and pinned by both version AND OCI manifest digest in the Makefile (mirroring the ouroboros lockstep pattern). The controller image at `ghcr.io/lexfrei/kuberture` is pinned by tag+sha256 in the shim values.yaml. Both pins advance in lockstep with each upstream release; the procedure is documented inline.

Install-order dependencies declared in `PackageSource`: `cozystack.networking` (CNI before pod scheduling) and `cozystack.prometheus-operator-crds` (ServiceMonitor CRD before the chart's enabled-by-default ServiceMonitor manifest). External-dns is deliberately NOT a dependency — kuberture creates annotated Services regardless of whether external-dns is installed; external-dns is a downstream consumer, not a runtime prerequisite.

Coverage:

- **helm-unittest** (`packages/system/kuberture/tests/kuberture_test.yaml`, 10 cases): fail-fast on empty outputs, ServiceMonitor enabled by default, source pinned to `default/kubernetes`, multi-output prefix isolation, empty-string `annotationPrefix` schema rejection, omitted-prefix fallback to controller default, ConfigMap → Deployment volume mount, controller image pinned by tag+sha256 digest, Role permits full Service lifecycle, metrics containerPort derived from `metricsBindAddress`.
- **bats e2e** (`hack/e2e-apps/kuberture.bats`): applies a `Package cozystack.kuberture` with two outputs (different `annotationPrefix` values), waits for HelmRelease and controller readiness, asserts both output Services are headless and carry the right `hostname`/`target`/`ttl` annotations under their configured prefix, cross-checks per-output isolation (each Service only carries its own prefix's annotations).

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

Not applicable — no UI changes.

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
feat(platform): add kuberture as an optional system package — translates the default/kubernetes EndpointSlice into annotated headless Services so external-dns can publish the Kubernetes API endpoint to DNS. Opt-in via bundles.enabledPackages: [cozystack.kuberture]; populate config.outputs to target one or more external-dns instances by annotationPrefix.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds kuberture as an optional system package to publish the Kubernetes API endpoint to DNS via configurable external-dns outputs; includes Helm chart, RBAC, NetworkPolicy, PDB, ServiceMonitor, and validated chart values/schema.

* **Tests**
  * Adds Helm unit tests and an end-to-end smoke test validating controller readiness, headless Service annotations, and external-dns routing/probe behavior.

* **Documentation**
  * Adds a full README with usage, configuration examples, and vendoring/pinning guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2647)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Documentation companion: [cozystack/website#539](https://github.com/cozystack/website/pull/539).
