### PR TITLE
fix(platform): add OpenSearch to PaaS bundle

### DIFF
--- a/packages/core/platform/templates/bundles/paas.yaml
+++ b/packages/core/platform/templates/bundles/paas.yaml
@@ -9,6 +9,7 @@
 {{include "cozystack.platform.package.default" (list "cozystack.rabbitmq-operator" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.redis-operator" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.mongodb-operator" $) }}
+{{include "cozystack.platform.package.default" (list "cozystack.opensearch-operator" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.clickhouse-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.foundationdb-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.harbor-application" $) }}
@@ -17,6 +18,7 @@
 {{include "cozystack.platform.package.default" (list "cozystack.mongodb-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.nats-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.openbao-application" $) }}
+{{include "cozystack.platform.package.default" (list "cozystack.opensearch-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.postgres-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.qdrant-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.rabbitmq-application" $) }}


### PR DESCRIPTION
## What this PR does

OpenSearch has shipped as a complete package set in the repo for several
releases — `packages/apps/opensearch/`, `packages/system/opensearch-operator/`,
`packages/system/opensearch-rd/`, and `PackageSource` files under
`packages/core/platform/sources/` — but the PaaS bundle template was never
updated to include the two `cozystack.opensearch-*` PackageSources.

Result on any cluster with `bundles.paas.enabled=true`:
- `opensearch-operator` is not deployed → no `OpenSearchCluster` CRD on cluster
- `opensearch-rd` release is not deployed → no `ApplicationDefinition/opensearch` → the dashboard catalog has no OpenSearch entry and tenants cannot create `opensearches.apps.cozystack.io`

This PR adds the missing includes alongside every other DB operator/application in `packages/core/platform/templates/bundles/paas.yaml`.

### Release note
```release-note
Fix: OpenSearch is now installed by the PaaS bundle (`bundles.paas.enabled=true`); previously the operator and ApplicationDefinition were defined but never referenced from the bundle, so OpenSearch did not appear in the dashboard catalog.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenSearch operator and application packages are now included in the PaaS bundle when enabled, providing additional search and analytics capabilities for supported deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2648)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->