### PR TITLE
fix(platform,dashboard): wire OpenSearch into PaaS bundle and form overrides

### DIFF
--- a/internal/controller/dashboard/customformsoverride.go
+++ b/internal/controller/dashboard/customformsoverride.go
@@ -244,7 +244,7 @@ func applyListInputOverrides(schema map[string]any, kind string, openAPIProps ma
 		}
 
 	case "ClickHouse", "Harbor", "HTTPCache", "Kubernetes", "MariaDB", "MongoDB",
-		"NATS", "OpenBAO", "Postgres", "Qdrant", "RabbitMQ", "Redis":
+		"NATS", "OpenBAO", "OpenSearch", "Postgres", "Qdrant", "RabbitMQ", "Redis":
 		specProps := ensureSchemaPath(schema, "spec")
 		specProps["storageClass"] = storageClassListInput()
 

--- a/internal/controller/dashboard/customformsoverride_test.go
+++ b/internal/controller/dashboard/customformsoverride_test.go
@@ -289,7 +289,7 @@ func TestHiddenDeprecatedFields_UnknownKind(t *testing.T) {
 func TestApplyListInputOverrides_StorageClassSimple(t *testing.T) {
 	for _, kind := range []string{
 		"ClickHouse", "Harbor", "HTTPCache", "Kubernetes", "MariaDB", "MongoDB",
-		"NATS", "OpenBAO", "Postgres", "Qdrant", "RabbitMQ", "Redis", "VMDisk",
+		"NATS", "OpenBAO", "OpenSearch", "Postgres", "Qdrant", "RabbitMQ", "Redis", "VMDisk",
 	} {
 		t.Run(kind, func(t *testing.T) {
 			schema := map[string]any{}

--- a/packages/core/platform/templates/bundles/paas.yaml
+++ b/packages/core/platform/templates/bundles/paas.yaml
@@ -9,6 +9,7 @@
 {{include "cozystack.platform.package.default" (list "cozystack.rabbitmq-operator" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.redis-operator" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.mongodb-operator" $) }}
+{{include "cozystack.platform.package.default" (list "cozystack.opensearch-operator" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.clickhouse-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.foundationdb-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.harbor-application" $) }}
@@ -17,6 +18,7 @@
 {{include "cozystack.platform.package.default" (list "cozystack.mongodb-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.nats-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.openbao-application" $) }}
+{{include "cozystack.platform.package.default" (list "cozystack.opensearch-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.postgres-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.qdrant-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.rabbitmq-application" $) }}


### PR DESCRIPTION
## What this PR does

This is the release-1.3 counterpart of #2648.

OpenSearch has shipped as a complete package set in 1.3 — `packages/apps/opensearch/`, `packages/system/opensearch-operator/`, `packages/system/opensearch-rd/`, plus the `cozystack.opensearch-*` PackageSources — but the PaaS bundle template never references the OpenSearch PackageSources. On any cluster with `bundles.paas.enabled=true`:

- `opensearch-operator` is not deployed → no `OpenSearchCluster` CRD on cluster
- `opensearch-rd` release is not deployed → no `ApplicationDefinition/opensearch` → the dashboard catalog has no OpenSearch entry and tenants cannot create `opensearches.apps.cozystack.io`

Two changes in this PR:

1. **`packages/core/platform/templates/bundles/paas.yaml`** — add `cozystack.opensearch-operator` and `cozystack.opensearch-application` to the bundle, matching every other DB application.
2. **`internal/controller/dashboard/customformsoverride.go` + test** — add `OpenSearch` to the StorageClass listInput override case so the create-form `storageClass` field renders as a dropdown in the legacy openapi-ui that ships with 1.3. (The new cozystack-ui in 1.4 derives this widget client-side from the schema, so the form-override change is not needed on main — see #2648.)

### Release note
```release-note
Fix: OpenSearch is now installed by the PaaS bundle (`bundles.paas.enabled=true`); previously the operator and ApplicationDefinition were defined but never referenced from the bundle, so OpenSearch did not appear in the dashboard catalog. The StorageClass field in the OpenSearch create form now renders as a dropdown.
```