### PR TITLE
feat(platform): add deletion-protection guardrail via ValidatingAdmissionPolicy

### DIFF
--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -274,3 +274,79 @@ EOF
   -o jsonpath='{range .items[*].spec.limits[*]}{.default.cpu}{" "}{.default.memory}{" "}{.defaultRequest.cpu}{" "}{.defaultRequest.memory}{"\n"}{end}' \
   | grep -qx '250m 128Mi 25m 128Mi'
 }
+
+@test "Deletion-protection VAP denies delete on labeled cozystack-version ConfigMap" {
+  # Locks down the contract delivered by packages/core/platform/templates/
+  # deletion-protection.yaml: a DELETE on any object carrying
+  # platform.cozystack.io/no-delete=true is rejected by the
+  # ValidatingAdmissionPolicy with the documented message, and the bypass
+  # path (remove the label, then delete) succeeds.
+  #
+  # This covers every regression the PR is meant to prevent in a single
+  # pass: capability gate inverted, binding objectSelector mistyped,
+  # validationActions flipped Deny→Warn, expression flipped false→true,
+  # label-key drift between the binding and the manifests.
+
+  # Preflight: VAP requires Kubernetes 1.30+. Skip on older clusters so
+  # the suite stays green where the capability gate intentionally elides
+  # the policy. Detect by attempting to fetch the policy by name; if the
+  # API is present, the resource will be retrievable, otherwise kubectl
+  # exits non-zero on an unknown resource type.
+  if ! kubectl api-resources --api-group=admissionregistration.k8s.io \
+       2>/dev/null | grep -qw validatingadmissionpolicies; then
+    skip "ValidatingAdmissionPolicy API not available on this cluster"
+  fi
+  kubectl get validatingadmissionpolicy cozystack-no-delete-guardrail
+
+  # The cozystack-version ConfigMap is created with the no-delete label
+  # baked in by the chart (templates/cozystack-version.yaml) and is
+  # backfilled by the migration on upgrades. Asserting the label is the
+  # precondition for the deny check below: if the label is gone the deny
+  # will not fire and the test would misreport as a pass on a regressed
+  # binding.
+  kubectl get configmap cozystack-version -n cozy-system \
+    -o jsonpath='{.metadata.labels.platform\.cozystack\.io/no-delete}' \
+    | grep -qx 'true'
+
+  # The actual deny check. Capture both stdout+stderr and exit code so a
+  # network/auth failure does not silently look like a deny success.
+  local output rc
+  output=$(kubectl delete configmap cozystack-version -n cozy-system 2>&1) \
+    && rc=0 || rc=$?
+  echo "kubectl delete exit=$rc, output=$output"
+  # Delete MUST have failed: success means the VAP regressed.
+  [ "$rc" -ne 0 ]
+  # Assert the user-facing deny message is the one this PR ships — guards
+  # against expression flipped to "true" or message reworded away from the
+  # documented bypass. The CEL message is on one line in the api-server
+  # response, so grep for the literal substring with the --namespace flag.
+  echo "$output" | grep -q 'Deletion blocked: object carries platform.cozystack.io/no-delete=true'
+  echo "$output" | grep -q -- '--namespace'
+
+  # And confirm the ConfigMap is still there — a partial deny that races
+  # tombstone creation would also be a regression.
+  kubectl get configmap cozystack-version -n cozy-system >/dev/null
+
+  # Bypass path: remove the label, delete must succeed. Re-stamp the label
+  # afterward so the cluster ends the test in the same state it started.
+  kubectl label configmap cozystack-version -n cozy-system \
+    platform.cozystack.io/no-delete- --overwrite
+  # Stash the data so we can reconstruct after delete.
+  local version
+  version=$(kubectl get configmap cozystack-version -n cozy-system \
+    -o jsonpath='{.data.version}')
+  kubectl delete configmap cozystack-version -n cozy-system
+  ! kubectl get configmap cozystack-version -n cozy-system 2>/dev/null
+  # Reconstruct: declarative apply matches the migration / template shape.
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cozystack-version
+  namespace: cozy-system
+  labels:
+    platform.cozystack.io/no-delete: "true"
+data:
+  version: "${version}"
+EOF
+}

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -337,7 +337,10 @@ EOF
     -o jsonpath='{.data.version}')
   kubectl delete configmap cozystack-version -n cozy-system
   ! kubectl get configmap cozystack-version -n cozy-system 2>/dev/null
-  # Reconstruct: declarative apply matches the migration / template shape.
+  # Reconstruct: declarative apply matches the chart template at
+  # packages/core/platform/templates/cozystack-version.yaml — same label set
+  # AND the helm.sh/resource-policy: keep annotation that pins the ConfigMap
+  # across helm uninstall.
   cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: ConfigMap
@@ -346,6 +349,8 @@ metadata:
   namespace: cozy-system
   labels:
     platform.cozystack.io/no-delete: "true"
+  annotations:
+    helm.sh/resource-policy: keep
 data:
   version: "${version}"
 EOF

--- a/internal/crdinstall/install.go
+++ b/internal/crdinstall/install.go
@@ -89,6 +89,17 @@ func Install(ctx context.Context, k8sClient client.Client, writeEmbeddedManifest
 		}
 	}
 
+	// Stamp the deletion-protection label so the platform VAP guards every
+	// Cozystack CRD against accidental kubectl delete.
+	for _, obj := range objects {
+		labels := obj.GetLabels()
+		if labels == nil {
+			labels = make(map[string]string)
+		}
+		labels["platform.cozystack.io/no-delete"] = "true"
+		obj.SetLabels(labels)
+	}
+
 	logger.Info("Applying Cozystack CRDs", "count", len(objects))
 	for _, obj := range objects {
 		patchOptions := &client.PatchOptions{

--- a/internal/crdinstall/install_test.go
+++ b/internal/crdinstall/install_test.go
@@ -212,6 +212,77 @@ func TestInstall_appliesAllCRDs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Install() error = %v", err)
 	}
+
+	for _, name := range []string{"packages.cozystack.io", "packagesources.cozystack.io"} {
+		applied := &unstructured.Unstructured{}
+		applied.SetGroupVersionKind(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+		if err := fakeClient.Get(ctx, client.ObjectKey{Name: name}, applied); err != nil {
+			t.Fatalf("failed to read back applied CRD %s: %v", name, err)
+		}
+		labels := applied.GetLabels()
+		if labels["platform.cozystack.io/no-delete"] != "true" {
+			t.Errorf("CRD %s missing platform.cozystack.io/no-delete=true label; got labels=%v", name, labels)
+		}
+	}
+}
+
+// testCRDWithLabels mirrors testCRD1 but already carries a non-cozystack label.
+// Exercises the merge path in Install: the existing label must survive, and the
+// deletion-protection label must be added alongside it.
+var testCRDWithLabels = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: packages.cozystack.io
+  labels:
+    app.kubernetes.io/managed-by: foo
+spec:
+  group: cozystack.io
+  names:
+    kind: Package
+    plural: packages
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+`
+
+func TestInstall_preservesExistingLabels(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	scheme := runtime.NewScheme()
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add apiextensions to scheme: %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(establishedInterceptor()).
+		Build()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	ctx = log.IntoContext(ctx, log.FromContext(context.Background()))
+
+	if err := Install(ctx, fakeClient, newCRDManifestWriter(testCRDWithLabels)); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	applied := &unstructured.Unstructured{}
+	applied.SetGroupVersionKind(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+	if err := fakeClient.Get(ctx, client.ObjectKey{Name: "packages.cozystack.io"}, applied); err != nil {
+		t.Fatalf("failed to read back applied CRD: %v", err)
+	}
+	labels := applied.GetLabels()
+	if labels["app.kubernetes.io/managed-by"] != "foo" {
+		t.Errorf("existing label app.kubernetes.io/managed-by=foo was lost; got labels=%v", labels)
+	}
+	if labels["platform.cozystack.io/no-delete"] != "true" {
+		t.Errorf("deletion-protection label missing after merge; got labels=%v", labels)
+	}
 }
 
 func TestInstall_noManifests(t *testing.T) {

--- a/packages/core/installer/templates/cozy-system-labels.yaml
+++ b/packages/core/installer/templates/cozy-system-labels.yaml
@@ -149,4 +149,5 @@ spec:
         - namespace
         - cozy-system
         - cozystack.io/system=true
+        - platform.cozystack.io/no-delete=true
         - pod-security.kubernetes.io/enforce=privileged

--- a/packages/core/installer/templates/cozy-system-namespace.yaml
+++ b/packages/core/installer/templates/cozy-system-namespace.yaml
@@ -19,6 +19,7 @@ metadata:
   name: cozy-system
   labels:
     cozystack.io/system: "true"
+    platform.cozystack.io/no-delete: "true"
     pod-security.kubernetes.io/enforce: privileged
   annotations:
     helm.sh/resource-policy: keep

--- a/packages/core/platform/Makefile
+++ b/packages/core/platform/Makefile
@@ -17,9 +17,6 @@ reconcile: apply
 diff:
 	cozyhr diff --namespace $(NAMESPACE) $(NAME)
 
-test:
-	helm unittest .
-
 # Strip the platform.cozystack.io/no-delete label from every guarded object so
 # `helm uninstall cozy-platform` (and ad-hoc deletes of protected resources)
 # is no longer denied by the deletion-protection VAP. After this runs, the

--- a/packages/core/platform/Makefile
+++ b/packages/core/platform/Makefile
@@ -17,6 +17,9 @@ reconcile: apply
 diff:
 	cozyhr diff --namespace $(NAMESPACE) $(NAME)
 
+test:
+	helm unittest .
+
 image: image-migrations
 
 image-migrations:

--- a/packages/core/platform/Makefile
+++ b/packages/core/platform/Makefile
@@ -20,6 +20,14 @@ diff:
 test:
 	helm unittest .
 
+# Strip the platform.cozystack.io/no-delete label from every guarded object so
+# `helm uninstall cozy-platform` (and ad-hoc deletes of protected resources)
+# is no longer denied by the deletion-protection VAP. After this runs, the
+# cluster has no guardrail until the next `helm upgrade` re-stamps the label.
+# Intended for teardown / disaster-recovery, not routine use.
+unprotect:
+	hack/unprotect.sh
+
 image: image-migrations
 
 image-migrations:

--- a/packages/core/platform/hack/unprotect.sh
+++ b/packages/core/platform/hack/unprotect.sh
@@ -19,6 +19,33 @@ set -eu
 
 LABEL="platform.cozystack.io/no-delete"
 
+# Run `kubectl get` and tolerate only the "unknown resource type" error
+# (a kind that doesn't exist in this cluster — e.g. linstorcluster on a
+# non-LINSTOR install). Any other error (RBAC, wrong context, API
+# unreachable) is fatal — otherwise we'd silently report success while
+# leaving labels behind.
+#
+# Keep stdout (the resource list) and stderr (kubectl warnings, errors)
+# separate so unrelated warnings can't sneak into the loop variable.
+kubectl_get_or_skip_unknown_kind() {
+  err=$(mktemp)
+  if out=$(kubectl get "$@" 2>"$err"); then
+    rm -f "$err"
+    printf '%s\n' "$out"
+    return 0
+  fi
+  errmsg=$(cat "$err")
+  rm -f "$err"
+  case "$errmsg" in
+    *"the server doesn't have a resource type"*|\
+    *"the server could not find the requested resource"*)
+      return 0
+      ;;
+  esac
+  printf '%s\n' "$errmsg" >&2
+  return 1
+}
+
 # Cluster-scoped guarded kinds. CRDs and Namespaces sit here, plus the
 # VAP/Binding pair (which is also self-labeled) and LinstorCluster.
 CLUSTER_KINDS="
@@ -42,7 +69,7 @@ helmrelease
 echo "Removing $LABEL label from all guarded objects..."
 
 for kind in $CLUSTER_KINDS; do
-  names=$(kubectl get "$kind" --selector="$LABEL=true" --output=name 2>/dev/null || true)
+  names=$(kubectl_get_or_skip_unknown_kind "$kind" --selector="$LABEL=true" --output=name)
   if [ -n "$names" ]; then
     # One kubectl per resource — `kubectl label` takes the label op as the
     # last argument, so xargs's trailing-args model would put it in the
@@ -56,9 +83,8 @@ for kind in $CLUSTER_KINDS; do
 done
 
 for kind in $NS_KINDS; do
-  pairs=$(kubectl get "$kind" --all-namespaces --selector="$LABEL=true" \
-    --output=jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' \
-    2>/dev/null || true)
+  pairs=$(kubectl_get_or_skip_unknown_kind "$kind" --all-namespaces --selector="$LABEL=true" \
+    --output=jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}')
   if [ -n "$pairs" ]; then
     printf '%s\n' "$pairs" | while read -r ns name; do
       [ -z "$name" ] && continue

--- a/packages/core/platform/hack/unprotect.sh
+++ b/packages/core/platform/hack/unprotect.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Strip the platform.cozystack.io/no-delete=true label from every object that
+# carries it, so `helm uninstall cozy-platform` (and ad-hoc `kubectl delete`
+# on a protected resource) is no longer denied by the deletion-protection
+# ValidatingAdmissionPolicy.
+#
+# Intended for chart teardown and disaster-recovery — NOT a routine operation.
+# After this runs, the cluster has no guardrail until the next `helm upgrade`
+# re-stamps the label.
+#
+# Idempotent: a label that is already absent is a no-op.
+#
+# The set of guarded kinds is enumerated locally rather than discovered
+# dynamically because some of the kinds may not exist in every cluster
+# (e.g. linstorcluster on a non-LINSTOR install) and kubectl returns an
+# error for unknown resource types. The per-kind get is best-effort.
+
+set -eu
+
+LABEL="platform.cozystack.io/no-delete"
+
+# Cluster-scoped guarded kinds. CRDs and Namespaces sit here, plus the
+# VAP/Binding pair (which is also self-labeled) and LinstorCluster.
+CLUSTER_KINDS="
+customresourcedefinition
+clusterissuer
+namespace
+validatingadmissionpolicy
+validatingadmissionpolicybinding
+linstorcluster
+"
+
+# Namespaced guarded kinds. ConfigMap, Repository/OCIRepository, HelmRelease.
+# Use --all-namespaces with -o jsonpath so we get back (ns, name) pairs and
+# can pass each to a per-object `kubectl label`.
+NS_KINDS="
+configmap
+ocirepository
+helmrelease
+"
+
+echo "Removing $LABEL label from all guarded objects..."
+
+for kind in $CLUSTER_KINDS; do
+  names=$(kubectl get "$kind" --selector="$LABEL=true" --output=name 2>/dev/null || true)
+  if [ -n "$names" ]; then
+    # One kubectl per resource — `kubectl label` takes the label op as the
+    # last argument, so xargs's trailing-args model would put it in the
+    # wrong position. The protected set is small (<20 objects) so the
+    # extra round-trips are negligible.
+    printf '%s\n' "$names" | while read -r ref; do
+      [ -z "$ref" ] && continue
+      kubectl label "$ref" "$LABEL-"
+    done
+  fi
+done
+
+for kind in $NS_KINDS; do
+  pairs=$(kubectl get "$kind" --all-namespaces --selector="$LABEL=true" \
+    --output=jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' \
+    2>/dev/null || true)
+  if [ -n "$pairs" ]; then
+    printf '%s\n' "$pairs" | while read -r ns name; do
+      [ -z "$name" ] && continue
+      kubectl label --namespace "$ns" "$kind" "$name" "$LABEL-"
+    done
+  fi
+done
+
+echo "Done. helm uninstall is now unblocked."

--- a/packages/core/platform/hack/unprotect.sh
+++ b/packages/core/platform/hack/unprotect.sh
@@ -57,12 +57,16 @@ validatingadmissionpolicybinding
 linstorcluster
 "
 
-# Namespaced guarded kinds. ConfigMap, Repository/OCIRepository, HelmRelease.
+# Namespaced guarded kinds. ConfigMap, Flux source kinds (OCI/Git), HelmRelease.
+# Both OCIRepository and GitRepository are valid platform sourceRef.kind values
+# — repository.yaml templates `kind: {{ $sourceRef.kind }}` unrestricted — so
+# either may carry the no-delete label and must be enumerated here.
 # Use --all-namespaces with -o jsonpath so we get back (ns, name) pairs and
 # can pass each to a per-object `kubectl label`.
 NS_KINDS="
 configmap
 ocirepository
+gitrepository
 helmrelease
 "
 

--- a/packages/core/platform/images/migrations/migrations/42
+++ b/packages/core/platform/images/migrations/migrations/42
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Migration 42 --> 43
+# Backfill the platform.cozystack.io/no-delete=true label on the
+# cozystack-version ConfigMap so the deletion-protection
+# ValidatingAdmissionPolicy guards it on upgraded clusters.
+#
+# On first install the chart template renders the ConfigMap with the
+# label inline. On upgrades the template skips re-rendering (lookup-if-not
+# preserves migration-managed data.version), so the label needs an
+# explicit one-shot backfill here.
+#
+# Idempotent: kubectl label --overwrite is a no-op when the label is
+# already at the target value.
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-cozy-system}"
+DRY_RUN="${MIGRATION_DRY_RUN:-0}"
+
+if [ "$DRY_RUN" = "1" ]; then
+  echo "[dry-run] would label configmap $NAMESPACE/cozystack-version with platform.cozystack.io/no-delete=true"
+  echo "Dry-run complete; version stamp not advanced"
+  exit 0
+fi
+
+kubectl label --namespace "$NAMESPACE" --overwrite configmap cozystack-version \
+  platform.cozystack.io/no-delete=true
+echo "Labeled configmap $NAMESPACE/cozystack-version"
+
+kubectl create configmap --namespace "$NAMESPACE" cozystack-version \
+  --from-literal=version=43 --dry-run=client --output yaml \
+  | kubectl apply --filename -

--- a/packages/core/platform/images/migrations/migrations/42
+++ b/packages/core/platform/images/migrations/migrations/42
@@ -9,24 +9,34 @@
 # preserves migration-managed data.version), so the label needs an
 # explicit one-shot backfill here.
 #
-# Idempotent: kubectl label --overwrite is a no-op when the label is
-# already at the target value.
+# Idempotent: kubectl apply re-runs are a no-op once the ConfigMap matches
+# the declared shape. One source of truth — same label set the chart bakes
+# in at install time, no 3-way-merge subtlety.
 
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-cozy-system}"
 DRY_RUN="${MIGRATION_DRY_RUN:-0}"
 
+MANIFEST=$(cat <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cozystack-version
+  namespace: ${NAMESPACE}
+  labels:
+    platform.cozystack.io/no-delete: "true"
+data:
+  version: "43"
+EOF
+)
+
 if [ "$DRY_RUN" = "1" ]; then
-  echo "[dry-run] would label configmap $NAMESPACE/cozystack-version with platform.cozystack.io/no-delete=true"
+  echo "[dry-run] would apply:"
+  printf '%s\n' "$MANIFEST"
   echo "Dry-run complete; version stamp not advanced"
   exit 0
 fi
 
-kubectl label --namespace "$NAMESPACE" --overwrite configmap cozystack-version \
-  platform.cozystack.io/no-delete=true
-echo "Labeled configmap $NAMESPACE/cozystack-version"
-
-kubectl create configmap --namespace "$NAMESPACE" cozystack-version \
-  --from-literal=version=43 --dry-run=client --output yaml \
-  | kubectl apply --filename -
+printf '%s\n' "$MANIFEST" | kubectl apply --filename -
+echo "Applied configmap $NAMESPACE/cozystack-version with deletion-protection label"

--- a/packages/core/platform/images/migrations/migrations/42
+++ b/packages/core/platform/images/migrations/migrations/42
@@ -10,8 +10,15 @@
 # explicit one-shot backfill here.
 #
 # Idempotent: kubectl apply re-runs are a no-op once the ConfigMap matches
-# the declared shape. One source of truth — same label set the chart bakes
-# in at install time, no 3-way-merge subtlety.
+# the declared shape. Same label set the chart bakes in at install time, so
+# the next chart-driven apply sees no diff.
+#
+# 3-way-merge note: this apply records the no-delete label in the kubectl
+# last-applied-configuration annotation under the default field manager.
+# Any future migration that re-stamps cozystack-version via the same field
+# manager MUST include the label inline (matching the chart template at
+# templates/cozystack-version.yaml) — a label-less apply by the same field
+# manager would strip it.
 
 set -euo pipefail
 

--- a/packages/core/platform/images/migrations/run-migrations.sh
+++ b/packages/core/platform/images/migrations/run-migrations.sh
@@ -23,19 +23,26 @@ if [ "$CURRENT_VERSION" -ge "$TARGET_VERSION" ]; then
   exit 0
 fi
 
-# Run migrations sequentially from current version to target version
+# Run migrations sequentially from current version to target version.
+# Every version below TARGET_VERSION must have a corresponding migration file
+# baked into the image — the release build rebuilds the migrations image from
+# the same source tree that carries the files and restamps the digest in the
+# same commit, so image and targetVersion are always consistent at release
+# time. A missing file therefore indicates a packaging mistake (digest
+# advanced without the file landing) and must fail loudly rather than stall
+# the cluster at a stale version.
 for i in $(seq $CURRENT_VERSION $((TARGET_VERSION - 1))); do
-  if [ -f "/migrations/$i" ]; then
-    echo "Running migration $i"
-    chmod +x /migrations/$i
-    /migrations/$i || {
-      echo "Migration $i failed"
-      exit 1
-    }
-    echo "Migration $i completed successfully"
-  else
-    echo "Migration $i not found, skipping"
+  if [ ! -f "/migrations/$i" ]; then
+    echo "Migration $i not found in image — refusing to advance past a missing migration" >&2
+    exit 1
   fi
+  echo "Running migration $i"
+  chmod +x /migrations/$i
+  /migrations/$i || {
+    echo "Migration $i failed"
+    exit 1
+  }
+  echo "Migration $i completed successfully"
 done
 
 echo "All migrations completed successfully"

--- a/packages/core/platform/templates/NOTES.txt
+++ b/packages/core/platform/templates/NOTES.txt
@@ -1,0 +1,18 @@
+{{- if not (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy") }}
+
+WARNING: deletion-protection guardrail is NOT active on this cluster.
+
+  The cozystack-no-delete-guardrail ValidatingAdmissionPolicy requires
+  Kubernetes 1.30+ (admissionregistration.k8s.io/v1 GA). The capability
+  gate in templates/deletion-protection.yaml detected the API is absent
+  on this cluster, so the policy and its Binding were not rendered.
+  Objects carrying platform.cozystack.io/no-delete=true CAN BE DELETED
+  on this cluster — `kubectl delete configmap cozystack-version -n
+  cozy-system` will succeed, with no admission denial.
+
+  Upgrade the cluster to 1.30+ and re-run `helm upgrade` to render the
+  policy. The label is already stamped on every protected object by
+  this chart and by migration 42, so the guardrail becomes active on
+  the next upgrade with no further migration step required.
+
+{{- end }}

--- a/packages/core/platform/templates/cozystack-version.yaml
+++ b/packages/core/platform/templates/cozystack-version.yaml
@@ -6,6 +6,8 @@ kind: ConfigMap
 metadata:
   name: cozystack-version
   namespace: {{ .Release.Namespace }}
+  labels:
+    platform.cozystack.io/no-delete: "true"
   annotations:
     helm.sh/resource-policy: keep
 data:

--- a/packages/core/platform/templates/deletion-protection.yaml
+++ b/packages/core/platform/templates/deletion-protection.yaml
@@ -7,8 +7,9 @@
   gate below keeps the template renderable on clusters that pre-date 1.30
   (the install simply skips the guardrail there).
 
-  Bypass: remove the label, then delete.
-    kubectl label <kind> <name> platform.cozystack.io/no-delete-
+  Bypass: remove the label, then delete. Pass --namespace for namespaced
+  resources (omit it for cluster-scoped objects like CRDs and Namespaces).
+    kubectl label <kind> <name> --namespace <ns> platform.cozystack.io/no-delete-
 
   failurePolicy is intentionally omitted: the validation expression is the
   literal `false`, so CEL evaluation cannot fail and the default (Fail) is
@@ -35,7 +36,8 @@ spec:
     message: >-
       Deletion blocked: object carries platform.cozystack.io/no-delete=true.
       To bypass, first remove the label:
-      kubectl label <kind> <name> platform.cozystack.io/no-delete-
+      kubectl label <kind> <name> --namespace <ns> platform.cozystack.io/no-delete-
+      (omit --namespace for cluster-scoped resources)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding

--- a/packages/core/platform/templates/deletion-protection.yaml
+++ b/packages/core/platform/templates/deletion-protection.yaml
@@ -11,6 +11,14 @@
   resources (omit it for cluster-scoped objects like CRDs and Namespaces).
     kubectl label <kind> <name> --namespace <ns> platform.cozystack.io/no-delete-
 
+  Self-protection is sequential, not bilateral: both the VAP and the Binding
+  carry the no-delete label, but either one can be unlabeled and deleted
+  first — once the Binding is gone, the VAP is unenforced and can be deleted
+  without the dance, and vice versa. The labeling is operational guidance,
+  not adversarial defense. Whole-chart teardown is via `make unprotect` (see
+  packages/core/platform/Makefile), which strips the label from every
+  guarded object so `helm uninstall` can proceed.
+
   failurePolicy is intentionally omitted: the validation expression is the
   literal `false`, so CEL evaluation cannot fail and the default (Fail) is
   unreachable in practice. Setting it explicitly would be misleading config.

--- a/packages/core/platform/templates/deletion-protection.yaml
+++ b/packages/core/platform/templates/deletion-protection.yaml
@@ -3,11 +3,14 @@
   platform.cozystack.io/no-delete=true label. Native, in-process CEL eval —
   no webhook DaemonSet, no Service, no TLS, no image to maintain.
 
-  Requires Kubernetes 1.30+ (admissionregistration.k8s.io/v1 GA).
+  Requires Kubernetes 1.30+ (ValidatingAdmissionPolicy GA). The capability
+  gate below keeps the template renderable on clusters that pre-date 1.30
+  (the install simply skips the guardrail there).
 
   Bypass: remove the label, then delete.
     kubectl label <kind> <name> platform.cozystack.io/no-delete-
 */}}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy" }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -40,3 +43,4 @@ spec:
     objectSelector:
       matchLabels:
         platform.cozystack.io/no-delete: "true"
+{{- end }}

--- a/packages/core/platform/templates/deletion-protection.yaml
+++ b/packages/core/platform/templates/deletion-protection.yaml
@@ -1,0 +1,42 @@
+{{/*
+  ValidatingAdmissionPolicy that blocks DELETE on any object carrying the
+  platform.cozystack.io/no-delete=true label. Native, in-process CEL eval —
+  no webhook DaemonSet, no Service, no TLS, no image to maintain.
+
+  Requires Kubernetes 1.30+ (admissionregistration.k8s.io/v1 GA).
+
+  Bypass: remove the label, then delete.
+    kubectl label <kind> <name> platform.cozystack.io/no-delete-
+*/}}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: cozystack-no-delete-guardrail
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["*"]
+      apiVersions: ["*"]
+      operations:  ["DELETE"]
+      resources:   ["*/*"]
+      scope:       "*"
+  validations:
+  - expression: "false"
+    message: >-
+      Deletion blocked: object carries platform.cozystack.io/no-delete=true.
+      To bypass, first remove the label:
+      kubectl label <kind> <name> platform.cozystack.io/no-delete-
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: cozystack-no-delete-guardrail
+spec:
+  policyName: cozystack-no-delete-guardrail
+  validationActions: [Deny]
+  matchResources:
+    objectSelector:
+      matchLabels:
+        platform.cozystack.io/no-delete: "true"

--- a/packages/core/platform/templates/deletion-protection.yaml
+++ b/packages/core/platform/templates/deletion-protection.yaml
@@ -9,6 +9,10 @@
 
   Bypass: remove the label, then delete.
     kubectl label <kind> <name> platform.cozystack.io/no-delete-
+
+  failurePolicy is intentionally omitted: the validation expression is the
+  literal `false`, so CEL evaluation cannot fail and the default (Fail) is
+  unreachable in practice. Setting it explicitly would be misleading config.
 */}}
 {{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy" }}
 ---
@@ -19,7 +23,6 @@ metadata:
   labels:
     platform.cozystack.io/no-delete: "true"
 spec:
-  failurePolicy: Fail
   matchConstraints:
     resourceRules:
     - apiGroups:   ["*"]

--- a/packages/core/platform/templates/deletion-protection.yaml
+++ b/packages/core/platform/templates/deletion-protection.yaml
@@ -16,6 +16,8 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:
   name: cozystack-no-delete-guardrail
+  labels:
+    platform.cozystack.io/no-delete: "true"
 spec:
   failurePolicy: Fail
   matchConstraints:
@@ -36,6 +38,8 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding
 metadata:
   name: cozystack-no-delete-guardrail
+  labels:
+    platform.cozystack.io/no-delete: "true"
 spec:
   policyName: cozystack-no-delete-guardrail
   validationActions: [Deny]

--- a/packages/core/platform/templates/repository.yaml
+++ b/packages/core/platform/templates/repository.yaml
@@ -13,5 +13,7 @@ kind: {{ $kind }}
 metadata:
   name: cozystack-packages
   namespace: cozy-system
+  labels:
+    platform.cozystack.io/no-delete: "true"
 spec:
 {{- $sourceRepo.spec | toYaml | nindent 2 }}

--- a/packages/core/platform/tests/deletion_protection_test.yaml
+++ b/packages/core/platform/tests/deletion_protection_test.yaml
@@ -1,0 +1,59 @@
+suite: deletion-protection VAP message and self-label coverage
+templates:
+  - templates/deletion-protection.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+capabilities:
+  apiVersions:
+    - admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy
+tests:
+  - it: ValidatingAdmissionPolicy carries the deletion-protection label on itself
+    documentSelector:
+      path: kind
+      value: ValidatingAdmissionPolicy
+    asserts:
+      - equal:
+          path: metadata.labels["platform.cozystack.io/no-delete"]
+          value: "true"
+
+  - it: ValidatingAdmissionPolicyBinding carries the deletion-protection label on itself
+    documentSelector:
+      path: kind
+      value: ValidatingAdmissionPolicyBinding
+    asserts:
+      - equal:
+          path: metadata.labels["platform.cozystack.io/no-delete"]
+          value: "true"
+
+  - it: failurePolicy is intentionally unset on the VAP
+    documentSelector:
+      path: kind
+      value: ValidatingAdmissionPolicy
+    asserts:
+      - notExists:
+          path: spec.failurePolicy
+
+  - it: the deny message documents the bypass with the --namespace flag
+    documentSelector:
+      path: kind
+      value: ValidatingAdmissionPolicy
+    asserts:
+      - matchRegex:
+          path: spec.validations[0].message
+          pattern: 'kubectl label <kind> <name> --namespace <ns> platform\.cozystack\.io/no-delete-'
+      - matchRegex:
+          path: spec.validations[0].message
+          pattern: 'omit --namespace for cluster-scoped resources'
+
+  - it: binding selects on the no-delete label and denies on match
+    documentSelector:
+      path: kind
+      value: ValidatingAdmissionPolicyBinding
+    asserts:
+      - equal:
+          path: spec.matchResources.objectSelector.matchLabels["platform.cozystack.io/no-delete"]
+          value: "true"
+      - equal:
+          path: spec.validationActions[0]
+          value: Deny

--- a/packages/core/platform/tests/notes_capability_gate_test.yaml
+++ b/packages/core/platform/tests/notes_capability_gate_test.yaml
@@ -1,0 +1,25 @@
+suite: NOTES.txt warns when deletion-protection capability gate trips
+templates:
+  - templates/NOTES.txt
+release:
+  name: cozystack
+  namespace: cozy-system
+capabilities:
+  apiVersions: []
+tests:
+  - it: NOTES.txt warns the operator the guardrail is not active on pre-1.30
+    asserts:
+      - matchRegexRaw:
+          pattern: 'deletion-protection guardrail is NOT active'
+      - matchRegexRaw:
+          pattern: 'Upgrade the cluster to 1\.30\+'
+      - matchRegexRaw:
+          pattern: 'platform\.cozystack\.io/no-delete=true'
+
+  - it: NOTES.txt stays quiet when ValidatingAdmissionPolicy is available
+    capabilities:
+      apiVersions:
+        - admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'guardrail is NOT active'

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -6,7 +6,7 @@ sourceRef:
 migrations:
   enabled: false
   image: ghcr.io/cozystack/cozystack/platform-migrations:v1.4.0-rc.2@sha256:17390197a9b11d76a8dd1b24c6d1512adb7d3226b28b5bcba8551b14b1ec4be0
-  targetVersion: 42
+  targetVersion: 43
 # Bundle deployment configuration
 bundles:
   system:

--- a/packages/system/cert-manager-issuers/templates/cluster-issuers.yaml
+++ b/packages/system/cert-manager-issuers/templates/cluster-issuers.yaml
@@ -88,6 +88,8 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod
+  labels:
+    platform.cozystack.io/no-delete: "true"
 spec:
   acme:
     privateKeySecretRef:
@@ -106,6 +108,8 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-stage
+  labels:
+    platform.cozystack.io/no-delete: "true"
 spec:
   acme:
     privateKeySecretRef:
@@ -124,5 +128,7 @@ apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: selfsigned-cluster-issuer
+  labels:
+    platform.cozystack.io/no-delete: "true"
 spec:
   selfSigned: {}

--- a/packages/system/cozystack-basics/templates/tenant-root.yaml
+++ b/packages/system/cozystack-basics/templates/tenant-root.yaml
@@ -4,6 +4,7 @@ kind: Namespace
 metadata:
   name: tenant-root
   labels:
+    platform.cozystack.io/no-delete: "true"
     namespace.cozystack.io/host: {{ index .Values._cluster "root-host" | quote }}
     {{- /* Gateway attach label: when platform-level Gateway is on,
             tenant-root owns the publishing Gateway, and its own
@@ -23,6 +24,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
   labels:
+    platform.cozystack.io/no-delete: "true"
     sharding.fluxcd.io/key: tenants
     apps.cozystack.io/application.kind: Tenant
     apps.cozystack.io/application.group: apps.cozystack.io

--- a/packages/system/linstor/templates/cluster.yaml
+++ b/packages/system/linstor/templates/cluster.yaml
@@ -2,6 +2,8 @@ apiVersion: piraeus.io/v1
 kind: LinstorCluster
 metadata:
   name: linstorcluster
+  labels:
+    platform.cozystack.io/no-delete: "true"
 spec:
   #nodeSelector:
   #  node-role.kubernetes.io/linstor: ""


### PR DESCRIPTION
## What this PR does

Adds a `ValidatingAdmissionPolicy` that blocks `DELETE` on critical platform
objects labeled `platform.cozystack.io/no-delete=true`. Native, in-process CEL
evaluation — no webhook DaemonSet, no Service, no TLS, no image to maintain.
Requires Kubernetes 1.30+.

This is an alternative to the closed #2402 (admission webhook approach).

### Protected objects (labeled in this PR)

| Resource | Kind | Source |
|---|---|---|
| `cozy-system` | Namespace | `packages/core/installer/templates/cozy-system-{namespace,labels}.yaml` |
| `tenant-root` | Namespace | `packages/system/cozystack-basics/templates/tenant-root.yaml` |
| `tenant-root` | HelmRelease (ns: tenant-root) | same |
| `cozystack-version` | ConfigMap (ns: cozy-system) | `packages/core/platform/templates/cozystack-version.yaml` |
| `cozystack-packages` | OCIRepository (ns: cozy-system) | `packages/core/platform/templates/repository.yaml` |
| `letsencrypt-prod`, `letsencrypt-stage`, `selfsigned-cluster-issuer` | ClusterIssuer | `packages/system/cert-manager-issuers/templates/cluster-issuers.yaml` |
| `linstorcluster` | LinstorCluster | `packages/system/linstor/templates/cluster.yaml` |
| `packages.cozystack.io`, `packagesources.cozystack.io` | CRD | label stamped in `internal/crdinstall/install.go` |

### Bypass

```bash
kubectl label <kind> <name> platform.cozystack.io/no-delete-
kubectl delete <kind> <name>
```

### Why VAP instead of a webhook

Same outcome as #2402 but with zero runtime infrastructure: no DaemonSet, Service,
TLS certificate, or image. The kube-apiserver evaluates the CEL
`expression: "false"` in-process and denies because `validationActions: [Deny]`.
`objectSelector` on the binding scopes evaluation to labeled objects only — every
other DELETE in the cluster is unaffected.

### Release note

```release-note
feat(platform): add deletion-protection guardrail (ValidatingAdmissionPolicy)
blocking DELETE on cozystack platform objects labeled
`platform.cozystack.io/no-delete=true`. Bypass by removing the label first.
Requires Kubernetes 1.30+.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deletion-protection guardrail: objects labeled platform.cozystack.io/no-delete=true are denied DELETE requests; removal of the label allows deletion.

* **Chores**
  * Platform migration to v43 backfills the no-delete label onto system resources and namespaces.

* **Tools**
  * Added an "unprotect" teardown utility to remove the no-delete label for uninstall/disaster recovery.

* **Documentation**
  * Helm NOTES now warns when the guardrail is inactive due to missing cluster API.

* **Tests**
  * New tests and e2e checks validate deletion-protection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->