### PR TITLE
[Backport release-1.2] fix(mariadb): remove duplicate template key in backup CronJob

### DIFF
--- a/packages/apps/mariadb/templates/backup-cronjob.yaml
+++ b/packages/apps/mariadb/templates/backup-cronjob.yaml
@@ -14,9 +14,6 @@ spec:
     spec:
       backoffLimit: 2
       template:
-        spec:
-          restartPolicy: OnFailure
-      template:
         metadata:
           annotations:
             checksum/config: {{ include (print $.Template.BasePath "/backup-script.yaml") . | sha256sum }}


### PR DESCRIPTION
## Summary

Minimal backport from #2279 to `release-1.2` — only the duplicate-`template:` key removal in `packages/apps/mariadb/templates/backup-cronjob.yaml`, without the breaking service-naming / forced-replication changes from #2279 (those are not appropriate for a patch release).

Fixes the `yaml: unmarshal errors: line 17: mapping key "template" already defined at line 14` error when deploying MariaDB with `backup.enabled: true` on v1.2.x.

Related: #2293

## Test plan
- [ ] `helm template` of the mariadb chart with `backup.enabled: true` renders without YAML duplicate-key errors
- [ ] CronJob deploys successfully on a v1.2.x cluster