### PR TITLE
fix(http-cache,vpa): fix haproxy 3.3 backend name conflict and vpa-for-vpa OOM

### DIFF
--- a/packages/apps/http-cache/templates/haproxy/configmap.yaml
+++ b/packages/apps/http-cache/templates/haproxy/configmap.yaml
@@ -63,9 +63,9 @@ data:
         # overwrite real IP header from anywhere else
         http-request set-header X-Forwarded-For %[src] if !from_cf
 
-        default_backend http
+        default_backend cache
 
-    backend http
+    backend cache
         mode http
         balance uri whole
         hash-type consistent

--- a/packages/system/vertical-pod-autoscaler/templates/vpa-for-vpa.yaml
+++ b/packages/system/vertical-pod-autoscaler/templates/vpa-for-vpa.yaml
@@ -46,7 +46,7 @@ spec:
           recommender-name: vpa-for-vpa
         resources:
           limits:
-            memory: 512Mi
+            memory: 1Gi
           requests:
             cpu: 100m
             memory: 512Mi


### PR DESCRIPTION
## What this PR does

Fixes two independent issues found during cluster operations:

**http-cache (HAProxy 3.3 breaking change)**

HAProxy 3.3 no longer allows a frontend and backend to share the same name. The existing config had both `frontend http` and `backend http`, which causes haproxy to refuse to start on upgrade. Rename `backend http` → `backend cache` and update the `default_backend` directive accordingly.

**vpa-for-vpa (OOMKilled recommender)**

The VPA recommender deployed by `vpa-for-vpa` was hitting its 512Mi memory limit and being OOMKilled. Increase the limit to 1Gi to keep the recommender running stably.

### Release note

```release-note
fix(http-cache): rename haproxy backend to avoid HAProxy 3.3 name conflict between frontend and backend
fix(vpa): increase vpa-for-vpa recommender memory limit from 512Mi to 1Gi to prevent OOMKilled restarts
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HAProxy routing so HTTP traffic is directed to the cache backend.
  * Increased the VPA recommender’s memory limit to improve reliability under higher workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->