### PR TITLE
docs(changelogs): add v1.2.4

### DIFF
--- a/docs/changelogs/v1.2.4.md
+++ b/docs/changelogs/v1.2.4.md
@@ -1,0 +1,19 @@
+<!--
+https://github.com/cozystack/cozystack/releases/tag/v1.2.4
+-->
+
+# v1.2.4 (2026-05-14)
+
+A patch release with a backport bug fix for MariaDB.
+
+## Features and Improvements
+
+_No notable features in this patch release._
+
+## Fixes
+
+* **fix(mariadb): remove duplicate template key in backup CronJob**: Removes the duplicate `template:` key in the MariaDB backup CronJob, which caused `yaml: unmarshal errors: line 17: mapping key "template" already defined at line 14` and prevented MariaDB instances from deploying with `backup.enabled: true`. Minimal backport — only the dup-key removal from #2279; the breaking service-naming changes in the original PR were intentionally omitted from this patch. ([**@sircthulhu**](https://github.com/sircthulhu) in #2279, minimal backport by [**@kvaps**](https://github.com/kvaps) in #2652).
+
+---
+
+**Full Changelog**: https://github.com/cozystack/cozystack/compare/v1.2.3...v1.2.4


### PR DESCRIPTION
## Summary

Adds `docs/changelogs/v1.2.4.md` so the `Update Release Notes` workflow can publish the existing `v1.2.4` draft release.

`v1.2.4` is a hotfix patch backporting only the duplicate-`template:` key removal from #2279 — the breaking service-naming changes in that PR were intentionally omitted as not appropriate for a patch (see #2652 for the minimal-backport details).

The `Generate Changelog` step on the tag-push workflow failed twice in a row (yesterday's cron run and today's manual dispatch) due to `402 You have no quota` on the Copilot API, so this changelog is hand-written following `docs/changelogs/patch-template.md` and matches the v1.2.3 style.

## Test plan
- [x] file follows `patch-template.md` structure
- [x] author attribution verified against `gh pr view` for #2279 and #2652
- [ ] CI passes
- [ ] after merge, `Update Release Notes` picks up the file and publishes draft release `v1.2.4`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved MariaDB backup deployment failure that occurred when the backup feature was enabled.

* **Documentation**
  * Added v1.2.4 changelog documenting the patch release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2655)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->