### PR TITLE
fix(csi): route RWX Block volumes to upstream hotplug detach

### DIFF
--- a/packages/apps/kubernetes/images/kubevirt-csi-driver/controller.go
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver/controller.go
@@ -362,12 +362,15 @@ func (w *WrappedControllerService) ControllerPublishVolume(ctx context.Context, 
 	}, nil
 }
 
-// ControllerUnpublishVolume for NFS volumes: deletes CiliumNetworkPolicy.
-// For RWO volumes, delegates to upstream (hotplug removal).
+// ControllerUnpublishVolume for NFS volumes (RWX Filesystem): deletes CiliumNetworkPolicy.
+// For everything else (RWO and RWX Block), delegates to upstream so the hotplug
+// DataVolume is removed from VM.spec.template.spec.volumes. RWX Block volumes used
+// for live migration must NOT be treated as NFS — their cleanup goes through upstream
+// hotplug removal, otherwise stale VM-spec entries permanently block re-attachment to
+// a different VM via the anti-split-brain check (issue #2634).
 func (w *WrappedControllerService) ControllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
 	dvName := req.GetVolumeId()
 
-	// Determine if NFS by checking infra PVC access modes
 	pvc, err := w.infraClient.CoreV1().PersistentVolumeClaims(w.infraNamespace).Get(ctx, dvName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -376,7 +379,7 @@ func (w *WrappedControllerService) ControllerUnpublishVolume(ctx context.Context
 		return nil, err
 	}
 
-	if !hasRWXAccessMode(pvc) {
+	if !isNFSVolume(pvc) {
 		return w.ControllerService.ControllerUnpublishVolume(ctx, req)
 	}
 
@@ -404,11 +407,12 @@ func (w *WrappedControllerService) ControllerExpandVolume(ctx context.Context, r
 		return nil, err
 	}
 
-	// For NFS volumes, no node-side expansion is needed
+	// For NFS volumes (RWX Filesystem), no node-side expansion is needed. RWX Block
+	// volumes still require node-side expansion of the in-VM disk.
 	pvc, err := w.infraClient.CoreV1().PersistentVolumeClaims(w.infraNamespace).Get(ctx, req.GetVolumeId(), metav1.GetOptions{})
 	if err != nil {
 		klog.Warningf("Failed to check PVC access mode for %s/%s: %v", w.infraNamespace, req.GetVolumeId(), err)
-	} else if hasRWXAccessMode(pvc) {
+	} else if isNFSVolume(pvc) {
 		resp.NodeExpansionRequired = false
 	}
 
@@ -542,6 +546,19 @@ func hasRWXAccessMode(pvc *corev1.PersistentVolumeClaim) bool {
 		}
 	}
 	return false
+}
+
+// isNFSVolume reports whether the PVC was provisioned by our CreateVolume NFS path
+// (RWX + Filesystem). RWX Block volumes are upstream hotplug volumes used for live
+// migration and must NOT be handled as NFS.
+func isNFSVolume(pvc *corev1.PersistentVolumeClaim) bool {
+	if !hasRWXAccessMode(pvc) {
+		return false
+	}
+	if pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == corev1.PersistentVolumeBlock {
+		return false
+	}
+	return true
 }
 
 // getNFSExport extracts the NFS export URL from a PersistentVolume.

--- a/packages/apps/kubernetes/images/kubevirt-csi-driver/controller.go
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver/controller.go
@@ -555,10 +555,7 @@ func isNFSVolume(pvc *corev1.PersistentVolumeClaim) bool {
 	if !hasRWXAccessMode(pvc) {
 		return false
 	}
-	if pvc.Spec.VolumeMode != nil && *pvc.Spec.VolumeMode == corev1.PersistentVolumeBlock {
-		return false
-	}
-	return true
+	return pvc.Spec.VolumeMode == nil || *pvc.Spec.VolumeMode == corev1.PersistentVolumeFilesystem
 }
 
 // getNFSExport extracts the NFS export URL from a PersistentVolume.


### PR DESCRIPTION
## What this PR does

Fixes routing in `WrappedControllerService` so RWX **Block** volumes (KubeVirt live-migration disks) are no longer treated as NFS during unpublish and expand.

### Root cause

`ControllerUnpublishVolume` selected the NFS cleanup branch based on `hasRWXAccessMode(pvc)` alone. RWX Block matched and went down the NFS path — which just deletes a `CiliumNetworkPolicy`. For a block volume that CNP does not exist, so `removeCNPOwnerReference` returns successfully without doing anything, and the function reports success without ever calling upstream's hotplug detach. The DataVolume entry stays in `VM.spec.template.spec.volumes` permanently. When the same PVC later attaches to a different VM, linstor-csi's anti-split-brain check sees pods from two different VMs referencing the same RWX block PVC and blocks the attach with:

```
RWX block volume <ns>/<pvc> is being used by pods from different VMs (<vm-a> and <vm-b>);
this is not supported - RWX block volumes with allow-two-primaries are only for live migration of a single VM
```

`ControllerPublishVolume` was unaffected because it routes on the explicit `nfsVolumeKey` from `VolumeContext`. `ControllerUnpublishVolume` does not receive `VolumeContext` and has to infer from the PVC, and the previous inference was incomplete.

### Fix

`isNFSVolume(pvc)` now requires `ReadWriteMany` access mode **and** `VolumeMode == Filesystem` (always set by our NFS `CreateVolume` path). RWX Block correctly delegates to upstream `ControllerUnpublishVolume`, which removes the entry from VM spec via `RemoveVolumeFromVM`. The same predicate replaces the previous access-mode check in `ControllerExpandVolume`, which was also clearing `NodeExpansionRequired` for RWX Block — block volumes still need in-VM disk expansion.

Fixes #2634.

### Release note

```release-note
fix(csi): route RWX Block volumes in kubevirt-csi-driver to upstream hotplug detach so VM spec entries are cleaned up on unpublish
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate detection of network-attached (NFS) vs block volumes, preventing incorrect cleanup of block volumes.
  * NFS volumes continue to receive special cleanup; non-NFS volumes now follow upstream cleanup paths.

* **Refactor**
  * Node-side expansion logic refined to base decisions on improved NFS classification (RWX + filesystem), reducing expansion errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2658?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->