### PR TITLE
fix(csi): verify VMI Ready after kubevirt-csi Publish to surface stuck-PVC failures

### DIFF
--- a/packages/apps/kubernetes/images/kubevirt-csi-driver/controller.go
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver/controller.go
@@ -257,14 +257,17 @@ func (w *WrappedControllerService) publishHotplugVolume(ctx context.Context, req
 
 	vmNamespace, vmName, parseErr := cache.SplitMetaNamespaceKey(req.GetNodeId())
 	if parseErr != nil {
-		klog.Warningf("Cannot verify VMI readiness after publish: failed to parse node ID %q: %v", req.GetNodeId(), parseErr)
-		return resp, nil
+		return nil, status.Errorf(codes.Internal,
+			"cannot verify VMI readiness after publish: failed to parse node ID %q: %v",
+			req.GetNodeId(), parseErr)
 	}
 	dvName := req.GetVolumeId()
+	// GetVirtualMachine on this client returns a VirtualMachineInstance, not a VM.
 	vmi, getErr := w.virtClient.GetVirtualMachine(ctx, vmNamespace, vmName)
 	if getErr != nil {
-		klog.Warningf("Cannot verify VMI %s/%s readiness after publish of %s: %v", vmNamespace, vmName, dvName, getErr)
-		return resp, nil
+		return nil, status.Errorf(codes.Unavailable,
+			"cannot verify VMI %s/%s readiness after publish of %s: %v",
+			vmNamespace, vmName, dvName, getErr)
 	}
 	for _, vs := range vmi.Status.VolumeStatus {
 		if vs.Name != dvName {

--- a/packages/apps/kubernetes/images/kubevirt-csi-driver/controller.go
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver/controller.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	kubevirtclient "kubevirt.io/csi-driver/pkg/kubevirt"
@@ -237,12 +238,56 @@ func (w *WrappedControllerService) determineDvSource(ctx context.Context, req *c
 	return res, nil
 }
 
+// publishHotplugVolume delegates to upstream for the hotplug attach, then re-verifies
+// that the volume reached VolumeReady in VMI.Status.VolumeStatus before returning
+// success. Upstream's fast path (EnsureVolumeAvailableVM) considers the volume
+// attached based only on its presence in VM.spec.template.spec.volumes — so when an
+// earlier attempt wrote that entry but the volume never became Ready (e.g. the infra
+// PVC is stuck ClaimPending because the storage backend cannot provision), the
+// retried Publish reports success and external-attacher sets Attached=true.
+// QEMU never received device_add, and the tenant kubelet's NodeStageVolume fails
+// with "couldn't find device by serial id". Verifying VMI Ready independently of
+// upstream propagates the not-ready condition back to external-attacher so it keeps
+// retrying instead of silently declaring the volume attached.
+func (w *WrappedControllerService) publishHotplugVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
+	resp, err := w.ControllerService.ControllerPublishVolume(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	vmNamespace, vmName, parseErr := cache.SplitMetaNamespaceKey(req.GetNodeId())
+	if parseErr != nil {
+		klog.Warningf("Cannot verify VMI readiness after publish: failed to parse node ID %q: %v", req.GetNodeId(), parseErr)
+		return resp, nil
+	}
+	dvName := req.GetVolumeId()
+	vmi, getErr := w.virtClient.GetVirtualMachine(ctx, vmNamespace, vmName)
+	if getErr != nil {
+		klog.Warningf("Cannot verify VMI %s/%s readiness after publish of %s: %v", vmNamespace, vmName, dvName, getErr)
+		return resp, nil
+	}
+	for _, vs := range vmi.Status.VolumeStatus {
+		if vs.Name != dvName {
+			continue
+		}
+		if vs.Phase == kubevirtv1.VolumeReady {
+			return resp, nil
+		}
+		return nil, status.Errorf(codes.Unavailable,
+			"volume %s is in VM %s/%s spec but not Ready in VMI status (phase=%q, message=%q)",
+			dvName, vmNamespace, vmName, vs.Phase, vs.Message)
+	}
+	return nil, status.Errorf(codes.Unavailable,
+		"volume %s not present in VMI %s/%s status after publish", dvName, vmNamespace, vmName)
+}
+
 // ControllerPublishVolume for NFS volumes: annotates infra PVC for WFFC binding,
 // waits for PVC bound, extracts NFS export from PV, and creates CiliumNetworkPolicy.
-// For RWO volumes, delegates to upstream (hotplug SCSI).
+// For hotplug volumes (RWO and RWX Block), delegates to upstream and then verifies
+// the volume is actually Ready in VMI.Status.VolumeStatus before returning success.
 func (w *WrappedControllerService) ControllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
 	if req.GetVolumeContext()[nfsVolumeKey] != "true" {
-		return w.ControllerService.ControllerPublishVolume(ctx, req)
+		return w.publishHotplugVolume(ctx, req)
 	}
 
 	if len(req.GetVolumeId()) == 0 {


### PR DESCRIPTION
## What this PR does

Stops `ControllerPublishVolume` from silently reporting success when the volume is in VM spec but the hotplug attach never actually completed.

### Root cause

Upstream's fast path (`EnsureVolumeAvailableVM`) checks only `vm.Spec.Template.Spec.Volumes`. If a prior Publish wrote that entry but timed out waiting for VMI Ready (e.g. the infra PVC is stuck `ClaimPending` because LINSTOR cannot autoplace), the next Publish short-circuits to success. external-attacher sets `Attached=true`, but QEMU was never sent `device_add`. The tenant kubelet's NodeStageVolume then fails with:

```
rpc error: code = Unknown desc = couldn't find device by serial id
```

Observed in production. Sequence from kubevirt-csi-driver controller logs:

```
16:53:13  /ControllerPublishVolume called
16:55:13  volume failed to be ready in time (2m), context deadline exceeded
16:55:14  /ControllerPublishVolume called  (retry)
16:55:14  Volume X already attached to VM Y - skipping hot-plug
16:55:14  /ControllerPublishVolume returned with response: {}
```

VMI volumeStatus during that window: `phase=Pending  message="PVC is in phase ClaimPending"`. VolumeAttachment then goes `Attached=true`; tenant kubelet surfaces "couldn't find device by serial id".

### Fix

After upstream Publish returns success for a hotplug volume, the wrapper re-reads VMI status and checks `Phase == VolumeReady` for this DataVolume. If it is not Ready (or not present), the RPC returns `codes.Unavailable` with the upstream reason, so external-attacher keeps retrying instead of declaring the volume attached. The underlying provisioning failure surfaces at the CSI layer instead of becoming a confusing kubelet-side "device not found by serial id".

This is a wrapper-side workaround for a defect in upstream `kubevirt.io/csi-driver`; the structural fix belongs upstream (tighten the fast path to require VMI Ready) and will be filed separately. The wrapper guard is safe to keep as defense-in-depth even after the upstream fix lands.

Relates to #2634.

### Release note

```release-note
fix(csi): kubevirt-csi-driver Publish now verifies VMI Ready before reporting attached, surfacing stuck-PVC failures at the CSI layer instead of as "couldn't find device by serial id" on the tenant kubelet
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hotplug volume publishing: non‑NFS volumes are now verified on the VM before being marked published; if the volume is missing or not ready, publishing returns unavailable, improving reliability for hotplugged storage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2659?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->