### PR TITLE
fix(platform): fix broken dashboard login by token

### DIFF
--- a/packages/system/dashboard/images/token-proxy/main.go
+++ b/packages/system/dashboard/images/token-proxy/main.go
@@ -82,31 +82,30 @@ func init() {
 		Timeout:   10 * time.Second,
 	}
 
-	// Create httprc client with custom HTTP client
-	httprcClient := httprc.NewClient(
-		httprc.WithHTTPClient(httpClient),
-	)
+	// jwx v3 / httprc v3 regression: jwk.Cache.Register *always* overrides
+	// the HTTPClient for each Resource. The client from httprc.NewClient is
+	// ignored; without an explicit jwk.WithHTTPClient on Register, jwk falls
+	// back to its own plain http.Client which has neither our cluster CA nor
+	// the SA bearer token, so the in-cluster JWKS fetch fails TLS verification
+	// and the controller's Ready() never signals — Register blocks forever.
+	// See jwx@v3.1.0/jwk/cache.go:141-180.
+	httprcClient := httprc.NewClient()
 
-	// Create JWK cache
 	jwkCache, err = jwk.NewCache(ctx, httprcClient)
 	if err != nil {
-		jwkCacheErr := fmt.Errorf("failed to create JWK cache: %w", err)
-		panic(jwkCacheErr)
+		panic(fmt.Errorf("failed to create JWK cache: %w", err))
 	}
 
-	// Register the JWKS URL with refresh settings
 	if err := jwkCache.Register(ctx, jwksURL,
+		jwk.WithHTTPClient(httpClient),
 		jwk.WithMinInterval(5*time.Minute),
 		jwk.WithMaxInterval(15*time.Minute),
 	); err != nil {
-		jwkCacheErr := fmt.Errorf("failed to register JWKS URL: %w", err)
-		panic(jwkCacheErr)
+		panic(fmt.Errorf("failed to register JWKS URL: %w", err))
 	}
 
-	// Perform initial fetch to ensure the JWKS is available
 	if _, err := jwkCache.Refresh(ctx, jwksURL); err != nil {
-		jwkCacheErr := fmt.Errorf("failed to fetch initial JWKS: %w", err)
-		panic(jwkCacheErr)
+		panic(fmt.Errorf("failed to fetch initial JWKS: %w", err))
 	}
 
 	log.Printf("JWK cache initialized with JWKS URL: %s", jwksURL)


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
fix regression of broken auth by token to the cozy-dashboard
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression in JWK cache initialization where custom HTTP client configurations for cluster authentication were not being properly applied, ensuring secure cluster communication and service-account token handling work as intended.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2661)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->