### PR TITLE
perf(lineage): cache owner GETs and short-circuit re-admission

### DIFF
--- a/internal/lineagecontrollerwebhook/types.go
+++ b/internal/lineagecontrollerwebhook/types.go
@@ -3,7 +3,9 @@ package lineagecontrollerwebhook
 import (
 	"sync"
 	"sync/atomic"
+	"time"
 
+	"github.com/cozystack/cozystack/pkg/lineage"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -11,13 +13,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+// ownerCacheTTL controls how long a successful or negative dynamic-client GET
+// result is reused across admission requests. The labels we derive are based on
+// stable identity (kind/name/owner refs), so even a generous TTL is safe; the
+// dominant cost we are saving is the apiserver round-trip on every admission.
+const ownerCacheTTL = 60 * time.Second
+
 // +kubebuilder:webhook:path=/mutate-lineage,mutating=true,failurePolicy=Fail,sideEffects=None,groups="",resources=pods,secrets,services,persistentvolumeclaims,verbs=create;update,versions=v1,name=mlineage.cozystack.io,admissionReviewVersions={v1}
 type LineageControllerWebhook struct {
 	client.Client
-	Scheme    *runtime.Scheme
-	decoder   admission.Decoder
-	dynClient dynamic.Interface
-	mapper    meta.RESTMapper
-	config    atomic.Value
-	initOnce  sync.Once
+	Scheme      *runtime.Scheme
+	decoder     admission.Decoder
+	dynClient   dynamic.Interface
+	mapper      meta.RESTMapper
+	config      atomic.Value
+	initOnce    sync.Once
+	ownerCache  *lineage.ObjectCache
 }

--- a/internal/lineagecontrollerwebhook/webhook.go
+++ b/internal/lineagecontrollerwebhook/webhook.go
@@ -73,6 +73,13 @@ func (h *LineageControllerWebhook) SetupWithManagerAsWebhook(mgr ctrl.Manager) e
 		return err
 	}
 
+	// Owner lookups dominate admission latency: each Pod admission walks the
+	// owner chain (Pod → STS → HelmRelease → app CR) with sequential dynamic
+	// GETs to the apiserver. The cache collapses repeat lookups across
+	// concurrent admissions for siblings of the same parent chain. TTL is short
+	// enough that DELETE/recreate of an owner is reflected within a minute.
+	h.ownerCache = lineage.NewObjectCache(ownerCacheTTL)
+
 	h.initConfig()
 	// Register HTTP path -> handler.
 	mgr.GetWebhookServer().Register("/mutate-lineage", &admission.Webhook{Handler: h})
@@ -99,6 +106,17 @@ func (h *LineageControllerWebhook) Handle(ctx context.Context, req admission.Req
 	obj := &unstructured.Unstructured{}
 	if err := h.decodeUnstructured(req, obj); err != nil {
 		return admission.Errored(400, fmt.Errorf("decode object: %w", err))
+	}
+
+	// Fast-path: the objectSelector on the MutatingWebhookConfiguration already
+	// skips admission for objects that carry the managed-by-cozystack label, so
+	// in steady state this branch only triggers for races (a controller
+	// re-applying labels mid-flight) and for safety if the selector is ever
+	// loosened. Pods still need applySchedulingClass each admission though, so
+	// we only short-circuit non-Pod kinds.
+	if obj.GetKind() != "Pod" && hasAllLineageLabels(obj) {
+		logger.V(1).Info("object already carries lineage labels, skipping owner walk")
+		return admission.Allowed("lineage labels already present")
 	}
 
 	owner, err := h.getOwner(ctx, obj)
@@ -133,11 +151,11 @@ func (h *LineageControllerWebhook) Handle(ctx context.Context, req admission.Req
 }
 
 func (h *LineageControllerWebhook) getOwner(ctx context.Context, o *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	owners := lineage.WalkOwnershipGraph(ctx, h.dynClient, h.mapper, h, o)
+	owners := lineage.WalkOwnershipGraphWithCache(ctx, h.dynClient, h.mapper, h, h.ownerCache, o)
 	if len(owners) == 0 {
 		return nil, NoAncestors
 	}
-	obj, err := owners[0].GetUnstructured(ctx, h.dynClient, h.mapper)
+	obj, err := owners[0].GetUnstructuredCached(ctx, h.dynClient, h.mapper, h.ownerCache)
 	if err != nil {
 		return nil, err
 	}
@@ -199,6 +217,26 @@ func (h *LineageControllerWebhook) applyLabels(o *unstructured.Unstructured, lab
 		existing[k] = v
 	}
 	o.SetLabels(existing)
+}
+
+// hasAllLineageLabels reports whether `o` already carries every label the
+// webhook would set. We treat ManagedObjectKey alone as insufficient because
+// the "unmanaged" path writes it with value "false" without setting the rest;
+// only the full set proves a previous successful walk.
+func hasAllLineageLabels(o *unstructured.Unstructured) bool {
+	labels := o.GetLabels()
+	if labels == nil {
+		return false
+	}
+	if labels[ManagedObjectKey] != "true" {
+		return false
+	}
+	for _, k := range []string{ManagerGroupKey, ManagerKindKey, ManagerNameKey} {
+		if _, ok := labels[k]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // applySchedulingClass injects schedulerName and scheduling-class annotation

--- a/pkg/lineage/cache.go
+++ b/pkg/lineage/cache.go
@@ -55,6 +55,10 @@ func NewObjectCache(ttl time.Duration) *ObjectCache {
 
 // Get returns a cached lookup, if any. The second return value reports whether
 // the entry was present and unexpired. A nil receiver is safe.
+//
+// The returned object is the stored pointer, not a copy: the cache is
+// process-wide and admissions run concurrently, so callers MUST treat it as
+// read-only and DeepCopy before any mutation.
 func (c *ObjectCache) Get(apiVersion, kind, namespace, name string) (*unstructured.Unstructured, error, bool) {
 	if c == nil {
 		return nil, nil, false
@@ -69,8 +73,8 @@ func (c *ObjectCache) Get(apiVersion, kind, namespace, name string) (*unstructur
 	return entry.obj, entry.err, true
 }
 
-// Set stores a lookup result. Both successful objects and errors are cached so
-// that repeated misses (NotFound, NoKindMatch) do not retry every admission.
+// Set stores a lookup result. Successful objects and permanent NotFound
+// errors are cached so that repeated misses do not retry every admission.
 // A nil receiver is safe.
 func (c *ObjectCache) Set(apiVersion, kind, namespace, name string, obj *unstructured.Unstructured, err error) {
 	if c == nil {
@@ -117,9 +121,9 @@ func (c *ObjectCache) evictExpiredSampleLocked(now time.Time, n int) {
 
 const (
 	// evictionThreshold is the size at which Set begins sampling for expired
-	// entries. Set high enough that the sweep stays infrequent under steady
-	// load, low enough that the map cannot grow unbounded under pathological
-	// admission patterns.
+	// entries. The sampling bounds the write-lock hold time, not the map
+	// size: the map remains bounded only by the number of distinct owners
+	// looked up within one TTL window.
 	evictionThreshold = 4096
 	// evictionSampleSize caps how many entries each Set inspects when
 	// evicting. With sampleSize ≪ threshold the work is amortised across many

--- a/pkg/lineage/cache.go
+++ b/pkg/lineage/cache.go
@@ -1,0 +1,128 @@
+package lineage
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// ObjectCache is a small TTL cache shared across WalkOwnershipGraph calls so the
+// admission webhook can avoid repeatedly issuing the same uncached dynamic GET to
+// the apiserver. A child Pod's owner (StatefulSet, HelmRelease, application CR)
+// is looked up on every admission of every sibling — the cache collapses those
+// per-process lookups to a single round-trip per TTL window.
+//
+// The cache stores both successful lookups and negative results (NotFound or
+// other transient errors) so a tight stream of admissions for the same parent
+// chain does not amplify pressure on the apiserver. Entries expire after `ttl`
+// from the time of insertion; staleness is acceptable because the labels we
+// compute are derived from immutable identity fields (kind, name, namespace,
+// owner refs) — not from object state that mutates frequently.
+//
+// A nil ObjectCache is a valid no-op cache: Get always misses, Set is a no-op.
+type ObjectCache struct {
+	ttl   time.Duration
+	mu    sync.RWMutex
+	items map[cacheKey]cacheEntry
+}
+
+type cacheKey struct {
+	apiVersion string
+	kind       string
+	namespace  string
+	name       string
+}
+
+type cacheEntry struct {
+	obj       *unstructured.Unstructured
+	err       error
+	expiresAt time.Time
+}
+
+// NewObjectCache returns a cache with the given TTL. A ttl of zero or less
+// disables caching by returning nil; callers can pass the result straight to
+// WalkOwnershipGraph without nil-checking.
+func NewObjectCache(ttl time.Duration) *ObjectCache {
+	if ttl <= 0 {
+		return nil
+	}
+	return &ObjectCache{
+		ttl:   ttl,
+		items: make(map[cacheKey]cacheEntry),
+	}
+}
+
+// Get returns a cached lookup, if any. The second return value reports whether
+// the entry was present and unexpired. A nil receiver is safe.
+func (c *ObjectCache) Get(apiVersion, kind, namespace, name string) (*unstructured.Unstructured, error, bool) {
+	if c == nil {
+		return nil, nil, false
+	}
+	k := cacheKey{apiVersion, kind, namespace, name}
+	c.mu.RLock()
+	entry, ok := c.items[k]
+	c.mu.RUnlock()
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil, nil, false
+	}
+	return entry.obj, entry.err, true
+}
+
+// Set stores a lookup result. Both successful objects and errors are cached so
+// that repeated misses (NotFound, NoKindMatch) do not retry every admission.
+// A nil receiver is safe.
+func (c *ObjectCache) Set(apiVersion, kind, namespace, name string, obj *unstructured.Unstructured, err error) {
+	if c == nil {
+		return
+	}
+	k := cacheKey{apiVersion, kind, namespace, name}
+	entry := cacheEntry{
+		obj:       obj,
+		err:       err,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+	c.mu.Lock()
+	c.items[k] = entry
+	// Bounded sampling eviction: when the map outgrows the threshold, scan a
+	// fixed slice of entries (cheap O(1) amortised, ~evictionSampleSize per
+	// Set) and drop the expired ones. This avoids the O(N) full-map scan
+	// pattern that would otherwise hold the write lock long enough to
+	// serialise admission webhook calls under bursty load.
+	if len(c.items) > evictionThreshold {
+		c.evictExpiredSampleLocked(time.Now(), evictionSampleSize)
+	}
+	c.mu.Unlock()
+}
+
+// evictExpiredSampleLocked scans at most n entries and removes the expired
+// ones. The caller must hold c.mu. Map iteration in Go is randomised, so
+// repeated invocations probabilistically cover the whole map without ever
+// holding the lock for an unbounded amount of time.
+func (c *ObjectCache) evictExpiredSampleLocked(now time.Time, n int) {
+	if n <= 0 {
+		return
+	}
+	i := 0
+	for key, e := range c.items {
+		if now.After(e.expiresAt) {
+			delete(c.items, key)
+		}
+		i++
+		if i >= n {
+			return
+		}
+	}
+}
+
+const (
+	// evictionThreshold is the size at which Set begins sampling for expired
+	// entries. Set high enough that the sweep stays infrequent under steady
+	// load, low enough that the map cannot grow unbounded under pathological
+	// admission patterns.
+	evictionThreshold = 4096
+	// evictionSampleSize caps how many entries each Set inspects when
+	// evicting. With sampleSize ≪ threshold the work is amortised across many
+	// Sets, bounding the write-lock hold time regardless of map size.
+	evictionSampleSize = 64
+)

--- a/pkg/lineage/cache_test.go
+++ b/pkg/lineage/cache_test.go
@@ -1,0 +1,206 @@
+package lineage
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestObjectCache_NilSafe(t *testing.T) {
+	var c *ObjectCache // explicitly nil
+
+	// All operations must be no-ops without panicking.
+	if obj, err, ok := c.Get("v1", "Pod", "ns", "n"); ok || obj != nil || err != nil {
+		t.Fatalf("nil cache must always miss, got ok=%v obj=%v err=%v", ok, obj, err)
+	}
+	c.Set("v1", "Pod", "ns", "n", &unstructured.Unstructured{}, nil) // must not panic
+}
+
+func TestObjectCache_DisabledByZeroTTL(t *testing.T) {
+	if got := NewObjectCache(0); got != nil {
+		t.Fatalf("NewObjectCache(0) should return nil to disable caching, got %v", got)
+	}
+	if got := NewObjectCache(-time.Second); got != nil {
+		t.Fatalf("NewObjectCache(<0) should return nil to disable caching, got %v", got)
+	}
+}
+
+func TestObjectCache_HitMiss(t *testing.T) {
+	c := NewObjectCache(time.Minute)
+
+	if _, _, ok := c.Get("v1", "Pod", "ns", "n"); ok {
+		t.Fatal("expected miss before Set")
+	}
+
+	obj := &unstructured.Unstructured{}
+	obj.SetName("foo")
+	c.Set("v1", "Pod", "ns", "n", obj, nil)
+
+	got, err, ok := c.Get("v1", "Pod", "ns", "n")
+	if !ok {
+		t.Fatal("expected hit after Set")
+	}
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if got != obj {
+		t.Fatalf("expected cached object pointer to match, got %v", got)
+	}
+}
+
+func TestObjectCache_NegativeResultIsCached(t *testing.T) {
+	c := NewObjectCache(time.Minute)
+	want := errors.New("not found")
+	c.Set("v1", "Pod", "ns", "n", nil, want)
+
+	got, err, ok := c.Get("v1", "Pod", "ns", "n")
+	if !ok {
+		t.Fatal("expected hit for negative cached entry")
+	}
+	if got != nil {
+		t.Fatalf("expected nil object for negative entry, got %v", got)
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("expected cached err to be %v, got %v", want, err)
+	}
+}
+
+func TestObjectCache_Expires(t *testing.T) {
+	c := NewObjectCache(20 * time.Millisecond)
+	c.Set("v1", "Pod", "ns", "n", &unstructured.Unstructured{}, nil)
+
+	if _, _, ok := c.Get("v1", "Pod", "ns", "n"); !ok {
+		t.Fatal("expected hit immediately after Set")
+	}
+
+	time.Sleep(40 * time.Millisecond)
+
+	if _, _, ok := c.Get("v1", "Pod", "ns", "n"); ok {
+		t.Fatal("expected miss after TTL elapsed")
+	}
+}
+
+func TestObjectCache_DistinctKeys(t *testing.T) {
+	// Sanity: cacheKey discriminates on every identity field so unrelated lookups
+	// don't collide.
+	c := NewObjectCache(time.Minute)
+	c.Set("v1", "Pod", "ns", "n", mustU("a"), nil)
+	c.Set("v1", "Pod", "ns-other", "n", mustU("b"), nil)
+	c.Set("v1", "Service", "ns", "n", mustU("c"), nil)
+	c.Set("apps/v1", "Pod", "ns", "n", mustU("d"), nil)
+
+	cases := []struct {
+		apiVersion, kind, namespace, name string
+		wantName                          string
+	}{
+		{"v1", "Pod", "ns", "n", "a"},
+		{"v1", "Pod", "ns-other", "n", "b"},
+		{"v1", "Service", "ns", "n", "c"},
+		{"apps/v1", "Pod", "ns", "n", "d"},
+	}
+	for _, tc := range cases {
+		got, _, ok := c.Get(tc.apiVersion, tc.kind, tc.namespace, tc.name)
+		if !ok {
+			t.Fatalf("expected hit for %s/%s in %s/%s", tc.apiVersion, tc.kind, tc.namespace, tc.name)
+		}
+		if got.GetName() != tc.wantName {
+			t.Fatalf("expected obj.name=%s, got %s for %s/%s in %s/%s", tc.wantName, got.GetName(), tc.apiVersion, tc.kind, tc.namespace, tc.name)
+		}
+	}
+}
+
+func TestParseWalkMemory(t *testing.T) {
+	// fresh state from no args
+	st, err := parseWalkMemory(nil)
+	if err != nil || st == nil || st.visited == nil {
+		t.Fatalf("expected fresh state, got st=%v err=%v", st, err)
+	}
+
+	// legacy map[ObjectID]bool form
+	legacy := map[ObjectID]bool{{Name: "x"}: true}
+	st, err = parseWalkMemory([]interface{}{legacy})
+	if err != nil {
+		t.Fatalf("legacy form should accept map[ObjectID]bool, got err=%v", err)
+	}
+	if !st.visited[ObjectID{Name: "x"}] {
+		t.Fatal("legacy visited map should be reused as-is")
+	}
+
+	// legacy nil map must not panic on writes
+	var nilLegacy map[ObjectID]bool
+	st, err = parseWalkMemory([]interface{}{nilLegacy})
+	if err != nil {
+		t.Fatalf("nil legacy map should be tolerated, got err=%v", err)
+	}
+	if st.visited == nil {
+		t.Fatal("nil legacy map should be replaced with a usable, non-nil map")
+	}
+	st.visited[ObjectID{Name: "z"}] = true // must not panic
+
+	// preferred *walkState form
+	cache := NewObjectCache(time.Minute)
+	original := &walkState{visited: map[ObjectID]bool{{Name: "y"}: true}, cache: cache}
+	st, err = parseWalkMemory([]interface{}{original})
+	if err != nil {
+		t.Fatalf("walkState form should be accepted, got err=%v", err)
+	}
+	if st != original {
+		t.Fatal("walkState should be reused by reference so recursion shares cache")
+	}
+
+	// invalid type returns fresh state + error
+	st, err = parseWalkMemory([]interface{}{"oops"})
+	if err == nil {
+		t.Fatal("expected error for unsupported memory type")
+	}
+	if st == nil || st.visited == nil {
+		t.Fatal("even on error, returned state must be usable to avoid nil-map panic in callers")
+	}
+}
+
+func TestObjectCache_EvictionSampleIsBounded(t *testing.T) {
+	// Fill the cache far beyond the threshold with expired entries, then call
+	// Set once and assert the sweep removed at most evictionSampleSize entries
+	// (cheap O(1) amortised) — not the whole map.
+	c := NewObjectCache(time.Hour)
+
+	for i := 0; i < evictionThreshold+1000; i++ {
+		key := cacheKey{apiVersion: "v1", kind: "Pod", namespace: "ns", name: keyName(i)}
+		c.items[key] = cacheEntry{
+			obj:       nil,
+			err:       nil,
+			expiresAt: time.Now().Add(-time.Minute), // expired
+		}
+	}
+	beforeLen := len(c.items)
+
+	// Trigger one Set, which adds 1 and then evicts ≤ evictionSampleSize.
+	c.Set("v1", "Pod", "ns", "trigger", mustU("t"), nil)
+
+	delta := beforeLen + 1 - len(c.items)
+	if delta < 0 {
+		t.Fatalf("expected map to shrink or stay equal after eviction, got delta=%d", delta)
+	}
+	if delta > evictionSampleSize {
+		t.Fatalf("eviction sample is unbounded: removed %d entries in one Set, expected ≤ %d", delta, evictionSampleSize)
+	}
+}
+
+func keyName(i int) string {
+	// avoid pulling in strconv just for tests — base16 is fine.
+	const hex = "0123456789abcdef"
+	buf := []byte{0, 0, 0, 0, 0, 0, 0, 0}
+	for j := 7; j >= 0; j-- {
+		buf[j] = hex[i&0xf]
+		i >>= 4
+	}
+	return string(buf)
+}
+
+func mustU(name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetName(name)
+	return u
+}

--- a/pkg/lineage/lineage.go
+++ b/pkg/lineage/lineage.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -35,11 +36,23 @@ type ObjectID struct {
 }
 
 func (o ObjectID) GetUnstructured(ctx context.Context, client dynamic.Interface, mapper meta.RESTMapper) (*unstructured.Unstructured, error) {
-	u, err := getUnstructuredObject(ctx, client, mapper, o.APIVersion, o.Kind, o.Namespace, o.Name)
-	if err != nil {
-		return nil, err
-	}
-	return u, nil
+	return o.GetUnstructuredCached(ctx, client, mapper, nil)
+}
+
+// GetUnstructuredCached fetches the object using the supplied cache. A nil
+// cache reverts to a direct, uncached dynamic.Get.
+func (o ObjectID) GetUnstructuredCached(ctx context.Context, client dynamic.Interface, mapper meta.RESTMapper, cache *ObjectCache) (*unstructured.Unstructured, error) {
+	return getUnstructuredObject(ctx, client, mapper, cache, o.APIVersion, o.Kind, o.Namespace, o.Name)
+}
+
+// walkState bundles the per-walk arguments that used to be threaded through the
+// variadic `memory` parameter. Encapsulating them keeps the variadic backwards
+// compatible (a single `*walkState` or the legacy `map[ObjectID]bool` are both
+// accepted) while letting callers thread a shared ObjectCache through the
+// recursion without changing every call site.
+type walkState struct {
+	visited map[ObjectID]bool
+	cache   *ObjectCache
 }
 
 func WalkOwnershipGraph(
@@ -55,47 +68,28 @@ func WalkOwnershipGraph(
 	out = []ObjectID{}
 	l := log.FromContext(ctx)
 
-	l.Info("processing object", "apiVersion", obj.GetAPIVersion(), "kind", obj.GetKind(), "name", obj.GetName())
-	var visited map[ObjectID]bool
-	var ok bool
-	if len(memory) == 1 {
-		visited, ok = memory[0].(map[ObjectID]bool)
-		if !ok {
-			l.Error(
-				fmt.Errorf("invalid argument"), "could not parse visited map in WalkOwnershipGraph call",
-				"received", memory[0], "expected", "map[ObjectID]bool",
-			)
-			return out
-		}
-	}
-
-	if len(memory) == 0 {
-		visited = make(map[ObjectID]bool)
-	}
-
-	if len(memory) != 0 && len(memory) != 1 {
-		l.Error(
-			fmt.Errorf("invalid argument count"), "could not parse variadic arguments to WalkOwnershipGraph",
-			"args passed", len(memory)+5, "expected args", "4|5",
-		)
+	l.V(1).Info("processing object", "apiVersion", obj.GetAPIVersion(), "kind", obj.GetKind(), "name", obj.GetName())
+	state, err := parseWalkMemory(memory)
+	if err != nil {
+		l.Error(err, "invalid WalkOwnershipGraph variadic arguments", "variadic_args_passed", len(memory), "expected", "0 or 1 (map[ObjectID]bool | *walkState)")
 		return out
 	}
 
-	if visited[id] {
+	if state.visited[id] {
 		return out
 	}
 
-	visited[id] = true
+	state.visited[id] = true
 
 	ownerRefs := obj.GetOwnerReferences()
 	for _, owner := range ownerRefs {
-		ownerObj, err := getUnstructuredObject(ctx, client, mapper, owner.APIVersion, owner.Kind, obj.GetNamespace(), owner.Name)
+		ownerObj, err := getUnstructuredObject(ctx, client, mapper, state.cache, owner.APIVersion, owner.Kind, obj.GetNamespace(), owner.Name)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Could not fetch owner %s/%s (%s): %v\n", obj.GetNamespace(), owner.Name, owner.Kind, err)
 			continue
 		}
 
-		out = append(out, WalkOwnershipGraph(ctx, client, mapper, appMapper, ownerObj, visited)...)
+		out = append(out, WalkOwnershipGraph(ctx, client, mapper, appMapper, ownerObj, state)...)
 	}
 
 	// if object has owners, it couldn't be owned directly by the custom app
@@ -119,7 +113,7 @@ func WalkOwnershipGraph(
 			l.Error(err, "failed to map HelmRelease to app")
 			break
 		}
-		ownerObj, err := getUnstructuredObject(ctx, client, mapper, a, k, obj.GetNamespace(), strings.TrimPrefix(obj.GetName(), p))
+		ownerObj, err := getUnstructuredObject(ctx, client, mapper, state.cache, a, k, obj.GetNamespace(), strings.TrimPrefix(obj.GetName(), p))
 		if err != nil {
 			l.Error(err, "couldn't get unstructured object", "APIVersion", a, "Kind", k, "Name", strings.TrimPrefix(obj.GetName(), p))
 			break
@@ -141,21 +135,82 @@ func WalkOwnershipGraph(
 	if !ok {
 		return
 	}
-	ownerObj, err := getUnstructuredObject(ctx, client, mapper, HRAPIVersion, HRKind, obj.GetNamespace(), name)
+	ownerObj, err := getUnstructuredObject(ctx, client, mapper, state.cache, HRAPIVersion, HRKind, obj.GetNamespace(), name)
 	if err != nil {
 		return
 	}
-	out = append(out, WalkOwnershipGraph(ctx, client, mapper, appMapper, ownerObj, visited)...)
+	out = append(out, WalkOwnershipGraph(ctx, client, mapper, appMapper, ownerObj, state)...)
 
 	return
+}
+
+// parseWalkMemory normalises the variadic `memory` argument of
+// WalkOwnershipGraph into a *walkState. Three forms are accepted for backwards
+// compatibility:
+//
+//   - no argument  → fresh state, no cache
+//   - *walkState   → use as-is (preferred, threads cache through recursion)
+//   - map[ObjectID]bool → legacy visited map (no cache)
+func parseWalkMemory(memory []interface{}) (*walkState, error) {
+	switch len(memory) {
+	case 0:
+		return &walkState{visited: make(map[ObjectID]bool)}, nil
+	case 1:
+		switch m := memory[0].(type) {
+		case *walkState:
+			if m == nil {
+				return &walkState{visited: make(map[ObjectID]bool)}, nil
+			}
+			if m.visited == nil {
+				m.visited = make(map[ObjectID]bool)
+			}
+			return m, nil
+		case map[ObjectID]bool:
+			if m == nil {
+				// Defend against callers who pass `map[ObjectID]bool(nil)` —
+				// writing into a nil map would panic on the first visited[id] = true.
+				m = make(map[ObjectID]bool)
+			}
+			return &walkState{visited: m}, nil
+		default:
+			return &walkState{visited: make(map[ObjectID]bool)}, fmt.Errorf("invalid argument: received %T, expected map[ObjectID]bool or *walkState", memory[0])
+		}
+	default:
+		return &walkState{visited: make(map[ObjectID]bool)}, fmt.Errorf("invalid argument count: %d", len(memory))
+	}
+}
+
+// WalkOwnershipGraphWithCache is the cache-aware entrypoint. It plumbs the
+// supplied ObjectCache through recursion so all dynamic GETs for the lifetime
+// of the walk (and across walks sharing the same cache) hit memory rather than
+// the apiserver. A nil cache is valid; it falls back to the original uncached
+// behaviour.
+func WalkOwnershipGraphWithCache(
+	ctx context.Context,
+	client dynamic.Interface,
+	mapper meta.RESTMapper,
+	appMapper AppMapper,
+	cache *ObjectCache,
+	obj *unstructured.Unstructured,
+) []ObjectID {
+	state := &walkState{
+		visited: make(map[ObjectID]bool),
+		cache:   cache,
+	}
+	return WalkOwnershipGraph(ctx, client, mapper, appMapper, obj, state)
 }
 
 func getUnstructuredObject(
 	ctx context.Context,
 	client dynamic.Interface,
 	mapper meta.RESTMapper,
+	cache *ObjectCache,
 	apiVersion, kind, namespace, name string,
 ) (*unstructured.Unstructured, error) {
+	if cached, cachedErr, ok := cache.Get(apiVersion, kind, namespace, name); ok {
+		return cached, cachedErr
+	}
+
 	l := log.FromContext(ctx)
 	gv, err := schema.ParseGroupVersion(apiVersion)
 	if err != nil {
@@ -163,6 +218,8 @@ func getUnstructuredObject(
 			err, "failed to parse groupversion",
 			"apiVersion", apiVersion,
 		)
+		// A parse error means the input was malformed — don't pollute the cache
+		// with what is effectively a permanent client-side error.
 		return nil, err
 	}
 	gvk := schema.GroupVersionKind{
@@ -174,6 +231,8 @@ func getUnstructuredObject(
 	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		l.Error(err, "Could not map GVK "+gvk.String())
+		// Cache the negative result: missing CRDs aren't a transient condition.
+		cache.Set(apiVersion, kind, namespace, name, nil, err)
 		return nil, err
 	}
 
@@ -183,6 +242,16 @@ func getUnstructuredObject(
 	}
 
 	ownerObj, err := client.Resource(mapping.Resource).Namespace(ns).Get(ctx, name, metav1.GetOptions{})
+	// Only cache results we are confident won't change soon:
+	//   - successful lookups (err == nil)
+	//   - permanent NotFound (object truly doesn't exist; recreate will get a
+	//     new resourceVersion and clear the cache through the TTL)
+	// Other errors (timeouts, transient 5xx, throttling) are intentionally
+	// not cached so the next admission retries against the apiserver instead
+	// of repeatedly returning a stale failure.
+	if err == nil || apierrors.IsNotFound(err) {
+		cache.Set(apiVersion, kind, namespace, name, ownerObj, err)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lineage/lineage.go
+++ b/pkg/lineage/lineage.go
@@ -231,8 +231,13 @@ func getUnstructuredObject(
 	mapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		l.Error(err, "Could not map GVK "+gvk.String())
-		// Cache the negative result: missing CRDs aren't a transient condition.
-		cache.Set(apiVersion, kind, namespace, name, nil, err)
+		// Never cache mapping failures: the apps.cozystack.io kinds walked here
+		// are served by the aggregated cozystack-api, so discovery fails
+		// transiently while it rolls (upgrade, drain) or before a new
+		// ApplicationDefinition is discovered. Caching the failure would mark
+		// every object admitted in the TTL window unmanaged — permanently,
+		// since the webhook's objectSelector never re-admits them. In steady
+		// state the mapper serves this from its own discovery cache anyway.
 		return nil, err
 	}
 


### PR DESCRIPTION
## What this PR does

The lineage mutating webhook walks the owner chain (`Pod → StatefulSet → HelmRelease → app CR`) on every admission of every Pod/Secret/Service/PVC/Ingress/WorkloadMonitor, using uncached `dynamic.Interface.Get()` calls.

In a multi-tenant Hikube cluster the result was a p99 of **300–500ms** for `lineage.cozystack.io` admissions, making it the top contributor to overall apiserver request latency (measured via `apiserver_admission_webhook_admission_duration_seconds_bucket`). Each level of the owner chain costs one apiserver round-trip; for sibling Pods of the same parent we re-do the same lookups every time.

Two changes:

- **TTL object cache** (`pkg/lineage/cache.go`) threaded through `WalkOwnershipGraph` via a new `*walkState` wrapper. Caches successful lookups and **permanent `NotFound`** errors via `apierrors.IsNotFound`; **transient** errors (timeouts, throttling, 5xx) are deliberately *not* cached so the next admission retries against the apiserver instead of returning a stale failure. The cache is opt-in (a `nil` `*ObjectCache` is a valid no-op) and the variadic `memory ...interface{}` parameter on `WalkOwnershipGraph` keeps accepting the legacy `map[ObjectID]bool` form — including the `map[ObjectID]bool(nil)` case, which is defensively replaced with an empty map to avoid a panic on the first `visited[id] = true`. Eviction is **bounded**: when the map outgrows `evictionThreshold`, `Set` scans only `evictionSampleSize` entries per call, bounding the write-lock hold time regardless of map size and amortising the work across many admissions. The webhook wires a process-wide cache with `60s` TTL — short enough that owner DELETEs propagate within a minute, long enough that the common case (many sibling admissions in a burst) hits memory after the first lookup.

- **Fast-path in `Handle()`**: if the incoming object already carries the full set of lineage labels (`internal.cozystack.io/managed-by-cozystack=true` + `apps.cozystack.io/application.{group,kind,name}`), return `admission.Allowed` immediately. Skipped for `Pod` kind because `applySchedulingClass` still needs to run on every admission. The MutatingWebhookConfiguration's `objectSelector` already excludes managed objects, but the in-handler check costs nothing and protects against the selector being relaxed or labels being applied by a concurrent controller mid-flight.

Addresses review feedback from CodeRabbit (nil-map guard in `parseWalkMemory`, no caching of transient errors) and Gemini Code Assist (bounded sampling eviction, clearer variadic-arg log message).

Unit tests cover:
- nil-safety of the cache (zero/negative TTL disables caching)
- hit/miss + TTL expiry
- negative-result caching (`NotFound`-style)
- key discrimination (apiVersion/Kind/namespace/name)
- backwards compatibility of `WalkOwnershipGraph` with the legacy `map[ObjectID]bool` memory argument, including the `nil` legacy-map case
- bounded eviction sweep under pathological load (≤ `evictionSampleSize` removals per `Set`)

## Release note

```release-note
perf(lineage): cache owner GETs in the lineage mutating webhook and short-circuit admission for objects that already carry lineage labels. Substantially reduces p99 admission latency on clusters with many tenants.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TTL-based in-memory cache for lineage/owner lookups to reduce repeated API calls and speed admission processing.
  * Fast-path: non-Pod objects that already carry a complete set of lineage labels are now allowed immediately without recomputing lineage or applying owner-dependent mutations.

* **Tests**
  * Added unit tests covering cache nil-safety, hit/miss behavior, negative-result caching, TTL expiration, and lineage-walk memory handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->