### PR TITLE
ci(tags): make generate-changelog non-blocking

### DIFF
--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -246,6 +246,8 @@ jobs:
       contents: write
       pull-requests: write
     if: needs.prepare-release.result == 'success'
+    # Non-blocking: failure here must not prevent update-website-docs from running.
+    continue-on-error: true
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -445,7 +447,9 @@ jobs:
     name: Update Website Docs
     runs-on: [self-hosted]
     needs: [generate-changelog, prepare-release]
-    if: needs.generate-changelog.result == 'success' && needs.prepare-release.outputs.skip != 'true'
+    # generate-changelog is non-blocking — run as long as prepare-release succeeded.
+    # `always()` is needed so this job runs even if generate-changelog failed/skipped.
+    if: always() && needs.prepare-release.result == 'success' && needs.prepare-release.outputs.skip != 'true'
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## What this PR does

Marks the `generate-changelog` job in `.github/workflows/tags.yaml` with `continue-on-error: true`, and changes the `update-website-docs` gate to `always() && needs.prepare-release.result == 'success' && needs.prepare-release.outputs.skip != 'true'`.

Result: a failure inside `generate-changelog` (AI step timing out, PR creation step erroring, etc.) no longer blocks `update-website-docs`. `prepare-release` remains the hard gate — if it fails or signals `skip=true`, downstream jobs still don't run.

### Release note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This pull request contains internal infrastructure changes only and has no impact on end-users or the product.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->