### PR TITLE
feat(kamaji): default to 2 replicas, drop telemetry webhook

### DIFF
--- a/packages/system/kamaji/Makefile
+++ b/packages/system/kamaji/Makefile
@@ -10,6 +10,10 @@ update:
 	curl -sSL https://github.com/clastix/kamaji/archive/refs/tags/$${tag}.tar.gz | \
 	tar -xzvf - --strip 1 kamaji-$${tag}/charts && \
 	sed -i "/ARG VERSION/ s|=.*|=$${tag}|g" images/kamaji/Dockerfile
+	# Re-apply Cozystack-side patches over the freshly extracted chart so
+	# `make update` stays reproducible. Mirrors the pattern used by
+	# packages/system/fluxcd-operator and packages/system/ingress-nginx.
+	patch --no-backup-if-mismatch -p1 < patches/1.diff
 
 image:
 	docker buildx build images/kamaji \

--- a/packages/system/kamaji/charts/kamaji/controller-gen/validating-webhook.yaml
+++ b/packages/system/kamaji/charts/kamaji/controller-gen/validating-webhook.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.telemetry.disabled }}
 - admissionReviewVersions:
     - v1
   clientConfig:
@@ -19,6 +20,7 @@
       resources:
         - tenantcontrolplanes
   sideEffects: None
+{{- end }}
 - admissionReviewVersions:
     - v1
   clientConfig:

--- a/packages/system/kamaji/patches/1.diff
+++ b/packages/system/kamaji/patches/1.diff
@@ -1,0 +1,17 @@
+diff --git a/packages/system/kamaji/charts/kamaji/controller-gen/validating-webhook.yaml b/packages/system/kamaji/charts/kamaji/controller-gen/validating-webhook.yaml
+index 0000000..0000001 100644
+--- a/charts/kamaji/controller-gen/validating-webhook.yaml
++++ b/charts/kamaji/controller-gen/validating-webhook.yaml
+@@ -1,3 +1,4 @@
++{{- if not .Values.telemetry.disabled }}
+ - admissionReviewVersions:
+     - v1
+   clientConfig:
+@@ -19,6 +20,7 @@
+       resources:
+         - tenantcontrolplanes
+   sideEffects: None
++{{- end }}
+ - admissionReviewVersions:
+     - v1
+   clientConfig:

--- a/packages/system/kamaji/values.yaml
+++ b/packages/system/kamaji/values.yaml
@@ -1,6 +1,33 @@
 kamaji:
   etcd:
     deploy: false
+  # HA-safe default: two replicas serve admission webhooks behind the
+  # kamaji-webhook-service Service. --leader-elect is already enabled
+  # upstream, so only one replica reconciles tenant control planes — the
+  # follower's CPU is fully available for webhook handlers, eliminating the
+  # CPU contention that pushes p99 admission latency from ~10ms (kamaji
+  # handler) up to ~90ms (apiserver-observed) on single-replica deployments.
+  replicaCount: 2
+  # Drop the telemetry handler and its admission webhook. With
+  # telemetry.disabled=true, the controller is started with
+  # --disable-telemetry AND the corresponding webhook entry is omitted
+  # from the ValidatingWebhookConfiguration (see patches/1.diff), so the
+  # apiserver no longer pays a round-trip to a no-op handler on every
+  # TenantControlPlane CREATE/UPDATE/DELETE.
+  telemetry:
+    disabled: true
+  # Soft anti-affinity: spread the kamaji controller replicas across nodes
+  # when possible. preferredDuringScheduling means single-node clusters
+  # still schedule both pods (just colocated, which is acceptable).
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: kamaji
+            topologyKey: kubernetes.io/hostname
   image:
     pullPolicy: IfNotPresent
     tag: v1.5.0@sha256:130d5013a9b35be0013b96efefc656210cc30c6fe92a8c39c9d2ab8d47f791e0


### PR DESCRIPTION
## What this PR does

`kamaji-controller-manager` runs **9 sub-controllers per TenantControlPlane** (bootstraptoken, coredns, konnectivity, kubeadm*, kubelet, kubeproxy, …) inside a single Go process, **and** serves the admission webhooks for `tenantcontrolplanes` + `datastores` from the same pod via `kamaji-webhook-service`. With the upstream default `replicaCount=1`, every webhook round-trip from the apiserver shares CPU with the reconciler goroutines. On a multi-tenant cluster this pushes the apiserver-observed p99 of `mtenantcontrolplane.kb.io` and `vtenantcontrolplane.kb.io` from the kamaji-side `~10ms` (per `controller_runtime_webhook_latency_seconds_count/sum`) up to `85–95ms` — purely due to CPU contention.

Three safe defaults are changed:

- **`kamaji.replicaCount: 2`** — HA-safe baseline. `--leader-elect` is already enabled upstream, so only one replica reconciles tenants; the follower's CPU is fully available for webhook handlers. On a single-node cluster both pods still schedule (just colocated).
- **`kamaji.telemetry.disabled: true`** — drops the `--disable-telemetry` handler **and** removes the `telemetry.kamaji.clastix.io` entry from the `ValidatingWebhookConfiguration`. The latter requires `patches/1.diff` to wrap the telemetry block in `{{- if not .Values.telemetry.disabled }} … {{- end }}` inside the vendored `controller-gen/validating-webhook.yaml`. Without the webhook entry, the apiserver no longer round-trips to a no-op handler on every TenantControlPlane CREATE/UPDATE/DELETE.
- **`kamaji.affinity` (soft `podAntiAffinity`)** — spread the two replicas across nodes when possible, while keeping single-node clusters working (`preferredDuringScheduling`, not required).

The `patches/1.diff` approach (re-applied by `make update`) mirrors the pattern already used in `packages/system/fluxcd-operator/Makefile` and `packages/system/ingress-nginx/Makefile`, and survives the next `clastix/kamaji` chart bump.

## Measured impact

Hikube prod, 22 TenantControlPlanes, before/after a manual rollout of the same configuration:

| webhook | p99 before | p99 after | Δ |
| --- | --- | --- | --- |
| `mtenantcontrolplane.kb.io` | 85 ms | 25 ms | **-71%** |
| `vtenantcontrolplane.kb.io` | 92 ms | 25 ms | **-73%** |
| `telemetry.kamaji.clastix.io` | 94 ms | _webhook removed_ | **-100%** |

Cumulative Kamaji admission **impact** (`p99 × calls/s`) dropped from **830 → 140 (-83%)**. The Kamaji webhooks moved from the top three of the `apiserver_admission_webhook_admission_duration_seconds_*` impact ranking down to positions #3-#4.

## Release note

```release-note
feat(kamaji): default to 2 replicas with soft pod anti-affinity and disable telemetry (handler + webhook entry). Reduces apiserver admission p99 for tenantcontrolplane mutating/validating webhooks by ~70% on multi-tenant clusters.
```

## Test plan

- [x] `helm template packages/system/kamaji` renders `replicas: 2`, `--disable-telemetry`, the soft anti-affinity, and **no** `telemetry.kamaji.clastix.io` entry in the `ValidatingWebhookConfiguration`.
- [x] `patches/1.diff` applies cleanly against the freshly extracted upstream chart (`patch --dry-run -p1 < patches/1.diff`).
- [x] `make update` re-applies the patch automatically.
- [x] Live deploy on a 22-TCP cluster: 3 pods Running (when overriden to `replicaCount: 3` via cozystack-values), zero pod restarts, leader election visible, `kamaji-webhook-service` Endpoints serving N IPs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telemetry can be disabled via configuration.
  * Controller configured for high availability with 2 replicas.
  * Pod anti-affinity added to spread replicas across nodes for better resilience.

* **Bug Fixes**
  * Validating webhook is now omitted when telemetry is disabled to avoid unintended behavior.

* **Chores**
  * Update process improved to re-apply chart patches after extraction for reproducible updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2671?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->