### PR TITLE
fix(kafka): remove ZooKeeper PVCs on uninstall

### DIFF
--- a/hack/e2e-apps/kafka.bats
+++ b/hack/e2e-apps/kafka.bats
@@ -50,7 +50,10 @@ EOF
   timeout 40 sh -ec "until kubectl -n tenant-test get svc kafka-$name-zookeeper-client -o jsonpath='{.spec.ports[0].port}' | grep -q '2181'; do sleep 10; done"
   timeout 40 sh -ec "until kubectl -n tenant-test get svc kafka-$name-zookeeper-nodes -o jsonpath='{.spec.ports[*].port}' | grep -q '2181 2888 3888'; do sleep 10; done"
   timeout 80 sh -ec "until kubectl -n tenant-test get endpoints kafka-$name-zookeeper-nodes -o jsonpath='{.subsets[*].addresses[0].ip}' | grep -q '[0-9]'; do sleep 10; done"
-  kubectl -n tenant-test delete kafka.apps.cozystack.io $name
-  kubectl -n tenant-test delete pvc data-kafka-$name-zookeeper-0
-  kubectl -n tenant-test delete pvc data-kafka-$name-zookeeper-1
+  kubectl -n tenant-test delete kafka.apps.cozystack.io $name --timeout=2m
+  # Strimzi reclaims ZooKeeper PVCs automatically when deleteClaim is true on
+  # the persistent-claim storage. Verify they disappear instead of issuing a
+  # manual kubectl delete, which would mask a regression in the operator.
+  timeout 60 sh -ec "while kubectl -n tenant-test get pvc data-kafka-$name-zookeeper-0 >/dev/null 2>&1; do sleep 2; done"
+  timeout 60 sh -ec "while kubectl -n tenant-test get pvc data-kafka-$name-zookeeper-1 >/dev/null 2>&1; do sleep 2; done"
 }

--- a/hack/e2e-apps/kafka.bats
+++ b/hack/e2e-apps/kafka.bats
@@ -47,6 +47,8 @@ EOF
   kubectl wait kafkas -n tenant-test $name --timeout=300s --for=condition=ready
   timeout 60 sh -ec "until kubectl -n tenant-test get pvc data-kafka-$name-zookeeper-0; do sleep 10; done"
   kubectl -n tenant-test wait pvc data-kafka-$name-zookeeper-0 --timeout=50s --for=jsonpath='{.status.phase}'=Bound
+  timeout 60 sh -ec "until kubectl -n tenant-test get pvc data-kafka-$name-zookeeper-1 >/dev/null 2>&1; do sleep 2; done"
+  kubectl -n tenant-test wait pvc data-kafka-$name-zookeeper-1 --timeout=50s --for=jsonpath='{.status.phase}'=Bound
   timeout 40 sh -ec "until kubectl -n tenant-test get svc kafka-$name-zookeeper-client -o jsonpath='{.spec.ports[0].port}' | grep -q '2181'; do sleep 10; done"
   timeout 40 sh -ec "until kubectl -n tenant-test get svc kafka-$name-zookeeper-nodes -o jsonpath='{.spec.ports[*].port}' | grep -q '2181 2888 3888'; do sleep 10; done"
   timeout 80 sh -ec "until kubectl -n tenant-test get endpoints kafka-$name-zookeeper-nodes -o jsonpath='{.subsets[*].addresses[0].ip}' | grep -q '[0-9]'; do sleep 10; done"

--- a/packages/apps/kafka/templates/kafka.yaml
+++ b/packages/apps/kafka/templates/kafka.yaml
@@ -73,7 +73,7 @@ spec:
       {{- with .Values.kafka.storageClass }}
       class: {{ . }}
       {{- end }}
-      deleteClaim: false
+      deleteClaim: true
     metricsConfig:
       type: jmxPrometheusExporter
       valueFrom:


### PR DESCRIPTION
## What this PR does

Aligns ZooKeeper storage cleanup with the existing Kafka broker behavior so deleting a Kafka release reclaims all of its persistent storage. The Strimzi `Kafka` CR template already set `deleteClaim: true` on the broker JBOD volume, but the ZooKeeper persistent-claim was left at `deleteClaim: false`. As a result, removing a Kafka application freed the broker PVCs while orphaning the ZooKeeper PVCs in the tenant namespace, requiring manual cleanup before the same release name could be reused.

The change is a single field flip in `packages/apps/kafka/templates/kafka.yaml` on the `spec.zookeeper.storage` block.

### Behavior change

Users who previously relied on orphaned ZooKeeper PVCs as an implicit "soft delete" for ZooKeeper state recovery should be aware that uninstalling a Kafka release now also removes the underlying ZooKeeper storage. Take a backup before deletion if ZooKeeper data retention is required.

### Screenshots

Not applicable — no UI changes.

### Release note

```release-note
fix(kafka): ZooKeeper PVCs are now reclaimed when a Kafka release is deleted, matching the existing Kafka broker storage behavior.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Kafka storage behavior updated so persistent volumes are automatically removed when claims are deleted, changing storage lifecycle for deployments.

* **Tests**
  * End-to-end cleanup adjusted to remove the Kafka resource and verify volumes are reclaimed automatically, adding waits to confirm PVC binding and removal.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2679?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->