### PR TITLE
fix(e2e-sandbox): use curl -fsSL when downloading mc

### DIFF
--- a/packages/core/testing/images/e2e-sandbox/Dockerfile
+++ b/packages/core/testing/images/e2e-sandbox/Dockerfile
@@ -19,8 +19,8 @@ RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_${TA
  && chmod +x /usr/local/bin/yq
 RUN curl -sSL "https://fluxcd.io/install.sh" | bash
 RUN curl -sSL "https://github.com/cozystack/cozyhr/raw/refs/heads/main/hack/install.sh" | sh -s -- -v "${COZYHR_VERSION}"
-RUN curl https://dl.min.io/client/mc/release/${TARGETOS}-${TARGETARCH}/mc --create-dirs -o  /usr/local/bin/mc \
-&& chmod +x /usr/local/bin/mc
+RUN curl -fsSL "https://dl.min.io/client/mc/release/${TARGETOS}-${TARGETARCH}/mc" --create-dirs -o /usr/local/bin/mc \
+ && chmod +x /usr/local/bin/mc
 RUN <<'EOF'
 cat <<'EOT' >> /etc/bash.bashrc
 . /etc/bash_completion


### PR DESCRIPTION
## Summary

- `RUN curl … mc` in `packages/core/testing/images/e2e-sandbox/Dockerfile` ran without `-L`, so when `dl.min.io` returned a 302, the HTML redirect body (`<a href=...>Found</a>`) was written to `/usr/local/bin/mc` and chmod'd executable.
- When the bucket E2E test then ran `mc alias set …`, the shell tried to interpret the HTML as a script and errored with `/usr/local/bin/mc: 1: cannot open a: No such file` (dash reading `<a` as an input redirect).
- Switching to `curl -fsSL` follows the redirect and fails fast on HTTP errors. The textual change to the `RUN` instruction also busts the cached layer so the next build pulls a real ELF binary.

## Test plan

- [x] CI Build job rebuilds `e2e-sandbox` image with the new layer
- [x] E2E `bucket` bats test runs `mc alias set` without the `cannot open a` error
- [x] `file /usr/local/bin/mc` inside the rebuilt image reports an ELF binary, not ASCII text

### Release note

```release-note
fix(e2e-sandbox): download `mc` with `curl -fsSL` so the image ships a real binary
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker sandbox test environment build reliability by enhancing MinIO client installation with robust error handling and corrected configuration paths to ensure consistent container image creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
