### PR TITLE
feat(kubeovn-webhook): add client-certificate verification, off by default

### DIFF
--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert.go
@@ -22,8 +22,16 @@ import "crypto/tls"
 //     LoadX509KeyPair therefore cannot observe a partial renewal.
 //   - The per-handshake cost (a few KB of file I/O plus a PEM/key parse) is
 //     negligible next to the asymmetric crypto the handshake already performs.
-//   - The webhook configures no mTLS (no ClientCAs), so GetCertificate's
-//     limitation of not refreshing client CA pools does not apply.
+//   - GetCertificate refreshes the serving key pair only. It does not refresh
+//     tls.Config.ClientCAs, which the handshake reads directly. When
+//     --client-ca-file is set, main reads that bundle once at startup and the
+//     pool stays fixed for the process lifetime: rotating the API server's
+//     client CA then requires restarting these pods, or the webhook keeps
+//     validating against the retired CA and rejects the API server. With
+//     failurePolicy: Fail that stops pod creation cluster-wide, so reloading
+//     the pool has to land together with the mount that makes enforcement
+//     reachable at all -- neither is usable without the other, and today
+//     --client-ca-file has no supported in-pod path to point at.
 //
 // If the mounted files genuinely become unreadable (Secret deleted, permissions
 // broken: an operator error, not a normal renewal) the handshake fails loudly

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/main.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/main.go
@@ -73,6 +73,8 @@ func main() {
 		log.Fatalf("Failed to load key pair: %v", err)
 	}
 
+	tlsConfig.MinVersion = tls.VersionTLS12
+
 	// Default: ask for a client certificate, accept the connection either way.
 	// This never rejects a caller, so it cannot break admission; it only makes
 	// the certificate visible to logClientCert.

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/main.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/main.go
@@ -16,38 +16,45 @@ var (
 	RoutesGlobal       string
 )
 
-// Observation state for logClientCert. The set is capped on purpose: with
-// tls.RequestClientCert the server accepts whatever certificate a caller
-// offers, so the issuer string is attacker-supplied. An unbounded set would
-// grow with every fabricated issuer and emit a log line for each — a memory
-// and log-volume amplifier reachable by anyone who can open a TCP connection.
-// Past the cap the webhook keeps serving and simply stops recording.
-const maxSeenClientIssuers = 32
+// Observation state for logClientCert.
+//
+// Deliberately NOT a set keyed on the issuer. With tls.RequestClientCert the
+// issuer string is supplied by the caller, so anything keyed on it is both
+// unbounded and forgeable: remembering every value grows without limit, and
+// remembering only the first N lets anyone who can reach the port fill those N
+// with fabricated issuers before the API server's first call and permanently
+// suppress the signal this exists to produce. Rate limiting cannot be starved
+// that way -- a burst costs the attacker at most the current interval, and the
+// next real handshake is logged in the one after it.
+//
+// The two outcomes are limited separately so a flood of one cannot hide the
+// other: "no certificate" and "certificate presented" answer different
+// questions, and it is the pair that decides whether enforcement is safe.
+const observationInterval = 30 * time.Second
 
-var (
-	clientIssuerMu     sync.Mutex
-	seenClientIssuers  = make(map[string]struct{}, maxSeenClientIssuers)
-	clientIssuerCapped bool
-)
+type observationLimiter struct {
+	mu   sync.Mutex
+	last time.Time
+	seen bool
+}
 
-// noteClientIssuer reports whether this issuer should be logged: true only when
-// it is new and there is still room to remember it.
-func noteClientIssuer(key string) bool {
-	clientIssuerMu.Lock()
-	defer clientIssuerMu.Unlock()
-	if _, seen := seenClientIssuers[key]; seen {
+// allow reports whether this observation should be logged: always the first
+// one, then at most one per observationInterval.
+func (l *observationLimiter) allow(now time.Time) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.seen && now.Sub(l.last) < observationInterval {
 		return false
 	}
-	if len(seenClientIssuers) >= maxSeenClientIssuers {
-		if !clientIssuerCapped {
-			clientIssuerCapped = true
-			log.Printf("client certificate: %d distinct issuers observed, no longer recording new ones; if this cap was reached on a quiet cluster the issuers are probably fabricated", maxSeenClientIssuers)
-		}
-		return false
-	}
-	seenClientIssuers[key] = struct{}{}
+	l.seen = true
+	l.last = now
 	return true
 }
+
+var (
+	noCertObservations   observationLimiter
+	withCertObservations observationLimiter
+)
 
 // logClientCert reports, once per distinct issuer, whether the caller presented
 // a client certificate and who signed it.
@@ -67,17 +74,21 @@ func noteClientIssuer(key string) bool {
 // RequireAndVerifyClientCert on a cluster that sends nothing would fail every
 // admission call, and this webhook is registered failurePolicy: Fail — so pod
 // creation would stop cluster-wide. Observe first, enforce second.
-func logClientCert(next http.Handler) http.Handler {
+func logClientCert(enforcing bool, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		key := "<none>"
+		issuer := ""
 		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
-			key = r.TLS.PeerCertificates[0].Issuer.String()
+			issuer = r.TLS.PeerCertificates[0].Issuer.String()
 		}
-		if noteClientIssuer(key) {
-			if key == "<none>" {
-				log.Printf("client certificate: none presented — client-ca-file enforcement is NOT yet safe on this cluster")
+		now := time.Now()
+		switch {
+		case issuer == "" && noCertObservations.allow(now):
+			log.Printf("client certificate: none presented by %s -- client-ca-file enforcement is NOT yet safe on this cluster", r.RemoteAddr)
+		case issuer != "" && withCertObservations.allow(now):
+			if enforcing {
+				log.Printf("client certificate: presented by %s, issuer %q -- verified against --client-ca-file during the handshake", r.RemoteAddr, issuer)
 			} else {
-				log.Printf("client certificate: presented, issuer %q (UNVERIFIED — nothing has checked this certificate, and any caller can claim any issuer). Confirm out of band that this is your API server's CA before pinning it with --client-ca-file", key)
+				log.Printf("client certificate: presented by %s, issuer %q (UNVERIFIED -- nothing has checked this certificate, and any caller can claim any issuer). Confirm out of band that this is your API server's CA before pinning it with --client-ca-file", r.RemoteAddr, issuer)
 			}
 		}
 		next.ServeHTTP(w, r)
@@ -133,7 +144,7 @@ func main() {
 	server := &http.Server{
 		Addr:              ":8443",
 		TLSConfig:         tlsConfig,
-		Handler:           logClientCert(mux),
+		Handler:           logClientCert(clientCAFile != "", mux),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      30 * time.Second,

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/main.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/main.go
@@ -16,16 +16,50 @@ var (
 	RoutesGlobal       string
 )
 
-// seenClientIssuers records which client-certificate issuers have already been
-// logged, so the observation below costs one line per distinct issuer rather
-// than one per admitted pod.
-var seenClientIssuers sync.Map
+// Observation state for logClientCert. The set is capped on purpose: with
+// tls.RequestClientCert the server accepts whatever certificate a caller
+// offers, so the issuer string is attacker-supplied. An unbounded set would
+// grow with every fabricated issuer and emit a log line for each — a memory
+// and log-volume amplifier reachable by anyone who can open a TCP connection.
+// Past the cap the webhook keeps serving and simply stops recording.
+const maxSeenClientIssuers = 32
+
+var (
+	clientIssuerMu     sync.Mutex
+	seenClientIssuers  = make(map[string]struct{}, maxSeenClientIssuers)
+	clientIssuerCapped bool
+)
+
+// noteClientIssuer reports whether this issuer should be logged: true only when
+// it is new and there is still room to remember it.
+func noteClientIssuer(key string) bool {
+	clientIssuerMu.Lock()
+	defer clientIssuerMu.Unlock()
+	if _, seen := seenClientIssuers[key]; seen {
+		return false
+	}
+	if len(seenClientIssuers) >= maxSeenClientIssuers {
+		if !clientIssuerCapped {
+			clientIssuerCapped = true
+			log.Printf("client certificate: %d distinct issuers observed, no longer recording new ones; if this cap was reached on a quiet cluster the issuers are probably fabricated", maxSeenClientIssuers)
+		}
+		return false
+	}
+	seenClientIssuers[key] = struct{}{}
+	return true
+}
 
 // logClientCert reports, once per distinct issuer, whether the caller presented
 // a client certificate and who signed it.
 //
-// This is the evidence needed to decide whether client-certificate enforcement
-// can be turned on. The handler serves namespace-derived values to whoever asks
+// What it reports is untrusted. With tls.RequestClientCert the certificate is
+// accepted without being verified against anything, so the issuer is a claim
+// and not an identity: it says what reaches this port, and feeds a decision a
+// human makes out of band. Nothing here turns it into a trust decision the
+// process makes for itself — enforcement depends solely on --client-ca-file.
+//
+// This is the evidence needed to decide whether that enforcement can be turned
+// on. The handler serves namespace-derived values to whoever asks
 // (see GHSA-g883-q79m-8225), and the fix is to accept only the API server — but
 // the API server presents a certificate only when the cluster is configured for
 // it (an AdmissionConfiguration with a kubeConfigFile), which is not universal
@@ -39,11 +73,11 @@ func logClientCert(next http.Handler) http.Handler {
 		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
 			key = r.TLS.PeerCertificates[0].Issuer.String()
 		}
-		if _, loaded := seenClientIssuers.LoadOrStore(key, struct{}{}); !loaded {
+		if noteClientIssuer(key) {
 			if key == "<none>" {
 				log.Printf("client certificate: none presented — client-ca-file enforcement is NOT yet safe on this cluster")
 			} else {
-				log.Printf("client certificate: presented, issuer %q — enforcement can be enabled with --client-ca-file for this CA", key)
+				log.Printf("client certificate: presented, issuer %q (UNVERIFIED — nothing has checked this certificate, and any caller can claim any issuer). Confirm out of band that this is your API server's CA before pinning it with --client-ca-file", key)
 			}
 		}
 		next.ServeHTTP(w, r)

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/main.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/main.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"log"
 	"net/http"
+	"os"
+	"sync"
 	"time"
 )
 
@@ -12,14 +16,50 @@ var (
 	RoutesGlobal       string
 )
 
+// seenClientIssuers records which client-certificate issuers have already been
+// logged, so the observation below costs one line per distinct issuer rather
+// than one per admitted pod.
+var seenClientIssuers sync.Map
+
+// logClientCert reports, once per distinct issuer, whether the caller presented
+// a client certificate and who signed it.
+//
+// This is the evidence needed to decide whether client-certificate enforcement
+// can be turned on. The handler serves namespace-derived values to whoever asks
+// (see GHSA-g883-q79m-8225), and the fix is to accept only the API server — but
+// the API server presents a certificate only when the cluster is configured for
+// it (an AdmissionConfiguration with a kubeConfigFile), which is not universal
+// across the variants this ships on. Switching straight to
+// RequireAndVerifyClientCert on a cluster that sends nothing would fail every
+// admission call, and this webhook is registered failurePolicy: Fail — so pod
+// creation would stop cluster-wide. Observe first, enforce second.
+func logClientCert(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := "<none>"
+		if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+			key = r.TLS.PeerCertificates[0].Issuer.String()
+		}
+		if _, loaded := seenClientIssuers.LoadOrStore(key, struct{}{}); !loaded {
+			if key == "<none>" {
+				log.Printf("client certificate: none presented — client-ca-file enforcement is NOT yet safe on this cluster")
+			} else {
+				log.Printf("client certificate: presented, issuer %q — enforcement can be enabled with --client-ca-file for this CA", key)
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 func main() {
 	var (
-		tlsCertFile string
-		tlsKeyFile  string
+		tlsCertFile  string
+		tlsKeyFile   string
+		clientCAFile string
 	)
 
 	flag.StringVar(&tlsCertFile, "tls-cert-file", "/etc/webhook/certs/tls.crt", "TLS certificate file.")
 	flag.StringVar(&tlsKeyFile, "tls-key-file", "/etc/webhook/certs/tls.key", "TLS key file.")
+	flag.StringVar(&clientCAFile, "client-ca-file", "", "CA bundle for verifying client certificates. When set, callers MUST present a certificate signed by it; when empty, certificates are requested and logged but not required.")
 	flag.BoolVar(&PortSecurityGlobal, "port-security", true, "If false, skip adding port_security unless specified by the Namespace.")
 	flag.StringVar(&RoutesGlobal, "routes", "", "Default ovn.kubernetes.io/routes if not in Namespace.")
 
@@ -33,10 +73,31 @@ func main() {
 		log.Fatalf("Failed to load key pair: %v", err)
 	}
 
+	// Default: ask for a client certificate, accept the connection either way.
+	// This never rejects a caller, so it cannot break admission; it only makes
+	// the certificate visible to logClientCert.
+	tlsConfig.ClientAuth = tls.RequestClientCert
+
+	if clientCAFile != "" {
+		clientCAPool := x509.NewCertPool()
+		clientCAData, err := os.ReadFile(clientCAFile)
+		if err != nil {
+			log.Fatalf("Failed to read client CA file: %v", err)
+		}
+		if !clientCAPool.AppendCertsFromPEM(clientCAData) {
+			log.Fatalf("Failed to parse client CA certificate")
+		}
+		tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+		tlsConfig.ClientCAs = clientCAPool
+		log.Printf("mTLS enabled: requiring client certificates signed by %s", clientCAFile)
+	} else {
+		log.Printf("mTLS not enforced (--client-ca-file empty): client certificates are requested and logged only")
+	}
+
 	server := &http.Server{
 		Addr:              ":8443",
 		TLSConfig:         tlsConfig,
-		Handler:           mux,
+		Handler:           logClientCert(mux),
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
 		WriteTimeout:      30 * time.Second,

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/observation_test.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/observation_test.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// captureLog redirects the standard logger for the duration of fn and returns
+// what was written.
+func captureLog(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf strings.Builder
+	flags := log.Flags()
+	out := log.Writer()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(out)
+		log.SetFlags(flags)
+	}()
+	fn()
+	return buf.String()
+}
+
+// resetObservations clears the package-level limiters between cases.
+func resetObservations() {
+	noCertObservations = observationLimiter{}
+	withCertObservations = observationLimiter{}
+}
+
+func TestObservationLimiterAllowsFirstThenRateLimits(t *testing.T) {
+	var l observationLimiter
+	base := time.Now()
+
+	if !l.allow(base) {
+		t.Fatal("first observation must always be logged")
+	}
+	if l.allow(base.Add(observationInterval - time.Nanosecond)) {
+		t.Error("a second observation inside the interval must be suppressed")
+	}
+	if !l.allow(base.Add(observationInterval)) {
+		t.Error("an observation at the interval boundary must be logged again")
+	}
+}
+
+// A burst of fabricated issuers is the attack the rate limiter exists to
+// survive: it may cost the current interval, but it must not suppress
+// observation permanently the way a first-come set of issuers would.
+func TestObservationSurvivesBurstOfFabricatedIssuers(t *testing.T) {
+	var l observationLimiter
+	base := time.Now()
+
+	for i := 0; i < 1000; i++ {
+		l.allow(base)
+	}
+	if !l.allow(base.Add(observationInterval)) {
+		t.Error("observation must resume after the interval, whatever the burst")
+	}
+}
+
+func TestObservationLimiterIsConcurrencySafe(t *testing.T) {
+	var l observationLimiter
+	now := time.Now()
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	allowed := 0
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if l.allow(now) {
+				mu.Lock()
+				allowed++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if allowed != 1 {
+		t.Errorf("exactly one concurrent observation may pass at a fixed instant, got %d", allowed)
+	}
+}
+
+// request builds a request carrying either no peer certificate or one issued by
+// the named issuer.
+func request(issuer string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/mutate-pods", nil)
+	r.RemoteAddr = "10.0.0.7:34512"
+	if issuer != "" {
+		r.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{
+			{Issuer: pkix.Name{CommonName: issuer}},
+		}}
+	}
+	return r
+}
+
+func TestLogClientCertNoCertificate(t *testing.T) {
+	resetObservations()
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+
+	out := captureLog(t, func() {
+		logClientCert(false, next).ServeHTTP(httptest.NewRecorder(), request(""))
+	})
+
+	if !strings.Contains(out, "none presented") {
+		t.Errorf("a certless caller must be reported, got %q", out)
+	}
+	if !strings.Contains(out, "10.0.0.7:34512") {
+		t.Errorf("the peer address must be logged so the caller can be attributed, got %q", out)
+	}
+}
+
+func TestLogClientCertUnverifiedWhenNotEnforcing(t *testing.T) {
+	resetObservations()
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+
+	out := captureLog(t, func() {
+		logClientCert(false, next).ServeHTTP(httptest.NewRecorder(), request("some-ca"))
+	})
+
+	if !strings.Contains(out, "UNVERIFIED") {
+		t.Errorf("without enforcement the issuer is a claim and must be marked unverified, got %q", out)
+	}
+	if !strings.Contains(out, "some-ca") {
+		t.Errorf("the issuer must appear in the log, got %q", out)
+	}
+}
+
+func TestLogClientCertVerifiedWhenEnforcing(t *testing.T) {
+	resetObservations()
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+
+	out := captureLog(t, func() {
+		logClientCert(true, next).ServeHTTP(httptest.NewRecorder(), request("some-ca"))
+	})
+
+	if strings.Contains(out, "UNVERIFIED") {
+		t.Errorf("with enforcement on the handshake has verified the chain; the warning is wrong, got %q", out)
+	}
+	if !strings.Contains(out, "verified against --client-ca-file") {
+		t.Errorf("the log should say the certificate was verified, got %q", out)
+	}
+}
+
+// The two outcomes are limited separately, so a caller flooding one branch
+// cannot hide the other. That pairing is what decides whether enforcement is
+// safe, so losing either half would defeat the observation.
+func TestLogClientCertBranchesAreLimitedIndependently(t *testing.T) {
+	resetObservations()
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})
+	h := logClientCert(false, next)
+
+	out := captureLog(t, func() {
+		for i := 0; i < 20; i++ {
+			h.ServeHTTP(httptest.NewRecorder(), request("flooding-ca"))
+		}
+		h.ServeHTTP(httptest.NewRecorder(), request(""))
+	})
+
+	// "none presented by ..." also contains "presented by", so key on the
+	// issuer field, which only the certificate branch emits.
+	if strings.Count(out, ", issuer ") != 1 {
+		t.Errorf("the flooded branch must be rate limited to one line, got %q", out)
+	}
+	if !strings.Contains(out, "none presented") {
+		t.Errorf("the other branch must still be reported despite the flood, got %q", out)
+	}
+}
+
+// The handler is observation only: it must never interfere with admission.
+func TestLogClientCertAlwaysCallsNext(t *testing.T) {
+	resetObservations()
+	called := 0
+	next := http.HandlerFunc(func(http.ResponseWriter, *http.Request) { called++ })
+	h := logClientCert(false, next)
+
+	captureLog(t, func() {
+		h.ServeHTTP(httptest.NewRecorder(), request(""))
+		h.ServeHTTP(httptest.NewRecorder(), request("some-ca"))
+		h.ServeHTTP(httptest.NewRecorder(), request("some-ca"))
+	})
+
+	if called != 3 {
+		t.Errorf("every request must reach the handler regardless of logging, got %d of 3", called)
+	}
+}

--- a/packages/system/kubeovn-webhook/templates/deployment.yaml
+++ b/packages/system/kubeovn-webhook/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
             - "--tls-key-file=/etc/webhook/certs/tls.key"
             - "--port-security={{ .Values.portSecurity }}"
             - "--routes={{ .Values.routes }}"
+            {{- with .Values.clientCAFile }}
+            - "--client-ca-file={{ . }}"
+            {{- end }}
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/packages/system/kubeovn-webhook/values.yaml
+++ b/packages/system/kubeovn-webhook/values.yaml
@@ -14,11 +14,16 @@ routes: ""
 #   "client certificate: presented, issuer ..."  → enforcement is possible
 #   "client certificate: none presented"         → it is not, yet
 #
-# Set it to the in-pod path of a CA bundle to switch to
-# RequireAndVerifyClientCert. Do this ONLY after the log confirms the API
-# server presents a certificate: this webhook is registered with
-# failurePolicy: Fail, so rejecting the API server stops pod creation
-# cluster-wide. The API server sends a certificate only when the cluster runs
-# with an AdmissionConfiguration that names a kubeConfigFile for this webhook.
+# Leave it empty. There is nothing to point it at yet: the pod mounts only its
+# own serving secret at /etc/webhook/certs, and the ca.crt in there is this
+# webhook's serving CA, not the API server's client CA. A path that does not
+# exist aborts startup; that ca.crt starts cleanly and then rejects every
+# API-server handshake. Either way this webhook is registered with
+# failurePolicy: Fail, so pod creation stops cluster-wide.
+#
+# Enabling enforcement is the second step, and it lands as one change: a volume
+# carrying the API server's client CA, a pool that reloads when that CA rotates,
+# and this key pointed at the mounted path. Until then the flag exists so the
+# observation above can run, not so it can be switched on.
 clientCAFile: ""
 image: ghcr.io/cozystack/cozystack/kubeovn-webhook:v1.6.0@sha256:593c324a38db59495497c5b68b90cad25dfe6753c73b7a287b3280e26f70a15f

--- a/packages/system/kubeovn-webhook/values.yaml
+++ b/packages/system/kubeovn-webhook/values.yaml
@@ -1,3 +1,24 @@
 portSecurity: true
 routes: ""
+# Client-certificate verification for callers of the /mutate-pods endpoint.
+#
+# The handler returns namespace-derived annotations to whoever asks it, so the
+# only thing that keeps it from answering an arbitrary in-cluster pod is
+# authenticating the caller (GHSA-g883-q79m-8225). NetworkPolicy is not an
+# option here: packages/system/kubeovn/values.yaml sets ENABLE_NP: false, so
+# kube-ovn-controller programs no ACLs and a NetworkPolicy object would be
+# created and never enforced.
+#
+# Empty (the default) = certificates are requested and logged, never required.
+# Nothing is rejected, so this cannot break admission. Read the webhook log:
+#   "client certificate: presented, issuer ..."  → enforcement is possible
+#   "client certificate: none presented"         → it is not, yet
+#
+# Set it to the in-pod path of a CA bundle to switch to
+# RequireAndVerifyClientCert. Do this ONLY after the log confirms the API
+# server presents a certificate: this webhook is registered with
+# failurePolicy: Fail, so rejecting the API server stops pod creation
+# cluster-wide. The API server sends a certificate only when the cluster runs
+# with an AdmissionConfiguration that names a kubeConfigFile for this webhook.
+clientCAFile: ""
 image: ghcr.io/cozystack/cozystack/kubeovn-webhook:v1.6.0@sha256:593c324a38db59495497c5b68b90cad25dfe6753c73b7a287b3280e26f70a15f


### PR DESCRIPTION
## What this PR does

Adds client-certificate verification to the kube-ovn webhook, and turns it on only when an operator supplies a CA bundle.

`--client-ca-file` is new and empty by default. With it empty the server sets `tls.RequestClientCert`: it asks callers for a certificate, records the issuer of whatever arrives, and serves the request either way. Set the flag and the server switches to `tls.RequireAndVerifyClientCert`, so a caller without a certificate signed by that CA is refused at the TLS handshake.

**This is step one of two, and on its own it does not close [GHSA-g883-q79m-8225](https://github.com/cozystack/cozystack/security/advisories/GHSA-g883-q79m-8225).** With the default empty value nothing is rejected — the webhook still answers an unauthenticated caller, and the only change is that the caller's issuer now appears in the logs. That is deliberate: switching straight to `RequireAndVerifyClientCert` would break every cluster whose API server sends no client certificate, and there is no way to know from here which those are. The logs are how we find out.

Step two, in a follow-up: read a day of issuer logs on a Talos cluster and on `isp-full-generic`, confirm the API server presents a certificate we can pin, then set the CA bundle so verification becomes mandatory. The advisory should be published as fixed only after that lands — not with this PR.

An earlier revision also carried a NetworkPolicy restricting ingress to `kube-system`. It was dropped, and the title has been corrected to match; only the TLS path is left here.

### Screenshots

N/A — no user-facing or UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

Walked the trigger map against the diff: no row matches. The change touches one system package and the Go image it builds — no app package, no `values.schema.json`, no `ApplicationDefinition`, no platform variant, no node prerequisite.

### Release note

```release-note
feat(kubeovn-webhook): the webhook now accepts --client-ca-file. Left empty (the default) it requests and logs client certificates without requiring them; set to a CA bundle it rejects callers that do not present a certificate signed by that CA.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional client-certificate verification for the pod mutation webhook through configurable CA settings.
  * Added separate rate limits for requests with and without client certificates.
  * Added remote-address logging and clearer verification status reporting.
* **Security**
  * Requests continue to be forwarded while certificate observations are recorded when verification is disabled.
  * Serving-certificate updates remain supported; client CA changes require a webhook restart.
* **Documentation**
  * Documented client CA configuration and current certificate rotation limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->