### PR TITLE
fix(info): use root-host for Keycloak OIDC issuer URL in tenant kubeconfig

### DIFF
--- a/packages/extra/info/templates/kubeconfig.yaml
+++ b/packages/extra/info/templates/kubeconfig.yaml
@@ -1,4 +1,4 @@
-{{- $host := .Values._namespace.host | default (index .Values._cluster "root-host") }}
+{{- $host := index .Values._cluster "root-host" }}
 {{- $oidcEnabled := index .Values._cluster "oidc-enabled" }}
 {{- if $oidcEnabled }}
 {{-   $apiServerEndpoint := index .Values._cluster "api-server-endpoint" }}
@@ -7,12 +7,6 @@
 {{-     $apiServerEndpoint = $managementKubeconfigEndpoint }}
 {{-   end }}
 {{-   $k8sCa := index .Values._cluster "kube-root-ca" }}
-{{-   if .Capabilities.APIVersions.Has "helm.toolkit.fluxcd.io/v2" }}
-{{-     $tenantRoot := lookup "helm.toolkit.fluxcd.io/v2" "HelmRelease" "tenant-root" "tenant-root" }}
-{{-     if and $tenantRoot $tenantRoot.spec $tenantRoot.spec.values $tenantRoot.spec.values.host }}
-{{-       $host = $tenantRoot.spec.values.host }}
-{{-     end }}
-{{-   end }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
## What this PR does

The kubeconfig generated by the `info` package for non-root tenants pointed `--oidc-issuer-url` at `keycloak.<TENANT>.<ROOT-DOMAIN>`, but Keycloak's ingress and cert live at `keycloak.<ROOT-DOMAIN>` (built from `_cluster.root-host`). `kubectl oidc-login` then failed TLS verification against the nginx-ingress default fake cert, so the auto-generated kubeconfig was unusable for any non-root tenant.

`$host` was being sourced from `_namespace.host` (tenant-specific subdomain) with a lookup-based override that tried to read `tenant-root`'s `spec.values.host`. That override has been dead since #1787 migrated `tenant-root` to `valuesFrom` (Secret-backed) — `spec.values` is now always empty, so the override never fires.

Source `$host` from `_cluster.root-host` directly, matching what `packages/system/dashboard/templates/gatekeeper.yaml` already does for the same Keycloak realm.

Verified with `helm template tenant1 packages/extra/info -n tenant-tenant1 --set-string _namespace.host=tenant1.example.org --set-string _cluster.root-host=example.org ...` — issuer URL is now `https://keycloak.example.org/realms/cozy` regardless of the per-namespace host.

### Release note

```release-note
fix(info): use root-host for the Keycloak OIDC issuer URL in tenant kubeconfigs so `kubectl oidc-login` succeeds against the real Keycloak cert on non-root tenants
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated kubeconfig generation to consolidate host configuration handling, now using a single authoritative source instead of multiple fallback mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->