### PR TITLE
ci(tags): include data/versions in website docs commit

### DIFF
--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -534,7 +534,7 @@ jobs:
         run: |
           git config user.name  "cozystack-ci[bot]"
           git config user.email "274107086+cozystack-ci[bot]@users.noreply.github.com"
-          git add content hugo.yaml
+          git add content hugo.yaml data/versions
           if git diff --cached --quiet; then
             echo "No changes to commit"
             echo "changed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## What this PR does

The `update-website-docs` job in `tags.yaml` runs `make release-next` (on new minor/major releases) and `make update-all` against `cozystack/website`. Both paths can create a new `data/versions/<DOC_VERSION>.yaml`:

- `release_next.sh` snapshots `data/versions/next.yaml → data/versions/vX.Y.yaml` at release time so the released docs freeze on the pins that were true at the cut.
- `init_version.sh` (invoked by `update-all → init-version`) seeds the same file from the source version when a target version directory doesn't yet exist.

The job's commit step staged only `content hugo.yaml`, so the new versions file was silently dropped from the website PR — leaving `{{< version-pin >}}` shortcodes in the released docs without a data file to resolve against.

This adds `data/versions` to `git add` so the snapshot lands in the same commit as the rest of the release-time docs update.

### Release note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation versioning management in the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->