### PR TITLE
fix(cluster-api): fix kamaji OOM and set limits on unset providers

### DIFF
--- a/packages/system/capi-providers-bootstrap/templates/providers.yaml
+++ b/packages/system/capi-providers-bootstrap/templates/providers.yaml
@@ -9,3 +9,13 @@ spec:
     selector:
       matchLabels:
         bootstrap-components: cozy
+  deployment:
+    containers:
+    - name: manager
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 10m
+          memory: 64Mi

--- a/packages/system/capi-providers-core/templates/providers.yaml
+++ b/packages/system/capi-providers-core/templates/providers.yaml
@@ -10,3 +10,13 @@ spec:
     selector:
       matchLabels:
         core-components: cozy
+  deployment:
+    containers:
+    - name: manager
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 10m
+          memory: 64Mi

--- a/packages/system/capi-providers-cpprovider/templates/providers.yaml
+++ b/packages/system/capi-providers-cpprovider/templates/providers.yaml
@@ -11,7 +11,7 @@ spec:
         cp-components: cozy
   deployment:
     containers:
-    - name: manager
+    - name: controller
       resources:
         limits:
           cpu: "1"

--- a/packages/system/capi-providers-infraprovider/templates/providers.yaml
+++ b/packages/system/capi-providers-infraprovider/templates/providers.yaml
@@ -9,3 +9,13 @@ spec:
     selector:
       matchLabels:
         infraprovider-components: cozy
+  deployment:
+    containers:
+    - name: manager
+      resources:
+        limits:
+          cpu: 500m
+          memory: 256Mi
+        requests:
+          cpu: 10m
+          memory: 64Mi


### PR DESCRIPTION
## What this PR does

Fixes resource specs on CAPI provider pods in `cozy-cluster-api`.

**Kamaji control-plane-provider — fix OOMKilled crashloop.**
The override in `packages/system/capi-providers-cpprovider/templates/providers.yaml` targeted `containers[name=manager]`, but the upstream container in `docker.io/clastix/cluster-api-control-plane-provider-kamaji` is named `controller`. The CAPI operator merges container overrides by container name, so the intended `cpu: 1 / memory: 1024Mi` limits were silently dropped and the upstream default of `memory: 128Mi` was used. The kamaji controller pod therefore restarts repeatedly with `exit code 137` (OOMKilled), even at idle.

**Core / bootstrap / kubevirt providers — add limits.**
Upstream `*-components.yaml` for these three providers ships with no `resources:` block, and cozystack added no override. The pods run BestEffort and are first to evict under memory pressure. Set modest limits (`500m / 256Mi`) and requests (`10m / 64Mi`) matching typical CAPI controller-manager footprint.

### Release note

```release-note
fix(cluster-api): fix the resource override for the kamaji control-plane-provider (was silently ignored due to a wrong container name, causing OOMKilled restarts) and set requests/limits for the core, kubeadm-bootstrap, and kubevirt-infrastructure providers (were running BestEffort).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated provider deployment configurations to establish resource management parameters (CPU/memory requests and limits) for container deployments across multiple provider types, improving scheduling optimization and resource predictability
  * Standardized container naming conventions in provider templates for consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->