### PR TITLE
refactor(build): standardize image tagging to fix concurrent PR push conflicts

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -70,6 +70,12 @@ jobs:
         run: make build
         env:
           DOCKER_CONFIG: ${{ runner.temp }}/.docker
+          # Unique per (PR, commit) so concurrent PR builds never push the same
+          # tag. PUBLISH_VERSIONED/PUBLISH_FLOATING stay off — PR images are
+          # consumed by digest, and :latest belongs to release builds.
+          IMAGE_TAG: pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          PUBLISH_VERSIONED: '0'
+          PUBLISH_FLOATING: '0'
 
       - name: Build Talos image
         run: make -C packages/core/talos talos-nocloud

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -118,6 +118,11 @@ jobs:
         run: make build
         env:
           DOCKER_CONFIG: ${{ runner.temp }}/.docker
+          # Release semantics: push the release tag as :IMAGE_TAG (vX.Y.Z),
+          # the component versions as :<component-ver>, and move :latest.
+          IMAGE_TAG: ${{ github.ref_name }}
+          PUBLISH_VERSIONED: '1'
+          PUBLISH_FLOATING: '1'
 
       # Commit built artifacts
       - name: Commit release artifacts

--- a/hack/common-envs.mk
+++ b/hack/common-envs.mk
@@ -6,11 +6,25 @@ else
 endif
 
 REGISTRY ?= ghcr.io/cozystack/cozystack
-TAG = $(shell git describe --tags --exact-match --match 'v*' 2>/dev/null || echo latest)
+
+# IMAGE_TAG: build-unique tag pushed for every image. Set by CI to a value
+# that does not collide between concurrent builds:
+#   * pull-requests.yaml -> pr-<N>-<sha>
+#   * tags.yaml          -> <ref_name>           (e.g. v1.5.0)
+#   * local              -> dev                  (with PUSH=0 by default)
+IMAGE_TAG ?= dev
+
+# Opt-in extra tags. Workflows set these explicitly; defaults are off so a
+# local `make build` never races with CI or accidentally moves :latest.
+#   PUBLISH_VERSIONED=1 -> also push :<component-version> (release semantics)
+#   PUBLISH_FLOATING=1  -> also push :latest             (release/main only)
+PUBLISH_VERSIONED ?= 0
+PUBLISH_FLOATING  ?= 0
+
 PUSH := 1
 LOAD := 0
 BUILDER ?=
-PLATFORM ?= 
+PLATFORM ?=
 BUILDX_EXTRA_ARGS ?=
 COZYSTACK_VERSION = $(patsubst v%,%,$(shell git describe --tags --match 'v*'))
 
@@ -20,9 +34,16 @@ BUILDX_ARGS := --provenance=false --push=$(PUSH) --load=$(LOAD) \
   $(if $(strip $(PLATFORM)),--platform=$(PLATFORM)) \
   $(BUILDX_EXTRA_ARGS)
 
-# Returns 'latest' if the git tag is not assigned, otherwise returns the provided value
-define settag
-$(if $(filter $(TAG),latest),latest,$(1))
+# image-tags <repo> <versioned-tag>
+# Expands to one or more `--tag` flags for `docker buildx build`:
+#   - always:                 :$(IMAGE_TAG)        (build-unique handle)
+#   - if PUBLISH_VERSIONED=1: :<versioned-tag>     (skipped when arg2 is empty)
+#   - if PUBLISH_FLOATING=1:  :latest
+# Consumers reference images by digest, so the build-unique tag is enough
+# for cluster-side pulls; the versioned and floating tags exist for human
+# discoverability and downstream tooling on releases.
+define image-tags
+--tag $(REGISTRY)/$(1):$(IMAGE_TAG)$(if $(filter 1,$(PUBLISH_VERSIONED)),$(if $(strip $(2)), --tag $(REGISTRY)/$(1):$(strip $(2))))$(if $(filter 1,$(PUBLISH_FLOATING)), --tag $(REGISTRY)/$(1):latest)
 endef
 
 ifeq ($(COZYSTACK_VERSION),)
@@ -30,4 +51,3 @@ ifeq ($(COZYSTACK_VERSION),)
     $(shell git fetch upstream --tags)
     COZYSTACK_VERSION = $(patsubst v%,%,$(shell git describe --tags --match 'v*'))
 endif
-

--- a/hack/common-envs.mk
+++ b/hack/common-envs.mk
@@ -37,13 +37,14 @@ BUILDX_ARGS := --provenance=false --push=$(PUSH) --load=$(LOAD) \
 # image-tags <repo> <versioned-tag>
 # Expands to one or more `--tag` flags for `docker buildx build`:
 #   - always:                 :$(IMAGE_TAG)        (build-unique handle)
-#   - if PUBLISH_VERSIONED=1: :<versioned-tag>     (skipped when arg2 is empty)
+#   - if PUBLISH_VERSIONED=1: :<versioned-tag>     (skipped when arg2 is empty
+#                                                  or equals IMAGE_TAG)
 #   - if PUBLISH_FLOATING=1:  :latest
 # Consumers reference images by digest, so the build-unique tag is enough
 # for cluster-side pulls; the versioned and floating tags exist for human
 # discoverability and downstream tooling on releases.
 define image-tags
---tag $(REGISTRY)/$(1):$(IMAGE_TAG)$(if $(filter 1,$(PUBLISH_VERSIONED)),$(if $(strip $(2)), --tag $(REGISTRY)/$(1):$(strip $(2))))$(if $(filter 1,$(PUBLISH_FLOATING)), --tag $(REGISTRY)/$(1):latest)
+--tag $(REGISTRY)/$(1):$(IMAGE_TAG)$(if $(filter 1,$(PUBLISH_VERSIONED)),$(if $(filter-out $(IMAGE_TAG),$(strip $(2))), --tag $(REGISTRY)/$(1):$(strip $(2))))$(if $(filter 1,$(PUBLISH_FLOATING)), --tag $(REGISTRY)/$(1):latest)
 endef
 
 ifeq ($(COZYSTACK_VERSION),)

--- a/packages/apps/clickhouse/Makefile
+++ b/packages/apps/clickhouse/Makefile
@@ -12,20 +12,20 @@ test:
 
 image:
 	docker buildx build images/clickhouse-backup \
-		--tag $(REGISTRY)/clickhouse-backup:$(call settag,$(CLICKHOUSE_BACKUP_TAG)) \
+		$(call image-tags,clickhouse-backup,$(CLICKHOUSE_BACKUP_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/clickhouse-backup:latest \
 		--cache-to type=inline \
 		--metadata-file images/clickhouse-backup.json \
 		$(BUILDX_ARGS)
-	echo "$(REGISTRY)/clickhouse-backup:$(call settag,$(CLICKHOUSE_BACKUP_TAG))@$$(yq e '."containerimage.digest"' images/clickhouse-backup.json -o json -r)" \
+	echo "$(REGISTRY)/clickhouse-backup:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/clickhouse-backup.json -o json -r)" \
 		> images/clickhouse-backup.tag
 	rm -f images/clickhouse-backup.json
 	docker buildx build images/altinity-clickhouse-backup \
-		--tag $(REGISTRY)/altinity-clickhouse-backup:$(call settag,$(CLICKHOUSE_BACKUP_TAG)) \
+		$(call image-tags,altinity-clickhouse-backup,$(CLICKHOUSE_BACKUP_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/altinity-clickhouse-backup:latest \
 		--cache-to type=inline \
 		--metadata-file images/altinity-clickhouse-backup.json \
 		$(BUILDX_ARGS)
-	echo "$(REGISTRY)/altinity-clickhouse-backup:$(call settag,$(CLICKHOUSE_BACKUP_TAG))@$$(yq e '."containerimage.digest"' images/altinity-clickhouse-backup.json -o json -r)" \
+	echo "$(REGISTRY)/altinity-clickhouse-backup:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/altinity-clickhouse-backup.json -o json -r)" \
 		> images/altinity-clickhouse-backup.tag
 	rm -f images/altinity-clickhouse-backup.json

--- a/packages/apps/http-cache/Makefile
+++ b/packages/apps/http-cache/Makefile
@@ -7,12 +7,12 @@ image: image-nginx
 
 image-nginx:
 	docker buildx build images/nginx-cache \
-		--tag $(REGISTRY)/nginx-cache:$(call settag,$(NGINX_CACHE_TAG)) \
+		$(call image-tags,nginx-cache,$(NGINX_CACHE_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/nginx-cache:latest \
 		--cache-to type=inline \
 		--metadata-file images/nginx-cache.json \
 		$(BUILDX_ARGS)
-	echo "$(REGISTRY)/nginx-cache:$(call settag,$(NGINX_CACHE_TAG))@$$(yq e '."containerimage.digest"' images/nginx-cache.json -o json -r)" \
+	echo "$(REGISTRY)/nginx-cache:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/nginx-cache.json -o json -r)" \
 		> images/nginx-cache.tag
 	rm -f images/nginx-cache.json
 

--- a/packages/apps/kubernetes/Makefile
+++ b/packages/apps/kubernetes/Makefile
@@ -23,38 +23,36 @@ image-ubuntu-container-disk:
 	$(foreach ver,$(KUBERNETES_VERSIONS), \
 		docker buildx build images/ubuntu-container-disk \
 			--build-arg KUBERNETES_VERSION=$(ver) \
-			--tag $(REGISTRY)/ubuntu-container-disk:$(call settag,$(ver)) \
-			--tag $(REGISTRY)/ubuntu-container-disk:$(call settag,$(ver)-$(TAG)) \
-			--cache-from type=registry,ref=$(REGISTRY)/ubuntu-container-disk:$(call settag,$(ver)) \
+			--tag $(REGISTRY)/ubuntu-container-disk:$(ver)-$(IMAGE_TAG) \
+			$(if $(filter 1,$(PUBLISH_VERSIONED)),--tag $(REGISTRY)/ubuntu-container-disk:$(ver)) \
+			--cache-from type=registry,ref=$(REGISTRY)/ubuntu-container-disk:$(ver) \
 			--cache-to type=inline \
 			--metadata-file images/ubuntu-container-disk-$(ver).json \
 			$(BUILDX_ARGS) && \
-		echo "$(REGISTRY)/ubuntu-container-disk:$(call settag,$(ver))@$$(yq e '."containerimage.digest"' images/ubuntu-container-disk-$(ver).json -o json -r)" \
+		echo "$(REGISTRY)/ubuntu-container-disk:$(ver)-$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/ubuntu-container-disk-$(ver).json -o json -r)" \
 			> images/ubuntu-container-disk-$(ver).tag && \
 		rm -f images/ubuntu-container-disk-$(ver).json; \
 	)
 
 image-kubevirt-cloud-provider:
 	docker buildx build images/kubevirt-cloud-provider \
-		--tag $(REGISTRY)/kubevirt-cloud-provider:$(call settag,$(KUBERNETES_PKG_TAG)) \
-		--tag $(REGISTRY)/kubevirt-cloud-provider:$(call settag,$(KUBERNETES_PKG_TAG)-$(TAG)) \
+		$(call image-tags,kubevirt-cloud-provider,$(KUBERNETES_PKG_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/kubevirt-cloud-provider:latest \
 		--cache-to type=inline \
 		--metadata-file images/kubevirt-cloud-provider.json \
 		$(BUILDX_ARGS)
-	echo "$(REGISTRY)/kubevirt-cloud-provider:$(call settag,$(KUBERNETES_PKG_TAG))@$$(yq e '."containerimage.digest"' images/kubevirt-cloud-provider.json -o json -r)" \
+	echo "$(REGISTRY)/kubevirt-cloud-provider:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/kubevirt-cloud-provider.json -o json -r)" \
 		> images/kubevirt-cloud-provider.tag
 	rm -f images/kubevirt-cloud-provider.json
 
 image-kubevirt-csi-driver:
 	docker buildx build images/kubevirt-csi-driver \
-		--tag $(REGISTRY)/kubevirt-csi-driver:$(call settag,$(KUBERNETES_PKG_TAG)) \
-		--tag $(REGISTRY)/kubevirt-csi-driver:$(call settag,$(KUBERNETES_PKG_TAG)-$(TAG)) \
+		$(call image-tags,kubevirt-csi-driver,$(KUBERNETES_PKG_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/kubevirt-csi-driver:latest \
 		--cache-to type=inline \
 		--metadata-file images/kubevirt-csi-driver.json \
 		$(BUILDX_ARGS)
-	echo "$(REGISTRY)/kubevirt-csi-driver:$(call settag,$(KUBERNETES_PKG_TAG))@$$(yq e '."containerimage.digest"' images/kubevirt-csi-driver.json -o json -r)" \
+	echo "$(REGISTRY)/kubevirt-csi-driver:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/kubevirt-csi-driver.json -o json -r)" \
 		> images/kubevirt-csi-driver.tag
 	IMAGE=$$(cat images/kubevirt-csi-driver.tag) \
 		yq -i '.csiDriver.image = strenv(IMAGE)' ../../system/kubevirt-csi-node/values.yaml
@@ -63,13 +61,12 @@ image-kubevirt-csi-driver:
 
 image-cluster-autoscaler:
 	docker buildx build images/cluster-autoscaler \
-		--tag $(REGISTRY)/cluster-autoscaler:$(call settag,$(KUBERNETES_PKG_TAG)) \
-		--tag $(REGISTRY)/cluster-autoscaler:$(call settag,$(KUBERNETES_PKG_TAG)-$(TAG)) \
+		$(call image-tags,cluster-autoscaler,$(KUBERNETES_PKG_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/cluster-autoscaler:latest \
 		--cache-to type=inline \
 		--metadata-file images/cluster-autoscaler.json \
 		$(BUILDX_ARGS)
-	echo "$(REGISTRY)/cluster-autoscaler:$(call settag,$(KUBERNETES_PKG_TAG))@$$(yq e '."containerimage.digest"' images/cluster-autoscaler.json -o json -r)" \
+	echo "$(REGISTRY)/cluster-autoscaler:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/cluster-autoscaler.json -o json -r)" \
 		> images/cluster-autoscaler.tag
 	rm -f images/cluster-autoscaler.json
 

--- a/packages/apps/mariadb/Makefile
+++ b/packages/apps/mariadb/Makefile
@@ -13,11 +13,11 @@ update:
 
 image:
 	docker buildx build images/mariadb-backup \
-		--tag $(REGISTRY)/mariadb-backup:$(call settag,$(MARIADB_BACKUP_TAG)) \
+		$(call image-tags,mariadb-backup,$(MARIADB_BACKUP_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/mariadb-backup:latest \
 		--cache-to type=inline \
 		--metadata-file images/mariadb-backup.json \
 		$(BUILDX_ARGS)
-	echo "$(REGISTRY)/mariadb-backup:$(call settag,$(MARIADB_BACKUP_TAG))@$$(yq e '."containerimage.digest"' images/mariadb-backup.json -o json -r)" \
+	echo "$(REGISTRY)/mariadb-backup:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/mariadb-backup.json -o json -r)" \
 		> images/mariadb-backup.tag
 	rm -f images/mariadb-backup.json

--- a/packages/core/installer/Makefile
+++ b/packages/core/installer/Makefile
@@ -19,13 +19,13 @@ image: pre-checks image-operator image-packages chart
 
 image-operator:
 	docker buildx build -f images/cozystack-operator/Dockerfile ../../.. \
-		--tag $(REGISTRY)/cozystack-operator:$(call settag,$(TAG)) \
-		--build-arg VERSION=$(call settag,$(TAG)) \
+		$(call image-tags,cozystack-operator,v$(COZYSTACK_VERSION)) \
+		--build-arg VERSION=v$(COZYSTACK_VERSION) \
 		--cache-from type=registry,ref=$(REGISTRY)/cozystack-operator:latest \
 		--cache-to type=inline \
 		--metadata-file images/cozystack-operator.json \
 		$(BUILDX_ARGS)
-	IMAGE="$(REGISTRY)/cozystack-operator:$(call settag,$(TAG))@$$(yq -e '.["containerimage.digest"]' images/cozystack-operator.json -o json -r)" \
+	IMAGE="$(REGISTRY)/cozystack-operator:$(IMAGE_TAG)@$$(yq -e '.["containerimage.digest"]' images/cozystack-operator.json -o json -r)" \
 		yq -i '.cozystackOperator.image = strenv(IMAGE)' values.yaml
 	rm -f images/cozystack-operator.json
 
@@ -33,7 +33,7 @@ image-packages:
 	mkdir -p ../../../_out/assets images
 	echo $$(git rev-parse HEAD; git diff HEAD; git ls-files --others --exclude-standard) | shasum -a 256 > ../platform/.build-revision
 	flux push artifact \
-		oci://$(REGISTRY)/cozystack-packages:$(call settag,$(TAG)) \
+		oci://$(REGISTRY)/cozystack-packages:$(IMAGE_TAG) \
 		--path=../../../packages \
 		--source=https://github.com/cozystack/cozystack \
 		--revision="$$(git describe --tags):$$(git rev-parse HEAD)" \

--- a/packages/core/platform/Makefile
+++ b/packages/core/platform/Makefile
@@ -18,11 +18,11 @@ image: image-migrations
 
 image-migrations:
 	docker buildx build images/migrations \
-		--tag $(REGISTRY)/platform-migrations:$(call settag,$(TAG)) \
+		$(call image-tags,platform-migrations,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/platform-migrations:latest \
 		--cache-to type=inline \
 		--metadata-file images/migrations.json \
 		$(BUILDX_ARGS)
-	IMAGE="$(REGISTRY)/platform-migrations:$(call settag,$(TAG))@$$(yq -e -o json -r '.["containerimage.digest"]' images/migrations.json)" \
+	IMAGE="$(REGISTRY)/platform-migrations:$(IMAGE_TAG)@$$(yq -e -o json -r '.["containerimage.digest"]' images/migrations.json)" \
 		yq --inplace '.migrations.image = strenv(IMAGE)' values.yaml
 	rm -f images/migrations.json

--- a/packages/core/talos/Makefile
+++ b/packages/core/talos/Makefile
@@ -12,10 +12,11 @@ image: image-matchbox image-talos
 
 image-talos:
 	test -f ../../../_out/assets/installer-amd64.tar || make talos-installer
+	set -e; \
 	SRC=docker-archive:../../../_out/assets/installer-amd64.tar; \
-	skopeo copy $$SRC docker://$(REGISTRY)/talos:$(IMAGE_TAG); \
-	if [ "$(PUBLISH_VERSIONED)" = "1" ]; then skopeo copy $$SRC docker://$(REGISTRY)/talos:$(TALOS_VERSION); fi; \
-	if [ "$(PUBLISH_FLOATING)" = "1" ]; then skopeo copy $$SRC docker://$(REGISTRY)/talos:latest; fi
+	skopeo copy "$$SRC" docker://$(REGISTRY)/talos:$(IMAGE_TAG); \
+	if [ "$(PUBLISH_VERSIONED)" = "1" ]; then skopeo copy "$$SRC" docker://$(REGISTRY)/talos:$(TALOS_VERSION); fi; \
+	if [ "$(PUBLISH_FLOATING)" = "1" ]; then skopeo copy "$$SRC" docker://$(REGISTRY)/talos:latest; fi
 
 image-matchbox:
 	test -f ../../../_out/assets/kernel-amd64 || make talos-kernel

--- a/packages/core/talos/Makefile
+++ b/packages/core/talos/Makefile
@@ -12,19 +12,21 @@ image: image-matchbox image-talos
 
 image-talos:
 	test -f ../../../_out/assets/installer-amd64.tar || make talos-installer
-	skopeo copy docker-archive:../../../_out/assets/installer-amd64.tar docker://$(REGISTRY)/talos:$(call settag,$(TALOS_VERSION))
+	SRC=docker-archive:../../../_out/assets/installer-amd64.tar; \
+	skopeo copy $$SRC docker://$(REGISTRY)/talos:$(IMAGE_TAG); \
+	if [ "$(PUBLISH_VERSIONED)" = "1" ]; then skopeo copy $$SRC docker://$(REGISTRY)/talos:$(TALOS_VERSION); fi; \
+	if [ "$(PUBLISH_FLOATING)" = "1" ]; then skopeo copy $$SRC docker://$(REGISTRY)/talos:latest; fi
 
 image-matchbox:
 	test -f ../../../_out/assets/kernel-amd64 || make talos-kernel
 	test -f ../../../_out/assets/initramfs-metal-amd64.xz || make talos-initramfs
 	docker buildx build -f images/matchbox/Dockerfile ../../.. \
-		--tag $(REGISTRY)/matchbox:$(call settag,$(TAG)) \
-		--tag $(REGISTRY)/matchbox:$(call settag,$(TALOS_VERSION)-$(TAG)) \
+		$(call image-tags,matchbox,$(TALOS_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/matchbox:latest \
 		--cache-to type=inline \
 		--metadata-file images/matchbox.json \
 		$(BUILDX_ARGS)
-	echo "$(REGISTRY)/matchbox:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/matchbox.json -o json -r)" \
+	echo "$(REGISTRY)/matchbox:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/matchbox.json -o json -r)" \
 		> ../../extra/bootbox/images/matchbox.tag
 	rm -f images/matchbox.json
 

--- a/packages/core/testing/Makefile
+++ b/packages/core/testing/Makefile
@@ -16,12 +16,12 @@ image: image-e2e-sandbox
 
 image-e2e-sandbox:
 	docker buildx build -f images/e2e-sandbox/Dockerfile images/e2e-sandbox \
-		--tag $(REGISTRY)/e2e-sandbox:$(call settag,$(TAG)) \
+		$(call image-tags,e2e-sandbox,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/e2e-sandbox:latest \
 		--cache-to type=inline \
 		--metadata-file images/e2e-sandbox.json \
 		$(BUILDX_ARGS)
-	IMAGE="$(REGISTRY)/e2e-sandbox:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/e2e-sandbox.json -o json -r)" \
+	IMAGE="$(REGISTRY)/e2e-sandbox:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/e2e-sandbox.json -o json -r)" \
 		yq -i '.e2e.image = strenv(IMAGE)' values.yaml
 	rm -f images/e2e-sandbox.json
 

--- a/packages/extra/monitoring/Makefile
+++ b/packages/extra/monitoring/Makefile
@@ -11,11 +11,11 @@ generate:
 
 image:
 	docker buildx build images/grafana \
-		--tag $(REGISTRY)/grafana:$(call settag,$(GRAFANA_TAG)) \
+		$(call image-tags,grafana,$(GRAFANA_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/grafana:latest \
 		--cache-to type=inline \
 		--metadata-file images/grafana.json \
 		$(BUILDX_ARGS)
-	echo "$(REGISTRY)/grafana:$(call settag,$(GRAFANA_TAG))@$$(yq e '."containerimage.digest"' images/grafana.json -o json -r)" \
+	echo "$(REGISTRY)/grafana:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/grafana.json -o json -r)" \
 		> images/grafana.tag
 	rm -f images/grafana.json

--- a/packages/system/backup-controller/Makefile
+++ b/packages/system/backup-controller/Makefile
@@ -8,11 +8,11 @@ image: image-backup-controller
 
 image-backup-controller:
 	docker buildx build -f images/backup-controller/Dockerfile ../../.. \
-		--tag $(REGISTRY)/backup-controller:$(call settag,$(TAG)) \
+		$(call image-tags,backup-controller,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/backup-controller:latest \
 		--cache-to type=inline \
 		--metadata-file images/backup-controller.json \
 		$(BUILDX_ARGS)
-	IMAGE="$(REGISTRY)/backup-controller:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/backup-controller.json -o json -r)" \
+	IMAGE="$(REGISTRY)/backup-controller:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/backup-controller.json -o json -r)" \
 		yq -i '.backupController.image = strenv(IMAGE)' values.yaml
 	rm -f images/backup-controller.json

--- a/packages/system/backupstrategy-controller/Makefile
+++ b/packages/system/backupstrategy-controller/Makefile
@@ -8,11 +8,11 @@ image: image-backupstrategy-controller
 
 image-backupstrategy-controller:
 	docker buildx build -f images/backupstrategy-controller/Dockerfile ../../.. \
-		--tag $(REGISTRY)/backupstrategy-controller:$(call settag,$(TAG)) \
+		$(call image-tags,backupstrategy-controller,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/backupstrategy-controller:latest \
 		--cache-to type=inline \
 		--metadata-file images/backupstrategy-controller.json \
 		$(BUILDX_ARGS)
-	IMAGE="$(REGISTRY)/backupstrategy-controller:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/backupstrategy-controller.json -o json -r)" \
+	IMAGE="$(REGISTRY)/backupstrategy-controller:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/backupstrategy-controller.json -o json -r)" \
 		yq -i '.backupStrategyController.image = strenv(IMAGE)' values.yaml
 	rm -f images/backupstrategy-controller.json

--- a/packages/system/bucket/Makefile
+++ b/packages/system/bucket/Makefile
@@ -12,11 +12,11 @@ image: image-s3manager
 
 image-s3manager:
 	docker buildx build images/s3manager \
-		--tag $(REGISTRY)/s3manager:$(call settag,$(S3MANAGER_TAG)) \
+		$(call image-tags,s3manager,$(S3MANAGER_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/s3manager:latest \
 		--cache-to type=inline \
 		--metadata-file images/s3manager.json \
 		$(BUILDX_ARGS)
-	echo "$(REGISTRY)/s3manager:$(call settag,$(S3MANAGER_TAG))@$$(yq e '."containerimage.digest"' images/s3manager.json -o json -r)" \
+	echo "$(REGISTRY)/s3manager:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/s3manager.json -o json -r)" \
 		> images/s3manager.tag
 	rm -f images/s3manager.json

--- a/packages/system/cilium/Makefile
+++ b/packages/system/cilium/Makefile
@@ -26,15 +26,14 @@ update:
 
 image:
 	docker buildx build images/cilium \
-		--tag $(REGISTRY)/cilium:$(call settag,$(CILIUM_TAG)) \
-		--tag $(REGISTRY)/cilium:$(call settag,$(CILIUM_TAG)-$(TAG)) \
+		$(call image-tags,cilium,$(CILIUM_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/cilium:latest \
 		--cache-to type=inline \
 		--metadata-file images/cilium.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/cilium" \
 		yq -i '.cilium.image.repository = strenv(REPOSITORY)' values.yaml
-	TAG=$(call settag,$(CILIUM_TAG)) \
+	TAG=$(IMAGE_TAG) \
 		yq -i '.cilium.image.tag = strenv(TAG)' values.yaml
 	DIGEST=$$(yq e '."containerimage.digest"' images/cilium.json -o json -r) \
 		yq -i '.cilium.image.digest = strenv(DIGEST)' values.yaml

--- a/packages/system/cozystack-api/Makefile
+++ b/packages/system/cozystack-api/Makefile
@@ -20,11 +20,11 @@ image: image-cozystack-api
 
 image-cozystack-api:
 	docker buildx build -f images/cozystack-api/Dockerfile ../../.. \
-		--tag $(REGISTRY)/cozystack-api:$(call settag,$(TAG)) \
+		$(call image-tags,cozystack-api,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/cozystack-api:latest \
 		--cache-to type=inline \
 		--metadata-file images/cozystack-api.json \
 		$(BUILDX_ARGS)
-	IMAGE="$(REGISTRY)/cozystack-api:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/cozystack-api.json -o json -r)" \
+	IMAGE="$(REGISTRY)/cozystack-api:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/cozystack-api.json -o json -r)" \
 		yq -i '.cozystackAPI.image = strenv(IMAGE)' values.yaml
 	rm -f images/cozystack-api.json

--- a/packages/system/cozystack-controller/Makefile
+++ b/packages/system/cozystack-controller/Makefile
@@ -8,12 +8,12 @@ image: image-cozystack-controller
 
 image-cozystack-controller:
 	docker buildx build -f images/cozystack-controller/Dockerfile ../../.. \
-		--tag $(REGISTRY)/cozystack-controller:$(call settag,$(TAG)) \
-		--build-arg VERSION=$(call settag,$(TAG)) \
+		$(call image-tags,cozystack-controller,v$(COZYSTACK_VERSION)) \
+		--build-arg VERSION=v$(COZYSTACK_VERSION) \
 		--cache-from type=registry,ref=$(REGISTRY)/cozystack-controller:latest \
 		--cache-to type=inline \
 		--metadata-file images/cozystack-controller.json \
 		$(BUILDX_ARGS)
-	IMAGE="$(REGISTRY)/cozystack-controller:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/cozystack-controller.json -o json -r)" \
+	IMAGE="$(REGISTRY)/cozystack-controller:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/cozystack-controller.json -o json -r)" \
 		yq -i '.cozystackController.image = strenv(IMAGE)' values.yaml
 	rm -f images/cozystack-controller.json

--- a/packages/system/dashboard/Makefile
+++ b/packages/system/dashboard/Makefile
@@ -25,7 +25,7 @@ build-console:
 		--provenance false \
 		--builder=$(BUILDER) \
 		--platform=linux/amd64 \
-		--tag $(REGISTRY)/cozystack-ui:$(call settag,$(TAG)) \
+		$(call image-tags,cozystack-ui,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/cozystack-ui:latest \
 		--cache-to type=inline \
 		--metadata-file images/console.json \
@@ -35,7 +35,7 @@ build-console:
 		--load=$(LOAD)
 
 update-values-console:
-	IMAGE="$(REGISTRY)/cozystack-ui:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/console.json -r)" \
+	IMAGE="$(REGISTRY)/cozystack-ui:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/console.json -r)" \
 		yq -i '.console.image = strenv(IMAGE)' values.yaml
 
 clean-console:
@@ -46,13 +46,13 @@ image-token-proxy:
 		--provenance false \
 		--builder=$(BUILDER) \
 		--platform=linux/amd64 \
-		--tag $(REGISTRY)/token-proxy:$(call settag,$(TAG)) \
+		$(call image-tags,token-proxy,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/token-proxy:latest \
 		--cache-to type=inline \
 		--metadata-file images/token-proxy.json \
 		--push=$(PUSH) \
 		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
 		--load=$(LOAD)
-	IMAGE="$(REGISTRY)/token-proxy:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/token-proxy.json -r)" \
+	IMAGE="$(REGISTRY)/token-proxy:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/token-proxy.json -r)" \
 		yq -i '.tokenProxy.image = strenv(IMAGE)' values.yaml
 	rm -f images/token-proxy.json

--- a/packages/system/flux-plunger/Makefile
+++ b/packages/system/flux-plunger/Makefile
@@ -7,13 +7,13 @@ include ../../../hack/package.mk
 image:
 	docker buildx build -f images/flux-plunger/Dockerfile ../../../ \
 		--provenance false \
-		--tag $(REGISTRY)/flux-plunger:$(call settag,$(TAG)) \
+		$(call image-tags,flux-plunger,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/flux-plunger:latest \
 		--cache-to type=inline \
 		--metadata-file images/flux-plunger.json \
 		--push=$(PUSH) \
 		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
 		--load=$(LOAD)
-	IMAGE="$(REGISTRY)/flux-plunger:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/flux-plunger.json -o json -r)" \
+	IMAGE="$(REGISTRY)/flux-plunger:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/flux-plunger.json -o json -r)" \
 		yq -i '.image = strenv(IMAGE)' values.yaml
 	rm -f images/flux-plunger.json

--- a/packages/system/flux-plunger/Makefile
+++ b/packages/system/flux-plunger/Makefile
@@ -1,7 +1,7 @@
 export NAME=flux-plunger
 export NAMESPACE=cozy-fluxcd
 
-include ../../../scripts/common-envs.mk
+include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
 
 image:

--- a/packages/system/grafana-operator/Makefile
+++ b/packages/system/grafana-operator/Makefile
@@ -12,11 +12,11 @@ update:
 
 image:
 	docker buildx build --file images/grafana-dashboards/Dockerfile ../../.. \
-		--tag $(REGISTRY)/grafana-dashboards:$(call settag,$(TAG)) \
+		$(call image-tags,grafana-dashboards,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/grafana-dashboards:latest \
 		--cache-to type=inline \
 		--metadata-file images/grafana-dashboards.json \
 		$(BUILDX_ARGS)
-	echo "$(REGISTRY)/grafana-dashboards:$(call settag,$(TAG))@$$(yq --exit-status '.["containerimage.digest"]' images/grafana-dashboards.json --output-format json -r)" \
+	echo "$(REGISTRY)/grafana-dashboards:$(IMAGE_TAG)@$$(yq --exit-status '.["containerimage.digest"]' images/grafana-dashboards.json --output-format json -r)" \
 		> images/grafana-dashboards.tag
 	rm -f images/grafana-dashboards.json

--- a/packages/system/kamaji/Makefile
+++ b/packages/system/kamaji/Makefile
@@ -13,14 +13,14 @@ update:
 
 image:
 	docker buildx build images/kamaji \
-		--tag $(REGISTRY)/kamaji:$(call settag,$(TAG)) \
+		$(call image-tags,kamaji,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/kamaji:latest \
 		--cache-to type=inline \
 		--metadata-file images/kamaji.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/kamaji" \
 		yq -i '.kamaji.image.repository = strenv(REPOSITORY)' values.yaml
-	TAG=$(TAG)@$$(yq e '."containerimage.digest"' images/kamaji.json -o json -r) \
+	TAG=$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/kamaji.json -o json -r) \
 		yq -i '.kamaji.image.tag = strenv(TAG)' values.yaml
 	yq -i '.kamaji.extraArgs[0] = "--migrate-image=" + .kamaji.image.repository + ":" + .kamaji.image.tag' values.yaml
 	rm -f images/kamaji.json

--- a/packages/system/keycloak-operator/Makefile
+++ b/packages/system/keycloak-operator/Makefile
@@ -6,12 +6,12 @@ include ../../../hack/package.mk
 
 image:
 	docker buildx build images/keycloak-operator \
-		--tag $(REGISTRY)/keycloak-operator:$(call settag,$(TAG)) \
+		$(call image-tags,keycloak-operator,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/keycloak-operator:latest \
 		--cache-to   type=inline \
 		--metadata-file images/keycloak-operator.json \
 		$(BUILDX_ARGS)
-	TAG="$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/keycloak-operator.json -r)" \
+	TAG="$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/keycloak-operator.json -r)" \
 		yq -i '.keycloak-operator.image.tag = strenv(TAG)' values.yaml
 	rm -f images/keycloak-operator.json
 

--- a/packages/system/kilo/Makefile
+++ b/packages/system/kilo/Makefile
@@ -10,13 +10,13 @@ update:
 
 image:
 	docker buildx build images/kilo \
-		--tag $(REGISTRY)/kilo:$(call settag,$(TAG)) \
+		$(call image-tags,kilo,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/kilo:latest \
 		--cache-to type=inline \
 		--metadata-file images/kilo.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/kilo" \
 		yq -i '.kilo.image.repository = strenv(REPOSITORY)' values.yaml
-	TAG=$(TAG)@$$(yq e '."containerimage.digest"' images/kilo.json -o json -r) \
+	TAG=$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/kilo.json -o json -r) \
 		yq -i '.kilo.image.tag = strenv(TAG)' values.yaml
 	rm -f images/kilo.json

--- a/packages/system/kubeovn-plunger/Makefile
+++ b/packages/system/kubeovn-plunger/Makefile
@@ -7,13 +7,13 @@ include ../../../hack/package.mk
 image:
 	docker buildx build -f images/kubeovn-plunger/Dockerfile ../../../ \
 		--provenance false \
-		--tag $(REGISTRY)/kubeovn-plunger:$(call settag,$(TAG)) \
+		$(call image-tags,kubeovn-plunger,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/kubeovn-plunger:latest \
 		--cache-to type=inline \
 		--metadata-file images/kubeovn-plunger.json \
 		--push=$(PUSH) \
 		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \
 		--load=$(LOAD)
-	IMAGE="$(REGISTRY)/kubeovn-plunger:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/kubeovn-plunger.json -o json -r)" \
+	IMAGE="$(REGISTRY)/kubeovn-plunger:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/kubeovn-plunger.json -o json -r)" \
 		yq -i '.image = strenv(IMAGE)' values.yaml
 	rm -f images/kubeovn-plunger.json

--- a/packages/system/kubeovn-webhook/Makefile
+++ b/packages/system/kubeovn-webhook/Makefile
@@ -6,11 +6,11 @@ include ../../../hack/package.mk
 
 image:
 	docker buildx build images/kubeovn-webhook \
-		--tag $(REGISTRY)/kubeovn-webhook:$(call settag,$(TAG)) \
+		$(call image-tags,kubeovn-webhook,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/kubeovn-webhook:latest \
 		--cache-to type=inline \
 		--metadata-file images/kubeovn-webhook.json \
 		$(BUILDX_ARGS)
-	IMAGE="$(REGISTRY)/kubeovn-webhook:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/kubeovn-webhook.json -o json -r)" \
+	IMAGE="$(REGISTRY)/kubeovn-webhook:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/kubeovn-webhook.json -o json -r)" \
 		yq -i '.image = strenv(IMAGE)' values.yaml
 	rm -f images/kubeovn-webhook.json

--- a/packages/system/lineage-controller-webhook/Makefile
+++ b/packages/system/lineage-controller-webhook/Makefile
@@ -13,11 +13,11 @@ test:
 
 image-lineage-controller-webhook:
 	docker buildx build -f images/lineage-controller-webhook/Dockerfile ../../.. \
-		--tag $(REGISTRY)/lineage-controller-webhook:$(call settag,$(TAG)) \
+		$(call image-tags,lineage-controller-webhook,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/lineage-controller-webhook:latest \
 		--cache-to type=inline \
 		--metadata-file images/lineage-controller-webhook.json \
 		$(BUILDX_ARGS)
-	IMAGE="$(REGISTRY)/lineage-controller-webhook:$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/lineage-controller-webhook.json -o json -r)" \
+	IMAGE="$(REGISTRY)/lineage-controller-webhook:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/lineage-controller-webhook.json -o json -r)" \
 		yq -i '.lineageControllerWebhook.image = strenv(IMAGE)' values.yaml
 	rm -f images/lineage-controller-webhook.json

--- a/packages/system/linstor-gui/Makefile
+++ b/packages/system/linstor-gui/Makefile
@@ -13,15 +13,14 @@ image: image-linstor-gui
 image-linstor-gui:
 	docker buildx build images/linstor-gui \
 		--build-arg LINSTOR_GUI_VERSION=$(LINSTOR_GUI_VERSION) \
-		--tag $(REGISTRY)/linstor-gui:$(call settag,$(LINSTOR_GUI_VERSION)) \
-		--tag $(REGISTRY)/linstor-gui:$(call settag,$(LINSTOR_GUI_VERSION)-$(TAG)) \
+		$(call image-tags,linstor-gui,$(LINSTOR_GUI_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/linstor-gui:latest \
 		--cache-to type=inline \
 		--metadata-file images/linstor-gui.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/linstor-gui" \
 		yq -i '.image.repository = strenv(REPOSITORY)' values.yaml
-	TAG="$(call settag,$(LINSTOR_GUI_VERSION))@$$(yq e '."containerimage.digest"' images/linstor-gui.json -o json -r)" \
+	TAG="$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/linstor-gui.json -o json -r)" \
 		yq -i '.image.tag = strenv(TAG)' values.yaml
 	rm -f images/linstor-gui.json
 

--- a/packages/system/linstor/Makefile
+++ b/packages/system/linstor/Makefile
@@ -13,29 +13,27 @@ image-piraeus-server:
 	docker buildx build images/piraeus-server \
 		--build-arg LINSTOR_VERSION=$(LINSTOR_VERSION) \
 		--build-arg K8S_AWAIT_ELECTION_VERSION=v0.4.2 \
-		--tag $(REGISTRY)/piraeus-server:$(call settag,$(LINSTOR_VERSION)) \
-		--tag $(REGISTRY)/piraeus-server:$(call settag,$(LINSTOR_VERSION)-$(TAG)) \
+		$(call image-tags,piraeus-server,$(LINSTOR_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/piraeus-server:latest \
 		--cache-to type=inline \
 		--metadata-file images/piraeus-server.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/piraeus-server" \
 		yq -i '.piraeusServer.image.repository = strenv(REPOSITORY)' values.yaml
-	TAG="$(call settag,$(LINSTOR_VERSION))@$$(yq e '."containerimage.digest"' images/piraeus-server.json -o json -r)" \
+	TAG="$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/piraeus-server.json -o json -r)" \
 		yq -i '.piraeusServer.image.tag = strenv(TAG)' values.yaml
 	rm -f images/piraeus-server.json
 
 image-linstor-csi:
 	docker buildx build images/linstor-csi \
 		--build-arg VERSION=$(LINSTOR_CSI_VERSION) \
-		--tag $(REGISTRY)/linstor-csi:$(call settag,$(LINSTOR_CSI_VERSION)) \
-		--tag $(REGISTRY)/linstor-csi:$(call settag,$(LINSTOR_CSI_VERSION)-$(TAG)) \
+		$(call image-tags,linstor-csi,$(LINSTOR_CSI_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/linstor-csi:latest \
 		--cache-to type=inline \
 		--metadata-file images/linstor-csi.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/linstor-csi" \
 		yq -i '.linstorCSI.image.repository = strenv(REPOSITORY)' values.yaml
-	TAG="$(call settag,$(LINSTOR_CSI_VERSION))@$$(yq e '."containerimage.digest"' images/linstor-csi.json -o json -r)" \
+	TAG="$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/linstor-csi.json -o json -r)" \
 		yq -i '.linstorCSI.image.tag = strenv(TAG)' values.yaml
 	rm -f images/linstor-csi.json

--- a/packages/system/metallb/Makefile
+++ b/packages/system/metallb/Makefile
@@ -17,14 +17,14 @@ image-controller image-speaker:
 	docker buildx build images/metallb \
 		--target $(TARGET) \
 		--build-arg VERSION=$(VERSION) \
-		--tag $(REGISTRY)/metallb-$(TARGET):$(VERSION) \
+		$(call image-tags,metallb-$(TARGET),$(VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/metallb-$(TARGET):latest \
 		--cache-to type=inline \
 		--metadata-file images/$(TARGET).json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/metallb-$(TARGET)" \
 		yq -i '.metallb.$(TARGET).image.repository = strenv(REPOSITORY)' values.yaml
-	TAG=$(VERSION)@$$(yq e '."containerimage.digest"' images/$(TARGET).json -o json -r) \
+	TAG=$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/$(TARGET).json -o json -r) \
 		yq -i '.metallb.$(TARGET).image.tag = strenv(TAG)' values.yaml
 	rm -f images/$(TARGET).json
 

--- a/packages/system/monitoring/Makefile
+++ b/packages/system/monitoring/Makefile
@@ -8,11 +8,11 @@ include ../../../hack/package.mk
 
 image:
 	docker buildx build images/grafana \
-		--tag $(REGISTRY)/grafana:$(call settag,$(GRAFANA_TAG)) \
+		$(call image-tags,grafana,$(GRAFANA_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/grafana:latest \
 		--cache-to type=inline \
 		--metadata-file images/grafana.json \
 		$(BUILDX_ARGS)
-	echo "$(REGISTRY)/grafana:$(call settag,$(GRAFANA_TAG))@$$(yq e '."containerimage.digest"' images/grafana.json -o json -r)" \
+	echo "$(REGISTRY)/grafana:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/grafana.json -o json -r)" \
 		> images/grafana.tag
 	rm -f images/grafana.json

--- a/packages/system/multus/Makefile
+++ b/packages/system/multus/Makefile
@@ -15,11 +15,11 @@ update:
 
 image:
 	docker buildx build images/multus-cni \
-		--tag $(REGISTRY)/multus-cni:$(call settag,$(TAG)) \
+		$(call image-tags,multus-cni,v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/multus-cni:latest \
 		--cache-to type=inline \
 		--metadata-file images/multus-cni.json \
 		$(BUILDX_ARGS)
 	DIGEST=$$(yq e '."containerimage.digest"' images/multus-cni.json -o json -r) && \
-		sed -i "s|image: .*multus-cni.*|image: $(REGISTRY)/multus-cni:$(TAG)@$${DIGEST}|g" templates/multus-daemonset-thick.yml
+		sed -i "s|image: .*multus-cni.*|image: $(REGISTRY)/multus-cni:$(IMAGE_TAG)@$${DIGEST}|g" templates/multus-daemonset-thick.yml
 	rm -f images/multus-cni.json

--- a/packages/system/objectstorage-controller/Makefile
+++ b/packages/system/objectstorage-controller/Makefile
@@ -18,12 +18,12 @@ image-controller image-sidecar:
 	$(eval YAML_PATH   := $(if $(filter sidecar,$(TARGET)),.seaweedfs.cosi.sidecar.image,.objectstorage.controller.image))
 	docker buildx build images/objectstorage \
 		--target $(TARGET) \
-		--tag $(REGISTRY)/objectstorage-$(TARGET):$(call settag,$(TAG)) \
+		$(call image-tags,objectstorage-$(TARGET),v$(COZYSTACK_VERSION)) \
 		--cache-from type=registry,ref=$(REGISTRY)/objectstorage-$(TARGET):latest \
 		--cache-to   type=inline \
 		--metadata-file images/$(TARGET).json \
 		$(BUILDX_ARGS)
-	IMAGE="$(REGISTRY)/objectstorage-$(TARGET):$(call settag,$(TAG))@$$(yq e '."containerimage.digest"' images/$(TARGET).json -r)" \
+	IMAGE="$(REGISTRY)/objectstorage-$(TARGET):$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/$(TARGET).json -r)" \
 		yq -i '$(YAML_PATH) = strenv(IMAGE)' $(VALUES_FILE)
 	rm -f images/$(TARGET).json
 	yq .seaweedfs.cosi.sidecar.image ../seaweedfs/values.yaml > ../../extra/seaweedfs/images/objectstorage-sidecar.tag

--- a/packages/system/redis-operator/Makefile
+++ b/packages/system/redis-operator/Makefile
@@ -14,13 +14,13 @@ update:
 
 image:
 	docker buildx build images/redis-operator \
-		--tag $(REGISTRY)/redis-operator:$(REDIS_OPERATOR_TAG) \
+		$(call image-tags,redis-operator,$(REDIS_OPERATOR_TAG)) \
 		--cache-from type=registry,ref=$(REGISTRY)/redis-operator:latest \
 		--cache-to type=inline \
 		--metadata-file images/redis-operator.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/redis-operator" \
 		yq -i '.redis-operator.image.repository = strenv(REPOSITORY)' values.yaml
-	TAG=$(REDIS_OPERATOR_TAG)@$$(yq e '."containerimage.digest"' images/redis-operator.json -o json -r) \
+	TAG=$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/redis-operator.json -o json -r) \
 		yq -i '.redis-operator.image.tag = strenv(TAG)' values.yaml
 	rm -f images/redis-operator.json


### PR DESCRIPTION
## What this PR does

Concurrent PR builds were racing in the OCIR registry. Every package Makefile tagged its images via `settag`, which on any non-release commit collapsed to `:latest` — so every image across every PR was pushed to the same tag, and parallel builds got 409s on the manifest PUT. Two outliers (`metallb`, `redis-operator`) used hardcoded version tags and collided across PRs unconditionally.

This PR replaces `settag` and the `TAG=latest` fallback in `hack/common-envs.mk` with a single `image-tags` macro driven by three env vars:

| Env | Meaning |
|---|---|
| `IMAGE_TAG` | Build-unique tag, always pushed |
| `PUBLISH_VERSIONED` | Also push `:<component-version>` (when provided) |
| `PUBLISH_FLOATING` | Also push `:latest` |

Wired into the two workflows:

- **`pull-requests.yaml`** — `IMAGE_TAG=pr-<N>-<sha>`, both `PUBLISH_*` off. Every PR build pushes a unique tag set; no collisions, no `:latest` move.
- **`tags.yaml`** — `IMAGE_TAG=<ref_name>`, both `PUBLISH_*` on. Release output preserved (component versions + `:latest`) plus a uniform `:<git-tag>` handle on every image for traceability.
- **Local** — defaults to `IMAGE_TAG=dev`, no flags, `PUSH=0`.

All 30 package Makefiles converted to `$(call image-tags,<repo>,<versioned-tag>)`. Image consumers reference digests pinned into `values.yaml` by each Makefile, so the tag is decorative for cluster-side pulls — the build-unique tag is sufficient for E2E.

Also drops the redundant `:<component-version>-<git-tag>` form (cilium, linstor, matchbox, ubuntu-container-disk, kubevirt-*, cluster-autoscaler). Nothing in the repo or downstream values.yaml consumed it; the same information is preserved via the new `:<git-tag>` plus the existing `:<component-version>` tags on release.

`ubuntu-container-disk` builds a separate image per Kubernetes version in a loop, so its primary tag became `:<k8s-ver>-<IMAGE_TAG>` to prevent loop iterations within a single build from pushing to the same tag.

Verified by dry-running `make -n image` across representative packages (simple, dual-tag, skopeo, flux-push, loop) under all four contexts (PR / release / main / dev) — tag sets are unique and behave as expected.

### Release note

```release-note
refactor(build): PR CI now pushes images under a unique `pr-<N>-<sha>` tag per build instead of `:latest`. Concurrent PR builds no longer race in the registry. Release builds keep the existing `:<component-version>` and `:latest` tags and additionally publish a uniform `:<git-tag>` handle across every image. The redundant `:<component-version>-<git-tag>` tag (cilium, linstor, matchbox, ubuntu-container-disk, kubevirt-*, cluster-autoscaler) is no longer published — image references in values.yaml are digest-pinned and were the only legitimate consumers.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized and simplified container image tagging across build workflows.
  * PR builds now use unique image tags derived from PR metadata for better isolation.
  * Added configurable flags to control publishing of versioned and floating tags, making release tagging behavior more predictable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->