### PR TITLE
chore(maintainers): update roster and add Emeritus section

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,14 +1,23 @@
 # The Cozystack Maintainers
 
+## Active Maintainers
+
 | Maintainer | GitHub Username | Company |          Responsibility           |
 | ---------- | --------------- | ------- | --------------------------------- |
 | Andrei Kvapil | [@kvaps](https://github.com/kvaps) | Ænix | Core Maintainer |
-| George Gaál | [@gecube](https://github.com/gecube) | Ænix | DevOps Practices in Platform, Developers Advocate |
+| George Gaál | [@gecube](https://github.com/gecube) | Independent | DevOps Practices in Platform, Developers Advocate |
 | Kingdon Barrett | [@kingdonb](https://github.com/kingdonb) | Urmanac | FluxCD and flux-operator |
-| Timofei Larkin | [@lllamnyp](https://github.com/lllamnyp) | 3commas | Etcd-operator Lead |
-| Artem Bortnikov | [@aobort](https://github.com/aobort) | Timescale | Etcd-operator Lead |
+| Timofei Larkin | [@lllamnyp](https://github.com/lllamnyp) | Ænix | Etcd-operator Lead |
 | Timur Tukaev | [@tym83](https://github.com/tym83) | Ænix | Cozystack Website, Marketing, Community Management |
-| Kirill Klinchenkov | [@klinch0](https://github.com/klinch0) | Ænix | Core Maintainer |
-| Nikita Bykov | [@nbykov0](https://github.com/nbykov0) | Ænix | Maintainer of ARM and stuff |
+| Nikita Bykov | [@nbykov0](https://github.com/nbykov0) | Independent | Maintainer of ARM and stuff |
 | Matthieu Robin | [@matthieu-robin](https://github.com/matthieu-robin) | Hidora | Managed Applications, Platform Quality & Benchmarking |
 | Mattia Eleuteri | [@mattia-eleuteri](https://github.com/mattia-eleuteri) | Hidora | CSI, Storage, Networking & Security |
+
+## Emeritus Maintainers
+
+We thank the following former maintainers for their contributions to Cozystack.
+
+| Maintainer | GitHub Username |
+| ---------- | --------------- |
+| Artem Bortnikov | [@aobort](https://github.com/aobort) |
+| Kirill Klinchenkov | [@klinch0](https://github.com/klinch0) |


### PR DESCRIPTION
## What this PR does

- Add `Active Maintainers` and `Emeritus Maintainers` sub-sections.
- Update @gecube affiliation to Independent (was Ænix).
- Update @lllamnyp affiliation to Ænix (was 3commas).
- Mark @nbykov0 as Independent (was Ænix).
- Move @aobort to Emeritus Maintainers.
- Move @klinch0 to Emeritus Maintainers.

### Release note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project maintainers information in the maintainers list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->