### PR TITLE
chore(maintainers): mark @lllamnyp as Core Maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,7 @@
 | Andrei Kvapil | [@kvaps](https://github.com/kvaps) | Ænix | Core Maintainer |
 | George Gaál | [@gecube](https://github.com/gecube) | Independent | DevOps Practices in Platform, Developers Advocate |
 | Kingdon Barrett | [@kingdonb](https://github.com/kingdonb) | Urmanac | FluxCD and flux-operator |
-| Timofei Larkin | [@lllamnyp](https://github.com/lllamnyp) | Ænix | Etcd-operator Lead |
+| Timofei Larkin | [@lllamnyp](https://github.com/lllamnyp) | Ænix | Core Maintainer |
 | Timur Tukaev | [@tym83](https://github.com/tym83) | Ænix | Cozystack Website, Marketing, Community Management |
 | Nikita Bykov | [@nbykov0](https://github.com/nbykov0) | Independent | Maintainer of ARM and stuff |
 | Matthieu Robin | [@matthieu-robin](https://github.com/matthieu-robin) | Hidora | Managed Applications, Platform Quality & Benchmarking |


### PR DESCRIPTION
## What this PR does

Updates @lllamnyp's responsibility in `MAINTAINERS.md` from `Etcd-operator Lead` to `Core Maintainer`.

The etcd-operator is hosted in the separate [aenix-io/etcd-operator](https://github.com/aenix-io/etcd-operator) repository — its leadership scope is tracked there. In `cozystack/cozystack`, @lllamnyp's role is a project-level Core Maintainer, which this change reflects.

### Release note

​```release-note
NONE
​```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated maintainers list to reflect current team roles and responsibilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->