### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,55 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    # Run weekly on Mondays at 06:00 UTC.
+    - cron: '0 6 * * 1'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Declare default permissions as read-only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to the GitHub code-scanning dashboard.
+      security-events: write
+      # Needed to publish results to the public scorecard.dev API
+      # (OIDC token allows publish without storing long-lived credentials).
+      id-token: write
+      # Needed to read repository contents.
+      contents: read
+      # Needed to read workflow definitions for the Dangerous-Workflow check.
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish the results to the OpenSSF Scorecard public API so the
+          # project appears at https://scorecard.dev/viewer/?uri=github.com/cozystack/cozystack
+          publish_results: true
+
+      - name: Upload SARIF as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## What this PR does

Adds a GitHub Actions workflow that runs the [OpenSSF Scorecard](https://github.com/ossf/scorecard) on this repository.

### Schedule

- Weekly on Mondays at 06:00 UTC
- On branch protection rule changes
- On pushes to `main`
- Manual dispatch

### Where results go

- **Public** [`scorecard.dev`](https://scorecard.dev/viewer/?uri=github.com/cozystack/cozystack) — transparency for adopters and reviewers (CNCF DD).
- **Code-scanning dashboard** (Security tab) — for in-team triage of individual findings.
- SARIF artifact retained for 5 days for local inspection.

### Token permissions

Default `read-all`, with the minimum required scopes elevated only inside the analysis job:
- `security-events: write` — upload to code scanning
- `id-token: write` — publish to `scorecard.dev` via OIDC, no long-lived secret
- `contents: read`, `actions: read`

### Why no README badge yet

This PR enables the workflow but **does not add a badge to the README**. Once the first scans have completed and quick-win improvements (token permissions across other workflows, dependency pinning in workflows, etc.) have landed, a follow-up PR will add the badge.

### Context

- Tracked under the project's CNCF Incubation readiness work and the in-progress security self-assessment.
- Companion to the OpenSSF Best Practices passing badge (https://www.bestpractices.dev/en/projects/10177) — Scorecard adds machine-verifiable, continuously-updated evidence; Best Practices captures self-attested controls.

### Release note

\`\`\`release-note
NONE
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated security scanning to the development process to continuously monitor codebase health and security posture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->