### PR TITLE
ci: pin Scorecard workflow actions by SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,12 +29,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
@@ -43,13 +43,13 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scorecard-sarif
           path: results.sarif
           retention-days: 5
 
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## What this PR does

Fixes the OpenSSF Scorecard workflow added in #2720.

The initial workflow used floating major-version tags (`@v2`, `@v4`, `@v3`). `ossf/scorecard-action` does not publish a floating `v2` tag — only specific patch releases — so the first scheduled run failed:

> Unable to resolve action `ossf/scorecard-action@v2`, unable to find version `v2`

This PR pins every action by its full commit SHA with a trailing comment showing the human-readable version. This also satisfies the **Pinned-Dependencies** Scorecard check itself.

- `actions/checkout@de0fac2` (v6.0.2)
- `ossf/scorecard-action@4eaacf0` (v2.4.3)
- `actions/upload-artifact@043fb46` (v7.0.1)
- `github/codeql-action/upload-sarif@03e4368` (v3)

### Release note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure dependency versions to maintain security and stability.

**Note:** This release contains no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2721?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->