### PR TITLE
fix(kubernetes): add config_path patch for containerd 2.x

### DIFF
--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -468,7 +468,8 @@ spec:
       - mkdir -p /persistent/kubelet /persistent/containerd /var/lib/kubelet /var/lib/containerd
       - mountpoint -q /var/lib/kubelet || mount -o bind /persistent/kubelet /var/lib/kubelet
       - mountpoint -q /var/lib/containerd || mount -o bind /persistent/containerd /var/lib/containerd
-      - sudo sed -i '/\[plugins."io.containerd.grpc.v1.cri".registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|' /etc/containerd/config.toml
+      - sed -i '/\[plugins\.[^]]*grpc\.v1\.cri[^]]*registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|' /etc/containerd/config.toml
+      - sed -i '/\[plugins\.[^]]*io\.containerd\.cri\.v1\.images[^]]*registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|' /etc/containerd/config.toml
       - systemctl start containerd.service
       joinConfiguration:
         nodeRegistration:


### PR DESCRIPTION
## What this PR does

This PR adds support for containerd 2.x CRI config_path configuration, as the CRI plugin section was renamed from `io.containerd.grpc.v1.cri` to `io.containerd.cri.v1.images`.

It also makes the `sed` patching regexes more resilient by matching any quotes (single or double) around the plugin names, which fixes the issue on Ubuntu 24.04 (Noble) where containerd 2.x uses single quotes: `[plugins.'io.containerd.cri.v1.images'.registry]`.

### Release note

```release-note
fix(kubernetes): add config_path patch for containerd 2.x
```
