### PR TITLE
fix(kubernetes): add config_path patch for containerd 2.x

### DIFF
--- a/packages/apps/kubernetes/Makefile
+++ b/packages/apps/kubernetes/Makefile
@@ -8,6 +8,7 @@ include ../../../hack/package.mk
 
 test:
 	helm unittest .
+	bash tests/containerd-config-path-test.sh
 
 generate:
 	cozyvalues-gen -m 'kubernetes' -v values.yaml -s values.schema.json -r README.md -g ../../../api/apps/v1alpha1/kubernetes/types.go

--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -468,6 +468,7 @@ spec:
       - mkdir -p /persistent/kubelet /persistent/containerd /var/lib/kubelet /var/lib/containerd
       - mountpoint -q /var/lib/kubelet || mount -o bind /persistent/kubelet /var/lib/kubelet
       - mountpoint -q /var/lib/containerd || mount -o bind /persistent/containerd /var/lib/containerd
+      {{/* containerd 2.x renamed the CRI plugin from io.containerd.grpc.v1.cri to io.containerd.cri.v1.images; both seds run unconditionally and the wrong-version one is a no-op */}}
       - sed -i '/\[plugins\.[^]]*grpc\.v1\.cri[^]]*registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|' /etc/containerd/config.toml
       - sed -i '/\[plugins\.[^]]*io\.containerd\.cri\.v1\.images[^]]*registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|' /etc/containerd/config.toml
       - systemctl start containerd.service

--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -468,7 +468,8 @@ spec:
       - mkdir -p /persistent/kubelet /persistent/containerd /var/lib/kubelet /var/lib/containerd
       - mountpoint -q /var/lib/kubelet || mount -o bind /persistent/kubelet /var/lib/kubelet
       - mountpoint -q /var/lib/containerd || mount -o bind /persistent/containerd /var/lib/containerd
-      - sudo sed -i '/\[plugins."io.containerd.grpc.v1.cri".registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|' /etc/containerd/config.toml
+      - sed -i '/\[plugins\.[^]]*grpc\.v1\.cri[^]]*registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|' /etc/containerd/config.toml
+      - sed -i '/\[plugins\.[^]]*io\.containerd\.cri\.v1\.images[^]]*registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|' /etc/containerd/config.toml
       - systemctl start containerd.service
       joinConfiguration:
         nodeRegistration:

--- a/packages/apps/kubernetes/tests/cluster_test.yaml
+++ b/packages/apps/kubernetes/tests/cluster_test.yaml
@@ -325,6 +325,20 @@ tests:
           content: "mkdir -p /persistent/kubelet /persistent/containerd /var/lib/kubelet /var/lib/containerd"
         documentIndex: 4
 
+  - it: patches containerd registry config_path for both 1.x and 2.x plugin schemas
+    release:
+      name: test-k8s
+      namespace: tenant-test
+    asserts:
+      - contains:
+          path: spec.template.spec.preKubeadmCommands
+          content: 'sed -i ''/\[plugins\.[^]]*grpc\.v1\.cri[^]]*registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|'' /etc/containerd/config.toml'
+        documentIndex: 4
+      - contains:
+          path: spec.template.spec.preKubeadmCommands
+          content: 'sed -i ''/\[plugins\.[^]]*io\.containerd\.cri\.v1\.images[^]]*registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|'' /etc/containerd/config.toml'
+        documentIndex: 4
+
   ###############################################
   # disk-kubelet matchVolume blockSize          #
   ###############################################

--- a/packages/apps/kubernetes/tests/containerd-config-path-test.sh
+++ b/packages/apps/kubernetes/tests/containerd-config-path-test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Regression test for the containerd registry config_path sed lines in
+# templates/cluster.yaml preKubeadmCommands.
+#
+# Prevents two failure modes:
+#   1. The sed lines in this script drift from the ones in cluster.yaml
+#      (drift detection via grep -F against the template).
+#   2. A future containerd release renames the registry plugin section or
+#      changes its default quoting, so the sed silently stops matching
+#      and per-registry mirroring under /etc/containerd/certs.d breaks
+#      (functional check via running the seds against minimal fixtures
+#      of the containerd 1.x and 2.x default configs).
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+template="$script_dir/../templates/cluster.yaml"
+fixtures_dir="$script_dir/fixtures"
+
+# Pick a GNU-compatible sed; the cluster.yaml sed uses \s and \( ... \)
+# which behave differently on BSD sed (macOS default).
+if sed --version >/dev/null 2>&1; then
+  SED=sed
+elif command -v gsed >/dev/null 2>&1; then
+  SED=gsed
+elif [[ "${CI:-}" == "true" ]]; then
+  echo "FAIL: CI must have GNU sed; refusing to skip the regression test"
+  exit 1
+else
+  echo "SKIP: GNU sed not found (install via 'brew install gnu-sed' on macOS)"
+  exit 0
+fi
+
+sed_legacy='sed -i '\''/\[plugins\.[^]]*grpc\.v1\.cri[^]]*registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|'\'' /etc/containerd/config.toml'
+sed_new='sed -i '\''/\[plugins\.[^]]*io\.containerd\.cri\.v1\.images[^]]*registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|'\'' /etc/containerd/config.toml'
+
+# Drift check: the strings above must appear verbatim in cluster.yaml.
+for line in "$sed_legacy" "$sed_new"; do
+  if ! grep -qF -- "$line" "$template"; then
+    echo "FAIL: sed line drifted from $template:"
+    echo "  expected: $line"
+    exit 1
+  fi
+done
+
+# Extract just the inline sed script (between the outer single quotes) for
+# applying via $SED -e.
+script_legacy=$(printf '%s' "$sed_legacy" | $SED -n "s/^sed -i '\\(.*\\)' \\/etc\\/containerd\\/config.toml$/\\1/p")
+script_new=$(printf '%s' "$sed_new" | $SED -n "s/^sed -i '\\(.*\\)' \\/etc\\/containerd\\/config.toml$/\\1/p")
+
+if [[ -z "$script_legacy" || -z "$script_new" ]]; then
+  echo "FAIL: could not parse sed scripts from the template lines"
+  exit 1
+fi
+
+# Functional check: run both seds against each fixture, assert the
+# config_path under the registry section was rewritten exactly once.
+for fixture in "$fixtures_dir"/containerd-1x.toml "$fixtures_dir"/containerd-2x.toml; do
+  name=$(basename "$fixture")
+  patched=$($SED -e "$script_legacy" -e "$script_new" "$fixture")
+
+  count=$(printf '%s\n' "$patched" | grep -cE '^[[:space:]]*config_path = "/etc/containerd/certs.d"$' || true)
+  if [[ "$count" -ne 1 ]]; then
+    echo "FAIL: $name: expected exactly 1 patched config_path line, got $count"
+    echo "--- patched output ---"
+    printf '%s\n' "$patched"
+    exit 1
+  fi
+done
+
+echo "OK: containerd config_path sed lines patch both 1.x and 2.x configs"

--- a/packages/apps/kubernetes/tests/fixtures/containerd-1x.toml
+++ b/packages/apps/kubernetes/tests/fixtures/containerd-1x.toml
@@ -1,0 +1,14 @@
+version = 2
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.8"
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      snapshotter = "overlayfs"
+      [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = ""
+      [plugins."io.containerd.grpc.v1.cri".registry.auths]
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+      [plugins."io.containerd.grpc.v1.cri".registry.headers]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]

--- a/packages/apps/kubernetes/tests/fixtures/containerd-2x.toml
+++ b/packages/apps/kubernetes/tests/fixtures/containerd-2x.toml
@@ -1,0 +1,16 @@
+version = 3
+
+[plugins]
+  [plugins.'io.containerd.cri.v1.images']
+    snapshotter = 'overlayfs'
+    [plugins.'io.containerd.cri.v1.images'.pinned_images]
+      sandbox = 'registry.k8s.io/pause:3.10'
+    [plugins.'io.containerd.cri.v1.images'.registry]
+      config_path = ''
+    [plugins.'io.containerd.cri.v1.images'.registry_credentials]
+
+  [plugins.'io.containerd.cri.v1.runtime']
+    enable_selinux = false
+    [plugins.'io.containerd.cri.v1.runtime'.containerd]
+      default_runtime_name = 'runc'
+      [plugins.'io.containerd.cri.v1.runtime'.containerd.runtimes]


### PR DESCRIPTION
What this PR does
This PR adds support for containerd 2.x CRI config_path configuration, as the CRI plugin section was renamed from io.containerd.grpc.v1.cri to io.containerd.cri.v1.images.

It also makes the sed patching regexes more resilient by matching any quotes (single or double) around the plugin names, which fixes the issue on Ubuntu 24.04 (Noble) where containerd 2.x uses single quotes: [plugins.'io.containerd.cri.v1.images'.registry].

Release note
fix(kubernetes): add config_path patch for containerd 2.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened Kubernetes cluster bootstrap handling to better support different containerd plugin layouts, improving compatibility when configuring container registry paths during cluster initialization.
* **Tests**
  * Added regression tests and fixtures to validate the containerd configuration patching logic and integrated the check into the Kubernetes test target.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->