### PR TITLE
test(e2e): pre-pull platform images via staged-busybox DaemonSet

### DIFF
--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -18,26 +18,24 @@
   # actually pulls (skips configmap fields and CRD examples that happen to
   # contain an `image:` key). Add a chart here when a new peer-sensitive
   # workload is found.
-  # Stage each render AND the yq filter through tmp files instead of
-  # piping. Two constraints stack here: `set -x` would expand any
-  # `var=$(helm ...)` capture into the trace and balloon CI logs, and
-  # `set -o pipefail` is unavailable because hack/cozytest.sh runs under
-  # /bin/sh which is dash on Ubuntu CI. Redirection keeps each step as a
-  # standalone command — set -e catches a failure at any stage (helm
-  # render, yq filter, prepull) without needing pipefail and without
-  # leaking rendered YAML into the trace.
-  local kubeovn_yaml linstor_yaml images_list
+  # Stage each render to a file: bats does not enable `pipefail`, so a
+  # direct `helm template | yq` pipe would let yq's exit code mask a
+  # helm-template failure and the test would pass while pre-pull was
+  # skipped. Writing to a file makes `set -e` trip on a render failure
+  # without using `var=$(helm template ...)` captures, which `set -x`
+  # would expand into the trace and balloon CI logs.
+  local kubeovn_yaml linstor_yaml certmanager_yaml
   kubeovn_yaml=$(mktemp)
   linstor_yaml=$(mktemp)
-  images_list=$(mktemp)
+  certmanager_yaml=$(mktemp)
   helm template packages/system/kubeovn > "$kubeovn_yaml"
   helm template packages/system/linstor > "$linstor_yaml"
-  yq -N '
+  helm template packages/system/cert-manager > "$certmanager_yaml"
+  cat "$kubeovn_yaml" "$linstor_yaml" "$certmanager_yaml" | yq -N '
       (..|select(has("containers"))|.containers[]|.image),
       (..|select(has("initContainers"))|.initContainers[]|.image)
-    ' "$kubeovn_yaml" "$linstor_yaml" > "$images_list"
-  hack/e2e-prepull-images.sh < "$images_list"
-  rm -f "$kubeovn_yaml" "$linstor_yaml" "$images_list"
+    ' | hack/e2e-prepull-images.sh
+  rm -f "$kubeovn_yaml" "$linstor_yaml" "$certmanager_yaml"
 }
 
 @test "Install Cozystack" {
@@ -141,9 +139,15 @@ EOF
   kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true, "seaweedfs": true}}'
 
   timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring seaweedfs tenant-root >/dev/null 2>&1; do sleep 1; done'
-  kubectl wait hr/etcd hr/ingress hr/tenant-root hr/seaweedfs -n tenant-root --timeout=4m --for=condition=ready
-
-  kubectl wait hr/monitoring hr/seaweedfs-system -n tenant-root --timeout=2m --for=condition=ready
+  # tenant-root parent HR only flips Ready after every child HR is Ready,
+  # so listing all four top-level children plus the parent gives precise
+  # failure messages without redundant separate waits. seaweedfs now
+  # installs as a serial chain seaweedfs-db (CNPG bootstrap) ->
+  # seaweedfs-system (master raft quorum) -> seaweedfs wrapper, which
+  # pushes the parent's Ready flip to ~5-6 min; tenant-root HR.spec.timeout
+  # is 15m and this 10m wait stays inside it.
+  kubectl wait hr/etcd hr/ingress hr/monitoring hr/seaweedfs hr/tenant-root \
+    -n tenant-root --timeout=10m --for=condition=ready
 
 
   # Expose Cozystack services through ingress

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -18,24 +18,28 @@
   # actually pulls (skips configmap fields and CRD examples that happen to
   # contain an `image:` key). Add a chart here when a new peer-sensitive
   # workload is found.
-  # Stage each render to a file: bats does not enable `pipefail`, so a
-  # direct `helm template | yq` pipe would let yq's exit code mask a
-  # helm-template failure and the test would pass while pre-pull was
-  # skipped. Writing to a file makes `set -e` trip on a render failure
-  # without using `var=$(helm template ...)` captures, which `set -x`
-  # would expand into the trace and balloon CI logs.
-  local kubeovn_yaml linstor_yaml certmanager_yaml
+  # Stage each render AND the yq filter through tmp files instead of
+  # piping. Two constraints stack here: `set -x` would expand any
+  # `var=$(helm ...)` capture into the trace and balloon CI logs, and
+  # `set -o pipefail` is unavailable because hack/cozytest.sh runs under
+  # /bin/sh which is dash on Ubuntu CI. Redirection keeps each step as a
+  # standalone command — set -e catches a failure at any stage (helm
+  # render, yq filter, prepull) without needing pipefail and without
+  # leaking rendered YAML into the trace.
+  local kubeovn_yaml linstor_yaml certmanager_yaml images_list
   kubeovn_yaml=$(mktemp)
   linstor_yaml=$(mktemp)
   certmanager_yaml=$(mktemp)
+  images_list=$(mktemp)
   helm template packages/system/kubeovn > "$kubeovn_yaml"
   helm template packages/system/linstor > "$linstor_yaml"
   helm template packages/system/cert-manager > "$certmanager_yaml"
-  cat "$kubeovn_yaml" "$linstor_yaml" "$certmanager_yaml" | yq -N '
+  yq -N '
       (..|select(has("containers"))|.containers[]|.image),
       (..|select(has("initContainers"))|.initContainers[]|.image)
-    ' | hack/e2e-prepull-images.sh
-  rm -f "$kubeovn_yaml" "$linstor_yaml" "$certmanager_yaml"
+    ' "$kubeovn_yaml" "$linstor_yaml" "$certmanager_yaml" > "$images_list"
+  hack/e2e-prepull-images.sh < "$images_list"
+  rm -f "$kubeovn_yaml" "$linstor_yaml" "$certmanager_yaml" "$images_list"
 }
 
 @test "Install Cozystack" {

--- a/hack/e2e-prepull-images.sh
+++ b/hack/e2e-prepull-images.sh
@@ -4,16 +4,15 @@
 # Reads image references from stdin, one per line. Empty lines and lines
 # starting with '#' are ignored.
 #
-# Some workloads (OVN raft, LINSTOR) are sensitive to peer-readiness at
-# startup: if nodes pull the image at different speeds, one replica boots
-# before its peers are reachable, exhausts its raft connection retries, and
-# the HelmRelease install times out. Pre-pulling eliminates the pull stagger
-# so all replicas start within milliseconds of each other.
+# Some workloads (OVN raft, LINSTOR, cert-manager) are sensitive to slow or
+# staggered pulls at install time: a HelmRelease can time out while one node
+# is still pulling. Pre-pulling eliminates the stagger.
 #
-# Implementation: a DaemonSet with one regular container per image (parallel
-# pulls — total time = max of any one image rather than sum). kubectl rollout
-# status blocks until all pods are Ready (= all containers running = all
-# images cached on every node), then we delete the DaemonSet.
+# Distroless images (cert-manager, etc.) ship no shell or `sleep`, so we
+# can't just `command: ["sleep", "infinity"]`. Trick: an initContainer copies
+# busybox (a static binary) into a shared emptyDir, then every prepull
+# container execs /shared/sleep — the kernel execve's the binary from the
+# volume, the container's filesystem doesn't need to provide it.
 
 set -euo pipefail
 
@@ -38,8 +37,11 @@ for image in "${images[@]}"; do
   containers+="
       - name: pull-${i}
         image: ${image}
-        command: [\"sleep\", \"infinity\"]
+        command: [\"/shared/sleep\", \"infinity\"]
         imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: bin
+          mountPath: /shared
         resources:
           requests:
             cpu: 1m
@@ -65,17 +67,27 @@ spec:
         app: e2e-image-prepuller
     spec:
       # hostNetwork bypasses the CNI: this script runs BEFORE Cozystack
-      # installs kube-ovn, so the cluster has no working CNI yet and a normal
-      # pod would stay ContainerCreating with NetworkPluginNotReady, never
-      # reaching image-pull. With hostNetwork the pod sandbox is created on
-      # the host's namespace and the kubelet pulls images right away.
-      # Same pattern the cozystack-operator pod uses for the same reason.
+      # installs kube-ovn, so a normal pod would stay ContainerCreating with
+      # NetworkPluginNotReady.
       hostNetwork: true
-      # No need for an SA token — this pod just sleeps while images pull.
       automountServiceAccountToken: false
       tolerations:
-      # Reach every node including control-plane and nodes still coming up.
       - operator: Exists
+      initContainers:
+      # Stage a static \`sleep\` into the shared volume so distroless images
+      # (no shell, no /bin/sleep) can still keep their container alive.
+      # musl tag = statically linked; the glibc default needs an ELF
+      # interpreter that distroless images don't ship, so execve fails with
+      # "no such file or directory" even though the binary is right there.
+      - name: stage-sleep
+        image: busybox:musl
+        command: ["cp", "/bin/busybox", "/shared/sleep"]
+        volumeMounts:
+        - name: bin
+          mountPath: /shared
+      volumes:
+      - name: bin
+        emptyDir: {}
       containers:${containers}
 EOF
 


### PR DESCRIPTION
## What this PR does

Pre-pulls every image referenced by `packages/system/kubeovn`, `packages/system/linstor`, and `packages/system/cert-manager` onto every node before those HelmReleases install. Cluster-member workloads (OVN raft, LINSTOR, cert-manager webhook) fail when replicas start at different times due to per-node image-pull stagger; pre-pulling means all replicas start with images already cached.

## Mechanics

Renders each chart with `helm template`, then runs a `yq` filter that walks every PodSpec-shaped object and emits the images of each container — scoping the output to images the kubelet actually pulls (skips configmap fields and CRD examples that happen to contain an `image:` key). Each render is staged through a tmp file so a helm-template failure trips `set -e` cleanly (cozytest.sh runs `@test` bodies under `/bin/sh`, which is dash on Ubuntu CI — no `pipefail`).

The pre-pull DaemonSet itself is the hard part: distroless images (cert-manager and friends) ship no shell and no `/bin/sleep`, so the obvious `command: ["sleep", "infinity"]` fails with `exec: ENOENT`. The script stages a statically-linked `busybox:musl` into a shared `emptyDir` from an initContainer; every prepull container then execs `/shared/sleep` regardless of what the image itself ships. The glibc `busybox` tag is unusable — it needs `/lib64/ld-linux-x86-64.so.2` which distroless lacks.

## Origin

Lifted from #2619 — squash of `test(e2e): pre-pull cert-manager images` → POSIX rewrite → cert-manager removal (failed on distroless) → reintroduction with the busybox helper that solves the distroless problem. Final state only — the four iterative commits aren't review-friendly individually.

## Verification

- `sh -n hack/e2e-prepull-images.sh` clean
- All chart-referenced images held Ready under the DaemonSet on local kind v1.33.1 single-node

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability for platform image pre-pulling by rendering charts separately and consolidating extracted images.
  * Simplified and consolidated readiness waits during tenant configuration for more robust application readiness checks.

* **Chores**
  * Enhanced image pre-pulling to reliably handle distroless images using a staged helper binary and shared volume approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2724?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->