### PR TITLE
fix: startupProbes for kubevirt-cdi-operator and grafana-operator

### DIFF
--- a/packages/system/grafana-operator/Makefile
+++ b/packages/system/grafana-operator/Makefile
@@ -9,6 +9,7 @@ update:
 	mkdir -p charts
 	curl -sSL https://github.com/grafana-operator/grafana-operator/archive/refs/heads/master.tar.gz | \
 	tar xzvf - --strip 3 -C charts grafana-operator-master/deploy/helm/grafana-operator
+	patch --no-backup-if-mismatch -p1 < patches/startupProbe.diff
 
 image:
 	docker buildx build --file images/grafana-dashboards/Dockerfile ../../.. \

--- a/packages/system/grafana-operator/charts/grafana-operator/templates/deployment.yaml
+++ b/packages/system/grafana-operator/charts/grafana-operator/templates/deployment.yaml
@@ -79,6 +79,13 @@ spec:
             httpGet:
               path: /readyz
               port: 8081
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            periodSeconds: 5
+            failureThreshold: 30
+            timeoutSeconds: 10
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/packages/system/grafana-operator/patches/startupProbe.diff
+++ b/packages/system/grafana-operator/patches/startupProbe.diff
@@ -1,0 +1,17 @@
+diff --git a/charts/grafana-operator/templates/deployment.yaml b/charts/grafana-operator/templates/deployment.yaml
+--- a/charts/grafana-operator/templates/deployment.yaml
++++ b/charts/grafana-operator/templates/deployment.yaml
+@@ -79,6 +79,13 @@ spec:
+             httpGet:
+               path: /readyz
+               port: 8081
++          startupProbe:
++            httpGet:
++              path: /healthz
++              port: 8081
++            periodSeconds: 5
++            failureThreshold: 30
++            timeoutSeconds: 10
+           {{- with .Values.resources }}
+           resources:
+             {{- toYaml . | nindent 12 }}

--- a/packages/system/kubevirt-cdi-operator/Makefile
+++ b/packages/system/kubevirt-cdi-operator/Makefile
@@ -10,3 +10,4 @@ update:
 	wget https://github.com/kubevirt/containerized-data-importer/releases/download/$$VERSION/cdi-operator.yaml -O templates/cdi-operator.yaml
 	sed -i 's/namespace: cdi/namespace: cozy-kubevirt-cdi/g' templates/cdi-operator.yaml
 	awk -i inplace -v RS="---" '!/kind: Namespace/{printf "%s", $$0 RS}' templates/cdi-operator.yaml
+	patch --no-backup-if-mismatch -p1 < patches/startupProbe.diff

--- a/packages/system/kubevirt-cdi-operator/patches/startupProbe.diff
+++ b/packages/system/kubevirt-cdi-operator/patches/startupProbe.diff
@@ -1,0 +1,19 @@
+diff --git a/packages/system/kubevirt-cdi-operator/templates/cdi-operator.yaml b/packages/system/kubevirt-cdi-operator/templates/cdi-operator.yaml
+index f46ba09e6..03ac3b3a2 100644
+--- a/packages/system/kubevirt-cdi-operator/templates/cdi-operator.yaml
++++ b/packages/system/kubevirt-cdi-operator/templates/cdi-operator.yaml
+@@ -5782,6 +5782,14 @@ spec:
+             scheme: HTTP
+           initialDelaySeconds: 5
+           timeoutSeconds: 10
++        startupProbe:
++          httpGet:
++            path: /healthz
++            port: 8444
++            scheme: HTTP
++          periodSeconds: 5
++          failureThreshold: 30
++          timeoutSeconds: 10
+         resources:
+           requests:
+             cpu: 100m

--- a/packages/system/kubevirt-cdi-operator/templates/cdi-operator.yaml
+++ b/packages/system/kubevirt-cdi-operator/templates/cdi-operator.yaml
@@ -5782,6 +5782,14 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 5
           timeoutSeconds: 10
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: 8444
+            scheme: HTTP
+          periodSeconds: 5
+          failureThreshold: 30
+          timeoutSeconds: 10
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## What this PR does

Adds `startupProbe` to two operator deployments whose readiness probes fail repeatedly during a cold cluster install, generating noise and (for CDI) blocking dependants on slow leader-election:

- **`kubevirt-cdi-operator`** — leader-election against a slow `kube-apiserver` (Kamaji control plane bringup) consistently takes >30s on a cold install. The default readinessProbe with 1s `periodSeconds` / 3 `failureThreshold` fires the first time election times out, the operator pod gets marked NotReady, and dependants block on it.
- **`grafana-operator`** — bootstrap CRD discovery + Helm-managed Dashboard reconcile loop spikes startup duration past readinessProbe's default budget under load.

`startupProbe` gives each operator a longer one-time window to reach steady state; the regular `readinessProbe` then takes over with its tight per-second cadence to detect genuine ongoing failures.

## Origin

Both commits lifted unchanged from #2619.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Added startup health checks to Grafana operator container
  * Added startup health checks to KubeVirt CDI operator container

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->