### PR TITLE
fix(platform): add cert-manager dependency to webhook-cert consumers

### DIFF
--- a/packages/core/platform/sources/capi-operator.yaml
+++ b/packages/core/platform/sources/capi-operator.yaml
@@ -13,6 +13,7 @@ spec:
   - name: default
     dependsOn:
     - cozystack.networking
+    - cozystack.cert-manager
     components:
     - name: capi-operator
       path: system/capi-operator

--- a/packages/core/platform/sources/cozystack-engine.yaml
+++ b/packages/core/platform/sources/cozystack-engine.yaml
@@ -13,6 +13,7 @@ spec:
   - name: default
     dependsOn:
     - cozystack.networking
+    - cozystack.cert-manager
     libraries:
     - name: cozy-lib
       path: library/cozy-lib

--- a/packages/core/platform/sources/cozystack-engine.yaml
+++ b/packages/core/platform/sources/cozystack-engine.yaml
@@ -58,6 +58,7 @@ spec:
   - name: oidc
     dependsOn:
     - cozystack.networking
+    - cozystack.cert-manager
     - cozystack.keycloak
     - cozystack.keycloak-operator
     libraries:

--- a/packages/core/platform/sources/ingress-nginx.yaml
+++ b/packages/core/platform/sources/ingress-nginx.yaml
@@ -14,6 +14,7 @@ spec:
     dependsOn:
     - cozystack.networking
     - cozystack.prometheus-operator-crds
+    - cozystack.cert-manager
     components:
     - name: ingress-nginx
       path: system/ingress-nginx

--- a/packages/core/platform/sources/kamaji.yaml
+++ b/packages/core/platform/sources/kamaji.yaml
@@ -13,6 +13,7 @@ spec:
   - name: default
     dependsOn:
     - cozystack.networking
+    - cozystack.cert-manager
     components:
     - name: kamaji
       path: system/kamaji

--- a/packages/core/platform/sources/rabbitmq-operator.yaml
+++ b/packages/core/platform/sources/rabbitmq-operator.yaml
@@ -13,6 +13,7 @@ spec:
   - name: default
     dependsOn:
     - cozystack.networking
+    - cozystack.cert-manager
     components:
     - name: rabbitmq-operator
       path: system/rabbitmq-operator


### PR DESCRIPTION
## What this PR does

Adds `cert-manager` as a `dependsOn` entry to the five PackageSources whose charts apply `cert-manager.io/v1` `Certificate` CRs and need the webhook ready before their first reconcile. Without this, the helm install renders Certificate manifests, the cert-manager webhook isn't admitting requests yet (cold cluster), the apply fails, and helm-controller retries until the webhook eventually comes up — burning ~2-3 minutes per affected package on cold installs.

The five PackageSources: `capi-operator`, `cozystack-engine`, `ingress-nginx`, `kamaji`, and `rabbitmq-operator` (the platform `cozy-system` set with webhook-cert consumers; not the apps layer).

In `cozystack-engine`, the dependency is added to both the `default` and `oidc` variants — the `oidc` variant installs the same `cozystack-api` and `lineage-controller-webhook` components that render Certificate resources, so it had the same race.

## Origin

First commit lifted unchanged from #2619. Second commit (`oidc` variant) added in response to review feedback.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated package source dependencies across multiple components to ensure proper installation sequencing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->