### PR TITLE
fix(kubernetes): add spec.timeout to tenant CSI HelmRelease

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/csi.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/csi.yaml
@@ -9,6 +9,7 @@ metadata:
     sharding.fluxcd.io/key: tenants
 spec:
   interval: 5m
+  timeout: 10m
   releaseName: csi
   chartRef:
     kind: ExternalArtifact


### PR DESCRIPTION
## What this PR does

Adds `spec.timeout: 10m` to the `kubevirt-csi-node` HelmRelease template in `packages/apps/kubernetes/templates/helmreleases/csi.yaml`, aligning it with every other tenant addon HR in the same directory (cilium, coredns, ingress-nginx, etc. — all set `timeout: 10m`). `csi.yaml` was the only one missing it; commit 9f9d8f85 ("Align timeouts for HelmReleases") missed this template.

## Symptom

E2E NFS test times out waiting for `nfs-test-pod` to reach `Succeeded`. Cozyreport events show the tenant `csi` HR running an Install → Uninstall → Install remediation cycle. With `install.remediation.retries: -1` and the default 5m Helm timeout, kstatus marks the `kubevirt-csi-node` DaemonSet `InProgress` past 5m on a slow tenant control-plane bringup (Kamaji APIs flapping, VM image pulls), helm-controller times out, the remediation uninstalls the DaemonSet, then reinstalls. Any volume mount in flight at that moment is wedged.

## Origin

Single commit lifted unchanged from #2619.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Container Storage Interface (CSI) Helm release settings to include a `spec.timeout` of **10 minutes** when the etcd namespace value is set (keeping the existing `spec.interval` at **5 minutes**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->