### PR TITLE
feat(platform): add cozystack.customizer system package

### DIFF
--- a/packages/core/platform/sources/customizer.yaml
+++ b/packages/core/platform/sources/customizer.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: cozystack.io/v1alpha1
+kind: PackageSource
+metadata:
+  name: cozystack.customizer
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: cozystack-packages
+    namespace: cozy-system
+    path: /
+  variants:
+  - name: default
+    components:
+    - name: customizer
+      path: system/customizer
+      install:
+        namespace: cozy-system
+        releaseName: customizer

--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -219,4 +219,10 @@
 {{- end }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.hetzner-robotlb" $) }}
 
+# Admin-facing GitOps customizer (opt-in via customizer.enabled)
+{{- if .Values.customizer.enabled }}
+{{- $customizerComponents := dict "customizer" (dict "values" .Values.customizer) }}
+{{include "cozystack.platform.package" (list "cozystack.customizer" "default" $ $customizerComponents) }}
+{{- end }}
+
 {{- end }}

--- a/packages/core/platform/tests/bundles_customizer_test.yaml
+++ b/packages/core/platform/tests/bundles_customizer_test.yaml
@@ -1,0 +1,80 @@
+suite: customizer bundle wiring
+templates:
+  - templates/bundles/system.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  - it: emits no cozystack.customizer Package when customizer.enabled is false
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+      customizer:
+        enabled: false
+    asserts:
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.customizer
+        not: true
+        documentIndex: -1
+
+  - it: emits cozystack.customizer Package with customizer values when customizer.enabled is true
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+      customizer:
+        enabled: true
+        source:
+          url: https://github.com/myorg/cozystack-customizer.git
+          ref:
+            branch: main
+          secretRef: cozystack-customizer-git
+        kustomization:
+          path: ./clusters/prod
+          ssaStrategy: Merge
+        rbac:
+          ownedNamespaces:
+            - cozy-customizer
+    documentSelector:
+      path: metadata.name
+      value: cozystack.customizer
+    asserts:
+      - equal:
+          path: kind
+          value: Package
+      - equal:
+          path: spec.variant
+          value: default
+      - equal:
+          path: spec.components.customizer.values.source.url
+          value: https://github.com/myorg/cozystack-customizer.git
+      - equal:
+          path: spec.components.customizer.values.kustomization.path
+          value: ./clusters/prod
+
+  - it: respects bundles.disabledPackages for cozystack.customizer
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        disabledPackages:
+          - cozystack.customizer
+      customizer:
+        enabled: true
+        source:
+          url: https://github.com/myorg/cozystack-customizer.git
+        kustomization:
+          path: ./clusters/prod
+    asserts:
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.customizer
+        not: true
+        documentIndex: -1

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -237,3 +237,27 @@ resources:
   cpuAllocationRatio: 10
   memoryAllocationRatio: 1
   ephemeralStorageAllocationRatio: 40
+# Admin-facing GitOps customizer (cozystack.customizer).
+# When enabled, a Flux GitRepository + Kustomization in cozy-system reconciles
+# an admin-owned git repo of cluster customizations using a curated
+# ServiceAccount. The admin pre-creates the git auth Secret named by
+# source.secretRef in cozy-system before enabling.
+#
+# Risk callout: as of MVP there is no admission webhook on packages.cozystack.io.
+# Customizer manifests can silently claim chart-owned fields on Package CRs
+# (kustomize-controller force-transfers ownership unconditionally). Treat the
+# field-ownership contract in operations/customizer as advisory until the
+# webhook lands. Review customizer patches accordingly.
+customizer:
+  enabled: false
+  source:
+    url: ""
+    ref:
+      branch: main
+    secretRef: ""
+  kustomization:
+    path: ""
+    ssaStrategy: Merge
+  rbac:
+    ownedNamespaces:
+      - cozy-customizer

--- a/packages/system/customizer/Chart.yaml
+++ b/packages/system/customizer/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cozy-customizer
+description: Admin-facing GitOps surface for Cozystack — Flux GitRepository + Kustomization driving an admin-owned git repo of cluster customizations, applied via a curated ServiceAccount.
+type: application
+version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process
+appVersion: "0.1.0"

--- a/packages/system/customizer/Makefile
+++ b/packages/system/customizer/Makefile
@@ -1,0 +1,4 @@
+export NAME=customizer
+export NAMESPACE=cozy-system
+
+include ../../../hack/package.mk

--- a/packages/system/customizer/templates/clusterrole.yaml
+++ b/packages/system/customizer/templates/clusterrole.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozystack-customizer
+rules:
+  # Patch Package CRs — but not delete them. Deletion of a platform Package
+  # would tear down its HelmReleases and leave the bundle in a partial state.
+  # Use bundles.disabledPackages on cozystack.cozystack-platform to disable.
+  - apiGroups: ["cozystack.io"]
+    resources: ["packages"]
+    verbs: ["get", "list", "watch", "patch", "update"]
+  # Admins can author their own PackageSources (custom OCI/Git chart sources).
+  - apiGroups: ["cozystack.io"]
+    resources: ["packagesources"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Read-only visibility on platform HelmReleases.
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "list", "watch"]
+  # Keycloak: declarative realm / client / user management when keycloak is enabled.
+  - apiGroups: ["k8s.keycloak.org"]
+    resources: ["keycloakrealmimports", "keycloaks", "keycloakusers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Source-controller objects so admins can declare additional GitRepositories /
+  # OCIRepositories (their own chart registry).
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: ["*"]
+    verbs: ["*"]

--- a/packages/system/customizer/templates/clusterrolebinding.yaml
+++ b/packages/system/customizer/templates/clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cozystack-customizer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cozystack-customizer
+subjects:
+  - kind: ServiceAccount
+    name: cozystack-customizer
+    namespace: {{ .Release.Namespace }}

--- a/packages/system/customizer/templates/gitrepository.yaml
+++ b/packages/system/customizer/templates/gitrepository.yaml
@@ -1,0 +1,18 @@
+{{- if not .Values.source.url -}}
+{{- fail "customizer: source.url is required when the package is enabled" -}}
+{{- end -}}
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: cozystack-customizer-config
+  namespace: {{ .Release.Namespace }}
+spec:
+  interval: {{ .Values.source.interval }}
+  url: {{ .Values.source.url | quote }}
+  ref:
+    {{- toYaml .Values.source.ref | nindent 4 }}
+  {{- with .Values.source.secretRef }}
+  secretRef:
+    name: {{ . }}
+  {{- end }}

--- a/packages/system/customizer/templates/kustomization.yaml
+++ b/packages/system/customizer/templates/kustomization.yaml
@@ -1,0 +1,33 @@
+{{- if not .Values.kustomization.path -}}
+{{- fail "customizer: kustomization.path is required when the package is enabled" -}}
+{{- end -}}
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cozystack-customizer
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    # kustomize-controller hardcodes client.ForceOwnership on Apply, so this
+    # annotation does NOT block silent field-ownership transfer. Merge is
+    # still preferred over Override because the cleanup pass is less
+    # aggressive (auto-clears fewer foreign managers). The actual contract
+    # enforcement is a follow-up admission webhook on packages.cozystack.io.
+    kustomize.toolkit.fluxcd.io/ssa: {{ .Values.kustomization.ssaStrategy }}
+spec:
+  interval: {{ .Values.kustomization.interval }}
+  path: {{ .Values.kustomization.path | quote }}
+  prune: {{ .Values.kustomization.prune }}
+  wait: {{ .Values.kustomization.wait }}
+  sourceRef:
+    kind: GitRepository
+    name: cozystack-customizer-config
+  serviceAccountName: cozystack-customizer
+  {{- with .Values.kustomization.decryption }}
+  decryption:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  healthChecks:
+    - apiVersion: cozystack.io/v1alpha1
+      kind: Package
+      name: cozystack.cozystack-platform

--- a/packages/system/customizer/templates/namespace.yaml
+++ b/packages/system/customizer/templates/namespace.yaml
@@ -1,0 +1,10 @@
+{{- range .Values.rbac.ownedNamespaces }}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ . }}
+  labels:
+    app.kubernetes.io/managed-by: cozystack
+    cozystack.io/customizer-owned: "true"
+{{- end }}

--- a/packages/system/customizer/templates/rolebindings.yaml
+++ b/packages/system/customizer/templates/rolebindings.yaml
@@ -1,0 +1,16 @@
+{{- range .Values.rbac.ownedNamespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cozystack-customizer
+  namespace: {{ . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: cozystack-customizer
+    namespace: {{ $.Release.Namespace }}
+{{- end }}

--- a/packages/system/customizer/templates/serviceaccount.yaml
+++ b/packages/system/customizer/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cozystack-customizer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: cozystack-customizer
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/packages/system/customizer/values.yaml
+++ b/packages/system/customizer/values.yaml
@@ -1,0 +1,34 @@
+source:
+  # https://github.com/myorg/cozystack-customizer or ssh://... — required when enabled.
+  url: ""
+  ref:
+    branch: main
+  # Secret in {{ .Release.Namespace }} with git credentials. Admin pre-creates;
+  # this chart does not generate it (the platform must never own admin credentials).
+  secretRef: ""
+  interval: 1m
+
+kustomization:
+  # Path inside the customizer repo that the Kustomization reconciles.
+  path: ""
+  interval: 5m
+  prune: true
+  wait: true
+  # decryption block per https://fluxcd.io/flux/components/kustomize/kustomizations/#decryption
+  decryption: {}
+  # SSA strategy applied to customizer-rendered manifests. Default Merge for
+  # safety (kustomize-controller will still force-transfer ownership on
+  # overlapping fields — Flux SSA conflict detection cannot catch this; the
+  # planned admission webhook on packages.cozystack.io is the enforcement
+  # path — but Merge avoids cleanup-side surprises). Set to Override only
+  # once admins are confident no chart-managed field will be claimed by
+  # their manifests.
+  ssaStrategy: Merge
+
+rbac:
+  # Namespaces in which the customizer SA is bound to cluster-admin (full
+  # mutate within these namespaces). cozy-customizer is the chart-created
+  # default — the admin's own playground for bring-your-own HelmReleases,
+  # NetworkPolicies, etc.
+  ownedNamespaces:
+    - cozy-customizer


### PR DESCRIPTION
## Summary
- Adds a new opt-in system package `cozystack.customizer` that provisions a Flux GitRepository + Kustomization in `cozy-system` reconciling an admin-owned git repo of cluster customizations via a curated ServiceAccount. Lets admins manage Package CR patches and bring-their-own HelmReleases / Keycloak realms / NetworkPolicies as code in a repo they own, rather than via in-cluster `kubectl patch`.
- Wired into the platform chart via a single `customizer.enabled` flag in values; off by default. Respects `bundles.disabledPackages`.
- Curated ClusterRole grants `patch` (not `delete`) on `packages.cozystack.io`, full ownership of PackageSources + customizer-owned namespaces (default `cozy-customizer`) + Keycloak realm CRs, and read-only on platform HelmReleases. Explicitly NO grant on CRDs, the cozystack-controller Deployment, or `kube-system`.

## Why no admission webhook in this PR
The values block carries an inline risk callout: the field-ownership contract between customizer manifests and chart-managed Package fields is currently **advisory**, not enforced. `kustomize-controller` hardcodes `client.ForceOwnership` on every SSA Apply, so Flux's own conflict detection cannot block silent transfer of chart-owned fields (e.g. `spec.variant`) when a customizer manifest happens to declare them. The intended enforcement is a validating admission webhook on `packages.cozystack.io`, which is a separate piece of work and deliberately out of scope here — this PR ships the GitOps surface itself and the contract as documentation, so admins can adopt the pattern while the webhook lands.

## Test plan
- [x] \`helm lint\` on standalone chart
- [x] \`helm template\` rendering with realistic values
- [x] \`helm unittest\` for bundle wiring (3 cases: off, on, disabledPackages override) — full platform suite stays green (4 suites, 14 tests)
- [x] Required-field guards (\`source.url\`, \`kustomization.path\`) trip cleanly
- [x] End-to-end install on a dev cluster (prior to rename, with original names):
  - All 7 resource kinds reconcile (Namespace, SA, ClusterRole, ClusterRoleBinding, RoleBinding, GitRepository, Kustomization)
  - GitRepository pulls via \`secretRef\`
  - Kustomization applies via the curated SA
  - RBAC boundaries verified with \`kubectl auth can-i --as=…cozystack-customizer\` (patch packages ✓, delete packages ✗, delete CRDs ✗, create HelmRelease in cozy-system ✗, create HelmRelease in cozy-customizer ✓, …)
  - SSA layering: customizer Kustomization and helm-controller coexist as separate field managers on a Package CR
- [ ] Maintainer review of the field-ownership contract (the bit upstream needs to sign off on before docs lead with this path)

## Out of scope (follow-ups)
- Validating admission webhook on \`packages.cozystack.io\`
- \`cozypkg lint customizer/\` CI-side pre-commit check
- Docs page (\`operations/customizer/_index.md\`)
- Sample customizer repo template
