### PR TITLE
feat(dashboard): add cluster-usage RBAC for the new admin page

### DIFF
--- a/packages/system/dashboard/templates/clusterrole-cluster-usage.yaml
+++ b/packages/system/dashboard/templates/clusterrole-cluster-usage.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozystack-dashboard-cluster-usage
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["nodes"]
+    verbs: ["get", "list"]

--- a/packages/system/dashboard/templates/clusterrolebinding-cluster-usage.yaml
+++ b/packages/system/dashboard/templates/clusterrolebinding-cluster-usage.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cozystack-dashboard-cluster-usage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cozystack-dashboard-cluster-usage
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: cozystack-cluster-admin

--- a/packages/system/dashboard/tests/cluster_usage_rbac_test.yaml
+++ b/packages/system/dashboard/tests/cluster_usage_rbac_test.yaml
@@ -1,0 +1,81 @@
+suite: dashboard cluster-usage RBAC
+templates:
+  - templates/clusterrole-cluster-usage.yaml
+  - templates/clusterrolebinding-cluster-usage.yaml
+
+release:
+  name: dashboard
+  namespace: cozy-dashboard
+
+# The cluster-usage admin page in the dashboard reads cluster-scoped
+# resources (nodes, pods, metrics.k8s.io) to render aggregate utilisation
+# and a per-node table including arbitrary extended resources (GPUs etc.).
+# The built-in `edit` ClusterRole already bound to cozystack-cluster-admin
+# does not grant cluster-wide pod read or `nodes` access, so the dashboard
+# needs an explicit grant. The page-side sidebar item is gated by SSAR on
+# `nodes list` — pinning the rules here keeps that gate meaningful.
+
+tests:
+  - it: ClusterRole exists and grants nodes/pods get/list/watch
+    template: templates/clusterrole-cluster-usage.yaml
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: apiVersion
+          value: rbac.authorization.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: cozystack-dashboard-cluster-usage
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["nodes", "pods"]
+            verbs: ["get", "list", "watch"]
+
+  - it: ClusterRole grants metrics.k8s.io nodes get/list
+    template: templates/clusterrole-cluster-usage.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["metrics.k8s.io"]
+            resources: ["nodes"]
+            verbs: ["get", "list"]
+
+  - it: ClusterRoleBinding binds the role to cozystack-cluster-admin group
+    template: templates/clusterrolebinding-cluster-usage.yaml
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: apiVersion
+          value: rbac.authorization.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: cozystack-dashboard-cluster-usage
+      - equal:
+          path: roleRef.kind
+          value: ClusterRole
+      - equal:
+          path: roleRef.name
+          value: cozystack-dashboard-cluster-usage
+      - equal:
+          path: subjects[0].kind
+          value: Group
+      - equal:
+          path: subjects[0].name
+          value: cozystack-cluster-admin
+      - equal:
+          path: subjects[0].apiGroup
+          value: rbac.authorization.k8s.io
+
+  - it: each template renders exactly one document
+    asserts:
+      - template: templates/clusterrole-cluster-usage.yaml
+        hasDocuments:
+          count: 1
+      - template: templates/clusterrolebinding-cluster-usage.yaml
+        hasDocuments:
+          count: 1


### PR DESCRIPTION
## What this PR does

Adds a new `ClusterRole` `cozystack-dashboard-cluster-usage` and its `ClusterRoleBinding` under `packages/system/dashboard/templates/`, plus the matching helm-unittest fixture. The role grants the `cozystack-cluster-admin` group cluster-wide read on `nodes`, `pods` (get/list/watch) and on `metrics.k8s.io` `nodes` (get/list).

Companion to the upcoming UI work in cozystack/cozystack-ui#15 — a new admin page `Console → Administration → Cluster Usage` that renders cluster-scoped resource utilisation and a per-node table including arbitrary extended resources (GPUs and other accelerators). The page-side sidebar item is gated by a `SelfSubjectAccessReview` on `nodes list`; without this binding the gate fails closed and the entry stays invisible, which is the desired fallback for clusters that have not adopted the new RBAC yet.

The built-in `edit` `ClusterRole` already bound to `cozystack-cluster-admin` via `cozystack-dashboard-cluster-admin` does not grant cluster-wide pod read or any access to `nodes`, so an explicit grant is required for the page to render anything beyond an error.

This chart intentionally does not add permissions for deeper sources (Prometheus, DCGM, HAMi). Those belong in their respective packages or in operator-provided RBAC; the page detects them via discovery and gates each section with its own per-source review.

### Screenshots

No UI in this PR — RBAC only.

### Release note

```release-note
feat(dashboard): grant cluster-admin read access to nodes, pods and metrics.k8s.io for the new Cluster Usage admin page
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard cluster usage monitoring now includes configured role-based access control with appropriate read permissions for nodes, pods, and metrics data.

* **Tests**
  * Added comprehensive test suite to validate the dashboard's role-based access control configuration, including verification of proper permission bindings and authorization rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->