### PR TITLE
feat(trust-manager): add as cozystack system package

### DIFF
--- a/hack/cozyreport.sh
+++ b/hack/cozyreport.sh
@@ -18,7 +18,7 @@ if kubectl get deploy -n cozy-system cozystack-operator >/dev/null 2>&1; then
   kubectl logs -n cozy-system deploy/cozystack-operator --tail=2000 --previous > $REPORT_DIR/cozystack/operator-previous.log 2>&1 || true
 fi
 kubectl get cm -n cozy-system --no-headers | awk '$1 ~ /^cozystack/' |
-  while read NAME _; do
+  while read -r NAME _; do
     DIR=$REPORT_DIR/cozystack/configs
     mkdir -p $DIR
     kubectl get cm -n cozy-system $NAME -o yaml > $DIR/$NAME.yaml 2>&1
@@ -52,7 +52,7 @@ if kubectl get crd certificates.cert-manager.io >/dev/null 2>&1; then
   kubectl get challenges.acme.cert-manager.io -A > $DIR/challenges.txt 2>&1
   # Per non-Ready cert: full yaml + describe
   kubectl get certificates.cert-manager.io -A --no-headers 2>/dev/null | awk '$3 != "True"' | \
-    while read NAMESPACE NAME _; do
+    while read -r NAMESPACE NAME _; do
       cdir=$DIR/certificates/$NAMESPACE/$NAME
       mkdir -p $cdir
       kubectl get certificates.cert-manager.io -n $NAMESPACE $NAME -o yaml > $cdir/cert.yaml 2>&1
@@ -61,6 +61,28 @@ if kubectl get crd certificates.cert-manager.io >/dev/null 2>&1; then
   if kubectl get deploy -n cozy-cert-manager cert-manager >/dev/null 2>&1; then
     kubectl logs -n cozy-cert-manager deploy/cert-manager --tail=2000 > $DIR/cert-manager.log 2>&1
     kubectl logs -n cozy-cert-manager deploy/cert-manager-webhook --tail=2000 > $DIR/cert-manager-webhook.log 2>&1
+  fi
+fi
+
+# -- trust-manager module
+if kubectl get crd bundles.trust.cert-manager.io >/dev/null 2>&1; then
+  echo "Collecting trust-manager state..."
+  DIR="$REPORT_DIR/trust-manager"
+  mkdir -p "$DIR"
+  kubectl get bundles.trust.cert-manager.io > "$DIR/bundles.txt" 2>&1
+  # Per non-Synced Bundle: full yaml + describe.
+  # Column order from Bundle CRD additionalPrinterColumns:
+  # NAME ConfigMap_Target Secret_Target Synced Reason Age — $4 is Synced.
+  kubectl get bundles.trust.cert-manager.io --no-headers 2>/dev/null | awk '$4 != "True"' | \
+    while read -r NAME _; do
+      bdir="$DIR/bundles/$NAME"
+      mkdir -p "$bdir"
+      kubectl get bundles.trust.cert-manager.io "$NAME" -o yaml > "$bdir/bundle.yaml" 2>&1
+      kubectl describe bundles.trust.cert-manager.io "$NAME" > "$bdir/describe.txt" 2>&1
+    done
+  if kubectl get deploy -n cozy-cert-manager trust-manager >/dev/null 2>&1; then
+    kubectl logs -n cozy-cert-manager deploy/trust-manager --tail=2000 > "$DIR/trust-manager.log" 2>&1
+    kubectl logs -n cozy-cert-manager deploy/trust-manager --previous --tail=2000 > "$DIR/trust-manager-previous.log" 2>&1 || true
   fi
 fi
 
@@ -73,7 +95,7 @@ kubectl version > $REPORT_DIR/kubernetes/version.txt 2>&1
 echo "Collecting nodes..."
 kubectl get nodes -o wide > $REPORT_DIR/kubernetes/nodes.txt 2>&1
 kubectl get nodes --no-headers | awk '$2 != "Ready"' |
-  while read NAME _; do
+  while read -r NAME _; do
     DIR=$REPORT_DIR/kubernetes/nodes/$NAME
     mkdir -p $DIR
     kubectl get node $NAME -o yaml > $DIR/node.yaml 2>&1
@@ -83,7 +105,7 @@ kubectl get nodes --no-headers | awk '$2 != "Ready"' |
 echo "Collecting namespaces..."
 kubectl get ns -o wide > $REPORT_DIR/kubernetes/namespaces.txt 2>&1
 kubectl get ns --no-headers | awk '$2 != "Active"' |
-  while read NAME _; do
+  while read -r NAME _; do
     DIR=$REPORT_DIR/kubernetes/namespaces/$NAME
     mkdir -p $DIR
     kubectl get ns $NAME -o yaml > $DIR/namespace.yaml 2>&1
@@ -100,14 +122,14 @@ kubectl get events -A --sort-by=.lastTimestamp \
 echo "Collecting helmreleases..."
 kubectl get hr -A > $REPORT_DIR/kubernetes/helmreleases.txt 2>&1
 kubectl get hr -A --no-headers | awk '$4 != "True"' | \
-  while read NAMESPACE NAME _; do
+  while read -r NAMESPACE NAME _; do
     DIR=$REPORT_DIR/kubernetes/helmreleases/$NAMESPACE/$NAME
     mkdir -p $DIR
     kubectl get hr -n $NAMESPACE $NAME -o yaml > $DIR/hr.yaml 2>&1
     kubectl describe hr -n $NAMESPACE $NAME > $DIR/describe.txt 2>&1
     # Helm storage secrets: latest revision per release.
     kubectl get secret -n $NAMESPACE -l owner=helm,name=$NAME --sort-by='.metadata.creationTimestamp' --no-headers 2>/dev/null | \
-      tail -1 | awk '{print $1}' | while read SECRET; do
+      tail -1 | awk '{print $1}' | while read -r SECRET; do
         [ -z "$SECRET" ] && continue
         kubectl get secret -n $NAMESPACE $SECRET -o jsonpath='{.data.release}' 2>/dev/null \
           | base64 -d | base64 -d | gzip -d > $DIR/helm-release.json 2>&1 || true
@@ -117,7 +139,7 @@ kubectl get hr -A --no-headers | awk '$4 != "True"' | \
 echo "Collecting packages..."
 kubectl get packages > $REPORT_DIR/kubernetes/packages.txt 2>&1
 kubectl get packages --no-headers | awk '$3 != "True"' | \
-  while read NAME _; do
+  while read -r NAME _; do
     DIR=$REPORT_DIR/kubernetes/packages/$NAME
     mkdir -p $DIR
     kubectl get package $NAME -o yaml > $DIR/package.yaml 2>&1
@@ -127,7 +149,7 @@ kubectl get packages --no-headers | awk '$3 != "True"' | \
 echo "Collecting packagesources..."
 kubectl get packagesources > $REPORT_DIR/kubernetes/packagesources.txt 2>&1
 kubectl get packagesources --no-headers | awk '$3 != "True"' | \
-  while read NAME _; do
+  while read -r NAME _; do
     DIR=$REPORT_DIR/kubernetes/packagesources/$NAME
     mkdir -p $DIR
     kubectl get packagesource $NAME -o yaml > $DIR/packagesource.yaml 2>&1
@@ -142,7 +164,7 @@ for kind in applications.apps.cozystack.io applicationdefinitions.apps.cozystack
   if kubectl get crd $kind >/dev/null 2>&1; then
     kubectl get $kind -A > $DIR/$short.txt 2>&1
     kubectl get $kind -A -o jsonpath='{range .items[?(@.status.conditions[?(@.type=="Ready")].status!="True")]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null | \
-      while read NAMESPACE NAME; do
+      while read -r NAMESPACE NAME; do
         [ -z "$NAMESPACE" ] && continue
         d=$DIR/$short/$NAMESPACE/$NAME
         mkdir -p $d
@@ -155,7 +177,7 @@ done
 echo "Collecting pods..."
 kubectl get pod -A -o wide > $REPORT_DIR/kubernetes/pods.txt 2>&1
 kubectl get pod -A --no-headers | awk '$4 !~ /Running|Succeeded|Completed/' |
-  while read NAMESPACE NAME _ STATE _; do
+  while read -r NAMESPACE NAME _ STATE _; do
     DIR=$REPORT_DIR/kubernetes/pods/$NAMESPACE/$NAME
     mkdir -p $DIR
     CONTAINERS=$(kubectl get pod -o jsonpath='{.spec.containers[*].name} {.spec.initContainers[*].name}' -n $NAMESPACE $NAME)
@@ -172,7 +194,7 @@ kubectl get pod -A --no-headers | awk '$4 !~ /Running|Succeeded|Completed/' |
 echo "Collecting virtualmachines..."
 kubectl get vm -A > $REPORT_DIR/kubernetes/vms.txt 2>&1
 kubectl get vm -A --no-headers | awk '$5 != "True"' |
-  while read NAMESPACE NAME _; do
+  while read -r NAMESPACE NAME _; do
     DIR=$REPORT_DIR/kubernetes/vm/$NAMESPACE/$NAME
     mkdir -p $DIR
     kubectl get vm -n $NAMESPACE $NAME -o yaml > $DIR/vm.yaml 2>&1
@@ -182,7 +204,7 @@ kubectl get vm -A --no-headers | awk '$5 != "True"' |
 echo "Collecting virtualmachine instances..."
 kubectl get vmi -A > $REPORT_DIR/kubernetes/vmis.txt 2>&1
 kubectl get vmi -A --no-headers | awk '$4 != "Running"' |
-  while read NAMESPACE NAME _; do
+  while read -r NAMESPACE NAME _; do
     DIR=$REPORT_DIR/kubernetes/vmi/$NAMESPACE/$NAME
     mkdir -p $DIR
     kubectl get vmi -n $NAMESPACE $NAME -o yaml > $DIR/vmi.yaml 2>&1
@@ -192,7 +214,7 @@ kubectl get vmi -A --no-headers | awk '$4 != "Running"' |
 echo "Collecting services..."
 kubectl get svc -A > $REPORT_DIR/kubernetes/services.txt 2>&1
 kubectl get svc -A --no-headers | awk '$4 == "<pending>"' |
-  while read NAMESPACE NAME _; do
+  while read -r NAMESPACE NAME _; do
     DIR=$REPORT_DIR/kubernetes/services/$NAMESPACE/$NAME
     mkdir -p $DIR
     kubectl get svc -n $NAMESPACE $NAME -o yaml > $DIR/service.yaml 2>&1
@@ -202,7 +224,7 @@ kubectl get svc -A --no-headers | awk '$4 == "<pending>"' |
 echo "Collecting pvcs..."
 kubectl get pvc -A > $REPORT_DIR/kubernetes/pvcs.txt 2>&1
 kubectl get pvc -A --no-headers | awk '$3 != "Bound"'  |
-  while read NAMESPACE NAME _; do
+  while read -r NAMESPACE NAME _; do
     DIR=$REPORT_DIR/kubernetes/pvc/$NAMESPACE/$NAME
     mkdir -p $DIR
     kubectl get pvc -n $NAMESPACE $NAME -o yaml > $DIR/pvc.yaml 2>&1

--- a/packages/core/platform/sources/trust-manager.yaml
+++ b/packages/core/platform/sources/trust-manager.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: cozystack.io/v1alpha1
+kind: PackageSource
+metadata:
+  name: cozystack.trust-manager
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: cozystack-packages
+    namespace: cozy-system
+    path: /
+  variants:
+  - name: default
+    dependsOn:
+    - cozystack.cert-manager
+    components:
+    - name: trust-manager-crds
+      path: system/trust-manager-crds
+      install:
+        namespace: cozy-cert-manager
+        releaseName: trust-manager-crds
+    - name: trust-manager
+      path: system/trust-manager
+      install:
+        namespace: cozy-cert-manager
+        releaseName: trust-manager
+        dependsOn:
+        - trust-manager-crds

--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -117,6 +117,7 @@
 # Common Packages
 {{include "cozystack.platform.package.default" (list "cozystack.gateway-api-crds" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.cert-manager" $) }}
+{{include "cozystack.platform.package.default" (list "cozystack.trust-manager" $) }}
 {{- /* Disable hazard guard. The vendored cozy-ouroboros chart (0.7.0)
        ships a pre-delete Helm hook that sed-strips the BEGIN/END
        block from kube-system/coredns Corefile when the chart is

--- a/packages/core/platform/tests/bundles_trust_manager_test.yaml
+++ b/packages/core/platform/tests/bundles_trust_manager_test.yaml
@@ -1,0 +1,148 @@
+suite: trust-manager bundle wiring
+templates:
+  - templates/bundles/system.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  - it: emits cozystack.trust-manager Package with resource-policy keep in isp-full
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+    documentSelector:
+      path: metadata.name
+      value: cozystack.trust-manager
+    asserts:
+      - equal:
+          path: apiVersion
+          value: cozystack.io/v1alpha1
+      - equal:
+          path: kind
+          value: Package
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+      - equal:
+          path: spec.variant
+          value: default
+
+  - it: emits cozystack.trust-manager Package with resource-policy keep in isp-full-generic
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full-generic
+      networking:
+        podCIDR: 10.244.0.0/16
+        podGateway: 10.244.0.1
+        serviceCIDR: 10.96.0.0/16
+        joinCIDR: 100.64.0.0/16
+        kubeovn:
+          MASTER_NODES: ""
+      publishing:
+        apiServerEndpoint: https://127.0.0.1:6443
+    documentSelector:
+      path: metadata.name
+      value: cozystack.trust-manager
+    asserts:
+      - equal:
+          path: kind
+          value: Package
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+      - equal:
+          path: spec.variant
+          value: default
+
+  - it: emits cozystack.trust-manager Package with resource-policy keep in isp-hosted
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-hosted
+    documentSelector:
+      path: metadata.name
+      value: cozystack.trust-manager
+    asserts:
+      - equal:
+          path: kind
+          value: Package
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+      - equal:
+          path: spec.variant
+          value: default
+
+  - it: bundles.disabledPackages suppresses cozystack.trust-manager in isp-full
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        disabledPackages:
+          - cozystack.trust-manager
+    asserts:
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.trust-manager
+        not: true
+        documentIndex: -1
+
+  - it: bundles.disabledPackages suppresses cozystack.trust-manager in isp-hosted
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-hosted
+        disabledPackages:
+          - cozystack.trust-manager
+    asserts:
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.trust-manager
+        not: true
+        documentIndex: -1
+
+  - it: bundles.disabledPackages suppresses cozystack.trust-manager in isp-full-generic
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full-generic
+        disabledPackages:
+          - cozystack.trust-manager
+      networking:
+        podCIDR: 10.244.0.0/16
+        podGateway: 10.244.0.1
+        serviceCIDR: 10.96.0.0/16
+        joinCIDR: 100.64.0.0/16
+        kubeovn:
+          MASTER_NODES: ""
+      publishing:
+        apiServerEndpoint: https://127.0.0.1:6443
+    asserts:
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.trust-manager
+        not: true
+        documentIndex: -1
+
+  - it: emits no cozystack.trust-manager Package when bundles.system.enabled is false
+    set:
+      bundles:
+        system:
+          enabled: false
+    asserts:
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.trust-manager
+        not: true
+        documentIndex: -1

--- a/packages/system/trust-manager-crds/.helmignore
+++ b/packages/system/trust-manager-crds/.helmignore
@@ -1,0 +1,2 @@
+images
+hack

--- a/packages/system/trust-manager-crds/Chart.yaml
+++ b/packages/system/trust-manager-crds/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: cozy-trust-manager-crds
+version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process

--- a/packages/system/trust-manager-crds/Makefile
+++ b/packages/system/trust-manager-crds/Makefile
@@ -1,0 +1,4 @@
+export NAME=trust-manager-crds
+export NAMESPACE=cozy-cert-manager
+
+include ../../../hack/package.mk

--- a/packages/system/trust-manager-crds/templates/_helpers.tpl
+++ b/packages/system/trust-manager-crds/templates/_helpers.tpl
@@ -1,0 +1,162 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "trust-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "trust-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "trust-manager.labels" -}}
+app.kubernetes.io/name: {{ include "trust-manager.name" . }}
+helm.sh/chart: {{ include "trust-manager.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Util function for generating the image URL based on the provided options.
+IMPORTANT: This function is standardized across all charts in the cert-manager GH organization.
+Any changes to this function should also be made in cert-manager, trust-manager, approver-policy, ...
+See https://github.com/cert-manager/cert-manager/issues/6329 for a list of linked PRs.
+*/}}
+{{- define "image" -}}
+{{- /*
+Calling convention:
+
+- (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>)
+
+We intentionally pass imageRegistry/imageNamespace as explicit arguments rather than reading
+from `.Values` inside this helper, because `helm-tool lint` does not reliably track `.Values.*`
+usage through tuple/variable indirection.
+*/ -}}
+
+{{- if ne (len .) 4 -}}
+    {{- fail (printf "ERROR: template \"image\" expects (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>), got %d arguments" (len .)) -}}
+{{- end -}}
+
+{{- $image := index . 0 -}}
+{{- $imageRegistry := index . 1 | default "" -}}
+{{- $imageNamespace := index . 2 | default "" -}}
+{{- $defaultReference := index . 3 -}}
+
+{{- $repository := "" -}}
+{{- if $image.repository -}}
+    {{- $repository = $image.repository -}}
+
+    {{- /*
+        Backwards compatibility: if image.registry is set, additionally prefix the repository with this registry.
+    */ -}}
+    {{- if $image.registry -}}
+        {{- $repository = printf "%s/%s" $image.registry $repository -}}
+    {{- end -}}
+{{- else -}}
+    {{- $name := required "ERROR: image.name must be set when image.repository is empty" $image.name -}}
+    {{- $repository = $name -}}
+
+    {{- if $imageNamespace -}}
+        {{- $repository = printf "%s/%s" $imageNamespace $repository -}}
+    {{- end -}}
+
+    {{- if $imageRegistry -}}
+        {{- $repository = printf "%s/%s" $imageRegistry $repository -}}
+    {{- end -}}
+
+    {{- /*
+        Backwards compatibility: if image.registry is set, additionally prefix the repository with this registry.
+    */ -}}
+    {{- if $image.registry -}}
+        {{- $repository = printf "%s/%s" $image.registry $repository -}}
+    {{- end -}}
+{{- end -}}
+
+{{- $repository -}}
+{{- if and $image.tag $image.digest -}}
+    {{- printf ":%s@%s" $image.tag $image.digest -}}
+{{- else if $image.tag -}}
+    {{- printf ":%s" $image.tag -}}
+{{- else if $image.digest -}}
+    {{- printf "@%s" $image.digest -}}
+{{- else -}}
+    {{- printf "%s" $defaultReference -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Namespace for all resources to be installed into
+If not defined in values file then the helm release namespace is used
+By default this is not set so the helm release namespace will be used
+
+This gets around an problem within helm discussed here
+https://github.com/helm/helm/issues/5358
+*/}}
+{{- define "trust-manager.namespace" -}}
+    {{ .Values.namespace | default .Release.Namespace }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "trust-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "trust-manager.name" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Namespaced resources rules
+*/}}
+{{- define "trust-manager.rbac.namespacedResourcesRules" -}}
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs: ["get","list","create","patch","watch","delete"]
+
+- apiGroups:
+  - "" {{/* TODO(erikgb): Remove; MIGRATION to new events API group. */}}
+  - "events.k8s.io"
+  resources:
+  - "events"
+  verbs: ["create","patch"]
+
+{{- if .Values.secretTargets.enabled }}
+  {{- if .Values.secretTargets.authorizedSecretsAll }}
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs: ["get","list","create","patch","watch","delete"]
+  {{- else if $.Values.secretTargets.authorizedSecrets }}
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs: ["get","list","watch"]
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs: ["create","patch","delete"]
+  resourceNames:
+{{ toYaml .Values.secretTargets.authorizedSecrets | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/packages/system/trust-manager-crds/templates/crd-trust.cert-manager.io_bundles.yaml
+++ b/packages/system/trust-manager-crds/templates/crd-trust.cert-manager.io_bundles.yaml
@@ -1,0 +1,514 @@
+{{- if .Values.crds.enabled }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: "bundles.trust.cert-manager.io"
+  {{- if .Values.crds.keep }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+spec:
+  group: trust.cert-manager.io
+  names:
+    kind: Bundle
+    listKind: BundleList
+    plural: bundles
+    singular: bundle
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Bundle ConfigMap Target Key
+          jsonPath: .spec.target.configMap.key
+          name: ConfigMap Target
+          type: string
+        - description: Bundle Secret Target Key
+          jsonPath: .spec.target.secret.key
+          name: Secret Target
+          type: string
+        - description: Bundle has been synced
+          jsonPath: .status.conditions[?(@.type == "Synced")].status
+          name: Synced
+          type: string
+        - description: Reason Bundle has Synced status
+          jsonPath: .status.conditions[?(@.type == "Synced")].reason
+          name: Reason
+          type: string
+        - description: Timestamp Bundle was created
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec represents the desired state of the Bundle resource.
+              properties:
+                sources:
+                  description: sources is a set of references to data whose data will sync to the target.
+                  items:
+                    description: |-
+                      BundleSource is the set of sources whose data will be appended and synced to
+                      the BundleTarget in all Namespaces.
+                    properties:
+                      configMap:
+                        description: |-
+                          configMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
+                          list of ConfigMap's `data` key(s) using label selector, in the trust namespace.
+                        properties:
+                          includeAllKeys:
+                            description: |-
+                              includeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                              This field must not be true when `key` is set.
+                            type: boolean
+                          key:
+                            description: key of the entry in the object's `data` field to be used.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              name is the name of the source object in the trust namespace.
+                              This field must be left empty when `selector` is set
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          selector:
+                            description: |-
+                              selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `name` is set.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                        x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                          - message: exactly one of the fields in [name selector] must be set
+                            rule: '[has(self.name),has(self.selector)].filter(x,x==true).size() == 1'
+                      inLine:
+                        description: inLine is a simple string to append as the source data.
+                        maxLength: 1048576
+                        minLength: 1
+                        type: string
+                      secret:
+                        description: |-
+                          secret is a reference (by name) to a Secret's `data` key(s), or to a
+                          list of Secret's `data` key(s) using label selector, in the trust namespace.
+                        properties:
+                          includeAllKeys:
+                            description: |-
+                              includeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                              This field must not be true when `key` is set.
+                            type: boolean
+                          key:
+                            description: key of the entry in the object's `data` field to be used.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              name is the name of the source object in the trust namespace.
+                              This field must be left empty when `selector` is set
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          selector:
+                            description: |-
+                              selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `name` is set.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                        x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                          - message: exactly one of the fields in [name selector] must be set
+                            rule: '[has(self.name),has(self.selector)].filter(x,x==true).size() == 1'
+                      useDefaultCAs:
+                        description: |-
+                          useDefaultCAs indicates whether the default CA bundle should be used as a source.
+                          The default CA bundle is available only if trust-manager was installed with
+                          default CA support enabled, either via the Helm chart or by starting the
+                          trust-manager controller with the "--default-package-location" flag.
+                          If default CA support was not enabled at startup, setting this field to true
+                          will result in reconciliation failure.
+                          The version of the default CA package used for this Bundle is reported in
+                          status.defaultCAVersion.
+                        type: boolean
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                      - message: exactly one of the fields in [configMap secret inLine useDefaultCAs] must be set
+                        rule: '[has(self.configMap),has(self.secret),has(self.inLine),has(self.useDefaultCAs)].filter(x,x==true).size() == 1'
+                  maxItems: 100
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: atomic
+                target:
+                  description: target is the target location in all namespaces to sync source data to.
+                  properties:
+                    additionalFormats:
+                      description: additionalFormats specifies any additional formats to write to the target
+                      properties:
+                        jks:
+                          description: |-
+                            jks requests a JKS-formatted binary trust bundle to be written to the target.
+                            The bundle has "changeit" as the default password.
+                            For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+                            Format is deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
+                            PKCS#12 trust stores created by trust-manager are compatible with Java.
+                          minProperties: 1
+                          properties:
+                            key:
+                              description: key is the key of the entry in the object's `data` field to be used.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            password:
+                              default: changeit
+                              description: password for JKS trust store
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        pkcs12:
+                          description: |-
+                            pkcs12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+
+                            The bundle is by default created without a password.
+                            For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+                          minProperties: 1
+                          properties:
+                            key:
+                              description: key is the key of the entry in the object's `data` field to be used.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            password:
+                              default: ""
+                              description: password for PKCS12 trust store
+                              maxLength: 128
+                              minLength: 0
+                              type: string
+                            profile:
+                              description: |-
+                                profile specifies the certificate encryption algorithms and the HMAC algorithm
+                                used to create the PKCS12 trust store.
+
+                                If provided, allowed values are:
+                                `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+                                `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+                                `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (e.g. because of company policy).
+
+                                Default value is `LegacyRC2` for backward compatibility.
+                              enum:
+                                - LegacyRC2
+                                - LegacyDES
+                                - Modern2023
+                              type: string
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                      x-kubernetes-validations:
+                        - message: at least one of the fields in [jks pkcs12] must be set
+                          rule: '[has(self.jks),has(self.pkcs12)].filter(x,x==true).size() >= 1'
+                    configMap:
+                      description: |-
+                        configMap is the target ConfigMap in Namespaces that all Bundle source
+                        data will be synced to.
+                      properties:
+                        key:
+                          description: key is the key of the entry in the object's `data` field to be used.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        metadata:
+                          description: metadata is an optional set of labels and annotations to be copied to the target.
+                          minProperties: 1
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: annotations is a key value map to be copied to the target.
+                              minProperties: 1
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: labels is a key value map to be copied to the target.
+                              minProperties: 1
+                              type: object
+                          type: object
+                      required:
+                        - key
+                      type: object
+                    namespaceSelector:
+                      description: |-
+                        namespaceSelector will, if set, only sync the target resource in
+                        Namespaces which match the selector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    secret:
+                      description: |-
+                        secret is the target Secret that all Bundle source data will be synced to.
+                        Using Secrets as targets is only supported if enabled at trust-manager startup.
+                        By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+                      properties:
+                        key:
+                          description: key is the key of the entry in the object's `data` field to be used.
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        metadata:
+                          description: metadata is an optional set of labels and annotations to be copied to the target.
+                          minProperties: 1
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: annotations is a key value map to be copied to the target.
+                              minProperties: 1
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: labels is a key value map to be copied to the target.
+                              minProperties: 1
+                              type: object
+                          type: object
+                      required:
+                        - key
+                      type: object
+                  type: object
+                  x-kubernetes-validations:
+                    - message: at least one of the fields in [configMap secret] must be set
+                      rule: '[has(self.configMap),has(self.secret)].filter(x,x==true).size() >= 1'
+              required:
+                - sources
+              type: object
+            status:
+              description: status of the Bundle. This is set and managed automatically.
+              minProperties: 1
+              properties:
+                conditions:
+                  description: conditions represent the latest available observations of the Bundle's current state.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 10
+                  minItems: 0
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                defaultCAVersion:
+                  description: |-
+                    defaultCAVersion is the version of the default CA package used when resolving
+                    the default CA source(s) for this Bundle (for example, when any source has
+                    useDefaultCAs set to true), if applicable.
+                    Bundles resolved from identical sets of default CA certificates will report
+                    the same defaultCAVersion value.
+                  maxLength: 253
+                  minLength: 1
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+{{- end }}

--- a/packages/system/trust-manager-crds/values.yaml
+++ b/packages/system/trust-manager-crds/values.yaml
@@ -1,0 +1,7 @@
+commonLabels: {}
+
+creator: helm
+
+crds:
+  enabled: true
+  keep: true

--- a/packages/system/trust-manager/.helmignore
+++ b/packages/system/trust-manager/.helmignore
@@ -1,0 +1,2 @@
+images
+hack

--- a/packages/system/trust-manager/Chart.yaml
+++ b/packages/system/trust-manager/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: cozy-trust-manager
+version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process

--- a/packages/system/trust-manager/Makefile
+++ b/packages/system/trust-manager/Makefile
@@ -1,0 +1,14 @@
+export NAME=trust-manager
+export NAMESPACE=cozy-cert-manager
+
+include ../../../hack/package.mk
+
+update:
+	rm -rf charts
+	helm repo add jetstack https://charts.jetstack.io
+	helm repo update jetstack
+	helm pull jetstack/trust-manager --version v0.22.1 --untar --untardir charts
+	mkdir -p ../trust-manager-crds/templates
+	rm -rf ../trust-manager-crds/templates/*
+	mv charts/trust-manager/templates/crd-*.yaml ../trust-manager-crds/templates/
+	cp charts/trust-manager/templates/_helpers.tpl ../trust-manager-crds/templates/

--- a/packages/system/trust-manager/charts/trust-manager/Chart.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/Chart.yaml
@@ -1,0 +1,28 @@
+annotations:
+  artifacthub.io/category: security
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/recommendations: |
+    - url: https://artifacthub.io/packages/helm/cert-manager/cert-manager
+apiVersion: v2
+appVersion: v0.22.1
+description: trust-manager is the easiest way to manage TLS trust bundles in Kubernetes
+  and OpenShift clusters
+home: https://cert-manager.io/docs/trust/trust-manager
+icon: https://raw.githubusercontent.com/cert-manager/community/4d35a69437d21b76322157e6284be4cd64e6d2b7/logo/logo-small.png
+keywords:
+- trust-manager
+- cert-manager
+- tls
+- trust bundle
+- trust anchor
+kubeVersion: '>= 1.25.0-0'
+maintainers:
+- email: cert-manager-maintainers@googlegroups.com
+  name: cert-manager-maintainers
+  url: https://cert-manager.io
+name: trust-manager
+sources:
+- https://github.com/cert-manager/trust-manager
+type: application
+version: v0.22.1

--- a/packages/system/trust-manager/charts/trust-manager/README.md
+++ b/packages/system/trust-manager/charts/trust-manager/README.md
@@ -1,0 +1,757 @@
+# trust-manager
+
+<!-- see https://artifacthub.io/packages/helm/cert-manager/trust-manager for the rendered version -->
+
+## Helm Values
+
+<!-- AUTO-GENERATED -->
+
+### Global
+
+#### **global.rbac.create** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Create required ClusterRoles, Roles, ClusterRoleBindings and RoleBindings for trust-manager.
+### CRDs
+
+#### **crds.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+This option decides if the CRDs should be installed as part of the Helm installation.
+#### **crds.keep** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+This option makes it so that the "helm.sh/resource-policy": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled. WARNING: when the CRDs are removed, all cert-manager custom resources  
+(Certificates, Issuers, ...) will be removed too by the garbage collector.
+### Trust Manager
+
+#### **replicaCount** ~ `number,string,null`
+> Default value:
+> ```yaml
+> 1
+> ```
+
+The number of replicas of trust-manager to run.  
+  
+For example:  
+ Use integer to set a fixed number of replicas
+
+```yaml
+replicaCount: 2
+```
+
+Use null, if you want to omit the replicas field and use the Kubernetes default value.
+
+```yaml
+replicaCount: null
+```
+
+Use a string if you want to insert a variable for post-processing of the rendered template.
+
+```yaml
+replicaCount: ${REPLICAS_OVERRIDE:=3}
+```
+
+
+
+#### **revisionHistoryLimit** ~ `number,null`
+> Default value:
+> ```yaml
+> 10
+> ```
+
+The number of old ReplicaSets to retain to allow rollback. This is used to control the number of old ReplicaSets that are retained to allow rollback.  
+If set to 0, no old ReplicaSets are retained.
+
+#### **nameOverride** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+#### **namespace** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+The namespace to install trust-manager into.  
+If not set, the namespace of the release is used.  
+This is helpful when installing trust-manager as a chart dependency (sub chart).
+#### **imagePullSecrets** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+For Private docker registries, authentication is needed. Registry secrets are applied to the service account.
+#### **imageRegistry** ~ `string`
+> Default value:
+> ```yaml
+> quay.io
+> ```
+
+The container registry used for trust-manager images by default. This can include path prefixes (e.g. "artifactory.example.com/docker").
+
+#### **imageNamespace** ~ `string`
+> Default value:
+> ```yaml
+> jetstack
+> ```
+
+The repository namespace used for trust-manager images by default.  
+Examples:  
+- jetstack  
+- cert-manager
+
+#### **image.registry** ~ `string`
+
+Target image registry. This value is prepended to the target image repository, if set.  
+For example:
+
+```yaml
+registry: legacy.example.io
+```
+
+Deprecated: per-component registry prefix.  
+  
+If set, this value is *prepended* to the image repository that the chart would otherwise render. This applies both when `image.repository` is set and when the repository is computed from  
+`imageRegistry` + `imageNamespace` + `image.name`.  
+  
+This can produce "double registry" style references such as  
+`legacy.example.io/quay.io/jetstack/...`. Prefer using the global  
+`imageRegistry`/`imageNamespace` values.
+
+#### **image.repository** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+Full repository override (takes precedence over `imageRegistry`, `imageNamespace`, and `image.name`).  
+Example: quay.io/jetstack/trust-manager
+
+#### **image.name** ~ `string`
+> Default value:
+> ```yaml
+> trust-manager
+> ```
+
+The image name for trust-manager.  
+This is used (together with `imageRegistry` and `imageNamespace`) to construct the full image reference.
+
+#### **image.tag** ~ `string`
+
+Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.
+
+#### **image.digest** ~ `string`
+
+Target image digest. Override any tag, if set.  
+For example:
+
+```yaml
+digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+```
+
+#### **image.pullPolicy** ~ `string`
+> Default value:
+> ```yaml
+> IfNotPresent
+> ```
+
+Kubernetes imagePullPolicy on Deployment.
+#### **defaultPackage.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Whether to load the default trust package during pod initialization, and include it in main container args. This container enables the 'useDefaultCAs' source on Bundles.
+#### **defaultPackage.resources** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Kubernetes pod resource limits for default package init container.  
+  
+For example:
+
+```yaml
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+```
+#### **defaultPackageImage.registry** ~ `string`
+
+Target image registry. This value is prepended to the target image repository, if set.  
+For example:
+
+```yaml
+registry: quay.io
+repository: jetstack/cert-manager-package-debian
+```
+
+Deprecated: per-component registry prefix.  
+  
+If set, this value is *prepended* to the image repository that the chart would otherwise render. This applies both when `image.repository` is set and when the repository is computed from  
+`imageRegistry` + `imageNamespace` + `image.name`.  
+  
+This can produce "double registry" style references such as  
+`legacy.example.io/quay.io/jetstack/...`. Prefer using the global  
+`imageRegistry`/`imageNamespace` values.
+
+#### **defaultPackageImage.repository** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+Full repository override (takes precedence over `imageRegistry`, `imageNamespace`, and `image.name`).  
+Example: quay.io/jetstack/trust-manager
+
+#### **defaultPackageImage.name** ~ `string`
+> Default value:
+> ```yaml
+> trust-pkg-debian-bookworm
+> ```
+
+The image name for trust-manager.  
+This is used (together with `imageRegistry` and `imageNamespace`) to construct the full image reference.
+
+#### **defaultPackageImage.tag** ~ `string`
+
+Override the image tag of the default package image. Is set at chart build time to the version specified in ./make/00_debian_bookworm_version.mk.
+
+#### **defaultPackageImage.digest** ~ `string`
+
+Target image digest. Override any tag, if set.  
+For example:
+
+```yaml
+digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+```
+
+#### **defaultPackageImage.pullPolicy** ~ `string`
+> Default value:
+> ```yaml
+> IfNotPresent
+> ```
+
+imagePullPolicy for the default package image.
+#### **automountServiceAccountToken** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Automounting API credentials for the trust-manager pod.
+
+#### **serviceAccount.create** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Specifies whether a service account should be created.
+#### **serviceAccount.name** ~ `string`
+
+The name of the service account to use.  
+If not set and create is true, a name is generated using the fullname template.
+
+#### **serviceAccount.automountServiceAccountToken** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Automount API credentials for a Service Account.
+
+#### **volumes** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Additional volumes to add to the trust-manager pod.
+#### **volumeMounts** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Additional volume mounts to add to the trust-manager container.
+#### **secretTargets.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+If set to true, enable writing trust bundles to Kubernetes Secrets as a target. trust-manager can only write to secrets which are explicitly allowed via either authorizedSecrets or authorizedSecretsAll. Note that enabling secret targets will grant trust-manager read access to all secrets in the cluster.
+#### **secretTargets.authorizedSecretsAll** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+If set to true, grant read/write permission to all secrets across the cluster. Use with caution!  
+If set, ignores the authorizedSecrets list.
+#### **secretTargets.authorizedSecrets** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+A list of secret names which trust-manager will be permitted to read and write across all namespaces. These are the only allowable Secrets that can be used as targets. If the list is empty (and authorizedSecretsAll is false), trust-manager can't write to secrets and can only read secrets in the trust namespace for use as sources.
+#### **resources** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Kubernetes pod resource limits for trust.  
+  
+For example:
+
+```yaml
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+```
+#### **priorityClassName** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+Configure the priority class of the pod. For more information, see [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass).
+#### **nodeSelector** ~ `object`
+> Default value:
+> ```yaml
+> kubernetes.io/os: linux
+> ```
+
+Configure the nodeSelector; defaults to any Linux node (trust-manager doesn't support Windows nodes)
+
+#### **affinity** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Kubernetes Affinity. For more information, see [Affinity v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core).  
+For example:
+
+```yaml
+affinity:
+  nodeAffinity:
+   requiredDuringSchedulingIgnoredDuringExecution:
+     nodeSelectorTerms:
+     - matchExpressions:
+       - key: foo.bar.com/role
+         operator: In
+         values:
+         - master
+```
+#### **tolerations** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+List of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).  
+For example:
+
+```yaml
+tolerations:
+- key: foo.bar.com/role
+  operator: Equal
+  value: master
+  effect: NoSchedule
+```
+#### **topologySpreadConstraints** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+List of Kubernetes TopologySpreadConstraints. For more information, see [TopologySpreadConstraint v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core).  
+For example:
+
+```yaml
+topologySpreadConstraints:
+- maxSkew: 2
+  topologyKey: topology.kubernetes.io/zone
+  whenUnsatisfiable: ScheduleAnyway
+  labelSelector:
+    matchLabels:
+      app.kubernetes.io/name: trust-manager
+```
+#### **filterExpiredCertificates.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+Whether to filter expired certificates from the trust bundle.
+#### **filterNonCACerts.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+Filter non-CA certificates, only CAs are used in the resulting Bundle.
+#### **app.minTLSVersion** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+Minimum TLS version supported. If omitted, the default Go minimum version will be used.
+#### **app.cipherSuites** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+Comma-separated list of cipher suites for the server. If omitted, the default Go cipher suites will be used.
+#### **app.logFormat** ~ `string`
+> Default value:
+> ```yaml
+> text
+> ```
+
+The format of trust-manager logging. Accepted values are text or json.
+#### **app.logLevel** ~ `number`
+> Default value:
+> ```yaml
+> 1
+> ```
+
+The verbosity of trust-manager logging. This takes a value from 1-5, with the higher value being more verbose.
+#### **app.leaderElection.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Whether to enable leader election for trust-manager.
+#### **app.leaderElection.leaseDuration** ~ `string`
+> Default value:
+> ```yaml
+> 15s
+> ```
+
+The duration that non-leader candidates will wait to force acquire leadership. The default should be sufficient in a healthy cluster but can be slightly increased to prevent trust-manager from restart-looping when the API server is overloaded.
+#### **app.leaderElection.renewDeadline** ~ `string`
+> Default value:
+> ```yaml
+> 10s
+> ```
+
+The interval between attempts by the acting leader to renew a leadership slot before it stops leading. This MUST be less than or equal to the lease duration. The default should be sufficient in a healthy cluster but can be slightly increased to prevent trust-manager from restart-looping when the API server is overloaded.
+#### **app.readinessProbe.port** ~ `number`
+> Default value:
+> ```yaml
+> 6060
+> ```
+
+The container port on which to expose the trust-manager HTTP readiness probe using the default network interface.
+#### **app.readinessProbe.path** ~ `string`
+> Default value:
+> ```yaml
+> /readyz
+> ```
+
+The path on which to expose the trust-manager HTTP readiness probe using the default network interface.
+#### **app.trust.namespace** ~ `string`
+> Default value:
+> ```yaml
+> cert-manager
+> ```
+
+The namespace used as the trust source. Note that the namespace _must_ exist before installing trust-manager.
+#### **app.targetNamespaces** ~ `array`
+
+List of target namespaces that trust-manager can write to. By default, trust-manager can write targets in any namespace.
+
+#### **app.securityContext.seccompProfileEnabled** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+If false, disables the default seccomp profile, which might be required to run on certain platforms.
+#### **app.podLabels** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Pod labels to add to trust-manager pods.
+#### **app.podAnnotations** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Pod annotations to add to trust-manager pods.
+### Webhook
+
+#### **app.webhook.host** ~ `string`
+> Default value:
+> ```yaml
+> 0.0.0.0
+> ```
+
+Host that the webhook listens on.
+#### **app.webhook.port** ~ `number`
+> Default value:
+> ```yaml
+> 6443
+> ```
+
+Port that the webhook listens on.
+#### **app.webhook.timeoutSeconds** ~ `number`
+> Default value:
+> ```yaml
+> 5
+> ```
+
+Timeout of webhook HTTP request.
+#### **app.webhook.service.type** ~ `string`
+> Default value:
+> ```yaml
+> ClusterIP
+> ```
+
+The type of Kubernetes Service used by the Webhook.
+#### **app.webhook.service.ipFamilyPolicy** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)
+#### **app.webhook.service.ipFamilies** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.
+#### **app.webhook.service.nodePort** ~ `number`
+
+The nodePort set on the Service used by the webhook.
+
+#### **app.webhook.tls.helmCert.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+Whether to issue a webhook cert using Helm, which removes the need to install cert-manager. Helm-issued certificates can be challenging to rotate and maintain, and the issued cert will have a duration of 10 years and be modified when trust-manager is updated. It's safer and easier to rely on cert-manager for issuing the webhook cert - avoid using Helm-generated certs in production.
+#### **app.webhook.tls.approverPolicy.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+Whether to create an approver-policy CertificateRequestPolicy allowing auto-approval of the trust-manager webhook certificate. If you have approver-policy installed, you almost certainly want to enable this.
+#### **app.webhook.tls.approverPolicy.certManagerNamespace** ~ `string`
+> Default value:
+> ```yaml
+> cert-manager
+> ```
+
+The namespace in which cert-manager was installed. Only used if `app.webhook.tls.approverPolicy.enabled` is true.
+#### **app.webhook.tls.approverPolicy.certManagerServiceAccount** ~ `string`
+> Default value:
+> ```yaml
+> cert-manager
+> ```
+
+The name of cert-manager's Service Account. Only used if `app.webhook.tls.approverPolicy.enabled` is true.
+#### **app.webhook.tls.certificate.secretTemplate** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+#### **app.webhook.hostNetwork** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+This value specifies if the app should be started in hostNetwork mode. It is required for use in some managed Kubernetes clusters (such as AWS EKS) with custom CNI.
+### Metrics
+
+#### **app.metrics.port** ~ `number`
+> Default value:
+> ```yaml
+> 9402
+> ```
+
+The port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.
+#### **app.metrics.service.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Create a Service resource to expose the metrics endpoint.
+#### **app.metrics.service.type** ~ `string`
+> Default value:
+> ```yaml
+> ClusterIP
+> ```
+
+The Service type to expose metrics.
+#### **app.metrics.service.ipFamilyPolicy** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)
+#### **app.metrics.service.ipFamilies** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.
+#### **app.metrics.service.servicemonitor.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+Create a Prometheus ServiceMonitor for trust-manager.
+#### **app.metrics.service.servicemonitor.prometheusInstance** ~ `string`
+> Default value:
+> ```yaml
+> default
+> ```
+
+Sets the value of the "prometheus" label on the ServiceMonitor. This is used so that separate Prometheus instances can select different ServiceMonitors using labels.
+#### **app.metrics.service.servicemonitor.interval** ~ `string`
+> Default value:
+> ```yaml
+> 10s
+> ```
+
+The interval to scrape the metrics.
+#### **app.metrics.service.servicemonitor.scrapeTimeout** ~ `string`
+> Default value:
+> ```yaml
+> 5s
+> ```
+
+The timeout for a metrics scrape.
+#### **app.metrics.service.servicemonitor.labels** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Additional labels to add to the ServiceMonitor.
+#### **app.metrics.service.servicemonitor.endpointAdditionalProperties** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+EndpointAdditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc.  
+  
+For example:
+
+```yaml
+endpointAdditionalProperties:
+ relabelings:
+ - action: replace
+   sourceLabels:
+   - __meta_kubernetes_pod_node_name
+   targetLabel: instance
+```
+
+
+
+#### **podDisruptionBudget.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+Enable or disable the PodDisruptionBudget resource.  
+  
+This prevents downtime during voluntary disruptions such as during a Node upgrade. For example, the PodDisruptionBudget will block `kubectl drain` if it is used on the Node where the only remaining trust-manager  
+Pod is currently running.
+#### **podDisruptionBudget.minAvailable** ~ `unknown`
+
+This configures the minimum available pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).  
+It cannot be used if `maxUnavailable` is set.
+
+
+#### **podDisruptionBudget.maxUnavailable** ~ `unknown`
+
+This configures the maximum unavailable pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%). it cannot be used if `minAvailable` is set.
+
+
+#### **commonLabels** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Labels to apply to all resources
+#### **commonAnnotations** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Annotations to apply to all resources  
+NOTE: These annotations won't be added to the CRDs.
+#### **extraObjects** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Extra manifests to be deployed. This is useful for deploying additional resources that are not part of the chart.  
+For example:
+
+```yaml
+extraObjects:
+ - apiVersion: cilium.io/v2
+   kind: CiliumNetworkPolicy
+   metadata:
+     name: trust-manager
+     namespace: trust-manager
+   spec:
+     endpointSelector:
+       matchLabels:
+         io.cilium.k8s.policy.serviceaccount: trust-manager
+     egress:
+       - toEntities:
+           - kube-apiserver
+```
+
+<!-- /AUTO-GENERATED -->

--- a/packages/system/trust-manager/charts/trust-manager/templates/NOTES.txt
+++ b/packages/system/trust-manager/charts/trust-manager/templates/NOTES.txt
@@ -1,0 +1,23 @@
+{{- if (lt (int .Values.replicaCount) 2) }}
+⚠️  WARNING: Consider increasing the Helm value `replicaCount` to 2 if you require high availability.
+{{- end }}
+
+{{- if (not .Values.podDisruptionBudget.enabled) }}
+⚠️  WARNING: Consider setting the Helm value `podDisruptionBudget.enabled` to true if you require high availability.
+{{- end }}
+
+trust-manager {{ .Chart.AppVersion }} has been deployed successfully!
+
+{{- if .Values.defaultPackage.enabled }}
+Your installation includes a default CA package, using the following
+default CA package image:
+
+{{ .Values.defaultPackageImage.repository }}:{{ .Values.defaultPackageImage.tag }}
+
+It's imperative that you keep the default CA package image up to date.
+{{- end }}
+To find out more about securely running trust-manager and to get started
+with creating your first bundle, check out the documentation on the
+cert-manager website:
+
+https://cert-manager.io/docs/projects/trust-manager/

--- a/packages/system/trust-manager/charts/trust-manager/templates/_helpers.tpl
+++ b/packages/system/trust-manager/charts/trust-manager/templates/_helpers.tpl
@@ -1,0 +1,162 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "trust-manager.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "trust-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "trust-manager.labels" -}}
+app.kubernetes.io/name: {{ include "trust-manager.name" . }}
+helm.sh/chart: {{ include "trust-manager.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Util function for generating the image URL based on the provided options.
+IMPORTANT: This function is standardized across all charts in the cert-manager GH organization.
+Any changes to this function should also be made in cert-manager, trust-manager, approver-policy, ...
+See https://github.com/cert-manager/cert-manager/issues/6329 for a list of linked PRs.
+*/}}
+{{- define "image" -}}
+{{- /*
+Calling convention:
+
+- (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>)
+
+We intentionally pass imageRegistry/imageNamespace as explicit arguments rather than reading
+from `.Values` inside this helper, because `helm-tool lint` does not reliably track `.Values.*`
+usage through tuple/variable indirection.
+*/ -}}
+
+{{- if ne (len .) 4 -}}
+    {{- fail (printf "ERROR: template \"image\" expects (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>), got %d arguments" (len .)) -}}
+{{- end -}}
+
+{{- $image := index . 0 -}}
+{{- $imageRegistry := index . 1 | default "" -}}
+{{- $imageNamespace := index . 2 | default "" -}}
+{{- $defaultReference := index . 3 -}}
+
+{{- $repository := "" -}}
+{{- if $image.repository -}}
+    {{- $repository = $image.repository -}}
+
+    {{- /*
+        Backwards compatibility: if image.registry is set, additionally prefix the repository with this registry.
+    */ -}}
+    {{- if $image.registry -}}
+        {{- $repository = printf "%s/%s" $image.registry $repository -}}
+    {{- end -}}
+{{- else -}}
+    {{- $name := required "ERROR: image.name must be set when image.repository is empty" $image.name -}}
+    {{- $repository = $name -}}
+
+    {{- if $imageNamespace -}}
+        {{- $repository = printf "%s/%s" $imageNamespace $repository -}}
+    {{- end -}}
+
+    {{- if $imageRegistry -}}
+        {{- $repository = printf "%s/%s" $imageRegistry $repository -}}
+    {{- end -}}
+
+    {{- /*
+        Backwards compatibility: if image.registry is set, additionally prefix the repository with this registry.
+    */ -}}
+    {{- if $image.registry -}}
+        {{- $repository = printf "%s/%s" $image.registry $repository -}}
+    {{- end -}}
+{{- end -}}
+
+{{- $repository -}}
+{{- if and $image.tag $image.digest -}}
+    {{- printf ":%s@%s" $image.tag $image.digest -}}
+{{- else if $image.tag -}}
+    {{- printf ":%s" $image.tag -}}
+{{- else if $image.digest -}}
+    {{- printf "@%s" $image.digest -}}
+{{- else -}}
+    {{- printf "%s" $defaultReference -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Namespace for all resources to be installed into
+If not defined in values file then the helm release namespace is used
+By default this is not set so the helm release namespace will be used
+
+This gets around an problem within helm discussed here
+https://github.com/helm/helm/issues/5358
+*/}}
+{{- define "trust-manager.namespace" -}}
+    {{ .Values.namespace | default .Release.Namespace }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "trust-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "trust-manager.name" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Namespaced resources rules
+*/}}
+{{- define "trust-manager.rbac.namespacedResourcesRules" -}}
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  verbs: ["get","list","create","patch","watch","delete"]
+
+- apiGroups:
+  - "" {{/* TODO(erikgb): Remove; MIGRATION to new events API group. */}}
+  - "events.k8s.io"
+  resources:
+  - "events"
+  verbs: ["create","patch"]
+
+{{- if .Values.secretTargets.enabled }}
+  {{- if .Values.secretTargets.authorizedSecretsAll }}
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs: ["get","list","create","patch","watch","delete"]
+  {{- else if $.Values.secretTargets.authorizedSecrets }}
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs: ["get","list","watch"]
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs: ["create","patch","delete"]
+  resourceNames:
+{{ toYaml .Values.secretTargets.authorizedSecrets | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/packages/system/trust-manager/charts/trust-manager/templates/certificate.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/templates/certificate.yaml
@@ -1,0 +1,116 @@
+{{- if not .Values.app.webhook.tls.helmCert.enabled -}}
+
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selfSigned: {}
+
+---
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  commonName: "{{ include "trust-manager.name" . }}.{{ include "trust-manager.namespace" . }}.svc"
+  dnsNames:
+  - "{{ include "trust-manager.name" . }}.{{ include "trust-manager.namespace" . }}.svc"
+  secretName: {{ include "trust-manager.name" . }}-tls
+  {{- with .Values.app.webhook.tls.certificate.secretTemplate }}
+  secretTemplate:
+    {{- toYaml .| nindent 4 }}
+  {{- end }}
+  privateKey:
+    rotationPolicy: Always
+  revisionHistoryLimit: 1
+  issuerRef:
+    name: {{ include "trust-manager.name" . }}
+    kind: Issuer
+    group: cert-manager.io
+
+---
+
+{{- if .Values.app.webhook.tls.approverPolicy.enabled }}
+
+apiVersion: policy.cert-manager.io/v1alpha1
+kind: CertificateRequestPolicy
+metadata:
+  name: trust-manager-policy
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  allowed:
+    commonName:
+      value: "{{ include "trust-manager.name" . }}.{{ include "trust-manager.namespace" . }}.svc"
+      required: true
+    dnsNames:
+      values: ["{{ include "trust-manager.name" . }}.{{ include "trust-manager.namespace" . }}.svc"]
+      required: true
+  selector:
+    issuerRef:
+      name: {{ include "trust-manager.name" . }}
+      kind: Issuer
+      group: cert-manager.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: trust-manager-policy-role
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups: ["policy.cert-manager.io"]
+    resources: ["certificaterequestpolicies"]
+    verbs: ["use"]
+    resourceNames: ["trust-manager-policy"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: trust-manager-policy-binding
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trust-manager-policy-role
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.app.webhook.tls.approverPolicy.certManagerServiceAccount }}
+  namespace: {{ .Values.app.webhook.tls.approverPolicy.certManagerNamespace }}
+
+{{ end }}
+
+{{ end }}

--- a/packages/system/trust-manager/charts/trust-manager/templates/clusterrole.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/templates/clusterrole.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.global.rbac.create }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "trust-manager.name" . }}
+rules:
+- apiGroups:
+  - "trust.cert-manager.io"
+  resources:
+  - "bundles"
+  verbs: ["get", "list", "watch"]
+
+# Permissions to update finalizers are required for trust-manager to work correctly
+# on OpenShift, even though we don't directly use finalizers at the time of writing
+- apiGroups:
+  - "trust.cert-manager.io"
+  resources:
+  - "bundles/finalizers"
+  verbs: ["update"]
+
+- apiGroups:
+  - "trust.cert-manager.io"
+  resources:
+  - "bundles/status"
+  verbs: ["patch"]
+
+- apiGroups:
+  - ""
+  resources:
+  - "namespaces"
+  verbs: ["get", "list", "watch"]
+
+{{- if not .Values.app.targetNamespaces }}
+{{ include "trust-manager.rbac.namespacedResourcesRules" . }}
+{{- end -}}
+{{- end -}}

--- a/packages/system/trust-manager/charts/trust-manager/templates/clusterrolebinding.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/templates/clusterrolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.global.rbac.create }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "trust-manager.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "trust-manager.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+{{- end -}}

--- a/packages/system/trust-manager/charts/trust-manager/templates/deployment.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/templates/deployment.yaml
@@ -1,0 +1,177 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  selector:
+    matchLabels:
+      app: {{ include "trust-manager.name" . }}
+  template:
+    metadata:
+      {{- if or .Values.app.podAnnotations .Values.app.webhook.tls.helmCert.enabled }}
+      annotations:
+        {{- if .Values.app.podAnnotations }}
+        {{- toYaml .Values.app.podAnnotations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.app.webhook.tls.helmCert.enabled }}
+        {{- /* When using a helm cert, the cert will be regenerated every time the chart is updated. When that happens, we need to restart the pods in the deployment to ensure the new cert is picked up. */}}
+        rollme-due-to-helm-cert: {{ randAlphaNum 5 | quote }}
+        {{- end }}
+      {{- end }}
+      labels:
+        app: {{ include "trust-manager.name" . }}
+        {{- include "trust-manager.labels" . | nindent 8 }}
+        {{- with .Values.app.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "trust-manager.serviceAccountName" . }}
+      {{- if hasKey .Values "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
+      {{- if .Values.defaultPackage.enabled }}
+      initContainers:
+      - name: cert-manager-package-debian
+        image: "{{ template "image" (tuple .Values.defaultPackageImage .Values.imageRegistry .Values.imageNamespace .Values.defaultPackageImage._defaultReference) }}"
+        imagePullPolicy: {{ .Values.defaultPackageImage.pullPolicy }}
+        args:
+          - "/copyandmaybepause"
+          - "/debian-package"
+          - "/packages"
+        volumeMounts:
+        - mountPath: /packages
+          name: packages
+          readOnly: false
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          {{- if .Values.app.securityContext.seccompProfileEnabled }}
+          seccompProfile:
+            type: RuntimeDefault
+          {{- end }}
+        {{- if .Values.defaultPackage.resources }}
+        resources:
+          {{- toYaml .Values.defaultPackage.resources | nindent 10 }}
+        {{- end }}
+      {{- end }}
+      containers:
+      - name: {{ include "trust-manager.name" . }}
+        image: "{{ template "image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" $.Chart.AppVersion)) }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: {{ .Values.app.webhook.port }}
+          name: webhook # for the PodMonitor port field
+        - containerPort: {{ .Values.app.metrics.port }}
+          name: metrics # for the PodMonitor port field
+        readinessProbe:
+          httpGet:
+            port: {{ .Values.app.readinessProbe.port }}
+            path: {{ .Values.app.readinessProbe.path }}
+          initialDelaySeconds: 3
+          periodSeconds: 7
+        args:
+          {{- with .Values.app.minTLSVersion }}
+          - "--tls-min-version={{.}}"
+          {{- end }}
+          {{- with .Values.app.cipherSuites }}
+          - "--tls-cipher-suites={{.}}"
+          {{- end }}
+          - "--log-format={{.Values.app.logFormat}}"
+          - "--log-level={{.Values.app.logLevel}}"
+          - "--metrics-port={{.Values.app.metrics.port}}"
+          - "--readiness-probe-port={{.Values.app.readinessProbe.port}}"
+          - "--readiness-probe-path={{.Values.app.readinessProbe.path}}"
+          - "--leader-elect={{.Values.app.leaderElection.enabled}}"
+          - "--leader-election-lease-duration={{.Values.app.leaderElection.leaseDuration}}"
+          - "--leader-election-renew-deadline={{.Values.app.leaderElection.renewDeadline}}"
+            # trust
+          - "--trust-namespace={{.Values.app.trust.namespace}}"
+            # webhook
+          - "--webhook-host={{.Values.app.webhook.host}}"
+          - "--webhook-port={{.Values.app.webhook.port}}"
+          - "--webhook-certificate-dir=/tls"
+          {{- if .Values.defaultPackage.enabled }}
+          - "--default-package-location=/packages/cert-manager-package-debian.json"
+          {{- end }}
+          {{- if .Values.secretTargets.enabled }}
+          - "--secret-targets-enabled=true"
+          {{- end }}
+          {{- if .Values.filterExpiredCertificates.enabled }}
+          - "--filter-expired-certificates=true"
+          {{- end }}
+          {{- if .Values.filterNonCACerts.enabled }}
+          - "--filter-non-ca-certs=true"
+          {{- end }}
+          {{- if .Values.app.targetNamespaces }}
+          - '--target-namespaces={{ join "," .Values.app.targetNamespaces }}'
+          {{- end }}
+        volumeMounts:
+        - mountPath: /tls
+          name: tls
+          readOnly: true
+        - mountPath: /packages
+          name: packages
+          readOnly: true
+        {{- with .Values.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          {{- if .Values.app.securityContext.seccompProfileEnabled }}
+          seccompProfile:
+            type: RuntimeDefault
+          {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: "{{ . }}"
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with  .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      - name: packages
+        emptyDir:
+          sizeLimit: 50M
+      - name: tls
+        secret:
+          defaultMode: 420
+          secretName: {{ include "trust-manager.name" . }}-tls
+      {{- with .Values.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- if .Values.app.webhook.hostNetwork }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}

--- a/packages/system/trust-manager/charts/trust-manager/templates/extra-manifests.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/packages/system/trust-manager/charts/trust-manager/templates/metrics-service.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/templates/metrics-service.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.app.metrics.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "trust-manager.name" . }}-metrics
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    app: {{ include "trust-manager.name" . }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.app.metrics.service.type }}
+  {{- if .Values.app.metrics.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.app.metrics.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.app.metrics.service.ipFamilies }}
+  ipFamilies: {{ .Values.app.metrics.service.ipFamilies | toYaml | nindent 2 }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.app.metrics.port }}
+      targetPort: {{ .Values.app.metrics.port }}
+      protocol: TCP
+      name: metrics
+  selector:
+    app: {{ include "trust-manager.name" . }}
+{{- end }}

--- a/packages/system/trust-manager/charts/trust-manager/templates/metrics-servicemonitor.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/templates/metrics-servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.app.metrics.service.enabled .Values.app.metrics.service.servicemonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    app: {{ include "trust-manager.name" . }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
+    prometheus: {{ .Values.app.metrics.service.servicemonitor.prometheusInstance }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if .Values.app.metrics.service.servicemonitor.labels }}
+{{ toYaml .Values.app.metrics.service.servicemonitor.labels | indent 4}}
+{{- end }}
+spec:
+  jobLabel: {{ include "trust-manager.name" . }}
+  selector:
+    matchLabels:
+      app: {{ include "trust-manager.name" . }}
+  namespaceSelector:
+    matchNames:
+      - {{ include "trust-manager.namespace" . }}
+  endpoints:
+  - targetPort: {{ .Values.app.metrics.port }}
+    path: "/metrics"
+    interval: {{ .Values.app.metrics.service.servicemonitor.interval }}
+    scrapeTimeout: {{ .Values.app.metrics.service.servicemonitor.scrapeTimeout }}
+    {{- with .Values.app.metrics.service.servicemonitor.endpointAdditionalProperties }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/packages/system/trust-manager/charts/trust-manager/templates/poddisruptionbudget.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/templates/poddisruptionbudget.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    app: {{ include "trust-manager.name" . }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ include "trust-manager.name" . }}
+
+  {{- if not (or (hasKey .Values.podDisruptionBudget "minAvailable") (hasKey .Values.podDisruptionBudget "maxUnavailable")) }}
+  minAvailable: 1 # Default value because minAvailable and maxUnavailable are not set
+  {{- end }}
+  {{- if hasKey .Values.podDisruptionBudget "minAvailable" }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if hasKey .Values.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/packages/system/trust-manager/charts/trust-manager/templates/rbac-per-namespace.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/templates/rbac-per-namespace.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.global.rbac.create .Values.app.targetNamespaces }}
+{{- $namespaces := append (append .Values.app.targetNamespaces .Values.app.trust.namespace) (include "trust-manager.namespace" . ) -}}
+{{- range $ns := uniq $namespaces }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: trust-manager-role
+  namespace: {{ $ns }}
+rules:
+{{ include "trust-manager.rbac.namespacedResourcesRules" $ }}
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: trust-manager-role-binding
+  namespace: {{ $ns }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: trust-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "trust-manager.name" $ }}
+    namespace: {{ include "trust-manager.namespace" $ }}
+{{- end }}
+{{- end }}

--- a/packages/system/trust-manager/charts/trust-manager/templates/role.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/templates/role.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.global.rbac.create }}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Values.app.trust.namespace }}
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "trust-manager.name" . }}:leaderelection
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - "leases"
+  verbs:
+  - "get"
+  - "create"
+  - "update"
+  - "watch"
+  - "list"
+{{- end -}}

--- a/packages/system/trust-manager/charts/trust-manager/templates/rolebinding.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/templates/rolebinding.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.global.rbac.create }}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Values.app.trust.namespace }}
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "trust-manager.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "trust-manager.name" . }}:leaderelection
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "trust-manager.name" . }}:leaderelection
+subjects:
+- kind: ServiceAccount
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+{{- end -}}

--- a/packages/system/trust-manager/charts/trust-manager/templates/serviceaccount.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/packages/system/trust-manager/charts/trust-manager/templates/webhook.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/templates/webhook.yaml
@@ -1,0 +1,126 @@
+{{- if and .Values.app.webhook.tls.helmCert.enabled .Values.app.webhook.tls.approverPolicy.enabled -}}
+{{- fail "cannot set .app.webhook.tls.helmCert.enabled and .Values.app.webhook.tls.approverPolicy.enabled" }}
+{{- end -}}
+
+{{- /*
+$ca is always generated here even if .Values.app.webhook.tls.helmCert.enabled is false because we need it to be
+visible in the scope for the ValidatingWebhookConfiguration below.
+
+genCA has two args - first is cert commonName (CN) and second is validity in days (9125 = ~25 years)
+
+We don't write this CA's private key to a secret because we don't want it to be used for any other purpose
+except for generating $cert below.
+
+DO NOT USE $ca ANYWHERE IF app.tls.helmCert.enabled IS FALSE
+*/}}
+
+{{- $ca := genCA (printf "*.%s.svc" .Release.Namespace ) 9125 -}}
+
+
+{{- if .Values.app.webhook.tls.helmCert.enabled -}}
+{{- $svcName := (printf "%s.%s.svc" (include "trust-manager.name" . ) .Release.Namespace ) -}}
+
+{{- /*
+genSignedCert has the following args, in order:
+1. The cert CN
+2. A list of IP addresses the cert is valid for
+3. A list of DNS altnames the cert is valid for
+4. The duration in days (3650 = ~10 years)
+5. The signing CA
+*/}}
+{{- $cert := genSignedCert $svcName nil (list $svcName) 3650 $ca -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "trust-manager.name" . }}-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: kubernetes.io/tls
+data:
+  ca.crt: {{ $ca.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+  tls.crt: {{ $cert.Cert | b64enc }}
+
+---
+
+{{ end }}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    app: {{ include "trust-manager.name" . }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.app.webhook.service.type }}
+  {{- if .Values.app.webhook.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.app.webhook.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.app.webhook.service.ipFamilies }}
+  ipFamilies: {{ .Values.app.webhook.service.ipFamilies | toYaml | nindent 2 }}
+  {{- end }}
+  ports:
+    - port: 443
+      targetPort: {{ .Values.app.webhook.port }}
+{{- if .Values.app.webhook.service.nodePort }}
+      nodePort: {{ .Values.app.webhook.service.nodePort }}
+{{- end }}
+      protocol: TCP
+      name: webhook
+  selector:
+    app: {{ include "trust-manager.name" . }}
+
+---
+
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  labels:
+    app: {{ include "trust-manager.name" . }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- if or (not .Values.app.webhook.tls.helmCert.enabled) .Values.commonAnnotations }}
+  annotations:
+    {{- if not .Values.app.webhook.tls.helmCert.enabled }}
+    cert-manager.io/inject-ca-from: "{{ include "trust-manager.namespace" . }}/{{ include "trust-manager.name" . }}"
+    {{- end }}
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+webhooks:
+  - name: trust.cert-manager.io
+    rules:
+      - apiGroups:
+          - "trust.cert-manager.io"
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - bundles
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: {{ .Values.app.webhook.timeoutSeconds }}
+    failurePolicy: Fail
+    sideEffects: None
+    clientConfig:
+{{ if .Values.app.webhook.tls.helmCert.enabled }}
+      caBundle: "{{ $ca.Cert | b64enc }}"
+{{ end }}
+      service:
+        name: {{ include "trust-manager.name" . }}
+        namespace: {{ include "trust-manager.namespace" . }}
+        path: /validate-trust-cert-manager-io-v1alpha1-bundle

--- a/packages/system/trust-manager/charts/trust-manager/values.linter.exceptions
+++ b/packages/system/trust-manager/charts/trust-manager/values.linter.exceptions
@@ -1,0 +1,1 @@
+value missing from templates: enabled

--- a/packages/system/trust-manager/charts/trust-manager/values.schema.json
+++ b/packages/system/trust-manager/charts/trust-manager/values.schema.json
@@ -1,0 +1,927 @@
+{
+  "$defs": {
+    "helm-values": {
+      "additionalProperties": false,
+      "properties": {
+        "affinity": {
+          "$ref": "#/$defs/helm-values.affinity"
+        },
+        "app": {
+          "$ref": "#/$defs/helm-values.app"
+        },
+        "automountServiceAccountToken": {
+          "$ref": "#/$defs/helm-values.automountServiceAccountToken"
+        },
+        "commonAnnotations": {
+          "$ref": "#/$defs/helm-values.commonAnnotations"
+        },
+        "commonLabels": {
+          "$ref": "#/$defs/helm-values.commonLabels"
+        },
+        "crds": {
+          "$ref": "#/$defs/helm-values.crds"
+        },
+        "defaultPackage": {
+          "$ref": "#/$defs/helm-values.defaultPackage"
+        },
+        "defaultPackageImage": {
+          "$ref": "#/$defs/helm-values.defaultPackageImage"
+        },
+        "enabled": {
+          "$ref": "#/$defs/helm-values.enabled"
+        },
+        "extraObjects": {
+          "$ref": "#/$defs/helm-values.extraObjects"
+        },
+        "filterExpiredCertificates": {
+          "$ref": "#/$defs/helm-values.filterExpiredCertificates"
+        },
+        "filterNonCACerts": {
+          "$ref": "#/$defs/helm-values.filterNonCACerts"
+        },
+        "global": {
+          "$ref": "#/$defs/helm-values.global"
+        },
+        "image": {
+          "$ref": "#/$defs/helm-values.image"
+        },
+        "imageNamespace": {
+          "$ref": "#/$defs/helm-values.imageNamespace"
+        },
+        "imagePullSecrets": {
+          "$ref": "#/$defs/helm-values.imagePullSecrets"
+        },
+        "imageRegistry": {
+          "$ref": "#/$defs/helm-values.imageRegistry"
+        },
+        "nameOverride": {
+          "$ref": "#/$defs/helm-values.nameOverride"
+        },
+        "namespace": {
+          "$ref": "#/$defs/helm-values.namespace"
+        },
+        "nodeSelector": {
+          "$ref": "#/$defs/helm-values.nodeSelector"
+        },
+        "podDisruptionBudget": {
+          "$ref": "#/$defs/helm-values.podDisruptionBudget"
+        },
+        "priorityClassName": {
+          "$ref": "#/$defs/helm-values.priorityClassName"
+        },
+        "replicaCount": {
+          "$ref": "#/$defs/helm-values.replicaCount"
+        },
+        "resources": {
+          "$ref": "#/$defs/helm-values.resources"
+        },
+        "revisionHistoryLimit": {
+          "$ref": "#/$defs/helm-values.revisionHistoryLimit"
+        },
+        "secretTargets": {
+          "$ref": "#/$defs/helm-values.secretTargets"
+        },
+        "serviceAccount": {
+          "$ref": "#/$defs/helm-values.serviceAccount"
+        },
+        "tolerations": {
+          "$ref": "#/$defs/helm-values.tolerations"
+        },
+        "topologySpreadConstraints": {
+          "$ref": "#/$defs/helm-values.topologySpreadConstraints"
+        },
+        "volumeMounts": {
+          "$ref": "#/$defs/helm-values.volumeMounts"
+        },
+        "volumes": {
+          "$ref": "#/$defs/helm-values.volumes"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.affinity": {
+      "default": {},
+      "description": "Kubernetes Affinity. For more information, see [Affinity v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core).\nFor example:\naffinity:\n  nodeAffinity:\n   requiredDuringSchedulingIgnoredDuringExecution:\n     nodeSelectorTerms:\n     - matchExpressions:\n       - key: foo.bar.com/role\n         operator: In\n         values:\n         - master",
+      "type": "object"
+    },
+    "helm-values.app": {
+      "additionalProperties": false,
+      "properties": {
+        "cipherSuites": {
+          "$ref": "#/$defs/helm-values.app.cipherSuites"
+        },
+        "leaderElection": {
+          "$ref": "#/$defs/helm-values.app.leaderElection"
+        },
+        "logFormat": {
+          "$ref": "#/$defs/helm-values.app.logFormat"
+        },
+        "logLevel": {
+          "$ref": "#/$defs/helm-values.app.logLevel"
+        },
+        "metrics": {
+          "$ref": "#/$defs/helm-values.app.metrics"
+        },
+        "minTLSVersion": {
+          "$ref": "#/$defs/helm-values.app.minTLSVersion"
+        },
+        "podAnnotations": {
+          "$ref": "#/$defs/helm-values.app.podAnnotations"
+        },
+        "podLabels": {
+          "$ref": "#/$defs/helm-values.app.podLabels"
+        },
+        "readinessProbe": {
+          "$ref": "#/$defs/helm-values.app.readinessProbe"
+        },
+        "securityContext": {
+          "$ref": "#/$defs/helm-values.app.securityContext"
+        },
+        "targetNamespaces": {
+          "$ref": "#/$defs/helm-values.app.targetNamespaces"
+        },
+        "trust": {
+          "$ref": "#/$defs/helm-values.app.trust"
+        },
+        "webhook": {
+          "$ref": "#/$defs/helm-values.app.webhook"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.cipherSuites": {
+      "default": "",
+      "description": "Comma-separated list of cipher suites for the server. If omitted, the default Go cipher suites will be used.",
+      "type": "string"
+    },
+    "helm-values.app.leaderElection": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.app.leaderElection.enabled"
+        },
+        "leaseDuration": {
+          "$ref": "#/$defs/helm-values.app.leaderElection.leaseDuration"
+        },
+        "renewDeadline": {
+          "$ref": "#/$defs/helm-values.app.leaderElection.renewDeadline"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.leaderElection.enabled": {
+      "default": true,
+      "description": "Whether to enable leader election for trust-manager.",
+      "type": "boolean"
+    },
+    "helm-values.app.leaderElection.leaseDuration": {
+      "default": "15s",
+      "description": "The duration that non-leader candidates will wait to force acquire leadership. The default should be sufficient in a healthy cluster but can be slightly increased to prevent trust-manager from restart-looping when the API server is overloaded.",
+      "type": "string"
+    },
+    "helm-values.app.leaderElection.renewDeadline": {
+      "default": "10s",
+      "description": "The interval between attempts by the acting leader to renew a leadership slot before it stops leading. This MUST be less than or equal to the lease duration. The default should be sufficient in a healthy cluster but can be slightly increased to prevent trust-manager from restart-looping when the API server is overloaded.",
+      "type": "string"
+    },
+    "helm-values.app.logFormat": {
+      "default": "text",
+      "description": "The format of trust-manager logging. Accepted values are text or json.",
+      "type": "string"
+    },
+    "helm-values.app.logLevel": {
+      "default": 1,
+      "description": "The verbosity of trust-manager logging. This takes a value from 1-5, with the higher value being more verbose.",
+      "type": "number"
+    },
+    "helm-values.app.metrics": {
+      "additionalProperties": false,
+      "properties": {
+        "port": {
+          "$ref": "#/$defs/helm-values.app.metrics.port"
+        },
+        "service": {
+          "$ref": "#/$defs/helm-values.app.metrics.service"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.metrics.port": {
+      "default": 9402,
+      "description": "The port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.",
+      "type": "number"
+    },
+    "helm-values.app.metrics.service": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.app.metrics.service.enabled"
+        },
+        "ipFamilies": {
+          "$ref": "#/$defs/helm-values.app.metrics.service.ipFamilies"
+        },
+        "ipFamilyPolicy": {
+          "$ref": "#/$defs/helm-values.app.metrics.service.ipFamilyPolicy"
+        },
+        "servicemonitor": {
+          "$ref": "#/$defs/helm-values.app.metrics.service.servicemonitor"
+        },
+        "type": {
+          "$ref": "#/$defs/helm-values.app.metrics.service.type"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.metrics.service.enabled": {
+      "default": true,
+      "description": "Create a Service resource to expose the metrics endpoint.",
+      "type": "boolean"
+    },
+    "helm-values.app.metrics.service.ipFamilies": {
+      "default": [],
+      "description": "Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.app.metrics.service.ipFamilyPolicy": {
+      "default": "",
+      "description": "Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)",
+      "type": "string"
+    },
+    "helm-values.app.metrics.service.servicemonitor": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.app.metrics.service.servicemonitor.enabled"
+        },
+        "endpointAdditionalProperties": {
+          "$ref": "#/$defs/helm-values.app.metrics.service.servicemonitor.endpointAdditionalProperties"
+        },
+        "interval": {
+          "$ref": "#/$defs/helm-values.app.metrics.service.servicemonitor.interval"
+        },
+        "labels": {
+          "$ref": "#/$defs/helm-values.app.metrics.service.servicemonitor.labels"
+        },
+        "prometheusInstance": {
+          "$ref": "#/$defs/helm-values.app.metrics.service.servicemonitor.prometheusInstance"
+        },
+        "scrapeTimeout": {
+          "$ref": "#/$defs/helm-values.app.metrics.service.servicemonitor.scrapeTimeout"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.metrics.service.servicemonitor.enabled": {
+      "default": false,
+      "description": "Create a Prometheus ServiceMonitor for trust-manager.",
+      "type": "boolean"
+    },
+    "helm-values.app.metrics.service.servicemonitor.endpointAdditionalProperties": {
+      "default": {},
+      "description": "EndpointAdditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc.\n\nFor example:\nendpointAdditionalProperties:\n relabelings:\n - action: replace\n   sourceLabels:\n   - __meta_kubernetes_pod_node_name\n   targetLabel: instance",
+      "type": "object"
+    },
+    "helm-values.app.metrics.service.servicemonitor.interval": {
+      "default": "10s",
+      "description": "The interval to scrape the metrics.",
+      "type": "string"
+    },
+    "helm-values.app.metrics.service.servicemonitor.labels": {
+      "default": {},
+      "description": "Additional labels to add to the ServiceMonitor.",
+      "type": "object"
+    },
+    "helm-values.app.metrics.service.servicemonitor.prometheusInstance": {
+      "default": "default",
+      "description": "Sets the value of the \"prometheus\" label on the ServiceMonitor. This is used so that separate Prometheus instances can select different ServiceMonitors using labels.",
+      "type": "string"
+    },
+    "helm-values.app.metrics.service.servicemonitor.scrapeTimeout": {
+      "default": "5s",
+      "description": "The timeout for a metrics scrape.",
+      "type": "string"
+    },
+    "helm-values.app.metrics.service.type": {
+      "default": "ClusterIP",
+      "description": "The Service type to expose metrics.",
+      "type": "string"
+    },
+    "helm-values.app.minTLSVersion": {
+      "default": "",
+      "description": "Minimum TLS version supported. If omitted, the default Go minimum version will be used.",
+      "type": "string"
+    },
+    "helm-values.app.podAnnotations": {
+      "default": {},
+      "description": "Pod annotations to add to trust-manager pods.",
+      "type": "object"
+    },
+    "helm-values.app.podLabels": {
+      "default": {},
+      "description": "Pod labels to add to trust-manager pods.",
+      "type": "object"
+    },
+    "helm-values.app.readinessProbe": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/helm-values.app.readinessProbe.path"
+        },
+        "port": {
+          "$ref": "#/$defs/helm-values.app.readinessProbe.port"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.readinessProbe.path": {
+      "default": "/readyz",
+      "description": "The path on which to expose the trust-manager HTTP readiness probe using the default network interface.",
+      "type": "string"
+    },
+    "helm-values.app.readinessProbe.port": {
+      "default": 6060,
+      "description": "The container port on which to expose the trust-manager HTTP readiness probe using the default network interface.",
+      "type": "number"
+    },
+    "helm-values.app.securityContext": {
+      "additionalProperties": false,
+      "properties": {
+        "seccompProfileEnabled": {
+          "$ref": "#/$defs/helm-values.app.securityContext.seccompProfileEnabled"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.securityContext.seccompProfileEnabled": {
+      "default": true,
+      "description": "If false, disables the default seccomp profile, which might be required to run on certain platforms.",
+      "type": "boolean"
+    },
+    "helm-values.app.targetNamespaces": {
+      "description": "List of target namespaces that trust-manager can write to. By default, trust-manager can write targets in any namespace.",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.app.trust": {
+      "additionalProperties": false,
+      "properties": {
+        "namespace": {
+          "$ref": "#/$defs/helm-values.app.trust.namespace"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.trust.namespace": {
+      "default": "cert-manager",
+      "description": "The namespace used as the trust source. Note that the namespace _must_ exist before installing trust-manager.",
+      "type": "string"
+    },
+    "helm-values.app.webhook": {
+      "additionalProperties": false,
+      "properties": {
+        "host": {
+          "$ref": "#/$defs/helm-values.app.webhook.host"
+        },
+        "hostNetwork": {
+          "$ref": "#/$defs/helm-values.app.webhook.hostNetwork"
+        },
+        "port": {
+          "$ref": "#/$defs/helm-values.app.webhook.port"
+        },
+        "service": {
+          "$ref": "#/$defs/helm-values.app.webhook.service"
+        },
+        "timeoutSeconds": {
+          "$ref": "#/$defs/helm-values.app.webhook.timeoutSeconds"
+        },
+        "tls": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.webhook.host": {
+      "default": "0.0.0.0",
+      "description": "Host that the webhook listens on.",
+      "type": "string"
+    },
+    "helm-values.app.webhook.hostNetwork": {
+      "default": false,
+      "description": "This value specifies if the app should be started in hostNetwork mode. It is required for use in some managed Kubernetes clusters (such as AWS EKS) with custom CNI.",
+      "type": "boolean"
+    },
+    "helm-values.app.webhook.port": {
+      "default": 6443,
+      "description": "Port that the webhook listens on.",
+      "type": "number"
+    },
+    "helm-values.app.webhook.service": {
+      "additionalProperties": false,
+      "properties": {
+        "ipFamilies": {
+          "$ref": "#/$defs/helm-values.app.webhook.service.ipFamilies"
+        },
+        "ipFamilyPolicy": {
+          "$ref": "#/$defs/helm-values.app.webhook.service.ipFamilyPolicy"
+        },
+        "nodePort": {
+          "$ref": "#/$defs/helm-values.app.webhook.service.nodePort"
+        },
+        "type": {
+          "$ref": "#/$defs/helm-values.app.webhook.service.type"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.webhook.service.ipFamilies": {
+      "default": [],
+      "description": "Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.app.webhook.service.ipFamilyPolicy": {
+      "default": "",
+      "description": "Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)",
+      "type": "string"
+    },
+    "helm-values.app.webhook.service.nodePort": {
+      "description": "The nodePort set on the Service used by the webhook.",
+      "type": "number"
+    },
+    "helm-values.app.webhook.service.type": {
+      "default": "ClusterIP",
+      "description": "The type of Kubernetes Service used by the Webhook.",
+      "type": "string"
+    },
+    "helm-values.app.webhook.timeoutSeconds": {
+      "default": 5,
+      "description": "Timeout of webhook HTTP request.",
+      "type": "number"
+    },
+    "helm-values.app.webhook.tls": {
+      "additionalProperties": false,
+      "properties": {
+        "approverPolicy": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.approverPolicy"
+        },
+        "certificate": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.certificate"
+        },
+        "helmCert": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.helmCert"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.webhook.tls.approverPolicy": {
+      "additionalProperties": false,
+      "properties": {
+        "certManagerNamespace": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.approverPolicy.certManagerNamespace"
+        },
+        "certManagerServiceAccount": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.approverPolicy.certManagerServiceAccount"
+        },
+        "enabled": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.approverPolicy.enabled"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.webhook.tls.approverPolicy.certManagerNamespace": {
+      "default": "cert-manager",
+      "description": "The namespace in which cert-manager was installed. Only used if `app.webhook.tls.approverPolicy.enabled` is true.",
+      "type": "string"
+    },
+    "helm-values.app.webhook.tls.approverPolicy.certManagerServiceAccount": {
+      "default": "cert-manager",
+      "description": "The name of cert-manager's Service Account. Only used if `app.webhook.tls.approverPolicy.enabled` is true.",
+      "type": "string"
+    },
+    "helm-values.app.webhook.tls.approverPolicy.enabled": {
+      "default": false,
+      "description": "Whether to create an approver-policy CertificateRequestPolicy allowing auto-approval of the trust-manager webhook certificate. If you have approver-policy installed, you almost certainly want to enable this.",
+      "type": "boolean"
+    },
+    "helm-values.app.webhook.tls.certificate": {
+      "additionalProperties": false,
+      "properties": {
+        "secretTemplate": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.certificate.secretTemplate"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.webhook.tls.certificate.secretTemplate": {
+      "default": {},
+      "type": "object"
+    },
+    "helm-values.app.webhook.tls.helmCert": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.helmCert.enabled"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.webhook.tls.helmCert.enabled": {
+      "default": false,
+      "description": "Whether to issue a webhook cert using Helm, which removes the need to install cert-manager. Helm-issued certificates can be challenging to rotate and maintain, and the issued cert will have a duration of 10 years and be modified when trust-manager is updated. It's safer and easier to rely on cert-manager for issuing the webhook cert - avoid using Helm-generated certs in production.",
+      "type": "boolean"
+    },
+    "helm-values.automountServiceAccountToken": {
+      "default": true,
+      "description": "Automounting API credentials for the trust-manager pod.",
+      "type": "boolean"
+    },
+    "helm-values.commonAnnotations": {
+      "default": {},
+      "description": "Annotations to apply to all resources\nNOTE: These annotations won't be added to the CRDs.",
+      "type": "object"
+    },
+    "helm-values.commonLabels": {
+      "default": {},
+      "description": "Labels to apply to all resources",
+      "type": "object"
+    },
+    "helm-values.crds": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.crds.enabled"
+        },
+        "keep": {
+          "$ref": "#/$defs/helm-values.crds.keep"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.crds.enabled": {
+      "default": true,
+      "description": "This option decides if the CRDs should be installed as part of the Helm installation.",
+      "type": "boolean"
+    },
+    "helm-values.crds.keep": {
+      "default": true,
+      "description": "This option makes it so that the \"helm.sh/resource-policy\": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled. WARNING: when the CRDs are removed, all cert-manager custom resources\n(Certificates, Issuers, ...) will be removed too by the garbage collector.",
+      "type": "boolean"
+    },
+    "helm-values.defaultPackage": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.defaultPackage.enabled"
+        },
+        "resources": {
+          "$ref": "#/$defs/helm-values.defaultPackage.resources"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.defaultPackage.enabled": {
+      "default": true,
+      "description": "Whether to load the default trust package during pod initialization, and include it in main container args. This container enables the 'useDefaultCAs' source on Bundles.",
+      "type": "boolean"
+    },
+    "helm-values.defaultPackage.resources": {
+      "default": {},
+      "description": "Kubernetes pod resource limits for default package init container.\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
+      "type": "object"
+    },
+    "helm-values.defaultPackageImage": {
+      "additionalProperties": false,
+      "properties": {
+        "_defaultReference": {
+          "$ref": "#/$defs/helm-values.defaultPackageImage._defaultReference"
+        },
+        "digest": {
+          "$ref": "#/$defs/helm-values.defaultPackageImage.digest"
+        },
+        "name": {
+          "$ref": "#/$defs/helm-values.defaultPackageImage.name"
+        },
+        "pullPolicy": {
+          "$ref": "#/$defs/helm-values.defaultPackageImage.pullPolicy"
+        },
+        "registry": {
+          "$ref": "#/$defs/helm-values.defaultPackageImage.registry"
+        },
+        "repository": {
+          "$ref": "#/$defs/helm-values.defaultPackageImage.repository"
+        },
+        "tag": {
+          "$ref": "#/$defs/helm-values.defaultPackageImage.tag"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.defaultPackageImage._defaultReference": {
+      "default": ":v0.0.0",
+      "description": "WARNING: For internal use only, is overwritten before releasing the chart.",
+      "type": "string"
+    },
+    "helm-values.defaultPackageImage.digest": {
+      "description": "Target image digest. Override any tag, if set.\nFor example:\ndigest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20",
+      "type": "string"
+    },
+    "helm-values.defaultPackageImage.name": {
+      "default": "trust-pkg-debian-bookworm",
+      "description": "The image name for trust-manager.\nThis is used (together with `imageRegistry` and `imageNamespace`) to construct the full image reference.",
+      "type": "string"
+    },
+    "helm-values.defaultPackageImage.pullPolicy": {
+      "default": "IfNotPresent",
+      "description": "imagePullPolicy for the default package image.",
+      "type": "string"
+    },
+    "helm-values.defaultPackageImage.registry": {
+      "description": "Target image registry. This value is prepended to the target image repository, if set.\nFor example:\nregistry: quay.io\nrepository: jetstack/cert-manager-package-debian\nDeprecated: per-component registry prefix.\n\nIf set, this value is *prepended* to the image repository that the chart would otherwise render. This applies both when `image.repository` is set and when the repository is computed from\n`imageRegistry` + `imageNamespace` + `image.name`.\n\nThis can produce \"double registry\" style references such as\n`legacy.example.io/quay.io/jetstack/...`. Prefer using the global\n`imageRegistry`/`imageNamespace` values.",
+      "type": "string"
+    },
+    "helm-values.defaultPackageImage.repository": {
+      "default": "",
+      "description": "Full repository override (takes precedence over `imageRegistry`, `imageNamespace`, and `image.name`).\nExample: quay.io/jetstack/trust-manager",
+      "type": "string"
+    },
+    "helm-values.defaultPackageImage.tag": {
+      "description": "Override the image tag of the default package image. Is set at chart build time to the version specified in ./make/00_debian_bookworm_version.mk.",
+      "type": "string"
+    },
+    "helm-values.enabled": {
+      "default": true,
+      "description": "Field to optionally disable installation of the chart when wrapping it as a dependency in another chart.\nThis matched the helm best practices:\nhttps://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags",
+      "type": "boolean"
+    },
+    "helm-values.extraObjects": {
+      "default": [],
+      "description": "Extra manifests to be deployed. This is useful for deploying additional resources that are not part of the chart.\nFor example:\nextraObjects:\n - apiVersion: cilium.io/v2\n   kind: CiliumNetworkPolicy\n   metadata:\n     name: trust-manager\n     namespace: trust-manager\n   spec:\n     endpointSelector:\n       matchLabels:\n         io.cilium.k8s.policy.serviceaccount: trust-manager\n     egress:\n       - toEntities:\n           - kube-apiserver",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.filterExpiredCertificates": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.filterExpiredCertificates.enabled"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.filterExpiredCertificates.enabled": {
+      "default": false,
+      "description": "Whether to filter expired certificates from the trust bundle.",
+      "type": "boolean"
+    },
+    "helm-values.filterNonCACerts": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.filterNonCACerts.enabled"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.filterNonCACerts.enabled": {
+      "default": false,
+      "description": "Filter non-CA certificates, only CAs are used in the resulting Bundle.",
+      "type": "boolean"
+    },
+    "helm-values.global": {
+      "description": "Global values shared across all (sub)charts",
+      "properties": {
+        "rbac": {
+          "$ref": "#/$defs/helm-values.global.rbac"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.global.rbac": {
+      "properties": {
+        "create": {
+          "$ref": "#/$defs/helm-values.global.rbac.create"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.global.rbac.create": {
+      "default": true,
+      "description": "Create required ClusterRoles, Roles, ClusterRoleBindings and RoleBindings for trust-manager.",
+      "type": "boolean"
+    },
+    "helm-values.image": {
+      "additionalProperties": false,
+      "properties": {
+        "digest": {
+          "$ref": "#/$defs/helm-values.image.digest"
+        },
+        "name": {
+          "$ref": "#/$defs/helm-values.image.name"
+        },
+        "pullPolicy": {
+          "$ref": "#/$defs/helm-values.image.pullPolicy"
+        },
+        "registry": {
+          "$ref": "#/$defs/helm-values.image.registry"
+        },
+        "repository": {
+          "$ref": "#/$defs/helm-values.image.repository"
+        },
+        "tag": {
+          "$ref": "#/$defs/helm-values.image.tag"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.image.digest": {
+      "description": "Target image digest. Override any tag, if set.\nFor example:\ndigest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20",
+      "type": "string"
+    },
+    "helm-values.image.name": {
+      "default": "trust-manager",
+      "description": "The image name for trust-manager.\nThis is used (together with `imageRegistry` and `imageNamespace`) to construct the full image reference.",
+      "type": "string"
+    },
+    "helm-values.image.pullPolicy": {
+      "default": "IfNotPresent",
+      "description": "Kubernetes imagePullPolicy on Deployment.",
+      "type": "string"
+    },
+    "helm-values.image.registry": {
+      "description": "Target image registry. This value is prepended to the target image repository, if set.\nFor example:\nregistry: legacy.example.io\nDeprecated: per-component registry prefix.\n\nIf set, this value is *prepended* to the image repository that the chart would otherwise render. This applies both when `image.repository` is set and when the repository is computed from\n`imageRegistry` + `imageNamespace` + `image.name`.\n\nThis can produce \"double registry\" style references such as\n`legacy.example.io/quay.io/jetstack/...`. Prefer using the global\n`imageRegistry`/`imageNamespace` values.",
+      "type": "string"
+    },
+    "helm-values.image.repository": {
+      "default": "",
+      "description": "Full repository override (takes precedence over `imageRegistry`, `imageNamespace`, and `image.name`).\nExample: quay.io/jetstack/trust-manager",
+      "type": "string"
+    },
+    "helm-values.image.tag": {
+      "description": "Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.",
+      "type": "string"
+    },
+    "helm-values.imageNamespace": {
+      "default": "jetstack",
+      "description": "The repository namespace used for trust-manager images by default.\nExamples:\n- jetstack\n- cert-manager",
+      "type": "string"
+    },
+    "helm-values.imagePullSecrets": {
+      "default": [],
+      "description": "For Private docker registries, authentication is needed. Registry secrets are applied to the service account.",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.imageRegistry": {
+      "default": "quay.io",
+      "description": "The container registry used for trust-manager images by default. This can include path prefixes (e.g. \"artifactory.example.com/docker\").",
+      "type": "string"
+    },
+    "helm-values.nameOverride": {
+      "default": "",
+      "type": "string"
+    },
+    "helm-values.namespace": {
+      "default": "",
+      "description": "The namespace to install trust-manager into.\nIf not set, the namespace of the release is used.\nThis is helpful when installing trust-manager as a chart dependency (sub chart).",
+      "type": "string"
+    },
+    "helm-values.nodeSelector": {
+      "default": {
+        "kubernetes.io/os": "linux"
+      },
+      "description": "Configure the nodeSelector; defaults to any Linux node (trust-manager doesn't support Windows nodes)",
+      "type": "object"
+    },
+    "helm-values.podDisruptionBudget": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.podDisruptionBudget.enabled"
+        },
+        "maxUnavailable": {
+          "$ref": "#/$defs/helm-values.podDisruptionBudget.maxUnavailable"
+        },
+        "minAvailable": {
+          "$ref": "#/$defs/helm-values.podDisruptionBudget.minAvailable"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.podDisruptionBudget.enabled": {
+      "default": false,
+      "description": "Enable or disable the PodDisruptionBudget resource.\n\nThis prevents downtime during voluntary disruptions such as during a Node upgrade. For example, the PodDisruptionBudget will block `kubectl drain` if it is used on the Node where the only remaining trust-manager\nPod is currently running.",
+      "type": "boolean"
+    },
+    "helm-values.podDisruptionBudget.maxUnavailable": {
+      "description": "This configures the maximum unavailable pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%). it cannot be used if `minAvailable` is set."
+    },
+    "helm-values.podDisruptionBudget.minAvailable": {
+      "description": "This configures the minimum available pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).\nIt cannot be used if `maxUnavailable` is set."
+    },
+    "helm-values.priorityClassName": {
+      "default": "",
+      "description": "Configure the priority class of the pod. For more information, see [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass).",
+      "type": "string"
+    },
+    "helm-values.replicaCount": {
+      "default": 1,
+      "description": "The number of replicas of trust-manager to run.\n\nFor example:\n Use integer to set a fixed number of replicas\nreplicaCount: 2\nUse null, if you want to omit the replicas field and use the Kubernetes default value.\nreplicaCount: null\nUse a string if you want to insert a variable for post-processing of the rendered template.\nreplicaCount: ${REPLICAS_OVERRIDE:=3}"
+    },
+    "helm-values.resources": {
+      "default": {},
+      "description": "Kubernetes pod resource limits for trust.\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
+      "type": "object"
+    },
+    "helm-values.revisionHistoryLimit": {
+      "default": 10,
+      "description": "The number of old ReplicaSets to retain to allow rollback. This is used to control the number of old ReplicaSets that are retained to allow rollback.\nIf set to 0, no old ReplicaSets are retained."
+    },
+    "helm-values.secretTargets": {
+      "additionalProperties": false,
+      "properties": {
+        "authorizedSecrets": {
+          "$ref": "#/$defs/helm-values.secretTargets.authorizedSecrets"
+        },
+        "authorizedSecretsAll": {
+          "$ref": "#/$defs/helm-values.secretTargets.authorizedSecretsAll"
+        },
+        "enabled": {
+          "$ref": "#/$defs/helm-values.secretTargets.enabled"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.secretTargets.authorizedSecrets": {
+      "default": [],
+      "description": "A list of secret names which trust-manager will be permitted to read and write across all namespaces. These are the only allowable Secrets that can be used as targets. If the list is empty (and authorizedSecretsAll is false), trust-manager can't write to secrets and can only read secrets in the trust namespace for use as sources.",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.secretTargets.authorizedSecretsAll": {
+      "default": false,
+      "description": "If set to true, grant read/write permission to all secrets across the cluster. Use with caution!\nIf set, ignores the authorizedSecrets list.",
+      "type": "boolean"
+    },
+    "helm-values.secretTargets.enabled": {
+      "default": false,
+      "description": "If set to true, enable writing trust bundles to Kubernetes Secrets as a target. trust-manager can only write to secrets which are explicitly allowed via either authorizedSecrets or authorizedSecretsAll. Note that enabling secret targets will grant trust-manager read access to all secrets in the cluster.",
+      "type": "boolean"
+    },
+    "helm-values.serviceAccount": {
+      "additionalProperties": false,
+      "properties": {
+        "automountServiceAccountToken": {
+          "$ref": "#/$defs/helm-values.serviceAccount.automountServiceAccountToken"
+        },
+        "create": {
+          "$ref": "#/$defs/helm-values.serviceAccount.create"
+        },
+        "name": {
+          "$ref": "#/$defs/helm-values.serviceAccount.name"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.serviceAccount.automountServiceAccountToken": {
+      "default": true,
+      "description": "Automount API credentials for a Service Account.",
+      "type": "boolean"
+    },
+    "helm-values.serviceAccount.create": {
+      "default": true,
+      "description": "Specifies whether a service account should be created.",
+      "type": "boolean"
+    },
+    "helm-values.serviceAccount.name": {
+      "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template.",
+      "type": "string"
+    },
+    "helm-values.tolerations": {
+      "default": [],
+      "description": "List of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).\nFor example:\ntolerations:\n- key: foo.bar.com/role\n  operator: Equal\n  value: master\n  effect: NoSchedule",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.topologySpreadConstraints": {
+      "default": [],
+      "description": "List of Kubernetes TopologySpreadConstraints. For more information, see [TopologySpreadConstraint v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core).\nFor example:\ntopologySpreadConstraints:\n- maxSkew: 2\n  topologyKey: topology.kubernetes.io/zone\n  whenUnsatisfiable: ScheduleAnyway\n  labelSelector:\n    matchLabels:\n      app.kubernetes.io/name: trust-manager",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.volumeMounts": {
+      "default": [],
+      "description": "Additional volume mounts to add to the trust-manager container.",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.volumes": {
+      "default": [],
+      "description": "Additional volumes to add to the trust-manager pod.",
+      "items": {},
+      "type": "array"
+    }
+  },
+  "$ref": "#/$defs/helm-values",
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/packages/system/trust-manager/charts/trust-manager/values.yaml
+++ b/packages/system/trust-manager/charts/trust-manager/values.yaml
@@ -1,0 +1,401 @@
+# +docs:section=Global
+global:
+  rbac:
+    # Create required ClusterRoles, Roles, ClusterRoleBindings and RoleBindings for trust-manager.
+    create: true
+# +docs:section=CRDs
+crds:
+  # This option decides if the CRDs should be installed
+  # as part of the Helm installation.
+  enabled: true
+  # This option makes it so that the "helm.sh/resource-policy": keep
+  # annotation is added to the CRD. This will prevent Helm from uninstalling
+  # the CRD when the Helm release is uninstalled.
+  # WARNING: when the CRDs are removed, all cert-manager custom resources
+  # (Certificates, Issuers, ...) will be removed too by the garbage collector.
+  keep: true
+# +docs:section=Trust Manager
+
+# The number of replicas of trust-manager to run.
+#
+# For example:
+#  Use integer to set a fixed number of replicas
+#   replicaCount: 2
+#
+#  Use null, if you want to omit the replicas field and use the Kubernetes default value.
+#   replicaCount: null
+#
+#  Use a string if you want to insert a variable for post-processing of the rendered template.
+#   replicaCount: ${REPLICAS_OVERRIDE:=3}
+#
+# +docs:type=number,string,null
+replicaCount: 1
+# The number of old ReplicaSets to retain to allow rollback.
+# This is used to control the number of old ReplicaSets that are retained to allow rollback.
+# If set to 0, no old ReplicaSets are retained.
+# +docs:type=number,null
+revisionHistoryLimit: 10
+nameOverride: ""
+# The namespace to install trust-manager into.
+# If not set, the namespace of the release is used.
+# This is helpful when installing trust-manager as a chart dependency (sub chart).
+namespace: ""
+# For Private docker registries, authentication is needed. Registry secrets are applied to the service account.
+imagePullSecrets: []
+# The container registry used for trust-manager images by default.
+# This can include path prefixes (e.g. "artifactory.example.com/docker").
+# +docs:property
+imageRegistry: quay.io
+# The repository namespace used for trust-manager images by default.
+# Examples:
+# - jetstack
+# - cert-manager
+# +docs:property
+imageNamespace: jetstack
+image:
+  # Target image registry. This value is prepended to the target image repository, if set.
+  # For example:
+  #   registry: legacy.example.io
+  # Deprecated: per-component registry prefix.
+  #
+  # If set, this value is *prepended* to the image repository that the chart would otherwise render.
+  # This applies both when `image.repository` is set and when the repository is computed from
+  # `imageRegistry` + `imageNamespace` + `image.name`.
+  #
+  # This can produce "double registry" style references such as
+  # `legacy.example.io/quay.io/jetstack/...`. Prefer using the global
+  # `imageRegistry`/`imageNamespace` values.
+  # +docs:property
+  # registry: quay.io
+
+  # Full repository override (takes precedence over `imageRegistry`, `imageNamespace`,
+  # and `image.name`).
+  # Example: quay.io/jetstack/trust-manager
+  # +docs:property
+  repository: ""
+  # The image name for trust-manager.
+  # This is used (together with `imageRegistry` and `imageNamespace`) to construct the full
+  # image reference.
+  # +docs:property
+  name: trust-manager
+  # Override the image tag to deploy by setting this variable.
+  # If no value is set, the chart's appVersion is used.
+  # +docs:property
+  # tag: vX.Y.Z
+
+  # Target image digest. Override any tag, if set.
+  # For example:
+  #   digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+  # +docs:property
+  # digest: sha256:...
+
+  # Kubernetes imagePullPolicy on Deployment.
+  pullPolicy: IfNotPresent
+defaultPackage:
+  # Whether to load the default trust package during pod initialization, and include it in main container args. This container enables the 'useDefaultCAs' source on Bundles.
+  enabled: true
+  # Kubernetes pod resource limits for default package init container.
+  #
+  # For example:
+  #  resources:
+  #    limits:
+  #      cpu: 100m
+  #      memory: 128Mi
+  #    requests:
+  #      cpu: 100m
+  #      memory: 128Mi
+  resources: {}
+defaultPackageImage:
+  # Target image registry. This value is prepended to the target image repository, if set.
+  # For example:
+  #   registry: quay.io
+  #   repository: jetstack/cert-manager-package-debian
+  # Deprecated: per-component registry prefix.
+  #
+  # If set, this value is *prepended* to the image repository that the chart would otherwise render.
+  # This applies both when `image.repository` is set and when the repository is computed from
+  # `imageRegistry` + `imageNamespace` + `image.name`.
+  #
+  # This can produce "double registry" style references such as
+  # `legacy.example.io/quay.io/jetstack/...`. Prefer using the global
+  # `imageRegistry`/`imageNamespace` values.
+  # +docs:property
+  # registry: quay.io
+
+  # Full repository override (takes precedence over `imageRegistry`, `imageNamespace`,
+  # and `image.name`).
+  # Example: quay.io/jetstack/trust-manager
+  # +docs:property
+  repository: ""
+  # The image name for trust-manager.
+  # This is used (together with `imageRegistry` and `imageNamespace`) to construct the full
+  # image reference.
+  # +docs:property
+  name: trust-pkg-debian-bookworm
+  # Override the image tag of the default package image.
+  # Is set at chart build time to the version specified in ./make/00_debian_bookworm_version.mk.
+  # +docs:property
+  # tag: vX.Y.Z
+
+  # Target image digest. Override any tag, if set.
+  # For example:
+  #   digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+  # +docs:property
+  # digest: sha256:...
+
+  # WARNING: For internal use only, is overwritten before releasing the chart.
+  # +docs:hidden
+  _defaultReference: :20230311-deb12u1.6
+  # imagePullPolicy for the default package image.
+  pullPolicy: IfNotPresent
+# Automounting API credentials for the trust-manager pod.
+# +docs:property
+automountServiceAccountToken: true
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  # +docs:property
+  # name: ""
+
+  # Automount API credentials for a Service Account.
+  # +docs:property
+  automountServiceAccountToken: true
+# Additional volumes to add to the trust-manager pod.
+volumes: []
+# Additional volume mounts to add to the trust-manager container.
+volumeMounts: []
+secretTargets:
+  # If set to true, enable writing trust bundles to Kubernetes Secrets as a target.
+  # trust-manager can only write to secrets which are explicitly allowed via either authorizedSecrets or authorizedSecretsAll.
+  # Note that enabling secret targets will grant trust-manager read access to all secrets in the cluster.
+  enabled: false
+  # If set to true, grant read/write permission to all secrets across the cluster. Use with caution!
+  # If set, ignores the authorizedSecrets list.
+  authorizedSecretsAll: false
+  # A list of secret names which trust-manager will be permitted to read and write across all namespaces.
+  # These are the only allowable Secrets that can be used as targets. If the list is empty (and authorizedSecretsAll is false),
+  # trust-manager can't write to secrets and can only read secrets in the trust namespace for use as sources.
+  authorizedSecrets: []
+# Kubernetes pod resource limits for trust.
+#
+# For example:
+#  resources:
+#    limits:
+#      cpu: 100m
+#      memory: 128Mi
+#    requests:
+#      cpu: 100m
+#      memory: 128Mi
+resources: {}
+# Configure the priority class of the pod. For more information, see [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass).
+priorityClassName: ""
+# Configure the nodeSelector; defaults to any Linux node (trust-manager doesn't support Windows nodes)
+# +docs:property
+nodeSelector:
+  kubernetes.io/os: linux
+# Kubernetes Affinity. For more information, see [Affinity v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core).
+# For example:
+#   affinity:
+#     nodeAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        nodeSelectorTerms:
+#        - matchExpressions:
+#          - key: foo.bar.com/role
+#            operator: In
+#            values:
+#            - master
+affinity: {}
+# List of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
+# For example:
+#   tolerations:
+#   - key: foo.bar.com/role
+#     operator: Equal
+#     value: master
+#     effect: NoSchedule
+tolerations: []
+# List of Kubernetes TopologySpreadConstraints. For more information, see [TopologySpreadConstraint v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core).
+# For example:
+#   topologySpreadConstraints:
+#   - maxSkew: 2
+#     topologyKey: topology.kubernetes.io/zone
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app.kubernetes.io/name: trust-manager
+topologySpreadConstraints: []
+filterExpiredCertificates:
+  # Whether to filter expired certificates from the trust bundle.
+  enabled: false
+filterNonCACerts:
+  # Filter non-CA certificates, only CAs are used in the resulting Bundle.
+  enabled: false
+app:
+  # Minimum TLS version supported. If omitted, the default Go minimum version will be used.
+  minTLSVersion: ""
+  # Comma-separated list of cipher suites for the server. If omitted, the default Go cipher suites will be used.
+  cipherSuites: ""
+  # The format of trust-manager logging. Accepted values are text or json.
+  logFormat: text
+  # The verbosity of trust-manager logging. This takes a value from 1-5, with the higher value being more verbose.
+  logLevel: 1
+  leaderElection:
+    # Whether to enable leader election for trust-manager.
+    enabled: true
+    # The duration that non-leader candidates will wait to force acquire leadership.
+    # The default should be sufficient in a healthy cluster but can be slightly increased to prevent trust-manager from restart-looping when the API server is overloaded.
+    leaseDuration: 15s
+    # The interval between attempts by the acting leader to renew a leadership slot before it stops leading.
+    # This MUST be less than or equal to the lease duration.
+    # The default should be sufficient in a healthy cluster but can be slightly increased to prevent trust-manager from restart-looping when the API server is overloaded.
+    renewDeadline: 10s
+  readinessProbe:
+    # The container port on which to expose the trust-manager HTTP readiness probe using the default network interface.
+    port: 6060
+    # The path on which to expose the trust-manager HTTP readiness probe using the default network interface.
+    path: "/readyz"
+  trust:
+    # The namespace used as the trust source. Note that the namespace _must_ exist
+    # before installing trust-manager.
+    namespace: cert-manager
+  # List of target namespaces that trust-manager can write to. By default, trust-manager can write targets in any namespace.
+  # +docs:property
+  # targetNamespaces: ["ns-1", "ns-2"]
+  securityContext:
+    # If false, disables the default seccomp profile, which might be required to run on certain platforms.
+    seccompProfileEnabled: true
+  # Pod labels to add to trust-manager pods.
+  podLabels: {}
+  # Pod annotations to add to trust-manager pods.
+  podAnnotations: {}
+  # +docs:section=Webhook
+  webhook:
+    # Host that the webhook listens on.
+    host: 0.0.0.0
+    # Port that the webhook listens on.
+    port: 6443
+    # Timeout of webhook HTTP request.
+    timeoutSeconds: 5
+    service:
+      # The type of Kubernetes Service used by the Webhook.
+      type: ClusterIP
+      # Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)
+      ipFamilyPolicy: ""
+      # Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.
+      ipFamilies: []
+      # The nodePort set on the Service used by the webhook.
+      # +docs:property
+      # nodePort: 8080
+    tls:
+      helmCert:
+        # Whether to issue a webhook cert using Helm, which removes the need to install cert-manager.
+        # Helm-issued certificates can be challenging to rotate and maintain, and the issued cert will have a duration of 10 years and be modified when trust-manager is updated.
+        # It's safer and easier to rely on cert-manager for issuing the webhook cert - avoid using Helm-generated certs in production.
+        enabled: false
+      approverPolicy:
+        # Whether to create an approver-policy CertificateRequestPolicy allowing auto-approval of the trust-manager webhook certificate. If you have approver-policy installed, you almost certainly want to enable this.
+        enabled: false
+        # The namespace in which cert-manager was installed. Only used if `app.webhook.tls.approverPolicy.enabled` is true.
+        certManagerNamespace: "cert-manager"
+        # The name of cert-manager's Service Account. Only used if `app.webhook.tls.approverPolicy.enabled` is true.
+        certManagerServiceAccount: "cert-manager"
+      # Add labels/annotations to secrets created by Certificate resources when using cert-manager provisioned TLS certificate.
+      certificate:
+        secretTemplate: {}
+        # For example:
+        #   annotations:
+        #     my-secret-annotation-1: "foo"
+        #     my-secret-annotation-2: "bar"
+        #   labels:
+        #     my-secret-label: foo
+    # This value specifies if the app should be started in hostNetwork mode. It is required for use in some managed Kubernetes clusters (such as AWS EKS) with custom CNI.
+    hostNetwork: false
+  # +docs:section=Metrics
+  metrics:
+    # The port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.
+    port: 9402
+    # The service to expose metrics endpoint.
+    service:
+      # Create a Service resource to expose the metrics endpoint.
+      enabled: true
+      # The Service type to expose metrics.
+      type: ClusterIP
+      # Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)
+      ipFamilyPolicy: ""
+      # Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.
+      ipFamilies: []
+      # The ServiceMonitor resource for this Service.
+      servicemonitor:
+        # Create a Prometheus ServiceMonitor for trust-manager.
+        enabled: false
+        # Sets the value of the "prometheus" label on the ServiceMonitor.
+        # This is used so that separate Prometheus instances can select different ServiceMonitors using labels.
+        prometheusInstance: default
+        # The interval to scrape the metrics.
+        interval: 10s
+        # The timeout for a metrics scrape.
+        scrapeTimeout: 5s
+        # Additional labels to add to the ServiceMonitor.
+        labels: {}
+        # EndpointAdditionalProperties allows setting additional properties on the
+        # endpoint such as relabelings, metricRelabelings etc.
+        #
+        # For example:
+        #  endpointAdditionalProperties:
+        #   relabelings:
+        #   - action: replace
+        #     sourceLabels:
+        #     - __meta_kubernetes_pod_node_name
+        #     targetLabel: instance
+        #
+        # +docs:property
+        endpointAdditionalProperties: {}
+podDisruptionBudget:
+  # Enable or disable the PodDisruptionBudget resource.
+  #
+  # This prevents downtime during voluntary disruptions such as during a Node upgrade.
+  # For example, the PodDisruptionBudget will block `kubectl drain`
+  # if it is used on the Node where the only remaining trust-manager
+  # Pod is currently running.
+  enabled: false
+  # This configures the minimum available pods for disruptions. It can either be set to
+  # an integer (e.g. 1) or a percentage value (e.g. 25%).
+  # It cannot be used if `maxUnavailable` is set.
+  # +docs:type=unknown
+  # +docs:property
+  # minAvailable: 1
+
+  # This configures the maximum unavailable pods for disruptions. It can either be set to
+  # an integer (e.g. 1) or a percentage value (e.g. 25%).
+  # it cannot be used if `minAvailable` is set.
+  # +docs:type=unknown
+  # +docs:property
+  # maxUnavailable: 1
+# Labels to apply to all resources
+commonLabels: {}
+# Annotations to apply to all resources
+# NOTE: These annotations won't be added to the CRDs.
+commonAnnotations: {}
+# Extra manifests to be deployed. This is useful for deploying additional resources that are not part of the chart.
+# For example:
+# extraObjects:
+#  - apiVersion: cilium.io/v2
+#    kind: CiliumNetworkPolicy
+#    metadata:
+#      name: trust-manager
+#      namespace: trust-manager
+#    spec:
+#      endpointSelector:
+#        matchLabels:
+#          io.cilium.k8s.policy.serviceaccount: trust-manager
+#      egress:
+#        - toEntities:
+#            - kube-apiserver
+extraObjects: []
+# Field to optionally disable installation of the chart when wrapping it as a
+# dependency in another chart.
+# This matched the helm best practices:
+# https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags
+# +docs:hidden
+enabled: true

--- a/packages/system/trust-manager/tests/values_test.yaml
+++ b/packages/system/trust-manager/tests/values_test.yaml
@@ -1,0 +1,32 @@
+suite: cozystack trust-manager value overrides
+templates:
+  - charts/trust-manager/templates/deployment.yaml
+  - charts/trust-manager/templates/poddisruptionbudget.yaml
+release:
+  name: trust-manager
+  namespace: cozy-cert-manager
+tests:
+  - it: deployment runs two replicas (webhook stays available during rolling restart)
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+        template: charts/trust-manager/templates/deployment.yaml
+
+  - it: PDB is enabled with minAvailable=1
+    asserts:
+      - equal:
+          path: kind
+          value: PodDisruptionBudget
+        template: charts/trust-manager/templates/poddisruptionbudget.yaml
+      - equal:
+          path: spec.minAvailable
+          value: 1
+        template: charts/trust-manager/templates/poddisruptionbudget.yaml
+
+  - it: deployment passes --trust-namespace=cozy-cert-manager
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --trust-namespace=cozy-cert-manager
+        template: charts/trust-manager/templates/deployment.yaml

--- a/packages/system/trust-manager/values.yaml
+++ b/packages/system/trust-manager/values.yaml
@@ -1,0 +1,11 @@
+trust-manager:
+  # Run two replicas so the ValidatingWebhookConfiguration
+  # (failurePolicy: Fail) keeps admitting Bundle CREATE/UPDATE
+  # during a rolling restart of trust-manager itself.
+  replicaCount: 2
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+  app:
+    trust:
+      namespace: cozy-cert-manager


### PR DESCRIPTION
## What this PR does

Adds [trust-manager](https://github.com/cert-manager/trust-manager) v0.22.1 as a cozystack system package alongside cert-manager. Trust-manager is the upstream cert-manager.io project that distributes trust bundles (CA certificates) into Kubernetes namespaces via the `Bundle` CRD — a companion to cert-manager that closes the gap between "I have a CA issued by cert-manager" and "every workload in every namespace can read that CA out of a ConfigMap".

### Why now

cozystack DBaaS charts (mariadb, redis, rabbitmq, etc.) live in the host cluster, not inside tenant Kamaji clusters. The CA TLS Secret each release issues stays in its host-side tenant namespace. Surfacing that CA to clients in the same release namespace currently requires hand-written ConfigMap copies or an external sync sidecar. Shipping trust-manager at the platform level means future TLS-bearing charts can render a `Bundle` CR in their release namespace pointing at `<release>-ca-tls` and have trust-manager project the CA into a sibling ConfigMap — no cross-namespace RBAC, no manual copy. This PR is the platform plumbing; a Bundle consumer in any specific chart is a follow-up.

### Architectural decisions

- **Root-only, no tenant scope.** Trust-manager is single-deployment, cluster-wide by design (one operator pod + `target.namespaceSelector` on Bundle resources). A per-tenant install adds the cost of an extra operator + webhook without changing the scoping model (Bundle is cluster-scoped; the operator's ServiceAccount governs reach, `namespaceSelector` governs distribution). For workloads that genuinely need trust-manager inside a tenant Kubernetes cluster, the tenant operator installs it themselves — out of scope for cozystack platform-side TLS.
- **Shared `cozy-cert-manager` namespace with cert-manager.** Upstream-recommended pattern — trust-manager talks to cert-manager via the local API for its webhook serving cert. Avoids a new namespace and an additional set of cross-namespace permissions.
- **CRDs split into a separate `trust-manager-crds` package.** Mirrors the existing cert-manager / cert-manager-crds split. Helm intentionally ignores chart-level `crds/` on upgrade; keeping the Bundle CRD in a standalone chart with `crds.keep: true` lets Flux re-apply it on every release.
- **`PackageSource.dependsOn: cozystack.cert-manager`.** Trust-manager's webhook serving cert is issued by cert-manager at install time. Without cert-manager already reconciled, the install hangs on webhook readiness.

### Known limitations

- No Bundle consumer in the tree yet — platform plumbing only; trust-manager runs even when no Bundle exists.
- Upstream chart version is pinned in `make update` (`--version v0.22.1`). Aligning the rest of the cert-manager family (cert-manager, cert-manager-crds, cert-manager-issuers) to the same pattern is tracked separately in cozystack/cozystack#2747.

### Verification

- `helm unittest packages/core/platform` — 24/24 passing (7 new + 17 pre-existing).
- `helm template` on both new packages renders cleanly with all resources in `cozy-cert-manager`.
- Two-pass independent branch-review: both passes LGTM, all surfaced findings addressed before the second pass.

### Docs

Companion docs PR: cozystack/website#550 — adds the trust-manager card to the platform-stack guide alongside cert-manager.

### Release note

```release-note
Add trust-manager v0.22.1 as a cozystack system component. Trust-manager installs into the cozy-cert-manager namespace alongside cert-manager and distributes CA bundles into release namespaces through the Bundle CRD (trust.cert-manager.io/v1alpha1). Enabled by default in all system variants (isp-full, isp-full-generic, isp-hosted); operators can opt out via `bundles.disabledPackages: [cozystack.trust-manager]`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trust-manager support with a Bundle CRD for managing trusted certificate bundles.
  * Added automated diagnostics to collect bundle state, manifests, describe output, and deployment logs.

* **Tests**
  * Added validation tests for trust-manager package wiring across system variants and enable/disable scenarios.

* **Chores**
  * Integrated trust-manager Helm charts, CRDs, defaults, and a comprehensive values schema for deployment/configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->