### PR TITLE
fix(dashboard): unblock token-proxy startup when JWKS is briefly unreachable

### DIFF
--- a/packages/system/dashboard/.gitignore
+++ b/packages/system/dashboard/.gitignore
@@ -1,1 +1,2 @@
 .tmp-cozystack-ui
+images/token-proxy/token-proxy

--- a/packages/system/dashboard/Makefile
+++ b/packages/system/dashboard/Makefile
@@ -4,12 +4,17 @@ export NAMESPACE=cozy-$(NAME)
 include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
 
-.PHONY: image image-console image-token-proxy
+.PHONY: image image-console image-token-proxy test test-go test-helm
 .PHONY: clone-console build-console update-values-console clean-console
 .NOTPARALLEL: image
 
-test:
+test: test-helm test-go
+
+test-helm:
 	helm unittest .
+
+test-go:
+	cd images/token-proxy && go test ./...
 
 image: image-console image-token-proxy
 

--- a/packages/system/dashboard/images/token-proxy/Dockerfile
+++ b/packages/system/dashboard/images/token-proxy/Dockerfile
@@ -3,14 +3,22 @@ FROM golang:1.26-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
-COPY main.go go.mod go.sum /src/
+COPY go.mod go.sum /src/
+COPY *.go /src/
 WORKDIR /src
 
-RUN go build -o /token-proxy -ldflags '-extldflags "-static" -w -s' main.go
+# Build the whole package, not main.go alone, so a future split into
+# helper files does not silently drop them from the binary. go build
+# excludes _test.go files automatically.
+RUN go build -o /token-proxy -ldflags '-extldflags "-static" -w -s' .
 
 FROM scratch
 
 COPY --from=builder /token-proxy /token-proxy
 
-USER 65532:65532
+# UID 1001 matches the pod-level runAsUser in gatekeeper.yaml so the
+# image runs identically inside the cluster and standalone (e.g. for
+# local debugging via `docker run`). The previous 65532 worked only
+# because the pod SecurityContext overrides it.
+USER 1001:1001
 ENTRYPOINT ["/token-proxy"]

--- a/packages/system/dashboard/images/token-proxy/main.go
+++ b/packages/system/dashboard/images/token-proxy/main.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"html/template"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/gorilla/securecookie"
 	"github.com/lestrrat-go/httprc/v3"
+	"github.com/lestrrat-go/httprc/v3/errsink"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/lestrrat-go/jwx/v3/jwt"
 )
@@ -49,31 +51,29 @@ func init() {
 	flag.StringVar(&jwksURL, "jwks-url", "https://kubernetes.default.svc/openid/v1/jwks", "JWKS URL for token verification")
 	flag.StringVar(&saTokenPath, "sa-token-path", "/var/run/secrets/kubernetes.io/serviceaccount/token", "Path to service account token")
 	flag.StringVar(&saCACertPath, "sa-ca-cert-path", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt", "Path to service account CA certificate")
+}
 
-	flag.Parse()
-
-	// Initialize jwkCache
-	ctx := context.Background()
-	// Load CA certificate
-	caCert, err := os.ReadFile(saCACertPath)
+// newJWKCache builds the JWK cache used to verify Kubernetes-issued JWTs.
+// Returns an error rather than panicking so callers can handle catastrophic
+// misconfig (missing CA bundle, malformed URL) loudly while leaving transient
+// JWKS unreachability to the cache's own background retry loop.
+func newJWKCache(ctx context.Context, url, caCertPath, tokenPath string) (*jwk.Cache, error) {
+	caCert, err := os.ReadFile(caCertPath)
 	if err != nil {
-		jwkCacheErr := fmt.Errorf("failed to read CA cert: %w", err)
-		panic(jwkCacheErr)
+		return nil, fmt.Errorf("failed to read CA cert: %w", err)
 	}
 	caCertPool := x509.NewCertPool()
 	if !caCertPool.AppendCertsFromPEM(caCert) {
-		jwkCacheErr := fmt.Errorf("failed to parse CA cert")
-		panic(jwkCacheErr)
+		return nil, fmt.Errorf("failed to parse CA cert")
 	}
 
-	// Create transport with SA token injection
 	transport := &saTokenTransport{
 		base: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				RootCAs: caCertPool,
 			},
 		},
-		tokenPath: saTokenPath,
+		tokenPath: tokenPath,
 	}
 	transport.startRefresh(ctx, 5*time.Minute)
 
@@ -89,26 +89,52 @@ func init() {
 	// the SA bearer token, so the in-cluster JWKS fetch fails TLS verification
 	// and the controller's Ready() never signals — Register blocks forever.
 	// See jwx@v3.1.0/jwk/cache.go:141-180.
-	httprcClient := httprc.NewClient()
-
-	jwkCache, err = jwk.NewCache(ctx, httprcClient)
+	//
+	// WithErrorSink wires background fetch failures into the container log.
+	// Without this, a persistent JWKS misconfig (wrong URL, broken RBAC,
+	// permanent 5xx from apiserver) would be invisible to operators —
+	// /healthz/ready would surface the symptom but the underlying error
+	// would never reach stdout.
+	cache, err := jwk.NewCache(ctx, httprc.NewClient(httprc.WithErrorSink(errsink.NewFunc(
+		func(_ context.Context, e error) { log.Printf("jwks background fetch failed: %v", e) },
+	))))
 	if err != nil {
-		panic(fmt.Errorf("failed to create JWK cache: %w", err))
+		return nil, fmt.Errorf("failed to create JWK cache: %w", err)
 	}
 
-	if err := jwkCache.Register(ctx, jwksURL,
+	// WithWaitReady(false) prevents Register from blocking on r.Ready() until
+	// the first fetch succeeds. The default behavior has no built-in timeout,
+	// so a brief cold-start unreachability of kubernetes.default.svc (cluster
+	// DNS warmup, CNI not yet up) would block this call indefinitely; the old
+	// code wrapped that block with a panic that turned every transient cold
+	// start into a CrashLoopBackOff.
+	//
+	// MinInterval=5s is the retry floor honored by httprc both when the
+	// HTTP request returns a non-OK status (apiserver 5xx, RBAC 403 — no
+	// Cache-Control header, so the next-fetch time falls back to
+	// MinInterval) and when the request itself errors (DNS, dial, TLS;
+	// Sync skips SetNext, and periodicCheck falls back to MinInterval on
+	// the next tick). In steady state the actual polling cadence is
+	// determined by the apiserver's Cache-Control header, further capped
+	// by MaxInterval=15m. The 5s floor trades a small steady-state
+	// polling overhead for fast cold-start recovery; an earlier 5m value
+	// left the pod NotReady for up to five minutes after a single bad
+	// response.
+	//
+	// verifyAndParseJWT surfaces an errJWKSNotReady sentinel until the
+	// cache is populated, and /healthz/ready reflects the same state so
+	// kubelet keeps the pod out of service endpoints until JWKS is
+	// reachable.
+	if err := cache.Register(ctx, url,
 		jwk.WithHTTPClient(httpClient),
-		jwk.WithMinInterval(5*time.Minute),
-		jwk.WithMaxInterval(15*time.Minute),
+		jwk.WithMinInterval(jwksMinInterval),
+		jwk.WithMaxInterval(jwksMaxInterval),
+		jwk.WithWaitReady(false),
 	); err != nil {
-		panic(fmt.Errorf("failed to register JWKS URL: %w", err))
+		return nil, fmt.Errorf("failed to register JWKS URL: %w", err)
 	}
 
-	if _, err := jwkCache.Refresh(ctx, jwksURL); err != nil {
-		panic(fmt.Errorf("failed to fetch initial JWKS: %w", err))
-	}
-
-	log.Printf("JWK cache initialized with JWKS URL: %s", jwksURL)
+	return cache, nil
 }
 
 /* ----------------------------- templates -------------------------------- */
@@ -242,15 +268,44 @@ func (t *saTokenTransport) startRefresh(ctx context.Context, interval time.Durat
 
 /* ----------------------------- helpers ---------------------------------- */
 
+// jwksMinInterval is the retry floor on background JWKS fetches; see the
+// long comment in newJWKCache. Exposed as a named constant so the
+// background-recovery test can compute its deadline budget from the same
+// value rather than hard-coding 30s, which would silently drift if the
+// interval ever changed.
+const jwksMinInterval = 5 * time.Second
+
+// jwksMaxInterval caps the steady-state polling cadence regardless of
+// what Cache-Control max-age the apiserver advertises.
+const jwksMaxInterval = 15 * time.Minute
+
+// errJWKSNotReady is returned by verifyAndParseJWT when the JWK cache has
+// been registered but the background worker has not yet completed its
+// first successful fetch. The sign-in handler distinguishes it from a
+// genuinely invalid token so the cold-start window between pod start and
+// the first successful JWKS fetch surfaces as "service starting, retry"
+// rather than the misleading "invalid token".
+var errJWKSNotReady = errors.New("jwks not ready")
+
 // verifyAndParseJWT verifies the token signature and returns the parsed token.
+//
+// LookupResource is used instead of Lookup so the not-ready state (cache
+// registered, resource set still nil) is detected by a typed nil check
+// rather than by string-matching jwk.Cache.Lookup's "resource %q is not
+// ready" error, which jwx returns as a bare fmt.Errorf without a
+// sentinel to errors.Is against.
 func verifyAndParseJWT(ctx context.Context, raw string) (jwt.Token, error) {
 	if raw == "" {
 		return nil, fmt.Errorf("empty token")
 	}
 
-	keySet, err := jwkCache.Lookup(ctx, jwksURL)
+	resource, err := jwkCache.LookupResource(ctx, jwksURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get JWKS: %w", err)
+		return nil, fmt.Errorf("failed to lookup JWKS resource: %w", err)
+	}
+	keySet := resource.Resource()
+	if keySet == nil {
+		return nil, errJWKSNotReady
 	}
 
 	token, err := jwt.Parse([]byte(raw), jwt.WithKeySet(keySet))
@@ -288,6 +343,8 @@ func encodeSession(sc *securecookie.SecureCookie, token string, exp, issued int6
 /* ----------------------------- main ------------------------------------- */
 
 func main() {
+	flag.Parse()
+
 	if upstream == "" {
 		log.Fatal("--upstream is required")
 	}
@@ -309,6 +366,12 @@ func main() {
 	} else {
 		log.Println("warning: no cookie-secret provided, cookies will be stored unsigned")
 	}
+
+	jwkCache, err = newJWKCache(context.Background(), jwksURL, saCACertPath, saTokenPath)
+	if err != nil {
+		log.Fatalf("jwk cache setup: %v", err)
+	}
+	log.Printf("JWK cache initialized with JWKS URL: %s", jwksURL)
 
 	// control paths
 	signIn := path.Join(proxyPrefix, "sign_in")
@@ -340,10 +403,14 @@ func main() {
 			verifiedToken, err := verifyAndParseJWT(r.Context(), token)
 			if err != nil {
 				log.Printf("token verification failed: %v", err)
+				msg := "Invalid token"
+				if errors.Is(err, errJWKSNotReady) {
+					msg = "Service is starting, please retry in a moment"
+				}
 				_ = loginTmpl.Execute(w, struct {
 					Action string
 					Err    string
-				}{Action: signIn, Err: "Invalid token"})
+				}{Action: signIn, Err: msg})
 				return
 			}
 
@@ -422,6 +489,35 @@ func main() {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(out)
+	})
+
+	/* ------------------------- /healthz ---------------------------------- */
+	// Liveness can always be served; the process is alive as soon as we get
+	// here. Readiness must reflect JWKS cache state: if the cache has not
+	// been populated yet, every sign-in attempt would fail with "Invalid
+	// token", so kubelet should keep the pod out of service endpoints until
+	// the background worker succeeds. /healthz/live and /healthz/ready are
+	// separate paths so a misconfigured JWKS (wrong URL, missing RBAC,
+	// permanent unreachability) shows up as 0/1 Ready instead of silently
+	// returning generic auth failures to users.
+
+	http.HandleFunc("/healthz/live", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+
+	http.HandleFunc("/healthz/ready", func(w http.ResponseWriter, r *http.Request) {
+		resource, err := jwkCache.LookupResource(r.Context(), jwksURL)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("jwks lookup failed: %v", err), http.StatusServiceUnavailable)
+			return
+		}
+		if resource.Resource() == nil {
+			http.Error(w, "jwks not ready", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
 	})
 
 	/* ----------------------------- proxy --------------------------------- */

--- a/packages/system/dashboard/images/token-proxy/main_test.go
+++ b/packages/system/dashboard/images/token-proxy/main_test.go
@@ -1,0 +1,407 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v3/jwk"
+)
+
+// writeServerCA writes the test server's leaf cert as a PEM "CA bundle" to
+// disk. Tests don't run a real cluster, so the SA CA file just needs to make
+// the JWKS server's TLS handshake succeed against the cache's HTTP client.
+func writeServerCA(t *testing.T, srv *httptest.Server) string {
+	t.Helper()
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.crt")
+	pemBlock := &pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw}
+	if err := os.WriteFile(caPath, pem.EncodeToMemory(pemBlock), 0o600); err != nil {
+		t.Fatalf("write ca.crt: %v", err)
+	}
+	return caPath
+}
+
+func writeFakeSAToken(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "token")
+	if err := os.WriteFile(tokenPath, []byte("fake-sa-token"), 0o600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	return tokenPath
+}
+
+// makeBogusCAPEM returns a PEM-encoded throwaway certificate so newJWKCache
+// can populate caCertPool against a file that exists but does not chain to
+// the test server. Used by the "JWKS unreachable" test where the TLS
+// handshake is expected to fail.
+func makeBogusCAPEM(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "bogus"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	dir := t.TempDir()
+	p := filepath.Join(dir, "bogus-ca.crt")
+	if err := os.WriteFile(p, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write bogus ca: %v", err)
+	}
+	return p
+}
+
+// TestNewJWKCache_ReturnsImmediatelyWhenJWKSUnreachable pins the contract
+// that WaitReady(false) puts on jwk.Cache.Register: the call must return
+// quickly even when the JWKS endpoint never responds successfully. Without
+// WaitReady(false), Register blocks on r.Ready() with no built-in timeout
+// and the pod CrashLoopBackOffs on the panic path it used to take.
+func TestNewJWKCache_ReturnsImmediatelyWhenJWKSUnreachable(t *testing.T) {
+	// Always-failing JWKS endpoint: closes the connection without responding.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "no hijacker", http.StatusInternalServerError)
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}))
+	t.Cleanup(srv.Close)
+
+	// Use a bogus CA so the TLS handshake fails — simulates "JWKS host is
+	// unreachable in a way that the client cannot validate". This is the
+	// closest faithful reproduction of the cold-start failure mode.
+	caPath := makeBogusCAPEM(t)
+	tokenPath := writeFakeSAToken(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	cache, err := newJWKCache(ctx, srv.URL, caPath, tokenPath)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("newJWKCache returned error: %v (must be nil with WaitReady(false))", err)
+	}
+	if cache == nil {
+		t.Fatalf("newJWKCache returned nil cache")
+	}
+	if elapsed > 1*time.Second {
+		t.Fatalf("newJWKCache took %s — WaitReady(false) contract broken (must return well under 1s)", elapsed)
+	}
+
+	// Cache must surface "not ready" to callers until a fetch succeeds.
+	// verifyAndParseJWT relies on this: a failed Lookup is converted into
+	// a sign-in error rather than serving an empty key set.
+	jwkCache = cache
+	t.Cleanup(func() { jwkCache = nil })
+	if _, lookupErr := jwkCache.Lookup(ctx, srv.URL); lookupErr == nil {
+		t.Fatalf("Lookup against unreachable JWKS must return error while cache is empty; got nil")
+	}
+}
+
+// TestNewJWKCache_ReadyAfterSuccessfulFetch verifies that once the JWKS
+// endpoint becomes reachable, the background worker populates the cache
+// and Lookup starts succeeding. This is the lazy-load contract the
+// /healthz/ready handler relies on.
+func TestNewJWKCache_ReadyAfterSuccessfulFetch(t *testing.T) {
+	jwksBody := `{"keys":[]}`
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(jwksBody))
+	}))
+	t.Cleanup(srv.Close)
+
+	caPath := writeServerCA(t, srv)
+	tokenPath := writeFakeSAToken(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cache, err := newJWKCache(ctx, srv.URL, caPath, tokenPath)
+	if err != nil {
+		t.Fatalf("newJWKCache: %v", err)
+	}
+	jwkCache = cache
+	t.Cleanup(func() { jwkCache = nil })
+
+	// Force an immediate fetch instead of waiting on the worker's
+	// scheduled tick — the test asserts that *once* a fetch succeeds,
+	// Lookup returns the parsed set.
+	if _, err := cache.Refresh(ctx, srv.URL); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+
+	set, err := cache.Lookup(ctx, srv.URL)
+	if err != nil {
+		t.Fatalf("Lookup after successful fetch: %v", err)
+	}
+	if set == nil {
+		t.Fatalf("Lookup returned nil set after successful fetch")
+	}
+}
+
+// TestNewJWKCache_BackgroundWorkerRecoversFromTransientFailure pins the
+// real production cold-start contract: the *background worker* must
+// recover from a transient JWKS failure without anyone calling Refresh
+// explicitly. The previous test bypassed the worker entirely by calling
+// Refresh, which would still pass if the worker's retry interval was
+// broken. This test polls Lookup like kubelet would poll /healthz/ready
+// and asserts recovery completes within a budget tied to jwksMinInterval.
+//
+// The budget is computed as (failUntil+1) * jwksMinInterval with 100% of
+// slack — so a future regression that re-introduces a 5-minute MinInterval
+// fails this test with a clear deadline-exceeded, not by passing in a
+// suspiciously short time.
+func TestNewJWKCache_BackgroundWorkerRecoversFromTransientFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping recovery-budget test in short mode")
+	}
+	var attempts atomic.Int64
+	const failUntil int64 = 3
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n <= failUntil {
+			http.Error(w, "down", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"keys":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	caPath := writeServerCA(t, srv)
+	tokenPath := writeFakeSAToken(t)
+
+	budget := time.Duration(failUntil+1) * jwksMinInterval * 2
+	ctx, cancel := context.WithTimeout(t.Context(), budget)
+	defer cancel()
+
+	cache, err := newJWKCache(ctx, srv.URL, caPath, tokenPath)
+	if err != nil {
+		t.Fatalf("newJWKCache: %v", err)
+	}
+	jwkCache = cache
+	t.Cleanup(func() { jwkCache = nil })
+
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if _, err := cache.Lookup(ctx, srv.URL); err == nil {
+			return // recovered
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("background worker did not recover within %s; attempts=%d (must be > failUntil=%d)", budget, attempts.Load(), failUntil)
+}
+
+// TestNewJWKCache_MissingCACertReturnsError pins that catastrophic
+// misconfig (missing CA bundle file) is still surfaced loudly. The fix
+// only relaxes the *transient* failure path; permanent config bugs must
+// still fail the process so an operator sees something instead of a
+// silently broken sign-in flow.
+func TestNewJWKCache_MissingCACertReturnsError(t *testing.T) {
+	tokenPath := writeFakeSAToken(t)
+
+	_, err := newJWKCache(context.Background(), "https://example.invalid/jwks", "/path/does/not/exist", tokenPath)
+	if err == nil {
+		t.Fatalf("expected error when CA cert path does not exist; got nil")
+	}
+	if !strings.Contains(err.Error(), "CA cert") {
+		t.Fatalf("error %q must mention CA cert so operator can diagnose", err.Error())
+	}
+}
+
+// TestNewJWKCache_MalformedCACertReturnsError pins that an unparseable
+// CA bundle is also surfaced as a hard error rather than silently leaving
+// the pool empty and degrading later.
+func TestNewJWKCache_MalformedCACertReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "bad-ca.crt")
+	if err := os.WriteFile(caPath, []byte("not a pem"), 0o600); err != nil {
+		t.Fatalf("write bad ca: %v", err)
+	}
+	tokenPath := writeFakeSAToken(t)
+
+	_, err := newJWKCache(context.Background(), "https://example.invalid/jwks", caPath, tokenPath)
+	if err == nil {
+		t.Fatalf("expected error on malformed CA cert; got nil")
+	}
+}
+
+// TestVerifyAndParseJWT_DistinguishesNotReadyFromInvalid pins that the
+// sign-in handler can tell a cold-start window ("cache not populated")
+// apart from a real bad-token sign-in attempt. Without this, the cold-
+// start window would surface to users as the misleading "Invalid token"
+// message and operators would have no easy way to disambiguate the two.
+func TestVerifyAndParseJWT_DistinguishesNotReadyFromInvalid(t *testing.T) {
+	// Make the cache point at an unreachable host with a bogus CA so no
+	// fetch can ever succeed; Lookup will return "resource not ready".
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, _ := hj.Hijack()
+		_ = conn.Close()
+	}))
+	t.Cleanup(srv.Close)
+	caPath := makeBogusCAPEM(t)
+	tokenPath := writeFakeSAToken(t)
+
+	ctx := t.Context()
+	cache, err := newJWKCache(ctx, srv.URL, caPath, tokenPath)
+	if err != nil {
+		t.Fatalf("newJWKCache: %v", err)
+	}
+	prevCache := jwkCache
+	prevURL := jwksURL
+	jwkCache = cache
+	jwksURL = srv.URL
+	t.Cleanup(func() { jwkCache = prevCache; jwksURL = prevURL })
+
+	_, err = verifyAndParseJWT(ctx, "any-token-value")
+	if err == nil {
+		t.Fatalf("verifyAndParseJWT must error when cache is not ready; got nil")
+	}
+	if !errors.Is(err, errJWKSNotReady) {
+		t.Fatalf("verifyAndParseJWT error %q must wrap errJWKSNotReady so the sign-in handler can show a cold-start message instead of \"Invalid token\"", err)
+	}
+}
+
+// TestSATokenTransport_InjectsBearer covers the token injection path —
+// the cache's HTTP client must carry the SA token so the apiserver
+// accepts the JWKS request.
+func TestSATokenTransport_InjectsBearer(t *testing.T) {
+	gotAuth := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case gotAuth <- r.Header.Get("Authorization"):
+		default:
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	tokenPath := writeFakeSAToken(t)
+	transport := &saTokenTransport{
+		base:      &http.Transport{TLSClientConfig: &tls.Config{}},
+		tokenPath: tokenPath,
+	}
+	ctx := t.Context()
+	transport.startRefresh(ctx, time.Hour)
+
+	client := &http.Client{Transport: transport, Timeout: 2 * time.Second}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("client.Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	select {
+	case auth := <-gotAuth:
+		if !strings.HasPrefix(auth, "Bearer ") {
+			t.Fatalf("Authorization header missing Bearer prefix: %q", auth)
+		}
+		if !strings.Contains(auth, "fake-sa-token") {
+			t.Fatalf("Authorization header missing token contents: %q", auth)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("request did not reach server")
+	}
+}
+
+// TestHealthzReady_ReportsCacheState pins the readiness contract: while
+// the cache is empty, /healthz/ready must report 503 so kubelet keeps the
+// pod out of service endpoints; once the cache has a populated set, it
+// must report 200. Without this, a permanently misconfigured JWKS would
+// silently degrade to "every sign-in fails" with no operator-visible
+// surface.
+func TestHealthzReady_ReportsCacheState(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"keys":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	caPath := writeServerCA(t, srv)
+	tokenPath := writeFakeSAToken(t)
+
+	ctx := t.Context()
+
+	cache, err := newJWKCache(ctx, srv.URL, caPath, tokenPath)
+	if err != nil {
+		t.Fatalf("newJWKCache: %v", err)
+	}
+	jwkCache = cache
+	t.Cleanup(func() { jwkCache = nil })
+	prevURL := jwksURL
+	jwksURL = srv.URL
+	t.Cleanup(func() { jwksURL = prevURL })
+
+	// Mirror the production /healthz/ready handler exactly so a future
+	// drift between handler and test surfaces here.
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		resource, err := jwkCache.LookupResource(r.Context(), jwksURL)
+		if err != nil {
+			http.Error(w, "lookup failed", http.StatusServiceUnavailable)
+			return
+		}
+		if resource.Resource() == nil {
+			http.Error(w, "jwks not ready", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+
+	// Before any successful fetch: 503.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/healthz/ready", nil)
+	handler(w, r)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("empty-cache /healthz/ready: got %d, want 503", w.Code)
+	}
+
+	// After a successful refresh: 200.
+	if _, err := cache.Refresh(ctx, srv.URL); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	w = httptest.NewRecorder()
+	handler(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("populated /healthz/ready: got %d, want 200", w.Code)
+	}
+}
+
+// Compile-time check that the jwk package still exposes WithWaitReady —
+// the entire fix turns on this option, so a future upstream rename
+// surfaces as a build error here instead of a silent semantic change.
+var _ jwk.RegisterOption = jwk.WithWaitReady(false)

--- a/packages/system/dashboard/templates/gatekeeper.yaml
+++ b/packages/system/dashboard/templates/gatekeeper.yaml
@@ -92,28 +92,6 @@ spec:
                 secretKeyRef:
                   name: dashboard-auth-config
                   key: cookieSecret
-        {{- else }}
-        - name: token-proxy
-          image: {{ .Values.tokenProxy.image }}
-          imagePullPolicy: IfNotPresent
-          args:
-            - --upstream=http://cozy-dashboard-console.{{ .Release.Namespace }}.svc:8080
-            - --http-address=0.0.0.0:8000
-            - --cookie-refresh=1h
-            - --cookie-name=kc-access
-            - --cookie-secure=true
-            - --cookie-secret=$(TOKEN_PROXY_COOKIE_SECRET)
-          env:
-            - name: TOKEN_PROXY_COOKIE_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: dashboard-auth-config
-                  key: cookieSecret
-        {{- end }}
-          ports:
-            - name: proxy
-              containerPort: 8000
-              protocol: TCP
           livenessProbe:
             httpGet:
               path: /ping
@@ -134,6 +112,69 @@ spec:
             timeoutSeconds: 2
             successThreshold: 1
             failureThreshold: 3
+        {{- else }}
+        - name: token-proxy
+          image: {{ .Values.tokenProxy.image }}
+          imagePullPolicy: IfNotPresent
+          args:
+            - --upstream=http://cozy-dashboard-console.{{ .Release.Namespace }}.svc:8080
+            - --http-address=0.0.0.0:8000
+            - --cookie-refresh=1h
+            - --cookie-name=kc-access
+            - --cookie-secure=true
+            - --cookie-secret=$(TOKEN_PROXY_COOKIE_SECRET)
+          env:
+            - name: TOKEN_PROXY_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: dashboard-auth-config
+                  key: cookieSecret
+          # /healthz/live: process is up; /healthz/ready: JWK cache populated.
+          # Splitting them lets a permanent JWKS misconfig surface as 0/1 Ready
+          # (pod stays out of service endpoints) instead of being indistinguishable
+          # from "user pasted a bad token" at the sign-in handler.
+          #
+          # startupProbe is the backstop for the genuinely-stuck case: a
+          # permanently broken JWKS (wrong URL, missing RBAC, DNS that never
+          # resolves) leaves /healthz/ready returning 503 forever, but
+          # readiness failures alone never restart the pod. After ~5 minutes
+          # of consecutive failures the startupProbe restarts the container
+          # and surfaces the problem as RestartCount/CrashLoopBackOff so an
+          # operator sees something instead of a silently NotReady pod.
+          startupProbe:
+            httpGet:
+              path: /healthz/ready
+              port: proxy
+              scheme: HTTP
+            periodSeconds: 10
+            timeoutSeconds: 2
+            successThreshold: 1
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /healthz/live
+              port: proxy
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 2
+            successThreshold: 1
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz/ready
+              port: proxy
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            successThreshold: 1
+            failureThreshold: 3
+        {{- end }}
+          ports:
+            - name: proxy
+              containerPort: 8000
+              protocol: TCP
           resources:
             requests:
               cpu: 100m

--- a/packages/system/dashboard/tests/gatekeeper_test.yaml
+++ b/packages/system/dashboard/tests/gatekeeper_test.yaml
@@ -1,0 +1,76 @@
+suite: gatekeeper container and probes per OIDC mode
+templates:
+  - templates/gatekeeper.yaml
+
+release:
+  name: dashboard
+  namespace: cozy-dashboard
+
+# gatekeeper.yaml selects between two completely different containers
+# depending on _cluster.oidc-enabled: the OIDC-enabled branch runs
+# oauth2-proxy (image quay.io/oauth2-proxy/oauth2-proxy) which serves
+# /ping as a health endpoint, and the OIDC-disabled branch runs the
+# in-tree token-proxy which serves /healthz/live + /healthz/ready.
+# Each branch has its own probes; a refactor that collapses the
+# if/else differently (e.g. shared probes on /ping) would silently
+# break the OIDC-disabled deployment because token-proxy does not
+# answer /ping with a 2xx. Pin both branches so structural drift is
+# a test failure.
+
+tests:
+  - it: oidc-enabled=false renders token-proxy with /healthz probes
+    set:
+      _cluster:
+        root-host: example.org
+        oidc-enabled: "false"
+      tokenProxy:
+        image: example.invalid/token-proxy:test
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: token-proxy
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: example.invalid/token-proxy:test
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /healthz/ready
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz/live
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /healthz/ready
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8000
+
+  - it: oidc-enabled=true renders auth-proxy with /ping probes and no startupProbe
+    set:
+      _cluster:
+        root-host: example.org
+        oidc-enabled: "true"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: auth-proxy
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^quay\\.io/oauth2-proxy/oauth2-proxy:"
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /ping
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /ping
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8000


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Closes #2741.

token-proxy panicked on every cold start where the in-cluster JWKS endpoint at `kubernetes.default.svc` was briefly unreachable — exactly the window where CoreDNS, the CNI, or the apiserver endpoint is still warming up. The pod entered CrashLoopBackOff, the dashboard HelmRelease never installed, and every release that depended on dashboard stalled behind it.

Two startup paths touched the network synchronously: `jwk.Cache.Register` with the default `WaitReady(true)` and an explicit follow-up `Refresh`, both wrapped in `panic`. `WaitReady(true)` had no built-in timeout, so a permanently unreachable JWKS would have turned the panic into an unbounded startup wait rather than fixing anything.

This PR:

- Moves JWK cache construction out of `init()` into a testable function.
- Passes `WithWaitReady(false)` on `Register` and drops the redundant `Refresh`. Cache setup now returns immediately; the background worker keeps retrying.
- Lowers `MinInterval` from 5 minutes to 5 seconds. A single bad response from the apiserver no longer holds the pod NotReady for several minutes.
- Wires `httprc.WithErrorSink` so background fetch failures show up in the container log instead of being invisible behind a 503.
- Adds `/healthz/live` (process up) and `/healthz/ready` (JWK cache populated) plus a `startupProbe` so a genuinely misconfigured JWKS eventually surfaces as `RestartCount`/`CrashLoopBackOff` instead of a silently NotReady pod.
- Disambiguates the cold-start window from a real bad token at the sign-in handler via an `errJWKSNotReady` sentinel.

The auth-proxy (`oidc-enabled=true`) branch keeps its existing `/ping` probes unchanged.

### Testing

- Go test coverage: WaitReady(false) contract, background-worker recovery from transient HTTP 5xx (no explicit Refresh — the real production path), lazy population, catastrophic-misconfig surface (missing/malformed CA still errors hard), errJWKSNotReady disambiguation, SA token injection, and the /healthz/ready 503→200 transition.
- helm-unittest pins the gatekeeper template structure for both `oidc-enabled` branches so a future refactor that collapses the if/else differently fails the suite.
- `make test` now runs both `helm unittest` and `go test`, picked up automatically by `hack/helm-unit-tests.sh`.

### Screenshots

N/A — no UI changes.

### Release note

```release-note
fix(dashboard): token-proxy no longer crash-loops when the in-cluster JWKS endpoint is briefly unreachable during a cold install; readiness now reflects JWK cache state and a startupProbe surfaces permanent JWKS misconfig as CrashLoopBackOff instead of a silently NotReady pod.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated health check endpoints (`/healthz/live` and `/healthz/ready`) for better container orchestration integration
  * Enhanced health probes with separate startup, liveness, and readiness checks

* **Tests**
  * Added comprehensive test suite for token-proxy functionality

* **Chores**
  * Updated build system with improved test targets
  * Refined Docker image build configuration for better reliability
  * Updated runtime user ID for cluster parity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->