### PR TITLE
ci(tests): snapshot e2e cluster state to a registry and restore it in a separate job

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -340,7 +340,9 @@ jobs:
       packages: read
       checks: write
     needs: ["save-state"]
-    if: ${{ needs.save-state.result == 'success' }}
+    # save-state has a hyphen, so it must be addressed with bracket notation —
+    # needs.save-state.result does not resolve in GitHub Actions expressions.
+    if: ${{ needs['save-state'].result == 'success' }}
 
     steps:
       # ▸ Checkout and prepare the codebase

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -169,7 +169,7 @@ jobs:
   # kubeconfig working dir) to the registry as an image. The e2e job below
   # pulls that image on another runner and boots the cluster from it — so the
   # slow bring-up happens once here and the tests run against a restored state.
-  save-state:
+  save_state:
     name: "Save cluster state"
     runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-24cpu-96gb-x86-64' }}
     timeout-minutes: 180
@@ -339,10 +339,7 @@ jobs:
       contents: read
       packages: read
       checks: write
-    needs: ["save-state"]
-    # save-state has a hyphen, so it must be addressed with bracket notation —
-    # needs.save-state.result does not resolve in GitHub Actions expressions.
-    if: ${{ needs['save-state'].result == 'success' }}
+    needs: ["save_state"]
 
     steps:
       # ▸ Checkout and prepare the codebase

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -340,6 +340,11 @@ jobs:
       packages: read
       checks: write
     needs: ["save_state"]
+    # always() is required because resolve_assets is skipped on regular (non-
+    # release) PRs and GHA's default success() gate propagates that skip down
+    # the needs graph, skipping e2e too. The explicit check on save_state's
+    # result keeps the intended semantics: e2e runs iff save_state succeeded.
+    if: ${{ always() && needs.save_state.result == 'success' }}
 
     steps:
       # ▸ Checkout and prepare the codebase

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -93,7 +93,7 @@ jobs:
         with:
           name: pr-patch
           path: _out/assets/pr.patch
-     
+
       - name: Upload Talos image
         uses: actions/upload-artifact@v4
         with:
@@ -164,14 +164,18 @@ jobs:
             core.setOutput('disk_id',     diskId);
 
 
-  e2e:
-    name: "E2E Tests"
+  # Provision a fresh cluster, install Cozystack into it, then force-stop the
+  # VMs and push a consistent snapshot of their disks (plus the talosconfig/
+  # kubeconfig working dir) to the registry as an image. The e2e job below
+  # pulls that image on another runner and boots the cluster from it — so the
+  # slow bring-up happens once here and the tests run against a restored state.
+  save-state:
+    name: "Save cluster state"
     runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-24cpu-96gb-x86-64' }}
-    #runs-on: [oracle-vm-32cpu-128gb-x86-64]
     timeout-minutes: 180
     permissions:
       contents: read
-      packages: read
+      packages: write
       checks: write
     needs: ["build", "resolve_assets"]
     if: ${{ always() && (needs.build.result == 'success' || needs.resolve_assets.result == 'success') }}
@@ -258,6 +262,134 @@ jobs:
             echo "❌ Attempt $attempt failed, retrying..."
           done
           echo "✅ The task completed successfully after $attempt attempts"
+
+      # ▸ Force-stop VMs and push a consistent snapshot to the registry. oras
+      #   logs in from inside the sandbox, so the credentials are forwarded as
+      #   env (GitHub masks them in the logs).
+      - name: Save cluster state
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME save-state
+        env:
+          REGISTRY_USERNAME: ${{ secrets.OCIR_USER }}
+          REGISTRY_PASSWORD: ${{ secrets.OCIR_TOKEN }}
+          IMAGE_TAG: pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+
+      # ▸ Collect debug information (always runs)
+      - name: Collect report
+        if: always()
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME collect-report || true
+
+      - name: Upload cozyreport.tgz
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cozyreport-save-state
+          path: /tmp/${{ env.SANDBOX_NAME }}/_out/cozyreport.tgz
+
+      # ▸ Open an SSH breakpoint to the sandbox if provisioning or install fails.
+      - name: Breakpoint on save-state failure
+        if: |
+          failure() &&
+          vars.BREAKPOINT_ENDPOINT != '' &&
+          (contains(github.event.pull_request.labels.*.name, 'debug')
+            || contains(github.event.pull_request.labels.*.name, 'release'))
+        # cozystack/breakpoint-action v2-cozy.1
+        # mode: pause-idle defaults: grace-period=20m, idle-timeout=10m
+        uses: cozystack/breakpoint-action@a6f3a6f87be398ad63b6577351e3398e53f578e4
+        with:
+          mode: pause-idle
+          endpoint: ${{ vars.BREAKPOINT_ENDPOINT }}
+          authorized-users: androndo, Arsolitt, IvanHunters, kvaps, lexfrei, lllamnyp, mattia-eleuteri, matthieu-robin, myasnikovdaniil, sircthulhu, tym83
+          check-run-name: "Breakpoint Open"
+          github-token: ${{ github.token }}
+          check-run-summary-template: |
+            ## 🔴 SSH breakpoint open — paused for debug
+
+            ```
+            {endpoint}
+            ```
+
+            Enter the e2e sandbox after SSH:
+            ```
+            docker exec -ti $(docker ps --filter name=cozy-e2e-sandbox -q | head -1) bash
+            export KUBECONFIG=/workspace/kubeconfig
+            ```
+
+            Resume from inside: `breakpoint resume`. Otherwise the breakpoint
+            exits 10 minutes after the last SSH session disconnects.
+
+      # ▸ Tear down environment (always runs)
+      - name: Tear down sandbox
+        if: always()
+        run: make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME delete || true
+
+      - name: Remove workspace
+        if: always()
+        run: rm -rf /tmp/$SANDBOX_NAME
+
+  e2e:
+    name: "E2E Tests"
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-24cpu-96gb-x86-64' }}
+    #runs-on: [oracle-vm-32cpu-128gb-x86-64]
+    timeout-minutes: 180
+    permissions:
+      contents: read
+      packages: read
+      checks: write
+    needs: ["save-state"]
+    if: ${{ needs.save-state.result == 'success' }}
+
+    steps:
+      # ▸ Checkout and prepare the codebase
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # ▸ Regular PR path – apply the patch so the sandbox repo (and the e2e app
+      #   tests in it) matches the PR under test. The state image already holds
+      #   the booted cluster, so no Talos image download is needed here.
+      - name: Download PR patch
+        if: "!contains(github.event.pull_request.labels.*.name, 'release')"
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-patch
+          path: _out/assets
+
+      - name: Apply patch
+        if: "!contains(github.event.pull_request.labels.*.name, 'release')"
+        run: |
+          git apply _out/assets/pr.patch
+
+      - name: Set sandbox ID
+        run: echo "SANDBOX_NAME=cozy-e2e-sandbox-$(echo "${GITHUB_REPOSITORY}:${GITHUB_WORKFLOW}:${GITHUB_REF}" | sha256sum | cut -c1-10)" >> $GITHUB_ENV
+
+      # ▸ Prepare environment
+      - name: Prepare workspace
+        run: |
+          rm -rf /tmp/$SANDBOX_NAME
+          cp -r ${{ github.workspace }} /tmp/$SANDBOX_NAME
+
+      # ▸ Pull the snapshot and boot the cluster from it. oras logs in from
+      #   inside the sandbox, so the credentials are forwarded as env.
+      - name: Restore cluster state and boot VMs
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          attempt=0
+          until make SANDBOX_NAME=$SANDBOX_NAME restore-env; do
+            attempt=$((attempt + 1))
+            if [ $attempt -ge 3 ]; then
+              echo "❌ Attempt $attempt failed, exiting..."
+              exit 1
+            fi
+            echo "❌ Attempt $attempt failed, retrying..."
+          done
+          echo "✅ The task completed successfully after $attempt attempts"
+        env:
+          REGISTRY_USERNAME: ${{ secrets.OCIR_USER }}
+          REGISTRY_PASSWORD: ${{ secrets.OCIR_TOKEN }}
+          IMAGE_TAG: pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
 
       - name: Run OpenAPI tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,13 @@ prepare-env:
 	make -C packages/core/testing apply
 	make -C packages/core/testing prepare-cluster
 
+# Counterpart to prepare-env for the restore side: bring up a fresh sandbox and
+# boot the cluster from a snapshot pulled out of the registry instead of
+# provisioning it from scratch.
+restore-env:
+	make -C packages/core/testing apply
+	make -C packages/core/testing restore-cluster
+
 generate:
 	hack/update-codegen.sh
 

--- a/hack/e2e-restore-state.bats
+++ b/hack/e2e-restore-state.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Cozystack end-to-end — restore a previously snapshotted cluster state
+# -----------------------------------------------------------------------------
+# Pulls the OCI artifact produced by e2e-save-state.bats, unpacks it (tar -Sx
+# recreates the holes, so the disks stay sparse on disk), rebuilds the exact
+# host networking the snapshot was taken with — same bridge, taps, IPs and MACs
+# — boots the VMs straight from their raw disks and waits until the cluster has
+# recovered from the power-off so e2e tests can run against it.
+# -----------------------------------------------------------------------------
+
+STATE_REF="${REGISTRY}/e2e-state:${STATE_TAG}"
+
+@test "IPv4 forwarding is enabled" {
+  if [ "$(cat /proc/sys/net/ipv4/ip_forward)" != 1 ]; then
+    echo 1 > /proc/sys/net/ipv4/ip_forward
+  fi
+}
+
+@test "Clean previous VMs" {
+  kill $(cat srv1/qemu.pid srv2/qemu.pid srv3/qemu.pid 2>/dev/null) 2>/dev/null || true
+  rm -rf srv1 srv2 srv3
+}
+
+@test "Pull and unpack cluster state from the registry" {
+  set +x
+  echo "$REGISTRY_PASSWORD" | oras login "${REGISTRY%%/*}" -u "$REGISTRY_USERNAME" --password-stdin
+  set -x
+
+  rm -f state.tar.zst
+  oras pull "$STATE_REF"
+  # -S recreates the holes, so the 50G/200G disks land as sparse files.
+  tar -S -I 'zstd -T0' -xf state.tar.zst
+  rm -f state.tar.zst
+}
+
+@test "Required disks were restored" {
+  for i in 1 2 3; do
+    if [ ! -f "srv${i}/system.img" ]; then
+      echo "Missing: srv${i}/system.img" >&2
+      exit 1
+    fi
+  done
+}
+
+@test "Prepare networking and masquerading" {
+  ip link del cozy-br0 2>/dev/null || true
+  ip link add cozy-br0 type bridge
+  ip link set cozy-br0 up
+  ip address add 192.168.123.1/24 dev cozy-br0
+
+  # Masquerading rule – idempotent (delete first, then add)
+  iptables -t nat -D POSTROUTING -s 192.168.123.0/24 ! -d 192.168.123.0/24 -j MASQUERADE 2>/dev/null || true
+  iptables -t nat -A POSTROUTING -s 192.168.123.0/24 ! -d 192.168.123.0/24 -j MASQUERADE
+}
+
+@test "Create tap devices" {
+  for i in 1 2 3; do
+    ip link del cozy-srv${i} 2>/dev/null || true
+    ip tuntap add dev cozy-srv${i} mode tap
+    ip link set cozy-srv${i} up
+    ip link set cozy-srv${i} master cozy-br0
+  done
+}
+
+@test "Boot QEMU VMs from snapshot" {
+  for i in 1 2 3; do
+    # Keep the same drive order (system, seed, data), MACs and IPs as the
+    # snapshot so the guests retain their disk identity and the VIP/endpoints
+    # baked into talosconfig/kubeconfig stay valid.
+    qemu-system-x86_64 -machine type=pc,accel=kvm -cpu host -smp 8 -m 24576 \
+      -device virtio-net,netdev=net0,mac=52:54:00:12:34:5${i} \
+      -netdev tap,id=net0,ifname=cozy-srv${i},script=no,downscript=no \
+      -drive file=srv${i}/system.img,if=virtio,format=raw \
+      -drive file=srv${i}/seed.img,if=virtio,format=raw \
+      -drive file=srv${i}/data.img,if=virtio,format=raw \
+      -display none -daemonize -pidfile srv${i}/qemu.pid
+  done
+
+  # Give qemu a few seconds to start up networking
+  sleep 5
+}
+
+@test "Wait until Talos API port 50000 is reachable on all machines" {
+  timeout 120 sh -ec 'until nc -nz 192.168.123.11 50000 && nc -nz 192.168.123.12 50000 && nc -nz 192.168.123.13 50000; do sleep 1; done'
+}
+
+@test "Wait until etcd is healthy" {
+  # Endpoint a concrete node (not the VIP) so this does not block on VIP
+  # re-election right after the power-on.
+  if ! timeout 180 sh -ec 'until talosctl etcd members -n 192.168.123.11,192.168.123.12,192.168.123.13 -e 192.168.123.11 >/dev/null 2>&1; do sleep 1; done'; then
+    talosctl dmesg -n 192.168.123.11,192.168.123.12,192.168.123.13 -e 192.168.123.11 || true
+    exit 1
+  fi
+}
+
+@test "Wait until all nodes are Ready" {
+  timeout 300 sh -ec 'until kubectl wait --for=condition=Ready --all nodes --timeout=10s >/dev/null 2>&1; do sleep 2; done'
+}
+
+@test "Wait until all HelmReleases are ready again" {
+  # The cluster comes back as if from a power cut; Flux reconciles every
+  # HelmRelease back to ready before the platform is usable for tests.
+  timeout 60 sh -ec 'until [ "$(kubectl get hr -A --no-headers 2>/dev/null | wc -l)" -gt 0 ]; do sleep 2; done'
+  kubectl get hr -A --no-headers | awk '{print "kubectl wait --timeout=15m --for=condition=ready -n "$1" hr/"$2" &"} END {print "wait"}' | sh -e
+}

--- a/hack/e2e-save-state.bats
+++ b/hack/e2e-save-state.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Cozystack end-to-end — snapshot a consistent cluster state
+# -----------------------------------------------------------------------------
+# Runs after install-cozystack, before any e2e app test. Force-powers-off all
+# QEMU VMs and streams a sparse-aware, zstd-compressed tarball of their disks
+# plus the cluster access files straight into the registry as an OCI artifact —
+# no qemu-img conversion and no docker cp, everything happens inside the
+# sandbox.
+#
+# Talos refuses a simultaneous graceful shutdown of every node, so we hard
+# power-off instead: SIGTERM makes QEMU stop the guest and flush its block
+# caches to the backing image before exiting. The result is crash-consistent at
+# the block level — etcd/LINSTOR recover on the next boot exactly as they would
+# after a power cut, which is all the e2e cluster needs.
+#
+# tar -S records the holes (GNU sparse format) and zstd compresses fast; the
+# restore side recreates the holes with tar -Sx, so the 50G/200G disks travel
+# and land as their few GB of actually-written data.
+# -----------------------------------------------------------------------------
+
+STATE_REF="${REGISTRY}/e2e-state:${STATE_TAG}"
+
+@test "Force power-off all VMs" {
+  pids=
+  for i in 1 2 3; do
+    if [ -f "srv${i}/qemu.pid" ]; then
+      pids="$pids $(cat srv${i}/qemu.pid)"
+    fi
+  done
+
+  # SIGTERM = orderly QEMU shutdown: the guest is hard powered-off while QEMU
+  # flushes the backing image, leaving a consistent file on the host.
+  for pid in $pids; do
+    kill "$pid" 2>/dev/null || true
+  done
+
+  # Wait until every QEMU process is actually gone (and has finished flushing)
+  # before reading the images, otherwise tar would race a live writer.
+  for pid in $pids; do
+    timeout 60 sh -ec "while kill -0 $pid 2>/dev/null; do sleep 1; done"
+  done
+}
+
+@test "Pack and push cluster state to the registry" {
+  # Keep the token out of the trace; GitHub also masks it, but belt and braces.
+  set +x
+  echo "$REGISTRY_PASSWORD" | oras login "${REGISTRY%%/*}" -u "$REGISTRY_USERNAME" --password-stdin
+  set -x
+
+  rm -f state.tar.zst
+  # -S: store holes efficiently. -I 'zstd -T0': multithreaded zstd (fast).
+  # The cluster access files (talosconfig/kubeconfig/...) ride along — without
+  # them the restored cluster is unreachable.
+  tar -S -I 'zstd -T0' -cf state.tar.zst \
+    srv1 srv2 srv3 \
+    talosconfig kubeconfig secrets.yaml \
+    controlplane.yaml worker.yaml patch.yaml patch-controlplane.yaml
+
+  oras push "$STATE_REF" state.tar.zst:application/zstd
+
+  rm -f state.tar.zst
+}

--- a/packages/core/testing/Makefile
+++ b/packages/core/testing/Makefile
@@ -36,6 +36,23 @@ prepare-cluster: copy-nocloud-image
 install-cozystack:
 	docker exec "${SANDBOX_NAME}" sh -c 'cd /workspace && hack/cozytest.sh hack/e2e-install-cozystack.bats'
 
+# The snapshot is pushed/pulled as an OCI artifact straight from inside the
+# sandbox (oras + sparse-aware tar). Tagged off the build-unique IMAGE_TAG so a
+# save in one job and a restore in another (different runner) of the same
+# workflow reference the exact same artifact. REGISTRY_USERNAME/REGISTRY_PASSWORD
+# are forwarded from the environment for the in-container `oras login`.
+save-state: ## Force-stop the VMs and push a consistent state to the registry.
+	docker exec \
+		-e REGISTRY="$(REGISTRY)" -e STATE_TAG="$(IMAGE_TAG)" \
+		-e REGISTRY_USERNAME -e REGISTRY_PASSWORD \
+		"${SANDBOX_NAME}" sh -c 'cd /workspace && hack/cozytest.sh hack/e2e-save-state.bats'
+
+restore-cluster: ## Pull the state from the registry, unpack it and boot the VMs.
+	docker exec \
+		-e REGISTRY="$(REGISTRY)" -e STATE_TAG="$(IMAGE_TAG)" \
+		-e REGISTRY_USERNAME -e REGISTRY_PASSWORD \
+		"${SANDBOX_NAME}" sh -c 'cd /workspace && hack/cozytest.sh hack/e2e-restore-state.bats'
+
 test-openapi:
 	docker exec "${SANDBOX_NAME}" sh -c 'cd /workspace && hack/cozytest.sh hack/e2e-test-openapi.bats'
 

--- a/packages/core/testing/images/e2e-sandbox/Dockerfile
+++ b/packages/core/testing/images/e2e-sandbox/Dockerfile
@@ -4,12 +4,19 @@ ARG KUBECTL_VERSION=1.33.2
 ARG TALOSCTL_VERSION=1.10.4
 ARG HELM_VERSION=3.18.3
 ARG COZYHR_VERSION=1.6.1
+ARG ORAS_VERSION=1.2.0
 
 ARG TARGETOS
 ARG TARGETARCH
 
 RUN apt update -q
-RUN apt install -yq --no-install-recommends psmisc genisoimage ca-certificates qemu-kvm qemu-utils iproute2 iptables wget xz-utils netcat curl jq make git bash-completion
+RUN apt install -yq --no-install-recommends psmisc genisoimage ca-certificates qemu-kvm qemu-utils iproute2 iptables wget xz-utils zstd netcat curl jq make git bash-completion
+# oras streams the cluster-state snapshot to/from the registry as an OCI
+# artifact (sparse-aware tar handles the holes), so the save/restore steps
+# never copy disk images out of the container.
+RUN curl -sSL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_${TARGETOS}_${TARGETARCH}.tar.gz" \
+ | tar -C /usr/local/bin -xzf - oras \
+ && chmod +x /usr/local/bin/oras
 RUN curl -sSL "https://github.com/siderolabs/talos/releases/download/v${TALOSCTL_VERSION}/talosctl-${TARGETOS}-${TARGETARCH}" -o /usr/local/bin/talosctl \
  && chmod +x /usr/local/bin/talosctl
 RUN curl -sSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl" -o /usr/local/bin/kubectl \


### PR DESCRIPTION
## What this PR does

Splits the PR e2e pipeline into two jobs. `save-state` provisions the cluster and installs Cozystack as before, then force-stops the VMs and pushes a consistent snapshot of the cluster to the registry. `e2e` pulls that snapshot on a separate runner, boots the cluster from it and runs the tests. This decouples the slow, flaky cluster bring-up from the test run and lays the groundwork for later reusing a release-time snapshot across pull requests.

The snapshot is a sparse-aware, zstd-compressed tarball of the three VM disks plus the Talos/Kubernetes working directory (talosconfig, kubeconfig, secrets, machine config patches). It is pushed and pulled as an OCI artifact with `oras` straight from inside the sandbox — no qemu-img conversion and no copying disk images out of the container.

Consistency is guaranteed by hard-powering-off every VM before the snapshot (Talos refuses to gracefully shut down all nodes at once). A forced power-off plus a flushed disk image is crash-consistent: etcd and LINSTOR recover on the next boot exactly as they would after a power cut.

The e2e-sandbox image gains `oras` and `zstd`. **The sandbox image must be rebuilt and `values.yaml` bumped (`make -C packages/core/testing image`) for CI to pick up the new tooling**, otherwise `save-state` fails with `oras: not found`.

### Release note

```release-note
ci(tests): e2e tests now run against a cluster restored from a registry snapshot, decoupling cluster bring-up from the test run
```
