### PR TITLE
[Backport release-1.4] fix(platform): add OpenSearch to PaaS bundle

### DIFF
--- a/packages/core/platform/templates/bundles/paas.yaml
+++ b/packages/core/platform/templates/bundles/paas.yaml
@@ -9,6 +9,7 @@
 {{include "cozystack.platform.package.default" (list "cozystack.rabbitmq-operator" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.redis-operator" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.mongodb-operator" $) }}
+{{include "cozystack.platform.package.default" (list "cozystack.opensearch-operator" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.clickhouse-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.foundationdb-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.harbor-application" $) }}
@@ -17,6 +18,7 @@
 {{include "cozystack.platform.package.default" (list "cozystack.mongodb-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.nats-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.openbao-application" $) }}
+{{include "cozystack.platform.package.default" (list "cozystack.opensearch-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.postgres-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.qdrant-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.rabbitmq-application" $) }}


### PR DESCRIPTION
## What this PR does

Backport of #2648 to `release-1.4`.

OpenSearch ships as a complete package set in `release-1.4`
(`packages/apps/opensearch/`, `packages/system/opensearch-operator/`,
`packages/system/opensearch-rd/`, and the `opensearch-operator` /
`opensearch-application` PackageSources), but the PaaS bundle template
never referenced the two `cozystack.opensearch-*` PackageSources.

Result on any cluster with `bundles.paas.enabled=true`:
- `opensearch-operator` is not deployed → no `OpenSearchCluster` CRD
- `opensearch-rd` is not deployed → no `ApplicationDefinition/opensearch`,
  so the dashboard catalog has no OpenSearch entry and tenants cannot
  create `opensearches.apps.cozystack.io`

This adds the two missing includes to
`packages/core/platform/templates/bundles/paas.yaml`, matching #2648 exactly.

### Release note
```release-note
Fix: OpenSearch is now installed by the PaaS bundle (`bundles.paas.enabled=true`); previously the operator and ApplicationDefinition were defined but never referenced from the bundle, so OpenSearch did not appear in the dashboard catalog.
```
