### PR TITLE
docs(harbor): document SeaweedFS dependency

### DIFF
--- a/packages/apps/harbor/README.md
+++ b/packages/apps/harbor/README.md
@@ -2,6 +2,12 @@
 
 Harbor is an open-source trusted cloud-native registry project that stores, signs, and scans content.
 
+## Requirements
+
+Harbor stores its registry data in an S3 bucket provisioned through COSI from a SeaweedFS deployment. SeaweedFS must be enabled either in the tenant where Harbor is installed, or in any ancestor tenant — the bucket class is inherited down the tenant tree via the `namespace.cozystack.io/seaweedfs` annotation.
+
+Enable it by setting `seaweedfs: true` on the tenant (`packages/apps/tenant` values). If neither the current tenant nor any parent has SeaweedFS enabled, the Harbor `BucketClaim` will reference an empty `bucketClassName` and the release will fail to provision.
+
 ## Parameters
 
 ### Common parameters


### PR DESCRIPTION
## What this PR does

Adds a Requirements section to the Harbor app README explaining that SeaweedFS must be enabled in the tenant where Harbor is installed, or in any ancestor tenant. Without it, Harbor's `BucketClaim` references the bucket class via `namespace.cozystack.io/seaweedfs` (which is inherited down the tenant tree), renders with an empty `bucketClassName`, and the release fails to provision.

The section sits above the auto-generated `## Parameters` table so `cozyvalues-gen` doesn't overwrite it.

### Release note

```release-note
docs(harbor): document SeaweedFS as a tenant-level prerequisite for the Harbor app
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Harbor setup requirements explaining S3 bucket storage configuration via SeaweedFS and necessary annotations to prevent provisioning failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->