### PR TITLE
ci(release): repair orphaned draft tag_name on retag

### DIFF
--- a/.github/workflows/pull-requests-release.yaml
+++ b/.github/workflows/pull-requests-release.yaml
@@ -159,9 +159,30 @@ jobs:
               per_page: 100
             });
 
-            // Find draft release to publish
-            const draft = releases.data.find(r => r.tag_name === tag && r.draft);
-            if (!draft) throw new Error(`Draft release for ${tag} not found`);
+            // Find draft release to publish.
+            //
+            // Normally the draft was created by tags.yaml with tag_name === tag.
+            // But if the git tag was deleted and re-created between draft creation
+            // and merge (e.g. the release branch was force-updated), GitHub orphans
+            // the draft: tag_name becomes "untagged-<hash>" while `name` is kept.
+            // Fall back to matching by `name` and repair the draft's tag_name
+            // before publishing — otherwise the published release would not point
+            // at the real git tag.
+            let draft = releases.data.find(r => r.draft && r.tag_name === tag);
+            if (!draft) {
+              const orphan = releases.data.find(r =>
+                r.draft && r.name === tag && /^untagged-/.test(r.tag_name)
+              );
+              if (!orphan) throw new Error(`Draft release for ${tag} not found`);
+              console.log(`🔧 Repairing orphaned draft ${orphan.id}: tag_name '${orphan.tag_name}' -> '${tag}'`);
+              const repaired = await github.rest.repos.updateRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: orphan.id,
+                tag_name: tag
+              });
+              draft = repaired.data;
+            }
 
             // Find max semver among published releases (excluding current draft)
             const publishedReleases = releases.data


### PR DESCRIPTION
## What this PR does

When a release-cut PR is merged after the underlying git tag was deleted and re-created (e.g. the release branch was force-updated between the initial tag push and the merge), GitHub orphans the corresponding draft release — its `tag_name` becomes `untagged-<hash>` while `name` is preserved.

The "Publish draft release" step in `pull-requests-release.yaml` looks up the draft strictly by `tag_name === tag` and throws `Draft release for <tag> not found`, blocking the release. Observed on run [#26558920814](https://github.com/cozystack/cozystack/actions/runs/26558920814/job/78236959976) cutting v1.4.2, and the same error fired on the earlier [v1.4.1 finalize run](https://github.com/cozystack/cozystack/actions/runs/26271301257).

This change adds a fallback: when the primary lookup misses, search for a draft where `name === tag` and `tag_name` matches `/^untagged-/`. If found, repair the draft's `tag_name` to the real tag via `updateRelease` before publishing, so the released artifact correctly points at the git tag created earlier in the same job. The strict-fail path is preserved when neither lookup matches.

The fix is forward-only and does **not** auto-recover the currently stuck v1.4.2 draft — that needs a one-time manual `tag_name` patch + job re-run, or publishing the draft via the GitHub UI.

### Release note

```release-note
ci(release): the release-finalize workflow now repairs an orphaned draft release (tag_name == `untagged-<hash>` after a tag delete + re-create) by re-linking it to the actual tag before publishing.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the robustness of the release publication process to handle edge cases when locating draft releases, ensuring more reliable and consistent release deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->