### PR TITLE
fix(backups): CI was broken after merge

### DIFF
--- a/internal/backupcontroller/jobstrategy_controller.go
+++ b/internal/backupcontroller/jobstrategy_controller.go
@@ -19,6 +19,7 @@ import (
 
 	strategyv1alpha1 "github.com/cozystack/cozystack/api/backups/strategy/v1alpha1"
 	backupsv1alpha1 "github.com/cozystack/cozystack/api/backups/v1alpha1"
+	"github.com/cozystack/cozystack/internal/template"
 )
 
 // ---------------------------------------------------------------------------
@@ -62,6 +63,53 @@ func jobStrategyParameters(b *backupsv1alpha1.Backup) map[string]string {
 		out[paramKey] = v
 	}
 	return out
+}
+
+// renderJobTemplate runs the strategy's PodTemplateSpec through the
+// repository's text/template engine with the same context shape as the
+// Altinity / CNPG drivers: every string field is templated against the
+// application object, the release shorthand, the run mode, and the resolved
+// parameters. Mirrors renderAltinityTemplate; the Job strategy carries the
+// same corev1.PodTemplateSpec shape and reuses the identical context, but
+// keeps its own per-driver render entrypoint so each strategy file owns its
+// rendering surface (matches the renderCNPGTemplate / renderEtcdTemplate /
+// renderFoundationDBTemplate convention).
+func renderJobTemplate(
+	tmpl corev1.PodTemplateSpec,
+	app map[string]interface{},
+	releaseName, releaseNamespace, mode string,
+	parameters map[string]string,
+	backup *backupsv1alpha1.Backup,
+) (*corev1.PodTemplateSpec, error) {
+	ctxMap := map[string]interface{}{
+		"Application": app,
+		"Release": map[string]string{
+			"Name":      releaseName,
+			"Namespace": releaseNamespace,
+		},
+		"Mode":       mode,
+		"Parameters": parameters,
+	}
+	if backup != nil {
+		// Expose ApplicationRef so restore strategies can reference the
+		// SOURCE release name even when restoring into a differently-named
+		// target. Mirrors the .Backup context exposed by the Altinity
+		// driver - see renderAltinityTemplate for the longer rationale.
+		sourceAPIGroup := ""
+		if backup.Spec.ApplicationRef.APIGroup != nil {
+			sourceAPIGroup = *backup.Spec.ApplicationRef.APIGroup
+		}
+		ctxMap["Backup"] = map[string]interface{}{
+			"Name":      backup.Name,
+			"Namespace": backup.Namespace,
+			"ApplicationRef": map[string]string{
+				"APIGroup": sourceAPIGroup,
+				"Kind":     backup.Spec.ApplicationRef.Kind,
+				"Name":     backup.Spec.ApplicationRef.Name,
+			},
+		}
+	}
+	return template.Template(&tmpl, ctxMap)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does
Fix CI break root cause: internal/backupcontroller/jobstrategy_controller.go:138, :422 calls renderJobTemplate which no longer exists — the rebased commit cefbaadc0 renamed it to renderAltinityTemplate in altinitystrategy_controller.go  (per the codebase's per-strategy convention: renderCNPGTemplate, renderEtcdTemplate, renderFoundationDBTemplate) but didn't add the corresponding renderJobTemplate to the Job strategy file. PR #2716 was merged with this break — main is currently broken.


### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced backup and restore operations to support templated Pod configurations, allowing dynamic configuration rendering during Job reconciliation with application context and backup metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2762?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->