### PR TITLE
feat(gpu-operator): add container variant for preinstalled host driver

### DIFF
--- a/docs/gpu-vgpu.md
+++ b/docs/gpu-vgpu.md
@@ -23,10 +23,11 @@ This guide focuses on the **SR-IOV path**, which is the only model NVIDIA suppor
 
 ## Variants
 
-The `gpu-operator` package exposes two variants:
+The `gpu-operator` package exposes three variants. This document is vGPU-focused; the variant inventory is shared.
 
 - **`default`** — passthrough mode (`vfio-pci`). Whole GPU goes to a single VM. Talos is supported here; the kernel module is the open-source `vfio-pci`, no proprietary driver is needed on the host.
 - **`vgpu`** — SR-IOV vGPU mode. One physical GPU is sliced into multiple VFs, each VF bound to a vGPU profile that the guest sees as its own GPU.
+- **`container`** — containerized GPU workloads (CUDA pods, ML training) via the standard NVIDIA device plugin on hosts that already provide both the NVIDIA driver and `nvidia-container-toolkit` (the typical apt-installed Ubuntu/Debian shape). Sandbox workloads are off, `devicePlugin` is on, `driver` / `toolkit` / `vfioManager` / `cdi` are off so that the operator does not fight the host install. Orthogonal to the two VM variants — it does not pass GPUs to KubeVirt VMs. Note that `apt install nvidia-container-toolkit` installs binaries only — it does not configure containerd. Because this variant disables the operator's toolkit component (which would normally do that wiring), the host must additionally have run `nvidia-ctk runtime configure --runtime=containerd` (followed by a containerd restart) and exposed the `nvidia` runtime as the default or via a RuntimeClass before the device plugin can serve GPUs.
 
 ## Building the vGPU Manager image
 
@@ -231,10 +232,12 @@ Other GPU families have analogous tables in the [NVIDIA Virtual GPU Software Doc
 
 ## OS support summary
 
-| Host OS | passthrough (`default`) | vGPU (`vgpu`) |
-| --- | --- | --- |
-| Ubuntu 24.04 | ✅ supported upstream | ✅ supported upstream (`vgpu-manager/ubuntu24.04`) |
-| Ubuntu 22.04 | ✅ | ✅ |
-| Ubuntu 20.04 | ✅ | ✅ |
-| Ubuntu 26.04 | ⚠️ patch needed in `nvidia-driver` for usr-merge | ⚠️ same patch + own Dockerfile fork |
-| Talos Linux | ✅ (open `vfio-pci`) | ❌ NVIDIA does not grant redistribution rights for the proprietary `.run`; we tried and the path is blocked |
+The `container` variant column assumes the host already ships the NVIDIA driver and `nvidia-container-toolkit` via the distro package manager, with the `nvidia` runtime registered in containerd (`nvidia-ctk runtime configure --runtime=containerd`). With `driver.enabled=false` the operator uses the pre-installed host driver at its standard location, so a stock apt install needs no `hostPaths.driverInstallDir` override. Talos installs the driver under a non-standard prefix, so the operator does not find it at the default location — see `packages/system/gpu-operator/examples/` for the Talos-specific path with a compat DaemonSet and an explicit `hostPaths.driverInstallDir` override.
+
+| Host OS | passthrough (`default`) | vGPU (`vgpu`) | container (`container`) |
+| --- | --- | --- | --- |
+| Ubuntu 24.04 | ✅ supported upstream | ✅ supported upstream (`vgpu-manager/ubuntu24.04`) | ✅ apt-installed driver + nvidia-container-toolkit |
+| Ubuntu 22.04 | ✅ | ✅ | ✅ |
+| Ubuntu 20.04 | ✅ | ✅ | ✅ |
+| Ubuntu 26.04 | ⚠️ patch needed in `nvidia-driver` for usr-merge | ⚠️ same patch + own Dockerfile fork | ✅ |
+| Talos Linux | ✅ (open `vfio-pci`) | ❌ NVIDIA does not grant redistribution rights for the proprietary `.run`; we tried and the path is blocked | ⚠️ host driver lands in a non-standard prefix — use `examples/values-native-talos.yaml` (compat DaemonSet + `hostPaths.driverInstallDir` override) as a starting point instead |

--- a/hack/check-gpu-operator-variants.bats
+++ b/hack/check-gpu-operator-variants.bats
@@ -1,23 +1,36 @@
 #!/usr/bin/env bats
 # -----------------------------------------------------------------------------
-# Catches silent regressions in the gpu-operator package's two variants:
+# Catches silent regressions in the gpu-operator package's three variants:
 #
 #   1. The base values.yaml pins ccManager.enabled=false and
 #      vgpuDeviceManager.enabled=false. Both upstream defaults are now true
 #      (chart v26.x). If the next chart bump silently un-pins either one,
 #      the `default` (passthrough) variant would gain confidential-computing
 #      auto-enable on Hopper hardware (ccManager) or render an mdev DaemonSet
-#      that crashloops on Ada+/Blackwell (vgpuDeviceManager).
+#      that crashloops on Ada+/Blackwell (vgpuDeviceManager). The same union
+#      must hold for the `container` variant; the `vgpu` variant re-affirms
+#      vgpuDeviceManager=false in its own overlay for the same reason.
 #
-#   2. Each variant's overlay must set sandboxWorkloads.defaultWorkload to its
-#      own enum value (vm-passthrough / vm-vgpu) — without it, GPU nodes that
-#      lack the per-node label nvidia.com/gpu.workload.config fall back to
-#      the upstream default 'container' workload, no DaemonSet renders, and
-#      the variant is silently a no-op.
+#   2. The sandbox variants must set sandboxWorkloads.defaultWorkload to
+#      their own enum value (vm-passthrough / vm-vgpu) — without it, GPU
+#      nodes that lack the per-node label nvidia.com/gpu.workload.config
+#      fall back to the upstream default 'container' workload, no DaemonSet
+#      renders, and the variant is silently a no-op. The container variant
+#      relies on the same upstream default but in the opposite direction:
+#      with sandboxWorkloads.enabled=false the chart picks defaultWorkload
+#      'container', which is what that variant wants — pinned here so an
+#      upstream rename does not silently break it.
 #
 #   3. The vgpu variant must enable the vGPU manager DaemonSet
-#      (vgpuManager.enabled=true) and the passthrough variant must keep
-#      driver.enabled / devicePlugin.enabled at false.
+#      (vgpuManager.enabled=true), the passthrough variant must keep
+#      driver.enabled / devicePlugin.enabled at false, and the container
+#      variant must keep driver / toolkit / vfioManager at false (host
+#      already provides them) while keeping devicePlugin enabled (publishes
+#      nvidia.com/gpu to the kubelet). The container variant must also pin
+#      cdi.enabled=false: upstream defaults it true, but CDI specs are
+#      serviced by the toolkit DaemonSet this variant disables, so leaving
+#      it on points the device plugin at CDI injection with no specs on an
+#      apt host and silently breaks allocation.
 #
 # Implementation: render the chart with the merged values for each variant
 # and grep for the relevant ClusterPolicy keys. We strip the package's
@@ -95,4 +108,33 @@ render_variant() {
   grep -A 1 '^  vgpuManager:'  "$TMP/rendered.yaml" | grep -q 'enabled: true'
   grep -A 1 '^  driver:'       "$TMP/rendered.yaml" | grep -q 'enabled: false'
   grep -A 1 '^  devicePlugin:' "$TMP/rendered.yaml" | grep -q 'enabled: false'
+}
+
+@test "container variant: ccManager and vgpuDeviceManager pinned off" {
+  TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+  render_variant container
+  grep -A 1 '^  ccManager:'         "$TMP/rendered.yaml" | grep -q 'enabled: false'
+  grep -A 1 '^  vgpuDeviceManager:' "$TMP/rendered.yaml" | grep -q 'enabled: false'
+}
+
+@test "container variant: sandboxWorkloads off, defaultWorkload stays upstream 'container'" {
+  TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+  render_variant container
+  grep -A 2 '^  sandboxWorkloads:' "$TMP/rendered.yaml" | grep -q 'enabled: false'
+  grep -A 2 '^  sandboxWorkloads:' "$TMP/rendered.yaml" | grep -q 'defaultWorkload: container'
+}
+
+@test "container variant: driver, toolkit, vfioManager off; devicePlugin on" {
+  TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+  render_variant container
+  grep -A 1 '^  driver:'       "$TMP/rendered.yaml" | grep -q 'enabled: false'
+  grep -A 1 '^  toolkit:'      "$TMP/rendered.yaml" | grep -q 'enabled: false'
+  grep -A 1 '^  vfioManager:'  "$TMP/rendered.yaml" | grep -q 'enabled: false'
+  grep -A 1 '^  devicePlugin:' "$TMP/rendered.yaml" | grep -q 'enabled: true'
+}
+
+@test "container variant: cdi pinned off (toolkit disabled cannot service CDI specs)" {
+  TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+  render_variant container
+  grep -A 1 '^  cdi:' "$TMP/rendered.yaml" | grep -q 'enabled: false'
 }

--- a/packages/core/platform/sources/gpu-operator.yaml
+++ b/packages/core/platform/sources/gpu-operator.yaml
@@ -36,3 +36,16 @@ spec:
         privileged: true
         namespace: cozy-gpu-operator
         releaseName: gpu-operator
+  - name: container
+    dependsOn:
+    - cozystack.networking
+    components:
+    - name: gpu-operator
+      path: system/gpu-operator
+      valuesFiles:
+      - values.yaml
+      - values-container.yaml
+      install:
+        privileged: true
+        namespace: cozy-gpu-operator
+        releaseName: gpu-operator

--- a/packages/system/gpu-operator/examples/README.md
+++ b/packages/system/gpu-operator/examples/README.md
@@ -1,16 +1,10 @@
 # GPU operator — native pod workload on Talos (reference)
 
-The files in this directory are **not** templates. They are reference
-artifacts that document one working configuration for running GPU
-workloads directly in pods on a Talos-based Cozystack cluster, together
-with the DCGM metrics needed by the `gpu/gpu-performance` Grafana
-dashboard.
+The files in this directory are **not** templates. They are reference artifacts that document one working configuration for running GPU workloads directly in pods on a Talos-based Cozystack cluster, together with the DCGM metrics needed by the `gpu/gpu-performance` Grafana dashboard.
 
-The out-of-the-box `values-passthrough.yaml` for this package targets the
-sandbox (VFIO passthrough to KubeVirt VMs) scenario. The files here
-illustrate an alternative — running CUDA workloads in regular pods with
-the NVIDIA device plugin — and the workarounds it currently requires on
-Talos.
+For non-Talos Linux hosts that already provide the NVIDIA driver and `nvidia-container-toolkit` via the distro package manager (the typical apt-installed Ubuntu/Debian shape), pick the first-class `container` variant instead — `variant: container` in your Package CR is the starting point. Two host prerequisites still apply: containerd must have the `nvidia` runtime registered (`nvidia-ctk runtime configure --runtime=containerd` + restart; `apt install` lays down binaries only, it does not wire containerd), and because the variant runs with `driver.enabled=false` the operator uses the pre-installed host driver at its standard location — so a stock apt install needs no `hostPaths.driverInstallDir` override. The files here remain the right starting point on Talos, where the driver lands under a non-standard prefix and the operator does not find it at the default location without the override below.
+
+The out-of-the-box `values-passthrough.yaml` for this package targets the sandbox (VFIO passthrough to KubeVirt VMs) scenario. The files here illustrate an alternative — running CUDA workloads in regular pods with the NVIDIA device plugin — and the workarounds it currently requires on Talos.
 
 ## Files
 

--- a/packages/system/gpu-operator/values-container.yaml
+++ b/packages/system/gpu-operator/values-container.yaml
@@ -1,0 +1,53 @@
+# Container variant: GPU workloads run in regular pods on hosts that
+# already have the NVIDIA driver and nvidia-container-toolkit installed
+# (typical Ubuntu/Debian shape: apt-installed driver + apt-installed
+# nvidia-container-toolkit). The third architectural mode that upstream
+# NVIDIA gpu-operator supports — sandboxWorkloads disabled,
+# devicePlugin enabled — surfaced here as a Cozystack variant.
+gpu-operator:
+  sandboxWorkloads:
+    # Default upstream workload on a node without the per-node
+    # 'nvidia.com/gpu.workload.config' label is 'container' when
+    # sandboxWorkloads is off — which is exactly what this variant
+    # wants. No defaultWorkload override needed; the counterpart
+    # overrides in values-passthrough.yaml / values-vgpu.yaml exist
+    # only because those variants flip sandboxWorkloads to true.
+    enabled: false
+  driver:
+    # Host already runs the NVIDIA driver (apt-installed). The
+    # operator's driver DaemonSet would attempt to load its own
+    # kernel module and clash with the host one.
+    enabled: false
+  devicePlugin:
+    # Publish nvidia.com/gpu to the kubelet so pods can request GPUs.
+    enabled: true
+  vfioManager:
+    # vfioManager unbinds the host driver to bind vfio-pci, which must
+    # not happen when the host driver is in use and devicePlugin is on.
+    # Upstream renders vfioManager.enabled=true into the ClusterPolicy
+    # unconditionally; it only stays at zero pods because the DaemonSet
+    # schedules solely onto nodes labeled
+    # nvidia.com/gpu.workload.config=vm-passthrough, and no node carries
+    # a sandbox assignment when sandboxWorkloads is off. Pin it off so
+    # the rendered policy matches intent regardless of upstream
+    # scheduling changes.
+    enabled: false
+  toolkit:
+    # Host already has nvidia-container-toolkit installed (the typical
+    # apt-installed shape). Running the operator's toolkit DaemonSet
+    # would overwrite /etc/containerd/config.toml that the host package
+    # configured (via `nvidia-ctk runtime configure`), breaking the
+    # host runtime wiring. NVIDIA's documentation recommends disabling
+    # this when the toolkit is preinstalled on the node.
+    enabled: false
+  cdi:
+    # Upstream defaults cdi.enabled=true, but CDI spec generation and
+    # runtime wiring are serviced by the operator-managed toolkit, which
+    # this variant disables. An apt-installed nvidia-container-toolkit
+    # does not generate CDI specs on its own (`nvidia-ctk cdi generate`
+    # is a manual step) and uses the classic nvidia-container-runtime
+    # hook path. Leaving CDI on would point the device plugin at a
+    # CDI-injection mode with no specs on the host and silently break
+    # GPU allocation. Pin off so device allocation matches the host
+    # runtime wiring.
+    enabled: false

--- a/packages/system/gpu-operator/values.yaml
+++ b/packages/system/gpu-operator/values.yaml
@@ -1,6 +1,6 @@
 # Defaults applied to every variant of the gpu-operator package.
-# The variant-specific files (values-passthrough.yaml, values-vgpu.yaml)
-# layer on top.
+# The variant-specific files (values-passthrough.yaml, values-vgpu.yaml,
+# values-container.yaml) layer on top.
 gpu-operator:
   # Upstream chart v26.x flips ccManager.enabled to true and
   # ccManager.defaultMode to "on". On Hopper-class hardware


### PR DESCRIPTION
## What this PR does

Add a third architectural variant to `cozystack.gpu-operator` for hosts where the NVIDIA driver and `nvidia-container-toolkit` are already installed by the distro package manager (the typical Ubuntu/Debian GPU node shape: apt-installed driver + apt-installed CT).

The existing variants do not produce a working setup in that shape. `default` (passthrough) runs `vfioManager`, which unbinds the host driver to bind `vfio-pci` — with the host driver active, `k8s-driver-manager` early-exits and the bind never happens, so the GPU never reaches a pod. `vgpu` requires the proprietary NVIDIA vGPU host driver and a license server; the user-installed open or proprietary driver does not satisfy it.

The new `container` variant maps onto upstream gpu-operator's third mode (`sandboxWorkloads.enabled=false` + `devicePlugin.enabled=true`) with every component that would conflict with the host install switched off:

- `driver.enabled=false` — use the host driver.
- `toolkit.enabled=false` — host already has `nvidia-container-toolkit`. Enabling the operator's toolkit DaemonSet would overwrite the `/etc/containerd/config.toml` the host package configured (via `nvidia-ctk runtime configure`), breaking the host runtime wiring. Matches NVIDIA's documented guidance and the existing `examples/values-native-talos.yaml` reference, which pins the same flag for the same reason.
- `devicePlugin.enabled=true` — publish `nvidia.com/gpu` to the kubelet.
- `vfioManager.enabled=false` — do not unbind the host driver. Upstream renders this `true` unconditionally; it only stays at zero pods because no node carries a `vm-passthrough` sandbox assignment when `sandboxWorkloads` is off — pinned off so the rendered policy matches intent.
- `cdi.enabled=false` — upstream defaults this `true`, but CDI spec generation is serviced by the operator-managed toolkit DaemonSet this variant disables. An apt host doesn't auto-generate CDI specs (`nvidia-ctk cdi generate` is a manual step) and uses the classic `nvidia-container-runtime` hook, so leaving CDI on would point the device plugin at CDI injection with no specs on the host and silently break allocation.
- `sandboxWorkloads.enabled=false` — regular pod workloads, not VMs. With this off, upstream `defaultWorkload` is already `container`, so no override is needed.

Host prerequisite: because the operator's toolkit component is disabled, the node's containerd must already have the `nvidia` runtime registered (`nvidia-ctk runtime configure --runtime=containerd`); `apt install nvidia-container-toolkit` installs binaries only and does not wire containerd. With `driver.enabled=false` the operator uses the pre-installed host driver at its standard location, so a stock apt install needs no `hostPaths.driverInstallDir` override (Talos lands the driver under a non-standard prefix — see `examples/values-native-talos.yaml`).

The bundle wiring (`packages/core/platform/templates/bundles/iaas.yaml`) already enables `cozystack.gpu-operator` as an optional package — no bundle changes required. Users opt into this variant by setting `variant: container` in their `Package` CR.

Verified locally with `helm template` against `values.yaml` + `values-container.yaml`: ClusterPolicy renders with `driver.enabled=false`, `toolkit.enabled=false`, `devicePlugin.enabled=true`, `vfioManager.enabled=false`, `cdi.enabled=false`, `sandboxWorkloads.enabled=false`. Platform `helm unittest` and the `gpu-operator` variant bats suite are green. Not yet smoke-tested on a real Ubuntu GPU node — the config matches the documented apt-host wiring (legacy `nvidia-container-runtime` hook, CDI off), but an end-to-end CUDA-pod run on hardware is still owed.

Closes #2764

### Release note

```release-note
feat(gpu-operator): add `container` variant for hosts with a pre-installed NVIDIA driver and nvidia-container-toolkit, exposing containerized GPU workloads via the standard NVIDIA device plugin without VFIO passthrough or vGPU.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "container" GPU operator variant to support containerized GPU workloads on hosts with the NVIDIA driver and nvidia-container-toolkit.

* **Documentation**
  * Updated variants documentation and OS support table to include the container variant and per-host requirements (including Ubuntu and Talos notes).
  * Clarified Talos native pod example wording.

* **Tests**
  * Added regression tests to verify container-variant configuration and component enablement/disablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
