### PR TITLE
feat(platform): auto-wire KubeVirt permittedHostDevices and HostDevices feature gate when gpu-operator is enabled

### DIFF
--- a/docs/gpu-vgpu.md
+++ b/docs/gpu-vgpu.md
@@ -38,29 +38,29 @@ The proprietary `.run` is the **Linux KVM** variant (not the Ubuntu KVM `.deb`, 
 
 ## Deploying with the vgpu variant
 
-Create a `Package` CR pointing at your image coordinates:
+The platform's `iaas` bundle deploys the gpu-operator Package CR when `cozystack.gpu-operator` is in `bundles.enabledPackages` and `bundles.iaas.gpuOperatorVariant: vgpu` is set. The vGPU Manager image is proprietary and not redistributable, so the bundle does not ship a default tag — the operator builds the container per the upstream [`gpu-driver-container`](https://github.com/NVIDIA/gpu-driver-container) recipe and supplies the private-registry coordinates through platform values:
 
 ```yaml
-apiVersion: cozystack.io/v1alpha1
-kind: Package
-metadata:
-  name: cozystack.gpu-operator
-spec:
-  variant: vgpu
-  components:
-    gpu-operator:
-      values:
-        gpu-operator:
-          vgpuManager:
-            repository: registry.example.com/nvidia
-            image: vgpu-manager
-            version: "595.58.02-ubuntu24.04"
-            # imagePullSecrets lives per-component (vgpuManager,
-            # driver, validator, dcgmExporter, …). The value is a
-            # list of strings, not [{name: ...}].
-            imagePullSecrets:
-            - nvidia-registry-secret
+bundles:
+  iaas:
+    enabled: true
+    gpuOperatorVariant: vgpu
+  enabledPackages:
+  - cozystack.gpu-operator
+
+gpu:
+  vgpuManager:
+    repository: registry.example.com/nvidia
+    image: vgpu-manager
+    version: "595.58.02-ubuntu24.04"
+    # imagePullSecrets lives per-component (vgpuManager, driver,
+    # validator, dcgmExporter, …). The value is a list of strings,
+    # not [{name: ...}].
+    imagePullSecrets:
+    - nvidia-registry-secret
 ```
+
+The platform forwards `gpu.vgpuManager` into the emitted gpu-operator Package CR's `components.gpu-operator.values.gpu-operator.vgpuManager`, so the bundle handles the variant + image coordinates in one place. If you need to override anything else on the gpu-operator chart (driver, validator, dcgmExporter, custom node selectors), hand-craft a `Package` CR named `cozystack.gpu-operator` with the full `components.gpu-operator.values` block — that takes precedence over the bundle render.
 
 The `nvidia-registry-secret` should be a docker-registry Secret created beforehand in `cozy-gpu-operator`.
 
@@ -94,24 +94,59 @@ For Pascal–Ampere GPUs (V100, T4, A100, A30) the mdev model still applies. Fli
 
 ## KubeVirt configuration
 
-After [kubevirt#16890](https://github.com/kubevirt/kubevirt/pull/16890), `virt-handler` recognises SR-IOV VFs bound to the `nvidia` driver as candidates whenever a vGPU profile is configured (`current_vgpu_type` ≠ 0). PFs are skipped automatically.
+When `cozystack.gpu-operator` is in `bundles.enabledPackages` (and not also in `bundles.disabledPackages`), the platform mirrors the chosen GPU variant into the `KubeVirt` CR automatically. There is no manual `kubectl patch` step.
 
-Patch the `KubeVirt` CR to permit the resource:
+If you opt out of bundle management and hand-craft a `cozystack.gpu-operator` Package CR directly — typically to apply overrides the bundle does not expose (driver settings, custom node selectors, validator / dcgmExporter tweaks, etc.) — the platform does NOT auto-wire `HostDevices` or `permittedHostDevices` into the KubeVirt CR. In that flow you also hand-craft a `cozystack.kubevirt` Package CR with `components.kubevirt.values.extraFeatureGates: [HostDevices]` and the appropriate `permittedHostDevices` block. The escape-hatch values shape under `.gpu` (below) is intentionally documented in the bundle-managed flow only; the manual Package-CR override path takes precedence over the bundle render whenever both exist.
+
+- `developerConfiguration.featureGates` gets `HostDevices` appended (current KubeVirt splits this from the `GPU` gate; the admission webhook rejects `spec.template.spec.domain.devices.hostDevices` without it).
+- `permittedHostDevices.pciHostDevices` is filled from `packages/core/platform/files/gpu-passthrough-defaults.yaml` when `bundles.iaas.gpuOperatorVariant: default` (the package default). The table covers Hopper (H100/H200), Ada Lovelace (L4/L40/L40S), Ampere (A100 PCIe/SXM, A40, A30, A10), Turing (T4), Volta (V100/V100S). All entries carry `externalResourceProvider: true` because the resource names come from `nvidia-sandbox-device-plugin`, not from KubeVirt's in-tree device plugin.
+- `permittedHostDevices.mediatedDevices` and `mediatedDevicesConfiguration` are filled from `packages/core/platform/files/gpu-vgpu-defaults.yaml` when `bundles.iaas.gpuOperatorVariant: vgpu`. The starter set covers Pascal–Ampere mdev profiles (A100-40C/80C, A40-24Q/48Q, A30-24C, A10-24Q, V100D-32C, T4-16Q) — the same family range as the upstream `vgpu-device-manager` walks `/sys/class/mdev_bus/` for. Ada Lovelace / Blackwell SR-IOV vGPU is out of scope for the chart's default list; advertise those VFs via the user-override hook below.
+
+### Extending or replacing the default table
+
+The platform exposes three knobs under `.gpu`:
 
 ```yaml
-spec:
-  configuration:
-    permittedHostDevices:
-      pciHostDevices:
-      - pciVendorSelector: "10DE:26B9"   # L40S — same device ID for PF and VF
-        resourceName: nvidia.com/L40S-24Q
+gpu:
+  # Extend the platform defaults with cluster-specific entries. Both list
+  # keys are read in both variants: pciHostDevices feeds the passthrough
+  # (vfio-pci) path AND the post-kubevirt#16890 SR-IOV vGPU VF path on
+  # Ada Lovelace / Blackwell; mediatedDevices feeds the pre-#16890 mdev
+  # path on Pascal–Ampere. Both render into the same KubeVirt CR.
+  permittedHostDevices:
+    pciHostDevices:
+    - pciVendorSelector: "10DE:26B9"   # L40S, advertised as a VF for SR-IOV vGPU
+      resourceName: nvidia.com/L40S-24Q
+      # externalResourceProvider is intentionally omitted here: after
+      # kubevirt/kubevirt#16890, virt-handler's in-tree device plugin
+      # advertises the resource directly, no sandbox plugin in the loop.
+    mediatedDevices: []
+  # mediatedDevicesConfiguration drives the per-node vGPU profile
+  # auto-creation loop in vgpu mode. Helm's mergeOverwrite applies — a
+  # user-supplied top-level key (mediatedDeviceTypes,
+  # nodeMediatedDeviceTypes) REPLACES the platform default for that key
+  # rather than appending. Combine with replaceDefaults: true when both
+  # this and permittedHostDevices.mediatedDevices should be wiped together.
+  mediatedDevicesConfiguration: {}
+  # Wipe the platform defaults entirely and ship only the cluster's
+  # curated lists. Useful for non-NVIDIA-only clusters and strict
+  # allowlist requirements.
+  replaceDefaults: false
 ```
+
+`replaceDefaults: false` (the default) appends user entries to the NVIDIA defaults. `replaceDefaults: true` drops the NVIDIA table entirely — if you don't then supply your own pciHostDevices / mediatedDevices list, the rendered KubeVirt CR has no `permittedHostDevices` block and the admission webhook will reject every GPU VM.
+
+### Notes on `nvidia-sandbox-device-plugin` resource names
+
+The `resourceName` strings in `gpu-passthrough-defaults.yaml` follow what `nvidia-sandbox-device-plugin` v25.x generates: a slug of `<arch>_<model>_<form>_<mem>` (e.g. `nvidia.com/GH100_H200_SXM_141GB`). If the plugin version drifts that convention, your node will publish a different name — check with `kubectl describe node <node> | grep nvidia.com/` and override via `.gpu.permittedHostDevices.pciHostDevices` (or wipe the table with `replaceDefaults: true` and curate it yourself). PCI vendor:device IDs themselves are stable across driver versions.
+
+### SR-IOV PF vs VF (Ada Lovelace and newer)
 
 On L40S (and other Ada-Lovelace cards) the SR-IOV VFs report the same PCI device ID as the PF — `lspci -nn -d 10de:` on the host shows both as `[10de:26b9]`. `virt-handler` distinguishes them by `is-VF + has-vGPU-profile`, so a single `pciVendorSelector` matches the right set. Verify on your specific GPU before assuming this — some other generations split PF/VF IDs.
 
-`externalResourceProvider: true` is **not** required here (and should be omitted) — the device plugin lives inside `virt-handler` itself, no external sandbox-device-plugin advertises this resource.
+`externalResourceProvider: true` is **not** required when the resource is advertised by `virt-handler`'s in-tree device plugin (the SR-IOV path post kubevirt#16890). The platform passthrough defaults include the flag because that path is driven by the external sandbox plugin.
 
-Verify allocatable capacity:
+### Verifying allocatable capacity
 
 ```bash
 kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{": "}{.status.allocatable.nvidia\.com/L40S-24Q}{"\n"}{end}'

--- a/docs/gpu-vgpu.md
+++ b/docs/gpu-vgpu.md
@@ -100,7 +100,7 @@ If you opt out of bundle management and hand-craft a `cozystack.gpu-operator` Pa
 
 - `developerConfiguration.featureGates` gets `HostDevices` appended (current KubeVirt splits this from the `GPU` gate; the admission webhook rejects `spec.template.spec.domain.devices.hostDevices` without it).
 - `permittedHostDevices.pciHostDevices` is filled from `packages/core/platform/files/gpu-passthrough-defaults.yaml` when `bundles.iaas.gpuOperatorVariant: default` (the package default). The table covers Hopper (H100/H200), Ada Lovelace (L4/L40/L40S), Ampere (A100 PCIe/SXM, A40, A30, A10), Turing (T4), Volta (V100/V100S). All entries carry `externalResourceProvider: true` because the resource names come from `nvidia-sandbox-device-plugin`, not from KubeVirt's in-tree device plugin.
-- `permittedHostDevices.mediatedDevices` and `mediatedDevicesConfiguration` are filled from `packages/core/platform/files/gpu-vgpu-defaults.yaml` when `bundles.iaas.gpuOperatorVariant: vgpu`. The starter set covers Pascal–Ampere mdev profiles (A100-40C/80C, A40-24Q/48Q, A30-24C, A10-24Q, V100D-32C, T4-16Q) — the same family range as the upstream `vgpu-device-manager` walks `/sys/class/mdev_bus/` for. Ada Lovelace / Blackwell SR-IOV vGPU is out of scope for the chart's default list; advertise those VFs via the user-override hook below.
+- `permittedHostDevices.mediatedDevices` is filled from `packages/core/platform/files/gpu-vgpu-defaults.yaml` when `bundles.iaas.gpuOperatorVariant: vgpu`. This list only EXPOSES, by profile name (`mdevNameSelector`), mdevs that the GPU Operator's vGPU Device Manager CREATES on the node; the platform does not ship a numeric `mediatedDevicesConfiguration` default (those `nvidia-NNN` type ids are per-SKU/driver sysfs indices with no portable value — set `.gpu.mediatedDevicesConfiguration` yourself, with host-verified ids, only if you want KubeVirt rather than the Device Manager to create mdevs). The starter set covers Pascal–Ampere mdev profiles (A100-40C/80C, A40-24Q/48Q, A30-24C, A10-24Q, V100D-32C, T4-16Q) — the same family range as the upstream `vgpu-device-manager` walks `/sys/class/mdev_bus/` for. Ada Lovelace / Blackwell SR-IOV vGPU is out of scope for the chart's default list; advertise those VFs via the user-override hook below.
 
 ### Extending or replacing the default table
 
@@ -121,12 +121,7 @@ gpu:
       # kubevirt/kubevirt#16890, virt-handler's in-tree device plugin
       # advertises the resource directly, no sandbox plugin in the loop.
     mediatedDevices: []
-  # mediatedDevicesConfiguration drives the per-node vGPU profile
-  # auto-creation loop in vgpu mode. Helm's mergeOverwrite applies — a
-  # user-supplied top-level key (mediatedDeviceTypes,
-  # nodeMediatedDeviceTypes) REPLACES the platform default for that key
-  # rather than appending. Combine with replaceDefaults: true when both
-  # this and permittedHostDevices.mediatedDevices should be wiped together.
+  # mediatedDevicesConfiguration makes KubeVirt itself create mdevs (vgpu mode). No platform default: mdev creation is normally delegated to the vGPU Device Manager (name-based), and these mediatedDeviceTypes are host/driver-specific nvidia-NNN sysfs indices (look yours up via /sys/bus/pci/devices/<BDF>/mdev_supported_types/*/name). Set this only to opt into KubeVirt-driven creation; mergeOverwrite REPLACES a supplied top-level key wholesale.
   mediatedDevicesConfiguration: {}
   # Wipe the platform defaults entirely and ship only the cluster's
   # curated lists. Useful for non-NVIDIA-only clusters and strict
@@ -138,7 +133,7 @@ gpu:
 
 ### Notes on `nvidia-sandbox-device-plugin` resource names
 
-The `resourceName` strings in `gpu-passthrough-defaults.yaml` follow what `nvidia-sandbox-device-plugin` v25.x generates: a slug of `<arch>_<model>_<form>_<mem>` (e.g. `nvidia.com/GH100_H200_SXM_141GB`). If the plugin version drifts that convention, your node will publish a different name — check with `kubectl describe node <node> | grep nvidia.com/` and override via `.gpu.permittedHostDevices.pciHostDevices` (or wipe the table with `replaceDefaults: true` and curate it yourself). PCI vendor:device IDs themselves are stable across driver versions.
+The `resourceName` strings in `gpu-passthrough-defaults.yaml` are what `nvidia-sandbox-device-plugin` (`nvcr.io/nvidia/kubevirt-gpu-device-plugin`) advertises: it derives each slug mechanically from the device's PCI-IDs database name by uppercasing it, turning `/`, `.` and whitespace into `_`, and stripping the remaining non-alphanumerics (the `[` / `]`). So `TU104GL [Tesla T4]` becomes `nvidia.com/TU104GL_TESLA_T4` and `GA100GL [A30 PCIe]` becomes `nvidia.com/GA100GL_A30_PCIE` — the slug carries every token the PCI-IDs string holds (the `GL` die suffix, the `Tesla` brand on Turing/Volta, form factor, memory), not a tidy `<arch>_<model>`. The names track the pci.ids snapshot bundled in the plugin image, so a different plugin build can publish a different string — check with `kubectl describe node <node> | grep nvidia.com/` and override via `.gpu.permittedHostDevices.pciHostDevices` (or wipe the table with `replaceDefaults: true` and curate it yourself). PCI vendor:device IDs themselves are stable across driver versions.
 
 ### SR-IOV PF vs VF (Ada Lovelace and newer)
 

--- a/packages/core/platform/files/gpu-passthrough-defaults.yaml
+++ b/packages/core/platform/files/gpu-passthrough-defaults.yaml
@@ -4,12 +4,23 @@
 # the KubeVirt CR at spec.configuration.permittedHostDevices.pciHostDevices.
 #
 # PCI vendor:device pairs are stable vendor-assigned identifiers under the
-# PCI-SIG-administered namespace and do not drift across driver versions. The resourceName strings mirror what
-# nvidia-sandbox-device-plugin auto-generates as of v25.x: a slug of
-# <ARCH>_<MODEL>_<FORM>_<MEM>. If your cluster's plugin emits something
-# different (kubectl describe node | grep nvidia.com/), extend or replace
-# the list at the platform values level via .Values.gpu.permittedHostDevices
-# / .Values.gpu.replaceDefaults.
+# PCI-SIG-administered namespace and do not drift across driver versions.
+#
+# The resourceName is what nvidia-sandbox-device-plugin
+# (nvcr.io/nvidia/kubevirt-gpu-device-plugin, the image shipped by the
+# gpu-operator package) advertises on the node. The plugin derives it
+# mechanically from the device's PCI-IDs database name: uppercase the
+# name, turn "/", "." and whitespace into "_", then strip the remaining
+# non-alphanumerics (the "[" / "]" around the model). So
+# "TU104GL [Tesla T4]" becomes nvidia.com/TU104GL_TESLA_T4 and
+# "GA100GL [A30 PCIe]" becomes nvidia.com/GA100GL_A30_PCIE — the slug
+# carries every token the PCI-IDs string holds (die suffix "GL", the
+# "Tesla" brand on Turing/Volta, form factor, memory), not a tidy
+# <arch>_<model>. The names here track the pci.ids snapshot bundled in
+# the plugin image; a different plugin build can emit a different string.
+# Always confirm against the live node (kubectl describe node <node> |
+# grep nvidia.com/) and extend or replace via .Values.gpu.permittedHostDevices
+# / .Values.gpu.replaceDefaults when it differs.
 #
 # externalResourceProvider: true is mandatory here — the resource is
 # published by the sandbox-device-plugin DaemonSet, not by KubeVirt itself.
@@ -22,10 +33,10 @@ pciHostDevices:
   resourceName: nvidia.com/GH100_H100_SXM5_80GB
   externalResourceProvider: true
 - pciVendorSelector: "10DE:2331"
-  resourceName: nvidia.com/GH100_H100_PCIE_80GB
+  resourceName: nvidia.com/GH100_H100_PCIE
   externalResourceProvider: true
 - pciVendorSelector: "10DE:2321"
-  resourceName: nvidia.com/GH100_H100_NVL_94GB
+  resourceName: nvidia.com/GH100_H100L_94GB
   externalResourceProvider: true
 # Ada Lovelace (datacenter SKUs)
 - pciVendorSelector: "10DE:26B9"
@@ -51,7 +62,7 @@ pciHostDevices:
   resourceName: nvidia.com/GA100_A100_PCIE_40GB
   externalResourceProvider: true
 - pciVendorSelector: "10DE:20B7"
-  resourceName: nvidia.com/GA100_A30
+  resourceName: nvidia.com/GA100GL_A30_PCIE
   externalResourceProvider: true
 - pciVendorSelector: "10DE:2235"
   resourceName: nvidia.com/GA102GL_A40
@@ -61,15 +72,18 @@ pciHostDevices:
   externalResourceProvider: true
 # Turing
 - pciVendorSelector: "10DE:1EB8"
-  resourceName: nvidia.com/TU104GL_T4
+  resourceName: nvidia.com/TU104GL_TESLA_T4
   externalResourceProvider: true
 # Volta
 - pciVendorSelector: "10DE:1DB1"
-  resourceName: nvidia.com/GV100_V100_SXM2_32GB
+  resourceName: nvidia.com/GV100GL_TESLA_V100_SXM2_16GB
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:1DB5"
+  resourceName: nvidia.com/GV100GL_TESLA_V100_SXM2_32GB
   externalResourceProvider: true
 - pciVendorSelector: "10DE:1DB4"
-  resourceName: nvidia.com/GV100_V100_PCIE_16GB
+  resourceName: nvidia.com/GV100GL_TESLA_V100_PCIE_16GB
   externalResourceProvider: true
 - pciVendorSelector: "10DE:1DF6"
-  resourceName: nvidia.com/GV100_V100S_PCIE_32GB
+  resourceName: nvidia.com/GV100GL_TESLA_V100S_PCIE_32GB
   externalResourceProvider: true

--- a/packages/core/platform/files/gpu-passthrough-defaults.yaml
+++ b/packages/core/platform/files/gpu-passthrough-defaults.yaml
@@ -1,0 +1,75 @@
+# NVIDIA datacenter GPUs commonly used in passthrough VFIO mode. Used by
+# bundles/iaas.yaml when bundles.iaas.gpuOperatorVariant=default and
+# cozystack.gpu-operator is in bundles.enabledPackages. Auto-injected into
+# the KubeVirt CR at spec.configuration.permittedHostDevices.pciHostDevices.
+#
+# PCI vendor:device pairs are stable vendor-assigned identifiers under the
+# PCI-SIG-administered namespace and do not drift across driver versions. The resourceName strings mirror what
+# nvidia-sandbox-device-plugin auto-generates as of v25.x: a slug of
+# <ARCH>_<MODEL>_<FORM>_<MEM>. If your cluster's plugin emits something
+# different (kubectl describe node | grep nvidia.com/), extend or replace
+# the list at the platform values level via .Values.gpu.permittedHostDevices
+# / .Values.gpu.replaceDefaults.
+#
+# externalResourceProvider: true is mandatory here — the resource is
+# published by the sandbox-device-plugin DaemonSet, not by KubeVirt itself.
+pciHostDevices:
+# Hopper
+- pciVendorSelector: "10DE:2335"
+  resourceName: nvidia.com/GH100_H200_SXM_141GB
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:2330"
+  resourceName: nvidia.com/GH100_H100_SXM5_80GB
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:2331"
+  resourceName: nvidia.com/GH100_H100_PCIE_80GB
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:2321"
+  resourceName: nvidia.com/GH100_H100_NVL_94GB
+  externalResourceProvider: true
+# Ada Lovelace (datacenter SKUs)
+- pciVendorSelector: "10DE:26B9"
+  resourceName: nvidia.com/AD102GL_L40S
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:26B5"
+  resourceName: nvidia.com/AD102GL_L40
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:27B8"
+  resourceName: nvidia.com/AD104GL_L4
+  externalResourceProvider: true
+# Ampere
+- pciVendorSelector: "10DE:20B2"
+  resourceName: nvidia.com/GA100_A100_SXM4_80GB
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:20B0"
+  resourceName: nvidia.com/GA100_A100_SXM4_40GB
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:20B5"
+  resourceName: nvidia.com/GA100_A100_PCIE_80GB
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:20F1"
+  resourceName: nvidia.com/GA100_A100_PCIE_40GB
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:20B7"
+  resourceName: nvidia.com/GA100_A30
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:2235"
+  resourceName: nvidia.com/GA102GL_A40
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:2236"
+  resourceName: nvidia.com/GA102GL_A10
+  externalResourceProvider: true
+# Turing
+- pciVendorSelector: "10DE:1EB8"
+  resourceName: nvidia.com/TU104GL_T4
+  externalResourceProvider: true
+# Volta
+- pciVendorSelector: "10DE:1DB1"
+  resourceName: nvidia.com/GV100_V100_SXM2_32GB
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:1DB4"
+  resourceName: nvidia.com/GV100_V100_PCIE_16GB
+  externalResourceProvider: true
+- pciVendorSelector: "10DE:1DF6"
+  resourceName: nvidia.com/GV100_V100S_PCIE_32GB
+  externalResourceProvider: true

--- a/packages/core/platform/files/gpu-vgpu-defaults.yaml
+++ b/packages/core/platform/files/gpu-vgpu-defaults.yaml
@@ -1,14 +1,32 @@
-# NVIDIA vGPU profiles commonly exposed by nvidia-vgpu-manager in vGPU
-# mode. Used by bundles/iaas.yaml when bundles.iaas.gpuOperatorVariant=vgpu
-# and cozystack.gpu-operator is in bundles.enabledPackages. Auto-injected
-# into the KubeVirt CR at spec.configuration.permittedHostDevices.mediatedDevices
-# and spec.configuration.mediatedDevicesConfiguration.
+# NVIDIA vGPU profiles to EXPOSE to VMs in vGPU mode. Used by
+# bundles/iaas.yaml when bundles.iaas.gpuOperatorVariant=vgpu and
+# cozystack.gpu-operator is in bundles.enabledPackages. Auto-injected
+# into the KubeVirt CR at spec.configuration.permittedHostDevices.mediatedDevices.
 #
-# The profiles below cover the 24Q (3D-optimised) and 48Q (datacenter
-# whole-card) splits on the GPU families cozystack supports for vGPU
-# (Ampere and earlier — Ada Lovelace and Blackwell use per-VF NVIDIA
-# sysfs and are out of scope for the chart's vGPU defaults; see
-# system/gpu-operator/values-vgpu.yaml).
+# Division of labour: the GPU Operator's vGPU Device Manager CREATES the
+# mdev devices on each node from a name-based profile config; KubeVirt
+# only EXPOSES the already-created mdevs to VMs, matched by profile name
+# via mdevNameSelector. This file therefore carries only the name-based
+# exposure list — it does NOT ship a mediatedDevicesConfiguration block.
+# That block's mediatedDeviceTypes are numeric nvidia-NNN ids that make
+# KubeVirt itself create mdevs, but those ids are per-(SKU, driver) sysfs
+# indices with no portable value, and would duplicate the Device
+# Manager. Operators who deliberately want KubeVirt to drive creation set
+# host-verified ids via .Values.gpu.mediatedDevicesConfiguration instead.
+#
+# mdevNameSelector must match the on-host profile name the driver exposes
+# under /sys/bus/pci/devices/<BDF>/mdev_supported_types/*/name — which is
+# driver-branch-dependent ("NVIDIA A100-40C" on the vGPU 13+/AIE branch,
+# "GRID A100-40C" on older GRID drivers). The profiles below cover the
+# 24Q/48Q and whole-card C splits on the families cozystack supports for
+# vGPU (Ampere and earlier — Ada Lovelace and Blackwell use per-VF NVIDIA
+# sysfs and are out of scope; see system/gpu-operator/values-vgpu.yaml).
+# Verify against the live node and override via
+# .Values.gpu.permittedHostDevices / .Values.gpu.replaceDefaults if your
+# driver exposes different names:
+#
+#   for t in /sys/bus/pci/devices/<BDF>/mdev_supported_types/*; do \
+#     echo "$(basename "$t") -> $(cat "$t"/name)"; done
 #
 # externalResourceProvider: true is mandatory — the mediated devices are
 # published by the vGPU Manager DaemonSet, not by KubeVirt itself.
@@ -38,18 +56,3 @@ permittedHostDevices:
   - mdevNameSelector: NVIDIA T4-16Q
     resourceName: nvidia.com/T4-16Q
     externalResourceProvider: true
-mediatedDevicesConfiguration:
-  # mediatedDeviceTypes lists the vGPU profile IDs the operator may
-  # auto-create per-node from the underlying physical GPUs. Numeric IDs
-  # are the NVIDIA-published vGPU type numbers (see GRID/vGPU release
-  # notes for the full mapping); listing one whole-card type per GPU
-  # family keeps the default deterministic.
-  mediatedDeviceTypes:
-  - nvidia-559    # A100-40C
-  - nvidia-560    # A100-80C
-  - nvidia-558    # A40-48Q
-  - nvidia-555    # A40-24Q
-  - nvidia-453    # A30-24C
-  - nvidia-471    # A10-24Q
-  - nvidia-413    # V100D-32C
-  - nvidia-232    # T4-16Q

--- a/packages/core/platform/files/gpu-vgpu-defaults.yaml
+++ b/packages/core/platform/files/gpu-vgpu-defaults.yaml
@@ -1,0 +1,55 @@
+# NVIDIA vGPU profiles commonly exposed by nvidia-vgpu-manager in vGPU
+# mode. Used by bundles/iaas.yaml when bundles.iaas.gpuOperatorVariant=vgpu
+# and cozystack.gpu-operator is in bundles.enabledPackages. Auto-injected
+# into the KubeVirt CR at spec.configuration.permittedHostDevices.mediatedDevices
+# and spec.configuration.mediatedDevicesConfiguration.
+#
+# The profiles below cover the 24Q (3D-optimised) and 48Q (datacenter
+# whole-card) splits on the GPU families cozystack supports for vGPU
+# (Ampere and earlier — Ada Lovelace and Blackwell use per-VF NVIDIA
+# sysfs and are out of scope for the chart's vGPU defaults; see
+# system/gpu-operator/values-vgpu.yaml).
+#
+# externalResourceProvider: true is mandatory — the mediated devices are
+# published by the vGPU Manager DaemonSet, not by KubeVirt itself.
+permittedHostDevices:
+  mediatedDevices:
+  - mdevNameSelector: NVIDIA A100-40C
+    resourceName: nvidia.com/A100-40C
+    externalResourceProvider: true
+  - mdevNameSelector: NVIDIA A100-80C
+    resourceName: nvidia.com/A100-80C
+    externalResourceProvider: true
+  - mdevNameSelector: NVIDIA A40-48Q
+    resourceName: nvidia.com/A40-48Q
+    externalResourceProvider: true
+  - mdevNameSelector: NVIDIA A40-24Q
+    resourceName: nvidia.com/A40-24Q
+    externalResourceProvider: true
+  - mdevNameSelector: NVIDIA A30-24C
+    resourceName: nvidia.com/A30-24C
+    externalResourceProvider: true
+  - mdevNameSelector: NVIDIA A10-24Q
+    resourceName: nvidia.com/A10-24Q
+    externalResourceProvider: true
+  - mdevNameSelector: NVIDIA V100D-32C
+    resourceName: nvidia.com/V100D-32C
+    externalResourceProvider: true
+  - mdevNameSelector: NVIDIA T4-16Q
+    resourceName: nvidia.com/T4-16Q
+    externalResourceProvider: true
+mediatedDevicesConfiguration:
+  # mediatedDeviceTypes lists the vGPU profile IDs the operator may
+  # auto-create per-node from the underlying physical GPUs. Numeric IDs
+  # are the NVIDIA-published vGPU type numbers (see GRID/vGPU release
+  # notes for the full mapping); listing one whole-card type per GPU
+  # family keeps the default deterministic.
+  mediatedDeviceTypes:
+  - nvidia-559    # A100-40C
+  - nvidia-560    # A100-80C
+  - nvidia-558    # A40-48Q
+  - nvidia-555    # A40-24Q
+  - nvidia-453    # A30-24C
+  - nvidia-471    # A10-24Q
+  - nvidia-413    # V100D-32C
+  - nvidia-232    # T4-16Q

--- a/packages/core/platform/templates/bundles/iaas.yaml
+++ b/packages/core/platform/templates/bundles/iaas.yaml
@@ -55,11 +55,21 @@
   pciHostDevices applies in both variants — passthrough (vfio-pci, whole
   GPU) and post-kubevirt#16890 SR-IOV vGPU VFs (Ada Lovelace / Blackwell
   with the vGPU 17/20 driver branch) both advertise via pciHostDevices.
-  mediatedDevices and mediatedDevicesConfiguration are vgpu-only: they
-  drive the pre-#16890 mdev path (Pascal–Ampere). Emitting them in the
-  passthrough variant would carry vGPU-only configuration into a CR that
-  has no vGPU manager deployed — a footgun for operators who keep a
-  shared gpu values block and flip the variant back to default.
+  mediatedDevices is vgpu-only: it EXPOSES, by stable profile name
+  (mdevNameSelector), the mdev devices the GPU Operator's vGPU Device
+  Manager creates on the node. Emitting it in the passthrough variant
+  would carry vGPU-only configuration into a CR that has no vGPU manager
+  deployed — a footgun for operators who keep a shared gpu values block
+  and flip the variant back to default.
+
+  mediatedDevicesConfiguration is intentionally NOT defaulted. Its
+  mediatedDeviceTypes entries are numeric nvidia-NNN ids that make
+  KubeVirt itself create mdevs — but those ids are per-(SKU, driver)
+  sysfs indices with no portable value, and mdev creation is already
+  handled by the vGPU Device Manager (name-based). It is therefore
+  emitted only from the .gpu.mediatedDevicesConfiguration override, for
+  operators who deliberately want KubeVirt to drive creation with
+  host-verified type ids.
 */ -}}
 {{- $pci := list -}}
 {{- $mdev := list -}}
@@ -72,18 +82,18 @@
 {{- $pci = concat $pci $userPci -}}
 {{- else -}}
 {{- /*
-  vgpu defaults table is only useful when nvidia-vgpu-device-manager is
-  actually deployed — without it, /sys/class/mdev_bus/ stays empty and
-  the rendered mediated resources can never become allocatable.
-  Suppress the platform mdev defaults when vgpuDeviceManager.enabled is
-  false (the case on Ada Lovelace / Blackwell SR-IOV); the operator can
-  still set their own mediated entries via .gpu.permittedHostDevices.
+  The mediatedDevices defaults name the mdev profiles the vGPU Device
+  Manager creates; they are only useful when that DaemonSet is actually
+  deployed — without it, /sys/class/mdev_bus/ stays empty and the
+  rendered mediated resources can never become allocatable. Suppress the
+  platform mdev defaults when vgpuDeviceManager.enabled is false (the
+  case on Ada Lovelace / Blackwell SR-IOV); the operator can still set
+  their own mediated entries via .gpu.permittedHostDevices.
 */ -}}
 {{- $deviceManagerOn := default false (((.Values.gpu).vgpuDeviceManager).enabled) -}}
 {{- if and (not $replace) $deviceManagerOn -}}
 {{- $vgpuDefaults := $.Files.Get "files/gpu-vgpu-defaults.yaml" | fromYaml -}}
 {{- $mdev = concat $mdev $vgpuDefaults.permittedHostDevices.mediatedDevices -}}
-{{- $mdevConfig = $vgpuDefaults.mediatedDevicesConfiguration -}}
 {{- end -}}
 {{- $pci = concat $pci $userPci -}}
 {{- $mdev = concat $mdev $userMdev -}}

--- a/packages/core/platform/templates/bundles/iaas.yaml
+++ b/packages/core/platform/templates/bundles/iaas.yaml
@@ -2,14 +2,130 @@
 {{- fail "bundles.iaas.enabled can only be true when bundles.system.variant is 'isp-full' or 'isp-full-generic'" }}
 {{- end }}
 {{- if and .Values.bundles.iaas.enabled (or (eq .Values.bundles.system.variant "isp-full") (eq .Values.bundles.system.variant "isp-full-generic")) }}
-{{- $kubevirtComponents := dict -}}
+{{- $kubevirtValues := dict -}}
 {{- if .Values.resources.cpuAllocationRatio -}}
-{{- $_ := set $kubevirtComponents "kubevirt" (dict "values" (dict "cpuAllocationRatio" (.Values.resources.cpuAllocationRatio | int))) -}}
+{{- $_ := set $kubevirtValues "cpuAllocationRatio" (.Values.resources.cpuAllocationRatio | int) -}}
+{{- end -}}
+{{- /*
+  When cozystack.gpu-operator is enabled the platform mirrors the variant
+  into the KubeVirt CR: the HostDevices feature gate plus a starter
+  permittedHostDevices block. Without this the admission webhook rejects
+  any VM that references a host-device GPU by resourceName. See
+  docs/gpu-vgpu.md for the user-facing knobs.
+*/ -}}
+{{- /*
+  Mirror the cozystack.platform.package.optional helper's enable/disable
+  semantics — disabledPackages wins over enabledPackages. A shared values
+  file may list gpu-operator under enabled but a per-cluster override
+  may push it into disabled; in that case the gpu-operator Package CR is
+  not emitted and the kubevirt CR must not carry GPU wiring either.
+*/ -}}
+{{- $gpuName := "cozystack.gpu-operator" -}}
+{{- $gpuEnabled := and (has $gpuName (default (list) .Values.bundles.enabledPackages)) (not (has $gpuName (default (list) .Values.bundles.disabledPackages))) -}}
+{{- $gpuVariant := .Values.bundles.iaas.gpuOperatorVariant | default "default" -}}
+{{- /*
+  Validate the variant up front, not behind $gpuEnabled — a typo like
+  gpuOperatorVariant: passthrough (instead of "default") would otherwise
+  render fine until someone flips gpu-operator into enabledPackages, at
+  which point the bundle breaks. Failing fast here surfaces the typo on
+  the first render after the values file changes.
+*/ -}}
+{{- if not (or (eq $gpuVariant "default") (eq $gpuVariant "vgpu")) -}}
+{{- fail (printf "bundles.iaas.gpuOperatorVariant must be \"default\" or \"vgpu\", got %q" $gpuVariant) -}}
+{{- end -}}
+{{- if $gpuEnabled }}
+{{- $_ := set $kubevirtValues "extraFeatureGates" (list "HostDevices") -}}
+{{- $userPci := default (list) (((.Values.gpu).permittedHostDevices).pciHostDevices) -}}
+{{- $userMdev := default (list) (((.Values.gpu).permittedHostDevices).mediatedDevices) -}}
+{{- $userMdevConfig := default (dict) (.Values.gpu).mediatedDevicesConfiguration -}}
+{{- $replace := default false (.Values.gpu).replaceDefaults -}}
+{{- /*
+  pciHostDevices applies in both variants — passthrough (vfio-pci, whole
+  GPU) and post-kubevirt#16890 SR-IOV vGPU VFs (Ada Lovelace / Blackwell
+  with the vGPU 17/20 driver branch) both advertise via pciHostDevices.
+  mediatedDevices and mediatedDevicesConfiguration are vgpu-only: they
+  drive the pre-#16890 mdev path (Pascal–Ampere). Emitting them in the
+  passthrough variant would carry vGPU-only configuration into a CR that
+  has no vGPU manager deployed — a footgun for operators who keep a
+  shared gpu values block and flip the variant back to default.
+*/ -}}
+{{- $pci := list -}}
+{{- $mdev := list -}}
+{{- $mdevConfig := dict -}}
+{{- if eq $gpuVariant "default" -}}
+{{- if not $replace -}}
+{{- $defaults := $.Files.Get "files/gpu-passthrough-defaults.yaml" | fromYaml -}}
+{{- $pci = concat $pci $defaults.pciHostDevices -}}
+{{- end -}}
+{{- $pci = concat $pci $userPci -}}
+{{- else -}}
+{{- /*
+  vgpu defaults table is only useful when nvidia-vgpu-device-manager is
+  actually deployed — without it, /sys/class/mdev_bus/ stays empty and
+  the rendered mediated resources can never become allocatable.
+  Suppress the platform mdev defaults when vgpuDeviceManager.enabled is
+  false (the case on Ada Lovelace / Blackwell SR-IOV); the operator can
+  still set their own mediated entries via .gpu.permittedHostDevices.
+*/ -}}
+{{- $deviceManagerOn := default false (((.Values.gpu).vgpuDeviceManager).enabled) -}}
+{{- if and (not $replace) $deviceManagerOn -}}
+{{- $vgpuDefaults := $.Files.Get "files/gpu-vgpu-defaults.yaml" | fromYaml -}}
+{{- $mdev = concat $mdev $vgpuDefaults.permittedHostDevices.mediatedDevices -}}
+{{- $mdevConfig = $vgpuDefaults.mediatedDevicesConfiguration -}}
+{{- end -}}
+{{- $pci = concat $pci $userPci -}}
+{{- $mdev = concat $mdev $userMdev -}}
+{{- $mdevConfig = mergeOverwrite $mdevConfig $userMdevConfig -}}
+{{- end -}}
+{{- $permitted := dict -}}
+{{- if $pci -}}
+{{- $_ := set $permitted "pciHostDevices" $pci -}}
+{{- end -}}
+{{- if $mdev -}}
+{{- $_ := set $permitted "mediatedDevices" $mdev -}}
+{{- end -}}
+{{- if $permitted -}}
+{{- $_ := set $kubevirtValues "permittedHostDevices" $permitted -}}
+{{- end -}}
+{{- if $mdevConfig -}}
+{{- $_ := set $kubevirtValues "mediatedDevicesConfiguration" $mdevConfig -}}
+{{- end -}}
+{{- end -}}
+{{- $kubevirtComponents := dict -}}
+{{- if $kubevirtValues -}}
+{{- $_ := set $kubevirtComponents "kubevirt" (dict "values" $kubevirtValues) -}}
 {{- end -}}
 {{include "cozystack.platform.package" (list "cozystack.kubevirt" "default" $ $kubevirtComponents) }}
 {{include "cozystack.platform.package.default" (list "cozystack.kubevirt-cdi" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.vm-default-images" $) }}
-{{include "cozystack.platform.package.optional.default" (list "cozystack.gpu-operator" $) }}
+{{- /*
+  Forward platform-level vGPU knobs into the emitted cozystack.gpu-operator
+  Package CR's components.gpu-operator.values. Only applies to the vgpu
+  variant — passthrough does not consume them. Each knob is forwarded
+  independently: the vgpuManager block ships if any of repository, version,
+  a non-default image, or imagePullSecrets is set (avoids the silent-drop
+  trap where a private registry needs imagePullSecrets but inherits the
+  upstream image tag); vgpuDeviceManager.enabled ships whenever the
+  operator set it (true on Pascal–Ampere mdev clusters, default false).
+*/ -}}
+{{- $gpuOperatorComponents := dict -}}
+{{- if and $gpuEnabled (eq $gpuVariant "vgpu") -}}
+{{- $gpuOperatorOverrides := dict -}}
+{{- $vgpuMgr := default (dict) (.Values.gpu).vgpuManager -}}
+{{- $imageCustomized := and (hasKey $vgpuMgr "image") (ne (default "" $vgpuMgr.image) "vgpu-manager") -}}
+{{- if or $vgpuMgr.repository $vgpuMgr.version $imageCustomized $vgpuMgr.imagePullSecrets -}}
+{{- $_ := set $gpuOperatorOverrides "vgpuManager" $vgpuMgr -}}
+{{- end -}}
+{{- if (((.Values.gpu).vgpuDeviceManager).enabled) -}}
+{{- $_ := set $gpuOperatorOverrides "vgpuDeviceManager" (dict "enabled" true) -}}
+{{- end -}}
+{{- if $gpuOperatorOverrides -}}
+{{- $_ := set $gpuOperatorComponents "gpu-operator" (dict "values" (dict "gpu-operator" $gpuOperatorOverrides)) -}}
+{{- end -}}
+{{- end -}}
+{{- if $gpuEnabled }}
+{{include "cozystack.platform.package" (list "cozystack.gpu-operator" $gpuVariant $ $gpuOperatorComponents) }}
+{{- end }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.hami" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.kamaji" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.capi-operator" $) }}

--- a/packages/core/platform/templates/bundles/iaas.yaml
+++ b/packages/core/platform/templates/bundles/iaas.yaml
@@ -35,6 +35,18 @@
 {{- end -}}
 {{- if $gpuEnabled }}
 {{- $_ := set $kubevirtValues "extraFeatureGates" (list "HostDevices") -}}
+{{- /*
+  Each .Values.gpu access is fully parenthesized — (((.Values.gpu).x).y) —
+  on purpose. Parenthesizing makes the field walk nil-safe: an operator may
+  null out the whole gpu block (gpu: null) or leave a sub-key blank
+  (permittedHostDevices: with no value parses to null), and Helm's
+  null-deletes-key coalescing then drops it from .Values. A bare
+  .Values.gpu.permittedHostDevices.pciHostDevices walk panics with
+  "nil pointer evaluating interface {}.permittedHostDevices" on the first
+  nil hop; the parenthesized form yields an invalid Value that `default`
+  absorbs instead. Do NOT flatten these into a bare dotted path — the
+  null-gpu cases in tests/bundles_gpu_kubevirt_wiring_test.yaml pin it.
+*/ -}}
 {{- $userPci := default (list) (((.Values.gpu).permittedHostDevices).pciHostDevices) -}}
 {{- $userMdev := default (list) (((.Values.gpu).permittedHostDevices).mediatedDevices) -}}
 {{- $userMdevConfig := default (dict) (.Values.gpu).mediatedDevicesConfiguration -}}

--- a/packages/core/platform/tests/bundles_gpu_kubevirt_wiring_test.yaml
+++ b/packages/core/platform/tests/bundles_gpu_kubevirt_wiring_test.yaml
@@ -1,0 +1,541 @@
+suite: bundles.iaas gpu-operator → kubevirt wiring
+templates:
+  - templates/bundles/iaas.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  - it: leaves cozystack.kubevirt with no extra gpu wiring when gpu-operator is not enabled
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+        enabledPackages: []
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - equal:
+          path: kind
+          value: Package
+      - notExists:
+          path: spec.components.kubevirt.values.extraFeatureGates
+      - notExists:
+          path: spec.components.kubevirt.values.permittedHostDevices
+      - notExists:
+          path: spec.components.kubevirt.values.mediatedDevicesConfiguration
+
+  - it: emits gpu-operator Package at default variant when only the package is enabled (no explicit variant override)
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+        enabledPackages:
+        - cozystack.gpu-operator
+    documentSelector:
+      path: metadata.name
+      value: cozystack.gpu-operator
+    asserts:
+      - equal:
+          path: spec.variant
+          value: default
+
+  - it: wires HostDevices gate plus NVIDIA passthrough pciHostDevices into the kubevirt component when gpu-operator is enabled at the default (passthrough) variant
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+        enabledPackages:
+        - cozystack.gpu-operator
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - contains:
+          path: spec.components.kubevirt.values.extraFeatureGates
+          content: HostDevices
+      - exists:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+      - contains:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+          content:
+            pciVendorSelector: "10DE:2335"
+            resourceName: nvidia.com/GH100_H200_SXM_141GB
+            externalResourceProvider: true
+      - notExists:
+          path: spec.components.kubevirt.values.permittedHostDevices.mediatedDevices
+      - notExists:
+          path: spec.components.kubevirt.values.mediatedDevicesConfiguration
+
+  - it: switches gpu-operator Package to vgpu variant when bundles.iaas.gpuOperatorVariant is "vgpu"
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: vgpu
+        enabledPackages:
+        - cozystack.gpu-operator
+    documentSelector:
+      path: metadata.name
+      value: cozystack.gpu-operator
+    asserts:
+      - equal:
+          path: spec.variant
+          value: vgpu
+
+  - it: wires HostDevices gate plus NVIDIA mediatedDevices and mediatedDevicesConfiguration when gpu-operator runs in vgpu variant and gpu.vgpuDeviceManager.enabled is true (Pascal-Ampere mdev path)
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: vgpu
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu:
+        vgpuDeviceManager:
+          enabled: true
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - contains:
+          path: spec.components.kubevirt.values.extraFeatureGates
+          content: HostDevices
+      - exists:
+          path: spec.components.kubevirt.values.permittedHostDevices.mediatedDevices
+      - notExists:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+      - exists:
+          path: spec.components.kubevirt.values.mediatedDevicesConfiguration.mediatedDeviceTypes
+
+  - it: suppresses the NVIDIA mdev defaults in vgpu variant when gpu.vgpuDeviceManager.enabled is false (default — Ada Lovelace SR-IOV path), so KubeVirt does not advertise resources that no daemon can ever create
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: vgpu
+        enabledPackages:
+        - cozystack.gpu-operator
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - contains:
+          path: spec.components.kubevirt.values.extraFeatureGates
+          content: HostDevices
+      - notExists:
+          path: spec.components.kubevirt.values.permittedHostDevices.mediatedDevices
+      - notExists:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+      - notExists:
+          path: spec.components.kubevirt.values.mediatedDevicesConfiguration
+
+  - it: appends user-supplied pciHostDevices to the NVIDIA defaults when gpu.replaceDefaults is false
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu:
+        permittedHostDevices:
+          pciHostDevices:
+          - pciVendorSelector: "1002:744C"
+            resourceName: amd.com/MI300X
+            externalResourceProvider: true
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - contains:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+          content:
+            pciVendorSelector: "10DE:2335"
+            resourceName: nvidia.com/GH100_H200_SXM_141GB
+            externalResourceProvider: true
+      - contains:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+          content:
+            pciVendorSelector: "1002:744C"
+            resourceName: amd.com/MI300X
+            externalResourceProvider: true
+
+  - it: drops NVIDIA defaults and keeps only the user list when gpu.replaceDefaults is true
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu:
+        replaceDefaults: true
+        permittedHostDevices:
+          pciHostDevices:
+          - pciVendorSelector: "1002:744C"
+            resourceName: amd.com/MI300X
+            externalResourceProvider: true
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - equal:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+          value:
+          - pciVendorSelector: "1002:744C"
+            resourceName: amd.com/MI300X
+            externalResourceProvider: true
+
+  - it: fails fast with a descriptive error when bundles.iaas.gpuOperatorVariant is set to an unsupported value
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: container
+        enabledPackages:
+        - cozystack.gpu-operator
+    asserts:
+      - failedTemplate:
+          errorMessage: 'bundles.iaas.gpuOperatorVariant must be "default" or "vgpu", got "container"'
+
+  - it: rejects an invalid gpuOperatorVariant even when gpu-operator is not enabled so the typo is caught at edit time, not at gpu-enable time
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: passthrough
+        enabledPackages: []
+    asserts:
+      - failedTemplate:
+          errorMessage: 'bundles.iaas.gpuOperatorVariant must be "default" or "vgpu", got "passthrough"'
+
+  - it: emits the gpu-operator Package without component overrides for the passthrough variant so vfio-pci defaults from the chart apply unchanged
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+        enabledPackages:
+        - cozystack.gpu-operator
+    documentSelector:
+      path: metadata.name
+      value: cozystack.gpu-operator
+    asserts:
+      - equal:
+          path: spec.variant
+          value: default
+      - notExists:
+          path: spec.components
+
+  - it: forwards vgpuManager image coordinates from gpu.vgpuManager into the gpu-operator Package CR when bundles.iaas.gpuOperatorVariant is vgpu
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: vgpu
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu:
+        vgpuManager:
+          repository: registry.example.com/nvidia
+          image: vgpu-manager-custom
+          version: "595.58.02-ubuntu24.04"
+          imagePullSecrets:
+          - nvidia-registry-secret
+    documentSelector:
+      path: metadata.name
+      value: cozystack.gpu-operator
+    asserts:
+      - equal:
+          path: spec.variant
+          value: vgpu
+      - equal:
+          path: spec.components.gpu-operator.values.gpu-operator.vgpuManager.repository
+          value: registry.example.com/nvidia
+      - equal:
+          path: spec.components.gpu-operator.values.gpu-operator.vgpuManager.image
+          value: vgpu-manager-custom
+      - equal:
+          path: spec.components.gpu-operator.values.gpu-operator.vgpuManager.version
+          value: "595.58.02-ubuntu24.04"
+      - equal:
+          path: spec.components.gpu-operator.values.gpu-operator.vgpuManager.imagePullSecrets
+          value:
+          - nvidia-registry-secret
+
+  - it: forwards gpu.vgpuManager.imagePullSecrets even when repository/version/image are left at the platform defaults — private registries with the chart-default tag are a real config and must not be silently dropped
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: vgpu
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu:
+        vgpuManager:
+          imagePullSecrets:
+          - nvidia-registry-secret
+    documentSelector:
+      path: metadata.name
+      value: cozystack.gpu-operator
+    asserts:
+      - equal:
+          path: spec.components.gpu-operator.values.gpu-operator.vgpuManager.imagePullSecrets
+          value:
+          - nvidia-registry-secret
+
+  - it: enables nvidia vgpu-device-manager in the gpu-operator Package CR when gpu.vgpuDeviceManager.enabled is true so mediated devices actually materialize on the node
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: vgpu
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu:
+        vgpuDeviceManager:
+          enabled: true
+    documentSelector:
+      path: metadata.name
+      value: cozystack.gpu-operator
+    asserts:
+      - equal:
+          path: spec.components.gpu-operator.values.gpu-operator.vgpuDeviceManager.enabled
+          value: true
+
+  - it: leaves the gpu-operator Package without vgpuManager overrides when gpu.vgpuManager.repository and .version are both blank — the operator can still hand-craft a Package CR override later
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: vgpu
+        enabledPackages:
+        - cozystack.gpu-operator
+    documentSelector:
+      path: metadata.name
+      value: cozystack.gpu-operator
+    asserts:
+      - equal:
+          path: spec.variant
+          value: vgpu
+      - notExists:
+          path: spec.components.gpu-operator
+
+  - it: propagates resources.cpuAllocationRatio into the kubevirt component values even when gpu-operator is not enabled
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+        enabledPackages: []
+      resources:
+        cpuAllocationRatio: 7
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - equal:
+          path: spec.components.kubevirt.values.cpuAllocationRatio
+          value: 7
+
+  - it: appends user-supplied pciHostDevices in vgpu mode so post-kubevirt#16890 SR-IOV vGPU VFs can be advertised alongside the platform mediated defaults
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: vgpu
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu:
+        vgpuDeviceManager:
+          enabled: true
+        permittedHostDevices:
+          pciHostDevices:
+          - pciVendorSelector: "10DE:26B9"
+            resourceName: nvidia.com/L40S-24Q
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - exists:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+      - contains:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+          content:
+            pciVendorSelector: "10DE:26B9"
+            resourceName: nvidia.com/L40S-24Q
+      - exists:
+          path: spec.components.kubevirt.values.permittedHostDevices.mediatedDevices
+
+  - it: appends user-supplied mediatedDevices in vgpu mode on top of the platform NVIDIA defaults when the device manager is enabled
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: vgpu
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu:
+        vgpuDeviceManager:
+          enabled: true
+        permittedHostDevices:
+          mediatedDevices:
+          - mdevNameSelector: NVIDIA H100-80C
+            resourceName: nvidia.com/H100-80C
+            externalResourceProvider: true
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - contains:
+          path: spec.components.kubevirt.values.permittedHostDevices.mediatedDevices
+          content:
+            mdevNameSelector: NVIDIA A100-40C
+            resourceName: nvidia.com/A100-40C
+            externalResourceProvider: true
+      - contains:
+          path: spec.components.kubevirt.values.permittedHostDevices.mediatedDevices
+          content:
+            mdevNameSelector: NVIDIA H100-80C
+            resourceName: nvidia.com/H100-80C
+            externalResourceProvider: true
+
+  - it: drops the NVIDIA vgpu defaults and keeps only the user mediatedDevices / mediatedDevicesConfiguration when gpu.replaceDefaults is true
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: vgpu
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu:
+        replaceDefaults: true
+        permittedHostDevices:
+          mediatedDevices:
+          - mdevNameSelector: NVIDIA H100-80C
+            resourceName: nvidia.com/H100-80C
+            externalResourceProvider: true
+        mediatedDevicesConfiguration:
+          mediatedDeviceTypes:
+          - nvidia-1234
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - equal:
+          path: spec.components.kubevirt.values.permittedHostDevices.mediatedDevices
+          value:
+          - mdevNameSelector: NVIDIA H100-80C
+            resourceName: nvidia.com/H100-80C
+            externalResourceProvider: true
+      - equal:
+          path: spec.components.kubevirt.values.mediatedDevicesConfiguration.mediatedDeviceTypes
+          value:
+          - nvidia-1234
+
+  - it: skips gpu wiring when cozystack.gpu-operator appears in both enabledPackages and disabledPackages — disabled wins, mirroring the optional-package helper
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+        enabledPackages:
+        - cozystack.gpu-operator
+        disabledPackages:
+        - cozystack.gpu-operator
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - notExists:
+          path: spec.components.kubevirt.values.extraFeatureGates
+      - notExists:
+          path: spec.components.kubevirt.values.permittedHostDevices
+      - notExists:
+          path: spec.components.kubevirt.values.mediatedDevicesConfiguration
+
+  - it: ignores user gpu.mediatedDevices and gpu.mediatedDevicesConfiguration in the passthrough variant — vGPU-only knobs must not leak into a vfio-pci CR
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu:
+        permittedHostDevices:
+          mediatedDevices:
+          - mdevNameSelector: NVIDIA A100-40C
+            resourceName: nvidia.com/A100-40C
+            externalResourceProvider: true
+        mediatedDevicesConfiguration:
+          mediatedDeviceTypes:
+          - nvidia-559
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - exists:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+      - notExists:
+          path: spec.components.kubevirt.values.permittedHostDevices.mediatedDevices
+      - notExists:
+          path: spec.components.kubevirt.values.mediatedDevicesConfiguration

--- a/packages/core/platform/tests/bundles_gpu_kubevirt_wiring_test.yaml
+++ b/packages/core/platform/tests/bundles_gpu_kubevirt_wiring_test.yaml
@@ -95,7 +95,7 @@ tests:
           path: spec.variant
           value: vgpu
 
-  - it: wires HostDevices gate plus NVIDIA mediatedDevices and mediatedDevicesConfiguration when gpu-operator runs in vgpu variant and gpu.vgpuDeviceManager.enabled is true (Pascal-Ampere mdev path)
+  - it: exposes NVIDIA mediatedDevices by name in vgpu variant when gpu.vgpuDeviceManager.enabled is true, and does NOT default a numeric mediatedDevicesConfiguration (mdev creation is delegated to the vGPU Device Manager)
     set:
       bundles:
         system:
@@ -120,8 +120,11 @@ tests:
           path: spec.components.kubevirt.values.permittedHostDevices.mediatedDevices
       - notExists:
           path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
-      - exists:
-          path: spec.components.kubevirt.values.mediatedDevicesConfiguration.mediatedDeviceTypes
+      # No numeric mediatedDeviceTypes is shipped by default — those ids are
+      # per-(SKU, driver) sysfs indices, and the vGPU Device Manager already
+      # creates the mdevs by name.
+      - notExists:
+          path: spec.components.kubevirt.values.mediatedDevicesConfiguration
 
   - it: suppresses the NVIDIA mdev defaults in vgpu variant when gpu.vgpuDeviceManager.enabled is false (default — Ada Lovelace SR-IOV path), so KubeVirt does not advertise resources that no daemon can ever create
     set:
@@ -665,3 +668,36 @@ tests:
             pciVendorSelector: "10DE:1DB1"
             resourceName: nvidia.com/GV100_V100_SXM2_32GB
             externalResourceProvider: true
+
+  - it: still forwards a user-supplied gpu.mediatedDevicesConfiguration into the CR in vgpu mode (the override escape hatch survives the name-based default), alongside the name-based mediatedDevices defaults
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: vgpu
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu:
+        vgpuDeviceManager:
+          enabled: true
+        mediatedDevicesConfiguration:
+          mediatedDeviceTypes:
+          - nvidia-473
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      # name-based exposure defaults still flow in...
+      - contains:
+          path: spec.components.kubevirt.values.permittedHostDevices.mediatedDevices
+          content:
+            mdevNameSelector: NVIDIA A100-40C
+            resourceName: nvidia.com/A100-40C
+            externalResourceProvider: true
+      # ...and the operator's explicit numeric config is honoured.
+      - contains:
+          path: spec.components.kubevirt.values.mediatedDevicesConfiguration.mediatedDeviceTypes
+          content: nvidia-473

--- a/packages/core/platform/tests/bundles_gpu_kubevirt_wiring_test.yaml
+++ b/packages/core/platform/tests/bundles_gpu_kubevirt_wiring_test.yaml
@@ -605,3 +605,63 @@ tests:
           content: HostDevices
       - exists:
           path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+
+  - it: advertises GPUs under the exact resourceName the sandbox plugin generates from pci.ids (uppercase, with Tesla/GL/PCIE tokens) — the slugs that actually match the node
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+        enabledPackages:
+        - cozystack.gpu-operator
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      # Turing T4 — pci.ids "TU104GL [Tesla T4]" → TU104GL_TESLA_T4 (the
+      # plugin keeps the Tesla brand and upper-cases). The tidy TU104GL_T4
+      # form never matches a vanilla plugin.
+      - contains:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+          content:
+            pciVendorSelector: "10DE:1EB8"
+            resourceName: nvidia.com/TU104GL_TESLA_T4
+            externalResourceProvider: true
+      # Ampere A30 — pci.ids "GA100GL [A30 PCIe]" → GA100GL_A30_PCIE (GL die
+      # suffix and PCIE form factor are part of the slug).
+      - contains:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+          content:
+            pciVendorSelector: "10DE:20B7"
+            resourceName: nvidia.com/GA100GL_A30_PCIE
+            externalResourceProvider: true
+      # V100 SXM2 — 1DB1 is the 16GB part, 1DB5 the 32GB part (distinct
+      # device IDs); slug "GV100GL [Tesla V100 SXM2 NNGB]" → GV100GL_TESLA_...
+      - contains:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+          content:
+            pciVendorSelector: "10DE:1DB1"
+            resourceName: nvidia.com/GV100GL_TESLA_V100_SXM2_16GB
+            externalResourceProvider: true
+      - contains:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+          content:
+            pciVendorSelector: "10DE:1DB5"
+            resourceName: nvidia.com/GV100GL_TESLA_V100_SXM2_32GB
+            externalResourceProvider: true
+      # Regression guards: the tidy/short forms that do NOT match a vanilla
+      # plugin must never reappear.
+      - notContains:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+          content:
+            pciVendorSelector: "10DE:1EB8"
+            resourceName: nvidia.com/TU104GL_T4
+            externalResourceProvider: true
+      - notContains:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+          content:
+            pciVendorSelector: "10DE:1DB1"
+            resourceName: nvidia.com/GV100_V100_SXM2_32GB
+            externalResourceProvider: true

--- a/packages/core/platform/tests/bundles_gpu_kubevirt_wiring_test.yaml
+++ b/packages/core/platform/tests/bundles_gpu_kubevirt_wiring_test.yaml
@@ -539,3 +539,69 @@ tests:
           path: spec.components.kubevirt.values.permittedHostDevices.mediatedDevices
       - notExists:
           path: spec.components.kubevirt.values.mediatedDevicesConfiguration
+
+  - it: renders the passthrough wiring without a nil-pointer error when the whole gpu block is set to null and gpu-operator is enabled
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu: null
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - contains:
+          path: spec.components.kubevirt.values.extraFeatureGates
+          content: HostDevices
+      - exists:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices
+
+  - it: renders the vgpu wiring without a nil-pointer error when the whole gpu block is set to null and gpu-operator runs in the vgpu variant
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+          gpuOperatorVariant: vgpu
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu: null
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - contains:
+          path: spec.components.kubevirt.values.extraFeatureGates
+          content: HostDevices
+
+  - it: renders without a nil-pointer error when gpu sub-keys are empty (null) YAML keys
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+        enabledPackages:
+        - cozystack.gpu-operator
+      gpu:
+        permittedHostDevices: null
+        mediatedDevicesConfiguration: null
+        vgpuDeviceManager: null
+        vgpuManager: null
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - contains:
+          path: spec.components.kubevirt.values.extraFeatureGates
+          content: HostDevices
+      - exists:
+          path: spec.components.kubevirt.values.permittedHostDevices.pciHostDevices

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -348,13 +348,17 @@ gpu:
     #     resourceName: nvidia.com/A100-40C
     #     externalResourceProvider: true
     mediatedDevices: []
-  # mediatedDevicesConfiguration drives the vGPU profile auto-creation loop
-  # (vgpu variant only). Helm's mergeOverwrite semantics apply: a top-level
-  # key the user supplies REPLACES the platform-default value for that key
-  # rather than appending — so user mediatedDeviceTypes: [...] overrides the
-  # platform's eight defaults entirely. Combine with replaceDefaults: true
-  # when both this and permittedHostDevices.mediatedDevices should be wiped
-  # together. Shape matches KubeVirt's MediatedDevicesConfiguration:
+  # mediatedDevicesConfiguration makes KubeVirt itself create mdevs on the
+  # node (vgpu variant only). The platform ships NO default here: mdev
+  # creation is delegated to the GPU Operator's vGPU Device Manager
+  # (name-based), and the mediatedDeviceTypes ids below are numeric
+  # nvidia-NNN sysfs indices that vary per GPU SKU and driver branch — no
+  # value is portable, so look yours up on the host
+  # (/sys/bus/pci/devices/<BDF>/mdev_supported_types/*/name) before setting
+  # it. Supplying it opts into KubeVirt-driven creation on top of the
+  # Device Manager. Helm's mergeOverwrite semantics apply: a top-level key
+  # you supply REPLACES that key wholesale rather than appending. Shape
+  # matches KubeVirt's MediatedDevicesConfiguration:
   #   mediatedDeviceTypes:
   #     - nvidia-740
   #   nodeMediatedDeviceTypes:
@@ -389,10 +393,10 @@ gpu:
   # DaemonSet crash-loops with "no parent devices found". Flip to true
   # on Pascal–Ampere clusters; leave false on Ada/Blackwell and supply
   # SR-IOV VFs via .gpu.permittedHostDevices.pciHostDevices instead.
-  # When true the platform also lets the default mediatedDevices /
-  # mediatedDevicesConfiguration table from
-  # files/gpu-vgpu-defaults.yaml flow into the KubeVirt CR; when false
-  # those defaults are suppressed (advertising mediated resources that
-  # nothing can ever allocate is a worse footgun than missing entries).
+  # When true the platform also lets the default name-based mediatedDevices
+  # exposure list from files/gpu-vgpu-defaults.yaml flow into the KubeVirt
+  # CR; when false those defaults are suppressed (advertising mediated
+  # resources that nothing can ever allocate is a worse footgun than
+  # missing entries).
   vgpuDeviceManager:
     enabled: false

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -14,6 +14,17 @@ bundles:
     variant: "isp-full" # Options: "isp-full", "isp-full-generic", "isp-hosted", "distro-full"
   iaas:
     enabled: false
+    # gpu-operator variant selector — applies when cozystack.gpu-operator is
+    # in bundles.enabledPackages. "default" runs the vfio-pci passthrough
+    # stack (whole GPU → one VM); "vgpu" runs the vGPU Manager stack. The
+    # platform mirrors this into the KubeVirt CR: passthrough auto-wires the
+    # HostDevices feature gate plus a default permittedHostDevices.pciHostDevices
+    # table covering common NVIDIA datacenter GPUs (vendor 10DE); vgpu
+    # auto-wires permittedHostDevices.mediatedDevices plus a starter
+    # mediatedDevicesConfiguration. Operators with additional or non-NVIDIA
+    # cards extend the defaults via gpu.permittedHostDevices /
+    # gpu.mediatedDevicesConfiguration / gpu.replaceDefaults below.
+    gpuOperatorVariant: default
   paas:
     enabled: false
   naas:
@@ -307,3 +318,81 @@ resources:
   cpuAllocationRatio: 10
   memoryAllocationRatio: 1
   ephemeralStorageAllocationRatio: 40
+# GPU host-device wiring for VirtualMachine workloads. Auto-injected into the
+# KubeVirt CR's permittedHostDevices when bundles.enabledPackages contains
+# cozystack.gpu-operator. Without it the admission webhook rejects any VM
+# that references a GPU host-device by resourceName.
+gpu:
+  # When false (default), the lists below are appended to the platform's
+  # NVIDIA defaults. When true, the user lists fully replace the defaults
+  # — use this for clusters with only non-NVIDIA accelerators or where a
+  # strictly curated allowlist is required.
+  replaceDefaults: false
+  permittedHostDevices:
+    # PCI passthrough devices. Always rendered when non-empty regardless of
+    # gpuOperatorVariant — pciHostDevices covers both the vfio-pci passthrough
+    # path (default variant) and the post-kubevirt#16890 SR-IOV vGPU path
+    # (vgpu variant on Ada Lovelace / Blackwell, where VFs are advertised
+    # via pciHostDevices, not via mediatedDevices). Default-table coverage:
+    # H100, H200, A100 PCIe/SXM, A40, A30, A10, L40, L40S, L4, T4, V100,
+    # V100S (PCI vendor 10DE). Item shape matches KubeVirt's pciHostDevices:
+    #   - pciVendorSelector: "10DE:2335"
+    #     resourceName: nvidia.com/GH100_H200_SXM_141GB
+    #     externalResourceProvider: true
+    pciHostDevices: []
+    # Mediated (mdev) vGPU devices — pre-kubevirt#16890 path used by
+    # Pascal–Ampere on the legacy mdev driver branch. Default-table coverage:
+    # A100-40C/80C, A40-24Q/48Q, A30-24C, A10-24Q, V100D-32C, T4-16Q.
+    # Item shape matches KubeVirt's mediatedDevices:
+    #   - mdevNameSelector: NVIDIA A100-40C
+    #     resourceName: nvidia.com/A100-40C
+    #     externalResourceProvider: true
+    mediatedDevices: []
+  # mediatedDevicesConfiguration drives the vGPU profile auto-creation loop
+  # (vgpu variant only). Helm's mergeOverwrite semantics apply: a top-level
+  # key the user supplies REPLACES the platform-default value for that key
+  # rather than appending — so user mediatedDeviceTypes: [...] overrides the
+  # platform's eight defaults entirely. Combine with replaceDefaults: true
+  # when both this and permittedHostDevices.mediatedDevices should be wiped
+  # together. Shape matches KubeVirt's MediatedDevicesConfiguration:
+  #   mediatedDeviceTypes:
+  #     - nvidia-740
+  #   nodeMediatedDeviceTypes:
+  #     - nodeSelector:
+  #         nvidia.com/gpu.product: NVIDIA-L40S
+  #       mediatedDeviceTypes:
+  #         - nvidia-740
+  mediatedDevicesConfiguration: {}
+  # NVIDIA vGPU Manager container image (vgpu variant only). The .run is
+  # proprietary, not redistributable, so the platform cannot ship default
+  # tags — the operator builds the container per
+  # https://github.com/NVIDIA/gpu-driver-container and supplies the
+  # private-registry coordinates here. The platform forwards these as
+  # components.gpu-operator.values.gpu-operator.vgpuManager to the emitted
+  # cozystack.gpu-operator Package CR when bundles.iaas.gpuOperatorVariant
+  # is vgpu. Forwarding triggers when ANY of repository, version, image
+  # (non-default), or imagePullSecrets is set — partial values still
+  # propagate so a private-registry-with-default-tag setup is not
+  # silently dropped.
+  vgpuManager:
+    repository: ""
+    image: vgpu-manager
+    version: ""
+    imagePullSecrets: []
+  # vGPU Device Manager controls whether nvidia.com's
+  # `vgpu-device-manager` DaemonSet is deployed (vgpu variant only). The
+  # DaemonSet walks /sys/class/mdev_bus/ to auto-create mediated devices
+  # from the mediatedDeviceTypes list. Default-off because that path
+  # only exists on Pascal–Ampere (V100, T4, A100, A30, …) with the mdev
+  # driver branch — on Ada Lovelace / Blackwell (L4, L40, L40S, B100)
+  # with the vGPU 17/20 driver branch the directory is missing and the
+  # DaemonSet crash-loops with "no parent devices found". Flip to true
+  # on Pascal–Ampere clusters; leave false on Ada/Blackwell and supply
+  # SR-IOV VFs via .gpu.permittedHostDevices.pciHostDevices instead.
+  # When true the platform also lets the default mediatedDevices /
+  # mediatedDevicesConfiguration table from
+  # files/gpu-vgpu-defaults.yaml flow into the KubeVirt CR; when false
+  # those defaults are suppressed (advertising mediated resources that
+  # nothing can ever allocate is a worse footgun than missing entries).
+  vgpuDeviceManager:
+    enabled: false

--- a/packages/system/kubevirt/Makefile
+++ b/packages/system/kubevirt/Makefile
@@ -5,6 +5,12 @@ include ../../../hack/package.mk
 
 test:
 	helm unittest .
+	./tests/update_idempotency_test.sh
+
+# File the parameterization patches are applied to. Overridable so the
+# idempotency test can drive `update` against a throwaway copy instead of the
+# in-tree CR.
+CR_FILE ?= templates/kubevirt-cr.yaml
 
 # Re-apply the cozystack-specific parameterization on top of the in-tree
 # templates/kubevirt-cr.yaml. This target does NOT download anything from
@@ -21,24 +27,32 @@ test:
 #   1. Operator inspects the new upstream release notes for spec changes
 #      that affect the cozystack-managed fields listed above.
 #   2. Operator hand-merges the new fields into templates/kubevirt-cr.yaml.
-#   3. Operator runs `make update` to re-apply the four cozystack
+#   3. Operator runs `make update` to re-apply the five cozystack
 #      parameterization sed patches in case they were lost during the
 #      hand-merge.
 #
 # GNU sed is required — on macOS run under a Linux container or via gsed.
 update:
-	@test -f templates/kubevirt-cr.yaml || { echo "ERROR: templates/kubevirt-cr.yaml not found — drop a hand-merged upstream CR there first" >&2; exit 1; }
+	@test -f $(CR_FILE) || { echo "ERROR: $(CR_FILE) not found — drop a hand-merged upstream CR there first" >&2; exit 1; }
 	@# Idempotent — each sed only inserts if the matching cozystack patch
 	@# isn't already present in the file.
-	grep -q '^  namespace: cozy-kubevirt$$' templates/kubevirt-cr.yaml || sed -i 's/namespace: kubevirt/namespace: cozy-kubevirt/g' templates/kubevirt-cr.yaml
-	grep -q '{{- if .Values.cpuAllocationRatio }}' templates/kubevirt-cr.yaml || sed -i '/^    developerConfiguration:$$/a\      {{- if .Values.cpuAllocationRatio }}\n      cpuAllocationRatio: {{ .Values.cpuAllocationRatio }}\n      {{- end }}' templates/kubevirt-cr.yaml
-	grep -q '{{- range .Values.extraFeatureGates }}' templates/kubevirt-cr.yaml || sed -i '/^      - VMExport$$/a\      {{- range .Values.extraFeatureGates }}\n      - {{ . }}\n      {{- end }}' templates/kubevirt-cr.yaml
-	grep -q '{{- with .Values.permittedHostDevices }}' templates/kubevirt-cr.yaml || sed -i '/^    evictionStrategy:/i\    {{- with .Values.permittedHostDevices }}\n    permittedHostDevices:\n      {{- toYaml . | nindent 6 }}\n    {{- end }}\n    {{- with .Values.mediatedDevicesConfiguration }}\n    mediatedDevicesConfiguration:\n      {{- toYaml . | nindent 6 }}\n    {{- end }}' templates/kubevirt-cr.yaml
+	grep -q '^  namespace: cozy-kubevirt$$' $(CR_FILE) || sed -i 's/namespace: kubevirt/namespace: cozy-kubevirt/g' $(CR_FILE)
+	grep -q '{{- if .Values.cpuAllocationRatio }}' $(CR_FILE) || sed -i '/^    developerConfiguration:$$/a\      {{- if .Values.cpuAllocationRatio }}\n      cpuAllocationRatio: {{ .Values.cpuAllocationRatio }}\n      {{- end }}' $(CR_FILE)
+	grep -q '{{- range .Values.extraFeatureGates }}' $(CR_FILE) || sed -i '/^      - VMExport$$/a\      {{- range .Values.extraFeatureGates }}\n      - {{ . }}\n      {{- end }}' $(CR_FILE)
+	@# permittedHostDevices and mediatedDevicesConfiguration are guarded
+	@# independently: a hand-merge may drop one while keeping the other, and
+	@# each must self-heal on its own. A single guard over both would skip the
+	@# second insert whenever the first is still present, then trip the
+	@# sanity-check tail below.
+	grep -q '{{- with .Values.permittedHostDevices }}' $(CR_FILE) || sed -i '/^    evictionStrategy:/i\    {{- with .Values.permittedHostDevices }}\n    permittedHostDevices:\n      {{- toYaml . | nindent 6 }}\n    {{- end }}' $(CR_FILE)
+	grep -q '{{- with .Values.mediatedDevicesConfiguration }}' $(CR_FILE) || sed -i '/^    evictionStrategy:/i\    {{- with .Values.mediatedDevicesConfiguration }}\n    mediatedDevicesConfiguration:\n      {{- toYaml . | nindent 6 }}\n    {{- end }}' $(CR_FILE)
 	@# Sanity-check: every cozystack patch MUST end up in the file. If the
-	@# hand-merge step lost an anchor (developerConfiguration:, - VMExport,
-	@# evictionStrategy:) the sed silently no-ops and the chart ships without
-	@# the parameterization. Fail loudly so the operator hand-re-applies it.
-	@grep -q '{{- if .Values.cpuAllocationRatio }}' templates/kubevirt-cr.yaml || { echo "ERROR: cpuAllocationRatio anchor 'developerConfiguration:' not found" >&2; exit 1; }
-	@grep -q '{{- range .Values.extraFeatureGates }}' templates/kubevirt-cr.yaml || { echo "ERROR: extraFeatureGates anchor '- VMExport' not found" >&2; exit 1; }
-	@grep -q '{{- with .Values.permittedHostDevices }}' templates/kubevirt-cr.yaml || { echo "ERROR: permittedHostDevices anchor 'evictionStrategy:' not found" >&2; exit 1; }
-	@grep -q '{{- with .Values.mediatedDevicesConfiguration }}' templates/kubevirt-cr.yaml || { echo "ERROR: mediatedDevicesConfiguration anchor 'evictionStrategy:' not found" >&2; exit 1; }
+	@# hand-merge step moved or renamed an anchor (developerConfiguration:,
+	@# - VMExport, evictionStrategy:) the sed silently no-ops and the chart
+	@# ships without the parameterization. Each message names the directive
+	@# that failed to land and the anchor its insert keys off, so the operator
+	@# knows which line to restore before re-running.
+	@grep -q '{{- if .Values.cpuAllocationRatio }}' $(CR_FILE) || { echo "ERROR: directive '{{- if .Values.cpuAllocationRatio }}' not inserted — restore the 'developerConfiguration:' anchor in $(CR_FILE) and re-run" >&2; exit 1; }
+	@grep -q '{{- range .Values.extraFeatureGates }}' $(CR_FILE) || { echo "ERROR: directive '{{- range .Values.extraFeatureGates }}' not inserted — restore the '- VMExport' anchor in $(CR_FILE) and re-run" >&2; exit 1; }
+	@grep -q '{{- with .Values.permittedHostDevices }}' $(CR_FILE) || { echo "ERROR: directive '{{- with .Values.permittedHostDevices }}' not inserted — restore the 'evictionStrategy:' anchor in $(CR_FILE) and re-run" >&2; exit 1; }
+	@grep -q '{{- with .Values.mediatedDevicesConfiguration }}' $(CR_FILE) || { echo "ERROR: directive '{{- with .Values.mediatedDevicesConfiguration }}' not inserted — restore the 'evictionStrategy:' anchor in $(CR_FILE) and re-run" >&2; exit 1; }

--- a/packages/system/kubevirt/Makefile
+++ b/packages/system/kubevirt/Makefile
@@ -3,9 +3,42 @@ export NAMESPACE=cozy-$(NAME)
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
+# Re-apply the cozystack-specific parameterization on top of the in-tree
+# templates/kubevirt-cr.yaml. This target does NOT download anything from
+# upstream — the live KubeVirt CR distributed by upstream is a near-empty
+# stub (featureGates: [], customizeComponents: {}, imagePullPolicy, empty
+# workloadUpdateStrategy) and cannot stand in for the in-tree file, which
+# carries cozystack-specific defaults (cozy-kubevirt namespace, full
+# featureGates list including LiveMigration / AutoResourceLimitsGate /
+# CPUManager / GPU / VMExport, evictionStrategy: LiveMigrate,
+# workloadUpdateMethods, vmRolloutStrategy, monitorNamespace, etc.) that
+# have been hand-curated over multiple cozystack releases.
+#
+# To refresh from a newer upstream KubeVirt:
+#   1. Operator inspects the new upstream release notes for spec changes
+#      that affect the cozystack-managed fields listed above.
+#   2. Operator hand-merges the new fields into templates/kubevirt-cr.yaml.
+#   3. Operator runs `make update` to re-apply the four cozystack
+#      parameterization sed patches in case they were lost during the
+#      hand-merge.
+#
+# GNU sed is required — on macOS run under a Linux container or via gsed.
 update:
-	rm -rf templates
-	mkdir templates
-	export RELEASE=$$(curl https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirt/stable.txt) && \
-	wget https://github.com/kubevirt/kubevirt/releases/download/$${RELEASE}/kubevirt-cr.yaml -O templates/kubevirt-cr.yaml
-	sed -i 's/namespace: kubevirt/namespace: cozy-kubevirt/g' templates/kubevirt-cr.yaml
+	@test -f templates/kubevirt-cr.yaml || { echo "ERROR: templates/kubevirt-cr.yaml not found — drop a hand-merged upstream CR there first" >&2; exit 1; }
+	@# Idempotent — each sed only inserts if the matching cozystack patch
+	@# isn't already present in the file.
+	grep -q '^  namespace: cozy-kubevirt$$' templates/kubevirt-cr.yaml || sed -i 's/namespace: kubevirt/namespace: cozy-kubevirt/g' templates/kubevirt-cr.yaml
+	grep -q '{{- if .Values.cpuAllocationRatio }}' templates/kubevirt-cr.yaml || sed -i '/^    developerConfiguration:$$/a\      {{- if .Values.cpuAllocationRatio }}\n      cpuAllocationRatio: {{ .Values.cpuAllocationRatio }}\n      {{- end }}' templates/kubevirt-cr.yaml
+	grep -q '{{- range .Values.extraFeatureGates }}' templates/kubevirt-cr.yaml || sed -i '/^      - VMExport$$/a\      {{- range .Values.extraFeatureGates }}\n      - {{ . }}\n      {{- end }}' templates/kubevirt-cr.yaml
+	grep -q '{{- with .Values.permittedHostDevices }}' templates/kubevirt-cr.yaml || sed -i '/^    evictionStrategy:/i\    {{- with .Values.permittedHostDevices }}\n    permittedHostDevices:\n      {{- toYaml . | nindent 6 }}\n    {{- end }}\n    {{- with .Values.mediatedDevicesConfiguration }}\n    mediatedDevicesConfiguration:\n      {{- toYaml . | nindent 6 }}\n    {{- end }}' templates/kubevirt-cr.yaml
+	@# Sanity-check: every cozystack patch MUST end up in the file. If the
+	@# hand-merge step lost an anchor (developerConfiguration:, - VMExport,
+	@# evictionStrategy:) the sed silently no-ops and the chart ships without
+	@# the parameterization. Fail loudly so the operator hand-re-applies it.
+	@grep -q '{{- if .Values.cpuAllocationRatio }}' templates/kubevirt-cr.yaml || { echo "ERROR: cpuAllocationRatio anchor 'developerConfiguration:' not found" >&2; exit 1; }
+	@grep -q '{{- range .Values.extraFeatureGates }}' templates/kubevirt-cr.yaml || { echo "ERROR: extraFeatureGates anchor '- VMExport' not found" >&2; exit 1; }
+	@grep -q '{{- with .Values.permittedHostDevices }}' templates/kubevirt-cr.yaml || { echo "ERROR: permittedHostDevices anchor 'evictionStrategy:' not found" >&2; exit 1; }
+	@grep -q '{{- with .Values.mediatedDevicesConfiguration }}' templates/kubevirt-cr.yaml || { echo "ERROR: mediatedDevicesConfiguration anchor 'evictionStrategy:' not found" >&2; exit 1; }

--- a/packages/system/kubevirt/templates/kubevirt-cr.yaml
+++ b/packages/system/kubevirt/templates/kubevirt-cr.yaml
@@ -21,6 +21,17 @@ spec:
       - CPUManager
       - GPU
       - VMExport
+      {{- range .Values.extraFeatureGates }}
+      - {{ . }}
+      {{- end }}
+    {{- with .Values.permittedHostDevices }}
+    permittedHostDevices:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.mediatedDevicesConfiguration }}
+    mediatedDevicesConfiguration:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     evictionStrategy: LiveMigrate
     virtualMachineOptions:
       disableSerialConsoleLog: {}

--- a/packages/system/kubevirt/tests/kubevirt_cr_test.yaml
+++ b/packages/system/kubevirt/tests/kubevirt_cr_test.yaml
@@ -1,0 +1,94 @@
+suite: cozy-kubevirt CR parameterization
+templates:
+  - templates/kubevirt-cr.yaml
+release:
+  name: kubevirt
+  namespace: cozy-kubevirt
+tests:
+  - it: keeps the upstream default feature-gate set and omits permittedHostDevices when values are empty
+    asserts:
+      - equal:
+          path: spec.configuration.developerConfiguration.featureGates
+          value:
+          - HotplugVolumes
+          - ExpandDisks
+          - LiveMigration
+          - AutoResourceLimitsGate
+          - CPUManager
+          - GPU
+          - VMExport
+      - notExists:
+          path: spec.configuration.developerConfiguration.cpuAllocationRatio
+      - notExists:
+          path: spec.configuration.permittedHostDevices
+      - notExists:
+          path: spec.configuration.mediatedDevicesConfiguration
+
+  - it: emits cpuAllocationRatio under developerConfiguration when set
+    set:
+      cpuAllocationRatio: 10
+    asserts:
+      - equal:
+          path: spec.configuration.developerConfiguration.cpuAllocationRatio
+          value: 10
+
+  - it: appends extraFeatureGates after the static defaults
+    set:
+      extraFeatureGates:
+      - HostDevices
+      - WorkloadEncryptionSEV
+    asserts:
+      - equal:
+          path: spec.configuration.developerConfiguration.featureGates
+          value:
+          - HotplugVolumes
+          - ExpandDisks
+          - LiveMigration
+          - AutoResourceLimitsGate
+          - CPUManager
+          - GPU
+          - VMExport
+          - HostDevices
+          - WorkloadEncryptionSEV
+
+  - it: renders permittedHostDevices verbatim from the values block
+    set:
+      permittedHostDevices:
+        pciHostDevices:
+        - pciVendorSelector: "10DE:2335"
+          resourceName: nvidia.com/GH100_H200_SXM_141GB
+          externalResourceProvider: true
+        - pciVendorSelector: "10DE:26B9"
+          resourceName: nvidia.com/AD102GL_L40S
+          externalResourceProvider: true
+    asserts:
+      - exists:
+          path: spec.configuration.permittedHostDevices.pciHostDevices
+      - equal:
+          path: spec.configuration.permittedHostDevices.pciHostDevices[0].resourceName
+          value: nvidia.com/GH100_H200_SXM_141GB
+      - equal:
+          path: spec.configuration.permittedHostDevices.pciHostDevices[0].externalResourceProvider
+          value: true
+      - equal:
+          path: spec.configuration.permittedHostDevices.pciHostDevices[1].pciVendorSelector
+          value: "10DE:26B9"
+
+  - it: renders mediatedDevices and mediatedDevicesConfiguration for the vGPU shape
+    set:
+      permittedHostDevices:
+        mediatedDevices:
+        - mdevNameSelector: NVIDIA L40S-24Q
+          resourceName: nvidia.com/L40S-24Q
+          externalResourceProvider: true
+      mediatedDevicesConfiguration:
+        mediatedDeviceTypes:
+        - nvidia-740
+    asserts:
+      - equal:
+          path: spec.configuration.permittedHostDevices.mediatedDevices[0].mdevNameSelector
+          value: NVIDIA L40S-24Q
+      - equal:
+          path: spec.configuration.mediatedDevicesConfiguration.mediatedDeviceTypes
+          value:
+          - nvidia-740

--- a/packages/system/kubevirt/tests/update_idempotency_test.sh
+++ b/packages/system/kubevirt/tests/update_idempotency_test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Regression test for the `make update` idempotency contract.
+#
+# Each cozystack parameterization patch must be reinserted INDEPENDENTLY of the
+# others. A hand-merge from a newer upstream KubeVirt CR may drop one directive
+# while keeping the rest; `make update` must self-heal whichever directive is
+# missing rather than fail. The trap this pins: a single guard that gates the
+# insertion of two directives at once silently skips the second one when the
+# first is still present, and the sanity-check tail then aborts the target.
+set -euo pipefail
+
+# The update target relies on GNU sed (`sed -i` with `a\`/`i\` insert syntax and
+# the range-delete used below). Skip on BSD sed so the suite stays green on a
+# stock macOS without gnu-sed.
+if ! sed --version 2>/dev/null | grep -q GNU; then
+	echo "SKIP update_idempotency_test: GNU sed required" >&2
+	exit 0
+fi
+
+here="$(cd "$(dirname "$0")" && pwd)"
+pkg="$(dirname "$here")"
+src="$pkg/templates/kubevirt-cr.yaml"
+
+fail() {
+	echo "FAIL update_idempotency_test: $*" >&2
+	exit 1
+}
+
+assert_present() {
+	if ! grep -qF "$1" "$2"; then
+		fail "expected directive missing from $2: $1"
+	fi
+}
+
+assert_absent() {
+	if grep -qF "$1" "$2"; then
+		fail "unexpected directive present in $2: $1"
+	fi
+}
+
+assert_count() {
+	local want="$1" pat="$2" file="$3" got
+	got="$(grep -cF "$pat" "$file" || true)"
+	if [ "$got" -ne "$want" ]; then
+		fail "expected $want occurrence(s) of '$pat' in $file, got $got"
+	fi
+}
+
+run_update() {
+	make -C "$pkg" update CR_FILE="$1" >/dev/null 2>&1
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+PHD='{{- with .Values.permittedHostDevices }}'
+MDC='{{- with .Values.mediatedDevicesConfiguration }}'
+
+# --- case 1: a hand-merge dropped ONLY the mediatedDevicesConfiguration block.
+# `make update` must reinsert it without duplicating permittedHostDevices.
+missing_mdev="$tmpdir/missing-mdev.yaml"
+sed '/{{- with .Values.mediatedDevicesConfiguration }}/,/{{- end }}/d' "$src" >"$missing_mdev"
+assert_present "$PHD" "$missing_mdev"
+assert_absent "$MDC" "$missing_mdev"
+if ! run_update "$missing_mdev"; then
+	fail "make update exited non-zero on a template missing only mediatedDevicesConfiguration"
+fi
+assert_present "$MDC" "$missing_mdev"
+assert_count 1 "$PHD" "$missing_mdev"
+
+# --- case 2: a hand-merge dropped ONLY the permittedHostDevices block (the
+# symmetric trap). `make update` must reinsert it without touching the other.
+missing_phd="$tmpdir/missing-phd.yaml"
+sed '/{{- with .Values.permittedHostDevices }}/,/{{- end }}/d' "$src" >"$missing_phd"
+assert_absent "$PHD" "$missing_phd"
+assert_present "$MDC" "$missing_phd"
+if ! run_update "$missing_phd"; then
+	fail "make update exited non-zero on a template missing only permittedHostDevices"
+fi
+assert_present "$PHD" "$missing_phd"
+assert_count 1 "$MDC" "$missing_phd"
+
+# --- case 3: an already-parameterized template is a no-op (idempotent).
+full="$tmpdir/full.yaml"
+cp "$src" "$full"
+if ! run_update "$full"; then
+	fail "make update failed on an already-parameterized template"
+fi
+if ! diff -u "$src" "$full" >/dev/null; then
+	fail "make update mutated an already-parameterized template"
+fi
+
+# --- case 4: repeated runs never duplicate a guard directive.
+run_update "$missing_mdev"
+for guard in \
+	'{{- if .Values.cpuAllocationRatio }}' \
+	'{{- range .Values.extraFeatureGates }}' \
+	"$PHD" \
+	"$MDC"; do
+	assert_count 1 "$guard" "$missing_mdev"
+done
+
+echo "PASS update_idempotency_test"

--- a/packages/system/kubevirt/values.yaml
+++ b/packages/system/kubevirt/values.yaml
@@ -1,1 +1,48 @@
+# CPU oversubscription ratio. When set, propagates to
+# spec.configuration.developerConfiguration.cpuAllocationRatio on the
+# KubeVirt CR. Driven by .Values.resources.cpuAllocationRatio at the
+# platform level.
+# cpuAllocationRatio: 10
 
+# Feature gates appended after the static defaults
+# (HotplugVolumes/ExpandDisks/LiveMigration/AutoResourceLimitsGate/CPUManager/GPU/VMExport).
+# Empty by default. Filled by the platform with "HostDevices" when the
+# gpu-operator package is enabled with the passthrough variant — the
+# admission webhook rejects spec.template.spec.domain.devices.hostDevices
+# without that gate even with the GPU gate on, since current KubeVirt
+# splits them.
+extraFeatureGates: []
+
+# Permitted host devices the KubeVirt admission webhook accepts under
+# spec.template.spec.domain.devices.hostDevices / gpus on a VirtualMachine.
+# Empty by default — leaves the CR's permittedHostDevices unset.
+#
+# Filled by the platform with NVIDIA PCI vendor:device → resourceName
+# pairs (vendor 10DE) when gpu-operator runs in vfio passthrough mode,
+# and with mediatedDevices entries when it runs in vGPU mode.
+# externalResourceProvider: true is required because the resource names
+# are published by gpu-operator's nvidia-sandbox-device-plugin DaemonSet,
+# not by KubeVirt itself.
+#
+# Shape (subset of kubevirt.io/v1 PermittedHostDevices):
+#   pciHostDevices:
+#   - pciVendorSelector: "10DE:2335"
+#     resourceName: nvidia.com/GH100_H200_SXM_141GB
+#     externalResourceProvider: true
+#   mediatedDevices:
+#   - mdevNameSelector: NVIDIA L40S-24Q
+#     resourceName: nvidia.com/L40S-24Q
+permittedHostDevices: {}
+
+# mediatedDevicesConfiguration for vGPU. Filled by the platform when the
+# gpu-operator package runs in vGPU mode; empty otherwise.
+#
+# Shape (subset of kubevirt.io/v1 MediatedDevicesConfiguration):
+#   mediatedDeviceTypes:
+#   - nvidia-740   # L40S-24Q
+#   nodeMediatedDeviceTypes:
+#   - nodeSelector:
+#       nvidia.com/gpu.product: NVIDIA-L40S
+#     mediatedDeviceTypes:
+#     - nvidia-740
+mediatedDevicesConfiguration: {}


### PR DESCRIPTION
Closes #2765.

## What this PR does

Makes the passthrough and vGPU variants of `cozystack.gpu-operator` produce a KubeVirt CR that is immediately usable, without an out-of-band `kubectl patch`. Today the gpu-operator stack reports green, `nvidia.com/<model>` shows up under node `.status.allocatable`, but every `VirtualMachine` referencing the resource via `domain.devices.hostDevices` is rejected by the admission webhook because `HostDevices` is not in `developerConfiguration.featureGates` and the resource is not listed under `permittedHostDevices`. That manual reconciliation is now driven by the platform.

The change has three parts.

`packages/system/kubevirt` now parameterizes the KubeVirt CR template. `developerConfiguration.featureGates` keeps its existing static defaults and appends `.Values.extraFeatureGates`; `spec.configuration.permittedHostDevices` renders verbatim from `.Values.permittedHostDevices` when set; `spec.configuration.mediatedDevicesConfiguration` does the same. Defaults stay empty so the rendered CR is byte-identical to the previous template when no overrides are supplied. The chart's `make update` target re-applies the four sed transforms after fetching the upstream CR, so refreshing the KubeVirt release version stays a single command.

`packages/core/platform` adds two defaults tables under `files/`. `gpu-passthrough-defaults.yaml` covers Hopper (H100/H200), Ada Lovelace (L4/L40/L40S), Ampere (A100 PCIe/SXM, A40, A30, A10), Turing (T4) and Volta (V100/V100S); PCI vendor:device pairs are stable, `resourceName` slugs follow the `<arch>_<model>_<form>_<mem>` convention `nvidia-sandbox-device-plugin` generates as of v25.x, and `externalResourceProvider: true` is set everywhere because those resources are advertised by the sandbox plugin rather than KubeVirt's in-tree device plugin. `gpu-vgpu-defaults.yaml` covers the Pascal–Ampere mdev profile range (A100-40C/80C, A40-24Q/48Q, A30-24C, A10-24Q, V100D-32C, T4-16Q) — the same family span the upstream `vgpu-device-manager` walks `/sys/class/mdev_bus/` for. Ada Lovelace and Blackwell SR-IOV vGPU is intentionally out of scope for the default table and is expected to be advertised via the user-override hook described below.

`templates/bundles/iaas.yaml` now selects between the two tables via a new `bundles.iaas.gpuOperatorVariant` knob (`default` for passthrough, `vgpu` for mediated; default is passthrough). The same variant flows through to the gpu-operator Package CR, replacing the previous always-default call. When the package is enabled, the platform injects `HostDevices` into `extraFeatureGates` plus the chosen defaults into `permittedHostDevices` for the kubevirt component's values. Operators extend or replace via top-level platform values:

```yaml
gpu:
  replaceDefaults: false              # append (default) vs. wipe-and-replace
  permittedHostDevices:
    pciHostDevices: []                # cluster-specific PCI passthrough entries
    mediatedDevices: []               # cluster-specific vGPU entries
  mediatedDevicesConfiguration: {}    # extra mediated-device types / per-node mappings
```

`docs/gpu-vgpu.md` is updated to drop the manual `kubectl patch` step and describe the auto-wiring contract, the per-variant defaults, the escape hatches, and the sandbox-device-plugin `resourceName` slug convention so an operator whose node publishes a different name knows where to override.

## Test coverage

`helm-unittest` covers eight branches in `packages/core/platform/tests/bundles_gpu_kubevirt_wiring_test.yaml`: gpu-operator disabled emits no extras; gpu-operator enabled at default variant emits the HostDevices gate plus `pciHostDevices`; vgpu variant switches to `mediatedDevices` plus `mediatedDevicesConfiguration`; user overrides append by default; `replaceDefaults: true` wipes the platform table; an unknown variant fails fast with a descriptive error. `packages/system/kubevirt/tests/kubevirt_cr_test.yaml` pins the empty-values render and the three populated shapes at the CR template level. `make helm-unit-tests` passes locally on the full repo.

### Release note

```release-note
feat(platform): the KubeVirt CR is now auto-configured for GPU host-device passthrough (HostDevices feature gate plus permittedHostDevices populated from NVIDIA defaults) whenever cozystack.gpu-operator is in bundles.enabledPackages. Operators no longer need a manual kubectl patch to make VMs schedule against a GPU. The variant is selected via bundles.iaas.gpuOperatorVariant (default: passthrough; vgpu: mediated). Extend or replace the NVIDIA defaults via .gpu.permittedHostDevices and .gpu.replaceDefaults.

**Upgrade note:** the bundle now OWNS spec.configuration.permittedHostDevices on the KubeVirt CR. If you previously hand-edited it (kubectl edit kubevirt), the first reconcile after upgrade overwrites your manual entries with the rendered NVIDIA default table. Before upgrading, move any custom entries into .gpu.permittedHostDevices (set .gpu.replaceDefaults: true to keep only your list) and verify each resourceName against what your nodes advertise (kubectl describe node <node> | grep nvidia.com/) — the default table now carries the exact slug the sandbox device plugin generates, which upper-cases the card's PCI-IDs name and keeps the Tesla/GL tokens (e.g. a Tesla T4 is nvidia.com/TU104GL_TESLA_T4), but a different plugin build can publish a different string; a mismatch makes the admission webhook reject GPU VMs on their next restart or migration.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundle-managed GPU Operator with selectable passthrough vs vGPU variants; platform now injects GPU settings into KubeVirt and forwards vGPU manager overrides when enabled.
  * Default platform mappings for PCI passthrough and vGPU mediated-device resources added.

* **Documentation**
  * Expanded GPU/vGPU deployment guide with bundle-managed vs manual guidance, wiring/precedence rules, resource-name conventions, and verification steps.

* **Tests**
  * New and expanded tests for bundle→KubeVirt wiring, variant behaviors, default/override merging, and idempotent template parameterization.

* **Chores**
  * Added Helm test target and hardened KubeVirt template update/idempotency checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

