### PR TITLE
feat(ci): guard migrations.targetVersion against silent skip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: manifests assets unit-tests helm-unit-tests bats-unit-tests rd-presets-check test-controllers preflight
+.PHONY: manifests assets unit-tests helm-unit-tests bats-unit-tests rd-presets-check migrations-target-check test-controllers preflight
 
 include hack/common-envs.mk
 
@@ -107,7 +107,7 @@ test:
 	make -C packages/core/testing apply
 	make -C packages/core/testing e2e
 
-unit-tests: helm-unit-tests bats-unit-tests go-unit-tests rd-presets-check test-check-readiness
+unit-tests: helm-unit-tests bats-unit-tests go-unit-tests rd-presets-check test-check-readiness migrations-target-check
 
 helm-unit-tests:
 	hack/helm-unit-tests.sh
@@ -118,6 +118,13 @@ helm-unit-tests:
 # hack/update-crd.sh and that RD's schema drifts from values.schema.json.
 rd-presets-check:
 	hack/check-rd-presets.sh
+
+# Catch the off-by-one where migrations/<N> is added but
+# migrations.targetVersion in packages/core/platform/values.yaml is not
+# bumped to >= N+1. run-migrations.sh loops `seq $$CURRENT $$((TARGET-1))`,
+# so the new migration is silently skipped on every cluster upgrade.
+migrations-target-check:
+	hack/check-migrations-target.sh
 
 # Scoped go test over the cozystack-api surface that this repo owns. Kept
 # narrow intentionally - running `go test ./...` pulls in generated code

--- a/hack/check-migrations-target.sh
+++ b/hack/check-migrations-target.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Verify packages/core/platform/values.yaml `migrations.targetVersion`
+# is at least 1 greater than the highest-numbered file in
+# packages/core/platform/images/migrations/migrations/.
+#
+# Catches the regression where a PR adds a new migration script but
+# forgets to bump targetVersion: run-migrations.sh loops
+# `seq $CURRENT_VERSION $((TARGET_VERSION - 1))`, so migration N never
+# runs unless targetVersion is >= N+1.
+set -euo pipefail
+
+MDIR="packages/core/platform/images/migrations/migrations"
+VALUES="packages/core/platform/values.yaml"
+
+if [ ! -d "$MDIR" ]; then
+  echo "ERROR: migrations dir not found: $MDIR" >&2
+  exit 1
+fi
+if [ ! -f "$VALUES" ]; then
+  echo "ERROR: values file not found: $VALUES" >&2
+  exit 1
+fi
+
+MAX_N=$(ls -1 "$MDIR" | grep -E '^[0-9]+$' | sort -n | tail -1 || true)
+if [ -z "$MAX_N" ]; then
+  echo "ERROR: no numbered migrations found under $MDIR" >&2
+  exit 1
+fi
+REQUIRED=$((MAX_N + 1))
+
+TARGET=$(yq -r '.migrations.targetVersion' "$VALUES")
+if [ -z "$TARGET" ] || [ "$TARGET" = "null" ]; then
+  echo "ERROR: migrations.targetVersion is not set in $VALUES" >&2
+  exit 1
+fi
+
+if [ "$TARGET" -lt "$REQUIRED" ]; then
+  cat >&2 <<EOF
+ERROR: latest migration is $MAX_N but $VALUES sets migrations.targetVersion=$TARGET (need >= $REQUIRED).
+
+run-migrations.sh loops 'seq \$CURRENT_VERSION \$((TARGET_VERSION - 1))', so migration $MAX_N never runs unless targetVersion is bumped.
+
+Fix: edit $VALUES and set migrations.targetVersion: $REQUIRED
+EOF
+  exit 1
+fi
+
+echo "OK: migrations.targetVersion=$TARGET >= $REQUIRED (latest migration $MAX_N)"

--- a/hack/check-migrations-target.sh
+++ b/hack/check-migrations-target.sh
@@ -21,8 +21,13 @@ if [ ! -f "$VALUES" ]; then
   exit 1
 fi
 
-MAX_N=$(ls -1 "$MDIR" | grep -E '^[0-9]+$' | sort -n | tail -1 || true)
-if [ -z "$MAX_N" ]; then
+MAX_N=0
+for f in "$MDIR"/*; do
+  name=${f##*/}
+  [[ "$name" =~ ^[0-9]+$ ]] || continue
+  [ "$name" -gt "$MAX_N" ] && MAX_N=$name
+done
+if [ "$MAX_N" -eq 0 ]; then
   echo "ERROR: no numbered migrations found under $MDIR" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Add `hack/check-migrations-target.sh` that fails when the latest numbered file under `packages/core/platform/images/migrations/migrations/` is not matched by a bumped `migrations.targetVersion` in `packages/core/platform/values.yaml`.
- Wire it into `unit-tests` via a new `migrations-target-check` Makefile target so PR CI catches the regression mechanically.

`run-migrations.sh:34` iterates `seq $CURRENT_VERSION $((TARGET_VERSION - 1))`, so a migration whose number equals the configured `targetVersion` is silently skipped. The cost is state corruption on upgrade — a class of bug worth eliminating with a 10-line check rather than relying on reviewer vigilance.

## Test plan

- [x] `make migrations-target-check` passes on `main` HEAD (`targetVersion=43`, latest migration `42`, `43 >= 43`).
- [x] Synthetic failure: `touch packages/core/platform/images/migrations/migrations/99` makes the script exit 1 with a clear error pointing at `packages/core/platform/values.yaml` and the required bump.
- [x] Tested on macOS (BSD `ls` + mikefarah `yq`).

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI validation step to unit tests to ensure `migrations.targetVersion` is kept in sync with newly added database migrations, preventing upgrade scripts from skipping new migration steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->