### PR TITLE
feat(rbac): allow tenants to start/stop/restart their VMs

### DIFF
--- a/packages/system/cozystack-basics/templates/clusterroles.yaml
+++ b/packages/system/cozystack-basics/templates/clusterroles.yaml
@@ -156,6 +156,17 @@ rules:
   verbs:
   - get
   - update
+# Power controls (start/stop/restart) for VMs owned by the tenant.
+# Operational, like console/vnc above, so granted at the "use" level
+# (aggregates into admin and super-admin). Without these the dashboard
+# power buttons return 403 even for tenant admins.
+- apiGroups: ["subresources.kubevirt.io"]
+  resources:
+  - virtualmachines/start
+  - virtualmachines/stop
+  - virtualmachines/restart
+  verbs:
+  - update
 - apiGroups:
   - core.cozystack.io
   resources:


### PR DESCRIPTION

<img width="2770" height="1970" alt="image" src="https://github.com/user-attachments/assets/774c7c71-0e6a-496a-9898-8ad1ed848b0a" />


## Summary

Grants tenant users permission to call the KubeVirt VM power-control subresources (`subresources.kubevirt.io` → `virtualmachines/{name}/start|stop|restart`, verb `update`) by adding them to the `cozy:tenant:use:base` ClusterRole, which aggregates into `tenant-use`, `tenant-admin`, and `tenant-super-admin`.

Without this, the dashboard VM power buttons return 403 even for tenant admins: `kubectl auth can-i update virtualmachines --subresource=start` is `no` for every tenant role today, while `virtualmachineinstances/console|vnc|portforward` are already granted at the same `use` level — so power control belongs there too.

## Companion PR

UI that consumes this permission (VM power controls + VNC fixes): cozystack/cozystack-ui#27

## Test

- `helm template` renders `cozy:tenant:use:base` with the new `virtualmachines/start|stop|restart` rule.
- After apply, `kubectl auth can-i update virtualmachines --subresource=start|stop|restart` flips from `no` to `yes` for the `tenant-*-use/admin/super-admin` groups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Virtual Machine Power Control: Users with tenant-level access can now start, stop, and restart virtual machines, providing enhanced management capabilities for VM operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->