### PR TITLE
fix(kubernetes): stamp application lineage labels on worker node VMs

### DIFF
--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -57,7 +57,7 @@ spec:
           labels:
             apps.cozystack.io/application.group: apps.cozystack.io
             apps.cozystack.io/application.kind: Kubernetes
-            apps.cozystack.io/application.name: {{ $.Release.Name | trimPrefix "kubernetes-" }}
+            apps.cozystack.io/application.name: {{ $.Release.Name | trimPrefix "kubernetes-" | quote }}
             {{- range .group.roles }}
             node-role.kubernetes.io/{{ . }}: ""
             {{- end }}

--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -55,6 +55,9 @@ spec:
           annotations:
             kubevirt.io/allow-pod-bridge-network-live-migration: "true"
           labels:
+            apps.cozystack.io/application.group: apps.cozystack.io
+            apps.cozystack.io/application.kind: Kubernetes
+            apps.cozystack.io/application.name: {{ $.Release.Name | trimPrefix "kubernetes-" }}
             {{- range .group.roles }}
             node-role.kubernetes.io/{{ . }}: ""
             {{- end }}

--- a/packages/apps/kubernetes/tests/cluster_test.yaml
+++ b/packages/apps/kubernetes/tests/cluster_test.yaml
@@ -458,3 +458,38 @@ tests:
                 if /root/kubelet --version ; then mv /root/kubelet /usr/bin/kubelet ; fi
                 if /root/kubeadm version ; then mv /root/kubeadm /usr/bin/kubeadm ; fi
         documentIndex: 4
+
+  ###############################################
+  # application lineage labels on worker VMs    #
+  ###############################################
+
+  - it: stamps application lineage labels on the worker VM template
+    release:
+      name: test-k8s
+      namespace: tenant-test
+    asserts:
+      - isKind:
+          of: KubevirtMachineTemplate
+        documentIndex: 5
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.metadata.labels["apps.cozystack.io/application.group"]
+          value: apps.cozystack.io
+        documentIndex: 5
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.metadata.labels["apps.cozystack.io/application.kind"]
+          value: Kubernetes
+        documentIndex: 5
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.metadata.labels["apps.cozystack.io/application.name"]
+          value: test-k8s
+        documentIndex: 5
+
+  - it: derives application.name by trimming the kubernetes- release prefix
+    release:
+      name: kubernetes-foo
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: spec.template.spec.virtualMachineTemplate.spec.template.metadata.labels["apps.cozystack.io/application.name"]
+          value: foo
+        documentIndex: 5


### PR DESCRIPTION
## What this PR does

Worker-node VMs of a tenant Kubernetes cluster are created by Cluster API / the KubeVirt provider, so their virt-launcher pods were never stamped with the `apps.cozystack.io/application.{group,kind,name}` lineage labels that the chart already sets on its other resources (`ingress.yaml`, `cloud-config.yaml`). As a result the dashboard could not attribute those pods to the owning `kubernetes` application instance — e.g. cluster resource-consumer views showed the raw `virt-launcher-…` pod name with no link to the cluster.

This adds the application lineage labels to the worker VM template (`KubevirtMachineTemplate` → `virtualMachineTemplate.spec.template.metadata.labels`), mirroring the existing stamping in `ingress.yaml`/`cloud-config.yaml`. KubeVirt propagates labels from this block to the VMI and the virt-launcher pods (the same path the existing `cluster.x-k8s.io/deployment-name` label already takes), so the dashboard now attributes worker VMs to their Kubernetes application.

### Screenshots

N/A — no UI changes; this only affects generated pod labels.

### Release note
```release-note
fix(kubernetes): stamp tenant Kubernetes worker-node VMs with apps.cozystack.io/application.{group,kind,name} so the dashboard attributes their pods to the owning Kubernetes application
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added application lineage labels to Kubernetes VM templates so cluster VMs include application group, kind, and name (release-name prefix trimmed).
* **Tests**
  * Added template tests validating those labels and the name-trimming behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->