### PR TITLE
feat(kubernetes): enable GPU passthrough out-of-the-box (NvLinkDisable + gpu=on)

### DIFF
--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -475,6 +475,15 @@ spec:
       joinConfiguration:
         nodeRegistration:
           kubeletExtraArgs:
+            {{- /*
+              GPU node-groups: label every node `gpu=on` so HAMi's
+              hami-device-plugin DaemonSet (nodeSelector gpu=on) schedules
+              and advertises nvidia.com/gpu. Without the label the plugin
+              stays at DESIRED=0 and no GPUs are exposed to the tenant.
+            */}}
+            {{- if $group.gpus }}
+            node-labels: "gpu=on"
+            {{- end }}
             system-reserved: "memory={{ $systemReservedMemory }},cpu={{ $systemReservedCpu }}"
             kube-reserved: "memory={{ $kubeReservedMemory }},cpu={{ $kubeReservedCpu }}"
             eviction-hard: "memory.available<{{ $evictionHardMemory }},nodefs.available<10%,imagefs.available<15%,nodefs.inodesFree<5%"

--- a/packages/apps/kubernetes/templates/helmreleases/gpu-operator.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/gpu-operator.yaml
@@ -1,6 +1,28 @@
 {{- define "cozystack.defaultGpuOperatorValues" -}}
-{{- if .Values.addons.hami.enabled }}
+{{- /*
+  GPU passthrough default: cozystack passes individual SXM GPUs (e.g.
+  H200) into tenant worker VMs WITHOUT the NVSwitches. The nvidia driver
+  then waits forever for an NVLink fabric that can never come up (no
+  NVSwitch / fabricmanager), leaving Fabric State: In Progress — every
+  CUDA call fails with "system not yet initialized" and the
+  nvidia-operator-validator crashloops. Loading the kernel module with
+  NVreg_NvLinkDisable=1 flips Fabric State to N/A so CUDA initializes.
+  This is correct for per-GPU passthrough since there is no in-VM
+  NVLink/NVSwitch peering anyway.
+
+  The upstream chart only references an existing ConfigMap by name; the
+  wrapper chart (packages/system/gpu-operator) renders that ConfigMap
+  when kernelModuleConfig.create is true. Overridable via
+  addons.gpuOperator.valuesOverride (mergeOverwrite below keeps user
+  values winning).
+*/}}
+kernelModuleConfig:
+  create: true
 gpu-operator:
+  driver:
+    kernelModuleConfig:
+      name: nvidia-kernel-module-params
+{{- if .Values.addons.hami.enabled }}
   devicePlugin:
     enabled: false
 {{- end }}

--- a/packages/apps/kubernetes/tests/gpu_node_labels_test.yaml
+++ b/packages/apps/kubernetes/tests/gpu_node_labels_test.yaml
@@ -1,0 +1,77 @@
+suite: GPU node-group kubelet node-labels tests
+
+templates:
+  - templates/cluster.yaml
+
+# The KubeadmConfigTemplate for the first nodeGroup is rendered at
+# document index 4 within cluster.yaml. The kubelet args live at:
+# spec.template.spec.joinConfiguration.nodeRegistration.kubeletExtraArgs
+# GPU node-groups must register their nodes with gpu=on so HAMi's
+# hami-device-plugin DaemonSet (nodeSelector gpu=on) schedules.
+
+tests:
+  - it: labels GPU node-groups with gpu=on
+    release:
+      name: test-k8s
+      namespace: tenant-test
+    set:
+      _namespace:
+        etcd: etcd
+        ingress: nginx
+        host: example.com
+      _cluster:
+        cluster-domain: cozy.local
+      nodeGroups:
+        md0:
+          minReplicas: 0
+          maxReplicas: 10
+          instanceType: ""
+          diskSize: 20Gi
+          roles:
+            - worker
+          resources:
+            cpu: 8
+            memory: 16Gi
+          gpus:
+            - name: nvidia.com/GH200
+          kubelet: {}
+    asserts:
+      - isKind:
+          of: KubeadmConfigTemplate
+        documentIndex: 4
+      - equal:
+          path: spec.template.spec.joinConfiguration.nodeRegistration.kubeletExtraArgs.node-labels
+          value: "gpu=on"
+        documentIndex: 4
+
+  - it: does not label non-GPU node-groups with gpu=on
+    release:
+      name: test-k8s
+      namespace: tenant-test
+    set:
+      _namespace:
+        etcd: etcd
+        ingress: nginx
+        host: example.com
+      _cluster:
+        cluster-domain: cozy.local
+      nodeGroups:
+        md0:
+          minReplicas: 0
+          maxReplicas: 10
+          instanceType: ""
+          diskSize: 20Gi
+          roles:
+            - worker
+          resources:
+            cpu: 2
+            memory: 4Gi
+          gpus: []
+          kubelet: {}
+    asserts:
+      - isKind:
+          of: KubeadmConfigTemplate
+        documentIndex: 4
+      - notExists:
+          path: spec.template.spec.joinConfiguration.nodeRegistration.kubeletExtraArgs.node-labels
+        documentIndex: 4

--- a/packages/apps/kubernetes/tests/gpu_operator_hami_test.yaml
+++ b/packages/apps/kubernetes/tests/gpu_operator_hami_test.yaml
@@ -18,7 +18,7 @@ tests:
           path: spec.values.gpu-operator.devicePlugin.enabled
           value: false
 
-  - it: should not have values when hami is disabled and no overrides
+  - it: should default the NvLinkDisable kernel module config even when hami is disabled
     set:
       addons:
         gpuOperator:
@@ -28,8 +28,35 @@ tests:
           enabled: false
           valuesOverride: {}
     asserts:
+      - equal:
+          path: spec.values.kernelModuleConfig.create
+          value: true
+      - equal:
+          path: spec.values.gpu-operator.driver.kernelModuleConfig.name
+          value: nvidia-kernel-module-params
       - notExists:
-          path: spec.values
+          path: spec.values.gpu-operator.devicePlugin
+
+  - it: should let user override the kernel module config name
+    set:
+      addons:
+        gpuOperator:
+          enabled: true
+          valuesOverride:
+            gpu-operator:
+              driver:
+                kernelModuleConfig:
+                  name: my-custom-kmc
+        hami:
+          enabled: false
+          valuesOverride: {}
+    asserts:
+      - equal:
+          path: spec.values.gpu-operator.driver.kernelModuleConfig.name
+          value: my-custom-kmc
+      - equal:
+          path: spec.values.kernelModuleConfig.create
+          value: true
 
   - it: should apply hami defaults when valuesOverride key is omitted
     set:

--- a/packages/system/gpu-operator/templates/kernel-module-config.yaml
+++ b/packages/system/gpu-operator/templates/kernel-module-config.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.kernelModuleConfig.create }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.kernelModuleConfig.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: gpu-operator
+data:
+  nvidia.conf: |
+    {{- .Values.kernelModuleConfig.content | nindent 4 }}
+{{- end }}

--- a/packages/system/gpu-operator/templates/kernel-module-config.yaml
+++ b/packages/system/gpu-operator/templates/kernel-module-config.yaml
@@ -1,8 +1,20 @@
 {{- if .Values.kernelModuleConfig.create }}
+{{- /*
+  Name the ConfigMap after the driver's effective kernelModuleConfig
+  reference (gpu-operator.driver.kernelModuleConfig.name) — that is the
+  name the operator mounts into the driver pod. Falling back to the
+  wrapper's own kernelModuleConfig.name keeps the two from ever diverging:
+  overriding only the driver reference would otherwise leave the driver
+  pointing at a ConfigMap that is never rendered.
+*/}}
+{{- $gpuOperator := index .Values "gpu-operator" | default dict -}}
+{{- $driver := index $gpuOperator "driver" | default dict -}}
+{{- $driverKmc := index $driver "kernelModuleConfig" | default dict -}}
+{{- $name := $driverKmc.name | default .Values.kernelModuleConfig.name -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Values.kernelModuleConfig.name }}
+  name: {{ $name }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/packages/system/gpu-operator/tests/kernel_module_config_test.yaml
+++ b/packages/system/gpu-operator/tests/kernel_module_config_test.yaml
@@ -1,0 +1,48 @@
+suite: GPU operator kernel module ConfigMap tests
+
+templates:
+  - templates/kernel-module-config.yaml
+
+tests:
+  - it: does not render the ConfigMap when create is false (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the ConfigMap into the release namespace with the nvidia.conf key when create is true
+    release:
+      name: gpu-operator
+      namespace: cozy-gpu-operator
+    set:
+      kernelModuleConfig:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: nvidia-kernel-module-params
+      - equal:
+          path: metadata.namespace
+          value: cozy-gpu-operator
+      - matchRegex:
+          path: data["nvidia.conf"]
+          pattern: NVreg_NvLinkDisable=1
+
+  - it: names the ConfigMap after the driver kernelModuleConfig reference so the two cannot diverge
+    release:
+      name: gpu-operator
+      namespace: cozy-gpu-operator
+    set:
+      kernelModuleConfig:
+        create: true
+      gpu-operator:
+        driver:
+          kernelModuleConfig:
+            name: my-custom-kmc
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-custom-kmc

--- a/packages/system/gpu-operator/values.yaml
+++ b/packages/system/gpu-operator/values.yaml
@@ -25,3 +25,19 @@ gpu-operator:
   # values-vgpu.yaml.
   vgpuDeviceManager:
     enabled: false
+
+# Optional ConfigMap holding extra nvidia kernel module parameters.
+# The upstream chart only references an existing ConfigMap by name via
+# driver.kernelModuleConfig.name — it never creates it. When create is
+# true this wrapper chart renders the ConfigMap into the release
+# namespace so the params actually land. The driver entrypoint reads
+# ${base}/nvidia.conf and appends each line to the nvidia modprobe
+# options. Used by tenant Kubernetes clusters to set
+# NVreg_NvLinkDisable=1 (see packages/apps/kubernetes gpu-operator
+# HelmRelease defaults); off by default for host-level passthrough/vgpu
+# variants where the in-host driver is disabled.
+kernelModuleConfig:
+  create: false
+  name: nvidia-kernel-module-params
+  content: |
+    NVreg_NvLinkDisable=1


### PR DESCRIPTION
## What this PR does

Makes GPU passthrough work out-of-the-box for tenant Kubernetes clusters (the `kubernetes` app), so operators no longer have to hand-fix it. Two defaults:

1. **Tenant gpu-operator loads the nvidia driver with `NVreg_NvLinkDisable=1`.**
2. **Nodes in GPU node-groups are labeled `gpu=on` automatically.**

### Root cause (validated empirically on a live cluster)

cozystack passes through individual SXM GPUs (e.g. H200) into tenant worker VMs **without** the NVSwitches. Such a GPU's driver then waits for an NVLink fabric that can never come up — there is no NVSwitch and fabricmanager has nothing to manage — so `nvidia-smi` reports `Fabric State: In Progress` indefinitely. As a result every CUDA call fails with `system not yet initialized`, `nvidia-operator-validator` (cuda-validation) crashloops, and no GPUs are advertised.

Loading the kernel module with `NVreg_NvLinkDisable=1` flips `Fabric State` to `N/A`, CUDA initializes, and the validators pass. This is the correct setting for per-GPU passthrough because there is no in-VM NVLink/NVSwitch peering — the GPU is alone in the VM, so there is nothing to disable that the workload needs.

The second issue: HAMi's `hami-device-plugin` DaemonSet has `nodeSelector: gpu=on` and stays at `DESIRED=0` because GPU worker nodes lack that label, so `nvidia.com/gpu` is never advertised. Labeling the GPU nodes `gpu=on` lets the device plugin schedule and advertise the GPUs.

### How it works

- **`gpu=on` label:** node-groups in `packages/apps/kubernetes/templates/cluster.yaml` that declare `gpus` get `--node-labels=gpu=on` appended to their kubelet args (in the `KubeadmConfigTemplate` `joinConfiguration`). Non-GPU node-groups are untouched.
- **`NVreg_NvLinkDisable=1`:** the upstream gpu-operator chart only references an existing ConfigMap by name (`driver.kernelModuleConfig.name`) and never creates it. The gpu-operator wrapper chart (`packages/system/gpu-operator`) now renders that ConfigMap (opt-in via `kernelModuleConfig.create`) so it deploys into the tenant `cozy-gpu-operator` namespace alongside the operator. The tenant gpu-operator HelmRelease defaults enable it and point `driver.kernelModuleConfig.name` at it.

Both defaults remain overridable: a user setting `addons.gpuOperator.valuesOverride` still wins via the existing `mergeOverwrite(defaults, overrides)` in the HelmRelease template.

### Screenshots

Not applicable — no UI changes.

### Release note

```release-note
feat(kubernetes): enable GPU passthrough out-of-the-box for tenant clusters. GPU node-groups are now labeled `gpu=on` so HAMi's device plugin schedules and advertises `nvidia.com/gpu`, and the tenant gpu-operator loads the nvidia driver with `NVreg_NvLinkDisable=1` so single-SXM-GPU passthrough (no NVSwitch in the VM) no longer hangs on `Fabric State: In Progress` / `system not yet initialized`. Both defaults are overridable via `addons.gpuOperator.valuesOverride`.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU-enabled node groups now get the expected GPU label during node registration.
  * GPU operator supports optional kernel-module parameter configuration with a default parameter set.

* **Tests**
  * Added tests verifying GPU node labeling is applied only for GPU-enabled node groups.
  * Added tests validating kernel-module config creation, naming, and content behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->