### PR TITLE
ci: bump cozyvalues-gen to v1.6.0

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install generate
         run: |
-          curl -sSL https://github.com/cozystack/cozyvalues-gen/releases/download/v1.5.0/cozyvalues-gen-linux-amd64.tar.gz | tar -xzvf- -C /usr/local/bin/ cozyvalues-gen
+          curl -sSL https://github.com/cozystack/cozyvalues-gen/releases/download/v1.6.0/cozyvalues-gen-linux-amd64.tar.gz | tar -xzvf- -C /usr/local/bin/ cozyvalues-gen
 
       - name: Run pre-commit hooks
         run: |


### PR DESCRIPTION
## What this PR does

Bumps the `cozyvalues-gen` version installed in the pre-commit CI workflow from v1.5.0 to v1.6.0.

v1.6.0 adds two additive, opt-in annotation features: the `date-time` string-format alias (mirroring the existing `date` alias) and the `@example` annotation, which accumulates JSON-encoded values into an `examples` array on the matching schema property.

Both are opt-in, so charts that do not use the new directives regenerate byte-identical `values.schema.json`, `README.md` and Go type output. Verified locally by regenerating all 31 packages (`apps/*`, `extra/*`, `library/cozy-lib`) with both v1.5.0 and v1.6.0 — every produced artifact is identical, so the pre-commit regeneration check stays green without touching any committed file.

### Release note

```release-note
ci: bump cozyvalues-gen to v1.6.0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tool to the latest version for improved code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->