### PR TITLE
fix(dashboard): unbreak CORS on expired session for k8s API calls

### DIFF
--- a/packages/system/dashboard/templates/gatekeeper.yaml
+++ b/packages/system/dashboard/templates/gatekeeper.yaml
@@ -68,6 +68,8 @@ spec:
             {{- end }}
             - --whitelist-domain=keycloak.{{ $host }}
             - --email-domain=*
+            - --api-route=^/api(/|$)
+            - --api-route=^/apis(/|$)
             - --pass-access-token=true
             - --pass-authorization-header=true
             - --cookie-refresh=3m

--- a/packages/system/dashboard/templates/keycloakclient.yaml
+++ b/packages/system/dashboard/templates/keycloakclient.yaml
@@ -64,6 +64,8 @@ spec:
   directAccess: true
   public: false
   webUrl: "https://dashboard.{{ $host }}"
+  webOrigins:
+    - "+"
   defaultClientScopes:
     - groups
     - kubernetes-client


### PR DESCRIPTION
## What this PR does

Fix two related issues that cause the dashboard SPA to break with CORS errors once the `kc-access` cookie expires.

1. `KeycloakClient` for dashboard had no `webOrigins` set, so the operator did not touch the field in Keycloak after initial creation. After any `rootUrl` change the existing `webOrigins` value got stuck at an old hostname and blocked CORS from the SPA. Setting it to `+` makes Keycloak derive the allowed origins from `redirectUris`.

2. `oauth2-proxy` answered `302` (redirect to Keycloak `/auth`) for unauthenticated XHR/fetch on `/api` and `/apis`. The login page does not emit `Access-Control-Allow-Origin`, so the browser blocked the fetch with a CORS error and the SPA had no way to recover. Adding `--api-route` makes `oauth2-proxy` answer `401` without a redirect for these paths, so the SPA can handle re-auth itself via a top-level navigation.

### Release note

```release-note
fix(dashboard): dashboard SPA no longer fails with CORS errors after the kc-access cookie expires; oauth2-proxy returns 401 (not 302) for /api and /apis, and the KeycloakClient declares webOrigins: ["+"].
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated API routing configuration to properly handle requests to API endpoints
* Enhanced web origins configuration for improved authentication system compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->