### PR TITLE
chore(seaweedfs): bump seaweedfs-cosi-driver to v0.3.1

### DIFF
--- a/packages/extra/seaweedfs/images/seaweedfs-cosi-driver.tag
+++ b/packages/extra/seaweedfs/images/seaweedfs-cosi-driver.tag
@@ -1,1 +1,1 @@
-ghcr.io/seaweedfs/seaweedfs-cosi-driver:v0.3.0
+ghcr.io/seaweedfs/seaweedfs-cosi-driver:v0.3.1


### PR DESCRIPTION
## What this PR does

Bumps the `seaweedfs-cosi-driver` image from `v0.3.0` to `v0.3.1`.

`v0.3.1` ships the stale-socket self-heal fix. After a non-graceful exit (SIGKILL / OOM / panic) Go does not unlink the COSI unix socket, and because it lives on an `emptyDir` that survives container restarts, the next start failed with `bind: address already in use` and the `objectstorage-provisioner` wedged in `CrashLoopBackOff`. While it was down, `BucketClaim` reconciliation stopped and buckets were never provisioned — the COSI `Bucket` could even report `bucketReady: true` while no bucket existed. This is the CrashLoopBackOff reported in #2429.

The driver now removes a leftover socket before binding (only when it exists, is a socket, and has no live listener), so the provisioner self-heals on restart.

Upstream: seaweedfs/seaweedfs-cosi-driver#8 (merged), released in v0.3.1. Points at the upstream published multi-arch image (amd64 + arm64) — no vendoring needed.

### Release note

```release-note
fix(seaweedfs): bump seaweedfs-cosi-driver to v0.3.1, which self-heals the object storage COSI provisioner from a CrashLoopBackOff caused by a stale unix socket
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SeaweedFS cosi driver container image to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->