### PR TITLE
fix(objectstorage-controller): propagate Bucket readiness to BucketClaim

### DIFF
--- a/packages/system/objectstorage-controller/images/objectstorage/patches/92-bucketclaim-propagate-ready.diff
+++ b/packages/system/objectstorage-controller/images/objectstorage/patches/92-bucketclaim-propagate-ready.diff
@@ -1,0 +1,29 @@
+diff --git a/controller/pkg/bucketclaim/bucketclaim.go b/controller/pkg/bucketclaim/bucketclaim.go
+index 2b55c49..038cf28 100644
+--- a/controller/pkg/bucketclaim/bucketclaim.go
++++ b/controller/pkg/bucketclaim/bucketclaim.go
+@@ -213,8 +213,23 @@ func (b *BucketClaimListener) provisionBucketClaimOperation(ctx context.Context,
+ 			return b.recordError(inputBucketClaim, v1.EventTypeWarning, v1alpha1.FailedCreateBucket, err)
+ 		}
+
++		// The Bucket for this claim may already exist from an earlier reconcile,
++		// in which case the sidecar may have provisioned the backend and flipped
++		// the Bucket to ready in the meantime. The controller does not watch
++		// Buckets, so re-read the live object and propagate its readiness here;
++		// otherwise the BucketClaim stays BucketReady=false forever (each resync
++		// re-enters this branch, Create returns AlreadyExists, and the readiness
++		// transition is never reflected), so BucketAccess can never be granted.
++		createdBucket, getErr := b.buckets().Get(ctx, bucketName, metav1.GetOptions{})
++		if getErr != nil {
++			klog.V(3).ErrorS(getErr, "Error reading bucket after create",
++				"bucket", bucketName,
++				"bucketClaim", bucketClaim.ObjectMeta.Name)
++			return b.recordError(inputBucketClaim, v1.EventTypeWarning, v1alpha1.FailedCreateBucket, getErr)
++		}
++
+ 		bucketClaim.Status.BucketName = bucketName
+-		bucketClaim.Status.BucketReady = false
++		bucketClaim.Status.BucketReady = createdBucket.Status.BucketReady
+ 	}
+
+ 	// Update status with retry logic for conflict errors


### PR DESCRIPTION
## What this PR does

The vendored COSI `objectstorage-controller` (built from upstream `v0.2.2`) leaves dynamically-provisioned buckets without credentials.

In the dynamic-provisioning path, `provisionBucketClaimOperation` sets `BucketClaim.status.bucketName` but hardcodes `bucketReady=false` and never re-reads the `Bucket`. The controller does not watch `Bucket` objects, so the readiness transition the sidecar performs after `DriverCreateBucket` (`Bucket.status.bucketReady` `false`→`true`) is never propagated back to the `BucketClaim`. Each periodic resync re-enters the same branch (`Buckets().Create` returns `AlreadyExists`, which is ignored) and re-sets `bucketReady=false`. As a result `BucketClaim.status.bucketReady` stays `false` forever, the sidecar refuses to grant the `BucketAccess` ("BucketAccess can't be granted to Bucket not in Ready state"), and the credentials secret is never created — even though the bucket exists in the backend and the `Bucket` CR already reports `bucketReady: true`.

This adds a vendored patch that re-reads the live `Bucket` after create and propagates its readiness onto the `BucketClaim`, so the existing periodic resync converges the claim to ready and access can be granted.

The fix mirrors what the rewritten upstream controller already does on `main` (`claim.Status.ReadyToUse = bucket.Status.ReadyToUse`). Upstream `main` is a `v1alpha2` rewrite and the maintained `release-0.2` branch still carries the bug, so this stays a vendored patch against `v0.2.2` until the controller is bumped to a release that includes the fix.

Verified: reproduced the stuck-`false` claim with a unit test against the upstream `v0.2.2` source and confirmed the patch resolves it, existing controller tests pass, the patch applies cleanly to `v0.2.2`, and the controller image builds.

### Release note

```release-note
fix(objectstorage-controller): propagate Bucket readiness to the BucketClaim so dynamically-provisioned buckets receive credentials instead of getting stuck without a granted BucketAccess
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where bucket readiness status was incorrectly reported when a bucket already existed. The status now accurately reflects the actual state of the existing bucket instead of being unconditionally set to not ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->