### PR TITLE
test(tests): exclude loop devices from host LVM scanning

### DIFF
--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -165,6 +165,17 @@ machine:
           device_ownership_from_security_context = true
     path: /etc/cri/conf.d/20-customization.part
     op: create
+  - op: overwrite
+    path: /etc/lvm/lvm.conf
+    permissions: 0o644
+    content: |
+      backup {
+        backup = 0
+        archive = 0
+      }
+      devices {
+        global_filter = [ "r|^/dev/drbd.*|", "r|^/dev/dm-.*|", "r|^/dev/zd.*|", "r|^/dev/loop.*|" ]
+      }
 
 cluster:
   apiServer:


### PR DESCRIPTION
## What this PR does

Adds an `/etc/lvm/lvm.conf` overwrite to the e2e Talos machine config so the host LVM ignores `/dev/loop` devices, alongside the existing `drbd`/`dm`/`zd` filters. This prevents the host from scanning and activating volume groups located inside loop-mounted disk images used during e2e.

### Release note

```release-note
test(e2e): exclude loop devices from host LVM scanning
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated cluster preparation to adjust LVM behavior in test environments: LVM backup/archive is disabled and device filtering was tightened to ignore ephemeral/virtual block devices.
  * This reduces interference from transient devices during end-to-end cluster tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2798?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->