### PR TITLE
fix(networking): point host ouroboros proxy at the root-tenant ingress

### DIFF
--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -157,7 +157,22 @@
        CrashLoop the controller on WaitForCacheSync against missing
        GVRs. Operators on hosts that do install Gateway-API CRDs out
        of band can enable it via the standard Package values override. */ -}}
-{{include "cozystack.platform.package.default" (list "cozystack.ouroboros" $) }}
+{{- /* Point the ouroboros proxy at the HOST ingress-nginx Service. The
+       wrapper chart default (cozy-ingress-nginx / ingress-nginx-controller)
+       describes a managed Kubernetes tenant cluster, NOT the host: on the
+       host, extra/ingress deploys ingress-nginx into the root tenant
+       namespace (publishing.ingressName, default tenant-root) with
+       fullnameOverride <short>-ingress, yielding the controller Service
+       <short>-ingress-controller (e.g. root-ingress-controller). Derive
+       namespace + serviceName from publishing.ingressName so a non-default
+       ingress name still resolves; mirror the trimPrefix "tenant-"
+       transform extra/ingress applies to .Release.Namespace. */ -}}
+{{- $ingressNs := .Values.publishing.ingressName | default "tenant-root" -}}
+{{- $ingressSvc := printf "%s-ingress-controller" (trimPrefix "tenant-" $ingressNs) -}}
+{{- $ouroborosTarget := dict "namespace" $ingressNs "serviceName" $ingressSvc -}}
+{{- $ouroborosValues := dict "ouroboros" (dict "proxy" (dict "target" $ouroborosTarget)) -}}
+{{- $ouroborosComponents := dict "ouroboros" (dict "values" $ouroborosValues) -}}
+{{include "cozystack.platform.package" (list "cozystack.ouroboros" "default" $ $ouroborosComponents) }}
 {{- end }}
 {{include "cozystack.platform.package.default" (list "cozystack.flux-plunger" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.victoria-metrics-operator" $) }}

--- a/packages/core/platform/tests/bundles_proxy_protocol_test.yaml
+++ b/packages/core/platform/tests/bundles_proxy_protocol_test.yaml
@@ -64,6 +64,50 @@ tests:
           path: spec.variant
           value: default
 
+  - it: points the host ouroboros proxy at the root-tenant ingress Service (default ingressName)
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+      publishing:
+        proxyProtocol: true
+    documentSelector:
+      path: metadata.name
+      value: cozystack.ouroboros
+    asserts:
+      # The host ingress-nginx is deployed by extra/ingress into the root
+      # tenant namespace as <short>-ingress-controller, NOT the chart
+      # default ingress-nginx-controller.cozy-ingress-nginx (which is the
+      # managed-Kubernetes-tenant layout). Both are derived from
+      # publishing.ingressName (default tenant-root).
+      - equal:
+          path: spec.components.ouroboros.values.ouroboros.proxy.target.namespace
+          value: tenant-root
+      - equal:
+          path: spec.components.ouroboros.values.ouroboros.proxy.target.serviceName
+          value: root-ingress-controller
+
+  - it: derives the ouroboros proxy target from a non-default publishing.ingressName
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+      publishing:
+        proxyProtocol: true
+        ingressName: tenant-foo
+    documentSelector:
+      path: metadata.name
+      value: cozystack.ouroboros
+    asserts:
+      - equal:
+          path: spec.components.ouroboros.values.ouroboros.proxy.target.namespace
+          value: tenant-foo
+      - equal:
+          path: spec.components.ouroboros.values.ouroboros.proxy.target.serviceName
+          value: foo-ingress-controller
+
   - it: injects three PROXY-protocol nginx config keys into ingress-application when proxyProtocol is true (use-proxy-protocol, real-ip-header, enable-real-ip)
     set:
       bundles:

--- a/packages/system/ouroboros/values.yaml
+++ b/packages/system/ouroboros/values.yaml
@@ -30,14 +30,26 @@ ouroboros:
     # this field for tenants that DO install Gateway-API.
   proxy:
     target:
-      # cozystack deploys ingress-nginx into cozy-ingress-nginx in both
-      # the host control plane and every tenant control plane (the tenant
-      # HelmRelease sets fullnameOverride: ingress-nginx + targetNamespace:
-      # cozy-ingress-nginx). Override the chart-default `ingress-nginx`
-      # namespace; the chart-default serviceName matches as-is. Leaving
-      # `host:` empty (chart-default) tells the proxy to compose the
-      # backend host at runtime as
+      # Tenant-cluster fallback default. A managed Kubernetes tenant
+      # cluster deploys ingress-nginx into cozy-ingress-nginx (its
+      # HelmRelease sets fullnameOverride: ingress-nginx +
+      # targetNamespace: cozy-ingress-nginx), so overriding the
+      # chart-default `ingress-nginx` namespace to cozy-ingress-nginx
+      # matches there; the chart-default serviceName lines up as-is.
+      #
+      # The HOST is different: extra/ingress deploys ingress-nginx into
+      # the root tenant namespace (publishing.ingressName, default
+      # tenant-root) as <short>-ingress-controller (e.g.
+      # root-ingress-controller), NOT cozy-ingress-nginx. The host
+      # platform bundle (core/platform templates/bundles/system.yaml)
+      # therefore overrides proxy.target.{namespace,serviceName} when it
+      # emits cozystack.ouroboros, derived from publishing.ingressName.
+      # This default is never effective on the host once that override
+      # lands.
+      #
+      # Leaving `host:` empty (chart-default) tells the proxy to compose
+      # the backend host at runtime as
       # `<serviceName>.<namespace>.svc.<auto-detected-cluster-domain>`,
-      # which works on cozy.local (cozystack tenants), cluster.local
-      # (kubeadm), or any other domain without operator override.
+      # which works on cozy.local (cozystack), cluster.local (kubeadm),
+      # or any other domain without operator override.
       namespace: cozy-ingress-nginx


### PR DESCRIPTION
## What this PR does

With `publishing.proxyProtocol: true`, the host emits a `cozystack.ouroboros` Package using the no-override Package macro, so the proxy inherits the wrapper chart default backend `ingress-nginx-controller.cozy-ingress-nginx`. That layout describes a managed Kubernetes tenant cluster, not the host: on the host, `extra/ingress` deploys ingress-nginx into the root tenant namespace as `root-ingress-controller` in `tenant-root`. The composed backend FQDN never resolves, so `ouroboros-proxy` never reaches Ready.

This emits the host ouroboros Package with a `proxy.target` override derived from `publishing.ingressName` — namespace plus `<short>-ingress-controller` service name — mirroring the `trimPrefix "tenant-"` transform `extra/ingress` applies to its release namespace. The derivation reuses the existing platform invariant that `publishing.ingressName` is the namespace where the host ingress controller runs.

Adds bundle helm-unittest coverage for the default ingress name and a non-default one, and corrects the misleading wrapper `values.yaml` comment that claimed the host uses `cozy-ingress-nginx`.

Scope: this fixes the ouroboros readiness defect only. The separate defect where the injected nginx PROXY-protocol config keys are not consumed by the host ingress is tracked independently and not touched here.

Closes #2797

### Release note

```release-note
fix(networking): point the host ouroboros PROXY-protocol proxy at the root-tenant ingress so it becomes Ready when publishing.proxyProtocol is enabled
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced proxy protocol configuration to automatically route through the appropriate ingress-nginx service based on your ingress name settings.

* **Tests**
  * Added test coverage for proxy protocol bundle wiring and ingress service routing.

* **Documentation**
  * Clarified proxy target configuration behavior and fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->