### PR TITLE
feat(ouroboros): bump to v0.8.0

### DIFF
--- a/packages/system/ouroboros/Makefile
+++ b/packages/system/ouroboros/Makefile
@@ -26,8 +26,8 @@ include ../../../hack/package.mk
 # and update both lines below; resolve the new image digest with
 #   crane digest ghcr.io/lexfrei/ouroboros:<new-tag>
 # and update values.yaml.
-OUROBOROS_CHART_VERSION ?= 0.7.2
-OUROBOROS_CHART_DIGEST ?= sha256:c67315551196a766aeb97cee6065083a5f4d78b67ab0377e25257e61d4615a43
+OUROBOROS_CHART_VERSION ?= 0.8.0
+OUROBOROS_CHART_DIGEST ?= sha256:b57255ef65a8eace361bf0e4eb93637e6a45315bc7744746b2e16ffa5bdd3744
 
 test:
 	helm unittest .

--- a/packages/system/ouroboros/charts/ouroboros/Chart.yaml
+++ b/packages/system/ouroboros/charts/ouroboros/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   artifacthub.io/category: networking
   artifacthub.io/license: BSD-3-Clause
 apiVersion: v2
-appVersion: 0.7.2
+appVersion: 0.8.0
 description: In-cluster controller + TCP proxy that fixes hairpin-NAT for Ingress
   controllers behind PROXY-protocol
 home: https://github.com/lexfrei/ouroboros
@@ -22,4 +22,4 @@ name: ouroboros
 sources:
 - https://github.com/lexfrei/ouroboros
 type: application
-version: 0.7.2
+version: 0.8.0

--- a/packages/system/ouroboros/charts/ouroboros/values.yaml
+++ b/packages/system/ouroboros/charts/ouroboros/values.yaml
@@ -105,8 +105,13 @@ controller:
     # alpine-based kubectl: needs a shell so the wrapper script can run.
     # rancher/kubectl is FROM scratch and StartErrors without /bin/sh.
     # alpine/kubectl is multi-arch and busybox-derived (sh + sed + kubectl).
-    repository: alpine/kubectl
-    # renovate: datasource=docker depName=alpine/kubectl
+    # Pulled via mirror.gcr.io (Google's read-only mirror for a curated set of
+    # popular Docker Hub images) to sidestep anonymous Docker Hub rate-limits on
+    # shared CI/runner IP ranges. alpine/kubectl is on the mirror's curated
+    # list; very recently cut tags may take a short window to propagate, so a
+    # Renovate-cut bump to a brand-new tag may temporarily render an image
+    # reference that 404s on pull until Google's mirror picks it up.
+    repository: mirror.gcr.io/alpine/kubectl
     tag: "1.36.0"
     pullPolicy: IfNotPresent
   # -- Informer resync period. Doubles as the worst-case event-to-reconcile
@@ -230,8 +235,13 @@ externalDns:
     # rancher/kubectl is FROM scratch with no /bin/sh — the wrapper script
     # would StartError immediately. alpine/kubectl is multi-arch and has
     # /bin/sh + kubectl + grep, which is everything the hook needs.
-    repository: alpine/kubectl
-    # renovate: datasource=docker depName=alpine/kubectl
+    # Pulled via mirror.gcr.io (Google's read-only mirror for a curated set of
+    # popular Docker Hub images) to sidestep anonymous Docker Hub rate-limits on
+    # shared CI/runner IP ranges. alpine/kubectl is on the mirror's curated
+    # list; very recently cut tags may take a short window to propagate, so a
+    # Renovate-cut bump to a brand-new tag may temporarily render an image
+    # reference that 404s on pull until Google's mirror picks it up.
+    repository: mirror.gcr.io/alpine/kubectl
     tag: "1.36.0"
     pullPolicy: IfNotPresent
 

--- a/packages/system/ouroboros/tests/cozystack_overrides_test.yaml
+++ b/packages/system/ouroboros/tests/cozystack_overrides_test.yaml
@@ -40,4 +40,4 @@ tests:
       # a Makefile bump that forgets to bump the tag (or vice versa).
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/lexfrei/ouroboros:0.7.2@sha256:1a8479b42ed34640752df2bfe0e9ccf052448c6849826c24cab4c30e10d76393
+          value: ghcr.io/lexfrei/ouroboros:0.8.0@sha256:9fe97093056d0bd05db667831a2a6270087ee648634d594e104c2d73f8aaa8ad

--- a/packages/system/ouroboros/values.yaml
+++ b/packages/system/ouroboros/values.yaml
@@ -6,7 +6,7 @@ ouroboros:
     # Air-gapped operators must mirror both this image and the OCI chart
     # at oci://ghcr.io/lexfrei/charts/ouroboros separately. Bump the tag
     # here together with OUROBOROS_CHART_VERSION in the Makefile.
-    tag: 0.7.2@sha256:1a8479b42ed34640752df2bfe0e9ccf052448c6849826c24cab4c30e10d76393
+    tag: 0.8.0@sha256:9fe97093056d0bd05db667831a2a6270087ee648634d594e104c2d73f8aaa8ad
   controller:
     # Host scenario default: mutate the live kube-system/coredns Corefile
     # directly. The host CoreDNS on cozystack is Talos-managed and its


### PR DESCRIPTION
## What this PR does

Bumps the vendored `ouroboros` chart and controller image in `packages/system/ouroboros` from 0.7.2 to 0.8.0.

v0.8.0 makes the in-cluster TCP proxy log an explicit reason when its backend readiness check fails, instead of staying silently NotReady. That silent failure mode is what makes a mispointed proxy backend hard to diagnose, so the upgrade pays off the moment the target is wrong. The bump also carries the v0.7.3 migration of the kubectl helper sidecar image off Docker Hub to `mirror.gcr.io`, sidestepping anonymous pull rate-limits on shared CI/runner IP ranges.

The chart manifest and controller image are re-pinned by digest in lockstep with the version, and the image-pin test fixture is updated to match. No values structure changed; cozystack-side overrides need no adaptation.

### Release note

```release-note
feat(ouroboros): bump ouroboros to v0.8.0 — the hairpin-NAT proxy now logs an explicit reason when its backend readiness check fails instead of staying silently NotReady, and the kubectl helper sidecar is pulled via mirror.gcr.io to avoid Docker Hub rate limits
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Ouroboros component from version 0.7.2 to 0.8.0, including updated container image digests.
  * Updated registry mirror configuration to improve image pull reliability and avoid rate-limiting issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/cozystack/pull/2807?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->