### PR TITLE
docs(harbor): document S3 object-storage (SeaweedFS) prerequisite

### DIFF
--- a/packages/apps/harbor/README.md
+++ b/packages/apps/harbor/README.md
@@ -2,6 +2,18 @@
 
 Harbor is an open-source trusted cloud-native registry project that stores, signs, and scans content.
 
+## Prerequisites
+
+The Cozystack Harbor app stores its registry data exclusively in S3-compatible object storage: the chart pins the registry backend to S3 and exposes no filesystem option. That bucket is provisioned through COSI (`objectstorage.k8s.io`) from a SeaweedFS deployment, so before deploying Harbor the tenant must have SeaweedFS available — enabled on the same tenant or inherited from a parent tenant (the resolved class is propagated down the tenant tree, surfaced as the `namespace.cozystack.io/seaweedfs` namespace annotation).
+
+Enable it by setting `seaweedfs: true` on the tenant (or a parent tenant):
+
+```yaml
+seaweedfs: true
+```
+
+Without object storage in the tenant chain, Harbor cannot provision its registry bucket: the `<release>-registry` `BucketClaim`/`BucketAccess` never produces the `<release>-registry-bucket` credentials secret, so the Harbor `HelmRelease` stays unreconciled, waiting on `BucketInfo`.
+
 > `storageClass` is annotated as immutable in the chart schema — see [`docs/storage-immutability.md`](../../../docs/storage-immutability.md) for the contract and which consumers enforce it.
 
 ## Parameters


### PR DESCRIPTION
## What this PR does

The Cozystack Harbor app requires S3-compatible object storage and has no filesystem fallback — the chart pins the registry backend to S3. If a tenant has no SeaweedFS in its tenant chain, Harbor cannot provision its registry bucket and the `HelmRelease` silently stays unreconciled, waiting on the `<release>-registry-bucket` `BucketInfo`. This is a common and confusing first-deploy failure, and nothing in the app docs stated the prerequisite.

This adds a **Prerequisites** section to the Harbor app README documenting the object-storage requirement and how to satisfy it (`seaweedfs: true` on the tenant or a parent tenant). The section is hand-written prose above the generated `## Parameters` block, so `cozyvalues-gen` does not clobber it on regeneration; the published app docs pick it up through the existing README-driven autoupdate.

No code or chart behavior changes.

### Screenshots

N/A — documentation only.

### Release note

```release-note
docs(harbor): document that the Harbor app requires S3 object storage (SeaweedFS) available in the tenant chain
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Prerequisites section clarifying Harbor stores registry data only in S3-compatible object storage (no filesystem fallback).
  * Notes requirement for SeaweedFS-provisioned object storage in the tenant inheritance chain and how to indicate it.
  * Explains that without available object storage, registry provisioning will not complete and Harbor will remain unreconciled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->