### PR TITLE
feat(platform): operator-provided wildcard certificate for platform and tenant ingress

### DIFF
--- a/api/gateway/v1alpha1/tenantgateway_types.go
+++ b/api/gateway/v1alpha1/tenantgateway_types.go
@@ -22,7 +22,7 @@ import (
 )
 
 // CertMode selects how the per-tenant Gateway sources TLS certificates.
-// +kubebuilder:validation:Enum=http01;dns01
+// +kubebuilder:validation:Enum=http01;dns01;existingSecret
 type CertMode string
 
 const (
@@ -35,6 +35,15 @@ const (
 	// (apex + *.apex) via DNS-01 ACME. Operator must configure a DNS
 	// provider in Spec.DNS01.
 	CertModeDNS01 CertMode = "dns01"
+
+	// CertModeExistingSecret references a pre-existing wildcard TLS
+	// Secret instead of issuing anything. No Issuer and no Certificate
+	// are minted; the wildcard/apex listeners reference the operator-
+	// supplied Secret named in Spec.WildcardSecretRef directly. Used
+	// when the operator already holds a wildcard cert (purchased, or
+	// issued by a corporate CA). The Secret must live in the
+	// TenantGateway's own namespace.
+	CertModeExistingSecret CertMode = "existingSecret"
 )
 
 // IssuerName selects the Let's Encrypt environment the per-tenant
@@ -157,6 +166,15 @@ type TenantGatewaySpec struct {
 	// CertMode=dns01.
 	// +optional
 	DNS01 *DNS01Config `json:"dns01,omitempty"`
+
+	// WildcardSecretRef names a pre-existing TLS Secret in the
+	// TenantGateway's own namespace used for the wildcard and apex
+	// listeners when CertMode=existingSecret. Required in that mode;
+	// ignored otherwise. The Secret must be of type kubernetes.io/tls
+	// and cover the tenant apex (and *.apex). Cross-namespace refs are
+	// intentionally unsupported to avoid requiring a ReferenceGrant.
+	// +optional
+	WildcardSecretRef *corev1.LocalObjectReference `json:"wildcardSecretRef,omitempty"`
 
 	// AttachedNamespaces lists namespace names that are allowed to
 	// attach HTTPRoute or TLSRoute to this tenant's Gateway. The

--- a/api/gateway/v1alpha1/zz_generated.deepcopy.go
+++ b/api/gateway/v1alpha1/zz_generated.deepcopy.go
@@ -211,6 +211,11 @@ func (in *TenantGatewaySpec) DeepCopyInto(out *TenantGatewaySpec) {
 		*out = new(DNS01Config)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.WildcardSecretRef != nil {
+		in, out := &in.WildcardSecretRef, &out.WildcardSecretRef
+		*out = new(v1.LocalObjectReference)
+		**out = **in
+	}
 	if in.AttachedNamespaces != nil {
 		in, out := &in.AttachedNamespaces, &out.AttachedNamespaces
 		*out = make([]string, len(*in))

--- a/internal/controller/tenantgateway/reconciler.go
+++ b/internal/controller/tenantgateway/reconciler.go
@@ -55,6 +55,24 @@ func gatewayCertificateName(tgw *gatewayv1alpha1.TenantGateway) string {
 	return tgw.Name + "-gateway-tls"
 }
 
+// wildcardListenerCertName returns the Secret name the wildcard, apex,
+// and per-child-apex HTTPS listeners reference. In DNS-01 mode this is
+// the controller-minted cert (gatewayCertificateName); in
+// existingSecret mode it is the operator-supplied Secret named in
+// Spec.WildcardSecretRef. Returns an error when existingSecret mode is
+// missing the reference — a misconfiguration that must surface as a
+// failed reconcile rather than a Gateway pointing at a nonexistent
+// Secret.
+func wildcardListenerCertName(tgw *gatewayv1alpha1.TenantGateway) (string, error) {
+	if tgw.Spec.CertMode == gatewayv1alpha1.CertModeExistingSecret {
+		if tgw.Spec.WildcardSecretRef == nil || tgw.Spec.WildcardSecretRef.Name == "" {
+			return "", fmt.Errorf("certMode=existingSecret requires spec.wildcardSecretRef.name to be set")
+		}
+		return tgw.Spec.WildcardSecretRef.Name, nil
+	}
+	return gatewayCertificateName(tgw), nil
+}
+
 // gatewayIssuerName returns the per-tenant ACME Issuer name. The
 // Issuer lives in the same namespace as the TenantGateway and is
 // referenced by every Certificate this controller renders.
@@ -262,7 +280,9 @@ func (r *Reconciler) reconcileHTTPToHTTPSRedirect(ctx context.Context, tgw *gate
 // through at runtime but no listener would accept it (no matching
 // hostname), so Accepted stays False indefinitely.
 func (r *Reconciler) collectHostnameClaims(ctx context.Context, tgw *gatewayv1alpha1.TenantGateway) (map[string][]routeRef, error) {
-	if tgw.Spec.CertMode == gatewayv1alpha1.CertModeDNS01 {
+	// DNS-01 and existingSecret both serve every hostname off a single
+	// wildcard listener, so neither needs per-host listeners or claims.
+	if tgw.Spec.CertMode == gatewayv1alpha1.CertModeDNS01 || tgw.Spec.CertMode == gatewayv1alpha1.CertModeExistingSecret {
 		return nil, nil
 	}
 
@@ -577,6 +597,31 @@ func labelsEqual(a, b map[string]string) bool {
 
 func (r *Reconciler) reconcileIssuer(ctx context.Context, tgw *gatewayv1alpha1.TenantGateway) error {
 	logger := log.FromContext(ctx)
+
+	if tgw.Spec.CertMode == gatewayv1alpha1.CertModeExistingSecret {
+		// existingSecret mode references an operator-supplied Secret and
+		// mints no ACME Issuer. Delete any owned Issuer left from a
+		// previous http01/dns01 phase so the mode switch doesn't leak
+		// ACME machinery. Same ownership-guarded cleanup contract as
+		// reconcileWildcardCertificate's HTTP-01 branch.
+		stale := &cmv1.Issuer{}
+		err := r.Get(ctx, types.NamespacedName{Namespace: tgw.Namespace, Name: gatewayIssuerName(tgw)}, stale)
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("get Issuer for cleanup: %w", err)
+		}
+		if !ownedByTenantGateway(stale.OwnerReferences, tgw) {
+			return nil
+		}
+		if err := r.Delete(ctx, stale); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("delete stale Issuer %s: %w", stale.Name, err)
+		}
+		logger.V(1).Info("deleted stale Issuer after switch to existingSecret", "name", stale.Name)
+		return nil
+	}
+
 	desired, err := r.renderIssuer(tgw)
 	if err != nil {
 		return fmt.Errorf("render Issuer: %w", err)
@@ -717,8 +762,14 @@ func (r *Reconciler) renderGateway(tgw *gatewayv1alpha1.TenantGateway, dynHostna
 		{Group: ptrGroup(gatewayv1.GroupName), Kind: "HTTPRoute"},
 	}
 
-	if tgw.Spec.CertMode == gatewayv1alpha1.CertModeDNS01 {
-		certName := gatewayCertificateName(tgw)
+	if tgw.Spec.CertMode == gatewayv1alpha1.CertModeDNS01 || tgw.Spec.CertMode == gatewayv1alpha1.CertModeExistingSecret {
+		// Both modes serve the apex and every subdomain off a single
+		// wildcard cert. The only difference is the Secret name: DNS-01
+		// mints it; existingSecret references the operator-supplied one.
+		certName, err := wildcardListenerCertName(tgw)
+		if err != nil {
+			return nil, err
+		}
 		wildcardHost := gatewayv1.Hostname("*." + tgw.Spec.Apex)
 		apexHost := gatewayv1.Hostname(tgw.Spec.Apex)
 		listeners = append(listeners,

--- a/internal/controller/tenantgateway/reconciler_test.go
+++ b/internal/controller/tenantgateway/reconciler_test.go
@@ -3326,3 +3326,377 @@ func TestReconcile_MultiParentRefRouteWritesPerRefStatus(t *testing.T) {
 		t.Errorf("expected status entries for both sectionNames, got %+v", sections)
 	}
 }
+
+// TestReconcile_ExistingSecretModeRendersWildcardListenerWithSecretRef
+// pins the existingSecret path: the Gateway gets the same wildcard +
+// apex HTTPS listeners as DNS-01 mode, but their CertificateRefs point
+// at the operator-supplied Secret named in Spec.WildcardSecretRef
+// instead of a controller-minted cert.
+func TestReconcile_ExistingSecretModeRendersWildcardListenerWithSecretRef(t *testing.T) {
+	s := newScheme(t)
+	tgw := &gatewayv1alpha1.TenantGateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "cozystack", Namespace: "tenant-foo"},
+		Spec: gatewayv1alpha1.TenantGatewaySpec{
+			Apex:              "foo.example.com",
+			CertMode:          gatewayv1alpha1.CertModeExistingSecret,
+			GatewayClassName:  "cilium",
+			WildcardSecretRef: &corev1.LocalObjectReference{Name: "wildcard-tls"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tgw).WithStatusSubresource(tgw).Build()
+
+	r := &Reconciler{Client: c, Scheme: s}
+	if _, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "cozystack", Namespace: "tenant-foo"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &gatewayv1.Gateway{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "cozystack", Namespace: "tenant-foo"}, got); err != nil {
+		t.Fatalf("get Gateway: %v", err)
+	}
+	var sawWildcard, sawApex bool
+	for _, l := range got.Spec.Listeners {
+		if l.Protocol != gatewayv1.HTTPSProtocolType || l.Hostname == nil {
+			continue
+		}
+		switch string(*l.Hostname) {
+		case "*.foo.example.com":
+			sawWildcard = true
+		case "foo.example.com":
+			sawApex = true
+		default:
+			continue
+		}
+		if l.TLS == nil || len(l.TLS.CertificateRefs) != 1 ||
+			string(l.TLS.CertificateRefs[0].Name) != "wildcard-tls" {
+			t.Errorf("listener %s must reference the operator Secret wildcard-tls, got %+v", *l.Hostname, l.TLS)
+		}
+	}
+	if !sawWildcard {
+		t.Errorf("expected wildcard *.foo.example.com HTTPS listener in existingSecret mode, got %+v", got.Spec.Listeners)
+	}
+	if !sawApex {
+		t.Errorf("expected apex foo.example.com HTTPS listener in existingSecret mode, got %+v", got.Spec.Listeners)
+	}
+}
+
+// TestReconcile_ExistingSecretModeCreatesNoIssuerOrCertificate pins the
+// "no minting" contract: existingSecret mode references a pre-existing
+// Secret, so the controller must not create a cert-manager Issuer or
+// any Certificate.
+func TestReconcile_ExistingSecretModeCreatesNoIssuerOrCertificate(t *testing.T) {
+	s := newScheme(t)
+	tgw := &gatewayv1alpha1.TenantGateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "cozystack", Namespace: "tenant-foo"},
+		Spec: gatewayv1alpha1.TenantGatewaySpec{
+			Apex:              "foo.example.com",
+			CertMode:          gatewayv1alpha1.CertModeExistingSecret,
+			GatewayClassName:  "cilium",
+			WildcardSecretRef: &corev1.LocalObjectReference{Name: "wildcard-tls"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tgw).WithStatusSubresource(tgw).Build()
+
+	r := &Reconciler{Client: c, Scheme: s}
+	if _, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "cozystack", Namespace: "tenant-foo"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "cozystack-gateway", Namespace: "tenant-foo"}, &cmv1.Issuer{}); err == nil {
+		t.Errorf("existingSecret mode must not create an Issuer")
+	}
+	certs := &cmv1.CertificateList{}
+	if err := c.List(context.TODO(), certs); err != nil {
+		t.Fatalf("list certs: %v", err)
+	}
+	if len(certs.Items) != 0 {
+		t.Errorf("existingSecret mode must not create any Certificate, got %d", len(certs.Items))
+	}
+}
+
+// TestReconcile_ExistingSecretModeMissingSecretRefFails pins the
+// fail-fast: CertMode=existingSecret without a WildcardSecretRef is a
+// misconfiguration. Reconcile must return an error and the
+// TenantGateway must carry Ready=False.
+func TestReconcile_ExistingSecretModeMissingSecretRefFails(t *testing.T) {
+	s := newScheme(t)
+	tgw := &gatewayv1alpha1.TenantGateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "cozystack", Namespace: "tenant-foo"},
+		Spec: gatewayv1alpha1.TenantGatewaySpec{
+			Apex:             "foo.example.com",
+			CertMode:         gatewayv1alpha1.CertModeExistingSecret,
+			GatewayClassName: "cilium",
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tgw).WithStatusSubresource(tgw).Build()
+
+	r := &Reconciler{Client: c, Scheme: s}
+	if _, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "cozystack", Namespace: "tenant-foo"},
+	}); err == nil {
+		t.Fatalf("expected error when WildcardSecretRef is missing in existingSecret mode")
+	}
+
+	got := &gatewayv1alpha1.TenantGateway{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "cozystack", Namespace: "tenant-foo"}, got); err != nil {
+		t.Fatalf("get tgw: %v", err)
+	}
+	var readyFalse bool
+	for _, cond := range got.Status.Conditions {
+		if cond.Type == "Ready" && cond.Status == metav1.ConditionFalse {
+			readyFalse = true
+		}
+	}
+	if !readyFalse {
+		t.Errorf("expected Ready=False condition after failed reconcile, got %+v", got.Status.Conditions)
+	}
+}
+
+// TestReconcile_CertModeTransitionHTTP01ToExistingSecretCleansCertsAndIssuer
+// pins the mode-switch cleanup: flipping from HTTP-01 to existingSecret
+// must reclaim the per-tenant ACME Issuer and any per-listener
+// Certificate left behind, so no orphaned ACME machinery lingers.
+func TestReconcile_CertModeTransitionHTTP01ToExistingSecretCleansCertsAndIssuer(t *testing.T) {
+	s := newScheme(t)
+	tgw := &gatewayv1alpha1.TenantGateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "cozystack", Namespace: "tenant-foo"},
+		Spec: gatewayv1alpha1.TenantGatewaySpec{
+			Apex:               "foo.example.com",
+			CertMode:           gatewayv1alpha1.CertModeHTTP01,
+			GatewayClassName:   "cilium",
+			AttachedNamespaces: []string{"cozy-harbor"},
+		},
+	}
+	route := httpRouteAttached("harbor", "cozy-harbor", "harbor.foo.example.com")
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tgw, route).WithStatusSubresource(tgw, &gatewayv1.Gateway{}).Build()
+	r := &Reconciler{Client: c, Scheme: s}
+
+	// Phase 1: HTTP-01 reconcile creates an Issuer + per-listener cert.
+	if _, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "cozystack", Namespace: "tenant-foo"},
+	}); err != nil {
+		t.Fatalf("phase 1 reconcile: %v", err)
+	}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "cozystack-gateway", Namespace: "tenant-foo"}, &cmv1.Issuer{}); err != nil {
+		t.Fatalf("expected Issuer after HTTP-01 phase: %v", err)
+	}
+	preCerts := &cmv1.CertificateList{}
+	if err := c.List(context.TODO(), preCerts); err != nil {
+		t.Fatalf("phase 1 list certs: %v", err)
+	}
+	if len(preCerts.Items) == 0 {
+		t.Fatalf("expected a per-listener cert after HTTP-01 phase")
+	}
+
+	// Phase 2: flip to existingSecret. Issuer + per-listener certs gone.
+	updated := &gatewayv1alpha1.TenantGateway{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "cozystack", Namespace: "tenant-foo"}, updated); err != nil {
+		t.Fatalf("get tgw: %v", err)
+	}
+	updated.Spec.CertMode = gatewayv1alpha1.CertModeExistingSecret
+	updated.Spec.WildcardSecretRef = &corev1.LocalObjectReference{Name: "wildcard-tls"}
+	if err := c.Update(context.TODO(), updated); err != nil {
+		t.Fatalf("flip certMode: %v", err)
+	}
+	if _, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "cozystack", Namespace: "tenant-foo"},
+	}); err != nil {
+		t.Fatalf("phase 2 reconcile: %v", err)
+	}
+
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "cozystack-gateway", Namespace: "tenant-foo"}, &cmv1.Issuer{}); err == nil {
+		t.Errorf("Issuer leaked after switch to existingSecret")
+	}
+	postCerts := &cmv1.CertificateList{}
+	if err := c.List(context.TODO(), postCerts); err != nil {
+		t.Fatalf("phase 2 list certs: %v", err)
+	}
+	if len(postCerts.Items) != 0 {
+		t.Errorf("per-listener certs leaked after switch to existingSecret: %d remain", len(postCerts.Items))
+	}
+}
+
+// TestReconcile_CertModeTransitionDNS01ToExistingSecretCleansWildcardCert
+// pins the symmetric DNS-01 cleanup: the controller-minted wildcard
+// Certificate from a prior DNS-01 phase must be deleted when switching
+// to existingSecret (the operator now owns the cert material).
+func TestReconcile_CertModeTransitionDNS01ToExistingSecretCleansWildcardCert(t *testing.T) {
+	s := newScheme(t)
+	tgw := &gatewayv1alpha1.TenantGateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "cozystack", Namespace: "tenant-foo"},
+		Spec: gatewayv1alpha1.TenantGatewaySpec{
+			Apex:             "foo.example.com",
+			CertMode:         gatewayv1alpha1.CertModeDNS01,
+			GatewayClassName: "cilium",
+			DNS01: &gatewayv1alpha1.DNS01Config{
+				Provider: "cloudflare",
+				Cloudflare: &gatewayv1alpha1.CloudflareDNS01{
+					APITokenSecretRef: corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "cf-token"},
+						Key:                  "api-token",
+					},
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tgw).WithStatusSubresource(tgw, &gatewayv1.Gateway{}).Build()
+	r := &Reconciler{Client: c, Scheme: s}
+
+	if _, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "cozystack", Namespace: "tenant-foo"},
+	}); err != nil {
+		t.Fatalf("phase 1 reconcile: %v", err)
+	}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "cozystack-gateway-tls", Namespace: "tenant-foo"}, &cmv1.Certificate{}); err != nil {
+		t.Fatalf("expected wildcard cert in DNS-01 phase: %v", err)
+	}
+
+	updated := &gatewayv1alpha1.TenantGateway{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "cozystack", Namespace: "tenant-foo"}, updated); err != nil {
+		t.Fatalf("get tgw: %v", err)
+	}
+	updated.Spec.CertMode = gatewayv1alpha1.CertModeExistingSecret
+	updated.Spec.DNS01 = nil
+	updated.Spec.WildcardSecretRef = &corev1.LocalObjectReference{Name: "wildcard-tls"}
+	if err := c.Update(context.TODO(), updated); err != nil {
+		t.Fatalf("flip certMode: %v", err)
+	}
+	if _, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "cozystack", Namespace: "tenant-foo"},
+	}); err != nil {
+		t.Fatalf("phase 2 reconcile: %v", err)
+	}
+
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "cozystack-gateway-tls", Namespace: "tenant-foo"}, &cmv1.Certificate{}); err == nil {
+		t.Errorf("wildcard cert leaked after switch to existingSecret")
+	}
+}
+
+// TestReconcile_ExistingSecretModeKeepsHTTPRedirectAndPassthrough pins
+// that switching off ACME does not regress the non-cert listeners: the
+// http→https redirect HTTPRoute and TLS-passthrough listeners must
+// still render in existingSecret mode.
+func TestReconcile_ExistingSecretModeKeepsHTTPRedirectAndPassthrough(t *testing.T) {
+	s := newScheme(t)
+	tgw := &gatewayv1alpha1.TenantGateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "cozystack", Namespace: "tenant-foo"},
+		Spec: gatewayv1alpha1.TenantGatewaySpec{
+			Apex:                   "foo.example.com",
+			CertMode:               gatewayv1alpha1.CertModeExistingSecret,
+			GatewayClassName:       "cilium",
+			WildcardSecretRef:      &corev1.LocalObjectReference{Name: "wildcard-tls"},
+			TLSPassthroughServices: []string{"api"},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(tgw).WithStatusSubresource(tgw).Build()
+
+	r := &Reconciler{Client: c, Scheme: s}
+	if _, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "cozystack", Namespace: "tenant-foo"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "cozystack-http-redirect", Namespace: "tenant-foo"}, &gatewayv1.HTTPRoute{}); err != nil {
+		t.Errorf("expected http→https redirect HTTPRoute in existingSecret mode: %v", err)
+	}
+
+	gw := &gatewayv1.Gateway{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "cozystack", Namespace: "tenant-foo"}, gw); err != nil {
+		t.Fatalf("get Gateway: %v", err)
+	}
+	var sawPassthrough bool
+	for _, l := range gw.Spec.Listeners {
+		if string(l.Name) == "tls-api" && l.Protocol == gatewayv1.TLSProtocolType &&
+			l.TLS != nil && l.TLS.Mode != nil && *l.TLS.Mode == gatewayv1.TLSModePassthrough {
+			sawPassthrough = true
+		}
+	}
+	if !sawPassthrough {
+		t.Errorf("expected tls-api passthrough listener in existingSecret mode, got %+v", gw.Spec.Listeners)
+	}
+}
+
+// TestReconcile_ExistingSecretModeRendersChildApexListenerWithOperatorSecret
+// pins the inheritance shape in existingSecret mode: like DNS-01, the
+// controller renders a `*.<child-apex>` listener for every inheriting
+// child tenant, all referencing the single operator-supplied Secret.
+//
+// This is a deliberately-degraded behavior worth pinning: unlike DNS-01
+// (where the controller mints a wildcard cert with child-apex SANs), in
+// existingSecret mode nothing extends the operator's static Secret, so a
+// `*.<apex>` cert does NOT cover `*.<child-apex>` and child subdomains
+// will present the parent cert. The MVP scopes operator-wildcard to the
+// root tenant for exactly this reason (see packages/extra/gateway
+// README). Pinning what gets rendered here means a future change to
+// child-apex handling cannot silently regress it.
+func TestReconcile_ExistingSecretModeRendersChildApexListenerWithOperatorSecret(t *testing.T) {
+	s := newScheme(t)
+	tgw := &gatewayv1alpha1.TenantGateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "cozystack", Namespace: "tenant-root"},
+		Spec: gatewayv1alpha1.TenantGatewaySpec{
+			Apex:              "example.org",
+			CertMode:          gatewayv1alpha1.CertModeExistingSecret,
+			GatewayClassName:  "cilium",
+			WildcardSecretRef: &corev1.LocalObjectReference{Name: "wildcard-tls"},
+		},
+	}
+	nsRoot := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tenant-root",
+			Labels: map[string]string{
+				"namespace.cozystack.io/host":    "example.org",
+				"namespace.cozystack.io/gateway": "tenant-root",
+			},
+		},
+	}
+	nsAlice := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tenant-root-alice",
+			Labels: map[string]string{
+				"namespace.cozystack.io/host":    "alice.example.org",
+				"namespace.cozystack.io/gateway": "tenant-root",
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(tgw, nsRoot, nsAlice).
+		WithStatusSubresource(tgw).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: s}
+	if _, err := r.Reconcile(context.TODO(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "cozystack", Namespace: "tenant-root"},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gw := &gatewayv1.Gateway{}
+	if err := c.Get(context.TODO(), types.NamespacedName{Name: "cozystack", Namespace: "tenant-root"}, gw); err != nil {
+		t.Fatalf("get Gateway: %v", err)
+	}
+
+	var sawChild bool
+	for i := range gw.Spec.Listeners {
+		l := &gw.Spec.Listeners[i]
+		if l.Hostname == nil || string(*l.Hostname) != "*.alice.example.org" {
+			continue
+		}
+		sawChild = true
+		if l.Protocol != gatewayv1.HTTPSProtocolType {
+			t.Errorf("child listener: expected HTTPS protocol, got %s", l.Protocol)
+		}
+		if l.TLS == nil || len(l.TLS.CertificateRefs) != 1 ||
+			string(l.TLS.CertificateRefs[0].Name) != "wildcard-tls" {
+			t.Errorf("child listener must reference the operator Secret wildcard-tls, got %+v", l.TLS)
+		}
+	}
+	if !sawChild {
+		t.Errorf("expected per-child-apex listener *.alice.example.org in existingSecret mode, got %+v", gw.Spec.Listeners)
+	}
+}

--- a/internal/controller/tenantgateway/renderers.go
+++ b/internal/controller/tenantgateway/renderers.go
@@ -360,6 +360,13 @@ func buildSolver(tgw *gatewayv1alpha1.TenantGateway) (*cmacmev1.ACMEChallengeSol
 			return nil, fmt.Errorf("unsupported dns01.provider=%q (supported: cloudflare, route53, digitalocean, rfc2136)", tgw.Spec.DNS01.Provider)
 		}
 
+	case gatewayv1alpha1.CertModeExistingSecret:
+		// existingSecret mode mints no Issuer, so reconcileIssuer never
+		// calls buildSolver in this mode. Guard defensively so a future
+		// caller gets a clear contract error instead of silently
+		// falling through to the unknown-certMode default below.
+		return nil, fmt.Errorf("certMode=existingSecret does not use an ACME solver")
+
 	default:
 		return nil, fmt.Errorf("unknown certMode=%q", tgw.Spec.CertMode)
 	}

--- a/packages/apps/harbor/Makefile
+++ b/packages/apps/harbor/Makefile
@@ -2,6 +2,9 @@ NAME=harbor
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 generate:
 	cozyvalues-gen -m 'harbor' -v values.yaml -s values.schema.json -r README.md -g ../../../api/apps/v1alpha1/harbor/types.go
 	../../../hack/update-crd.sh

--- a/packages/apps/harbor/templates/ingress.yaml
+++ b/packages/apps/harbor/templates/ingress.yaml
@@ -4,6 +4,7 @@
 {{- $harborHost := .Values.host | default (printf "%s.%s" .Release.Name $host) }}
 {{- $solver := (index .Values._cluster "solver") | default "http01" }}
 {{- $clusterIssuer := (index .Values._cluster "issuer-name") | default "letsencrypt-prod" }}
+{{- $wildcardSecret := (index .Values._cluster "wildcard-secret-name") | default "" }}
 {{- if not $gateway }}
 ---
 apiVersion: networking.k8s.io/v1
@@ -16,16 +17,21 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "900"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    {{- /* Operator wildcard mode: nginx serves the default SSL cert, so skip per-host ACME. */}}
+    {{- if not $wildcardSecret }}
     {{- if eq $solver "http01" }}
     acme.cert-manager.io/http01-ingress-ingressclassname: {{ $ingress }}
     {{- end }}
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
+    {{- end }}
 spec:
   ingressClassName: {{ $ingress }}
+  {{- if not $wildcardSecret }}
   tls:
     - hosts:
         - {{ $harborHost | quote }}
       secretName: {{ .Release.Name }}-ingress-tls
+  {{- end }}
   rules:
     - host: {{ $harborHost | quote }}
       http:

--- a/packages/apps/harbor/templates/ingress.yaml
+++ b/packages/apps/harbor/templates/ingress.yaml
@@ -26,12 +26,15 @@ metadata:
     {{- end }}
 spec:
   ingressClassName: {{ $ingress }}
-  {{- if not $wildcardSecret }}
   tls:
     - hosts:
         - {{ $harborHost | quote }}
+      {{- /* Operator wildcard mode: no per-host secret — ingress-nginx falls
+             back to the default SSL certificate while the tls section keeps
+             the HTTP-to-HTTPS redirect enforced. */}}
+      {{- if not $wildcardSecret }}
       secretName: {{ .Release.Name }}-ingress-tls
-  {{- end }}
+      {{- end }}
   rules:
     - host: {{ $harborHost | quote }}
       http:

--- a/packages/apps/harbor/tests/ingress_wildcard_test.yaml
+++ b/packages/apps/harbor/tests/ingress_wildcard_test.yaml
@@ -1,0 +1,49 @@
+suite: harbor ingress wildcard mode drops per-host ACME
+templates:
+  - templates/ingress.yaml
+
+release:
+  name: harbor
+  namespace: tenant-root
+
+# harbor gates its Ingress on an empty _namespace.gateway. In wildcard
+# mode the cert-manager + http01 annotations and the tls block are
+# dropped; the other nginx annotations stay.
+
+tests:
+  - it: drops cert-manager annotation and tls block when wildcard secret is set
+    set:
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+        gateway: ""
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+        wildcard-secret-name: wildcard-tls
+    asserts:
+      - equal:
+          path: kind
+          value: Ingress
+      - notExists:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+      - notExists:
+          path: spec.tls
+      - exists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
+
+  - it: keeps cert-manager annotation and tls block without wildcard secret
+    set:
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+        gateway: ""
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+      - exists:
+          path: spec.tls[0].secretName

--- a/packages/apps/harbor/tests/ingress_wildcard_test.yaml
+++ b/packages/apps/harbor/tests/ingress_wildcard_test.yaml
@@ -7,11 +7,13 @@ release:
   namespace: tenant-root
 
 # harbor gates its Ingress on an empty _namespace.gateway. In wildcard
-# mode the cert-manager + http01 annotations and the tls block are
-# dropped; the other nginx annotations stay.
+# mode the cert-manager + http01 annotations and the per-host tls
+# secretName are dropped (the tls section stays so the HTTPS redirect
+# keeps working against the default SSL certificate); the other nginx
+# annotations stay.
 
 tests:
-  - it: drops cert-manager annotation and tls block when wildcard secret is set
+  - it: drops cert-manager annotation and tls secretName when wildcard secret is set
     set:
       _namespace:
         host: example.org
@@ -27,12 +29,14 @@ tests:
           value: Ingress
       - notExists:
           path: metadata.annotations["cert-manager.io/cluster-issuer"]
-      - notExists:
+      - exists:
           path: spec.tls
+      - notExists:
+          path: spec.tls[0].secretName
       - exists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
 
-  - it: keeps cert-manager annotation and tls block without wildcard secret
+  - it: keeps cert-manager annotation and tls secretName without wildcard secret
     set:
       _namespace:
         host: example.org

--- a/packages/core/platform/templates/apps.yaml
+++ b/packages/core/platform/templates/apps.yaml
@@ -24,6 +24,17 @@ stringData:
       solver: {{ .Values.publishing.certificates.solver | quote }}
       issuer-name: {{ .Values.publishing.certificates.issuerName | quote }}
       {{- /*
+        Operator-supplied wildcard mode. Only the Secret NAME rides this
+        channel — never the cert/key material (unlike a private key, the
+        name is not sensitive). When set, the ingress flow points the
+        root ingress controller's --default-ssl-certificate at it and
+        drops per-host ACME, and the gateway chart switches the
+        TenantGateway to certMode=existingSecret. The Secret itself must
+        be pre-created by the operator in the publishing namespace
+        (tenant-root). Empty string = ACME issuance as before.
+      */}}
+      wildcard-secret-name: {{ .Values.publishing.certificates.wildcardSecretName | default "" | quote }}
+      {{- /*
         DNS-01 solver wiring. Read only when solver=dns01, but the
         keys are written unconditionally so a render-time switch from
         http01 to dns01 doesn't require chart redeploy of every

--- a/packages/core/platform/tests/apps_wildcard_secret_test.yaml
+++ b/packages/core/platform/tests/apps_wildcard_secret_test.yaml
@@ -1,0 +1,28 @@
+suite: apps.yaml operator wildcard secret name wiring
+templates:
+  - templates/apps.yaml
+
+release:
+  name: cozy-platform
+  namespace: cozy-system
+
+# Asserts that publishing.certificates.wildcardSecretName lands in the
+# _cluster.wildcard-secret-name key that the ingress flow and the
+# gateway chart read to switch into operator-supplied-wildcard mode.
+# Only the Secret NAME travels on this channel — never the cert/key
+# material — so the value is a plain quoted string.
+
+tests:
+  - it: writes empty wildcard-secret-name by default
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-secret-name:\s*""'
+
+  - it: writes the operator-supplied wildcard secret name when set
+    set:
+      publishing.certificates.wildcardSecretName: wildcard-tls
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-secret-name:\s*"wildcard-tls"'

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -199,6 +199,21 @@ publishing:
   certificates:
     solver: http01 # "http01" or "dns01"
     issuerName: letsencrypt-prod
+    # Operator-provided wildcard certificate. When set, platform
+    # services and the root tenant's ingress/Gateway serve under this
+    # pre-existing TLS Secret instead of minting per-host ACME certs.
+    # The Secret must already exist in the publishing namespace — the
+    # one that runs the root ingress controller / Gateway, which follows
+    # publishing.ingressName (tenant-root by default) — be of type
+    # kubernetes.io/tls, and cover the root host (typically a wildcard
+    # *.<root-host> + <root-host>). Only the
+    # NAME is distributed through the platform values channel — the
+    # cert/key material is never broadcast. Leave empty to keep ACME
+    # issuance (solver/issuerName above). This is per-controller and
+    # currently applies to the root tenant only; propagating it to
+    # child tenants requires replicating the Secret into each tenant
+    # namespace (tracked separately).
+    wildcardSecretName: ""
     # Rate-limit note: every tenant with gateway=true issues one
     # Certificate for its wildcard + apex hostnames. If many tenants share
     # the same apex domain with issuerName=letsencrypt-prod, the cluster

--- a/packages/extra/bootbox/Makefile
+++ b/packages/extra/bootbox/Makefile
@@ -3,6 +3,9 @@ NAMESPACE=tenant-root
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 generate:
 	cozyvalues-gen -v values.yaml -s values.schema.json -r README.md
 	../../../hack/update-crd.sh

--- a/packages/extra/bootbox/templates/matchbox/ingress.yaml
+++ b/packages/extra/bootbox/templates/matchbox/ingress.yaml
@@ -2,26 +2,34 @@
 {{- $clusterIssuer := (index .Values._cluster "issuer-name") | default "letsencrypt-prod" }}
 {{- $ingress := .Values._namespace.ingress }}
 {{- $host := .Values._namespace.host }}
+{{- $wildcardSecret := (index .Values._cluster "wildcard-secret-name") | default "" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: bootbox
   labels:
     app: bootbox
+  {{- /* Operator wildcard mode: nginx serves the default SSL cert, so skip per-host ACME. Render annotations only when something remains. */}}
+  {{- if or (not $wildcardSecret) .Values.whitelistHTTP }}
   annotations:
+    {{- if not $wildcardSecret }}
     {{- if eq $solver "http01" }}
     acme.cert-manager.io/http01-ingress-ingressclassname: {{ $ingress }}
     {{- end }}
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
+    {{- end }}
     {{- if .Values.whitelistHTTP }}
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ join "," (.Values.whitelist | default "0.0.0.0/32") }}"
     {{- end }}
+  {{- end }}
 spec:
   ingressClassName: {{ $ingress }}
+  {{- if not $wildcardSecret }}
   tls:
     - hosts:
         - "{{ printf "bootbox.%s" (.Values.host | default $host) }}"
       secretName: bootbox-tls
+  {{- end }}
   rules:
     - host: "{{ printf "bootbox.%s" (.Values.host | default $host) }}"
       http:

--- a/packages/extra/bootbox/templates/matchbox/ingress.yaml
+++ b/packages/extra/bootbox/templates/matchbox/ingress.yaml
@@ -24,12 +24,15 @@ metadata:
   {{- end }}
 spec:
   ingressClassName: {{ $ingress }}
-  {{- if not $wildcardSecret }}
   tls:
     - hosts:
         - "{{ printf "bootbox.%s" (.Values.host | default $host) }}"
+      {{- /* Operator wildcard mode: no per-host secret — ingress-nginx falls
+             back to the default SSL certificate while the tls section keeps
+             the HTTP-to-HTTPS redirect enforced. */}}
+      {{- if not $wildcardSecret }}
       secretName: bootbox-tls
-  {{- end }}
+      {{- end }}
   rules:
     - host: "{{ printf "bootbox.%s" (.Values.host | default $host) }}"
       http:

--- a/packages/extra/bootbox/tests/ingress_wildcard_test.yaml
+++ b/packages/extra/bootbox/tests/ingress_wildcard_test.yaml
@@ -9,13 +9,15 @@ release:
 # bootbox deploys into tenant-root and uses the publishing tenant's
 # ingress controller (_namespace.ingress), so in wildcard mode it must
 # also stop minting its own per-host ACME cert. The cert-manager + http01
-# annotations and the tls block are dropped. bootbox's only other
-# annotation (whitelist-source-range) is conditional, so the annotations
+# annotations and the per-host tls secretName are dropped; the tls
+# section itself stays so the HTTPS redirect keeps working against the
+# default SSL certificate. bootbox's only other annotation
+# (whitelist-source-range) is conditional, so the annotations
 # block must collapse entirely when wildcard is set and no whitelist is
 # configured.
 
 tests:
-  - it: collapses the annotations block and drops tls when wildcard set and no whitelist
+  - it: collapses the annotations block and drops tls secretName when wildcard set and no whitelist
     set:
       whitelistHTTP: false
       _namespace:
@@ -31,10 +33,12 @@ tests:
           value: Ingress
       - notExists:
           path: metadata.annotations
-      - notExists:
+      - exists:
           path: spec.tls
+      - notExists:
+          path: spec.tls[0].secretName
 
-  - it: keeps cert-manager annotation and tls block without wildcard secret
+  - it: keeps cert-manager annotation and tls secretName without wildcard secret
     set:
       _namespace:
         host: example.org
@@ -68,5 +72,7 @@ tests:
       - equal:
           path: metadata.annotations["nginx.ingress.kubernetes.io/whitelist-source-range"]
           value: "192.0.2.0/24"
-      - notExists:
+      - exists:
           path: spec.tls
+      - notExists:
+          path: spec.tls[0].secretName

--- a/packages/extra/bootbox/tests/ingress_wildcard_test.yaml
+++ b/packages/extra/bootbox/tests/ingress_wildcard_test.yaml
@@ -1,0 +1,72 @@
+suite: bootbox ingress wildcard mode drops per-host ACME
+templates:
+  - templates/matchbox/ingress.yaml
+
+release:
+  name: bootbox
+  namespace: tenant-root
+
+# bootbox deploys into tenant-root and uses the publishing tenant's
+# ingress controller (_namespace.ingress), so in wildcard mode it must
+# also stop minting its own per-host ACME cert. The cert-manager + http01
+# annotations and the tls block are dropped. bootbox's only other
+# annotation (whitelist-source-range) is conditional, so the annotations
+# block must collapse entirely when wildcard is set and no whitelist is
+# configured.
+
+tests:
+  - it: collapses the annotations block and drops tls when wildcard set and no whitelist
+    set:
+      whitelistHTTP: false
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+        wildcard-secret-name: wildcard-tls
+    asserts:
+      - equal:
+          path: kind
+          value: Ingress
+      - notExists:
+          path: metadata.annotations
+      - notExists:
+          path: spec.tls
+
+  - it: keeps cert-manager annotation and tls block without wildcard secret
+    set:
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+      - equal:
+          path: spec.tls[0].secretName
+          value: bootbox-tls
+
+  - it: keeps whitelist annotation but drops cert-manager when wildcard set with whitelist
+    set:
+      whitelistHTTP: true
+      whitelist:
+        - "192.0.2.0/24"
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+        wildcard-secret-name: wildcard-tls
+    asserts:
+      - notExists:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/whitelist-source-range"]
+          value: "192.0.2.0/24"
+      - notExists:
+          path: spec.tls

--- a/packages/extra/gateway/README.md
+++ b/packages/extra/gateway/README.md
@@ -12,9 +12,9 @@ The `apps/tenant` chart writes a namespace label `namespace.cozystack.io/gateway
 
 Owning a separate Gateway makes sense for: a tenant that needs its own LB IP (DNS already pinned, firewall rule on a specific address), a tenant whose apex is not derived from the parent (custom `host`, e.g. `customer1.io` not under the platform apex — the ancestor's cert/Issuer can't cover it), or a tenant that wants its own ACME account / cert authority. Otherwise leave `gateway` unset and inherit.
 
-## Cert mode: HTTP-01 (default) vs DNS-01 (opt-in)
+## Cert mode: HTTP-01 (default) vs DNS-01 (opt-in) vs existing Secret
 
-The platform-wide `publishing.certificates.solver` value selects how the controller sources TLS certificates for the tenant Gateway.
+The platform-wide `publishing.certificates.solver` value selects how the controller sources TLS certificates for the tenant Gateway. Setting `publishing.certificates.wildcardSecretName` switches to a third mode (existing Secret) that overrides the solver entirely — see below.
 
 ### Default — HTTP-01
 
@@ -47,6 +47,17 @@ For inheriting child tenants under this Gateway: the controller extends the same
 Pick DNS-01 when you specifically want a wildcard cert (e.g. a long-lived staging cluster with many short-lived apps and tight LE rate limits). Otherwise stay on HTTP-01.
 
 > **Listener-cap considerations.** Gateway API caps `Gateway.spec.listeners` at 64. In HTTP-01 mode, every published hostname adds one HTTPS listener, plus the mandatory `http` listener and one extra per TLS-passthrough service — so a tenant approaching 60+ published apps on HTTP-01 hits the spec cap and the rendered `Gateway` fails admission. DNS-01 mode collapses every hostname under the apex into one wildcard listener and is the right choice for high-fanout single-tenant deployments.
+
+### Opt-in — existing wildcard Secret (operator-provided)
+
+Set `publishing.certificates.wildcardSecretName` in the platform chart values to point the tenant Gateway at a pre-existing wildcard TLS Secret instead of issuing anything via ACME. Use this when the operator already holds a wildcard certificate — purchased, or issued by a corporate CA — and wants platform services to serve under it. This mode takes precedence over `solver`: when `wildcardSecretName` is set, the solver / provider / issuer values are ignored.
+
+The platform chart writes the value into `_cluster.wildcard-secret-name` (the name only — the certificate and private key never travel on the values channel), and the gateway chart renders `certMode: existingSecret` with `wildcardSecretRef.name` on the `TenantGateway` CR. The controller then:
+
+- Mints no `Issuer` and no `Certificate`. Switching into this mode from HTTP-01 or DNS-01 garbage-collects the now-unused per-tenant `Issuer` and any per-listener / wildcard `Certificate` the controller previously owned.
+- Renders the same single-wildcard listener shape as DNS-01: a `https` (`*.<apex>`) listener and a `https-apex` (`<apex>`) listener (plus one `*.<child-apex>` listener per inheriting child), all with `certificateRefs` pointing at the operator-supplied Secret.
+
+The Secret must already exist in the `TenantGateway`'s own namespace (the publishing tenant namespace, e.g. `tenant-root`), be of type `kubernetes.io/tls`, and cover the apex (and `*.<apex>`). Cross-namespace references are intentionally unsupported, so coverage for inheriting child apexes depends on the operator-supplied certificate's SAN list — a single `*.<apex>` does not match `*.<child-apex>`. The controller still renders a `*.<child-apex>` listener bound to the operator Secret for each inheriting child, so if the SAN list does not cover that child apex, clients of the child subdomain are served the parent certificate and see a hostname-mismatch TLS error. This is why operator-wildcard support is scoped to the root tenant for now; extending it to child tenants needs the Secret replicated per tenant namespace (tracked separately). Like DNS-01, this mode collapses every hostname under the apex into one wildcard listener, so it is also a way to stay clear of the 64-listener cap.
 
 ## External IP allocation
 

--- a/packages/extra/gateway/templates/tenantgateway.yaml
+++ b/packages/extra/gateway/templates/tenantgateway.yaml
@@ -5,6 +5,15 @@
 {{- $solver := (index .Values._cluster "solver") | default "http01" }}
 {{- $issuerName := (index .Values._cluster "issuer-name") | default "letsencrypt-prod" }}
 {{- $provider := (index .Values._cluster "dns01-provider") | default "cloudflare" }}
+{{- $wildcardSecret := (index .Values._cluster "wildcard-secret-name") | default "" }}
+{{- /*
+  Operator-supplied wildcard mode wins over ACME. When
+  _cluster.wildcard-secret-name is set, the Gateway references that
+  pre-existing Secret directly (certMode=existingSecret) and the
+  controller mints no Issuer/Certificate — so the solver, provider,
+  and issuer-name validations below (all ACME concerns) are skipped.
+*/}}
+{{- if not $wildcardSecret }}
 {{- /*
   Validate solver early — same check the old issuer.yaml ran. The
   controller will refuse to render an Issuer with an unsupported
@@ -22,6 +31,7 @@
 {{- if and (ne $issuerName "letsencrypt-prod") (ne $issuerName "letsencrypt-stage") }}
   {{- fail (printf "packages/extra/gateway currently supports publishing.certificates.issuerName=letsencrypt-prod or letsencrypt-stage (got %q). For other issuers, extend the controller to map the name to the corresponding ACME server URL." $issuerName) }}
 {{- end }}
+{{- end }}
 {{- $extraNs := list }}
 {{- range splitList "," ((index .Values._cluster "gateway-attached-namespaces") | default "") }}
   {{- $ns := . | trim }}
@@ -37,6 +47,11 @@ metadata:
 spec:
   apex: {{ $host | quote }}
   gatewayClassName: {{ .Values.gatewayClassName | quote }}
+  {{- if $wildcardSecret }}
+  certMode: existingSecret
+  wildcardSecretRef:
+    name: {{ $wildcardSecret | quote }}
+  {{- else }}
   certMode: {{ $solver | quote }}
   issuerName: {{ $issuerName | quote }}
   {{- if eq $solver "dns01" }}
@@ -74,6 +89,7 @@ spec:
         name: {{ (index .Values._cluster "dns01-rfc2136-secret-name") | quote }}
         key: {{ (index .Values._cluster "dns01-rfc2136-secret-key") | default "tsig-secret-key" | quote }}
     {{- end }}
+  {{- end }}
   {{- end }}
   {{- with $extraNs }}
   attachedNamespaces:

--- a/packages/extra/gateway/tests/tenantgateway_test.yaml
+++ b/packages/extra/gateway/tests/tenantgateway_test.yaml
@@ -274,3 +274,77 @@ tests:
             - api
             - vm-exportproxy
             - cdi-uploadproxy
+
+  - it: wildcard-secret-name switches to certMode=existingSecret with wildcardSecretRef
+    set:
+      _cluster:
+        solver: http01
+        expose-ingress: tenant-root
+        issuer-name: letsencrypt-prod
+        wildcard-secret-name: wildcard-tls
+      _namespace:
+        host: example.org
+    asserts:
+      - equal:
+          path: spec.certMode
+          value: existingSecret
+      - equal:
+          path: spec.wildcardSecretRef.name
+          value: wildcard-tls
+      - notExists:
+          path: spec.dns01
+      - notExists:
+          path: spec.issuerName
+
+  - it: wildcard-secret-name takes precedence over solver=dns01
+    set:
+      _cluster:
+        solver: dns01
+        dns01-provider: cloudflare
+        expose-ingress: tenant-root
+        issuer-name: letsencrypt-prod
+        wildcard-secret-name: wildcard-tls
+      _namespace:
+        host: example.org
+    asserts:
+      - equal:
+          path: spec.certMode
+          value: existingSecret
+      - equal:
+          path: spec.wildcardSecretRef.name
+          value: wildcard-tls
+      - notExists:
+          path: spec.dns01
+
+  - it: wildcard mode skips ACME validations (custom issuer-name ignored)
+    set:
+      _cluster:
+        solver: http01
+        expose-ingress: tenant-root
+        issuer-name: my-custom-ca
+        wildcard-secret-name: wildcard-tls
+      _namespace:
+        host: example.org
+    asserts:
+      - equal:
+          path: spec.certMode
+          value: existingSecret
+      - notExists:
+          path: spec.issuerName
+
+  - it: tlsPassthroughServices still render in wildcard mode
+    set:
+      _cluster:
+        solver: http01
+        expose-ingress: tenant-root
+        issuer-name: letsencrypt-prod
+        wildcard-secret-name: wildcard-tls
+      _namespace:
+        host: example.org
+    asserts:
+      - equal:
+          path: spec.tlsPassthroughServices
+          value:
+            - api
+            - vm-exportproxy
+            - cdi-uploadproxy

--- a/packages/extra/ingress/templates/nginx-ingress.yaml
+++ b/packages/extra/ingress/templates/nginx-ingress.yaml
@@ -1,5 +1,6 @@
 {{- $exposeIngress := (index .Values._cluster "expose-ingress") | default "tenant-root" }}
 {{- $exposeExternalIPs := (index .Values._cluster "expose-external-ips") | default "" | nospace }}
+{{- $wildcardSecret := (index .Values._cluster "wildcard-secret-name") | default "" }}
 {{- /* PROXY-protocol is enabled either explicitly per-app (.Values.proxyProtocol)
        or, for the host control plane, via the platform-level publishing.proxyProtocol
        switch carried in _cluster.proxy-protocol and applied only to the external-facing
@@ -47,6 +48,19 @@ spec:
       controller:
         replicaCount: {{ .Values.replicas }}
         ingressClass: {{ .Release.Namespace }}
+        {{- /*
+          Operator-supplied wildcard mode. Serve the pre-existing
+          wildcard Secret as the default SSL certificate so per-host
+          ACME certs are unnecessary. Only the publishing controller
+          (Release.Namespace == expose-ingress) gets the flag: the
+          Secret lives in that namespace and ingress-nginx must read it
+          from its own namespace, so child-tenant controllers cannot
+          point at it. The reference is therefore always same-namespace.
+        */}}
+        {{- if and $wildcardSecret (eq .Release.Namespace $exposeIngress) }}
+        extraArgs:
+          default-ssl-certificate: "{{ $exposeIngress }}/{{ $wildcardSecret }}"
+        {{- end }}
         resources: {{- include "cozy-lib.resources.defaultingSanitize" (list .Values.resourcesPreset .Values.resources $) | nindent 10 }}
         ingressClassResource:
           name: {{ .Release.Namespace }}

--- a/packages/extra/ingress/tests/default_ssl_certificate_test.yaml
+++ b/packages/extra/ingress/tests/default_ssl_certificate_test.yaml
@@ -1,0 +1,46 @@
+suite: ingress-nginx default-ssl-certificate wiring
+templates:
+  - templates/nginx-ingress.yaml
+
+release:
+  name: ingress
+  namespace: tenant-root
+
+# When the operator supplies a wildcard Secret
+# (_cluster.wildcard-secret-name), the publishing tenant's ingress
+# controller must serve it as the default SSL certificate so per-host
+# ACME certs are no longer needed. The reference is same-namespace
+# (publishing namespace == controller namespace), and the flag is set
+# only on the publishing controller — child-tenant controllers cannot
+# read a Secret from another namespace, so they must NOT get the flag.
+
+tests:
+  - it: sets default-ssl-certificate on the publishing controller when wildcard is set
+    set:
+      _cluster:
+        expose-ingress: tenant-root
+        wildcard-secret-name: wildcard-tls
+    asserts:
+      - equal:
+          path: spec.values.ingress-nginx.controller.extraArgs.default-ssl-certificate
+          value: tenant-root/wildcard-tls
+
+  - it: does not set default-ssl-certificate when no wildcard secret
+    set:
+      _cluster:
+        expose-ingress: tenant-root
+    asserts:
+      - notExists:
+          path: spec.values.ingress-nginx.controller.extraArgs.default-ssl-certificate
+
+  - it: does not set default-ssl-certificate on a non-publishing tenant controller
+    release:
+      name: ingress
+      namespace: tenant-foo
+    set:
+      _cluster:
+        expose-ingress: tenant-root
+        wildcard-secret-name: wildcard-tls
+    asserts:
+      - notExists:
+          path: spec.values.ingress-nginx.controller.extraArgs.default-ssl-certificate

--- a/packages/extra/seaweedfs/Makefile
+++ b/packages/extra/seaweedfs/Makefile
@@ -2,6 +2,9 @@ NAME=seaweedfs
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 generate:
 	cozyvalues-gen -v values.yaml -s values.schema.json -r README.md
 	../../../hack/update-crd.sh

--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -264,12 +264,15 @@ spec:
             {{- end }}
             cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
             {{- end }}
-          {{- if not $wildcardSecret }}
           tls:
             - hosts:
               - {{ .Values.host | default (printf "s3.%s" $host) }}
+              {{- /* Operator wildcard mode: no per-host secret — ingress-nginx
+                     falls back to the default SSL certificate while the tls
+                     section keeps the HTTP-to-HTTPS redirect enforced. */}}
+              {{- if not $wildcardSecret }}
               secretName: {{ .Release.Name }}-s3-ingress-tls
-          {{- end }}
+              {{- end }}
         resources: {{- include "cozy-lib.resources.defaultingSanitize" (list .Values.s3.resourcesPreset .Values.s3.resources $) | nindent 10 }}
       cosi:
         driverName: "{{ .Release.Namespace }}.seaweedfs.objectstorage.k8s.io"

--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -97,6 +97,7 @@
 {{- $host := .Values._namespace.host }}
 {{- $solver := (index .Values._cluster "solver") | default "http01" }}
 {{- $clusterIssuer := (index .Values._cluster "issuer-name") | default "letsencrypt-prod" }}
+{{- $wildcardSecret := (index .Values._cluster "wildcard-secret-name") | default "" }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -256,14 +257,19 @@ spec:
             nginx.ingress.kubernetes.io/client-body-timeout: "3600"
             nginx.ingress.kubernetes.io/client-header-timeout: "120"
             nginx.ingress.kubernetes.io/service-upstream: "true"
+            {{- /* Operator wildcard mode: nginx serves the default SSL cert, so skip per-host ACME. */}}
+            {{- if not $wildcardSecret }}
             {{- if eq $solver "http01" }}
             acme.cert-manager.io/http01-ingress-ingressclassname: {{ $ingress }}
             {{- end }}
             cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
+            {{- end }}
+          {{- if not $wildcardSecret }}
           tls:
             - hosts:
               - {{ .Values.host | default (printf "s3.%s" $host) }}
               secretName: {{ .Release.Name }}-s3-ingress-tls
+          {{- end }}
         resources: {{- include "cozy-lib.resources.defaultingSanitize" (list .Values.s3.resourcesPreset .Values.s3.resources $) | nindent 10 }}
       cosi:
         driverName: "{{ .Release.Namespace }}.seaweedfs.objectstorage.k8s.io"

--- a/packages/extra/seaweedfs/tests/ingress_wildcard_test.yaml
+++ b/packages/extra/seaweedfs/tests/ingress_wildcard_test.yaml
@@ -10,10 +10,12 @@ release:
 # S3 ingress (spec.values.seaweedfs.s3.ingress). documentSelector
 # targets that HelmRelease (the template also emits WorkloadMonitor
 # docs). In wildcard mode the cert-manager + http01 annotations and the
-# tls block are dropped; the other nginx annotations stay.
+# per-host tls secretName are dropped (the tls section stays so the
+# HTTPS redirect keeps working against the default SSL certificate);
+# the other nginx annotations stay.
 
 tests:
-  - it: drops cert-manager annotation and tls block when wildcard secret is set
+  - it: drops cert-manager annotation and tls secretName when wildcard secret is set
     documentSelector:
       path: kind
       value: HelmRelease
@@ -30,12 +32,14 @@ tests:
     asserts:
       - notExists:
           path: spec.values.seaweedfs.s3.ingress.annotations["cert-manager.io/cluster-issuer"]
-      - notExists:
+      - exists:
           path: spec.values.seaweedfs.s3.ingress.tls
+      - notExists:
+          path: spec.values.seaweedfs.s3.ingress.tls[0].secretName
       - exists:
           path: spec.values.seaweedfs.s3.ingress.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
 
-  - it: keeps cert-manager annotation and tls block without wildcard secret
+  - it: keeps cert-manager annotation and tls secretName without wildcard secret
     documentSelector:
       path: kind
       value: HelmRelease

--- a/packages/extra/seaweedfs/tests/ingress_wildcard_test.yaml
+++ b/packages/extra/seaweedfs/tests/ingress_wildcard_test.yaml
@@ -1,0 +1,56 @@
+suite: seaweedfs S3 ingress wildcard mode drops per-host ACME
+templates:
+  - templates/seaweedfs.yaml
+
+release:
+  name: seaweedfs
+  namespace: tenant-root
+
+# seaweedfs.yaml renders a HelmRelease whose values carry the inline
+# S3 ingress (spec.values.seaweedfs.s3.ingress). documentSelector
+# targets that HelmRelease (the template also emits WorkloadMonitor
+# docs). In wildcard mode the cert-manager + http01 annotations and the
+# tls block are dropped; the other nginx annotations stay.
+
+tests:
+  - it: drops cert-manager annotation and tls block when wildcard secret is set
+    documentSelector:
+      path: kind
+      value: HelmRelease
+    set:
+      topology: Simple
+      replicationFactor: 2
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+        wildcard-secret-name: wildcard-tls
+    asserts:
+      - notExists:
+          path: spec.values.seaweedfs.s3.ingress.annotations["cert-manager.io/cluster-issuer"]
+      - notExists:
+          path: spec.values.seaweedfs.s3.ingress.tls
+      - exists:
+          path: spec.values.seaweedfs.s3.ingress.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
+
+  - it: keeps cert-manager annotation and tls block without wildcard secret
+    documentSelector:
+      path: kind
+      value: HelmRelease
+    set:
+      topology: Simple
+      replicationFactor: 2
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+    asserts:
+      - equal:
+          path: spec.values.seaweedfs.s3.ingress.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+      - exists:
+          path: spec.values.seaweedfs.s3.ingress.tls[0].secretName

--- a/packages/system/bucket/Makefile
+++ b/packages/system/bucket/Makefile
@@ -8,6 +8,9 @@ include ../../../hack/package.mk
 update:
 	@echo Nothing to update
 
+test:
+	helm unittest .
+
 image: image-s3manager
 
 image-s3manager:

--- a/packages/system/bucket/templates/ingress.yaml
+++ b/packages/system/bucket/templates/ingress.yaml
@@ -3,6 +3,7 @@
 {{- $gateway := .Values._namespace.gateway | default "" }}
 {{- $solver := (index .Values._cluster "solver") | default "http01" }}
 {{- $clusterIssuer := (index .Values._cluster "issuer-name") | default "letsencrypt-prod" }}
+{{- $wildcardSecret := (index .Values._cluster "wildcard-secret-name") | default "" }}
 {{- if not $gateway }}
 
 apiVersion: networking.k8s.io/v1
@@ -13,16 +14,21 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "99999"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "99999"
+    {{- /* Operator wildcard mode: nginx serves the default SSL cert, so skip per-host ACME. */}}
+    {{- if not $wildcardSecret }}
     {{- if eq $solver "http01" }}
     acme.cert-manager.io/http01-ingress-ingressclassname: {{ $ingress }}
     {{- end }}
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
+    {{- end }}
 spec:
   ingressClassName: {{ $ingress }}
+  {{- if not $wildcardSecret }}
   tls:
     - hosts:
         - "{{ .Values.bucketName }}.{{ $host }}"
       secretName: {{ .Values.bucketName }}-ui-tls
+  {{- end }}
   rules:
   - host: {{ .Values.bucketName }}.{{ $host }}
     http:

--- a/packages/system/bucket/templates/ingress.yaml
+++ b/packages/system/bucket/templates/ingress.yaml
@@ -23,12 +23,15 @@ metadata:
     {{- end }}
 spec:
   ingressClassName: {{ $ingress }}
-  {{- if not $wildcardSecret }}
   tls:
     - hosts:
         - "{{ .Values.bucketName }}.{{ $host }}"
+      {{- /* Operator wildcard mode: no per-host secret — ingress-nginx falls
+             back to the default SSL certificate while the tls section keeps
+             the HTTP-to-HTTPS redirect enforced. */}}
+      {{- if not $wildcardSecret }}
       secretName: {{ .Values.bucketName }}-ui-tls
-  {{- end }}
+      {{- end }}
   rules:
   - host: {{ .Values.bucketName }}.{{ $host }}
     http:

--- a/packages/system/bucket/tests/ingress_wildcard_test.yaml
+++ b/packages/system/bucket/tests/ingress_wildcard_test.yaml
@@ -1,0 +1,50 @@
+suite: bucket ingress wildcard mode drops per-host ACME
+templates:
+  - templates/ingress.yaml
+
+release:
+  name: bucket
+  namespace: tenant-root
+
+# bucket gates its Ingress on an empty _namespace.gateway. In wildcard
+# mode the cert-manager + http01 annotations and the tls block are
+# dropped; the other nginx annotations stay so the annotations map is
+# never empty.
+
+tests:
+  - it: drops cert-manager annotation and tls block when wildcard secret is set
+    set:
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+        gateway: ""
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+        wildcard-secret-name: wildcard-tls
+    asserts:
+      - equal:
+          path: kind
+          value: Ingress
+      - notExists:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+      - notExists:
+          path: spec.tls
+      - exists:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
+
+  - it: keeps cert-manager annotation and tls block without wildcard secret
+    set:
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+        gateway: ""
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+      - exists:
+          path: spec.tls[0].secretName

--- a/packages/system/bucket/tests/ingress_wildcard_test.yaml
+++ b/packages/system/bucket/tests/ingress_wildcard_test.yaml
@@ -7,12 +7,13 @@ release:
   namespace: tenant-root
 
 # bucket gates its Ingress on an empty _namespace.gateway. In wildcard
-# mode the cert-manager + http01 annotations and the tls block are
-# dropped; the other nginx annotations stay so the annotations map is
-# never empty.
+# mode the cert-manager + http01 annotations and the per-host tls
+# secretName are dropped (the tls section stays so the HTTPS redirect
+# keeps working against the default SSL certificate); the other nginx
+# annotations stay so the annotations map is never empty.
 
 tests:
-  - it: drops cert-manager annotation and tls block when wildcard secret is set
+  - it: drops cert-manager annotation and tls secretName when wildcard secret is set
     set:
       _namespace:
         host: example.org
@@ -28,12 +29,14 @@ tests:
           value: Ingress
       - notExists:
           path: metadata.annotations["cert-manager.io/cluster-issuer"]
-      - notExists:
+      - exists:
           path: spec.tls
+      - notExists:
+          path: spec.tls[0].secretName
       - exists:
           path: metadata.annotations["nginx.ingress.kubernetes.io/proxy-body-size"]
 
-  - it: keeps cert-manager annotation and tls block without wildcard secret
+  - it: keeps cert-manager annotation and tls secretName without wildcard secret
     set:
       _namespace:
         host: example.org

--- a/packages/system/cozystack-controller/definitions/gateway.cozystack.io_tenantgateways.yaml
+++ b/packages/system/cozystack-controller/definitions/gateway.cozystack.io_tenantgateways.yaml
@@ -81,6 +81,7 @@ spec:
                 enum:
                 - http01
                 - dns01
+                - existingSecret
                 type: string
               dns01:
                 description: |-
@@ -276,6 +277,26 @@ spec:
                 items:
                   type: string
                 type: array
+              wildcardSecretRef:
+                description: |-
+                  WildcardSecretRef names a pre-existing TLS Secret in the
+                  TenantGateway's own namespace used for the wildcard and apex
+                  listeners when CertMode=existingSecret. Required in that mode;
+                  ignored otherwise. The Secret must be of type kubernetes.io/tls
+                  and cover the tenant apex (and *.apex). Cross-namespace refs are
+                  intentionally unsupported to avoid requiring a ReferenceGrant.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
             required:
             - apex
             type: object

--- a/packages/system/dashboard/templates/ingress.yaml
+++ b/packages/system/dashboard/templates/ingress.yaml
@@ -4,15 +4,19 @@
 {{- $exposeServices := splitList "," ((index .Values._cluster "expose-services") | default "") }}
 {{- $exposeIngress := (index .Values._cluster "expose-ingress") | default "tenant-root" }}
 {{- $gatewayEnabled := (index .Values._cluster "gateway-enabled") | default "false" }}
+{{- $wildcardSecret := (index .Values._cluster "wildcard-secret-name") | default "" }}
 
 {{- if and (has "dashboard" $exposeServices) (ne $gatewayEnabled "true") }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
+    {{- /* Operator wildcard mode: nginx serves the default SSL cert, so skip per-host ACME. */}}
+    {{- if not $wildcardSecret }}
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
     {{- if eq $solver "http01" }}
     acme.cert-manager.io/http01-ingress-ingressclassname: {{ $exposeIngress }}
+    {{- end }}
     {{- end }}
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/server-snippet: |
@@ -39,8 +43,10 @@ spec:
                   number: 8000
             path: /
             pathType: Prefix
+  {{- if not $wildcardSecret }}
   tls:
     - hosts:
         - dashboard.{{ $host }}
       secretName: dashboard-web-tls
+  {{- end }}
 {{- end }}

--- a/packages/system/dashboard/templates/ingress.yaml
+++ b/packages/system/dashboard/templates/ingress.yaml
@@ -43,10 +43,13 @@ spec:
                   number: 8000
             path: /
             pathType: Prefix
-  {{- if not $wildcardSecret }}
   tls:
     - hosts:
         - dashboard.{{ $host }}
+      {{- /* Operator wildcard mode: no per-host secret — ingress-nginx falls
+             back to the default SSL certificate while the tls section keeps
+             the HTTP-to-HTTPS redirect enforced. */}}
+      {{- if not $wildcardSecret }}
       secretName: dashboard-web-tls
-  {{- end }}
+      {{- end }}
 {{- end }}

--- a/packages/system/dashboard/tests/ingress_wildcard_test.yaml
+++ b/packages/system/dashboard/tests/ingress_wildcard_test.yaml
@@ -9,11 +9,13 @@ release:
 # In operator-supplied wildcard mode (_cluster.wildcard-secret-name set)
 # the ingress controller serves the wildcard as its default SSL cert, so
 # the dashboard Ingress must not request its own cert-manager cert: the
-# cert-manager annotation and the tls block are dropped. Without wildcard
-# mode the per-host ACME path is unchanged.
+# cert-manager annotation and the per-host tls secretName are dropped
+# (the tls section stays so the HTTPS redirect keeps working against
+# the default SSL certificate). Without wildcard mode the per-host ACME
+# path is unchanged.
 
 tests:
-  - it: drops cert-manager annotation and tls block when wildcard secret is set
+  - it: drops cert-manager annotation and tls secretName when wildcard secret is set
     set:
       _cluster:
         root-host: example.org
@@ -26,10 +28,12 @@ tests:
           value: Ingress
       - notExists:
           path: metadata.annotations["cert-manager.io/cluster-issuer"]
-      - notExists:
+      - exists:
           path: spec.tls
+      - notExists:
+          path: spec.tls[0].secretName
 
-  - it: keeps cert-manager annotation and tls block without wildcard secret
+  - it: keeps cert-manager annotation and tls secretName without wildcard secret
     set:
       _cluster:
         root-host: example.org

--- a/packages/system/dashboard/tests/ingress_wildcard_test.yaml
+++ b/packages/system/dashboard/tests/ingress_wildcard_test.yaml
@@ -1,0 +1,44 @@
+suite: dashboard ingress wildcard mode drops per-host ACME
+templates:
+  - templates/ingress.yaml
+
+release:
+  name: dashboard
+  namespace: cozy-dashboard
+
+# In operator-supplied wildcard mode (_cluster.wildcard-secret-name set)
+# the ingress controller serves the wildcard as its default SSL cert, so
+# the dashboard Ingress must not request its own cert-manager cert: the
+# cert-manager annotation and the tls block are dropped. Without wildcard
+# mode the per-host ACME path is unchanged.
+
+tests:
+  - it: drops cert-manager annotation and tls block when wildcard secret is set
+    set:
+      _cluster:
+        root-host: example.org
+        expose-services: "dashboard"
+        gateway-enabled: "false"
+        wildcard-secret-name: wildcard-tls
+    asserts:
+      - equal:
+          path: kind
+          value: Ingress
+      - notExists:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+      - notExists:
+          path: spec.tls
+
+  - it: keeps cert-manager annotation and tls block without wildcard secret
+    set:
+      _cluster:
+        root-host: example.org
+        expose-services: "dashboard"
+        gateway-enabled: "false"
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+      - equal:
+          path: spec.tls[0].secretName
+          value: dashboard-web-tls

--- a/packages/system/keycloak/Makefile
+++ b/packages/system/keycloak/Makefile
@@ -3,3 +3,6 @@ export NAMESPACE=cozy-keycloak
 
 include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
+
+test:
+	helm unittest .

--- a/packages/system/keycloak/templates/ingress.yaml
+++ b/packages/system/keycloak/templates/ingress.yaml
@@ -4,6 +4,7 @@
 {{- $clusterIssuer := (index .Values._cluster "issuer-name") | default "letsencrypt-prod" }}
 {{- $exposeIngress := (index .Values._cluster "expose-ingress") | default "tenant-root" }}
 {{- $gatewayEnabled := (index .Values._cluster "gateway-enabled") | default "false" }}
+{{- $wildcardSecret := (index .Values._cluster "wildcard-secret-name") | default "" }}
 {{- if ne $gatewayEnabled "true" }}
 
 apiVersion: networking.k8s.io/v1
@@ -12,18 +13,23 @@ metadata:
   name: keycloak-ingress
   {{- with .Values.ingress.annotations }}
   annotations:
+    {{- /* Operator wildcard mode: nginx serves the default SSL cert, so skip per-host ACME. */}}
+    {{- if not $wildcardSecret }}
     {{- if eq $solver "http01" }}
     acme.cert-manager.io/http01-ingress-ingressclassname: {{ $exposeIngress }}
     {{- end }}
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
+    {{- end }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   ingressClassName: {{ $exposeIngress }}
+  {{- if not $wildcardSecret }}
   tls:
   - hosts:
       - {{ $ingressHost }}
     secretName: web-tls
+  {{- end }}
   rules:
   - host: {{ $ingressHost }}
     http:

--- a/packages/system/keycloak/templates/ingress.yaml
+++ b/packages/system/keycloak/templates/ingress.yaml
@@ -24,12 +24,15 @@ metadata:
   {{- end }}
 spec:
   ingressClassName: {{ $exposeIngress }}
-  {{- if not $wildcardSecret }}
   tls:
   - hosts:
       - {{ $ingressHost }}
+    {{- /* Operator wildcard mode: no per-host secret — ingress-nginx falls
+           back to the default SSL certificate while the tls section keeps
+           the HTTP-to-HTTPS redirect enforced. */}}
+    {{- if not $wildcardSecret }}
     secretName: web-tls
-  {{- end }}
+    {{- end }}
   rules:
   - host: {{ $ingressHost }}
     http:

--- a/packages/system/keycloak/tests/ingress_wildcard_test.yaml
+++ b/packages/system/keycloak/tests/ingress_wildcard_test.yaml
@@ -1,0 +1,48 @@
+suite: keycloak ingress wildcard mode drops per-host ACME
+templates:
+  - templates/ingress.yaml
+
+release:
+  name: keycloak
+  namespace: cozy-keycloak
+
+# keycloak wraps its cert-manager annotations inside
+# `with .Values.ingress.annotations`; the chart ships default
+# session-cookie annotations, so the block always renders. In wildcard
+# mode the cert-manager + http01 annotations and the tls block are
+# dropped while the user annotations are preserved.
+
+tests:
+  - it: drops cert-manager annotation and tls block when wildcard secret is set
+    set:
+      _cluster:
+        root-host: example.org
+        issuer-name: letsencrypt-prod
+        solver: http01
+        expose-ingress: tenant-root
+        gateway-enabled: "false"
+        wildcard-secret-name: wildcard-tls
+    asserts:
+      - equal:
+          path: kind
+          value: Ingress
+      - notExists:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+      - notExists:
+          path: spec.tls
+
+  - it: keeps cert-manager annotation and tls block without wildcard secret
+    set:
+      _cluster:
+        root-host: example.org
+        issuer-name: letsencrypt-prod
+        solver: http01
+        expose-ingress: tenant-root
+        gateway-enabled: "false"
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+      - equal:
+          path: spec.tls[0].secretName
+          value: web-tls

--- a/packages/system/keycloak/tests/ingress_wildcard_test.yaml
+++ b/packages/system/keycloak/tests/ingress_wildcard_test.yaml
@@ -9,11 +9,13 @@ release:
 # keycloak wraps its cert-manager annotations inside
 # `with .Values.ingress.annotations`; the chart ships default
 # session-cookie annotations, so the block always renders. In wildcard
-# mode the cert-manager + http01 annotations and the tls block are
-# dropped while the user annotations are preserved.
+# mode the cert-manager + http01 annotations and the per-host tls
+# secretName are dropped (the tls section stays so the HTTPS redirect
+# keeps working against the default SSL certificate); the user
+# annotations are preserved.
 
 tests:
-  - it: drops cert-manager annotation and tls block when wildcard secret is set
+  - it: drops cert-manager annotation and tls secretName when wildcard secret is set
     set:
       _cluster:
         root-host: example.org
@@ -28,10 +30,12 @@ tests:
           value: Ingress
       - notExists:
           path: metadata.annotations["cert-manager.io/cluster-issuer"]
-      - notExists:
+      - exists:
           path: spec.tls
+      - notExists:
+          path: spec.tls[0].secretName
 
-  - it: keeps cert-manager annotation and tls block without wildcard secret
+  - it: keeps cert-manager annotation and tls secretName without wildcard secret
     set:
       _cluster:
         root-host: example.org

--- a/packages/system/linstor-gui/templates/ingress.yaml
+++ b/packages/system/linstor-gui/templates/ingress.yaml
@@ -51,10 +51,13 @@ spec:
                 name: linstor-gui-gatekeeper
                 port:
                   number: 8000
-  {{- if not $wildcardSecret }}
   tls:
     - hosts:
         - linstor-gui.{{ $host }}
+      {{- /* Operator wildcard mode: no per-host secret — ingress-nginx falls
+             back to the default SSL certificate while the tls section keeps
+             the HTTP-to-HTTPS redirect enforced. */}}
+      {{- if not $wildcardSecret }}
       secretName: linstor-gui-ingress-tls
-  {{- end }}
+      {{- end }}
 {{- end }}

--- a/packages/system/linstor-gui/templates/ingress.yaml
+++ b/packages/system/linstor-gui/templates/ingress.yaml
@@ -1,5 +1,6 @@
 {{- $solver := (index .Values._cluster "solver") | default "http01" }}
 {{- $clusterIssuer := (index .Values._cluster "issuer-name") | default "letsencrypt-prod" }}
+{{- $wildcardSecret := (index .Values._cluster "wildcard-secret-name") | default "" }}
 {{- $host := index .Values._cluster "root-host" }}
 {{- $oidcEnabled := index .Values._cluster "oidc-enabled" }}
 {{- $exposeServices := splitList "," ((index .Values._cluster "expose-services") | default "") }}
@@ -20,9 +21,12 @@ metadata:
   labels:
     {{- include "linstor-gui.labels" . | nindent 4 }}
   annotations:
+    {{- /* Operator wildcard mode: nginx serves the default SSL cert, so skip per-host ACME. */}}
+    {{- if not $wildcardSecret }}
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
     {{- if eq $solver "http01" }}
     acme.cert-manager.io/http01-ingress-ingressclassname: {{ $exposeIngress }}
+    {{- end }}
     {{- end }}
     nginx.ingress.kubernetes.io/proxy-body-size: 100m
     # Keycloak access+refresh+id tokens make the oauth2-proxy session
@@ -47,8 +51,10 @@ spec:
                 name: linstor-gui-gatekeeper
                 port:
                   number: 8000
+  {{- if not $wildcardSecret }}
   tls:
     - hosts:
         - linstor-gui.{{ $host }}
       secretName: linstor-gui-ingress-tls
+  {{- end }}
 {{- end }}

--- a/packages/system/linstor-gui/tests/ingress_wildcard_test.yaml
+++ b/packages/system/linstor-gui/tests/ingress_wildcard_test.yaml
@@ -10,10 +10,11 @@ release:
 # expose-services + oidc-enabled), so it exercises the drop-cert path
 # for the no-gateway-guard convention. In wildcard mode the controller
 # serves the default SSL cert, so the per-host cert-manager annotation
-# and tls block are dropped.
+# and per-host tls secretName are dropped; the tls section stays so
+# the HTTPS redirect keeps working against the default SSL certificate.
 
 tests:
-  - it: drops cert-manager annotation and tls block when wildcard secret is set
+  - it: drops cert-manager annotation and tls secretName when wildcard secret is set
     set:
       _cluster:
         root-host: example.org
@@ -26,10 +27,12 @@ tests:
           value: Ingress
       - notExists:
           path: metadata.annotations["cert-manager.io/cluster-issuer"]
-      - notExists:
+      - exists:
           path: spec.tls
+      - notExists:
+          path: spec.tls[0].secretName
 
-  - it: keeps cert-manager annotation and tls block without wildcard secret
+  - it: keeps cert-manager annotation and tls secretName without wildcard secret
     set:
       _cluster:
         root-host: example.org

--- a/packages/system/linstor-gui/tests/ingress_wildcard_test.yaml
+++ b/packages/system/linstor-gui/tests/ingress_wildcard_test.yaml
@@ -1,0 +1,44 @@
+suite: linstor-gui ingress wildcard mode drops per-host ACME
+templates:
+  - templates/ingress.yaml
+
+release:
+  name: linstor-gui
+  namespace: cozy-linstor-gui
+
+# linstor-gui has no gateway guard (it only publishes under
+# expose-services + oidc-enabled), so it exercises the drop-cert path
+# for the no-gateway-guard convention. In wildcard mode the controller
+# serves the default SSL cert, so the per-host cert-manager annotation
+# and tls block are dropped.
+
+tests:
+  - it: drops cert-manager annotation and tls block when wildcard secret is set
+    set:
+      _cluster:
+        root-host: example.org
+        expose-services: "linstor-gui"
+        oidc-enabled: "true"
+        wildcard-secret-name: wildcard-tls
+    asserts:
+      - equal:
+          path: kind
+          value: Ingress
+      - notExists:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+      - notExists:
+          path: spec.tls
+
+  - it: keeps cert-manager annotation and tls block without wildcard secret
+    set:
+      _cluster:
+        root-host: example.org
+        expose-services: "linstor-gui"
+        oidc-enabled: "true"
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+      - equal:
+          path: spec.tls[0].secretName
+          value: linstor-gui-ingress-tls

--- a/packages/system/monitoring/Makefile
+++ b/packages/system/monitoring/Makefile
@@ -6,6 +6,9 @@ NAMESPACE=cozy-$(NAME)
 include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 image:
 	docker buildx build images/grafana \
 		$(call image-tags,grafana,$(GRAFANA_TAG)) \

--- a/packages/system/monitoring/templates/alerta/alerta.yaml
+++ b/packages/system/monitoring/templates/alerta/alerta.yaml
@@ -4,6 +4,7 @@
 {{- $host := .Values._namespace.host }}
 {{- $exposeIngress := (index .Values._cluster "expose-ingress") | default "tenant-root" }}
 {{- $gatewayEnabled := (index .Values._cluster "gateway-enabled") | default "false" }}
+{{- $wildcardSecret := (index .Values._cluster "wildcard-secret-name") | default "" }}
 
 {{- $apiKey := randAlphaNum 32 }}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace "alerta" }}
@@ -182,17 +183,22 @@ metadata:
   name: alerta
   labels:
     app: alerta
+  {{- /* Operator wildcard mode: nginx serves the default SSL cert, so skip per-host ACME. */}}
+  {{- if not $wildcardSecret }}
   annotations:
     {{- if eq $solver "http01" }}
     acme.cert-manager.io/http01-ingress-ingressclassname: {{ $ingress }}
     {{- end }}
     cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
+  {{- end }}
 spec:
   ingressClassName: {{ $ingress }}
+  {{- if not $wildcardSecret }}
   tls:
     - hosts:
         - "{{ printf "alerta.%s" (.Values.host | default $host) }}"
       secretName: alerta-tls
+  {{- end }}
   rules:
     - host: "{{ printf "alerta.%s" (.Values.host | default $host) }}"
       http:

--- a/packages/system/monitoring/templates/alerta/alerta.yaml
+++ b/packages/system/monitoring/templates/alerta/alerta.yaml
@@ -193,12 +193,15 @@ metadata:
   {{- end }}
 spec:
   ingressClassName: {{ $ingress }}
-  {{- if not $wildcardSecret }}
   tls:
     - hosts:
         - "{{ printf "alerta.%s" (.Values.host | default $host) }}"
+      {{- /* Operator wildcard mode: no per-host secret — ingress-nginx falls
+             back to the default SSL certificate while the tls section keeps
+             the HTTP-to-HTTPS redirect enforced. */}}
+      {{- if not $wildcardSecret }}
       secretName: alerta-tls
-  {{- end }}
+      {{- end }}
   rules:
     - host: "{{ printf "alerta.%s" (.Values.host | default $host) }}"
       http:

--- a/packages/system/monitoring/templates/grafana/grafana.yaml
+++ b/packages/system/monitoring/templates/grafana/grafana.yaml
@@ -3,6 +3,7 @@
 {{- $ingress := .Values._namespace.ingress }}
 {{- $host := .Values._namespace.host }}
 {{- $gatewayEnabled := (index .Values._cluster "gateway-enabled") | default "false" }}
+{{- $wildcardSecret := (index .Values._cluster "wildcard-secret-name") | default "" }}
 ---
 apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
@@ -73,12 +74,15 @@ spec:
                     name: grafana-admin-password
   {{- if ne $gatewayEnabled "true" }}
   ingress:
+    {{- /* Operator wildcard mode: nginx serves the default SSL cert, so skip per-host ACME. */}}
+    {{- if not $wildcardSecret }}
     metadata:
       annotations:
         {{- if eq $solver "http01" }}
         acme.cert-manager.io/http01-ingress-ingressclassname: "{{ $ingress }}"
         {{- end }}
         cert-manager.io/cluster-issuer: {{ $clusterIssuer }}
+    {{- end }}
     spec:
       ingressClassName: "{{ $ingress }}"
       rules:
@@ -92,8 +96,10 @@ spec:
                       number: 3000
                 path: /
                 pathType: Prefix
+      {{- if not $wildcardSecret }}
       tls:
       - hosts:
         - "{{ printf "grafana.%s" (.Values.host | default $host) }}"
         secretName: grafana-ingress-tls
+      {{- end }}
   {{- end }}

--- a/packages/system/monitoring/templates/grafana/grafana.yaml
+++ b/packages/system/monitoring/templates/grafana/grafana.yaml
@@ -96,10 +96,13 @@ spec:
                       number: 3000
                 path: /
                 pathType: Prefix
-      {{- if not $wildcardSecret }}
       tls:
       - hosts:
         - "{{ printf "grafana.%s" (.Values.host | default $host) }}"
+        {{- /* Operator wildcard mode: no per-host secret — ingress-nginx falls
+               back to the default SSL certificate while the tls section keeps
+               the HTTP-to-HTTPS redirect enforced. */}}
+        {{- if not $wildcardSecret }}
         secretName: grafana-ingress-tls
-      {{- end }}
+        {{- end }}
   {{- end }}

--- a/packages/system/monitoring/tests/alerta_ingress_wildcard_test.yaml
+++ b/packages/system/monitoring/tests/alerta_ingress_wildcard_test.yaml
@@ -8,11 +8,12 @@ release:
 
 # alerta.yaml renders several documents; documentSelector targets the
 # Ingress. In wildcard mode the cert-manager annotations block (the
-# Ingress carries only the labels otherwise) and the tls block are
-# dropped.
+# Ingress carries only the labels otherwise) and the per-host tls
+# secretName are dropped (the tls section stays so the HTTPS redirect
+# keeps working against the default SSL certificate).
 
 tests:
-  - it: drops cert-manager annotations and tls block when wildcard secret is set
+  - it: drops cert-manager annotations and tls secretName when wildcard secret is set
     documentSelector:
       path: kind
       value: Ingress
@@ -29,10 +30,12 @@ tests:
     asserts:
       - notExists:
           path: metadata.annotations
-      - notExists:
+      - exists:
           path: spec.tls
+      - notExists:
+          path: spec.tls[0].secretName
 
-  - it: keeps cert-manager annotations and tls block without wildcard secret
+  - it: keeps cert-manager annotations and tls secretName without wildcard secret
     documentSelector:
       path: kind
       value: Ingress

--- a/packages/system/monitoring/tests/alerta_ingress_wildcard_test.yaml
+++ b/packages/system/monitoring/tests/alerta_ingress_wildcard_test.yaml
@@ -1,0 +1,54 @@
+suite: alerta ingress wildcard mode drops per-host ACME
+templates:
+  - templates/alerta/alerta.yaml
+
+release:
+  name: monitoring
+  namespace: tenant-root
+
+# alerta.yaml renders several documents; documentSelector targets the
+# Ingress. In wildcard mode the cert-manager annotations block (the
+# Ingress carries only the labels otherwise) and the tls block are
+# dropped.
+
+tests:
+  - it: drops cert-manager annotations and tls block when wildcard secret is set
+    documentSelector:
+      path: kind
+      value: Ingress
+    set:
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+        expose-ingress: tenant-root
+        gateway-enabled: "false"
+        wildcard-secret-name: wildcard-tls
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+    asserts:
+      - notExists:
+          path: metadata.annotations
+      - notExists:
+          path: spec.tls
+
+  - it: keeps cert-manager annotations and tls block without wildcard secret
+    documentSelector:
+      path: kind
+      value: Ingress
+    set:
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+        expose-ingress: tenant-root
+        gateway-enabled: "false"
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+    asserts:
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+      - equal:
+          path: spec.tls[0].secretName
+          value: alerta-tls

--- a/packages/system/monitoring/tests/grafana_ingress_wildcard_test.yaml
+++ b/packages/system/monitoring/tests/grafana_ingress_wildcard_test.yaml
@@ -10,11 +10,12 @@ release:
 # Issue #2812 names grafana explicitly in its acceptance criteria, so
 # this is the load-bearing acceptance test for the ingress-nginx path.
 # In wildcard mode the whole spec.ingress.metadata block (its only
-# content was the cert-manager annotations) and the tls block are
-# dropped; nginx serves the default SSL cert.
+# content was the cert-manager annotations) and the per-host tls
+# secretName are dropped (the tls section stays so the HTTPS redirect
+# keeps working against the default SSL certificate).
 
 tests:
-  - it: drops cert-manager metadata and tls block when wildcard secret is set
+  - it: drops cert-manager metadata and tls secretName when wildcard secret is set
     set:
       _cluster:
         issuer-name: letsencrypt-prod
@@ -30,10 +31,12 @@ tests:
           value: Grafana
       - notExists:
           path: spec.ingress.metadata
-      - notExists:
+      - exists:
           path: spec.ingress.spec.tls
+      - notExists:
+          path: spec.ingress.spec.tls[0].secretName
 
-  - it: keeps cert-manager metadata and tls block without wildcard secret
+  - it: keeps cert-manager metadata and tls secretName without wildcard secret
     set:
       _cluster:
         issuer-name: letsencrypt-prod

--- a/packages/system/monitoring/tests/grafana_ingress_wildcard_test.yaml
+++ b/packages/system/monitoring/tests/grafana_ingress_wildcard_test.yaml
@@ -1,0 +1,51 @@
+suite: grafana ingress wildcard mode drops per-host ACME
+templates:
+  - templates/grafana/grafana.yaml
+
+release:
+  name: monitoring
+  namespace: tenant-root
+
+# grafana exposes its ingress inside the Grafana CR's spec.ingress.
+# Issue #2812 names grafana explicitly in its acceptance criteria, so
+# this is the load-bearing acceptance test for the ingress-nginx path.
+# In wildcard mode the whole spec.ingress.metadata block (its only
+# content was the cert-manager annotations) and the tls block are
+# dropped; nginx serves the default SSL cert.
+
+tests:
+  - it: drops cert-manager metadata and tls block when wildcard secret is set
+    set:
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+        gateway-enabled: "false"
+        wildcard-secret-name: wildcard-tls
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+    asserts:
+      - equal:
+          path: kind
+          value: Grafana
+      - notExists:
+          path: spec.ingress.metadata
+      - notExists:
+          path: spec.ingress.spec.tls
+
+  - it: keeps cert-manager metadata and tls block without wildcard secret
+    set:
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+        gateway-enabled: "false"
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+    asserts:
+      - equal:
+          path: spec.ingress.metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+      - equal:
+          path: spec.ingress.spec.tls[0].secretName
+          value: grafana-ingress-tls


### PR DESCRIPTION
## What this PR does

Adds an operator-facing way to serve platform services and the root tenant's ingress under a pre-existing wildcard TLS certificate instead of minting per-host ACME certificates. Implements the "native references" design decided on #2812.

A single value, `publishing.certificates.wildcardSecretName`, names a TLS Secret the operator has already created in the publishing namespace (`tenant-root` by default). Only the name travels through the `cozystack-values` channel — the certificate and private key are never broadcast, unlike the public `kube-root-ca` that already rides it.

When set:

- **ingress-nginx path** (`gateway.enabled=false`): the publishing tenant's ingress controller serves the Secret as its `--default-ssl-certificate`, and the platform service Ingresses drop their cert-manager cluster-issuer annotation and `tls` block. No per-host ACME.
- **Gateway API path** (`gateway.enabled=true`): a new `TenantGateway` cert mode, `existingSecret`, references the Secret in the wildcard/apex listener `certificateRefs` and mints no Issuer or Certificate. Switching into this mode garbage-collects any ACME machinery left from `http01`/`dns01`.

Scope is the root tenant — everything is same-namespace, so no RBAC or NetworkPolicy changes. Extending wildcard mode to child tenants needs the Secret replicated into each tenant namespace and is left as a follow-up.

Closes #2812. Part of #2811.

### Screenshots

N/A — no UI changes.

### Release note

```release-note
feat(platform): operators can serve platform services and the root tenant's ingress under a pre-existing wildcard TLS certificate via `publishing.certificates.wildcardSecretName`, instead of minting per-host ACME certificates
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "existingSecret" TLS certificate mode and a wildcardSecretRef option for TenantGateway and platform values to use a pre-existing wildcard TLS Secret.

* **Platform / Templates**
  * Introduced operator "wildcard secret" mode across Gateway and many Helm charts (Ingress, apps) to skip per-host ACME provisioning and optionally wire a default SSL cert.

* **Tests**
  * Added extensive chart and controller tests covering existingSecret behavior and cert-mode transitions.

* **Documentation**
  * Updated gateway docs describing the new wildcard secret mode and requirements.

* **Chores**
  * Added Helm unit test makefile targets to several packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->