### PR TITLE
test(e2e): fail install test when HelmReleases are not Ready

### DIFF
--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -109,7 +109,12 @@ EOF
   # signal for "all platform HRs have been emitted" without hard-coding the
   # expected list, so the 5s pad lets a few late-arrivals join the snapshot.
   sleep 5
-  kubectl get hr -A | awk 'NR>1 {print "kubectl wait --timeout=15m --for=condition=ready -n "$1" hr/"$2" &"} END {print "wait"}' | sh -ex
+  # Pacing only (|| true): a backgrounded fan-out's exit codes are discarded
+  # by a bare POSIX `wait`, which let permanently-failing HRs ship green
+  # (#2822). A single kubectl wait names every HR that timed out in the
+  # trace; the authoritative pass/fail gate is the outcome-based re-list
+  # below, which also covers HRs created after this snapshot.
+  kubectl wait hr --all -A --timeout=15m --for=condition=ready || true
 
   echo "Waiting for post-install-prep to complete"
   if ! wait $POST_PREP_PID; then
@@ -119,10 +124,20 @@ EOF
   fi
   cat /tmp/post-install-prep.log
 
-  # Fail the test if any HelmRelease is not Ready
-  if kubectl get hr -A | grep -v " True " | grep -v NAME; then
+  # Fail the test if any HelmRelease is not Ready. Re-list rather than trust
+  # the wait above so late-created HRs are gated too; the brief retry absorbs
+  # momentary Unknown flaps from helm-controller drift reconciles.
+  if ! timeout 120 sh -ec 'while kubectl get hr -A --no-headers | grep -v " True " | grep -q .; do sleep 5; done'; then
     kubectl get hr -A
+    # kubectl's STATUS column truncates long messages; dump the full Ready
+    # condition per non-ready HR so the real error (e.g. a rejected CRD) is
+    # visible in the test output instead of only inside the cozyreport.
+    kubectl get hr -A --no-headers | grep -v " True " | while read -r ns name rest; do
+      echo "--- Non-ready HelmRelease: $ns/$name" >&2
+      kubectl get hr -n "$ns" "$name" -o jsonpath='{range .status.conditions[*]}{.type}={.status} reason={.reason}: {.message}{"\n"}{end}' >&2
+    done
     echo "Some HelmReleases failed to reconcile" >&2
+    exit 1
   fi
 }
 


### PR DESCRIPTION
## What this PR does

Restores the HelmRelease readiness gate in `e2e-install-cozystack.bats`, which was toothless in two layers:

1. The backgrounded `kubectl wait ... &` fan-out discarded child exit codes — POSIX `wait` without arguments returns 0 regardless of children's failures.
2. The final check echoed "Some HelmReleases failed to reconcile" without exiting non-zero — a regression from 1f240387f, which replaced the bats `fail` helper (undefined under cozytest's `sh` runner) with a bare echo.

As a result, a permanently-failing platform HelmRelease shipped through green CI for weeks — see #2822 (backup-controller CRDs rejected by SSA, controller in CrashLoopBackOff, present in the cozyreport of green runs).

Changes:

- Replace the awk-generated fan-out with a single `kubectl wait hr --all -A --timeout=15m` — same per-HR trace visibility ("condition met" / "timed out waiting" lines), no swallowed exit codes.
- Gate on an outcome-based re-list after post-install-prep: covers HRs created after the wait snapshot, with a 120s retry to absorb momentary `Unknown` flaps from drift reconciles, then `exit 1`.
- On failure, dump the full Ready condition message per non-ready HR (kubectl's STATUS column truncates — the actual error, e.g. a rejected CRD, was only visible inside the cozyreport artifact until now).

Note: with this gate restored, CI on `main` will go red until #2822 (backup-controller CRD `x-cozystack-options` rejection) is fixed — that is the intended behavior.

Fixes the CI-gap half of #2822.

### Release note

```release-note
E2E: the install test now fails when any platform HelmRelease is not Ready and prints the full failure reason for each non-ready release, instead of logging a warning and passing.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Cozystack installation end-to-end test reliability and diagnostics for HelmRelease readiness verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->