### PR TITLE
fix(platform): install velero by default

### DIFF
--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -196,6 +196,11 @@
 {{include "cozystack.platform.package.default" (list "cozystack.cozystack-basics" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.backupstrategy-controller" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.backup-controller" $) }}
+{{- /* velero must be a default package: backupstrategy-controller (default)
+hard-depends on cozystack.velero, so an optional velero leaves the
+backupstrategy-controller Package permanently DependenciesNotReady and the
+cozystack-platform HelmRelease never becomes Ready. */}}
+{{include "cozystack.platform.package.default" (list "cozystack.velero" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.vertical-pod-autoscaler" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.metrics-server" $) }}
 {{- $monitoringAgentsComponents := dict "monitoring-agents" (dict "values" (dict "global" (dict "target" "tenant-root"))) -}}
@@ -214,7 +219,6 @@
 {{include "cozystack.platform.package.optional.default" (list "cozystack.external-dns-application" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.kuberture" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.external-secrets-operator" $) }}
-{{include "cozystack.platform.package.optional.default" (list "cozystack.velero" $) }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.linstor-gui" $) }}
 {{- if has "cozystack.bootbox" (default (list) .Values.bundles.enabledPackages) }}
 {{include "cozystack.platform.package.default" (list "cozystack.bootbox-application" $) }}

--- a/packages/core/platform/tests/bundles_velero_default_test.yaml
+++ b/packages/core/platform/tests/bundles_velero_default_test.yaml
@@ -1,0 +1,45 @@
+suite: velero installed by default (backupstrategy-controller hard dependency)
+templates:
+  - templates/bundles/system.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  # backupstrategy-controller is a default package and its PackageSource
+  # declares dependsOn: cozystack.velero. If velero is optional and not
+  # enabled, the backupstrategy-controller Package stays
+  # DependenciesNotReady forever and the cozystack-platform HelmRelease
+  # never becomes Ready. Guard against velero regressing to optional.
+  - it: emits the cozystack.velero Package by default (no enabledPackages)
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+    asserts:
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.velero
+          any: true
+
+  - it: keeps the disabledPackages opt-out working for cozystack.velero
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        disabledPackages:
+          - cozystack.velero
+          - cozystack.backupstrategy-controller
+    asserts:
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.velero
+        not: true
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.backupstrategy-controller
+        not: true

--- a/packages/core/platform/values-isp-full-generic.yaml
+++ b/packages/core/platform/values-isp-full-generic.yaml
@@ -11,5 +11,4 @@ bundles:
   naas:
     enabled: true
   enabledPackages:
-    - cozystack.velero
     - cozystack.backupstrategy-controller


### PR DESCRIPTION
## What this PR does

`backupstrategy-controller` has been installed by default since 494144fb9, and since f17ead3d2 its PackageSource declares a hard `dependsOn: cozystack.velero`. But `cozystack.velero` remained an *optional* package — so on any bundle that doesn't explicitly enable it (including the e2e sandbox, which enables only `cozystack.external-dns-application`), the `backupstrategy-controller` Package stays `DependenciesNotReady` forever and the `cozystack-platform` HelmRelease never becomes Ready:

```
Helm upgrade failed for release cozy-system/cozystack-platform: timeout waiting for:
[Package/cozystack.backupstrategy-controller status: 'InProgress']
```

Since 67b1a960d made the e2e install test gate on HelmRelease readiness, this deterministically fails CI on every PR (e.g. runs [27005526972](https://github.com/cozystack/cozystack/actions/runs/27005526972), [26974531181](https://github.com/cozystack/cozystack/actions/runs/26974531181) — the latter failed all 3 retry attempts with the same signature).

This PR promotes `cozystack.velero` from optional to default in the system bundle, so the dependency is always satisfiable. Velero deploys standalone (`backupStorageLocation: null`); the cozy-default BSL still materialises only after the platform Bucket reconciles. The `bundles.disabledPackages` opt-out keeps working (covered by a new unit test), and the now-redundant velero entry is dropped from the isp-full-generic `enabledPackages`.

### Release note

```release-note
fix(platform): Velero is now installed by default as a hard dependency of the backup subsystem. Existing clusters will get Velero deployed in the cozy-velero namespace on upgrade; opt out with bundles.disabledPackages if VM backups are not used.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Velero backup and restore functionality is now installed by default with every system deployment, providing automatic backup management capabilities out of the box.

* **Tests**
  * Added test coverage for default Velero installation behavior and package disable scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->