### PR TITLE
fix(platform): order cozystack-basics after the APIs its admission policies type-check

### DIFF
--- a/packages/core/platform/sources/cozystack-basics.yaml
+++ b/packages/core/platform/sources/cozystack-basics.yaml
@@ -13,6 +13,25 @@ spec:
   - name: default
     dependsOn:
     - cozystack.tenant-application
+    # cozystack-basics ships cluster-wide ValidatingAdmissionPolicies (the
+    # gateway / route / tenant host policies). kube-controller-manager's VAP
+    # status type-checker panics (nil-pointer deref in cel/openapi) when it
+    # type-checks a policy against a matched type whose schema it cannot
+    # resolve yet, so these policies must never predate the APIs they match:
+    #   - cozystack-engine serves tenants.apps.cozystack.io (via cozystack-api);
+    #     without this dependency the tenant-host policy is created before
+    #     cozystack-api is Ready, crashes KCM, and deadlocks the whole install
+    #     (KCM down -> cert/token issuance stalls -> cozystack-api never starts
+    #     -> the tenants schema never resolves -> KCM keeps crashing).
+    #   - gateway-api-crds establishes gateways/httproutes/tlsroutes for the
+    #     gateway/route host policies.
+    # Drift detection is off on operator-generated HelmReleases, so a
+    # capability gate in the templates would render the policy out at first
+    # install and never add it back; ordering via dependsOn is the reliable
+    # fix. cozystack-basics is a dependency-graph leaf (nothing dependsOn it)
+    # and engine components consume none of its outputs, so this adds no cycle.
+    - cozystack.cozystack-engine
+    - cozystack.gateway-api-crds
     components:
     - name: cozystack-basics
       path: system/cozystack-basics

--- a/packages/core/platform/tests/sources_basics_dependson_test.yaml
+++ b/packages/core/platform/tests/sources_basics_dependson_test.yaml
@@ -1,0 +1,27 @@
+suite: cozystack-basics waits for the APIs its admission policies type-check
+# Regression guard for the kube-controller-manager VAP-status-controller panic:
+# cozystack-basics ships cluster-wide ValidatingAdmissionPolicies that match
+# tenants.apps.cozystack.io (served by cozystack-api, in cozystack-engine) and
+# the Gateway API types (from gateway-api-crds). If the package installs before
+# those APIs are served, KCM type-checks a policy against an unresolvable schema,
+# panics, and deadlocks the install. The dependsOn edges below must stay.
+templates:
+  - templates/sources.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  - it: cozystack-basics dependsOn cozystack-engine and gateway-api-crds (and tenant-application)
+    documentSelector:
+      path: metadata.name
+      value: cozystack.cozystack-basics
+    asserts:
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.tenant-application
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.cozystack-engine
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.gateway-api-crds


### PR DESCRIPTION
## What this PR does

`cozystack-basics` ships cluster-wide ValidatingAdmissionPolicies — the gateway / route / tenant host policies — that match `tenants.apps.cozystack.io` (served by `cozystack-api`) and the Gateway API types (`gateways`, `httproutes`, `tlsroutes`). kube-controller-manager's ValidatingAdmissionPolicy *status* type-checker panics with a nil-pointer dereference in `k8s.io/apiserver/pkg/cel/openapi` when it type-checks a policy against a matched type whose schema it cannot resolve yet.

During a cold install this is a deadlock. `cozystack-basics` can install before `cozystack-api` is Ready; the tenant-host policy is created; KCM panics type-checking it against the not-yet-served `tenants` schema and CrashLoops; that stalls cert/token issuance, so `cozystack-api` never starts and the schema never resolves — KCM keeps crashing and every HelmRelease times out on `DependencyNotReady`.

This adds `dependsOn` edges so `cozystack-basics` installs only after `cozystack-engine` (which serves `tenants.apps.cozystack.io` via `cozystack-api`) and `gateway-api-crds` are Ready. The policies are then never created before the APIs they type-check are served.

A template capability gate (`.Capabilities.APIVersions.Has`) was considered and rejected: operator-generated HelmReleases run without drift detection, so helm-controller is checksum-driven — it would render the policy out at first install and never re-add it once the API appears, silently dropping the protection. Ordering via `dependsOn` gates the first install on Ready, which is reliable.

No cycle risk: nothing `dependsOn` `cozystack-basics`, and no `cozystack-engine` component consumes a `cozystack-basics` output, so engine becomes Ready independently.

Includes a helm-unittest regression test asserting the `dependsOn` edges stay.

The underlying nil-pointer panic is an upstream Kubernetes bug (the best-effort status type-checker should never crash kube-controller-manager); it is unguarded as of the current release and will be reported separately. This change removes the trigger on the cozystack side.

### Release note

```release-note
fix(platform): order cozystack-basics after the APIs its admission policies type-check, fixing a cold-install deadlock where kube-controller-manager could crash type-checking policies against APIs (tenants, Gateway API) not yet served
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cluster stability by implementing proper dependency ordering for validation policies during initialization, preventing resource configuration conflicts.

* **Tests**
  * Added integration tests to validate cluster-wide policy dependencies and ordering, ensuring continuous system stability verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->