### PR TITLE
fix(dashboard): grant tenant dashboard read on cozy-public PVCs

### DIFF
--- a/packages/system/cozystack-basics/templates/dashboard-role.yaml
+++ b/packages/system/cozystack-basics/templates/dashboard-role.yaml
@@ -1,6 +1,6 @@
 ---
 # == dashboard role ==
-# Single namespaced role for tenant dashboard access to helm resources
+# Single namespaced role for tenant dashboard access to shared cozy-public resources
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -13,3 +13,11 @@ rules:
 - apiGroups: ["source.toolkit.fluxcd.io"]
   resources: ["helmcharts"]
   verbs: ["get", "list"]
+# The console lists PVCs in cozy-public (the vm-default-images-* golden images)
+# to populate the source image dropdown when creating a vm-disk. The browser
+# issues this list as the tenant identity, so without a read grant here it gets
+# 403 and the dropdown is empty. cozy-public is a shared public namespace, so
+# read on its PVCs is safe to expose to every tenant dashboard subject.
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "watch"]

--- a/packages/system/cozystack-basics/tests/dashboard-role_test.yaml
+++ b/packages/system/cozystack-basics/tests/dashboard-role_test.yaml
@@ -1,0 +1,29 @@
+suite: cozystack-basics tenant dashboard Role grants read on cozy-public resources
+
+templates:
+  - templates/dashboard-role.yaml
+
+release:
+  name: cozystack-basics
+  namespace: cozy-system
+
+# The vm-disk source image dropdown lists PersistentVolumeClaims in cozy-public
+# (the vm-default-images-* golden images). The console issues that list as the
+# tenant identity (e.g. the tenant-root ServiceAccount), so the cozy:tenant:dashboard
+# Role must grant read on PVCs; otherwise the browser gets 403 and the dropdown
+# is empty even though the images exist.
+tests:
+  - it: cozy:tenant:dashboard grants read on persistentvolumeclaims in cozy-public
+    documentSelector:
+      path: metadata.name
+      value: cozy:tenant:dashboard
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: cozy-public
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["persistentvolumeclaims"]
+            verbs: ["get", "list", "watch"]


### PR DESCRIPTION
## What this PR does

The vm-disk **source image** dropdown in the console lists `PersistentVolumeClaims` in `cozy-public` (the `vm-default-images-*` golden images) to offer them when creating a VM disk. That list is issued by the browser as the **tenant identity** (e.g. `system:serviceaccount:tenant-root:tenant-root`), but the `cozy:tenant:dashboard` Role in `cozy-public` only granted read on Flux `helmrepositories`/`helmcharts`. The list returned `403 Forbidden` and the dropdown stayed empty even when images had been enabled (e.g. via `bundles.enabledPackages`).

This is identity-dependent, which is why it can look intermittent: a cluster-admin login bypasses tenant RBAC and sees the images, while any real tenant — including `tenant-root-super-admin` — hits the 403.

This PR adds `get`/`list`/`watch` on `persistentvolumeclaims` to the Role. `cozy-public` is a shared public namespace, so read on its PVCs is safe to expose to every tenant dashboard subject (the Role is already bound to the tenant groups and the tenant ServiceAccount). A helm-unittest regression pins the grant.

Verified with `kubectl auth can-i list pvc -n cozy-public`:
- `--as=system:serviceaccount:tenant-root:tenant-root` → no (before this PR)
- `--as-group=tenant-root-super-admin` → no (before this PR)
- cluster-admin → yes (why it "worked" for admins)

No console code changed — this is an RBAC-only fix.

### Release note

```release-note
fix(dashboard): allow tenant dashboards to list VM images in cozy-public, fixing the empty source-image dropdown when creating a vm-disk
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard access permissions have been expanded to include read-level access to persistent volume claims, enabling users to manage and select images through the dashboard more effectively.

* **Tests**
  * Added test suite to verify dashboard role permissions are correctly configured and functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->