### PR TITLE
ci: harden workflow token permissions and pin actions by SHA

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -11,6 +11,10 @@ concurrency:
   group: auto-release-${{ github.workflow }}
   cancel-in-progress: false
 
+# Top-level token defaults to read-only; jobs request the minimum extra scopes.
+permissions:
+  contents: read
+
 jobs:
   auto-release:
     name: Auto Patch Release
@@ -22,14 +26,14 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.COZYSTACK_CI_APP_ID }}
           private-key: ${{ secrets.COZYSTACK_CI_PRIVATE_KEY }}
           owner: cozystack
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -44,7 +48,7 @@ jobs:
           git config --unset-all http.https://github.com/.extraheader || true
 
       - name: Process release branches
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           APP_TOKEN: ${{ steps.app-token.outputs.token }}
         with:

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -8,9 +8,9 @@ concurrency:
   group: backport-${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Top-level token defaults to read-only; jobs request the minimum extra scopes.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   # Determine which backports are needed
@@ -24,6 +24,8 @@ jobs:
         (github.event.action == 'labeled' && (github.event.label.name == 'backport' || github.event.label.name == 'backport-previous'))
       )
     runs-on: [self-hosted]
+    permissions:
+      contents: read
     outputs:
       backport_current: ${{ steps.labels.outputs.backport }}
       backport_previous: ${{ steps.labels.outputs.backport_previous }}
@@ -32,7 +34,7 @@ jobs:
     steps:
       - name: Check which labels are present
         id: labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -47,7 +49,7 @@ jobs:
       
       - name: Determine target branches
         id: branches
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             // Get latest release
@@ -94,6 +96,9 @@ jobs:
       github.event.pull_request.base.ref == 'main' &&
       (needs.prepare.outputs.backport_current == 'true' || needs.prepare.outputs.backport_previous == 'true')
     runs-on: [self-hosted]
+    permissions:
+      contents: write
+      pull-requests: write
     strategy:
       matrix:
         backport_type: [current, previous]
@@ -116,13 +121,13 @@ jobs:
       # 2. Checkout (required by backport‑action)
       - name: Checkout repository
         if: steps.target.outcome == 'success'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       # 3. Create the back‑port pull request
       - name: Create back‑port PR
         id: backport
         if: steps.target.outcome == 'success'
-        uses: korthout/backport-action@v3.2.1
+        uses: korthout/backport-action@0193454f0c5947491d348f33a275c119f30eb736 # v3.2.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           label_pattern: '' # don't read labels for targets

--- a/.github/workflows/codegen-drift.yml
+++ b/.github/workflows/codegen-drift.yml
@@ -23,16 +23,22 @@ concurrency:
   group: codegen-drift-${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Top-level token defaults to read-only; jobs request the minimum extra scopes.
+permissions:
+  contents: read
+
 jobs:
   codegen-drift:
     name: Verify generated code is up to date
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -24,8 +24,10 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Validate labels.yml schema
         run: |
@@ -74,11 +76,12 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: EndBug/label-sync@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2
         with:
           config-file: .github/labels.yml
           delete-other-labels: false

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -4,16 +4,18 @@ on:
   pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
+# Top-level token defaults to read-only; jobs request the minimum extra scopes.
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   label:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Apply labels from PR title
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             // Conventional Commits types accepted by Cozystack (per docs/agents/contributing.md):

--- a/.github/workflows/pr-size.yaml
+++ b/.github/workflows/pr-size.yaml
@@ -4,9 +4,9 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+# Top-level token defaults to read-only; jobs request the minimum extra scopes.
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: pr-size-${{ github.event.pull_request.number }}
@@ -15,8 +15,10 @@ concurrency:
 jobs:
   size:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,18 +8,24 @@ concurrency:
   group: pre-commit-${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Top-level token defaults to read-only; jobs request the minimum extra scopes.
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.11'
 
@@ -27,7 +33,7 @@ jobs:
         run: pip install pre-commit
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/pull-requests-release.yaml
+++ b/.github/workflows/pull-requests-release.yaml
@@ -11,6 +11,10 @@ concurrency:
   group: pr-${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Top-level token defaults to read-only; jobs request the minimum extra scopes.
+permissions:
+  contents: read
+
 jobs:
   finalize:
     name: Finalize Release
@@ -25,7 +29,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.COZYSTACK_CI_APP_ID }}
           private-key: ${{ secrets.COZYSTACK_CI_PRIVATE_KEY }}
@@ -34,7 +38,7 @@ jobs:
       # Extract tag from branch name  (branch = release-X.Y.Z*)
       - name: Extract tag from branch name
         id: get_tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;
@@ -49,7 +53,7 @@ jobs:
 
       # Checkout repo & create / push annotated tag
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -65,7 +69,7 @@ jobs:
 
       # Ensure maintenance branch release-X.Y
       - name: Ensure maintenance branch release-X.Y
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -120,7 +124,7 @@ jobs:
 
       # Publish draft release and ensure correct latest flag
       - name: Publish draft release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -12,14 +12,21 @@ concurrency:
   group: pr-${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Top-level token defaults to read-only; jobs request the minimum extra scopes.
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         id: filter
         with:
           filters: |
@@ -52,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -84,7 +91,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         if: ${{ !github.event.pull_request.head.repo.fork }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.OCIR_USER}}
           password: ${{ secrets.OCIR_TOKEN }}
@@ -112,13 +119,13 @@ jobs:
 
       - name: Upload git diff patch
         if: "!contains(github.event.pull_request.labels.*.name, 'release')"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pr-patch
           path: _out/assets/pr.patch
      
       - name: Upload Talos image
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: talos-image
           path: _out/assets/nocloud-amd64.raw.xz
@@ -130,10 +137,12 @@ jobs:
     outputs:
       disk_id:      ${{ steps.fetch_assets.outputs.disk_id }}
 
+    permissions:
+      contents: read
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.COZYSTACK_CI_APP_ID }}
           private-key: ${{ secrets.COZYSTACK_CI_PRIVATE_KEY }}
@@ -141,7 +150,7 @@ jobs:
 
       - name: Checkout code
         if: contains(github.event.pull_request.labels.*.name, 'release')
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -149,7 +158,7 @@ jobs:
       - name: Extract tag from PR branch (release PR)
         if: contains(github.event.pull_request.labels.*.name, 'release')
         id: get_tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;
@@ -163,7 +172,7 @@ jobs:
       - name: Find draft release & asset IDs (release PR)
         if: contains(github.event.pull_request.labels.*.name, 'release')
         id: fetch_assets
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -203,7 +212,7 @@ jobs:
       - name: Generate GitHub App token
         if: contains(github.event.pull_request.labels.*.name, 'release')
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.COZYSTACK_CI_APP_ID }}
           private-key: ${{ secrets.COZYSTACK_CI_PRIVATE_KEY }}
@@ -213,21 +222,21 @@ jobs:
       # fetch-depth: 0 is required by the "Select E2E tests" step so that
       # `git diff origin/${BASE_REF}...HEAD` can resolve the base ref.
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       # ▸ Regular PR path – download artefacts produced by the *build* job
       - name: "Download Talos image (regular PR)"
         if: "!contains(github.event.pull_request.labels.*.name, 'release')"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: talos-image
           path: _out/assets
 
       - name: Download PR patch
         if: "!contains(github.event.pull_request.labels.*.name, 'release')"
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: pr-patch
           path: _out/assets
@@ -376,7 +385,7 @@ jobs:
 
       - name: Upload cozyreport.tgz
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: cozyreport
           path: /tmp/${{ env.SANDBOX_NAME }}/_out/cozyreport.tgz
@@ -389,7 +398,7 @@ jobs:
 
       - name: Upload image list
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: image-list
           path: /tmp/${{ env.SANDBOX_NAME }}/_out/images.txt

--- a/.github/workflows/retest.yaml
+++ b/.github/workflows/retest.yaml
@@ -4,6 +4,10 @@ on:
   issue_comment:
     types: [created]
 
+# Top-level token defaults to read-only; jobs request the minimum extra scopes.
+permissions:
+  contents: read
+
 jobs:
   retest:
     name: Retest PR
@@ -17,7 +21,7 @@ jobs:
 
     steps:
       - name: Rerun from Prepare environment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const prNumber = context.issue.number;

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,10 +5,9 @@ on:
     - cron: '37 4 * * *'  # daily at 04:37 UTC
   workflow_dispatch:
 
+# Top-level token defaults to read-only; jobs request the minimum extra scopes.
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
 
 concurrency:
   group: stale
@@ -17,8 +16,11 @@ concurrency:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10
         with:
           stale-issue-label: lifecycle/stale
           stale-pr-label: lifecycle/stale

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -12,6 +12,10 @@ concurrency:
   group: tags-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Top-level token defaults to read-only; jobs request the minimum extra scopes.
+permissions:
+  contents: read
+
 jobs:
   prepare-release:
     name: Prepare Release
@@ -27,7 +31,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.COZYSTACK_CI_APP_ID }}
           private-key: ${{ secrets.COZYSTACK_CI_PRIVATE_KEY }}
@@ -36,7 +40,7 @@ jobs:
       # Check if a non-draft release with this tag already exists
       - name: Check if release already exists
         id: check_release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const tag = context.ref.replace('refs/tags/', '');
@@ -57,7 +61,7 @@ jobs:
       - name: Parse tag
         if: steps.check_release.outputs.skip == 'false'
         id: tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const ref = context.ref.replace('refs/tags/', '');           // e.g. v0.31.5-rc.1
@@ -78,7 +82,7 @@ jobs:
       - name: Get base branch
         if: steps.check_release.outputs.skip == 'false'
         id: get_base
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const baseRef = context.payload.base_ref;
@@ -97,14 +101,14 @@ jobs:
       # Checkout & login once
       - name: Checkout code
         if: steps.check_release.outputs.skip == 'false'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           fetch-tags:  true
 
       - name: Login to GHCR
         if: steps.check_release.outputs.skip == 'false'
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -156,7 +160,7 @@ jobs:
       - name: Create / reuse draft release
         if: steps.check_release.outputs.skip == 'false'
         id: release
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const tag      = '${{ steps.tag.outputs.tag }}';
@@ -208,7 +212,7 @@ jobs:
       # Create pull request into original base branch (if absent)
       - name: Create pull request if not exists
         if: steps.check_release.outputs.skip == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -256,7 +260,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.COZYSTACK_CI_APP_ID }}
           private-key: ${{ secrets.COZYSTACK_CI_PRIVATE_KEY }}
@@ -268,7 +272,7 @@ jobs:
       # regardless of whether the agent follows the prompt's instructions.
       - name: Generate read-only GitHub App token
         id: app-token-read
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.COZYSTACK_CI_APP_ID }}
           private-key: ${{ secrets.COZYSTACK_CI_PRIVATE_KEY }}
@@ -279,7 +283,7 @@ jobs:
 
       - name: Parse tag
         id: tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const ref = context.ref.replace('refs/tags/', '');
@@ -300,7 +304,7 @@ jobs:
       # contents. The Create changelog branch step below resets the file
       # onto a fresh branch from origin/main for the PR.
       - name: Checkout release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ steps.tag.outputs.tag }}
           fetch-depth: 0
@@ -329,7 +333,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.check_changelog.outputs.exists == 'false'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
@@ -395,7 +399,7 @@ jobs:
 
       - name: Create PR for changelog
         if: steps.check_changelog.outputs.exists == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -460,7 +464,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.COZYSTACK_CI_APP_ID }}
           private-key: ${{ secrets.COZYSTACK_CI_PRIVATE_KEY }}
@@ -468,7 +472,7 @@ jobs:
 
       - name: Parse tag
         id: tag
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const ref = context.ref.replace('refs/tags/', '');
@@ -482,7 +486,7 @@ jobs:
             core.setOutput('version', version);  // 0.22.0
 
       - name: Checkout website repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: cozystack/website
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-releasenotes.yaml
+++ b/.github/workflows/update-releasenotes.yaml
@@ -9,6 +9,10 @@ concurrency:
   group: update-releasenotes-${{ github.workflow }}
   cancel-in-progress: false
 
+# Top-level token defaults to read-only; jobs request the minimum extra scopes.
+permissions:
+  contents: read
+
 jobs:
   update-releasenotes:
     name: Update Release Notes
@@ -18,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Update release notes from changelogs
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## What this PR does

Hardens GitHub Actions security posture to raise two OpenSSF Scorecard checks that currently score **0/10**, as part of the push to ≥7.5 ahead of CNCF Incubation due diligence. No workflow triggers, job graphs, or step logic change — only `GITHUB_TOKEN` scopes and action pin refs.

### Token-Permissions (was 0/10)

The check failed because several workflows (`codegen-drift.yml`, `pre-commit.yml`, `retest.yaml`, `tags.yaml`, …) declared **no `permissions:` block at all**, so their jobs inherited the repository default token — typically read/write across all scopes.

This PR applies the OpenSSF-recommended pattern to **every** workflow:

- A **top-level read-only default**: `permissions: { contents: read }`.
- An **explicit per-job `permissions:` block** granting only the writes that job needs. Workflows that previously held write scopes at the *workflow* level (`backport`, `pr-labeler`, `pr-size`, `stale`) now hold them at *job* level, so the read-only default applies everywhere else.

Per-job scopes were derived from what each job actually calls:

| Workflow | Job | Scopes granted |
|---|---|---|
| auto-release | auto-release | `contents: write, pull-requests: read` *(unchanged)* |
| backport | prepare | `contents: read` |
| backport | backport | `contents: write, pull-requests: write` |
| codegen-drift | codegen-drift | `contents: read` |
| labels | validate | `contents: read` |
| labels | sync | `contents: read, issues: write, pull-requests: write` |
| pre-commit | pre-commit | `contents: read` |
| pr-labeler | label | `pull-requests: write` |
| pr-size | size | `pull-requests: write` |
| retest | retest | `actions: write, pull-requests: read` *(unchanged)* |
| stale | stale | `issues: write, pull-requests: write` |
| update-releasenotes | update-releasenotes | `contents: write` *(unchanged)* |
| pull-requests | detect-changes | `contents: read, pull-requests: read` |
| pull-requests | build | `contents: read, packages: write` *(unchanged)* |
| pull-requests | resolve_assets | `contents: read` |
| pull-requests | e2e | `contents: read, packages: read, checks: write` *(unchanged)* |
| pull-requests-release | finalize | `contents: write` *(unchanged)* |
| tags | prepare-release | `contents/packages/pull-requests/actions: write` *(unchanged)* |
| tags | generate-changelog | `contents: write, pull-requests: write` *(unchanged)* |
| tags | update-website-docs | `contents: read` *(unchanged)* |

Self-hosted release jobs that push tags/branches/releases authenticate via the `cozystack-ci` GitHub App token, so reducing the workflow `GITHUB_TOKEN` does not affect them; the job-level write scopes they already declared are preserved verbatim.

### Pinned-Dependencies (was 0/10)

Every GitHub-owned and third-party action is now pinned to a **full commit SHA** with a human-readable version comment, e.g. `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4`. `scorecard.yml` was already SHA-pinned in #2721; `breakpoint-action` was already pinned. SHAs were resolved from each tag's current commit at authoring time, so behavior is identical to the previously-referenced tag.

> **Scope note:** this PR pins **GitHub Actions** only. Dockerfile `FROM` digest pinning (≈40 images) is deliberately out of scope here — it touches image builds and is higher blast-radius; tracked separately.

### Verification

- `actionlint` over all workflows: **exit 0**.
- All 14 workflow files parse as valid YAML.
- Diff is mechanical: only `permissions:` blocks and action `@ref`s changed.

### Release note

```release-note
ci: declare least-privilege per-job GITHUB_TOKEN permissions and pin all GitHub Actions by commit SHA across CI workflows (OpenSSF Scorecard hardening)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened CI/CD security with least-privilege workflow token permissions: workflows now default to read-only access (`contents: read`), with select jobs requesting write or additional scopes only when needed.
  * Improved supply-chain safety and consistency by pinning GitHub Actions (and related third-party actions) to specific commit SHAs across multiple workflows, reducing reliance on floating version tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->