### PR TITLE
ci: add CodeQL workflow for Go (SAST)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,19 +36,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # build-mode "none" extracts Go source without compiling it, so the
-          # job can never fail on the monorepo's generated files, build tags,
-          # or the api/apps/v1alpha1 submodule. It still produces real alerts
-          # and satisfies the OpenSSF Scorecard SAST check. Switch to
-          # "autobuild" later if deeper, build-aware analysis is wanted.
+          # Go only supports "autobuild" or "manual" (not "none"). autobuild
+          # runs the Go build the same way `go build ./...` does — the repo
+          # already compiles cleanly there, including the committed generated
+          # files. setup-go below pins the toolchain to the go.mod version so
+          # autobuild does not fall back to whatever Go the runner ships.
           - language: go
-            build-mode: none
+            build-mode: autobuild
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,8 +6,9 @@ on:
   pull_request:
     branches: [main]
   schedule:
-    # Weekly, off-peak and offset from the other Monday cron jobs
-    # (scorecard 06:00, labels 04:17, stale 04:37).
+    # Weekly on Monday 03:27 UTC — off-peak and offset from the other
+    # scheduled jobs (scorecard 06:00 Mon, labels 04:17 Mon, stale 04:37
+    # daily).
     - cron: '27 3 * * 1'
 
 # Default to read-only; the analyze job opts into security-events: write.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,62 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, off-peak and offset from the other Monday cron jobs
+    # (scorecard 06:00, labels 04:17, stale 04:37).
+    - cron: '27 3 * * 1'
+
+# Default to read-only; the analyze job opts into security-events: write.
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      # Upload CodeQL results to the code-scanning dashboard.
+      security-events: write
+      # Check out the repository.
+      contents: read
+      # Read workflow run metadata (required by codeql-action on private
+      # repos; harmless on a public repo).
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # build-mode "none" extracts Go source without compiling it, so the
+          # job can never fail on the monorepo's generated files, build tags,
+          # or the api/apps/v1alpha1 submodule. It still produces real alerts
+          # and satisfies the OpenSSF Scorecard SAST check. Switch to
+          # "autobuild" later if deeper, build-aware analysis is wanted.
+          - language: go
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,12 +57,12 @@ jobs:
           cache: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,10 +37,15 @@ jobs:
       matrix:
         include:
           # Go only supports "autobuild" or "manual" (not "none"). autobuild
-          # runs the Go build the same way `go build ./...` does — the repo
-          # already compiles cleanly there, including the committed generated
-          # files. setup-go below pins the toolchain to the go.mod version so
-          # autobuild does not fall back to whatever Go the runner ships.
+          # discovers every go.mod in the tree and extracts each module
+          # separately (the root module, api/apps/v1alpha1, and the three
+          # nested image modules that `go build ./...` from the root never
+          # reaches), so coverage is broader than a single root build. It first
+          # attempts `make` from the repo root — which runs the default Makefile
+          # goal, including a network `git fetch upstream --tags` — before
+          # falling back to the Go build. setup-go below pins the toolchain to
+          # the go.mod version so autobuild does not use whatever Go the runner
+          # ships.
           - language: go
             build-mode: autobuild
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -50,6 +50,6 @@ jobs:
           retention-days: 5
 
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## What this PR does

Raises the OpenSSF Scorecard **SAST** check (was **0/10**) by adding GitHub's recommended CodeQL static analysis for Go. CodeQL is free for public repositories and is the SAST tool Scorecard recognizes directly.

- Triggers on push to `main`, PRs to `main`, and a weekly schedule (Mon 03:27 UTC, offset from the other Monday cron jobs).
- Results are uploaded to the code-scanning dashboard via `github/codeql-action/analyze`.

### Why `autobuild`

The Go analysis uses **`build-mode: autobuild`**. Go's CodeQL extractor only supports `autobuild` or `manual` (not `none`), so autobuild is the low-friction choice. It discovers every `go.mod` in the tree and extracts each module separately — the root module, `api/apps/v1alpha1`, and the three nested image modules a root `go build ./...` never reaches — giving broader coverage than a single root build. Before falling back to the Go build it first attempts `make` from the repo root, which runs the default Makefile goal (including a network `git fetch upstream --tags`). `setup-go` pins the toolchain to the `go.mod` version so the extractor uses the project's Go rather than whatever the runner ships.

### Security posture

- Top-level token is **read-only**; the `analyze` job opts into `security-events: write` (plus `contents: read`, `actions: read`) only.
- `actions/checkout` is pinned to **v6.0.2** (matching `scorecard.yml`) with `persist-credentials: false`.
- `codeql-action/init` and `/analyze` are pinned to the **v4.36.2 SHA** — the same commit as `scorecard.yml`'s `upload-sarif`, keeping every codeql-action ref in the repo on one commit and clear of the v3 deprecation warning.

### Verification

- `actionlint`: **exit 0**.
- Valid YAML.
- No `run:` steps → no untrusted-input injection surface.

> SAST is a ramping check: Scorecard credits the CodeQL workflow's presence immediately and the score climbs toward full as subsequent merged PRs get analyzed.

### Release note

```release-note
ci: add CodeQL static analysis (SAST) for Go, running on push/PR to main and weekly
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated security scanning via CodeQL on pushes, pull requests targeting the main branch, and on a weekly schedule.
  * Added workflow controls for concurrency and longer execution time, with support for Go-based analysis using an autobuild setup.
  * Updated the SARIF upload step to use the latest CodeQL action version to improve reliability while maintaining secure, minimal permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
