### PR TITLE
docs: route bugs, features, and proposals to the right repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Question, help, or an early idea
+    url: https://github.com/cozystack/cozystack/discussions
+    about: Usage questions, troubleshooting, or a "should we…" idea that isn't a concrete request yet — start a Discussion. The community and maintainers answer here.
+  - name: 📐 Design proposal / RFC (architectural or cross-cutting)
+    url: https://github.com/cozystack/community/tree/main/design-proposals
+    about: Changes that affect multiple components or APIs, or that need a decision before any code is written (a new subsystem, an API change with tradeoffs). Open a design-proposal PR in the community repo.
+  - name: 🏛️ Governance, process, or community
+    url: https://github.com/cozystack/community/issues/new
+    about: Maintainership, decision-making, meetings, working groups, community resources — these live in the community repo.
+  - name: 💬 Chat (Telegram / CNCF Slack)
+    url: https://t.me/cozystack
+    about: Real-time discussion with the Cozystack community.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,42 @@
+---
+name: Feature request
+about: Propose a concrete, scoped improvement to Cozystack
+labels: 'kind/feature'
+assignees: ''
+
+---
+<!--
+Before you file, make sure this is the right place:
+
+  • A usage question or a half-formed idea?
+    → Start a GitHub Discussion instead: https://github.com/cozystack/cozystack/discussions
+
+  • A cross-cutting or architectural change — one that affects multiple components
+    or APIs, or that needs a decision agreed before any code is written?
+    → Open a design proposal in the community repo:
+      https://github.com/cozystack/community/tree/main/design-proposals
+
+This template is for a CONCRETE, SCOPED feature that a maintainer could pick up
+and implement without first settling an open design question.
+-->
+
+**Problem / motivation**
+
+What are you trying to do, and what is missing or painful today?
+
+**Proposed solution**
+
+What should Cozystack do? Be as concrete as you can — the API field, flag, value, or behavior you expect.
+
+**Scope check**
+
+- [ ] This affects a single component / package (if it spans many, consider a [design proposal](https://github.com/cozystack/community/tree/main/design-proposals))
+- [ ] I can describe the expected behavior concretely (if not, consider a [Discussion](https://github.com/cozystack/cozystack/discussions) first)
+
+**Alternatives considered**
+
+Other approaches you weighed, and why this one.
+
+**Additional context**
+
+Links, related issues, screenshots, prior art.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,20 @@ We welcome many types of contributions including:
 The best way to reach us with a question when contributing is to drop a line in
 our [Telegram channel](https://t.me/cozystack), or start a new GitHub discussion.
 
+## Where do I file?
+
+Cozystack work is split across two repositories. Use this table to land in the right place:
+
+| You have… | Where it goes |
+|---|---|
+| A **bug** | [New issue → Bug report](https://github.com/cozystack/cozystack/issues/new/choose) in this repo (`kind/bug`) |
+| A **concrete, scoped feature** | [New issue → Feature request](https://github.com/cozystack/cozystack/issues/new/choose) in this repo (`kind/feature`) |
+| A **usage question** or an early idea | [GitHub Discussions](https://github.com/cozystack/cozystack/discussions) |
+| A **cross-cutting / architectural change** — affects multiple components or APIs, or needs a decision before code | A [design proposal](https://github.com/cozystack/community/tree/main/design-proposals) in the [**community**](https://github.com/cozystack/community) repo |
+| **Governance, process, or community** matters | The [community](https://github.com/cozystack/community) repo |
+
+Rule of thumb: **bugs and concrete features live here; "what or whether we should build it" lives in [community](https://github.com/cozystack/community)** as a design proposal or discussion. A large feature often starts as a Discussion, graduates to a design-proposal PR, then spawns implementation issues here.
+
 ## Raising Issues
 
 When raising issues, please specify the following:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If it isn't, you can open a new one. A detailed report will help us replicate it
 You can express your intention to on the fix on your own.
 Commits are used to generate the changelog, and their author will be referenced in it.
 
-If you have **Feature Requests** please use the [Discussion's Feature Request section](https://github.com/cozystack/cozystack/discussions/categories/feature-requests).
+If you have a **concrete feature request**, [open an issue](https://github.com/cozystack/cozystack/issues/new/choose). For a **cross-cutting or architectural change**, open a [design proposal](https://github.com/cozystack/community/tree/main/design-proposals) in the [community](https://github.com/cozystack/community) repo. For **questions or early ideas**, use [GitHub Discussions](https://github.com/cozystack/cozystack/discussions). See [CONTRIBUTING.md](CONTRIBUTING.md#where-do-i-file) for the full routing.
 
 ## Community
 


### PR DESCRIPTION
## What

Make it unambiguous where each kind of contribution lands:

| Contribution | Destination |
|---|---|
| Bug | issue here (`kind/bug`) |
| Concrete, scoped feature | issue here (`kind/feature`) |
| Question / early idea | GitHub Discussions |
| Cross-cutting / architectural change | design proposal in cozystack/community |
| Governance / process / community | cozystack/community |

## Changes

- Add `.github/ISSUE_TEMPLATE/config.yml` — a chooser (`blank_issues_enabled: false`) linking to Discussions, the community design-proposal process, community governance issues, and chat.
- Add `.github/ISSUE_TEMPLATE/feature_request.md` (`kind/feature`) with an up-front gate (question → Discussion; cross-cutting → design proposal) and a scope checklist.
- `CONTRIBUTING.md`: add a "Where do I file?" routing table.
- `README.md`: feature requests now point at issues instead of a Discussions category, reconciling a contradiction with the actively-used issue tracker.

## Notes

- `blank_issues_enabled: false` removes the blank-issue escape hatch to keep triage clean — easy to flip if you'd rather keep it.
- Pairs with a companion PR in cozystack/community (routing table + dead-link fix).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added “Where do I file?” guidance to help route bugs, scoped feature requests, questions/early ideas, cross-cutting design proposals, and community/process topics.
  * Updated the README “Contributions” section with clearer links and pointers to the right place for each request type.
* **New Features**
  * Added a structured “Feature request” issue template to collect consistent, scoped details.
  * Disabled blank issue submissions and provided curated entry points for common support and discussion paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->