### PR TITLE
fix(build): read --cache-from from ghcr :latest so PR builds warm-start

### DIFF
--- a/hack/common-envs.mk
+++ b/hack/common-envs.mk
@@ -7,6 +7,14 @@ endif
 
 REGISTRY ?= ghcr.io/cozystack/cozystack
 
+# CACHE_REGISTRY: registry that `--cache-from` reads build cache from. It must
+# point at a registry where a `:latest` tag is actually published. PR builds
+# set REGISTRY to a per-CI registry and push only unique `pr-<N>-<sha>` tags
+# (PUBLISH_FLOATING=0), so they never refresh `:latest` there — reading cache
+# from $(REGISTRY):latest would always 404. Release builds publish `:latest`
+# to ghcr.io, so default cache reads there and stays warm across PR builds.
+CACHE_REGISTRY ?= ghcr.io/cozystack/cozystack
+
 # IMAGE_TAG: build-unique tag pushed for every image. Set by CI to a value
 # that does not collide between concurrent builds:
 #   * pull-requests.yaml -> pr-<N>-<sha>

--- a/packages/apps/clickhouse/Makefile
+++ b/packages/apps/clickhouse/Makefile
@@ -13,7 +13,7 @@ test:
 image:
 	docker buildx build images/clickhouse-backup \
 		$(call image-tags,clickhouse-backup,$(CLICKHOUSE_BACKUP_TAG)) \
-		--cache-from type=registry,ref=$(REGISTRY)/clickhouse-backup:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/clickhouse-backup:latest \
 		--cache-to type=inline \
 		--metadata-file images/clickhouse-backup.json \
 		$(BUILDX_ARGS)
@@ -22,7 +22,7 @@ image:
 	rm -f images/clickhouse-backup.json
 	docker buildx build images/altinity-clickhouse-backup \
 		$(call image-tags,altinity-clickhouse-backup,$(CLICKHOUSE_BACKUP_TAG)) \
-		--cache-from type=registry,ref=$(REGISTRY)/altinity-clickhouse-backup:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/altinity-clickhouse-backup:latest \
 		--cache-to type=inline \
 		--metadata-file images/altinity-clickhouse-backup.json \
 		$(BUILDX_ARGS)

--- a/packages/apps/http-cache/Makefile
+++ b/packages/apps/http-cache/Makefile
@@ -8,7 +8,7 @@ image: image-nginx
 image-nginx:
 	docker buildx build images/nginx-cache \
 		$(call image-tags,nginx-cache,$(NGINX_CACHE_TAG)) \
-		--cache-from type=registry,ref=$(REGISTRY)/nginx-cache:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/nginx-cache:latest \
 		--cache-to type=inline \
 		--metadata-file images/nginx-cache.json \
 		$(BUILDX_ARGS)

--- a/packages/apps/kubernetes/Makefile
+++ b/packages/apps/kubernetes/Makefile
@@ -26,7 +26,7 @@ image-ubuntu-container-disk:
 			--build-arg KUBERNETES_VERSION=$(ver) \
 			--tag $(REGISTRY)/ubuntu-container-disk:$(ver)-$(IMAGE_TAG) \
 			$(if $(filter 1,$(PUBLISH_VERSIONED)),--tag $(REGISTRY)/ubuntu-container-disk:$(ver)) \
-			--cache-from type=registry,ref=$(REGISTRY)/ubuntu-container-disk:$(ver) \
+			--cache-from type=registry,ref=$(CACHE_REGISTRY)/ubuntu-container-disk:$(ver) \
 			--cache-to type=inline \
 			--metadata-file images/ubuntu-container-disk-$(ver).json \
 			$(BUILDX_ARGS) && \
@@ -38,7 +38,7 @@ image-ubuntu-container-disk:
 image-kubevirt-cloud-provider:
 	docker buildx build images/kubevirt-cloud-provider \
 		$(call image-tags,kubevirt-cloud-provider,$(KUBERNETES_PKG_TAG)) \
-		--cache-from type=registry,ref=$(REGISTRY)/kubevirt-cloud-provider:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/kubevirt-cloud-provider:latest \
 		--cache-to type=inline \
 		--metadata-file images/kubevirt-cloud-provider.json \
 		$(BUILDX_ARGS)
@@ -49,7 +49,7 @@ image-kubevirt-cloud-provider:
 image-kubevirt-csi-driver:
 	docker buildx build images/kubevirt-csi-driver \
 		$(call image-tags,kubevirt-csi-driver,$(KUBERNETES_PKG_TAG)) \
-		--cache-from type=registry,ref=$(REGISTRY)/kubevirt-csi-driver:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/kubevirt-csi-driver:latest \
 		--cache-to type=inline \
 		--metadata-file images/kubevirt-csi-driver.json \
 		$(BUILDX_ARGS)
@@ -63,7 +63,7 @@ image-kubevirt-csi-driver:
 image-cluster-autoscaler:
 	docker buildx build images/cluster-autoscaler \
 		$(call image-tags,cluster-autoscaler,$(KUBERNETES_PKG_TAG)) \
-		--cache-from type=registry,ref=$(REGISTRY)/cluster-autoscaler:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/cluster-autoscaler:latest \
 		--cache-to type=inline \
 		--metadata-file images/cluster-autoscaler.json \
 		$(BUILDX_ARGS)

--- a/packages/apps/mariadb/Makefile
+++ b/packages/apps/mariadb/Makefile
@@ -14,7 +14,7 @@ update:
 image:
 	docker buildx build images/mariadb-backup \
 		$(call image-tags,mariadb-backup,$(MARIADB_BACKUP_TAG)) \
-		--cache-from type=registry,ref=$(REGISTRY)/mariadb-backup:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/mariadb-backup:latest \
 		--cache-to type=inline \
 		--metadata-file images/mariadb-backup.json \
 		$(BUILDX_ARGS)

--- a/packages/core/installer/Makefile
+++ b/packages/core/installer/Makefile
@@ -21,7 +21,7 @@ image-operator:
 	docker buildx build -f images/cozystack-operator/Dockerfile ../../.. \
 		$(call image-tags,cozystack-operator,v$(COZYSTACK_VERSION)) \
 		--build-arg VERSION=v$(COZYSTACK_VERSION) \
-		--cache-from type=registry,ref=$(REGISTRY)/cozystack-operator:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/cozystack-operator:latest \
 		--cache-to type=inline \
 		--metadata-file images/cozystack-operator.json \
 		$(BUILDX_ARGS)

--- a/packages/core/platform/Makefile
+++ b/packages/core/platform/Makefile
@@ -30,7 +30,7 @@ image: image-migrations
 image-migrations:
 	docker buildx build images/migrations \
 		$(call image-tags,platform-migrations,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/platform-migrations:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/platform-migrations:latest \
 		--cache-to type=inline \
 		--metadata-file images/migrations.json \
 		$(BUILDX_ARGS)

--- a/packages/core/talos/Makefile
+++ b/packages/core/talos/Makefile
@@ -23,7 +23,7 @@ image-matchbox:
 	test -f ../../../_out/assets/initramfs-metal-amd64.xz || make talos-initramfs
 	docker buildx build -f images/matchbox/Dockerfile ../../.. \
 		$(call image-tags,matchbox,$(TALOS_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/matchbox:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/matchbox:latest \
 		--cache-to type=inline \
 		--metadata-file images/matchbox.json \
 		$(BUILDX_ARGS)

--- a/packages/core/testing/Makefile
+++ b/packages/core/testing/Makefile
@@ -17,7 +17,7 @@ image: image-e2e-sandbox
 image-e2e-sandbox:
 	docker buildx build -f images/e2e-sandbox/Dockerfile images/e2e-sandbox \
 		$(call image-tags,e2e-sandbox,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/e2e-sandbox:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/e2e-sandbox:latest \
 		--cache-to type=inline \
 		--metadata-file images/e2e-sandbox.json \
 		$(BUILDX_ARGS)

--- a/packages/extra/monitoring/Makefile
+++ b/packages/extra/monitoring/Makefile
@@ -12,7 +12,7 @@ generate:
 image:
 	docker buildx build images/grafana \
 		$(call image-tags,grafana,$(GRAFANA_TAG)) \
-		--cache-from type=registry,ref=$(REGISTRY)/grafana:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/grafana:latest \
 		--cache-to type=inline \
 		--metadata-file images/grafana.json \
 		$(BUILDX_ARGS)

--- a/packages/system/backup-controller/Makefile
+++ b/packages/system/backup-controller/Makefile
@@ -12,7 +12,7 @@ image: image-backup-controller
 image-backup-controller:
 	docker buildx build -f images/backup-controller/Dockerfile ../../.. \
 		$(call image-tags,backup-controller,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/backup-controller:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/backup-controller:latest \
 		--cache-to type=inline \
 		--metadata-file images/backup-controller.json \
 		$(BUILDX_ARGS)

--- a/packages/system/backupstrategy-controller/Makefile
+++ b/packages/system/backupstrategy-controller/Makefile
@@ -9,7 +9,7 @@ image: image-backupstrategy-controller
 image-backupstrategy-controller:
 	docker buildx build -f images/backupstrategy-controller/Dockerfile ../../.. \
 		$(call image-tags,backupstrategy-controller,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/backupstrategy-controller:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/backupstrategy-controller:latest \
 		--cache-to type=inline \
 		--metadata-file images/backupstrategy-controller.json \
 		$(BUILDX_ARGS)

--- a/packages/system/bucket/Makefile
+++ b/packages/system/bucket/Makefile
@@ -13,7 +13,7 @@ image: image-s3manager
 image-s3manager:
 	docker buildx build images/s3manager \
 		$(call image-tags,s3manager,$(S3MANAGER_TAG)) \
-		--cache-from type=registry,ref=$(REGISTRY)/s3manager:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/s3manager:latest \
 		--cache-to type=inline \
 		--metadata-file images/s3manager.json \
 		$(BUILDX_ARGS)

--- a/packages/system/cilium/Makefile
+++ b/packages/system/cilium/Makefile
@@ -27,7 +27,7 @@ update:
 image:
 	docker buildx build images/cilium \
 		$(call image-tags,cilium,$(CILIUM_TAG)) \
-		--cache-from type=registry,ref=$(REGISTRY)/cilium:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/cilium:latest \
 		--cache-to type=inline \
 		--metadata-file images/cilium.json \
 		$(BUILDX_ARGS)

--- a/packages/system/cozystack-api/Makefile
+++ b/packages/system/cozystack-api/Makefile
@@ -24,7 +24,7 @@ image: image-cozystack-api
 image-cozystack-api:
 	docker buildx build -f images/cozystack-api/Dockerfile ../../.. \
 		$(call image-tags,cozystack-api,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/cozystack-api:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/cozystack-api:latest \
 		--cache-to type=inline \
 		--metadata-file images/cozystack-api.json \
 		$(BUILDX_ARGS)

--- a/packages/system/cozystack-controller/Makefile
+++ b/packages/system/cozystack-controller/Makefile
@@ -10,7 +10,7 @@ image-cozystack-controller:
 	docker buildx build -f images/cozystack-controller/Dockerfile ../../.. \
 		$(call image-tags,cozystack-controller,v$(COZYSTACK_VERSION)) \
 		--build-arg VERSION=v$(COZYSTACK_VERSION) \
-		--cache-from type=registry,ref=$(REGISTRY)/cozystack-controller:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/cozystack-controller:latest \
 		--cache-to type=inline \
 		--metadata-file images/cozystack-controller.json \
 		$(BUILDX_ARGS)

--- a/packages/system/dashboard/Makefile
+++ b/packages/system/dashboard/Makefile
@@ -34,7 +34,7 @@ build-console:
 		--builder=$(BUILDER) \
 		--platform=linux/amd64 \
 		$(call image-tags,cozystack-ui,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/cozystack-ui:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/cozystack-ui:latest \
 		--cache-to type=inline \
 		--metadata-file images/console.json \
 		--build-arg APP_VERSION=$(COZYSTACK_VERSION) \
@@ -55,7 +55,7 @@ image-token-proxy:
 		--builder=$(BUILDER) \
 		--platform=linux/amd64 \
 		$(call image-tags,token-proxy,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/token-proxy:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/token-proxy:latest \
 		--cache-to type=inline \
 		--metadata-file images/token-proxy.json \
 		--push=$(PUSH) \

--- a/packages/system/flux-plunger/Makefile
+++ b/packages/system/flux-plunger/Makefile
@@ -8,7 +8,7 @@ image:
 	docker buildx build -f images/flux-plunger/Dockerfile ../../../ \
 		--provenance false \
 		$(call image-tags,flux-plunger,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/flux-plunger:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/flux-plunger:latest \
 		--cache-to type=inline \
 		--metadata-file images/flux-plunger.json \
 		--push=$(PUSH) \

--- a/packages/system/grafana-operator/Makefile
+++ b/packages/system/grafana-operator/Makefile
@@ -14,7 +14,7 @@ update:
 image:
 	docker buildx build --file images/grafana-dashboards/Dockerfile ../../.. \
 		$(call image-tags,grafana-dashboards,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/grafana-dashboards:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/grafana-dashboards:latest \
 		--cache-to type=inline \
 		--metadata-file images/grafana-dashboards.json \
 		$(BUILDX_ARGS)

--- a/packages/system/kamaji/Makefile
+++ b/packages/system/kamaji/Makefile
@@ -14,7 +14,7 @@ update:
 image:
 	docker buildx build images/kamaji \
 		$(call image-tags,kamaji,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/kamaji:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/kamaji:latest \
 		--cache-to type=inline \
 		--metadata-file images/kamaji.json \
 		$(BUILDX_ARGS)

--- a/packages/system/keycloak-operator/Makefile
+++ b/packages/system/keycloak-operator/Makefile
@@ -7,7 +7,7 @@ include ../../../hack/package.mk
 image:
 	docker buildx build images/keycloak-operator \
 		$(call image-tags,keycloak-operator,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/keycloak-operator:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/keycloak-operator:latest \
 		--cache-to   type=inline \
 		--metadata-file images/keycloak-operator.json \
 		$(BUILDX_ARGS)

--- a/packages/system/kilo/Makefile
+++ b/packages/system/kilo/Makefile
@@ -11,7 +11,7 @@ update:
 image:
 	docker buildx build images/kilo \
 		$(call image-tags,kilo,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/kilo:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/kilo:latest \
 		--cache-to type=inline \
 		--metadata-file images/kilo.json \
 		$(BUILDX_ARGS)

--- a/packages/system/kubeovn-plunger/Makefile
+++ b/packages/system/kubeovn-plunger/Makefile
@@ -8,7 +8,7 @@ image:
 	docker buildx build -f images/kubeovn-plunger/Dockerfile ../../../ \
 		--provenance false \
 		$(call image-tags,kubeovn-plunger,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/kubeovn-plunger:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/kubeovn-plunger:latest \
 		--cache-to type=inline \
 		--metadata-file images/kubeovn-plunger.json \
 		--push=$(PUSH) \

--- a/packages/system/kubeovn-webhook/Makefile
+++ b/packages/system/kubeovn-webhook/Makefile
@@ -7,7 +7,7 @@ include ../../../hack/package.mk
 image:
 	docker buildx build images/kubeovn-webhook \
 		$(call image-tags,kubeovn-webhook,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/kubeovn-webhook:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/kubeovn-webhook:latest \
 		--cache-to type=inline \
 		--metadata-file images/kubeovn-webhook.json \
 		$(BUILDX_ARGS)

--- a/packages/system/lineage-controller-webhook/Makefile
+++ b/packages/system/lineage-controller-webhook/Makefile
@@ -14,7 +14,7 @@ test:
 image-lineage-controller-webhook:
 	docker buildx build -f images/lineage-controller-webhook/Dockerfile ../../.. \
 		$(call image-tags,lineage-controller-webhook,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/lineage-controller-webhook:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/lineage-controller-webhook:latest \
 		--cache-to type=inline \
 		--metadata-file images/lineage-controller-webhook.json \
 		$(BUILDX_ARGS)

--- a/packages/system/linstor-gui/Makefile
+++ b/packages/system/linstor-gui/Makefile
@@ -14,7 +14,7 @@ image-linstor-gui:
 	docker buildx build images/linstor-gui \
 		--build-arg LINSTOR_GUI_VERSION=$(LINSTOR_GUI_VERSION) \
 		$(call image-tags,linstor-gui,$(LINSTOR_GUI_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/linstor-gui:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/linstor-gui:latest \
 		--cache-to type=inline \
 		--metadata-file images/linstor-gui.json \
 		$(BUILDX_ARGS)

--- a/packages/system/linstor/Makefile
+++ b/packages/system/linstor/Makefile
@@ -14,7 +14,7 @@ image-piraeus-server:
 		--build-arg LINSTOR_VERSION=$(LINSTOR_VERSION) \
 		--build-arg K8S_AWAIT_ELECTION_VERSION=v0.4.2 \
 		$(call image-tags,piraeus-server,$(LINSTOR_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/piraeus-server:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/piraeus-server:latest \
 		--cache-to type=inline \
 		--metadata-file images/piraeus-server.json \
 		$(BUILDX_ARGS)
@@ -28,7 +28,7 @@ image-linstor-csi:
 	docker buildx build images/linstor-csi \
 		--build-arg VERSION=$(LINSTOR_CSI_VERSION) \
 		$(call image-tags,linstor-csi,$(LINSTOR_CSI_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/linstor-csi:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/linstor-csi:latest \
 		--cache-to type=inline \
 		--metadata-file images/linstor-csi.json \
 		$(BUILDX_ARGS)

--- a/packages/system/metallb/Makefile
+++ b/packages/system/metallb/Makefile
@@ -21,7 +21,7 @@ image-controller image-speaker:
 		--target $(TARGET) \
 		--build-arg VERSION=$(VERSION) \
 		$(call image-tags,metallb-$(TARGET),$(VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/metallb-$(TARGET):latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/metallb-$(TARGET):latest \
 		--cache-to type=inline \
 		--metadata-file images/$(TARGET).json \
 		$(BUILDX_ARGS)

--- a/packages/system/monitoring/Makefile
+++ b/packages/system/monitoring/Makefile
@@ -9,7 +9,7 @@ include ../../../hack/package.mk
 image:
 	docker buildx build images/grafana \
 		$(call image-tags,grafana,$(GRAFANA_TAG)) \
-		--cache-from type=registry,ref=$(REGISTRY)/grafana:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/grafana:latest \
 		--cache-to type=inline \
 		--metadata-file images/grafana.json \
 		$(BUILDX_ARGS)

--- a/packages/system/multus/Makefile
+++ b/packages/system/multus/Makefile
@@ -16,7 +16,7 @@ update:
 image:
 	docker buildx build images/multus-cni \
 		$(call image-tags,multus-cni,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/multus-cni:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/multus-cni:latest \
 		--cache-to type=inline \
 		--metadata-file images/multus-cni.json \
 		$(BUILDX_ARGS)

--- a/packages/system/objectstorage-controller/Makefile
+++ b/packages/system/objectstorage-controller/Makefile
@@ -19,7 +19,7 @@ image-controller image-sidecar:
 	docker buildx build images/objectstorage \
 		--target $(TARGET) \
 		$(call image-tags,objectstorage-$(TARGET),v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(REGISTRY)/objectstorage-$(TARGET):latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/objectstorage-$(TARGET):latest \
 		--cache-to   type=inline \
 		--metadata-file images/$(TARGET).json \
 		$(BUILDX_ARGS)

--- a/packages/system/redis-operator/Makefile
+++ b/packages/system/redis-operator/Makefile
@@ -15,7 +15,7 @@ update:
 image:
 	docker buildx build images/redis-operator \
 		$(call image-tags,redis-operator,$(REDIS_OPERATOR_TAG)) \
-		--cache-from type=registry,ref=$(REGISTRY)/redis-operator:latest \
+		--cache-from type=registry,ref=$(CACHE_REGISTRY)/redis-operator:latest \
 		--cache-to type=inline \
 		--metadata-file images/redis-operator.json \
 		$(BUILDX_ARGS)


### PR DESCRIPTION
## What this PR does

[#2711](https://github.com/cozystack/cozystack/pull/2711) moved PR builds to unique `pr-<N>-<sha>` tags (`PUBLISH_FLOATING=0`) to end concurrent-push 409 conflicts, but left `--cache-from` pointing at `$(REGISTRY)/<img>:latest`. PR builds set `REGISTRY` to the per-CI registry, which never publishes `:latest`, so every PR build's registry cache lookup `404`s and rebuilds cold — slowing builds and, on a loaded runner, pushing them into the 30-minute job timeout.

This adds a `CACHE_REGISTRY` knob (default `ghcr.io/cozystack/cozystack`, where release builds *do* publish `:latest`) and points every `--cache-from` at it. Push targets (`$(REGISTRY)`) and the unique per-PR tags are unchanged, so #2711's anti-conflict behaviour is preserved while PR builds regain a warm cache from the last release.

- `hack/common-envs.mk`: new `CACHE_REGISTRY ?= ghcr.io/cozystack/cozystack` with rationale.
- 31 package Makefiles: 37 `--cache-from type=registry,ref=$(REGISTRY)/…` → `$(CACHE_REGISTRY)/…`.

Verified with `make -n image REGISTRY=iad.ocir.io/…`: push tag stays on OCIR (`…/cozystack-controller:pr-<N>-<sha>`), cache-from now reads `ghcr.io/cozystack/cozystack/cozystack-controller:latest`. Makefile-only change — no generated artifacts affected.

> Note: cache freshness is bounded by the last release's `:latest`. PR-to-PR freshness (a `main`-built `:buildcache` tag) is a possible follow-up, intentionally out of scope here.

### Release note

```release-note
fix(build): PR CI image builds now read layer cache from ghcr.io `:latest` (published by releases) instead of the per-CI registry where `:latest` was never pushed after #2711, restoring warm-start caching for PR builds.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration across multiple components to use a dedicated cache registry for improved build layer reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->