### PR TITLE
ci(release): auto-patch-release only the 2 newest release lines

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -79,7 +79,7 @@ jobs:
               .sort((a, b) => lineNum(b) - lineNum(a))
               .slice(0, SUPPORTED_LINE_COUNT);
 
-            const skipped = allBranches.filter(b => !branches.includes(b)).sort();
+            const skipped = allBranches.filter(b => !branches.includes(b)).sort((a, b) => lineNum(a) - lineNum(b));
             console.log(`Found ${allBranches.length} release branches; auto-releasing the ${SUPPORTED_LINE_COUNT} newest: ${branches.join(', ')}`);
             if (skipped.length) {
               console.log(`Skipping ${skipped.length} EOL release branches: ${skipped.join(', ')}`);

--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -60,12 +60,30 @@ jobs:
             execSync('git config --unset-all http.https://github.com/.extraheader || true', { encoding: 'utf8' });
 
             // Get all release-X.Y branches
-            const branches = execSync('git branch -r | grep -E "origin/release-[0-9]+\\.[0-9]+$" | sed "s|origin/||" | tr -d " "', { encoding: 'utf8' })
+            const allBranches = execSync('git branch -r | grep -E "origin/release-[0-9]+\\.[0-9]+$" | sed "s|origin/||" | tr -d " "', { encoding: 'utf8' })
               .split('\n')
               .filter(b => b.trim())
               .filter(b => /^release-\d+\.\d+$/.test(b));
-            
-            console.log(`Found ${branches.length} release branches: ${branches.join(', ')}`);
+
+            // Only auto-patch-release the N newest minor lines. Older lines are
+            // EOL: we don't want stray patch tags (and broken release PRs) cut
+            // on them. The window slides automatically as new release-X.Y
+            // branches are created — once release-1.5 exists the window becomes
+            // {1.5, 1.4} and the trailing line retires on its own.
+            const SUPPORTED_LINE_COUNT = 2;
+            const lineNum = b => {
+              const [maj, min] = b.replace('release-', '').split('.').map(Number);
+              return maj * 1000 + min;
+            };
+            const branches = [...allBranches]
+              .sort((a, b) => lineNum(b) - lineNum(a))
+              .slice(0, SUPPORTED_LINE_COUNT);
+
+            const skipped = allBranches.filter(b => !branches.includes(b)).sort();
+            console.log(`Found ${allBranches.length} release branches; auto-releasing the ${SUPPORTED_LINE_COUNT} newest: ${branches.join(', ')}`);
+            if (skipped.length) {
+              console.log(`Skipping ${skipped.length} EOL release branches: ${skipped.join(', ')}`);
+            }
             
             // Get all published releases (not draft)
             const allReleases = await github.rest.repos.listReleases({

--- a/docs/release.md
+++ b/docs/release.md
@@ -246,15 +246,19 @@ Fires on every push to `main`. Reads each `docs/changelogs/vX.Y.Z.md` and PATCHe
 
 ## Automated patch tag (`auto-release.yaml`)
 
-Cron: daily at 01:00 UTC. For every `release-X.Y` branch:
+Cron: daily at 01:00 UTC. It only auto-releases the **2 newest minor `release-X.Y` lines** (`SUPPORTED_LINE_COUNT` in the workflow); older lines are treated as EOL and skipped, so long-unmaintained branches no longer accumulate stray patch tags and broken release PRs. The window is derived from the live branch list, so it slides automatically — once `release-1.5` exists the window becomes `{1.5, 1.4}` and the trailing line retires with no edits.
+
+For each supported line:
 
 1. Find the latest published `vX.Y.*` GA release tag.
 2. If the branch has commits ahead of that tag, increment Z and push a new `vX.Y.(Z+1)` tag.
 3. Push via `git push origin HEAD:refs/tags/<tag>` so `base_ref` is set and `tags.yaml` runs.
 
-So **any commit that lands on `release-X.Y` triggers a patch release on the next nightly run.** If you want to batch backports across a couple of days before cutting, hold the cherry-picks. Conversely, if a critical fix lands you can do nothing and it ships in <24h.
+So **any commit that lands on a supported `release-X.Y` line triggers a patch release on the next nightly run.** If you want to batch backports across a couple of days before cutting, hold the cherry-picks. Conversely, if a critical fix lands you can do nothing and it ships in <24h.
 
 To skip the nightly cut: don't merge to `release-X.Y` yet. There is no "block this branch this cycle" knob.
+
+**Cutting a patch on an EOL line.** The window only governs *automatic* tagging. A maintainer can still release any branch by pushing a `vX.Y.Z` tag manually — [`tags.yaml`](../.github/workflows/tags.yaml) fires on any `v*.*.*` tag push, so the full pipeline runs regardless of whether the line is inside the auto-release window.
 
 ## Backports
 


### PR DESCRIPTION
## What this PR does

The **Auto Patch Release** cron (`.github/workflows/auto-release.yaml`) walked
*every* `release-X.Y` branch — 21 of them, back to `release-0.9` — and cut a
`vX.Y.(Z+1)` tag whenever a branch had commits after its latest published
release. This fires patch releases on long-EOL lines (e.g. `v1.3.6`), whose
release PRs then sit blocked on unrelated CI failures and accumulate stray
draft releases, tags and changelog PRs.

This restricts the cron to the **2 newest minor lines** (`SUPPORTED_LINE_COUNT`).
The window is derived from the live branch list, so it slides automatically as
new `release-X.Y` branches are cut — once `release-1.5` exists the window
becomes `{1.5, 1.4}` and the trailing line retires with no further edits.

Currently active: `release-1.4`, `release-1.3`. Skipped: 19 EOL lines.

### Release note

```release-note
ci(release): the automated patch-release job now only cuts releases for the two newest release branches; older EOL lines no longer receive automatic patch tags.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the automated release workflow to focus patch automation on only the two newest minor `release-X.Y` maintenance lines.
  * Enhanced workflow logging to report the selected branches and any older/EOL branches skipped.
* **Documentation**
  * Refined release documentation to explain the sliding-window selection for automated patch tagging, including how next patch versions are determined and when tags are created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->