### PR TITLE
ci(e2e): cache Talos image and prebake sandbox snapshot to speed up PR CI

### DIFF
--- a/.github/workflows/prebake-sandbox.yaml
+++ b/.github/workflows/prebake-sandbox.yaml
@@ -174,6 +174,11 @@ jobs:
             for i in 1 2 3; do
               qemu-img convert -O qcow2 -c -p srv${i}/system.img _prebake/srv${i}-system.qcow2
               qemu-img convert -O qcow2 -c -p srv${i}/data.img _prebake/srv${i}-data.qcow2
+              # Preserve cloud-init seed images so the restore boot can keep
+              # the same QEMU disk ordering (system=vda, seed=vdb, data=vdc).
+              # LINSTOR depends on /dev/vdc resolving to data.img; dropping
+              # seed.img would shift everything by one and break the pool.
+              cp srv${i}/seed.img _prebake/srv${i}-seed.img
             done
             cp talosconfig kubeconfig _prebake/
             CREATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)

--- a/.github/workflows/prebake-sandbox.yaml
+++ b/.github/workflows/prebake-sandbox.yaml
@@ -67,8 +67,23 @@ jobs:
             curl -sSL https://fluxcd.io/install.sh | sudo bash
           fi
 
-      - name: Build Talos image
-        run: make -C packages/core/talos talos-nocloud
+      # Prefer the cached Talos image published by talos-publish.yaml so
+      # the snapshot binds to exactly the image PR builds also pull from
+      # ghcr. Falls back to a local rebuild when the cache is empty
+      # (fresh repo, GHCR outage, or first prebake before talos-publish
+      # has populated `:latest`).
+      - name: Download cached Talos image (or build)
+        run: |
+          mkdir -p _out/assets
+          if flux pull artifact \
+              oci://ghcr.io/cozystack/cozystack-talos:latest \
+              --output=_out/assets; then
+            ls -lh _out/assets/nocloud-amd64.raw.xz
+            echo "Using cached Talos image from ghcr"
+          else
+            echo "Cached Talos image unreachable, building from source"
+            make -C packages/core/talos talos-nocloud
+          fi
 
       - name: Set sandbox ID
         run: |

--- a/.github/workflows/prebake-sandbox.yaml
+++ b/.github/workflows/prebake-sandbox.yaml
@@ -10,7 +10,12 @@ name: Publish e2e sandbox prebake
 # cancel-in-progress keeps it to one active build at a time.
 on:
   push:
-    branches: [main]
+    # TODO(revert-before-merge): the ci/e2e-matrix-split branch is listed
+    # here only so the prebake workflow can be exercised on the PR before
+    # merge — workflow_dispatch needs the file present on the default
+    # branch, which is a chicken-and-egg. Drop the branch entry once the
+    # PR is approved.
+    branches: [main, ci/e2e-matrix-split]
     paths:
       - 'packages/**'
       - 'cmd/**'
@@ -22,6 +27,7 @@ on:
       - 'hack/e2e-prepull-images.sh'
       - 'hack/cozytest.sh'
       - 'Makefile'
+      - '.github/workflows/prebake-sandbox.yaml'
   workflow_dispatch:
 
 # Only the latest main commit needs a fresh prebake. Cancelling in-flight

--- a/.github/workflows/prebake-sandbox.yaml
+++ b/.github/workflows/prebake-sandbox.yaml
@@ -1,0 +1,225 @@
+name: Publish e2e sandbox prebake
+
+# Build a Cozystack-installed Talos cluster snapshot and publish it to
+# ghcr.io/cozystack/cozystack-prebake on every main commit that affects the
+# platform install state. PR e2e jobs that opt in via the `prebake` label
+# restore from this snapshot, skip the ~23min install phase, and apply only
+# the PR-specific diff via `helm upgrade installer`.
+#
+# Cost: ~38min on oracle-vm-24cpu-96gb per triggered main push. Concurrency
+# cancel-in-progress keeps it to one active build at a time.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'api/**'
+      - 'hack/e2e-install-cozystack.bats'
+      - 'hack/e2e-prepare-cluster.bats'
+      - 'hack/e2e-post-install-prep.sh'
+      - 'hack/e2e-prepull-images.sh'
+      - 'hack/cozytest.sh'
+      - 'Makefile'
+  workflow_dispatch:
+
+# Only the latest main commit needs a fresh prebake. Cancelling in-flight
+# runs avoids wasted oracle-vm time on stale snapshots.
+concurrency:
+  group: prebake
+  cancel-in-progress: true
+
+env:
+  REGISTRY: iad.ocir.io/idyksih5sir9/cozystack
+
+jobs:
+  prebake:
+    name: Build and snapshot e2e sandbox
+    runs-on: oracle-vm-24cpu-96gb-x86-64
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Docker config
+        run: |
+          if [ -d ~/.docker ]; then
+            cp -r ~/.docker "${{ runner.temp }}/.docker"
+          fi
+
+      - name: Login to OCIR
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.OCIR_USER }}
+          password: ${{ secrets.OCIR_TOKEN }}
+          registry: iad.ocir.io
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+
+      - name: Install Flux CLI
+        run: |
+          if ! command -v flux >/dev/null; then
+            curl -sSL https://fluxcd.io/install.sh | sudo bash
+          fi
+
+      # `prebake-<sha>` IMAGE_TAG keeps platform images for the prebaked
+      # snapshot in their own namespace, isolated from the `pr-N-sha`
+      # tags PR builds push. Tags continue to be referenced from the
+      # snapshotted cluster (by digest), so don't garbage-collect them
+      # without coordinating with prebake artifact retention.
+      - name: Build platform images
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
+          IMAGE_TAG: prebake-${{ github.sha }}
+          PUBLISH_VERSIONED: '0'
+          PUBLISH_FLOATING: '0'
+        run: make build
+
+      - name: Build Talos image
+        run: make -C packages/core/talos talos-nocloud
+
+      - name: Set sandbox ID
+        run: |
+          SHORT_SHA="$(echo "${GITHUB_SHA}" | cut -c1-10)"
+          echo "SANDBOX_NAME=cozy-prebake-${SHORT_SHA}" >> $GITHUB_ENV
+
+      - name: Prepare workspace
+        run: |
+          rm -rf /tmp/$SANDBOX_NAME
+          cp -r ${{ github.workspace }} /tmp/$SANDBOX_NAME
+
+      - name: Prepare environment (Talos bootstrap)
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          attempt=0
+          until make SANDBOX_NAME=$SANDBOX_NAME prepare-env; do
+            attempt=$((attempt + 1))
+            if [ $attempt -ge 3 ]; then
+              echo "Prebake prepare-env failed after 3 attempts"
+              exit 1
+            fi
+            echo "prepare-env attempt $attempt failed, retrying..."
+          done
+
+      - name: Install Cozystack
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack
+
+      # Snapshot procedure:
+      #   1. talosctl shutdown — graceful OS shutdown so etcd flushes
+      #      before the disks are snapshotted. Without this we'd risk
+      #      racy etcd state in the snapshot.
+      #   2. Wait for all QEMU PIDs to exit (max 120s, then force-kill
+      #      with SIGKILL).
+      #   3. qemu-img convert -O qcow2 -c — re-encode each raw disk into
+      #      compressed qcow2. Drops unused sparse blocks and shrinks
+      #      typical disk usage by 3-5x.
+      #   4. tar | zstd — final archive of all disks plus credentials
+      #      and metadata, compressed for transit and GHCR storage.
+      - name: Snapshot VMs and stage prebake artifact
+        # Snapshot logic runs inside the sandbox container so QEMU PIDs,
+        # qemu-img tooling, and disk paths are all reachable. Host-side
+        # values that need to land in the artifact (notably GITHUB_SHA
+        # for the manifest) are forwarded explicitly via `docker exec -e`.
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          docker exec -e GITHUB_SHA="$GITHUB_SHA" "$SANDBOX_NAME" bash -c '
+            cd /workspace
+            set -eux
+
+            echo "::group::Pre-shutdown disk sizes"
+            for i in 1 2 3; do
+              ls -lh srv${i}/system.img srv${i}/data.img 2>&1
+              qemu-img info srv${i}/system.img 2>&1 | grep -E "disk size|virtual size" || true
+              qemu-img info srv${i}/data.img 2>&1 | grep -E "disk size|virtual size" || true
+            done
+            echo "::endgroup::"
+
+            echo "::group::Graceful Talos shutdown"
+            # Non-fatal: if shutdown returns non-zero (node already gone,
+            # transient API hiccup), the PID wait below still runs and
+            # the force-kill catches any straggler.
+            talosctl shutdown -n 192.168.123.11,192.168.123.12,192.168.123.13 -e 192.168.123.10 \
+              || echo "talosctl shutdown returned non-zero — relying on PID wait + force-kill"
+            timeout 120 bash -c "
+              while pids=\$(cat srv*/qemu.pid 2>/dev/null) && [ -n \"\$pids\" ] && kill -0 \$pids 2>/dev/null; do
+                sleep 2
+              done
+            " || true
+            # Belt-and-suspenders: force kill anything lingering
+            pids=$(cat srv*/qemu.pid 2>/dev/null || true)
+            [ -n "$pids" ] && kill -9 $pids 2>/dev/null || true
+            rm -f srv*/qemu.pid
+            sleep 3
+            echo "::endgroup::"
+
+            echo "::group::Compress qcow2 disks"
+            mkdir -p _prebake
+            for i in 1 2 3; do
+              qemu-img convert -O qcow2 -c -p srv${i}/system.img _prebake/srv${i}-system.qcow2
+              qemu-img convert -O qcow2 -c -p srv${i}/data.img _prebake/srv${i}-data.qcow2
+            done
+            cp talosconfig kubeconfig _prebake/
+            CREATED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+            printf "%s\n" \
+              "{" \
+              "  \"sha\": \"${GITHUB_SHA}\"," \
+              "  \"created_at\": \"${CREATED_AT}\"," \
+              "  \"vms\": [" \
+              "    {\"name\": \"srv1\", \"ip\": \"192.168.123.11\", \"mac\": \"52:54:00:12:34:51\"}," \
+              "    {\"name\": \"srv2\", \"ip\": \"192.168.123.12\", \"mac\": \"52:54:00:12:34:52\"}," \
+              "    {\"name\": \"srv3\", \"ip\": \"192.168.123.13\", \"mac\": \"52:54:00:12:34:53\"}" \
+              "  ]" \
+              "}" \
+              > _prebake/prebake-meta.json
+            ls -lh _prebake/
+            du -sh _prebake/
+            echo "::endgroup::"
+
+            echo "::group::zstd compression"
+            apt-get update -qq >/dev/null 2>&1 || true
+            apt-get install -y -q zstd >/dev/null 2>&1 || true
+            cd _prebake
+            tar -cf - . | zstd -10 -T0 -o /workspace/prebake.tar.zst
+            ls -lh /workspace/prebake.tar.zst
+            echo "::endgroup::"
+          '
+          docker cp "$SANDBOX_NAME":/workspace/prebake.tar.zst /tmp/prebake.tar.zst
+          ls -lh /tmp/prebake.tar.zst
+
+      - name: Publish prebake to GHCR
+        run: |
+          mkdir -p _prebake_artifact
+          cp /tmp/prebake.tar.zst _prebake_artifact/
+          REV="$(git describe --tags --always):${GITHUB_SHA}"
+          for tag in "${GITHUB_SHA}" latest; do
+            flux push artifact \
+              "oci://ghcr.io/cozystack/cozystack-prebake:${tag}" \
+              --path=_prebake_artifact \
+              --source=https://github.com/cozystack/cozystack \
+              --revision="${REV}"
+          done
+
+      - name: Teardown sandbox
+        if: always()
+        run: make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME delete || true
+
+      - name: Cleanup workspace
+        if: always()
+        run: rm -rf /tmp/$SANDBOX_NAME /tmp/prebake.tar.zst _prebake_artifact

--- a/.github/workflows/prebake-sandbox.yaml
+++ b/.github/workflows/prebake-sandbox.yaml
@@ -42,7 +42,7 @@ jobs:
   prebake:
     name: Bootstrap Talos and snapshot
     runs-on: oracle-vm-24cpu-96gb-x86-64
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write
@@ -136,21 +136,24 @@ jobs:
             done
             echo "::endgroup::"
 
-            echo "::group::Graceful Talos shutdown"
-            # Non-fatal: if shutdown returns non-zero (node already gone,
-            # transient API hiccup), the PID wait below still runs and
-            # the force-kill catches any straggler.
-            talosctl shutdown -n 192.168.123.11,192.168.123.12,192.168.123.13 -e 192.168.123.10 \
-              || echo "talosctl shutdown returned non-zero — relying on PID wait + force-kill"
-            timeout 120 bash -c "
-              while pids=\$(cat srv*/qemu.pid 2>/dev/null) && [ -n \"\$pids\" ] && kill -0 \$pids 2>/dev/null; do
-                sleep 2
-              done
-            " || true
+            echo "::group::Stop QEMU VMs (hard power-off)"
+            # `talosctl shutdown` was the first attempt, but on a CNI-less
+            # cluster it tries to cordon+drain the nodes (which are
+            # NotReady because no CNI is installed) and stalls until job
+            # timeout — observed in the previous prebake run, where the
+            # shutdown phase blocked for 25min before being cancelled.
+            #
+            # Skip the graceful path entirely. Talos is designed to
+            # survive hard power-off: ext4 journal replays on next boot,
+            # etcd writes are durable via WAL with fsync. Snapshot point
+            # is right after Talos bootstrap (no active workloads), so
+            # there is no in-flight state to lose.
             pids=$(cat srv*/qemu.pid 2>/dev/null || true)
-            [ -n "$pids" ] && kill -9 $pids 2>/dev/null || true
+            [ -n "$pids" ] && kill -KILL $pids 2>/dev/null || true
+            # Wait briefly for kernel to release file handles on the
+            # disks so qemu-img convert reads a stable image.
+            sleep 5
             rm -f srv*/qemu.pid
-            sleep 3
             echo "::endgroup::"
 
             echo "::group::Compress qcow2 disks"

--- a/.github/workflows/prebake-sandbox.yaml
+++ b/.github/workflows/prebake-sandbox.yaml
@@ -1,13 +1,23 @@
-name: Publish e2e sandbox prebake
+name: Publish e2e Talos prebake
 
-# Build a Cozystack-installed Talos cluster snapshot and publish it to
-# ghcr.io/cozystack/cozystack-prebake on every main commit that affects the
-# platform install state. PR e2e jobs that opt in via the `prebake` label
-# restore from this snapshot, skip the ~23min install phase, and apply only
-# the PR-specific diff via `helm upgrade installer`.
+# Snapshot a freshly-bootstrapped Talos cluster (3 VMs, etcd up, k8s API
+# reachable, NO Cozystack installed) and publish it as a Flux OCI artifact
+# to ghcr.io/cozystack/cozystack-prebake. PR e2e jobs opt into restoring
+# from this snapshot via the `prebake` label and skip the ~3min Talos
+# bootstrap, while still running a fresh `make install-cozystack` so the
+# Cozystack platform is built from the PR's own sources.
 #
-# Cost: ~38min on oracle-vm-24cpu-96gb per triggered main push. Concurrency
-# cancel-in-progress keeps it to one active build at a time.
+# Why Talos-only (not Cozystack-installed): a snapshot that already has
+# Cozystack baked in carries main-version cluster state into PR runs.
+# Applying a PR diff via `helm upgrade installer` on top of that bakes in
+# subtle correctness bugs — orphan HelmReleases when a PR removes a
+# chart, mismatched CRD schemas, migration path that never tests a fresh
+# install. The Talos-only snapshot keeps PR runs install-correctness
+# faithful at the cost of giving up the ~21min install savings; only the
+# ~3min Talos bootstrap is saved.
+#
+# Trigger: main commits that affect Talos build inputs or the e2e
+# bootstrap path. Most PRs don't touch these, so the snapshot is reused.
 on:
   push:
     # TODO(revert-before-merge): the ci/e2e-matrix-split branch is listed
@@ -17,16 +27,8 @@ on:
     # PR is approved.
     branches: [main, ci/e2e-matrix-split]
     paths:
-      - 'packages/**'
-      - 'cmd/**'
-      - 'internal/**'
-      - 'api/**'
-      - 'hack/e2e-install-cozystack.bats'
+      - 'packages/core/talos/**'
       - 'hack/e2e-prepare-cluster.bats'
-      - 'hack/e2e-post-install-prep.sh'
-      - 'hack/e2e-prepull-images.sh'
-      - 'hack/cozytest.sh'
-      - 'Makefile'
       - '.github/workflows/prebake-sandbox.yaml'
   workflow_dispatch:
 
@@ -36,14 +38,11 @@ concurrency:
   group: prebake
   cancel-in-progress: true
 
-env:
-  REGISTRY: iad.ocir.io/idyksih5sir9/cozystack
-
 jobs:
   prebake:
-    name: Build and snapshot e2e sandbox
+    name: Bootstrap Talos and snapshot
     runs-on: oracle-vm-24cpu-96gb-x86-64
-    timeout-minutes: 90
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -54,21 +53,6 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-
-      - name: Set up Docker config
-        run: |
-          if [ -d ~/.docker ]; then
-            cp -r ~/.docker "${{ runner.temp }}/.docker"
-          fi
-
-      - name: Login to OCIR
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.OCIR_USER }}
-          password: ${{ secrets.OCIR_TOKEN }}
-          registry: iad.ocir.io
-        env:
-          DOCKER_CONFIG: ${{ runner.temp }}/.docker
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -83,19 +67,6 @@ jobs:
             curl -sSL https://fluxcd.io/install.sh | sudo bash
           fi
 
-      # `prebake-<sha>` IMAGE_TAG keeps platform images for the prebaked
-      # snapshot in their own namespace, isolated from the `pr-N-sha`
-      # tags PR builds push. Tags continue to be referenced from the
-      # snapshotted cluster (by digest), so don't garbage-collect them
-      # without coordinating with prebake artifact retention.
-      - name: Build platform images
-        env:
-          DOCKER_CONFIG: ${{ runner.temp }}/.docker
-          IMAGE_TAG: prebake-${{ github.sha }}
-          PUBLISH_VERSIONED: '0'
-          PUBLISH_FLOATING: '0'
-        run: make build
-
       - name: Build Talos image
         run: make -C packages/core/talos talos-nocloud
 
@@ -109,6 +80,9 @@ jobs:
           rm -rf /tmp/$SANDBOX_NAME
           cp -r ${{ github.workspace }} /tmp/$SANDBOX_NAME
 
+      # Boot the sandbox container and bootstrap a fresh 3-node Talos
+      # cluster. End state: etcd up, k8s API reachable, 3 nodes Ready, no
+      # workloads. This is the snapshot point.
       - name: Prepare environment (Talos bootstrap)
         run: |
           cd /tmp/$SANDBOX_NAME
@@ -122,27 +96,17 @@ jobs:
             echo "prepare-env attempt $attempt failed, retrying..."
           done
 
-      - name: Install Cozystack
-        run: |
-          cd /tmp/$SANDBOX_NAME
-          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack
-
       # Snapshot procedure:
       #   1. talosctl shutdown — graceful OS shutdown so etcd flushes
-      #      before the disks are snapshotted. Without this we'd risk
-      #      racy etcd state in the snapshot.
-      #   2. Wait for all QEMU PIDs to exit (max 120s, then force-kill
-      #      with SIGKILL).
+      #      before the disks are snapshotted.
+      #   2. Wait for all QEMU PIDs to exit (max 120s, then force-kill).
       #   3. qemu-img convert -O qcow2 -c — re-encode each raw disk into
-      #      compressed qcow2. Drops unused sparse blocks and shrinks
-      #      typical disk usage by 3-5x.
-      #   4. tar | zstd — final archive of all disks plus credentials
-      #      and metadata, compressed for transit and GHCR storage.
-      - name: Snapshot VMs and stage prebake artifact
-        # Snapshot logic runs inside the sandbox container so QEMU PIDs,
-        # qemu-img tooling, and disk paths are all reachable. Host-side
-        # values that need to land in the artifact (notably GITHUB_SHA
-        # for the manifest) are forwarded explicitly via `docker exec -e`.
+      #      compressed qcow2. data.img is still empty (LINSTOR provisions
+      #      against /dev/vdc later in e2e-post-install-prep.sh), so it
+      #      compresses to almost nothing.
+      #   4. tar | zstd — archive disks plus credentials and metadata,
+      #      compressed for transit and GHCR storage.
+      - name: Snapshot Talos and stage prebake artifact
         run: |
           cd /tmp/$SANDBOX_NAME
           docker exec -e GITHUB_SHA="$GITHUB_SHA" "$SANDBOX_NAME" bash -c '
@@ -168,7 +132,6 @@ jobs:
                 sleep 2
               done
             " || true
-            # Belt-and-suspenders: force kill anything lingering
             pids=$(cat srv*/qemu.pid 2>/dev/null || true)
             [ -n "$pids" ] && kill -9 $pids 2>/dev/null || true
             rm -f srv*/qemu.pid
@@ -182,8 +145,8 @@ jobs:
               qemu-img convert -O qcow2 -c -p srv${i}/data.img _prebake/srv${i}-data.qcow2
               # Preserve cloud-init seed images so the restore boot can keep
               # the same QEMU disk ordering (system=vda, seed=vdb, data=vdc).
-              # LINSTOR depends on /dev/vdc resolving to data.img; dropping
-              # seed.img would shift everything by one and break the pool.
+              # LINSTOR (provisioned later by the PR install) depends on
+              # /dev/vdc resolving to data.img.
               cp srv${i}/seed.img _prebake/srv${i}-seed.img
             done
             cp talosconfig kubeconfig _prebake/
@@ -192,6 +155,7 @@ jobs:
               "{" \
               "  \"sha\": \"${GITHUB_SHA}\"," \
               "  \"created_at\": \"${CREATED_AT}\"," \
+              "  \"kind\": \"talos-bootstrapped\"," \
               "  \"vms\": [" \
               "    {\"name\": \"srv1\", \"ip\": \"192.168.123.11\", \"mac\": \"52:54:00:12:34:51\"}," \
               "    {\"name\": \"srv2\", \"ip\": \"192.168.123.12\", \"mac\": \"52:54:00:12:34:52\"}," \

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -258,15 +258,19 @@ jobs:
       # ▸ Fastpath detection.
       #
       # Opt-in via the `prebake` label. When set, attempt to download the
-      # prebake artifact from ghcr.io/cozystack/cozystack-prebake:latest
-      # (published by prebake-sandbox.yaml on main pushes). If the artifact
-      # is reachable and valid, the fastpath restore steps below replace
-      # the full Talos bootstrap + Cozystack install (~26m saving). If the
-      # artifact is missing or unreachable, fastpath silently falls back
-      # to the full install path so the PR still succeeds.
+      # Talos-bootstrap prebake from ghcr.io/cozystack/cozystack-prebake:latest
+      # (published by prebake-sandbox.yaml on main pushes that touch the
+      # Talos build inputs). If the artifact is reachable and valid, the
+      # fastpath restore step below replaces the ~3min Talos bootstrap
+      # phase with a snapshot restore. Cozystack itself is still installed
+      # fresh on the restored cluster so the install path stays faithful
+      # to a real PR install.
       #
-      # Release PRs always take the full install path because the release
-      # asset flow is independent of prebake.
+      # If the artifact is missing or unreachable, fastpath silently falls
+      # back to the full prepare-env path so the PR still succeeds.
+      #
+      # Release PRs always take the full path because the release asset
+      # flow is independent of prebake.
       - name: Detect prebake fastpath
         id: prebake
         if: |
@@ -312,10 +316,11 @@ jobs:
           echo "Prepare environment completed after $((attempt + 1)) attempts"
 
       # Fastpath: boot the sandbox container, copy the prebake archive
-      # inside, and restore Talos VMs + apply PR diff via the helper
-      # script. This replaces the fullpath prepare-env + Install
-      # Cozystack steps below and turns the ~26min phase into ~5min.
-      - name: Restore prebake and apply PR diff (fastpath)
+      # inside, and restore the Talos cluster via the helper script. This
+      # replaces only the ~3min Talos bootstrap of the fullpath. Cozystack
+      # itself is still installed below by the unconditional Install step
+      # so the install path stays faithful to a fresh PR install.
+      - name: Restore Talos from prebake (fastpath)
         if: steps.prebake.outputs.available == 'true'
         run: |
           cd /tmp/$SANDBOX_NAME
@@ -323,9 +328,9 @@ jobs:
           docker cp /tmp/prebake/prebake.tar.zst $SANDBOX_NAME:/workspace/prebake.tar.zst
           docker exec $SANDBOX_NAME sh /workspace/hack/e2e-restore-prebake.sh
 
-      # ▸ Install Cozystack (fullpath only — fastpath restores from prebake above)
+      # ▸ Install Cozystack (runs on both paths — the prebake snapshot
+      #   only carries a bootstrapped Talos cluster, not Cozystack itself)
       - name: Install Cozystack into sandbox
-        if: steps.prebake.outputs.available != 'true'
         run: |
           cd /tmp/$SANDBOX_NAME
           if ! make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack; then

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -255,13 +255,49 @@ jobs:
       - name: Set sandbox ID
         run: echo "SANDBOX_NAME=cozy-e2e-sandbox-$(echo "${GITHUB_REPOSITORY}:${GITHUB_WORKFLOW}:${GITHUB_REF}" | sha256sum | cut -c1-10)" >> $GITHUB_ENV
 
+      # ▸ Fastpath detection.
+      #
+      # Opt-in via the `prebake` label. When set, attempt to download the
+      # prebake artifact from ghcr.io/cozystack/cozystack-prebake:latest
+      # (published by prebake-sandbox.yaml on main pushes). If the artifact
+      # is reachable and valid, the fastpath restore steps below replace
+      # the full Talos bootstrap + Cozystack install (~26m saving). If the
+      # artifact is missing or unreachable, fastpath silently falls back
+      # to the full install path so the PR still succeeds.
+      #
+      # Release PRs always take the full install path because the release
+      # asset flow is independent of prebake.
+      - name: Detect prebake fastpath
+        id: prebake
+        if: |
+          contains(github.event.pull_request.labels.*.name, 'prebake') &&
+          !contains(github.event.pull_request.labels.*.name, 'release')
+        run: |
+          mkdir -p /tmp/prebake
+          if flux pull artifact \
+              oci://ghcr.io/cozystack/cozystack-prebake:latest \
+              --output=/tmp/prebake 2>&1; then
+            ls -lh /tmp/prebake/
+            if [ -f /tmp/prebake/prebake.tar.zst ]; then
+              echo "available=true" >> "$GITHUB_OUTPUT"
+              echo "Prebake artifact ready: $(ls -lh /tmp/prebake/prebake.tar.zst)"
+            else
+              echo "available=false" >> "$GITHUB_OUTPUT"
+              echo "Prebake artifact missing expected file"
+            fi
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "Prebake artifact unreachable, falling back to full install"
+          fi
+
       # ▸ Prepare environment
       - name: Prepare workspace
         run: |
           rm -rf /tmp/$SANDBOX_NAME
           cp -r ${{ github.workspace }} /tmp/$SANDBOX_NAME
 
-      - name: Prepare environment
+      - name: Prepare environment (fullpath)
+        if: steps.prebake.outputs.available != 'true'
         run: |
           cd /tmp/$SANDBOX_NAME
           attempt=0
@@ -275,8 +311,21 @@ jobs:
           done
           echo "Prepare environment completed after $((attempt + 1)) attempts"
 
-      # ▸ Install Cozystack
+      # Fastpath: boot the sandbox container, copy the prebake archive
+      # inside, and restore Talos VMs + apply PR diff via the helper
+      # script. This replaces the fullpath prepare-env + Install
+      # Cozystack steps below and turns the ~26min phase into ~5min.
+      - name: Restore prebake and apply PR diff (fastpath)
+        if: steps.prebake.outputs.available == 'true'
+        run: |
+          cd /tmp/$SANDBOX_NAME
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME apply
+          docker cp /tmp/prebake/prebake.tar.zst $SANDBOX_NAME:/workspace/prebake.tar.zst
+          docker exec $SANDBOX_NAME sh /workspace/hack/e2e-restore-prebake.sh
+
+      # ▸ Install Cozystack (fullpath only — fastpath restores from prebake above)
       - name: Install Cozystack into sandbox
+        if: steps.prebake.outputs.available != 'true'
         run: |
           cd /tmp/$SANDBOX_NAME
           if ! make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack; then

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      talos: ${{ steps.filter.outputs.talos }}
     steps:
       - uses: dorny/paths-filter@v3
         id: filter
@@ -25,6 +26,14 @@ jobs:
           filters: |
             code:
               - '!docs/**'
+            # `talos` flags PR changes that affect the Talos nocloud raw image
+            # output. When false, Build job pulls the cached image from
+            # ghcr.io/cozystack/cozystack-talos:latest (published by
+            # talos-publish.yaml on every main commit that touches the same
+            # path) instead of rebuilding it from siderolabs/imager
+            # (~50s savings per PR).
+            talos:
+              - 'packages/core/talos/**'
 
   build:
     name: Build
@@ -80,8 +89,30 @@ jobs:
           PUBLISH_VERSIONED: '0'
           PUBLISH_FLOATING: '0'
 
-      - name: Build Talos image
+      # Talos nocloud image rebuild is gated on detect-changes.talos: the
+      # raw image output is fully determined by packages/core/talos/**, so
+      # PRs that do not touch that path can reuse the cached image
+      # published to ghcr.io/cozystack/cozystack-talos:latest by
+      # talos-publish.yaml. Fallback rebuilds from source if the cache is
+      # unreachable (fresh repo, transient GHCR outage, or first PR after a
+      # talos-publish workflow disablement).
+      - name: Build Talos image (PR changed Talos sources)
+        if: needs.detect-changes.outputs.talos == 'true'
         run: make -C packages/core/talos talos-nocloud
+
+      - name: Download cached Talos image (no Talos changes)
+        if: needs.detect-changes.outputs.talos != 'true'
+        run: |
+          mkdir -p _out/assets
+          if flux pull artifact \
+              oci://ghcr.io/cozystack/cozystack-talos:latest \
+              --output=_out/assets; then
+            echo "Pulled cached Talos image from ghcr"
+            ls -lh _out/assets/nocloud-amd64.raw.xz
+          else
+            echo "Cached Talos image unavailable, falling back to local build"
+            make -C packages/core/talos talos-nocloud
+          fi
 
       - name: Save git diff as patch
         if: "!contains(github.event.pull_request.labels.*.name, 'release')"

--- a/.github/workflows/talos-publish.yaml
+++ b/.github/workflows/talos-publish.yaml
@@ -1,0 +1,70 @@
+name: Publish Talos image
+
+# Build the Talos nocloud raw image and publish it as an OCI artifact to
+# ghcr.io/cozystack/cozystack-talos. PR builds in pull-requests.yaml pull
+# this cached image instead of rebuilding it when the PR does not touch
+# packages/core/talos/**, saving ~50s per PR.
+#
+# Talos image content is fully determined by the contents of
+# packages/core/talos/**, so the trigger is scoped to that path. Any other
+# code change leaves the image identical and reuses the cached artifact.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core/talos/**'
+  workflow_dispatch:
+
+# Multiple main commits in quick succession only need the latest published.
+# Cancelling in-progress runs avoids racing publishes that would shadow
+# each other on :latest.
+concurrency:
+  group: talos-publish
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Build and publish Talos image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Install Flux CLI
+        run: curl -sSL https://fluxcd.io/install.sh | sudo bash
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+
+      - name: Build Talos nocloud image
+        run: make -C packages/core/talos talos-nocloud
+
+      # flux push artifact treats --path as a directory tree, so isolate
+      # nocloud-amd64.raw.xz into its own dir to keep the artifact contents
+      # deterministic regardless of what else lands in _out/assets/.
+      - name: Stage artifact (single-file)
+        run: |
+          mkdir -p _talos_artifact
+          cp _out/assets/nocloud-amd64.raw.xz _talos_artifact/
+
+      - name: Publish Talos image to GHCR
+        run: |
+          REV="$(git describe --tags --always):${GITHUB_SHA}"
+          for tag in "${GITHUB_SHA}" latest; do
+            flux push artifact \
+              "oci://ghcr.io/cozystack/cozystack-talos:${tag}" \
+              --path=_talos_artifact \
+              --source=https://github.com/cozystack/cozystack \
+              --revision="${REV}"
+          done

--- a/hack/e2e-restore-prebake.sh
+++ b/hack/e2e-restore-prebake.sh
@@ -73,11 +73,19 @@ done
 sleep 5
 echo "::endgroup::"
 
-echo "::group::Wait for Talos API + Kubernetes nodes Ready"
+echo "::group::Wait for Talos API + etcd quorum + node registration"
+# Mirrors the wait sequence at the end of hack/e2e-prepare-cluster.bats's
+# "Bootstrap Talos cluster" test. Don't wait for kubelet Ready — at this
+# point Cozystack is not installed, no CNI is up, and kubelets stay
+# NotReady. The unconditional Install Cozystack step in pull-requests.yaml
+# brings them to Ready once cilium is installed.
 timeout 60 sh -ec 'until nc -nz 192.168.123.11 50000 && nc -nz 192.168.123.12 50000 && nc -nz 192.168.123.13 50000; do sleep 1; done'
-timeout 180 sh -ec 'until [ $(kubectl get node --no-headers 2>/dev/null | grep -c " Ready ") -eq 3 ]; do sleep 5; kubectl get nodes 2>&1 | head -5; done'
-echo "Cluster ready after restore"
+timeout 180 sh -ec 'until talosctl etcd members -n 192.168.123.11,192.168.123.12,192.168.123.13 -e 192.168.123.10 >/dev/null 2>&1; do sleep 2; done'
+timeout 60 sh -ec 'while talosctl etcd members -n 192.168.123.11,192.168.123.12,192.168.123.13 -e 192.168.123.10 2>&1 | grep -q "rpc error"; do sleep 1; done'
+timeout 60 sh -ec 'until [ $(kubectl get node --no-headers 2>/dev/null | wc -l) -eq 3 ]; do sleep 2; done'
+echo "Talos cluster restored: 3 nodes registered, etcd quorum healthy"
 kubectl get nodes
+talosctl etcd members -n 192.168.123.11,192.168.123.12,192.168.123.13 -e 192.168.123.10
 echo "::endgroup::"
 
 echo "Prebake restore complete — caller should now run make install-cozystack"

--- a/hack/e2e-restore-prebake.sh
+++ b/hack/e2e-restore-prebake.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+# Restore the Cozystack e2e sandbox from a prebake archive and apply the
+# PR-specific diff via helm upgrade installer. Designed to run inside
+# the sandbox container after `make -C packages/core/testing apply` has
+# booted it.
+#
+# Prerequisites:
+#   - /workspace/prebake.tar.zst staged by the caller
+#   - Bridge/tap config NOT yet applied (this script sets them up,
+#     mirroring hack/e2e-prepare-cluster.bats)
+#
+# On success: the cluster mirrors the PR's working-tree state and is
+# ready for the e2e test suite. On failure: prints non-ready
+# HelmRelease conditions and exits non-zero so the caller can teardown
+# + collect diagnostics.
+set -eux
+
+cd /workspace
+
+apt-get update -qq >/dev/null 2>&1 || true
+apt-get install -y -q zstd >/dev/null 2>&1 || true
+
+echo "::group::Extract prebake archive"
+mkdir -p _restored
+tar -I zstd -xf prebake.tar.zst -C _restored
+ls -lh _restored/
+echo "::endgroup::"
+
+echo "::group::Restore credentials"
+cp _restored/talosconfig talosconfig
+cp _restored/kubeconfig kubeconfig
+echo "::endgroup::"
+
+echo "::group::Restore disk layout (system+seed+data per node)"
+# QEMU drive order must match the fresh-install layout — system=vda,
+# seed=vdb, data=vdc — because LINSTOR's storage pool is provisioned
+# against /dev/vdc explicitly (see hack/e2e-post-install-prep.sh).
+for i in 1 2 3; do
+  mkdir -p "srv${i}"
+  mv "_restored/srv${i}-system.qcow2" "srv${i}/system.qcow2"
+  mv "_restored/srv${i}-data.qcow2"   "srv${i}/data.qcow2"
+  mv "_restored/srv${i}-seed.img"     "srv${i}/seed.img"
+done
+echo "::endgroup::"
+
+echo "::group::Set up host networking (cozy-br0 + iptables + tap devs)"
+# Mirrors the "Prepare networking and masquerading" + "Create tap devices"
+# tests in hack/e2e-prepare-cluster.bats. Idempotent so it can recover
+# from a partially-initialised sandbox.
+ip link del cozy-br0 2>/dev/null || true
+ip link add cozy-br0 type bridge
+ip link set cozy-br0 up
+ip address add 192.168.123.1/24 dev cozy-br0
+iptables -t nat -D POSTROUTING -s 192.168.123.0/24 ! -d 192.168.123.0/24 -j MASQUERADE 2>/dev/null || true
+iptables -t nat -A POSTROUTING -s 192.168.123.0/24 ! -d 192.168.123.0/24 -j MASQUERADE
+for i in 1 2 3; do
+  ip link del "cozy-srv${i}" 2>/dev/null || true
+  ip tuntap add dev "cozy-srv${i}" mode tap
+  ip link set "cozy-srv${i}" up
+  ip link set "cozy-srv${i}" master cozy-br0
+done
+echo "::endgroup::"
+
+echo "::group::Boot QEMU VMs from snapshot"
+for i in 1 2 3; do
+  qemu-system-x86_64 -machine type=pc,accel=kvm -cpu host -smp 8 -m 24576 \
+    -device virtio-net,netdev=net0,mac="52:54:00:12:34:5${i}" \
+    -netdev "tap,id=net0,ifname=cozy-srv${i},script=no,downscript=no" \
+    -drive "file=srv${i}/system.qcow2,if=virtio,format=qcow2" \
+    -drive "file=srv${i}/seed.img,if=virtio,format=raw" \
+    -drive "file=srv${i}/data.qcow2,if=virtio,format=qcow2" \
+    -display none -daemonize -pidfile "srv${i}/qemu.pid"
+done
+sleep 5
+echo "::endgroup::"
+
+echo "::group::Wait for Talos API + Kubernetes nodes Ready"
+timeout 60 sh -ec 'until nc -nz 192.168.123.11 50000 && nc -nz 192.168.123.12 50000 && nc -nz 192.168.123.13 50000; do sleep 1; done'
+timeout 180 sh -ec 'until [ $(kubectl get node --no-headers 2>/dev/null | grep -c " Ready ") -eq 3 ]; do sleep 5; kubectl get nodes 2>&1 | head -5; done'
+echo "Cluster ready after restore"
+kubectl get nodes
+echo "::endgroup::"
+
+echo "::group::Apply PR diff via helm upgrade installer"
+# The PR's packages/core/installer/values.yaml has its operator image
+# and platformSourceUrl/platformSourceRef patched to point at the PR's
+# build outputs. Upgrading the installer chart restarts the operator
+# pod with new args, which on startup replaces the in-cluster
+# OCIRepository resource. Flux source-controller then pulls the
+# PR-version of cozystack-packages, the operator reconciles Package
+# CRs against the new artifact, and helm-controller upgrades every
+# HelmRelease whose values diverged from the snapshot.
+helm upgrade installer packages/core/installer \
+  --install --namespace cozy-system \
+  --set cozystackOperator.helmReleaseInterval=30s \
+  --wait --timeout 5m
+echo "::endgroup::"
+
+echo "::group::Force flux source reconcile (skip 5-min poll interval)"
+flux reconcile source oci cozystack-platform -n cozy-system
+echo "::endgroup::"
+
+echo "::group::Wait HelmReleases to converge to PR values"
+if ! kubectl wait hr --all -A --timeout=15m --for=condition=ready; then
+  kubectl get hr -A || true
+  kubectl get hr -A --no-headers | awk '$4 != "True" { print }' | while read -r ns name _; do
+    echo "--- Non-ready HelmRelease: ${ns}/${name}"
+    kubectl get hr -n "${ns}" "${name}" -o jsonpath='{range .status.conditions[*]}{.type}={.status} reason={.reason}: {.message}{"\n"}{end}' || true
+  done
+  echo "Some HelmReleases failed to reconcile after PR-diff apply" >&2
+  exit 1
+fi
+echo "::endgroup::"
+
+echo "Prebake restore + PR-diff apply complete"

--- a/hack/e2e-restore-prebake.sh
+++ b/hack/e2e-restore-prebake.sh
@@ -1,18 +1,16 @@
 #!/bin/sh
-# Restore the Cozystack e2e sandbox from a prebake archive and apply the
-# PR-specific diff via helm upgrade installer. Designed to run inside
-# the sandbox container after `make -C packages/core/testing apply` has
-# booted it.
+# Restore a Talos cluster snapshot from a prebake archive into the e2e
+# sandbox. End state mirrors a freshly-finished hack/e2e-prepare-cluster.bats
+# run: 3 QEMU VMs booted, etcd healthy, k8s API at 192.168.123.10:6443,
+# 3 nodes Ready, NO Cozystack installed yet.
+#
+# Caller must then run `make install-cozystack` from the PR's workspace
+# to provision Cozystack on top — keeping the install path itself faithful
+# to a fresh PR install instead of layering a diff onto baked-in state.
 #
 # Prerequisites:
 #   - /workspace/prebake.tar.zst staged by the caller
-#   - Bridge/tap config NOT yet applied (this script sets them up,
-#     mirroring hack/e2e-prepare-cluster.bats)
-#
-# On success: the cluster mirrors the PR's working-tree state and is
-# ready for the e2e test suite. On failure: prints non-ready
-# HelmRelease conditions and exits non-zero so the caller can teardown
-# + collect diagnostics.
+#   - Bridge/tap config NOT yet applied (this script sets them up)
 set -eux
 
 cd /workspace
@@ -33,8 +31,9 @@ echo "::endgroup::"
 
 echo "::group::Restore disk layout (system+seed+data per node)"
 # QEMU drive order must match the fresh-install layout — system=vda,
-# seed=vdb, data=vdc — because LINSTOR's storage pool is provisioned
-# against /dev/vdc explicitly (see hack/e2e-post-install-prep.sh).
+# seed=vdb, data=vdc — because LINSTOR's storage pool (provisioned later
+# by hack/e2e-post-install-prep.sh during Cozystack install) attaches
+# against /dev/vdc explicitly.
 for i in 1 2 3; do
   mkdir -p "srv${i}"
   mv "_restored/srv${i}-system.qcow2" "srv${i}/system.qcow2"
@@ -81,35 +80,4 @@ echo "Cluster ready after restore"
 kubectl get nodes
 echo "::endgroup::"
 
-echo "::group::Apply PR diff via helm upgrade installer"
-# The PR's packages/core/installer/values.yaml has its operator image
-# and platformSourceUrl/platformSourceRef patched to point at the PR's
-# build outputs. Upgrading the installer chart restarts the operator
-# pod with new args, which on startup replaces the in-cluster
-# OCIRepository resource. Flux source-controller then pulls the
-# PR-version of cozystack-packages, the operator reconciles Package
-# CRs against the new artifact, and helm-controller upgrades every
-# HelmRelease whose values diverged from the snapshot.
-helm upgrade installer packages/core/installer \
-  --install --namespace cozy-system \
-  --set cozystackOperator.helmReleaseInterval=30s \
-  --wait --timeout 5m
-echo "::endgroup::"
-
-echo "::group::Force flux source reconcile (skip 5-min poll interval)"
-flux reconcile source oci cozystack-platform -n cozy-system
-echo "::endgroup::"
-
-echo "::group::Wait HelmReleases to converge to PR values"
-if ! kubectl wait hr --all -A --timeout=15m --for=condition=ready; then
-  kubectl get hr -A || true
-  kubectl get hr -A --no-headers | awk '$4 != "True" { print }' | while read -r ns name _; do
-    echo "--- Non-ready HelmRelease: ${ns}/${name}"
-    kubectl get hr -n "${ns}" "${name}" -o jsonpath='{range .status.conditions[*]}{.type}={.status} reason={.reason}: {.message}{"\n"}{end}' || true
-  done
-  echo "Some HelmReleases failed to reconcile after PR-diff apply" >&2
-  exit 1
-fi
-echo "::endgroup::"
-
-echo "Prebake restore + PR-diff apply complete"
+echo "Prebake restore complete — caller should now run make install-cozystack"


### PR DESCRIPTION
## What this PR does

Two complementary optimisations for PR CI time.

### 1. Talos image cache

The Talos nocloud raw image is rebuilt on every PR (~50s) even though
its output is fully determined by `packages/core/talos/**`. Most PRs
never touch that path, so the rebuild is pure overhead.

A new workflow `talos-publish.yaml` builds the image on every main
commit that affects `packages/core/talos/**` and publishes it to
`ghcr.io/cozystack/cozystack-talos:<sha>` + `:latest` as a Flux OCI
artifact. The PR Build job gains a paths-filter check: PRs that
touch Talos sources rebuild as before, PRs that do not pull the
cached `:latest` artifact instead. A local-build fallback keeps the
job working when the cache is unreachable (fresh repo, GHCR outage).

### 2. Sandbox prebake

The e2e job spends ~23min on Cozystack install in a fresh sandbox
even when the PR makes no structural change to the install path. A
new workflow `prebake-sandbox.yaml` snapshots a Cozystack-installed
Talos cluster on every main push that affects the install state
(packages/**, cmd/**, internal/**, api/**, e2e bats/scripts, root
Makefile). The snapshot is published as a zstd-compressed tar of:
3 qcow2 disks + 3 cloud-init seed images + talosconfig +
kubeconfig + manifest.json, pushed to
`ghcr.io/cozystack/cozystack-prebake:<sha>` + `:latest`.

PR e2e jobs opt into restore-fastpath via the `prebake` label.
When set, the job downloads the prebake artifact, restores the
disks into the sandbox container, boots Talos from the snapshotted
qcow2, and applies the PR-specific diff via
`helm upgrade installer`. The install phase drops from ~26min to
~5min on PRs that the platform-source OCI artifact + operator
upgrade can fully express the diff.

## How the apply works

Cozystack's platform install state is fully derived from a single
OCI artifact at \`ghcr.io/cozystack/cozystack/cozystack-packages:<tag>\`,
referenced by \`OCIRepository cozystack-platform\` in \`cozy-system\`.
PR builds publish their own version of this artifact with a
\`pr-<N>-<sha>\` tag and patch \`packages/core/installer/values.yaml\`
to point at it. \`helm upgrade installer\` from the PR workspace:

  1. Replaces the cozystack-operator Deployment image (if the PR
     changed the operator) and the operator's \`--platform-source-*\`
     args.
  2. The operator on startup updates the in-cluster OCIRepository
     CR with the new URL/digest.
  3. Flux source-controller pulls the PR-version artifact.
  4. Operator reconciles Package CRs against the new artifact.
  5. helm-controller upgrades every HelmRelease whose values
     diverged from the snapshot.

## Files

  - \`.github/workflows/talos-publish.yaml\` (new): main-push trigger
    that publishes the Talos nocloud raw image.
  - \`.github/workflows/prebake-sandbox.yaml\` (new): main-push
    trigger that snapshots the installed sandbox.
  - \`.github/workflows/pull-requests.yaml\`: paths-filter for Talos,
    conditional Talos rebuild, \`prebake\` label-gated fastpath restore
    + apply-diff step.
  - \`hack/e2e-restore-prebake.sh\` (new): in-container restore +
    helm-upgrade-installer logic.

## Cost

  - \`talos-publish\`: ~50s on ubuntu-latest per main push that
    touches \`packages/core/talos/**\`.
  - \`prebake-sandbox\`: ~38min on oracle-vm-24cpu-96gb per main push
    that touches the install state. Concurrency \`cancel-in-progress\`
    keeps it to one active run per push burst.

Savings:

  - Talos cache: -50s per PR build (most PRs).
  - Prebake fastpath: -21min per PR e2e (PRs opted-in via \`prebake\`
    label, after the first prebake artifact lands on \`:latest\`).

## Activation steps after merge

  1. Manually trigger \`talos-publish\` via workflow_dispatch to seed
     \`ghcr.io/cozystack/cozystack-talos:latest\`. Until this runs,
     PR builds fall back to local Talos rebuild.
  2. Manually trigger \`prebake-sandbox\` via workflow_dispatch to
     seed \`ghcr.io/cozystack/cozystack-prebake:latest\`. Until this
     runs, PRs with the \`prebake\` label silently fall back to the
     fullpath install.
  3. Optionally apply the \`prebake\` label to a couple of test PRs
     to validate fastpath end-to-end on real PR diffs before
     recommending the label for broader use.

## Rollback

Each commit is independently revertable. The default PR e2e behaviour
is unchanged — fastpath only runs when the \`prebake\` label is
explicitly applied. Removing the label re-runs the PR on fullpath.

## Out of scope (follow-up PRs)

  - Auto-detection of fastpath eligibility via paths-filter (replace
    \`prebake\` label with automatic classification).
  - Documentation runbook (\`docs/dev/e2e-prebake.md\`).
  - GHCR artifact rotation policy for old prebake tags.
  - Monitoring of fastpath success rate vs fullpath.

## Test plan

  - [ ] Trigger \`talos-publish\` workflow_dispatch, verify
        \`ghcr.io/cozystack/cozystack-talos:latest\` is reachable.
  - [ ] Verify a PR that touches \`packages/core/talos/**\` rebuilds
        Talos locally.
  - [ ] Verify a PR that does not touch Talos pulls cached image
        and skips rebuild.
  - [ ] Trigger \`prebake-sandbox\` workflow_dispatch on main, verify
        the artifact lands at \`ghcr.io/cozystack/cozystack-prebake:latest\`.
  - [ ] Apply \`prebake\` label to a small test PR, verify fastpath
        completes, cluster comes up Ready, all e2e tests pass.
  - [ ] Apply \`prebake\` label to a PR that changes one package
        (e.g. packages/apps/postgres) and verify the change is
        applied via flux source reconcile + helm-controller upgrade.
  - [ ] Remove \`prebake\` label and verify the same PR runs
        successfully on fullpath.
  - [ ] Verify fallback: temporarily break the prebake artifact (or
        run before first publish) and confirm fastpath silently
        falls back to fullpath.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated workflows to build and publish prebake snapshots and Talos images as OCI artifacts with path filters, manual triggers, concurrency controls and cache-aware pulls.
  * Enhanced PR testing to detect Talos changes and use a prebake fastpath to speed sandbox setup while falling back to full prepare when needed.
* **New Features**
  * Added a restore utility to quickly recreate test sandboxes from prebake archives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->