### PR TITLE
fix(mongodb): surface per-user credentials to the tenant

### DIFF
--- a/packages/apps/mongodb/templates/user-secrets.yaml
+++ b/packages/apps/mongodb/templates/user-secrets.yaml
@@ -5,8 +5,14 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $.Release.Name }}-user-{{ $username }}
+  labels:
+    # Surfaces this per-user credential to the tenant: the mongodb-rd
+    # cozyrd includes secrets carrying this label, so the lineage
+    # controller stamps internal.cozystack.io/tenantresource=true on them.
+    apps.cozystack.io/user-secret: "true"
 type: Opaque
 stringData:
+  username: {{ $username | quote }}
   {{- if $user.password }}
   password: {{ $user.password | quote }}
   {{- else if and $existingSecret (hasKey $existingSecret.data "password") }}

--- a/packages/apps/mongodb/tests/user-secrets_test.yaml
+++ b/packages/apps/mongodb/tests/user-secrets_test.yaml
@@ -36,6 +36,12 @@ tests:
           value: Opaque
       - exists:
           path: stringData.password
+      - equal:
+          path: stringData.username
+          value: myuser
+      - equal:
+          path: metadata.labels["apps.cozystack.io/user-secret"]
+          value: "true"
 
   # Multiple users
   - it: creates separate secrets for multiple users

--- a/packages/system/mongodb-rd/cozyrds/mongodb.yaml
+++ b/packages/system/mongodb-rd/cozyrds/mongodb.yaml
@@ -31,6 +31,8 @@ spec:
     include:
       - resourceNames:
           - mongodb-{{ .name }}-credentials
+      - matchLabels:
+          apps.cozystack.io/user-secret: "true"
   services:
     exclude: []
     include:


### PR DESCRIPTION
## What this PR does

MongoDB exposes each managed user's password as a separate
`<release>-user-<user>` secret, but the `mongodb-rd` cozyrd only included
the cluster `<release>-credentials` secret (the `databaseAdmin` pair) in
its `secrets.include` rules. As a result the lineage controller never
stamped `internal.cozystack.io/tenantresource=true` on the per-user
secrets, so a provisioned user's password was invisible to the tenant and
to anything reading the `core.cozystack.io` TenantSecret projection.

This labels each per-user secret `apps.cozystack.io/user-secret=true` and
adds a matching `matchLabels` include rule to the cozyrd — the same
pattern the bucket chart already uses for its per-user S3 credentials. A
`username` field is also added so the forwarded secret is self-describing
instead of relying on the secret-name suffix.

helm-unittest for the mongodb chart is green (94 tests).

### Release note

```release-note
fix(mongodb): expose per-user credentials as tenant secrets so a managed user's password is visible to the tenant
```


## Related

Found while building the cozyportal managed-services integration, where per-user credentials are surfaced to the portal user:

- aenix-org/cozyportal#867 — portal apiserver (credentials subresource)
- aenix-org/cozyportal-ui#188 — console UI consuming the credentials
