### PR TITLE
test(api): add read-path authorization tests for TenantNamespace registry

### DIFF
--- a/pkg/registry/core/tenantnamespace/rest.go
+++ b/pkg/registry/core/tenantnamespace/rest.go
@@ -216,6 +216,10 @@ func (r *REST) Watch(ctx context.Context, opts *metainternal.ListOptions) (watch
 	pw := watch.NewProxyWatcher(events)
 
 	go func() {
+		// This goroutine is the sole writer to events; closing it on exit
+		// signals end-of-stream to the consumer (ProxyWatcher.Stop does not
+		// close the channel it proxies).
+		defer close(events)
 		defer pw.Stop()
 		defer nsWatch.Stop()
 

--- a/pkg/registry/core/tenantnamespace/rest_test.go
+++ b/pkg/registry/core/tenantnamespace/rest_test.go
@@ -275,13 +275,9 @@ func TestHasAccessToNamespace_CozyAdminGroup(t *testing.T) {
 // grant anything, and multiple matching RoleBindings in one namespace don't
 // duplicate it in the result.
 func TestList_FiltersUnauthorizedNamespaces(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
-
 	roleRef := rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "test-role"}
 	client := fake.NewClientBuilder().
-		WithScheme(scheme).
+		WithScheme(newTestScheme(t)).
 		WithObjects(
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-allowed"}},
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-denied"}},
@@ -334,12 +330,8 @@ func TestList_FiltersUnauthorizedNamespaces(t *testing.T) {
 func TestList_PrivilegedGroups_SeeAllTenantNamespaces(t *testing.T) {
 	for _, group := range []string{"system:masters", "cozystack-cluster-admin"} {
 		t.Run(group, func(t *testing.T) {
-			scheme := runtime.NewScheme()
-			_ = corev1.AddToScheme(scheme)
-			_ = rbacv1.AddToScheme(scheme)
-
 			client := fake.NewClientBuilder().
-				WithScheme(scheme).
+				WithScheme(newTestScheme(t)).
 				WithObjects(
 					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-zebra"}},
 					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-alpha"}},
@@ -378,12 +370,8 @@ func TestList_PrivilegedGroups_SeeAllTenantNamespaces(t *testing.T) {
 // TestList_MissingUser_ReturnsError asserts List fails when no user is in the
 // context instead of returning an unfiltered list.
 func TestList_MissingUser_ReturnsError(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
-
 	client := fake.NewClientBuilder().
-		WithScheme(scheme).
+		WithScheme(newTestScheme(t)).
 		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-test"}}).
 		Build()
 
@@ -405,12 +393,8 @@ func TestList_MissingUser_ReturnsError(t *testing.T) {
 // outside the tenant namespace set grants nothing: filterAccessible
 // intersects RoleBinding namespaces with the tenant name-set.
 func TestList_RoleBindingInNonTenantNamespace_Ignored(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
-
 	client := fake.NewClientBuilder().
-		WithScheme(scheme).
+		WithScheme(newTestScheme(t)).
 		WithObjects(
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-test"}},
 			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
@@ -446,13 +430,9 @@ func TestList_RoleBindingInNonTenantNamespace_Ignored(t *testing.T) {
 // TestList_NamespaceListError_Propagates asserts a failure to list namespaces
 // is returned to the caller.
 func TestList_NamespaceListError_Propagates(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
-
 	wantErr := errors.New("namespace list failed")
 	fc := fake.NewClientBuilder().
-		WithScheme(scheme).
+		WithScheme(newTestScheme(t)).
 		WithInterceptorFuncs(interceptor.Funcs{
 			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
 				if _, ok := list.(*corev1.NamespaceList); ok {
@@ -480,13 +460,9 @@ func TestList_NamespaceListError_Propagates(t *testing.T) {
 // RoleBindings during access filtering fails the List instead of returning an
 // unfiltered or silently truncated result.
 func TestList_RoleBindingListError_Propagates(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
-
 	wantErr := errors.New("rolebinding list failed")
 	fc := fake.NewClientBuilder().
-		WithScheme(scheme).
+		WithScheme(newTestScheme(t)).
 		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-test"}}).
 		WithInterceptorFuncs(interceptor.Funcs{
 			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
@@ -514,12 +490,8 @@ func TestList_RoleBindingListError_Propagates(t *testing.T) {
 // TestGet_MissingUser_ReturnsError asserts Get fails when no user is in the
 // context.
 func TestGet_MissingUser_ReturnsError(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
-
 	client := fake.NewClientBuilder().
-		WithScheme(scheme).
+		WithScheme(newTestScheme(t)).
 		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-test"}}).
 		Build()
 
@@ -536,11 +508,7 @@ func TestGet_MissingUser_ReturnsError(t *testing.T) {
 // TestGet_NamespaceNotFound asserts the backing Get error surfaces when the
 // namespace disappears after the access check passes.
 func TestGet_NamespaceNotFound(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
-
-	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	client := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 
 	r := &REST{
 		c:   client,
@@ -568,12 +536,8 @@ func TestMatchesSubject_UnknownKind(t *testing.T) {
 }
 
 func TestHasAccessToNamespace_MissingUser(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = rbacv1.AddToScheme(scheme)
-
 	client := fake.NewClientBuilder().
-		WithScheme(scheme).
+		WithScheme(newTestScheme(t)).
 		Build()
 
 	r := &REST{

--- a/pkg/registry/core/tenantnamespace/rest_test.go
+++ b/pkg/registry/core/tenantnamespace/rest_test.go
@@ -4,6 +4,7 @@ package tenantnamespace
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -14,7 +15,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	corev1alpha1 "github.com/cozystack/cozystack/pkg/apis/core/v1alpha1"
 )
@@ -264,6 +267,326 @@ func TestHasAccessToNamespace_CozyAdminGroup(t *testing.T) {
 	}
 	if !hasAccess {
 		t.Error("expected cozystack-cluster-admin to have access, but got false")
+	}
+}
+
+// TestList_FiltersUnauthorizedNamespaces asserts the List path returns only
+// tenant namespaces the user can access: RoleBindings for other users don't
+// grant anything, and multiple matching RoleBindings in one namespace don't
+// duplicate it in the result.
+func TestList_FiltersUnauthorizedNamespaces(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+
+	roleRef := rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "test-role"}
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-allowed"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-denied"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
+			&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "user-binding", Namespace: "tenant-allowed"},
+				Subjects:   []rbacv1.Subject{{Kind: "User", Name: "test-user", APIGroup: "rbac.authorization.k8s.io"}},
+				RoleRef:    roleRef,
+			},
+			&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "group-binding", Namespace: "tenant-allowed"},
+				Subjects:   []rbacv1.Subject{{Kind: "Group", Name: "system:authenticated", APIGroup: "rbac.authorization.k8s.io"}},
+				RoleRef:    roleRef,
+			},
+			&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "other-binding", Namespace: "tenant-denied"},
+				Subjects:   []rbacv1.Subject{{Kind: "User", Name: "other-user", APIGroup: "rbac.authorization.k8s.io"}},
+				RoleRef:    roleRef,
+			},
+		).
+		Build()
+
+	r := &REST{
+		c:   client,
+		gvr: schema.GroupVersionResource{Group: "core.cozystack.io", Version: "v1alpha1", Resource: "tenantnamespaces"},
+	}
+
+	u := &user.DefaultInfo{Name: "test-user", Groups: []string{"system:authenticated"}}
+	ctx := request.WithUser(context.Background(), u)
+
+	obj, err := r.List(ctx, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	list, ok := obj.(*corev1alpha1.TenantNamespaceList)
+	if !ok {
+		t.Fatalf("expected *TenantNamespaceList, got %T", obj)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d: %+v", len(list.Items), list.Items)
+	}
+	if list.Items[0].Name != "tenant-allowed" {
+		t.Errorf("expected tenant-allowed, got %q", list.Items[0].Name)
+	}
+}
+
+// TestList_PrivilegedGroups_SeeAllTenantNamespaces asserts privileged groups
+// get every tenant namespace (and only tenant namespaces) without any
+// RoleBindings, sorted by name.
+func TestList_PrivilegedGroups_SeeAllTenantNamespaces(t *testing.T) {
+	for _, group := range []string{"system:masters", "cozystack-cluster-admin"} {
+		t.Run(group, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			_ = corev1.AddToScheme(scheme)
+			_ = rbacv1.AddToScheme(scheme)
+
+			client := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(
+					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-zebra"}},
+					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-alpha"}},
+					&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+				).
+				Build()
+
+			r := &REST{
+				c:   client,
+				gvr: schema.GroupVersionResource{Group: "core.cozystack.io", Version: "v1alpha1", Resource: "tenantnamespaces"},
+			}
+
+			u := &user.DefaultInfo{Name: "admin", Groups: []string{group}}
+			ctx := request.WithUser(context.Background(), u)
+
+			obj, err := r.List(ctx, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			list, ok := obj.(*corev1alpha1.TenantNamespaceList)
+			if !ok {
+				t.Fatalf("expected *TenantNamespaceList, got %T", obj)
+			}
+			if len(list.Items) != 2 {
+				t.Fatalf("expected 2 items, got %d: %+v", len(list.Items), list.Items)
+			}
+			for i, want := range []string{"tenant-alpha", "tenant-zebra"} {
+				if list.Items[i].Name != want {
+					t.Errorf("item %d: expected %q, got %q", i, want, list.Items[i].Name)
+				}
+			}
+		})
+	}
+}
+
+// TestList_MissingUser_ReturnsError asserts List fails when no user is in the
+// context instead of returning an unfiltered list.
+func TestList_MissingUser_ReturnsError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-test"}}).
+		Build()
+
+	r := &REST{
+		c:   client,
+		gvr: schema.GroupVersionResource{Group: "core.cozystack.io", Version: "v1alpha1", Resource: "tenantnamespaces"},
+	}
+
+	obj, err := r.List(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for missing user in context, got nil")
+	}
+	if obj != nil {
+		t.Errorf("expected nil list on error, got %+v", obj)
+	}
+}
+
+// TestList_RoleBindingInNonTenantNamespace_Ignored asserts a RoleBinding
+// outside the tenant namespace set grants nothing: filterAccessible
+// intersects RoleBinding namespaces with the tenant name-set.
+func TestList_RoleBindingInNonTenantNamespace_Ignored(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-test"}},
+			&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}},
+			&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "default-binding", Namespace: "default"},
+				Subjects:   []rbacv1.Subject{{Kind: "User", Name: "test-user", APIGroup: "rbac.authorization.k8s.io"}},
+				RoleRef:    rbacv1.RoleRef{APIGroup: "rbac.authorization.k8s.io", Kind: "Role", Name: "test-role"},
+			},
+		).
+		Build()
+
+	r := &REST{
+		c:   client,
+		gvr: schema.GroupVersionResource{Group: "core.cozystack.io", Version: "v1alpha1", Resource: "tenantnamespaces"},
+	}
+
+	u := &user.DefaultInfo{Name: "test-user", Groups: []string{"system:authenticated"}}
+	ctx := request.WithUser(context.Background(), u)
+
+	obj, err := r.List(ctx, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	list, ok := obj.(*corev1alpha1.TenantNamespaceList)
+	if !ok {
+		t.Fatalf("expected *TenantNamespaceList, got %T", obj)
+	}
+	if len(list.Items) != 0 {
+		t.Errorf("expected empty list, got %+v", list.Items)
+	}
+}
+
+// TestList_NamespaceListError_Propagates asserts a failure to list namespaces
+// is returned to the caller.
+func TestList_NamespaceListError_Propagates(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+
+	wantErr := errors.New("namespace list failed")
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*corev1.NamespaceList); ok {
+					return wantErr
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+
+	r := &REST{
+		c:   fc,
+		gvr: schema.GroupVersionResource{Group: "core.cozystack.io", Version: "v1alpha1", Resource: "tenantnamespaces"},
+	}
+
+	u := &user.DefaultInfo{Name: "test-user", Groups: []string{"system:authenticated"}}
+	ctx := request.WithUser(context.Background(), u)
+
+	if _, err := r.List(ctx, nil); !errors.Is(err, wantErr) {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+}
+
+// TestList_RoleBindingListError_Propagates asserts a failure to list
+// RoleBindings during access filtering fails the List instead of returning an
+// unfiltered or silently truncated result.
+func TestList_RoleBindingListError_Propagates(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+
+	wantErr := errors.New("rolebinding list failed")
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-test"}}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*rbacv1.RoleBindingList); ok {
+					return wantErr
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+
+	r := &REST{
+		c:   fc,
+		gvr: schema.GroupVersionResource{Group: "core.cozystack.io", Version: "v1alpha1", Resource: "tenantnamespaces"},
+	}
+
+	u := &user.DefaultInfo{Name: "test-user", Groups: []string{"system:authenticated"}}
+	ctx := request.WithUser(context.Background(), u)
+
+	if _, err := r.List(ctx, nil); !errors.Is(err, wantErr) {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+}
+
+// TestGet_MissingUser_ReturnsError asserts Get fails when no user is in the
+// context.
+func TestGet_MissingUser_ReturnsError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-test"}}).
+		Build()
+
+	r := &REST{
+		c:   client,
+		gvr: schema.GroupVersionResource{Group: "core.cozystack.io", Version: "v1alpha1", Resource: "tenantnamespaces"},
+	}
+
+	if _, err := r.Get(context.Background(), "tenant-test", &metav1.GetOptions{}); err == nil {
+		t.Fatal("expected error for missing user in context, got nil")
+	}
+}
+
+// TestGet_NamespaceNotFound asserts the backing Get error surfaces when the
+// namespace disappears after the access check passes.
+func TestGet_NamespaceNotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	r := &REST{
+		c:   client,
+		gvr: schema.GroupVersionResource{Group: "core.cozystack.io", Version: "v1alpha1", Resource: "tenantnamespaces"},
+	}
+
+	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
+	ctx := request.WithUser(context.Background(), u)
+
+	_, err := r.Get(ctx, "tenant-missing", &metav1.GetOptions{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("expected NotFound, got %v", err)
+	}
+}
+
+// TestMatchesSubject_UnknownKind asserts unknown subject kinds never match.
+func TestMatchesSubject_UnknownKind(t *testing.T) {
+	subj := rbacv1.Subject{Kind: "UnknownKind", Name: "test-user"}
+	if matchesSubject(subj, "tenant-test", "test-user", map[string]struct{}{}) {
+		t.Error("expected unknown subject kind not to match")
+	}
+}
+
+func TestHasAccessToNamespace_MissingUser(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = rbacv1.AddToScheme(scheme)
+
+	client := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	r := &REST{
+		c:   client,
+		gvr: schema.GroupVersionResource{Group: "core.cozystack.io", Version: "v1alpha1", Resource: "tenantnamespaces"},
+	}
+
+	hasAccess, err := r.hasAccessToNamespace(context.Background(), "tenant-test")
+	if err == nil {
+		t.Fatal("expected error for missing user in context, got nil")
+	}
+	if hasAccess {
+		t.Error("expected no access when user is missing in context")
 	}
 }
 

--- a/pkg/registry/core/tenantnamespace/rest_watch_test.go
+++ b/pkg/registry/core/tenantnamespace/rest_watch_test.go
@@ -27,9 +27,9 @@ import (
 	corev1alpha1 "github.com/cozystack/cozystack/pkg/apis/core/v1alpha1"
 )
 
-// newWatchTestScheme returns a scheme with the types Watch tests need: core
+// newTestScheme returns a scheme with the types Watch tests need: core
 // (namespaces drive the watch) and rbac (RoleBindings drive the access check).
-func newWatchTestScheme(t *testing.T) *runtime.Scheme {
+func newTestScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
 	scheme := runtime.NewScheme()
 	if err := corev1.AddToScheme(scheme); err != nil {
@@ -133,7 +133,7 @@ func collectEvents(t *testing.T, w watch.Interface, n int, timeout time.Duration
 // namespace is created after the watch starts and then mutated to drive a live
 // event.
 func TestWatch_SendInitialEvents_EmitsInitialEventsEndBookmark(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	r := newTestREST(fc, fc)
 
 	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
@@ -200,7 +200,7 @@ func TestWatch_SendInitialEvents_EmitsInitialEventsEndBookmark(t *testing.T) {
 // check: with a RoleBinding in only one of two tenant namespaces, ADD/MODIFY/
 // DELETE events for the other never reach the client.
 func TestWatch_FiltersUnauthorizedNamespaceEvents(t *testing.T) {
-	scheme := newWatchTestScheme(t)
+	scheme := newTestScheme(t)
 	fc := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(userRoleBinding("tenant-allowed", "test-user")).
@@ -252,7 +252,7 @@ func TestWatch_FiltersUnauthorizedNamespaceEvents(t *testing.T) {
 func TestWatch_PrivilegedGroups_SeeEverything(t *testing.T) {
 	for _, group := range []string{"system:masters", "cozystack-cluster-admin"} {
 		t.Run(group, func(t *testing.T) {
-			fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+			fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 			r := newTestREST(fc, fc)
 
 			u := &user.DefaultInfo{Name: "admin", Groups: []string{group}}
@@ -285,7 +285,7 @@ func TestWatch_PrivilegedGroups_SeeEverything(t *testing.T) {
 // TestWatch_DropsNonTenantNamespaces asserts that events for namespaces
 // without the tenant- prefix are dropped even for privileged users.
 func TestWatch_DropsNonTenantNamespaces(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	r := newTestREST(fc, fc)
 
 	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
@@ -315,7 +315,7 @@ func TestWatch_DropsNonTenantNamespaces(t *testing.T) {
 // TestWatch_DropsNonNamespaceObjects asserts that backing events carrying an
 // object that is not a *corev1.Namespace are dropped.
 func TestWatch_DropsNonNamespaceObjects(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	fw := watch.NewFake()
 	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
 
@@ -344,7 +344,7 @@ func TestWatch_DropsNonNamespaceObjects(t *testing.T) {
 // resourceVersion. Without SendInitialEvents it must not be annotated as the
 // initial-events-end marker.
 func TestWatch_ForwardsBackingBookmarks(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	fw := watch.NewFake()
 	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
 
@@ -387,7 +387,7 @@ func TestWatch_ForwardsBackingBookmarks(t *testing.T) {
 // TestWatch_FieldSelectorFiltersEvents asserts metadata.name field selector
 // filtering at the watch level.
 func TestWatch_FieldSelectorFiltersEvents(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	r := newTestREST(fc, fc)
 
 	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
@@ -419,7 +419,7 @@ func TestWatch_FieldSelectorFiltersEvents(t *testing.T) {
 // TestWatch_LabelSelectorFiltersEvents asserts label selector filtering at the
 // watch level.
 func TestWatch_LabelSelectorFiltersEvents(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	r := newTestREST(fc, fc)
 
 	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
@@ -456,7 +456,7 @@ func TestWatch_LabelSelectorFiltersEvents(t *testing.T) {
 // TestWatch_MissingUser_ReturnsUnauthorized asserts Watch rejects a context
 // without user info up front instead of failing per event.
 func TestWatch_MissingUser_ReturnsUnauthorized(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	r := newTestREST(fc, fc)
 
 	w, err := r.Watch(context.Background(), &metainternal.ListOptions{})
@@ -474,7 +474,7 @@ func TestWatch_MissingUser_ReturnsUnauthorized(t *testing.T) {
 // TestWatch_AccessCheckError_SkipsEvent asserts that an error from the
 // RoleBinding lookup drops the affected event without killing the watch.
 func TestWatch_AccessCheckError_SkipsEvent(t *testing.T) {
-	scheme := newWatchTestScheme(t)
+	scheme := newTestScheme(t)
 	fc := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(userRoleBinding("tenant-ok", "test-user")).
@@ -518,7 +518,7 @@ func TestWatch_AccessCheckError_SkipsEvent(t *testing.T) {
 // supplies a resourceVersion, ADDED events at or below it are skipped as
 // already known from the preceding List.
 func TestWatch_SkipsAddedAtOrBelowStartingRV(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	fw := watch.NewFake()
 	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
 
@@ -546,7 +546,7 @@ func TestWatch_SkipsAddedAtOrBelowStartingRV(t *testing.T) {
 // watcher closes before any event was observed, a SendInitialEvents watch
 // still emits the terminating bookmark at the starting resourceVersion.
 func TestWatch_OnClose_FlushesTerminatingBookmark(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	fw := watch.NewFake()
 	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
 
@@ -595,7 +595,7 @@ func TestWatch_OnClose_FlushesTerminatingBookmark(t *testing.T) {
 // channel is intentionally never read, so the goroutine's send can only
 // observe the stop signal.
 func TestWatch_StopTerminatesGoroutine(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	fw := watch.NewFake()
 	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
 
@@ -625,7 +625,7 @@ func TestWatch_StopTerminatesGoroutine(t *testing.T) {
 // request context makes the filtering goroutine exit and stop the backing
 // watcher. As above, the result channel is never read.
 func TestWatch_ContextCancelTerminatesGoroutine(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	fw := watch.NewFake()
 	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
 
@@ -655,7 +655,7 @@ func TestWatch_ContextCancelTerminatesGoroutine(t *testing.T) {
 // stopped: the result channel is never read, so the bookmark send can only
 // observe the stop signal and the goroutine must exit.
 func TestWatch_StoppedDuringBookmarkSend_TerminatesGoroutine(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	fw := watch.NewFake()
 	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
 
@@ -684,7 +684,7 @@ func TestWatch_StoppedDuringBookmarkSend_TerminatesGoroutine(t *testing.T) {
 // asserts the early return when delivering the initial-events-end bookmark
 // ahead of the first live event fails because the watch was stopped.
 func TestWatch_StoppedDuringInitialEventsEndBookmarkSend_TerminatesGoroutine(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	fw := watch.NewFake()
 	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
 
@@ -715,7 +715,7 @@ func TestWatch_StoppedDuringInitialEventsEndBookmarkSend_TerminatesGoroutine(t *
 // TestWatch_BackingWatchError_Propagates asserts that a failure to start the
 // backing watch is returned to the caller.
 func TestWatch_BackingWatchError_Propagates(t *testing.T) {
-	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fc := fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build()
 	wantErr := errors.New("backing watch failed")
 	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, err: wantErr})
 

--- a/pkg/registry/core/tenantnamespace/rest_watch_test.go
+++ b/pkg/registry/core/tenantnamespace/rest_watch_test.go
@@ -116,6 +116,22 @@ func waitForFakeWatcherStop(t *testing.T, fw *watch.FakeWatcher, timeout time.Du
 	}
 }
 
+// requireResultChanClosed asserts the watch result channel closes within the
+// timeout without delivering any further events.
+func requireResultChanClosed(t *testing.T, w watch.Interface, timeout time.Duration) {
+	t.Helper()
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	select {
+	case ev, open := <-w.ResultChan():
+		if open {
+			t.Fatalf("expected result channel to close, got event %+v", ev)
+		}
+	case <-deadline.C:
+		t.Fatal("timed out waiting for the result channel to close")
+	}
+}
+
 // collectEvents drains up to n events from the watch, or returns early if the
 // channel closes or the timeout fires.
 func collectEvents(t *testing.T, w watch.Interface, n int, timeout time.Duration) []watch.Event {
@@ -583,11 +599,9 @@ func TestWatch_OnClose_FlushesTerminatingBookmark(t *testing.T) {
 	if len(evs) != 1 {
 		t.Fatalf("expected 1 bookmark event, got %d: %+v", len(evs), evs)
 	}
-	// Nothing else may arrive after the terminating bookmark; short window only,
-	// the result channel itself never closes (ProxyWatcher.Stop does not close it).
-	if extra := collectEvents(t, w, 1, 200*time.Millisecond); len(extra) != 0 {
-		t.Fatalf("expected no events after the terminating bookmark, got %+v", extra)
-	}
+	// The terminating bookmark is the last event: the goroutine closes the
+	// result channel on exit, signalling end-of-stream to the consumer.
+	requireResultChanClosed(t, w, 2*time.Second)
 	if evs[0].Type != watch.Bookmark {
 		t.Fatalf("expected Bookmark, got %s", evs[0].Type)
 	}
@@ -626,6 +640,7 @@ func TestWatch_StopTerminatesGoroutine(t *testing.T) {
 	fw.Add(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-foo"}})
 
 	waitForFakeWatcherStop(t, fw, 2*time.Second)
+	requireResultChanClosed(t, w, 2*time.Second)
 }
 
 // TestWatch_ContextCancelTerminatesGoroutine asserts that cancelling the
@@ -649,6 +664,7 @@ func TestWatch_ContextCancelTerminatesGoroutine(t *testing.T) {
 	fw.Add(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-foo"}})
 
 	waitForFakeWatcherStop(t, fw, 2*time.Second)
+	requireResultChanClosed(t, w, 2*time.Second)
 }
 
 // TestWatch_StoppedDuringBookmarkSend_TerminatesGoroutine asserts the early
@@ -673,6 +689,7 @@ func TestWatch_StoppedDuringBookmarkSend_TerminatesGoroutine(t *testing.T) {
 	fw.Action(watch.Bookmark, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "7"}})
 
 	waitForFakeWatcherStop(t, fw, 2*time.Second)
+	requireResultChanClosed(t, w, 2*time.Second)
 }
 
 // TestWatch_StoppedDuringInitialEventsEndBookmarkSend_TerminatesGoroutine
@@ -699,6 +716,7 @@ func TestWatch_StoppedDuringInitialEventsEndBookmarkSend_TerminatesGoroutine(t *
 	fw.Modify(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-foo", ResourceVersion: "8"}})
 
 	waitForFakeWatcherStop(t, fw, 2*time.Second)
+	requireResultChanClosed(t, w, 2*time.Second)
 }
 
 // TestWatch_BackingWatchError_Propagates asserts that a failure to start the

--- a/pkg/registry/core/tenantnamespace/rest_watch_test.go
+++ b/pkg/registry/core/tenantnamespace/rest_watch_test.go
@@ -103,6 +103,19 @@ func requireTenantNamespaceEvent(t *testing.T, ev watch.Event, evType watch.Even
 	return tn
 }
 
+// waitForFakeWatcherStop polls until the filtering goroutine stops the
+// backing watcher (via its deferred Stop) or the timeout fires.
+func waitForFakeWatcherStop(t *testing.T, fw *watch.FakeWatcher, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for !fw.IsStopped() {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the goroutine to stop the backing watcher")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // collectEvents drains up to n events from the watch, or returns early if the
 // channel closes or the timeout fires.
 func collectEvents(t *testing.T, w watch.Interface, n int, timeout time.Duration) []watch.Event {
@@ -612,13 +625,7 @@ func TestWatch_StopTerminatesGoroutine(t *testing.T) {
 	// Push an event the goroutine must try (and fail) to deliver.
 	fw.Add(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-foo"}})
 
-	deadline := time.Now().Add(2 * time.Second)
-	for !fw.IsStopped() {
-		if time.Now().After(deadline) {
-			t.Fatal("timed out waiting for the goroutine to stop the backing watcher")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForFakeWatcherStop(t, fw, 2*time.Second)
 }
 
 // TestWatch_ContextCancelTerminatesGoroutine asserts that cancelling the
@@ -641,13 +648,7 @@ func TestWatch_ContextCancelTerminatesGoroutine(t *testing.T) {
 	cancel()
 	fw.Add(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-foo"}})
 
-	deadline := time.Now().Add(2 * time.Second)
-	for !fw.IsStopped() {
-		if time.Now().After(deadline) {
-			t.Fatal("timed out waiting for the goroutine to stop the backing watcher")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForFakeWatcherStop(t, fw, 2*time.Second)
 }
 
 // TestWatch_StoppedDuringBookmarkSend_TerminatesGoroutine asserts the early
@@ -671,13 +672,7 @@ func TestWatch_StoppedDuringBookmarkSend_TerminatesGoroutine(t *testing.T) {
 	w.Stop()
 	fw.Action(watch.Bookmark, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "7"}})
 
-	deadline := time.Now().Add(2 * time.Second)
-	for !fw.IsStopped() {
-		if time.Now().After(deadline) {
-			t.Fatal("timed out waiting for the goroutine to stop the backing watcher")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForFakeWatcherStop(t, fw, 2*time.Second)
 }
 
 // TestWatch_StoppedDuringInitialEventsEndBookmarkSend_TerminatesGoroutine
@@ -703,13 +698,7 @@ func TestWatch_StoppedDuringInitialEventsEndBookmarkSend_TerminatesGoroutine(t *
 	// initial-events-end bookmark first; its send must fail and exit.
 	fw.Modify(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-foo", ResourceVersion: "8"}})
 
-	deadline := time.Now().Add(2 * time.Second)
-	for !fw.IsStopped() {
-		if time.Now().After(deadline) {
-			t.Fatal("timed out waiting for the goroutine to stop the backing watcher")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForFakeWatcherStop(t, fw, 2*time.Second)
 }
 
 // TestWatch_BackingWatchError_Propagates asserts that a failure to start the

--- a/pkg/registry/core/tenantnamespace/rest_watch_test.go
+++ b/pkg/registry/core/tenantnamespace/rest_watch_test.go
@@ -4,21 +4,104 @@ package tenantnamespace
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternal "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	corev1alpha1 "github.com/cozystack/cozystack/pkg/apis/core/v1alpha1"
 )
+
+// newWatchTestScheme returns a scheme with the types Watch tests need: core
+// (namespaces drive the watch) and rbac (RoleBindings drive the access check).
+func newWatchTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+	if err := rbacv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add rbacv1 to scheme: %v", err)
+	}
+	return scheme
+}
+
+func newTestREST(c client.Client, w client.WithWatch) *REST {
+	return &REST{
+		c: c,
+		w: w,
+		gvr: schema.GroupVersionResource{
+			Group:    corev1alpha1.GroupName,
+			Version:  "v1alpha1",
+			Resource: "tenantnamespaces",
+		},
+	}
+}
+
+// stubWithWatch backs REST.Watch with a test-owned FakeWatcher so tests can
+// inject arbitrary backing events (bookmarks, foreign object types, chosen
+// resourceVersions) that the controller-runtime fake client never produces.
+// All other client calls fall through to the embedded fake client.
+type stubWithWatch struct {
+	client.WithWatch
+	fw  *watch.FakeWatcher
+	err error
+}
+
+// Watch ignores ListOptions entirely: selector propagation cannot be asserted
+// through this stub, only through the real fake client.
+func (s *stubWithWatch) Watch(_ context.Context, _ client.ObjectList, _ ...client.ListOption) (watch.Interface, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.fw, nil
+}
+
+func userRoleBinding(namespace, username string) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-binding", Namespace: namespace},
+		Subjects: []rbacv1.Subject{
+			{Kind: "User", Name: username, APIGroup: "rbac.authorization.k8s.io"},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "Role",
+			Name:     "test-role",
+		},
+	}
+}
+
+// requireTenantNamespaceEvent asserts the event has the given type and carries
+// a *TenantNamespace with the given name.
+func requireTenantNamespaceEvent(t *testing.T, ev watch.Event, evType watch.EventType, name string) *corev1alpha1.TenantNamespace {
+	t.Helper()
+	if ev.Type != evType {
+		t.Fatalf("expected event type %s, got %s (%+v)", evType, ev.Type, ev)
+	}
+	tn, ok := ev.Object.(*corev1alpha1.TenantNamespace)
+	if !ok {
+		t.Fatalf("expected *TenantNamespace, got %T", ev.Object)
+	}
+	if tn.Name != name {
+		t.Fatalf("expected namespace %q, got %q", name, tn.Name)
+	}
+	return tn
+}
 
 // collectEvents drains up to n events from the watch, or returns early if the
 // channel closes or the timeout fires.
@@ -50,20 +133,8 @@ func collectEvents(t *testing.T, w watch.Interface, n int, timeout time.Duration
 // namespace is created after the watch starts and then mutated to drive a live
 // event.
 func TestWatch_SendInitialEvents_EmitsInitialEventsEndBookmark(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add corev1 to scheme: %v", err)
-	}
-	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
-	r := &REST{
-		c: fc,
-		w: fc,
-		gvr: schema.GroupVersionResource{
-			Group:    corev1alpha1.GroupName,
-			Version:  "v1alpha1",
-			Resource: "tenantnamespaces",
-		},
-	}
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	r := newTestREST(fc, fc)
 
 	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
 	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
@@ -117,5 +188,545 @@ func TestWatch_SendInitialEvents_EmitsInitialEventsEndBookmark(t *testing.T) {
 
 	if evs[2].Type != watch.Modified {
 		t.Fatalf("event[2]: expected Modified after bookmark, got %s", evs[2].Type)
+	}
+}
+
+// The dropped-event assertions below rely on the watch pipeline being FIFO: a
+// dropped backing event always precedes the next delivered one, so when the
+// first event a test receives is the later fixture, the earlier one was
+// provably filtered rather than still in flight.
+
+// TestWatch_FiltersUnauthorizedNamespaceEvents asserts the per-event access
+// check: with a RoleBinding in only one of two tenant namespaces, ADD/MODIFY/
+// DELETE events for the other never reach the client.
+func TestWatch_FiltersUnauthorizedNamespaceEvents(t *testing.T) {
+	scheme := newWatchTestScheme(t)
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(userRoleBinding("tenant-allowed", "test-user")).
+		Build()
+	r := newTestREST(fc, fc)
+
+	u := &user.DefaultInfo{Name: "test-user", Groups: []string{"system:authenticated"}}
+	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+	defer cancel()
+
+	w, err := r.Watch(ctx, &metainternal.ListOptions{})
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+	defer w.Stop()
+
+	denied := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-denied"}}
+	allowed := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-allowed"}}
+	// Interleave so every authorized event is preceded by an unauthorized one.
+	for _, ns := range []*corev1.Namespace{denied, allowed} {
+		if err := fc.Create(ctx, ns); err != nil {
+			t.Fatalf("create %s: %v", ns.Name, err)
+		}
+	}
+	for _, ns := range []*corev1.Namespace{denied, allowed} {
+		ns.Labels = map[string]string{"touched": "1"}
+		if err := fc.Update(ctx, ns); err != nil {
+			t.Fatalf("update %s: %v", ns.Name, err)
+		}
+	}
+	for _, ns := range []*corev1.Namespace{denied, allowed} {
+		if err := fc.Delete(ctx, ns); err != nil {
+			t.Fatalf("delete %s: %v", ns.Name, err)
+		}
+	}
+
+	evs := collectEvents(t, w, 3, 2*time.Second)
+	if len(evs) != 3 {
+		t.Fatalf("expected 3 events for tenant-allowed, got %d: %+v", len(evs), evs)
+	}
+	requireTenantNamespaceEvent(t, evs[0], watch.Added, "tenant-allowed")
+	requireTenantNamespaceEvent(t, evs[1], watch.Modified, "tenant-allowed")
+	requireTenantNamespaceEvent(t, evs[2], watch.Deleted, "tenant-allowed")
+}
+
+// TestWatch_PrivilegedGroups_SeeEverything asserts that members of the
+// privileged groups receive events for every tenant namespace without any
+// RoleBinding fixtures.
+func TestWatch_PrivilegedGroups_SeeEverything(t *testing.T) {
+	for _, group := range []string{"system:masters", "cozystack-cluster-admin"} {
+		t.Run(group, func(t *testing.T) {
+			fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+			r := newTestREST(fc, fc)
+
+			u := &user.DefaultInfo{Name: "admin", Groups: []string{group}}
+			ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+			defer cancel()
+
+			w, err := r.Watch(ctx, &metainternal.ListOptions{})
+			if err != nil {
+				t.Fatalf("Watch returned error: %v", err)
+			}
+			defer w.Stop()
+
+			for _, name := range []string{"tenant-a", "tenant-b"} {
+				ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+				if err := fc.Create(ctx, ns); err != nil {
+					t.Fatalf("create %s: %v", name, err)
+				}
+			}
+
+			evs := collectEvents(t, w, 2, 2*time.Second)
+			if len(evs) != 2 {
+				t.Fatalf("expected 2 events, got %d: %+v", len(evs), evs)
+			}
+			requireTenantNamespaceEvent(t, evs[0], watch.Added, "tenant-a")
+			requireTenantNamespaceEvent(t, evs[1], watch.Added, "tenant-b")
+		})
+	}
+}
+
+// TestWatch_DropsNonTenantNamespaces asserts that events for namespaces
+// without the tenant- prefix are dropped even for privileged users.
+func TestWatch_DropsNonTenantNamespaces(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	r := newTestREST(fc, fc)
+
+	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
+	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+	defer cancel()
+
+	w, err := r.Watch(ctx, &metainternal.ListOptions{})
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+	defer w.Stop()
+
+	for _, name := range []string{"kube-whatever", "tenant-foo"} {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		if err := fc.Create(ctx, ns); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	evs := collectEvents(t, w, 1, 2*time.Second)
+	if len(evs) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(evs), evs)
+	}
+	requireTenantNamespaceEvent(t, evs[0], watch.Added, "tenant-foo")
+}
+
+// TestWatch_DropsNonNamespaceObjects asserts that backing events carrying an
+// object that is not a *corev1.Namespace are dropped.
+func TestWatch_DropsNonNamespaceObjects(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fw := watch.NewFake()
+	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
+
+	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
+	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+	defer cancel()
+
+	w, err := r.Watch(ctx, &metainternal.ListOptions{})
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+	defer w.Stop()
+
+	fw.Action(watch.Added, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "not-a-namespace"}})
+	fw.Add(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-foo"}})
+
+	evs := collectEvents(t, w, 1, 2*time.Second)
+	if len(evs) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(evs), evs)
+	}
+	requireTenantNamespaceEvent(t, evs[0], watch.Added, "tenant-foo")
+}
+
+// TestWatch_ForwardsBackingBookmarks asserts that a bookmark from the backing
+// watch is forwarded as a TenantNamespace bookmark carrying the backing
+// resourceVersion. Without SendInitialEvents it must not be annotated as the
+// initial-events-end marker.
+func TestWatch_ForwardsBackingBookmarks(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fw := watch.NewFake()
+	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
+
+	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
+	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+	defer cancel()
+
+	w, err := r.Watch(ctx, &metainternal.ListOptions{})
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+	defer w.Stop()
+
+	// A bookmark carrying a non-Namespace object must be dropped, not forwarded.
+	fw.Action(watch.Bookmark, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "41"}})
+	fw.Action(watch.Bookmark, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "42"}})
+
+	evs := collectEvents(t, w, 1, 2*time.Second)
+	if len(evs) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(evs), evs)
+	}
+	if evs[0].Type != watch.Bookmark {
+		t.Fatalf("expected Bookmark, got %s", evs[0].Type)
+	}
+	bookmark, ok := evs[0].Object.(*corev1alpha1.TenantNamespace)
+	if !ok {
+		t.Fatalf("expected *TenantNamespace, got %T", evs[0].Object)
+	}
+	if bookmark.Kind != "TenantNamespace" {
+		t.Errorf("expected kind TenantNamespace, got %q", bookmark.Kind)
+	}
+	if bookmark.ResourceVersion != "42" {
+		t.Errorf("expected resourceVersion 42, got %q", bookmark.ResourceVersion)
+	}
+	if _, ok := bookmark.Annotations[metav1.InitialEventsAnnotationKey]; ok {
+		t.Errorf("bookmark must not carry %s without SendInitialEvents", metav1.InitialEventsAnnotationKey)
+	}
+}
+
+// TestWatch_FieldSelectorFiltersEvents asserts metadata.name field selector
+// filtering at the watch level.
+func TestWatch_FieldSelectorFiltersEvents(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	r := newTestREST(fc, fc)
+
+	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
+	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+	defer cancel()
+
+	w, err := r.Watch(ctx, &metainternal.ListOptions{
+		FieldSelector: fields.OneTermEqualSelector("metadata.name", "tenant-foo"),
+	})
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+	defer w.Stop()
+
+	for _, name := range []string{"tenant-bar", "tenant-foo"} {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		if err := fc.Create(ctx, ns); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	evs := collectEvents(t, w, 1, 2*time.Second)
+	if len(evs) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(evs), evs)
+	}
+	requireTenantNamespaceEvent(t, evs[0], watch.Added, "tenant-foo")
+}
+
+// TestWatch_LabelSelectorFiltersEvents asserts label selector filtering at the
+// watch level.
+func TestWatch_LabelSelectorFiltersEvents(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	r := newTestREST(fc, fc)
+
+	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
+	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+	defer cancel()
+
+	w, err := r.Watch(ctx, &metainternal.ListOptions{
+		LabelSelector: labels.SelectorFromSet(labels.Set{"team": "a"}),
+	})
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+	defer w.Stop()
+
+	unlabeled := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-bar"}}
+	if err := fc.Create(ctx, unlabeled); err != nil {
+		t.Fatalf("create tenant-bar: %v", err)
+	}
+	labeled := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   "tenant-foo",
+		Labels: map[string]string{"team": "a"},
+	}}
+	if err := fc.Create(ctx, labeled); err != nil {
+		t.Fatalf("create tenant-foo: %v", err)
+	}
+
+	evs := collectEvents(t, w, 1, 2*time.Second)
+	if len(evs) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(evs), evs)
+	}
+	requireTenantNamespaceEvent(t, evs[0], watch.Added, "tenant-foo")
+}
+
+// TestWatch_MissingUser_ReturnsUnauthorized asserts Watch rejects a context
+// without user info up front instead of failing per event.
+func TestWatch_MissingUser_ReturnsUnauthorized(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	r := newTestREST(fc, fc)
+
+	w, err := r.Watch(context.Background(), &metainternal.ListOptions{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !apierrors.IsUnauthorized(err) {
+		t.Fatalf("expected Unauthorized error, got %v", err)
+	}
+	if w != nil {
+		t.Fatalf("expected nil watch on error, got %v", w)
+	}
+}
+
+// TestWatch_AccessCheckError_SkipsEvent asserts that an error from the
+// RoleBinding lookup drops the affected event without killing the watch.
+func TestWatch_AccessCheckError_SkipsEvent(t *testing.T) {
+	scheme := newWatchTestScheme(t)
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(userRoleBinding("tenant-ok", "test-user")).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				lo := (&client.ListOptions{}).ApplyOptions(opts)
+				if lo.Namespace == "tenant-broken" {
+					return errors.New("rolebinding list failed")
+				}
+				return c.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+	r := newTestREST(fc, fc)
+
+	u := &user.DefaultInfo{Name: "test-user", Groups: []string{"system:authenticated"}}
+	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+	defer cancel()
+
+	w, err := r.Watch(ctx, &metainternal.ListOptions{})
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+	defer w.Stop()
+
+	for _, name := range []string{"tenant-broken", "tenant-ok"} {
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		if err := fc.Create(ctx, ns); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+
+	evs := collectEvents(t, w, 1, 2*time.Second)
+	if len(evs) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(evs), evs)
+	}
+	requireTenantNamespaceEvent(t, evs[0], watch.Added, "tenant-ok")
+}
+
+// TestWatch_SkipsAddedAtOrBelowStartingRV asserts that when the client
+// supplies a resourceVersion, ADDED events at or below it are skipped as
+// already known from the preceding List.
+func TestWatch_SkipsAddedAtOrBelowStartingRV(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fw := watch.NewFake()
+	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
+
+	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
+	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+	defer cancel()
+
+	w, err := r.Watch(ctx, &metainternal.ListOptions{ResourceVersion: "100"})
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+	defer w.Stop()
+
+	fw.Add(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-old", ResourceVersion: "100"}})
+	fw.Add(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-new", ResourceVersion: "101"}})
+
+	evs := collectEvents(t, w, 1, 2*time.Second)
+	if len(evs) != 1 {
+		t.Fatalf("expected 1 event, got %d: %+v", len(evs), evs)
+	}
+	requireTenantNamespaceEvent(t, evs[0], watch.Added, "tenant-new")
+}
+
+// TestWatch_OnClose_FlushesTerminatingBookmark asserts that when the backing
+// watcher closes before any event was observed, a SendInitialEvents watch
+// still emits the terminating bookmark at the starting resourceVersion.
+func TestWatch_OnClose_FlushesTerminatingBookmark(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fw := watch.NewFake()
+	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
+
+	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
+	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+	defer cancel()
+
+	sendInitialEvents := true
+	w, err := r.Watch(ctx, &metainternal.ListOptions{
+		ResourceVersion:   "5",
+		SendInitialEvents: &sendInitialEvents,
+	})
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+	defer w.Stop()
+
+	fw.Stop()
+
+	evs := collectEvents(t, w, 1, 2*time.Second)
+	if len(evs) != 1 {
+		t.Fatalf("expected 1 bookmark event, got %d: %+v", len(evs), evs)
+	}
+	// Nothing else may arrive after the terminating bookmark; short window only,
+	// the result channel itself never closes (ProxyWatcher.Stop does not close it).
+	if extra := collectEvents(t, w, 1, 200*time.Millisecond); len(extra) != 0 {
+		t.Fatalf("expected no events after the terminating bookmark, got %+v", extra)
+	}
+	if evs[0].Type != watch.Bookmark {
+		t.Fatalf("expected Bookmark, got %s", evs[0].Type)
+	}
+	bookmark, ok := evs[0].Object.(*corev1alpha1.TenantNamespace)
+	if !ok {
+		t.Fatalf("expected *TenantNamespace, got %T", evs[0].Object)
+	}
+	if got := bookmark.Annotations[metav1.InitialEventsAnnotationKey]; got != "true" {
+		t.Errorf("expected annotation %s=true, got %q", metav1.InitialEventsAnnotationKey, got)
+	}
+	if bookmark.ResourceVersion != "5" {
+		t.Errorf("expected resourceVersion 5, got %q", bookmark.ResourceVersion)
+	}
+}
+
+// TestWatch_StopTerminatesGoroutine asserts that stopping the returned watch
+// makes the filtering goroutine exit and stop the backing watcher. The result
+// channel is intentionally never read, so the goroutine's send can only
+// observe the stop signal.
+func TestWatch_StopTerminatesGoroutine(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fw := watch.NewFake()
+	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
+
+	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
+	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+	defer cancel()
+
+	w, err := r.Watch(ctx, &metainternal.ListOptions{})
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+
+	w.Stop()
+	// Push an event the goroutine must try (and fail) to deliver.
+	fw.Add(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-foo"}})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !fw.IsStopped() {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the goroutine to stop the backing watcher")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestWatch_ContextCancelTerminatesGoroutine asserts that cancelling the
+// request context makes the filtering goroutine exit and stop the backing
+// watcher. As above, the result channel is never read.
+func TestWatch_ContextCancelTerminatesGoroutine(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fw := watch.NewFake()
+	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
+
+	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
+	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+
+	w, err := r.Watch(ctx, &metainternal.ListOptions{})
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+	defer w.Stop()
+
+	cancel()
+	fw.Add(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-foo"}})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !fw.IsStopped() {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the goroutine to stop the backing watcher")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestWatch_StoppedDuringBookmarkSend_TerminatesGoroutine asserts the early
+// return when forwarding a backing bookmark fails because the watch was
+// stopped: the result channel is never read, so the bookmark send can only
+// observe the stop signal and the goroutine must exit.
+func TestWatch_StoppedDuringBookmarkSend_TerminatesGoroutine(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fw := watch.NewFake()
+	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
+
+	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
+	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+	defer cancel()
+
+	w, err := r.Watch(ctx, &metainternal.ListOptions{})
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+
+	w.Stop()
+	fw.Action(watch.Bookmark, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "7"}})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !fw.IsStopped() {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the goroutine to stop the backing watcher")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestWatch_StoppedDuringInitialEventsEndBookmarkSend_TerminatesGoroutine
+// asserts the early return when delivering the initial-events-end bookmark
+// ahead of the first live event fails because the watch was stopped.
+func TestWatch_StoppedDuringInitialEventsEndBookmarkSend_TerminatesGoroutine(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	fw := watch.NewFake()
+	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, fw: fw})
+
+	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
+	ctx, cancel := context.WithCancel(request.WithUser(context.Background(), u))
+	defer cancel()
+
+	sendInitialEvents := true
+	w, err := r.Watch(ctx, &metainternal.ListOptions{SendInitialEvents: &sendInitialEvents})
+	if err != nil {
+		t.Fatalf("Watch returned error: %v", err)
+	}
+
+	w.Stop()
+	// A live (non-ADDED) event makes the bookmarker emit the pending
+	// initial-events-end bookmark first; its send must fail and exit.
+	fw.Modify(&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "tenant-foo", ResourceVersion: "8"}})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !fw.IsStopped() {
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for the goroutine to stop the backing watcher")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// TestWatch_BackingWatchError_Propagates asserts that a failure to start the
+// backing watch is returned to the caller.
+func TestWatch_BackingWatchError_Propagates(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newWatchTestScheme(t)).Build()
+	wantErr := errors.New("backing watch failed")
+	r := newTestREST(fc, &stubWithWatch{WithWatch: fc, err: wantErr})
+
+	u := &user.DefaultInfo{Name: "admin", Groups: []string{"system:masters"}}
+	ctx := request.WithUser(context.Background(), u)
+
+	w, err := r.Watch(ctx, &metainternal.ListOptions{})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("expected %v, got %v", wantErr, err)
+	}
+	if w != nil {
+		t.Fatalf("expected nil watch on error, got %v", w)
 	}
 }


### PR DESCRIPTION
## What this PR does

Adds direct unit coverage for the authorization-sensitive read paths of the TenantNamespace registry. PR #2471 fixed the IDOR on `Get`/`Watch`, but the watch path's per-event authorization filtering was only exercised transitively, which was flagged during review.

New Watch tests cover: authorization filtering (events for namespaces without a matching RoleBinding never reach the client), privileged groups (`system:masters`, `cozystack-cluster-admin`), dropping of non-tenant namespaces and non-Namespace objects, backing bookmark forwarding with the right kind and resourceVersion, field and label selector filtering, `Unauthorized` on missing user, resilience to RoleBinding lookup errors, ADDED deduplication against the client's starting resourceVersion, terminating bookmark flush when the backing watcher closes, and goroutine shutdown on `Stop()` and context cancellation, including the bookmark-send failure paths.

Beyond the ticket's Watch scope, the sibling read paths sharing the same authorization logic are brought to full coverage too: `List`/`filterAccessible` (per-user filtering, privileged groups, missing user, RoleBindings outside the tenant namespace set, backing list errors) and the `Get` error branches.

The new termination tests surfaced one production gap, fixed here as well: the Watch goroutine never closed its result channel, so consumers ranging over `ResultChan()` after the backing watcher ended blocked until their own timeout instead of seeing end-of-stream. The goroutine now closes the channel on exit, matching the `watch.Interface` contract and the tenantmodule/application registries.

Branches the controller-runtime fake client cannot drive (backing bookmarks, foreign object types, chosen resourceVersions, backing watch startup errors) are exercised through a small stub `client.WithWatch` backed by a test-owned `watch.FakeWatcher`. Every `continue` and early return in the watch goroutine is covered deterministically; `Watch`, `List`, `Get` and all authorization helpers are at 100% statement coverage.

Closes #2520

### Screenshots

Not applicable — no UI changes.

### Release note

```release-note
fix(api): TenantNamespace watch now signals end-of-stream by closing its result channel when the watch terminates
```
