### PR TITLE
fix(csi): detach orphan hot-plug volumes when VMI outlives its VM

### DIFF
--- a/packages/apps/kubernetes/images/kubevirt-csi-driver/controller.go
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver/controller.go
@@ -410,9 +410,65 @@ func (w *WrappedControllerService) ControllerPublishVolume(ctx context.Context, 
 	}, nil
 }
 
+// unpublishHotplugVolume delegates to upstream for the hot-unplug, then re-verifies
+// that the volume is gone from VMI.Status.VolumeStatus before returning success.
+// Upstream treats a missing parent VM as "detach succeeded", but during a CAPI/CAPK
+// teardown the VMI (and its hot-plug pod) can outlive the VM: the hot-plug pod then
+// keeps the infra storage device exclusively attached to the source host, and every
+// subsequent attach of the same volume fails (on DRBD with "failed to set source
+// device readwrite"). When the VMI still reports the hot-plug after upstream
+// returned success, detach it from the VMI directly. Backport of
+// kubevirt/csi-driver#184; drop once it is merged and the module is bumped past it.
+func (w *WrappedControllerService) unpublishHotplugVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
+	if _, err := w.ControllerService.ControllerUnpublishVolume(ctx, req); err != nil {
+		return nil, err
+	}
+
+	dvName := req.GetVolumeId()
+	_, vmName, err := cache.SplitMetaNamespaceKey(req.GetNodeId())
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to parse node ID %q: %v", req.GetNodeId(), err)
+	}
+
+	// GetVirtualMachine on this client returns a VirtualMachineInstance, not a VM.
+	vmi, err := w.virtClient.GetVirtualMachine(ctx, w.infraNamespace, vmName)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return &csi.ControllerUnpublishVolumeResponse{}, nil
+		}
+		return nil, status.Errorf(codes.Unavailable,
+			"cannot verify VMI %s/%s after unpublish of %s: %v", w.infraNamespace, vmName, dvName, err)
+	}
+
+	stillAttached := false
+	for _, vs := range vmi.Status.VolumeStatus {
+		if vs.HotplugVolume != nil && vs.Name == dvName {
+			stillAttached = true
+			break
+		}
+	}
+	if !stillAttached {
+		return &csi.ControllerUnpublishVolumeResponse{}, nil
+	}
+
+	klog.Infof("Volume %s still reported by VMI %s/%s after unpublish – detaching from the VMI", dvName, w.infraNamespace, vmName)
+	if err := w.virtClient.RemoveVolumeFromVMI(ctx, w.infraNamespace, vmName, &kubevirtv1.RemoveVolumeOptions{Name: dvName}); err != nil {
+		return nil, status.Errorf(codes.Unavailable,
+			"failed to remove volume %s from VMI %s/%s: %v", dvName, w.infraNamespace, vmName, err)
+	}
+	if err := w.virtClient.EnsureVolumeRemoved(ctx, w.infraNamespace, vmName, dvName, 2*time.Minute); err != nil {
+		return nil, status.Errorf(codes.Unavailable,
+			"volume %s failed to be removed from VMI %s/%s in time: %v", dvName, w.infraNamespace, vmName, err)
+	}
+
+	klog.V(3).Infof("Successfully unpublished volume %s from VMI %s/%s", dvName, w.infraNamespace, vmName)
+	return &csi.ControllerUnpublishVolumeResponse{}, nil
+}
+
 // ControllerUnpublishVolume for NFS volumes (RWX Filesystem): deletes CiliumNetworkPolicy.
 // For everything else (RWO and RWX Block), delegates to upstream so the hotplug
-// DataVolume is removed from VM.spec.template.spec.volumes. RWX Block volumes used
+// DataVolume is removed from VM.spec.template.spec.volumes, then verifies the volume
+// actually left VMI.Status.VolumeStatus. RWX Block volumes used
 // for live migration must NOT be treated as NFS — their cleanup goes through upstream
 // hotplug removal, otherwise stale VM-spec entries permanently block re-attachment to
 // a different VM via the anti-split-brain check (issue #2634).
@@ -428,7 +484,7 @@ func (w *WrappedControllerService) ControllerUnpublishVolume(ctx context.Context
 	}
 
 	if !isNFSVolume(pvc) {
-		return w.ControllerService.ControllerUnpublishVolume(ctx, req)
+		return w.unpublishHotplugVolume(ctx, req)
 	}
 
 	// NFS volume: remove VMI ownerReference from CiliumNetworkPolicy

--- a/packages/apps/kubernetes/images/kubevirt-csi-driver/go.mod
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver/go.mod
@@ -11,6 +11,7 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog/v2 v2.140.0
 	k8s.io/mount-utils v0.36.0
+	kubevirt.io/api v1.2.2
 	kubevirt.io/containerized-data-importer-api v1.59.0
 	kubevirt.io/csi-driver v0.0.0-20260424143118-bee6c348c004
 )
@@ -57,7 +58,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.26.4 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
-	kubevirt.io/api v1.2.2 // indirect
 	kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
@@ -91,5 +91,5 @@ replace (
 	k8s.io/mount-utils => k8s.io/mount-utils v0.36.0
 	k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.36.0
 	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.36.0
-	kubevirt.io/csi-driver => github.com/kubevirt/csi-driver v0.0.0-20260424143118-bee6c348c004
+	kubevirt.io/csi-driver => github.com/kubevirt/csi-driver v0.0.0-20260430151523-51c6bca7c611
 )

--- a/packages/apps/kubernetes/images/kubevirt-csi-driver/go.sum
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver/go.sum
@@ -113,8 +113,8 @@ github.com/kubernetes-csi/csi-lib-utils v0.18.1 h1:vpg1kbQ6lFVCz7mY71zcqVE7W0GAQ
 github.com/kubernetes-csi/csi-lib-utils v0.18.1/go.mod h1:PIcn27zmbY0KBue4JDdZVfDF56tjcS3jKroZPi+pMoY=
 github.com/kubernetes-csi/external-snapshotter/client/v6 v6.3.0 h1:qS4r4ljINLWKJ9m9Ge3Q3sGZ/eIoDVDT2RhAdQFHb1k=
 github.com/kubernetes-csi/external-snapshotter/client/v6 v6.3.0/go.mod h1:oGXx2XTEzs9ikW2V6IC1dD8trgjRsS/Mvc2JRiC618Y=
-github.com/kubevirt/csi-driver v0.0.0-20260424143118-bee6c348c004 h1:fEnd+1kIEuzpFJt9slCylHsgPmxyLFO8K83hrToMkWs=
-github.com/kubevirt/csi-driver v0.0.0-20260424143118-bee6c348c004/go.mod h1:Pzl14YlqPpoK/ZdS79tUSuHbC2L/NPqOIjFTN5kTmUg=
+github.com/kubevirt/csi-driver v0.0.0-20260430151523-51c6bca7c611 h1:+H0mgU24rS+Xc7yrrhHm6qvWkgE0OjzygjCodkEx0cI=
+github.com/kubevirt/csi-driver v0.0.0-20260430151523-51c6bca7c611/go.mod h1:V3eUEyaoPV7Z6COyaVoBodHl22hYTlLvHivBCQkyH0E=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=


### PR DESCRIPTION
## What this PR does

During node reprovisioning in tenant Kubernetes clusters, the VMI (and its hot-plug pod) can outlive the parent VirtualMachine. The upstream kubevirt-csi-driver treats a missing VM as "detach succeeded", so the hot-plug pod stays alive and keeps the infra storage device exclusively attached to the source host — every subsequent attach of that volume fails, on DRBD with `failed to set source device readwrite`. This was hit repeatedly in production tenant clusters (see kubevirt/csi-driver#182).

This PR:

- updates the pinned `kubevirt.io/csi-driver` module to the latest upstream commit;
- backports kubevirt/csi-driver#184 into the controller wrapper: after the upstream unpublish returns success, the wrapper re-checks `VMI.status.volumeStatus` and, if the hot-plug is still reported there (e.g. because the parent VM is already gone), detaches it from the VMI directly via the `removevolume` subresource and waits until it disappears.

The backport is self-contained in the wrapper and can be dropped once kubevirt/csi-driver#184 merges upstream and the module pin is bumped past it.

Credit to @mattia-eleuteri for the root-cause analysis and the upstream fix.

### Screenshots

Not a UI change.

### Release note

```release-note
fix(csi): tenant CSI driver no longer leaves orphan hot-plug volumes exclusively attached to the source host when the VMI outlives its deleted VirtualMachine during node reprovisioning
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced hotplug volume unpublishing with automatic verification to ensure volumes are fully detached before completion, including retry logic with up to 2-minute timeout.
* **Dependencies**
  * Updated KubeVirt API and CSI driver dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->