### PR TITLE
fix(api): publish open spec as x-kubernetes-preserve-unknown-fields, not additionalProperties:true

### DIFF
--- a/pkg/cmd/server/openapi.go
+++ b/pkg/cmd/server/openapi.go
@@ -81,7 +81,7 @@ func markOpenObject(s *spec.Schema) {
 	}
 	s.AdditionalProperties = nil
 	if s.Extensions == nil {
-		s.Extensions = map[string]any{}
+		s.Extensions = spec.Extensions{}
 	}
 	s.Extensions["x-kubernetes-preserve-unknown-fields"] = true
 }
@@ -384,7 +384,7 @@ func sanitizeForV2(s *spec.Schema) {
 		if hasIntAndStringAnyOf(s.AnyOf) {
 			s.Type = spec.StringOrArray{"string"}
 			if s.Extensions == nil {
-				s.Extensions = map[string]any{}
+				s.Extensions = spec.Extensions{}
 			}
 			s.Extensions["x-kubernetes-int-or-string"] = true
 		}

--- a/pkg/cmd/server/openapi.go
+++ b/pkg/cmd/server/openapi.go
@@ -63,6 +63,29 @@ func findSpecContainer(s *spec.Schema) *spec.Schema {
 	return nil
 }
 
+// markOpenObject marks a schema as a free-form object that accepts arbitrary
+// properties, using the x-kubernetes-preserve-unknown-fields extension rather
+// than the boolean additionalProperties:true form.
+//
+// This distinction matters: the boolean additionalProperties:true construct
+// makes the Kubernetes ValidatingAdmissionPolicy status type-checker (run by
+// kube-controller-manager) nil-dereference when it recurses into the node,
+// crash-looping KCM cluster-wide as soon as a VAP matches one of these
+// aggregated resources (e.g. cozystack-tenant-host-policy on tenants). The
+// extension is semantically equivalent ("arbitrary fields allowed") and the
+// type-checker handles it safely. See
+// https://github.com/cozystack/cozystack/issues/2863.
+func markOpenObject(s *spec.Schema) {
+	if len(s.Type) == 0 {
+		s.Type = spec.StringOrArray{"object"}
+	}
+	s.AdditionalProperties = nil
+	if s.Extensions == nil {
+		s.Extensions = map[string]any{}
+	}
+	s.Extensions["x-kubernetes-preserve-unknown-fields"] = true
+}
+
 // patchSpec injects/overrides ".spec" with user JSON (or schemaless object).
 func patchSpec(target *spec.Schema, raw string) error {
 	if strings.TrimSpace(raw) == "" {
@@ -70,7 +93,7 @@ func patchSpec(target *spec.Schema, raw string) error {
 			target.Properties = map[string]spec.Schema{}
 		}
 		prop := target.Properties["spec"]
-		prop.AdditionalProperties = &spec.SchemaOrBool{Allows: true}
+		markOpenObject(&prop)
 		target.Properties["spec"] = prop
 		return nil
 	}
@@ -80,7 +103,7 @@ func patchSpec(target *spec.Schema, raw string) error {
 		return err
 	}
 	if custom.AdditionalProperties == nil {
-		custom.AdditionalProperties = &spec.SchemaOrBool{Allows: true}
+		markOpenObject(&custom)
 	}
 	if target.Properties == nil {
 		target.Properties = map[string]spec.Schema{}

--- a/pkg/cmd/server/openapi.go
+++ b/pkg/cmd/server/openapi.go
@@ -67,14 +67,14 @@ func findSpecContainer(s *spec.Schema) *spec.Schema {
 // properties, using the x-kubernetes-preserve-unknown-fields extension rather
 // than the boolean additionalProperties:true form.
 //
-// This distinction matters: the boolean additionalProperties:true construct
-// makes the Kubernetes ValidatingAdmissionPolicy status type-checker (run by
-// kube-controller-manager) nil-dereference when it recurses into the node,
-// crash-looping KCM cluster-wide as soon as a VAP matches one of these
-// aggregated resources (e.g. cozystack-tenant-host-policy on tenants). The
-// extension is semantically equivalent ("arbitrary fields allowed") and the
-// type-checker handles it safely. See
-// https://github.com/cozystack/cozystack/issues/2863.
+// This distinction matters: a boolean additionalProperties node (the JSON
+// `true` or `false` form) carries a nil inner schema. The Kubernetes
+// ValidatingAdmissionPolicy status type-checker (run by kube-controller-manager)
+// dereferences that nil inner schema, crash-looping KCM cluster-wide as soon as
+// a VAP matches one of these aggregated resources (e.g.
+// cozystack-tenant-host-policy on tenants). The extension is semantically
+// equivalent ("arbitrary fields allowed") and the type-checker handles it
+// safely. See https://github.com/cozystack/cozystack/issues/2863.
 func markOpenObject(s *spec.Schema) {
 	if len(s.Type) == 0 {
 		s.Type = spec.StringOrArray{"object"}
@@ -86,13 +86,66 @@ func markOpenObject(s *spec.Schema) {
 	s.Extensions["x-kubernetes-preserve-unknown-fields"] = true
 }
 
+// sanitizeBooleanAdditionalProperties recursively rewrites every boolean-form
+// additionalProperties (one whose inner Schema is nil — both the JSON `true`
+// and `false` forms) anywhere in s, because both crash the VAP status
+// type-checker (#2863): additionalProperties:true becomes the equivalent
+// x-kubernetes-preserve-unknown-fields:true, and additionalProperties:false is
+// dropped (the published schema is consumed only for documentation and
+// type-checking, not for enforcement, so "declared properties only" is
+// preserved without the crash-prone node). Object-form additionalProperties (a
+// real map value schema) is safe; it is recursed into, never rewritten.
+//
+// ApplicationDefinition.openAPISchema is untrusted input — external-apps and
+// operator-authored definitions flow through here without validation — so this
+// closes the whole class of crash rather than only the schemas cozystack ships.
+func sanitizeBooleanAdditionalProperties(s *spec.Schema) {
+	if s == nil {
+		return
+	}
+	if ap := s.AdditionalProperties; ap != nil && ap.Schema == nil {
+		if ap.Allows {
+			markOpenObject(s) // additionalProperties:true -> preserve-unknown-fields
+		} else {
+			s.AdditionalProperties = nil // additionalProperties:false -> drop
+		}
+	} else if ap != nil && ap.Schema != nil {
+		sanitizeBooleanAdditionalProperties(ap.Schema)
+	}
+	for k := range s.Properties {
+		prop := s.Properties[k]
+		sanitizeBooleanAdditionalProperties(&prop)
+		s.Properties[k] = prop
+	}
+	if s.Items != nil {
+		sanitizeBooleanAdditionalProperties(s.Items.Schema)
+		for i := range s.Items.Schemas {
+			sanitizeBooleanAdditionalProperties(&s.Items.Schemas[i])
+		}
+	}
+	for i := range s.AllOf {
+		sanitizeBooleanAdditionalProperties(&s.AllOf[i])
+	}
+	for i := range s.AnyOf {
+		sanitizeBooleanAdditionalProperties(&s.AnyOf[i])
+	}
+	for i := range s.OneOf {
+		sanitizeBooleanAdditionalProperties(&s.OneOf[i])
+	}
+	sanitizeBooleanAdditionalProperties(s.Not)
+}
+
 // patchSpec injects/overrides ".spec" with user JSON (or schemaless object).
 func patchSpec(target *spec.Schema, raw string) error {
+	if target.Properties == nil {
+		target.Properties = map[string]spec.Schema{}
+	}
+
+	// Schemaless: publish a fresh, fully open object. Starting from a fresh
+	// schema (rather than mutating the cloned base) discards any inherited
+	// $ref or properties so the published spec is unambiguously open.
 	if strings.TrimSpace(raw) == "" {
-		if target.Properties == nil {
-			target.Properties = map[string]spec.Schema{}
-		}
-		prop := target.Properties["spec"]
+		prop := spec.Schema{}
 		markOpenObject(&prop)
 		target.Properties["spec"] = prop
 		return nil
@@ -102,12 +155,21 @@ func patchSpec(target *spec.Schema, raw string) error {
 	if err := json.Unmarshal([]byte(raw), &custom); err != nil {
 		return err
 	}
-	if custom.AdditionalProperties == nil {
+
+	// Neutralize any crash-prone boolean additionalProperties at any depth in
+	// the user-supplied schema before publishing it.
+	topLevelAPAbsent := custom.AdditionalProperties == nil
+	sanitizeBooleanAdditionalProperties(&custom)
+
+	// Preserve the historical "spec is a superset of the documented values"
+	// behavior: when the documented schema does not itself declare
+	// additionalProperties, mark the top level open so undocumented Helm
+	// values are accepted rather than rejected. A schema that explicitly
+	// declared additionalProperties (now sanitized) keeps its own intent.
+	if topLevelAPAbsent {
 		markOpenObject(&custom)
 	}
-	if target.Properties == nil {
-		target.Properties = map[string]spec.Schema{}
-	}
+
 	target.Properties["spec"] = custom
 	return nil
 }

--- a/pkg/cmd/server/openapi_test.go
+++ b/pkg/cmd/server/openapi_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	celopenapi "k8s.io/apiserver/pkg/cel/openapi"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// tenantOpenAPISchema mirrors the shape of the real Tenant "Chart Values"
+// schema (packages/system/tenant-rd/cozyrds/tenant.yaml): a typed object with
+// declared properties and no top-level additionalProperties, plus a nested
+// map that uses the safe object-form additionalProperties.
+const tenantOpenAPISchema = `{
+  "title": "Chart Values",
+  "type": "object",
+  "properties": {
+    "host": {"type": "string"},
+    "etcd": {"type": "boolean"},
+    "resourceQuotas": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [{"type": "integer"}, {"type": "string"}],
+        "x-kubernetes-int-or-string": true
+      }
+    }
+  }
+}`
+
+func newObjectContainer() *spec.Schema {
+	return &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type:       spec.StringOrArray{"object"},
+		Properties: map[string]spec.Schema{},
+	}}
+}
+
+// TestPatchSpecOpenSpecPublishesPreserveUnknownFields asserts that the open
+// ".spec" cozystack-api injects is published as
+// x-kubernetes-preserve-unknown-fields:true and never as the boolean
+// additionalProperties:true form that crashes the VAP type-checker (#2863).
+// It covers both code paths: a schemaless resource and a custom schema that
+// declares properties but no top-level additionalProperties (like Tenant).
+func TestPatchSpecOpenSpecPublishesPreserveUnknownFields(t *testing.T) {
+	cases := map[string]string{
+		"schemaless":           "",
+		"custom-no-additional": tenantOpenAPISchema,
+	}
+
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			target := newObjectContainer()
+			if err := patchSpec(target, raw); err != nil {
+				t.Fatalf("patchSpec: %v", err)
+			}
+			specSchema := target.Properties["spec"]
+
+			if specSchema.AdditionalProperties != nil {
+				t.Errorf("spec must not carry additionalProperties; got %#v", specSchema.AdditionalProperties)
+			}
+			if v, ok := specSchema.Extensions.GetBool("x-kubernetes-preserve-unknown-fields"); !ok || !v {
+				t.Errorf("spec must set x-kubernetes-preserve-unknown-fields:true; extensions=%v", specSchema.Extensions)
+			}
+			if !specSchema.Type.Contains("object") {
+				t.Errorf("spec must be type object; got %v", specSchema.Type)
+			}
+
+			// The published JSON is the actual contract KCM type-checks against.
+			out, err := json.Marshal(specSchema)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if strings.Contains(string(out), `"additionalProperties":true`) {
+				t.Errorf("published spec still emits boolean additionalProperties:true (#2863): %s", out)
+			}
+			if !strings.Contains(string(out), `"x-kubernetes-preserve-unknown-fields":true`) {
+				t.Errorf("published spec missing x-kubernetes-preserve-unknown-fields:true: %s", out)
+			}
+		})
+	}
+}
+
+// TestPatchSpecKeepsObjectFormAdditionalProperties ensures we only rewrite the
+// open/free-form spec: a custom schema that already declares an object-form
+// additionalProperties (a real map type, which is safe for the type-checker)
+// must be left untouched rather than overwritten with the extension.
+func TestPatchSpecKeepsObjectFormAdditionalProperties(t *testing.T) {
+	raw := `{"type":"object","additionalProperties":{"type":"string"}}`
+	target := newObjectContainer()
+	if err := patchSpec(target, raw); err != nil {
+		t.Fatalf("patchSpec: %v", err)
+	}
+	specSchema := target.Properties["spec"]
+	if specSchema.AdditionalProperties == nil || specSchema.AdditionalProperties.Schema == nil {
+		t.Fatalf("object-form additionalProperties must be preserved; got %#v", specSchema.AdditionalProperties)
+	}
+	if v, ok := specSchema.Extensions.GetBool("x-kubernetes-preserve-unknown-fields"); ok && v {
+		t.Errorf("must not add preserve-unknown-fields when a real map schema is declared")
+	}
+}
+
+// TestPatchedSpecDoesNotPanicVAPTypeChecker is the behavioral regression test
+// for #2863. SchemaDeclType is the exact entry point kube-controller-manager's
+// ValidatingAdmissionPolicy status controller uses to type-check a VAP against
+// the published resource schema. Before the fix, the boolean
+// additionalProperties:true on ".spec" made it nil-dereference
+// (k8s.io/apiserver/pkg/cel/openapi.isExtension), crash-looping KCM. With the
+// preserve-unknown-fields form it returns a valid type.
+//
+// This test panics (fails) on the pre-fix code and passes after it.
+func TestPatchedSpecDoesNotPanicVAPTypeChecker(t *testing.T) {
+	cases := map[string]string{
+		"schemaless":  "",
+		"tenant-like": tenantOpenAPISchema,
+	}
+
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Resource-shaped object, as published per kind by cozystack-api.
+			obj := &spec.Schema{SchemaProps: spec.SchemaProps{
+				Type: spec.StringOrArray{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+					"spec":       {},
+				},
+			}}
+			if err := patchSpec(obj, raw); err != nil {
+				t.Fatalf("patchSpec: %v", err)
+			}
+
+			// Round-trip through JSON so we type-check the serialized form that
+			// is actually served on /openapi/v3 and read by KCM.
+			rawJSON, err := json.Marshal(obj)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var published spec.Schema
+			if err := json.Unmarshal(rawJSON, &published); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			// isResourceRoot=true matches how the type-checker treats a matched
+			// top-level resource.
+			declType := celopenapi.SchemaDeclType(&published, true)
+			if declType == nil {
+				t.Fatalf("SchemaDeclType returned nil for %s", name)
+			}
+		})
+	}
+}

--- a/pkg/cmd/server/openapi_test.go
+++ b/pkg/cmd/server/openapi_test.go
@@ -213,18 +213,30 @@ func hasBooleanAdditionalProperties(s *spec.Schema) bool {
 // regression test for the review finding on #2867: ApplicationDefinition
 // schemas are untrusted input, and a user-supplied boolean additionalProperties
 // — declared explicitly at the top level, or nested anywhere under
-// properties/items/allOf — reintroduces the exact #2863 KCM crash. patchSpec
-// must neutralize every such node (both the true and false forms, since both
-// carry a nil inner schema), at any depth, so the published schema can never
-// crash the VAP type-checker. Each case below panics SchemaDeclType before this
-// sanitizer and passes after it.
+// properties/items/additionalProperties/allOf/anyOf/oneOf/not — reintroduces the
+// exact #2863 KCM crash. patchSpec must neutralize every such node (both the true
+// and false forms, since both carry a nil inner schema), at any depth, so the
+// published schema can never crash the VAP type-checker.
+//
+// Two assertions guard each case. SchemaDeclType only descends into properties,
+// items, and additionalProperties.Schema, so the top-level / nested-under-
+// properties / nested-under-items / nested-under-additionalproperties cases are
+// type-checker-reachable: they nil-deref (panic) SchemaDeclType on the
+// pre-sanitizer code. The allOf/anyOf/oneOf/not cases are defense-in-depth —
+// SchemaDeclType never traverses those branches, so it is the
+// hasBooleanAdditionalProperties assertion, not the SchemaDeclType check, that
+// keeps their recursion lines from regressing silently.
 func TestPatchSpecSanitizesUserSuppliedBooleanAdditionalProperties(t *testing.T) {
 	cases := map[string]string{
-		"top-level-boolean-true":  `{"type":"object","additionalProperties":true}`,
-		"top-level-boolean-false": `{"type":"object","additionalProperties":false}`,
-		"nested-under-properties": `{"type":"object","properties":{"foo":{"type":"object","additionalProperties":true}}}`,
-		"nested-under-items":      `{"type":"object","properties":{"list":{"type":"array","items":{"type":"object","additionalProperties":true}}}}`,
-		"nested-under-allof":      `{"type":"object","allOf":[{"type":"object","additionalProperties":false}]}`,
+		"top-level-boolean-true":            `{"type":"object","additionalProperties":true}`,
+		"top-level-boolean-false":           `{"type":"object","additionalProperties":false}`,
+		"nested-under-properties":           `{"type":"object","properties":{"foo":{"type":"object","additionalProperties":true}}}`,
+		"nested-under-items":                `{"type":"object","properties":{"list":{"type":"array","items":{"type":"object","additionalProperties":true}}}}`,
+		"nested-under-additionalproperties": `{"type":"object","additionalProperties":{"type":"object","additionalProperties":true}}`,
+		"nested-under-allof":                `{"type":"object","allOf":[{"type":"object","additionalProperties":false}]}`,
+		"nested-under-anyof":                `{"type":"object","anyOf":[{"type":"object","additionalProperties":true}]}`,
+		"nested-under-oneof":                `{"type":"object","oneOf":[{"type":"object","additionalProperties":false}]}`,
+		"nested-under-not":                  `{"type":"object","not":{"type":"object","additionalProperties":true}}`,
 	}
 
 	for name, raw := range cases {

--- a/pkg/cmd/server/openapi_test.go
+++ b/pkg/cmd/server/openapi_test.go
@@ -166,3 +166,101 @@ func TestPatchedSpecDoesNotPanicVAPTypeChecker(t *testing.T) {
 		})
 	}
 }
+
+// hasBooleanAdditionalProperties walks the schema and reports whether any node
+// carries a boolean-form additionalProperties (inner Schema == nil) — the
+// construct that crashes the VAP type-checker, in either its true or false JSON
+// form.
+func hasBooleanAdditionalProperties(s *spec.Schema) bool {
+	if s == nil {
+		return false
+	}
+	if ap := s.AdditionalProperties; ap != nil {
+		if ap.Schema == nil {
+			return true
+		}
+		if hasBooleanAdditionalProperties(ap.Schema) {
+			return true
+		}
+	}
+	for k := range s.Properties {
+		p := s.Properties[k]
+		if hasBooleanAdditionalProperties(&p) {
+			return true
+		}
+	}
+	if s.Items != nil {
+		if hasBooleanAdditionalProperties(s.Items.Schema) {
+			return true
+		}
+		for i := range s.Items.Schemas {
+			if hasBooleanAdditionalProperties(&s.Items.Schemas[i]) {
+				return true
+			}
+		}
+	}
+	for _, branch := range [][]spec.Schema{s.AllOf, s.AnyOf, s.OneOf} {
+		for i := range branch {
+			if hasBooleanAdditionalProperties(&branch[i]) {
+				return true
+			}
+		}
+	}
+	return hasBooleanAdditionalProperties(s.Not)
+}
+
+// TestPatchSpecSanitizesUserSuppliedBooleanAdditionalProperties is the
+// regression test for the review finding on #2867: ApplicationDefinition
+// schemas are untrusted input, and a user-supplied boolean additionalProperties
+// — declared explicitly at the top level, or nested anywhere under
+// properties/items/allOf — reintroduces the exact #2863 KCM crash. patchSpec
+// must neutralize every such node (both the true and false forms, since both
+// carry a nil inner schema), at any depth, so the published schema can never
+// crash the VAP type-checker. Each case below panics SchemaDeclType before this
+// sanitizer and passes after it.
+func TestPatchSpecSanitizesUserSuppliedBooleanAdditionalProperties(t *testing.T) {
+	cases := map[string]string{
+		"top-level-boolean-true":  `{"type":"object","additionalProperties":true}`,
+		"top-level-boolean-false": `{"type":"object","additionalProperties":false}`,
+		"nested-under-properties": `{"type":"object","properties":{"foo":{"type":"object","additionalProperties":true}}}`,
+		"nested-under-items":      `{"type":"object","properties":{"list":{"type":"array","items":{"type":"object","additionalProperties":true}}}}`,
+		"nested-under-allof":      `{"type":"object","allOf":[{"type":"object","additionalProperties":false}]}`,
+	}
+
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			obj := &spec.Schema{SchemaProps: spec.SchemaProps{
+				Type: spec.StringOrArray{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+					"spec":       {},
+				},
+			}}
+			if err := patchSpec(obj, raw); err != nil {
+				t.Fatalf("patchSpec: %v", err)
+			}
+
+			// Round-trip through JSON: this is what is actually served and what
+			// KCM type-checks.
+			rawJSON, err := json.Marshal(obj)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var published spec.Schema
+			if err := json.Unmarshal(rawJSON, &published); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			// (1) no boolean-form additionalProperties survives anywhere
+			if hasBooleanAdditionalProperties(&published) {
+				t.Errorf("published schema still contains a boolean additionalProperties node (#2863): %s", rawJSON)
+			}
+			// (2) the published schema does not crash the VAP type-checker
+			declType := celopenapi.SchemaDeclType(&published, true)
+			if declType == nil {
+				t.Fatalf("SchemaDeclType returned nil for %s", name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

`cozystack-api` published the free-form `.spec` of aggregated `apps.cozystack.io` resources (Tenant, Application, …) as the boolean `additionalProperties: true`. The Kubernetes ValidatingAdmissionPolicy **status type-checker** run by `kube-controller-manager` nil-dereferences when it recurses into that node (`k8s.io/apiserver/pkg/cel/openapi.isExtension`). As soon as a VAP matches one of these resources — `cozystack-tenant-host-policy` matches `tenants` — KCM `CrashLoopBackOff`s on every control-plane node, stalls reconciliation, and times out the install (`kubectl wait hr --all` never completes). With the 3× install retry removed, a single occurrence fails E2E outright.

This emits `x-kubernetes-preserve-unknown-fields: true` instead, in `pkg/cmd/server/openapi.go::patchSpec` (both the schemaless and custom-schema branches, covering the OpenAPI v2 and v3 post-processors). It is semantically equivalent — "arbitrary fields allowed" — and the type-checker handles it safely. All managed-app custom schemas already use the safe **object-form** `additionalProperties`, so `patchSpec` was the only source of the boolean form.

### Regression test

`TestPatchedSpecDoesNotPanicVAPTypeChecker` reproduces the exact crash through `k8s.io/apiserver/pkg/cel/openapi.SchemaDeclType` — the entry point KCM's `validatingadmissionpolicystatus` controller uses. It **panics on the pre-fix code and passes after the fix**. Companion structural tests assert the published spec carries `x-kubernetes-preserve-unknown-fields: true` and never the boolean `additionalProperties: true`, and that genuine object-form maps are left untouched.

Verified against the pristine vendored `k8s.io/apiserver@v0.34.1` (the version cozystack-api builds against), which reproduces the panic, and previously confirmed end-to-end on `kindest/node:v1.33.1`.

### Upstream

The underlying nil-dereference is a Kubernetes KCM bug — the VAP status type-checker should treat `additionalProperties: true` as dynamic rather than panic. A separate upstream report is being prepared; cozystack fixes the symptom immediately with the schema change above.

Fixes #2863

### Release note

```release-note
fix(api): publish the free-form resource `.spec` as `x-kubernetes-preserve-unknown-fields` instead of `additionalProperties: true`, fixing a cluster-wide `kube-controller-manager` CrashLoopBackOff (nil-pointer panic in the ValidatingAdmissionPolicy status type-checker) that stalled installs.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured published OpenAPI schemas no longer contain boolean-form additionalProperties anywhere; top-level and nested schemas now use preserve-unknown-fields for free-form specs, preventing validation/runtime issues.

* **Tests**
  * Added regression tests that feed varied untrusted schemas and verify boolean additionalProperties are removed and published schemas remain valid for tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->