### PR TITLE
test(e2e): pin Kubernetes to v1.33.12 to avoid KCM VAP type-checker panic

### DIFF
--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -231,7 +231,14 @@ EOF
   fi
 
   rm -f controlplane.yaml worker.yaml talosconfig kubeconfig
+  # Pin Kubernetes to v1.33.12 instead of talosctl's bundled default (v1.33.1).
+  # v1.33.1 predates the fix for the kube-controller-manager VAP status
+  # type-checker nil-pointer panic on `additionalProperties: true` schemas
+  # (kubernetes/kubernetes#135155, backported to release-1.33 in #136958,
+  # first released in v1.33.10). On the older default, cozystack-api's
+  # aggregated Tenant schema crash-loops KCM during install. See cozystack#2863.
   talosctl gen config --with-secrets secrets.yaml cozystack https://192.168.123.10:6443 \
+           --kubernetes-version v1.33.12 \
            --config-patch=@patch.yaml --config-patch-control-plane @patch-controlplane.yaml
 }
 


### PR DESCRIPTION
## What this PR does

The e2e cluster bootstrap (`hack/e2e-prepare-cluster.bats`) let `talosctl gen config`
pick its bundled default Kubernetes version — **v1.33.1** for Talos v1.13.0.

v1.33.1 predates the fix for the kube-controller-manager `ValidatingAdmissionPolicy`
status type-checker nil-pointer panic on `additionalProperties: true` schemas
([kubernetes/kubernetes#135155](https://github.com/kubernetes/kubernetes/pull/135155),
backported to `release-1.33` in
[#136958](https://github.com/kubernetes/kubernetes/pull/136958), first released in
**v1.33.10**). Because `cozystack-api` publishes `additionalProperties: true` on the
aggregated Tenant schema, KCM crash-loops cluster-wide during install on the old
default and fails E2E (#2863).

This pins the e2e **management** cluster to **v1.33.12** (latest 1.33 patch), which
contains the fix. It complements — and is independent of — the schema-side fix in
#2867; either alone avoids the panic.

Refs: #2863

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end test cluster configuration to explicitly pin the Kubernetes version for more consistent test execution.
  * Added explanatory comments clarifying the version choice and kept existing secret/configuration wiring intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->