### PR TITLE
fix(cilium): pass IPv6 to kernel stack when IPv6 datapath is disabled

### DIFF
--- a/packages/system/cilium/Makefile
+++ b/packages/system/cilium/Makefile
@@ -23,6 +23,18 @@ update:
 		{ echo 'ERROR: perl patch did not remove the upstream AppArmor block from cilium-agent/daemonset.yaml (upstream template format may have changed)' >&2; exit 1; }
 	version=$$(awk '$$1 == "version:" {print $$2}' charts/cilium/Chart.yaml) && \
 	$(SED_INPLACE) "s/ARG VERSION=.*/ARG VERSION=v$${version}/" images/cilium/Dockerfile
+	# Verify the IPv6-passthrough BPF patch still applies to the new upstream tag,
+	# so the bump author learns about drift immediately instead of at image build.
+	version=$$(awk '$$1 == "version:" {print $$2}' charts/cilium/Chart.yaml) && \
+	tmpdir=$$(mktemp -d) && \
+	{ curl --fail --silent --show-error --location \
+		"https://raw.githubusercontent.com/cilium/cilium/v$${version}/bpf/bpf_host.c" \
+		-o "$$tmpdir/bpf_host.c" || { rm -rf "$$tmpdir"; exit 1; }; } && \
+	{ patch --dry-run --batch --forward --fuzz=0 -p1 -d "$$tmpdir" \
+		< images/cilium/patches/pass-ipv6-to-stack-when-ipv6-datapath-disabled.diff || \
+		{ echo "ERROR: images/cilium/patches/pass-ipv6-to-stack-when-ipv6-datapath-disabled.diff no longer applies to upstream bpf/bpf_host.c v$${version}; regenerate it for the new cilium version" >&2; \
+		rm -rf "$$tmpdir"; exit 1; }; } && \
+	rm -rf "$$tmpdir"
 
 image:
 	docker buildx build images/cilium \

--- a/packages/system/cilium/images/cilium/Dockerfile
+++ b/packages/system/cilium/images/cilium/Dockerfile
@@ -1,2 +1,25 @@
 ARG VERSION=v1.19.3
-FROM quay.io/cilium/cilium:${VERSION}
+
+FROM quay.io/cilium/cilium:${VERSION} AS upstream
+
+# The upstream runtime image ships no `patch`; apply the BPF patch in a
+# throwaway alpine stage and copy the result back over the upstream image.
+# The agent compiles BPF at startup from /var/lib/cilium/bpf, so replacing
+# the source file is sufficient.
+FROM docker.io/library/alpine:3.22 AS patcher
+RUN apk add --no-cache patch
+WORKDIR /work
+COPY --from=upstream /var/lib/cilium/bpf/bpf_host.c ./bpf_host.c
+COPY patches/pass-ipv6-to-stack-when-ipv6-datapath-disabled.diff /patches/
+# --fuzz=0: any upstream drift in the patched context must fail the build, loudly.
+RUN patch --batch --forward --fuzz=0 -p1 < /patches/pass-ipv6-to-stack-when-ipv6-datapath-disabled.diff || { \
+      echo 'ERROR: the IPv6 passthrough patch no longer applies to bpf/bpf_host.c.' >&2; \
+      echo 'Upstream cilium changed the host-firewall protocol switches (version bump?).' >&2; \
+      echo 'Regenerate packages/system/cilium/images/cilium/patches/*.diff against the new tag.' >&2; \
+      exit 1; }
+RUN test "$(grep -c 'cozystack-ipv6-passthrough' bpf_host.c)" = 3 || { \
+      echo 'ERROR: expected exactly 3 cozystack-ipv6-passthrough markers in bpf_host.c' >&2; \
+      exit 1; }
+
+FROM upstream
+COPY --from=patcher /work/bpf_host.c /var/lib/cilium/bpf/bpf_host.c

--- a/packages/system/cilium/images/cilium/patches/pass-ipv6-to-stack-when-ipv6-datapath-disabled.diff
+++ b/packages/system/cilium/images/cilium/patches/pass-ipv6-to-stack-when-ipv6-datapath-disabled.diff
@@ -1,0 +1,70 @@
+Pass IPv6 to the kernel stack when the IPv6 datapath is disabled.
+
+Generated against cilium v1.19.3 bpf/bpf_host.c. With ENABLE_HOST_FIREWALL
+defined but ENABLE_IPV6 not compiled in, the protocol-switch default case
+drops all IPv6 as DROP_UNKNOWN_L3 ("Unsupported L3 protocol") before any
+policy evaluation, in both directions. That breaks ICMPv6 Neighbor Discovery
+and BGP unnumbered over link-local addresses on IPv6/L3 fabrics, and no
+CiliumClusterwideNetworkPolicy can allow the traffic back. Upstream report:
+https://github.com/cilium/cilium/issues/33155 (closed stale, not fixed).
+
+Three of the four DROP_UNKNOWN_L3 sites are covered: do_netdev (ingress and
+from-host), cil_to_netdev (egress), and host_ingress_policy (cil_to_host).
+The fourth site, from_host_to_lxc (host to local pod), is intentionally not
+covered: with the IPv6 datapath disabled bpf_lxc drops IPv6 regardless of the
+host firewall, so a passthrough there would restore nothing.
+
+Regenerate for a new cilium version by re-applying the same three cases and
+running `make update`, which dry-runs this patch against the new tag.
+
+--- a/bpf_host.c
++++ b/bpf_host.c
+@@ -1132,6 +1132,18 @@
+ 		return send_drop_notify_error_with_exitcode_ext(ctx, identity, ret, ext_err,
+ 								CTX_ACT_OK, METRIC_INGRESS);
+ #endif /* ENABLE_IPV4 */
++#ifndef ENABLE_IPV6
++	/* cozystack-ipv6-passthrough: the IPv6 datapath is not compiled in, but
++	 * the node may still rely on IPv6 (ICMPv6 ND, BGP unnumbered over
++	 * link-local). Mirror the !ENABLE_HOST_FIREWALL behaviour and pass IPv6
++	 * to the kernel stack instead of dropping it as unknown L3.
++	 */
++	case bpf_htons(ETH_P_IPV6):
++		send_trace_notify(ctx, obs_point, identity, UNKNOWN_ID, TRACE_EP_ID_UNKNOWN,
++				  ctx->ingress_ifindex, trace.reason, trace.monitor, proto);
++		ret = CTX_ACT_OK;
++		break;
++#endif /* !ENABLE_IPV6 */
+ 	case bpf_htons(ETH_P_ARP):
+ 		if (is_defined(ENABLE_ARP_PASSTHROUGH) ||
+ 		    is_defined(ENABLE_ARP_RESPONDER) ||
+@@ -1411,6 +1423,14 @@
+ 					    &trace, &ext_err);
+ 		break;
+ # endif
++# ifndef ENABLE_IPV6
++	/* cozystack-ipv6-passthrough: IPv6 datapath disabled; let the kernel
++	 * stack handle host IPv6 instead of dropping it as unknown L3.
++	 */
++	case bpf_htons(ETH_P_IPV6):
++		ret = CTX_ACT_OK;
++		break;
++# endif /* !ENABLE_IPV6 */
+ # ifdef ENABLE_IPV4
+ 	case bpf_htons(ETH_P_IP): {
+ 		ret = handle_to_netdev_ipv4(ctx, src_sec_identity,
+@@ -1634,6 +1654,14 @@
+ 
+ 		break;
+ # endif
++# ifndef ENABLE_IPV6
++	/* cozystack-ipv6-passthrough: IPv6 datapath disabled; pass IPv6
++	 * destined to the host to the kernel stack instead of dropping it.
++	 */
++	case bpf_htons(ETH_P_IPV6):
++		ret = CTX_ACT_OK;
++		break;
++# endif /* !ENABLE_IPV6 */
+ # ifdef ENABLE_IPV4
+ 	case bpf_htons(ETH_P_IP):
+ 		if (use_tailcall) {

--- a/packages/system/cilium/values.yaml
+++ b/packages/system/cilium/values.yaml
@@ -1,5 +1,13 @@
 cilium:
   kubeProxyReplacement: true
+  # Upstream cilium with hostFirewall enabled and the IPv6 datapath disabled
+  # (ipv6.enabled=false, the default here) drops ALL node IPv6 before any
+  # policy evaluation ("Unsupported L3 protocol", DROP_UNKNOWN_L3 in
+  # bpf/bpf_host.c), breaking ICMPv6 Neighbor Discovery and BGP unnumbered on
+  # IPv6/L3 fabrics. The cozystack cilium image carries a BPF patch
+  # (images/cilium/patches/) that passes IPv6 to the kernel stack instead.
+  # Consequence: Cilium host policies apply to IPv4 only; node IPv6 is not
+  # filtered by Cilium.
   hostFirewall:
     enabled: true
   hubble:


### PR DESCRIPTION
## What this PR does

Cozystack enables Cilium's host firewall by default while the Cilium IPv6 datapath stays disabled (`ipv6.enabled=false`). In upstream Cilium this combination drops all node IPv6 on managed devices as "Unsupported L3 protocol" (`DROP_UNKNOWN_L3` in `bpf_host.c`) before any policy evaluation, in both directions. This breaks ICMPv6 Neighbor Discovery — and with it all node-level IPv6, e.g. BGP unnumbered over link-local addresses on L3 fabrics. No `CiliumClusterwideNetworkPolicy` can allow this traffic, because the drop happens before policy enforcement (upstream report: cilium/cilium#33155, closed stale).

The cozystack cilium image now carries a minimal BPF patch that passes IPv6 to the kernel stack instead, mirroring the behavior with the host firewall disabled:

- `packages/system/cilium/images/cilium/patches/` — three `ETH_P_IPV6` passthrough cases under `#ifndef ENABLE_IPV6` in `bpf_host.c`. The fourth `DROP_UNKNOWN_L3` site (`from_host_to_lxc`) is intentionally not covered: bpf_lxc drops IPv6 without the v6 datapath regardless, so a passthrough there restores nothing.
- The multi-stage Dockerfile applies the patch with `patch --fuzz=0` plus a marker-count check, so upstream drift fails the image build loudly.
- `make update` dry-runs the patch against the freshly vendored upstream tag, so a cilium version bump surfaces drift immediately.
- `values.yaml` documents the consequence: Cilium host policies apply to IPv4 only; node IPv6 is not filtered by Cilium.

The same fix was submitted upstream: cilium/cilium#46473. The local patch is carried until it lands in a release Cozystack ships.

Verification: the image builds and contains the patched source; a corrupted patch context fails the build with a clear error; the upstream variant of this change passes new BPF unit tests that fail without the fix with exactly the "Unsupported L3 protocol" drop from the field report; existing host-firewall and IPv6 BPF tests still compile. PR e2e exercises runtime BPF compilation of the patched source, since the agent compiles `bpf_host.c` at startup.

Docs: cozystack/website#574

Closes #2806

### Screenshots

Not a UI change.

### Release note

```release-note
fix(cilium): node IPv6 (ICMPv6 Neighbor Discovery, BGP unnumbered over link-local) now works with the host firewall enabled; Cilium host policies apply to IPv4 only, node IPv6 is not filtered by Cilium
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pass IPv6 traffic to the kernel stack when the Cilium IPv6 datapath is disabled, preventing it from being treated as an unknown L3 protocol.
* **Documentation**
  * Added clarification on host firewall behavior: with hostFirewall enabled and IPv6 datapath disabled, policies apply to IPv4 only.
* **Chores**
  * Improved the Cilium image build/update flow by validating the IPv6 patch against the upstream Cilium version to ensure compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->