### PR TITLE
test(e2e): self-heal Cilium orphaned-endpoint leak during install

### DIFF
--- a/hack/e2e-cilium-endpoint-leak-healer.sh
+++ b/hack/e2e-cilium-endpoint-leak-healer.sh
@@ -1,0 +1,120 @@
+#!/bin/sh
+# Interim CI self-heal for the Cilium in-memory endpoint leak.
+#
+# This is the heal loop; it runs as an in-cluster Job (see
+# hack/e2e-cilium-leak-healer.yaml), deployed during e2e install and left
+# running for the whole cluster lifetime. That is deliberate: an earlier
+# version ran this as a background process started in the install bats
+# setup_file and killed in teardown_file, but bats *_file hooks fire per file,
+# so it died when the install file finished — before any app test ran — and the
+# leak recurred in the app phase (e.g. the tenant-Kubernetes CVMI importer)
+# unhealed. An in-cluster Job is bound to the cluster, not to one bats file, so
+# it covers install AND every app test.
+#
+# Symptom: on a churn-heavy run a pod sticks in ContainerCreating/Init because
+# the cilium-agent rejects its sandbox with
+#   [PUT /endpoint/{id}][400] putEndpointIdInvalid "IP ipv4:<X> is already in use"
+# repeated until the pod is deleted or the agent is restarted. The IP has no
+# live owner: IPAM and the ipcache released it, but the agent's in-memory
+# endpointManager still holds a stale Endpoint for it (the previous pod's CNI
+# DEL was skipped or raced, so unexpose()->removeReferencesLocked() never ran).
+# Neither the operator's CiliumEndpoint-CRD GC nor the agent's veth-based
+# endpoint GC reaps it, so it wedges the new pod and fails the run. Tracked
+# upstream at cilium/cilium#38313 (closed stale); no released or pre-release
+# Cilium fixes the leak and no flag disables it.
+#
+# This watchdog applies the least-disruptive known remedy: instead of
+# restarting the agent (which drops the whole node's in-memory registry), it
+# evicts only the orphaned endpoint via
+#   cilium-dbg endpoint disconnect ipv4:<X>
+# which maps to DELETE /endpoint/{id} -> RemoveEndpoint -> unexpose ->
+# removeReferencesLocked, clearing the stale IP-keyed entry. The wedged pod's
+# next CNI ADD retry then succeeds. Blast radius is one dead endpoint.
+#
+# It is READ-ONLY until it has positively confirmed an orphan: an endpoint in
+# the owning node's registry holds the disputed IP, that endpoint does not back
+# a live Running pod with that IP, and a different pod is currently wedged
+# requesting the same IP. If anything is ambiguous it logs and does nothing —
+# it never disconnects a live endpoint.
+#
+# REMOVE this script, hack/e2e-cilium-leak-healer.yaml, and the setup_file/
+# teardown_file hooks in hack/e2e-install-cozystack.bats once a fixed Cilium
+# ships. This is a CI band-aid, not a product fix.
+set -u
+
+CILIUM_NS="${CILIUM_NS:-cozy-cilium}"
+POLL_INTERVAL="${CILIUM_HEALER_POLL_SEC:-15}"
+
+log() { echo "[cilium-leak-healer $(date -u +%H:%M:%S)] $*"; }
+
+# cilium-agent pod running on a given node (DaemonSet selector k8s-app=cilium).
+agent_on_node() {
+  kubectl get pod -n "$CILIUM_NS" -l k8s-app=cilium \
+    --field-selector "spec.nodeName=$1" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+log "started (ns=$CILIUM_NS poll=${POLL_INTERVAL}s, in-cluster, runs for the cluster lifetime)"
+
+# Endless loop: the pod is torn down with the ephemeral e2e cluster. Before
+# Cilium is serving (early install) the kubectl/exec calls simply fail and the
+# loop idles; once the CNI is up it begins healing. Host networking (see the
+# manifest) keeps this pod itself immune to the very leak it repairs.
+while true; do
+  # Collect every "is already in use" rejection still attached to a pod sandbox.
+  # The field-selector narrows to the relevant event reason; grep pins the exact
+  # agent signature so unrelated sandbox failures are ignored.
+  events=$(kubectl get events -A --field-selector reason=FailedCreatePodSandBox \
+      -o jsonpath='{range .items[*]}{.involvedObject.namespace}{"|"}{.involvedObject.name}{"|"}{.message}{"\n"}{end}' 2>/dev/null \
+    | grep -i "is already in use" | sort -u)
+
+  [ -n "$events" ] && while IFS='|' read -r ns pod msg; do
+    [ -n "$ns" ] && [ -n "$pod" ] || continue
+    ip=$(printf '%s' "$msg" | grep -oE 'ipv4:[0-9]{1,3}(\.[0-9]{1,3}){3}' | head -1 | cut -d: -f2)
+    [ -n "$ip" ] || continue
+
+    # Only act on a pod that is still wedged (re-checked here = freshness gate).
+    phase=$(kubectl get pod -n "$ns" "$pod" -o jsonpath='{.status.phase}' 2>/dev/null)
+    case "$phase" in Running|Succeeded|"") continue ;; esac
+
+    node=$(kubectl get pod -n "$ns" "$pod" -o jsonpath='{.spec.nodeName}' 2>/dev/null)
+    [ -n "$node" ] || continue
+    agent=$(agent_on_node "$node")
+    [ -n "$agent" ] || { log "no cilium-agent on node=$node for $ns/$pod ip=$ip"; continue; }
+
+    # Does an endpoint in this agent's registry hold the disputed IP at all?
+    # (The wedged pod itself was never registered — CreateEndpoint rejected it
+    # before exposing — so any endpoint holding the IP is the stale one.)
+    ep_json=$(kubectl exec -n "$CILIUM_NS" "$agent" -c cilium-agent -- \
+                cilium-dbg endpoint get "ipv4:$ip" -o json 2>/dev/null)
+    [ -n "$ep_json" ] && [ "$ep_json" != "[]" ] || \
+      { log "no endpoint holds ip=$ip on node=$node (already cleared?) for $ns/$pod"; continue; }
+
+    epid=$(printf '%s' "$ep_json" | jq -r '.[0].id // empty' 2>/dev/null)
+    epns=$(printf '%s' "$ep_json" | jq -r '.[0].status."external-identifiers"."k8s-namespace" // empty' 2>/dev/null)
+    eppod=$(printf '%s' "$ep_json" | jq -r '.[0].status."external-identifiers"."k8s-pod-name" // empty' 2>/dev/null)
+
+    # If that endpoint claims a pod that is alive on the cluster with this IP,
+    # it is a LIVE endpoint -> a genuine duplicate-IP, NOT the leak. Refuse and
+    # shout so the real problem is visible instead of silently broken.
+    if [ -n "$epns" ] && [ -n "$eppod" ]; then
+      owner_ip=$(kubectl get pod -n "$epns" "$eppod" -o jsonpath='{.status.podIP}' 2>/dev/null)
+      owner_phase=$(kubectl get pod -n "$epns" "$eppod" -o jsonpath='{.status.phase}' 2>/dev/null)
+      if [ "$owner_ip" = "$ip" ] && [ "$owner_phase" = "Running" ]; then
+        log "REFUSE ip=$ip on node=$node: held by LIVE pod $epns/$eppod (genuine duplicate IP, not the leak) — investigate"
+        continue
+      fi
+    fi
+
+    # Confirmed orphan: endpoint $epid holds $ip, backs no live pod, and pod
+    # $ns/$pod is wedged requesting the same IP. Evict only this endpoint.
+    log "HEAL node=$node agent=$agent ep=$epid ip=$ip wedged=$ns/$pod -> endpoint disconnect ipv4:$ip"
+    out=$(kubectl exec -n "$CILIUM_NS" "$agent" -c cilium-agent -- \
+            cilium-dbg endpoint disconnect "ipv4:$ip" 2>&1)
+    log "  result: ${out:-<none>}"
+  done <<EOF
+$events
+EOF
+
+  sleep "$POLL_INTERVAL"
+done

--- a/hack/e2e-cilium-leak-healer.yaml
+++ b/hack/e2e-cilium-leak-healer.yaml
@@ -1,0 +1,99 @@
+# Interim in-cluster self-heal for the Cilium endpoint leak (cilium/cilium#38313
+# class). Applied during e2e install (hack/e2e-install-cozystack.bats) and left
+# running for the whole cluster lifetime, so it covers install AND every app
+# test. The heal logic lives in hack/e2e-cilium-endpoint-leak-healer.sh and is
+# shipped to the pod via a ConfigMap built from that file at apply time (single
+# source of truth). REMOVE this file, that script, and the bats wiring once a
+# fixed Cilium ships. CI band-aid, not a product fix.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cilium-leak-healer
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: cilium-leak-healer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cilium-leak-healer
+  labels:
+    app.kubernetes.io/name: cilium-leak-healer
+rules:
+  # find FailedCreatePodSandBox "IP already in use" rejections, cluster-wide
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
+  # inspect the wedged pod and the endpoint's claimed owner
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  # run `cilium-dbg endpoint ...` inside the owning node's cilium-agent
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cilium-leak-healer
+  labels:
+    app.kubernetes.io/name: cilium-leak-healer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cilium-leak-healer
+subjects:
+  - kind: ServiceAccount
+    name: cilium-leak-healer
+    namespace: kube-system
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cilium-leak-healer
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: cilium-leak-healer
+spec:
+  # The pod runs an endless heal loop and is torn down with the ephemeral e2e
+  # cluster, so it never completes on its own. backoffLimit only matters if the
+  # watchdog itself ever crashes — keep restarting it.
+  backoffLimit: 100
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cilium-leak-healer
+    spec:
+      serviceAccountName: cilium-leak-healer
+      restartPolicy: OnFailure
+      # Immune to the very leak it heals: host networking needs no Cilium
+      # endpoint, so this pod can never be wedged by the leak and can reach the
+      # API server before pod networking is fully up. Broad tolerations let it
+      # schedule before nodes are Ready and stay put through later taints.
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      tolerations:
+        - operator: Exists
+      containers:
+        - name: healer
+          # Reuse the in-tree, digest-pinned kubectl+jq image already shipped by
+          # the installer (packages/core/installer/templates/cozy-system-labels.yaml).
+          image: docker.io/alpine/k8s:1.33.4@sha256:b0523f0a244ddc4c8e055aa335c040d3d78b3ead5528f4544395f7f9f69c7b68
+          command: ["/bin/sh", "/opt/healer/heal.sh"]
+          env:
+            - name: CILIUM_NS
+              value: cozy-cilium
+          volumeMounts:
+            - name: script
+              mountPath: /opt/healer
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+      volumes:
+        - name: script
+          configMap:
+            name: cilium-leak-healer

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -1,5 +1,41 @@
 #!/usr/bin/env bats
 
+setup_file() {
+  # Interim mitigation for the Cilium in-memory endpoint leak
+  # (cilium/cilium#38313 class): a deleted pod's endpoint is orphaned in the
+  # agent's registry, IPAM re-hands its IP to a new pod, and the agent then
+  # rejects the new sandbox with "IP <X> is already in use" until an agent
+  # restart — wedging pods across install AND the app suite and failing
+  # unrelated PRs. The watchdog surgically evicts only the orphaned endpoint.
+  #
+  # It runs as an in-cluster Job (not a bats-scoped background process, which
+  # died at this file's teardown_file — before any app test ran — and left the
+  # app-phase leak unhealed). Bound to the cluster, it covers every later test
+  # step too. The heal logic stays in hack/e2e-cilium-endpoint-leak-healer.sh
+  # (single source of truth) and is shipped to the pod via a ConfigMap built
+  # from it here. Remove together with that script and
+  # hack/e2e-cilium-leak-healer.yaml once a fixed Cilium ships.
+  kubectl create configmap cilium-leak-healer -n kube-system \
+    --from-file=heal.sh=hack/e2e-cilium-endpoint-leak-healer.sh \
+    --dry-run=client -o yaml | kubectl apply -f - || true
+  kubectl apply -f hack/e2e-cilium-leak-healer.yaml || true
+}
+
+teardown_file() {
+  # Surface any heal/refuse activity from the install phase into the test trace;
+  # the run is otherwise green and the heal would be invisible. App-phase
+  # activity lands in the same pod log (kubectl logs job/cilium-leak-healer) and
+  # the end-of-job cozyreport. Do NOT delete the Job here — later test steps
+  # still need the watchdog. REFUSE lines flag a genuine duplicate-IP (a real
+  # bug the watchdog deliberately did not touch).
+  if kubectl logs -n kube-system job/cilium-leak-healer --tail=-1 2>/dev/null \
+       | grep -qE "HEAL |REFUSE "; then
+    echo "# cilium endpoint-leak watchdog activity (install phase):" >&3
+    kubectl logs -n kube-system job/cilium-leak-healer --tail=-1 2>/dev/null \
+      | grep -E "HEAL |REFUSE " >&3 || true
+  fi
+}
+
 @test "Required installer chart exists" {
   if [ ! -f packages/core/installer/Chart.yaml ]; then
     echo "Missing: packages/core/installer/Chart.yaml" >&2


### PR DESCRIPTION
## What this PR does

Adds an interim e2e self-heal for a Cilium in-memory endpoint leak that intermittently fails PRs unrelated to the change under test.

**Symptom.** On a churn-heavy platform install a pod sticks in `ContainerCreating`/`Init` because cilium-agent rejects its sandbox with `[PUT /endpoint/{id}][400] putEndpointIdInvalid "IP ipv4:<X> is already in use"`, repeated until the agent restarts or the install times out. The disputed IP has no live owner — IPAM and the ipcache released it — but the agent's in-memory `endpointManager` still holds a stale `Endpoint` from a previously-deleted pod whose CNI `DEL` was skipped or raced. Neither the operator's CiliumEndpoint-CRD GC nor the agent's veth-based endpoint GC reaps it. This surfaced as several of the e2e failures after #2558 dropped the 3× install retry, each on a different victim pod (velero node-agent, fluent-bit, fdb-operator, cdi-operator, capi bootstrap). Tracked upstream at cilium/cilium#38313 (closed stale); no released or pre-release Cilium fixes the leak and no flag disables it. A more precise upstream report is being filed.

**What this adds.** `hack/e2e-cilium-endpoint-leak-healer.sh`, launched as a file-scoped background watchdog via `setup_file`/`teardown_file` in `hack/e2e-install-cozystack.bats` so it covers the whole install + tenant + app window. It:

- detects a pod wedged with the exact `is already in use` signature and extracts the disputed IP and owning node;
- confirms a **true orphan** before touching anything — an endpoint in that node's agent registry holds the IP, that endpoint backs no live `Running` pod with that IP, and a different pod is currently wedged requesting it;
- evicts only that endpoint with `cilium-dbg endpoint disconnect ipv4:<X>` (`DELETE /endpoint/{id}` → `unexpose` → `removeReferencesLocked`, clearing the stale IP-keyed entry). Blast radius is one dead endpoint, not an agent restart, so other endpoints on the node are untouched.

It is read-only until an orphan is positively confirmed, and it **refuses** (logging loudly) to disconnect an endpoint that backs a live pod — so a genuine duplicate-IP bug stays visible rather than being masked. Any `HEAL`/`REFUSE` action is surfaced into the test trace on teardown.

**Scope / lifetime.** CI-only; no product or runtime code is touched. This is a band-aid to stop the leak from failing unrelated PRs while the upstream fix lands — remove the script and the bats hooks once a fixed Cilium ships (called out in the script header and commit message).

### Screenshots

N/A — no UI changes.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an in-cluster watchdog to the e2e suite that detects and remediates a known Cilium endpoint IP leak, reducing pod creation failures from IP conflicts.
  * Enhanced the COSI install e2e suite to surface watchdog activity in test logs.
  * Improved the SeaweedFS bucket e2e test port-forward and local S3 access behavior.
* **Bug Fixes**
  * Adjusted readiness probing to use localhost addressing for the SeaweedFS S3 setup.
* **New Features**
  * Updated SeaweedFS Helm chart to generate additional bucket/access classes, including a lock configuration and explicit read/write vs read-only access policies.
* **Chores**
  * Added a startup probe for core components.
  * Tweaked SeaweedFS S3 service naming and reduced the default master volume size limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->