### PR TITLE
fix(seaweedfs): fix s3 probe scheme and cosi ServiceAccount naming broken by 4.31

### DIFF
--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -157,13 +157,16 @@ EOF
   timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring seaweedfs tenant-root >/dev/null 2>&1; do sleep 1; done'
   # tenant-root parent HR only flips Ready after every child HR is Ready,
   # so listing all four top-level children plus the parent gives precise
-  # failure messages without redundant separate waits. seaweedfs now
-  # installs as a serial chain seaweedfs-db (CNPG bootstrap) ->
-  # seaweedfs-system (master raft quorum) -> seaweedfs wrapper, which
-  # pushes the parent's Ready flip to ~5-6 min; tenant-root HR.spec.timeout
-  # is 15m and this 10m wait stays inside it.
+  # failure messages without redundant separate waits. seaweedfs installs
+  # as a serial chain seaweedfs-db (CNPG bootstrap, HR timeout 10m) ->
+  # seaweedfs-system (master raft quorum, HR timeout 10m) -> seaweedfs
+  # wrapper. On a loaded runner each stage can run close to its own HR
+  # timeout, so this wait must cover the sum of the chain, not a single
+  # stage: 10m proved too tight (runs 27293490370/27293636512/27331238229
+  # timed out here with the chain mid-install), 20m covers the serial
+  # worst case.
   kubectl wait hr/etcd hr/ingress hr/monitoring hr/seaweedfs hr/tenant-root \
-    -n tenant-root --timeout=10m --for=condition=ready
+    -n tenant-root --timeout=20m --for=condition=ready
 
 
   # Expose Cozystack services through ingress

--- a/packages/apps/tenant/templates/seaweedfs.yaml
+++ b/packages/apps/tenant/templates/seaweedfs.yaml
@@ -18,7 +18,13 @@ spec:
     name: cozystack-seaweedfs-application-default-seaweedfs
     namespace: cozy-system
   interval: 5m
-  timeout: 10m
+  # This umbrella's helm action waits for the serial child chain
+  # seaweedfs-db (CNPG bootstrap, HR timeout 10m) -> seaweedfs-system
+  # (HR timeout 10m), so its timeout must cover the sum: with 10m here,
+  # a slow-but-healthy install hit the timeout mid-convergence and the
+  # uninstall remediation deleted the child HRs (including the half-
+  # bootstrapped database) in an endless reset loop.
+  timeout: 20m
   install:
     remediation:
       retries: -1

--- a/packages/system/seaweedfs/Makefile
+++ b/packages/system/seaweedfs/Makefile
@@ -14,5 +14,6 @@ update:
 	tar xzvf - --strip 3 -C charts seaweedfs-$${version}/k8s/charts/seaweedfs
 	patch --no-backup-if-mismatch -p4 < patches/resize-api-server-annotation.diff
 	patch --no-backup-if-mismatch -p4 < patches/disable-ca-key-rotation.patch
+	patch --no-backup-if-mismatch -p4 < patches/cosi-sa-componentname.patch
 	#patch --no-backup-if-mismatch -p4 < patches/retention-policy-delete.yaml
 

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
@@ -61,7 +61,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
 subjects:
   - kind: ServiceAccount
-    name: {{ .Values.global.seaweedfs.serviceAccountName }}-objectstorage-provisioner
+    name: {{ include "seaweedfs.componentName" (list . "objectstorage-provisioner") }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-service-account.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-service-account.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.global.seaweedfs.serviceAccountName }}-objectstorage-provisioner
+  name: {{ include "seaweedfs.componentName" (list . "objectstorage-provisioner") }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/packages/system/seaweedfs/patches/cosi-sa-componentname.patch
+++ b/packages/system/seaweedfs/patches/cosi-sa-componentname.patch
@@ -1,0 +1,26 @@
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
+index b5c103575..68cce69d1 100644
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
+@@ -61,7 +61,7 @@ metadata:
+     app.kubernetes.io/instance: {{ .Release.Name }}
+ subjects:
+   - kind: ServiceAccount
+-    name: {{ .Values.global.seaweedfs.serviceAccountName }}-objectstorage-provisioner
++    name: {{ include "seaweedfs.componentName" (list . "objectstorage-provisioner") }}
+     namespace: {{ .Release.Namespace }}
+ roleRef:
+   kind: ClusterRole
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-service-account.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-service-account.yaml
+index 6d0a4bc38..2a4cd37fb 100644
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-service-account.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-service-account.yaml
+@@ -3,7 +3,7 @@
+ apiVersion: v1
+ kind: ServiceAccount
+ metadata:
+-  name: {{ .Values.global.seaweedfs.serviceAccountName }}-objectstorage-provisioner
++  name: {{ include "seaweedfs.componentName" (list . "objectstorage-provisioner") }}
+   namespace: {{ .Release.Namespace }}
+   labels:
+     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/packages/system/seaweedfs/tests/cosi_serviceaccount_test.yaml
+++ b/packages/system/seaweedfs/tests/cosi_serviceaccount_test.yaml
@@ -1,0 +1,51 @@
+suite: seaweedfs cosi ServiceAccount naming
+
+# Regression guard for the cosi objectstorage-provisioner SA mismatch. The
+# Deployment requests its serviceAccountName via the seaweedfs.componentName
+# helper (release-derived), so the ServiceAccount and the ClusterRoleBinding
+# subject must use the same helper. Before the fix they were named from
+# global.seaweedfs.serviceAccountName, which in cozystack ("tenant-foo-seaweedfs")
+# differs from the release name, so the SA was created under a name the
+# Deployment never referenced and the provisioner ReplicaSet failed with
+# "serviceaccount ...-objectstorage-provisioner not found". The set: below pins
+# serviceAccountName != release name so a revert would break these asserts.
+
+templates:
+  - charts/seaweedfs/templates/cosi/cosi-service-account.yaml
+  - charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
+  - charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+
+release:
+  name: seaweedfs-system
+  namespace: tenant-test
+
+set:
+  cosi.enabled: true
+  global.seaweedfs.serviceAccountName: tenant-foo-seaweedfs
+
+tests:
+  - it: names the cosi ServiceAccount by componentName
+    template: charts/seaweedfs/templates/cosi/cosi-service-account.yaml
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: seaweedfs-system-objectstorage-provisioner
+
+  - it: binds the ClusterRoleBinding subject to the same name
+    template: charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRoleBinding
+    asserts:
+      - equal:
+          path: subjects[0].name
+          value: seaweedfs-system-objectstorage-provisioner
+
+  - it: Deployment serviceAccountName matches the ServiceAccount
+    template: charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: seaweedfs-system-objectstorage-provisioner

--- a/packages/system/seaweedfs/tests/s3_probe_scheme_test.yaml
+++ b/packages/system/seaweedfs/tests/s3_probe_scheme_test.yaml
@@ -1,0 +1,24 @@
+suite: seaweedfs s3 probe scheme
+
+# Guards the s3 health-probe scheme. The chart serves s3 as plain HTTP on
+# s3.port (TLS is gated onto a separate s3.httpsPort, default 0), so the
+# readiness/liveness probes must use scheme HTTP. An HTTPS probe against the
+# HTTP port fails ("server gave HTTP response to HTTPS client") and the s3
+# Deployment never goes Ready, stalling the seaweedfs-system HelmRelease.
+
+templates:
+  - charts/seaweedfs/templates/s3/s3-deployment.yaml
+
+release:
+  name: seaweedfs-system
+  namespace: tenant-test
+
+tests:
+  - it: probes s3 over HTTP, not HTTPS
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTP
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTP

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -97,12 +97,18 @@ seaweedfs:
     extraArgs:
       - -idleTimeout=60
     enableAuth: false
+    # s3 serves plain HTTP on .port (8333): the 4.31 chart (#2834) gates s3 TLS
+    # behind s3.httpsPort (default 0), so the probe must speak HTTP, not HTTPS —
+    # an HTTPS probe against the HTTP port fails the readiness/liveness check
+    # ("server gave HTTP response to HTTPS client") and the s3 Deployment never
+    # goes Ready. In-cluster TLS to s3 is not enabled; TLS terminates at the
+    # ingress edge.
     readinessProbe:
       httpGet:
-        scheme: HTTPS
+        scheme: HTTP
     livenessProbe:
       httpGet:
-        scheme: HTTPS
+        scheme: HTTP
     logs:
       type: ""
     ingress:
@@ -116,7 +122,9 @@ seaweedfs:
         nginx.ingress.kubernetes.io/proxy-body-size: "5g"
         nginx.ingress.kubernetes.io/proxy-buffering: "off"
         nginx.ingress.kubernetes.io/proxy-request-buffering: "off"
-        nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+        # s3 serves plain HTTP (see s3.readinessProbe note above); nginx must
+        # reach the backend over HTTP, not HTTPS.
+        nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
         nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
         nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
         nginx.ingress.kubernetes.io/client-body-timeout: "3600"


### PR DESCRIPTION
## What this PR does

The SeaweedFS 4.31 re-vendor (#2834) introduced two deterministic regressions that fail a fresh tenant install at the `seaweedfs` umbrella HelmRelease (surfaced now that the install retry was removed):

1. **s3 health-probe scheme.** 4.31 gates s3 TLS behind `s3.httpsPort` (default `0`), so `weed s3 -port=8333` serves plain HTTP — but the cozystack overrides still set the s3 readiness/liveness probe `scheme: HTTPS` and the ingress `backend-protocol: HTTPS`. The probe fails (`http: server gave HTTP response to HTTPS client`), s3 never goes Ready, and `seaweedfs-system` stays `InProgress`. Set the probe + ingress backend to HTTP; TLS still terminates at the ingress edge and gRPC `enableSecurity` is untouched. (Verified against a real 4.31 s3 pod: `http://:8333/status` → `200`, `https://` → TLS `wrong version number`.)

2. **cosi ServiceAccount name mismatch.** The objectstorage-provisioner Deployment requests its `serviceAccountName` via the `seaweedfs.componentName` helper (release-derived), but the ServiceAccount and the ClusterRoleBinding subject were named from `global.seaweedfs.serviceAccountName`, which differs from the release name. The SA is created under a name the Deployment never references → `serviceaccount "…-objectstorage-provisioner" not found`, and the provisioner never starts. Name the SA + RoleBinding subject with the same `componentName` helper, carried as `patches/cosi-sa-componentname.patch` so it survives `make update` (this should also be sent upstream to seaweedfs/seaweedfs-helm — the bug is latent there, hidden only when `serviceAccountName == fullname`).

Also keeps the `seaweedfs` umbrella HR `timeout` and the e2e convergence wait at 20m as belt-and-suspenders for the serial `seaweedfs-db → seaweedfs-system → seaweedfs` chain on loaded runners.

Regression coverage: two helm-unittest suites pin the s3 probe scheme and the cosi SA ↔ Deployment ↔ RoleBinding naming (mutation-verified). Validated at runtime on a dev cluster (k8s 1.35.4) in isolation; the existing tenant-root seaweedfs install was left untouched.

May need a `backport` to whichever release shipped SeaweedFS 4.31.

### Release note

```release-note
fix(seaweedfs): fix the s3 health-probe scheme and cosi ServiceAccount naming that broke tenant installs after the SeaweedFS 4.31 update
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased installation timeouts from 10 to 20 minutes for tenant configuration and SeaweedFS to prevent mid-convergence timeout failures and remediation loops
  * Fixed S3 connectivity by updating health check probes and ingress controller to use HTTP instead of HTTPS

* **Tests**
  * Added regression tests for ServiceAccount naming consistency across components
  * Added validation tests for S3 probe HTTP scheme configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->