### PR TITLE
fix(seaweedfs): configure postgres2 connection pool for the filer

### DIFF
--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -70,6 +70,14 @@ seaweedfs:
     extraEnvironmentVars:
       WEED_LEVELDB2_ENABLED: "false"
       WEED_POSTGRES2_ENABLED: "true"
+      # Without explicit pool settings the Go sql pool keeps zero idle
+      # connections, so every filer metadata lookup opens a fresh PostgreSQL
+      # connection (TCP + TLS + SCRAM, ~300ms each), adding seconds of latency
+      # to every S3 operation. Keep max_open * filer.replicas below the
+      # database max_connections (CNPG default: 100).
+      WEED_POSTGRES2_CONNECTION_MAX_IDLE: "20"
+      WEED_POSTGRES2_CONNECTION_MAX_OPEN: "40"
+      WEED_POSTGRES2_CONNECTION_MAX_LIFETIME_SECONDS: "600"
       WEED_POSTGRES2_CREATETABLE: |
         CREATE TABLE IF NOT EXISTS "%s" (
           dirhash   BIGINT,


### PR DESCRIPTION
## What this PR does

- Adds `WEED_POSTGRES2_CONNECTION_MAX_IDLE=20`, `WEED_POSTGRES2_CONNECTION_MAX_OPEN=40` and `WEED_POSTGRES2_CONNECTION_MAX_LIFETIME_SECONDS=600` to the filer `extraEnvironmentVars` in `packages/system/seaweedfs/values.yaml`.

The vendored seaweedfs chart only ships connection pool settings for the **mysql** store (`WEED_MYSQL_CONNECTION_MAX_*`), which cozystack does not use. The **postgres2** store, which cozystack enables, has no pool settings at all. As a result the Go `database/sql` pool runs with `SetMaxIdleConns(0)`: every filer metadata lookup opens a fresh PostgreSQL connection (TCP + TLS + SCRAM, ~300 ms each). With ~5 path-component lookups per S3 operation, this adds roughly **2 seconds of latency to every S3 request**, even on an idle cluster.

### Measurements (production cluster, 12 nodes, 2 filers, CNPG backend)

Before / after applying these three variables, same test (sequential ops through the S3 gateway):

| Operation | Before | After |
|---|---|---|
| PUT 4 KiB (p50) | 10.0 s | 0.28 s |
| GET 4 KiB (p50) | 3.0 s | 0.14 s |
| HEAD (p50) | 2.6 s | 0.16 s |
| Bounded LIST, 100 keys (p50) | 3.8 s | 0.37 s |

`pg_stat_activity` confirmed the root cause: before the fix every backend was younger than ~200 ms (permanent connection churn); after the fix connections are reused for minutes. Real-traffic p95 of `SeaweedFS_filerStore_request_seconds` dropped from 1.3–6.5 s to ~0.18 s.

`max_open` is capped at 40 so that the default two filer replicas stay below the CNPG default `max_connections` of 100.

## Release note

```release-note
fix(seaweedfs): configure postgres2 connection pool for the filer, removing ~2s of per-request S3 latency caused by PostgreSQL connection churn
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized PostgreSQL connection pool configuration in SeaweedFS to reduce latency and improve performance during metadata operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->