### PR TITLE
feat(keycloak): allow overriding the database host/port/properties

### DIFF
--- a/packages/system/keycloak/templates/sts.yaml
+++ b/packages/system/keycloak/templates/sts.yaml
@@ -142,15 +142,23 @@ spec:
             - name: KC_DB
               value: "postgres"
             - name: KC_DB_URL_HOST
+              {{- if .Values.db.host }}
+              value: {{ .Values.db.host | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: keycloak-db-app
                   key: "host"
+              {{- end }}
             - name: KC_DB_URL_PORT
+              {{- if .Values.db.port }}
+              value: {{ .Values.db.port | quote }}
+              {{- else }}
               valueFrom:
                 secretKeyRef:
                   name: keycloak-db-app
                   key: "port"
+              {{- end }}
             - name: KC_DB_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -166,6 +174,10 @@ spec:
                 secretKeyRef:
                   name: keycloak-db-app
                   key: "dbname"
+            {{- with .Values.db.urlProperties }}
+            - name: KC_DB_URL_PROPERTIES
+              value: {{ . | quote }}
+            {{- end }}
             - name: KC_FEATURES
               value: "docker"
             - name: KC_HOSTNAME
@@ -175,10 +187,15 @@ spec:
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- if .Values.themes }}
+          {{- if or .Values.themes .Values.extraVolumeMounts }}
           volumeMounts:
+            {{- if .Values.themes }}
             - name: themes
               mountPath: /opt/keycloak/themes
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- end }}
           ports:
             - name: http
@@ -207,10 +224,15 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
-      {{- if .Values.themes }}
+      {{- if or .Values.themes .Values.extraVolumes }}
       volumes:
+        {{- if .Values.themes }}
         - name: themes
           emptyDir:
             sizeLimit: 256Mi
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       terminationGracePeriodSeconds: 60

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -39,3 +39,29 @@ extraEnv: []
 #     secretKeyRef:
 #       name: my-secret
 #       key: my-key
+
+# Database connection. By default Keycloak connects directly to the chart's
+# CNPG cluster using the keycloak-db-app secret. Override these to route the
+# connection through an external endpoint (e.g. a connection proxy such as
+# PgBouncer) without the chart needing to know about it.
+db:
+  # DB host. Empty = use the keycloak-db-app secret's "host" key.
+  host: ""
+  # DB port. Empty = use the keycloak-db-app secret's "port" key.
+  port: ""
+  # Extra JDBC URL properties, appended verbatim as KC_DB_URL_PROPERTIES, e.g.
+  #   "?sslmode=verify-full&prepareThreshold=0&sslrootcert=/etc/keycloak-db-ca/ca.crt"
+  # Empty = KC_DB_URL_PROPERTIES is not set.
+  urlProperties: ""
+
+# Extra volumes and volume mounts on the Keycloak container (in addition to
+# themes). Useful for mounting a CA so KC_DB_URL_PROPERTIES can reference an
+# sslrootcert when routing the DB connection through a proxy.
+extraVolumes: []
+# - name: keycloak-db-ca
+#   secret:
+#     secretName: keycloak-db-ca
+extraVolumeMounts: []
+# - name: keycloak-db-ca
+#   mountPath: /etc/keycloak-db-ca
+#   readOnly: true


### PR DESCRIPTION
## What this PR does

Makes the Keycloak database connection target configurable, so the connection
can be routed through an external endpoint (for example a connection proxy such
as PgBouncer or another pgwire proxy) without forking the chart:

- `db.host` / `db.port` — override the host/port otherwise read from the
  `keycloak-db-app` secret.
- `db.urlProperties` — sets `KC_DB_URL_PROPERTIES` (previously never set), e.g.
  `?sslmode=verify-full&prepareThreshold=0&sslrootcert=/etc/keycloak-db-ca/ca.crt`.
- `extraVolumes` / `extraVolumeMounts` — mount additional volumes on the
  Keycloak container (e.g. a CA for `sslrootcert`).

All new values default to empty, so the rendered StatefulSet is byte-for-byte
unchanged for existing installs (verified with `helm template`). Credentials
and database name are still taken from the `keycloak-db-app` secret.

### Release note

```release-note
feat(keycloak): allow overriding the database host/port/URL properties (db.host, db.port, db.urlProperties) and add extraVolumes/extraVolumeMounts, so the DB connection can be routed through an external proxy
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keycloak database host and port are now configurable through deployment values
  * Added support for custom database connection properties
  * Enhanced container storage configuration with additional volume and mount options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->