### PR TITLE
feat(tenant): allow egress to vlinsert in parent tenants

### DIFF
--- a/packages/apps/tenant/templates/networkpolicy.yaml
+++ b/packages/apps/tenant/templates/networkpolicy.yaml
@@ -52,7 +52,20 @@ spec:
     {{- end }}
     {{- end }}
     {{- end }}
-  {{- end }}    
+  {{- end }}
+  {{- if ne (include "tenant.name" .) "tenant-root" }}
+  - toEndpoints:
+    {{- if hasPrefix "tenant-" .Release.Namespace }}
+    {{- $parts := splitList "-" .Release.Namespace }}
+    {{- range $i, $v := $parts }}
+    {{- if ne $i 0 }}
+    - matchLabels:
+        "k8s:app.kubernetes.io/name": "vlinsert"
+        "k8s:io.kubernetes.pod.namespace": {{ join "-" (slice $parts 0 (add $i 1)) }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
   {{- if ne (include "tenant.name" .) "tenant-root" }}
   - toEndpoints:
     {{- if hasPrefix "tenant-" .Release.Namespace }}


### PR DESCRIPTION
## Summary

Tenant egress `CiliumClusterwideNetworkPolicy` already permits child tenants to reach `vminsert` (VictoriaMetrics ingest) and `etcd` and ingress controllers in any ancestor namespace. `vlinsert` (VictoriaLogs ingest) was missing — so a child tenant that runs its own `monitoring-agents` cannot forward container logs to a parent tenant's VictoriaLogs.

Mirrors the existing `vminsert` block.

## Problem statement

In a chain `tenant-root → tenant-a → tenant-a-b`, the `tenant-a-b` tenant's fluent-bit (deployed via `monitoring-agents`) tries to POST to `vlinsert-generic.tenant-a.svc:9481` (parent's VictoriaLogs). The current `tenant-a-b-egress` CCNP only allows egress to ancestor namespaces for `vminsert` / `etcd` / `ingress`-labelled endpoints. Connections to `vlinsert` are dropped at L4 by Cilium.

Observable as `no upstream connections available` errors in fluent-bit, with no visible drops anywhere downstream — the dropped packets never leave the source node.

## Change

Add a third `toEndpoints` block matching `app.kubernetes.io/name: vlinsert` in any ancestor namespace, identical in structure to the existing `vminsert` block.

## Test plan

- [x] `helm template packages/apps/tenant` for a child tenant — verify the new block appears.
- [ ] Real-world: deploy a `kubernetes` app inside a tenant with `addons.monitoringAgents.enabled: true`; verify fluent-bit logs reach the parent tenant's VictoriaLogs without manual CCNP additions.

## Notes

The same `splitList \"-\"` pattern is used as in the surrounding blocks, which assumes the parent name encodes the full hierarchy via dashes — that ancestor-walk bug is tracked separately in #2810 / #2171 and is intentionally not touched here to keep this PR minimal.

## Release note

```release-note
feat(tenant): allow child tenants running monitoring-agents to forward container logs to a parent tenant's VictoriaLogs (vlinsert) without manual CiliumClusterwideNetworkPolicy edits
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Modified cluster-wide egress policies for tenants to permit communication with vlinsert components and removed previous policy allowances for etcd and ingress endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
