### PR TITLE
feat(seaweedfs): expose JWT `expires_after_seconds` via values

### DIFF
--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/security-configmap.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/security-configmap.yaml
@@ -19,14 +19,20 @@ data:
   {{- $existing = lookup "v1" "ConfigMap" .Release.Namespace $legacyName }}
   {{- end }}
   {{- $securityConfig := fromToml (dig "data" "security.toml" "" $existing) }}
+  {{- $expiresAfter := default dict .Values.global.seaweedfs.securityConfig.jwtSigning.expiresAfterSeconds }}
   security.toml: |-
     # this file is read by master, volume server, and filer
 
     {{- if .Values.global.seaweedfs.securityConfig.jwtSigning.volumeWrite }}
-    # the jwt signing key is read by master and volume server
-    # a jwt expires in 10 seconds
+    # the jwt signing key is read by master and volume server.
+    # a jwt expires in 10 seconds by default; override via
+    # global.seaweedfs.securityConfig.jwtSigning.expiresAfterSeconds.volumeWrite
     [jwt.signing]
     key = "{{ dig "jwt" "signing" "key" (randAlphaNum 10 | b64enc) $securityConfig }}"
+    {{- $ttl := int (dig "volumeWrite" 0 $expiresAfter) }}
+    {{- if gt $ttl 0 }}
+    expires_after_seconds = {{ $ttl }}
+    {{- end }}
     {{- end }}
 
     {{- if .Values.global.seaweedfs.securityConfig.jwtSigning.volumeRead }}
@@ -35,24 +41,38 @@ data:
     # - the Volume server validates the JWT on reading
     [jwt.signing.read]
     key = "{{ dig "jwt" "signing" "read" "key" (randAlphaNum 10 | b64enc) $securityConfig }}"
+    {{- $ttl := int (dig "volumeRead" 0 $expiresAfter) }}
+    {{- if gt $ttl 0 }}
+    expires_after_seconds = {{ $ttl }}
+    {{- end }}
     {{- end }}
 
     {{- if .Values.global.seaweedfs.securityConfig.jwtSigning.filerWrite }}
     # If this JWT key is configured, Filer only accepts writes over HTTP if they are signed with this JWT:
     # - f.e. the S3 API Shim generates the JWT
     # - the Filer server validates the JWT on writing
-    # the jwt defaults to expire after 10 seconds.
+    # the jwt defaults to expire after 10 seconds; override via
+    # global.seaweedfs.securityConfig.jwtSigning.expiresAfterSeconds.filerWrite
     [jwt.filer_signing]
     key = "{{ dig "jwt" "filer_signing" "key" (randAlphaNum 10 | b64enc) $securityConfig }}"
+    {{- $ttl := int (dig "filerWrite" 0 $expiresAfter) }}
+    {{- if gt $ttl 0 }}
+    expires_after_seconds = {{ $ttl }}
+    {{- end }}
     {{- end }}
 
     {{- if .Values.global.seaweedfs.securityConfig.jwtSigning.filerRead }}
     # If this JWT key is configured, Filer only accepts reads over HTTP if they are signed with this JWT:
     # - f.e. the S3 API Shim generates the JWT
     # - the Filer server validates the JWT on reading
-    # the jwt defaults to expire after 10 seconds.
+    # the jwt defaults to expire after 10 seconds; override via
+    # global.seaweedfs.securityConfig.jwtSigning.expiresAfterSeconds.filerRead
     [jwt.filer_signing.read]
     key = "{{ dig "jwt" "filer_signing" "read" "key" (randAlphaNum 10 | b64enc) $securityConfig }}"
+    {{- $ttl := int (dig "filerRead" 0 $expiresAfter) }}
+    {{- if gt $ttl 0 }}
+    expires_after_seconds = {{ $ttl }}
+    {{- end }}
     {{- end }}
 
     {{- if .Values.global.seaweedfs.enableSecurity }}

--- a/packages/system/seaweedfs/charts/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/values.yaml
@@ -26,6 +26,14 @@ global:
         volumeRead: false
         filerWrite: false
         filerRead: false
+        # Token lifetime in seconds for each JWT section. The SeaweedFS default
+        # (when omitted) is 10 seconds, which can be too short for large blob
+        # uploads or busy backends. Set to 0 to keep the SeaweedFS default.
+        expiresAfterSeconds:
+          volumeWrite: 0
+          volumeRead: 0
+          filerWrite: 0
+          filerRead: 0
     # we will use this serviceAccountName for all ClusterRoles/ClusterRoleBindings
     serviceAccountName: "seaweedfs"
     serviceAccountAnnotations: {}


### PR DESCRIPTION
## Summary

The SeaweedFS upstream default JWT TTL is 10 seconds. The current Cozystack chart hardcodes the absence of `expires_after_seconds` in `security.toml`, so operators get the 10-second behaviour with no way to override.

For larger backends — most visibly Harbor's S3 backend (the `s3aws` registry driver against SeaweedFS' S3 frontend) — this default is too short. Blob uploads that take longer than ~10 seconds, or volume → master heartbeat / inter-process traffic on a slow link, end up seeing `token has invalid claims: token is expired` and the write fails. Symptom from Harbor's perspective:

```
POST /v2/<project>/<repo>/blobs/uploads/:
UNKNOWN: unknown error;
map[DriverName:s3aws Enclosed:map[RequestFailure:map[]]]
```

The corresponding SeaweedFS-side error in volume / s3 logs is `wrong jwt` with reason `token is expired`. Restarting the volume server forces re-issuing of tokens (with the same 10-second TTL), so the situation recurs.

## Change

Add an optional `expiresAfterSeconds` block under `global.seaweedfs.securityConfig.jwtSigning`:

```yaml
global:
  seaweedfs:
    securityConfig:
      jwtSigning:
        volumeWrite: true
        volumeRead: false
        filerWrite: false
        filerRead: false
        expiresAfterSeconds:
          volumeWrite: 3600   # 1 hour, or any positive integer
          volumeRead: 3600
          filerWrite: 3600
          filerRead: 3600
```

When the value is `0` (the default) the `expires_after_seconds` line is omitted from `security.toml`, preserving SeaweedFS' built-in 10-second default for backwards compatibility. When set to a positive integer, the value is emitted under the matching `[jwt.*]` section.

## Test plan

- [x] `helm template` with default values — no `expires_after_seconds` line emitted (current behaviour preserved).
- [x] `helm template` with `expiresAfterSeconds.volumeWrite: 3600` — `expires_after_seconds = 3600` appears under `[jwt.signing]`, nothing under other sections.
- [ ] Live cluster: bump to `3600`, restart master + volume pods, confirm large Harbor uploads succeed and `token is expired` errors stop appearing in volume logs.

## Reference

SeaweedFS source: `weed/security/jwt.go` reads `expiresAfterSec` and only sets the `exp` claim when value is positive. Scaffold ([security.toml](https://github.com/seaweedfs/seaweedfs/blob/master/weed/command/scaffold/security.toml)) documents the 10-second default but doesn't include a way to override via Helm-style config — that's what this PR adds at the Cozystack chart level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JWT token expiration times are now independently configurable for volume and filer operations (read/write). Default settings preserve SeaweedFS's built-in behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->