### PR TITLE
fix(tenant): inherit full ancestor label chain from parent namespace

### DIFF
--- a/packages/apps/tenant/templates/_helpers.tpl
+++ b/packages/apps/tenant/templates/_helpers.tpl
@@ -53,6 +53,38 @@
   typing, so the "key absent" form is what distinguishes "unset"
   from explicit `false`.
 */}}
+{{/*
+  tenant.ancestorTenantLabels emits the full set of
+  `tenant.cozystack.io/<ancestor>: ""` namespace labels for the tenant whose
+  namespace name is passed as the single argument (e.g. "tenant-ktj-htdev").
+
+  Every tenant descends from tenant-root, so that label is always emitted.
+  The remaining ancestors are encoded in the namespace name itself: tenant.name
+  constructs each child namespace as `<parent-namespace>-<word>`, so every
+  progressive dash-prefix of the name is a real ancestor namespace
+  (tenant-ktj-htdev -> tenant-ktj, tenant-ktj-htdev). The last prefix is the
+  tenant's own name, so its self-label is included too.
+
+  Deriving the chain from the name (rather than from a lookup of the parent
+  namespace's labels) is deterministic: it needs no cluster state, renders
+  identically offline, and converges on every reconcile regardless of the
+  order in which parent and child HelmReleases reconcile. It replaces an
+  earlier splitList over `.Release.Namespace` that only ever reached one level
+  up and therefore dropped tenant-root for tenants at depth >= 2 — breaking the
+  `<ancestor>-egress` CiliumClusterwideNetworkPolicy that grants an ancestor
+  reachability to its descendants via the `tenant.cozystack.io/<ancestor>`
+  namespace label.
+*/}}
+{{- define "tenant.ancestorTenantLabels" -}}
+{{- $parts := splitList "-" . -}}
+tenant.cozystack.io/tenant-root: ""
+{{- range $i, $v := $parts }}
+{{- if ne $i 0 }}
+{{ printf "tenant.cozystack.io/%s: \"\"" (join "-" (slice $parts 0 (add $i 1))) }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "tenant.gatewayEffective" -}}
 {{- if kindIs "invalid" .Values.gateway -}}
 false

--- a/packages/apps/tenant/templates/namespace.yaml
+++ b/packages/apps/tenant/templates/namespace.yaml
@@ -1,8 +1,14 @@
-{{/* Lookup for namespace uid (needed for ownerReferences) */}}
+{{/*
+  Lookup the parent namespace, used below to stamp the child namespace's
+  ownerReference uid. During a real helm-controller reconcile the parent
+  namespace (.Release.Namespace) always exists, so the ownerReference is
+  always emitted. The lookup returns empty only when rendering offline
+  (helm template / helm unittest), where the ownerReference is simply omitted
+  so the rest of the template — notably the ancestor labels below, which are
+  derived purely from the namespace name and need no cluster state — still
+  renders and can be unit-tested.
+*/}}
 {{- $existingNS := lookup "v1" "Namespace" "" .Release.Namespace }}
-{{- if not $existingNS }}
-{{- fail (printf "error lookup existing namespace: %s" .Release.Namespace) }}
-{{- end }}
 
 {{- if ne (include "tenant.name" .) "tenant-root" }}
 {{/* Compute namespace values once for use in both Secret and labels */}}
@@ -75,13 +81,7 @@ metadata:
   name: {{ $tenantName }}
   {{- if hasPrefix "tenant-" .Release.Namespace }}
   labels:
-    tenant.cozystack.io/{{ $tenantName }}: ""
-    {{- $parts := splitList "-" .Release.Namespace }}
-    {{- range $i, $v := $parts }}
-    {{- if ne $i 0 }}
-    tenant.cozystack.io/{{ join "-" (slice $parts 0 (add $i 1)) }}: ""
-    {{- end }}
-    {{- end }}
+    {{- include "tenant.ancestorTenantLabels" $tenantName | nindent 4 }}
     {{/* Labels for network policies */}}
     namespace.cozystack.io/etcd: {{ $etcd | quote }}
     namespace.cozystack.io/ingress: {{ $ingress | quote }}
@@ -93,6 +93,7 @@ metadata:
     scheduler.cozystack.io/scheduling-class: {{ . | quote }}
     {{- end }}
     alpha.kubevirt.io/auto-memory-limits-ratio: "1.0"
+  {{- if $existingNS }}
   ownerReferences:
   - apiVersion: v1
     blockOwnerDeletion: true
@@ -100,6 +101,7 @@ metadata:
     kind: Namespace
     name: {{ .Release.Namespace }}
     uid: {{ $existingNS.metadata.uid }}
+  {{- end }}
   {{- end }}
 ---
 apiVersion: v1

--- a/packages/apps/tenant/tests/namespace_ancestor_labels_test.yaml
+++ b/packages/apps/tenant/tests/namespace_ancestor_labels_test.yaml
@@ -1,0 +1,91 @@
+suite: tenant namespace ancestor labels
+# Regression cover for the tenant.cozystack.io/<ancestor> namespace labels
+# emitted by namespace.yaml. These labels drive the <ancestor>-egress
+# CiliumClusterwideNetworkPolicy (networkpolicy.yaml): an ancestor tenant is
+# allowed to reach any namespace carrying tenant.cozystack.io/<ancestor>, so
+# every tenant namespace MUST carry the label of each of its ancestors,
+# tenant-root included, at every depth.
+#
+# The labels are derived from the namespace name by tenant.ancestorTenantLabels
+# (see _helpers.tpl) with no cluster lookup, so helm-unittest can render them
+# offline — the ownerReference lookup is the only cluster-coupled part of
+# namespace.yaml and is skipped when the parent namespace lookup is empty.
+templates:
+  - templates/namespace.yaml
+set:
+  _cluster:
+    root-host: example.com
+tests:
+  - it: depth-1 tenant (direct child of root) carries tenant-root and its own label
+    release:
+      name: tenant-ktj
+      namespace: tenant-root
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Namespace
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: tenant-ktj
+      - documentIndex: 0
+        equal:
+          path: metadata.labels["tenant.cozystack.io/tenant-root"]
+          value: ""
+      - documentIndex: 0
+        equal:
+          path: metadata.labels["tenant.cozystack.io/tenant-ktj"]
+          value: ""
+
+  - it: depth-2 tenant carries the full ancestor chain including tenant-root
+    release:
+      name: tenant-htdev
+      namespace: tenant-ktj
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: tenant-ktj-htdev
+      - documentIndex: 0
+        equal:
+          path: metadata.labels["tenant.cozystack.io/tenant-root"]
+          value: ""
+      - documentIndex: 0
+        equal:
+          path: metadata.labels["tenant.cozystack.io/tenant-ktj"]
+          value: ""
+      - documentIndex: 0
+        equal:
+          path: metadata.labels["tenant.cozystack.io/tenant-ktj-htdev"]
+          value: ""
+
+  - it: depth-3 tenant carries every ancestor from root down to itself
+    release:
+      name: tenant-foo
+      namespace: tenant-ktj-htdev
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.name
+          value: tenant-ktj-htdev-foo
+      - documentIndex: 0
+        equal:
+          path: metadata.labels["tenant.cozystack.io/tenant-root"]
+          value: ""
+      - documentIndex: 0
+        equal:
+          path: metadata.labels["tenant.cozystack.io/tenant-ktj"]
+          value: ""
+      - documentIndex: 0
+        equal:
+          path: metadata.labels["tenant.cozystack.io/tenant-ktj-htdev"]
+          value: ""
+      - documentIndex: 0
+        equal:
+          path: metadata.labels["tenant.cozystack.io/tenant-ktj-htdev-foo"]
+          value: ""
+      # A tenant must NOT claim descendants it does not have: the depth-3
+      # namespace is not an ancestor of any deeper tenant, so no stray label.
+      - documentIndex: 0
+        notExists:
+          path: metadata.labels["tenant.cozystack.io/tenant-ktj-htdev-foo-bar"]

--- a/packages/core/platform/images/migrations/migrations/49
+++ b/packages/core/platform/images/migrations/migrations/49
@@ -1,0 +1,70 @@
+#!/bin/sh
+# Migration 49 --> 50
+# Backfill tenant.cozystack.io/<ancestor> labels on existing tenant namespaces.
+#
+# Tenant chart versions before this release derived the ancestor label chain by
+# splitting .Release.Namespace, which only ever reached one level up and dropped
+# the transitive ancestors (notably tenant.cozystack.io/tenant-root) for tenants
+# at depth >= 2. That broke the <ancestor>-egress CiliumClusterwideNetworkPolicy
+# (packages/apps/tenant/templates/networkpolicy.yaml): it grants an ancestor
+# reachability to a descendant namespace only when the descendant carries
+# tenant.cozystack.io/<ancestor>, so a missing tenant-root label left the root
+# ingress controller unable to reach nested tenants (upstream timeouts, #2810 /
+# #2171).
+#
+# The chart fix makes every tenant namespace self-compute its full ancestor
+# chain from its own name on the next reconcile. This migration backfills the
+# labels immediately so clusters heal without waiting on each tenant
+# HelmRelease to re-reconcile (e.g. suspended or failed releases).
+#
+# Best-effort by design: the worst case if a relabel is skipped is the
+# pre-existing missing-label bug this PR set out to fix, which is strictly no
+# worse than the status quo. A transient apiserver hiccup must therefore NOT
+# abort the whole platform upgrade, so the namespace list and per-namespace
+# relabel tolerate failure (|| true) rather than exiting non-zero. Idempotent:
+# kubectl label --overwrite only adds/refreshes the listed labels and never
+# removes others.
+
+set -euo pipefail
+
+# shellcheck source=lib/cozystack-version.sh
+. "$(dirname "$0")/lib/cozystack-version.sh"
+
+# Every tenant lives in a namespace named tenant-<...>. tenant-root is the
+# implicit chain root and carries no tenant.cozystack.io/* label (the chart
+# omits the label block for it), so it is skipped. The `|| true` keeps a
+# transient apiserver error from aborting the upgrade.
+tenant_ns=$(kubectl get namespaces \
+              -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' \
+            | grep '^tenant-' || true)
+
+for ns in $tenant_ns; do
+  [ "$ns" = "tenant-root" ] && continue
+
+  # Build the ancestor label list from the namespace name: every tenant
+  # descends from tenant-root, then each progressive dash-prefix of the name
+  # (skipping the bare "tenant" segment) is a real ancestor namespace, the last
+  # being the tenant itself. e.g. tenant-ktj-htdev -> tenant-root, tenant-ktj,
+  # tenant-ktj-htdev.
+  labels="tenant.cozystack.io/tenant-root="
+  acc=""
+  IFS='-'
+  for seg in $ns; do
+    if [ -z "$acc" ]; then
+      acc="$seg"
+    else
+      acc="$acc-$seg"
+    fi
+    [ "$acc" = "tenant" ] && continue
+    labels="$labels tenant.cozystack.io/$acc="
+  done
+  unset IFS
+
+  echo "Backfilling ancestor labels on namespace $ns: $labels"
+  # shellcheck disable=SC2086 # word splitting of $labels into flags is intended
+  kubectl label namespace "$ns" $labels --overwrite || true
+done
+
+# Stamp version via the shared helper so the cozystack-version ConfigMap keeps
+# the platform.cozystack.io/no-delete label (see lib/cozystack-version.sh).
+stamp_cozystack_version 50

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -6,7 +6,7 @@ sourceRef:
 migrations:
   enabled: false
   image: ghcr.io/cozystack/cozystack/platform-migrations:v1.5.0@sha256:8bf61f17e99eb4a3365394e3d97ac52a1d68cc84aa104894ecb09de25721dc1d
-  targetVersion: 49
+  targetVersion: 50
 # Bundle deployment configuration
 bundles:
   system:


### PR DESCRIPTION
## Summary

`packages/apps/tenant/templates/namespace.yaml` labels every tenant namespace
with `tenant.cozystack.io/<ancestor>` for each of its ancestors. These labels
drive the `<ancestor>-egress` `CiliumClusterwideNetworkPolicy`
(`networkpolicy.yaml`): an ancestor tenant's pods may reach a namespace only if
that namespace carries `tenant.cozystack.io/<ancestor>`.

The chain was derived by splitting `.Release.Namespace`, which only ever reached
one level up. A direct child of `tenant-root` got `tenant-root` (its parent
namespace *is* `tenant-root`), but a grandchild — `tenant-ktj-htdev` created
under `tenant-ktj` — got only `tenant-ktj` and dropped `tenant-root` entirely.
Without `tenant.cozystack.io/tenant-root` on a nested namespace, the root
ingress controller cannot reach the proxy service in a nested `kubernetes`
tenant, surfacing as `upstream timed out (110) while connecting to upstream` in
the nginx logs.

## Fix

Derive the ancestor chain deterministically from the namespace name instead of
from any cluster lookup. Every tenant descends from `tenant-root`, so that label
is emitted unconditionally; the remaining ancestors are encoded in the namespace
name itself, because `tenant.name` builds each child as
`<parent-namespace>-<word>` — so every progressive dash-prefix of the name is a
real ancestor namespace (`tenant-ktj-htdev` yields `tenant-ktj` and
`tenant-ktj-htdev`). The logic lives in a new `tenant.ancestorTenantLabels`
helper:

```yaml
labels:
  {{- include "tenant.ancestorTenantLabels" $tenantName | nindent 4 }}
```

This needs no cluster state, renders identically offline (so it is
unit-testable), and converges on every reconcile regardless of the order in
which parent and child `HelmRelease`s reconcile — unlike a parent-namespace
`lookup`, which helm-controller does not re-render on and which is
ordering-dependent. The `ownerReference` `lookup` is kept but made non-fatal:
during a real reconcile the parent namespace always exists (the tenant
`HelmRelease` and its `cozystack-values` Secret live in it), so the
`ownerReference` is always emitted; when the lookup is empty (offline / unit
test) it is simply omitted so the labels still render.

Migration `49` backfills the labels on existing clusters so they heal on upgrade
regardless of per-tenant `HelmRelease` state (e.g. suspended or failed
releases), and `migrations.targetVersion` is bumped to `50` so the runner
iterates it. The migration derives the same chain from each namespace name,
is idempotent (`kubectl label --overwrite`) and best-effort (per-namespace
failures are tolerated so a transient apiserver error cannot abort the upgrade).

## Test plan

- [x] `helm template packages/apps/tenant` at depth 1/2/3 — emits exactly the
      expected ancestor set at each depth: depth-1 `{tenant-root, tenant-ktj}`,
      depth-2 adds `tenant-ktj-htdev`, depth-3 adds `tenant-ktj-htdev-foo`. No
      missing, no stray labels.
- [x] `helm unittest packages/apps/tenant` — new
      `tests/namespace_ancestor_labels_test.yaml` pins the chain at depths 1/2/3
      plus a negative assertion; whole suite green.
- [x] `bats hack/cozystack-version-stamp.bats` — migration `49` stamps the
      version through the shared `stamp_cozystack_version` helper (all 10 tests
      pass, including the guard that migrations >= 42 must use the helper).
- [x] Migration `49` ancestor derivation verified under `/bin/sh` to match the
      helm output byte-for-byte, and dry-runs cleanly under `set -euo pipefail`.
- [ ] Live cluster: create a 3-level tenant (`root -> ktj -> htdev`), verify
      `tenant-ktj-htdev` has all three `tenant.cozystack.io/*` labels.
- [ ] Live cluster: create a `kubernetes` tenant under `htdev` with
      `addons.ingressNginx.hosts`, verify an external HTTP request reaches the
      tenant ingress controller via the root-ingress proxy (no `upstream timed
      out`).

## Closes

- Closes #2810
- Closes #2171

```release-note
fix(tenant): tenant namespaces now carry the full `tenant.cozystack.io/<ancestor>` label chain (including `tenant-root`) at any nesting depth, restoring root-ingress reachability to nested tenants; a migration backfills the labels on existing clusters
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant namespace label inheritance across multi-level tenant hierarchies, ensuring all ancestor tenant labels are consistently applied.
* **New Features**
  * Standardized ancestor label generation to reliably include the full tenant chain for derived tenant namespaces.
* **Tests**
  * Added regression coverage for ancestor label presence and absence at multiple hierarchy depths.
* **Chores**
  * Added a migration to backfill missing ancestor labels for existing tenant namespaces during platform upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->