### PR TITLE
fix(api): preserve foreign HelmRelease metadata on Application update

### DIFF
--- a/pkg/registry/apps/application/rest.go
+++ b/pkg/registry/apps/application/rest.go
@@ -1173,15 +1173,13 @@ func (r *REST) hasRequiredApplicationLabelsWithName(hr *helmv2.HelmRelease, appN
 }
 
 // mergeMaps combines two maps of labels or annotations
+// mergeMaps merges b over a into a freshly allocated map. It never returns
+// either input: callers mutate the result in place, and a may be a long-lived
+// shared map (e.g. r.releaseConfig.Labels) that concurrent requests must not
+// write to.
 func mergeMaps(a, b map[string]string) map[string]string {
 	if a == nil && b == nil {
 		return nil
-	}
-	if a == nil {
-		return b
-	}
-	if b == nil {
-		return a
 	}
 	merged := make(map[string]string, len(a)+len(b))
 	for k, v := range a {

--- a/pkg/registry/apps/application/rest.go
+++ b/pkg/registry/apps/application/rest.go
@@ -557,9 +557,19 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 		return nil, false, fmt.Errorf("conversion error: %v", err)
 	}
 
-	// Fetch the live HelmRelease: it backs the ResourceVersion when the
-	// converted object carries none, and runtime-managed labels are carried
-	// over from it below.
+	// The conversion above rebuilds the HelmRelease from the Application
+	// alone, but parts of the HelmRelease metadata are owned by other
+	// controllers and must survive the update. Fetch the current object
+	// and carry them over before issuing the full-replace PUT:
+	//   - finalizers: helm-controller's finalizers.fluxcd.io guarantees
+	//     `helm uninstall` runs on deletion. Stripping it here lets a
+	//     subsequent delete remove the HelmRelease instantly, orphaning
+	//     every resource of the release.
+	//   - ownerReferences: garbage collection and lineage.
+	//   - labels/annotations outside the apps.cozystack.io- prefix: set
+	//     directly on the HelmRelease by Flux or other controllers.
+	// Keys under the prefix are owned by this API: stale ones are dropped
+	// so deleting a label or annotation on the Application propagates.
 	cur := &helmv2.HelmRelease{}
 	if err := r.c.Get(ctx, client.ObjectKey{Namespace: helmRelease.Namespace, Name: helmRelease.Name}, cur, &client.GetOptions{Raw: &metav1.GetOptions{}}); err != nil {
 		return nil, false, fmt.Errorf("failed to fetch current HelmRelease: %w", err)
@@ -567,6 +577,10 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 	if helmRelease.ResourceVersion == "" {
 		helmRelease.SetResourceVersion(cur.GetResourceVersion())
 	}
+	helmRelease.Finalizers = cur.Finalizers
+	helmRelease.OwnerReferences = cur.OwnerReferences
+	helmRelease.Labels = mergeMaps(omitPrefixedMap(cur.Labels, LabelPrefix), helmRelease.Labels)
+	helmRelease.Annotations = mergeMaps(omitPrefixedMap(cur.Annotations, AnnotationPrefix), helmRelease.Annotations)
 
 	// Merge system labels (from config) directly
 	helmRelease.Labels = mergeMaps(r.releaseConfig.Labels, helmRelease.Labels)
@@ -1201,6 +1215,24 @@ func filterPrefixedMap(original map[string]string, prefix string) map[string]str
 		if strings.HasPrefix(k, prefix) {
 			newKey := strings.TrimPrefix(k, prefix)
 			processed[newKey] = v
+		}
+	}
+	return processed
+}
+
+// omitPrefixedMap returns the entries of a map whose keys do NOT carry the
+// predefined prefix, keeping the keys as-is. It is the complement of
+// filterPrefixedMap: prefixed keys are owned by this API and recomputed from
+// the Application on every write, while the remaining keys belong to other
+// controllers and must be preserved.
+func omitPrefixedMap(original map[string]string, prefix string) map[string]string {
+	if original == nil {
+		return nil
+	}
+	processed := make(map[string]string)
+	for k, v := range original {
+		if !strings.HasPrefix(k, prefix) {
+			processed[k] = v
 		}
 	}
 	return processed

--- a/pkg/registry/apps/application/rest_update_metadata_test.go
+++ b/pkg/registry/apps/application/rest_update_metadata_test.go
@@ -1,0 +1,108 @@
+package application
+
+import (
+	"context"
+	"testing"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appsv1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
+)
+
+// TestUpdate_PreservesForeignHelmReleaseMetadata pins the metadata
+// carry-over contract on the Update path. Update rebuilds the
+// HelmRelease from the Application and issues a full-replace PUT, so
+// without an explicit carry-over every update strips metadata owned by
+// other controllers. The most harmful instance is helm-controller's
+// finalizers.fluxcd.io finalizer: once stripped, a delete that lands
+// before helm-controller re-adds it removes the HelmRelease without
+// running `helm uninstall`, orphaning every resource of the release
+// (VMs, databases, PVCs). A label patch immediately followed by a
+// delete — a common client pattern — hits that window almost every
+// time.
+func TestUpdate_PreservesForeignHelmReleaseMetadata(t *testing.T) {
+	existing := &helmv2.HelmRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "postgresql-mydb",
+			Namespace:  "default",
+			Finalizers: []string{"finalizers.fluxcd.io"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps.cozystack.io/v1alpha1",
+				Kind:       "Tenant",
+				Name:       "root",
+				UID:        types.UID("owner-uid"),
+			}},
+			Labels: map[string]string{
+				ApplicationKindLabel:               "PostgreSQL",
+				ApplicationGroupLabel:              "apps.cozystack.io",
+				ApplicationNameLabel:               "mydb",
+				"kustomize.toolkit.fluxcd.io/name": "core",
+				LabelPrefix + "stale":              "removed-by-this-update",
+			},
+			Annotations: map[string]string{
+				"reconcile.fluxcd.io/requestedAt": "2026-06-12T00:00:00Z",
+				AnnotationPrefix + "stale":        "removed-by-this-update",
+			},
+		},
+	}
+	r := newTestRESTWithSchemes(existing)
+
+	app := &appsv1alpha1.Application{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.cozystack.io/v1alpha1",
+			Kind:       "PostgreSQL",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mydb",
+			Namespace: "default",
+			Labels:    map[string]string{"fresh": "yes"},
+		},
+	}
+
+	ctx := request.WithNamespace(context.Background(), "default")
+	if _, _, err := r.Update(
+		ctx,
+		"mydb",
+		newDefaultUpdatedObjectInfo(app),
+		nil,
+		nil,
+		false,
+		&metav1.UpdateOptions{},
+	); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &helmv2.HelmRelease{}
+	if err := r.c.Get(ctx, client.ObjectKey{Namespace: "default", Name: "postgresql-mydb"}, got); err != nil {
+		t.Fatalf("failed to fetch updated HelmRelease: %v", err)
+	}
+
+	if len(got.Finalizers) != 1 || got.Finalizers[0] != "finalizers.fluxcd.io" {
+		t.Errorf("expected finalizers.fluxcd.io to be preserved, got %v", got.Finalizers)
+	}
+	if len(got.OwnerReferences) != 1 || got.OwnerReferences[0].UID != types.UID("owner-uid") {
+		t.Errorf("expected ownerReferences to be preserved, got %v", got.OwnerReferences)
+	}
+	if got.Labels["kustomize.toolkit.fluxcd.io/name"] != "core" {
+		t.Errorf("expected foreign label to be preserved, got labels %v", got.Labels)
+	}
+	if got.Annotations["reconcile.fluxcd.io/requestedAt"] != "2026-06-12T00:00:00Z" {
+		t.Errorf("expected foreign annotation to be preserved, got annotations %v", got.Annotations)
+	}
+	if got.Labels[LabelPrefix+"fresh"] != "yes" {
+		t.Errorf("expected new prefixed user label to be set, got labels %v", got.Labels)
+	}
+	if _, ok := got.Labels[LabelPrefix+"stale"]; ok {
+		t.Errorf("expected stale prefixed label to be dropped, got labels %v", got.Labels)
+	}
+	if _, ok := got.Annotations[AnnotationPrefix+"stale"]; ok {
+		t.Errorf("expected stale prefixed annotation to be dropped, got annotations %v", got.Annotations)
+	}
+	if got.Labels[ApplicationNameLabel] != "mydb" {
+		t.Errorf("expected application metadata labels to remain, got labels %v", got.Labels)
+	}
+}

--- a/pkg/registry/apps/application/rest_update_metadata_test.go
+++ b/pkg/registry/apps/application/rest_update_metadata_test.go
@@ -106,3 +106,41 @@ func TestUpdate_PreservesForeignHelmReleaseMetadata(t *testing.T) {
 		t.Errorf("expected application metadata labels to remain, got labels %v", got.Labels)
 	}
 }
+
+// TestCreate_DoesNotMutateSharedConfigLabels pins mergeMaps' allocation
+// contract. Create and Update build the HelmRelease label set starting
+// from r.releaseConfig.Labels, a long-lived map shared by every request
+// for the kind, and then write the application metadata labels into the
+// result in place. If mergeMaps returns one of its inputs instead of a
+// fresh map — which the old implementation did whenever the other input
+// was nil, e.g. for an Application with no labels — those in-place
+// writes land on the shared config map: requests cross-contaminate
+// (application.name varies per request) and concurrent map writes crash
+// the apiserver.
+func TestCreate_DoesNotMutateSharedConfigLabels(t *testing.T) {
+	configLabels := map[string]string{"cozystack.io/ui": "true"}
+	r := newTestRESTWithSchemes()
+	r.releaseConfig.Labels = configLabels
+
+	app := &appsv1alpha1.Application{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.cozystack.io/v1alpha1",
+			Kind:       "PostgreSQL",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nolabels",
+			Namespace: "default",
+			// No labels: the conversion yields a nil label map, the
+			// trigger for mergeMaps returning the config map itself.
+		},
+	}
+
+	ctx := request.WithNamespace(context.Background(), "default")
+	if _, err := r.Create(ctx, app, nil, &metav1.CreateOptions{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(configLabels) != 1 || configLabels["cozystack.io/ui"] != "true" {
+		t.Errorf("expected shared config labels to be untouched, got %v", configLabels)
+	}
+}


### PR DESCRIPTION
## What this PR does

The aggregated `apps.cozystack.io` API rebuilds the HelmRelease from the Application on `Update` and issues a full-replace PUT. This strips metadata owned by other controllers:

- `metadata.finalizers` — including helm-controller's `finalizers.fluxcd.io`
- `metadata.ownerReferences`
- labels and annotations outside the `apps.cozystack.io-` prefix (e.g. `reconcile.fluxcd.io/requestedAt`)

Losing the Flux finalizer is the harmful case: helm-controller re-adds it on the next reconcile, but a delete landing in that window removes the HelmRelease **without running `helm uninstall`**, orphaning every resource of the release (VMs, databases, PVCs...). A label patch immediately followed by a delete — a common client pattern — hits that window almost every time. We traced ~106 orphaned releases across 39 tenants on a production cluster back to this.

Reproduction:
1. `kubectl patch <any apps.cozystack.io resource> --type merge -p '{"metadata":{"labels":{"foo":"bar"}}}'` → the backing HelmRelease loses `finalizers.fluxcd.io`
2. `kubectl delete` the resource right after → HelmRelease is removed instantly, Helm uninstall never runs, child resources stay alive

Changes:

- `Update` now fetches the current HelmRelease and carries over `finalizers`, `ownerReferences`, and non-prefixed labels/annotations before the PUT
- Keys under the `apps.cozystack.io-` prefix remain owned by the API and are recomputed from the Application, so label/annotation deletions still propagate
- Regression test `TestUpdate_PreservesForeignHelmReleaseMetadata` pins the carry-over contract (fails on the previous behavior with exactly the stripped fields)

## Release note

```release-note
fix(api): updating an Application no longer strips finalizers, ownerReferences, and foreign labels/annotations from the backing HelmRelease, which could cause deletion to skip helm uninstall and orphan the release's resources
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Application updates now consistently preserve metadata owned by external controllers (resource version, finalizers, owner references, and non-application prefixed labels/annotations) when syncing related releases.
* **Tests**
  * Added tests verifying preservation of foreign release metadata during updates and that shared config label maps are not mutated during creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->