### PR TITLE
fix(kubernetes): support repository ports in containerd certs path

### DIFF
--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -474,6 +474,18 @@ spec:
       {{/* containerd 2.x renamed the CRI plugin from io.containerd.grpc.v1.cri to io.containerd.cri.v1.images; both seds run unconditionally and the wrong-version one is a no-op */}}
       - sed -i '/\[plugins\.[^]]*grpc\.v1\.cri[^]]*registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|' /etc/containerd/config.toml
       - sed -i '/\[plugins\.[^]]*io\.containerd\.cri\.v1\.images[^]]*registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|' /etc/containerd/config.toml
+      - |
+        for hosts_file in /etc/containerd/certs.d/*/hosts.toml; do
+          [ -f "$hosts_file" ] || continue
+          registry=$(basename "$(dirname "$hosts_file")")
+          username=$(awk -F'"' '/username =/ {print $2}' "$hosts_file" | tr -d '[:space:]')
+          password=$(awk -F'"' '/password =/ {print $2}' "$hosts_file" | tr -d '[:space:]')
+          if [ -n "$username" ] && [ -n "$password" ]; then
+            echo "Configuring auth for $registry in config.toml"
+            printf "\n[plugins.\"io.containerd.cri.v1.images\".registry.configs.\"%s\".auth]\n  username = \"%s\"\n  password = \"%s\"\n" "$registry" "$username" "$password" >> /etc/containerd/config.toml
+            printf "\n[plugins.\"io.containerd.grpc.v1.cri\".registry.configs.\"%s\".auth]\n  username = \"%s\"\n  password = \"%s\"\n" "$registry" "$username" "$password" >> /etc/containerd/config.toml
+          fi
+        done
       - systemctl start containerd.service
       joinConfiguration:
         nodeRegistration:

--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -444,7 +444,7 @@ spec:
       {{- $sec := lookup "v1" "Secret" $.Release.Namespace (printf "%s-patch-containerd" $.Release.Name) }}
       {{- if $sec }}
         {{- range $key, $_ := $sec.data }}
-      - path: /etc/containerd/certs.d/{{ trimSuffix ".toml" $key }}/hosts.toml
+      - path: /etc/containerd/certs.d/{{ regexReplaceAll "_([0-9]+)$" (trimSuffix ".toml" $key) ":${1}" }}/hosts.toml
         contentFrom:
           secret:
             name: {{ $.Release.Name }}-patch-containerd

--- a/packages/apps/kubernetes/tests/cluster_test.yaml
+++ b/packages/apps/kubernetes/tests/cluster_test.yaml
@@ -339,6 +339,27 @@ tests:
           content: 'sed -i ''/\[plugins\.[^]]*io\.containerd\.cri\.v1\.images[^]]*registry\]/,/^\[/ s|^\(\s*config_path\s*=\s*\).*|\1"/etc/containerd/certs.d"|'' /etc/containerd/config.toml'
         documentIndex: 4
 
+  - it: includes containerd v2 registry auth config parser in preKubeadmCommands
+    release:
+      name: test-k8s
+      namespace: tenant-test
+    asserts:
+      - contains:
+          path: spec.template.spec.preKubeadmCommands
+          content: |
+            for hosts_file in /etc/containerd/certs.d/*/hosts.toml; do
+              [ -f "$hosts_file" ] || continue
+              registry=$(basename "$(dirname "$hosts_file")")
+              username=$(awk -F'"' '/username =/ {print $2}' "$hosts_file" | tr -d '[:space:]')
+              password=$(awk -F'"' '/password =/ {print $2}' "$hosts_file" | tr -d '[:space:]')
+              if [ -n "$username" ] && [ -n "$password" ]; then
+                echo "Configuring auth for $registry in config.toml"
+                printf "\n[plugins.\"io.containerd.cri.v1.images\".registry.configs.\"%s\".auth]\n  username = \"%s\"\n  password = \"%s\"\n" "$registry" "$username" "$password" >> /etc/containerd/config.toml
+                printf "\n[plugins.\"io.containerd.grpc.v1.cri\".registry.configs.\"%s\".auth]\n  username = \"%s\"\n  password = \"%s\"\n" "$registry" "$username" "$password" >> /etc/containerd/config.toml
+              fi
+            done
+        documentIndex: 4
+
   ###############################################
   # disk-kubelet matchVolume blockSize          #
   ###############################################

--- a/packages/core/platform/templates/containerd-registry-secret.yaml
+++ b/packages/core/platform/templates/containerd-registry-secret.yaml
@@ -9,7 +9,7 @@ stringData:
 {{- range $registry, $mirror := .Values.registries.mirrors }}
 {{- if $mirror.endpoints }}
   {{ $registry }}.toml: |
-    server = "https://{{ $registry }}"
+    server = "https://{{ regexReplaceAll `_([0-9]+)$` $registry `:${1}` }}"
 {{- range $endpoint := $mirror.endpoints }}
     [host."{{ $endpoint }}"]
       capabilities = ["pull", "resolve"]

--- a/packages/core/platform/templates/containerd-registry-secret.yaml
+++ b/packages/core/platform/templates/containerd-registry-secret.yaml
@@ -13,7 +13,9 @@ stringData:
 {{- range $endpoint := $mirror.endpoints }}
     [host."{{ $endpoint }}"]
       capabilities = ["pull", "resolve"]
-{{- $endpointConfig := index $.Values.registries.config $endpoint }}
+{{- $endpointWithoutScheme := $endpoint | trimPrefix "https://" | trimPrefix "http://" }}
+{{- $endpointWithUnderscore := replace ":" "_" $endpointWithoutScheme }}
+{{- $endpointConfig := or (index $.Values.registries.config $endpointWithoutScheme) (index $.Values.registries.config $endpointWithUnderscore) }}
 {{- if $endpointConfig }}
 {{- if $endpointConfig.tls }}
 {{- if $endpointConfig.tls.insecureSkipVerify }}


### PR DESCRIPTION
## What this PR does

This PR adds support for repository ports in the containerd configuration path (`KubeadmConfigTemplate` and `/etc/containerd/certs.d/`).
It replaces the last occurrence of `_` followed by digits (the port number) and `.toml` with a colon `:` and the port number.

For example, a secret key `fontanero.hoztnode.net_5050.toml` will now correctly map to:
- path: `/etc/containerd/certs.d/fontanero.hoztnode.net:5050/hosts.toml`

The regex ensures that only the last `_` followed by digits is replaced, leaving other underscores in the domain untouched.

### Screenshots

N/A (no UI changes)

### Release note

```release-note
fix(kubernetes): support repository ports in containerd certs path
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed containerd registry certificate/`hosts.toml` mounting to use the correct directory naming, so containerd reliably reads the intended configuration.
  * Improved containerd mirror, TLS, and credential resolution by normalizing registry endpoints and ensuring the corresponding `auth` settings are applied consistently across supported containerd registry plugins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->