### PR TITLE
fix(seaweedfs): restore S3 TLS and COSI provisioner SA after 4.31 bump

### DIFF
--- a/packages/system/seaweedfs/Makefile
+++ b/packages/system/seaweedfs/Makefile
@@ -14,5 +14,7 @@ update:
 	tar xzvf - --strip 3 -C charts seaweedfs-$${version}/k8s/charts/seaweedfs
 	patch --no-backup-if-mismatch -p4 < patches/resize-api-server-annotation.diff
 	patch --no-backup-if-mismatch -p4 < patches/disable-ca-key-rotation.patch
+	patch --no-backup-if-mismatch -p4 < patches/s3-tls-main-port.patch
+	patch --no-backup-if-mismatch -p4 < patches/cosi-provisioner-sa-name.patch
 	#patch --no-backup-if-mismatch -p4 < patches/retention-policy-delete.yaml
 

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
@@ -58,7 +58,7 @@ spec:
       priorityClassName: {{ .Values.cosi.priorityClassName | quote }}
       {{- end }}
       enableServiceLinks: false
-      serviceAccountName: {{ include "seaweedfs.componentName" (list . "objectstorage-provisioner") }}
+      serviceAccountName: {{ .Values.global.seaweedfs.serviceAccountName }}-objectstorage-provisioner
       {{- if .Values.cosi.initContainers }}
       initContainers:
         {{ tpl .Values.cosi.initContainers . | nindent 8 | trim }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
@@ -127,8 +127,8 @@ spec:
               {{- if .Values.global.seaweedfs.enableSecurity }}
               {{- if .Values.s3.httpsPort }}
               -port.https={{ .Values.s3.httpsPort }} \
-              {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "") | nindent 14 }}
               {{- end }}
+              {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "") | nindent 14 }}
               {{- end }}
               {{- if .Values.s3.domainName }}
               -domainName={{ .Values.s3.domainName }} \

--- a/packages/system/seaweedfs/patches/cosi-provisioner-sa-name.patch
+++ b/packages/system/seaweedfs/patches/cosi-provisioner-sa-name.patch
@@ -1,0 +1,13 @@
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+index aefc9d369..d485e0678 100644
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+@@ -58,7 +58,7 @@ spec:
+       priorityClassName: {{ .Values.cosi.priorityClassName | quote }}
+       {{- end }}
+       enableServiceLinks: false
+-      serviceAccountName: {{ include "seaweedfs.componentName" (list . "objectstorage-provisioner") }}
++      serviceAccountName: {{ .Values.global.seaweedfs.serviceAccountName }}-objectstorage-provisioner
+       {{- if .Values.cosi.initContainers }}
+       initContainers:
+         {{ tpl .Values.cosi.initContainers . | nindent 8 | trim }}

--- a/packages/system/seaweedfs/patches/s3-tls-main-port.patch
+++ b/packages/system/seaweedfs/patches/s3-tls-main-port.patch
@@ -1,0 +1,14 @@
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+index db231fc96..efb967bb2 100644
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+@@ -127,8 +127,8 @@ spec:
+               {{- if .Values.global.seaweedfs.enableSecurity }}
+               {{- if .Values.s3.httpsPort }}
+               -port.https={{ .Values.s3.httpsPort }} \
+-              {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "") | nindent 14 }}
+               {{- end }}
++              {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "") | nindent 14 }}
+               {{- end }}
+               {{- if .Values.s3.domainName }}
+               -domainName={{ .Values.s3.domainName }} \

--- a/packages/system/seaweedfs/tests/s3_tls_cosi_sa_test.yaml
+++ b/packages/system/seaweedfs/tests/s3_tls_cosi_sa_test.yaml
@@ -1,0 +1,78 @@
+suite: seaweedfs s3 TLS on main port + COSI provisioner SA name
+
+# Pins two regressions introduced by the 4.31 chart bump:
+#
+# 1. S3 TLS. Until 4.05 the `-cert.file`/`-key.file` args were rendered whenever
+#    enableSecurity was on, so `weed s3` served TLS on the main port (8333) and
+#    our HTTPS readiness/liveness probes (and the ingress backend-protocol=HTTPS
+#    and the COSI sidecar's https:// endpoint) worked. 4.31 nested those args
+#    inside `if .Values.s3.httpsPort`, and we ship httpsPort=0, so s3 served
+#    plaintext and every probe failed with "server gave HTTP response to HTTPS
+#    client". The s3-tls-main-port.patch restores the 4.05 behaviour.
+#
+# 2. COSI provisioner ServiceAccount. cosi-service-account.yaml and the
+#    ClusterRoleBinding both name the SA <serviceAccountName>-objectstorage-provisioner,
+#    but the Deployment referenced componentName (<release>-objectstorage-provisioner).
+#    Whenever serviceAccountName != release name the Deployment could not create
+#    pods ("serviceaccount not found"). The cosi-provisioner-sa-name.patch aligns
+#    the Deployment with the SA + binding.
+
+templates:
+  - charts/seaweedfs/templates/s3/s3-deployment.yaml
+  - charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+
+release:
+  name: seaweedfs
+  namespace: cozy-seaweedfs
+
+tests:
+  - it: renders s3 TLS cert/key args under enableSecurity even when httpsPort is 0
+    template: charts/seaweedfs/templates/s3/s3-deployment.yaml
+    set:
+      global.seaweedfs.enableSecurity: true
+      seaweedfs.s3.enabled: true
+      seaweedfs.s3.httpsPort: 0
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "-cert\\.file=/usr/local/share/ca-certificates/client/tls\\.crt"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "-key\\.file=/usr/local/share/ca-certificates/client/tls\\.key"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "-port\\.https"
+
+  - it: still gates the cert args on enableSecurity
+    template: charts/seaweedfs/templates/s3/s3-deployment.yaml
+    set:
+      global.seaweedfs.enableSecurity: false
+      seaweedfs.s3.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "-cert\\.file"
+
+  - it: renders -port.https alongside the cert args when httpsPort is set
+    template: charts/seaweedfs/templates/s3/s3-deployment.yaml
+    set:
+      global.seaweedfs.enableSecurity: true
+      seaweedfs.s3.enabled: true
+      seaweedfs.s3.httpsPort: 8334
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "-port\\.https=8334"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "-cert\\.file=/usr/local/share/ca-certificates/client/tls\\.crt"
+
+  - it: COSI provisioner Deployment uses the serviceAccountName-based SA, not componentName
+    template: charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+    set:
+      seaweedfs.cosi.enabled: true
+      global.seaweedfs.serviceAccountName: custom-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: custom-sa-objectstorage-provisioner


### PR DESCRIPTION
## What this PR does

The SeaweedFS 4.31 chart bump (#2834) broke E2E for **every** PR on `main`: in `tenant-root` the `seaweedfs-system` release never becomes ready, so `install-cozystack` times out waiting on its HelmRelease. Two regressions came in with the new chart; both reproduce with a plain `helm template` of `packages/system/seaweedfs` (no cluster needed) and are fixed here as vendored patches re-applied by `make update`, with helm-unittest coverage.

**1. S3 served plaintext while everything expected HTTPS.** Until chart 4.05 the `-cert.file`/`-key.file` args were rendered whenever `enableSecurity` was set, so `weed s3` served TLS on the main port (8333). Chart 4.31 nested those args inside `{{- if .Values.s3.httpsPort }}`, and we ship `httpsPort: 0` — so no TLS args rendered, s3 spoke HTTP, and the HTTPS readiness/liveness probes (plus the ingress `backend-protocol: HTTPS` and the COSI sidecar's `https://` endpoint) all failed with `server gave HTTP response to HTTPS client`. `patches/s3-tls-main-port.patch` moves the cert/key args back out of the `httpsPort` gate, restoring TLS-on-main-port; `-port.https` is still only added when `httpsPort` is set.

**2. COSI provisioner ServiceAccount name mismatch.** `cosi-service-account.yaml` and the `ClusterRoleBinding` name the SA `<global.seaweedfs.serviceAccountName>-objectstorage-provisioner`, but the Deployment referenced `componentName` (`<release>-objectstorage-provisioner`). Whenever `serviceAccountName` != release name — our case, `tenant-root-seaweedfs` vs `seaweedfs-system` — the Deployment could not create pods (`serviceaccount "seaweedfs-system-objectstorage-provisioner" not found`). `patches/cosi-provisioner-sa-name.patch` aligns the Deployment with the SA and the binding. (Upstream installs only avoid this because their release name and serviceAccountName usually coincide.)

This is `main`-only: the 4.31 chart landed only on `main`, every release branch is still on 4.05, so no `backport` is needed.

### Release note

```release-note
fix(seaweedfs): restore S3 TLS on the main port and fix the COSI provisioner ServiceAccount name after the 4.31 chart bump, so tenant SeaweedFS becomes ready again
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed S3 TLS certificate arguments to render correctly when HTTPS port is disabled.
  * Updated COSI provisioner to use configurable service account naming.

* **Tests**
  * Added regression tests for S3 TLS configuration and COSI service account handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->