### PR TITLE
feat(seaweedfs): bump chart to 4.34

### DIFF
--- a/packages/system/seaweedfs/charts/seaweedfs/Chart.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: SeaweedFS
 name: seaweedfs
-appVersion: "4.31"
+appVersion: "4.34"
 # Dev note: Trigger a helm chart release by `git tag -a helm-<version>`
-version: 4.31.0
+version: 4.34.0

--- a/packages/system/seaweedfs/charts/seaweedfs/dashboards/seaweedfs-grafana-dashboard.json
+++ b/packages/system/seaweedfs/charts/seaweedfs/dashboards/seaweedfs-grafana-dashboard.json
@@ -3666,6 +3666,291 @@
       ],
       "title": "S3 Bucket Object Count",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 130
+      },
+      "id": 92,
+      "panels": [],
+      "title": "Filer Object Size Distribution",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rate of new objects created, split by size range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "objects/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 131
+      },
+      "id": 93,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.1.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1024\",namespace=\"$NAMESPACE\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "< 1KB",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"102400\",namespace=\"$NAMESPACE\"}[$__rate_interval])) - sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1024\",namespace=\"$NAMESPACE\"}[$__rate_interval])), 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "1KB - 100KB",
+          "refId": "B",
+          "step": 60
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+06\",namespace=\"$NAMESPACE\"}[$__rate_interval])) - sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"102400\",namespace=\"$NAMESPACE\"}[$__rate_interval])), 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "100KB - 1MB",
+          "refId": "C",
+          "step": 60
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+08\",namespace=\"$NAMESPACE\"}[$__rate_interval])) - sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+06\",namespace=\"$NAMESPACE\"}[$__rate_interval])), 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "1MB - 100MB",
+          "refId": "D",
+          "step": 60
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.073741824e+09\",namespace=\"$NAMESPACE\"}[$__rate_interval])) - sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+08\",namespace=\"$NAMESPACE\"}[$__rate_interval])), 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "100MB - 1GB",
+          "refId": "E",
+          "step": 60
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(rate(SeaweedFS_filer_object_size_bytes_count{namespace=\"$NAMESPACE\"}[$__rate_interval])) - sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.073741824e+09\",namespace=\"$NAMESPACE\"}[$__rate_interval])), 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "> 1GB",
+          "refId": "F",
+          "step": 60
+        }
+      ],
+      "title": "Filer Object Write Rate by Size Range",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Objects created per size range over the selected time window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 131
+      },
+      "id": 94,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "pluginVersion": "8.1.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1024\",namespace=\"$NAMESPACE\"}[$__range]))",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "< 1KB",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"102400\",namespace=\"$NAMESPACE\"}[$__range])) - sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1024\",namespace=\"$NAMESPACE\"}[$__range])), 0)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "1KB - 100KB",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+06\",namespace=\"$NAMESPACE\"}[$__range])) - sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"102400\",namespace=\"$NAMESPACE\"}[$__range])), 0)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "100KB - 1MB",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+08\",namespace=\"$NAMESPACE\"}[$__range])) - sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+06\",namespace=\"$NAMESPACE\"}[$__range])), 0)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "1MB - 100MB",
+          "refId": "D"
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.073741824e+09\",namespace=\"$NAMESPACE\"}[$__range])) - sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+08\",namespace=\"$NAMESPACE\"}[$__range])), 0)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "100MB - 1GB",
+          "refId": "E"
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(increase(SeaweedFS_filer_object_size_bytes_count{namespace=\"$NAMESPACE\"}[$__range])) - sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.073741824e+09\",namespace=\"$NAMESPACE\"}[$__range])), 0)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "> 1GB",
+          "refId": "F"
+        }
+      ],
+      "title": "Filer Object Size Distribution",
+      "type": "bargauge"
     }
   ],
   "refresh": "",

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
@@ -81,8 +81,9 @@ spec:
           imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
           env:
             {{- /* Determine default cluster alias and the corresponding env var keys to avoid conflicts */}}
-            {{- $envMerged := merge (.Values.global.seaweedfs.extraEnvironmentVars | default dict) (.Values.allInOne.extraEnvironmentVars | default dict) }}
-            {{- $clusterDefault := default "sw" (index $envMerged "WEED_CLUSTER_DEFAULT") }}
+            {{- $mergedExtraEnvironmentVars := dict }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.allInOne "target" $mergedExtraEnvironmentVars) }}
+            {{- $clusterDefault := default "sw" (index $mergedExtraEnvironmentVars "WEED_CLUSTER_DEFAULT") }}
             {{- $clusterUpper := upper $clusterDefault }}
             {{- $clusterMasterKey := printf "WEED_CLUSTER_%s_MASTER" $clusterUpper }}
             {{- $clusterFilerKey := printf "WEED_CLUSTER_%s_FILER" $clusterUpper }}
@@ -100,8 +101,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: SEAWEEDFS_FULLNAME
               value: "{{ include "seaweedfs.fullname" . }}"
-            {{- if .Values.allInOne.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.allInOne.extraEnvironmentVars }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
             {{- if and (ne $key $clusterMasterKey) (ne $key $clusterFilerKey) }}
             - name: {{ $key }}
               {{- if kindIs "string" $value }}
@@ -110,20 +111,6 @@ spec:
               valueFrom:
                 {{ toYaml $value | nindent 16 }}
               {{- end }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.global.seaweedfs.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.global.seaweedfs.extraEnvironmentVars }}
-            {{- if and (ne $key $clusterMasterKey) (ne $key $clusterFilerKey) }}
-            - name: {{ $key }}
-              {{- if kindIs "string" $value }}
-              value: {{ tpl $value $ | quote }}
-              {{- else }}
-              valueFrom:
-                {{ toYaml $value | nindent 16 }}
-              {{- end }}
-            {{- end }}
             {{- end }}
             {{- end }}
             # Inject computed cluster endpoints for the default cluster
@@ -272,6 +259,9 @@ spec:
               {{- $authMethods := .Values.allInOne.sftp.authMethods | default .Values.sftp.authMethods }}
               {{- if $authMethods }}
               -sftp.authMethods={{ $authMethods }} \
+              {{- if contains "certificate" $authMethods }}
+              -sftp.trustedUserCAKeysFile=/etc/sw/sftp_ca/ca_user.pub \
+              {{- end }}
               {{- end }}
               {{- $maxAuthTries := .Values.allInOne.sftp.maxAuthTries | default .Values.sftp.maxAuthTries }}
               {{- if $maxAuthTries }}
@@ -317,6 +307,12 @@ spec:
             {{- if or .Values.allInOne.sftp.enableAuth .Values.sftp.enableAuth }}
             - mountPath: /etc/sw/sftp
               name: config-users
+              readOnly: true
+            {{- end }}
+            {{- $aioAuthMethods := .Values.allInOne.sftp.authMethods | default .Values.sftp.authMethods }}
+            {{- if and $aioAuthMethods (contains "certificate" $aioAuthMethods) }}
+            - mountPath: /etc/sw/sftp_ca
+              name: config-sftp-ca
               readOnly: true
             {{- end }}
             {{- end }}
@@ -453,6 +449,18 @@ spec:
           secret:
             defaultMode: 420
             secretName: {{ default (printf "%s-sftp-secret" (include "seaweedfs.fullname" .)) (or .Values.allInOne.sftp.existingConfigSecret .Values.sftp.existingConfigSecret) }}
+        {{- end }}
+        {{- $aioAuthMethodsVol := .Values.allInOne.sftp.authMethods | default .Values.sftp.authMethods }}
+        {{- if and $aioAuthMethodsVol (contains "certificate" $aioAuthMethodsVol) }}
+        {{- $aioCASecret := or .Values.allInOne.sftp.existingCAKeysSecret .Values.sftp.existingCAKeysSecret }}
+        {{- $aioCAKeys := or .Values.allInOne.sftp.trustedUserCAKeys .Values.sftp.trustedUserCAKeys }}
+        {{- if and (not $aioCASecret) (not $aioCAKeys) }}
+        {{- fail "allInOne.sftp.authMethods includes \"certificate\" but neither trustedUserCAKeys nor existingCAKeysSecret is set" }}
+        {{- end }}
+        - name: config-sftp-ca
+          secret:
+            defaultMode: 420
+            secretName: {{ default (printf "%s-sftp-ca-secret" (include "seaweedfs.fullname" .)) $aioCASecret }}
         {{- end }}
         {{- end }}
         {{- if .Values.filer.notificationConfig }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-ca-secret.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-ca-secret.yaml
@@ -1,0 +1,40 @@
+{{- include "seaweedfs.compat" . -}}
+{{- /*
+Render a chart-managed Secret carrying the SSH user CA public key(s) for
+certificate-based SFTP authentication, but only when:
+  - SFTP (standalone or all-in-one) is enabled,
+  - "certificate" is in the relevant authMethods list,
+  - the user provided inline CA keys via sftp.trustedUserCAKeys, and
+  - no existingCAKeysSecret is set (which would supersede this Secret).
+*/}}
+{{- $sftpEnabled := or .Values.sftp.enabled (and .Values.allInOne.enabled .Values.allInOne.sftp.enabled) -}}
+{{- $authMethods := .Values.sftp.authMethods -}}
+{{- if and .Values.allInOne.enabled .Values.allInOne.sftp.authMethods -}}
+{{- $authMethods = .Values.allInOne.sftp.authMethods -}}
+{{- end -}}
+{{- $certInMethods := and $authMethods (contains "certificate" $authMethods) -}}
+{{- $inlineCAKeys := .Values.sftp.trustedUserCAKeys -}}
+{{- if and .Values.allInOne.enabled .Values.allInOne.sftp.trustedUserCAKeys -}}
+{{- $inlineCAKeys = .Values.allInOne.sftp.trustedUserCAKeys -}}
+{{- end -}}
+{{- $existingSecret := .Values.sftp.existingCAKeysSecret -}}
+{{- if and .Values.allInOne.enabled .Values.allInOne.sftp.existingCAKeysSecret -}}
+{{- $existingSecret = .Values.allInOne.sftp.existingCAKeysSecret -}}
+{{- end -}}
+{{- if and $sftpEnabled $certInMethods $inlineCAKeys (not $existingSecret) }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-sftp-ca-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: sftp
+stringData:
+  ca_user.pub: |
+{{ $inlineCAKeys | indent 4 }}
+{{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
@@ -135,6 +135,9 @@ spec:
               {{- end }}
               {{- if .Values.sftp.authMethods }}
               -authMethods={{ .Values.sftp.authMethods }} \
+              {{- if contains "certificate" .Values.sftp.authMethods }}
+              -trustedUserCAKeysFile=/etc/sw/sftp_ca/ca_user.pub \
+              {{- end }}
               {{- end }}
               {{- if .Values.sftp.maxAuthTries }}
               -maxAuthTries={{ .Values.sftp.maxAuthTries }} \
@@ -176,6 +179,11 @@ spec:
             - mountPath: /etc/sw/ssh
               name: config-ssh
               readOnly: true
+            {{- if and .Values.sftp.authMethods (contains "certificate" .Values.sftp.authMethods) }}
+            - mountPath: /etc/sw/sftp_ca
+              name: config-sftp-ca
+              readOnly: true
+            {{- end }}
             {{- if include "seaweedfs.securityConfigEnabled" . }}
             - name: security-config
               readOnly: true
@@ -256,6 +264,19 @@ spec:
             {{- else }}
             secretName: {{ include "seaweedfs.fullname" . }}-sftp-ssh-secret
             {{- end }}
+        {{- if and .Values.sftp.authMethods (contains "certificate" .Values.sftp.authMethods) }}
+        {{- if and (not .Values.sftp.existingCAKeysSecret) (not .Values.sftp.trustedUserCAKeys) }}
+        {{- fail "sftp.authMethods includes \"certificate\" but neither sftp.trustedUserCAKeys nor sftp.existingCAKeysSecret is set" }}
+        {{- end }}
+        - name: config-sftp-ca
+          secret:
+            defaultMode: 420
+            {{- if .Values.sftp.existingCAKeysSecret }}
+            secretName: {{ .Values.sftp.existingCAKeysSecret }}
+            {{- else }}
+            secretName: {{ include "seaweedfs.fullname" . }}-sftp-ca-secret
+            {{- end }}
+        {{- end }}
         {{- if eq .Values.sftp.logs.type "hostPath" }}
         - name: logs
           hostPath:

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -333,11 +333,13 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/* True when security.toml should be rendered and mounted. volumeWrite is
-     excluded since it defaults to true. */}}
+     excluded unless its non-default expiration is configured. */}}
 {{- define "seaweedfs.securityConfigEnabled" -}}
 {{- $sec := (.Values.global.seaweedfs).securityConfig | default dict -}}
 {{- $jwt := $sec.jwtSigning | default dict -}}
-{{- if or .Values.global.seaweedfs.enableSecurity $jwt.volumeRead $jwt.filerWrite $jwt.filerRead -}}
+{{- $expiresAfterSeconds := $jwt.expiresAfterSeconds | default dict -}}
+{{- $volumeWriteExpirationConfigured := and $jwt.volumeWrite (gt (int $expiresAfterSeconds.volumeWrite) 0) -}}
+{{- if or .Values.global.seaweedfs.enableSecurity $volumeWriteExpirationConfigured $jwt.volumeRead $jwt.filerWrite $jwt.filerRead -}}
 true
 {{- end -}}
 {{- end -}}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -143,6 +143,8 @@ spec:
           {{- if kindIs "bool" .versioning }}
             {{- if .versioning }}
               {{- $bucketVersioning = "Enabled" }}
+            {{- else }}
+              {{- $bucketVersioning = "Suspended" }}
             {{- end }}
           {{- else if kindIs "string" .versioning }}
             {{- $versioningLower := lower .versioning }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/security-configmap.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/security-configmap.yaml
@@ -19,40 +19,56 @@ data:
   {{- $existing = lookup "v1" "ConfigMap" .Release.Namespace $legacyName }}
   {{- end }}
   {{- $securityConfig := fromToml (dig "data" "security.toml" "" $existing) }}
+  {{- $securityConfigValues := .Values.global.seaweedfs.securityConfig | default dict }}
+  {{- $jwtSigning := $securityConfigValues.jwtSigning | default dict }}
+  {{- $expiresAfterSeconds := $jwtSigning.expiresAfterSeconds | default dict }}
   security.toml: |-
     # this file is read by master, volume server, and filer
 
-    {{- if .Values.global.seaweedfs.securityConfig.jwtSigning.volumeWrite }}
+    {{- if $jwtSigning.volumeWrite }}
     # the jwt signing key is read by master and volume server
-    # a jwt expires in 10 seconds
+    # the jwt defaults to expire after 10 seconds
     [jwt.signing]
     key = "{{ dig "jwt" "signing" "key" (randAlphaNum 10 | b64enc) $securityConfig }}"
+    {{- if gt (int $expiresAfterSeconds.volumeWrite) 0 }}
+    expires_after_seconds = {{ int $expiresAfterSeconds.volumeWrite }}
+    {{- end }}
     {{- end }}
 
-    {{- if .Values.global.seaweedfs.securityConfig.jwtSigning.volumeRead }}
+    {{- if $jwtSigning.volumeRead }}
     # this jwt signing key is read by master and volume server, and it is used for read operations:
     # - the Master server generates the JWT, which can be used to read a certain file on a volume server
     # - the Volume server validates the JWT on reading
+    # the jwt defaults to expire after 60 seconds
     [jwt.signing.read]
     key = "{{ dig "jwt" "signing" "read" "key" (randAlphaNum 10 | b64enc) $securityConfig }}"
+    {{- if gt (int $expiresAfterSeconds.volumeRead) 0 }}
+    expires_after_seconds = {{ int $expiresAfterSeconds.volumeRead }}
+    {{- end }}
     {{- end }}
 
-    {{- if .Values.global.seaweedfs.securityConfig.jwtSigning.filerWrite }}
+    {{- if $jwtSigning.filerWrite }}
     # If this JWT key is configured, Filer only accepts writes over HTTP if they are signed with this JWT:
     # - f.e. the S3 API Shim generates the JWT
     # - the Filer server validates the JWT on writing
-    # the jwt defaults to expire after 10 seconds.
+    # the jwt defaults to expire after 10 seconds
     [jwt.filer_signing]
     key = "{{ dig "jwt" "filer_signing" "key" (randAlphaNum 10 | b64enc) $securityConfig }}"
+    {{- if gt (int $expiresAfterSeconds.filerWrite) 0 }}
+    expires_after_seconds = {{ int $expiresAfterSeconds.filerWrite }}
+    {{- end }}
     {{- end }}
 
-    {{- if .Values.global.seaweedfs.securityConfig.jwtSigning.filerRead }}
+    {{- if $jwtSigning.filerRead }}
     # If this JWT key is configured, Filer only accepts reads over HTTP if they are signed with this JWT:
     # - f.e. the S3 API Shim generates the JWT
     # - the Filer server validates the JWT on reading
-    # the jwt defaults to expire after 10 seconds.
+    # the jwt defaults to expire after 60 seconds
     [jwt.filer_signing.read]
     key = "{{ dig "jwt" "filer_signing" "read" "key" (randAlphaNum 10 | b64enc) $securityConfig }}"
+    {{- if gt (int $expiresAfterSeconds.filerRead) 0 }}
+    expires_after_seconds = {{ int $expiresAfterSeconds.filerRead }}
+    {{- end }}
     {{- end }}
 
     {{- if .Values.global.seaweedfs.enableSecurity }}

--- a/packages/system/seaweedfs/charts/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/values.yaml
@@ -26,6 +26,13 @@ global:
         volumeRead: false
         filerWrite: false
         filerRead: false
+        # Positive values override SeaweedFS token lifetime defaults.
+        # Zero keeps the runtime defaults: 10s for writes and 60s for reads.
+        expiresAfterSeconds:
+          volumeWrite: 0
+          volumeRead: 0
+          filerWrite: 0
+          filerRead: 0
     # we will use this serviceAccountName for all ClusterRoles/ClusterRoleBindings
     serviceAccountName: "seaweedfs"
     serviceAccountAnnotations: {}
@@ -919,7 +926,7 @@ filer:
     # Buckets may be exposed publicly by setting `anonymousRead` to `true`
     # ttl format: [1-255][m|h|d|w|M|y] (e.g., 7d)
     # objectLock enables S3 Object Lock (irreversible, forces versioning)
-    # versioning: Enabled or Suspended (or true to enable)
+    # versioning: Enabled or Suspended (or bool true/false)
     # createBuckets:
     #   - name: bucket-a
     #     anonymousRead: true
@@ -972,7 +979,7 @@ s3:
   # Buckets may be exposed publicly by setting `anonymousRead` to `true`
   # ttl format: [1-255][m|h|d|w|M|y] (e.g., 7d)
   # objectLock enables S3 Object Lock (irreversible, forces versioning)
-  # versioning: Enabled or Suspended (or true to enable)
+  # versioning: Enabled or Suspended (or bool true/false)
   # createBuckets:
   #   - name: bucket-a
   #     anonymousRead: true
@@ -1138,7 +1145,7 @@ sftp:
   # SSH server configuration
   sshPrivateKey: "/etc/sw/seaweedfs_sftp_ssh_private_key"  # Path to the SSH private key file for host authentication
   hostKeysFolder: "/etc/sw/ssh"  # path to folder containing SSH private key files for host authentication
-  authMethods: "password,publickey"  # Comma-separated list of allowed auth methods: password, publickey, keyboard-interactive
+  authMethods: "password,publickey"  # Comma-separated list of allowed auth methods: password, publickey, certificate
   maxAuthTries: 6  # Maximum number of authentication attempts per connection
   bannerMessage: "SeaweedFS SFTP Server"  # Message displayed before authentication
   loginGraceTime: "2m"  # Timeout for authentication
@@ -1154,6 +1161,18 @@ sftp:
   existingConfigSecret: null
   # Set to the name of an existing kubernetes Secret with the list of ssh private keys for sftp
   existingSshConfigSecret: null
+
+  # SSH user-certificate authentication (CA-signed user certs). Mirrors
+  # OpenSSH `TrustedUserCAKeys` and MinIO `--sftp=trusted-user-ca-key`.
+  # Add "certificate" to `authMethods` to activate; when active, plain
+  # public keys are rejected on the public-key channel.
+  #
+  # Inline CA public keys in OpenSSH authorized_keys format (one per
+  # line). Ignored when `existingCAKeysSecret` is set.
+  trustedUserCAKeys: ""
+  # Set to the name of an existing kubernetes Secret carrying the CA
+  # public keys under data key `ca_user.pub`.
+  existingCAKeysSecret: null
 
   # Additional resources
   sidecars: []
@@ -1514,7 +1533,7 @@ allInOne:
     # Buckets may be exposed publicly by setting `anonymousRead` to `true`
     # ttl format: [1-255][m|h|d|w|M|y] (e.g., 7d)
     # objectLock enables S3 Object Lock (irreversible, forces versioning)
-    # versioning: Enabled or Suspended (or true to enable)
+    # versioning: Enabled or Suspended (or bool true/false)
     # createBuckets:
     #   - name: bucket-a
     #     anonymousRead: true
@@ -1545,6 +1564,10 @@ allInOne:
     existingConfigSecret: null
     # Set to the name of an existing kubernetes Secret with the SSH keys
     existingSshConfigSecret: null
+    # SSH user-certificate authentication. See sftp.trustedUserCAKeys above.
+    # (null on either field inherits from the top-level sftp.* setting.)
+    trustedUserCAKeys: null
+    existingCAKeysSecret: null
 
   # Service settings
   service:


### PR DESCRIPTION
## Summary

Pulls in upstream SeaweedFS **4.34**, which includes:

- **SIGHUP-based hot-reload of JWT signing keys** (seaweedfs/seaweedfs#9826, fixing seaweedfs/seaweedfs#9823). Operators recovering from key rotation or mismatch no longer need to restart `weed` processes — `kill -HUP` is enough.
- **Native `expires_after_seconds` values** for `jwt.signing` / `jwt.signing.read` / `jwt.filer_signing` / `jwt.filer_signing.read`, exposed under `global.seaweedfs.securityConfig.jwtSigning.expiresAfterSeconds`. This supersedes the patch attempted in the now-closed #2911.

`make update` driven; patches in `patches/` (resize-api-server-annotation, disable-ca-key-rotation) reapply cleanly against 4.34.

Supersedes #2913.

## Test plan

- [ ] CI green (chart lint + helm unittest + e2e)
- [ ] Manual: install 4.34 chart in dev cluster, kill -HUP master pod after rotating jwt.signing key in security.toml, verify volume/master/filer pick up new key without restart
- [ ] Manual: set values.global.seaweedfs.securityConfig.jwtSigning.expiresAfterSeconds.volumeWrite=3600, verify rendered security.toml contains the field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SFTP certificate-based authentication support with configurable CA keys
  * Introduced configurable JWT signing token lifetimes for volume and filer operations
  * Added "Filer Object Size Distribution" monitoring section to Grafana dashboard

* **Bug Fixes**
  * Fixed bucket versioning handling for disabled state

* **Chores**
  * Updated chart version to 4.34

<!-- end of auto-generated comment: release notes by coderabbit.ai -->