### PR TITLE
test(ci): seed branch to hunt and fix E2E flakes on main

### DIFF
--- a/hack/cozyreport.sh
+++ b/hack/cozyreport.sh
@@ -134,6 +134,24 @@ kubectl get packagesources --no-headers | awk '$3 != "True"' | \
     kubectl describe packagesource $NAME > $DIR/describe.txt 2>&1
   done
 
+echo "Collecting source-watcher diagnostics..."
+DIR=$REPORT_DIR/kubernetes/source-watcher
+mkdir -p $DIR
+# PackageSource copies its Ready condition straight from ArtifactGenerator.Status,
+# so a stuck PackageSource ultimately means a stuck ArtifactGenerator or its OCIRepository source.
+kubectl get artifactgenerators -A > $DIR/artifactgenerators.txt 2>&1 || true
+kubectl get artifactgenerators -A -o yaml > $DIR/artifactgenerators.yaml 2>&1 || true
+kubectl get ocirepositories -A > $DIR/ocirepositories.txt 2>&1 || true
+kubectl get ocirepositories -A -o yaml > $DIR/ocirepositories.yaml 2>&1 || true
+kubectl get pods -n cozy-fluxcd -l app.kubernetes.io/name=source-watcher -o wide > $DIR/pods.txt 2>&1 || true
+kubectl get pods -n cozy-fluxcd -l app.kubernetes.io/name=source-watcher -o name 2>/dev/null | \
+  while read POD; do
+    POD=${POD#pod/}
+    kubectl logs -n cozy-fluxcd $POD --all-containers --prefix --tail=2000 > $DIR/$POD.log 2>&1 || true
+    kubectl logs -n cozy-fluxcd $POD --all-containers --prefix --tail=2000 --previous > $DIR/$POD-previous.log 2>&1 || true
+  done
+kubectl get events -n cozy-fluxcd --sort-by=.lastTimestamp > $DIR/events.txt 2>&1 || true
+
 echo "Collecting cozystack apps..."
 DIR=$REPORT_DIR/cozystack-apps
 mkdir -p $DIR

--- a/hack/cozytest.sh
+++ b/hack/cozytest.sh
@@ -120,3 +120,5 @@ awk -v pat="$PATTERN" '
 ' "$TMP_SH" | while IFS=' ' read -r fn title; do
   run_one "$fn" "$title"
 done
+
+

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -45,7 +45,7 @@ EOF
   timeout 30 sh -ec 'until nc -z localhost 8333; do sleep 1; done'
 
   # --- Test readwrite user (admin) ---
-  mc alias set rw-user https://localhost:8333 $ADMIN_ACCESS_KEY $ADMIN_SECRET_KEY --insecure
+  mc alias set rw-user https://127.0.0.1:8333 $ADMIN_ACCESS_KEY $ADMIN_SECRET_KEY --insecure
 
   # Admin can upload
   echo "readwrite test" > /tmp/rw-test.txt
@@ -58,7 +58,7 @@ EOF
   mc cp --insecure rw-user/$BUCKET_NAME/rw-test.txt /tmp/rw-test-download.txt
 
   # --- Test readonly user (viewer) ---
-  mc alias set ro-user https://localhost:8333 $VIEWER_ACCESS_KEY $VIEWER_SECRET_KEY --insecure
+  mc alias set ro-user https://127.0.0.1:8333 $VIEWER_ACCESS_KEY $VIEWER_SECRET_KEY --insecure
 
   # Viewer can list
   mc ls --insecure ro-user/$BUCKET_NAME/rw-test.txt

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -38,11 +38,17 @@ EOF
   VIEWER_ACCESS_KEY=$(jq -r '.spec.secretS3.accessKeyID' bucket-viewer-credentials.json)
   VIEWER_SECRET_KEY=$(jq -r '.spec.secretS3.accessSecretKey' bucket-viewer-credentials.json)
 
-  # Start port-forwarding
-  bash -c 'timeout 100s kubectl port-forward service/seaweedfs-s3 -n tenant-root 8333:8333 > /dev/null 2>&1 &'
+  # Start port-forwarding in this shell (not via `bash -c '... &'` — the
+  # wrapper subshell exits immediately, the backgrounded kubectl becomes an
+  # orphan and gets reaped before the first mc S3 request, so `mc cp` sees
+  # `dial tcp 127.0.0.1:8333: connect: connection refused` even though the
+  # earlier `nc -z` probe succeeded.
+  kubectl port-forward service/seaweedfs-s3 -n tenant-root 8333:8333 >/dev/null 2>&1 &
+  PORT_FORWARD_PID=$!
+  trap 'kill ${PORT_FORWARD_PID} 2>/dev/null || true' RETURN
 
   # Wait for port-forward to be ready
-  timeout 30 sh -ec 'until nc -z localhost 8333; do sleep 1; done'
+  timeout 30 sh -ec 'until nc -z 127.0.0.1 8333; do sleep 1; done'
 
   # --- Test readwrite user (admin) ---
   mc alias set rw-user https://127.0.0.1:8333 $ADMIN_ACCESS_KEY $ADMIN_SECRET_KEY --insecure

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -42,10 +42,10 @@ EOF
   # wrapper subshell exits immediately, the backgrounded kubectl becomes an
   # orphan and gets reaped before the first mc S3 request, so `mc cp` sees
   # `dial tcp 127.0.0.1:8333: connect: connection refused` even though the
-  # earlier `nc -z` probe succeeded.
+  # earlier `nc -z` probe succeeded). The forked port-forward inherits the
+  # test process group; cozytest.sh kills the whole group when the test
+  # function returns, so no explicit cleanup is needed.
   kubectl port-forward service/seaweedfs-s3 -n tenant-root 8333:8333 >/dev/null 2>&1 &
-  PORT_FORWARD_PID=$!
-  trap 'kill ${PORT_FORWARD_PID} 2>/dev/null || true' RETURN
 
   # Wait for port-forward to be ready
   timeout 30 sh -ec 'until nc -z 127.0.0.1 8333; do sleep 1; done'

--- a/hack/e2e-cilium-endpoint-leak-healer.sh
+++ b/hack/e2e-cilium-endpoint-leak-healer.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Interim CI self-heal for the Cilium in-memory endpoint leak.
+#
+# Symptom: on a churn-heavy install a pod sticks in ContainerCreating/Init
+# because the cilium-agent rejects its sandbox with
+#   [PUT /endpoint/{id}][400] putEndpointIdInvalid "IP ipv4:<X> is already in use"
+# repeated until the pod is deleted or the agent is restarted. The IP has no
+# live owner: IPAM and the ipcache released it, but the agent's in-memory
+# endpointManager still holds a stale Endpoint for it (the previous pod's CNI
+# DEL was skipped or raced, so unexpose()->removeReferencesLocked() never ran).
+# Neither the operator's CiliumEndpoint-CRD GC nor the agent's veth-based
+# endpoint GC reaps it, so it wedges the new pod for the whole install and
+# fails the run. Tracked upstream at cilium/cilium#38313 (closed stale); no
+# released or pre-release Cilium fixes the leak and no flag disables it.
+#
+# This watchdog applies the least-disruptive known remedy: instead of
+# restarting the agent (which drops the whole node's in-memory registry), it
+# evicts only the orphaned endpoint via
+#   cilium-dbg endpoint disconnect ipv4:<X>
+# which maps to DELETE /endpoint/{id} -> RemoveEndpoint -> unexpose ->
+# removeReferencesLocked, clearing the stale IP-keyed entry. The wedged pod's
+# next CNI ADD retry then succeeds. Blast radius is one dead endpoint.
+#
+# It is READ-ONLY until it has positively confirmed an orphan: an endpoint in
+# the owning node's registry holds the disputed IP, that endpoint does not back
+# a live Running pod with that IP, and a different pod is currently wedged
+# requesting the same IP. If anything is ambiguous it logs and does nothing —
+# it never disconnects a live endpoint.
+#
+# REMOVE this script and the setup_file/teardown_file hooks in
+# hack/e2e-install-cozystack.bats once a fixed Cilium ships. This is a CI
+# band-aid, not a product fix.
+set -u
+
+CILIUM_NS="${CILIUM_NS:-cozy-cilium}"
+POLL_INTERVAL="${CILIUM_HEALER_POLL_SEC:-15}"
+MAX_RUNTIME="${CILIUM_HEALER_MAX_SEC:-2700}"   # 45m: covers install + tenant + app suite
+PIDFILE="${CILIUM_HEALER_PIDFILE:-/tmp/cilium-leak-healer.pid}"
+
+echo $$ > "$PIDFILE" 2>/dev/null || true
+deadline=$(( $(date +%s) + MAX_RUNTIME ))
+
+log() { echo "[cilium-leak-healer $(date -u +%H:%M:%S)] $*"; }
+
+# cilium-agent pod running on a given node (DaemonSet selector k8s-app=cilium).
+agent_on_node() {
+  kubectl get pod -n "$CILIUM_NS" -l k8s-app=cilium \
+    --field-selector "spec.nodeName=$1" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+log "started (ns=$CILIUM_NS poll=${POLL_INTERVAL}s deadline=+${MAX_RUNTIME}s)"
+
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  # Collect every "is already in use" rejection still attached to a pod sandbox.
+  # The field-selector narrows to the relevant event reason; grep pins the exact
+  # agent signature so unrelated sandbox failures are ignored.
+  events=$(kubectl get events -A --field-selector reason=FailedCreatePodSandBox \
+      -o jsonpath='{range .items[*]}{.involvedObject.namespace}{"|"}{.involvedObject.name}{"|"}{.message}{"\n"}{end}' 2>/dev/null \
+    | grep -i "is already in use" | sort -u)
+
+  [ -n "$events" ] && while IFS='|' read -r ns pod msg; do
+    [ -n "$ns" ] && [ -n "$pod" ] || continue
+    ip=$(printf '%s' "$msg" | grep -oE 'ipv4:[0-9]{1,3}(\.[0-9]{1,3}){3}' | head -1 | cut -d: -f2)
+    [ -n "$ip" ] || continue
+
+    # Only act on a pod that is still wedged (re-checked here = freshness gate).
+    phase=$(kubectl get pod -n "$ns" "$pod" -o jsonpath='{.status.phase}' 2>/dev/null)
+    case "$phase" in Running|Succeeded|"") continue ;; esac
+
+    node=$(kubectl get pod -n "$ns" "$pod" -o jsonpath='{.spec.nodeName}' 2>/dev/null)
+    [ -n "$node" ] || continue
+    agent=$(agent_on_node "$node")
+    [ -n "$agent" ] || { log "no cilium-agent on node=$node for $ns/$pod ip=$ip"; continue; }
+
+    # Does an endpoint in this agent's registry hold the disputed IP at all?
+    # (The wedged pod itself was never registered — CreateEndpoint rejected it
+    # before exposing — so any endpoint holding the IP is the stale one.)
+    ep_json=$(kubectl exec -n "$CILIUM_NS" "$agent" -c cilium-agent -- \
+                cilium-dbg endpoint get "ipv4:$ip" -o json 2>/dev/null)
+    [ -n "$ep_json" ] && [ "$ep_json" != "[]" ] || \
+      { log "no endpoint holds ip=$ip on node=$node (already cleared?) for $ns/$pod"; continue; }
+
+    epid=$(printf '%s' "$ep_json" | jq -r '.[0].id // empty' 2>/dev/null)
+    epns=$(printf '%s' "$ep_json" | jq -r '.[0].status."external-identifiers"."k8s-namespace" // empty' 2>/dev/null)
+    eppod=$(printf '%s' "$ep_json" | jq -r '.[0].status."external-identifiers"."k8s-pod-name" // empty' 2>/dev/null)
+
+    # If that endpoint claims a pod that is alive on the cluster with this IP,
+    # it is a LIVE endpoint -> a genuine duplicate-IP, NOT the leak. Refuse and
+    # shout so the real problem is visible instead of silently broken.
+    if [ -n "$epns" ] && [ -n "$eppod" ]; then
+      owner_ip=$(kubectl get pod -n "$epns" "$eppod" -o jsonpath='{.status.podIP}' 2>/dev/null)
+      owner_phase=$(kubectl get pod -n "$epns" "$eppod" -o jsonpath='{.status.phase}' 2>/dev/null)
+      if [ "$owner_ip" = "$ip" ] && [ "$owner_phase" = "Running" ]; then
+        log "REFUSE ip=$ip on node=$node: held by LIVE pod $epns/$eppod (genuine duplicate IP, not the leak) — investigate"
+        continue
+      fi
+    fi
+
+    # Confirmed orphan: endpoint $epid holds $ip, backs no live pod, and pod
+    # $ns/$pod is wedged requesting the same IP. Evict only this endpoint.
+    log "HEAL node=$node agent=$agent ep=$epid ip=$ip wedged=$ns/$pod -> endpoint disconnect ipv4:$ip"
+    out=$(kubectl exec -n "$CILIUM_NS" "$agent" -c cilium-agent -- \
+            cilium-dbg endpoint disconnect "ipv4:$ip" 2>&1)
+    log "  result: ${out:-<none>}"
+  done <<EOF
+$events
+EOF
+
+  sleep "$POLL_INTERVAL"
+done
+
+log "deadline reached, exiting"
+rm -f "$PIDFILE" 2>/dev/null || true

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -1,5 +1,32 @@
 #!/usr/bin/env bats
 
+setup_file() {
+  # Interim mitigation for the Cilium in-memory endpoint leak
+  # (cilium/cilium#38313 class): a deleted pod's endpoint is orphaned in the
+  # agent's registry, IPAM re-hands its IP to a new pod, and the agent then
+  # rejects the new sandbox with "IP <X> is already in use" until an agent
+  # restart — wedging the pod for the whole install and failing unrelated PRs.
+  # The watchdog surgically evicts only the orphaned endpoint. Detached here so
+  # it covers every test in this file (platform install + tenant + apps); it
+  # self-bounds with its own deadline and writes a PID file we stop below.
+  # Remove together with hack/e2e-cilium-endpoint-leak-healer.sh once a fixed
+  # Cilium ships.
+  hack/e2e-cilium-endpoint-leak-healer.sh > /tmp/cilium-leak-healer.log 2>&1 &
+}
+
+teardown_file() {
+  if [ -f /tmp/cilium-leak-healer.pid ]; then
+    kill "$(cat /tmp/cilium-leak-healer.pid)" 2>/dev/null || true
+  fi
+  # Surface any action it took into the test trace; the run is otherwise green
+  # and the heal would be invisible. REFUSE lines flag a genuine duplicate-IP
+  # (a real bug the watchdog deliberately did not touch).
+  if grep -qE "HEAL |REFUSE " /tmp/cilium-leak-healer.log 2>/dev/null; then
+    echo "# cilium endpoint-leak watchdog activity:" >&3
+    grep -E "HEAL |REFUSE " /tmp/cilium-leak-healer.log >&3 || true
+  fi
+}
+
 @test "Required installer chart exists" {
   if [ ! -f packages/core/installer/Chart.yaml ]; then
     echo "Missing: packages/core/installer/Chart.yaml" >&2

--- a/packages/system/seaweedfs/Makefile
+++ b/packages/system/seaweedfs/Makefile
@@ -14,5 +14,7 @@ update:
 	tar xzvf - --strip 3 -C charts seaweedfs-$${version}/k8s/charts/seaweedfs
 	patch --no-backup-if-mismatch -p4 < patches/resize-api-server-annotation.diff
 	patch --no-backup-if-mismatch -p4 < patches/disable-ca-key-rotation.patch
+	patch --no-backup-if-mismatch -p4 < patches/s3-tls-main-port.patch
+	patch --no-backup-if-mismatch -p4 < patches/cosi-provisioner-sa-name.patch
 	#patch --no-backup-if-mismatch -p4 < patches/retention-policy-delete.yaml
 

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
@@ -11,10 +11,32 @@ parameters:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 ---
+kind: BucketClass
+apiVersion: objectstorage.k8s.io/v1alpha1
+metadata:
+  name: {{ .Values.cosi.bucketClassName }}-lock
+driverName: {{ .Values.cosi.driverName }}
+deletionPolicy: Retain
+parameters:
+  objectLockEnabled: "true"
+  objectLockRetentionMode: "COMPLIANCE"
+  objectLockRetentionDays: "365"
+---
 kind: BucketAccessClass
 apiVersion: objectstorage.k8s.io/v1alpha1
 metadata:
   name: {{ .Values.cosi.bucketClassName }}
 driverName: {{ .Values.cosi.driverName }}
 authenticationType: KEY
+parameters:
+  accessPolicy: readwrite
+---
+kind: BucketAccessClass
+apiVersion: objectstorage.k8s.io/v1alpha1
+metadata:
+  name: {{ .Values.cosi.bucketClassName }}-readonly
+driverName: {{ .Values.cosi.driverName }}
+authenticationType: KEY
+parameters:
+  accessPolicy: readonly
 {{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
@@ -58,7 +58,7 @@ spec:
       priorityClassName: {{ .Values.cosi.priorityClassName | quote }}
       {{- end }}
       enableServiceLinks: false
-      serviceAccountName: {{ include "seaweedfs.componentName" (list . "objectstorage-provisioner") }}
+      serviceAccountName: {{ .Values.global.seaweedfs.serviceAccountName }}-objectstorage-provisioner
       {{- if .Values.cosi.initContainers }}
       initContainers:
         {{ tpl .Values.cosi.initContainers . | nindent 8 | trim }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
@@ -127,8 +127,8 @@ spec:
               {{- if .Values.global.seaweedfs.enableSecurity }}
               {{- if .Values.s3.httpsPort }}
               -port.https={{ .Values.s3.httpsPort }} \
-              {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "") | nindent 14 }}
               {{- end }}
+              {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "") | nindent 14 }}
               {{- end }}
               {{- if .Values.s3.domainName }}
               -domainName={{ .Values.s3.domainName }} \

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-service.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "seaweedfs.componentName" (list . "s3") }}
+  name: {{ template "seaweedfs.name" . }}-s3
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/packages/system/seaweedfs/patches/cosi-provisioner-sa-name.patch
+++ b/packages/system/seaweedfs/patches/cosi-provisioner-sa-name.patch
@@ -1,0 +1,13 @@
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+index aefc9d369..d485e0678 100644
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+@@ -58,7 +58,7 @@ spec:
+       priorityClassName: {{ .Values.cosi.priorityClassName | quote }}
+       {{- end }}
+       enableServiceLinks: false
+-      serviceAccountName: {{ include "seaweedfs.componentName" (list . "objectstorage-provisioner") }}
++      serviceAccountName: {{ .Values.global.seaweedfs.serviceAccountName }}-objectstorage-provisioner
+       {{- if .Values.cosi.initContainers }}
+       initContainers:
+         {{ tpl .Values.cosi.initContainers . | nindent 8 | trim }}

--- a/packages/system/seaweedfs/patches/s3-tls-main-port.patch
+++ b/packages/system/seaweedfs/patches/s3-tls-main-port.patch
@@ -1,0 +1,14 @@
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+index db231fc96..efb967bb2 100644
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+@@ -127,8 +127,8 @@ spec:
+               {{- if .Values.global.seaweedfs.enableSecurity }}
+               {{- if .Values.s3.httpsPort }}
+               -port.https={{ .Values.s3.httpsPort }} \
+-              {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "") | nindent 14 }}
+               {{- end }}
++              {{- include "seaweedfs.s3.tlsArgs" (dict "root" . "prefix" "") | nindent 14 }}
+               {{- end }}
+               {{- if .Values.s3.domainName }}
+               -domainName={{ .Values.s3.domainName }} \

--- a/packages/system/seaweedfs/tests/s3_tls_cosi_sa_test.yaml
+++ b/packages/system/seaweedfs/tests/s3_tls_cosi_sa_test.yaml
@@ -1,0 +1,78 @@
+suite: seaweedfs s3 TLS on main port + COSI provisioner SA name
+
+# Pins two regressions introduced by the 4.31 chart bump:
+#
+# 1. S3 TLS. Until 4.05 the `-cert.file`/`-key.file` args were rendered whenever
+#    enableSecurity was on, so `weed s3` served TLS on the main port (8333) and
+#    our HTTPS readiness/liveness probes (and the ingress backend-protocol=HTTPS
+#    and the COSI sidecar's https:// endpoint) worked. 4.31 nested those args
+#    inside `if .Values.s3.httpsPort`, and we ship httpsPort=0, so s3 served
+#    plaintext and every probe failed with "server gave HTTP response to HTTPS
+#    client". The s3-tls-main-port.patch restores the 4.05 behaviour.
+#
+# 2. COSI provisioner ServiceAccount. cosi-service-account.yaml and the
+#    ClusterRoleBinding both name the SA <serviceAccountName>-objectstorage-provisioner,
+#    but the Deployment referenced componentName (<release>-objectstorage-provisioner).
+#    Whenever serviceAccountName != release name the Deployment could not create
+#    pods ("serviceaccount not found"). The cosi-provisioner-sa-name.patch aligns
+#    the Deployment with the SA + binding.
+
+templates:
+  - charts/seaweedfs/templates/s3/s3-deployment.yaml
+  - charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+
+release:
+  name: seaweedfs
+  namespace: cozy-seaweedfs
+
+tests:
+  - it: renders s3 TLS cert/key args under enableSecurity even when httpsPort is 0
+    template: charts/seaweedfs/templates/s3/s3-deployment.yaml
+    set:
+      global.seaweedfs.enableSecurity: true
+      seaweedfs.s3.enabled: true
+      seaweedfs.s3.httpsPort: 0
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "-cert\\.file=/usr/local/share/ca-certificates/client/tls\\.crt"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "-key\\.file=/usr/local/share/ca-certificates/client/tls\\.key"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "-port\\.https"
+
+  - it: still gates the cert args on enableSecurity
+    template: charts/seaweedfs/templates/s3/s3-deployment.yaml
+    set:
+      global.seaweedfs.enableSecurity: false
+      seaweedfs.s3.enabled: true
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "-cert\\.file"
+
+  - it: renders -port.https alongside the cert args when httpsPort is set
+    template: charts/seaweedfs/templates/s3/s3-deployment.yaml
+    set:
+      global.seaweedfs.enableSecurity: true
+      seaweedfs.s3.enabled: true
+      seaweedfs.s3.httpsPort: 8334
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "-port\\.https=8334"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "-cert\\.file=/usr/local/share/ca-certificates/client/tls\\.crt"
+
+  - it: COSI provisioner Deployment uses the serviceAccountName-based SA, not componentName
+    template: charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+    set:
+      seaweedfs.cosi.enabled: true
+      global.seaweedfs.serviceAccountName: custom-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: custom-sa-objectstorage-provisioner

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -12,7 +12,16 @@ global:
       enabled: true
 seaweedfs:
   master:
-    volumeSizeLimitMB: 30000
+    # 30 GB per volume × 10 GiB PVC = 0 → rounded to 1 maxVolume per
+    # volume server. With defaultReplication=001 (one replica on a
+    # different node) two volume servers can host exactly one logical
+    # volume between them. The platform now ships a default
+    # bucket-cozy-backups Bucket that grabs that single slot, so any
+    # second collection (the bucket E2E, a tenant app bucket, etc.)
+    # blocks on `assign volume: No writable volumes` until the test
+    # times out. Smaller volumes = more parallel collections on a
+    # 10 GiB E2E sandbox PVC. The upstream chart default is 1000.
+    volumeSizeLimitMB: 1000
     replicas: 3
     #  replication type is XYZ:
     # X number of replica in other data centers

--- a/pkg/cmd/server/openapi.go
+++ b/pkg/cmd/server/openapi.go
@@ -81,7 +81,7 @@ func markOpenObject(s *spec.Schema) {
 	}
 	s.AdditionalProperties = nil
 	if s.Extensions == nil {
-		s.Extensions = map[string]any{}
+		s.Extensions = spec.Extensions{}
 	}
 	s.Extensions["x-kubernetes-preserve-unknown-fields"] = true
 }
@@ -384,7 +384,7 @@ func sanitizeForV2(s *spec.Schema) {
 		if hasIntAndStringAnyOf(s.AnyOf) {
 			s.Type = spec.StringOrArray{"string"}
 			if s.Extensions == nil {
-				s.Extensions = map[string]any{}
+				s.Extensions = spec.Extensions{}
 			}
 			s.Extensions["x-kubernetes-int-or-string"] = true
 		}

--- a/pkg/cmd/server/openapi.go
+++ b/pkg/cmd/server/openapi.go
@@ -63,6 +63,29 @@ func findSpecContainer(s *spec.Schema) *spec.Schema {
 	return nil
 }
 
+// markOpenObject marks a schema as a free-form object that accepts arbitrary
+// properties, using the x-kubernetes-preserve-unknown-fields extension rather
+// than the boolean additionalProperties:true form.
+//
+// This distinction matters: the boolean additionalProperties:true construct
+// makes the Kubernetes ValidatingAdmissionPolicy status type-checker (run by
+// kube-controller-manager) nil-dereference when it recurses into the node,
+// crash-looping KCM cluster-wide as soon as a VAP matches one of these
+// aggregated resources (e.g. cozystack-tenant-host-policy on tenants). The
+// extension is semantically equivalent ("arbitrary fields allowed") and the
+// type-checker handles it safely. See
+// https://github.com/cozystack/cozystack/issues/2863.
+func markOpenObject(s *spec.Schema) {
+	if len(s.Type) == 0 {
+		s.Type = spec.StringOrArray{"object"}
+	}
+	s.AdditionalProperties = nil
+	if s.Extensions == nil {
+		s.Extensions = map[string]any{}
+	}
+	s.Extensions["x-kubernetes-preserve-unknown-fields"] = true
+}
+
 // patchSpec injects/overrides ".spec" with user JSON (or schemaless object).
 func patchSpec(target *spec.Schema, raw string) error {
 	if strings.TrimSpace(raw) == "" {
@@ -70,7 +93,7 @@ func patchSpec(target *spec.Schema, raw string) error {
 			target.Properties = map[string]spec.Schema{}
 		}
 		prop := target.Properties["spec"]
-		prop.AdditionalProperties = &spec.SchemaOrBool{Allows: true}
+		markOpenObject(&prop)
 		target.Properties["spec"] = prop
 		return nil
 	}
@@ -80,7 +103,7 @@ func patchSpec(target *spec.Schema, raw string) error {
 		return err
 	}
 	if custom.AdditionalProperties == nil {
-		custom.AdditionalProperties = &spec.SchemaOrBool{Allows: true}
+		markOpenObject(&custom)
 	}
 	if target.Properties == nil {
 		target.Properties = map[string]spec.Schema{}

--- a/pkg/cmd/server/openapi.go
+++ b/pkg/cmd/server/openapi.go
@@ -67,14 +67,14 @@ func findSpecContainer(s *spec.Schema) *spec.Schema {
 // properties, using the x-kubernetes-preserve-unknown-fields extension rather
 // than the boolean additionalProperties:true form.
 //
-// This distinction matters: the boolean additionalProperties:true construct
-// makes the Kubernetes ValidatingAdmissionPolicy status type-checker (run by
-// kube-controller-manager) nil-dereference when it recurses into the node,
-// crash-looping KCM cluster-wide as soon as a VAP matches one of these
-// aggregated resources (e.g. cozystack-tenant-host-policy on tenants). The
-// extension is semantically equivalent ("arbitrary fields allowed") and the
-// type-checker handles it safely. See
-// https://github.com/cozystack/cozystack/issues/2863.
+// This distinction matters: a boolean additionalProperties node (the JSON
+// `true` or `false` form) carries a nil inner schema. The Kubernetes
+// ValidatingAdmissionPolicy status type-checker (run by kube-controller-manager)
+// dereferences that nil inner schema, crash-looping KCM cluster-wide as soon as
+// a VAP matches one of these aggregated resources (e.g.
+// cozystack-tenant-host-policy on tenants). The extension is semantically
+// equivalent ("arbitrary fields allowed") and the type-checker handles it
+// safely. See https://github.com/cozystack/cozystack/issues/2863.
 func markOpenObject(s *spec.Schema) {
 	if len(s.Type) == 0 {
 		s.Type = spec.StringOrArray{"object"}
@@ -86,13 +86,66 @@ func markOpenObject(s *spec.Schema) {
 	s.Extensions["x-kubernetes-preserve-unknown-fields"] = true
 }
 
+// sanitizeBooleanAdditionalProperties recursively rewrites every boolean-form
+// additionalProperties (one whose inner Schema is nil — both the JSON `true`
+// and `false` forms) anywhere in s, because both crash the VAP status
+// type-checker (#2863): additionalProperties:true becomes the equivalent
+// x-kubernetes-preserve-unknown-fields:true, and additionalProperties:false is
+// dropped (the published schema is consumed only for documentation and
+// type-checking, not for enforcement, so "declared properties only" is
+// preserved without the crash-prone node). Object-form additionalProperties (a
+// real map value schema) is safe; it is recursed into, never rewritten.
+//
+// ApplicationDefinition.openAPISchema is untrusted input — external-apps and
+// operator-authored definitions flow through here without validation — so this
+// closes the whole class of crash rather than only the schemas cozystack ships.
+func sanitizeBooleanAdditionalProperties(s *spec.Schema) {
+	if s == nil {
+		return
+	}
+	if ap := s.AdditionalProperties; ap != nil && ap.Schema == nil {
+		if ap.Allows {
+			markOpenObject(s) // additionalProperties:true -> preserve-unknown-fields
+		} else {
+			s.AdditionalProperties = nil // additionalProperties:false -> drop
+		}
+	} else if ap != nil && ap.Schema != nil {
+		sanitizeBooleanAdditionalProperties(ap.Schema)
+	}
+	for k := range s.Properties {
+		prop := s.Properties[k]
+		sanitizeBooleanAdditionalProperties(&prop)
+		s.Properties[k] = prop
+	}
+	if s.Items != nil {
+		sanitizeBooleanAdditionalProperties(s.Items.Schema)
+		for i := range s.Items.Schemas {
+			sanitizeBooleanAdditionalProperties(&s.Items.Schemas[i])
+		}
+	}
+	for i := range s.AllOf {
+		sanitizeBooleanAdditionalProperties(&s.AllOf[i])
+	}
+	for i := range s.AnyOf {
+		sanitizeBooleanAdditionalProperties(&s.AnyOf[i])
+	}
+	for i := range s.OneOf {
+		sanitizeBooleanAdditionalProperties(&s.OneOf[i])
+	}
+	sanitizeBooleanAdditionalProperties(s.Not)
+}
+
 // patchSpec injects/overrides ".spec" with user JSON (or schemaless object).
 func patchSpec(target *spec.Schema, raw string) error {
+	if target.Properties == nil {
+		target.Properties = map[string]spec.Schema{}
+	}
+
+	// Schemaless: publish a fresh, fully open object. Starting from a fresh
+	// schema (rather than mutating the cloned base) discards any inherited
+	// $ref or properties so the published spec is unambiguously open.
 	if strings.TrimSpace(raw) == "" {
-		if target.Properties == nil {
-			target.Properties = map[string]spec.Schema{}
-		}
-		prop := target.Properties["spec"]
+		prop := spec.Schema{}
 		markOpenObject(&prop)
 		target.Properties["spec"] = prop
 		return nil
@@ -102,12 +155,21 @@ func patchSpec(target *spec.Schema, raw string) error {
 	if err := json.Unmarshal([]byte(raw), &custom); err != nil {
 		return err
 	}
-	if custom.AdditionalProperties == nil {
+
+	// Neutralize any crash-prone boolean additionalProperties at any depth in
+	// the user-supplied schema before publishing it.
+	topLevelAPAbsent := custom.AdditionalProperties == nil
+	sanitizeBooleanAdditionalProperties(&custom)
+
+	// Preserve the historical "spec is a superset of the documented values"
+	// behavior: when the documented schema does not itself declare
+	// additionalProperties, mark the top level open so undocumented Helm
+	// values are accepted rather than rejected. A schema that explicitly
+	// declared additionalProperties (now sanitized) keeps its own intent.
+	if topLevelAPAbsent {
 		markOpenObject(&custom)
 	}
-	if target.Properties == nil {
-		target.Properties = map[string]spec.Schema{}
-	}
+
 	target.Properties["spec"] = custom
 	return nil
 }

--- a/pkg/cmd/server/openapi_test.go
+++ b/pkg/cmd/server/openapi_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	celopenapi "k8s.io/apiserver/pkg/cel/openapi"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// tenantOpenAPISchema mirrors the shape of the real Tenant "Chart Values"
+// schema (packages/system/tenant-rd/cozyrds/tenant.yaml): a typed object with
+// declared properties and no top-level additionalProperties, plus a nested
+// map that uses the safe object-form additionalProperties.
+const tenantOpenAPISchema = `{
+  "title": "Chart Values",
+  "type": "object",
+  "properties": {
+    "host": {"type": "string"},
+    "etcd": {"type": "boolean"},
+    "resourceQuotas": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [{"type": "integer"}, {"type": "string"}],
+        "x-kubernetes-int-or-string": true
+      }
+    }
+  }
+}`
+
+func newObjectContainer() *spec.Schema {
+	return &spec.Schema{SchemaProps: spec.SchemaProps{
+		Type:       spec.StringOrArray{"object"},
+		Properties: map[string]spec.Schema{},
+	}}
+}
+
+// TestPatchSpecOpenSpecPublishesPreserveUnknownFields asserts that the open
+// ".spec" cozystack-api injects is published as
+// x-kubernetes-preserve-unknown-fields:true and never as the boolean
+// additionalProperties:true form that crashes the VAP type-checker (#2863).
+// It covers both code paths: a schemaless resource and a custom schema that
+// declares properties but no top-level additionalProperties (like Tenant).
+func TestPatchSpecOpenSpecPublishesPreserveUnknownFields(t *testing.T) {
+	cases := map[string]string{
+		"schemaless":           "",
+		"custom-no-additional": tenantOpenAPISchema,
+	}
+
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			target := newObjectContainer()
+			if err := patchSpec(target, raw); err != nil {
+				t.Fatalf("patchSpec: %v", err)
+			}
+			specSchema := target.Properties["spec"]
+
+			if specSchema.AdditionalProperties != nil {
+				t.Errorf("spec must not carry additionalProperties; got %#v", specSchema.AdditionalProperties)
+			}
+			if v, ok := specSchema.Extensions.GetBool("x-kubernetes-preserve-unknown-fields"); !ok || !v {
+				t.Errorf("spec must set x-kubernetes-preserve-unknown-fields:true; extensions=%v", specSchema.Extensions)
+			}
+			if !specSchema.Type.Contains("object") {
+				t.Errorf("spec must be type object; got %v", specSchema.Type)
+			}
+
+			// The published JSON is the actual contract KCM type-checks against.
+			out, err := json.Marshal(specSchema)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if strings.Contains(string(out), `"additionalProperties":true`) {
+				t.Errorf("published spec still emits boolean additionalProperties:true (#2863): %s", out)
+			}
+			if !strings.Contains(string(out), `"x-kubernetes-preserve-unknown-fields":true`) {
+				t.Errorf("published spec missing x-kubernetes-preserve-unknown-fields:true: %s", out)
+			}
+		})
+	}
+}
+
+// TestPatchSpecKeepsObjectFormAdditionalProperties ensures we only rewrite the
+// open/free-form spec: a custom schema that already declares an object-form
+// additionalProperties (a real map type, which is safe for the type-checker)
+// must be left untouched rather than overwritten with the extension.
+func TestPatchSpecKeepsObjectFormAdditionalProperties(t *testing.T) {
+	raw := `{"type":"object","additionalProperties":{"type":"string"}}`
+	target := newObjectContainer()
+	if err := patchSpec(target, raw); err != nil {
+		t.Fatalf("patchSpec: %v", err)
+	}
+	specSchema := target.Properties["spec"]
+	if specSchema.AdditionalProperties == nil || specSchema.AdditionalProperties.Schema == nil {
+		t.Fatalf("object-form additionalProperties must be preserved; got %#v", specSchema.AdditionalProperties)
+	}
+	if v, ok := specSchema.Extensions.GetBool("x-kubernetes-preserve-unknown-fields"); ok && v {
+		t.Errorf("must not add preserve-unknown-fields when a real map schema is declared")
+	}
+}
+
+// TestPatchedSpecDoesNotPanicVAPTypeChecker is the behavioral regression test
+// for #2863. SchemaDeclType is the exact entry point kube-controller-manager's
+// ValidatingAdmissionPolicy status controller uses to type-check a VAP against
+// the published resource schema. Before the fix, the boolean
+// additionalProperties:true on ".spec" made it nil-dereference
+// (k8s.io/apiserver/pkg/cel/openapi.isExtension), crash-looping KCM. With the
+// preserve-unknown-fields form it returns a valid type.
+//
+// This test panics (fails) on the pre-fix code and passes after it.
+func TestPatchedSpecDoesNotPanicVAPTypeChecker(t *testing.T) {
+	cases := map[string]string{
+		"schemaless":  "",
+		"tenant-like": tenantOpenAPISchema,
+	}
+
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Resource-shaped object, as published per kind by cozystack-api.
+			obj := &spec.Schema{SchemaProps: spec.SchemaProps{
+				Type: spec.StringOrArray{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+					"spec":       {},
+				},
+			}}
+			if err := patchSpec(obj, raw); err != nil {
+				t.Fatalf("patchSpec: %v", err)
+			}
+
+			// Round-trip through JSON so we type-check the serialized form that
+			// is actually served on /openapi/v3 and read by KCM.
+			rawJSON, err := json.Marshal(obj)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var published spec.Schema
+			if err := json.Unmarshal(rawJSON, &published); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			// isResourceRoot=true matches how the type-checker treats a matched
+			// top-level resource.
+			declType := celopenapi.SchemaDeclType(&published, true)
+			if declType == nil {
+				t.Fatalf("SchemaDeclType returned nil for %s", name)
+			}
+		})
+	}
+}

--- a/pkg/cmd/server/openapi_test.go
+++ b/pkg/cmd/server/openapi_test.go
@@ -213,18 +213,30 @@ func hasBooleanAdditionalProperties(s *spec.Schema) bool {
 // regression test for the review finding on #2867: ApplicationDefinition
 // schemas are untrusted input, and a user-supplied boolean additionalProperties
 // — declared explicitly at the top level, or nested anywhere under
-// properties/items/allOf — reintroduces the exact #2863 KCM crash. patchSpec
-// must neutralize every such node (both the true and false forms, since both
-// carry a nil inner schema), at any depth, so the published schema can never
-// crash the VAP type-checker. Each case below panics SchemaDeclType before this
-// sanitizer and passes after it.
+// properties/items/additionalProperties/allOf/anyOf/oneOf/not — reintroduces the
+// exact #2863 KCM crash. patchSpec must neutralize every such node (both the true
+// and false forms, since both carry a nil inner schema), at any depth, so the
+// published schema can never crash the VAP type-checker.
+//
+// Two assertions guard each case. SchemaDeclType only descends into properties,
+// items, and additionalProperties.Schema, so the top-level / nested-under-
+// properties / nested-under-items / nested-under-additionalproperties cases are
+// type-checker-reachable: they nil-deref (panic) SchemaDeclType on the
+// pre-sanitizer code. The allOf/anyOf/oneOf/not cases are defense-in-depth —
+// SchemaDeclType never traverses those branches, so it is the
+// hasBooleanAdditionalProperties assertion, not the SchemaDeclType check, that
+// keeps their recursion lines from regressing silently.
 func TestPatchSpecSanitizesUserSuppliedBooleanAdditionalProperties(t *testing.T) {
 	cases := map[string]string{
-		"top-level-boolean-true":  `{"type":"object","additionalProperties":true}`,
-		"top-level-boolean-false": `{"type":"object","additionalProperties":false}`,
-		"nested-under-properties": `{"type":"object","properties":{"foo":{"type":"object","additionalProperties":true}}}`,
-		"nested-under-items":      `{"type":"object","properties":{"list":{"type":"array","items":{"type":"object","additionalProperties":true}}}}`,
-		"nested-under-allof":      `{"type":"object","allOf":[{"type":"object","additionalProperties":false}]}`,
+		"top-level-boolean-true":            `{"type":"object","additionalProperties":true}`,
+		"top-level-boolean-false":           `{"type":"object","additionalProperties":false}`,
+		"nested-under-properties":           `{"type":"object","properties":{"foo":{"type":"object","additionalProperties":true}}}`,
+		"nested-under-items":                `{"type":"object","properties":{"list":{"type":"array","items":{"type":"object","additionalProperties":true}}}}`,
+		"nested-under-additionalproperties": `{"type":"object","additionalProperties":{"type":"object","additionalProperties":true}}`,
+		"nested-under-allof":                `{"type":"object","allOf":[{"type":"object","additionalProperties":false}]}`,
+		"nested-under-anyof":                `{"type":"object","anyOf":[{"type":"object","additionalProperties":true}]}`,
+		"nested-under-oneof":                `{"type":"object","oneOf":[{"type":"object","additionalProperties":false}]}`,
+		"nested-under-not":                  `{"type":"object","not":{"type":"object","additionalProperties":true}}`,
 	}
 
 	for name, raw := range cases {

--- a/pkg/cmd/server/openapi_test.go
+++ b/pkg/cmd/server/openapi_test.go
@@ -166,3 +166,101 @@ func TestPatchedSpecDoesNotPanicVAPTypeChecker(t *testing.T) {
 		})
 	}
 }
+
+// hasBooleanAdditionalProperties walks the schema and reports whether any node
+// carries a boolean-form additionalProperties (inner Schema == nil) — the
+// construct that crashes the VAP type-checker, in either its true or false JSON
+// form.
+func hasBooleanAdditionalProperties(s *spec.Schema) bool {
+	if s == nil {
+		return false
+	}
+	if ap := s.AdditionalProperties; ap != nil {
+		if ap.Schema == nil {
+			return true
+		}
+		if hasBooleanAdditionalProperties(ap.Schema) {
+			return true
+		}
+	}
+	for k := range s.Properties {
+		p := s.Properties[k]
+		if hasBooleanAdditionalProperties(&p) {
+			return true
+		}
+	}
+	if s.Items != nil {
+		if hasBooleanAdditionalProperties(s.Items.Schema) {
+			return true
+		}
+		for i := range s.Items.Schemas {
+			if hasBooleanAdditionalProperties(&s.Items.Schemas[i]) {
+				return true
+			}
+		}
+	}
+	for _, branch := range [][]spec.Schema{s.AllOf, s.AnyOf, s.OneOf} {
+		for i := range branch {
+			if hasBooleanAdditionalProperties(&branch[i]) {
+				return true
+			}
+		}
+	}
+	return hasBooleanAdditionalProperties(s.Not)
+}
+
+// TestPatchSpecSanitizesUserSuppliedBooleanAdditionalProperties is the
+// regression test for the review finding on #2867: ApplicationDefinition
+// schemas are untrusted input, and a user-supplied boolean additionalProperties
+// — declared explicitly at the top level, or nested anywhere under
+// properties/items/allOf — reintroduces the exact #2863 KCM crash. patchSpec
+// must neutralize every such node (both the true and false forms, since both
+// carry a nil inner schema), at any depth, so the published schema can never
+// crash the VAP type-checker. Each case below panics SchemaDeclType before this
+// sanitizer and passes after it.
+func TestPatchSpecSanitizesUserSuppliedBooleanAdditionalProperties(t *testing.T) {
+	cases := map[string]string{
+		"top-level-boolean-true":  `{"type":"object","additionalProperties":true}`,
+		"top-level-boolean-false": `{"type":"object","additionalProperties":false}`,
+		"nested-under-properties": `{"type":"object","properties":{"foo":{"type":"object","additionalProperties":true}}}`,
+		"nested-under-items":      `{"type":"object","properties":{"list":{"type":"array","items":{"type":"object","additionalProperties":true}}}}`,
+		"nested-under-allof":      `{"type":"object","allOf":[{"type":"object","additionalProperties":false}]}`,
+	}
+
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			obj := &spec.Schema{SchemaProps: spec.SchemaProps{
+				Type: spec.StringOrArray{"object"},
+				Properties: map[string]spec.Schema{
+					"apiVersion": {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+					"kind":       {SchemaProps: spec.SchemaProps{Type: spec.StringOrArray{"string"}}},
+					"spec":       {},
+				},
+			}}
+			if err := patchSpec(obj, raw); err != nil {
+				t.Fatalf("patchSpec: %v", err)
+			}
+
+			// Round-trip through JSON: this is what is actually served and what
+			// KCM type-checks.
+			rawJSON, err := json.Marshal(obj)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			var published spec.Schema
+			if err := json.Unmarshal(rawJSON, &published); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			// (1) no boolean-form additionalProperties survives anywhere
+			if hasBooleanAdditionalProperties(&published) {
+				t.Errorf("published schema still contains a boolean additionalProperties node (#2863): %s", rawJSON)
+			}
+			// (2) the published schema does not crash the VAP type-checker
+			declType := celopenapi.SchemaDeclType(&published, true)
+			if declType == nil {
+				t.Fatalf("SchemaDeclType returned nil for %s", name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Seed commit that triggers the full Pull Request workflow on a clean `main`,
so we can iterate on real E2E flakes here without mixing them with any
in-flight feature changes. The first commit adds two trailing blank lines
to `hack/cozytest.sh` — a no-op, only there to make the paths filter pick
the change up (anything outside `docs/**` is enough).

Context: since `2026-06-10T11:00Z`, no non-docs PR on `main` has produced
a green E2E run. The dominant symptoms across recent failures are:

- `Install Cozystack into sandbox` step times out at 15:50, with a wide
  fan of HelmReleases never reaching Ready (`kafka-operator`, `kamaji`,
  `kubeovn`, `kubevirt`, `linstor`, `cert-manager`, ...).
- `bucketclaim/bucket-cozy-backups` fails with
  `bucketclasses.objectstorage.k8s.io "tenant-root" not found` — race
  between `BucketClass` creation and the `BucketClaim` that references it.
- `strimzi-cluster-operator` (kafka-operator) crashloops on a liveness
  probe to `:8080`, blocking `kafka-rd`.
- The bats test `Create and Verify Seeweedfs Bucket` consistently times
  out on `kubectl wait hr bucket-test --timeout=100s --for=condition=ready`.

Subsequent commits on this branch will be targeted fixes for whichever of
these (or others) reproduce on the first run, one fix per commit so they
can be cherry-picked or reviewed individually.

### Screenshots

N/A — no UI changes.

### Release note

\`\`\`release-note
NONE
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Kubernetes admission/VAP crashes during OpenAPI schema publication by sanitizing boolean-form `additionalProperties`, and ensured open `.spec` schemas are published when needed.
  * Improved SeaweedFS Helm output for S3 TLS CLI arguments and corrected COSI `serviceAccountName`; also adjusted the generated S3 Service naming.
* **New Features**
  * Added SeaweedFS COSI lock bucket class and readonly bucket access configuration.
* **Tests**
  * Added Helm and OpenAPI regression tests covering TLS argument behavior, service account naming, and schema publication safety.
* **Chores**
  * Expanded report output with “source-watcher diagnostics” collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->