### PR TITLE
fix(cozy-lib): round CPU request to whole milliCPU

### DIFF
--- a/packages/library/cozy-lib/templates/_resources.tpl
+++ b/packages/library/cozy-lib/templates/_resources.tpl
@@ -97,7 +97,15 @@
 {{-     if eq $k "cpu" }}
 {{-       $vcpuRequestF64 := (include "cozy-lib.resources.toFloat" $v) | float64 }}
 {{-       $cpuRequestF64 := divf $vcpuRequestF64 $cpuAllocationRatio }}
-{{-       $_ := set $output.requests $k ($cpuRequestF64 | toString) }}
+{{- /*
+        Round the CPU request to whole milliCPU. The VPA admission webhook
+        rejects MinAllowed and MaxAllowed when they are not integer milliCPU
+        (e.g. when cpuAllocationRatio does not evenly divide the input);
+        kube-apiserver tolerates sub-milliCPU on pod requests, but VPA does
+        not. See https://github.com/cozystack/cozystack/issues/2917
+*/ -}}
+{{-       $cpuRequestMilli := mulf $cpuRequestF64 1000.0 | addf 0.5 | int }}
+{{-       $_ := set $output.requests $k (printf "%dm" $cpuRequestMilli) }}
 {{-       $_ := set $output.limits $k ($v | toString) }}
 {{-     else if eq $k "memory" }}
 {{-       $vMemoryRequestF64 := (include "cozy-lib.resources.toFloat" $v) | float64 }}

--- a/packages/tests/cozy-lib-tests/templates/tests/resources.yaml
+++ b/packages/tests/cozy-lib-tests/templates/tests/resources.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  containers:
+    - name: test
+      resources: {{- include "cozy-lib.resources.sanitize" (list .Values.resources $) | nindent 8 }}

--- a/packages/tests/cozy-lib-tests/tests/quota_test.yaml
+++ b/packages/tests/cozy-lib-tests/tests/quota_test.yaml
@@ -22,7 +22,7 @@ tests:
 
       - equal:
           path: spec.hard["requests.cpu"]
-          value: "2"
+          value: "2000m"
 
       - equal:
           path: spec.hard["limits.foobar"]

--- a/packages/tests/cozy-lib-tests/tests/resources_test.yaml
+++ b/packages/tests/cozy-lib-tests/tests/resources_test.yaml
@@ -1,0 +1,85 @@
+suite: resources.sanitize CPU formatting
+
+# CPU requests must always be emitted as whole milliCPU. The VPA admission
+# webhook rejects MinAllowed/MaxAllowed when the value is not an integer
+# milliCPU (e.g. when cpuAllocationRatio does not evenly divide the input).
+# Pod resources.requests.cpu also gets the same integer-mCPU formatting for
+# consistency; kube-apiserver accepts both forms.
+#
+# Regression: https://github.com/cozystack/cozystack/issues/2917
+
+templates:
+  - templates/tests/resources.yaml
+
+release:
+  name: r
+  namespace: default
+  revision: 1
+  isUpgrade: false
+
+tests:
+  - it: emits whole milliCPU with the default cpuAllocationRatio (10)
+    set:
+      _cluster: {}
+      _namespace: {}
+      resources:
+        cpu: "250m"
+        memory: "256Mi"
+    asserts:
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: "25m"
+      - equal:
+          path: spec.containers[0].resources.limits.cpu
+          value: "250m"
+
+  - it: rounds to the nearest milliCPU when cpuAllocationRatio does not divide the input evenly
+    set:
+      _cluster:
+        cpu-allocation-ratio: "7"
+      _namespace: {}
+      resources:
+        cpu: "250m"
+        memory: "256Mi"
+    asserts:
+      # 250m / 7 = 35.714...m, rounded to nearest = 36m (integer mCPU,
+      # accepted by VPA admission webhook).
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: "36m"
+      - equal:
+          path: spec.containers[0].resources.limits.cpu
+          value: "250m"
+
+  - it: rounds the upper bound to integer milliCPU too
+    set:
+      _cluster:
+        cpu-allocation-ratio: "7"
+      _namespace: {}
+      resources:
+        cpu: "5000m"
+        memory: "8Gi"
+    asserts:
+      # 5000m / 7 = 714.285...m, rounded to nearest = 714m.
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: "714m"
+      - equal:
+          path: spec.containers[0].resources.limits.cpu
+          value: "5000m"
+
+  - it: accepts whole-core CPU input and still emits milliCPU
+    set:
+      _cluster: {}
+      _namespace: {}
+      resources:
+        cpu: "2"
+        memory: "256Mi"
+    asserts:
+      # 2 cores / 10 = 0.2 cores = 200m.
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: "200m"
+      - equal:
+          path: spec.containers[0].resources.limits.cpu
+          value: "2"


### PR DESCRIPTION
## What this PR does

`cozy-lib.resources.sanitize` divided the CPU limit by `cpuAllocationRatio` without rounding to an integer milliCPU, producing values like `0.035714286` (kube-apiserver representation: `35714286n`) when `cpuAllocationRatio` did not evenly divide the input.

`kube-apiserver` tolerates sub-milliCPU on pod `requests`, but the VPA admission webhook rejects `MinAllowed`/`MaxAllowed` that are not whole milliCPU. As a result, charts that feed the sanitized output into VPA bounds (the etcd chart is currently the only one in-tree) failed to install for any `cpuAllocationRatio` that is not a divisor of 250 (e.g. 3, 6, 7, 8, 9):

```
Helm install failed for release <namespace>/etcd with chart etcd@0.0.0+...:
  admission webhook "vpa.k8s.io" denied the request:
  MinAllowed: CPU [35714286n] must be a whole number of milli CPUs
```

This PR rounds the milliCPU value to the nearest whole milliCPU in `_resources.tpl` before formatting, and emits the value with the `m` suffix (`200m` instead of `0.2`) which is semantically identical for `kube-apiserver`.

### Verification

* `helm template etcd packages/extra/etcd --set _cluster.cpu-allocation-ratio=7 --show-only templates/vpa.yaml`:
  - `minAllowed.cpu: 36m` (was rejected as `35714286n`)
  - `maxAllowed.cpu: 714m` (was rejected as `714285714n`)
* `helm template etcd packages/extra/etcd --set _cluster.cpu-allocation-ratio=3 --show-only templates/vpa.yaml`:
  - `minAllowed.cpu: 83m`, `maxAllowed.cpu: 1667m`
* `helm unittest` passes in all packages that exercise `sanitize` (cozy-lib-tests, backupstrategy-controller, cilium-networkpolicy, ouroboros, harbor, linstor-scheduler, platform).
* New regression test under `packages/tests/cozy-lib-tests/tests/resources_test.yaml` covers default ratio (10), non-divisor ratio (7), upper-bound rounding, and whole-core inputs.

The format change from `0.025` to `25m` flows through to every Pod template that uses `sanitize`. Both forms are accepted by `kube-apiserver`; existing HelmReleases will see a one-time diff on the `requests.cpu` field.

### Release note

```release-note
fix(cozy-lib): CPU requests produced by `cozy-lib.resources.sanitize` are now rounded to whole milliCPU. This unblocks `cpuAllocationRatio` values that are not divisors of 250 (e.g. 3, 6, 7, 8, 9), which previously caused the etcd HelmRelease to fail with VPA admission webhook errors like `MinAllowed: CPU [...n] must be a whole number of milli CPUs`. Pod `requests.cpu` is now emitted in milliCPU form (e.g. `200m` instead of `0.2`) — semantically identical for kube-apiserver.
```

Closes #2917

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CPU resource requests are now rounded to whole milliCPU values for improved Kubernetes and VPA compatibility.
  - CPU limits retain their original formatting while requests use consistent milliCPU notation.
  - CPU quota expectations now correctly use milliCPU formatting.

- **Tests**
  - Added coverage for rounding behavior across allocation ratios, upper-bound inputs, and whole-core CPU values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->