### PR TITLE
fix(kubevirt-cdi): drop global cloneStrategyOverride

### DIFF
--- a/packages/system/kubevirt-cdi/templates/cdi-cr.yaml
+++ b/packages/system/kubevirt-cdi/templates/cdi-cr.yaml
@@ -3,7 +3,14 @@ kind: CDI
 metadata:
   name: cdi
 spec:
-  cloneStrategyOverride: csi-clone
+  # No cloneStrategyOverride: let CDI pick the clone strategy per StorageProfile.
+  # The previous global "csi-clone" override bypassed CDI's same-StorageClass
+  # guard, so cross-StorageClass clones (e.g. cloning a golden image from a
+  # replicated StorageClass into a node-local one) were issued as csi-clone
+  # and could never satisfy on the target driver — the PVC stayed unbound.
+  # Per-StorageProfile selection lets CSI-snapshot clones stay fast for the
+  # same-class case while falling back to host-assisted copy across classes.
+  # See https://github.com/cozystack/cozystack/issues/2908
   config:
     {{- with .Values.uploadProxyURL }}
     uploadProxyURLOverride: {{ quote . }}


### PR DESCRIPTION
## What this PR does

`packages/system/kubevirt-cdi/templates/cdi-cr.yaml` pinned `cloneStrategyOverride: csi-clone` on the CDI CR globally (introduced with the golden-disks feature, switched from `snapshot` to `csi-clone` in 42778cf4b).

That override bypassed CDI's same-StorageClass guard: CDI's snapshot-based smart-clone path checks that source and target PVCs share a StorageClass and falls back to host-assisted copy otherwise, but the csi-clone path has no such guard — Kubernetes allows cross-StorageClass PVC cloning at the API level and delegates satisfiability to the CSI driver. Forced csi-clone was therefore issued as-is for every clone, including cross-class ones.

The concrete failure (#2908): a `vm-disk` created from a golden image (which lives in a replicated StorageClass) into a `local` (node-local, placement count 1) StorageClass — CDI emits a `tmp-pvc-…` in `cozy-public` with the target StorageClass and a `prep-…` pod, but `local` cannot materialise the clone on a node that does not already hold the source data. The PVC stays unbound forever, LINSTOR CSI logs `context deadline exceeded`, and no error is surfaced to the user.

This PR removes the global override so CDI picks the clone strategy per `StorageProfile`. The same-class path still uses CSI-snapshot clones (fast); the cross-class path falls back to host-assisted copy (slow but correct).

### Verification

```
$ helm template kubevirt-cdi packages/system/kubevirt-cdi --namespace cozy-cdi \
    --set '_cluster.root-host=example.cozy.local' \
    | grep -A2 'kind: CDI'
kind: CDI
metadata:
  name: cdi
  # No cloneStrategyOverride (removed)
```

The CRD schema in `packages/system/kubevirt-cdi-operator/templates/cdi-operator.yaml` still documents the `cloneStrategyOverride` field — that is the CRD definition, not its value, and remains unchanged.

### Performance and behavioural implications

* Same-StorageClass clones (the common case for VMs with a disk in the same SC as their golden image): unchanged user-visible behaviour. CDI will still pick `snapshot` for any StorageProfile whose CSI driver advertises `VolumeSnapshot` support (e.g. LINSTOR).
* Cross-StorageClass clones (the broken case): falls back to host-assisted copy. Slower than csi-clone but actually completes; without this fix it never did.
* If a particular StorageClass benefits from csi-clone in the same-class path and is being defaulted to `snapshot`, a `StorageProfile` CR with `cloneStrategy: csi-clone` for that class would restore the previous fast path without re-introducing the cross-class bug. None are shipped today and none are required by this PR.

### Release note

```release-note
fix(kubevirt-cdi): remove the global cloneStrategyOverride on the CDI CR. The override forced csi-clone for every CDI clone, including cross-StorageClass ones, which has no same-class guard — vm-disks cloned from a golden image into a different StorageClass (typically a node-local one) stayed unbound forever. Without the override CDI picks the clone strategy per StorageProfile: same-StorageClass clones still use CSI snapshots (fast), cross-StorageClass clones fall back to host-assisted copy (slower but correct).
```

Closes #2908