### PR TITLE
feat(kubevirt-cdi): make cloneStrategyOverride configurable

### DIFF
--- a/packages/system/kubevirt-cdi/templates/cdi-cr.yaml
+++ b/packages/system/kubevirt-cdi/templates/cdi-cr.yaml
@@ -3,7 +3,7 @@ kind: CDI
 metadata:
   name: cdi
 spec:
-  cloneStrategyOverride: csi-clone
+  cloneStrategyOverride: {{ quote .Values.cloneStrategyOverride }}
   config:
     {{- with .Values.uploadProxyURL }}
     uploadProxyURLOverride: {{ quote . }}

--- a/packages/system/kubevirt-cdi/values.yaml
+++ b/packages/system/kubevirt-cdi/values.yaml
@@ -1,1 +1,5 @@
 uploadProxyURL: ""
+
+## @param cloneStrategyOverride Strategy CDI uses to clone DataVolumes (golden image -> VM disk).
+## One of: csi-clone, snapshot, copy. Defaults to csi-clone (unchanged behavior).
+cloneStrategyOverride: csi-clone


### PR DESCRIPTION
## What this PR does

- Exposes the CDI `cloneStrategyOverride` as a Helm value in `packages/system/kubevirt-cdi` instead of hardcoding it in the CR template.
- Default stays `csi-clone`, so **behavior is unchanged** for everyone.
- It can now be overridden via a cozystack `Package` (e.g. `cloneStrategyOverride: copy`), the same way `uploadProxyURL` already is — no fork needed.

### Why

The value was hardcoded, so the only way to change the clone strategy was to fork the package. On some storage backends `csi-clone` is problematic: with LINSTOR/DRBD a CSI clone is created co-located with the source golden image and then relocated to optimal nodes asynchronously; that async relocation (`migrate-disk`) can race the post-clone resize CDI performs, occasionally leaving a volume whose DRBD device is smaller than its PVC capacity. Being able to select `snapshot` or `copy` per cluster, without maintaining a fork, is a useful escape hatch.

This only adds a knob; it does not change the default or recommend a strategy.

## Release note

```release-note
feat(kubevirt-cdi): make CDI cloneStrategyOverride configurable via values (default csi-clone)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The KubeVirt CDI clone strategy is now configurable via Helm chart values, allowing selection of `csi-clone`, `snapshot`, or `copy` for DataVolume cloning.  
  * The default remains `csi-clone` to preserve existing behavior and ensure backward compatibility.
* **Documentation**
  * Added the `cloneStrategyOverride` Helm value description and allowed options to the chart’s configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->