### PR TITLE
feat(kubernetes,tenant): copy patch-containerd secret into tenant namespaces

### DIFF
--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -441,13 +441,13 @@ spec:
           chmod 0755 /root/kubeadm
           if /root/kubelet --version ; then mv /root/kubelet /usr/bin/kubelet ; fi
           if /root/kubeadm version ; then mv /root/kubeadm /usr/bin/kubeadm ; fi
-      {{- $sec := lookup "v1" "Secret" $.Release.Namespace (printf "%s-patch-containerd" $.Release.Name) }}
+      {{- $sec := lookup "v1" "Secret" $.Release.Namespace "patch-containerd" }}
       {{- if $sec }}
         {{- range $key, $_ := $sec.data }}
       - path: /etc/containerd/certs.d/{{ trimSuffix ".toml" $key }}/hosts.toml
         contentFrom:
           secret:
-            name: {{ $.Release.Name }}-patch-containerd
+            name: patch-containerd
             key: {{ $key }}
         permissions: "0400"
         {{- end }}

--- a/packages/apps/tenant/templates/copy-patch-containerd.yaml
+++ b/packages/apps/tenant/templates/copy-patch-containerd.yaml
@@ -1,13 +1,16 @@
+{{- if ne (include "tenant.name" .) "tenant-root" }}
 {{- $sourceSecret := lookup "v1" "Secret" "cozy-system" "patch-containerd" }}
 {{- if $sourceSecret }}
+---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-patch-containerd
-  namespace: {{ .Release.Namespace }}
+  name: patch-containerd
+  namespace: {{ include "tenant.name" . }}
 type: {{ $sourceSecret.type }}
 data:
 {{- range $key, $value := $sourceSecret.data }}
-  {{ printf "%s: %s" $key ($value | quote) | indent 2 }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR moves the `patch-containerd` secret copying logic from the `kubernetes` chart to the `tenant` chart. This ensures that the secret is available in each tenant namespace, allowing the `kubernetes` chart to consume it directly from the namespace rather than maintaining a separate copy.

### Release note
```release-note
feat(kubernetes,tenant): copy `patch-containerd` secret into tenant namespaces
```