### PR TITLE
fix(harbor): preserve jobservice and trivy storageClass on upgrade

### DIFF
--- a/packages/apps/harbor/templates/harbor.yaml
+++ b/packages/apps/harbor/templates/harbor.yaml
@@ -23,6 +23,46 @@
   {{- end }}
 {{- end }}
 
+{{- /*
+  storageClassName on a PVC is immutable, and a StatefulSet's volumeClaimTemplate
+  cannot be patched at all. The upstream chart renders both the jobservice PVC and
+  the trivy VCT without a storageClassName unless one is passed, so on first install
+  the default-StorageClass admission stamps the cluster default onto the live object.
+  To avoid an immutable-field rejection on upgrade we keep the rendered value equal
+  to the live one: preserve an existing object's storageClassName, and only fall back
+  to the configured storageClass for a fresh install. See issue #2368.
+
+  A live object pinned to an explicit "" (no dynamic provisioning) must round-trip
+  too: upstream maps the "-" sentinel back to storageClassName: "", so forward "-"
+  rather than letting "" collapse to an omitted field. An object carrying no
+  storageClassName key at all keeps the empty fallback so the field stays omitted,
+  matching the live object.
+*/}}
+{{- $jobservicePvc := lookup "v1" "PersistentVolumeClaim" .Release.Namespace (printf "%s-jobservice" .Release.Name) }}
+{{- $jobserviceStorageClass := .Values.storageClass }}
+{{- if $jobservicePvc }}
+  {{- $jobserviceSpec := $jobservicePvc.spec | default dict }}
+  {{- if hasKey $jobserviceSpec "storageClassName" }}
+    {{- $jobserviceStorageClass = $jobserviceSpec.storageClassName | default "-" }}
+  {{- else }}
+    {{- $jobserviceStorageClass = "" }}
+  {{- end }}
+{{- end }}
+
+{{- /* The trivy StatefulSet's VCT is named "data", so its PVCs are
+       data-<release>-trivy-0..N; the class is identical across ordinals, so the
+       first ordinal is representative. */}}
+{{- $trivyPvc := lookup "v1" "PersistentVolumeClaim" .Release.Namespace (printf "data-%s-trivy-0" .Release.Name) }}
+{{- $trivyStorageClass := .Values.storageClass }}
+{{- if $trivyPvc }}
+  {{- $trivySpec := $trivyPvc.spec | default dict }}
+  {{- if hasKey $trivySpec "storageClassName" }}
+    {{- $trivyStorageClass = $trivySpec.storageClassName | default "-" }}
+  {{- else }}
+    {{- $trivyStorageClass = "" }}
+  {{- end }}
+{{- end }}
+
 apiVersion: v1
 kind: Secret
 metadata:
@@ -108,13 +148,20 @@ spec:
             bucket: {{ .Release.Name }}-registry
             secure: false
             v4auth: true
-        {{- if .Values.trivy.enabled }}
+        {{- if or $jobserviceStorageClass .Values.trivy.enabled }}
         persistentVolumeClaim:
+          {{- with $jobserviceStorageClass }}
+          jobservice:
+            jobLog:
+              storageClass: {{ . | quote }}
+          {{- end }}
+          {{- if .Values.trivy.enabled }}
           trivy:
             size: {{ .Values.trivy.size }}
-            {{- with .Values.storageClass }}
-            storageClass: {{ . }}
+            {{- with $trivyStorageClass }}
+            storageClass: {{ . | quote }}
             {{- end }}
+          {{- end }}
         {{- end }}
       portal:
         resources: {{- include "cozy-lib.resources.defaultingSanitize" (list "t1.nano" (dict) $) | nindent 10 }}

--- a/packages/apps/harbor/tests/jobservice_storageclass_test.yaml
+++ b/packages/apps/harbor/tests/jobservice_storageclass_test.yaml
@@ -1,0 +1,64 @@
+suite: jobservice storageClass propagation
+
+release:
+  name: harbor
+  namespace: tenant-test
+
+# Regression test for issue #2368: the jobservice PVC must receive the
+# configured storageClass so it is created with an explicit storageClassName
+# instead of relying on the default-StorageClass admission. Because PVC
+# storageClassName is immutable, the template preserves an existing PVC's
+# class when one is found; under `helm template`/unittest the cluster lookup
+# returns empty, so these cases exercise the fresh-install fallback path.
+#
+# The rendered HelmRelease (documentIndex 1) carries the values that the
+# cozy-harbor chart forwards to the upstream harbor subchart.
+# helm-unittest renders every template in the chart, so the platform-injected
+# globals consumed by the ingress/httproute/bucket templates must be supplied
+# even though only templates/harbor.yaml is asserted on.
+set:
+  _namespace:
+    host: example.org
+    ingress: nginx
+    gateway: ""
+    seaweedfs: seaweedfs
+  _cluster:
+    solver: http01
+
+tests:
+  - it: forwards storageClass to jobservice jobLog on a fresh install
+    template: templates/harbor.yaml
+    documentIndex: 1
+    set:
+      storageClass: local-3rep
+    asserts:
+      - equal:
+          path: spec.values.harbor.persistence.persistentVolumeClaim.jobservice.jobLog.storageClass
+          value: local-3rep
+
+  - it: still forwards storageClass to trivy alongside jobservice
+    template: templates/harbor.yaml
+    documentIndex: 1
+    set:
+      storageClass: local-3rep
+    asserts:
+      - equal:
+          path: spec.values.harbor.persistence.persistentVolumeClaim.trivy.storageClass
+          value: local-3rep
+
+  - it: omits the jobservice block when storageClass is unset
+    template: templates/harbor.yaml
+    documentIndex: 1
+    asserts:
+      - notExists:
+          path: spec.values.harbor.persistence.persistentVolumeClaim.jobservice
+
+  - it: emits no persistentVolumeClaim block when storageClass is unset and trivy is disabled
+    template: templates/harbor.yaml
+    documentIndex: 1
+    set:
+      trivy:
+        enabled: false
+    asserts:
+      - notExists:
+          path: spec.values.harbor.persistence.persistentVolumeClaim


### PR DESCRIPTION
## What this PR does

The `apps/harbor` chart never passed `storageClass` to the jobservice `jobLog` PVC, so the upstream chart rendered it without a `storageClassName`. On first install the default-StorageClass admission then stamps the cluster default onto the live PVC. Because a PVC's `storageClassName` is immutable, the rendered manifest (no class) and the live object (admission-defaulted class) drift apart, which surfaced as upgrade failures on the `harbor-*-system` HelmRelease.

This propagates `storageClass` to the jobservice PVC, with one safeguard: a `lookup` reads the live jobservice PVC and reuses its current `storageClassName` when the PVC already exists, only falling back to the configured `storageClass` for a fresh install. Keeping the rendered value equal to the live one means an existing PVC whose admission-defaulted class differs from the configured `storageClass` is preserved rather than triggering an immutable-field rejection on upgrade. A live PVC pinned to an explicit `""` (no dynamic provisioning) round-trips through the upstream `"-"` sentinel instead of collapsing to an omitted field, and the spec access is guarded so a PVC with no `storageClassName` key stays omitted.

The trivy `StatefulSet`'s `volumeClaimTemplate` carried the same latent drift — `.Values.storageClass` was forwarded blindly into a VCT, which cannot be patched at all — so it now gets the identical lookup-preserve treatment, keyed off `data-<release>-trivy-0`. This closes both halves of #2368.

Also adds a helm-unittest regression suite and wires a `test:` target so `make unit-tests` stops skipping `packages/apps/harbor`.

Validated with `helm template` across storageClass/trivy permutations and the new unit tests. The jobservice preserve path was additionally confirmed with a server-side dry-run against a running harbor release: `lookup` resolved the live PVC's class, and with `storageClass` overridden to a different class the jobservice render stayed pinned to the live PVC's class — confirming the immutable-field rejection is avoided. The trivy change applies the same proven pattern. Note: under `helm template`/helm-unittest `lookup` returns empty, so the unit suite exercises only the fresh-install fallback; the preserve branches are covered by the live `lookup`.

Fixes #2368

### Release note

```release-note
fix(harbor): preserve the jobservice PVC and trivy volumeClaimTemplate storageClass on upgrade, fixing upgrade failures caused by storageClassName drift
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Harbor now preserves the existing jobservice storage class during upgrades and ensures it’s applied on initial installation when available, with consistent handling for Trivy persistence as well.

* **Tests**
  * Added a Helm unittest regression suite covering storage class propagation and the correct conditional rendering of persistence blocks when storage class and Trivy settings vary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
