### PR TITLE
docs(agents): consolidate build, test, and verification guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+The single source of truth for all agents in this repo is `AGENTS.md` (the open standard that Codex, Cursor, and other tools read too). Claude Code has no native `AGENTS.md` support, so this file imports it. Put personal, untracked overrides in `CLAUDE.local.md`.
+
+@AGENTS.md

--- a/docs/agents/contributing.md
+++ b/docs/agents/contributing.md
@@ -142,7 +142,7 @@ Create the PR with `gh pr create --title "type(scope): brief description" --body
 ## Review Expectations
 
 - A bug-fix PR should include a behavioural regression test, not just a single field assertion — prove the bug can no longer recur.
-- Keep the PR description on the template: `## What this PR does` plus the `release-note` block.
+- Keep the PR description aligned with the template: `## What this PR does` plus the `release-note` block.
 
 ## Fetching Unresolved Review Comments
 

--- a/docs/agents/contributing.md
+++ b/docs/agents/contributing.md
@@ -33,6 +33,15 @@ To locate packages a WIP branch likely needs to be regenerated:
 git diff --name-only | xargs -n1 dirname | sort -u | grep ^packages/
 ```
 
+## Verify Before Considering Done
+
+After every change, verify the relevant artifacts before opening the PR:
+
+- **Helm templates changed:** `make show` in the package directory renders cleanly.
+- **Go code changed:** `make generate && make manifests` at the repo root, then commit the regenerated files.
+- **`values.yaml` annotations changed:** `make generate` in the package; review the `values.schema.json` diff.
+- **Migration scripts:** confirm what data actually exists first with `kubectl get <resource> -A -o jsonpath='{...}'` on a dev cluster before writing the logic.
+
 ## Commit Format
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/) with `--signoff`:
@@ -129,6 +138,11 @@ git push -f origin my-feature
 Fill in the template at [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md). It includes the required `release-note` block.
 
 Create the PR with `gh pr create --title "type(scope): brief description" --body-file <file>`.
+
+## Review Expectations
+
+- A bug-fix PR should include a behavioural regression test, not just a single field assertion — prove the bug can no longer recur.
+- Keep the PR description on the template: `## What this PR does` plus the `release-note` block.
 
 ## Fetching Unresolved Review Comments
 

--- a/docs/agents/overview.md
+++ b/docs/agents/overview.md
@@ -69,7 +69,7 @@ Root targets (run from the repo root):
 
 ```bash
 make build          # Build all Docker images (needs: docker, skopeo, jq, gh, helm, yq, GNU tar/sed/awk)
-make unit-tests     # Run Helm unit tests across all packages
+make unit-tests     # Run all unit tests (Helm, BATS, Go, etc.)
 make generate       # Code generation (hack/update-codegen.sh) — CRDs, DeepCopy, clients, RBAC
 make manifests      # Generate CRD manifests and operator YAML variants
 make cozypkg        # Build the cozypkg CLI

--- a/docs/agents/overview.md
+++ b/docs/agents/overview.md
@@ -142,7 +142,6 @@ Documentation is organized as follows:
 
 Before working on these areas, read the relevant doc first:
 
-- **Dashboard resources:** `internal/controller/dashboard/README.md`
 - **Backup subsystem design:** `api/backups/v1alpha1/DESIGN.md`
 - **A new app package:** copy the structure of an existing one (e.g. `packages/apps/postgres/`)
 

--- a/docs/agents/overview.md
+++ b/docs/agents/overview.md
@@ -100,7 +100,7 @@ Package `values.yaml` files carry annotations (`@param`, `@typedef`, `@field`, `
 
 ## Testing
 
-- **Helm unit tests:** `make unit-tests` (runs `hack/helm-unit-tests.sh` over every package that defines a `test` target).
+- **Helm unit tests:** `make helm-unit-tests` (runs `hack/helm-unit-tests.sh` over every package that defines a `test` target). `make unit-tests` runs the full unit suite — Helm, BATS, Go, and the preset/readiness checks.
 - **E2E tests:** BATS suites in `hack/e2e-apps/` (one `.bats` per app), run through `hack/cozytest.sh`. Conventions for writing and stabilising them — and the CI that runs them — live in [`e2e-testing.md`](./e2e-testing.md).
 - **Go tests:** standard `go test`, with Ginkgo/Gomega for controllers.
 

--- a/docs/agents/overview.md
+++ b/docs/agents/overview.md
@@ -63,6 +63,47 @@ packages/<category>/<package-name>/
 └── values.schema.json                   # JSON schema for validation and UI
 ```
 
+## Build and Development Commands
+
+Root targets (run from the repo root):
+
+```bash
+make build          # Build all Docker images (needs: docker, skopeo, jq, gh, helm, yq, GNU tar/sed/awk)
+make unit-tests     # Run Helm unit tests across all packages
+make generate       # Code generation (hack/update-codegen.sh) — CRDs, DeepCopy, clients, RBAC
+make manifests      # Generate CRD manifests and operator YAML variants
+make cozypkg        # Build the cozypkg CLI
+make test           # Full E2E tests (requires a cluster)
+make prepare-env    # Prepare the E2E test environment (apply + prepare-cluster)
+```
+
+Per-package targets (run inside `packages/{apps,system,extra,core}/<name>/`):
+
+```bash
+make image          # Build the package image
+make show           # Render the Helm template
+make apply          # Apply the Helm release to a cluster (needs NAME, NAMESPACE)
+make diff           # Diff the template against the cluster
+make test           # Package-specific tests
+make generate       # Regenerate values.schema.json + README.md from values.yaml
+```
+
+Build environment variables:
+
+- `REGISTRY` — Docker registry (default `ghcr.io/cozystack/cozystack`).
+- `PUSH=1` / `LOAD=0` — control buildx push/load behaviour.
+- `LOAD=1 PUSH=0` — load images locally instead of pushing.
+
+### Values schema generation
+
+Package `values.yaml` files carry annotations (`@param`, `@typedef`, `@field`, `@enum`, `@section`) that `cozyvalues-gen` turns into `values.schema.json` and `README.md`. Run `make generate` in the package after editing annotations. A pre-commit hook runs `make generate` across `packages/apps/*` and `packages/extra/*` on every commit to keep these in sync — see [`contributing.md`](./contributing.md) for the regenerate-before-commit rule.
+
+## Testing
+
+- **Helm unit tests:** `make unit-tests` (runs `hack/helm-unit-tests.sh` over every package that defines a `test` target).
+- **E2E tests:** BATS suites in `hack/e2e-apps/` (one `.bats` per app), run through `hack/cozytest.sh`. Conventions for writing and stabilising them — and the CI that runs them — live in [`e2e-testing.md`](./e2e-testing.md).
+- **Go tests:** standard `go test`, with Ginkgo/Gomega for controllers.
+
 ## Conventions
 
 ### Helm Charts
@@ -78,10 +119,8 @@ packages/<category>/<package-name>/
 - Add proper error handling and structured logging
 
 ### Git Commits
-- Follow [Conventional Commits](https://www.conventionalcommits.org/) format: `type(scope): description`
-- Always use `--signoff` flag
-- Reference PR numbers when available
-- Keep commits atomic and focused
+
+Conventional Commits (`type(scope): description`) with `--signoff`, kept atomic and focused. Full format, scopes, AI-attribution trailer, and PR workflow are in [`contributing.md`](./contributing.md) — the source of truth; do not duplicate them here.
 
 ### PackageSource CRD upgrade policy
 
@@ -98,6 +137,14 @@ Documentation is organized as follows:
 - `docs/agents/` - Instructions for AI agents
 - `docs/changelogs/` - Release changelogs
 - Main website: https://github.com/cozystack/website
+
+### Domain references for specific tasks
+
+Before working on these areas, read the relevant doc first:
+
+- **Dashboard resources:** `internal/controller/dashboard/README.md`
+- **Backup subsystem design:** `api/backups/v1alpha1/DESIGN.md`
+- **A new app package:** copy the structure of an existing one (e.g. `packages/apps/postgres/`)
 
 ## Things Agents Should Not Do
 


### PR DESCRIPTION
## What this PR does

Promotes universal project guidance that previously lived only in a local
(gitignored) `CLAUDE.md` into the committed agent docs, so every contributor and
every tool (Codex/Cursor/etc., not just Claude) gets it from a fresh clone.

- `overview.md`: Build & Development Commands (root + per-package make targets,
  build env vars), Values schema generation, a Testing section, Domain references
- `contributing.md`: a "Verify Before Considering Done" matrix + Review Expectations
- Dedup: `overview.md`'s Git Commits block now points to `contributing.md`

> Note: `overview.md` links to `docs/agents/e2e-testing.md` added in #2932 — merge
> that one first or together.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded contribution guidance with a “Verify Before Considering Done” pre-submission checklist and clearer expectations for including behavioral regression tests in bug-fix PRs.
  * Broadened build/development documentation with a “Build and Development Commands” guide, including required environment variables, values-schema generation, and test entry points.
  * Updated contribution workflow notes by consolidating commit-convention guidance and adding pointers to task-specific design references.
  * Added a Claude entry-point document that directs to the main agents guide and explains local override placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->