### PR TITLE
fix(kafka): set entity-operator resources to avoid OOM under tenant LimitRange

### DIFF
--- a/packages/apps/kafka/templates/kafka.yaml
+++ b/packages/apps/kafka/templates/kafka.yaml
@@ -97,8 +97,25 @@ spec:
           name: {{ .Release.Name }}-metrics
           key: kafka-metrics-config.yml
   entityOperator:
-    topicOperator: {}
-    userOperator: {}
+    # Tenant namespaces ship a LimitRange that defaults containers to 128Mi.
+    # The topic-operator and user-operator are JVM processes and OOMKill at
+    # that default, leaving the entity-operator in CrashLoopBackOff so
+    # KafkaTopics/KafkaUsers never reconcile. Set explicit resources so they
+    # don't inherit the namespace default.
+    topicOperator:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
+    userOperator:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 512Mi
     template:
       # `pod` accepts metadata + a flat set of pod-spec fields
       # (enableServiceLinks, securityContext, affinity, …) directly.

--- a/packages/apps/kafka/tests/entityoperator_template_test.yaml
+++ b/packages/apps/kafka/tests/entityoperator_template_test.yaml
@@ -20,3 +20,15 @@ tests:
       # the phantom template.spec key must not reappear
       - notExists:
           path: spec.entityOperator.template.spec
+
+  - it: topic-operator and user-operator set explicit resources (avoid 128Mi LimitRange OOM)
+    release:
+      name: test-kafka
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: spec.entityOperator.topicOperator.resources.limits.memory
+          value: 512Mi
+      - equal:
+          path: spec.entityOperator.userOperator.resources.limits.memory
+          value: 512Mi


### PR DESCRIPTION
## What this PR does

`packages/apps/kafka` rendered the Strimzi `Kafka` CR with `entityOperator.topicOperator: {}` / `userOperator: {}` and no `resources`. Tenant namespaces ship a `LimitRange` that defaults containers to `memory: 128Mi`, so the topic-operator and user-operator JVM containers (Kafka 3.9.1 + fabric8/vertx) are **OOMKilled (exit 137)** on startup. The `<cluster>-entity-operator` Deployment never becomes Ready (CrashLoopBackOff), so:

- `KafkaTopic` / `KafkaUser` CRs never reconcile — topic creation effectively fails;
- the cluster-operator logs `Exceeded timeout of 300000ms while waiting for Deployment ...-entity-operator ... to be ready`;
- on teardown, `KafkaTopic`s get stuck permanently with the `strimzi.io/topic-operator` finalizer (no operator left to clear them), blocking namespace deletion.

The Kafka broker + ZooKeeper come up fine — only the entity-operator dies. The `apps.cozystack.io/Kafka` schema exposes no field for entity-operator resources, so there is no user-side workaround.

## Fix

Set explicit `resources` (requests `256Mi`/`100m`, limit `512Mi` memory) on `entityOperator.topicOperator` and `userOperator` so they no longer inherit the 128Mi namespace default. Adds a `helm-unittest` assertion for the rendered limits.

## Testing

Reproduced on a clean cluster (Cozystack v1.4.3 and v1.5.0-rc.2; Strimzi 0.45.1, Kafka 3.9.1): both entity-operator containers `OOMKilled` at 128Mi → CrashLoopBackOff → `KafkaTopic` never `READY`. After bumping to 512Mi the entity-operator rolls cleanly (both containers Ready, 0 restarts) and the `KafkaTopic` reconciles to `READY=True`.

### Release note
```release-note
fix(kafka): give entity-operator (topic/user-operator) explicit resources so they no longer inherit the 128Mi tenant LimitRange default and OOMKill, which left KafkaTopics/KafkaUsers unreconciled.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Kafka topic and user operators now use explicit CPU and memory requests and limits, avoiding reliance on namespace-level defaults.

* **Tests**
  * Added regression coverage to verify the Kafka entity operator’s topic and user operator memory limits are explicitly set (512Mi).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->