### PR TITLE
refactor(build): mode=max registry cache with a main-only warmer

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -1,0 +1,67 @@
+name: Build cache (main)
+
+# Warms the shared mode=max build cache so PR builds start hot.
+#
+# PR builds (pull-requests.yaml) read the cache but never write it
+# (WRITE_CACHE unset -> 0). Only this serialized main build writes
+# CACHE_REGISTRY/<img>:buildcache, so concurrent PR builds never race on the
+# cache manifest -- the 409 collisions PR #2711 fixed for image tags would
+# otherwise reappear on the cache ref. Cache is mode=max so all multistage
+# `builder` stages are cached, not just the final stage as with inline.
+
+env:
+  # Same per-CI registry as pull-requests.yaml; the cache is co-located here.
+  REGISTRY: iad.ocir.io/idyksih5sir9/cozystack
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+
+# Only the newest main commit's cache matters; cancel older in-flight warmers.
+concurrency:
+  group: build-main-cache
+  cancel-in-progress: true
+
+jobs:
+  warm-cache:
+    name: Warm build cache
+    runs-on: [self-hosted]
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Docker config
+        run: |
+          if [ -d ~/.docker ]; then
+            cp -r ~/.docker "${{ runner.temp }}/.docker"
+          fi
+
+      - name: Login to OCIR
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.OCIR_USER }}
+          password: ${{ secrets.OCIR_TOKEN }}
+          registry: iad.ocir.io
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
+
+      - name: Build all images and write mode=max cache
+        run: make build
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
+          # WRITE_CACHE=1 turns on --cache-to (mode=max) for every image.
+          WRITE_CACHE: '1'
+          # Publish a floating :main handle; do not move :latest (releases do).
+          IMAGE_TAG: main
+          PUBLISH_VERSIONED: '0'
+          PUBLISH_FLOATING: '0'

--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -8,6 +8,13 @@ name: Build cache (main)
 # cache manifest -- the 409 collisions PR #2711 fixed for image tags would
 # otherwise reappear on the cache ref. Cache is mode=max so all multistage
 # `builder` stages are cached, not just the final stage as with inline.
+#
+# This job builds on a docker-container buildx builder, NOT the host's default
+# embedded `docker` driver: `--cache-to type=registry,mode=max` is unsupported
+# on the docker driver unless the daemon runs the containerd image store, so on
+# a classic store the warmer would otherwise fail to export any cache. The
+# container driver also gives this build its own buildkit (separate bbolt), so
+# the warmer never contends with PR builds on the shared embedded buildkit.
 
 env:
   # Same per-CI registry as pull-requests.yaml; the cache is co-located here.
@@ -55,10 +62,23 @@ jobs:
         env:
           DOCKER_CONFIG: ${{ runner.temp }}/.docker
 
+      # docker-container driver: required for `--cache-to type=registry,mode=max`
+      # (unsupported on the host's default docker driver) and gives this build an
+      # isolated buildkit so it never contends with PR builds on the shared one.
+      - name: Set up Buildx (docker-container driver)
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+
       - name: Build all images and write mode=max cache
         run: make build
         env:
           DOCKER_CONFIG: ${{ runner.temp }}/.docker
+          # Build on the docker-container builder created above (BUILDX_ARGS adds
+          # --builder=$(BUILDER)); buildx forwards the OCIR auth from DOCKER_CONFIG
+          # to the container builder for cache reads/writes and image pushes.
+          BUILDER: ${{ steps.buildx.outputs.name }}
           # WRITE_CACHE=1 turns on --cache-to (mode=max) for every image.
           WRITE_CACHE: '1'
           # Publish a floating :main handle; do not move :latest (releases do).

--- a/hack/common-envs.mk
+++ b/hack/common-envs.mk
@@ -7,13 +7,12 @@ endif
 
 REGISTRY ?= ghcr.io/cozystack/cozystack
 
-# CACHE_REGISTRY: registry that `--cache-from` reads build cache from. It must
-# point at a registry where a `:latest` tag is actually published. PR builds
-# set REGISTRY to a per-CI registry and push only unique `pr-<N>-<sha>` tags
-# (PUBLISH_FLOATING=0), so they never refresh `:latest` there — reading cache
-# from $(REGISTRY):latest would always 404. Release builds publish `:latest`
-# to ghcr.io, so default cache reads there and stays warm across PR builds.
-CACHE_REGISTRY ?= ghcr.io/cozystack/cozystack
+# CACHE_REGISTRY: registry holding the `:buildcache` mode=max cache images that
+# `--cache-from`/`--cache-to` read and write (see the cache-args macro below).
+# Defaults to $(REGISTRY) so the cache is co-located with the build registry —
+# in CI that is the per-CI registry the runners are closest to, keeping cache
+# transfers fast and egress-free.
+CACHE_REGISTRY ?= $(REGISTRY)
 
 # IMAGE_TAG: build-unique tag pushed for every image. Set by CI to a value
 # that does not collide between concurrent builds:
@@ -28,6 +27,12 @@ IMAGE_TAG ?= dev
 #   PUBLISH_FLOATING=1  -> also push :latest             (release/main only)
 PUBLISH_VERSIONED ?= 0
 PUBLISH_FLOATING  ?= 0
+
+# WRITE_CACHE=1 enables `--cache-to` (mode=max) to CACHE_REGISTRY/<img>:buildcache.
+# Default off: only the serialized main/release cache-warming build writes the
+# shared cache ref. PR builds keep it 0 and read-only, so concurrent PR builds
+# never race on the cache manifest (the 409 collisions PR #2711 fixed for tags).
+WRITE_CACHE ?= 0
 
 PUSH := 1
 LOAD := 0
@@ -54,6 +59,20 @@ BUILDX_ARGS := --provenance=false --push=$(PUSH) --load=$(LOAD) \
 define image-tags
 --tag $(REGISTRY)/$(1):$(IMAGE_TAG)$(if $(filter 1,$(PUBLISH_VERSIONED)),$(if $(filter-out $(IMAGE_TAG),$(strip $(2))), --tag $(REGISTRY)/$(1):$(strip $(2))))$(if $(filter 1,$(PUBLISH_FLOATING)), --tag $(REGISTRY)/$(1):latest)
 endef
+
+# cache-args <image-name> [<cache-tag>]
+# Expands to buildx cache flags for one image:
+#   --cache-from is always emitted (a missing cache 404s harmlessly -> cold build)
+#   --cache-to is emitted only when WRITE_CACHE=1 (main/release), writing mode=max
+#     so ALL stages are cached -- including the multistage `builder` layers that
+#     `--cache-to type=inline` could never export. oci-mediatypes + image-manifest
+#     keep the cache manifest portable across registries (OCIR/ghcr/ECR).
+# <cache-tag> defaults to `buildcache`; pass an explicit tag for images that build
+# a distinct artifact per loop iteration (e.g. ubuntu-container-disk per k8s ver).
+# $(comma) escapes the literal commas in the --cache-to value so make does not
+# mis-parse them as $(if ...) argument separators.
+comma := ,
+cache-args = --cache-from type=registry,ref=$(CACHE_REGISTRY)/$(1):$(if $(2),$(2),buildcache)$(if $(filter 1,$(WRITE_CACHE)), --cache-to type=registry$(comma)ref=$(CACHE_REGISTRY)/$(1):$(if $(2),$(2),buildcache)$(comma)mode=max$(comma)oci-mediatypes=true$(comma)image-manifest=true)
 
 ifeq ($(COZYSTACK_VERSION),)
     $(shell git remote add upstream https://github.com/cozystack/cozystack.git || true)

--- a/packages/apps/clickhouse/Makefile
+++ b/packages/apps/clickhouse/Makefile
@@ -13,8 +13,7 @@ test:
 image:
 	docker buildx build images/clickhouse-backup \
 		$(call image-tags,clickhouse-backup,$(CLICKHOUSE_BACKUP_TAG)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/clickhouse-backup:latest \
-		--cache-to type=inline \
+		$(call cache-args,clickhouse-backup) \
 		--metadata-file images/clickhouse-backup.json \
 		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/clickhouse-backup:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/clickhouse-backup.json -o json -r)" \
@@ -22,8 +21,7 @@ image:
 	rm -f images/clickhouse-backup.json
 	docker buildx build images/altinity-clickhouse-backup \
 		$(call image-tags,altinity-clickhouse-backup,$(CLICKHOUSE_BACKUP_TAG)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/altinity-clickhouse-backup:latest \
-		--cache-to type=inline \
+		$(call cache-args,altinity-clickhouse-backup) \
 		--metadata-file images/altinity-clickhouse-backup.json \
 		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/altinity-clickhouse-backup:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/altinity-clickhouse-backup.json -o json -r)" \

--- a/packages/apps/http-cache/Makefile
+++ b/packages/apps/http-cache/Makefile
@@ -8,8 +8,7 @@ image: image-nginx
 image-nginx:
 	docker buildx build images/nginx-cache \
 		$(call image-tags,nginx-cache,$(NGINX_CACHE_TAG)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/nginx-cache:latest \
-		--cache-to type=inline \
+		$(call cache-args,nginx-cache) \
 		--metadata-file images/nginx-cache.json \
 		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/nginx-cache:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/nginx-cache.json -o json -r)" \

--- a/packages/apps/kubernetes/Makefile
+++ b/packages/apps/kubernetes/Makefile
@@ -26,8 +26,7 @@ image-ubuntu-container-disk:
 			--build-arg KUBERNETES_VERSION=$(ver) \
 			--tag $(REGISTRY)/ubuntu-container-disk:$(ver)-$(IMAGE_TAG) \
 			$(if $(filter 1,$(PUBLISH_VERSIONED)),--tag $(REGISTRY)/ubuntu-container-disk:$(ver)) \
-			--cache-from type=registry,ref=$(CACHE_REGISTRY)/ubuntu-container-disk:$(ver) \
-			--cache-to type=inline \
+			$(call cache-args,ubuntu-container-disk,$(ver)-buildcache) \
 			--metadata-file images/ubuntu-container-disk-$(ver).json \
 			$(BUILDX_ARGS) && \
 		echo "$(REGISTRY)/ubuntu-container-disk:$(ver)-$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/ubuntu-container-disk-$(ver).json -o json -r)" \
@@ -38,8 +37,7 @@ image-ubuntu-container-disk:
 image-kubevirt-cloud-provider:
 	docker buildx build images/kubevirt-cloud-provider \
 		$(call image-tags,kubevirt-cloud-provider,$(KUBERNETES_PKG_TAG)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/kubevirt-cloud-provider:latest \
-		--cache-to type=inline \
+		$(call cache-args,kubevirt-cloud-provider) \
 		--metadata-file images/kubevirt-cloud-provider.json \
 		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/kubevirt-cloud-provider:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/kubevirt-cloud-provider.json -o json -r)" \
@@ -49,8 +47,7 @@ image-kubevirt-cloud-provider:
 image-kubevirt-csi-driver:
 	docker buildx build images/kubevirt-csi-driver \
 		$(call image-tags,kubevirt-csi-driver,$(KUBERNETES_PKG_TAG)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/kubevirt-csi-driver:latest \
-		--cache-to type=inline \
+		$(call cache-args,kubevirt-csi-driver) \
 		--metadata-file images/kubevirt-csi-driver.json \
 		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/kubevirt-csi-driver:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/kubevirt-csi-driver.json -o json -r)" \
@@ -63,8 +60,7 @@ image-kubevirt-csi-driver:
 image-cluster-autoscaler:
 	docker buildx build images/cluster-autoscaler \
 		$(call image-tags,cluster-autoscaler,$(KUBERNETES_PKG_TAG)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/cluster-autoscaler:latest \
-		--cache-to type=inline \
+		$(call cache-args,cluster-autoscaler) \
 		--metadata-file images/cluster-autoscaler.json \
 		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/cluster-autoscaler:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/cluster-autoscaler.json -o json -r)" \

--- a/packages/apps/mariadb/Makefile
+++ b/packages/apps/mariadb/Makefile
@@ -14,8 +14,7 @@ update:
 image:
 	docker buildx build images/mariadb-backup \
 		$(call image-tags,mariadb-backup,$(MARIADB_BACKUP_TAG)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/mariadb-backup:latest \
-		--cache-to type=inline \
+		$(call cache-args,mariadb-backup) \
 		--metadata-file images/mariadb-backup.json \
 		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/mariadb-backup:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/mariadb-backup.json -o json -r)" \

--- a/packages/core/installer/Makefile
+++ b/packages/core/installer/Makefile
@@ -21,8 +21,7 @@ image-operator:
 	docker buildx build -f images/cozystack-operator/Dockerfile ../../.. \
 		$(call image-tags,cozystack-operator,v$(COZYSTACK_VERSION)) \
 		--build-arg VERSION=v$(COZYSTACK_VERSION) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/cozystack-operator:latest \
-		--cache-to type=inline \
+		$(call cache-args,cozystack-operator) \
 		--metadata-file images/cozystack-operator.json \
 		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/cozystack-operator:$(IMAGE_TAG)@$$(yq -e '.["containerimage.digest"]' images/cozystack-operator.json -o json -r)" \

--- a/packages/core/platform/Makefile
+++ b/packages/core/platform/Makefile
@@ -30,8 +30,7 @@ image: image-migrations
 image-migrations:
 	docker buildx build images/migrations \
 		$(call image-tags,platform-migrations,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/platform-migrations:latest \
-		--cache-to type=inline \
+		$(call cache-args,platform-migrations) \
 		--metadata-file images/migrations.json \
 		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/platform-migrations:$(IMAGE_TAG)@$$(yq -e -o json -r '.["containerimage.digest"]' images/migrations.json)" \

--- a/packages/core/talos/Makefile
+++ b/packages/core/talos/Makefile
@@ -23,8 +23,7 @@ image-matchbox:
 	test -f ../../../_out/assets/initramfs-metal-amd64.xz || make talos-initramfs
 	docker buildx build -f images/matchbox/Dockerfile ../../.. \
 		$(call image-tags,matchbox,$(TALOS_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/matchbox:latest \
-		--cache-to type=inline \
+		$(call cache-args,matchbox) \
 		--metadata-file images/matchbox.json \
 		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/matchbox:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/matchbox.json -o json -r)" \

--- a/packages/core/testing/Makefile
+++ b/packages/core/testing/Makefile
@@ -17,8 +17,7 @@ image: image-e2e-sandbox
 image-e2e-sandbox:
 	docker buildx build -f images/e2e-sandbox/Dockerfile images/e2e-sandbox \
 		$(call image-tags,e2e-sandbox,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/e2e-sandbox:latest \
-		--cache-to type=inline \
+		$(call cache-args,e2e-sandbox) \
 		--metadata-file images/e2e-sandbox.json \
 		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/e2e-sandbox:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/e2e-sandbox.json -o json -r)" \

--- a/packages/extra/monitoring/Makefile
+++ b/packages/extra/monitoring/Makefile
@@ -12,8 +12,7 @@ generate:
 image:
 	docker buildx build images/grafana \
 		$(call image-tags,grafana,$(GRAFANA_TAG)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/grafana:latest \
-		--cache-to type=inline \
+		$(call cache-args,grafana) \
 		--metadata-file images/grafana.json \
 		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/grafana:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/grafana.json -o json -r)" \

--- a/packages/system/backup-controller/Makefile
+++ b/packages/system/backup-controller/Makefile
@@ -12,8 +12,7 @@ image: image-backup-controller
 image-backup-controller:
 	docker buildx build -f images/backup-controller/Dockerfile ../../.. \
 		$(call image-tags,backup-controller,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/backup-controller:latest \
-		--cache-to type=inline \
+		$(call cache-args,backup-controller) \
 		--metadata-file images/backup-controller.json \
 		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/backup-controller:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/backup-controller.json -o json -r)" \

--- a/packages/system/backupstrategy-controller/Makefile
+++ b/packages/system/backupstrategy-controller/Makefile
@@ -9,8 +9,7 @@ image: image-backupstrategy-controller
 image-backupstrategy-controller:
 	docker buildx build -f images/backupstrategy-controller/Dockerfile ../../.. \
 		$(call image-tags,backupstrategy-controller,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/backupstrategy-controller:latest \
-		--cache-to type=inline \
+		$(call cache-args,backupstrategy-controller) \
 		--metadata-file images/backupstrategy-controller.json \
 		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/backupstrategy-controller:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/backupstrategy-controller.json -o json -r)" \

--- a/packages/system/bucket/Makefile
+++ b/packages/system/bucket/Makefile
@@ -13,8 +13,7 @@ image: image-s3manager
 image-s3manager:
 	docker buildx build images/s3manager \
 		$(call image-tags,s3manager,$(S3MANAGER_TAG)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/s3manager:latest \
-		--cache-to type=inline \
+		$(call cache-args,s3manager) \
 		--metadata-file images/s3manager.json \
 		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/s3manager:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/s3manager.json -o json -r)" \

--- a/packages/system/cilium/Makefile
+++ b/packages/system/cilium/Makefile
@@ -27,8 +27,7 @@ update:
 image:
 	docker buildx build images/cilium \
 		$(call image-tags,cilium,$(CILIUM_TAG)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/cilium:latest \
-		--cache-to type=inline \
+		$(call cache-args,cilium) \
 		--metadata-file images/cilium.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/cilium" \

--- a/packages/system/cozystack-api/Makefile
+++ b/packages/system/cozystack-api/Makefile
@@ -24,8 +24,7 @@ image: image-cozystack-api
 image-cozystack-api:
 	docker buildx build -f images/cozystack-api/Dockerfile ../../.. \
 		$(call image-tags,cozystack-api,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/cozystack-api:latest \
-		--cache-to type=inline \
+		$(call cache-args,cozystack-api) \
 		--metadata-file images/cozystack-api.json \
 		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/cozystack-api:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/cozystack-api.json -o json -r)" \

--- a/packages/system/cozystack-controller/Makefile
+++ b/packages/system/cozystack-controller/Makefile
@@ -10,8 +10,7 @@ image-cozystack-controller:
 	docker buildx build -f images/cozystack-controller/Dockerfile ../../.. \
 		$(call image-tags,cozystack-controller,v$(COZYSTACK_VERSION)) \
 		--build-arg VERSION=v$(COZYSTACK_VERSION) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/cozystack-controller:latest \
-		--cache-to type=inline \
+		$(call cache-args,cozystack-controller) \
 		--metadata-file images/cozystack-controller.json \
 		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/cozystack-controller:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/cozystack-controller.json -o json -r)" \

--- a/packages/system/dashboard/Makefile
+++ b/packages/system/dashboard/Makefile
@@ -34,8 +34,7 @@ build-console:
 		--builder=$(BUILDER) \
 		--platform=linux/amd64 \
 		$(call image-tags,cozystack-ui,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/cozystack-ui:latest \
-		--cache-to type=inline \
+		$(call cache-args,cozystack-ui) \
 		--metadata-file images/console.json \
 		--build-arg APP_VERSION=$(COZYSTACK_VERSION) \
 		--push=$(PUSH) \
@@ -55,8 +54,7 @@ image-token-proxy:
 		--builder=$(BUILDER) \
 		--platform=linux/amd64 \
 		$(call image-tags,token-proxy,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/token-proxy:latest \
-		--cache-to type=inline \
+		$(call cache-args,token-proxy) \
 		--metadata-file images/token-proxy.json \
 		--push=$(PUSH) \
 		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \

--- a/packages/system/flux-plunger/Makefile
+++ b/packages/system/flux-plunger/Makefile
@@ -7,6 +7,7 @@ include ../../../hack/package.mk
 image:
 	docker buildx build -f images/flux-plunger/Dockerfile ../../../ \
 		--provenance false \
+		$(if $(strip $(BUILDER)),--builder=$(BUILDER)) \
 		$(call image-tags,flux-plunger,v$(COZYSTACK_VERSION)) \
 		$(call cache-args,flux-plunger) \
 		--metadata-file images/flux-plunger.json \

--- a/packages/system/flux-plunger/Makefile
+++ b/packages/system/flux-plunger/Makefile
@@ -8,8 +8,7 @@ image:
 	docker buildx build -f images/flux-plunger/Dockerfile ../../../ \
 		--provenance false \
 		$(call image-tags,flux-plunger,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/flux-plunger:latest \
-		--cache-to type=inline \
+		$(call cache-args,flux-plunger) \
 		--metadata-file images/flux-plunger.json \
 		--push=$(PUSH) \
 		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \

--- a/packages/system/grafana-operator/Makefile
+++ b/packages/system/grafana-operator/Makefile
@@ -14,8 +14,7 @@ update:
 image:
 	docker buildx build --file images/grafana-dashboards/Dockerfile ../../.. \
 		$(call image-tags,grafana-dashboards,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/grafana-dashboards:latest \
-		--cache-to type=inline \
+		$(call cache-args,grafana-dashboards) \
 		--metadata-file images/grafana-dashboards.json \
 		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/grafana-dashboards:$(IMAGE_TAG)@$$(yq --exit-status '.["containerimage.digest"]' images/grafana-dashboards.json --output-format json -r)" \

--- a/packages/system/kamaji/Makefile
+++ b/packages/system/kamaji/Makefile
@@ -14,8 +14,7 @@ update:
 image:
 	docker buildx build images/kamaji \
 		$(call image-tags,kamaji,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/kamaji:latest \
-		--cache-to type=inline \
+		$(call cache-args,kamaji) \
 		--metadata-file images/kamaji.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/kamaji" \

--- a/packages/system/keycloak-operator/Makefile
+++ b/packages/system/keycloak-operator/Makefile
@@ -7,8 +7,7 @@ include ../../../hack/package.mk
 image:
 	docker buildx build images/keycloak-operator \
 		$(call image-tags,keycloak-operator,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/keycloak-operator:latest \
-		--cache-to   type=inline \
+		$(call cache-args,keycloak-operator) \
 		--metadata-file images/keycloak-operator.json \
 		$(BUILDX_ARGS)
 	TAG="$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/keycloak-operator.json -r)" \

--- a/packages/system/kilo/Makefile
+++ b/packages/system/kilo/Makefile
@@ -11,8 +11,7 @@ update:
 image:
 	docker buildx build images/kilo \
 		$(call image-tags,kilo,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/kilo:latest \
-		--cache-to type=inline \
+		$(call cache-args,kilo) \
 		--metadata-file images/kilo.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/kilo" \

--- a/packages/system/kubeovn-plunger/Makefile
+++ b/packages/system/kubeovn-plunger/Makefile
@@ -7,6 +7,7 @@ include ../../../hack/package.mk
 image:
 	docker buildx build -f images/kubeovn-plunger/Dockerfile ../../../ \
 		--provenance false \
+		$(if $(strip $(BUILDER)),--builder=$(BUILDER)) \
 		$(call image-tags,kubeovn-plunger,v$(COZYSTACK_VERSION)) \
 		$(call cache-args,kubeovn-plunger) \
 		--metadata-file images/kubeovn-plunger.json \

--- a/packages/system/kubeovn-plunger/Makefile
+++ b/packages/system/kubeovn-plunger/Makefile
@@ -8,8 +8,7 @@ image:
 	docker buildx build -f images/kubeovn-plunger/Dockerfile ../../../ \
 		--provenance false \
 		$(call image-tags,kubeovn-plunger,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/kubeovn-plunger:latest \
-		--cache-to type=inline \
+		$(call cache-args,kubeovn-plunger) \
 		--metadata-file images/kubeovn-plunger.json \
 		--push=$(PUSH) \
 		--label "org.opencontainers.image.source=https://github.com/cozystack/cozystack" \

--- a/packages/system/kubeovn-webhook/Makefile
+++ b/packages/system/kubeovn-webhook/Makefile
@@ -7,8 +7,7 @@ include ../../../hack/package.mk
 image:
 	docker buildx build images/kubeovn-webhook \
 		$(call image-tags,kubeovn-webhook,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/kubeovn-webhook:latest \
-		--cache-to type=inline \
+		$(call cache-args,kubeovn-webhook) \
 		--metadata-file images/kubeovn-webhook.json \
 		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/kubeovn-webhook:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/kubeovn-webhook.json -o json -r)" \

--- a/packages/system/lineage-controller-webhook/Makefile
+++ b/packages/system/lineage-controller-webhook/Makefile
@@ -14,8 +14,7 @@ test:
 image-lineage-controller-webhook:
 	docker buildx build -f images/lineage-controller-webhook/Dockerfile ../../.. \
 		$(call image-tags,lineage-controller-webhook,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/lineage-controller-webhook:latest \
-		--cache-to type=inline \
+		$(call cache-args,lineage-controller-webhook) \
 		--metadata-file images/lineage-controller-webhook.json \
 		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/lineage-controller-webhook:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/lineage-controller-webhook.json -o json -r)" \

--- a/packages/system/linstor-gui/Makefile
+++ b/packages/system/linstor-gui/Makefile
@@ -14,8 +14,7 @@ image-linstor-gui:
 	docker buildx build images/linstor-gui \
 		--build-arg LINSTOR_GUI_VERSION=$(LINSTOR_GUI_VERSION) \
 		$(call image-tags,linstor-gui,$(LINSTOR_GUI_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/linstor-gui:latest \
-		--cache-to type=inline \
+		$(call cache-args,linstor-gui) \
 		--metadata-file images/linstor-gui.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/linstor-gui" \

--- a/packages/system/linstor/Makefile
+++ b/packages/system/linstor/Makefile
@@ -14,8 +14,7 @@ image-piraeus-server:
 		--build-arg LINSTOR_VERSION=$(LINSTOR_VERSION) \
 		--build-arg K8S_AWAIT_ELECTION_VERSION=v0.4.2 \
 		$(call image-tags,piraeus-server,$(LINSTOR_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/piraeus-server:latest \
-		--cache-to type=inline \
+		$(call cache-args,piraeus-server) \
 		--metadata-file images/piraeus-server.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/piraeus-server" \
@@ -28,8 +27,7 @@ image-linstor-csi:
 	docker buildx build images/linstor-csi \
 		--build-arg VERSION=$(LINSTOR_CSI_VERSION) \
 		$(call image-tags,linstor-csi,$(LINSTOR_CSI_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/linstor-csi:latest \
-		--cache-to type=inline \
+		$(call cache-args,linstor-csi) \
 		--metadata-file images/linstor-csi.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/linstor-csi" \

--- a/packages/system/metallb/Makefile
+++ b/packages/system/metallb/Makefile
@@ -21,8 +21,7 @@ image-controller image-speaker:
 		--target $(TARGET) \
 		--build-arg VERSION=$(VERSION) \
 		$(call image-tags,metallb-$(TARGET),$(VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/metallb-$(TARGET):latest \
-		--cache-to type=inline \
+		$(call cache-args,metallb-$(TARGET)) \
 		--metadata-file images/$(TARGET).json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/metallb-$(TARGET)" \

--- a/packages/system/monitoring/Makefile
+++ b/packages/system/monitoring/Makefile
@@ -9,8 +9,7 @@ include ../../../hack/package.mk
 image:
 	docker buildx build images/grafana \
 		$(call image-tags,grafana,$(GRAFANA_TAG)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/grafana:latest \
-		--cache-to type=inline \
+		$(call cache-args,grafana) \
 		--metadata-file images/grafana.json \
 		$(BUILDX_ARGS)
 	echo "$(REGISTRY)/grafana:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/grafana.json -o json -r)" \

--- a/packages/system/multus/Makefile
+++ b/packages/system/multus/Makefile
@@ -16,8 +16,7 @@ update:
 image:
 	docker buildx build images/multus-cni \
 		$(call image-tags,multus-cni,v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/multus-cni:latest \
-		--cache-to type=inline \
+		$(call cache-args,multus-cni) \
 		--metadata-file images/multus-cni.json \
 		$(BUILDX_ARGS)
 	DIGEST=$$(yq e '."containerimage.digest"' images/multus-cni.json -o json -r) && \

--- a/packages/system/objectstorage-controller/Makefile
+++ b/packages/system/objectstorage-controller/Makefile
@@ -19,8 +19,7 @@ image-controller image-sidecar:
 	docker buildx build images/objectstorage \
 		--target $(TARGET) \
 		$(call image-tags,objectstorage-$(TARGET),v$(COZYSTACK_VERSION)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/objectstorage-$(TARGET):latest \
-		--cache-to   type=inline \
+		$(call cache-args,objectstorage-$(TARGET)) \
 		--metadata-file images/$(TARGET).json \
 		$(BUILDX_ARGS)
 	IMAGE="$(REGISTRY)/objectstorage-$(TARGET):$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/$(TARGET).json -r)" \

--- a/packages/system/redis-operator/Makefile
+++ b/packages/system/redis-operator/Makefile
@@ -15,8 +15,7 @@ update:
 image:
 	docker buildx build images/redis-operator \
 		$(call image-tags,redis-operator,$(REDIS_OPERATOR_TAG)) \
-		--cache-from type=registry,ref=$(CACHE_REGISTRY)/redis-operator:latest \
-		--cache-to type=inline \
+		$(call cache-args,redis-operator) \
 		--metadata-file images/redis-operator.json \
 		$(BUILDX_ARGS)
 	REPOSITORY="$(REGISTRY)/redis-operator" \


### PR DESCRIPTION
## What this PR does

`--cache-to type=inline` only exports the **final** stage, so the expensive `builder` stages of our **25 multistage Dockerfiles** (Go/Node compiles) were never cached even with a warm tag. This switches all images to a shared **`mode=max` registry cache**:

- **New `cache-args` macro** (`hack/common-envs.mk`): emits `--cache-from` always; `--cache-to … mode=max` **only when `WRITE_CACHE=1`** → PR builds stay **read-only**, so concurrent PRs never race on the cache ref (the `409` class #2711 fixed for image tags). `oci-mediatypes=true,image-manifest=true` keep the cache manifest portable across registries.
- Cache ref is `CACHE_REGISTRY/<img>:buildcache`, **co-located** with the build registry (`CACHE_REGISTRY` defaults to `$(REGISTRY)`).
- **New `build-main.yaml`** warms `:buildcache` on every push to `main` (serialized via `concurrency`), so PR builds start hot.
- All 31 package image recipes converted from the `--cache-from`/`--cache-to type=inline` pair to `$(call cache-args,…)`. `ubuntu-container-disk` keeps a per-k8s-version cache tag (`:<ver>-buildcache`).

Verified with `make -n image` across **all 31 packages** in both PR (`WRITE_CACHE=0`, read-only) and main (`WRITE_CACHE=1`, `mode=max` write) contexts — push `--tag` targets are unchanged. CI itself validates that OCIR accepts the `mode=max` cache manifest.

> Note: the **first** `build-main` run is fully cold (no `:buildcache` yet) and seeds the cache; subsequent PR builds warm-start from it.

### Release note

```release-note
refactor(build): CI image builds now use a mode=max registry cache (caching all multistage stages, not just the final one), warmed by a serialized build-on-main workflow. PR builds read the cache and never write it, so concurrent builds no longer race or rebuild cold.
```

Part of #2937.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a self-healing e2e mechanism for Cilium endpoint leaks via an in-cluster loop/job and test-time wiring.
  * Extended SeaweedFS COSI chart to support separate lock buckets and read/write access classes.

* **Bug Fixes / Improvements**
  * Updated Kubernetes health probing for core components with a dedicated startup probe.
  * Adjusted e2e bucket port-forward readiness to use loopback and aligned client traffic accordingly.
  * Reduced SeaweedFS master volume size limit to improve test stability.

* **Chores**
  * Added a main-branch cache-warming workflow and standardized Docker Buildx cache argument generation, including configurable cache writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->