### PR TITLE
ci(build): isolate each PR build on its own ephemeral runner VM

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -57,15 +57,18 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      # Ephemeral runners don't carry the helm unittest plugin that the
-      # persistent self-hosted runner accreted. Install it if absent
-      # (idempotent; the debug/self-hosted path already has it). The durable
-      # fix is the container-based builder (separate PR) that bakes the full
-      # toolchain into an image instead of depending on the host.
+      # Ephemeral runners don't carry two tools the persistent self-hosted
+      # runner accreted: the helm-unittest plugin (make unit-tests) and the
+      # flux CLI (the installer's `flux push artifact` publishes the
+      # cozystack-packages OCI artifact the operator pulls). Install if absent
+      # (idempotent; the debug/self-hosted path already has them). Durable fix:
+      # bake both into the oracle-vm runner image, then drop this step.
       - name: Set up build toolchain
         run: |
           helm plugin list 2>/dev/null | grep -q unittest \
             || helm plugin install https://github.com/helm-unittest/helm-unittest
+          command -v flux >/dev/null \
+            || curl -s https://fluxcd.io/install.sh | sudo bash
 
       - name: Run unit tests
         run: make unit-tests

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -57,6 +57,16 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      # Ephemeral runners don't carry the helm unittest plugin that the
+      # persistent self-hosted runner accreted. Install it if absent
+      # (idempotent; the debug/self-hosted path already has it). The durable
+      # fix is the container-based builder (separate PR) that bakes the full
+      # toolchain into an image instead of depending on the host.
+      - name: Set up build toolchain
+        run: |
+          helm plugin list 2>/dev/null | grep -q unittest \
+            || helm plugin install https://github.com/helm-unittest/helm-unittest
+
       - name: Run unit tests
         run: make unit-tests
 

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -28,7 +28,17 @@ jobs:
 
   build:
     name: Build
-    runs-on: [self-hosted]
+    # Run each Build on its own ephemeral VM instead of the shared self-hosted
+    # runner. The shared host runs 4 runner agents against one dockerd-embedded
+    # buildkit; concurrent build jobs serialize on buildkit's single-writer bbolt
+    # cache lock + exporter mutex and stall to the 30-min timeout (proven via a
+    # live SIGUSR1 goroutine dump). One VM per job => one buildkit per job => that
+    # contention is severed by construction. `make build` is serial (one image at
+    # a time), so a small shape suffices -- 4cpu/16gb, not the 24cpu the e2e job
+    # uses -- and it leans on the warm mode=max cache (#2938) to stay under the
+    # 30-min wall. The `debug` label still routes to self-hosted for the
+    # breakpoint path. Phase 0.5 of #2937.
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-4cpu-16gb-x86-64' }}
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
## What this PR does

Runs the PR **`Build`** job on an ephemeral one-job-per-VM runner (`oracle-vm-4cpu-16gb-x86-64`) instead of the shared self-hosted runner. The `debug` label still routes to `self-hosted` for the interactive breakpoint path (mirrors the existing e2e job idiom).

**Why.** The shared self-hosted runner runs several runner agents against a single dockerd-embedded BuildKit. Concurrent build *jobs* serialize on BuildKit's single-writer bbolt cache-metadata lock + exporter mutex and stall to the 30-minute job timeout (root-caused via a live goroutine dump — full analysis in #2937). A standalone build of an image is ~2 min; under concurrent multi-PR load the *same* image hangs ~30 min while CPU/RAM/disk stay idle. It's the *sharing*, not resource exhaustion.

One VM per job ⇒ one BuildKit per job ⇒ the cross-job lock contention is severed by construction.

**Sizing.** `make build` is serial (one image at a time, no `-j`), so it does not need the e2e job's 24-CPU shape — a 4cpu/16gb VM is enough. It relies on the warm `mode=max` registry cache (#2938, the base of this PR) to stay well under the 30-min wall on cold VMs.

This is **Phase 0.5** of #2937: the interim contention fix is sequenced *with* the cache layer (#2938), since the cache is what isolated/ephemeral builders need to start hot — it is not itself the hang fix.

## Stacked on #2938

Base branch is `ci/build-cache-mode-max` (#2938). Merge #2938 first (or merge this into it); ephemeral builders depend on #2938's cache to start hot.

## Verification gates (CI-observable, settle before merge)

- [ ] `oracle-vm-4cpu-16gb-x86-64` is genuinely one-job-per-VM (if VMs are reused/co-hosted, contention returns)
- [ ] the runner image carries the full build toolchain (buildx, skopeo, jq, gh, helm, mikefarah yq, GNU tar/sed/awk) and can run the privileged talos-nocloud imager
- [ ] cold-VM full build stays under `timeout-minutes: 30` (bump the shape or the timeout if it does not)

### Release note

```release-note
NONE
```

Part of #2937.
