### PR TITLE
fix(kubevirt): update KubeVirt to v1.8.4

### DIFF
--- a/packages/system/kubevirt-operator/Makefile
+++ b/packages/system/kubevirt-operator/Makefile
@@ -6,8 +6,8 @@ include ../../../hack/package.mk
 update:
 	rm -rf templates
 	mkdir templates
-	# v1.7.0 blocked by https://github.com/kubevirt/kubevirt/issues/16386
-	export RELEASE=v1.8.2 && \
+	# Skipping v1.7.x: live-migration regression, https://github.com/kubevirt/kubevirt/issues/16386
+	export RELEASE=v1.8.4 && \
 	wget https://github.com/kubevirt/kubevirt/releases/download/$${RELEASE}/kubevirt-operator.yaml -O templates/kubevirt-operator.yaml && \
 	sed -i 's/namespace: kubevirt/namespace: $(NAMESPACE)/g' templates/kubevirt-operator.yaml
 	awk -i inplace -v RS="---" '!/kind: Namespace/{printf "%s", $$0 RS}' templates/kubevirt-operator.yaml

--- a/packages/system/kubevirt-operator/templates/kubevirt-operator.yaml
+++ b/packages/system/kubevirt-operator/templates/kubevirt-operator.yaml
@@ -8536,14 +8536,14 @@ spec:
         - virt-operator
         env:
         - name: VIRT_OPERATOR_IMAGE
-          value: quay.io/kubevirt/virt-operator:v1.8.2
+          value: quay.io/kubevirt/virt-operator:v1.8.4
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.annotations['olm.targetNamespaces']
         - name: KUBEVIRT_VERSION
-          value: v1.8.2
-        image: quay.io/kubevirt/virt-operator:v1.8.2
+          value: v1.8.4
+        image: quay.io/kubevirt/virt-operator:v1.8.4
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## What this PR does

Updates kubevirt-operator from v1.8.2 to v1.8.4. This backports the VMI checksum status-field validation fix (uint32 range) that Kubernetes 1.36 requires — without it, strict CRD numeric-format validation leaves VMIs stuck in `Scheduled`. The release also carries assorted bug fixes and CVE remediations. The v1.7.x line is skipped (live-migration regression, kubevirt/kubevirt#16386).

The KubeVirt custom resource is unchanged — upstream ships a byte-identical CR across these versions.

Verified on a dev cluster: all virt-* components roll out to v1.8.4 and become ready.

Closes #2769

### Screenshots

Not applicable — no UI changes.

### Release note

```release-note
fix(kubevirt): update KubeVirt to v1.8.4; fixes VMIs stuck in Scheduled on Kubernetes 1.36 (strict CRD numeric-format validation of VMI checksum status fields)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the KubeVirt operator version from v1.8.2 to v1.8.4, including the corresponding deployment configuration and operator image/environment version bumps.
  * Adjusted the operator update process to download the manifest using v1.8.4 while skipping v1.7.x.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->