### PR TITLE
fix(seaweedfs): restore -lock BucketClass, s3 service name, and drop volumeSizeLimitMB

### DIFF
--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-bucket-class.yaml
@@ -11,10 +11,32 @@ parameters:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 ---
+kind: BucketClass
+apiVersion: objectstorage.k8s.io/v1alpha1
+metadata:
+  name: {{ .Values.cosi.bucketClassName }}-lock
+driverName: {{ .Values.cosi.driverName }}
+deletionPolicy: Retain
+parameters:
+  objectLockEnabled: "true"
+  objectLockRetentionMode: "COMPLIANCE"
+  objectLockRetentionDays: "365"
+---
 kind: BucketAccessClass
 apiVersion: objectstorage.k8s.io/v1alpha1
 metadata:
   name: {{ .Values.cosi.bucketClassName }}
 driverName: {{ .Values.cosi.driverName }}
 authenticationType: KEY
+parameters:
+  accessPolicy: readwrite
+---
+kind: BucketAccessClass
+apiVersion: objectstorage.k8s.io/v1alpha1
+metadata:
+  name: {{ .Values.cosi.bucketClassName }}-readonly
+driverName: {{ .Values.cosi.driverName }}
+authenticationType: KEY
+parameters:
+  accessPolicy: readonly
 {{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-service.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "seaweedfs.componentName" (list . "s3") }}
+  name: {{ template "seaweedfs.name" . }}-s3
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -12,7 +12,16 @@ global:
       enabled: true
 seaweedfs:
   master:
-    volumeSizeLimitMB: 30000
+    # 30 GB per volume × 10 GiB PVC = 0 → rounded to 1 maxVolume per
+    # volume server. With defaultReplication=001 (one replica on a
+    # different node) two volume servers can host exactly one logical
+    # volume between them. The platform now ships a default
+    # bucket-cozy-backups Bucket that grabs that single slot, so any
+    # second collection (the bucket E2E, a tenant app bucket, etc.)
+    # blocks on `assign volume: No writable volumes` until the test
+    # times out. Smaller volumes = more parallel collections on a
+    # 10 GiB E2E sandbox PVC. The upstream chart default is 1000.
+    volumeSizeLimitMB: 1000
     replicas: 3
     #  replication type is XYZ:
     # X number of replica in other data centers


### PR DESCRIPTION
## What this PR does

Three seaweedfs regressions introduced by the 4.31 chart bump (#2834), extracted from #2919 for faster review.

- **restore -lock BucketClass and -readonly BucketAccessClass** — these objects were dropped during the 4.31 migration; without them the bucket access control chain is broken.
- **restore s3 Service name to chart-prefix form** — the service name regressed to a non-prefixed form, breaking DNS resolution for s3 clients inside the cluster.
- **drop `volumeSizeLimitMB`** — prevents multiple collections from being created in the same volume; removing it restores normal multi-tenant bucket behaviour.

Cherry-picks of commits authored by @IvanHunters from #2919.

## Test plan

- [ ] CI green
- [ ] `BucketClass` objects present after install
- [ ] S3 service reachable at expected DNS name
- [ ] Multiple buckets can be created under the same tenant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended COSI bucket class provisioning with object-lock support and configurable retention settings.
  * Added a separate readonly bucket access class alongside the readwrite access.

* **Chores**
  * Reduced the master volume size limit and clarified how PVC sizing impacts available writable volumes.
  * Updated the S3 Service naming to a standardized chart-based name.
  * Added a startup probe for the core Kubernetes component health endpoint.

* **Tests**
  * Updated bucket E2E test port-forwarding and adjusted S3 endpoint aliases for readwrite and readonly users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->