### PR TITLE
test(e2e): fix bucket.bats port-forward and S3 client reliability

### DIFF
--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -45,7 +45,7 @@ EOF
   timeout 30 sh -ec 'until nc -z localhost 8333; do sleep 1; done'
 
   # --- Test readwrite user (admin) ---
-  mc alias set rw-user https://localhost:8333 $ADMIN_ACCESS_KEY $ADMIN_SECRET_KEY --insecure
+  mc alias set rw-user https://127.0.0.1:8333 $ADMIN_ACCESS_KEY $ADMIN_SECRET_KEY --insecure
 
   # Admin can upload
   echo "readwrite test" > /tmp/rw-test.txt
@@ -58,7 +58,7 @@ EOF
   mc cp --insecure rw-user/$BUCKET_NAME/rw-test.txt /tmp/rw-test-download.txt
 
   # --- Test readonly user (viewer) ---
-  mc alias set ro-user https://localhost:8333 $VIEWER_ACCESS_KEY $VIEWER_SECRET_KEY --insecure
+  mc alias set ro-user https://127.0.0.1:8333 $VIEWER_ACCESS_KEY $VIEWER_SECRET_KEY --insecure
 
   # Viewer can list
   mc ls --insecure ro-user/$BUCKET_NAME/rw-test.txt

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -38,11 +38,17 @@ EOF
   VIEWER_ACCESS_KEY=$(jq -r '.spec.secretS3.accessKeyID' bucket-viewer-credentials.json)
   VIEWER_SECRET_KEY=$(jq -r '.spec.secretS3.accessSecretKey' bucket-viewer-credentials.json)
 
-  # Start port-forwarding
-  bash -c 'timeout 100s kubectl port-forward service/seaweedfs-s3 -n tenant-root 8333:8333 > /dev/null 2>&1 &'
+  # Start port-forwarding in this shell (not via `bash -c '... &'` — the
+  # wrapper subshell exits immediately, the backgrounded kubectl becomes an
+  # orphan and gets reaped before the first mc S3 request, so `mc cp` sees
+  # `dial tcp 127.0.0.1:8333: connect: connection refused` even though the
+  # earlier `nc -z` probe succeeded.
+  kubectl port-forward service/seaweedfs-s3 -n tenant-root 8333:8333 >/dev/null 2>&1 &
+  PORT_FORWARD_PID=$!
+  trap 'kill ${PORT_FORWARD_PID} 2>/dev/null || true' RETURN
 
   # Wait for port-forward to be ready
-  timeout 30 sh -ec 'until nc -z localhost 8333; do sleep 1; done'
+  timeout 30 sh -ec 'until nc -z 127.0.0.1 8333; do sleep 1; done'
 
   # --- Test readwrite user (admin) ---
   mc alias set rw-user https://127.0.0.1:8333 $ADMIN_ACCESS_KEY $ADMIN_SECRET_KEY --insecure

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -42,10 +42,10 @@ EOF
   # wrapper subshell exits immediately, the backgrounded kubectl becomes an
   # orphan and gets reaped before the first mc S3 request, so `mc cp` sees
   # `dial tcp 127.0.0.1:8333: connect: connection refused` even though the
-  # earlier `nc -z` probe succeeded.
+  # earlier `nc -z` probe succeeded). The forked port-forward inherits the
+  # test process group; cozytest.sh kills the whole group when the test
+  # function returns, so no explicit cleanup is needed.
   kubectl port-forward service/seaweedfs-s3 -n tenant-root 8333:8333 >/dev/null 2>&1 &
-  PORT_FORWARD_PID=$!
-  trap 'kill ${PORT_FORWARD_PID} 2>/dev/null || true' RETURN
 
   # Wait for port-forward to be ready
   timeout 30 sh -ec 'until nc -z 127.0.0.1 8333; do sleep 1; done'


### PR DESCRIPTION
## What this PR does

Three bucket.bats reliability fixes extracted from #2919:

- **bind S3 client to 127.0.0.1** — `mc` was resolving `localhost` to `::1` on some runners, causing connection refused against the IPv4 port-forward.
- **keep port-forward alive across mc operations** — the port-forward process was being reaped between `mc alias set` and subsequent mc commands; now held open for the full test scope.
- **drop bash-only RETURN trap** — the RETURN trap is a bash extension not available in POSIX sh; caused test teardown to fail on strict shells.

Cherry-picks of commits authored by @IvanHunters from #2919.

## Test plan

- [ ] CI green
- [ ] bucket.bats passes end-to-end without port-forward flakes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of bucket creation and verification tests by starting the SeaweedFS S3 port-forward within the current shell and adjusting readiness checks to use `127.0.0.1`.
  * Updated S3 alias setup to point to `https://127.0.0.1:8333` for both admin and readonly credentials.
* **Chores**
  * Added a startup probe for the core component, performing HTTP health checks against `/healthz` to improve controlled startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->