### PR TITLE
fix(dashboard): pin UI source branch to release-1.4

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -164,3 +164,39 @@ gitGraph
    1. Moves the tag `v0.42.1` to the newly created merge commit by force-pushing a tag to GitHub.
    2. Publishes the release page (`draft` → `latest`).
 7. The maintainer can now announce the release to the community.
+
+## UI Release Branch
+
+`packages/system/dashboard/Makefile` has a `CONSOLE_BRANCH` variable that controls which branch of [`cozystack/cozystack-ui`](https://github.com/cozystack/cozystack-ui) is cloned when building the dashboard image. Each cozystack release branch must point at a matching `cozystack-ui` branch so that patch builds on `release-X.Y` never pull in unreleased UI features from `main`.
+
+### When cutting a new minor (`vX.Y.0`)
+
+Do this once, after `pull-requests-release.yaml` creates the `release-X.Y` maintenance branch:
+
+1. **Create `cozystack-ui/release-X.Y`** from `cozystack-ui/main` HEAD:
+
+   ```bash
+   SHA=$(gh api repos/cozystack/cozystack-ui/git/ref/heads/main --jq '.object.sha')
+   gh api repos/cozystack/cozystack-ui/git/refs \
+     --method POST \
+     --field ref="refs/heads/release-X.Y" \
+     --field sha="$SHA"
+   ```
+
+2. **Pin `CONSOLE_BRANCH`** — open a PR to `cozystack/release-X.Y` changing `packages/system/dashboard/Makefile`:
+
+   ```makefile
+   CONSOLE_BRANCH ?= release-X.Y   # was: main
+   ```
+
+   The `main` branch Makefile keeps `CONSOLE_BRANCH ?= main` and is never touched.
+
+3. **Triage recent `cozystack-ui/main` commits** since the previous minor's cut point. Cherry-pick pure bug fixes to `cozystack-ui/release-X.Y`. Features stay on `main` only — same discipline as cozystack backports.
+
+### Backporting UI fixes to an existing release branch
+
+UI bug fixes follow the same backport rule as backend fixes:
+
+- Fix lands on `cozystack-ui/main` first.
+- Cherry-pick to `cozystack-ui/release-X.Y` after review.
+- The next `make image` on `cozystack/release-X.Y` picks up the fix automatically.

--- a/packages/system/dashboard/Makefile
+++ b/packages/system/dashboard/Makefile
@@ -11,7 +11,7 @@ include ../../../hack/package.mk
 image: image-console image-token-proxy
 
 CONSOLE_REPO ?= https://github.com/cozystack/cozystack-ui.git
-CONSOLE_BRANCH ?= main
+CONSOLE_BRANCH ?= release-1.4
 
 image-console: clone-console build-console update-values-console clean-console
 


### PR DESCRIPTION
## What this PR does

Pins `CONSOLE_BRANCH` to `release-1.4` in the dashboard Makefile so that patch builds of cozystack 1.4.x clone `cozystack-ui@release-1.4` instead of `cozystack-ui@main`.

Before this change, every `make image` on the `release-1.4` branch cloned the latest HEAD of `cozystack-ui/main`, which could pull in unreleased UI features and break the patch release gate entirely.

### Release note

\`\`\`release-note
fix(dashboard): patch builds now clone cozystack-ui@release-1.4 instead of @main
\`\`\`