### PR TITLE
fix(capi): add startupProbe to capi-controller-manager to survive cert provisioning delay

### DIFF
--- a/packages/system/capi-providers-core/files/core-components.yaml
+++ b/packages/system/capi-providers-core/files/core-components.yaml
@@ -15144,6 +15144,12 @@ spec:
               fieldPath: metadata.uid
         image: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.1
         imagePullPolicy: IfNotPresent
+        startupProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          failureThreshold: 30
+          periodSeconds: 10
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## What this PR does

The `capi-controller-manager` liveness probe has no `initialDelaySeconds`
(defaults to 0), giving the container only 30s (3×10s) to serve `/healthz`.
In controller-runtime, the health endpoint starts after the webhook server,
which needs its TLS cert from cert-manager. During a loaded install,
cert-manager issues many certs simultaneously and the CAPI webhook cert can
take >30s — causing a kill/restart loop (6+ restarts observed in E2E CI).

A `startupProbe` with `failureThreshold: 30` gives up to 300s for initial
startup, after which the regular `livenessProbe` takes over. This is the
standard pattern for slow-starting containers with external dependencies.

## Test plan

- [ ] CI green — specifically no `capi-controller-manager` CrashLoopBackOff in E2E cozyreport

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced service startup health checks to improve deployment reliability and stability during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->