### PR TITLE
ci(release): auto-create cozystack-ui maintenance branch on minor cut

### DIFF
--- a/.github/workflows/pull-requests-release.yaml
+++ b/.github/workflows/pull-requests-release.yaml
@@ -118,6 +118,54 @@ jobs:
               }
             }
 
+      # Ensure the matching cozystack-ui maintenance branch exists.
+      #
+      # release-X.Y dashboard builds clone the UI from a pinned branch
+      # (packages/system/dashboard/Makefile -> CONSOLE_BRANCH), so a new minor
+      # line needs a matching cozystack-ui/release-X.Y. We branch it from
+      # cozystack-ui/main HEAD the first time the line is cut, then leave it
+      # alone — UI fixes are cherry-picked onto it manually, the same way
+      # backend fixes are backported. Idempotent: on later patch releases the
+      # branch already exists (422) and is left untouched, never reset to main.
+      - name: Ensure cozystack-ui maintenance branch release-X.Y
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const tag = '${{ steps.get_tag.outputs.tag }}';
+            const match = tag.match(/^v(\d+)\.(\d+)\.\d+(?:[-\w\.]+)?$/);
+            if (!match) {
+              core.setFailed(`❌ tag '${tag}' must match 'vX.Y.Z' or 'vX.Y.Z-suffix'`);
+              return;
+            }
+            const branch = `release-${match[1]}.${match[2]}`;
+            const uiRepo = 'cozystack-ui';
+
+            // Branch cozystack-ui/release-X.Y from cozystack-ui/main HEAD.
+            const main = await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo:  uiRepo,
+              ref:   'heads/main'
+            });
+
+            try {
+              await github.rest.git.createRef({
+                owner: context.repo.owner,
+                repo:  uiRepo,
+                ref:   `refs/heads/${branch}`,
+                sha:   main.data.object.sha
+              });
+              console.log(`✅ Created ${uiRepo} branch '${branch}' at ${main.data.object.sha}`);
+            } catch (err) {
+              if (err.status === 422) {
+                console.log(`ℹ️  ${uiRepo} branch '${branch}' already exists, leaving as-is`);
+              } else {
+                console.error('Unexpected error --', err);
+                core.setFailed(`Unexpected error creating ${uiRepo} branch: ${err.message}`);
+                throw err;
+              }
+            }
+
       # Publish draft release and ensure correct latest flag
       - name: Publish draft release
         uses: actions/github-script@v7

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -123,6 +123,11 @@ jobs:
           IMAGE_TAG: ${{ github.ref_name }}
           PUBLISH_VERSIONED: '1'
           PUBLISH_FLOATING: '1'
+          # Build the dashboard UI from the cozystack-ui branch that matches
+          # the cozystack branch this tag came from (main -> main,
+          # release-X.Y -> release-X.Y). The tag checkout is a detached HEAD,
+          # so the dashboard Makefile cannot infer the branch itself.
+          CONSOLE_BRANCH: ${{ steps.get_base.outputs.branch }}
 
       # Commit built artifacts
       - name: Commit release artifacts

--- a/docs/multirepo-development.md
+++ b/docs/multirepo-development.md
@@ -1,0 +1,67 @@
+# Multirepo Development (cozystack + cozystack-ui)
+
+Cozystack spans two repositories that ship as one product:
+
+| Repo | Role |
+|------|------|
+| [`cozystack/cozystack`](https://github.com/cozystack/cozystack) | monorepo — Helm charts, Go controllers, CRDs, the release pipeline |
+| [`cozystack/cozystack-ui`](https://github.com/cozystack/cozystack-ui) | the dashboard frontend, built into the dashboard image |
+
+Both repos use the same branching model — `main` for development, `release-X.Y` for maintenance — and the two `release-X.Y` lines are kept in lockstep so a patch release never ships unreleased UI work. This guide explains how the two repos move together. For the release pipeline itself, see [`release.md`](./release.md).
+
+## The seam: how the UI gets into a build
+
+The dashboard image is built by `packages/system/dashboard/Makefile`, which clones **one** branch of `cozystack-ui` at build time, selected by `CONSOLE_BRANCH`. That single variable is what ties a cozystack release line to a cozystack-ui release line.
+
+`CONSOLE_BRANCH` is resolved automatically — there is no per-branch value to maintain by hand:
+
+| Build context | How it's resolved | Result |
+|---------------|-------------------|--------|
+| `cozystack/main`, feature branches (CI or local) | Makefile derives from git branch | `cozystack-ui@main` |
+| `cozystack/release-X.Y` checkout (local) | Makefile derives from git branch | `cozystack-ui@release-X.Y` |
+| Release build (`tags.yaml`, detached HEAD on a tag) | workflow passes the tag's base branch explicitly | `main` for `vX.Y.0`, `release-X.Y` for patch tags |
+
+The release build must supply the value explicitly because a tag checkout is a detached `HEAD` where the branch name is unavailable. Local builds derive it from the checked-out branch, so a `release-X.Y` checkout always builds the matching UI without any extra flags.
+
+## Developing a feature
+
+Everything new lands on `main` first — in **both** repos, always.
+
+- **Backend / chart / CRD change** → PR to `cozystack/main`.
+- **UI change** → PR to `cozystack-ui/main`. The repo's `test` job (type-check + build) gates the PR.
+
+Because a `cozystack/main` build clones `cozystack-ui@main`, the development branch always integrates the latest UI. No coordination commit is needed between the repos for day-to-day feature work.
+
+## Cutting a new minor (`vX.Y.0`)
+
+This is automatic. When the regular-release PR merges, `pull-requests-release.yaml` finalize:
+
+1. Creates `cozystack/release-X.Y` (the cozystack maintenance branch).
+2. Creates `cozystack-ui/release-X.Y` from `cozystack-ui/main` HEAD.
+
+The new `cozystack/release-X.Y` inherits the branch-deriving Makefile, so it is wired to `cozystack-ui/release-X.Y` from the moment it exists. Nothing to pin, nothing to remember.
+
+> Prerequisite: the `cozystack-ci` GitHub App must be installed on `cozystack-ui` with `contents:write`, so finalize can create the branch cross-repo.
+
+## Backporting a fix to a patch release (`vX.Y.Z`)
+
+This is the one step that needs human judgment, and it is symmetric across both repos — the same discipline as any backend backport:
+
+- **Backend fix**: land on `cozystack/main` → cherry-pick to `cozystack/release-X.Y`.
+- **UI fix**: land on `cozystack-ui/main` → cherry-pick to `cozystack-ui/release-X.Y`.
+
+`auto-release.yaml` (nightly) notices commits ahead of the latest tag on `cozystack/release-X.Y`, cuts `vX.Y.Z`, and the build clones `cozystack-ui@release-X.Y` automatically. A UI-only fix therefore needs **no** cozystack-side commit — the next patch build picks it up on its own.
+
+Features are never cherry-picked. Only fixes to functionality that already shipped in `vX.Y.0` belong on a release branch.
+
+## Mental model
+
+A change is "in" a release line only when it has been cherry-picked to that line in **both** repos. Everything else lives on `main`.
+
+The minor cut and the build wiring are automatic. The cherry-pick triage — deciding what is a safe backport versus an unreleased feature — is the human's job, identical on both sides of the seam.
+
+## See also
+
+- [`release.md`](./release.md) — the full release pipeline, including the "UI release branch (dashboard)" section.
+- [`agents/contributing.md`](./agents/contributing.md) — commit/PR conventions and backport label semantics.
+- [`../packages/system/dashboard/Makefile`](../packages/system/dashboard/Makefile) — `CONSOLE_BRANCH` resolution.

--- a/docs/release.md
+++ b/docs/release.md
@@ -561,6 +561,26 @@ Sometimes the work that has to land before a release is a 40-commit grab bag (CI
 - The `update-releasenotes.yaml` workflow syncs `docs/changelogs/vX.Y.Z.md` into the GitHub Release body on the next push to `main`. Edits to a published changelog file land on the release page the next time `main` moves.
 - Local cleanup: remove your worktree (`git worktree remove`) and prune merged release branches.
 
+## UI release branch (dashboard)
+
+The dashboard image is built from the separate [`cozystack/cozystack-ui`](https://github.com/cozystack/cozystack-ui) repository. `packages/system/dashboard/Makefile` clones a single branch of it at build time, controlled by `CONSOLE_BRANCH`. To keep patch releases from silently shipping unreleased UI work, each cozystack release line builds from a matching `cozystack-ui` branch — the same backport discipline as backend code.
+
+How `CONSOLE_BRANCH` is resolved (no manual pinning required):
+
+- **Release builds** (`tags.yaml`) pass `CONSOLE_BRANCH` explicitly, set to the branch the release tag came from (`steps.get_base.outputs.branch`): `main` for `vX.Y.0` cut from `main`, `release-X.Y` for patch tags cut from the maintenance branch. The tag checkout is a detached HEAD, so the Makefile cannot infer the branch on its own — the workflow supplies it.
+- **Local/manual builds** derive it from the current git branch: a `release-X.Y` checkout builds `cozystack-ui@release-X.Y`, anything else (main, feature branches) builds `cozystack-ui@main`.
+
+What happens automatically when a new minor is cut:
+
+- `pull-requests-release.yaml::Ensure cozystack-ui maintenance branch release-X.Y` branches `cozystack-ui/release-X.Y` from `cozystack-ui/main` HEAD the first time the line is cut (idempotent — left untouched on later patch releases). This requires the `cozystack-ci` GitHub App to be installed on `cozystack-ui` with `contents:write`.
+- From then on, every `release-X.Y` dashboard build clones `cozystack-ui@release-X.Y` automatically.
+
+The only manual step — UI fix backports:
+
+- A UI fix lands on `cozystack-ui/main` first.
+- Cherry-pick it to `cozystack-ui/release-X.Y` after review, exactly as backend fixes are backported. Features stay on `main` only.
+- The next `release-X.Y` patch build picks up the fix automatically; no cozystack-side change is needed.
+
 ## See also
 
 - [`agents/changelog.md`](./agents/changelog.md) — canonical changelog generation process.
@@ -569,5 +589,6 @@ Sometimes the work that has to land before a release is a 40-commit grab bag (CI
 - [`.github/workflows/tags.yaml`](../.github/workflows/tags.yaml) — tag-push pipeline.
 - [`.github/workflows/pull-requests-release.yaml`](../.github/workflows/pull-requests-release.yaml) — merge-finalize pipeline.
 - [`.github/workflows/auto-release.yaml`](../.github/workflows/auto-release.yaml) — nightly auto-patch.
+- [`packages/system/dashboard/Makefile`](../packages/system/dashboard/Makefile) — `CONSOLE_BRANCH` resolution for the dashboard UI build.
 - [`.github/workflows/backport.yaml`](../.github/workflows/backport.yaml) — automatic cherry-pick bot.
 - [`.github/workflows/update-releasenotes.yaml`](../.github/workflows/update-releasenotes.yaml) — sync changelog → GitHub Release body.

--- a/docs/release.md
+++ b/docs/release.md
@@ -563,7 +563,7 @@ Sometimes the work that has to land before a release is a 40-commit grab bag (CI
 
 ## UI release branch (dashboard)
 
-The dashboard image is built from the separate [`cozystack/cozystack-ui`](https://github.com/cozystack/cozystack-ui) repository. `packages/system/dashboard/Makefile` clones a single branch of it at build time, controlled by `CONSOLE_BRANCH`. To keep patch releases from silently shipping unreleased UI work, each cozystack release line builds from a matching `cozystack-ui` branch — the same backport discipline as backend code.
+The dashboard image is built from the separate [`cozystack/cozystack-ui`](https://github.com/cozystack/cozystack-ui) repository. `packages/system/dashboard/Makefile` clones a single branch of it at build time, controlled by `CONSOLE_BRANCH`. To keep patch releases from silently shipping unreleased UI work, each cozystack release line builds from a matching `cozystack-ui` branch — the same backport discipline as backend code. For the end-to-end two-repo workflow, see [`multirepo-development.md`](./multirepo-development.md).
 
 How `CONSOLE_BRANCH` is resolved (no manual pinning required):
 
@@ -583,6 +583,7 @@ The only manual step — UI fix backports:
 
 ## See also
 
+- [`multirepo-development.md`](./multirepo-development.md) — how the cozystack and cozystack-ui repos move together across `main` and release branches.
 - [`agents/changelog.md`](./agents/changelog.md) — canonical changelog generation process.
 - [`agents/contributing.md`](./agents/contributing.md) — commit/PR conventions, backport label semantics.
 - [`agents/releasing.md`](./agents/releasing.md) — pointer file for AI agents handling release tasks.

--- a/packages/system/dashboard/Makefile
+++ b/packages/system/dashboard/Makefile
@@ -26,7 +26,7 @@ CONSOLE_REPO ?= https://github.com/cozystack/cozystack-ui.git
 # tag checkout is a detached HEAD where the branch name is unavailable. For
 # local/manual builds we derive it from the current branch: a release-X.Y
 # checkout builds the matching UI branch; everything else builds from main.
-CONSOLE_GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+CONSOLE_GIT_BRANCH = $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 CONSOLE_BRANCH ?= $(if $(filter release-%,$(CONSOLE_GIT_BRANCH)),$(CONSOLE_GIT_BRANCH),main)
 
 image-console: clone-console build-console update-values-console clean-console

--- a/packages/system/dashboard/Makefile
+++ b/packages/system/dashboard/Makefile
@@ -19,7 +19,15 @@ test-go:
 image: image-console image-token-proxy
 
 CONSOLE_REPO ?= https://github.com/cozystack/cozystack-ui.git
-CONSOLE_BRANCH ?= main
+
+# CONSOLE_BRANCH: which cozystack-ui branch to build the dashboard from.
+# Release builds (tags.yaml) pass this explicitly, derived from the release
+# tag's base branch (main -> main, release-X.Y -> release-X.Y), because the
+# tag checkout is a detached HEAD where the branch name is unavailable. For
+# local/manual builds we derive it from the current branch: a release-X.Y
+# checkout builds the matching UI branch; everything else builds from main.
+CONSOLE_GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+CONSOLE_BRANCH ?= $(if $(filter release-%,$(CONSOLE_GIT_BRANCH)),$(CONSOLE_GIT_BRANCH),main)
 
 image-console: clone-console build-console update-values-console clean-console
 


### PR DESCRIPTION
## Problem

The dashboard image is built from a separate repo, `cozystack/cozystack-ui`,
and `packages/system/dashboard/Makefile` hardcoded `CONSOLE_BRANCH ?= main`.
That meant **every** dashboard build — including patch builds on a
`release-X.Y` branch — cloned the UI from `cozystack-ui/main` HEAD. Unreleased
UI work could silently ship in a patch release, bypassing the release gate that
backend code is held to.

Wiring a release line to a matching `cozystack-ui` branch was also entirely
manual: create the branch, pin the Makefile. Easy to forget when cutting a new
minor.

## What this does

Makes the UI release branch fully automatic, with no per-branch pinning commit:

- **`pull-requests-release.yaml`** — when a new minor line is cut, a new
  idempotent step branches `cozystack-ui/release-X.Y` from `cozystack-ui/main`
  HEAD. On later patch releases the branch already exists (422) and is left
  untouched — never reset to main.
- **`tags.yaml`** — the release build passes `CONSOLE_BRANCH` explicitly, set to
  the branch the tag came from (`steps.get_base.outputs.branch`): `main` for
  `vX.Y.0`, `release-X.Y` for patch tags. The tag checkout is a detached HEAD,
  so the Makefile can't infer this itself.
- **`packages/system/dashboard/Makefile`** — `CONSOLE_BRANCH` now derives from
  the current git branch for local/manual builds (`release-X.Y` checkout →
  matching UI branch; anything else → `main`). CI still overrides via env.
- **`docs/release.md`** — new "UI release branch (dashboard)" section.

The only remaining manual step is cherry-picking UI fixes onto
`cozystack-ui/release-X.Y` — a judgment call, identical to backend backports.

## Resolution matrix

| Build context | git branch | env | `CONSOLE_BRANCH` |
|---|---|---|---|
| Local on main / feature | `main` / `feat-*` | — | `main` |
| Local on `release-1.5` | `release-1.5` | — | `release-1.5` |
| CI tag build (detached) | `HEAD` | — | `main` (fallback) |
| CI release build | `HEAD` | `release-1.5` | `release-1.5` |

## Prerequisite

The `cozystack-ci` GitHub App must be installed on `cozystack-ui` with
`contents:write` (confirmed installed).

## Notes

- Independent of the 1.4-specific UI-branch work — can merge on its own.
- The `CONSOLE_BRANCH` env value is regex-validated upstream (`main` or
  `^release-\d+\.\d+$`) and used via `env:`, not interpolated into a shell
  `run:` — no injection surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation to create the dashboard UI maintenance branch (`release-X.Y`) at the current `main` commit when backend minor releases are merged (with graceful handling if the branch already exists).
  * Updated CI dashboard build wiring to pass the correct UI branch selector via `CONSOLE_BRANCH`.
  * Improved dashboard build logic to derive `CONSOLE_BRANCH` from the current Git branch when it matches `release-*`, otherwise defaulting to `main`.
* **Documentation**
  * Added/expanded release-line documentation covering UI branch selection and required backport/cherry-pick workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->