### PR TITLE
fix(api): retry HelmRelease update on resourceVersion conflict

### DIFF
--- a/pkg/registry/apps/application/rest.go
+++ b/pkg/registry/apps/application/rest.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -566,8 +567,27 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 
 	klog.V(6).Infof("Updating HelmRelease %s in namespace %s", helmRelease.Name, helmRelease.Namespace)
 
-	// Update the HelmRelease in Kubernetes
-	err = r.c.Update(ctx, helmRelease, &client.UpdateOptions{Raw: &metav1.UpdateOptions{}})
+	// Update the HelmRelease in Kubernetes.
+	//
+	// Flux's helm-controller (and other controllers) continuously write the
+	// HelmRelease's status, which shares the object's resourceVersion. When a
+	// caller updates an app CR while a prior reconcile is still in flight, the
+	// resourceVersion read above goes stale and the Update is rejected with a
+	// 409 Conflict. The HelmRelease spec is fully derived from the Application
+	// the caller just applied, so a stale-resourceVersion conflict is never a
+	// real spec conflict here: refresh the resourceVersion from the live object
+	// and retry.
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		updateErr := r.c.Update(ctx, helmRelease, &client.UpdateOptions{Raw: &metav1.UpdateOptions{}})
+		if apierrors.IsConflict(updateErr) {
+			cur := &helmv2.HelmRelease{}
+			if getErr := r.c.Get(ctx, client.ObjectKey{Namespace: helmRelease.Namespace, Name: helmRelease.Name}, cur, &client.GetOptions{Raw: &metav1.GetOptions{}}); getErr != nil {
+				return getErr
+			}
+			helmRelease.SetResourceVersion(cur.GetResourceVersion())
+		}
+		return updateErr
+	})
 	if err != nil {
 		klog.Errorf("Failed to update HelmRelease %s: %v", helmRelease.Name, err)
 		return nil, false, fmt.Errorf("failed to update HelmRelease: %v", err)


### PR DESCRIPTION
## What this PR does

The aggregated API server (`cozystack-api`) translates updates to app CRs (`Etcd`, `Postgres`, …) into a read-convert-update of the backing `HelmRelease`. Flux's `helm-controller` continuously writes the HelmRelease's **status**, which shares the object's `resourceVersion`. So when a CR update lands while a prior reconcile is still in flight, the `resourceVersion` read at the start of `REST.Update` goes stale before the `Update` call, and the request is rejected with a 409 Conflict:

```
failed to update HelmRelease: Operation cannot be fulfilled on
helmreleases.helm.toolkit.fluxcd.io "etcd": the object has been modified;
please apply your changes to the latest version and try again
```

The HelmRelease spec is **fully derived** from the Application the caller just applied, so a stale-`resourceVersion` conflict here is never a real spec conflict — it only reflects a concurrent status write. This wraps the `Update` in `retry.RetryOnConflict`, refreshing the live `resourceVersion` from the object on each conflict before retrying. The no-conflict path is unchanged (single `Update`), and this mirrors the existing `retry.RetryOnConflict` usage in `internal/controller/workloadmonitor_controller.go`.

Only `Update` is affected: `Create` cannot 409 (it returns `AlreadyExists`) and `Delete` is by-name.

### How it surfaced

The `etcd.bats` e2e test applies the same singleton `Etcd` resource three times back-to-back; the third apply intermittently failed with the 409 above while Flux was still reconciling the previous apply. In production the same race can bite any read-modify-write against an app CR (the UI / API automation, or scripted GitOps sequences) while a prior change is reconciling.

### Release note

```release-note
fix(api): retry HelmRelease update on resourceVersion conflict so app CR updates no longer intermittently fail with "the object has been modified" while Flux is reconciling a prior change
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced update operations to automatically handle and recover from conflicts, ensuring consistent and reliable updates even when simultaneous changes occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->