### PR TITLE
fix(e2e): stop the install pipeline flaking (VPA OOM/churn + wait budgets)

### DIFF
--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -193,10 +193,13 @@ EOF
   # failure messages without redundant separate waits. seaweedfs now
   # installs as a serial chain seaweedfs-db (CNPG bootstrap) ->
   # seaweedfs-system (master raft quorum) -> seaweedfs wrapper, which
-  # pushes the parent's Ready flip to ~5-6 min; tenant-root HR.spec.timeout
-  # is 15m and this 10m wait stays inside it.
+  # pushes the parent's Ready flip to ~5-6 min on an idle runner. On a loaded
+  # runner the tenant stack only starts creating pods ~9-10 min in, so the
+  # parent's Ready can land past the HR's single 15m timeout window; the HR
+  # re-reconciles every 1m until it converges, so this wait is 20m to observe
+  # that eventual Ready rather than expiring first.
   kubectl wait hr/etcd hr/ingress hr/monitoring hr/seaweedfs hr/tenant-root \
-    -n tenant-root --timeout=10m --for=condition=ready
+    -n tenant-root --timeout=20m --for=condition=ready
 
 
   # Expose Cozystack services through ingress
@@ -204,26 +207,26 @@ EOF
 
   # NGINX ingress controller
   timeout 60 sh -ec 'until kubectl get deploy root-ingress-controller -n tenant-root >/dev/null 2>&1; do sleep 1; done'
-  kubectl wait deploy/root-ingress-controller -n tenant-root --timeout=5m --for=condition=available
+  kubectl wait deploy/root-ingress-controller -n tenant-root --timeout=10m --for=condition=available
 
   # etcd statefulset
   timeout 60 sh -ec 'until kubectl get sts/etcd -n tenant-root >/dev/null 2>&1; do sleep 2; done'
-  kubectl wait sts/etcd -n tenant-root --for=jsonpath='{.status.readyReplicas}'=3 --timeout=5m
+  kubectl wait sts/etcd -n tenant-root --for=jsonpath='{.status.readyReplicas}'=3 --timeout=10m
 
   # VictoriaMetrics components
   timeout 60 sh -ec 'until kubectl get vmalert/vmalert-shortterm -n tenant-root >/dev/null 2>&1; do sleep 2; done'
   timeout 60 sh -ec 'until kubectl get vmalertmanager/alertmanager -n tenant-root >/dev/null 2>&1; do sleep 2; done'
   kubectl wait vmalert/vmalert-shortterm vmalertmanager/alertmanager -n tenant-root --for=jsonpath='{.status.updateStatus}'=operational --timeout=15m
   timeout 60 sh -ec 'until kubectl get vlclusters/generic -n tenant-root >/dev/null 2>&1; do sleep 2; done'
-  kubectl wait vlclusters/generic -n tenant-root --for=jsonpath='{.status.updateStatus}'=operational --timeout=5m
+  kubectl wait vlclusters/generic -n tenant-root --for=jsonpath='{.status.updateStatus}'=operational --timeout=10m
   timeout 60 sh -ec 'until kubectl get vmcluster/shortterm vmcluster/longterm -n tenant-root >/dev/null 2>&1; do sleep 2; done'
-  kubectl wait vmcluster/shortterm vmcluster/longterm -n tenant-root --for=jsonpath='{.status.updateStatus}'=operational --timeout=5m
+  kubectl wait vmcluster/shortterm vmcluster/longterm -n tenant-root --for=jsonpath='{.status.updateStatus}'=operational --timeout=10m
 
   # Grafana
   timeout 60 sh -ec 'until kubectl get clusters.postgresql.cnpg.io/grafana-db -n tenant-root >/dev/null 2>&1; do sleep 2; done'
-  kubectl wait clusters.postgresql.cnpg.io/grafana-db -n tenant-root --for=condition=ready --timeout=5m
+  kubectl wait clusters.postgresql.cnpg.io/grafana-db -n tenant-root --for=condition=ready --timeout=10m
   timeout 60 sh -ec 'until kubectl get deploy/grafana-deployment -n tenant-root >/dev/null 2>&1; do sleep 2; done'
-  kubectl wait deploy/grafana-deployment -n tenant-root --for=condition=available --timeout=5m
+  kubectl wait deploy/grafana-deployment -n tenant-root --for=condition=available --timeout=10m
 
   # Verify Grafana via ingress
   ingress_ip=$(kubectl get svc root-ingress-controller -n tenant-root -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
@@ -243,7 +246,7 @@ EOF
   kubectl patch package cozystack.cozystack-platform --type merge -p '{"spec":{"components":{"platform":{"values":{"authentication":{"oidc":{"enabled":true,"keycloakInternalUrl":"http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy"}}}}}}}'
 
   timeout 120 sh -ec 'until kubectl get hr -n cozy-keycloak keycloak keycloak-configure keycloak-operator >/dev/null 2>&1; do sleep 1; done'
-  kubectl wait hr/keycloak hr/keycloak-configure hr/keycloak-operator -n cozy-keycloak --timeout=10m --for=condition=ready
+  kubectl wait hr/keycloak hr/keycloak-configure hr/keycloak-operator -n cozy-keycloak --timeout=20m --for=condition=ready
 }
 
 @test "Aggregated API rejects Tenant name with dashes" {

--- a/packages/system/vertical-pod-autoscaler/templates/vpa-for-vpa.yaml
+++ b/packages/system/vertical-pod-autoscaler/templates/vpa-for-vpa.yaml
@@ -69,7 +69,10 @@ spec:
     kind: Deployment
     name: {{ dig "vertical-pod-autoscaler" "nameOverride" "" .Values.AsMap | default "vertical-pod-autoscaler" | trunc 63 | trimSuffix "-" }}-recommender
   updatePolicy:
-    updateMode: Recreate
+    # Initial (not Recreate): size at pod creation without ever evicting.
+    # Recreate here evicts the VPA recommender during install, adding pod churn
+    # on an already busy cluster. Matches the monitoring/etcd VPA->Initial fixes.
+    updateMode: Initial
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -82,5 +85,5 @@ spec:
     kind: Deployment
     name: vpa-for-vpa-recommender
   updatePolicy:
-    updateMode: Recreate
+    updateMode: Initial
 {{- end }}

--- a/packages/system/vertical-pod-autoscaler/tests/vpa_test.yaml
+++ b/packages/system/vertical-pod-autoscaler/tests/vpa_test.yaml
@@ -29,11 +29,11 @@ tests:
       - hasDocuments:
           count: 0
 
-  # updateMode Auto is deprecated since VPA 1.4 (an alias for Recreate that will
-  # be removed in a future API version). Pin the vpa-for-vpa
-  # VerticalPodAutoscalers to the explicit, non-deprecated Recreate so the bump
-  # does not leave a deprecated value behind.
-  - it: pins the vpa-for-vpa VerticalPodAutoscalers to updateMode Recreate
+  # The vpa-for-vpa VerticalPodAutoscalers use updateMode Initial: they size the
+  # VPA components at pod creation without ever evicting them. Recreate (and its
+  # deprecated Auto alias) would evict the recommender mid-install, adding pod
+  # churn on an already busy cluster. Pin Initial so a bump cannot regress it.
+  - it: pins the vpa-for-vpa VerticalPodAutoscalers to updateMode Initial
     template: templates/vpa-for-vpa.yaml
     documentSelector:
       path: kind
@@ -42,4 +42,4 @@ tests:
     asserts:
       - equal:
           path: spec.updatePolicy.updateMode
-          value: Recreate
+          value: Initial

--- a/packages/system/vertical-pod-autoscaler/values.yaml
+++ b/packages/system/vertical-pod-autoscaler/values.yaml
@@ -11,11 +11,16 @@ vertical-pod-autoscaler:
 
   updater:
     resources:
+      # The updater watches every pod in the cluster; a 110Mi limit OOM-kills it
+      # on a full cozystack install, which trips ProgressDeadlineExceeded and
+      # makes Flux fail the HelmRelease (cascading to monitoring/velero/etc).
+      # Give it real headroom; the recommender (which holds more state) is
+      # already unlimited.
       limits:
-        memory: 110Mi
+        memory: 512Mi
       requests:
         cpu: 200m
-        memory: 110Mi
+        memory: 200Mi
 
   recommender:
     extraArgs:


### PR DESCRIPTION
## What

The e2e install pipeline still flakes on a loaded runner, failing at a different point each run. Root-caused via repeated runs and a live SSH breakpoint; the platform itself is fine (the components do converge), the failures are slowness + self-inflicted churn under resource pressure.

### Fixes

1. **VPA updater OOM** — the `vertical-pod-autoscaler-updater` memory limit was `110Mi`. The updater watches every pod in the cluster, so on a full install it OOM-kills → `ProgressDeadlineExceeded` → Flux fails the HelmRelease "early due to stalled resources", cascading NotReady to monitoring, velero, etcd-operator and everything downstream. Raised to `512Mi` (request `200Mi`).

2. **VPA-for-VPA eviction churn** — the two VPA-for-VPA `VerticalPodAutoscaler` objects ran `updateMode: Auto`, evicting the VPA recommender(s) during install and adding pod churn on an already busy cluster. Switched to `Initial`, matching the existing monitoring/etcd `VPA->Initial` fixes.

3. **Install wait budgets** — components reach readiness but overshoot tight waits on a busy runner: keycloak HR chain `10m→20m`, tenant aggregate wait `10m→20m`, per-app tenant readiness waits `5m→10m`.

(The crust-gather failure-snapshot timeout that kept whole jobs hanging to the 3h cancel is already on `main`.)

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased several installation and readiness wait times to better handle slower environment startup and reduce premature failures.
  * Updated vertical autoscaling behavior to avoid unnecessary pod restarts during deployment.
  * Raised resource limits for the autoscaling updater to improve reliability under load.

* **Tests**
  * Aligned automated checks with the new autoscaling behavior and longer readiness expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->