### PR TITLE
fix(ci): create buildx builder in the build step's DOCKER_CONFIG

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -74,6 +74,13 @@ jobs:
         uses: docker/setup-buildx-action@v3
         with:
           driver: docker-container
+        env:
+          # buildx stores builder instances under $DOCKER_CONFIG/buildx/instances/.
+          # Create the builder in the SAME config the build step reads
+          # (runner.temp/.docker, seeded above and holding the OCIR auth); without
+          # this the builder lands in the default ~/.docker and the build step fails
+          # with `no builder "<name>" found`.
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
 
       - name: Build all images and write mode=max cache
         run: make build


### PR DESCRIPTION
## What this PR does

The `Build cache (main)` workflow (`build-main.yaml`, added in #2948) failed on
its first run: https://github.com/cozystack/cozystack/actions/runs/27929277423

The `Set up Buildx` step ran without `DOCKER_CONFIG`, so
`docker/setup-buildx-action` created the docker-container builder under the
runner's default `~/.docker`. The build step runs with
`DOCKER_CONFIG=$RUNNER_TEMP/.docker` (seeded earlier, holding the OCIR auth), so
buildx couldn't find the builder and failed immediately:

```
ERROR: no builder "builder-6fb46242-…" found
```

The post-job `docker buildx rm` still succeeded — because the action's cleanup
runs under the default config where the builder actually lived — which confirms
the builder existed but in the wrong config store.

This sets `DOCKER_CONFIG` on the `Set up Buildx` step so the builder instance is
created in the same config the build step reads.

Impact: only the main cache-warmer was broken. PR builds `--cache-from` this
ref, so a missing cache is a cold build, not a failure — but the warm-cache
speedup from #2948 wasn't being delivered until this fix.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline stability by ensuring consistent Docker configuration across workflow steps. This enhances the reliability of the container build and deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->