### PR TITLE
chore(keycloak): bump Keycloak server to 26.6.3

### DIFF
--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -1,4 +1,4 @@
-image: quay.io/keycloak/keycloak:26.5.2
+image: quay.io/keycloak/keycloak:26.6.3
 
 ingress:
   # Custom hostname for the Keycloak Ingress.


### PR DESCRIPTION
## What this PR does

Bumps the Keycloak server image from `26.5.2` to `26.6.3` (latest upstream stable, published 2026-06-04), picking up the published security fixes the issue enumerates (patched Netty 4.1.135+/4.2.15+ and the bundled-package CVE fixes).

Keycloak 26.6 adds zero-downtime patch upgrades and startup/liveness probes that report `UP` during DB migrations (smoother rolling updates on Kubernetes). Targeting 26.6.3 specifically — 26.6.0/26.6.1 shipped a migration-persistence bug (server exits with code 1 after an async realm migration) that later patches fix.

The chart runs a plain Keycloak StatefulSet with no custom browser flows or realm import, so the `MigrateTo26_6_0` realm migration and the 26.6 runtime breaking changes (outbound HTTP redirects now opt-in, stricter WebAuthn attestation, SAML REDIRECT inflate capped at 128KB) don't affect chart-managed config. The StatefulSet env (`KC_DB`, `KC_CACHE=ispn`, `KC_PROXY_HEADERS`, health endpoints) stays valid in 26.6.

Verified locally: `helm unittest` 2/2 pass; `helm template` renders the new image with cluster values.

Closes #2878

### Release note

```release-note
chore(keycloak): bump Keycloak server image to 26.6.3
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Keycloak container image to version 26.6.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->