### PR TITLE
chore(nfs-driver): bump csi-driver-nfs to 4.13.3

### DIFF
--- a/packages/system/nfs-driver/charts/csi-driver-nfs/Chart.yaml
+++ b/packages/system/nfs-driver/charts/csi-driver-nfs/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 4.11.0
+appVersion: 4.13.3
 description: CSI NFS Driver for Kubernetes
 name: csi-driver-nfs
-version: 4.11.0
+version: 4.13.3

--- a/packages/system/nfs-driver/charts/csi-driver-nfs/templates/csi-nfs-controller.yaml
+++ b/packages/system/nfs-driver/charts/csi-driver-nfs/templates/csi-nfs-controller.yaml
@@ -71,7 +71,7 @@ spec:
             - "--leader-election"
             - "--leader-election-namespace={{ .Release.Namespace }}"
             - "--extra-create-metadata=true"
-            - "--feature-gates=HonorPVReclaimPolicy=true"
+            - "--feature-gates=HonorPVReclaimPolicy=true,VolumeAttributesClass=false"
             - "--timeout=1200s"
             - "--retry-interval-max=30m"
           env:
@@ -99,6 +99,7 @@ spec:
             - "-leader-election"
             - "--leader-election-namespace={{ .Release.Namespace }}"
             - '-handle-volume-inuse-error=false'
+            - '-feature-gates=VolumeAttributesClass=false'
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -182,6 +183,7 @@ spec:
             - "--working-mount-dir={{ .Values.controller.workingMountDir }}"
             - "--default-ondelete-policy={{ .Values.controller.defaultOnDeletePolicy }}"
             - "--use-tar-command-in-snapshot={{ .Values.controller.useTarCommandInSnapshot }}"
+            - "--enable-snapshot-compression={{ .Values.controller.enableSnapshotCompression }}"
           env:
             - name: NODE_ID
               valueFrom:

--- a/packages/system/nfs-driver/charts/csi-driver-nfs/templates/csi-nfs-node.yaml
+++ b/packages/system/nfs-driver/charts/csi-driver-nfs/templates/csi-nfs-node.yaml
@@ -23,7 +23,7 @@ spec:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
       hostNetwork: true # original nfs connection would be broken without hostNetwork setting
-      dnsPolicy: {{ .Values.controller.dnsPolicy }}
+      dnsPolicy: {{ .Values.node.dnsPolicy }}
       serviceAccountName: {{ .Values.serviceAccount.node }}
       priorityClassName: {{ .Values.node.priorityClassName }}
       securityContext:
@@ -74,6 +74,10 @@ spec:
             - --v=2
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --timeout={{ .Values.nodeDriverRegistrar.timeout }}s
+{{- if .Values.nodeDriverRegistrar.livenessProbe.enabled }}
+            - --http-endpoint=localhost:{{ .Values.nodeDriverRegistrar.healthPort }}
+{{- end }}
           env:
             - name: DRIVER_REG_SOCK_PATH
               value: {{ .Values.kubeletDir }}/plugins/csi-nfsplugin/csi.sock
@@ -87,6 +91,21 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+{{- if .Values.nodeDriverRegistrar.livenessProbe.enabled }}
+          ports:
+            - name: healthz
+              containerPort: {{ .Values.nodeDriverRegistrar.healthPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              host: localhost
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: {{ .Values.nodeDriverRegistrar.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.nodeDriverRegistrar.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.nodeDriverRegistrar.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.nodeDriverRegistrar.livenessProbe.failureThreshold }}
+{{- end }}
           resources: {{- toYaml .Values.node.resources.nodeDriverRegistrar | nindent 12 }}
           securityContext:
             capabilities:

--- a/packages/system/nfs-driver/charts/csi-driver-nfs/templates/storageclass.yaml
+++ b/packages/system/nfs-driver/charts/csi-driver-nfs/templates/storageclass.yaml
@@ -5,10 +5,10 @@ kind: StorageClass
 metadata:
   name: {{ .Values.storageClass.name }}
 {{ include "nfs.labels" . | indent 2 }}
+  {{- with .Values.storageClass.annotations }}
   annotations:
-    {{- with .Values.storageClass.annotations }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
 provisioner: {{ .Values.driver.name }}
 {{- with .Values.storageClass.parameters }}
 parameters:
@@ -20,5 +20,35 @@ allowVolumeExpansion: true
 {{- with .Values.storageClass.mountOptions }}
 mountOptions:
 {{ toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- if .Values.storageClasses }}
+{{- range .Values.storageClasses }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .name }}
+{{ include "nfs.labels" $ | indent 2 }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+provisioner: {{ $.Values.driver.name }}
+{{- with .parameters }}
+parameters:
+{{ toYaml . | indent 2 }}
+{{- end }}
+reclaimPolicy: {{ .reclaimPolicy | default "Delete" }}
+volumeBindingMode: {{ .volumeBindingMode | default "Immediate" }}
+{{- if hasKey . "allowVolumeExpansion" }}
+allowVolumeExpansion: {{ .allowVolumeExpansion }}
+{{- else }}
+allowVolumeExpansion: true
+{{- end }}
+{{- with .mountOptions }}
+mountOptions:
+{{ toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/packages/system/nfs-driver/charts/csi-driver-nfs/values.yaml
+++ b/packages/system/nfs-driver/charts/csi-driver-nfs/values.yaml
@@ -3,31 +3,31 @@ image:
     baseRepo: registry.k8s.io
     nfs:
         repository: registry.k8s.io/sig-storage/nfsplugin
-        tag: v4.11.0
+        tag: v4.13.3
         pullPolicy: IfNotPresent
     csiProvisioner:
-        repository: registry.k8s.io/sig-storage/csi-provisioner
-        tag: v5.2.0
+        repository: /sig-storage/csi-provisioner
+        tag: v6.1.0
         pullPolicy: IfNotPresent
     csiResizer:
-        repository: registry.k8s.io/sig-storage/csi-resizer
-        tag: v1.13.1
+        repository: /sig-storage/csi-resizer
+        tag: v2.0.0
         pullPolicy: IfNotPresent
     csiSnapshotter:
-        repository: registry.k8s.io/sig-storage/csi-snapshotter
-        tag: v8.2.0
+        repository: /sig-storage/csi-snapshotter
+        tag: v8.4.0
         pullPolicy: IfNotPresent
     livenessProbe:
-        repository: registry.k8s.io/sig-storage/livenessprobe
-        tag: v2.15.0
+        repository: /sig-storage/livenessprobe
+        tag: v2.17.0
         pullPolicy: IfNotPresent
     nodeDriverRegistrar:
-        repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
-        tag: v2.13.0
+        repository: /sig-storage/csi-node-driver-registrar
+        tag: v2.15.0
         pullPolicy: IfNotPresent
     externalSnapshotter:
-        repository: registry.k8s.io/sig-storage/snapshot-controller
-        tag: v8.2.0
+        repository: /sig-storage/snapshot-controller
+        tag: v8.4.0
         pullPolicy: IfNotPresent
 
 serviceAccount:
@@ -58,6 +58,7 @@ controller:
   runOnControlPlane: false
   enableSnapshotter: true
   useTarCommandInSnapshot: false
+  enableSnapshotCompression: true
   livenessProbe:
     healthPort: 29652
   logLevel: 5
@@ -111,6 +112,16 @@ controller:
       requests:
         cpu: 10m
         memory: 20Mi
+
+nodeDriverRegistrar:
+  timeout: 60
+  healthPort: 19809
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 20
+    timeoutSeconds: 10
+    periodSeconds: 5
+    failureThreshold: 2
 
 node:
   name: csi-nfs-node
@@ -183,7 +194,7 @@ storageClass:
 #     server: nfs-server.default.svc.cluster.local
 #     share: /
 #     subDir:
-#     mountPermissions: "0"
+#     mountPermissions: "0755"
 #     csi.storage.k8s.io/provisioner-secret is only needed for providing mountOptions in DeleteVolume
 #     csi.storage.k8s.io/provisioner-secret-name: "mount-options"
 #     csi.storage.k8s.io/provisioner-secret-namespace: "default"
@@ -191,3 +202,30 @@ storageClass:
 #   volumeBindingMode: Immediate
 #   mountOptions:
 #     - nfsvers=4.1
+
+## StorageClass resources for creating multiple storage classes:
+## If you want multiple storage classes with different configurations, use this instead of storageClass above
+# storageClasses:
+#   - name: nfs-delete
+#     annotations:
+#       storageclass.kubernetes.io/is-default-class: "true"
+#     parameters:
+#       server: nfs-server.default.svc.cluster.local
+#       share: /
+#       # subDir:
+#       # mountPermissions: "0"
+#       # csi.storage.k8s.io/provisioner-secret is only needed for providing mountOptions in DeleteVolume
+#       # csi.storage.k8s.io/provisioner-secret-name: "mount-options"
+#       # csi.storage.k8s.io/provisioner-secret-namespace: "default"
+#     reclaimPolicy: Delete
+#     volumeBindingMode: Immediate
+#     mountOptions:
+#       - nfsvers=4.1
+#   - name: nfs-retain
+#     parameters:
+#       server: nfs-server.default.svc.cluster.local
+#       share: /
+#     reclaimPolicy: Retain
+#     volumeBindingMode: Immediate
+#     mountOptions:
+#       - nfsvers=4.1


### PR DESCRIPTION
## What this PR does

Re-vendors the upstream `csi-driver-nfs` Helm chart from 4.11.0 to 4.13.3 (latest upstream release) via `make update`, picking up the published security fixes in the bundled base layers and Go toolchain that the issue enumerates.

All six CSI sidecar/plugin images move to current sig-storage releases: nfsplugin v4.13.3, csi-provisioner v6.1.0, csi-resizer v2.0.0, csi-snapshotter and snapshot-controller v8.4.0, livenessprobe v2.17.0, node-driver-registrar v2.15.0.

The vendored tree is byte-for-byte identical to a fresh upstream pull (no hand-edits). cozystack overrides are empty (`csi-driver-nfs: {}`) and the platform pins the package by path, so nothing else needs touching. New upstream defaults arrive with the bump and are opt-in-safe: `enableSnapshotCompression`, the `VolumeAttributesClass=false` feature-gate paired with the provisioner/resizer majors, and a node-driver-registrar liveness probe. `helm template` renders all images correctly.

Closes #2884

### Release note

```release-note
chore(nfs-driver): bump csi-driver-nfs chart and images to 4.13.3
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generating multiple StorageClass resources from chart values
  * Enabled snapshot compression for controller operations
* **Updates**
  * Upgraded the NFS CSI driver chart/image version to **4.13.3** and updated related container images
  * Improved node-side setup with node-specific DNS handling and enhanced node-driver-registrar health/liveness probing (including configurable timeouts)
* **Configuration Enhancements**
  * Extended CSI feature gates and improved StorageClass handling (conditional annotations and per-class settings)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->