### PR TITLE
chore(mongodb): bump psmdb-operator and CR to 1.22.0

### DIFF
--- a/packages/apps/mongodb/templates/mongodb.yaml
+++ b/packages/apps/mongodb/templates/mongodb.yaml
@@ -8,7 +8,7 @@ metadata:
     - percona.com/delete-psmdb-pods-in-order
     - percona.com/delete-psmdb-pvc
 spec:
-  crVersion: 1.21.1
+  crVersion: 1.22.0
   clusterServiceDNSSuffix: svc.{{ $clusterDomain }}
   secrets:
     users: {{ .Release.Name }}-percona-server-mongodb-users

--- a/packages/apps/mongodb/tests/mongodb_test.yaml
+++ b/packages/apps/mongodb/tests/mongodb_test.yaml
@@ -106,7 +106,7 @@ tests:
   # CR Version     #
   ##################
 
-  - it: sets crVersion to 1.21.1
+  - it: sets crVersion to 1.22.0
     release:
       name: test-mongodb
       namespace: tenant-test
@@ -116,7 +116,7 @@ tests:
     asserts:
       - equal:
           path: spec.crVersion
-          value: "1.21.1"
+          value: "1.22.0"
         documentIndex: 0
 
   #####################

--- a/packages/core/platform/sources/mongodb-operator.yaml
+++ b/packages/core/platform/sources/mongodb-operator.yaml
@@ -21,3 +21,4 @@ spec:
       install:
         namespace: cozy-mongodb-operator
         releaseName: mongodb-operator
+        upgradeCRDs: CreateReplace

--- a/packages/core/platform/tests/sources_mongodb_operator_crds_test.yaml
+++ b/packages/core/platform/tests/sources_mongodb_operator_crds_test.yaml
@@ -1,0 +1,21 @@
+suite: mongodb-operator applies CRD updates on upgrade
+# psmdb-operator evolves its CRD schema between minor versions (1.21 -> 1.22 adds
+# storageScaling/storageAutoscaling, vault and other fields). Helm never upgrades
+# CRDs shipped in crds/, so the PackageSource must opt into CreateReplace; without
+# it the operator binary upgrades while the live CRD stays behind and the
+# apiserver rejects the new fields on existing clusters. Pin the policy so an
+# upgrade cannot silently regress.
+templates:
+  - templates/sources.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  - it: mongodb-operator PackageSource sets upgradeCRDs to CreateReplace
+    documentSelector:
+      path: metadata.name
+      value: cozystack.mongodb-operator
+    asserts:
+      - equal:
+          path: spec.variants[0].components[0].install.upgradeCRDs
+          value: CreateReplace

--- a/packages/system/mongodb-operator/charts/psmdb-operator/Chart.yaml
+++ b/packages/system/mongodb-operator/charts/psmdb-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.21.1
+appVersion: 1.22.0
 description: A Helm chart for deploying the Percona Operator for MongoDB
 home: https://docs.percona.com/percona-operator-for-mongodb/
 maintainers:
@@ -9,5 +9,7 @@ maintainers:
   name: jvpasinatto
 - email: eleonora.zinchenko@percona.com
   name: eleo007
+- email: valmira.nogueira@percona.com
+  name: valmiranogueira
 name: psmdb-operator
-version: 1.21.2
+version: 1.22.0

--- a/packages/system/mongodb-operator/charts/psmdb-operator/README.md
+++ b/packages/system/mongodb-operator/charts/psmdb-operator/README.md
@@ -6,7 +6,7 @@ Useful links:
 - [Operator Documentation](https://www.percona.com/doc/kubernetes-operator-for-psmongodb/index.html)
 
 ## Pre-requisites
-* Kubernetes 1.30+
+* Kubernetes 1.32+
 * Helm v3
 
 # Installation
@@ -15,22 +15,75 @@ This chart will deploy the Operator Pod for the further Percona Server for Mongo
 
 ## Installing the chart
 
-To install the chart with the `psmdb` release name using a dedicated namespace (recommended):
+There are two ways to insall operator: using separate chart with operator Custom Resource Defenitions or using CRDs from the `crds/` directory.
+
+### Using separate chart
+
+Install CRD chart:
 
 ```sh
 helm repo add percona https://percona.github.io/percona-helm-charts/
-helm install my-operator percona/psmdb-operator --version 1.21.2 --namespace my-namespace
+helm install psmdb-operator-crds percona/psmdb-operator-crds --namespace psmdb --create-namespace
 ```
+> **Note:** Deleting CRD chart will trigger deletion of all the custom resources created using the CRDs thus deleting all clusters.
+>  Uninstalling percona/psmdb-operator-crds chart should be approached with caution.
+
+
+Install operator chart:
+```sh
+helm install my-operator percona/psmdb-operator --version 1.22.0 --namespace my-namespace
+```
+
+### Using the `crds/` directory.
+
+```sh
+helm repo add percona https://percona.github.io/percona-helm-charts/
+helm install my-operator percona/psmdb-operator --version 1.22.0 --namespace my-namespace
+```
+
+## Upgrading CRDs
+
+By default, Helm installs CRDs from the `crds/` directory only during initial installation and does not upgrade them. To upgrade CRDs, you have two options:
+
+### Option 1: Use the Separate CRD Chart
+
+Install or upgrade CRDs using the dedicated CRD chart:
+
+```sh
+helm repo update
+helm upgrade --install psmdb-operator-crds percona/psmdb-operator-crds --namespace my-namespace
+```
+
+> **Note:** If you're using Helm 3.17.0 or later, use `--take-ownership` to take over CRDs that were previously installed via the `crds/` directory:
+>
+> ```sh
+> helm upgrade --install psmdb-operator-crds percona/psmdb-operator-crds --namespace my-namespace --take-ownership
+> ```
+
+For Helm versions older than 3.17.0, manually add ownership labels and annotations before running the upgrade:
+
+```sh
+CRDS=(perconaservermongodbs.psmdb.percona.com perconaservermongodbbackups.psmdb.percona.com perconaservermongodbrestores.psmdb.percona.com)
+kubectl label crds "${CRDS[@]}" app.kubernetes.io/managed-by=Helm --overwrite
+kubectl annotate crds "${CRDS[@]}" meta.helm.sh/release-name=psmdb-operator-crds --overwrite
+kubectl annotate crds "${CRDS[@]}" meta.helm.sh/release-namespace=my-namespace --overwrite
+```
+
+### Option 2: Use kubectl to upgrade the CRDs
+
+kubectl apply --server-side -f https://raw.githubusercontent.com/percona/percona-server-mongodb-operator/v1.22.0/deploy/crd.yaml -n my-namespace
+
 
 The chart can be customized using the following configurable parameters:
 
 | Parameter                    | Description                                                                                                  | Default                                   |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
 | `image.repository`           | PSMDB Operator Container image name                                                                          | `percona/percona-server-mongodb-operator` |
-| `image.tag`                  | PSMDB Operator Container image tag                                                                           | `1.21.1`                                  |
-| `image.pullPolicy`           | PSMDB Operator Container pull policy                                                                         | `Always`                                  |
-| `image.pullSecrets`          | PSMDB Operator Pod pull secret                                                                               | `[]`                                      |
+| `image.tag`                  | PSMDB Operator Container image tag                                                                           | `1.22.0`                                  |
+| `image.pullPolicy`           | PSMDB Operator Container pull policy                                                                         | `IfNotPresent`                            |
+| `imagePullSecrets`           | PSMDB Operator Pod pull secret                                                                               | `[]`                                      |
 | `replicaCount`               | PSMDB Operator Pod quantity                                                                                  | `1`                                       |
+| `revisionHistoryLimit`       | Quantity of old ReplicaSets to retain for rollback purposes                                                  | ``                                        |
 | `tolerations`                | List of node taints to tolerate                                                                              | `[]`                                      |
 | `annotations`                | PSMDB Operator Deployment annotations                                                                        | `{}`                                      |
 | `podAnnotations`             | PSMDB Operator Pod annotations                                                                               | `{}`                                      |
@@ -38,7 +91,6 @@ The chart can be customized using the following configurable parameters:
 | `podLabels`                  | PSMDB Operator Pod labels                                                                                    | `{}`                                      |
 | `resources`                  | Resource requests and limits                                                                                 | `{}`                                      |
 | `nodeSelector`               | Labels for Pod assignment                                                                                    | `{}`                                      |
-| `podAnnotations`             | Annotations for pod                                                                                          | `{}`                                      |
 | `podSecurityContext`         | Pod Security Context                                                                                         | `{}`                                      |
 | `watchNamespace`             | Set when a different from default namespace is needed to watch (comma separated if multiple needed)          | `""`                                      |
 | `createNamespace`            | Set if you want to create watched namespaces with helm                                                       | `false`                                   |

--- a/packages/system/mongodb-operator/charts/psmdb-operator/crds/crd.yaml
+++ b/packages/system/mongodb-operator/charts/psmdb-operator/crds/crd.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/component: crd
     app.kubernetes.io/name: percona-server-mongodb
     app.kubernetes.io/part-of: percona-server-mongodb-operator
-    app.kubernetes.io/version: v1.21.1
+    app.kubernetes.io/version: v1.22.0
   name: perconaservermongodbbackups.psmdb.percona.com
 spec:
   group: psmdb.percona.com
@@ -72,7 +72,9 @@ spec:
               compressionType:
                 type: string
               startingDeadlineSeconds:
+                default: 120
                 format: int64
+                minimum: 1
                 type: integer
               storageName:
                 type: string
@@ -151,6 +153,50 @@ spec:
               latestRestorableTime:
                 format: date-time
                 type: string
+              minio:
+                properties:
+                  bucket:
+                    type: string
+                  caBundle:
+                    properties:
+                      key:
+                        type: string
+                      name:
+                        default: ""
+                        type: string
+                      optional:
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  credentialsSecret:
+                    type: string
+                  debugTrace:
+                    type: boolean
+                  endpointUrl:
+                    type: string
+                  forcePathStyle:
+                    type: boolean
+                  insecureSkipTLSVerify:
+                    type: boolean
+                  partSize:
+                    format: int64
+                    type: integer
+                  prefix:
+                    type: string
+                  region:
+                    type: string
+                  retryer:
+                    properties:
+                      numMaxRetries:
+                        type: integer
+                    required:
+                    - numMaxRetries
+                    type: object
+                  secure:
+                    type: boolean
+                type: object
               pbmName:
                 type: string
               pbmPod:
@@ -238,7 +284,7 @@ metadata:
     app.kubernetes.io/component: crd
     app.kubernetes.io/name: percona-server-mongodb
     app.kubernetes.io/part-of: percona-server-mongodb-operator
-    app.kubernetes.io/version: v1.21.1
+    app.kubernetes.io/version: v1.22.0
   name: perconaservermongodbrestores.psmdb.percona.com
 spec:
   group: psmdb.percona.com
@@ -345,6 +391,50 @@ spec:
                   latestRestorableTime:
                     format: date-time
                     type: string
+                  minio:
+                    properties:
+                      bucket:
+                        type: string
+                      caBundle:
+                        properties:
+                          key:
+                            type: string
+                          name:
+                            default: ""
+                            type: string
+                          optional:
+                            type: boolean
+                        required:
+                        - key
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      credentialsSecret:
+                        type: string
+                      debugTrace:
+                        type: boolean
+                      endpointUrl:
+                        type: string
+                      forcePathStyle:
+                        type: boolean
+                      insecureSkipTLSVerify:
+                        type: boolean
+                      partSize:
+                        format: int64
+                        type: integer
+                      prefix:
+                        type: string
+                      region:
+                        type: string
+                      retryer:
+                        properties:
+                          numMaxRetries:
+                            type: integer
+                        required:
+                        - numMaxRetries
+                        type: object
+                      secure:
+                        type: boolean
+                    type: object
                   pbmName:
                     type: string
                   pbmPod:
@@ -433,8 +523,10 @@ spec:
                     ([01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]$'))
                 - message: Date should not be used when 'latest' type is used
                   rule: self.type != 'latest' || !has(self.date)
-              replset:
-                type: string
+              replsetRemapping:
+                additionalProperties:
+                  type: string
+                type: object
               selective:
                 properties:
                   namespaces:
@@ -479,7 +571,7 @@ metadata:
     app.kubernetes.io/component: crd
     app.kubernetes.io/name: percona-server-mongodb
     app.kubernetes.io/part-of: percona-server-mongodb-operator
-    app.kubernetes.io/version: v1.21.1
+    app.kubernetes.io/version: v1.22.0
   name: perconaservermongodbs.psmdb.percona.com
 spec:
   group: psmdb.percona.com
@@ -958,6 +1050,16 @@ spec:
                     type: object
                   enabled:
                     type: boolean
+                  hookScript:
+                    properties:
+                      configMapRef:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      script:
+                        type: string
+                    type: object
                   image:
                     type: string
                   labels:
@@ -1094,7 +1196,9 @@ spec:
                   serviceAccountName:
                     type: string
                   startingDeadlineSeconds:
+                    default: 120
                     format: int64
+                    minimum: 1
                     type: integer
                   storages:
                     additionalProperties:
@@ -1150,6 +1254,50 @@ spec:
                           type: object
                         main:
                           type: boolean
+                        minio:
+                          properties:
+                            bucket:
+                              type: string
+                            caBundle:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            credentialsSecret:
+                              type: string
+                            debugTrace:
+                              type: boolean
+                            endpointUrl:
+                              type: string
+                            forcePathStyle:
+                              type: boolean
+                            insecureSkipTLSVerify:
+                              type: boolean
+                            partSize:
+                              format: int64
+                              type: integer
+                            prefix:
+                              type: string
+                            region:
+                              type: string
+                            retryer:
+                              properties:
+                                numMaxRetries:
+                                  type: integer
+                              required:
+                              - numMaxRetries
+                              type: object
+                            secure:
+                              type: boolean
+                          type: object
                         s3:
                           properties:
                             bucket:
@@ -1458,10 +1606,133 @@ spec:
                     type: object
                   enabled:
                     type: boolean
+                  env:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                        value:
+                          type: string
+                        valueFrom:
+                          properties:
+                            configMapKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            fileKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                optional:
+                                  default: false
+                                  type: boolean
+                                path:
+                                  type: string
+                                volumeName:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              - volumeName
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            secretKeyRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              required:
+                              - key
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  envFrom:
+                    items:
+                      properties:
+                        configMapRef:
+                          properties:
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        prefix:
+                          type: string
+                        secretRef:
+                          properties:
+                            name:
+                              default: ""
+                              type: string
+                            optional:
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    type: array
                   image:
                     type: string
                   imagePullPolicy:
                     type: string
+                  logrotate:
+                    properties:
+                      configuration:
+                        type: string
+                      extraConfig:
+                        properties:
+                          name:
+                            default: ""
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      schedule:
+                        default: 0 0 * * *
+                        type: string
+                    type: object
                   resources:
                     properties:
                       claims:
@@ -2534,6 +2805,16 @@ spec:
                           type: object
                         enabled:
                           type: boolean
+                        hookScript:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            script:
+                              type: string
+                          type: object
                         labels:
                           additionalProperties:
                             type: string
@@ -3369,6 +3650,10 @@ spec:
                                               type: integer
                                             signerName:
                                               type: string
+                                            userAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
                                           required:
                                           - keyType
                                           - signerName
@@ -4438,6 +4723,114 @@ spec:
                               type: string
                           type: object
                       type: object
+                    env:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fileKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  optional:
+                                    default: false
+                                    type: boolean
+                                  path:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                - volumeName
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    default: ""
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    envFrom:
+                      items:
+                        properties:
+                          configMapRef:
+                            properties:
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          prefix:
+                            type: string
+                          secretRef:
+                            properties:
+                              name:
+                                default: ""
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      type: array
                     expose:
                       properties:
                         annotations:
@@ -5026,6 +5419,16 @@ spec:
                           type: object
                         enabled:
                           type: boolean
+                        hookScript:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            script:
+                              type: string
+                          type: object
                         labels:
                           additionalProperties:
                             type: string
@@ -6104,6 +6507,10 @@ spec:
                                               type: integer
                                             signerName:
                                               type: string
+                                            userAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
                                           required:
                                           - keyType
                                           - signerName
@@ -7216,6 +7623,16 @@ spec:
                       - enabled
                       - size
                       type: object
+                    hookScript:
+                      properties:
+                        configMapRef:
+                          properties:
+                            name:
+                              type: string
+                          type: object
+                        script:
+                          type: string
+                      type: object
                     hostAliases:
                       items:
                         properties:
@@ -7849,6 +8266,16 @@ spec:
                           type: object
                         enabled:
                           type: boolean
+                        hookScript:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            script:
+                              type: string
+                          type: object
                         labels:
                           additionalProperties:
                             type: string
@@ -8927,6 +9354,10 @@ spec:
                                               type: integer
                                             signerName:
                                               type: string
+                                            userAnnotations:
+                                              additionalProperties:
+                                                type: string
+                                              type: object
                                           required:
                                           - keyType
                                           - signerName
@@ -11047,6 +11478,10 @@ spec:
                                           type: integer
                                         signerName:
                                           type: string
+                                        userAnnotations:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
                                       required:
                                       - keyType
                                       - signerName
@@ -13199,6 +13634,16 @@ spec:
                             type: object
                           enabled:
                             type: boolean
+                          hookScript:
+                            properties:
+                              configMapRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              script:
+                                type: string
+                            type: object
                           labels:
                             additionalProperties:
                               type: string
@@ -14034,6 +14479,10 @@ spec:
                                                 type: integer
                                               signerName:
                                                 type: string
+                                              userAnnotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
                                             required:
                                             - keyType
                                             - signerName
@@ -15103,6 +15552,114 @@ spec:
                                 type: string
                             type: object
                         type: object
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
                       expose:
                         properties:
                           annotations:
@@ -15691,6 +16248,16 @@ spec:
                             type: object
                           enabled:
                             type: boolean
+                          hookScript:
+                            properties:
+                              configMapRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              script:
+                                type: string
+                            type: object
                           labels:
                             additionalProperties:
                               type: string
@@ -16769,6 +17336,10 @@ spec:
                                                 type: integer
                                               signerName:
                                                 type: string
+                                              userAnnotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
                                             required:
                                             - keyType
                                             - signerName
@@ -17881,6 +18452,16 @@ spec:
                         - enabled
                         - size
                         type: object
+                      hookScript:
+                        properties:
+                          configMapRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          script:
+                            type: string
+                        type: object
                       hostAliases:
                         items:
                           properties:
@@ -18514,6 +19095,16 @@ spec:
                             type: object
                           enabled:
                             type: boolean
+                          hookScript:
+                            properties:
+                              configMapRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              script:
+                                type: string
+                            type: object
                           labels:
                             additionalProperties:
                               type: string
@@ -19592,6 +20183,10 @@ spec:
                                                 type: integer
                                               signerName:
                                                 type: string
+                                              userAnnotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
                                             required:
                                             - keyType
                                             - signerName
@@ -21712,6 +22307,10 @@ spec:
                                             type: integer
                                           signerName:
                                             type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
                                         required:
                                         - keyType
                                         - signerName
@@ -23401,6 +24000,114 @@ spec:
                                 type: string
                             type: object
                         type: object
+                      env:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                            valueFrom:
+                              properties:
+                                configMapKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fileKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    optional:
+                                      default: false
+                                      type: boolean
+                                    path:
+                                      type: string
+                                    volumeName:
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  - volumeName
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  properties:
+                                    key:
+                                      type: string
+                                    name:
+                                      default: ""
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      envFrom:
+                        items:
+                          properties:
+                            configMapRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            prefix:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  default: ""
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        type: array
                       expose:
                         properties:
                           annotations:
@@ -23437,6 +24144,16 @@ spec:
                           servicePerPod:
                             type: boolean
                           type:
+                            type: string
+                        type: object
+                      hookScript:
+                        properties:
+                          configMapRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          script:
                             type: string
                         type: object
                       hostAliases:
@@ -24542,6 +25259,10 @@ spec:
                                             type: integer
                                           signerName:
                                             type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
                                         required:
                                         - keyType
                                         - signerName
@@ -25535,6 +26256,46 @@ spec:
                 required:
                 - enabled
                 type: object
+              storageScaling:
+                properties:
+                  autoscaling:
+                    properties:
+                      enabled:
+                        type: boolean
+                      growthStep:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        default: 2Gi
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      maxSize:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      triggerThresholdPercent:
+                        default: 80
+                        maximum: 95
+                        minimum: 50
+                        type: integer
+                    type: object
+                  enableExternalAutoscaling:
+                    type: boolean
+                  enableVolumeScaling:
+                    type: boolean
+                type: object
+                x-kubernetes-validations:
+                - message: autoscaling cannot be enabled when enableVolumeScaling
+                    is disabled
+                  rule: '!has(self.autoscaling) || !has(self.autoscaling.enabled)
+                    || !self.autoscaling.enabled || self.enableVolumeScaling'
+                - message: autoscaling cannot be enabled when enableExternalAutoscaling
+                    is enabled
+                  rule: '!has(self.autoscaling) || !has(self.autoscaling.enabled)
+                    || !self.autoscaling.enabled || !has(self.enableExternalAutoscaling)
+                    || !self.enableExternalAutoscaling'
               tls:
                 properties:
                   allowInvalidCertificates:
@@ -25616,6 +26377,29 @@ spec:
                   - roles
                   type: object
                 type: array
+              vault:
+                properties:
+                  endpointURL:
+                    type: string
+                    x-kubernetes-validations:
+                    - message: endpointURL must be a valid URL
+                      rule: isURL(self)
+                  syncUsers:
+                    properties:
+                      keyPath:
+                        type: string
+                      mountPath:
+                        type: string
+                      role:
+                        type: string
+                      tokenSecret:
+                        type: string
+                    type: object
+                  tlsSecret:
+                    type: string
+                required:
+                - endpointURL
+                type: object
             required:
             - image
             type: object
@@ -25718,6 +26502,21 @@ spec:
                 type: integer
               state:
                 type: string
+              storageAutoscaling:
+                additionalProperties:
+                  properties:
+                    currentSize:
+                      type: string
+                    lastError:
+                      type: string
+                    lastResizeTime:
+                      format: date-time
+                      type: string
+                    resizeCount:
+                      format: int32
+                      type: integer
+                  type: object
+                type: object
             required:
             - ready
             - size

--- a/packages/system/mongodb-operator/charts/psmdb-operator/templates/NOTES.txt
+++ b/packages/system/mongodb-operator/charts/psmdb-operator/templates/NOTES.txt
@@ -1,16 +1,16 @@
 1. Percona Operator for MongoDB is deployed.
   See if the operator Pod is running:
 
-    kubectl get pods -l app.kubernetes.io/name=psmdb-operator --namespace {{ .Release.Namespace }}
+    kubectl get pods -l app.kubernetes.io/name=psmdb-operator --namespace {{ include "psmdb-operator.namespace" . }}
 
   Check the operator logs if the Pod is not starting:
 
-    export POD=$(kubectl get pods -l app.kubernetes.io/name=psmdb-operator --namespace {{ .Release.Namespace }} --output name)
-    kubectl logs $POD --namespace={{ .Release.Namespace }}
+    export POD=$(kubectl get pods -l app.kubernetes.io/name=psmdb-operator --namespace {{ include "psmdb-operator.namespace" . }} --output name)
+    kubectl logs $POD --namespace={{ include "psmdb-operator.namespace" . }}
 
 2. Deploy the database cluster from psmdb-db chart:
 
-    helm install my-db percona/psmdb-db --namespace={{ .Release.Namespace }}
+    helm install my-db percona/psmdb-db --namespace={{ include "psmdb-operator.namespace" . }}
 
 {{- if .Release.IsUpgrade }}
   {{- $ctx := dict "upgradeCrd" false }}

--- a/packages/system/mongodb-operator/charts/psmdb-operator/templates/_helpers.tpl
+++ b/packages/system/mongodb-operator/charts/psmdb-operator/templates/_helpers.tpl
@@ -25,6 +25,17 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Create a default namespace.
+*/}}
+{{- define "psmdb-operator.namespace" -}}
+{{- if .Values.namespaceOverride }}
+{{- .Values.namespaceOverride }}
+{{- else }}
+{{- .Release.Namespace }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "psmdb-operator.chart" -}}

--- a/packages/system/mongodb-operator/charts/psmdb-operator/templates/deployment.yaml
+++ b/packages/system/mongodb-operator/charts/psmdb-operator/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "psmdb-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "psmdb-operator.namespace" . }}
   labels:
     {{- include "psmdb-operator.labels" . | nindent 4 }}
     {{- with .Values.labels }}
@@ -14,6 +14,9 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "psmdb-operator.name" . }}
@@ -67,7 +70,7 @@ spec:
               {{- if .Values.watchAllNamespaces }}
               value: ""
               {{- else }}
-              value: "{{ default .Release.Namespace .Values.watchNamespace }}"
+              value: "{{ default (include "psmdb-operator.namespace" .) .Values.watchNamespace }}"
               {{- end }}
             - name: POD_NAME
               valueFrom:

--- a/packages/system/mongodb-operator/charts/psmdb-operator/templates/role-binding.yaml
+++ b/packages/system/mongodb-operator/charts/psmdb-operator/templates/role-binding.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "psmdb-operator.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "psmdb-operator.namespace" . }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -20,7 +20,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-account-{{ include "psmdb-operator.fullname" . }}
 {{- if not (or .Values.watchNamespace .Values.watchAllNamespaces) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "psmdb-operator.namespace" . }}
 {{- end }}
   labels:
 {{ include "psmdb-operator.labels" . | indent 4 }}
@@ -28,7 +28,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "psmdb-operator.fullname" . }}
   {{- if or .Values.watchNamespace .Values.watchAllNamespaces }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "psmdb-operator.namespace" . }}
   {{- end }}
 roleRef:
   {{- if or .Values.watchNamespace .Values.watchAllNamespaces }}

--- a/packages/system/mongodb-operator/charts/psmdb-operator/templates/role.yaml
+++ b/packages/system/mongodb-operator/charts/psmdb-operator/templates/role.yaml
@@ -8,7 +8,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "psmdb-operator.fullname" . }}
 {{- if not (or .Values.watchNamespace .Values.watchAllNamespaces) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "psmdb-operator.namespace" . }}
 {{- end }}
   labels:
 {{ include "psmdb-operator.labels" . | indent 4 }}
@@ -133,6 +133,15 @@ rules:
     - watch
     - create
     - patch
+{{- if or .Values.watchNamespace .Values.watchAllNamespaces }}
+  - apiGroups:
+    - metrics.k8s.io
+    resources:
+    - pods
+    verbs:
+    - get
+    - list
+{{- end }}
   - apiGroups:
     - certmanager.k8s.io
     - cert-manager.io

--- a/packages/system/mongodb-operator/charts/psmdb-operator/values.yaml
+++ b/packages/system/mongodb-operator/charts/psmdb-operator/values.yaml
@@ -3,10 +3,11 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
+# revisionHistoryLimit: 10
 
 image:
   repository: percona/percona-server-mongodb-operator
-  tag: 1.21.1
+  tag: 1.22.0
   pullPolicy: IfNotPresent
 
 # disableTelemetry: according to
@@ -16,7 +17,7 @@ image:
 disableTelemetry: false
 
 # set if you want to specify a namespace to watch
-# defaults to `.Release.namespace` if left blank
+# defaults to the operator namespace (`namespaceOverride` or `.Release.Namespace`) if left blank
 # multiple namespaces can be specified and separated by comma
 # watchNamespace:
 # set if you want that watched namespaces are created by helm
@@ -72,6 +73,7 @@ securityContext: {}
 
 imagePullSecrets: []
 nameOverride: ""
+namespaceOverride: ""
 fullnameOverride: ""
 
 env:
@@ -98,6 +100,6 @@ affinity: {}
 logStructured: false
 logLevel: "INFO"
 
-# maxConcurrentReconciles controls the number of concurrent workers 
+# maxConcurrentReconciles controls the number of concurrent workers
 # that can reconcile resources in Percona Server for MongoDB clusters in parallel.
 maxConcurrentReconciles: "1"


### PR DESCRIPTION
## What this PR does

Bumps the Percona Operator for MongoDB stack from 1.21.x to 1.22.0 (latest upstream release), picking up the published security fixes in the operator image that the issue enumerates.

Two coupled changes:

- `system/mongodb-operator`: re-vendors the upstream psmdb-operator chart 1.21.2 → 1.22.0 via `make update` (operator image → `percona/percona-server-mongodb-operator:1.22.0`). The vendored tree is byte-for-byte identical to a fresh upstream pull.
- `apps/mongodb`: bumps the managed CR `spec.crVersion` 1.21.1 → 1.22.0 so the platform tracks the deployed operator instead of running at the N-1 skew, plus the matching helm-unittest assertion.

The 1.22.0 CRD diff is additive (native MinIO backup storage, storage scaling, `hookScript`, `PBMReady` condition, new `metrics.k8s.io` RBAC that activates under our `watchAllNamespaces: true`). The only schema removal — the restore-spec `replset` string, renamed upstream to `replsetRemapping` — is unused by the cozystack mongodb app (restore template uses `clusterName`/`pitr`/`backupSource` only). Deprecations (PSMDB 6.0, PMM2, `enableVolumeExpansion`) stay backward-compatible. The PBM (`2.11.0`) and PMM (`2.44.1`, disabled by default) sidecars stay compatible with 1.22.0 and are out of scope here.

Verified: `helm unittest packages/apps/mongodb` 94/94 pass; `helm template` renders the operator with the new image.

**Upgrade note:** Helm v3 does not update CRDs on `helm upgrade`. On existing clusters the 1.22.0 CRD must be applied manually (`kubectl apply --server-side -f .../crds/crd.yaml`); the operator pod itself runs fine against the older CRD until then.

Closes #2888

### Release note

```release-note
chore(mongodb): bump psmdb-operator to 1.22.0 and managed CR to crVersion 1.22.0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MongoDB Operator upgraded to version 1.22.0 with enhanced custom resource definitions supporting backup storage configuration, hook scripts, and storage autoscaling capabilities
  * Added configurable namespace override for flexible operator deployment
  * Extended RBAC permissions for metrics collection

* **Chores**
  * Kubernetes minimum version requirement updated to 1.32+
  * Helm chart version bumped to 1.22.0

* **Documentation**
  * Expanded CRD upgrade and installation guidance with multiple upgrade strategies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->