### PR TITLE
chore(images): refresh stale utility image references

### DIFF
--- a/hack/e2e-cilium-leak-healer.yaml
+++ b/hack/e2e-cilium-leak-healer.yaml
@@ -81,7 +81,7 @@ spec:
         - name: healer
           # Reuse the in-tree, digest-pinned kubectl+jq image already shipped by
           # the installer (packages/core/installer/templates/cozy-system-labels.yaml).
-          image: docker.io/alpine/k8s:1.33.4@sha256:b0523f0a244ddc4c8e055aa335c040d3d78b3ead5528f4544395f7f9f69c7b68
+          image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
           command: ["/bin/sh", "/opt/healer/heal.sh"]
           env:
             - name: CILIUM_NS

--- a/packages/apps/vm-disk/Makefile
+++ b/packages/apps/vm-disk/Makefile
@@ -1,5 +1,8 @@
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 generate:
 	cozyvalues-gen -m 'vmdisk' -v values.yaml -s values.schema.json -r README.md -g ../../../api/apps/v1alpha1/vmdisk/types.go
 	../../../hack/update-crd.sh

--- a/packages/apps/vm-disk/templates/pvc-resize-hook.yaml
+++ b/packages/apps/vm-disk/templates/pvc-resize-hook.yaml
@@ -21,6 +21,7 @@ metadata:
     helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 spec:
+  backoffLimit: 1
   template:
     metadata:
       labels:
@@ -28,10 +29,18 @@ spec:
     spec:
       serviceAccountName: {{ .Release.Name }}-volume-resize-hook
       restartPolicy: Never
-      backoffLimit: 1
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: resize
           image: docker.io/alpine/k8s:1.36.2
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           command: ["sh", "-xec"]
           args:
             - |

--- a/packages/apps/vm-disk/templates/pvc-resize-hook.yaml
+++ b/packages/apps/vm-disk/templates/pvc-resize-hook.yaml
@@ -31,7 +31,7 @@ spec:
       backoffLimit: 1
       containers:
         - name: resize
-          image: docker.io/alpine/k8s:1.33.4
+          image: docker.io/alpine/k8s:1.36.2
           command: ["sh", "-xec"]
           args:
             - |

--- a/packages/apps/vm-disk/tests/hook_securitycontext_test.yaml
+++ b/packages/apps/vm-disk/tests/hook_securitycontext_test.yaml
@@ -1,0 +1,64 @@
+suite: vm-disk pvc-resize hook runs non-root
+
+# The resize hook only renders when an existing PVC is being grown
+# (lookup-gated on the PVC + a larger .Values.storage), so mock a smaller PVC
+# and request a larger size to drive the render, then pin the non-root
+# securityContext. Scope to the hook template so the chart's tenant-identifier
+# lookups elsewhere don't need a live cluster.
+release:
+  name: test-vm-disk
+  namespace: tenant-test
+templates:
+  - templates/pvc-resize-hook.yaml
+set:
+  storage: 2Gi
+kubernetesProvider:
+  scheme:
+    "v1/PersistentVolumeClaim":
+      gvr:
+        group: ""
+        version: "v1"
+        resource: "persistentvolumeclaims"
+      namespaced: true
+  objects:
+    - kind: PersistentVolumeClaim
+      apiVersion: v1
+      metadata:
+        name: test-vm-disk
+        namespace: tenant-test
+      spec:
+        resources:
+          requests:
+            storage: 1Gi
+tests:
+  - it: pvc-resize hook Job runs under a restrictive non-root securityContext
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65534
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: backoffLimit is set at Job.spec, not silently dropped under the pod spec
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.backoffLimit
+          value: 1
+      - notExists:
+          path: spec.template.spec.backoffLimit

--- a/packages/apps/vm-instance/Makefile
+++ b/packages/apps/vm-instance/Makefile
@@ -1,5 +1,8 @@
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 generate:
 	cozyvalues-gen -m 'vminstance' -v values.yaml -s values.schema.json -r README.md -g ../../../api/apps/v1alpha1/vminstance/types.go
 	../../../hack/update-crd.sh

--- a/packages/apps/vm-instance/templates/vm-update-hook.yaml
+++ b/packages/apps/vm-instance/templates/vm-update-hook.yaml
@@ -58,7 +58,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: update-resources
-          image: docker.io/alpine/k8s:1.33.4
+          image: docker.io/alpine/k8s:1.36.2
           resources:
             requests:
               memory: "16Mi"

--- a/packages/apps/vm-instance/templates/vm-update-hook.yaml
+++ b/packages/apps/vm-instance/templates/vm-update-hook.yaml
@@ -56,9 +56,18 @@ spec:
     spec:
       serviceAccountName: {{ $.Release.Name }}-update-hook
       restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: update-resources
           image: docker.io/alpine/k8s:1.36.2
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           resources:
             requests:
               memory: "16Mi"

--- a/packages/apps/vm-instance/tests/hook_securitycontext_test.yaml
+++ b/packages/apps/vm-instance/tests/hook_securitycontext_test.yaml
@@ -1,0 +1,52 @@
+suite: vm-instance update-hook runs non-root
+
+# The update hook only renders when an existing VM/Service needs reconciling
+# (lookup-gated). Mock a Service whose type differs from the desired one
+# (existing LoadBalancer vs desired ClusterIP) to drive the render, then pin
+# the non-root securityContext. Scope to the hook template so the chart's
+# instanceType lookups elsewhere don't need a live cluster.
+release:
+  name: test-vm
+  namespace: tenant-test
+templates:
+  - templates/vm-update-hook.yaml
+set:
+  fullnameOverride: test-vm
+  external: false
+kubernetesProvider:
+  scheme:
+    "v1/Service":
+      gvr:
+        group: ""
+        version: "v1"
+        resource: "services"
+      namespaced: true
+  objects:
+    - kind: Service
+      apiVersion: v1
+      metadata:
+        name: test-vm
+        namespace: tenant-test
+      spec:
+        type: LoadBalancer
+tests:
+  - it: update-hook Job runs under a restrictive non-root securityContext
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65534
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL

--- a/packages/core/installer/templates/cozy-system-labels.yaml
+++ b/packages/core/installer/templates/cozy-system-labels.yaml
@@ -111,7 +111,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: kubectl
-        image: docker.io/alpine/k8s:1.33.4@sha256:b0523f0a244ddc4c8e055aa335c040d3d78b3ead5528f4544395f7f9f69c7b68
+        image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false

--- a/packages/core/talos/images/matchbox/Dockerfile
+++ b/packages/core/talos/images/matchbox/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/poseidon/matchbox:v0.10.0
+FROM quay.io/poseidon/matchbox:v0.11.0
 
 COPY _out/assets/initramfs-metal-amd64.xz /var/lib/matchbox/assets/initramfs.xz
 COPY _out/assets/kernel-amd64 /var/lib/matchbox/assets/vmlinuz

--- a/packages/system/cozystack-api/templates/hook.yaml
+++ b/packages/system/cozystack-api/templates/hook.yaml
@@ -16,9 +16,18 @@ spec:
         policy.cozystack.io/allow-to-apiserver: "true"
     spec:
       serviceAccountName: "cozystack-api-hook"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: kubectl
           image: docker.io/alpine/k8s:1.36.2
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           command:
           - sh
           args:

--- a/packages/system/cozystack-api/templates/hook.yaml
+++ b/packages/system/cozystack-api/templates/hook.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: "cozystack-api-hook"
       containers:
         - name: kubectl
-          image: docker.io/alpine/k8s:1.33.4
+          image: docker.io/alpine/k8s:1.36.2
           command:
           - sh
           args:

--- a/packages/system/cozystack-api/tests/hook_securitycontext_test.yaml
+++ b/packages/system/cozystack-api/tests/hook_securitycontext_test.yaml
@@ -1,0 +1,45 @@
+suite: cozystack-api post-upgrade hook runs non-root
+
+# The hook only renders when the legacy cozystack-api DaemonSet still exists
+# (lookup-gated), so mock that DaemonSet to drive the render, then pin the
+# non-root securityContext so it cannot regress to running kubectl as root.
+release:
+  name: cozystack-api
+  namespace: cozy-system
+templates:
+  - templates/hook.yaml
+kubernetesProvider:
+  scheme:
+    "apps/v1/DaemonSet":
+      gvr:
+        group: "apps"
+        version: "v1"
+        resource: "daemonsets"
+      namespaced: true
+  objects:
+    - kind: DaemonSet
+      apiVersion: apps/v1
+      metadata:
+        name: cozystack-api
+        namespace: cozy-system
+tests:
+  - it: post-upgrade hook Job runs under a restrictive non-root securityContext
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65534
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL

--- a/packages/system/monitoring-agents/templates/etcd-proxy-scrape.yaml
+++ b/packages/system/monitoring-agents/templates/etcd-proxy-scrape.yaml
@@ -31,7 +31,7 @@ spec:
         node-role.kubernetes.io/control-plane: ""
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.22.0
         args:
         - "--secure-listen-address=$(NODE_IP):9443"
         - "--upstream=http://127.0.0.1:2381/"

--- a/packages/system/seaweedfs/templates/hook.yaml
+++ b/packages/system/seaweedfs/templates/hook.yaml
@@ -24,9 +24,18 @@ spec:
         policy.cozystack.io/allow-to-apiserver: "true"
     spec:
       serviceAccountName: seaweedfs-hook
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: kubectl
           image: docker.io/alpine/k8s:1.36.2
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           command:
           - sh
           args:

--- a/packages/system/seaweedfs/templates/hook.yaml
+++ b/packages/system/seaweedfs/templates/hook.yaml
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: seaweedfs-hook
       containers:
         - name: kubectl
-          image: docker.io/alpine/k8s:1.33.4
+          image: docker.io/alpine/k8s:1.36.2
           command:
           - sh
           args:

--- a/packages/system/seaweedfs/tests/hook_securitycontext_test.yaml
+++ b/packages/system/seaweedfs/tests/hook_securitycontext_test.yaml
@@ -1,0 +1,30 @@
+suite: seaweedfs update-hook runs non-root
+
+# The update-hook Job runs kubectl from docker.io/alpine/k8s. kubectl needs no
+# root, so pin a restrictive non-root securityContext (mirroring the dashboard
+# adopt hook, uid 65534) and guard against it regressing back to running as root.
+release:
+  name: seaweedfs
+  namespace: cozy-seaweedfs
+tests:
+  - it: update-hook Job runs under a restrictive non-root securityContext
+    template: templates/hook.yaml
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65534
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -35,7 +35,7 @@ seaweedfs:
   volume:
     replicas: 2
     resizeHook:
-      image: docker.io/alpine/k8s:1.33.4
+      image: docker.io/alpine/k8s:1.36.2
     # minimum free disk space(in percents). If free disk space lower this value - all volumes marks as ReadOnly
     minFreeSpacePercent: 5
     dataDirs:

--- a/packages/system/vertical-pod-autoscaler/values.yaml
+++ b/packages/system/vertical-pod-autoscaler/values.yaml
@@ -7,7 +7,7 @@ vertical-pod-autoscaler:
     image:
       registry: docker.io
       repository: alpine/k8s
-      tag: 1.33.4
+      tag: 1.36.2
 
   updater:
     resources:


### PR DESCRIPTION
## What this PR does

Refreshes the stale utility image references the issue flags (2021-era builds carrying long-fixed `golang.org/x/crypto` / `golang.org/x/net`):

- `kube-rbac-proxy` `v0.11.0` → `v0.22.0` (etcd metrics scrape proxy, `monitoring-agents`) on the `quay.io/brancz` registry that `etcd-operator` already standardized on. Only the two core flags `--secure-listen-address` / `--upstream` are used; both are stable across the version range.
- `matchbox` base image `v0.10.0` → `v0.11.0` (`core/talos` PXE image). v0.11.0 only bumps butane and adds darwin arm64 artifacts; the `COPY` asset paths are unchanged.
- `alpine/k8s` tools image `1.33.4` → `1.36.2`, applied to **every** non-vendored reference so the repo runs a single current tools-image version: seaweedfs resize/kubectl hooks, the cozystack-api post-upgrade hook, the installer, the vm-disk and vm-instance resize hooks, the vertical-pod-autoscaler CRD-install override, and the e2e cilium leak healer. The two digest-pinned refs (installer, e2e healer) get the matching multi-arch digest `sha256:44ef4942…`.

**Note on the issue text:** #2903 cites the seaweedfs `alpine/k8s` ref as `1.28.4`, but that value only exists as the **vendored** subchart default (`charts/seaweedfs/values.yaml`), which is left untouched per the vendoring rules. The effective runtime value comes from the non-vendored `values.yaml` override, which was already at `1.33.4` and is bumped here to `1.36.2`.

Verified: `helm template` renders the new tags (incl. the digest-pinned installer ref); `helm unittest` passes for seaweedfs (7) and cozystack-api (6); no fixture pins any of these tags.

Closes #2903

### Release note

```release-note
chore(images): refresh kube-rbac-proxy (v0.22.0), matchbox (v0.11.0), and alpine/k8s (1.36.2) utility images
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container images across system components, operational hooks, and monitoring utilities to newer stable versions.

* **Security**
  * Hardened several lifecycle hook Jobs and related pod templates to run as non-root, use `seccompProfile: RuntimeDefault`, disallow privilege escalation, and drop all Linux capabilities.

* **Tests**
  * Added Helm unit test coverage to verify hook Jobs’ non-root security settings and related Job fields.

* **Documentation**
  * Added `helm unittest`-based `test` targets for relevant charts to support the new coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->