### PR TITLE
ci(tests): fix OCIR registry login in Release E2E workflow

### DIFF
--- a/.github/workflows/release-e2e.yaml
+++ b/.github/workflows/release-e2e.yaml
@@ -36,15 +36,25 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Set up Docker config
+        run: |
+          if [ -d ~/.docker ]; then
+            cp -r ~/.docker "${{ runner.temp }}/.docker"
+          fi
+
       - name: Login to registry
         uses: docker/login-action@v3
         with:
           registry: iad.ocir.io
-          username: ${{ secrets.OCI_REGISTRY_USERNAME }}
-          password: ${{ secrets.OCI_REGISTRY_PASSWORD }}
+          username: ${{ secrets.OCIR_USER }}
+          password: ${{ secrets.OCIR_TOKEN }}
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
 
       - name: Build images
         run: make build PUSH=1
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
 
       - name: Build Talos image
         run: make -C packages/core/talos build


### PR DESCRIPTION
## What this PR does

The `Release E2E` workflow's build job logged into `iad.ocir.io` using `secrets.OCI_REGISTRY_USERNAME` / `secrets.OCI_REGISTRY_PASSWORD` — secret names that don't exist in the repo. `docker/login-action` therefore received empty credentials and failed at the very first step with `Username and password required`, before any image was built or any test ran.

The workflow has **never** succeeded since it was added (2026-05-02): all three tag runs to date died at this step — `v1.5.0-rc.2`, `v1.5.0-rc.3`, and `v1.5.0`.

This switches the login to the configured `OCIR_USER` / `OCIR_TOKEN` secrets — the same ones `build-main.yaml` and `pull-requests.yaml` use against the same registry — and adds the per-job Docker config isolation those workflows already use (`Set up Docker config` step + `DOCKER_CONFIG` env on the login and build steps), so the login doesn't clobber the shared `~/.docker/config.json` on the self-hosted runner.

### Release note

```release-note
ci(tests): fix OCIR registry login in the Release E2E workflow so it can build and run the full suite on release tags
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved the release workflow with enhanced Docker credential isolation and configuration handling during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->