### PR TITLE
chore(velero): bump velero to 12.0.3

### DIFF
--- a/packages/system/velero/Makefile
+++ b/packages/system/velero/Makefile
@@ -3,9 +3,12 @@ export NAMESPACE=cozy-$(NAME)
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	# Velero
 	helm repo add tanzu https://vmware-tanzu.github.io/helm-charts
 	helm repo update tanzu
-	helm pull tanzu/velero --untar --untardir charts
+	helm pull tanzu/velero --untar --untardir charts --version 12.0.3

--- a/packages/system/velero/charts/velero/Chart.yaml
+++ b/packages/system/velero/charts/velero/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.17.0
+appVersion: 1.18.1
 description: A Helm chart for velero
 home: https://github.com/vmware-tanzu/velero
 icon: https://cdn-images-1.medium.com/max/1600/1*-9mb3AKnKdcL_QD3CMnthQ.png
@@ -14,4 +14,4 @@ maintainers:
 name: velero
 sources:
 - https://github.com/vmware-tanzu/velero
-version: 11.0.0
+version: 12.0.3

--- a/packages/system/velero/charts/velero/ci/test-values.yaml
+++ b/packages/system/velero/charts/velero/ci/test-values.yaml
@@ -14,6 +14,7 @@ configuration:
   - name: backups-secondary
     bucket: velero-backups
     provider: aws
+    backupSyncPeriod: "3h"
     config:
       region: us-west-1
       profile: us-west-1-profile

--- a/packages/system/velero/charts/velero/crds/backuprepositories.yaml
+++ b/packages/system/velero/charts/velero/crds/backuprepositories.yaml
@@ -116,8 +116,8 @@ spec:
                       nullable: true
                       type: string
                     message:
-                      description: Message is a message about the current status
-                        of the repo maintenance.
+                      description: Message is a message about the current status of
+                        the repo maintenance.
                       type: string
                     result:
                       description: Result is the result of the repo maintenance.
@@ -126,8 +126,7 @@ spec:
                       - Failed
                       type: string
                     startTimestamp:
-                      description: StartTimestamp is the start time of the repo
-                        maintenance.
+                      description: StartTimestamp is the start time of the repo maintenance.
                       format: date-time
                       nullable: true
                       type: string

--- a/packages/system/velero/charts/velero/crds/backups.yaml
+++ b/packages/system/velero/charts/velero/crds/backups.yaml
@@ -124,8 +124,8 @@ spec:
                           nullable: true
                           type: array
                         excludedResources:
-                          description: ExcludedResources specifies the resources
-                            to which this hook spec does not apply.
+                          description: ExcludedResources specifies the resources to
+                            which this hook spec does not apply.
                           items:
                             type: string
                           nullable: true
@@ -147,8 +147,8 @@ spec:
                           nullable: true
                           type: array
                         labelSelector:
-                          description: LabelSelector, if specified, filters the
-                            resources to which this hook spec applies.
+                          description: LabelSelector, if specified, filters the resources
+                            to which this hook spec applies.
                           nullable: true
                           properties:
                             matchExpressions:
@@ -202,8 +202,7 @@ spec:
                             PostHooks is a list of BackupResourceHooks to execute after storing the item in the backup.
                             These are executed after all "additional items" from item actions are processed.
                           items:
-                            description: BackupResourceHook defines a hook for a
-                              resource.
+                            description: BackupResourceHook defines a hook for a resource.
                             properties:
                               exec:
                                 description: Exec defines an exec hook.
@@ -222,8 +221,8 @@ spec:
                                     type: string
                                   onError:
                                     description: OnError specifies how Velero should
-                                      behave if it encounters an error executing
-                                      this hook.
+                                      behave if it encounters an error executing this
+                                      hook.
                                     enum:
                                     - Continue
                                     - Fail
@@ -245,8 +244,7 @@ spec:
                             PreHooks is a list of BackupResourceHooks to execute prior to storing the item in the backup.
                             These are executed before any "additional items" from item actions are processed.
                           items:
-                            description: BackupResourceHook defines a hook for a
-                              resource.
+                            description: BackupResourceHook defines a hook for a resource.
                             properties:
                               exec:
                                 description: Exec defines an exec hook.
@@ -265,8 +263,8 @@ spec:
                                     type: string
                                   onError:
                                     description: OnError specifies how Velero should
-                                      behave if it encounters an error executing
-                                      this hook.
+                                      behave if it encounters an error executing this
+                                      hook.
                                     enum:
                                     - Continue
                                     - Fail
@@ -407,16 +405,16 @@ spec:
                     label selector matches no objects.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector
-                        requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
                         description: |-
                           A label selector requirement is a selector that contains values, a key, and an operator that
                           relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector
-                              applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
                             description: |-
@@ -494,8 +492,8 @@ spec:
                 nullable: true
                 type: boolean
               storageLocation:
-                description: StorageLocation is a string containing the name of
-                  a BackupStorageLocation where the backup should be stored.
+                description: StorageLocation is a string containing the name of a
+                  BackupStorageLocation where the backup should be stored.
                 type: string
               ttl:
                 description: |-
@@ -503,8 +501,7 @@ spec:
                   the Backup should be retained for.
                 type: string
               uploaderConfig:
-                description: UploaderConfig specifies the configuration for the
-                  uploader.
+                description: UploaderConfig specifies the configuration for the uploader.
                 nullable: true
                 properties:
                   parallelFilesUpload:
@@ -513,12 +510,12 @@ spec:
                     type: integer
                 type: object
               volumeGroupSnapshotLabelKey:
-                description: VolumeGroupSnapshotLabelKey specifies the label key
-                  to group PVCs under a VGS.
+                description: VolumeGroupSnapshotLabelKey specifies the label key to
+                  group PVCs under a VGS.
                 type: string
               volumeSnapshotLocations:
-                description: VolumeSnapshotLocations is a list containing names
-                  of VolumeSnapshotLocations associated with this backup.
+                description: VolumeSnapshotLocations is a list containing names of
+                  VolumeSnapshotLocations associated with this backup.
                 items:
                   type: string
                 type: array
@@ -580,8 +577,8 @@ spec:
                   major, minor, and patch version.
                 type: string
               hookStatus:
-                description: HookStatus contains information about the status of
-                  the hooks.
+                description: HookStatus contains information about the status of the
+                  hooks.
                 nullable: true
                 properties:
                   hooksAttempted:
@@ -591,14 +588,16 @@ spec:
                       and the number of hooks that executed successfully.
                     type: integer
                   hooksFailed:
-                    description: HooksFailed is the total number of hooks which
-                      ended with an error
+                    description: HooksFailed is the total number of hooks which ended
+                      with an error
                     type: integer
                 type: object
               phase:
                 description: Phase is the current state of the Backup.
                 enum:
                 - New
+                - Queued
+                - ReadyToStart
                 - FailedValidation
                 - InProgress
                 - WaitingForPluginOperations
@@ -630,6 +629,11 @@ spec:
                       filters that happen as items are processed.
                     type: integer
                 type: object
+              queuePosition:
+                description: |-
+                  QueuePosition is the position of the backup in the queue.
+                  Only relevant when Phase is "Queued"
+                type: integer
               startTimestamp:
                 description: |-
                   StartTimestamp records the time a backup was started.

--- a/packages/system/velero/charts/velero/crds/backupstoragelocations.yaml
+++ b/packages/system/velero/charts/velero/crds/backupstoragelocations.yaml
@@ -23,8 +23,8 @@ spec:
       jsonPath: .status.phase
       name: Phase
       type: string
-    - description: LastValidationTime is the last time the backup store location
-        was validated
+    - description: LastValidationTime is the last time the backup store location was
+        validated
       jsonPath: .status.lastValidationTime
       name: Last Validated
       type: date
@@ -59,8 +59,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupStorageLocationSpec defines the desired state of
-              a Velero BackupStorageLocation
+            description: BackupStorageLocationSpec defines the desired state of a
+              Velero BackupStorageLocation
             properties:
               accessMode:
                 description: AccessMode defines the permissions for the backup storage
@@ -84,8 +84,8 @@ spec:
                   to be used with this location
                 properties:
                   key:
-                    description: The key of the secret to select from.  Must be
-                      a valid secret key.
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
                     type: string
                   name:
                     default: ""
@@ -115,10 +115,38 @@ spec:
                     description: Bucket is the bucket to use for object storage.
                     type: string
                   caCert:
-                    description: CACert defines a CA bundle to use when verifying
-                      TLS connections to the provider.
+                    description: |-
+                      CACert defines a CA bundle to use when verifying TLS connections to the provider.
+                      Deprecated: Use CACertRef instead.
                     format: byte
                     type: string
+                  caCertRef:
+                    description: |-
+                      CACertRef is a reference to a Secret containing the CA certificate bundle to use
+                      when verifying TLS connections to the provider. The Secret must be in the same
+                      namespace as the BackupStorageLocation.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
                   prefix:
                     description: Prefix is the path inside a bucket to use for Velero
                       storage. Optional.
@@ -139,8 +167,8 @@ spec:
             - provider
             type: object
           status:
-            description: BackupStorageLocationStatus defines the observed state
-              of BackupStorageLocation
+            description: BackupStorageLocationStatus defines the observed state of
+              BackupStorageLocation
             properties:
               accessMode:
                 description: |-

--- a/packages/system/velero/charts/velero/crds/datadownloads.yaml
+++ b/packages/system/velero/charts/velero/crds/datadownloads.yaml
@@ -35,8 +35,7 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where the backup data is
-        stored
+    - description: Name of the Backup Storage Location where the backup data is stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -96,8 +95,7 @@ spec:
                   If DataMover is "" or "velero", the built-in data mover will be used.
                 type: string
               nodeOS:
-                description: NodeOS is OS of the node where the DataDownload is
-                  processed.
+                description: NodeOS is OS of the node where the DataDownload is processed.
                 enum:
                 - auto
                 - linux
@@ -109,9 +107,13 @@ spec:
                   before returning error as timeout.
                 type: string
               snapshotID:
-                description: SnapshotID is the ID of the Velero backup snapshot
-                  to be restored from.
+                description: SnapshotID is the ID of the Velero backup snapshot to
+                  be restored from.
                 type: string
+              snapshotSize:
+                description: SnapshotSize is the logical size in Bytes of the snapshot.
+                format: int64
+                type: integer
               sourceNamespace:
                 description: |-
                   SourceNamespace is the original namespace where the volume is backed up from.
@@ -125,8 +127,8 @@ spec:
                     description: Namespace is the target namespace
                     type: string
                   pv:
-                    description: PV is the name of the target PV that is created
-                      by Velero restore
+                    description: PV is the name of the target PV that is created by
+                      Velero restore
                     type: string
                   pvc:
                     description: PVC is the name of the target PVC that is created
@@ -169,8 +171,7 @@ spec:
                 description: Message is a message about the DataDownload's status.
                 type: string
               node:
-                description: Node is name of the node where the DataDownload is
-                  processed.
+                description: Node is name of the node where the DataDownload is processed.
                 type: string
               phase:
                 description: Phase is the current state of the DataDownload.

--- a/packages/system/velero/charts/velero/crds/datauploads.yaml
+++ b/packages/system/velero/charts/velero/crds/datauploads.yaml
@@ -35,8 +35,14 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where this backup should
-        be stored
+    - description: Incremental bytes
+      format: int64
+      jsonPath: .status.incrementalBytes
+      name: Incremental Bytes
+      priority: 10
+      type: integer
+    - description: Name of the Backup Storage Location where this backup should be
+        stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -51,8 +57,8 @@ spec:
     name: v2alpha1
     schema:
       openAPIV3Schema:
-        description: DataUpload acts as the protocol between data mover plugins
-          and data mover controller for the datamover backup operation
+        description: DataUpload acts as the protocol between data mover plugins and
+          data mover controller for the datamover backup operation
         properties:
           apiVersion:
             description: |-
@@ -93,8 +99,8 @@ spec:
                     description: Driver is the driver used by the VolumeSnapshotContent
                     type: string
                   snapshotClass:
-                    description: SnapshotClass is the name of the snapshot class
-                      that the volume snapshot is created with
+                    description: SnapshotClass is the name of the snapshot class that
+                      the volume snapshot is created with
                     type: string
                   storageClass:
                     description: StorageClass is the name of the storage class of
@@ -135,8 +141,8 @@ spec:
                   It is the same namespace for SourcePVC and CSI namespaced objects.
                 type: string
               sourcePVC:
-                description: SourcePVC is the name of the PVC which the snapshot
-                  is taken for.
+                description: SourcePVC is the name of the PVC which the snapshot is
+                  taken for.
                 type: string
             required:
             - backupStorageLocation
@@ -175,6 +181,11 @@ spec:
                   as a result of the DataUpload.
                 nullable: true
                 type: object
+              incrementalBytes:
+                description: IncrementalBytes holds the number of bytes new or changed
+                  since the last backup
+                format: int64
+                type: integer
               message:
                 description: Message is a message about the DataUpload's status.
                 type: string
@@ -189,8 +200,8 @@ spec:
                 - windows
                 type: string
               path:
-                description: Path is the full path of the snapshot volume being
-                  backed up.
+                description: Path is the full path of the snapshot volume being backed
+                  up.
                 type: string
               phase:
                 description: Phase is the current state of the DataUpload.

--- a/packages/system/velero/charts/velero/crds/deletebackuprequests.yaml
+++ b/packages/system/velero/charts/velero/crds/deletebackuprequests.yaml
@@ -48,8 +48,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: DeleteBackupRequestSpec is the specification for which
-              backups to delete.
+            description: DeleteBackupRequestSpec is the specification for which backups
+              to delete.
             properties:
               backupName:
                 type: string

--- a/packages/system/velero/charts/velero/crds/downloadrequests.yaml
+++ b/packages/system/velero/charts/velero/crds/downloadrequests.yaml
@@ -41,8 +41,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: DownloadRequestSpec is the specification for a download
-              request.
+            description: DownloadRequestSpec is the specification for a download request.
             properties:
               target:
                 description: Target is what to download (e.g. logs for a backup).
@@ -84,8 +83,8 @@ spec:
                   file.
                 type: string
               expiration:
-                description: Expiration is when this DownloadRequest expires and
-                  can be deleted by the system.
+                description: Expiration is when this DownloadRequest expires and can
+                  be deleted by the system.
                 format: date-time
                 nullable: true
                 type: string

--- a/packages/system/velero/charts/velero/crds/podvolumebackups.yaml
+++ b/packages/system/velero/charts/velero/crds/podvolumebackups.yaml
@@ -35,8 +35,14 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where this backup should
-        be stored
+    - description: Incremental bytes
+      format: int64
+      jsonPath: .status.incrementalBytes
+      name: Incremental Bytes
+      priority: 10
+      type: integer
+    - description: Name of the Backup Storage Location where this backup should be
+        stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -91,8 +97,8 @@ spec:
                   on.
                 type: string
               pod:
-                description: Pod is a reference to the pod containing the volume
-                  to be backed up.
+                description: Pod is a reference to the pod containing the volume to
+                  be backed up.
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -153,8 +159,8 @@ spec:
                 nullable: true
                 type: object
               uploaderType:
-                description: UploaderType is the type of the uploader to handle
-                  the data transfer.
+                description: UploaderType is the type of the uploader to handle the
+                  data transfer.
                 enum:
                 - kopia
                 - restic
@@ -191,9 +197,13 @@ spec:
                 format: date-time
                 nullable: true
                 type: string
+              incrementalBytes:
+                description: IncrementalBytes holds the number of bytes new or changed
+                  since the last backup
+                format: int64
+                type: integer
               message:
-                description: Message is a message about the pod volume backup's
-                  status.
+                description: Message is a message about the pod volume backup's status.
                 type: string
               path:
                 description: Path is the full path within the controller pod being

--- a/packages/system/velero/charts/velero/crds/podvolumerestores.yaml
+++ b/packages/system/velero/charts/velero/crds/podvolumerestores.yaml
@@ -35,8 +35,7 @@ spec:
       jsonPath: .status.progress.totalBytes
       name: Total Bytes
       type: integer
-    - description: Name of the Backup Storage Location where the backup data is
-        stored
+    - description: Name of the Backup Storage Location where the backup data is stored
       jsonPath: .spec.backupStorageLocation
       name: Storage Location
       type: string
@@ -87,8 +86,8 @@ spec:
                   when the PodVolumeRestore is in InProgress phase
                 type: boolean
               pod:
-                description: Pod is a reference to the pod containing the volume
-                  to be restored.
+                description: Pod is a reference to the pod containing the volume to
+                  be restored.
                 properties:
                   apiVersion:
                     description: API version of the referent.
@@ -136,6 +135,10 @@ spec:
               snapshotID:
                 description: SnapshotID is the ID of the volume snapshot to be restored.
                 type: string
+              snapshotSize:
+                description: SnapshotSize is the logical size in Bytes of the snapshot.
+                format: int64
+                type: integer
               sourceNamespace:
                 description: SourceNamespace is the original namespace for namaspace
                   mapping.
@@ -149,16 +152,16 @@ spec:
                 nullable: true
                 type: object
               uploaderType:
-                description: UploaderType is the type of the uploader to handle
-                  the data transfer.
+                description: UploaderType is the type of the uploader to handle the
+                  data transfer.
                 enum:
                 - kopia
                 - restic
                 - ""
                 type: string
               volume:
-                description: Volume is the name of the volume within the Pod to
-                  be restored.
+                description: Volume is the name of the volume within the Pod to be
+                  restored.
                 type: string
             required:
             - backupStorageLocation
@@ -187,8 +190,7 @@ spec:
                 nullable: true
                 type: string
               message:
-                description: Message is a message about the pod volume restore's
-                  status.
+                description: Message is a message about the pod volume restore's status.
                 type: string
               node:
                 description: Node is name of the node where the pod volume restore

--- a/packages/system/velero/charts/velero/crds/restores.yaml
+++ b/packages/system/velero/charts/velero/crds/restores.yaml
@@ -87,8 +87,8 @@ spec:
                           nullable: true
                           type: array
                         excludedResources:
-                          description: ExcludedResources specifies the resources
-                            to which this hook spec does not apply.
+                          description: ExcludedResources specifies the resources to
+                            which this hook spec does not apply.
                           items:
                             type: string
                           nullable: true
@@ -110,8 +110,8 @@ spec:
                           nullable: true
                           type: array
                         labelSelector:
-                          description: LabelSelector, if specified, filters the
-                            resources to which this hook spec applies.
+                          description: LabelSelector, if specified, filters the resources
+                            to which this hook spec applies.
                           nullable: true
                           properties:
                             matchExpressions:
@@ -172,8 +172,8 @@ spec:
                                 properties:
                                   command:
                                     description: Command is the command and arguments
-                                      to execute from within a container after a
-                                      pod has been restored.
+                                      to execute from within a container after a pod
+                                      has been restored.
                                     items:
                                       type: string
                                     minItems: 1
@@ -190,8 +190,8 @@ spec:
                                     type: string
                                   onError:
                                     description: OnError specifies how Velero should
-                                      behave if it encounters an error executing
-                                      this hook.
+                                      behave if it encounters an error executing this
+                                      hook.
                                     enum:
                                     - Continue
                                     - Fail
@@ -214,9 +214,8 @@ spec:
                                 description: Init defines an init restore hook.
                                 properties:
                                   initContainers:
-                                    description: InitContainers is list of init
-                                      containers to be added to a pod during its
-                                      restore.
+                                    description: InitContainers is list of init containers
+                                      to be added to a pod during its restore.
                                     items:
                                       type: object
                                       x-kubernetes-preserve-unknown-fields: true
@@ -336,16 +335,16 @@ spec:
                     label selector matches no objects.
                   properties:
                     matchExpressions:
-                      description: matchExpressions is a list of label selector
-                        requirements. The requirements are ANDed.
+                      description: matchExpressions is a list of label selector requirements.
+                        The requirements are ANDed.
                       items:
                         description: |-
                           A label selector requirement is a selector that contains values, a key, and an operator that
                           relates the key and values.
                         properties:
                           key:
-                            description: key is the label key that the selector
-                              applies to.
+                            description: key is the label key that the selector applies
+                              to.
                             type: string
                           operator:
                             description: |-
@@ -381,8 +380,8 @@ spec:
                 nullable: true
                 type: array
               preserveNodePorts:
-                description: PreserveNodePorts specifies whether to restore old
-                  nodePorts from backup.
+                description: PreserveNodePorts specifies whether to restore old nodePorts
+                  from backup.
                 nullable: true
                 type: boolean
               resourceModifier:
@@ -442,17 +441,16 @@ spec:
                   from the most recent successful backup created from this schedule.
                 type: string
               uploaderConfig:
-                description: UploaderConfig specifies the configuration for the
-                  restore.
+                description: UploaderConfig specifies the configuration for the restore.
                 nullable: true
                 properties:
                   parallelFilesDownload:
-                    description: ParallelFilesDownload is the concurrency number
-                      setting for restore.
+                    description: ParallelFilesDownload is the concurrency number setting
+                      for restore.
                     type: integer
                   writeSparseFiles:
-                    description: WriteSparseFiles is a flag to indicate whether
-                      write files sparsely or not.
+                    description: WriteSparseFiles is a flag to indicate whether write
+                      files sparsely or not.
                     nullable: true
                     type: boolean
                 type: object
@@ -478,8 +476,8 @@ spec:
                   to fail.
                 type: string
               hookStatus:
-                description: HookStatus contains information about the status of
-                  the hooks.
+                description: HookStatus contains information about the status of the
+                  hooks.
                 nullable: true
                 properties:
                   hooksAttempted:
@@ -489,8 +487,8 @@ spec:
                       and the number of hooks that executed successfully.
                     type: integer
                   hooksFailed:
-                    description: HooksFailed is the total number of hooks which
-                      ended with an error
+                    description: HooksFailed is the total number of hooks which ended
+                      with an error
                     type: integer
                 type: object
               phase:
@@ -515,8 +513,8 @@ spec:
                 nullable: true
                 properties:
                   itemsRestored:
-                    description: ItemsRestored is the number of items that have
-                      actually been restored so far
+                    description: ItemsRestored is the number of items that have actually
+                      been restored so far
                     type: integer
                   totalItems:
                     description: |-

--- a/packages/system/velero/charts/velero/crds/schedules.yaml
+++ b/packages/system/velero/charts/velero/crds/schedules.yaml
@@ -63,8 +63,7 @@ spec:
             description: ScheduleSpec defines the specification for a Velero schedule
             properties:
               paused:
-                description: Paused specifies whether the schedule is paused or
-                  not
+                description: Paused specifies whether the schedule is paused or not
                 type: boolean
               schedule:
                 description: |-
@@ -145,12 +144,12 @@ spec:
                     nullable: true
                     type: array
                   hooks:
-                    description: Hooks represent custom behaviors that should be
-                      executed at different phases of the backup.
+                    description: Hooks represent custom behaviors that should be executed
+                      at different phases of the backup.
                     properties:
                       resources:
-                        description: Resources are hooks that should be executed
-                          when backing up individual instances of a resource.
+                        description: Resources are hooks that should be executed when
+                          backing up individual instances of a resource.
                         items:
                           description: |-
                             BackupResourceHookSpec defines one or more BackupResourceHooks that should be executed based on
@@ -187,14 +186,13 @@ spec:
                               nullable: true
                               type: array
                             labelSelector:
-                              description: LabelSelector, if specified, filters
-                                the resources to which this hook spec applies.
+                              description: LabelSelector, if specified, filters the
+                                resources to which this hook spec applies.
                               nullable: true
                               properties:
                                 matchExpressions:
                                   description: matchExpressions is a list of label
-                                    selector requirements. The requirements are
-                                    ANDed.
+                                    selector requirements. The requirements are ANDed.
                                   items:
                                     description: |-
                                       A label selector requirement is a selector that contains values, a key, and an operator that
@@ -250,8 +248,8 @@ spec:
                                     description: Exec defines an exec hook.
                                     properties:
                                       command:
-                                        description: Command is the command and
-                                          arguments to execute.
+                                        description: Command is the command and arguments
+                                          to execute.
                                         items:
                                           type: string
                                         minItems: 1
@@ -293,8 +291,8 @@ spec:
                                     description: Exec defines an exec hook.
                                     properties:
                                       command:
-                                        description: Command is the command and
-                                          arguments to execute.
+                                        description: Command is the command and arguments
+                                          to execute.
                                         items:
                                           type: string
                                         minItems: 1
@@ -535,8 +533,8 @@ spec:
                     nullable: true
                     type: boolean
                   storageLocation:
-                    description: StorageLocation is a string containing the name
-                      of a BackupStorageLocation where the backup should be stored.
+                    description: StorageLocation is a string containing the name of
+                      a BackupStorageLocation where the backup should be stored.
                     type: string
                   ttl:
                     description: |-
@@ -544,18 +542,18 @@ spec:
                       the Backup should be retained for.
                     type: string
                   uploaderConfig:
-                    description: UploaderConfig specifies the configuration for
-                      the uploader.
+                    description: UploaderConfig specifies the configuration for the
+                      uploader.
                     nullable: true
                     properties:
                       parallelFilesUpload:
-                        description: ParallelFilesUpload is the number of files
-                          parallel uploads to perform when using the uploader.
+                        description: ParallelFilesUpload is the number of files parallel
+                          uploads to perform when using the uploader.
                         type: integer
                     type: object
                   volumeGroupSnapshotLabelKey:
-                    description: VolumeGroupSnapshotLabelKey specifies the label
-                      key to group PVCs under a VGS.
+                    description: VolumeGroupSnapshotLabelKey specifies the label key
+                      to group PVCs under a VGS.
                     type: string
                   volumeSnapshotLocations:
                     description: VolumeSnapshotLocations is a list containing names

--- a/packages/system/velero/charts/velero/crds/serverstatusrequests.yaml
+++ b/packages/system/velero/charts/velero/crds/serverstatusrequests.yaml
@@ -55,8 +55,8 @@ spec:
                 - Processed
                 type: string
               plugins:
-                description: Plugins list information about the plugins running
-                  on the Velero server
+                description: Plugins list information about the plugins running on
+                  the Velero server
                 items:
                   description: PluginInfo contains attributes of a Velero plugin
                   properties:

--- a/packages/system/velero/charts/velero/crds/volumesnapshotlocations.yaml
+++ b/packages/system/velero/charts/velero/crds/volumesnapshotlocations.yaml
@@ -55,8 +55,8 @@ spec:
                   to be used with this location
                 properties:
                   key:
-                    description: The key of the secret to select from.  Must be
-                      a valid secret key.
+                    description: The key of the secret to select from.  Must be a
+                      valid secret key.
                     type: string
                   name:
                     default: ""
@@ -85,8 +85,8 @@ spec:
               of a Velero VolumeSnapshotLocation.
             properties:
               phase:
-                description: VolumeSnapshotLocationPhase is the lifecycle phase
-                  of a Velero VolumeSnapshotLocation.
+                description: VolumeSnapshotLocationPhase is the lifecycle phase of
+                  a Velero VolumeSnapshotLocation.
                 enum:
                 - Available
                 - Unavailable

--- a/packages/system/velero/charts/velero/templates/_helpers.tpl
+++ b/packages/system/velero/charts/velero/templates/_helpers.tpl
@@ -99,16 +99,11 @@ Create the node-Agent runtime class name.
 
 {{/*
 Kubernetes version
-Built-in object .Capabilities.KubeVersion.Minor can provide non-number output
-For examples:
-- on GKE it returns "18+" instead of "18"
-- on EKS it returns "20+" instead of "20"
 */}}
 {{- define "chart.KubernetesVersion" -}}
-{{- $minorVersion := .Capabilities.KubeVersion.Minor | regexFind "[0-9]+" -}}
-{{- printf "%s.%s" .Capabilities.KubeVersion.Major $minorVersion -}}
+{{- $version := .Capabilities.KubeVersion.Version | regexFind "v[0-9]+\\.[0-9]+\\.[0-9]+" -}}
+{{- printf "%s" $version -}}
 {{- end -}}
-
 
 {{/*
 Calculate the checksum of the credentials secret.

--- a/packages/system/velero/charts/velero/templates/backupstoragelocation.yaml
+++ b/packages/system/velero/charts/velero/templates/backupstoragelocation.yaml
@@ -18,6 +18,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" $ }}
 spec:
   {{- if not (empty .credential) }}
@@ -36,6 +37,9 @@ spec:
   {{- end }}
   {{- with .validationFrequency }}
   validationFrequency: {{ . }}
+  {{- end }}
+  {{- with .backupSyncPeriod }}
+  backupSyncPeriod: {{ . }}
   {{- end }}
   objectStorage:
     bucket: {{ .bucket | quote }}

--- a/packages/system/velero/charts/velero/templates/cleanup-crds.yaml
+++ b/packages/system/velero/charts/velero/templates/cleanup-crds.yaml
@@ -3,6 +3,8 @@
 # Using this on production systems, especially those that have multiple releases of Velero, will be destructive.
 {{/* 'securityContext' got renamed to 'podSecurityContext', merge both dicts into one for backward compatibility */}}
 {{- $podSecurityContext := merge (.Values.podSecurityContext | default dict) (.Values.securityContext | default dict) -}}
+{{/* Define the list of resources to clean up */}}
+{{- $cleanupResources := list "restore" "backup" "backupstoragelocation" "volumesnapshotlocation" "podvolumerestore" -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -37,6 +39,32 @@ spec:
       {{- end }}
     {{- end }}
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}
+      initContainers:
+        {{- range $cleanupResources }}
+        - name: delete-{{ . }}
+          {{- if $.Values.kubectl.image.digest }}
+          image: "{{ $.Values.kubectl.image.repository }}@{{ $.Values.kubectl.image.digest }}"
+          {{- else if $.Values.kubectl.image.tag }}
+          image: "{{ $.Values.kubectl.image.repository }}:{{ $.Values.kubectl.image.tag }}"
+          {{- else }}
+          image: "{{ $.Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" $ }}"
+          {{- end }}
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          command:
+            - /bin/kubectl
+          args:
+            - delete
+            - {{ . }}
+            - --all
+          {{- with $.Values.kubectl.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.kubectl.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
       containers:
         - name: kubectl
           {{- if .Values.kubectl.image.digest }}
@@ -48,15 +76,12 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - /bin/sh
-            - -c
-            - >
-              kubectl delete restore --all;
-              kubectl delete backup --all;
-              kubectl delete backupstoragelocation --all;
-              kubectl delete volumesnapshotlocation --all;
-              kubectl delete podvolumerestore --all;
-              kubectl delete crd -l component=velero;
+            - /bin/kubectl
+          args:
+            - delete
+            - crd
+            - -l
+            - component=velero
           {{- with .Values.kubectl.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/packages/system/velero/charts/velero/templates/configmaps.yaml
+++ b/packages/system/velero/charts/velero/templates/configmaps.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" $ }}
   {{- with $configMap.labels }}
     {{- toYaml . | nindent 4 }}

--- a/packages/system/velero/charts/velero/templates/label-namespace/labelnamespace.yaml
+++ b/packages/system/velero/charts/velero/templates/label-namespace/labelnamespace.yaml
@@ -28,11 +28,13 @@ spec:
         image: "{{ .Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" . }}"
         {{- end }}
         command:
-        - /bin/sh
-        - -c
-        - |
+          - /bin/kubectl
+        args:
+          - label
+          - namespace
+          - {{ .Release.Namespace }}
           {{- range $key, $value := .Values.namespace.labels }}
-          kubectl label namespace {{ $.Release.Namespace }} {{ $key }}={{ $value }}
+          - {{ $key }}={{ $value }}
           {{- end }}
         {{- if .Values.kubectl.extraVolumeMounts }}
         volumeMounts:

--- a/packages/system/velero/charts/velero/templates/node-agent-daemonset.yaml
+++ b/packages/system/velero/charts/velero/templates/node-agent-daemonset.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" . }}
     {{- with .Values.nodeAgent.labels }}
       {{- toYaml . | nindent 4 }}
@@ -30,6 +31,7 @@ spec:
         app.kubernetes.io/name: {{ include "velero.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/managed-by: {{ .Release.Service }}
+        app.kubernetes.io/version: {{ .Chart.AppVersion }}
         helm.sh/chart: {{ include "velero.chart" . }}
       {{- if .Values.nodeAgent.podLabels }}
         {{- toYaml .Values.nodeAgent.podLabels | nindent 8 }}
@@ -78,12 +80,14 @@ spec:
           secret:
             secretName: {{ include "velero.secretName" . }}
         {{- end }}
+        {{- if not (.Values.nodeAgent.disableHostPath) }}
         - name: host-pods
           hostPath:
             path: {{ .Values.nodeAgent.podVolumePath }}
         - name: host-plugins
           hostPath:
             path: {{ .Values.nodeAgent.pluginVolumePath | default "/var/lib/kubelet/plugins" }}
+        {{- end }}
         {{- if .Values.nodeAgent.useScratchEmptyDir }}
         - name: scratch
           emptyDir: {}
@@ -132,12 +136,14 @@ spec:
             - name: cloud-credentials
               mountPath: /credentials
             {{- end }}
+            {{- if not (.Values.nodeAgent.disableHostPath) }}
             - name: host-pods
               mountPath: /host_pods
               mountPropagation: HostToContainer
             - name: host-plugins
               mountPath: /host_plugins
               mountPropagation: HostToContainer
+            {{- end }}
             {{- if .Values.nodeAgent.useScratchEmptyDir }}
             - name: scratch
               mountPath: /scratch

--- a/packages/system/velero/charts/velero/templates/podmonitor.yaml
+++ b/packages/system/velero/charts/velero/templates/podmonitor.yaml
@@ -32,13 +32,22 @@ spec:
     {{- end }}
   podMetricsEndpoints:
   - port: http-monitoring
-    interval: {{ .Values.metrics.scrapeInterval }}
-    scrapeTimeout: {{ .Values.metrics.scrapeTimeout }}
-    {{- if .Values.metrics.nodeAgentPodMonitor.scheme }}
-    scheme: {{ .Values.metrics.nodeAgentPodMonitor.scheme }}
+    {{- with .Values.metrics.scrapeInterval }}
+    interval: {{ . }}
     {{- end }}
-    {{- if .Values.metrics.nodeAgentPodMonitor.tlsConfig }}
-    tlsConfig:
-      {{- toYaml .Values.metrics.nodeAgentPodMonitor.tlsConfig | nindent 6 }}
+    {{- with .Values.metrics.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.nodeAgentPodMonitor.scheme }}
+    scheme: {{ . }}
+    {{- end }}
+    {{- with .Values.metrics.nodeAgentPodMonitor.metricRelabelings }}
+    metricRelabelings: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.nodeAgentPodMonitor.relabelings }}
+    relabelings: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.nodeAgentPodMonitor.tlsConfig }}
+    tlsConfig: {{ toYaml . | nindent 6 }}
     {{- end }}
 {{- end }}

--- a/packages/system/velero/charts/velero/templates/prometheusrule.yaml
+++ b/packages/system/velero/charts/velero/templates/prometheusrule.yaml
@@ -10,6 +10,8 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: {{ include "velero.chart" . }}
     {{- if .Values.metrics.prometheusRule.additionalLabels }}
     {{- toYaml .Values.metrics.prometheusRule.additionalLabels | nindent 4 }}
     {{- end }}

--- a/packages/system/velero/charts/velero/templates/schedule.yaml
+++ b/packages/system/velero/charts/velero/templates/schedule.yaml
@@ -13,6 +13,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" $ }}
     {{- if $schedule.labels }}
       {{- toYaml $schedule.labels | nindent 4 }}

--- a/packages/system/velero/charts/velero/templates/service.yaml
+++ b/packages/system/velero/charts/velero/templates/service.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" . }}
     {{- with .Values.metrics.service.labels }}
       {{- toYaml . | nindent 4 }}

--- a/packages/system/velero/charts/velero/templates/servicemonitor.yaml
+++ b/packages/system/velero/charts/velero/templates/servicemonitor.yaml
@@ -28,19 +28,22 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   endpoints:
   - port: http-monitoring
-    interval: {{ .Values.metrics.scrapeInterval }}
-    scrapeTimeout: {{ .Values.metrics.scrapeTimeout }}
-    {{- if .Values.metrics.serviceMonitor.scheme }}
-    scheme: {{ .Values.metrics.serviceMonitor.scheme }}
+    {{- with .Values.metrics.scrapeInterval }}
+    interval: {{ . }}
     {{- end }}
-    {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
-    metricRelabelings: {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- with .Values.metrics.scrapeTimeout }}
+    scrapeTimeout: {{ . }}
     {{- end }}
-    {{- if .Values.metrics.serviceMonitor.relabelings }}
-    relabelings: {{ toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
+    {{- with .Values.metrics.serviceMonitor.scheme }}
+    scheme: {{ . }}
     {{- end }}
-    {{- if .Values.metrics.serviceMonitor.tlsConfig }}
-    tlsConfig:
-      {{- toYaml .Values.metrics.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- with .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.relabelings }}
+    relabelings: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.metrics.serviceMonitor.tlsConfig }}
+    tlsConfig: {{ toYaml . | nindent 6 }}
     {{- end }}
 {{- end }}

--- a/packages/system/velero/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+++ b/packages/system/velero/charts/velero/templates/upgrade-crds/upgrade-crds.yaml
@@ -40,32 +40,6 @@ spec:
     {{- end }}
       serviceAccountName: {{ include "velero.serverServiceAccount" . }}-upgrade-crds
       automountServiceAccountToken: {{ .Values.upgradeCRDsJob.automountServiceAccountToken }}
-      initContainers:
-        - name: kubectl
-          {{- if .Values.kubectl.image.digest }}
-          image: "{{ .Values.kubectl.image.repository }}@{{ .Values.kubectl.image.digest }}"
-          {{- else if .Values.kubectl.image.tag }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
-          {{- else }}
-          image: "{{ .Values.kubectl.image.repository }}:{{ template "chart.KubernetesVersion" . }}"
-          {{- end }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command:
-            - /bin/sh
-          args:
-            - -c
-            - cp `which sh` /tmp && cp `which kubectl` /tmp
-          {{- with .Values.kubectl.resources }}
-          resources:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with .Values.kubectl.containerSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - mountPath: /tmp
-              name: crds
       containers:
         - name: velero
           {{- if .Values.image.digest }}
@@ -75,10 +49,11 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-            - {{ .Values.upgradeCRDsJob.shellCmd | default "/tmp/sh" }}
+            - /velero
           args:
-            - -c
-            - {{ .Values.upgradeCRDsJob.updateCmd | default "/velero install --crds-only --dry-run -o yaml | /tmp/kubectl apply -f -" }}
+            - install
+            - --crds-only
+            - --apply
           {{- with .Values.upgradeJobResources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -87,10 +62,8 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          volumeMounts:
-            - mountPath: /tmp
-              name: crds
           {{- if (.Values.upgradeCRDsJob).extraVolumeMounts }}
+          volumeMounts:
           {{- toYaml .Values.upgradeCRDsJob.extraVolumeMounts | nindent 12 }}
           {{- end }}
           {{- if (.Values.upgradeCRDsJob).extraEnvVars }}
@@ -99,12 +72,10 @@ spec:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- end }}
+      {{- if (.Values.upgradeCRDsJob).extraVolumes }}
       volumes:
-        - name: crds
-          emptyDir: {}
-        {{- if (.Values.upgradeCRDsJob).extraVolumes }}
         {{- toYaml .Values.upgradeCRDsJob.extraVolumes | nindent 8 }}
-        {{- end }}
+      {{- end }}
       restartPolicy: OnFailure
       {{- with $podSecurityContext }}
       securityContext:

--- a/packages/system/velero/charts/velero/templates/volumesnapshotlocation.yaml
+++ b/packages/system/velero/charts/velero/templates/volumesnapshotlocation.yaml
@@ -18,6 +18,7 @@ metadata:
     app.kubernetes.io/name: {{ include "velero.name" $ }}
     app.kubernetes.io/instance: {{ $.Release.Name }}
     app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/version: {{ $.Chart.AppVersion }}
     helm.sh/chart: {{ include "velero.chart" $ }}
 spec:
   {{- if not (empty .credential) }}

--- a/packages/system/velero/charts/velero/values.schema.json
+++ b/packages/system/velero/charts/velero/values.schema.json
@@ -293,8 +293,6 @@
             },
             "required": [
                 "enabled",
-                "scrapeInterval",
-                "scrapeTimeout",
                 "service",
                 "podAnnotations",
                 "serviceMonitor",
@@ -382,6 +380,9 @@
                                 "type": ["boolean", "null"]
                             },
                             "validationFrequency": {
+                                "type": ["string", "null"]
+                            },
+                            "backupSyncPeriod": {
                                 "type": ["string", "null"]
                             },
                             "accessMode": {

--- a/packages/system/velero/charts/velero/values.yaml
+++ b/packages/system/velero/charts/velero/values.yaml
@@ -26,9 +26,9 @@ namespace:
 # Details of the container image to use in the Velero deployment & daemonset (if
 # enabling node-agent). Required.
 image:
-  repository: velero/velero
-  tag: v1.17.0
-  # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
+  repository: docker.io/velero/velero
+  tag: v1.18.1
+  # Digest value example: sha256:73266e6bd7e2fe3f65fb20677d36c4a8df76d417d9ba76bd9932e0d983a776ec.
   # If used, it will take precedence over the image.tag.
   # digest:
   pullPolicy: IfNotPresent
@@ -130,7 +130,7 @@ dnsPolicy: ClusterFirst
 # If the value is a string then it is evaluated as a template.
 initContainers:
   # - name: velero-plugin-for-aws
-  #   image: velero/velero-plugin-for-aws:v1.13.0
+  #   image: velero/velero-plugin-for-aws:v1.13.1
   #   imagePullPolicy: IfNotPresent
   #   volumeMounts:
   #     - mountPath: /target
@@ -282,11 +282,16 @@ metrics:
     enabled: false
     annotations: {}
     additionalLabels: {}
-    # ServiceMonitor namespace. Default to Velero namespace.
+    # metrics.nodeAgentPodMonitor.metricRelabelings Specify Metric Relabelings to add to the scrape endpoint
+    # ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    # metricRelabelings: []
+    # metrics.nodeAgentPodMonitor.relabelings [array] Prometheus relabeling rules
+    # relabelings: []
+    # PodMonitor namespace. Default to Velero namespace.
     # namespace:
-    # ServiceMonitor connection scheme. Defaults to HTTP.
+    # PodMonitor connection scheme. Defaults to HTTP.
     # scheme: ""
-    # ServiceMonitor connection tlsConfig. Defaults to {}.
+    # PodMonitor connection tlsConfig. Defaults to {}.
     # tlsConfig: {}
 
   prometheusRule:
@@ -316,14 +321,14 @@ metrics:
     #     severity: critical
     # - alert: VeleroNoNewBackup
     #   annotations:
-    #     message: Velero backup {{ $labels.schedule }} has not run successfuly in the last 30h
+    #     message: Velero backup {{ $labels.schedule }} has not run successfully in the last 25h
     #   expr: |-
     #     (
-    #     rate(velero_backup_last_successful_timestamp{schedule!=""}[15m]) <=bool 0
+    #     (time() - velero_backup_last_successful_timestamp{schedule!=""}) >bool (25 * 3600)
     #     or
     #     absent(velero_backup_last_successful_timestamp{schedule!=""})
     #     ) == 1
-    #   for: 30h
+    #   for: 1h
     #   labels:
     #     severity: critical
     # - alert: VeleroBackupPartialFailures
@@ -338,12 +343,12 @@ metrics:
 
 kubectl:
   image:
-    repository: alpine/k8s
-    # Digest value example: sha256:d238835e151cec91c6a811fe3a89a66d3231d9f64d09e5f3c49552672d271f38.
+    repository: registry.k8s.io/kubectl
+    # Digest value example: sha256:c7bf8cf6e79f474fda2623a7b98572a1b909c4d912b05062b444ffe79883fdbe.
     # If used, it will take precedence over the kubectl.image.tag.
     # digest:
     # kubectl image tag. If used, it will take precedence over the cluster Kubernetes version.
-    tag: "1.35.0"
+    # tag: v1.34.5
   # Container Level Security Context for the 'kubectl' container of the crd jobs. Optional.
   # See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
   containerSecurityContext: {}
@@ -355,7 +360,7 @@ kubectl:
   labels: {}
   # Extra volumes for the upgrade/cleanup job. Optional.
   extraVolumes: []
-  # Extra volumeMounts for the upgrade/cleanup job.. Optional.
+  # Extra volumeMounts for the upgrade/cleanup job. Optional.
   extraVolumeMounts: []
 
 # This job upgrades the CRDs.
@@ -393,6 +398,8 @@ configuration:
     default: false
     # validationFrequency defines how frequently Velero should validate the object storage. Optional.
     validationFrequency:
+    # backupSyncPeriod defines how frequently Velero should synchronize backups in object storage. Optional.
+    backupSyncPeriod:
     # accessMode determines if velero can write to this backup storage location. Optional.
     # default to ReadWrite, ReadOnly is used during migrations and restores.
     accessMode: ReadWrite
@@ -649,6 +656,8 @@ snapshotsEnabled: true
 deployNodeAgent: false
 
 nodeAgent:
+  # Disables Host Path volumes for node-agent.
+  disableHostPath: false
   podVolumePath: /var/lib/kubelet/pods
   pluginVolumePath: /var/lib/kubelet/plugins
   # Pod priority class name to use for the node-agent daemonset. Optional.
@@ -784,7 +793,7 @@ schedules: {}
 #       velero.io/plugin-config: ""
 #       velero.io/pod-volume-restore: RestoreItemAction
 #     data:
-#       image: velero/velero:v1.17.0
+#       image: velero/velero:v1.17.1
 #       cpuRequest: 200m
 #       memRequest: 128Mi
 #       cpuLimit: 200m

--- a/packages/system/velero/tests/velero_test.yaml
+++ b/packages/system/velero/tests/velero_test.yaml
@@ -26,9 +26,11 @@ tests:
           path: spec.template.spec.initContainers[1].image
           value: quay.io/kubevirt/kubevirt-velero-plugin:v0.9.0
 
-  # Cozystack disables the upgrade-crds Job (upgradeCRDs: false) because the
-  # job has kubectl-image compatibility issues; CRDs ship via the chart's
-  # crds/ directory instead. Pin that invariant — it silently regressed once.
+  # Cozystack disables the upgrade-crds Job (upgradeCRDs: false) because CRDs
+  # ship via the chart's crds/ directory, making the Job redundant. (The old
+  # kubectl-image-compatibility rationale is obsolete in velero 12.x, where the
+  # Job now runs the velero image natively.) Pin that invariant — it silently
+  # regressed once.
   - it: does not emit the upgrade-crds Job when upgradeCRDs is disabled
     template: charts/velero/templates/upgrade-crds/upgrade-crds.yaml
     asserts:

--- a/packages/system/velero/tests/velero_test.yaml
+++ b/packages/system/velero/tests/velero_test.yaml
@@ -1,0 +1,36 @@
+suite: cozy-velero chart rendering invariants
+release:
+  name: velero
+  namespace: cozy-velero
+tests:
+  - it: renders the velero server Deployment on the pinned upstream image
+    template: charts/velero/templates/deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: velero
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/velero/velero:v1.18.1
+
+  - it: pins the backup-plugin initContainers to velero-1.18-compatible releases
+    template: charts/velero/templates/deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: velero
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: velero/velero-plugin-for-aws:v1.14.1
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: quay.io/kubevirt/kubevirt-velero-plugin:v0.9.0
+
+  # Cozystack disables the upgrade-crds Job (upgradeCRDs: false) because the
+  # job has kubectl-image compatibility issues; CRDs ship via the chart's
+  # crds/ directory instead. Pin that invariant — it silently regressed once.
+  - it: does not emit the upgrade-crds Job when upgradeCRDs is disabled
+    template: charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/packages/system/velero/values.yaml
+++ b/packages/system/velero/values.yaml
@@ -4,12 +4,12 @@ velero:
   upgradeCRDs: false
   initContainers:
     - name: velero-plugin-for-aws
-      image: velero/velero-plugin-for-aws:v1.12.1
+      image: velero/velero-plugin-for-aws:v1.14.1
       imagePullPolicy: IfNotPresent
       volumeMounts:
         - mountPath: /target
           name: plugins
-    - image: quay.io/kubevirt/kubevirt-velero-plugin:v0.8.0
+    - image: quay.io/kubevirt/kubevirt-velero-plugin:v0.9.0
       name: kubevirt-kubevirt-velero-plugin
       imagePullPolicy: IfNotPresent
       volumeMounts:

--- a/packages/system/velero/values.yaml
+++ b/packages/system/velero/values.yaml
@@ -1,6 +1,8 @@
 velero:
-  # Disable CRD upgrade job - CRDs are installed as part of helm chart
-  # The upgrade job has issues with kubectl image compatibility
+  # Disable the upgrade-crds Job: CRDs ship via the chart's crds/ directory, so
+  # the Job is redundant. (The old kubectl-image-compatibility rationale is
+  # obsolete in velero 12.x — the Job now runs the velero image natively, not a
+  # kubectl one — but it stays disabled because cozystack manages CRDs via crds/.)
   upgradeCRDs: false
   initContainers:
     - name: velero-plugin-for-aws


### PR DESCRIPTION
## What this PR does

Bumps velero from 11.0.0 to 12.0.3 (appVersion 1.17.0 → 1.18.1, latest upstream), picking up the published security fixes the issue enumerates across the velero server and its backup plugins.

- Re-vendors the chart via `make update` (now pinned to `--version 12.0.3` for reproducible re-vendoring). The 12.0 major bump's values-schema changes are backward-compatible (two required fields relaxed, one optional key added), so all cozystack overrides (`upgradeCRDs`, `initContainers`, `configuration.*`, `deployNodeAgent`) stay valid.
- Moves the backup-plugin initContainers to their velero-1.18-aligned releases: `velero-plugin-for-aws` v1.12.1 → v1.14.1 (the release that bumps to velero 1.18.1; also corrects a pre-existing plugin/server skew) and `kubevirt-velero-plugin` v0.8.0 → v0.9.0.
- Adds helm-unittest coverage (the package shipped none): pins the server + plugin image tags and the `upgradeCRDs: false` → no upgrade-crds Job invariant, which has silently regressed before.

The 1.18 "PVC selected-node" deprecation needs no action (velero handles it transparently); CRD changes are additive.

Verified: `helm template` renders all three images; `helm unittest` 3/3 pass (mutation-checked).

**Upgrade note:** Helm v3 does not update CRDs on `helm upgrade` (upgradeCRDs is disabled). On existing clusters the 1.18 CRDs must be applied manually (`kubectl apply --filename packages/system/velero/charts/velero/crds/`).

Closes #2886

### Release note

```release-note
chore(velero): bump velero to 12.0.3 (app 1.18.1) and backup plugins to velero-1.18-compatible releases
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Backup status queue tracking (`queuePosition`) plus new `phase` states.
  * Added `caCertRef` Secret reference for BackupStorageLocation (with `caCert` marked deprecated).
  * Added incremental-bytes reporting (DataUpload, PodVolumeBackup) and `snapshotSize` for PodVolumeRestore.
  * Added `backupSyncPeriod` configuration and `nodeAgent.disableHostPath` option.
* **Upgrades**
  * Updated Velero to app 1.18.1 / chart 12.0.3, including plugin image tag bumps and updated kubectl image defaults.
  * Added chart/app version labels across key resources.
* **Operational Improvements**
  * Improved CRD cleanup/upgrade job execution and tuned the “VeleroNoNewBackup” alert.
* **Tests**
  * Added a `test` target (runs `helm unittest`) and expanded chart rendering invariants checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->