### PR TITLE
chore(vertical-pod-autoscaler): bump VPA to 11.1.1

### DIFF
--- a/packages/system/vertical-pod-autoscaler/Makefile
+++ b/packages/system/vertical-pod-autoscaler/Makefile
@@ -3,9 +3,12 @@ export NAMESPACE=cozy-$(NAME)
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	# VirtualPodAutoscaler operator
 	helm repo add cowboysysop https://cowboysysop.github.io/charts/
 	helm repo update cowboysysop
-	helm pull cowboysysop/vertical-pod-autoscaler --untar --untardir charts
+	helm pull cowboysysop/vertical-pod-autoscaler --untar --untardir charts --version 11.1.1

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.lock
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami/
-  version: 2.21.0
-digest: sha256:e25ca51f064e63a6b2d595f4bb318563de95e5e7ee2534b0457010be6acefc1e
-generated: "2025-01-28T22:38:50.721673297Z"
+  repository: oci://ghcr.io/cowboysysop/charts
+  version: 2.31.3
+digest: sha256:97c0702416bf7bd224e8a2fa1e13f01521c6fef4909fc387c28778dd5ceb5442
+generated: "2025-10-06T16:51:00.77929793Z"

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/Chart.yaml
@@ -4,11 +4,11 @@ annotations:
     url: https://cowboysysop.github.io/charts/pgp-public-key-2022-02-19.asc
   kubeVersion: '>=1.24'
 apiVersion: v2
-appVersion: 1.3.0
+appVersion: 1.5.0
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami/
-  version: 2.21.0
+  repository: oci://ghcr.io/cowboysysop/charts
+  version: 2.31.3
 description: Set of components that automatically adjust the amount of CPU and memory
   requested by pods running in the Kubernetes Cluster
 home: https://github.com/kubernetes/autoscaler
@@ -20,4 +20,4 @@ name: vertical-pod-autoscaler
 sources:
 - https://github.com/kubernetes/autoscaler
 - https://github.com/cowboysysop/charts/tree/master/charts/vertical-pod-autoscaler
-version: 10.0.0
+version: 11.1.1

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/README.md
@@ -11,6 +11,12 @@ $ helm repo add cowboysysop https://cowboysysop.github.io/charts/
 $ helm install my-release cowboysysop/vertical-pod-autoscaler
 ```
 
+or for an OCI-based registry:
+
+```bash
+$ helm install my-release oci://ghcr.io/cowboysysop/charts/vertical-pod-autoscaler
+```
+
 ## Introduction
 
 This chart bootstraps a Vertical Pod Autoscaler deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
@@ -30,6 +36,12 @@ $ helm repo add cowboysysop https://cowboysysop.github.io/charts/
 $ helm install my-release cowboysysop/vertical-pod-autoscaler
 ```
 
+or for an OCI-based registry:
+
+```bash
+$ helm install my-release oci://ghcr.io/cowboysysop/charts/vertical-pod-autoscaler
+```
+
 These commands deploy Vertical Pod Autoscaler on the Kubernetes cluster in the default configuration and with the release name `my-release`. The deployment configuration can be customized by specifying the customization parameters with the `helm install` command using the `--values` or `--set` arguments. Find more information in the [configuration section](#configuration) of this document.
 
 ## Upgrading
@@ -40,9 +52,22 @@ Upgrade the chart deployment using:
 $ helm upgrade my-release cowboysysop/vertical-pod-autoscaler
 ```
 
+or for an OCI-based registry:
+
+```bash
+$ helm upgrade my-release oci://ghcr.io/cowboysysop/charts/vertical-pod-autoscaler
+```
+
 The command upgrades the existing `my-release` deployment with the most latest release of the chart.
 
-**TIP**: Use `helm repo update` to update information on available charts in the chart repositories.
+### Upgrading to version 11.0.0
+
+The chart now uses forked versions of the Bitnami charts to reference the Bitnami Legacy repository:
+
+- https://github.com/bitnami/containers/issues/83267
+
+Pod and container security contexts have been hardened and some values are now configured at
+the container level instead of the pod level.
 
 ### Upgrading to version 10.0.0
 
@@ -143,6 +168,7 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 | `kubeVersion`       | Override Kubernetes version                                                                                  | `""`    |
 | `nameOverride`      | Partially override `vertical-pod-autoscaler.fullname` template with a string (will prepend the release name) | `""`    |
 | `fullnameOverride`  | Fully override `vertical-pod-autoscaler.fullname` template with a string                                     | `""`    |
+| `namespaceOverride` | Fully override `common.names.namespace` template with a string                                               | `""`    |
 | `commonAnnotations` | Annotations to add to all deployed objects                                                                   | `{}`    |
 | `commonLabels`      | Labels to add to all deployed objects                                                                        | `{}`    |
 | `extraDeploy`       | Array of extra objects to deploy with the release                                                            | `[]`    |
@@ -153,9 +179,10 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
 | `admissionController.enabled`                                  | Enable the component                                                                                                | `true`                                 |
 | `admissionController.replicaCount`                             | Number of replicas                                                                                                  | `1`                                    |
+| `admissionController.revisionHistoryLimit`                     | Number of old history to retain to allow rollback                                                                   | `10`                                   |
 | `admissionController.image.registry`                           | Image registry                                                                                                      | `registry.k8s.io`                      |
 | `admissionController.image.repository`                         | Image repository                                                                                                    | `autoscaling/vpa-admission-controller` |
-| `admissionController.image.tag`                                | Image tag                                                                                                           | `1.3.0`                                |
+| `admissionController.image.tag`                                | Image tag                                                                                                           | `1.5.0`                                |
 | `admissionController.image.digest`                             | Image digest                                                                                                        | `""`                                   |
 | `admissionController.image.pullPolicy`                         | Image pull policy                                                                                                   | `IfNotPresent`                         |
 | `admissionController.pdb.create`                               | Specifies whether a pod disruption budget should be created                                                         | `false`                                |
@@ -170,14 +197,18 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 | `admissionController.podAnnotations`                           | Additional pod annotations                                                                                          | `{}`                                   |
 | `admissionController.podLabels`                                | Additional pod labels                                                                                               | `{}`                                   |
 | `admissionController.podSecurityContext`                       | Pod security context                                                                                                |                                        |
-| `admissionController.podSecurityContext.runAsNonRoot`          | Whether the container must run as a non-root user                                                                   | `true`                                 |
-| `admissionController.podSecurityContext.runAsUser`             | The UID to run the entrypoint of the container process                                                              | `65534`                                |
-| `admissionController.podSecurityContext.runAsGroup`            | The GID to run the entrypoint of the container process                                                              | `65534`                                |
+| `admissionController.podSecurityContext.seccompProfile.type`   | Set pod's Security Context seccomp profile                                                                          | `RuntimeDefault`                       |
 | `admissionController.hostNetwork`                              | Use the host network                                                                                                | `false`                                |
 | `admissionController.priorityClassName`                        | Priority class name                                                                                                 | `nil`                                  |
 | `admissionController.runtimeClassName`                         | Runtime class name                                                                                                  | `""`                                   |
 | `admissionController.topologySpreadConstraints`                | Topology Spread Constraints for pod assignment                                                                      | `[]`                                   |
-| `admissionController.securityContext`                          | Container security context                                                                                          | `{}`                                   |
+| `admissionController.securityContext`                          | Container security context                                                                                          |                                        |
+| `admissionController.securityContext.allowPrivilegeEscalation` | Set container's Security Context allowPrivilegeEscalation                                                           | `false`                                |
+| `admissionController.securityContext.capabilities.drop`        | List of capabilities to be dropped                                                                                  | `["ALL"]`                              |
+| `admissionController.securityContext.readOnlyRootFilesystem`   | Set container's Security Context readOnlyRootFilesystem                                                             | `true`                                 |
+| `admissionController.securityContext.runAsNonRoot`             | Whether the container must run as a non-root user                                                                   | `true`                                 |
+| `admissionController.securityContext.runAsUser`                | The UID to run the entrypoint of the container process                                                              | `65534`                                |
+| `admissionController.securityContext.runAsGroup`               | The GID to run the entrypoint of the container process                                                              | `65534`                                |
 | `admissionController.containerPorts.https`                     | Container port for HTTPS                                                                                            | `8000`                                 |
 | `admissionController.containerPorts.metrics`                   | Container port for Metrics                                                                                          | `8944`                                 |
 | `admissionController.livenessProbe.enabled`                    | Enable liveness probe                                                                                               | `true`                                 |
@@ -243,9 +274,10 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 | Name                                                   | Description                                                                                                         | Default                       |
 | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
 | `recommender.replicaCount`                             | Number of replicas                                                                                                  | `1`                           |
+| `recommender.revisionHistoryLimit`                     | Number of old history to retain to allow rollback                                                                   | `10`                          |
 | `recommender.image.registry`                           | Image registry                                                                                                      | `registry.k8s.io`             |
 | `recommender.image.repository`                         | Image repository                                                                                                    | `autoscaling/vpa-recommender` |
-| `recommender.image.tag`                                | Image tag                                                                                                           | `1.3.0`                       |
+| `recommender.image.tag`                                | Image tag                                                                                                           | `1.5.0`                       |
 | `recommender.image.digest`                             | Image digest                                                                                                        | `""`                          |
 | `recommender.image.pullPolicy`                         | Image pull policy                                                                                                   | `IfNotPresent`                |
 | `recommender.pdb.create`                               | Specifies whether a pod disruption budget should be created                                                         | `false`                       |
@@ -260,13 +292,17 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 | `recommender.podAnnotations`                           | Additional pod annotations                                                                                          | `{}`                          |
 | `recommender.podLabels`                                | Additional pod labels                                                                                               | `{}`                          |
 | `recommender.podSecurityContext`                       | Pod security context                                                                                                |                               |
-| `recommender.podSecurityContext.runAsNonRoot`          | Whether the container must run as a non-root user                                                                   | `true`                        |
-| `recommender.podSecurityContext.runAsUser`             | The UID to run the entrypoint of the container process                                                              | `65534`                       |
-| `recommender.podSecurityContext.runAsGroup`            | The GID to run the entrypoint of the container process                                                              | `65534`                       |
+| `recommender.podSecurityContext.seccompProfile.type`   | Set pod's Security Context seccomp profile                                                                          | `RuntimeDefault`              |
 | `recommender.priorityClassName`                        | Priority class name                                                                                                 | `nil`                         |
 | `recommender.runtimeClassName`                         | Runtime class name                                                                                                  | `""`                          |
 | `recommender.topologySpreadConstraints`                | Topology Spread Constraints for pod assignment                                                                      | `[]`                          |
-| `recommender.securityContext`                          | Container security context                                                                                          | `{}`                          |
+| `recommender.securityContext`                          | Container security context                                                                                          |                               |
+| `recommender.securityContext.allowPrivilegeEscalation` | Set container's Security Context allowPrivilegeEscalation                                                           | `false`                       |
+| `recommender.securityContext.capabilities.drop`        | List of capabilities to be dropped                                                                                  | `["ALL"]`                     |
+| `recommender.securityContext.readOnlyRootFilesystem`   | Set container's Security Context readOnlyRootFilesystem                                                             | `true`                        |
+| `recommender.securityContext.runAsNonRoot`             | Whether the container must run as a non-root user                                                                   | `true`                        |
+| `recommender.securityContext.runAsUser`                | The UID to run the entrypoint of the container process                                                              | `65534`                       |
+| `recommender.securityContext.runAsGroup`               | The GID to run the entrypoint of the container process                                                              | `65534`                       |
 | `recommender.containerPorts.metrics`                   | Container port for Metrics                                                                                          | `8942`                        |
 | `recommender.livenessProbe.enabled`                    | Enable liveness probe                                                                                               | `true`                        |
 | `recommender.livenessProbe.initialDelaySeconds`        | Delay before the liveness probe is initiated                                                                        | `0`                           |
@@ -320,9 +356,10 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------- |
 | `updater.enabled`                                  | Enable the component                                                                                                | `true`                    |
 | `updater.replicaCount`                             | Number of replicas                                                                                                  | `1`                       |
+| `updater.revisionHistoryLimit`                     | Number of old history to retain to allow rollback                                                                   | `10`                      |
 | `updater.image.registry`                           | Image registry                                                                                                      | `registry.k8s.io`         |
 | `updater.image.repository`                         | Image repository                                                                                                    | `autoscaling/vpa-updater` |
-| `updater.image.tag`                                | Image tag                                                                                                           | `1.3.0`                   |
+| `updater.image.tag`                                | Image tag                                                                                                           | `1.5.0`                   |
 | `updater.image.digest`                             | Image digest                                                                                                        | `""`                      |
 | `updater.image.pullPolicy`                         | Image pull policy                                                                                                   | `IfNotPresent`            |
 | `updater.pdb.create`                               | Specifies whether a pod disruption budget should be created                                                         | `false`                   |
@@ -337,13 +374,17 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 | `updater.podAnnotations`                           | Additional pod annotations                                                                                          | `{}`                      |
 | `updater.podLabels`                                | Additional pod labels                                                                                               | `{}`                      |
 | `updater.podSecurityContext`                       | Pod security context                                                                                                |                           |
-| `updater.podSecurityContext.runAsNonRoot`          | Whether the container must run as a non-root user                                                                   | `true`                    |
-| `updater.podSecurityContext.runAsUser`             | The UID to run the entrypoint of the container process                                                              | `65534`                   |
-| `updater.podSecurityContext.runAsGroup`            | The GID to run the entrypoint of the container process                                                              | `65534`                   |
+| `updater.podSecurityContext.seccompProfile.type`   | Set pod's Security Context seccomp profile                                                                          | `RuntimeDefault`          |
 | `updater.priorityClassName`                        | Priority class name                                                                                                 | `nil`                     |
 | `updater.runtimeClassName`                         | Runtime class name                                                                                                  | `""`                      |
 | `updater.topologySpreadConstraints`                | Topology Spread Constraints for pod assignment                                                                      | `[]`                      |
-| `updater.securityContext`                          | Container security context                                                                                          | `{}`                      |
+| `updater.securityContext`                          | Container security context                                                                                          |                           |
+| `updater.securityContext.allowPrivilegeEscalation` | Set container's Security Context allowPrivilegeEscalation                                                           | `false`                   |
+| `updater.securityContext.capabilities.drop`        | List of capabilities to be dropped                                                                                  | `["ALL"]`                 |
+| `updater.securityContext.readOnlyRootFilesystem`   | Set container's Security Context readOnlyRootFilesystem                                                             | `true`                    |
+| `updater.securityContext.runAsNonRoot`             | Whether the container must run as a non-root user                                                                   | `true`                    |
+| `updater.securityContext.runAsUser`                | The UID to run the entrypoint of the container process                                                              | `65534`                   |
+| `updater.securityContext.runAsGroup`               | The GID to run the entrypoint of the container process                                                              | `65534`                   |
 | `updater.containerPorts.metrics`                   | Container port for Metrics                                                                                          | `8943`                    |
 | `updater.livenessProbe.enabled`                    | Enable liveness probe                                                                                               | `true`                    |
 | `updater.livenessProbe.initialDelaySeconds`        | Delay before the liveness probe is initiated                                                                        | `0`                       |
@@ -393,25 +434,29 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 
 ### CRDs parameters
 
-| Name                                   | Description                                            | Default           |
-| -------------------------------------- | ------------------------------------------------------ | ----------------- |
-| `crds.enabled`                         | Enable CRDs                                            | `true`            |
-| `crds.image.registry`                  | Image registry                                         | `docker.io`       |
-| `crds.image.repository`                | Image repository                                       | `bitnami/kubectl` |
-| `crds.image.tag`                       | Image tag                                              | `1.29.3`          |
-| `crds.image.digest`                    | Image digest                                           | `""`              |
-| `crds.image.pullPolicy`                | Image pull policy                                      | `IfNotPresent`    |
-| `crds.podAnnotations`                  | Additional pod annotations                             | `{}`              |
-| `crds.podLabels`                       | Additional pod labels                                  | `{}`              |
-| `crds.podSecurityContext`              | Pod security context                                   |                   |
-| `crds.podSecurityContext.runAsNonRoot` | Whether the container must run as a non-root user      | `true`            |
-| `crds.podSecurityContext.runAsUser`    | The UID to run the entrypoint of the container process | `1001`            |
-| `crds.podSecurityContext.runAsGroup`   | The GID to run the entrypoint of the container process | `1001`            |
-| `crds.securityContext`                 | Container security context                             | `{}`              |
-| `crds.resources`                       | CPU/Memory resource requests/limits                    | `{}`              |
-| `crds.nodeSelector`                    | Node labels for pod assignment                         | `{}`              |
-| `crds.tolerations`                     | Tolerations for pod assignment                         | `[]`              |
-| `crds.affinity`                        | Map of node/pod affinities                             | `{}`              |
+| Name                                            | Description                                               | Default                 |
+| ----------------------------------------------- | --------------------------------------------------------- | ----------------------- |
+| `crds.enabled`                                  | Enable CRDs                                               | `true`                  |
+| `crds.image.registry`                           | Image registry                                            | `docker.io`             |
+| `crds.image.repository`                         | Image repository                                          | `bitnamilegacy/kubectl` |
+| `crds.image.tag`                                | Image tag                                                 | `1.29.3`                |
+| `crds.image.digest`                             | Image digest                                              | `""`                    |
+| `crds.image.pullPolicy`                         | Image pull policy                                         | `IfNotPresent`          |
+| `crds.podAnnotations`                           | Additional pod annotations                                | `{}`                    |
+| `crds.podLabels`                                | Additional pod labels                                     | `{}`                    |
+| `crds.podSecurityContext`                       | Pod security context                                      |                         |
+| `crds.podSecurityContext.seccompProfile.type`   | Set pod's Security Context seccomp profile                | `RuntimeDefault`        |
+| `crds.securityContext`                          | Container security context                                |                         |
+| `crds.securityContext.allowPrivilegeEscalation` | Set container's Security Context allowPrivilegeEscalation | `false`                 |
+| `crds.securityContext.capabilities.drop`        | List of capabilities to be dropped                        | `["ALL"]`               |
+| `crds.securityContext.readOnlyRootFilesystem`   | Set container's Security Context readOnlyRootFilesystem   | `true`                  |
+| `crds.securityContext.runAsNonRoot`             | Whether the container must run as a non-root user         | `true`                  |
+| `crds.securityContext.runAsUser`                | The UID to run the entrypoint of the container process    | `65534`                 |
+| `crds.securityContext.runAsGroup`               | The GID to run the entrypoint of the container process    | `65534`                 |
+| `crds.resources`                                | CPU/Memory resource requests/limits                       | `{}`                    |
+| `crds.nodeSelector`                             | Node labels for pod assignment                            | `{}`                    |
+| `crds.tolerations`                              | Tolerations for pod assignment                            | `[]`                    |
+| `crds.affinity`                                 | Map of node/pod affinities                                | `{}`                    |
 
 ### Tests parameters
 
@@ -419,7 +464,7 @@ $ kubectl delete crd verticalpodautoscalercheckpoints.autoscaling.k8s.io
 | ------------------------ | ----------------- | -------------------- |
 | `tests.image.registry`   | Image registry    | `ghcr.io`            |
 | `tests.image.repository` | Image repository  | `cowboysysop/pytest` |
-| `tests.image.tag`        | Image tag         | `1.0.41`             |
+| `tests.image.tag`        | Image tag         | `1.2.0`              |
 | `tests.image.digest`     | Image digest      | `""`                 |
 | `tests.image.pullPolicy` | Image pull policy | `IfNotPresent`       |
 
@@ -432,6 +477,13 @@ $ helm install my-release \
     --set nameOverride=my-name cowboysysop/vertical-pod-autoscaler
 ```
 
+or for an OCI-based registry:
+
+```bash
+$ helm install my-release \
+    --set nameOverride=my-name oci://ghcr.io/cowboysysop/charts/vertical-pod-autoscaler
+```
+
 The above command sets the `nameOverride` to `my-name`.
 
 Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
@@ -439,6 +491,13 @@ Alternatively, a YAML file that specifies the values for the above parameters ca
 ```bash
 $ helm install my-release \
     --values values.yaml cowboysysop/vertical-pod-autoscaler
+```
+
+or for an OCI-based registry:
+
+```bash
+$ helm install my-release \
+    --values values.yaml oci://ghcr.io/cowboysysop/charts/vertical-pod-autoscaler
 ```
 
 **TIP**: You can use the default [values.yaml](values.yaml).

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/Chart.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/Chart.yaml
@@ -2,11 +2,10 @@ annotations:
   category: Infrastructure
   licenses: Apache-2.0
 apiVersion: v2
-appVersion: 2.21.0
+appVersion: 2.31.3
 description: A Library Helm Chart for grouping common logic between bitnami charts.
   This chart is not deployable by itself.
-home: https://bitnami.com
-icon: https://bitnami.com/downloads/logos/bitnami-mark.png
+home: https://github.com/cowboysysop/charts/tree/master/charts/common
 keywords:
 - common
 - helper
@@ -14,10 +13,10 @@ keywords:
 - function
 - bitnami
 maintainers:
-- name: Broadcom, Inc. All Rights Reserved.
-  url: https://github.com/bitnami/charts
+- email: sebastien.prudhomme@gmail.com
+  name: sebastien-prudhomme
 name: common
 sources:
-- https://github.com/bitnami/charts/tree/main/bitnami/common
+- https://github.com/cowboysysop/charts/tree/master/charts/common
 type: library
-version: 2.21.0
+version: 2.31.3

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/README.md
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/README.md
@@ -26,11 +26,20 @@ data:
 
 Looking to use our applications in production? Try [VMware Tanzu Application Catalog](https://bitnami.com/enterprise), the commercial edition of the Bitnami catalog.
 
+## ⚠️ Important Notice: Upcoming changes to the Bitnami Catalog
+
+Beginning August 28th, 2025, Bitnami will evolve its public catalog to offer a curated set of hardened, security-focused images under the new [Bitnami Secure Images initiative](https://news.broadcom.com/app-dev/broadcom-introduces-bitnami-secure-images-for-production-ready-containerized-applications). As part of this transition:
+
+- Granting community users access for the first time to security-optimized versions of popular container images.
+- Bitnami will begin deprecating support for non-hardened, Debian-based software images in its free tier and will gradually remove non-latest tags from the public catalog. As a result, community users will have access to a reduced number of hardened images. These images are published only under the “latest” tag and are intended for development purposes
+- Starting August 28th, over two weeks, all existing container images, including older or versioned tags (e.g., 2.50.0, 10.6), will be migrated from the public catalog (docker.io/bitnami) to the “Bitnami Legacy” repository (docker.io/bitnamilegacy), where they will no longer receive updates.
+- For production workloads and long-term support, users are encouraged to adopt Bitnami Secure Images, which include hardened containers, smaller attack surfaces, CVE transparency (via VEX/KEV), SBOMs, and enterprise support.
+
+These changes aim to improve the security posture of all Bitnami users by promoting best practices for software supply chain integrity and up-to-date deployments. For more details, visit the [Bitnami Secure Images announcement](https://github.com/bitnami/containers/issues/83267).
+
 ## Introduction
 
 This chart provides a common template helpers which can be used to develop new charts using [Helm](https://helm.sh) package manager.
-
-Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment and management of Helm Charts in clusters.
 
 ## Prerequisites
 
@@ -38,6 +47,152 @@ Bitnami charts can be used with [Kubeapps](https://kubeapps.dev/) for deployment
 - Helm 3.8.0+
 
 ## Parameters
+
+The following table lists the helpers available in the library which are scoped in different sections.
+
+### Affinities
+
+| Helper identifier               | Description                                          | Expected Input                                               |
+| ------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------ |
+| `common.affinities.nodes.soft`  | Return a soft nodeAffinity definition                | `dict "key" "FOO" "values" (list "BAR" "BAZ")`               |
+| `common.affinities.nodes.hard`  | Return a hard nodeAffinity definition                | `dict "key" "FOO" "values" (list "BAR" "BAZ")`               |
+| `common.affinities.nodes`       | Return a nodeAffinity definition                     | `dict "type" "soft" "key" "FOO" "values" (list "BAR" "BAZ")` |
+| `common.affinities.topologyKey` | Return a topologyKey definition                      | `dict "topologyKey" "FOO"`                                   |
+| `common.affinities.pods.soft`   | Return a soft podAffinity/podAntiAffinity definition | `dict "component" "FOO" "context" $`                         |
+| `common.affinities.pods.hard`   | Return a hard podAffinity/podAntiAffinity definition | `dict "component" "FOO" "context" $`                         |
+| `common.affinities.pods`        | Return a podAffinity/podAntiAffinity definition      | `dict "type" "soft" "key" "FOO" "values" (list "BAR" "BAZ")` |
+
+### Capabilities
+
+| Helper identifier                                         | Description                                                                                    | Expected Input                          |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `common.capabilities.kubeVersion`                         | Return the target Kubernetes version (using client default if .Values.kubeVersion is not set). | `.` Chart context                       |
+| `common.capabilities.apiVersions.has`                     | Return true if the apiVersion is supported                                                     | `dict "version" "batch/v1" "context" $` |
+| `common.capabilities.job.apiVersion`                      | Return the appropriate apiVersion for job.                                                     | `.` Chart context                       |
+| `common.capabilities.cronjob.apiVersion`                  | Return the appropriate apiVersion for cronjob.                                                 | `.` Chart context                       |
+| `common.capabilities.daemonset.apiVersion`                | Return the appropriate apiVersion for daemonset.                                               | `.` Chart context                       |
+| `common.capabilities.cronjob.apiVersion`                  | Return the appropriate apiVersion for cronjob.                                                 | `.` Chart context                       |
+| `common.capabilities.deployment.apiVersion`               | Return the appropriate apiVersion for deployment.                                              | `.` Chart context                       |
+| `common.capabilities.statefulset.apiVersion`              | Return the appropriate apiVersion for statefulset.                                             | `.` Chart context                       |
+| `common.capabilities.ingress.apiVersion`                  | Return the appropriate apiVersion for ingress.                                                 | `.` Chart context                       |
+| `common.capabilities.rbac.apiVersion`                     | Return the appropriate apiVersion for RBAC resources.                                          | `.` Chart context                       |
+| `common.capabilities.crd.apiVersion`                      | Return the appropriate apiVersion for CRDs.                                                    | `.` Chart context                       |
+| `common.capabilities.policy.apiVersion`                   | Return the appropriate apiVersion for podsecuritypolicy.                                       | `.` Chart context                       |
+| `common.capabilities.networkPolicy.apiVersion`            | Return the appropriate apiVersion for networkpolicy.                                           | `.` Chart context                       |
+| `common.capabilities.apiService.apiVersion`               | Return the appropriate apiVersion for APIService.                                              | `.` Chart context                       |
+| `common.capabilities.hpa.apiVersion`                      | Return the appropriate apiVersion for Horizontal Pod Autoscaler                                | `.` Chart context                       |
+| `common.capabilities.vpa.apiVersion`                      | Return the appropriate apiVersion for Vertical Pod Autoscaler.                                 | `.` Chart context                       |
+| `common.capabilities.psp.supported`                       | Returns true if PodSecurityPolicy is supported                                                 | `.` Chart context                       |
+| `common.capabilities.supportsHelmVersion`                 | Returns true if the used Helm version is 3.3+                                                  | `.` Chart context                       |
+| `common.capabilities.admissionConfiguration.supported`    | Returns true if AdmissionConfiguration is supported                                            | `.` Chart context                       |
+| `common.capabilities.admissionConfiguration.apiVersion`   | Return the appropriate apiVersion for AdmissionConfiguration.                                  | `.` Chart context                       |
+| `common.capabilities.podSecurityConfiguration.apiVersion` | Return the appropriate apiVersion for PodSecurityConfiguration.                                | `.` Chart context                       |
+
+### Compatibility
+
+| Helper identifier                            | Description                                                                                                                                                                                                                           | Expected Input                                                   |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `common.compatibility.isOpenshift`           | Return true if the detected platform is Openshift                                                                                                                                                                                     | `.` Chart context                                                |
+| `common.compatibility.renderSecurityContext` | Render a compatible securityContext depending on the platform. By default it is maintained as it is. In other platforms like Openshift we remove default user/group values that do not work out of the box with the restricted-v1 SCC | `dict "secContext" .Values.containerSecurityContext "context" $` |
+
+### Errors
+
+| Helper identifier                       | Description                                                                                                                                                            | Expected Input                                                                      |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `common.errors.upgrade.passwords.empty` | It will ensure required passwords are given when we are upgrading a chart. If `validationErrors` is not empty it will throw an error and will stop the upgrade action. | `dict "validationErrors" (list $validationError00 $validationError01)  "context" $` |
+| `common.errors.insecureImages`          | Throw error when original container images are replaced. The error can be bypassed by setting the `global.security.allowInsecureImages` to true.                       | `dict "images" (list .Values.path.to.the.imageRoot) "context" $`                    |
+
+### Images
+
+| Helper identifier                 | Description                                                                                                    | Expected Input                                                                                               |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `common.images.image`             | Return the proper and full image name                                                                          | `dict "imageRoot" .Values.path.to.the.image "global" $`, see [ImageRoot](#imageroot) for the structure.      |
+| `common.images.pullSecrets`       | Return the proper Docker Image Registry Secret Names (deprecated: use common.images.renderPullSecrets instead) | `dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "global" .Values.global`        |
+| `common.images.renderPullSecrets` | Return the proper Docker Image Registry Secret Names (evaluates values as templates)                           | `dict "images" (list .Values.path.to.the.image1, .Values.path.to.the.image2) "context" $`                    |
+| `common.images.version`           | Return the proper image version                                                                                | `dict "imageRoot" .Values.path.to.the.image "chart" .Chart` , see [ImageRoot](#imageroot) for the structure. |
+
+### Ingress
+
+| Helper identifier                         | Description                                                                                                       | Expected Input                                                                                                                                                                   |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `common.ingress.backend`                  | Generate a proper Ingress backend entry depending on the API version                                              | `dict "serviceName" "foo" "servicePort" "bar"`, see the [Ingress deprecation notice](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) for the syntax differences |
+| `common.ingress.supportsPathType`         | Prints "true" if the pathType field is supported                                                                  | `.` Chart context                                                                                                                                                                |
+| `common.ingress.supportsIngressClassname` | Prints "true" if the ingressClassname field is supported                                                          | `.` Chart context                                                                                                                                                                |
+| `common.ingress.certManagerRequest`       | Prints "true" if required cert-manager annotations for TLS signed certificates are set in the Ingress annotations | `dict "annotations" .Values.path.to.the.ingress.annotations`                                                                                                                     |
+
+### Labels
+
+| Helper identifier           | Description                                                                 | Expected Input    |
+| --------------------------- | --------------------------------------------------------------------------- | ----------------- |
+| `common.labels.standard`    | Return Kubernetes standard labels                                           | `.` Chart context |
+| `common.labels.matchLabels` | Labels to use on `deploy.spec.selector.matchLabels` and `svc.spec.selector` | `.` Chart context |
+
+### Names
+
+| Helper identifier                  | Description                                                           | Expected Input                                                                                |
+| ---------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `common.names.name`                | Expand the name of the chart or use `.Values.nameOverride`            | `.` Chart context                                                                             |
+| `common.names.fullname`            | Create a default fully qualified app name.                            | `.` Chart context                                                                             |
+| `common.names.namespace`           | Allow the release namespace to be overridden                          | `.` Chart context                                                                             |
+| `common.names.fullname.namespace`  | Create a fully qualified app name adding the installation's namespace | `.` Chart context                                                                             |
+| `common.names.chart`               | Chart name plus version                                               | `.` Chart context                                                                             |
+| `common.names.dependency.fullname` | Create a default fully qualified dependency name.                     | `dict "chartName" "dependency-chart-name" "chartValues" .Values.dependency-chart "context" $` |
+
+### Resources
+
+| Helper identifier         | Description                                                                                                                                 | Expected Input       |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `common.resources.preset` | Return a resource request/limit object based on a given preset. These presets are for basic testing and not meant to be used in production. | `dict "type" "nano"` |
+
+### Secrets
+
+| Helper identifier                 | Description                                                                            | Expected Input                                                                                                                                                                                                                                                                   |
+| --------------------------------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `common.secrets.name`             | Generate the name of the secret.                                                       | `dict "existingSecret" .Values.path.to.the.existingSecret "defaultNameSuffix" "mySuffix" "context" $` see [ExistingSecret](#existingsecret) for the structure.                                                                                                                   |
+| `common.secrets.key`              | Generate secret key.                                                                   | `dict "existingSecret" .Values.path.to.the.existingSecret "key" "keyName"` see [ExistingSecret](#existingsecret) for the structure.                                                                                                                                              |
+| `common.secrets.passwords.manage` | Generate secret password or retrieve one if already created.                           | `dict "secret" "secret-name" "key" "keyName" "providedValues" (list "path.to.password1" "path.to.password2") "length" 10 "strong" false "chartName" "chartName" "honorProvidedValues" false "context" $`, length, strong, honorProvidedValues and chartName fields are optional. |
+| `common.secrets.exists`           | Returns whether a previous generated secret already exists.                            | `dict "secret" "secret-name" "context" $`                                                                                                                                                                                                                                        |
+| `common.secrets.lookup`           | Reuses the value from an existing secret, otherwise sets its value to a default value. | `dict "secret" "secret-name" "key" "keyName" "defaultValue" .Values.myValue "context" $`                                                                                                                                                                                         |
+
+### Storage
+
+| Helper identifier      | Description                      | Expected Input                                                                                                      |
+| ---------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `common.storage.class` | Return  the proper Storage Class | `dict "persistence" .Values.path.to.the.persistence "global" $`, see [Persistence](#persistence) for the structure. |
+
+### TplValues
+
+| Helper identifier                  | Description                                                         | Expected Input                                                                                                                                           |
+| ---------------------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `common.tplvalues.render`          | Renders a value that contains template                              | `dict "value" .Values.path.to.the.Value "context" $`, value is the value should rendered as template, context frequently is the chart context `$` or `.` |
+| `common.tplvalues.merge`           | Merge a list of values that contains template after rendering them. | `dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $`                                                                 |
+| `common.tplvalues.merge-overwrite` | Merge a list of values that contains template after rendering them. | `dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $`                                                                 |
+
+### Utils
+
+| Helper identifier               | Description                                                                                                                                     | Expected Input                                                         |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `common.utils.fieldToEnvVar`    | Build environment variable name given a field.                                                                                                  | `dict "field" "my-password"`                                           |
+| `common.utils.secret.getvalue`  | Print instructions to get a secret value.                                                                                                       | `dict "secret" "secret-name" "field" "secret-value-field" "context" $` |
+| `common.utils.getValueFromKey`  | Gets a value from `.Values` object given its key path                                                                                           | `dict "key" "path.to.key" "context" $`                                 |
+| `common.utils.getKeyFromList`   | Returns first `.Values` key with a defined value or first of the list if all non-defined                                                        | `dict "keys" (list "path.to.key1" "path.to.key2") "context" $`         |
+| `common.utils.checksumTemplate` | Checksum a template at "path" containing a *single* resource (ConfigMap,Secret) for use in pod annotations, excluding the metadata (see #18376) | `dict "path" "/configmap.yaml" "context" $`                            |
+
+### Validations
+
+| Helper identifier                             | Description                                                                                                        | Expected Input                                                                                                                                                                                                                                                           |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `common.validations.values.single.empty`      | Validate a value must not be empty.                                                                                | `dict "valueKey" "path.to.value" "secret" "secret.name" "field" "my-password" "subchart" "subchart" "context" $` secret, field and subchart are optional. In case they are given, the helper will generate a how to get instruction. See [ValidateValue](#validatevalue) |
+| `common.validations.values.multiple.empty`    | Validate a multiple values must not be empty. It returns a shared error for all the values.                        | `dict "required" (list $validateValueConf00 $validateValueConf01) "context" $`. See [ValidateValue](#validatevalue)                                                                                                                                                      |
+| `common.validations.values.mariadb.passwords` | This helper will ensure required password for MariaDB are not empty. It returns a shared error for all the values. | `dict "secret" "mariadb-secret" "subchart" "true" "context" $` subchart field is optional and could be true or false it depends on where you will use mariadb chart and the helper.                                                                                      |
+
+### Warnings
+
+| Helper identifier                | Description                                                       | Expected Input                                             |
+| -------------------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------- |
+| `common.warnings.rollingTag`     | Warning about using rolling tag.                                  | `ImageRoot` see [ImageRoot](#imageroot) for the structure. |
+| `common.warnings.modifiedImages` | Warning about replaced images from the original.                  | `ImageRoot` see [ImageRoot](#imageroot) for the structure. |
+| `common.warnings.resources`      | Warning about not setting the resource object in all deployments. | `dict "sections" (list "path1" "path2") context $`         |
 
 ## Special input schemas
 
@@ -61,7 +216,7 @@ tag:
 
 pullPolicy:
   type: string
-  description: Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  description: Specify a imagePullPolicy.'
 
 pullSecrets:
   type: array
@@ -214,13 +369,13 @@ helm install test mychart --set path.to.value00="",path.to.value01=""
 
 #### Useful links
 
-- <https://docs.vmware.com/en/VMware-Tanzu-Application-Catalog/services/tutorials/GUID-resolve-helm2-helm3-post-migration-issues-index.html>
+- <https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-resolve-helm2-helm3-post-migration-issues-index.html>
 - <https://helm.sh/docs/topics/v2_v3_migration/>
 - <https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/>
 
 ## License
 
-Copyright &copy; 2024 Broadcom. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+Copyright &copy; 2025 Broadcom. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_affinities.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_affinities.tpl
@@ -60,13 +60,14 @@ Return a topologyKey definition
 
 {{/*
 Return a soft podAffinity/podAntiAffinity definition
-{{ include "common.affinities.pods.soft" (dict "component" "FOO" "customLabels" .Values.podLabels "extraMatchLabels" .Values.extraMatchLabels "topologyKey" "BAR" "extraPodAffinityTerms" .Values.extraPodAffinityTerms "context" $) -}}
+{{ include "common.affinities.pods.soft" (dict "component" "FOO" "customLabels" .Values.podLabels "extraMatchLabels" .Values.extraMatchLabels "topologyKey" "BAR" "extraPodAffinityTerms" .Values.extraPodAffinityTerms "extraNamespaces" (list "namespace1" "namespace2") "context" $) -}}
 */}}
 {{- define "common.affinities.pods.soft" -}}
 {{- $component := default "" .component -}}
 {{- $customLabels := default (dict) .customLabels -}}
 {{- $extraMatchLabels := default (dict) .extraMatchLabels -}}
 {{- $extraPodAffinityTerms := default (list) .extraPodAffinityTerms -}}
+{{- $extraNamespaces := default (list) .extraNamespaces -}}
 preferredDuringSchedulingIgnoredDuringExecution:
   - podAffinityTerm:
       labelSelector:
@@ -77,6 +78,13 @@ preferredDuringSchedulingIgnoredDuringExecution:
           {{- range $key, $value := $extraMatchLabels }}
           {{ $key }}: {{ $value | quote }}
           {{- end }}
+      {{- if $extraNamespaces }}
+      namespaces:
+        - {{ .context.Release.Namespace }}
+        {{- with $extraNamespaces }}
+        {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
       topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
     weight: 1
   {{- range $extraPodAffinityTerms }}
@@ -89,6 +97,13 @@ preferredDuringSchedulingIgnoredDuringExecution:
           {{- range $key, $value := .extraMatchLabels }}
           {{ $key }}: {{ $value | quote }}
           {{- end }}
+      {{- if .namespaces }}
+      namespaces:
+        - {{ $.context.Release.Namespace }}
+        {{- with .namespaces }}
+        {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
+        {{- end }}
+      {{- end }}
       topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
     weight: {{ .weight | default 1 -}}
   {{- end -}}
@@ -96,13 +111,14 @@ preferredDuringSchedulingIgnoredDuringExecution:
 
 {{/*
 Return a hard podAffinity/podAntiAffinity definition
-{{ include "common.affinities.pods.hard" (dict "component" "FOO" "customLabels" .Values.podLabels "extraMatchLabels" .Values.extraMatchLabels "topologyKey" "BAR" "extraPodAffinityTerms" .Values.extraPodAffinityTerms "context" $) -}}
+{{ include "common.affinities.pods.hard" (dict "component" "FOO" "customLabels" .Values.podLabels "extraMatchLabels" .Values.extraMatchLabels "topologyKey" "BAR" "extraPodAffinityTerms" .Values.extraPodAffinityTerms "extraNamespaces" (list "namespace1" "namespace2") "context" $) -}}
 */}}
 {{- define "common.affinities.pods.hard" -}}
 {{- $component := default "" .component -}}
 {{- $customLabels := default (dict) .customLabels -}}
 {{- $extraMatchLabels := default (dict) .extraMatchLabels -}}
 {{- $extraPodAffinityTerms := default (list) .extraPodAffinityTerms -}}
+{{- $extraNamespaces := default (list) .extraNamespaces -}}
 requiredDuringSchedulingIgnoredDuringExecution:
   - labelSelector:
       matchLabels: {{- (include "common.labels.matchLabels" ( dict "customLabels" $customLabels "context" .context )) | nindent 8 }}
@@ -112,6 +128,13 @@ requiredDuringSchedulingIgnoredDuringExecution:
         {{- range $key, $value := $extraMatchLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+    {{- if $extraNamespaces }}
+    namespaces:
+      - {{ .context.Release.Namespace }}
+      {{- with $extraNamespaces }}
+      {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}
+      {{- end }}
+    {{- end }}
     topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
   {{- range $extraPodAffinityTerms }}
   - labelSelector:
@@ -122,6 +145,13 @@ requiredDuringSchedulingIgnoredDuringExecution:
         {{- range $key, $value := .extraMatchLabels }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
+    {{- if .namespaces }}
+    namespaces:
+      - {{ $.context.Release.Namespace }}
+      {{- with .namespaces }}
+      {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}
+      {{- end }}
+    {{- end }}
     topologyKey: {{ include "common.affinities.topologyKey" (dict "topologyKey" .topologyKey) }}
   {{- end -}}
 {{- end -}}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_capabilities.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_capabilities.tpl
@@ -13,127 +13,94 @@ Return the target Kubernetes version
 {{- end -}}
 
 {{/*
+Return true if the apiVersion is supported
+Usage:
+{{ include "common.capabilities.apiVersions.has" (dict "version" "batch/v1" "context" $) }}
+*/}}
+{{- define "common.capabilities.apiVersions.has" -}}
+{{- $providedAPIVersions := default .context.Values.apiVersions ((.context.Values.global).apiVersions) -}}
+{{- if and (empty $providedAPIVersions) (.context.Capabilities.APIVersions.Has .version) -}}
+    {{- true -}}
+{{- else if has .version $providedAPIVersions -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the appropriate apiVersion for poddisruptionbudget.
 */}}
 {{- define "common.capabilities.policy.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.21-0" $kubeVersion) -}}
-{{- print "policy/v1beta1" -}}
-{{- else -}}
 {{- print "policy/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for networkpolicy.
 */}}
 {{- define "common.capabilities.networkPolicy.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.7-0" $kubeVersion) -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
 {{- print "networking.k8s.io/v1" -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for job.
+*/}}
+{{- define "common.capabilities.job.apiVersion" -}}
+{{- print "batch/v1" -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for cronjob.
 */}}
 {{- define "common.capabilities.cronjob.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.21-0" $kubeVersion) -}}
-{{- print "batch/v1beta1" -}}
-{{- else -}}
 {{- print "batch/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for daemonset.
 */}}
 {{- define "common.capabilities.daemonset.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.14-0" $kubeVersion) -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
 {{- print "apps/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for deployment.
 */}}
 {{- define "common.capabilities.deployment.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.14-0" $kubeVersion) -}}
-{{- print "extensions/v1beta1" -}}
-{{- else -}}
 {{- print "apps/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for statefulset.
 */}}
 {{- define "common.capabilities.statefulset.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.14-0" $kubeVersion) -}}
-{{- print "apps/v1beta1" -}}
-{{- else -}}
 {{- print "apps/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for ingress.
 */}}
 {{- define "common.capabilities.ingress.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if (.Values.ingress).apiVersion -}}
-{{- .Values.ingress.apiVersion -}}
-{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.14-0" $kubeVersion) -}}
-{{- print "extensions/v1beta1" -}}
-{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.19-0" $kubeVersion) -}}
-{{- print "networking.k8s.io/v1beta1" -}}
-{{- else -}}
 {{- print "networking.k8s.io/v1" -}}
-{{- end }}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for RBAC resources.
 */}}
 {{- define "common.capabilities.rbac.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.17-0" $kubeVersion) -}}
-{{- print "rbac.authorization.k8s.io/v1beta1" -}}
-{{- else -}}
 {{- print "rbac.authorization.k8s.io/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for CRDs.
 */}}
 {{- define "common.capabilities.crd.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.19-0" $kubeVersion) -}}
-{{- print "apiextensions.k8s.io/v1beta1" -}}
-{{- else -}}
 {{- print "apiextensions.k8s.io/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for APIService.
 */}}
 {{- define "common.capabilities.apiService.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.10-0" $kubeVersion) -}}
-{{- print "apiregistration.k8s.io/v1beta1" -}}
-{{- else -}}
 {{- print "apiregistration.k8s.io/v1" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
@@ -141,30 +108,18 @@ Return the appropriate apiVersion for Horizontal Pod Autoscaler.
 */}}
 {{- define "common.capabilities.hpa.apiVersion" -}}
 {{- $kubeVersion := include "common.capabilities.kubeVersion" .context -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.23-0" $kubeVersion) -}}
-{{- if .beta2 -}}
-{{- print "autoscaling/v2beta2" -}}
-{{- else -}}
-{{- print "autoscaling/v2beta1" -}}
-{{- end -}}
-{{- else -}}
 {{- print "autoscaling/v2" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
 Return the appropriate apiVersion for Vertical Pod Autoscaler.
 */}}
 {{- define "common.capabilities.vpa.apiVersion" -}}
-{{- $kubeVersion := include "common.capabilities.kubeVersion" .context -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.23-0" $kubeVersion) -}}
-{{- if .beta2 -}}
-{{- print "autoscaling/v2beta2" -}}
+{{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
+{{- print "autoscaling/v1beta2" -}}
 {{- else -}}
-{{- print "autoscaling/v2beta1" -}}
-{{- end -}}
-{{- else -}}
-{{- print "autoscaling/v2" -}}
+{{- print "autoscaling/v1" -}}
 {{- end -}}
 {{- end -}}
 
@@ -183,9 +138,7 @@ Returns true if AdmissionConfiguration is supported
 */}}
 {{- define "common.capabilities.admissionConfiguration.supported" -}}
 {{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if or (empty $kubeVersion) (not (semverCompare "<1.23-0" $kubeVersion)) -}}
   {{- true -}}
-{{- end -}}
 {{- end -}}
 
 {{/*
@@ -193,9 +146,7 @@ Return the appropriate apiVersion for AdmissionConfiguration.
 */}}
 {{- define "common.capabilities.admissionConfiguration.apiVersion" -}}
 {{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.23-0" $kubeVersion) -}}
-{{- print "apiserver.config.k8s.io/v1alpha1" -}}
-{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
 {{- print "apiserver.config.k8s.io/v1beta1" -}}
 {{- else -}}
 {{- print "apiserver.config.k8s.io/v1" -}}
@@ -207,9 +158,7 @@ Return the appropriate apiVersion for PodSecurityConfiguration.
 */}}
 {{- define "common.capabilities.podSecurityConfiguration.apiVersion" -}}
 {{- $kubeVersion := include "common.capabilities.kubeVersion" . -}}
-{{- if and (not (empty $kubeVersion)) (semverCompare "<1.23-0" $kubeVersion) -}}
-{{- print "pod-security.admission.config.k8s.io/v1alpha1" -}}
-{{- else if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
+{{- if and (not (empty $kubeVersion)) (semverCompare "<1.25-0" $kubeVersion) -}}
 {{- print "pod-security.admission.config.k8s.io/v1beta1" -}}
 {{- else -}}
 {{- print "pod-security.admission.config.k8s.io/v1" -}}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_compatibility.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_compatibility.tpl
@@ -34,9 +34,13 @@ Usage:
     {{- end -}}
   {{- end -}}
 {{- end -}}
+{{/* Remove empty seLinuxOptions object if global.compatibility.omitEmptySeLinuxOptions is set to true */}}
+{{- if and (((.context.Values.global).compatibility).omitEmptySeLinuxOptions) (not .secContext.seLinuxOptions) -}}
+  {{- $adaptedContext = omit $adaptedContext "seLinuxOptions" -}}
+{{- end -}}
 {{/* Remove fields that are disregarded when running the container in privileged mode */}}
 {{- if $adaptedContext.privileged -}}
-  {{- $adaptedContext = omit $adaptedContext "capabilities" "seLinuxOptions" -}}
+  {{- $adaptedContext = omit $adaptedContext "capabilities" -}}
 {{- end -}}
 {{- omit $adaptedContext "enabled" | toYaml -}}
 {{- end -}}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_errors.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_errors.tpl
@@ -5,7 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Through error when upgrading using empty passwords values that must not be empty.
+Throw error when upgrading using empty passwords values that must not be empty.
 
 Usage:
 {{- $validationError00 := include "common.validations.values.single.empty" (dict "valueKey" "path.to.password00" "secret" "secretName" "field" "password-00") -}}
@@ -25,4 +25,61 @@ Required password params:
     {{- $errorString = print $errorString "\n%s" -}}
     {{- printf $errorString $validationErrors | fail -}}
   {{- end -}}
+{{- end -}}
+
+{{/*
+Throw error when original container images are replaced.
+The error can be bypassed by setting the "global.security.allowInsecureImages" to true. In this case,
+a warning message will be shown instead.
+
+Usage:
+{{ include "common.errors.insecureImages" (dict "images" (list .Values.path.to.the.imageRoot) "context" $) }}
+*/}}
+{{- define "common.errors.insecureImages" -}}
+{{- $relocatedImages := list -}}
+{{- $replacedImages := list -}}
+{{- $retaggedImages := list -}}
+{{- $globalRegistry := ((.context.Values.global).imageRegistry) -}}
+{{- $originalImages := .context.Chart.Annotations.images -}}
+{{- range .images -}}
+  {{- $registryName := default .registry $globalRegistry -}}
+  {{- $fullImageNameNoTag := printf "%s/%s" $registryName .repository -}}
+  {{- $fullImageName := printf "%s:%s" $fullImageNameNoTag .tag -}}
+  {{- if not (contains $fullImageNameNoTag $originalImages) -}}
+    {{- if not (contains $registryName $originalImages) -}}
+      {{- $relocatedImages = append $relocatedImages $fullImageName  -}}
+    {{- else if not (contains .repository $originalImages) -}}
+      {{- $replacedImages = append $replacedImages $fullImageName  -}}
+    {{- end -}}
+  {{- end -}}
+  {{- if not (contains (printf "%s:%s" .repository .tag) $originalImages) -}}
+    {{- $retaggedImages = append $retaggedImages $fullImageName  -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if and (or (gt (len $relocatedImages) 0) (gt (len $replacedImages) 0)) (((.context.Values.global).security).allowInsecureImages) -}}
+  {{- print "\n\n⚠ SECURITY WARNING: Verifying original container images was skipped. Please note this Helm chart was designed, tested, and validated on multiple platforms using a specific set of Bitnami and Tanzu Application Catalog containers. Substituting other containers is likely to cause degraded security and performance, broken chart features, and missing environment variables.\n" -}}
+{{- else if (or (gt (len $relocatedImages) 0) (gt (len $replacedImages) 0)) -}}
+  {{- $errorString := "Original containers have been substituted for unrecognized ones. Deploying this chart with non-standard containers is likely to cause degraded security and performance, broken chart features, and missing environment variables." -}}
+  {{- $errorString = print $errorString "\n\nUnrecognized images:" -}}
+  {{- range (concat $relocatedImages $replacedImages) -}}
+    {{- $errorString = print $errorString "\n  - " . -}}
+  {{- end -}}
+  {{- if or (contains "docker.io/bitnami/" $originalImages) (contains "docker.io/bitnamiprem/" $originalImages) -}}
+    {{- $errorString = print "\n\n⚠ ERROR: " $errorString -}}
+    {{- $errorString = print $errorString "\n\nIf you are sure you want to proceed with non-standard containers, you can skip container image verification by setting the global parameter 'global.security.allowInsecureImages' to true." -}}
+    {{- $errorString = print $errorString "\nFurther information can be obtained at https://github.com/bitnami/charts/issues/30850" -}}
+    {{- print $errorString | fail -}}
+  {{- else if gt (len $replacedImages) 0 -}}
+    {{- $errorString = print "\n\n⚠ WARNING: " $errorString -}}
+    {{- print $errorString -}}
+  {{- end -}}
+{{- else if gt (len $retaggedImages) 0 -}}
+  {{- $warnString := "\n\n⚠ WARNING: Original containers have been retagged. Please note this Helm chart was tested, and validated on multiple platforms using a specific set of Tanzu Application Catalog containers. Substituting original image tags could cause unexpected behavior." -}}
+  {{- $warnString = print $warnString "\n\nRetagged images:" -}}
+  {{- range $retaggedImages -}}
+    {{- $warnString = print $warnString "\n  - " . -}}
+  {{- end -}}
+  {{- print $warnString -}}
+{{- end -}}
 {{- end -}}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_images.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_images.tpl
@@ -5,8 +5,9 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Return the proper image name
-{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" .Values.global ) }}
+Return the proper image name.
+If image tag and digest are not defined, termination fallbacks to chart appVersion.
+{{ include "common.images.image" ( dict "imageRoot" .Values.path.to.the.image "global" .Values.global "chart" .Chart ) }}
 */}}
 {{- define "common.images.image" -}}
 {{- $registryName := default .imageRoot.registry ((.global).imageRegistry) -}}
@@ -14,6 +15,11 @@ Return the proper image name
 {{- $separator := ":" -}}
 {{- $termination := .imageRoot.tag | toString -}}
 
+{{- if not .imageRoot.tag }}
+  {{- if .chart }}
+    {{- $termination = .chart.AppVersion | toString -}}
+  {{- end -}}
+{{- end -}}
 {{- if .imageRoot.digest }}
     {{- $separator = "@" -}}
     {{- $termination = .imageRoot.digest | toString -}}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_ingress.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_ingress.tpl
@@ -17,11 +17,6 @@ Params:
   - context - Dict - Required. The context for the template evaluation.
 */}}
 {{- define "common.ingress.backend" -}}
-{{- $apiVersion := (include "common.capabilities.ingress.apiVersion" .context) -}}
-{{- if or (eq $apiVersion "extensions/v1beta1") (eq $apiVersion "networking.k8s.io/v1beta1") -}}
-serviceName: {{ .serviceName }}
-servicePort: {{ .servicePort }}
-{{- else -}}
 service:
   name: {{ .serviceName }}
   port:
@@ -30,33 +25,6 @@ service:
     {{- else if or (typeIs "int" .servicePort) (typeIs "float64" .servicePort) }}
     number: {{ .servicePort | int }}
     {{- end }}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Print "true" if the API pathType field is supported
-Usage:
-{{ include "common.ingress.supportsPathType" . }}
-*/}}
-{{- define "common.ingress.supportsPathType" -}}
-{{- if (semverCompare "<1.18-0" (include "common.capabilities.kubeVersion" .)) -}}
-{{- print "false" -}}
-{{- else -}}
-{{- print "true" -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Returns true if the ingressClassname field is supported
-Usage:
-{{ include "common.ingress.supportsIngressClassname" . }}
-*/}}
-{{- define "common.ingress.supportsIngressClassname" -}}
-{{- if semverCompare "<1.18-0" (include "common.capabilities.kubeVersion" .) -}}
-{{- print "false" -}}
-{{- else -}}
-{{- print "true" -}}
-{{- end -}}
 {{- end -}}
 
 {{/*

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_names.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_names.tpl
@@ -28,10 +28,11 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- $releaseName := regexReplaceAll "(-?[^a-z\\d\\-])+-?" (lower .Release.Name) "-" -}}
+{{- if contains $name $releaseName -}}
+{{- $releaseName | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" $releaseName $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_secrets.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_secrets.tpl
@@ -67,7 +67,7 @@ Params:
 Generate secret password or retrieve one if already created.
 
 Usage:
-{{ include "common.secrets.passwords.manage" (dict "secret" "secret-name" "key" "keyName" "providedValues" (list "path.to.password1" "path.to.password2") "length" 10 "strong" false "chartName" "chartName" "context" $) }}
+{{ include "common.secrets.passwords.manage" (dict "secret" "secret-name" "key" "keyName" "providedValues" (list "path.to.password1" "path.to.password2") "length" 10 "strong" false "chartName" "chartName" "honorProvidedValues" false "context" $) }}
 
 Params:
   - secret - String - Required - Name of the 'Secret' resource where the password is stored.
@@ -80,12 +80,15 @@ Params:
   - failOnNew - Boolean - Optional - Default to true. If set to false, skip errors adding new keys to existing secrets.
   - skipB64enc - Boolean - Optional - Default to false. If set to true, no the secret will not be base64 encrypted.
   - skipQuote - Boolean - Optional - Default to false. If set to true, no quotes will be added around the secret.
+  - honorProvidedValues - Boolean - Optional - Default to false. If set to true, the values in providedValues have higher priority than an existing secret
 The order in which this function returns a secret password:
-  1. Already existing 'Secret' resource
-     (If a 'Secret' resource is found under the name provided to the 'secret' parameter to this function and that 'Secret' resource contains a key with the name passed as the 'key' parameter to this function then the value of this existing secret password will be returned)
-  2. Password provided via the values.yaml
+  1. Password provided via the values.yaml if honorProvidedValues = true
      (If one of the keys passed to the 'providedValues' parameter to this function is a valid path to a key in the values.yaml and has a value, the value of the first key with a value will be returned)
-  3. Randomly generated secret password
+  2. Already existing 'Secret' resource
+     (If a 'Secret' resource is found under the name provided to the 'secret' parameter to this function and that 'Secret' resource contains a key with the name passed as the 'key' parameter to this function then the value of this existing secret password will be returned)
+  3. Password provided via the values.yaml if honorProvidedValues = false
+     (If one of the keys passed to the 'providedValues' parameter to this function is a valid path to a key in the values.yaml and has a value, the value of the first key with a value will be returned)
+  4. Randomly generated secret password
      (A new random secret password with the length specified in the 'length' parameter will be generated and returned)
 
 */}}
@@ -106,9 +109,13 @@ The order in which this function returns a secret password:
   {{- end -}}
 {{- end }}
 
+{{- if and $providedPasswordValue .honorProvidedValues }}
+  {{- $password = tpl ($providedPasswordValue | toString) .context }}
+{{- end }}
+
 {{- if not $password }}
   {{- if $providedPasswordValue }}
-    {{- $password = $providedPasswordValue | toString }}
+    {{- $password = tpl ($providedPasswordValue | toString) .context }}
   {{- else }}
     {{- if .context.Values.enabled }}
       {{- $subchart = $chartName }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_tplvalues.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_tplvalues.tpl
@@ -36,3 +36,17 @@ Usage:
 {{- end -}}
 {{ $dst | toYaml }}
 {{- end -}}
+
+{{/*
+Merge a list of values that contains template after rendering them.
+Merge precedence is consistent with https://masterminds.github.io/sprig/dicts.html#mergeoverwrite-mustmergeoverwrite
+Usage:
+{{ include "common.tplvalues.merge-overwrite" ( dict "values" (list .Values.path.to.the.Value1 .Values.path.to.the.Value2) "context" $ ) }}
+*/}}
+{{- define "common.tplvalues.merge-overwrite" -}}
+{{- $dst := dict -}}
+{{- range .values -}}
+{{- $dst = include "common.tplvalues.render" (dict "value" . "context" $.context "scope" $.scope) | fromYaml | mergeOverwrite $dst -}}
+{{- end -}}
+{{ $dst | toYaml }}
+{{- end -}}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_warnings.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/_warnings.tpl
@@ -13,7 +13,7 @@ Usage:
 
 {{- if and (contains "bitnami/" .repository) (not (.tag | toString | regexFind "-r\\d+$|sha256:")) }}
 WARNING: Rolling tag detected ({{ .repository }}:{{ .tag }}), please note that it is strongly recommended to avoid using rolling tags in a production environment.
-+info https://docs.vmware.com/en/VMware-Tanzu-Application-Catalog/services/tutorials/GUID-understand-rolling-tags-containers-index.html
++info https://techdocs.broadcom.com/us/en/vmware-tanzu/application-catalog/tanzu-application-catalog/services/tac-doc/apps-tutorials-understand-rolling-tags-containers-index.html
 {{- end }}
 {{- end -}}
 

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/validations/_cassandra.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/validations/_cassandra.tpl
@@ -5,32 +5,6 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Validate Cassandra required passwords are not empty.
-
-Usage:
-{{ include "common.validations.values.cassandra.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}
-Params:
-  - secret - String - Required. Name of the secret where Cassandra values are stored, e.g: "cassandra-passwords-secret"
-  - subchart - Boolean - Optional. Whether Cassandra is used as subchart or not. Default: false
-*/}}
-{{- define "common.validations.values.cassandra.passwords" -}}
-  {{- $existingSecret := include "common.cassandra.values.existingSecret" . -}}
-  {{- $enabled := include "common.cassandra.values.enabled" . -}}
-  {{- $dbUserPrefix := include "common.cassandra.values.key.dbUser" . -}}
-  {{- $valueKeyPassword := printf "%s.password" $dbUserPrefix -}}
-
-  {{- if and (or (not $existingSecret) (eq $existingSecret "\"\"")) (eq $enabled "true") -}}
-    {{- $requiredPasswords := list -}}
-
-    {{- $requiredPassword := dict "valueKey" $valueKeyPassword "secret" .secret "field" "cassandra-password" -}}
-    {{- $requiredPasswords = append $requiredPasswords $requiredPassword -}}
-
-    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
-
-  {{- end -}}
-{{- end -}}
-
-{{/*
 Auxiliary function to get the right value for existingSecret.
 
 Usage:

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/validations/_mongodb.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/validations/_mongodb.tpl
@@ -5,52 +5,6 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Validate MongoDB&reg; required passwords are not empty.
-
-Usage:
-{{ include "common.validations.values.mongodb.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}
-Params:
-  - secret - String - Required. Name of the secret where MongoDB&reg; values are stored, e.g: "mongodb-passwords-secret"
-  - subchart - Boolean - Optional. Whether MongoDB&reg; is used as subchart or not. Default: false
-*/}}
-{{- define "common.validations.values.mongodb.passwords" -}}
-  {{- $existingSecret := include "common.mongodb.values.auth.existingSecret" . -}}
-  {{- $enabled := include "common.mongodb.values.enabled" . -}}
-  {{- $authPrefix := include "common.mongodb.values.key.auth" . -}}
-  {{- $architecture := include "common.mongodb.values.architecture" . -}}
-  {{- $valueKeyRootPassword := printf "%s.rootPassword" $authPrefix -}}
-  {{- $valueKeyUsername := printf "%s.username" $authPrefix -}}
-  {{- $valueKeyDatabase := printf "%s.database" $authPrefix -}}
-  {{- $valueKeyPassword := printf "%s.password" $authPrefix -}}
-  {{- $valueKeyReplicaSetKey := printf "%s.replicaSetKey" $authPrefix -}}
-  {{- $valueKeyAuthEnabled := printf "%s.enabled" $authPrefix -}}
-
-  {{- $authEnabled := include "common.utils.getValueFromKey" (dict "key" $valueKeyAuthEnabled "context" .context) -}}
-
-  {{- if and (or (not $existingSecret) (eq $existingSecret "\"\"")) (eq $enabled "true") (eq $authEnabled "true") -}}
-    {{- $requiredPasswords := list -}}
-
-    {{- $requiredRootPassword := dict "valueKey" $valueKeyRootPassword "secret" .secret "field" "mongodb-root-password" -}}
-    {{- $requiredPasswords = append $requiredPasswords $requiredRootPassword -}}
-
-    {{- $valueUsername := include "common.utils.getValueFromKey" (dict "key" $valueKeyUsername "context" .context) }}
-    {{- $valueDatabase := include "common.utils.getValueFromKey" (dict "key" $valueKeyDatabase "context" .context) }}
-    {{- if and $valueUsername $valueDatabase -}}
-        {{- $requiredPassword := dict "valueKey" $valueKeyPassword "secret" .secret "field" "mongodb-password" -}}
-        {{- $requiredPasswords = append $requiredPasswords $requiredPassword -}}
-    {{- end -}}
-
-    {{- if (eq $architecture "replicaset") -}}
-        {{- $requiredReplicaSetKey := dict "valueKey" $valueKeyReplicaSetKey "secret" .secret "field" "mongodb-replica-set-key" -}}
-        {{- $requiredPasswords = append $requiredPasswords $requiredReplicaSetKey -}}
-    {{- end -}}
-
-    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
-
-  {{- end -}}
-{{- end -}}
-
-{{/*
 Auxiliary function to get the right value for existingSecret.
 
 Usage:

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/validations/_mysql.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/validations/_mysql.tpl
@@ -5,47 +5,6 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Validate MySQL required passwords are not empty.
-
-Usage:
-{{ include "common.validations.values.mysql.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}
-Params:
-  - secret - String - Required. Name of the secret where MySQL values are stored, e.g: "mysql-passwords-secret"
-  - subchart - Boolean - Optional. Whether MySQL is used as subchart or not. Default: false
-*/}}
-{{- define "common.validations.values.mysql.passwords" -}}
-  {{- $existingSecret := include "common.mysql.values.auth.existingSecret" . -}}
-  {{- $enabled := include "common.mysql.values.enabled" . -}}
-  {{- $architecture := include "common.mysql.values.architecture" . -}}
-  {{- $authPrefix := include "common.mysql.values.key.auth" . -}}
-  {{- $valueKeyRootPassword := printf "%s.rootPassword" $authPrefix -}}
-  {{- $valueKeyUsername := printf "%s.username" $authPrefix -}}
-  {{- $valueKeyPassword := printf "%s.password" $authPrefix -}}
-  {{- $valueKeyReplicationPassword := printf "%s.replicationPassword" $authPrefix -}}
-
-  {{- if and (or (not $existingSecret) (eq $existingSecret "\"\"")) (eq $enabled "true") -}}
-    {{- $requiredPasswords := list -}}
-
-    {{- $requiredRootPassword := dict "valueKey" $valueKeyRootPassword "secret" .secret "field" "mysql-root-password" -}}
-    {{- $requiredPasswords = append $requiredPasswords $requiredRootPassword -}}
-
-    {{- $valueUsername := include "common.utils.getValueFromKey" (dict "key" $valueKeyUsername "context" .context) }}
-    {{- if not (empty $valueUsername) -}}
-        {{- $requiredPassword := dict "valueKey" $valueKeyPassword "secret" .secret "field" "mysql-password" -}}
-        {{- $requiredPasswords = append $requiredPasswords $requiredPassword -}}
-    {{- end -}}
-
-    {{- if (eq $architecture "replication") -}}
-        {{- $requiredReplicationPassword := dict "valueKey" $valueKeyReplicationPassword "secret" .secret "field" "mysql-replication-password" -}}
-        {{- $requiredPasswords = append $requiredPasswords $requiredReplicationPassword -}}
-    {{- end -}}
-
-    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
-
-  {{- end -}}
-{{- end -}}
-
-{{/*
 Auxiliary function to get the right value for existingSecret.
 
 Usage:

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/validations/_postgresql.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/validations/_postgresql.tpl
@@ -5,35 +5,6 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Validate PostgreSQL required passwords are not empty.
-
-Usage:
-{{ include "common.validations.values.postgresql.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}
-Params:
-  - secret - String - Required. Name of the secret where postgresql values are stored, e.g: "postgresql-passwords-secret"
-  - subchart - Boolean - Optional. Whether postgresql is used as subchart or not. Default: false
-*/}}
-{{- define "common.validations.values.postgresql.passwords" -}}
-  {{- $existingSecret := include "common.postgresql.values.existingSecret" . -}}
-  {{- $enabled := include "common.postgresql.values.enabled" . -}}
-  {{- $valueKeyPostgresqlPassword := include "common.postgresql.values.key.postgressPassword" . -}}
-  {{- $valueKeyPostgresqlReplicationEnabled := include "common.postgresql.values.key.replicationPassword" . -}}
-  {{- if and (or (not $existingSecret) (eq $existingSecret "\"\"")) (eq $enabled "true") -}}
-    {{- $requiredPasswords := list -}}
-    {{- $requiredPostgresqlPassword := dict "valueKey" $valueKeyPostgresqlPassword "secret" .secret "field" "postgresql-password" -}}
-    {{- $requiredPasswords = append $requiredPasswords $requiredPostgresqlPassword -}}
-
-    {{- $enabledReplication := include "common.postgresql.values.enabled.replication" . -}}
-    {{- if (eq $enabledReplication "true") -}}
-        {{- $requiredPostgresqlReplicationPassword := dict "valueKey" $valueKeyPostgresqlReplicationEnabled "secret" .secret "field" "postgresql-replication-password" -}}
-        {{- $requiredPasswords = append $requiredPasswords $requiredPostgresqlReplicationPassword -}}
-    {{- end -}}
-
-    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
-  {{- end -}}
-{{- end -}}
-
-{{/*
 Auxiliary function to decide whether evaluate global values.
 
 Usage:

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/validations/_redis.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/charts/common/templates/validations/_redis.tpl
@@ -6,39 +6,6 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{/* vim: set filetype=mustache: */}}
 {{/*
-Validate Redis&reg; required passwords are not empty.
-
-Usage:
-{{ include "common.validations.values.redis.passwords" (dict "secret" "secretName" "subchart" false "context" $) }}
-Params:
-  - secret - String - Required. Name of the secret where redis values are stored, e.g: "redis-passwords-secret"
-  - subchart - Boolean - Optional. Whether redis is used as subchart or not. Default: false
-*/}}
-{{- define "common.validations.values.redis.passwords" -}}
-  {{- $enabled := include "common.redis.values.enabled" . -}}
-  {{- $valueKeyPrefix := include "common.redis.values.keys.prefix" . -}}
-  {{- $standarizedVersion := include "common.redis.values.standarized.version" . }}
-
-  {{- $existingSecret := ternary (printf "%s%s" $valueKeyPrefix "auth.existingSecret") (printf "%s%s" $valueKeyPrefix "existingSecret") (eq $standarizedVersion "true") }}
-  {{- $existingSecretValue := include "common.utils.getValueFromKey" (dict "key" $existingSecret "context" .context) }}
-
-  {{- $valueKeyRedisPassword := ternary (printf "%s%s" $valueKeyPrefix "auth.password") (printf "%s%s" $valueKeyPrefix "password") (eq $standarizedVersion "true") }}
-  {{- $valueKeyRedisUseAuth := ternary (printf "%s%s" $valueKeyPrefix "auth.enabled") (printf "%s%s" $valueKeyPrefix "usePassword") (eq $standarizedVersion "true") }}
-
-  {{- if and (or (not $existingSecret) (eq $existingSecret "\"\"")) (eq $enabled "true") -}}
-    {{- $requiredPasswords := list -}}
-
-    {{- $useAuth := include "common.utils.getValueFromKey" (dict "key" $valueKeyRedisUseAuth "context" .context) -}}
-    {{- if eq $useAuth "true" -}}
-      {{- $requiredRedisPassword := dict "valueKey" $valueKeyRedisPassword "secret" .secret "field" "redis-password" -}}
-      {{- $requiredPasswords = append $requiredPasswords $requiredRedisPassword -}}
-    {{- end -}}
-
-    {{- include "common.validations.values.multiple.empty" (dict "required" $requiredPasswords "context" .context) -}}
-  {{- end -}}
-{{- end -}}
-
-{{/*
 Auxiliary function to get the right value for enabled redis.
 
 Usage:

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/files/crds/verticalpodautoscalercheckpoints.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/files/crds/verticalpodautoscalercheckpoints.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
   labels:
-    {{- include "vertical-pod-autoscaler.labels" . | nindent 4 }}
+    {{- include "vertical-pod-autoscaler.commonLabels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/files/crds/verticalpodautoscalers.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/files/crds/verticalpodautoscalers.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   name: verticalpodautoscalers.autoscaling.k8s.io
   labels:
-    {{- include "vertical-pod-autoscaler.labels" . | nindent 4 }}
+    {{- include "vertical-pod-autoscaler.commonLabels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
     {{- end }}
@@ -244,6 +244,7 @@ spec:
                     - "Off"
                     - Initial
                     - Recreate
+                    - InPlaceOrRecreate
                     - Auto
                     type: string
                 type: object

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/_helpers.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/_helpers.tpl
@@ -34,9 +34,9 @@ Create chart name and version as used by the chart label.
 {{/*
 Common labels
 */}}
-{{- define "vertical-pod-autoscaler.labels" -}}
+{{- define "vertical-pod-autoscaler.commonLabels" -}}
 helm.sh/chart: {{ include "vertical-pod-autoscaler.chart" . }}
-{{ include "vertical-pod-autoscaler.selectorLabels" . }}
+{{ include "vertical-pod-autoscaler.commonSelectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -44,9 +44,9 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{/*
-Selector labels
+Common selector labels
 */}}
-{{- define "vertical-pod-autoscaler.selectorLabels" -}}
+{{- define "vertical-pod-autoscaler.commonSelectorLabels" -}}
 app.kubernetes.io/name: {{ include "vertical-pod-autoscaler.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/_helpers.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/_helpers.tpl
@@ -21,10 +21,10 @@ app.kubernetes.io/component: admission-controller
 {{- end -}}
 
 {{/*
-Common labels
+Labels
 */}}
 {{- define "vertical-pod-autoscaler.admissionController.labels" -}}
-{{ include "vertical-pod-autoscaler.labels" . }}
+{{ include "vertical-pod-autoscaler.commonLabels" . }}
 {{ include "vertical-pod-autoscaler.admissionController.componentLabels" . }}
 {{- end -}}
 
@@ -32,7 +32,7 @@ Common labels
 Selector labels
 */}}
 {{- define "vertical-pod-autoscaler.admissionController.selectorLabels" -}}
-{{ include "vertical-pod-autoscaler.selectorLabels" . }}
+{{ include "vertical-pod-autoscaler.commonSelectorLabels" . }}
 {{ include "vertical-pod-autoscaler.admissionController.componentLabels" . }}
 {{- end -}}
 

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/clusterrole.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/clusterrole.yaml
@@ -69,6 +69,7 @@ rules:
       - delete
       - get
       - list
+      - patch
   - apiGroups:
       - "poc.autoscaling.k8s.io"
     resources:

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/clusterrolebinding.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/clusterrolebinding.yaml
@@ -18,5 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "vertical-pod-autoscaler.admissionController.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "vertical-pod-autoscaler.admissionController.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -14,6 +15,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.admissionController.replicaCount }}
+  revisionHistoryLimit: {{ .Values.admissionController.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "vertical-pod-autoscaler.admissionController.selectorLabels" . | nindent 6 }}
@@ -76,7 +78,7 @@ spec:
             {{- end }}
           env:
             - name: NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ include "common.names.namespace" . | quote }}
             {{- if .Values.admissionController.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.admissionController.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/metrics-service.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/metrics-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "vertical-pod-autoscaler.admissionController.metrics.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/pdb.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "vertical-pod-autoscaler.admissionController.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/service.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: vpa-webhook
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/serviceaccount.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "vertical-pod-autoscaler.admissionController.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/servicemonitor.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/servicemonitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "vertical-pod-autoscaler.admissionController.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.admissionController.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.admissionController.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.admissionController.metrics.serviceMonitor.labels }}
@@ -25,13 +25,13 @@ spec:
     - port: http-metrics
       {{- if .Values.admissionController.metrics.serviceMonitor.interval }}
       interval: {{ .Values.admissionController.metrics.serviceMonitor.interval }}
-      {{- end}}
+      {{- end }}
       {{- if .Values.admissionController.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.admissionController.metrics.serviceMonitor.scrapeTimeout }}
-      {{- end}}
+      {{- end }}
       {{- if .Values.admissionController.metrics.serviceMonitor.honorLabels }}
       honorLabels: {{ .Values.admissionController.metrics.serviceMonitor.honorLabels }}
-      {{- end}}
+      {{- end }}
       {{- if .Values.admissionController.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings: {{ toYaml .Values.admissionController.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
       {{- end }}
@@ -41,7 +41,7 @@ spec:
       path: /metrics
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace | quote }}
+      - {{ include "common.names.namespace" . | quote }}
   selector:
     matchLabels:
       {{- include "vertical-pod-autoscaler.admissionController.selectorLabels" . | nindent 6 }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/tls-secret.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/admission-controller/tls-secret.yaml
@@ -1,12 +1,13 @@
 {{- if .Values.admissionController.enabled }}
 {{- if not .Values.admissionController.tls.existingSecret }}
 {{- $ca := genCA (include "vertical-pod-autoscaler.admissionController.fullname" .) 365 }}
-{{- $cn := printf "%s.%s.svc" "vpa-webhook" .Release.Namespace }}
+{{- $cn := printf "%s.%s.svc" "vpa-webhook" (include "common.names.namespace" .) }}
 {{- $cert := genSignedCert $cn nil (list $cn) 365 $ca }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "vertical-pod-autoscaler.admissionController.tls.secretName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.admissionController.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/crds/_helpers.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/crds/_helpers.tpl
@@ -14,10 +14,10 @@ app.kubernetes.io/component: crds
 {{- end -}}
 
 {{/*
-Common labels
+Labels
 */}}
 {{- define "vertical-pod-autoscaler.crds.labels" -}}
-{{ include "vertical-pod-autoscaler.labels" . }}
+{{ include "vertical-pod-autoscaler.commonLabels" . }}
 {{ include "vertical-pod-autoscaler.crds.componentLabels" . }}
 {{- end -}}
 
@@ -25,6 +25,6 @@ Common labels
 Selector labels
 */}}
 {{- define "vertical-pod-autoscaler.crds.selectorLabels" -}}
-{{ include "vertical-pod-autoscaler.selectorLabels" . }}
+{{ include "vertical-pod-autoscaler.commonSelectorLabels" . }}
 {{ include "vertical-pod-autoscaler.crds.componentLabels" . }}
 {{- end -}}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/crds/clusterrolebinding.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/crds/clusterrolebinding.yaml
@@ -21,5 +21,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "vertical-pod-autoscaler.crds.fullname" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/crds/configmap.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/crds/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "vertical-pod-autoscaler.crds.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.crds.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -15,7 +16,7 @@ metadata:
     {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
     {{- end }}
 data:
-  {{- range $path, $_ := .Files.Glob  "files/crds/*" }}
+  {{- range $path, $_ := .Files.Glob  "files/crds/*.yaml" }}
   {{ base $path }}: |
     {{- tpl ($.Files.Get $path) $ | nindent 4 }}
   {{- end }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/crds/job.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/crds/job.yaml
@@ -1,8 +1,9 @@
 {{- if .Values.crds.enabled }}
-apiVersion: batch/v1
+apiVersion: {{ include "common.capabilities.job.apiVersion" . }}
 kind: Job
 metadata:
   name: {{ include "vertical-pod-autoscaler.crds.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.crds.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -42,7 +43,7 @@ spec:
           imagePullPolicy: {{ .Values.crds.image.pullPolicy }}
           args:
             - apply
-            {{- range $path, $_ := .Files.Glob  "files/crds/*" }}
+            {{- range $path, $_ := .Files.Glob  "files/crds/*.yaml" }}
             - --filename=/config/{{ base $path }}
             {{- end }}
           resources:

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/crds/serviceaccount.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/crds/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "vertical-pod-autoscaler.crds.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.crds.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/_helpers.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/_helpers.tpl
@@ -21,10 +21,10 @@ app.kubernetes.io/component: recommender
 {{- end -}}
 
 {{/*
-Common labels
+Labels
 */}}
 {{- define "vertical-pod-autoscaler.recommender.labels" -}}
-{{ include "vertical-pod-autoscaler.labels" . }}
+{{ include "vertical-pod-autoscaler.commonLabels" . }}
 {{ include "vertical-pod-autoscaler.recommender.componentLabels" . }}
 {{- end -}}
 
@@ -32,7 +32,7 @@ Common labels
 Selector labels
 */}}
 {{- define "vertical-pod-autoscaler.recommender.selectorLabels" -}}
-{{ include "vertical-pod-autoscaler.selectorLabels" . }}
+{{ include "vertical-pod-autoscaler.commonSelectorLabels" . }}
 {{ include "vertical-pod-autoscaler.recommender.componentLabels" . }}
 {{- end -}}
 

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/clusterrole.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/clusterrole.yaml
@@ -32,13 +32,16 @@ rules:
       - watch
   - apiGroups:
       - ""
+      - events.k8s.io
     resources:
       - events
     verbs:
+      - create
       - get
       - list
       - watch
-      - create
+      - patch
+      - update
   - apiGroups:
       - "poc.autoscaling.k8s.io"
     resources:

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/clusterrolebinding.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/clusterrolebinding.yaml
@@ -17,4 +17,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "vertical-pod-autoscaler.recommender.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "common.names.namespace" . | quote }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/deployment.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -13,6 +14,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.recommender.replicaCount }}
+  revisionHistoryLimit: {{ .Values.recommender.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "vertical-pod-autoscaler.recommender.selectorLabels" . | nindent 6 }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/metrics-service.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/metrics-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "vertical-pod-autoscaler.recommender.metrics.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/pdb.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/pdb.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/serviceaccount.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "vertical-pod-autoscaler.recommender.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/servicemonitor.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/recommender/servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "vertical-pod-autoscaler.recommender.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.recommender.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.recommender.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.recommender.labels" . | nindent 4 }}
     {{- if .Values.recommender.metrics.serviceMonitor.labels }}
@@ -24,13 +24,13 @@ spec:
     - port: http-metrics
       {{- if .Values.recommender.metrics.serviceMonitor.interval }}
       interval: {{ .Values.recommender.metrics.serviceMonitor.interval }}
-      {{- end}}
+      {{- end }}
       {{- if .Values.recommender.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.recommender.metrics.serviceMonitor.scrapeTimeout }}
-      {{- end}}
+      {{- end }}
       {{- if .Values.recommender.metrics.serviceMonitor.honorLabels }}
       honorLabels: {{ .Values.recommender.metrics.serviceMonitor.honorLabels }}
-      {{- end}}
+      {{- end }}
       {{- if .Values.recommender.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings: {{ toYaml .Values.recommender.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
       {{- end }}
@@ -40,7 +40,7 @@ spec:
       path: /metrics
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace | quote }}
+      - {{ include "common.names.namespace" . | quote }}
   selector:
     matchLabels:
       {{- include "vertical-pod-autoscaler.recommender.selectorLabels" . | nindent 6 }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/tests/_helpers.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/tests/_helpers.tpl
@@ -14,9 +14,9 @@ app.kubernetes.io/component: tests
 {{- end -}}
 
 {{/*
-Common labels
+Labels
 */}}
 {{- define "vertical-pod-autoscaler.tests.labels" -}}
-{{ include "vertical-pod-autoscaler.labels" . }}
+{{ include "vertical-pod-autoscaler.commonLabels" . }}
 {{ include "vertical-pod-autoscaler.tests.componentLabels" . }}
 {{- end -}}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/tests/configmap.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/tests/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "vertical-pod-autoscaler.tests.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.tests.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -18,7 +19,7 @@ data:
 
 
     def test_admission_controller_service_connection():
-        url = "https://vpa-webhook.{{ .Release.Namespace }}.svc:{{ .Values.admissionController.service.ports.https }}/"
+        url = "https://vpa-webhook.{{ include "common.names.namespace" . }}.svc:{{ .Values.admissionController.service.ports.https }}/"
         verify = "/admission-controller-tls-secret/ca.crt"
 
         response = requests.get(url, verify=verify)

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/tests/pod.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/tests/pod.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "vertical-pod-autoscaler.tests.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.tests.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/_helpers.tpl
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/_helpers.tpl
@@ -21,10 +21,10 @@ app.kubernetes.io/component: updater
 {{- end -}}
 
 {{/*
-Common labels
+Labels
 */}}
 {{- define "vertical-pod-autoscaler.updater.labels" -}}
-{{ include "vertical-pod-autoscaler.labels" . }}
+{{ include "vertical-pod-autoscaler.commonLabels" . }}
 {{ include "vertical-pod-autoscaler.updater.componentLabels" . }}
 {{- end -}}
 
@@ -32,7 +32,7 @@ Common labels
 Selector labels
 */}}
 {{- define "vertical-pod-autoscaler.updater.selectorLabels" -}}
-{{ include "vertical-pod-autoscaler.selectorLabels" . }}
+{{ include "vertical-pod-autoscaler.commonSelectorLabels" . }}
 {{ include "vertical-pod-autoscaler.updater.componentLabels" . }}
 {{- end -}}
 

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/clusterrole.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/clusterrole.yaml
@@ -25,13 +25,16 @@ rules:
       - watch
   - apiGroups:
       - ""
+      - events.k8s.io
     resources:
       - events
     verbs:
+      - create
       - get
       - list
       - watch
-      - create
+      - patch
+      - update
   - apiGroups:
       - "poc.autoscaling.k8s.io"
     resources:
@@ -124,4 +127,12 @@ rules:
       - get
       - watch
       - update
+  # system:vpa-updater-in-place
+  - apiGroups:
+      - ""
+    resources:
+      - pods/resize
+      - pods
+    verbs:
+      - patch
 {{- end }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/clusterrolebinding.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/clusterrolebinding.yaml
@@ -18,5 +18,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "vertical-pod-autoscaler.updater.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
+    namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/deployment.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}
@@ -14,6 +15,7 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.updater.replicaCount }}
+  revisionHistoryLimit: {{ .Values.updater.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "vertical-pod-autoscaler.updater.selectorLabels" . | nindent 6 }}
@@ -67,7 +69,7 @@ spec:
             {{- end }}
           env:
             - name: NAMESPACE
-              value: {{ .Release.Namespace }}
+              value: {{ include "common.names.namespace" . | quote }}
             {{- if .Values.updater.extraEnvVars }}
             {{- include "common.tplvalues.render" (dict "value" .Values.updater.extraEnvVars "context" $) | nindent 12 }}
             {{- end }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/metrics-service.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/metrics-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.metrics.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/pdb.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/pdb.yaml
@@ -4,6 +4,7 @@ apiVersion: {{ include "common.capabilities.policy.apiVersion" . }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/serviceaccount.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.serviceAccountName" . }}
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/servicemonitor.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/templates/updater/servicemonitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "vertical-pod-autoscaler.updater.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.updater.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default (include "common.names.namespace" .) .Values.updater.metrics.serviceMonitor.namespace | quote }}
   labels:
     {{- include "vertical-pod-autoscaler.updater.labels" . | nindent 4 }}
     {{- if .Values.updater.metrics.serviceMonitor.labels }}
@@ -25,13 +25,13 @@ spec:
     - port: http-metrics
       {{- if .Values.updater.metrics.serviceMonitor.interval }}
       interval: {{ .Values.updater.metrics.serviceMonitor.interval }}
-      {{- end}}
+      {{- end }}
       {{- if .Values.updater.metrics.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.updater.metrics.serviceMonitor.scrapeTimeout }}
-      {{- end}}
+      {{- end }}
       {{- if .Values.updater.metrics.serviceMonitor.honorLabels }}
       honorLabels: {{ .Values.updater.metrics.serviceMonitor.honorLabels }}
-      {{- end}}
+      {{- end }}
       {{- if .Values.updater.metrics.serviceMonitor.metricRelabelings }}
       metricRelabelings: {{ toYaml .Values.updater.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
       {{- end }}
@@ -41,7 +41,7 @@ spec:
       path: /metrics
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace | quote }}
+      - {{ include "common.names.namespace" . | quote }}
   selector:
     matchLabels:
       {{- include "vertical-pod-autoscaler.updater.selectorLabels" . | nindent 6 }}

--- a/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
+++ b/packages/system/vertical-pod-autoscaler/charts/vertical-pod-autoscaler/values.yaml
@@ -22,6 +22,9 @@ nameOverride: ""
 ## @param fullnameOverride Fully override `vertical-pod-autoscaler.fullname` template with a string
 fullnameOverride: ""
 
+## @param namespaceOverride Fully override `common.names.namespace` template with a string
+namespaceOverride: ""
+
 ## @param commonAnnotations Annotations to add to all deployed objects
 commonAnnotations: {}
 
@@ -34,11 +37,14 @@ extraDeploy: []
 ## @section Admission controller parameters
 
 admissionController:
-## @param admissionController.enabled Enable the component
+  ## @param admissionController.enabled Enable the component
   enabled: true
 
   ## @param admissionController.replicaCount Number of replicas
   replicaCount: 1
+
+  ## @param admissionController.revisionHistoryLimit Number of old history to retain to allow rollback
+  revisionHistoryLimit: 10
 
   image:
     ## @param admissionController.image.registry Image registry
@@ -48,7 +54,7 @@ admissionController:
     repository: autoscaling/vpa-admission-controller
 
     ## @param admissionController.image.tag Image tag
-    tag: 1.3.0
+    tag: 1.5.1
 
     ## @param admissionController.image.digest Image digest
     digest: ""
@@ -93,14 +99,10 @@ admissionController:
   podLabels: {}
 
   ## @extra admissionController.podSecurityContext Pod security context
-  ## @param admissionController.podSecurityContext.runAsNonRoot Whether the container must run as a non-root user
-  ## @param admissionController.podSecurityContext.runAsUser The UID to run the entrypoint of the container process
-  ## @param admissionController.podSecurityContext.runAsGroup The GID to run the entrypoint of the container process
+  ## @param admissionController.podSecurityContext.seccompProfile.type Set pod's Security Context seccomp profile
   podSecurityContext:
-    # fsGroup: 2000
-    runAsNonRoot: true
-    runAsUser: 65534
-    runAsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
 
   ## @param admissionController.hostNetwork Use the host network
   hostNetwork: false
@@ -115,14 +117,22 @@ admissionController:
   ## @param admissionController.topologySpreadConstraints Topology Spread Constraints for pod assignment
   topologySpreadConstraints: []
 
-  ## @param admissionController.securityContext Container security context
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  ## @extra admissionController.securityContext Container security context
+  ## @param admissionController.securityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+  ## @param admissionController.securityContext.capabilities.drop List of capabilities to be dropped
+  ## @param admissionController.securityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+  ## @param admissionController.securityContext.runAsNonRoot Whether the container must run as a non-root user
+  ## @param admissionController.securityContext.runAsUser The UID to run the entrypoint of the container process
+  ## @param admissionController.securityContext.runAsGroup The GID to run the entrypoint of the container process
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
 
   containerPorts:
     ## @param admissionController.containerPorts.https Container port for HTTPS
@@ -217,12 +227,12 @@ admissionController:
 
   ## @param admissionController.resources CPU/Memory resource requests/limits
   resources: {}
-    # limits:
-    #   cpu: 200m
-    #   memory: 512Mi
     # requests:
     #   cpu: 50m
     #   memory: 256Mi
+    # limits:
+    #   cpu: 200m
+    #   memory: 512Mi
 
   ## @param admissionController.nodeSelector Node labels for pod assignment
   nodeSelector: {}
@@ -236,8 +246,8 @@ admissionController:
   ## @extra admissionController.extraArgs [object] Additional container arguments
   ## @param admissionController.extraArgs.v Number for the log level verbosity
   extraArgs:
-    # kube-api-burst: 10
-    # kube-api-qps: 5
+    # kube-api-burst: 100
+    # kube-api-qps: 50
     v: 2
     # vpa-object-namespace: ""
     # webhook-timeout-seconds: 30
@@ -328,8 +338,11 @@ admissionController:
 ## @section Recommender parameters
 
 recommender:
-## @param recommender.replicaCount Number of replicas
+  ## @param recommender.replicaCount Number of replicas
   replicaCount: 1
+
+  ## @param recommender.revisionHistoryLimit Number of old history to retain to allow rollback
+  revisionHistoryLimit: 10
 
   image:
     ## @param recommender.image.registry Image registry
@@ -339,7 +352,7 @@ recommender:
     repository: autoscaling/vpa-recommender
 
     ## @param recommender.image.tag Image tag
-    tag: 1.3.0
+    tag: 1.5.1
 
     ## @param recommender.image.digest Image digest
     digest: ""
@@ -384,14 +397,10 @@ recommender:
   podLabels: {}
 
   ## @extra recommender.podSecurityContext Pod security context
-  ## @param recommender.podSecurityContext.runAsNonRoot Whether the container must run as a non-root user
-  ## @param recommender.podSecurityContext.runAsUser The UID to run the entrypoint of the container process
-  ## @param recommender.podSecurityContext.runAsGroup The GID to run the entrypoint of the container process
+  ## @param recommender.podSecurityContext.seccompProfile.type Set pod's Security Context seccomp profile
   podSecurityContext:
-    # fsGroup: 2000
-    runAsNonRoot: true
-    runAsUser: 65534
-    runAsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
 
   ## @param recommender.priorityClassName Priority class name
   priorityClassName:
@@ -403,14 +412,22 @@ recommender:
   ## @param recommender.topologySpreadConstraints Topology Spread Constraints for pod assignment
   topologySpreadConstraints: []
 
-  ## @param recommender.securityContext Container security context
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  ## @extra recommender.securityContext Container security context
+  ## @param recommender.securityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+  ## @param recommender.securityContext.capabilities.drop List of capabilities to be dropped
+  ## @param recommender.securityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+  ## @param recommender.securityContext.runAsNonRoot Whether the container must run as a non-root user
+  ## @param recommender.securityContext.runAsUser The UID to run the entrypoint of the container process
+  ## @param recommender.securityContext.runAsGroup The GID to run the entrypoint of the container process
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
 
   containerPorts:
     ## @param recommender.containerPorts.metrics Container port for Metrics
@@ -475,12 +492,12 @@ recommender:
 
   ## @param recommender.resources CPU/Memory resource requests/limits
   resources: {}
-    # limits:
-    #   cpu: 200m
-    #   memory: 1024Mi
     # requests:
     #   cpu: 50m
     #   memory: 512Mi
+    # limits:
+    #   cpu: 200m
+    #   memory: 1024Mi
 
   ## @param recommender.nodeSelector Node labels for pod assignment
   nodeSelector: {}
@@ -506,8 +523,8 @@ recommender:
     # history-length: 8d
     # history-resolution: 1h
     # ignored-vpa-object-namespaces: ""
-    # kube-api-burst: 10
-    # kube-api-qps: 5
+    # kube-api-burst: 100
+    # kube-api-qps: 50
     # leader-elect: false
     # leader-elect-lease-duration: 15s
     # leader-elect-renew-deadline: 10s
@@ -520,7 +537,6 @@ recommender:
     # memory-histogram-decay-half-life: 24h0m0s
     # memory-saver: false
     # metric-for-pod-labels: up{job="kubernetes-pods"}
-    # min-checkpoints: 10
     # oom-bump-up-ratio: 1.2
     # oom-min-bump-up-bytes: 104857600
     # password: ""
@@ -542,6 +558,7 @@ recommender:
     # storage: checkpoint
     # target-cpu-percentile: 0.9
     # target-memory-percentile: 0.9
+    # update-worker-count: 10
     # use-external-metrics: false
     # username: ""
     v: 2
@@ -620,11 +637,14 @@ recommender:
 ## @section Updater parameters
 
 updater:
-## @param updater.enabled Enable the component
+  ## @param updater.enabled Enable the component
   enabled: true
 
   ## @param updater.replicaCount Number of replicas
   replicaCount: 1
+
+  ## @param updater.revisionHistoryLimit Number of old history to retain to allow rollback
+  revisionHistoryLimit: 10
 
   image:
     ## @param updater.image.registry Image registry
@@ -634,7 +654,7 @@ updater:
     repository: autoscaling/vpa-updater
 
     ## @param updater.image.tag Image tag
-    tag: 1.3.0
+    tag: 1.5.1
 
     ## @param updater.image.digest Image digest
     digest: ""
@@ -679,14 +699,10 @@ updater:
   podLabels: {}
 
   ## @extra updater.podSecurityContext Pod security context
-  ## @param updater.podSecurityContext.runAsNonRoot Whether the container must run as a non-root user
-  ## @param updater.podSecurityContext.runAsUser The UID to run the entrypoint of the container process
-  ## @param updater.podSecurityContext.runAsGroup The GID to run the entrypoint of the container process
+  ## @param updater.podSecurityContext.seccompProfile.type Set pod's Security Context seccomp profile
   podSecurityContext:
-    # fsGroup: 2000
-    runAsNonRoot: true
-    runAsUser: 65534
-    runAsGroup: 65534
+    seccompProfile:
+      type: RuntimeDefault
 
   ## @param updater.priorityClassName Priority class name
   priorityClassName:
@@ -698,14 +714,22 @@ updater:
   ## @param updater.topologySpreadConstraints Topology Spread Constraints for pod assignment
   topologySpreadConstraints: []
 
-  ## @param updater.securityContext Container security context
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  ## @extra updater.securityContext Container security context
+  ## @param updater.securityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+  ## @param updater.securityContext.capabilities.drop List of capabilities to be dropped
+  ## @param updater.securityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+  ## @param updater.securityContext.runAsNonRoot Whether the container must run as a non-root user
+  ## @param updater.securityContext.runAsUser The UID to run the entrypoint of the container process
+  ## @param updater.securityContext.runAsGroup The GID to run the entrypoint of the container process
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
 
   containerPorts:
     ## @param updater.containerPorts.metrics Container port for Metrics
@@ -770,12 +794,12 @@ updater:
 
   ## @param updater.resources CPU/Memory resource requests/limits
   resources: {}
-    # limits:
-    #   cpu: 200m
-    #   memory: 1024Mi
     # requests:
     #   cpu: 50m
     #   memory: 512Mi
+    # limits:
+    #   cpu: 200m
+    #   memory: 1024Mi
 
   ## @param updater.nodeSelector Node labels for pod assignment
   nodeSelector: {}
@@ -795,8 +819,8 @@ updater:
     # eviction-tolerance: 0.5
     # ignored-vpa-object-namespaces: ""
     # in-recommendation-bounds-eviction-lifetime-threshold: 12h0m0s
-    # kube-api-burst: 10
-    # kube-api-qps: 5
+    # kube-api-burst: 100
+    # kube-api-qps: 50
     # leader-elect: false
     # leader-elect-lease-duration: 15s
     # leader-elect-renew-deadline: 10s
@@ -892,7 +916,7 @@ crds:
     registry: docker.io
 
     ## @param crds.image.repository Image repository
-    repository: bitnami/kubectl
+    repository: bitnamilegacy/kubectl
 
     ## @param crds.image.tag Image tag
     tag: 1.29.3
@@ -910,30 +934,34 @@ crds:
   podLabels: {}
 
   ## @extra crds.podSecurityContext Pod security context
-  ## @param crds.podSecurityContext.runAsNonRoot Whether the container must run as a non-root user
-  ## @param crds.podSecurityContext.runAsUser The UID to run the entrypoint of the container process
-  ## @param crds.podSecurityContext.runAsGroup The GID to run the entrypoint of the container process
+  ## @param crds.podSecurityContext.seccompProfile.type Set pod's Security Context seccomp profile
   podSecurityContext:
-    # fsGroup: 2000
-    runAsNonRoot: true
-    runAsUser: 1001
-    runAsGroup: 1001
+    seccompProfile:
+      type: RuntimeDefault
 
-  ## @param crds.securityContext Container security context
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  ## @extra crds.securityContext Container security context
+  ## @param crds.securityContext.allowPrivilegeEscalation Set container's Security Context allowPrivilegeEscalation
+  ## @param crds.securityContext.capabilities.drop List of capabilities to be dropped
+  ## @param crds.securityContext.readOnlyRootFilesystem Set container's Security Context readOnlyRootFilesystem
+  ## @param crds.securityContext.runAsNonRoot Whether the container must run as a non-root user
+  ## @param crds.securityContext.runAsUser The UID to run the entrypoint of the container process
+  ## @param crds.securityContext.runAsGroup The GID to run the entrypoint of the container process
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
 
   ## @param crds.resources CPU/Memory resource requests/limits
   resources: {}
-    # limits:
+    # requests:
     #   cpu: 100m
     #   memory: 128Mi
-    # requests:
+    # limits:
     #   cpu: 100m
     #   memory: 128Mi
 
@@ -957,7 +985,7 @@ tests:
     repository: cowboysysop/pytest
 
     ## @param tests.image.tag Image tag
-    tag: 1.0.41
+    tag: 1.2.0
 
     ## @param tests.image.digest Image digest
     digest: ""

--- a/packages/system/vertical-pod-autoscaler/templates/vpa-for-vpa.yaml
+++ b/packages/system/vertical-pod-autoscaler/templates/vpa-for-vpa.yaml
@@ -69,7 +69,7 @@ spec:
     kind: Deployment
     name: {{ dig "vertical-pod-autoscaler" "nameOverride" "" .Values.AsMap | default "vertical-pod-autoscaler" | trunc 63 | trimSuffix "-" }}-recommender
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
 ---
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
@@ -82,5 +82,5 @@ spec:
     kind: Deployment
     name: vpa-for-vpa-recommender
   updatePolicy:
-    updateMode: Auto
+    updateMode: Recreate
 {{- end }}

--- a/packages/system/vertical-pod-autoscaler/tests/vpa_test.yaml
+++ b/packages/system/vertical-pod-autoscaler/tests/vpa_test.yaml
@@ -1,0 +1,30 @@
+suite: cozy-vertical-pod-autoscaler chart rendering invariants
+release:
+  name: vpa
+  namespace: cozy-vertical-pod-autoscaler
+tests:
+  - it: drives the recommender off cluster prometheus (cozystack storage config)
+    template: charts/vertical-pod-autoscaler/templates/recommender/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--storage=prometheus"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--prometheus-address=http://vmselect-shortterm.tenant-root.svc.cozy.local:8481/select/0/prometheus/"
+
+  - it: renders the recommender on the upstream registry.k8s.io image, not Bitnami
+    template: charts/vertical-pod-autoscaler/templates/recommender/deployment.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^registry\.k8s\.io/autoscaling/vpa-recommender:'
+
+  # Cozystack disables the bundled CRD-install Job (crds.enabled: false) — CRDs
+  # are managed out-of-band — so the upstream chart's Bitnami-based kubectl
+  # Job (and the Bitnami image override it would otherwise need) never renders.
+  - it: does not emit the CRD-install Job when crds.enabled is false
+    template: charts/vertical-pod-autoscaler/templates/crds/job.yaml
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/packages/system/vertical-pod-autoscaler/tests/vpa_test.yaml
+++ b/packages/system/vertical-pod-autoscaler/tests/vpa_test.yaml
@@ -28,3 +28,18 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # updateMode Auto is deprecated since VPA 1.4 (an alias for Recreate that will
+  # be removed in a future API version). Pin the vpa-for-vpa
+  # VerticalPodAutoscalers to the explicit, non-deprecated Recreate so the bump
+  # does not leave a deprecated value behind.
+  - it: pins the vpa-for-vpa VerticalPodAutoscalers to updateMode Recreate
+    template: templates/vpa-for-vpa.yaml
+    documentSelector:
+      path: kind
+      value: VerticalPodAutoscaler
+      matchMany: true
+    asserts:
+      - equal:
+          path: spec.updatePolicy.updateMode
+          value: Recreate


### PR DESCRIPTION
## What this PR does

Bumps the vertical-pod-autoscaler chart from 10.0.0 to 11.1.1 (app 1.3.0 → 1.5.0, latest upstream), moving the VPA components (admission-controller, recommender, updater) to `registry.k8s.io/autoscaling/vpa-*:1.5.1` and picking up the published security fixes the issue enumerates.

The chart-major bump keeps every cozystack override valid: the recommender's prometheus storage config (`storage=prometheus`, `prometheus-address`, container labels), `crds.enabled: false`, and the updater/admissionController resource blocks.

Two Bitnami-adjacent details, both correctly neutralized:

- Upstream 11.0 switched the bundled CRD-install Job image to `bitnamilegacy/kubectl`. cozystack disables that Job (`crds.enabled: false`) and overrides `crds.image` to `docker.io/alpine/k8s`, so no Bitnami image is ever pulled — verified by render.
- The `common` library subchart dependency moved off the sunset Bitnami repo (`charts.bitnami.com` → `oci://ghcr.io/cowboysysop/charts`), a free supply-chain improvement.

VPA 1.5 deprecations (humanized memory flag, UpdateMode `Auto`) are not used by cozystack.

Adds helm-unittest coverage (the package shipped none): pins the recommender prometheus args, the non-Bitnami `registry.k8s.io` image, and the `crds.enabled=false` → no CRD-install Job invariant. `helm unittest` 3/3 pass.

Closes #2882

### Release note

```release-note
chore(vertical-pod-autoscaler): bump VPA to 11.1.1 (app 1.5.0)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `InPlaceOrRecreate` pod update mode.
  * Improved OCI-based Helm install/upgrade documentation and examples.
* **Improvements**
  * Updated chart/component versions (including VPA components to 1.5.x and chart to 11.1.1).
  * Hardened security defaults (seccomp RuntimeDefault and container hardening) and added image integrity checks during upgrades.
  * Expanded RBAC permissions for admission controller and event/workload handling.
* **Chores**
  * Updated the shared Helm library version and refreshed chart tests/invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->