### PR TITLE
chore(nats): bump nats to 1.3.16

### DIFF
--- a/packages/system/nats/Makefile
+++ b/packages/system/nats/Makefile
@@ -1,7 +1,10 @@
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	helm repo add nats https://nats-io.github.io/k8s/helm/charts/
 	helm repo update nats
-	helm pull nats/nats --untar --untardir charts
+	helm pull nats/nats --untar --untardir charts --version 1.3.16

--- a/packages/system/nats/charts/nats/Chart.yaml
+++ b/packages/system/nats/charts/nats/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 2.11.8
+appVersion: 2.11.10
 description: A Helm chart for the NATS.io High Speed Cloud Native Distributed Communications
   Technology.
 home: http://github.com/nats-io/k8s
@@ -13,4 +13,4 @@ maintainers:
   name: The NATS Authors
   url: https://github.com/nats-io
 name: nats
-version: 1.3.13
+version: 1.3.16

--- a/packages/system/nats/charts/nats/files/nats-box/deployment/container.yaml
+++ b/packages/system/nats/charts/nats/files/nats-box/deployment/container.yaml
@@ -44,3 +44,6 @@ volumeMounts:
 - name: {{ .name | quote }}
   mountPath: {{ .dir | quote }}
 {{- end }}
+
+resources:
+  {{- toYaml .Values.natsBox.container.resources | nindent 2 }}

--- a/packages/system/nats/charts/nats/files/stateful-set/nats-container.yaml
+++ b/packages/system/nats/charts/nats/files/stateful-set/nats-container.yaml
@@ -104,3 +104,6 @@ volumeMounts:
 - name: {{ .name | quote }}
   mountPath: {{ .dir | quote }}
 {{- end }}
+
+resources:
+  {{- toYaml .Values.container.resources | nindent 2 }}

--- a/packages/system/nats/charts/nats/values.yaml
+++ b/packages/system/nats/charts/nats/values.yaml
@@ -313,7 +313,7 @@ config:
 container:
   image:
     repository: nats
-    tag: 2.11.8-alpine
+    tag: 2.11.10-alpine
     pullPolicy:
     registry:
     # if digest is provided, it overrides tag (example: "sha256:abcdef1234567890")
@@ -351,6 +351,15 @@ container:
   merge: {}
   patch: []
 
+  # container resources
+  resources: {}
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+
 ############################################################
 # stateful set -> pod template -> reloader container
 ############################################################
@@ -358,7 +367,7 @@ reloader:
   enabled: true
   image:
     repository: natsio/nats-server-config-reloader
-    tag: 0.19.1
+    tag: 0.20.1
     pullPolicy:
     registry:
     digest:
@@ -574,11 +583,12 @@ natsBox:
   container:
     image:
       repository: natsio/nats-box
-      tag: 0.18.0
+      tag: 0.19.2
       pullPolicy:
       registry:
       digest:
       fullImageName:
+      resources: {}
 
     # env var map, see nats.env for an example
     env: {}

--- a/packages/system/nats/tests/nats_test.yaml
+++ b/packages/system/nats/tests/nats_test.yaml
@@ -1,0 +1,36 @@
+suite: cozy-nats chart rendering invariants
+release:
+  name: nats
+  namespace: cozy-nats
+tests:
+  - it: renders the nats StatefulSet on the pinned server image
+    template: charts/nats/templates/stateful-set.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: nats:2.11.10-alpine
+
+  - it: keeps the cozystack PVC retention policy (delete on scale-down and teardown)
+    template: charts/nats/templates/stateful-set.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Delete
+      - equal:
+          path: spec.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Delete
+
+  - it: emits a PodMonitor when the cozystack prometheus exporter is enabled
+    template: charts/nats/templates/pod-monitor.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: PodMonitor


### PR DESCRIPTION
## What this PR does

Bumps the nats chart from 1.3.13 to 1.3.16 (app 2.11.8 → 2.11.10), the latest patch in the 1.3 line, picking up the published security fixes the issue enumerates (nats-server 2.11.10 bumps `golang.org/x/crypto` to v0.42.0 and the Go toolchain to 1.24.7) plus upstream bug fixes (route-reconnect storms, stream interest loss when lowering max-connections, JetStream meta performance).

Pins the `update` target to `--version 1.3.16` so `make update` stays on the 1.3 line instead of floating to the 2.x chart restructure. The cozystack overrides (PVC retention policy, cluster routeURLs domain, prometheus exporter PodMonitor) stay valid.

Adds helm-unittest coverage (the package shipped none): pins the server image, the PVC retention policy, and the PodMonitor invariant. `helm unittest` 3/3 pass.

Verified: `helm template` renders `nats:2.11.10-alpine`, the retention policy, and the PodMonitor; vendored tree is byte-identical to a fresh upstream pull.

Closes #2890

### Release note

```release-note
chore(nats): bump nats to 1.3.16 (app 2.11.10)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable Kubernetes `resources` (requests/limits) for the NATS container and nats-box.

* **Chores**
  * Updated NATS image to `2.11.10-alpine`.
  * Updated config reloader image to `0.20.1`.
  * Updated nats-box image to `0.19.2`.
  * Updated the Helm chart to `1.3.16` (NATS appVersion to `2.11.10`).

* **Tests**
  * Added automated Helm chart validation tests, including stricter rendering checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->