### PR TITLE
refactor(platform): factor the cozystack-version stamp into a shared migration helper

### DIFF
--- a/hack/cozystack-version-stamp.bats
+++ b/hack/cozystack-version-stamp.bats
@@ -70,6 +70,16 @@
     fi
 }
 
+@test "stamp_cozystack_version requires a version argument" {
+    # The guard fires before the kubectl pipe, so this needs no cluster: a
+    # missing version must abort rather than apply empty input to kubectl.
+    . packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
+    if ( stamp_cozystack_version ) 2>/dev/null; then
+        echo "expected non-zero exit when version arg is missing" >&2
+        exit 1
+    fi
+}
+
 @test "render output matches the canonical labeled manifest" {
     # Golden test: pins the exact bytes migrations 42/43/44 apply today, so the
     # refactor that routes them through this helper is provably manifest-stable.

--- a/hack/cozystack-version-stamp.bats
+++ b/hack/cozystack-version-stamp.bats
@@ -1,0 +1,95 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Unit tests for
+# packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
+#
+# render_cozystack_version_manifest <version> emits the cozystack-version
+# ConfigMap manifest on stdout, always carrying the
+# platform.cozystack.io/no-delete=true label that the
+# cozystack-no-delete-guardrail ValidatingAdmissionPolicy keys on. Migrations
+# apply it under the default kubectl field manager; a label-less apply by that
+# same manager would strip the label, so the manifest is centralized here and
+# every migration sources it instead of copy-pasting a heredoc.
+#
+# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
+# own line; there is no bats `run` or `$status`. Assertions are expressed as
+# direct shell tests that exit non-zero on failure. Each test runs in its own
+# subshell, so NAMESPACE set/unset in one test does not leak into another.
+#
+# Run with: hack/cozytest.sh hack/cozystack-version-stamp.bats
+# -----------------------------------------------------------------------------
+
+@test "renders parseable YAML for a version" {
+    . packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
+    render_cozystack_version_manifest 45 | yq . >/dev/null
+}
+
+@test "carries the no-delete label set to true" {
+    . packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
+    val=$(render_cozystack_version_manifest 45 \
+      | yq -r '.metadata.labels."platform.cozystack.io/no-delete"')
+    [ "$val" = "true" ]
+}
+
+@test "names the ConfigMap cozystack-version" {
+    . packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
+    name=$(render_cozystack_version_manifest 45 | yq -r '.metadata.name')
+    [ "$name" = "cozystack-version" ]
+}
+
+@test "stamps the requested version as a quoted string" {
+    # The version MUST render as a quoted YAML string; an unquoted numeric
+    # scalar (version: 45) would change the ConfigMap data type the rest of
+    # the platform reads as a string.
+    . packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
+    out=$(render_cozystack_version_manifest 45)
+    printf '%s\n' "$out" | grep -qx '  version: "45"'
+    v=$(printf '%s\n' "$out" | yq -r '.data.version')
+    [ "$v" = "45" ]
+}
+
+@test "defaults namespace to cozy-system when NAMESPACE is unset" {
+    unset NAMESPACE
+    . packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
+    ns=$(render_cozystack_version_manifest 45 | yq -r '.metadata.namespace')
+    [ "$ns" = "cozy-system" ]
+}
+
+@test "honors a NAMESPACE override" {
+    . packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
+    out=$(export NAMESPACE=cozy-other; render_cozystack_version_manifest 45)
+    ns=$(printf '%s\n' "$out" | yq -r '.metadata.namespace')
+    [ "$ns" = "cozy-other" ]
+}
+
+@test "requires a version argument" {
+    . packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
+    if ( render_cozystack_version_manifest ) 2>/dev/null; then
+        echo "expected non-zero exit when version arg is missing" >&2
+        exit 1
+    fi
+}
+
+@test "render output matches the canonical labeled manifest" {
+    # Golden test: pins the exact bytes migrations 42/43/44 apply today, so the
+    # refactor that routes them through this helper is provably manifest-stable.
+    unset NAMESPACE
+    . packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
+    expected=$(cat <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cozystack-version
+  namespace: cozy-system
+  labels:
+    platform.cozystack.io/no-delete: "true"
+data:
+  version: "45"
+EOF
+)
+    actual=$(render_cozystack_version_manifest 45)
+    if [ "$actual" != "$expected" ]; then
+        printf 'expected:\n%s\n---\nactual:\n%s\n' "$expected" "$actual" >&2
+        exit 1
+    fi
+}

--- a/hack/cozystack-version-stamp.bats
+++ b/hack/cozystack-version-stamp.bats
@@ -103,3 +103,41 @@ EOF
         exit 1
     fi
 }
+
+@test "no go-forward stamp bypasses the helper (migrations >= 42 and run-migrations.sh)" {
+    # The helper exists so go-forward stamps cannot drift back to a label-less
+    # apply that drops the no-delete label. Migrations 1-41 are frozen and
+    # backfilled by 42, so they are exempt; migration 42 onward and the
+    # bootstrap path must each source the helper, call its API, and never stamp
+    # cozystack-version directly with kubectl. Blocking only the historical
+    # 'kubectl create configmap' shape is too weak — an inline 'kubectl apply'
+    # of a hand-rolled label-less manifest would slip past it.
+    mig_dir=packages/core/platform/images/migrations/migrations
+    files=""
+    for f in "$mig_dir"/*; do
+        n=$(basename "$f")
+        case "$n" in *[!0-9]*) continue ;; esac   # skip lib/ and other non-numeric
+        [ "$n" -ge 42 ] || continue
+        files="$files $f"
+    done
+    files="$files packages/core/platform/images/migrations/run-migrations.sh"
+
+    for f in $files; do
+        if ! grep -Eq 'cozystack-version\.sh' "$f"; then
+            echo "$f does not source the cozystack-version helper" >&2
+            exit 1
+        fi
+        if ! grep -Eq '(render_cozystack_version_manifest|stamp_cozystack_version)' "$f"; then
+            echo "$f does not call the cozystack-version helper API" >&2
+            exit 1
+        fi
+        # Strip full-comment lines first: a comment that explains why a stamp
+        # routes through the helper must not read as a direct stamp itself. A
+        # real bypass command never starts with '#', so the guard keeps its
+        # strength against actual direct stamping.
+        if grep -v '^[[:space:]]*#' "$f" | grep -Eq 'kubectl[[:space:]].*(create[[:space:]]+configmap|apply).*cozystack-version'; then
+            echo "$f stamps cozystack-version directly instead of via the helper" >&2
+            exit 1
+        fi
+    done
+}

--- a/packages/core/platform/images/migrations/migrations/42
+++ b/packages/core/platform/images/migrations/migrations/42
@@ -14,29 +14,20 @@
 # the next chart-driven apply sees no diff.
 #
 # 3-way-merge note: this apply records the no-delete label in the kubectl
-# last-applied-configuration annotation under the default field manager.
-# Any future migration that re-stamps cozystack-version via the same field
-# manager MUST include the label inline (matching the chart template at
-# templates/cozystack-version.yaml) — a label-less apply by the same field
-# manager would strip it.
+# last-applied-configuration annotation under the default field manager. A
+# label-less apply by the same field manager would strip it, so the manifest
+# is rendered by the shared helper (lib/cozystack-version.sh) that every
+# migration sources rather than a hand-copied heredoc.
 
 set -euo pipefail
+
+# shellcheck source=lib/cozystack-version.sh
+. "$(dirname "$0")/lib/cozystack-version.sh"
 
 NAMESPACE="${NAMESPACE:-cozy-system}"
 DRY_RUN="${MIGRATION_DRY_RUN:-0}"
 
-MANIFEST=$(cat <<EOF
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cozystack-version
-  namespace: ${NAMESPACE}
-  labels:
-    platform.cozystack.io/no-delete: "true"
-data:
-  version: "43"
-EOF
-)
+MANIFEST=$(render_cozystack_version_manifest 43)
 
 if [ "$DRY_RUN" = "1" ]; then
   echo "[dry-run] would apply:"

--- a/packages/core/platform/images/migrations/migrations/43
+++ b/packages/core/platform/images/migrations/migrations/43
@@ -12,6 +12,9 @@
 
 set -euo pipefail
 
+# shellcheck source=lib/cozystack-version.sh
+. "$(dirname "$0")/lib/cozystack-version.sh"
+
 # Iterate every namespace that has a Cluster named "seaweedfs-db".
 for ns in $(kubectl get cluster.postgresql.cnpg.io -A \
               -o jsonpath='{range .items[?(@.metadata.name=="seaweedfs-db")]}{.metadata.namespace}{"\n"}{end}'); do
@@ -27,21 +30,6 @@ for ns in $(kubectl get cluster.postgresql.cnpg.io -A \
   fi
 done
 
-# Stamp version.
-# Mirror migration 42's labeled manifest. A label-less apply by the same field
-# manager (kubectl create | kubectl apply) would strip the
-# platform.cozystack.io/no-delete label migration 42 added, dropping
-# cozystack-version out of the cozystack-no-delete-guardrail
-# ValidatingAdmissionPolicy. templates/cozystack-version.yaml only re-renders the
-# labeled ConfigMap on first install, so the label must be carried inline here.
-kubectl apply --filename - <<EOF
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cozystack-version
-  namespace: cozy-system
-  labels:
-    platform.cozystack.io/no-delete: "true"
-data:
-  version: "44"
-EOF
+# Stamp version. The labeled manifest lives in the shared helper so it cannot
+# drift back to a label-less apply that strips platform.cozystack.io/no-delete.
+stamp_cozystack_version 44

--- a/packages/core/platform/images/migrations/migrations/44
+++ b/packages/core/platform/images/migrations/migrations/44
@@ -10,6 +10,9 @@
 
 set -euo pipefail
 
+# shellcheck source=lib/cozystack-version.sh
+. "$(dirname "$0")/lib/cozystack-version.sh"
+
 if kubectl get deployment flux-tenants -n cozy-fluxcd >/dev/null 2>&1; then
   # No early-close (head) in the pipe: under pipefail a large name list would
   # SIGPIPE kubectl and abort the migration.
@@ -23,21 +26,6 @@ if kubectl get deployment flux-tenants -n cozy-fluxcd >/dev/null 2>&1; then
   fi
 fi
 
-# Stamp version.
-# Mirror migration 43's labeled manifest. A label-less apply by the same field
-# manager would strip the platform.cozystack.io/no-delete label, dropping
-# cozystack-version out of the cozystack-no-delete-guardrail
-# ValidatingAdmissionPolicy. templates/cozystack-version.yaml only re-renders
-# the labeled ConfigMap on first install, so the label must be carried inline
-# here.
-kubectl apply --filename - <<EOF
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cozystack-version
-  namespace: cozy-system
-  labels:
-    platform.cozystack.io/no-delete: "true"
-data:
-  version: "45"
-EOF
+# Stamp version. The labeled manifest lives in the shared helper so it cannot
+# drift back to a label-less apply that strips platform.cozystack.io/no-delete.
+stamp_cozystack_version 45

--- a/packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
+++ b/packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
@@ -39,5 +39,8 @@ EOF
 # stamp_cozystack_version <version>
 # Render and apply the labeled manifest under the default kubectl field manager.
 stamp_cozystack_version() {
+  # Guard the version here too, not only in render: without pipefail a render
+  # failure would not abort the pipeline and kubectl would apply empty input.
+  : "${1:?stamp_cozystack_version: version argument required}"
   render_cozystack_version_manifest "$1" | kubectl apply --filename -
 }

--- a/packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
+++ b/packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
@@ -10,10 +10,15 @@
 # stamp must re-emit the label by hand.
 #
 # Centralizing the manifest here means migration 45+ cannot drift back to a
-# label-less apply: each migration sources this file and calls the helper
-# instead of copy-pasting a heredoc.
+# label-less apply: every go-forward stamp (migration 42 onward and the
+# bootstrap path in run-migrations.sh) sources this file and calls the helper
+# instead of copy-pasting a heredoc. Migrations 1-41 predate the no-delete
+# label and stamp label-less on purpose; migration 42 backfills the label on
+# any upgrade path through them, so they are left frozen. The
+# cozystack-version-stamp.bats suite pins this — no migration numbered >= 42
+# (nor run-migrations.sh) may stamp cozystack-version without the helper.
 #
-# Sourced, not executed. Each migrations/<N> script does:
+# Sourced, not executed. Each migrations/<N> script (42+) does:
 #   . "$(dirname "$0")/lib/cozystack-version.sh"
 # and run-migrations.sh sources /migrations/lib/cozystack-version.sh.
 

--- a/packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
+++ b/packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh
@@ -1,0 +1,43 @@
+# shellcheck shell=sh
+# Shared helper for stamping the cozystack-version ConfigMap during migrations.
+#
+# The ConfigMap MUST carry the platform.cozystack.io/no-delete=true label so the
+# cozystack-no-delete-guardrail ValidatingAdmissionPolicy guards it against
+# deletion. Migrations apply it under the default kubectl field manager; a
+# label-less apply by that same manager would strip the label (the failure mode
+# migration 42 first fixed). templates/cozystack-version.yaml renders the
+# labeled ConfigMap only on first install (lookup-if-not), so every upgrade-time
+# stamp must re-emit the label by hand.
+#
+# Centralizing the manifest here means migration 45+ cannot drift back to a
+# label-less apply: each migration sources this file and calls the helper
+# instead of copy-pasting a heredoc.
+#
+# Sourced, not executed. Each migrations/<N> script does:
+#   . "$(dirname "$0")/lib/cozystack-version.sh"
+# and run-migrations.sh sources /migrations/lib/cozystack-version.sh.
+
+# render_cozystack_version_manifest <version>
+# Emit the labeled cozystack-version ConfigMap manifest on stdout. Pure (no
+# kubectl), so it is unit-testable in isolation. The namespace defaults to
+# cozy-system and is overridable via $NAMESPACE.
+render_cozystack_version_manifest() {
+  : "${1:?render_cozystack_version_manifest: version argument required}"
+  cat <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cozystack-version
+  namespace: ${NAMESPACE:-cozy-system}
+  labels:
+    platform.cozystack.io/no-delete: "true"
+data:
+  version: "$1"
+EOF
+}
+
+# stamp_cozystack_version <version>
+# Render and apply the labeled manifest under the default kubectl field manager.
+stamp_cozystack_version() {
+  render_cozystack_version_manifest "$1" | kubectl apply --filename -
+}

--- a/packages/core/platform/images/migrations/run-migrations.sh
+++ b/packages/core/platform/images/migrations/run-migrations.sh
@@ -14,7 +14,9 @@ echo "Starting migrations from version $CURRENT_VERSION to $TARGET_VERSION"
 if ! kubectl get configmap --namespace "$NAMESPACE" cozystack-version >/dev/null 2>&1; then
   echo "ConfigMap cozystack-version does not exist, creating it with version $TARGET_VERSION"
   # Stamp via the shared helper so the bootstrap ConfigMap carries the
-  # platform.cozystack.io/no-delete label like every migration-driven stamp.
+  # platform.cozystack.io/no-delete label, matching every go-forward stamp
+  # (migration 42 onward; migrations 1-41 stamp label-less and are backfilled
+  # by migration 42, so they are intentionally left as-is).
   stamp_cozystack_version "$TARGET_VERSION"
   echo "ConfigMap created with version $TARGET_VERSION"
   exit 0

--- a/packages/core/platform/images/migrations/run-migrations.sh
+++ b/packages/core/platform/images/migrations/run-migrations.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -euo pipefail
 
+# shellcheck source=migrations/lib/cozystack-version.sh
+. /migrations/lib/cozystack-version.sh
+
 NAMESPACE="${NAMESPACE:-cozy-system}"
 CURRENT_VERSION="${CURRENT_VERSION:-0}"
 TARGET_VERSION="${TARGET_VERSION:-0}"
@@ -10,9 +13,9 @@ echo "Starting migrations from version $CURRENT_VERSION to $TARGET_VERSION"
 # Check if ConfigMap exists
 if ! kubectl get configmap --namespace "$NAMESPACE" cozystack-version >/dev/null 2>&1; then
   echo "ConfigMap cozystack-version does not exist, creating it with version $TARGET_VERSION"
-  kubectl create configmap --namespace "$NAMESPACE" cozystack-version \
-    --from-literal=version="$TARGET_VERSION" \
-    --dry-run=client --output yaml | kubectl apply --filename -
+  # Stamp via the shared helper so the bootstrap ConfigMap carries the
+  # platform.cozystack.io/no-delete label like every migration-driven stamp.
+  stamp_cozystack_version "$TARGET_VERSION"
   echo "ConfigMap created with version $TARGET_VERSION"
   exit 0
 fi


### PR DESCRIPTION
## What this PR does

Every migration that stamps the `cozystack-version` ConfigMap must carry the `platform.cozystack.io/no-delete=true` label so the `cozystack-no-delete-guardrail` ValidatingAdmissionPolicy guards it. The chart template renders the labeled ConfigMap only on first install, so each upgrade-time stamp has to re-emit the label by hand — migration 43 had to inline-copy migration 42's heredoc to avoid a label-less apply by the same field manager stripping it. The bug class was patched per-migration, not eliminated.

This extracts the stamp into a shared, sourced helper (`render_cozystack_version_manifest` + `stamp_cozystack_version`) under `images/migrations/migrations/lib/`, and routes migrations 42, 43, 44 and the `run-migrations.sh` bootstrap path through it. The labeled manifest now has a single definition, so future migrations cannot drift back to a label-less apply.

The upgrade path is behavior-preserving: the rendered manifest is byte-identical to the previous heredocs (pinned by a golden unit test). The bootstrap path in `run-migrations.sh` previously created the ConfigMap without the label — it now carries it like every migration-driven stamp.

Adds `hack/cozystack-version-stamp.bats` (8 tests) covering the helper: label presence, ConfigMap name, quoted-string version type, namespace default and override, required-argument guard, and the byte-exact golden manifest.

Closes #2781

### Release note

```release-note
fix(platform): always stamp the platform.cozystack.io/no-delete label on the cozystack-version ConfigMap, including the migration bootstrap path, so deletion protection cannot be silently dropped
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded validation to confirm the version-stamp manifest is parseable YAML, includes the required no-delete label, targets the correct `cozystack-version` ConfigMap, and quotes the version value correctly.
  * Added coverage for default and overridden namespaces, argument validation failures, and a golden “byte-for-byte” render check.
  * Added a guardrail test to prevent bypassing the shared stamping logic by direct `kubectl` ConfigMap stamping.

* **Refactor**
  * Centralized `cozystack-version` rendering and stamping into a shared helper and updated migrations and the migrations runner to use it consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->