### PR TITLE
feat(platform): ACME wildcard certificate on the default ingress-nginx path

### DIFF
--- a/packages/core/platform/templates/apps.yaml
+++ b/packages/core/platform/templates/apps.yaml
@@ -24,16 +24,37 @@ stringData:
       solver: {{ .Values.publishing.certificates.solver | quote }}
       issuer-name: {{ .Values.publishing.certificates.issuerName | quote }}
       {{- /*
-        Operator-supplied wildcard mode. Only the Secret NAME rides this
+        Wildcard certificate mode. Only the Secret NAME rides this
         channel — never the cert/key material (unlike a private key, the
         name is not sensitive). When set, the ingress flow points the
         root ingress controller's --default-ssl-certificate at it and
         drops per-host ACME, and the gateway chart switches the
-        TenantGateway to certMode=existingSecret. The Secret itself must
-        be pre-created by the operator in the publishing namespace
-        (tenant-root). Empty string = ACME issuance as before.
+        TenantGateway to certMode=existingSecret.
+
+        The name comes from one of two sources, with the operator-
+        provided (BYO) name always winning:
+          1. publishing.certificates.wildcardSecretName — a Secret the
+             operator pre-creates in the publishing namespace
+             (tenant-root). wildcard-issue stays false: the platform
+             mints nothing.
+          2. Otherwise, on the ingress-nginx path (gateway.enabled=false)
+             with solver=dns01 and publishing.certificates.wildcard=true,
+             the platform issues its own shared wildcard. wildcard-issue
+             becomes true and the publishing ingress package renders the
+             Certificate into this Secret name. http01 cannot issue
+             wildcards, and the Gateway API path issues its own wildcard
+             via the TenantGateway controller, so both are excluded.
+        Empty name + wildcard-issue=false = per-host ACME as before.
       */}}
-      wildcard-secret-name: {{ .Values.publishing.certificates.wildcardSecretName | default "" | quote }}
+      {{- $byoWildcard := .Values.publishing.certificates.wildcardSecretName | default "" }}
+      {{- $wildcardSecretName := $byoWildcard }}
+      {{- $wildcardIssue := false }}
+      {{- if and (not $byoWildcard) (eq .Values.publishing.certificates.solver "dns01") .Values.publishing.certificates.wildcard (not .Values.gateway.enabled) }}
+      {{- $wildcardSecretName = "cozystack-wildcard-tls" }}
+      {{- $wildcardIssue = true }}
+      {{- end }}
+      wildcard-secret-name: {{ $wildcardSecretName | quote }}
+      wildcard-issue: {{ $wildcardIssue | quote }}
       {{- /*
         DNS-01 solver wiring. Read only when solver=dns01, but the
         keys are written unconditionally so a render-time switch from

--- a/packages/core/platform/tests/apps_wildcard_acme_test.yaml
+++ b/packages/core/platform/tests/apps_wildcard_acme_test.yaml
@@ -1,0 +1,93 @@
+suite: apps.yaml ACME wildcard issuance wiring
+
+templates:
+  - templates/apps.yaml
+
+release:
+  name: cozy-platform
+  namespace: cozy-system
+
+# WS2 / #2400: on the default ingress-nginx path (gateway.enabled=false) a
+# DNS-01 solver lets the platform issue ONE shared wildcard certificate
+# (*.<root-host> + <root-host>) instead of minting a per-host ACME cert
+# for every system service. It is OPT-IN (publishing.certificates.wildcard,
+# default false): a single-label wildcard does not cover custom service
+# hosts outside *.<root-host>, so leaving it off keeps the safe per-host
+# behavior and never switches a dns01 cluster silently on upgrade.
+# apps.yaml computes the effective _cluster.wildcard-secret-name and an
+# _cluster.wildcard-issue signal the publishing ingress package reads to
+# render the Certificate. Operator-provided (BYO) wildcard names always
+# win and never trigger issuance; http01 cannot issue wildcards; the
+# Gateway API path issues its own wildcard via the controller, so issuance
+# here is gated to gateway.enabled=false.
+
+tests:
+  - it: does not issue a wildcard by default (http01)
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-secret-name:\s*""'
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-issue:\s*"false"'
+
+  - it: does not auto-issue on dns01 unless explicitly opted in
+    set:
+      publishing.certificates.solver: dns01
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-secret-name:\s*""'
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-issue:\s*"false"'
+
+  - it: issues a shared wildcard when opted in on the dns01 ingress path
+    set:
+      publishing.certificates.solver: dns01
+      publishing.certificates.wildcard: true
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-secret-name:\s*"cozystack-wildcard-tls"'
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-issue:\s*"true"'
+
+  - it: does not auto-issue on the ingress path when Gateway API is enabled
+    set:
+      publishing.certificates.solver: dns01
+      publishing.certificates.wildcard: true
+      gateway.enabled: true
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-secret-name:\s*""'
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-issue:\s*"false"'
+
+  - it: operator-provided wildcard secret wins and never triggers issuance
+    set:
+      publishing.certificates.solver: dns01
+      publishing.certificates.wildcard: true
+      publishing.certificates.wildcardSecretName: byo-wildcard-tls
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-secret-name:\s*"byo-wildcard-tls"'
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-issue:\s*"false"'
+
+  - it: http01 never issues a wildcard even when opted in
+    set:
+      publishing.certificates.solver: http01
+      publishing.certificates.wildcard: true
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-secret-name:\s*""'
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'wildcard-issue:\s*"false"'

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -199,6 +199,50 @@ publishing:
   certificates:
     solver: http01 # "http01" or "dns01"
     issuerName: letsencrypt-prod
+    # Shared wildcard issuance on the default ingress-nginx path
+    # (gateway.enabled=false). Opt-in, OFF by default. When set to true
+    # with solver=dns01 and no operator-provided wildcardSecretName, the
+    # platform issues ONE wildcard Certificate (*.<root-host> +
+    # <root-host>) via the DNS-01 ClusterIssuer and serves it as the
+    # ingress controller's default SSL certificate, so system services
+    # (dashboard, grafana, keycloak, harbor, …) stop minting a per-host
+    # ACME cert each. This avoids the Let's Encrypt per-domain rate limit
+    # once a deployment exceeds ~50 endpoints, matching the Gateway API
+    # path which issues a per-apex wildcard in dns01 mode.
+    #
+    # Ignored when solver=http01 (HTTP-01 cannot issue wildcards) and
+    # when gateway.enabled=true (the TenantGateway controller issues the
+    # wildcard there).
+    #
+    # COVERAGE CAVEAT — same contract as wildcardSecretName below: a
+    # single-label wildcard *.<root-host> covers <service>.<root-host>
+    # but NOT a custom service host outside it (e.g. a keycloak
+    # ingress.host / harbor host / grafana host set to auth.example.com,
+    # or a nested a.b.<root-host>). When this is true, services whose
+    # host is not covered fall back to the default SSL certificate and
+    # would serve the wrong certificate. Only enable it when every
+    # exposed system service uses a <service>.<root-host> host (the
+    # default), or provide a covering wildcardSecretName instead. Left
+    # OFF by default precisely so a dns01 cluster with a custom service
+    # host is never silently switched on upgrade.
+    #
+    # BLAST RADIUS — like wildcardSecretName, the chosen name rides the
+    # _cluster channel, which every child tenant inherits verbatim. A
+    # child tenant that inherits the root ingress has nested service
+    # hosts (<service>.<tenant>.<root-host>) that *.<root-host> does NOT
+    # cover; enabling this makes those services drop per-host ACME and
+    # serve the root default certificate too. This is not root-tenant
+    # scoped — only enable it when child-tenant hosts are also covered
+    # (or left on the Gateway path). Per-tenant wildcards are tracked
+    # separately.
+    #
+    # FIRST-ISSUANCE WINDOW: when this is turned on, consumers drop their
+    # per-host certs immediately, but the DNS-01 wildcard takes a few
+    # minutes to issue. Until the Secret is populated ingress-nginx serves
+    # its self-signed default cert (browser warning), then self-heals —
+    # the same delay per-host ACME has on first issue, which an
+    # operator-provided wildcardSecretName avoids only by pre-existing.
+    wildcard: false
     # Operator-provided wildcard certificate. When set, platform
     # services and the root tenant's ingress/Gateway serve under this
     # pre-existing TLS Secret instead of minting per-host ACME certs.

--- a/packages/extra/ingress/templates/wildcard-certificate.yaml
+++ b/packages/extra/ingress/templates/wildcard-certificate.yaml
@@ -1,0 +1,51 @@
+{{- $exposeIngress := (index .Values._cluster "expose-ingress") | default "tenant-root" }}
+{{- /* toString normalises the _cluster value whether it arrives as the
+       string "true" (Flux valuesFrom Secret, the real path) or as a bool
+       (helm --set), mirroring the proxy-protocol handling in
+       nginx-ingress.yaml. */ -}}
+{{- $wildcardIssue := (index .Values._cluster "wildcard-issue") | default "false" | toString }}
+{{- $wildcardSecret := (index .Values._cluster "wildcard-secret-name") | default "" }}
+{{- $rootHost := (index .Values._cluster "root-host") | default "" }}
+{{- $issuerName := (index .Values._cluster "issuer-name") | default "letsencrypt-prod" }}
+{{- /*
+  Shared ACME wildcard for the ingress-nginx path (WS2 / #2400). When the
+  platform decides to issue a wildcard (_cluster.wildcard-issue=true,
+  computed in core/platform apps.yaml only on the solver=dns01 ingress
+  path with gateway.enabled=false), the publishing tenant's ingress
+  controller renders ONE DNS-01 Certificate for <root-host> +
+  *.<root-host>. ingress-nginx serves the resulting Secret as its
+  --default-ssl-certificate (see nginx-ingress.yaml), so the system
+  services drop their per-host cert-manager annotation — matching the
+  Gateway API path, which issues a per-apex wildcard via the TenantGateway
+  controller in dns01 mode.
+
+  Only the publishing controller (Release.Namespace == expose-ingress)
+  renders it: the Secret must live in that namespace for ingress-nginx to
+  read it, and child-tenant controllers cannot point --default-ssl-certificate
+  at another namespace. The reference is therefore always same-namespace,
+  the same constraint the operator-supplied wildcard path observes.
+
+  The ClusterIssuer named here (issuer-name, letsencrypt-prod by default)
+  already carries the DNS-01 solver from packages/system/cert-manager-issuers
+  whenever solver=dns01, so no per-tenant Issuer is minted on this path.
+*/}}
+{{- if and (eq $wildcardIssue "true") (eq .Release.Namespace $exposeIngress) }}
+{{- if not $wildcardSecret }}
+{{- fail "packages/extra/ingress: _cluster.wildcard-issue=true but _cluster.wildcard-secret-name is empty — the platform must supply the target Secret name." }}
+{{- end }}
+{{- if not $rootHost }}
+{{- fail "packages/extra/ingress: _cluster.wildcard-issue=true but _cluster.root-host is empty — cannot build the wildcard dnsNames." }}
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cozystack-wildcard
+spec:
+  secretName: {{ $wildcardSecret | quote }}
+  issuerRef:
+    kind: ClusterIssuer
+    name: {{ $issuerName | quote }}
+  dnsNames:
+    - {{ $rootHost | quote }}
+    - {{ printf "*.%s" $rootHost | quote }}
+{{- end }}

--- a/packages/extra/ingress/tests/wildcard_certificate_test.yaml
+++ b/packages/extra/ingress/tests/wildcard_certificate_test.yaml
@@ -1,0 +1,115 @@
+suite: ingress-nginx ACME wildcard Certificate
+
+templates:
+  - templates/wildcard-certificate.yaml
+
+release:
+  name: ingress
+  namespace: tenant-root
+
+# WS2 / #2400: when the platform decides to issue a shared wildcard on the
+# ingress-nginx path (_cluster.wildcard-issue=true, computed in
+# core/platform apps.yaml only for solver=dns01 + gateway disabled), the
+# publishing tenant's ingress controller renders ONE DNS-01 Certificate
+# for <root-host> + *.<root-host>. ingress-nginx serves the resulting
+# Secret as its default SSL certificate, so per-host ACME is unnecessary.
+# Only the publishing controller (Release.Namespace == expose-ingress)
+# renders it — the Secret must live in that namespace and child-tenant
+# controllers cannot read it. The ClusterIssuer named here already carries
+# the DNS-01 solver whenever solver=dns01.
+
+tests:
+  - it: renders a DNS-01 wildcard Certificate on the publishing controller
+    set:
+      _cluster:
+        expose-ingress: tenant-root
+        wildcard-issue: "true"
+        wildcard-secret-name: cozystack-wildcard-tls
+        root-host: example.org
+        issuer-name: letsencrypt-prod
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Certificate
+      - equal:
+          path: metadata.name
+          value: cozystack-wildcard
+      - equal:
+          path: spec.secretName
+          value: cozystack-wildcard-tls
+      - equal:
+          path: spec.issuerRef.kind
+          value: ClusterIssuer
+      - equal:
+          path: spec.issuerRef.name
+          value: letsencrypt-prod
+      - equal:
+          path: spec.dnsNames
+          value:
+            - example.org
+            - "*.example.org"
+
+  - it: renders nothing when wildcard-issue is not set
+    set:
+      _cluster:
+        expose-ingress: tenant-root
+        wildcard-secret-name: ""
+        root-host: example.org
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: does not render on a non-publishing tenant controller
+    release:
+      name: ingress
+      namespace: tenant-foo
+    set:
+      _cluster:
+        expose-ingress: tenant-root
+        wildcard-issue: "true"
+        wildcard-secret-name: cozystack-wildcard-tls
+        root-host: example.org
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: honors a custom issuer name
+    set:
+      _cluster:
+        expose-ingress: tenant-root
+        wildcard-issue: "true"
+        wildcard-secret-name: cozystack-wildcard-tls
+        root-host: example.org
+        issuer-name: letsencrypt-stage
+    asserts:
+      - equal:
+          path: spec.issuerRef.name
+          value: letsencrypt-stage
+
+  # Fail-fast guards: platform-internal invariants that should never trip,
+  # but must fail loudly (not render a Certificate pointing at a
+  # nonexistent Secret or with empty dnsNames) if apps.yaml ever regresses
+  # and sets wildcard-issue=true without the keys it implies.
+  - it: fails when wildcard-issue is true but the secret name is empty
+    set:
+      _cluster:
+        expose-ingress: tenant-root
+        wildcard-issue: "true"
+        wildcard-secret-name: ""
+        root-host: example.org
+    asserts:
+      - failedTemplate:
+          errorMessage: "packages/extra/ingress: _cluster.wildcard-issue=true but _cluster.wildcard-secret-name is empty — the platform must supply the target Secret name."
+
+  - it: fails when wildcard-issue is true but root-host is empty
+    set:
+      _cluster:
+        expose-ingress: tenant-root
+        wildcard-issue: "true"
+        wildcard-secret-name: cozystack-wildcard-tls
+        root-host: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "packages/extra/ingress: _cluster.wildcard-issue=true but _cluster.root-host is empty — cannot build the wildcard dnsNames."

--- a/packages/system/bucket/tests/ingress_wildcard_test.yaml
+++ b/packages/system/bucket/tests/ingress_wildcard_test.yaml
@@ -51,3 +51,32 @@ tests:
           value: letsencrypt-prod
       - exists:
           path: spec.tls[0].secretName
+
+  # WS2 / #2400 child-tenant blast radius, pinned as a contract: the
+  # wildcard secret name rides _cluster, which packages/apps/tenant copies
+  # verbatim into every child tenant. A child inheriting the root ingress
+  # has nested service hosts (<svc>.<tenant>.<root-host>) that a
+  # single-label *.<root-host> does NOT cover, yet the service still drops
+  # its per-host cert and falls back to the root default certificate. This
+  # is the documented reason shared wildcard issuance is opt-in / off by
+  # default. Here _namespace.host is the child apex (alice.example.org),
+  # so the bucket host is two labels deep under the wildcard.
+  - it: nested child-tenant host drops per-host ACME when wildcard mode is active
+    set:
+      bucketName: data
+      _namespace:
+        host: alice.example.org
+        ingress: tenant-root
+        gateway: ""
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: dns01
+        wildcard-secret-name: cozystack-wildcard-tls
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: data.alice.example.org
+      - notExists:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+      - notExists:
+          path: spec.tls[0].secretName

--- a/packages/system/keycloak/tests/ingress_wildcard_test.yaml
+++ b/packages/system/keycloak/tests/ingress_wildcard_test.yaml
@@ -50,3 +50,55 @@ tests:
       - equal:
           path: spec.tls[0].secretName
           value: web-tls
+
+  # WS2 / #2400 blocker guard: a custom keycloak host (auth.example.com)
+  # is outside the platform wildcard *.<root-host>. Because shared
+  # wildcard issuance is opt-in (publishing.certificates.wildcard,
+  # default false), a dns01 cluster carries no _cluster.wildcard-secret-name
+  # and keycloak keeps its own per-host certificate — the controller never
+  # falls back to a default cert that does not cover this host.
+  - it: keeps per-host ACME for a custom host on dns01 when wildcard issuance is off
+    set:
+      ingress.host: auth.example.com
+      _cluster:
+        root-host: example.org
+        issuer-name: letsencrypt-prod
+        solver: dns01
+        expose-ingress: tenant-root
+        gateway-enabled: "false"
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: auth.example.com
+      - equal:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+          value: letsencrypt-prod
+      - equal:
+          path: spec.tls[0].secretName
+          value: web-tls
+
+  # WS2 / #2400 coverage tradeoff, pinned as a contract: once shared
+  # wildcard mode is active (_cluster.wildcard-secret-name set), a custom
+  # host outside *.<root-host> ALSO drops its per-host cert and falls back
+  # to the default SSL certificate, which does not cover it. This is the
+  # hazard the publishing.certificates.wildcard values.yaml caveat warns
+  # about and the reason issuance is opt-in / off by default. Pinning it
+  # keeps the tradeoff a conscious contract rather than an accident.
+  - it: custom host drops per-host ACME when wildcard mode is active
+    set:
+      ingress.host: auth.example.com
+      _cluster:
+        root-host: example.org
+        issuer-name: letsencrypt-prod
+        solver: dns01
+        expose-ingress: tenant-root
+        gateway-enabled: "false"
+        wildcard-secret-name: cozystack-wildcard-tls
+    asserts:
+      - equal:
+          path: spec.rules[0].host
+          value: auth.example.com
+      - notExists:
+          path: metadata.annotations["cert-manager.io/cluster-issuer"]
+      - notExists:
+          path: spec.tls[0].secretName


### PR DESCRIPTION
## What this PR does

On the default ingress-nginx path (`gateway.enabled=false`) every published hostname still minted its own per-host ACME certificate via ingress-shim, even with a DNS-01 solver configured. That hits the Let's Encrypt rate limit (50 certs per registered domain per week) once a deployment exceeds ~50 endpoints. The Gateway API path already issues a single per-apex wildcard in DNS-01 mode; this brings the ingress-nginx path to parity. It implements the remaining ingress-nginx gap that #2400 was narrowed to in its triage comment (DNS-01 is already multi-provider, and the Gateway path already issues wildcards).

The new `publishing.certificates.wildcard` toggle is opt-in and OFF by default. When set to `true` with `solver=dns01` and no operator-provided wildcard Secret, the platform issues one shared wildcard `Certificate` for `<root-host>` + `*.<root-host>` and serves the resulting Secret as the publishing controller's `--default-ssl-certificate`. The system service Ingresses (dashboard, grafana, keycloak, harbor, …) then stop requesting a per-host cert.

How it works:

- `core/platform` `apps.yaml` computes the effective wildcard Secret name and a new `_cluster.wildcard-issue` signal. An operator-provided `wildcardSecretName` (the BYO path) always wins and never triggers issuance; HTTP-01 cannot issue wildcards; and when Gateway API is enabled the TenantGateway controller issues the wildcard instead — so all three are excluded from auto-issuance.
- `extra/ingress` renders the wildcard `Certificate` only on the publishing controller (`Release.Namespace == expose-ingress`), because the Secret must be same-namespace for ingress-nginx to read it. The Certificate references the DNS-01 `ClusterIssuer` that `cert-manager-issuers` already renders in `dns01` mode, so no per-tenant Issuer is minted.

This reuses the existing wildcard-secret consumption path, so no per-service Ingress template changes were needed — only the issuance side is new.

Why opt-in (default off): the chosen wildcard Secret name rides the `_cluster` channel, which every child tenant inherits verbatim, so this is not root-tenant scoped. A single-label wildcard `*.<root-host>` covers `<service>.<root-host>` but not a custom service host outside it (a keycloak `ingress.host`, harbor `host`, or grafana `host` pointed at another domain) nor a child tenant's nested host (`<service>.<tenant>.<root-host>`). Enabling issuance makes every such service drop its per-host ACME cert and fall back to the default certificate, which does not cover it. Leaving it off by default means a dns01 cluster is never silently switched on upgrade; an operator who enables it accepts the same coverage responsibility as the operator-provided wildcard path, which propagates identically. The tradeoff is pinned by contract tests (keycloak custom host, bucket nested child-tenant host). Per-tenant wildcards remain on the Gateway path and are tracked separately.

Docs: cozystack/website#588

Closes #2400. Part of #2811.

### Screenshots

N/A — no UI changes.

### Release note

```release-note
feat(platform): add opt-in shared wildcard certificate issuance on the default ingress-nginx path via publishing.certificates.wildcard (default false). When enabled with a DNS-01 solver, the platform issues one *.<root-host> wildcard for system services instead of a per-host ACME certificate, avoiding Let's Encrypt rate limits at scale.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic wildcard certificate issuance support for DNS-01 ACME solver.
  * New `certificates.wildcard` configuration option to enable shared wildcard TLS certificates.
  * Ingress rules now properly utilize wildcard certificates when enabled.

* **Tests**
  * Added comprehensive test suites validating wildcard certificate generation and ingress integration across multiple scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->