### PR TITLE
feat(cozy-lib): add CA-only TLS trust-anchor helper for tenants

### DIFF
--- a/packages/library/cozy-lib/templates/_tls.tpl
+++ b/packages/library/cozy-lib/templates/_tls.tpl
@@ -1,0 +1,112 @@
+{{/*
+=============================================================================
+ TLS trust-anchor helpers
+=============================================================================
+
+Per-app TLS in the Cozystack catalog issues a per-release, self-signed CA (via
+cert-manager or the app operator). A tenant that connects to such an endpoint
+needs the CA certificate (ca.crt) to verify the server — but nothing more. The
+objects that hold ca.crt today also hold private keys:
+
+  - the cert-manager CA secret  <release>-ca   carries the CA private key
+    (tls.key) — full trust-chain compromise if leaked;
+  - the cert-manager leaf secret <release>-tls  carries the server private key
+    (tls.key) — server impersonation / MITM if leaked.
+
+So any RBAC path that hands a tenant ca.crt by granting read on one of those
+Secrets also hands over a private key. cozy-lib.tls.caCertSecret breaks that
+coupling: it renders a canonical trust-anchor object that carries ONLY ca.crt,
+labelled so tenants reach it through the core.cozystack.io/tenantsecrets API
+that the base tenant roles already grant — never through a Secret that contains
+tls.key.
+
+Delivery mechanism (grounded in the platform RBAC, not invented here):
+
+  - pkg/registry/core/tenantsecret/rest.go surfaces, under the virtual resource
+    core.cozystack.io/tenantsecrets, exactly the namespace Secrets labelled
+    internal.cozystack.io/tenantresource=true (TenantResourceLabelKey /
+    TenantResourceLabelValue in pkg/apis/core/v1alpha1/tenantresource_types.go).
+  - packages/system/cozystack-basics/templates/clusterroles.yaml grants
+    get/list/watch on core.cozystack.io/tenantsecrets to tenant ServiceAccounts
+    (cozy:tenant:base) and to use/admin/super-admin subjects (cozy:tenant:use:
+    base). No grant on raw core/v1 secrets is involved, so attaching the label
+    to a key-free object exposes the trust anchor without exposing any key.
+  - internal/backupcontroller/credentials_projector.go relies on the same rule
+    in reverse: it deliberately OMITS the label so its key-bearing projection
+    is NOT promoted to a TenantSecret. This helper is the positive counterpart —
+    a key-FREE object that is safe to promote.
+
+This is the chart-side shape every per-app TLS PR converges on; population of
+ca.crt stays the responsibility of whatever owns the PKI (the app operator, as
+the redis-operator fork does with its CA-only Opaque Secret, or a cert-manager
+chain resolved at the chart level). The helper itself is pure and value-driven
+so it renders deterministically and refuses, by construction and by guard, to
+carry a private key.
+*/}}
+
+{{/*
+cozy-lib.tls.caCertSecret renders the canonical CA-only trust-anchor Secret.
+
+Invoked with a single dict argument (named parameters, not the (arg, $) list
+form, because it needs no global scope):
+
+  {{ include "cozy-lib.tls.caCertSecret" (dict
+       "name"      (printf "%s-ca-cert" .Release.Name)
+       "namespace" .Release.Namespace
+       "caCert"    $caCertPem
+       "labels"    (dict "app.kubernetes.io/instance" .Release.Name)
+  ) }}
+
+Parameters:
+  - name      (required) Secret name. Convention: "<release>-ca-cert".
+  - caCert    (required) the CA certificate chain in PEM. Must contain a
+              BEGIN CERTIFICATE PEM header and must NOT contain a
+              BEGIN...PRIVATE KEY PEM header; the helper fails closed on either
+              violation. Both checks are anchored to the PEM header line and are
+              case-insensitive, so they neither false-positive on certificate
+              body/comment text nor miss a lowercased hand-pasted header.
+  - namespace (optional) metadata.namespace.
+  - labels    (optional) extra labels merged onto the mandatory
+              internal.cozystack.io/tenantresource label (which always wins).
+  - annotations (optional) extra annotations.
+*/}}
+{{- define "cozy-lib.tls.caCertSecret" -}}
+{{-   if not (kindIs "map" .) -}}
+{{-     fail "cozy-lib.tls.caCertSecret: expected a single dict argument" -}}
+{{-   end -}}
+{{-   $name := default "" .name -}}
+{{-   if eq $name "" -}}
+{{-     fail "cozy-lib.tls.caCertSecret: name is required" -}}
+{{-   end -}}
+{{-   $caCert := default "" .caCert -}}
+{{-   if eq (trim $caCert) "" -}}
+{{-     fail "cozy-lib.tls.caCertSecret: caCert is required and must be a non-empty PEM" -}}
+{{-   end -}}
+{{- /* Anchor both guards to the PEM header form, case-insensitively. A free
+       substring match would false-positive on a legitimate certificate whose
+       subject/comment text happens to contain "PRIVATE KEY", and would miss a
+       lowercase hand-pasted header. The (?i) header regex catches every key
+       variant (PKCS#8, RSA, EC, ENCRYPTED, OPENSSH, DSA) and only a real
+       BEGIN...PRIVATE KEY line, not arbitrary blob text. */ -}}
+{{-   if regexMatch "(?i)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----" $caCert -}}
+{{-     fail "cozy-lib.tls.caCertSecret: caCert must not contain private key material" -}}
+{{-   end -}}
+{{-   if not (regexMatch "(?i)-----BEGIN CERTIFICATE-----" $caCert) -}}
+{{-     fail "cozy-lib.tls.caCertSecret: caCert must contain a PEM certificate (BEGIN CERTIFICATE)" -}}
+{{-   end -}}
+{{-   $labels := merge (dict "internal.cozystack.io/tenantresource" "true") (default (dict) .labels) -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+{{-   with .namespace }}
+  namespace: {{ . }}
+{{-   end }}
+  labels: {{- toYaml $labels | nindent 4 }}
+{{-   with .annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+{{-   end }}
+type: Opaque
+stringData:
+  ca.crt: {{ $caCert | quote }}
+{{- end -}}

--- a/packages/tests/cozy-lib-tests/templates/tests/tls-cacert-nondict.yaml
+++ b/packages/tests/cozy-lib-tests/templates/tests/tls-cacert-nondict.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.nonDict -}}
+{{ include "cozy-lib.tls.caCertSecret" "not-a-dict" }}
+{{- end -}}

--- a/packages/tests/cozy-lib-tests/templates/tests/tls-cacert-params.yaml
+++ b/packages/tests/cozy-lib-tests/templates/tests/tls-cacert-params.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.useParams -}}
+{{ include "cozy-lib.tls.caCertSecret" (dict
+     "name" .Values.name
+     "namespace" .Values.namespace
+     "caCert" .Values.caCert
+) }}
+{{- end -}}

--- a/packages/tests/cozy-lib-tests/templates/tests/tls-cacert.yaml
+++ b/packages/tests/cozy-lib-tests/templates/tests/tls-cacert.yaml
@@ -1,0 +1,7 @@
+{{ include "cozy-lib.tls.caCertSecret" (dict
+     "name" (printf "%s-ca-cert" .Release.Name)
+     "namespace" .Release.Namespace
+     "caCert" .Values.caCert
+     "labels" (merge (dict "app.kubernetes.io/instance" .Release.Name) (default (dict) .Values.callerLabels))
+     "annotations" (dict "cozystack.io/example" "yes")
+) }}

--- a/packages/tests/cozy-lib-tests/tests/tls_cacert_test.yaml
+++ b/packages/tests/cozy-lib-tests/tests/tls_cacert_test.yaml
@@ -1,0 +1,216 @@
+# ./tests/tls_cacert_test.yaml
+suite: tls caCertSecret helper
+
+templates:
+  - templates/tests/tls-cacert.yaml
+  - templates/tests/tls-cacert-params.yaml
+  - templates/tests/tls-cacert-nondict.yaml
+
+release:
+  name: myrelease
+  namespace: tenant-acme
+  revision: 1
+  isUpgrade: false
+
+tests:
+  - it: renders an Opaque Secret carrying only ca.crt
+    templates:
+      - templates/tests/tls-cacert.yaml
+    values:
+      - tls_cacert_values.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+      - equal:
+          path: apiVersion
+          value: v1
+      - equal:
+          path: metadata.name
+          value: myrelease-ca-cert
+      - equal:
+          path: metadata.namespace
+          value: tenant-acme
+      - equal:
+          path: type
+          value: Opaque
+      - isNotNullOrEmpty:
+          path: stringData["ca.crt"]
+      # The trust anchor must never carry private key material. The helper
+      # only ever emits stringData, so these are the meaningful assertions.
+      - notExists:
+          path: stringData["tls.key"]
+      - notExists:
+          path: stringData["tls.crt"]
+
+  - it: carries the tenantresource label so it is delivered via core.cozystack.io/tenantsecrets
+    templates:
+      - templates/tests/tls-cacert.yaml
+    values:
+      - tls_cacert_values.yaml
+    asserts:
+      # This label is the entire RBAC delivery mechanism: the tenantsecret
+      # registry surfaces only Secrets bearing it, and the base tenant roles
+      # grant read on core.cozystack.io/tenantsecrets (not raw core secrets).
+      - equal:
+          path: metadata.labels["internal.cozystack.io/tenantresource"]
+          value: "true"
+
+  - it: merges caller-supplied labels and annotations
+    templates:
+      - templates/tests/tls-cacert.yaml
+    values:
+      - tls_cacert_values.yaml
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: myrelease
+      - equal:
+          path: metadata.annotations["cozystack.io/example"]
+          value: "yes"
+
+  - it: keeps the mandatory tenantresource label even when a caller tries to override it
+    templates:
+      - templates/tests/tls-cacert.yaml
+    values:
+      - tls_cacert_values.yaml
+    set:
+      # A caller (or a compromised values override) attempting to opt the object
+      # out of tenant delivery — or worse, flip the label onto a key-bearing
+      # Secret — must not win. The helper's mandatory label always overrides.
+      callerLabels:
+        internal.cozystack.io/tenantresource: "false"
+    asserts:
+      - equal:
+          path: metadata.labels["internal.cozystack.io/tenantresource"]
+          value: "true"
+
+  - it: fails closed when caCert is empty
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      caCert: ""
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert is required and must be a non-empty PEM"
+
+  - it: refuses to publish private key material to tenants
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      caCert: |
+        -----BEGIN EC PRIVATE KEY-----
+        MHcCAQEEexampleprivatekeymaterialthatmustneverreachtenants00000000
+        -----END EC PRIVATE KEY-----
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert must not contain private key material"
+
+  - it: refuses private key material regardless of PEM header casing
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      # RFC 7468 mandates uppercase headers, but the guard must also catch
+      # malformed / hand-pasted input where the casing differs.
+      caCert: |
+        -----begin private key-----
+        MIIExampleLowercaseHeaderPrivateKeyMustStillBeRejected0000000000
+        -----end private key-----
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert must not contain private key material"
+
+  - it: refuses a certificate bundle that also carries a private key block
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      # The realistic accident: a full keypair pasted into the CA field. The
+      # guard must scan the entire blob, not merely reject key-only input — a
+      # valid leading certificate block must not let a trailing private key
+      # slip through to a tenant-readable trust anchor.
+      caCert: |
+        -----BEGIN CERTIFICATE-----
+        MIIBExampleCertificateBodyOnlyNoPrivateKeyHeaderPresent0000000000
+        -----END CERTIFICATE-----
+        -----BEGIN PRIVATE KEY-----
+        MIIExamplePrivateKeyThatMustNeverReachTenantsViaCABundle00000000
+        -----END PRIVATE KEY-----
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert must not contain private key material"
+
+  - it: rejects input that is not a PEM certificate
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      caCert: |
+        this is not a certificate at all
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert must contain a PEM certificate (BEGIN CERTIFICATE)"
+
+  - it: accepts a certificate even when the literal text PRIVATE KEY appears outside a PEM header
+    templates:
+      - templates/tests/tls-cacert-params.yaml
+    set:
+      useParams: true
+      name: my-ca-cert
+      namespace: tenant-acme
+      # "PRIVATE KEY" here is in a friendlyName line, not a PEM header — a free
+      # substring guard would wrongly reject this valid, key-free certificate.
+      caCert: |
+        Bag Attributes: friendlyName=acme PRIVATE KEY authority
+        -----BEGIN CERTIFICATE-----
+        MIIBExampleCertificateBodyOnlyNoPrivateKeyHeaderPresent0000000000
+        -----END CERTIFICATE-----
+    asserts:
+      - isKind:
+          of: Secret
+      - isNotNullOrEmpty:
+          path: stringData["ca.crt"]
+
+  - it: fails closed when name is empty
+    templates:
+      - templates/tests/tls-cacert-params.yaml
+    set:
+      useParams: true
+      name: ""
+      namespace: tenant-acme
+      caCert: |
+        -----BEGIN CERTIFICATE-----
+        MIIBExampleCertificateBodyOnlyNoPrivateKeyHeaderPresent0000000000
+        -----END CERTIFICATE-----
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: name is required"
+
+  - it: omits metadata.namespace when namespace is not supplied
+    templates:
+      - templates/tests/tls-cacert-params.yaml
+    set:
+      useParams: true
+      name: my-ca-cert
+      caCert: |
+        -----BEGIN CERTIFICATE-----
+        MIIBExampleCertificateBodyOnlyNoPrivateKeyHeaderPresent0000000000
+        -----END CERTIFICATE-----
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-ca-cert
+      - notExists:
+          path: metadata.namespace
+
+  - it: fails closed when invoked with a non-dict argument
+    templates:
+      - templates/tests/tls-cacert-nondict.yaml
+    # A valid caCert keeps the other fixtures rendering cleanly so the only
+    # failure is the non-dict guard on this fixture.
+    values:
+      - tls_cacert_values.yaml
+    set:
+      nonDict: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: expected a single dict argument"

--- a/packages/tests/cozy-lib-tests/tests/tls_cacert_values.yaml
+++ b/packages/tests/cozy-lib-tests/tests/tls_cacert_values.yaml
@@ -1,0 +1,4 @@
+caCert: |
+  -----BEGIN CERTIFICATE-----
+  MIIBExampleCACertificateOnlyNoPrivateKeyMaterialPresentHere00000000
+  -----END CERTIFICATE-----


### PR DESCRIPTION
## What this PR does

Part of #2814. Part of #2811.

This is the foundational ("keystone") piece of WS3: a canonical, reusable trust-anchor object that lets a tenant obtain `ca.crt` to verify a per-app TLS endpoint **without** read access to any object that also carries a private key. It unblocks the per-app TLS series (WS4/WS5) by giving every chart one agreed, key-free delivery shape instead of each chart inventing its own.

### The problem (verified against current `main`)

Per-app TLS issues a per-release, self-signed CA. The only objects that hold `ca.crt` today also hold private keys:

- the cert-manager CA Secret `<release>-ca` carries the CA private key (`tls.key`) — full trust-chain compromise if leaked (`packages/apps/nats/templates/certmanager.yaml`, the `isCA` Certificate);
- the cert-manager leaf Secret `<release>-tls` carries the server private key (`tls.key`) plus `ca.crt` (same file, the leaf Certificate);
- CNPG surfaces `ca.crt` only inside its user-credentials Secret (`packages/apps/postgres/templates/db.yaml`, the operator-managed TLS block).

So any RBAC path that hands a tenant `ca.crt` by granting read on one of those Secrets also hands over a private key. On `main` today the cert-manager apps grant tenants no access to those Secrets at all, so a tenant currently cannot obtain `ca.crt` to verify the server — the gap this object closes safely.

### Design decision: key-free Opaque object delivered through `tenantsecrets`, not trust-manager

I evaluated the two candidate delivery mechanisms.

**Rejected — trust-manager.** A trust-manager `Bundle` reads its sources only from trust-manager's single configured "trust namespace"; its `namespaceSelector` governs only where the bundle is *distributed to*, not where it is *sourced from*. A per-release self-signed CA lives in the tenant namespace, so trust-manager cannot use it as a source, and projecting one shared CA to all tenants would defeat per-release isolation. I re-verified this against current upstream docs (cert-manager.io trust-manager) and the open per-namespace-trust-bundle request (cert-manager/trust-manager#131, which is target-side only). The prior analysis still holds.

**Chosen — a `ca.crt`-only Opaque Secret surfaced through the existing tenant-secret API.** This generalizes the reference pattern from the redis work (#2729), where the operator publishes a CA-only Opaque Secret and RBAC is scoped to it instead of to the CA-private-key Secret. The new `cozy-lib.tls.caCertSecret` helper renders that object once, identically, for every chart:

- `type: Opaque`, a single `ca.crt` data key, no `tls.key`/`tls.crt`;
- label `internal.cozystack.io/tenantresource: "true"`;
- fails closed on empty input and refuses any PEM that contains private key material.

### How the RBAC wiring works (no new roles needed)

The label is the entire mechanism, and it routes through RBAC that already exists:

- `pkg/registry/core/tenantsecret/rest.go` surfaces, under the virtual resource `core.cozystack.io/tenantsecrets`, exactly the namespace Secrets bearing `internal.cozystack.io/tenantresource=true` (`buildTenantSelector`, lines 199-213; label constants `pkg/apis/core/v1alpha1/tenantresource_types.go:3-4`; full `Data` copied through by `secretToTenant`, lines 84-103).
- `packages/system/cozystack-basics/templates/clusterroles.yaml` grants `get/list/watch` on `core.cozystack.io/tenantsecrets` to tenant ServiceAccounts via `cozy:tenant:base` (lines 44-47) and to `use`/`admin`/`super-admin` subjects via `cozy:tenant:use:base` (lines 179-180). None of this touches raw core `secrets`, so attaching the label to a key-free object exposes the trust anchor and nothing else.
- `internal/backupcontroller/credentials_projector.go:128-133` relies on the same rule in reverse — it deliberately *omits* the label so its key-bearing projection is not promoted to a `TenantSecret`. This helper is the positive counterpart: a key-free object that is safe to promote.

`view` deliberately does not receive the trust anchor through this path: `cozy:tenant:view:base` grants only `core.cozystack.io/options` (lines 120-126), and `tenantsecrets` also includes credential Secrets, so granting it to a read-only role would leak passwords. The trust anchor reaches `use` and above plus tenant ServiceAccounts — the same access level at which connection credentials are already surfaced (the per-release dashboard Role binds at `use`, e.g. `packages/apps/postgres/templates/dashboard-resourcemap.yaml` via `cozy-lib.rbac.subjectsForTenantAndAccessLevel`). A chart that must show `ca.crt` at `view` level in the dashboard can additionally name the key-free Secret in its own per-release Role; that is a per-app detail, not a base-role change.

### Why a library helper and not a controller here

Populating `ca.crt` stays the responsibility of whatever owns the PKI — the app operator (as the redis fork does) or a cert-manager chain resolved at the chart level. The helper is intentionally pure and value-driven so it renders deterministically and is the single shape every per-app PR converges on. A shared key-stripping projection controller is a reasonable future generalization but is out of scope for this foundational object.

### Convergence plan for the per-app TLS series (follow-up, not this PR)

I did not modify any of the open per-app branches. Each should adopt the canonical object as follows:

- redis #2729 — already publishes an operator-side CA-only Opaque Secret and already drops the grant on the CA-private-key Secret; converging means emitting it through the helper / carrying the `tenantresource` label so delivery matches the rest of the catalog.
- nats, qdrant (merged, cert-manager) — emit the canonical object via the helper and withhold `<release>-ca` / `<release>-tls` from tenants.
- mariadb #2680, opensearch #2682, rabbitmq #2683, mongodb #2692 — same: emit the canonical object, never grant a Secret that contains `tls.key`.

### Tests

`helm-unittest` in the cozy-lib test chart (`make -C packages/tests/cozy-lib-tests test`) covers: the rendered object is `Opaque` with `ca.crt` and no `tls.key`/`tls.crt`; the `tenantresource` label is present; caller labels/annotations merge while the security label always wins; the helper fails closed on empty `caCert`; and it refuses a PEM that carries private key material.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Helm helper to generate CA-only Kubernetes TLS trust-anchor secrets, including input validation (rejects private key material, requires a properly formatted certificate, and ensures required metadata).

* **Tests**
  * Introduced a dedicated test suite covering successful rendering, metadata and content assertions, tenant label enforcement, label/annotation merging, and detailed failure cases for invalid inputs and incorrect arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->