### PR TITLE
chore(openbao): bump openbao chart to 0.25.7

### DIFF
--- a/packages/apps/openbao/Chart.yaml
+++ b/packages/apps/openbao/Chart.yaml
@@ -4,4 +4,4 @@ description: Managed OpenBAO secrets management service
 icon: /logos/openbao.svg
 type: application
 version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process
-appVersion: "2.5.0"
+appVersion: "2.5.1"

--- a/packages/system/openbao/Makefile
+++ b/packages/system/openbao/Makefile
@@ -7,4 +7,7 @@ export CHART_VERSION=^0.25
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update: clean openbao-update

--- a/packages/system/openbao/charts/openbao/Chart.yaml
+++ b/packages/system/openbao/charts/openbao/Chart.yaml
@@ -2,11 +2,10 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        fix: Add extraPorts to server Service in ha
-  artifacthub.io/containsSecurityUpdates: "false"
+        fix: Add job selector in Grafana dashboard
   charts.openshift.io/name: Openbao
 apiVersion: v2
-appVersion: v2.5.0
+appVersion: v2.5.1
 description: Official OpenBao Chart
 home: https://github.com/openbao/openbao-helm
 icon: https://raw.githubusercontent.com/openbao/artwork/refs/heads/main/color/openbao-color.svg
@@ -27,4 +26,4 @@ maintainers:
 name: openbao
 sources:
 - https://github.com/openbao/openbao-helm
-version: 0.25.3
+version: 0.25.7

--- a/packages/system/openbao/charts/openbao/README.md
+++ b/packages/system/openbao/charts/openbao/README.md
@@ -1,6 +1,6 @@
 # openbao
 
-![Version: 0.25.3](https://img.shields.io/badge/Version-0.25.3-informational?style=flat-square) ![AppVersion: v2.5.0](https://img.shields.io/badge/AppVersion-v2.5.0-informational?style=flat-square)
+![Version: 0.25.7](https://img.shields.io/badge/Version-0.25.7-informational?style=flat-square) ![AppVersion: v2.5.1](https://img.shields.io/badge/AppVersion-v2.5.1-informational?style=flat-square)
 
 Official OpenBao Chart
 
@@ -280,6 +280,7 @@ Kubernetes: `>= 1.30.0-0`
 | server.service.externalTrafficPolicy | string | `"Cluster"` |  |
 | server.service.extraLabels | object | `{}` |  |
 | server.service.extraPorts | list | `[]` | extraPorts is a list of extra ports. Specified as a YAML list. This is useful if you need to add additional ports to the server service in dynamic way. |
+| server.service.headless.annotations | object | `{}` |  |
 | server.service.instanceSelector.enabled | bool | `true` |  |
 | server.service.ipFamilies | list | `[]` |  |
 | server.service.ipFamilyPolicy | string | `""` |  |
@@ -337,7 +338,7 @@ Kubernetes: `>= 1.30.0-0`
 | snapshotAgent.extraVolumeMounts | list | `[]` | List of additional volumeMounts for the snapshot cronjob container. |
 | snapshotAgent.extraVolumes | list | `[]` | List of extraVolumes made available to the snapshot cronjob container. |
 | snapshotAgent.image.repository | string | `"ghcr.io/openbao/openbao-snapshot-agent"` |  |
-| snapshotAgent.image.tag | string | `"0.2.4"` |  |
+| snapshotAgent.image.tag | string | `"0.3.0"` |  |
 | snapshotAgent.resources | object | `{}` |  |
 | snapshotAgent.restartPolicy | string | `"OnFailure"` |  |
 | snapshotAgent.s3CredentialsSecret | string | `"my-s3-credentials"` |  |

--- a/packages/system/openbao/charts/openbao/grafana/dashboards/dashboard.json
+++ b/packages/system/openbao/charts/openbao/grafana/dashboards/dashboard.json
@@ -133,7 +133,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "up{job=\"openbao-internal\"}",
+          "expr": "up{job=\"${job}\"}",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{ instance }}",
@@ -203,7 +203,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "sum by (exported_namespace,mount_point) (${metrics_prefix}_secret_kv_count)",
+          "expr": "sum by (exported_namespace,mount_point) (${metrics_prefix}_secret_kv_count{job=\"${job}\"})",
           "format": "table",
           "instant": true,
           "interval": "",
@@ -284,7 +284,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "avg(${metrics_prefix}_identity_num_entities)",
+          "expr": "avg(${metrics_prefix}_identity_num_entities{job=\"${job}\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -353,7 +353,7 @@
       "strokeWidth": "3",
       "targets": [
         {
-          "expr": "avg without(instance) (${metrics_prefix}_identity_entity_alias_count)",
+          "expr": "avg without(instance) (${metrics_prefix}_identity_entity_alias_count{job=\"${job}\"})",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{ auth_method }}",
@@ -433,7 +433,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "max(1 + ${metrics_prefix}_core_unsealed{})",
+          "expr": "max(1 + ${metrics_prefix}_core_unsealed{job=\"${job}\"})",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{ instance }}",
@@ -496,7 +496,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "avg(${metrics_prefix}_expire_num_leases)",
+          "expr": "avg(${metrics_prefix}_expire_num_leases{job=\"${job}\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -580,7 +580,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(increase(${metrics_prefix}_route_create_${mountpoint}__count[5m]))",
+              "expr": "avg(increase(${metrics_prefix}_route_create_${mountpoint}__count{job=\"${job}\"}[5m]))",
               "format": "time_series",
               "hide": false,
               "interval": "5m",
@@ -588,14 +588,14 @@
               "refId": "A"
             },
             {
-              "expr": "avg(increase(${metrics_prefix}_route_delete_${mountpoint}__count[5m]))",
+              "expr": "avg(increase(${metrics_prefix}_route_delete_${mountpoint}__count{job=\"${job}\"}[5m]))",
               "hide": false,
               "interval": "5m",
               "legendFormat": "Delete",
               "refId": "B"
             },
             {
-              "expr": "avg(increase(${metrics_prefix}_route_read_${mountpoint}__count[5m]))",
+              "expr": "avg(increase(${metrics_prefix}_route_read_${mountpoint}__count{job=\"${job}\"}[5m]))",
               "format": "time_series",
               "hide": false,
               "instant": false,
@@ -605,7 +605,7 @@
               "refId": "C"
             },
             {
-              "expr": "avg(increase(${metrics_prefix}_route_list_${mountpoint}__count[5m]))",
+              "expr": "avg(increase(${metrics_prefix}_route_list_${mountpoint}__count{job=\"${job}\"}[5m]))",
               "format": "time_series",
               "hide": false,
               "interval": "5m",
@@ -613,7 +613,7 @@
               "refId": "D"
             },
             {
-              "expr": "avg(increase(${metrics_prefix}_route_rollback_${mountpoint}__count[5m]))",
+              "expr": "avg(increase(${metrics_prefix}_route_rollback_${mountpoint}__count{job=\"${job}\"}[5m]))",
               "hide": true,
               "interval": "5m",
               "legendFormat": "Rollback",
@@ -726,7 +726,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(rate(${metrics_prefix}_route_create_${mountpoint}__sum[1m]) / rate(${metrics_prefix}_route_create_${mountpoint}__count[1m]) * 1000)",
+              "expr": "avg(rate(${metrics_prefix}_route_create_${mountpoint}__sum{job=\"${job}\"}[1m]) / rate(${metrics_prefix}_route_create_${mountpoint}__count{job=\"${job}\"}[1m]) * 1000)",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -734,27 +734,27 @@
               "refId": "A"
             },
             {
-              "expr": "avg(rate(${metrics_prefix}_route_delete_${mountpoint}__sum[1m]) / rate(${metrics_prefix}_route_delete_${mountpoint}__count[1m]) * 1000)",
+              "expr": "avg(rate(${metrics_prefix}_route_delete_${mountpoint}__sum{job=\"${job}\"}[1m]) / rate(${metrics_prefix}_route_delete_${mountpoint}__count{job=\"${job}\"}[1m]) * 1000)",
               "interval": "",
               "legendFormat": "Delete",
               "refId": "B"
             },
             {
-              "expr": "avg(rate(${metrics_prefix}_route_read_${mountpoint}__sum[1m]) / rate(${metrics_prefix}_route_read_${mountpoint}__count[1m]) * 1000)",
+              "expr": "avg(rate(${metrics_prefix}_route_read_${mountpoint}__sum{job=\"${job}\"}[1m]) / rate(${metrics_prefix}_route_read_${mountpoint}__count{job=\"${job}\"}[1m]) * 1000)",
               "hide": false,
               "interval": "",
               "legendFormat": "Read",
               "refId": "C"
             },
             {
-              "expr": "avg(rate(${metrics_prefix}_route_list_${mountpoint}__sum[1m]) / rate(${metrics_prefix}_route_list_${mountpoint}__count[1m]) * 1000)",
+              "expr": "avg(rate(${metrics_prefix}_route_list_${mountpoint}__sum{job=\"${job}\"}[1m]) / rate(${metrics_prefix}_route_list_${mountpoint}__count{job=\"${job}\"}[1m]) * 1000)",
               "hide": false,
               "interval": "",
               "legendFormat": "List",
               "refId": "D"
             },
             {
-              "expr": "avg(rate(${metrics_prefix}_route_rollback_${mountpoint}__sum[1m]) / rate(${metrics_prefix}_route_rollback_${mountpoint}__count[1m]) * 1000)",
+              "expr": "avg(rate(${metrics_prefix}_route_rollback_${mountpoint}__sum{job=\"${job}\"}[1m]) / rate(${metrics_prefix}_route_rollback_${mountpoint}__count{job=\"${job}\"}[1m]) * 1000)",
               "hide": true,
               "interval": "",
               "legendFormat": "Rollback",
@@ -870,7 +870,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "avg(${metrics_prefix}_runtime_heap_objects{} / ${metrics_prefix}_runtime_malloc_count{})",
+          "expr": "avg(${metrics_prefix}_runtime_heap_objects{job=\"${job}\"} / ${metrics_prefix}_runtime_malloc_count{job=\"${job}\"})",
           "interval": "",
           "intervalFactor": 10,
           "legendFormat": "",
@@ -934,7 +934,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "avg(${metrics_prefix}_runtime_num_goroutines{})",
+          "expr": "avg(${metrics_prefix}_runtime_num_goroutines{job=\"${job}\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -1012,7 +1012,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(${metrics_prefix}_runtime_alloc_bytes{})",
+          "expr": "avg(${metrics_prefix}_runtime_alloc_bytes{job=\"${job}\"})",
           "interval": "",
           "intervalFactor": 5,
           "legendFormat": "$node",
@@ -1116,7 +1116,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "avg(${metrics_prefix}_token_count)",
+          "expr": "avg(${metrics_prefix}_token_count{job=\"${job}\"})",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
@@ -1177,7 +1177,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg without(instance) (${metrics_prefix}_token_count_by_policy)",
+          "expr": "avg without(instance) (${metrics_prefix}_token_count_by_policy{job=\"${job}\"})",
           "interval": "",
           "legendFormat": "{{ policy }}",
           "refId": "A"
@@ -1283,7 +1283,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "avg(${metrics_prefix}_token_create_count - ${metrics_prefix}_token_store_count)",
+          "expr": "avg(${metrics_prefix}_token_create_count{job=\"${job}\"} - ${metrics_prefix}_token_store_count{job=\"${job}\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1346,7 +1346,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg without(instance) (${metrics_prefix}_token_count_by_ttl)",
+          "expr": "avg without(instance) (${metrics_prefix}_token_count_by_ttl{job=\"${job}\"})",
           "format": "time_series",
           "interval": "",
           "legendFormat": "{{ creation_ttl }}",
@@ -1446,7 +1446,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg without(instance) (${metrics_prefix}_token_count_by_auth)",
+          "expr": "avg without(instance) (${metrics_prefix}_token_count_by_auth{job=\"${job}\"})",
           "interval": "",
           "legendFormat": "{{ auth_method }}",
           "refId": "A"
@@ -1563,7 +1563,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by(auth_method, creation_ttl) (${metrics_prefix}_token_creation)",
+          "expr": "avg by(auth_method, creation_ttl) (${metrics_prefix}_token_creation{job=\"${job}\"})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1667,7 +1667,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg without(instance) (${metrics_prefix}_token_create_count)",
+          "expr": "avg without(instance) (${metrics_prefix}_token_create_count{job=\"${job}\"})",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1676,7 +1676,7 @@
           "refId": "A"
         },
         {
-          "expr": "avg without(instance) (${metrics_prefix}_token_store_count)",
+          "expr": "avg without(instance) (${metrics_prefix}_token_store_count{job=\"${job}\"})",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1784,7 +1784,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(irate(${metrics_prefix}_token_lookup_count[1m]))",
+          "expr": "avg(irate(${metrics_prefix}_token_lookup_count{job=\"${job}\"}[1m]))",
           "hide": false,
           "interval": "",
           "legendFormat": "Lookups",
@@ -1894,7 +1894,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "max(idelta(${metrics_prefix}_audit_log_request_failure[1m]))",
+          "expr": "max(idelta(${metrics_prefix}_audit_log_request_failure{job=\"${job}\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "legendFormat": "Request",
@@ -1959,7 +1959,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(irate(${metrics_prefix}_audit_log_request_count[1m]))",
+          "expr": "avg(irate(${metrics_prefix}_audit_log_request_count{job=\"${job}\"}[1m]))",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1968,7 +1968,7 @@
           "refId": "A"
         },
         {
-          "expr": "avg(irate(${metrics_prefix}_audit_log_response_count[1m]))",
+          "expr": "avg(irate(${metrics_prefix}_audit_log_response_count{job=\"${job}\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1978,7 +1978,7 @@
           "refId": "B"
         },
         {
-          "expr": "avg(irate(${metrics_prefix}_core_handle_request_count[1m]))",
+          "expr": "avg(irate(${metrics_prefix}_core_handle_request_count{job=\"${job}\"}[1m]))",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -2079,26 +2079,26 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(irate(${metrics_prefix}_consul_get_count[1m]))",
+          "expr": "avg(irate(${metrics_prefix}_consul_get_count{job=\"${job}\"}[1m]))",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "GET",
           "refId": "A"
         },
         {
-          "expr": "avg(irate(${metrics_prefix}_consul_put_count[1m]))",
+          "expr": "avg(irate(${metrics_prefix}_consul_put_count{job=\"${job}\"}[1m]))",
           "interval": "",
           "legendFormat": "PUT",
           "refId": "B"
         },
         {
-          "expr": "avg(irate(${metrics_prefix}_consul_delete_count[1m]))",
+          "expr": "avg(irate(${metrics_prefix}_consul_delete_count{job=\"${job}\"}[1m]))",
           "interval": "",
           "legendFormat": "DELETE",
           "refId": "C"
         },
         {
-          "expr": "irate(${metrics_prefix}_consul_list_count{instance=\"$node:$port\"}[1m])",
+          "expr": "irate(${metrics_prefix}_consul_list_count{instance=\"$node:$port\", job=\"${job}\"}[1m])",
           "interval": "",
           "legendFormat": "LIST",
           "refId": "D"
@@ -2192,7 +2192,7 @@
       "pluginVersion": "7.0.3",
       "targets": [
         {
-          "expr": "max(idelta(${metrics_prefix}_audit_log_response_failure[1m]))",
+          "expr": "max(idelta(${metrics_prefix}_audit_log_response_failure{job=\"${job}\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "legendFormat": "Request",
@@ -2269,7 +2269,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(irate(${metrics_prefix}_policy_set_policy_count[1m]))",
+          "expr": "avg(irate(${metrics_prefix}_policy_set_policy_count{job=\"${job}\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2370,7 +2370,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(irate(${metrics_prefix}_policy_get_policy_count[1m]))",
+          "expr": "avg(irate(${metrics_prefix}_policy_get_policy_count{job=\"${job}\"}[1m]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -2445,16 +2445,39 @@
       },
       {
         "allValue": null,
+        "allowCustomValue": false,
         "current": {},
         "datasource": "${DS_PROMXY}",
-        "definition": "label_values(up{job=\"openbao-internal\"}, instance)",
+        "definition": "label_values(${metrics_prefix}_core_active,job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Job:",
+        "name": "job",
+        "multi": false,
+        "options": [],
+        "query": "label_values(${metrics_prefix}_core_active,job)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_PROMXY}",
+        "definition": "label_values(up{job=\"$job\"}, instance)",
         "hide": 2,
         "includeAll": false,
         "label": "Host:",
         "multi": false,
         "name": "node",
         "options": [],
-        "query": "label_values(up{job=\"openbao-internal\"}, instance)",
+        "query": "label_values(up{job=\"$job\"}, instance)",
         "refresh": 1,
         "regex": "/([^:]+):.*/",
         "skipUrlSync": false,
@@ -2469,14 +2492,14 @@
         "allValue": null,
         "current": {},
         "datasource": "${DS_PROMXY}",
-        "definition": "label_values(up{job=\"openbao-internal\",instance=~\"$node:(.*)\"}, instance)",
+        "definition": "label_values(up{job=\"$job\",instance=~\"$node:(.*)\"}, instance)",
         "hide": 2,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "port",
         "options": [],
-        "query": "label_values(up{job=\"openbao-internal\",instance=~\"$node:(.*)\"}, instance)",
+        "query": "label_values(up{job=\"$job\",instance=~\"$node:(.*)\"}, instance)",
         "refresh": 1,
         "regex": "/[^:]+:(.*)/",
         "skipUrlSync": false,
@@ -2491,14 +2514,14 @@
         "allValue": "",
         "current": {},
         "datasource": "${DS_PROMXY}",
-        "definition": "label_values(${metrics_prefix}_secret_kv_count, mount_point)",
+        "definition": "label_values(${metrics_prefix}_secret_kv_count{job=\"$job\"}, mount_point)",
         "hide": 0,
         "includeAll": true,
         "label": "Mount Point:",
         "multi": true,
         "name": "mountpoint",
         "options": [],
-        "query": "label_values(${metrics_prefix}_secret_kv_count, mount_point)",
+        "query": "label_values(${metrics_prefix}_secret_kv_count{job=\"$job\"}, mount_point)",
         "refresh": 2,
         "regex": "/(.*)//",
         "skipUrlSync": false,

--- a/packages/system/openbao/charts/openbao/templates/_helpers.tpl
+++ b/packages/system/openbao/charts/openbao/templates/_helpers.tpl
@@ -787,6 +787,23 @@ Sets extra openbao server Service (standby) annotations
 {{- end -}}
 
 {{/*
+Sets extra openbao server Service (headless) annotations
+*/}}
+{{- define "openbao.service.headless.annotations" -}}
+  {{- $headless := .Values.server.service.headless.annotations -}}
+  {{- $generic := .Values.server.service.annotations -}}
+  {{- if or $headless $generic }}
+  annotations:
+    {{- if $headless }}
+      {{- include "openbao.annotations.render.4" (list . $headless) -}}
+    {{- end }}
+    {{- if $generic }}
+      {{- include "openbao.annotations.render.4" (list . $generic) -}}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Sets PodSecurityPolicy annotations
 */}}
 {{- define "openbao.psp.annotations" -}}

--- a/packages/system/openbao/charts/openbao/templates/server-headless-service.yaml
+++ b/packages/system/openbao/charts/openbao/templates/server-headless-service.yaml
@@ -19,7 +19,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     openbao-internal: "true"
-{{ template "openbao.service.annotations" .}}
+{{- template "openbao.service.headless.annotations" .}}
 spec:
   {{- if (semverCompare ">= 1.23-0" .Capabilities.KubeVersion.Version) }}
   {{- if .Values.server.service.ipFamilyPolicy }}

--- a/packages/system/openbao/charts/openbao/values.yaml
+++ b/packages/system/openbao/charts/openbao/values.yaml
@@ -807,6 +807,11 @@ server:
       # Extra labels for the service definition.
       # This should be a YAML map of the labels to apply to the standby service
       extraLabels: {}
+    headless:
+      # Extra annotations for the headless service definition. This can either be YAML or a
+      # YAML-formatted multi-line templated string map of the annotations to apply
+      # to the headless service.
+      annotations: {}
     # If enabled, the service selectors will include `app.kubernetes.io/instance: {{ .Release.Name }}`
     # When disabled, services may select OpenBao pods not deployed from the chart.
     # Does not affect the headless openbao-internal service with `ClusterIP: None`
@@ -1524,7 +1529,7 @@ snapshotAgent:
   # The image settings for the snapshot agent
   image:
     repository: ghcr.io/openbao/openbao-snapshot-agent
-    tag: 0.2.4
+    tag: 0.3.0
 
   # -- List of extraVolumes made available to the snapshot cronjob container.
   extraVolumes: []

--- a/packages/system/openbao/tests/openbao_test.yaml
+++ b/packages/system/openbao/tests/openbao_test.yaml
@@ -1,0 +1,29 @@
+suite: cozy-openbao chart rendering invariants
+release:
+  name: openbao
+  namespace: cozy-openbao
+tests:
+  - it: renders the openbao server StatefulSet on the pinned image
+    template: charts/openbao/templates/server-statefulset.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    asserts:
+      # Pin the full registry-qualified image. A partial regex on
+      # openbao/openbao:2.5.1 would also pass a wrong registry (e.g.
+      # docker.io); the chart configures quay.io, so assert it verbatim.
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: quay.io/openbao/openbao:2.5.1
+
+  - it: keeps the agent injector disabled (cozystack override)
+    template: charts/openbao/templates/injector-deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: keeps the CSI provider disabled (cozystack override)
+    template: charts/openbao/templates/csi-daemonset.yaml
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## What this PR does

Re-vendors the openbao-helm chart from 0.25.3 to 0.25.7 (appVersion v2.5.0 → v2.5.1), the latest in the `^0.25` line the Makefile pins. The vendored tree is byte-identical to a fresh upstream pull; cozystack overrides (`injector.enabled: false`, `csi.enabled: false`) are untouched and still render nothing, so the changed runtime surface is the openbao server StatefulSet image.

**Security scope (honest accounting):** v2.5.1 fixes two OpenBao CVEs — including the critical **CVE-2025-68121** (Go stdlib TLS, CVSS 10.0, via a Go 1.25.7 rebuild) and **CVE-2026-24051** (otel/sdk). The issue also lists `github.com/jackc/pgx/v5` — that is **not** addressed: pgx is unchanged in v2.5.1 upstream, so it can't be closed by an in-`^0.25` bump. `libcap2`/`libexpat` are base-image packages picked up incidentally by the rebuild (not verified here). Widening past 0.25.x to 0.28.x (app v2.5.5) would need a CHART_VERSION constraint change plus a 0.26/0.27/0.28 changelog review and is intentionally left out.

Adds helm-unittest coverage (the package shipped none): pins the server image and the injector/CSI-disabled invariants. `helm unittest` 3/3 pass.

Closes #2895

### Release note

```release-note
chore(openbao): bump openbao chart to 0.25.7 (app v2.5.1, fixes critical CVE-2025-68121)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring headless service annotations (including HA standby headless service).
  * Enhanced the Grafana dashboard with consistent dynamic job filtering across Prometheus queries.
* **Updates**
  * Upgraded Helm chart to **0.25.7** (OpenBao app **v2.5.1**).
  * Updated snapshot agent image tag to **0.3.0**.
* **Tests**
  * Added Helm unit test coverage via a `helm unittest` Makefile target and new chart rendering invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->