### PR TITLE
chore(foundationdb-operator): bump fdb-operator to v2.30.0

### DIFF
--- a/packages/system/foundationdb-operator/Makefile
+++ b/packages/system/foundationdb-operator/Makefile
@@ -3,9 +3,12 @@ export NAMESPACE=cozy-$(NAME)
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
-	rm -rf charts
-	git clone --depth 1 --branch v2.13.0 https://github.com/FoundationDB/fdb-kubernetes-operator.git tmp-repo
+	rm -rf charts tmp-repo
+	git clone --depth 1 --branch v2.30.0 https://github.com/FoundationDB/fdb-kubernetes-operator.git tmp-repo
 	mkdir -p charts
 	cp -r tmp-repo/charts/fdb-operator charts/
 	# Remove symlinked CRDs and replace with actual files

--- a/packages/system/foundationdb-operator/charts/fdb-operator/Chart.yaml
+++ b/packages/system/foundationdb-operator/charts/fdb-operator/Chart.yaml
@@ -15,9 +15,9 @@ sources:
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.0
+version: 0.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: v2.13.0
+appVersion: v2.30.0
 maintainers:
   - name: "foundationdb-ci"

--- a/packages/system/foundationdb-operator/charts/fdb-operator/crds/apps.foundationdb.org_foundationdbbackups.yaml
+++ b/packages/system/foundationdb-operator/charts/fdb-operator/crds/apps.foundationdb.org_foundationdbbackups.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
-    foundationdb.org/release: v2.13.0
+    controller-gen.kubebuilder.io/version: v0.20.1
+    foundationdb.org/release: v2.30.0
   name: foundationdbbackups.apps.foundationdb.org
 spec:
   group: apps.foundationdb.org
@@ -26,6 +26,10 @@ spec:
       jsonPath: .status.generations.reconciled
       name: Reconciled
       type: integer
+    - description: If the backup is restorable
+      jsonPath: .status.backupDetails.restorable
+      name: Restorable
+      type: boolean
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -65,6 +69,13 @@ spec:
                   namespace:
                     type: string
                 type: object
+              backupMode:
+                default: continuous
+                enum:
+                - continuous
+                - oneTime
+                maxLength: 64
+                type: string
               backupState:
                 enum:
                 - Running
@@ -76,6 +87,7 @@ spec:
                 enum:
                 - backup_agent
                 - partitioned_log
+                - unmanaged
                 maxLength: 64
                 type: string
               blobStoreConfiguration:
@@ -107,6 +119,16 @@ spec:
                   type: string
                 maxItems: 100
                 type: array
+              dataCenter:
+                type: string
+              deletionPolicy:
+                default: noop
+                enum:
+                - noop
+                - stop
+                - cleanup
+                maxLength: 64
+                type: string
               encryptionKeyPath:
                 maxLength: 4096
                 type: string
@@ -659,6 +681,23 @@ spec:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -1087,6 +1126,29 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -1371,6 +1433,23 @@ spec:
                                         - fieldPath
                                         type: object
                                         x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
+                                        type: object
+                                        x-kubernetes-map-type: atomic
                                       resourceFieldRef:
                                         properties:
                                           containerName:
@@ -1799,6 +1878,29 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -2040,6 +2142,8 @@ spec:
                         type: boolean
                       hostname:
                         type: string
+                      hostnameOverride:
+                        type: string
                       imagePullSecrets:
                         items:
                           properties:
@@ -2095,6 +2199,23 @@ spec:
                                             type: string
                                         required:
                                         - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      fileKeyRef:
+                                        properties:
+                                          key:
+                                            type: string
+                                          optional:
+                                            default: false
+                                            type: boolean
+                                          path:
+                                            type: string
+                                          volumeName:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        - volumeName
                                         type: object
                                         x-kubernetes-map-type: atomic
                                       resourceFieldRef:
@@ -2525,6 +2646,29 @@ spec:
                               type: object
                             restartPolicy:
                               type: string
+                            restartPolicyRules:
+                              items:
+                                properties:
+                                  action:
+                                    type: string
+                                  exitCodes:
+                                    properties:
+                                      operator:
+                                        type: string
+                                      values:
+                                        items:
+                                          format: int32
+                                          type: integer
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                    required:
+                                    - operator
+                                    type: object
+                                required:
+                                - action
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
                             securityContext:
                               properties:
                                 allowPrivilegeEscalation:
@@ -3621,6 +3765,29 @@ spec:
                                             type: array
                                             x-kubernetes-list-type: atomic
                                         type: object
+                                      podCertificate:
+                                        properties:
+                                          certificateChainPath:
+                                            type: string
+                                          credentialBundlePath:
+                                            type: string
+                                          keyPath:
+                                            type: string
+                                          keyType:
+                                            type: string
+                                          maxExpirationSeconds:
+                                            format: int32
+                                            type: integer
+                                          signerName:
+                                            type: string
+                                          userAnnotations:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        required:
+                                        - keyType
+                                        - signerName
+                                        type: object
                                       secret:
                                         properties:
                                           items:
@@ -3811,6 +3978,18 @@ spec:
                         x-kubernetes-list-map-keys:
                         - name
                         x-kubernetes-list-type: map
+                      workloadRef:
+                        properties:
+                          name:
+                            type: string
+                          podGroup:
+                            type: string
+                          podGroupReplicaKey:
+                            type: string
+                        required:
+                        - name
+                        - podGroup
+                        type: object
                     required:
                     - containers
                     type: object
@@ -3860,6 +4039,8 @@ spec:
               backupDetails:
                 properties:
                   paused:
+                    type: boolean
+                  restorable:
                     type: boolean
                   running:
                     type: boolean

--- a/packages/system/foundationdb-operator/charts/fdb-operator/crds/apps.foundationdb.org_foundationdbclusters.yaml
+++ b/packages/system/foundationdb-operator/charts/fdb-operator/crds/apps.foundationdb.org_foundationdbclusters.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
-    foundationdb.org/release: v2.13.0
+    controller-gen.kubebuilder.io/version: v0.20.1
+    foundationdb.org/release: v2.30.0
   name: foundationdbclusters.apps.foundationdb.org
 spec:
   group: apps.foundationdb.org
@@ -324,6 +324,7 @@ spec:
                     maxLength: 100
                     type: string
                   perpetual_storage_wiggle_locality:
+                    pattern: ^([\w.-]+:[\w.-]+|0)$
                     type: string
                   proxies:
                     type: integer
@@ -1091,6 +1092,23 @@ spec:
                                               - fieldPath
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               properties:
                                                 containerName:
@@ -1519,6 +1537,29 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -1803,6 +1844,23 @@ spec:
                                               - fieldPath
                                               type: object
                                               x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
+                                              type: object
+                                              x-kubernetes-map-type: atomic
                                             resourceFieldRef:
                                               properties:
                                                 containerName:
@@ -2231,6 +2289,29 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -2472,6 +2553,8 @@ spec:
                               type: boolean
                             hostname:
                               type: string
+                            hostnameOverride:
+                              type: string
                             imagePullSecrets:
                               items:
                                 properties:
@@ -2527,6 +2610,23 @@ spec:
                                                   type: string
                                               required:
                                               - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fileKeyRef:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                optional:
+                                                  default: false
+                                                  type: boolean
+                                                path:
+                                                  type: string
+                                                volumeName:
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              - volumeName
                                               type: object
                                               x-kubernetes-map-type: atomic
                                             resourceFieldRef:
@@ -2957,6 +3057,29 @@ spec:
                                     type: object
                                   restartPolicy:
                                     type: string
+                                  restartPolicyRules:
+                                    items:
+                                      properties:
+                                        action:
+                                          type: string
+                                        exitCodes:
+                                          properties:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                format: int32
+                                                type: integer
+                                              type: array
+                                              x-kubernetes-list-type: set
+                                          required:
+                                          - operator
+                                          type: object
+                                      required:
+                                      - action
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
                                   securityContext:
                                     properties:
                                       allowPrivilegeEscalation:
@@ -4053,6 +4176,29 @@ spec:
                                                   type: array
                                                   x-kubernetes-list-type: atomic
                                               type: object
+                                            podCertificate:
+                                              properties:
+                                                certificateChainPath:
+                                                  type: string
+                                                credentialBundlePath:
+                                                  type: string
+                                                keyPath:
+                                                  type: string
+                                                keyType:
+                                                  type: string
+                                                maxExpirationSeconds:
+                                                  format: int32
+                                                  type: integer
+                                                signerName:
+                                                  type: string
+                                                userAnnotations:
+                                                  additionalProperties:
+                                                    type: string
+                                                  type: object
+                                              required:
+                                              - keyType
+                                              - signerName
+                                              type: object
                                             secret:
                                               properties:
                                                 items:
@@ -4243,6 +4389,18 @@ spec:
                               x-kubernetes-list-map-keys:
                               - name
                               x-kubernetes-list-type: map
+                            workloadRef:
+                              properties:
+                                name:
+                                  type: string
+                                podGroup:
+                                  type: string
+                                podGroupReplicaKey:
+                                  type: string
+                              required:
+                              - name
+                              - podGroup
+                              type: object
                           required:
                           - containers
                           type: object
@@ -4557,6 +4715,7 @@ spec:
                     maxLength: 100
                     type: string
                   perpetual_storage_wiggle_locality:
+                    pattern: ^([\w.-]+:[\w.-]+|0)$
                     type: string
                   proxies:
                     type: integer

--- a/packages/system/foundationdb-operator/charts/fdb-operator/crds/apps.foundationdb.org_foundationdbrestores.yaml
+++ b/packages/system/foundationdb-operator/charts/fdb-operator/crds/apps.foundationdb.org_foundationdbrestores.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
-    foundationdb.org/release: v2.13.0
+    controller-gen.kubebuilder.io/version: v0.20.1
+    foundationdb.org/release: v2.30.0
   name: foundationdbrestores.apps.foundationdb.org
 spec:
   group: apps.foundationdb.org
@@ -36,6 +36,10 @@ spec:
             type: object
           spec:
             properties:
+              backupVersion:
+                format: int64
+                nullable: true
+                type: integer
               blobStoreConfiguration:
                 properties:
                   accountName:

--- a/packages/system/foundationdb-operator/charts/fdb-operator/templates/manager/deployment.yaml
+++ b/packages/system/foundationdb-operator/charts/fdb-operator/templates/manager/deployment.yaml
@@ -71,13 +71,16 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /manager
-        {{- if not .Values.globalMode.enabled }}
         env:
+        {{- if not .Values.globalMode.enabled }}
         - name: WATCH_NAMESPACE
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
         {{- end }}
+        {{- with .Values.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end}}
         ports:
         - containerPort: 8080
           name: metrics
@@ -88,6 +91,9 @@ spec:
           mountPath: /var/log/fdb
         - name: fdb-binaries
           mountPath: /usr/bin/fdb
+        {{- with .Values.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         securityContext:
           {{- toYaml .Values.containerSecurityContext | nindent 10 }}
         livenessProbe:
@@ -115,3 +121,6 @@ spec:
         emptyDir: {}
       - name: fdb-binaries
         emptyDir: {}
+      {{- with .Values.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}

--- a/packages/system/foundationdb-operator/charts/fdb-operator/templates/rbac/rbac_role_binding.yaml
+++ b/packages/system/foundationdb-operator/charts/fdb-operator/templates/rbac/rbac_role_binding.yaml
@@ -38,7 +38,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "fdb-operator.serviceAccountName" . }}
-  {{- if .Values.globalMode.enabled }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
 {{- end }}

--- a/packages/system/foundationdb-operator/charts/fdb-operator/values.yaml
+++ b/packages/system/foundationdb-operator/charts/fdb-operator/values.yaml
@@ -1,7 +1,7 @@
 ---
 image:
   repository: foundationdb/fdb-kubernetes-operator
-  tag: v2.13.0
+  tag: v2.30.0
   pullPolicy: IfNotPresent
 initContainers:
   7.1:
@@ -46,6 +46,9 @@ containerSecurityContext:
 nodeSelector: {}
 affinity: {}
 tolerations: {}
+extraEnv: []
+volumes: []
+volumeMounts: []
 resources:
   limits:
     cpu: 500m

--- a/packages/system/foundationdb-operator/tests/fdb-operator_test.yaml
+++ b/packages/system/foundationdb-operator/tests/fdb-operator_test.yaml
@@ -1,0 +1,43 @@
+suite: cozy-foundationdb-operator image pin
+release:
+  name: fdb-operator
+  namespace: cozy-foundationdb-operator
+tests:
+  - it: renders the operator on the pinned upstream image
+    template: charts/fdb-operator/templates/manager/deployment.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      # Pin the full image. A partial regex would also pass a wrong
+      # registry; assert the verbatim upstream reference instead.
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: foundationdb/fdb-kubernetes-operator:v2.30.0
+      # The CVE remediation also rides the init-monitor base images, so
+      # pin those too — a silent upstream retag would otherwise slip past.
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: foundationdb/fdb-kubernetes-monitor:7.1.67
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: foundationdb/fdb-kubernetes-monitor:7.3.63
+      - equal:
+          path: spec.template.spec.initContainers[2].image
+          value: foundationdb/fdb-kubernetes-monitor:7.4.1
+
+  - it: renders the operator image in the cozystack globalMode (the shipping config)
+    template: charts/fdb-operator/templates/manager/deployment.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      # cozystack ships globalMode.enabled=true (package-level values.yaml).
+      # The chart default is false, so without this the suite never renders
+      # the mode that actually deploys.
+      globalMode:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: foundationdb/fdb-kubernetes-operator:v2.30.0


### PR DESCRIPTION
## What this PR does

Re-vendors the FoundationDB Kubernetes operator chart from v2.13.0 to v2.30.0 (chart 0.2.0 → 0.3.0), 17 minor releases forward, picking up the published security fixes the issue enumerates. The operator + init-monitor images advance to the current upstream tags that carry the patched base packages.

The vendored tree is byte-identical to a fresh upstream `v2.30.0` clone (templates + values + the three CRDs copied from `config/crd/bases/`). The CRD changes are **additive only** — new fields, no property removals (only the controller-gen / `foundationdb.org/release` version annotations change) — so the `apps/foundationdb` FDB CR stays valid against the new operator. cozystack overrides (`globalMode`, `nodeReadClusterRole`) remain valid and consumed by the v2.30.0 templates. The one removed CLI flag (`genericclioption`) is not used by cozystack; the chart's RBAC role binding is now unconditional (previously globalMode-gated) — a no-op for cozystack, which sets `globalMode=true`.

Adds helm-unittest coverage (the package shipped none): pins the operator image.

Verified: `helm template` renders the operator at `v2.30.0`; `helm unittest` 1/1 pass.

Closes #2879

### Release note

```release-note
chore(foundationdb-operator): bump fdb-operator to v2.30.0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom environment variables plus additional pod volumes and mounts for the operator.
  * Expanded FoundationDB backup/cluster/restore CRD capabilities (new backup modes, deletion policies, workload references, and pod template options).

* **Bug Fixes**
  * Adjusted RBAC service account binding behavior to use the release namespace consistently.

* **Tests**
  * Added image pin and global-mode rendering checks for operator deployment.

* **Chores**
  * Upgraded the FoundationDB operator Helm chart/app version and image to v2.30.0; added a Helm unittest `test` target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->