### PR TITLE
fix(kubevirt-instancetypes): drop persistent EFI/TPM to unblock live-migration

### DIFF
--- a/packages/system/kubevirt-instancetypes/Makefile
+++ b/packages/system/kubevirt-instancetypes/Makefile
@@ -16,6 +16,12 @@ update:
 	mkdir templates
 	kustomize build https://github.com/kubevirt/common-instancetypes/preferences?ref=$(COMMON_INSTANCETYPES_REF) > templates/preferences.yaml
 	yq -i 'select(.kind != "VirtualMachinePreference")' templates/preferences.yaml
+	# TEMPORARY (see #3005): drop persistent EFI/TPM state. With persistence on,
+	# KubeVirt creates a backend-storage PVC that is RWO on the default StorageClass,
+	# which pins the VM to its node and blocks live-migration / drain. Use `del` (not
+	# `sed -d`) so an emptied preferredTPM stays `{}` rather than null, which the
+	# KubeVirt v1.8 CRD structural schema rejects. Revert once vm-state can request RWX.
+	yq -i 'del(.spec.firmware.preferredEfi.persistent) | del(.spec.devices.preferredTPM.persistent)' templates/preferences.yaml
 	kustomize build https://github.com/kubevirt/common-instancetypes/instancetypes?ref=$(COMMON_INSTANCETYPES_REF) > templates/instancetypes.yaml
 	yq -i 'select(.kind != "VirtualMachineInstancetype")' templates/instancetypes.yaml
 	# Re-append Cozystack-local instancetypes the pinned catalog no longer ships

--- a/packages/system/kubevirt-instancetypes/templates/preferences.yaml
+++ b/packages/system/kubevirt-instancetypes/templates/preferences.yaml
@@ -1352,8 +1352,7 @@ spec:
     preferredAutoattachInputDevice: true
     preferredDiskBus: sata
     preferredInterfaceModel: e1000e
-    preferredTPM:
-      persistent: true
+    preferredTPM: {}
   features:
     preferredAcpi: {}
     preferredApic: {}
@@ -1375,7 +1374,6 @@ spec:
     preferredSmm: {}
   firmware:
     preferredEfi:
-      persistent: true
       secureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
   requirements:
@@ -1424,8 +1422,7 @@ spec:
     preferredInputBus: virtio
     preferredInputType: tablet
     preferredInterfaceModel: virtio
-    preferredTPM:
-      persistent: true
+    preferredTPM: {}
   features:
     preferredAcpi: {}
     preferredApic: {}
@@ -1447,7 +1444,6 @@ spec:
     preferredSmm: {}
   firmware:
     preferredEfi:
-      persistent: true
       secureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
   requirements:
@@ -1894,8 +1890,7 @@ spec:
     preferredAutoattachInputDevice: true
     preferredDiskBus: sata
     preferredInterfaceModel: e1000e
-    preferredTPM:
-      persistent: true
+    preferredTPM: {}
   features:
     preferredAcpi: {}
     preferredApic: {}
@@ -1917,7 +1912,6 @@ spec:
     preferredSmm: {}
   firmware:
     preferredEfi:
-      persistent: true
       secureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
   requirements:
@@ -1966,8 +1960,7 @@ spec:
     preferredInputBus: virtio
     preferredInputType: tablet
     preferredInterfaceModel: virtio
-    preferredTPM:
-      persistent: true
+    preferredTPM: {}
   features:
     preferredAcpi: {}
     preferredApic: {}
@@ -1989,7 +1982,6 @@ spec:
     preferredSmm: {}
   firmware:
     preferredEfi:
-      persistent: true
       secureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
   requirements:
@@ -2036,8 +2028,7 @@ spec:
     preferredAutoattachInputDevice: true
     preferredDiskBus: sata
     preferredInterfaceModel: e1000e
-    preferredTPM:
-      persistent: true
+    preferredTPM: {}
   features:
     preferredAcpi: {}
     preferredApic: {}
@@ -2059,7 +2050,6 @@ spec:
     preferredSmm: {}
   firmware:
     preferredEfi:
-      persistent: true
       secureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
   requirements:
@@ -2108,8 +2098,7 @@ spec:
     preferredInputBus: virtio
     preferredInputType: tablet
     preferredInterfaceModel: virtio
-    preferredTPM:
-      persistent: true
+    preferredTPM: {}
   features:
     preferredAcpi: {}
     preferredApic: {}
@@ -2131,7 +2120,6 @@ spec:
     preferredSmm: {}
   firmware:
     preferredEfi:
-      persistent: true
       secureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
   requirements:


### PR DESCRIPTION
## What this PR does

Temporary revert. v1.5.0 restored persistent EFI/TPM state for the `windows.11` / `windows.2k22` / `windows.2k25` profiles. With persistence on, KubeVirt creates a backend-storage PVC (`persistent-state-for-<vm>`) which, on the default `replicated` StorageClass, is **ReadWriteOnce** — it pins the VM to its node and **blocks live-migration and node drains**. With `evictionStrategy: LiveMigrate` this can stall cluster upgrades. See #3005.

This strips persistent EFI/TPM from the preferences again — but via `yq del` instead of the original `sed -d`, so an emptied `preferredTPM` stays `{}` (the v1.8 CRD rejects `null`, which is the bug the original strip caused). **Secure Boot and the vTPM remain present, just non-persistent** — Windows VMs still boot; they just don't persist EFI/TPM across reboots.

⚠️ **Temporary stopgap** until vm-state can request an RWX backend — either RWX-Block via the upstream KubeVirt change (kubevirt/kubevirt#18215), or an RWX-Filesystem `vmStateStorageClass`. Once that lands, persistence can be re-enabled with live-migration intact.

### Screenshots

No UI changes.

### Release note

```release-note
fix(kubevirt-instancetypes): temporarily disable persistent EFI/TPM state to unblock live-migration of Windows VMs. Persistence created a ReadWriteOnce backend-storage PVC on the default storage class, pinning the VM to its node. Secure Boot and vTPM remain available (non-persistent); to be re-enabled once vm-state can use RWX storage.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Windows virtual machine preferences to enable live migration and drain operations
  * Fixed compatibility issues with KubeVirt v1.8 virtual machine preference configurations
  * Removed persistent settings from TPM and EFI configurations to prevent blocking behaviors on Windows 11 and Windows Server 2022/2025 variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->