### PR TITLE
chore(kilo): rebuild kilo image on current upstream and alpine 3.24

### DIFF
--- a/packages/system/kilo/Makefile
+++ b/packages/system/kilo/Makefile
@@ -4,6 +4,9 @@ export NAMESPACE=cozy-$(NAME)
 include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	sha=$$(git ls-remote https://github.com/squat/kilo refs/heads/main | awk '{print $$1}') && \
 	sed -i "/ARG VERSION/ s|=.*|=$${sha}|g" images/kilo/Dockerfile

--- a/packages/system/kilo/images/kilo/Dockerfile
+++ b/packages/system/kilo/images/kilo/Dockerfile
@@ -1,7 +1,7 @@
 # Build the kg binary
 FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 
-ARG VERSION=fbce60d8033da073748f5b0d6ce0f1e216f03e7f
+ARG VERSION=944dff5745d747c06555a964c2137b9a986ff6ec
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -23,14 +23,14 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build \
     -a -o kgctl ./cmd/kgctl
 
 # Download CNI plugins
-FROM alpine:3.23 AS cni
+FROM alpine:3.24 AS cni
 ARG TARGETARCH
-ARG CNI_PLUGINS_VERSION=v1.9.0
+ARG CNI_PLUGINS_VERSION=v1.9.1
 RUN apk add --no-cache curl && \
     curl -Lo cni.tar.gz https://github.com/containernetworking/plugins/releases/download/$CNI_PLUGINS_VERSION/cni-plugins-linux-$TARGETARCH-$CNI_PLUGINS_VERSION.tgz && \
     tar -xf cni.tar.gz
 
-FROM alpine:3.23
+FROM alpine:3.24
 RUN apk add --no-cache ipset iptables ip6tables graphviz font-noto
 COPY --from=cni bridge host-local loopback portmap /opt/cni/bin/
 ADD https://raw.githubusercontent.com/kubernetes-sigs/iptables-wrappers/e139a115350974aac8a82ec4b815d2845f86997e/iptables-wrapper-installer.sh /

--- a/packages/system/kilo/tests/kilo_test.yaml
+++ b/packages/system/kilo/tests/kilo_test.yaml
@@ -1,0 +1,66 @@
+suite: kilo DaemonSet image pin and mesh-arg wiring
+
+# Pins the surface this package owns on top of the vendored squat/kilo binary:
+#   - the kilo DaemonSet pulls the first-party image from the cozystack
+#     registry (repository is the load-bearing ref re-pinned by `make image`);
+#   - the default mesh args (location granularity, transit subnet, auto MTU,
+#     cni disabled, crosssubnet encapsulation) render as the kg binary expects;
+#   - meshGranularity plumbs through verbatim, including the `cross` value that
+#     the in-repo feat-add-cross-mesh-granularity.diff teaches the image to
+#     accept (the chart passes it straight to --mesh-granularity);
+#   - the cilium compatibility overlay adds --compatibility=cilium, and the
+#     default render carries no --compatibility arg.
+
+templates:
+  - templates/kilo.yaml
+
+tests:
+  - it: "DaemonSet pulls the first-party kilo image from the cozystack registry"
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^ghcr\\.io/cozystack/cozystack/kilo:"
+
+  - it: "default mesh args render as the kg binary expects"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--cni=false"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--encapsulate=crosssubnet"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--mesh-granularity=location"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--subnet=100.66.0.0/16"
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--mtu=auto"
+
+  - it: "meshGranularity=cross plumbs through to the patched binary"
+    set:
+      kilo:
+        meshGranularity: cross
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--mesh-granularity=cross"
+
+  - it: "cilium compatibility overlay adds --compatibility=cilium"
+    set:
+      kilo:
+        compatibility: cilium
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--compatibility=cilium"
+
+  - it: "no --compatibility arg in the default render"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--compatibility=cilium"

--- a/packages/system/kilo/values.yaml
+++ b/packages/system/kilo/values.yaml
@@ -1,7 +1,7 @@
 kilo:
   image:
     pullPolicy: IfNotPresent
-    tag: latest@sha256:016d054fcbb31d77ecfc8a0e7ead9f8cc01fb2f5a12b619d4fb0b7d745414df0
+    tag: v1.5.0@sha256:fe837f428504f6c6e9e4582326a3bf9cd507a9cca58c975952f5cc0b34728f63
     repository: ghcr.io/cozystack/cozystack/kilo
   transitCIDR: 100.66.0.0/16
   meshGranularity: location


### PR DESCRIPTION
## What this PR does

Rebuilds the first-party `kilo` image to clear the published `libpng16-16` / `libpng` advisories carried by the stale pinned layers, and refreshes it onto current upstream.

- `images/kilo/Dockerfile`: `ARG VERSION` `fbce60d8` → `944dff57` (current `squat/kilo` `main` HEAD); the rebuild also refreshes the `golang:1.25` stdlib compiled into the `kg` / `kgctl` binaries. The builder tag stays `golang:1.25` (upstream `go.mod` is `go 1.25.0`).
- runtime and `cni` base: `alpine:3.23` → `alpine:3.24`, which clears the `libpng` advisories pulled in through the `graphviz` / `font-noto` dependency chain.
- CNI plugins: `v1.9.0` → `v1.9.1`.
- `values.yaml`: re-pinned to the rebuilt multi-arch digest (`linux/amd64` + `linux/arm64`); the human-readable tag handle moves from `latest` to `v<version>` to match the sibling first-party images.

The in-repo cross-mesh-granularity feature patch still applies cleanly on the new HEAD and is verified present in the built binary (`kg --mesh-granularity` lists `cross`). Adds the package's first helm-unittest coverage, pinning the image ref and the default mesh-arg wiring.

### Release note

```release-note
chore(kilo): rebuild kilo image on current upstream and alpine 3.24 to clear the libpng advisories
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded Kilo to **v1.5.0**.
  * Updated bundled CNI plugins to **v1.9.1**.
  * Updated Kilo build/runtime base to **Alpine 3.24**.
* **Tests**
  * Added Helm/unit coverage to validate Kilo DaemonSet image pinning and default/overridden argument behavior (including compatibility options).
  * Added a `test` make target to run Helm unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->