### PR TITLE
chore(build): refresh first-party Alpine runtime bases to 3.24

### DIFF
--- a/packages/apps/mariadb/images/mariadb-backup/Dockerfile
+++ b/packages/apps/mariadb/images/mariadb-backup/Dockerfile
@@ -1,2 +1,2 @@
-FROM alpine:3.20
+FROM alpine:3.24
 RUN apk add --no-cache mariadb-client uuidgen restic

--- a/packages/core/installer/images/cozystack-operator/Dockerfile
+++ b/packages/core/installer/images/cozystack-operator/Dockerfile
@@ -17,7 +17,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
   -o /cozystack-operator \
   ./cmd/cozystack-operator
 
-FROM alpine:3.22
+FROM alpine:3.24
 
 COPY --from=builder /cozystack-operator /usr/bin/cozystack-operator
 

--- a/packages/core/platform/images/migrations/Dockerfile
+++ b/packages/core/platform/images/migrations/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22
+FROM alpine:3.24
 
 RUN wget -O- https://github.com/cozystack/cozyhr/raw/refs/heads/main/hack/install.sh | sh -s -- -v 1.6.1
 

--- a/packages/system/grafana-operator/images/grafana-dashboards/Dockerfile
+++ b/packages/system/grafana-operator/images/grafana-dashboards/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22
+FROM alpine:3.24
 
 RUN apk add --no-cache darkhttpd
 

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/Dockerfile
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/Dockerfile
@@ -10,7 +10,7 @@ RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go mod download
 COPY . .
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -o webhook .
 
-FROM alpine:3.21.3
+FROM alpine:3.24
 WORKDIR /app
 
 COPY --from=builder /app/webhook /app/webhook

--- a/packages/system/redis-operator/images/redis-operator/Dockerfile
+++ b/packages/system/redis-operator/images/redis-operator/Dockerfile
@@ -14,7 +14,7 @@ RUN git apply /patches/*.diff
 
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH VERSION=$VERSION ./scripts/build.sh
 
-FROM alpine:latest
+FROM alpine:3.24
 RUN apk --no-cache add \
   ca-certificates
 COPY --from=builder /workspace/bin/redis-operator /usr/local/bin


### PR DESCRIPTION
## What this PR does

Moves the pinned Alpine runtime bases of the first-party images forward to `alpine:3.24`, clearing the published `musl` / `zlib` advisories carried by the stale layers.

| image | base |
| --- | --- |
| mariadb-backup | 3.20 → 3.24 |
| cozystack-operator | 3.22 → 3.24 |
| platform-migrations | 3.22 → 3.24 |
| grafana-dashboards | 3.22 → 3.24 |
| kubeovn-webhook | 3.21.3 → 3.24 |
| redis-operator | latest → 3.24 |

Each runtime `apk` set was verified to resolve on `alpine:3.24`. These images rebuild on the release asset pipeline, which re-pins the digests in `values.yaml` on the next build — matching how the rest of the ~30 first-party images pick up the shared base (the issue's "rebuild and run the standard test pipeline").

**Scope notes:**

- The build-only `alpine AS source` stages (keycloak-operator, objectstorage-controller) are left as-is: their final images are distroless, so no Alpine layer ships.
- The s3manager base is owned by the separate bucket bump (#2887), and kilo's base moves in its own image rebuild (#2898).
- **Side effect for platform-migrations**: its `kubectl` / `helm` come from the Alpine repo, so the base bump moves them `1.33 → 1.36` and `3.18 → 3.19`. Both are current upstream stable and in skew with the modern control plane for the migration scripts' operations (apply / get / label / helm release ops).

Closes #2902

### Release note

```release-note
chore(images): refresh first-party Alpine runtime bases to 3.24 to clear the musl/zlib advisories
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Alpine Linux base images across multiple application containers to version 3.24 (including backup utilities, platform/operator components, monitoring dashboards, and networking/webhook components) to improve security and build consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->