### PR TITLE
chore(testing): refresh e2e-sandbox tools and base to current upstream

### DIFF
--- a/docs/agents/e2e-testing.md
+++ b/docs/agents/e2e-testing.md
@@ -102,5 +102,4 @@ These are being explored on branches and may become conventions; do not assume t
 
 - **BATS → Kyverno Chainsaw migration** — declarative asserts replace the `until … wait` boilerplate, with automatic events/describe/podLogs capture. Imperative suites (openbao unseal, vminstance, gateway, the kubernetes cluster tests) stay as script steps. Gotcha: Chainsaw v0.2.15 needs condition assertions in **filter-as-list** form `(conditions[?type == 'Ready'])`; the `(...)[0]` indexed form throws "field not found".
 - **Cilium orphaned-endpoint self-heal** — an interim CI watchdog that evicts a single confirmed-orphan Cilium endpoint ("IP already in use", cilium/cilium#38313). Explicitly a mitigation to remove once a fixed Cilium ships; it refuses to touch an endpoint backing a live pod so real duplicate-IP bugs stay visible.
-- **Pin the e2e management cluster Kubernetes version** to dodge the kube-controller-manager ValidatingAdmissionPolicy type-checker panic on `additionalProperties: true` schemas (kubernetes/kubernetes#135155).
 - **Cluster state snapshot/restore** between test groups instead of reinstalling.

--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -231,12 +231,14 @@ EOF
   fi
 
   rm -f controlplane.yaml worker.yaml talosconfig kubeconfig
-  # Pin Kubernetes to v1.33.12 instead of talosctl's bundled default (v1.33.1).
-  # v1.33.1 predates the fix for the kube-controller-manager VAP status
-  # type-checker nil-pointer panic on `additionalProperties: true` schemas
-  # (kubernetes/kubernetes#135155, backported to release-1.33 in #136958,
-  # first released in v1.33.10). On the older default, cozystack-api's
-  # aggregated Tenant schema crash-loops KCM during install. See cozystack#2863.
+  # Pin Kubernetes to v1.33.12. talosctl v1.13.5 now defaults to a much newer
+  # k8s (1.36.x) that is outside cozystack's supported range, so e2e pins back
+  # to the 1.33 line. v1.33.12 also carries the fix for the
+  # kube-controller-manager VAP status type-checker nil-pointer panic on
+  # `additionalProperties: true` schemas (kubernetes/kubernetes#135155,
+  # backported to release-1.33 in #136958, first released in v1.33.10); without
+  # it, cozystack-api's aggregated Tenant schema crash-loops KCM during install.
+  # See cozystack#2863.
   talosctl gen config --with-secrets secrets.yaml cozystack https://192.168.123.10:6443 \
            --kubernetes-version v1.33.12 \
            --config-patch=@patch.yaml --config-patch-control-plane @patch-controlplane.yaml

--- a/packages/core/testing/images/e2e-sandbox/Dockerfile
+++ b/packages/core/testing/images/e2e-sandbox/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
-ARG KUBECTL_VERSION=1.33.2
-ARG TALOSCTL_VERSION=1.10.4
-ARG HELM_VERSION=3.18.3
+ARG KUBECTL_VERSION=1.33.13
+ARG TALOSCTL_VERSION=1.13.5
+ARG HELM_VERSION=3.21.2
 ARG COZYHR_VERSION=1.6.1
 ARG CRUST_GATHER_VERSION=v0.15.2
 
@@ -10,13 +10,13 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN apt update -q
-RUN apt install -yq --no-install-recommends psmisc genisoimage ca-certificates qemu-kvm qemu-utils iproute2 iptables wget xz-utils netcat curl jq make git bash-completion
+RUN apt install -yq --no-install-recommends psmisc genisoimage ca-certificates qemu-kvm qemu-utils iproute2 iptables wget xz-utils netcat-openbsd curl jq make git bash-completion
 RUN curl -sSL "https://github.com/siderolabs/talos/releases/download/v${TALOSCTL_VERSION}/talosctl-${TARGETOS}-${TARGETARCH}" -o /usr/local/bin/talosctl \
  && chmod +x /usr/local/bin/talosctl
 RUN curl -sSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl" -o /usr/local/bin/kubectl \
  && chmod +x /usr/local/bin/kubectl
 RUN curl -sSL "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3" | bash -s - --version "v${HELM_VERSION}"
-RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_${TARGETOS}_${TARGETARCH}" -o /usr/local/bin/yq \
+RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_${TARGETOS}_${TARGETARCH}" -o /usr/local/bin/yq \
  && chmod +x /usr/local/bin/yq
 RUN curl -sSL "https://fluxcd.io/install.sh" | bash
 RUN curl -sSL "https://github.com/cozystack/cozyhr/raw/refs/heads/main/hack/install.sh" | sh -s -- -v "${COZYHR_VERSION}"

--- a/packages/core/testing/values.yaml
+++ b/packages/core/testing/values.yaml
@@ -1,2 +1,2 @@
 e2e:
-  image: ghcr.io/cozystack/cozystack/e2e-sandbox:v1.5.0@sha256:91b9a2985bcadea4e74cf9cd644a6d4c19442a7270fe14ac52e766b4ec0c93d8
+  image: ghcr.io/cozystack/cozystack/e2e-sandbox:v1.5.0@sha256:4ab29cccd8fabb6ff265c7602bdfda40509071301da396c8a5123ca4d10e9dda


### PR DESCRIPTION
## What this PR does

Rebuilds the e2e test sandbox on current upstream to clear the published advisories (containerd, helm, go-git, moby/spdystream, Go stdlib) carried by the stale tool binaries and base layers.

- base: `ubuntu:22.04` → `24.04`; `netcat` → `netcat-openbsd` (on 24.04 `netcat` is a candidate-less virtual package, so the concrete provider must be named)
- kubectl: `1.33.2` → `1.33.13` — stays on the 1.33 line that the e2e control plane pins at `v1.33.12` (`hack/e2e-prepare-cluster.bats`), so client/server skew is unchanged
- talosctl: `1.10.4` → `1.13.5` — aligns the client with the v1.13.x Talos nodes the sandbox provisions
- helm: `3.18.3` → `3.21.2` (latest helm 3) — the e2e flow drives the v3 CLI, so it stays on the 3.x line rather than moving to the breaking 4.x
- yq: `4.44.3` → `4.53.3`
- `values.yaml`: re-pinned to the rebuilt multi-arch digest (`linux/amd64` + `linux/arm64`)

`crust-gather` and `cozyhr` already track their latest releases; `flux` and `mc` install the current release at build time. The built image's tool versions were verified in place (kubectl `v1.33.13`, talosctl `v1.13.5`, helm `v3.21.2`, yq `v4.53.3`, flux `2.8.8`, ubuntu `24.04`).

Closes #2891

### Release note

```release-note
chore(testing): refresh e2e-sandbox tools and base (ubuntu 24.04, kubectl 1.33.13, talosctl 1.13.5, helm 3.21.2)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the e2e sandbox image to a new fixed digest for more consistent test runs.
  * Refreshed the sandbox build environment (Ubuntu 24.04) and upgraded tooling (Kubernetes, Talos, Helm, and yq) to newer stable versions.
  * Improved OS package setup by switching from `netcat` to `netcat-openbsd` and consolidating apt cleanup to reduce image size.
* **Documentation**
  * Updated e2e testing guidance: removed the recommendation to pin the management cluster Kubernetes version, and added guidance to snapshot/restore cluster state between test groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->