### PR TITLE
chore(monitoring): bump Grafana to 11.6.15, victorialogs datasource and alerta

### DIFF
--- a/packages/system/monitoring/images/grafana.tag
+++ b/packages/system/monitoring/images/grafana.tag
@@ -1,1 +1,1 @@
-ghcr.io/cozystack/cozystack/grafana:v1.5.0@sha256:086f1502edf64d2aabcda6e6505b7ee4673b0d3a14cdb7ca9e90a1d91d6e78f4
+ghcr.io/cozystack/cozystack/grafana:v1.5.0@sha256:e96e95564788a7f770ee9556fefa59b7ca15109e3ad9f32c4bc3f230ef862245

--- a/packages/system/monitoring/images/grafana/Dockerfile
+++ b/packages/system/monitoring/images/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:11.4.0
+FROM grafana/grafana:11.6.15
 
 USER root
 
@@ -7,7 +7,7 @@ RUN mkdir -p /var/lib/grafana-plugins \
 
 USER grafana
 
-ARG VLOGS_VERSION=v0.14.1
+ARG VLOGS_VERSION=v0.28.0
 RUN curl -L https://github.com/VictoriaMetrics/victorialogs-datasource/releases/download/${VLOGS_VERSION}/victoriametrics-logs-datasource-${VLOGS_VERSION}.tar.gz | \
       tar -xzf - -C /var/lib/grafana-plugins
 

--- a/packages/system/monitoring/templates/alerta/alerta.yaml
+++ b/packages/system/monitoring/templates/alerta/alerta.yaml
@@ -76,7 +76,7 @@ spec:
     spec:
       containers:
         - name: alerta
-          image: "alerta/alerta-web:9.0.4"
+          image: "alerta/alerta-web:9.1.0"
           imagePullPolicy: IfNotPresent
           resources: {{- toYaml .Values.alerta.resources | nindent 12 }}
           env:


### PR DESCRIPTION
## What this PR does

Refreshes the `system/monitoring` image anchors onto current upstream to clear the published advisories (8 CVEs, 1 critical) carried by the stale pins.

- **grafana image**: base `grafana/grafana` `11.4.0` → `11.6.15` (latest 11.x). The rebuild clears the Go-dependency advisories in the grafana binary (`x/crypto`, `moby/spdystream`, `jackc/pgx/v5`, `russellhaering/goxmldsig`, `buger/jsonparser`, `golang-jwt/jwt/v4`, `getkin/kin-openapi`). It stays on the 11.x line rather than 12.x to keep the bundled panel plugins compatible (`grafana-worldmap-panel` is deprecated upstream) and avoid a dashboard-schema migration.
- **victorialogs-datasource** plugin: `v0.14.1` → `v0.28.0` (`grafanaDependency >=10.4.0`, so it loads on 11.6.15).
- **alerta-web**: `9.0.4` → `9.1.0`, clearing the python `cryptography` advisory.
- `images/grafana.tag`: re-pinned to the rebuilt multi-arch digest (`linux/amd64` + `linux/arm64`).

The built grafana image was verified in place: grafana `11.6.15`, all four plugins present (`natel-discrete-panel`, `grafana-worldmap-panel`, `marcusolsson-dynamictext-panel`, `victoriametrics-logs-datasource`), vlogs `0.28.0`. helm-unittest passes (4/4).

Closes #2892

### Release note

```release-note
chore(monitoring): bump Grafana to 11.6.15, victorialogs-datasource to v0.28.0 and alerta-web to 9.1.0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Grafana monitoring dashboard base image to 11.6.15 and VictoriaLogs datasource plugin to v0.28.0
  * Upgraded Alerta monitoring and alerting tool to 9.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->