### PR TITLE
ci(renovate): force chore(deps) commits and add area/dependencies label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -170,6 +170,10 @@
   color: 'bfd4f2'
   description: Issues or PRs related to CI workflows, GitHub Actions, automation
 
+- name: area/dependencies
+  color: 'bfd4f2'
+  description: Dependency bumps (Renovate, go.mod); scope `deps`
+
 - name: area/dashboard
   color: 'bfd4f2'
   description: Issues or PRs related to the dashboard / UI

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,12 @@
   },
   "packageRules": [
     {
+      "description": "Force chore(deps) for all Go module bumps. config:recommended pulls in :semanticPrefixFixDepsChoreOthers, whose packageRule re-sets semanticCommitType=fix for direct deps (depType require), overriding the top-level chore. packageRules override top-level config, so a user rule evaluated last is required to win it back; without this, direct-dep PRs land as fix(deps) and get auto-labeled kind/bug.",
+      "matchManagers": ["gomod"],
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps"
+    },
+    {
       "description": "Bump indirect Go modules too. Transitive deps such as golang.org/x/crypto, golang.org/x/net and golang.org/x/sys carry OSV advisories that drive the OpenSSF Scorecard Vulnerabilities check to 0, but Renovate skips indirect gomod deps by default so they never get a PR. Grouped into one rolling PR to keep volume sane; security fixes are still split out by vulnerabilityAlerts above. Placed before the kubernetes rule on purpose: an indirect k8s.io/** dep matches both, and Renovate applies last-match-wins, so the later kubernetes rule keeps it in the kubernetes lockstep group.",
       "matchManagers": ["gomod"],
       "matchDepTypes": ["indirect"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,8 @@
   "enabledManagers": ["gomod", "dockerfile", "github-actions"],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "labels": ["automated", "do-not-merge/hold"],
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
   "automerge": false,
   "platformAutomerge": false,
   "prConcurrentLimit": 5,
@@ -46,6 +48,12 @@
       "matchUpdateTypes": ["digest", "pinDigest"],
       "groupName": "container image & action digests",
       "schedule": ["before 6am on monday"]
+    },
+    {
+      "description": "kubevirt.io/csi-driver is pinned to an untagged pseudo-version commit and publishes no release tags, so Renovate's go datasource returns no-result and the lookup failure lingers on the Dependency Dashboard. Disable it; this module is advanced deliberately alongside the kubevirt-csi-driver image build.",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["kubevirt.io/csi-driver"],
+      "enabled": false
     }
   ]
 }

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -47,6 +47,9 @@ jobs:
               // area/ci
               'ci':                  'area/ci',
 
+              // area/dependencies — Renovate uses scope `deps` (see .github/renovate.json)
+              'deps':                'area/dependencies',
+
               // area/dashboard
               'dashboard':           'area/dashboard',
 


### PR DESCRIPTION
## What

Make Renovate PRs land with consistent, conventional labels and clear a recurring Dependency Dashboard warning.

## Why

Renovate's `:semanticCommits` preset picks `fix(deps)` for stable (`>=1.0`) production modules and `chore(deps)` for `0.x` modules. The result:

- `fix(deps)` bumps were auto-labeled **`kind/bug`** by the PR auto-labeler → routine dependency updates polluted the bug list.
- The auto-labeler has no `deps → area/*` mapping, so **every** Renovate PR fell through to **`area/uncategorized`**.
- `kubevirt.io/csi-driver` is pinned to an untagged pseudo-version (`v0.0.0-2026…`) with no release tags, producing a permanent `no-result` lookup failure on the Dependency Dashboard.

## Changes

- **`.github/renovate.json`**
  - Pin `semanticCommitType: chore` + `semanticCommitScope: deps` → every dependency PR is now `chore(deps): …` (maps to `kind/cleanup`, no more bogus `kind/bug`).
  - Disable Renovate for `kubevirt.io/csi-driver` (commit-pinned, unbumpable) to clear the dashboard lookup warning.
- **`.github/labels.yml`** — add `area/dependencies` (justified: 25+ dependency PRs queued, well over the 3-issue threshold for a new area).
- **`.github/workflows/pr-labeler.yaml`** — map scope `deps → area/dependencies`.

## Result

Future Renovate PRs: `chore(deps): …` → `automated` + `kind/cleanup` + `area/dependencies` + `do-not-merge/hold`.

## Notes

- `renovate.json` / `labels.yml` take effect once merged; the labeler change applies to PRs opened or edited after merge.
- The `sigs.k8s.io/yaml` lookup warning on the dashboard is left untouched — it's a normal module and reads as a transient datasource hiccup, not a config issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new `area/dependencies` label to consistently tag dependency-related pull requests.
  * Updated the PR auto-labeler to map commit/title `deps` scopes to `area/dependencies`.
  * Standardized Renovate dependency commit messages to use `chore(deps)`, including special handling for Go module updates, and disabled Renovate updates for the `kubevirt.io/csi-driver` Go module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->