### PR TITLE
ci(renovate): pin base images and GitHub Actions to digests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
     "config:recommended",
     ":semanticCommits"
   ],
-  "enabledManagers": ["gomod"],
+  "enabledManagers": ["gomod", "dockerfile", "github-actions"],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "labels": ["automated", "do-not-merge/hold"],
   "automerge": false,
@@ -22,6 +22,18 @@
       "matchManagers": ["gomod"],
       "matchDepTypes": ["golang"],
       "enabled": false
+    },
+    {
+      "description": "Pin Dockerfile base images and GitHub Actions to immutable digests so OpenSSF Scorecard Pinned-Dependencies passes and supply-chain refs stay reproducible. The tag is kept in front of the digest so it stays human-readable and trackable.",
+      "matchManagers": ["dockerfile", "github-actions"],
+      "pinDigests": true
+    },
+    {
+      "description": "Batch the initial pin and all digest-only refreshes (same tag, rebuilt upstream) into a single weekly PR. Without this, frequently-rebuilt bases (alpine, debian, golang, distroless) would trickle in one rebuild-triggering PR each, loading the shared CI runner. Real tag bumps (major/minor/patch) are intentionally left out of this group so they get individual review.",
+      "matchManagers": ["dockerfile", "github-actions"],
+      "matchUpdateTypes": ["digest", "pinDigest"],
+      "groupName": "container image & action digests",
+      "schedule": ["before 6am on monday"]
     }
   ]
 }

--- a/packages/system/bucket/images/s3manager/Dockerfile
+++ b/packages/system/bucket/images/s3manager/Dockerfile
@@ -1,6 +1,6 @@
 # Source: https://github.com/cloudlena/s3manager/blob/main/Dockerfile
 
-FROM docker.io/library/golang:1 AS builder
+FROM docker.io/library/golang:1.26 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -12,7 +12,7 @@ RUN git apply /cozystack.patch
 RUN go mod tidy
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build -ldflags="-s -w" -a -installsuffix cgo -o bin/s3manager
 
-FROM docker.io/library/alpine:latest
+FROM docker.io/library/alpine:3.24
 WORKDIR /usr/src/app
 RUN addgroup -S s3manager && adduser -S s3manager -G s3manager
 RUN apk add --no-cache \


### PR DESCRIPTION
## What this PR does

Raises OpenSSF Scorecard **Pinned-Dependencies** (currently **1/10**) by having Renovate manage and pin container base images and GitHub Actions to immutable digests.

[PR #2849](https://github.com/cozystack/cozystack/pull/2849) SHA-pinned actions in 13 workflows, but the Scorecard check also scores **container base images** — 58 unpinned `FROM` lines across **27 distinct images** — which dominate the score and keep it at 1/10. #2849 also left `build-main.yaml` and `release-e2e.yaml` actions unpinned, and nothing in the Renovate config kept the newly-added action SHAs updated (they were set to rot).

### Changes

- **`.github/renovate.json`**
  - Add `dockerfile` and `github-actions` to `enabledManagers` (was `gomod`-only).
  - `pinDigests: true` for both managers — Renovate opens the initial "pin to `@sha256:`" PR (including the two workflows #2849 missed) and keeps digests fresh thereafter.
  - Batch the initial pin + all digest-only refreshes into a **single weekly PR** (`matchUpdateTypes: ["digest", "pinDigest"]`, scheduled Monday). Frequently-rebuilt bases (alpine, debian, golang, distroless) would otherwise trickle in one rebuild-triggering PR each and load the shared CI runner. Real tag bumps (major/minor/patch) are intentionally excluded from the group so they get individual review.
  - Existing `do-not-merge/hold` label + `automerge: false` are unchanged, so every PR still requires a manual merge.

- **`packages/system/bucket/images/s3manager/Dockerfile`** — pin floating tags to concrete versions so digest tracking doesn't churn endlessly: `golang:1` → `golang:1.26`, `alpine:latest` → `alpine:3.24`.

### Notes

- The bulk digest pin of the 27 images is left to Renovate's first run (one grouped PR) rather than hand-edited here, keeping this PR to the config + tag-hygiene prerequisites.
- Expected effect once the follow-up pin PR merges: Pinned-Dependencies **1 → ~7–8**. The remaining `downloadThenRun` / pip / npm items cap it below 10.

### Release note

```release-note
ci(renovate): enable Renovate digest pinning for Dockerfile base images and GitHub Actions to improve the OpenSSF Scorecard Pinned-Dependencies score
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency management for container images and GitHub Actions, including clearer update grouping and digest pinning.
  * Updated container base images to newer, fixed versions for more predictable builds and deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->