### PR TITLE
ci(renovate): bump indirect Go deps and enable OSV vuln alerts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,19 @@
   "automerge": false,
   "platformAutomerge": false,
   "prConcurrentLimit": 5,
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["automated", "security"]
+  },
   "packageRules": [
+    {
+      "description": "Bump indirect Go modules too. Transitive deps such as golang.org/x/crypto, golang.org/x/net and golang.org/x/sys carry OSV advisories that drive the OpenSSF Scorecard Vulnerabilities check to 0, but Renovate skips indirect gomod deps by default so they never get a PR. Grouped into one rolling PR to keep volume sane; security fixes are still split out by vulnerabilityAlerts above. Placed before the kubernetes rule on purpose: an indirect k8s.io/** dep matches both, and Renovate applies last-match-wins, so the later kubernetes rule keeps it in the kubernetes lockstep group.",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["indirect"],
+      "enabled": true,
+      "groupName": "indirect go modules"
+    },
     {
       "description": "Keep controller-runtime and the Kubernetes libraries in lockstep. A split bump breaks compilation because a given controller-runtime release expects a matching client-go / apimachinery line.",
       "groupName": "kubernetes",


### PR DESCRIPTION
## What

Makes Renovate open the dependency PRs that close the OpenSSF Scorecard `Vulnerabilities` advisories, instead of doing them by hand (as in #3019).

- Enable **indirect** gomod updates (grouped into one rolling "indirect go modules" PR). Renovate skips indirect Go deps by default, which is why `golang.org/x/crypto`, `x/net`, and `x/sys` — the transitive deps carrying the 20 OSV advisories — never got a PR.
- Enable **`osvVulnerabilityAlerts`** so vulnerable deps get dedicated, mergeable security PRs (labeled `security`, not the global `do-not-merge/hold`).

## Why #3019 wasn't enough

#3019 bumped `x/crypto` in the **root** module only. The repo has 5 `go.mod` modules; the same advisories live in `token-proxy` (x/crypto v0.50.0), `kubevirt-csi-driver`, and `kubeovn-webhook` (x/net / x/sys). The Scorecard `Vulnerabilities` check scans repo-wide and is all-or-nothing, so the count never dropped (still 0/10, 21 advisories).

## Known gap

This does **not** fix `GO-2025-3512` (`kubevirt.io/csi-driver`): no fixed version exists upstream and Renovate can't even resolve the module (`no-result` in the Dependency Dashboard #2996). Until that one advisory is suppressed via `.osv-scanner.toml` or patched upstream, the Vulnerabilities check stays at 0/10. Tracked separately as a follow-up.

## Validation

- `renovate-config-validator`: **Config validated successfully**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for automated handling of vulnerability alerts.
  * Enabled updates for indirect Go module dependencies and grouped them together for easier review.
* **Chores**
  * Updated automation settings to label security-related update pull requests appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->