### PR TITLE
feat(keycloak): expose organizationsEnabled realm toggle

### DIFF
--- a/packages/system/keycloak-configure/templates/configure-kk.yaml
+++ b/packages/system/keycloak-configure/templates/configure-kk.yaml
@@ -27,6 +27,7 @@ metadata:
 spec:
   realmName: cozy
   clusterKeycloakRef: keycloak-cozy
+  organizationsEnabled: {{ .Values.organizationsEnabled | default false }}
   {{- if $brandingConfig }}
   {{- if hasKey $brandingConfig "brandName" }}
   displayName: {{ $brandingConfig.brandName }}

--- a/packages/system/keycloak-configure/tests/organizations_enabled_test.yaml
+++ b/packages/system/keycloak-configure/tests/organizations_enabled_test.yaml
@@ -1,0 +1,38 @@
+suite: keycloak realm organizations toggle
+
+# organizationsEnabled must reach ClusterKeycloakRealm.spec.organizationsEnabled:
+# the keycloak-operator PUTs the rendered spec back on every reconcile, so a
+# toggle flipped in the admin console is reverted unless it is a chart value.
+# The default must render false — no behaviour change on stock installs.
+release:
+  name: keycloak-configure
+  namespace: cozy-keycloak
+tests:
+  - it: default renders organizationsEnabled false
+    template: templates/configure-kk.yaml
+    documentSelector:
+      path: kind
+      value: ClusterKeycloakRealm
+    set:
+      _cluster:
+        root-host: example.com
+        kube-root-ca: ""
+    asserts:
+      - equal:
+          path: spec.organizationsEnabled
+          value: false
+
+  - it: organizationsEnabled true renders through to the realm spec
+    template: templates/configure-kk.yaml
+    documentSelector:
+      path: kind
+      value: ClusterKeycloakRealm
+    set:
+      _cluster:
+        root-host: example.com
+        kube-root-ca: ""
+      organizationsEnabled: true
+    asserts:
+      - equal:
+          path: spec.organizationsEnabled
+          value: true

--- a/packages/system/keycloak-configure/values.yaml
+++ b/packages/system/keycloak-configure/values.yaml
@@ -3,6 +3,12 @@
 # to track the Keycloak server major version (packages/system/keycloak).
 image: quay.io/keycloak/keycloak:26.5.2
 
+# Enable the Keycloak Organizations feature for the `cozy` realm.
+# Mapped to ClusterKeycloakRealm.spec.organizationsEnabled. Defaults to
+# false to preserve the current behaviour; set to true to manage
+# organizations (and KeycloakOrganization resources) in the realm.
+organizationsEnabled: false
+
 # login:
 #   userRegistration: false
 #   verifyEmail: false


### PR DESCRIPTION
## What this PR does

- Adds an `organizationsEnabled` value to the `cozy-keycloak-configure` chart (default `false`, no behaviour change).
- Maps it to `ClusterKeycloakRealm.spec.organizationsEnabled` so the Keycloak [Organizations](https://www.keycloak.org/docs/latest/server_admin/#_managing_organizations) feature can be turned on declaratively for the `cozy` realm.

### Why

The chart hardcoded the realm without exposing this field. Enabling Organizations through the Keycloak admin console is not durable: the EDP keycloak-operator reconciles `ClusterKeycloakRealm` by `PUT`ting the chart-rendered spec back to the realm, so the console change is reverted on the next reconcile (operator restart, periodic resync, or any CR change). Verified on Keycloak 26.5.2.

### Release note

```release-note
feat(keycloak): add `organizationsEnabled` value to the keycloak-configure chart to enable the Keycloak Organizations feature on the cozy realm (default: false)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to enable or disable Keycloak Organizations for the Cozy realm.
  * The feature remains off by default, preserving current behavior unless explicitly turned on.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->