### PR TITLE
fix(kamaji): close Go stdlib and module CVEs in the shipped binary

### DIFF
--- a/packages/system/kamaji/images/kamaji/Dockerfile
+++ b/packages/system/kamaji/images/kamaji/Dockerfile
@@ -12,6 +12,13 @@ RUN curl -sSL https://github.com/clastix/kamaji/archive/refs/tags/${VERSION}.tar
 COPY patches /patches
 RUN git apply /patches/*.diff
 
+# Overlay patched Go modules. The kamaji edge tags up to 26.6.4 still pin
+# vulnerable golang.org/x/net (< 0.55.0), golang.org/x/crypto (< 0.52.0) and
+# go.opentelemetry.io/otel/sdk (< 1.43.0). These advisories ship inside the
+# compiled binary, so force the fixed versions before building.
+RUN go get golang.org/x/net@v0.55.0 golang.org/x/crypto@v0.52.0 go.opentelemetry.io/otel/sdk@v1.43.0 && \
+    go mod tidy
+
 RUN GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 go build \
     -ldflags "-X github.com/clastix/kamaji/internal.GitRepo=$GIT_REPO -X github.com/clastix/kamaji/internal.GitTag=$GIT_LAST_TAG -X github.com/clastix/kamaji/internal.GitCommit=$GIT_HEAD_COMMIT -X github.com/clastix/kamaji/internal.GitDirty=$GIT_MODIFIED -X github.com/clastix/kamaji/internal.BuildTime=$BUILD_DATE" \
     -a -o kamaji main.go

--- a/packages/system/kamaji/images/kamaji/Dockerfile
+++ b/packages/system/kamaji/images/kamaji/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
 FROM golang:1.26 AS builder
 
-ARG VERSION=26.3.5-edge
+ARG VERSION=26.3.6-edge
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## What

Rebuild the kamaji image and force the fixed versions of three Go modules whose advisories are compiled into the manager binary. Two build changes:

- Advance the build source from `26.3.5-edge` to `26.3.6-edge`, recompiling on the current `golang:1.26` toolchain (1.26.4) to close the Go stdlib advisories.
- After applying the source patches and before `go build`, run `go get golang.org/x/net@v0.55.0 golang.org/x/crypto@v0.52.0 go.opentelemetry.io/otel/sdk@v1.43.0 && go mod tidy` to pull the patched module versions into the build.

## Why

The pinned image is flagged for a set of CVEs that fall into three groups:

- 16 OS-package findings (libpython, libexpat, gnutls, krb5, sqlite, curl, libgcrypt, libcap, nghttp2). The base is `gcr.io/distroless/static:nonroot`, which ships no OS packages, so these do not apply to the image — false positives.
- 1 `stdlib` finding: the binary was compiled with a go1.26 patch older than 1.26.4. The `26.3.6-edge` rebuild on the current toolchain closes it (crypto/x509 CVE-2026-27145, mime CVE-2026-42504, net/textproto CVE-2026-42507).
- Go-module advisories that, unlike the OS-package noise, are genuinely present in the compiled binary. `26.3.6-edge` pins `golang.org/x/net v0.51.0`, `golang.org/x/crypto v0.49.0` and `go.opentelemetry.io/otel/sdk v1.41.0`, all carrying published advisories:
  - `golang.org/x/net` < 0.55.0: CVE-2026-42506, CVE-2026-42502, CVE-2026-39821, CVE-2026-25680, CVE-2026-25681, CVE-2026-27136 (plus CVE-2026-33814, fixed at 0.53.0). Target 0.55.0.
  - `golang.org/x/crypto` < 0.52.0: 13 advisories in `golang.org/x/crypto/ssh` (e.g. CVE-2026-39827, CVE-2026-46595, CVE-2026-46598). Target 0.52.0.
  - `go.opentelemetry.io/otel/sdk` < 1.43.0: CVE-2026-39883 (GHSA-hfvc-g4fc-pqhx), a PATH-hijack on BSD/Solaris only; the affected code path does not run on the Linux distroless target, but the bump clears the finding at no runtime cost. Target 1.43.0.

A source-version bump cannot close the module advisories: no kamaji edge tag up to `26.6.4-edge` ships the fixed module versions (it still pins x/net 0.53.0, x/crypto 0.51.0, otel/sdk 1.41.0), and the tags that advance the k8s line to 1.36 regress tenant control-plane RBAC. Forcing the modules during the build is the minimal correct lever, and the overlay already triggers a fresh compile, so it subsumes the stdlib rebuild.

## Verification

Built the image source end to end: extracted `26.3.6-edge`, applied the patch, ran the overlay (`go get` + `go mod tidy`, clean), and compiled with `CGO_ENABLED=0 go build -a -o kamaji main.go`. The build succeeds and `go version -m` on the binary embeds `golang.org/x/net v0.55.0`, `golang.org/x/crypto v0.52.0` and the `go.opentelemetry.io/otel` set at v1.43.0. The source has no `vendor/` directory, so `go get` + `go mod tidy` is sufficient. Advisory IDs and fixed boundaries verified against the OSV database.

After this change the shipped binary carries no Go advisory with an available fix; the only residual scanner entries are in `k8s.io/kubernetes` with no upstream fix, which no version bump can close.

Closes #2885


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kamaji image version to a newer patch release.
  * Refreshed several bundled Go dependencies to newer pinned versions before building.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->