### PR TITLE
test(e2e): widen etcd convergence budget to 5m in Talos bootstrap

### DIFF
--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -261,8 +261,15 @@ EOF
   # ephemeral runners can take several attempts of ~5s each.
   timeout 60 sh -ec 'until talosctl bootstrap -n 192.168.123.11 -e 192.168.123.11; do sleep 2; done'
 
-  # Wait until etcd is healthy
-  if ! timeout 180 sh -ec 'until talosctl etcd members -n 192.168.123.11,192.168.123.12,192.168.123.13 -e 192.168.123.10 >/dev/null 2>&1; do sleep 1; done'; then
+  # Wait until etcd is healthy.
+  # Budget is 5m, not 3m: a 3-node etcd converges via Talos's serialized
+  # learner promotion (etcd admits one learner at a time), so the third member
+  # is only promoted after the second is fully caught up. On a loaded ephemeral
+  # runner this deterministic path can legitimately approach ~3m wall clock —
+  # a 180s ceiling photo-finishes against it and times out a cluster that is
+  # actually healthy. The wait itself is already event-driven (poll until
+  # members respond); only the ceiling needed widening.
+  if ! timeout 300 sh -ec 'until talosctl etcd members -n 192.168.123.11,192.168.123.12,192.168.123.13 -e 192.168.123.10 >/dev/null 2>&1; do sleep 1; done'; then
     talosctl dmesg -n 192.168.123.11,192.168.123.12,192.168.123.13 -e 192.168.123.10 || true
     exit 1
   fi


### PR DESCRIPTION
## Problem

The `Bootstrap Talos cluster` E2E step fails intermittently with `❌ Test failed: Bootstrap Talos cluster (exit 1)` even though the cluster is healthy. The exit comes from the etcd-members convergence gate, which is bounded at `timeout 180`.

A 3-node etcd converges via Talos's serialized learner promotion — etcd admits one learner at a time, so the third member is only promoted after the second has fully caught up. On a loaded ephemeral runner this deterministic path can legitimately approach ~3 minutes of wall clock and photo-finish against the 180s ceiling, timing out a cluster that has in fact converged (every member reaches `Health check successful`; no kernel panic / OOM / boot failure / network-unreachable in dmesg). Observed: a run where the third member reached etcd health at +178.6s against the 180s budget, failing ~1.4s short.

## Fix

Widen the etcd-members convergence budget from 180s to 300s. The wait is already event-driven (`until talosctl etcd members …; do sleep 1; done`) — only the ceiling was too tight. No retry is added and the dmesg-on-failure diagnostic is preserved.

300s matches the repo's other in-line budgets for deterministic convergence (HelmRelease-ready 5m, harbor/NFS 10m, install 15m).

## Why not just rerun

This is not environmental noise: the cluster converges correctly every time, it is only timed out. Rerunning wastes a full ~1h E2E cycle to re-roll the dice on whether the runner shaves the last ~2s. Correcting the mistuned budget removes the photo-finish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the cluster bootstrap wait time for control plane health checks, reducing false failures during slow startup.
  * Improved readiness handling so cluster setup is more resilient before moving on to later initialization steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->