### PR TITLE
fix(platform): order backupstrategy-controller after cozystack-basics

### DIFF
--- a/packages/core/platform/sources/backupstrategy-controller.yaml
+++ b/packages/core/platform/sources/backupstrategy-controller.yaml
@@ -18,8 +18,16 @@ spec:
     # All three must be installed before the templates render, otherwise
     # the Helm release fails with "no matches for kind". Order is enforced
     # via dependsOn so a fresh-cluster bootstrap cannot race the CRDs.
+    #
+    # The cozy-backups Bucket is also created INTO the tenant-root namespace,
+    # which is provisioned by cozystack-basics (the static tenant-root release).
+    # Without the cozystack-basics edge the Bucket patch can race namespace
+    # creation on a fresh install and fail with `namespaces "tenant-root" not
+    # found`, which then races the install script's wait deadline. Depend on
+    # cozystack-basics so the target namespace exists first.
     dependsOn:
     - cozystack.networking
+    - cozystack.cozystack-basics
     - cozystack.backup-controller
     - cozystack.bucket-application
     - cozystack.objectstorage-controller

--- a/packages/core/platform/sources/cozystack-basics.yaml
+++ b/packages/core/platform/sources/cozystack-basics.yaml
@@ -28,8 +28,11 @@ spec:
     # Drift detection is off on operator-generated HelmReleases, so a
     # capability gate in the templates would render the policy out at first
     # install and never add it back; ordering via dependsOn is the reliable
-    # fix. cozystack-basics is a dependency-graph leaf (nothing dependsOn it)
-    # and engine components consume none of its outputs, so this adds no cycle.
+    # fix. The cozystack-engine and gateway-api-crds packages it depends on
+    # consume none of cozystack-basics' outputs and do not depend back on it,
+    # so these edges add no cycle. (Downstream packages such as backupstrategy-
+    # controller dependsOn cozystack-basics, but those do not feed engine or
+    # gateway-api-crds, so they cannot close a loop here.)
     - cozystack.cozystack-engine
     - cozystack.gateway-api-crds
     components:

--- a/packages/core/platform/tests/sources_backupstrategy_dependson_test.yaml
+++ b/packages/core/platform/tests/sources_backupstrategy_dependson_test.yaml
@@ -1,0 +1,34 @@
+suite: backupstrategy-controller waits for the tenant-root namespace and its CRDs
+# Regression guard for a fresh-install ordering race: backupstrategy-controller
+# creates the cozy-backups Bucket INTO the tenant-root namespace, which is
+# provisioned by cozystack-basics. Without the cozystack-basics edge the Bucket
+# patch races namespace creation and fails with `namespaces "tenant-root" not
+# found`, which then races the install script's wait deadline. The CRD edges
+# (backup-controller / bucket-application / objectstorage-controller / velero)
+# guard the `no matches for kind` race. All edges below must stay.
+templates:
+  - templates/sources.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  - it: backupstrategy-controller dependsOn cozystack-basics and the CRD providers
+    documentSelector:
+      path: metadata.name
+      value: cozystack.backupstrategy-controller
+    asserts:
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.cozystack-basics
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.backup-controller
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.bucket-application
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.objectstorage-controller
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.velero


### PR DESCRIPTION
## Problem

On a fresh install, the install step can fail with:

```text
Error creating resource via patch ... apps.cozystack.io/v1alpha1 Kind=Bucket
  name=cozy-backups namespace=tenant-root: namespaces "tenant-root" not found
```

`backupstrategy-controller` renders the `cozy-backups` Bucket **into** the `tenant-root` namespace, but its `dependsOn` only guards the CRDs it needs (backup-controller / bucket-application / objectstorage-controller / velero) — not the existence of the target namespace. `tenant-root` is provisioned by `cozystack-basics` (the static tenant-root release), and there is no ordering edge to it. On an unlucky Flux reconcile order the Bucket patch races namespace creation, fails, and that transient failure races the install script's `kubectl wait` deadline → the run fails.

This is latent and not introduced by any particular change — the Bucket-into-tenant-root predates recent branches — so it flakes installs on changes that have nothing to do with backups.

## Fix

Add `cozystack.cozystack-basics` to `backupstrategy-controller`'s `dependsOn` so the `tenant-root` namespace exists before the Bucket is applied. `cozystack-basics` is a dependency-graph leaf (nothing depends on it), so no cycle is introduced.

Pinned with a helm-unittest regression guard (`tests/sources_backupstrategy_dependson_test.yaml`) asserting the edge — mirroring the existing `sources_basics_dependson_test.yaml` pattern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved install ordering so the backup strategy component waits for required foundational services before deploying, reducing race conditions during fresh installs.
  * Clarified dependency relationships for cluster-wide platform components to better reflect safe upgrade and installation behavior.

* **Tests**
  * Added regression coverage to verify the backup strategy package declares all required dependencies, including namespace and CRD providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->