### PR TITLE
test(foundationdb): widen late-converging status wait budgets

### DIFF
--- a/hack/e2e-apps/foundationdb.bats
+++ b/hack/e2e-apps/foundationdb.bats
@@ -91,15 +91,27 @@ EOF
   # Validate status.desiredProcessGroups field
   timeout 60 sh -ec "until kubectl -n tenant-test get foundationdbclusters.apps.foundationdb.org foundationdb-$name -o jsonpath='{.status.desiredProcessGroups}' | grep -q '^[0-9][0-9]*$'; do sleep 10; done"
 
-  # Validate status.generations.reconciled field
-  timeout 60 sh -ec "until kubectl -n tenant-test get foundationdbclusters.apps.foundationdb.org foundationdb-$name -o jsonpath='{.status.generations.reconciled}' | grep -q '^[0-9][0-9]*$'; do sleep 10; done"
+  # Validate status.generations.reconciled field.
+  # The operator only stamps generations.reconciled after every process has
+  # held its role for minimumUptimeSecondsForBounce (60s, see
+  # packages/apps/foundationdb/templates/cluster.yaml), so this is structurally
+  # the last status field to converge. It needs at least the same budget as the
+  # earlier health.available gate (300s), not the short 60s ceiling.
+  timeout 300 sh -ec "until kubectl -n tenant-test get foundationdbclusters.apps.foundationdb.org foundationdb-$name -o jsonpath='{.status.generations.reconciled}' | grep -q '^[0-9][0-9]*$'; do sleep 10; done"
 
-  # Validate status.hasListenIPsForAllPods field
-  timeout 60 sh -ec "until kubectl -n tenant-test get foundationdbclusters.apps.foundationdb.org foundationdb-$name -o jsonpath='{.status.hasListenIPsForAllPods}' | grep -q 'true'; do sleep 10; done"
+  # Validate status.hasListenIPsForAllPods field. A bounce restarts fdbserver
+  # in-place, so pods and their listen IPs do not churn and this usually settles
+  # before the reconciled gate. Widened to 300s for a conservative ceiling
+  # consistent with the surrounding gates; the 300s is headroom, not because
+  # this field is as late-converging as generations.reconciled.
+  timeout 300 sh -ec "until kubectl -n tenant-test get foundationdbclusters.apps.foundationdb.org foundationdb-$name -o jsonpath='{.status.hasListenIPsForAllPods}' | grep -q 'true'; do sleep 10; done"
 
-  # Validate comprehensive status.health fields
-  timeout 60 sh -ec "until kubectl -n tenant-test get foundationdbclusters.apps.foundationdb.org foundationdb-$name -o jsonpath='{.status.health.fullReplication}' | grep -q 'true'; do sleep 10; done"
-  timeout 60 sh -ec "until kubectl -n tenant-test get foundationdbclusters.apps.foundationdb.org foundationdb-$name -o jsonpath='{.status.health.healthy}' | grep -q 'true'; do sleep 10; done"
+  # Validate comprehensive status.health fields. fullReplication and healthy
+  # settle only once the cluster is fully reconciled (after the post-bounce
+  # uptime gate), so they share the same 300s budget rather than the short 60s
+  # ceiling.
+  timeout 300 sh -ec "until kubectl -n tenant-test get foundationdbclusters.apps.foundationdb.org foundationdb-$name -o jsonpath='{.status.health.fullReplication}' | grep -q 'true'; do sleep 10; done"
+  timeout 300 sh -ec "until kubectl -n tenant-test get foundationdbclusters.apps.foundationdb.org foundationdb-$name -o jsonpath='{.status.health.healthy}' | grep -q 'true'; do sleep 10; done"
 
   # Verify security context is applied correctly (non-root user)
   storage_pod=$(kubectl -n tenant-test get pods -l foundationdb.org/fdb-cluster-name=foundationdb-$name,foundationdb.org/fdb-process-class=storage --no-headers | head -n1 | awk '{print $1}')


### PR DESCRIPTION
## What this PR does

**Problem**

The `foundationdb` e2e test fails intermittently with a `.status` jsonpath poll timeout even though the FoundationDB cluster is fully healthy and reconciled. The `generations.reconciled`, `hasListenIPsForAllPods`, `health.fullReplication` and `health.healthy` gates polled their status fields with a 60s ceiling, while the strictly-earlier `health.available` gate already allowed 300s. The operator stamps `generations.reconciled` only after every process holds its role for `minimumUptimeSecondsForBounce` (60s, set in `packages/apps/foundationdb/templates/cluster.yaml`), which makes `reconciled` — and the health fields gated on it — structurally the last status fields to converge. The short ceiling closed the gate seconds before the field landed; a snapshot taken a few seconds after a failure shows the live object fully reconciled (`generations.reconciled: 1`, `health.healthy: true`).

**Fix**

Raise those four late-converging gates to 300s, matching the existing `health.available` budget. The waits stay event-driven (`until …; do sleep …; done`) — only the ceilings widen, no new retries or fixed sleeps. A comment records why `reconciled` converges last so the budget ordering stays legible to future readers. The early-converging 60s gates (`configured`, `connectionString`, `databaseConfiguration.*`, `desiredProcessGroups`) and the spec-field gates are left untouched, since they settle before `health.available` and 60s is already adequate.

**Why not just rerun**

Rerunning masks a deterministic ordering bug: the latest-converging field carried the tightest budget. The cluster was healthy on every "failure" — the test was racing its own success criteria, so the failure recurs until the budget ordering is corrected. This change touches only the test harness; the platform behaviour it asserts is unchanged.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased waiting time in one end-to-end FoundationDB setup test so cluster status checks have more time to stabilize.
  * Reduced flaky failures by allowing key health and reconciliation fields to converge before the test continues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->