### PR TITLE
fix(opensearch-operator): gate leader election on replica count

### DIFF
--- a/packages/system/opensearch-operator/Makefile
+++ b/packages/system/opensearch-operator/Makefile
@@ -8,3 +8,4 @@ update:
 	helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
 	helm repo update opensearch-operator
 	helm pull opensearch-operator/opensearch-operator --version 2.8.0 --untar --untardir charts
+	patch --no-backup-if-mismatch -p1 < patches/leaderElection.diff

--- a/packages/system/opensearch-operator/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/packages/system/opensearch-operator/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -5,7 +5,14 @@ metadata:
     control-plane: controller-manager
   name: {{ include "opensearch-operator.fullname" . }}-controller-manager
 spec:
-  replicas: 1
+  replicas: {{ .Values.manager.replicaCount | default 1 }}
+  {{- if le (int (.Values.manager.replicaCount | default 1)) 1 }}
+  # On a single replica a RollingUpdate briefly runs two managers (maxSurge) during
+  # an upgrade; with leader election gated off they would both reconcile without lease
+  # coordination. Recreate closes that window at zero availability cost on one replica.
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       control-plane: controller-manager
@@ -49,7 +56,9 @@ spec:
       - args:
         - --health-probe-bind-address=:8081
         - --metrics-bind-address=127.0.0.1:8080
+        {{- if gt (int (.Values.manager.replicaCount | default 1)) 1 }}
         - --leader-elect
+        {{- end }}
         {{- if .Values.manager.watchNamespace }}
         - --watch-namespace={{ .Values.manager.watchNamespace }}
         {{- end }}

--- a/packages/system/opensearch-operator/patches/leaderElection.diff
+++ b/packages/system/opensearch-operator/patches/leaderElection.diff
@@ -1,0 +1,29 @@
+diff --git a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+--- a/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
++++ b/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+@@ -5,7 +5,14 @@
+     control-plane: controller-manager
+   name: {{ include "opensearch-operator.fullname" . }}-controller-manager
+ spec:
+-  replicas: 1
++  replicas: {{ .Values.manager.replicaCount | default 1 }}
++  {{- if le (int (.Values.manager.replicaCount | default 1)) 1 }}
++  # On a single replica a RollingUpdate briefly runs two managers (maxSurge) during
++  # an upgrade; with leader election gated off they would both reconcile without lease
++  # coordination. Recreate closes that window at zero availability cost on one replica.
++  strategy:
++    type: Recreate
++  {{- end }}
+   selector:
+     matchLabels:
+       control-plane: controller-manager
+@@ -49,7 +56,9 @@
+       - args:
+         - --health-probe-bind-address=:8081
+         - --metrics-bind-address=127.0.0.1:8080
++        {{- if gt (int (.Values.manager.replicaCount | default 1)) 1 }}
+         - --leader-elect
++        {{- end }}
+         {{- if .Values.manager.watchNamespace }}
+         - --watch-namespace={{ .Values.manager.watchNamespace }}
+         {{- end }}

--- a/packages/system/opensearch-operator/tests/leader_election_test.yaml
+++ b/packages/system/opensearch-operator/tests/leader_election_test.yaml
@@ -1,0 +1,57 @@
+suite: opensearch-operator leader election is gated on replica count
+
+# The operator Deployment ships a single replica. Leader election on one replica
+# adds no HA value but lets a transient apiserver/etcd lease-renewal blip make the
+# manager self-terminate (controller-runtime os.Exit on "leader election lost"),
+# which surfaces at install time as a crashlooping Deployment marked Failed.
+# Gate --leader-elect on replica count: off for the default single replica, back
+# on automatically when an operator scales to more than one replica for real HA.
+release:
+  name: opensearch-operator
+  namespace: cozy-opensearch-operator
+tests:
+  - it: default single-replica install drops --leader-elect from the manager
+    template: charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+      # Guard container ordering: kube-rbac-proxy is [0], manager is [1].
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: operator-controller-manager
+      - notContains:
+          path: spec.template.spec.containers[1].args
+          content: --leader-elect
+      # Recreate avoids two uncoordinated managers overlapping during an upgrade
+      # while leader election is gated off on the single replica.
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: scaling past one replica re-enables --leader-elect for real HA
+    template: charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      opensearch-operator:
+        manager:
+          replicaCount: 2
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: operator-controller-manager
+      - contains:
+          path: spec.template.spec.containers[1].args
+          content: --leader-elect
+      # Multi-replica installs keep the default RollingUpdate (no explicit
+      # strategy) so rollouts stay available.
+      - notExists:
+          path: spec.strategy

--- a/packages/system/opensearch-operator/values.yaml
+++ b/packages/system/opensearch-operator/values.yaml
@@ -1,5 +1,11 @@
 opensearch-operator:
   manager:
+    # Number of operator replicas. Leader election is enabled automatically only
+    # when this is greater than 1. On a single replica leader election adds no HA
+    # value but lets a transient apiserver/etcd lease-renewal blip self-terminate
+    # the manager (controller-runtime exits on "leader election lost"), which
+    # surfaces at install time as a crashlooping, Failed Deployment.
+    replicaCount: 1
     # Enable cluster-wide mode to watch all namespaces
     watchNamespace: ""
   kubeRbacProxy:


### PR DESCRIPTION
## What this PR does

**Problem**

opensearch-operator installs intermittently fail with Helm reporting the controller-manager `Deployment status: 'Failed'`. The real driver is the manager container (`operator-controller-manager`) crashlooping on `leader election lost`: controller-runtime calls `os.Exit(1)` when it misses a lease-renewal deadline under the apiserver/etcd latency that install-time load creates. The Deployment runs a single replica (`replicas: 1`) yet still passes `--leader-elect`, so leader election adds no availability — its only effect is to let a transient control-plane blip self-terminate the sole manager. The kube-rbac-proxy `BackOff` seen alongside is collateral restart-window noise, not the cause: on a long-running cluster the proxy shows `restartCount: 0` while the manager has restarted repeatedly with `exitCode: 1`, `reason: Error`.

**Fix**

Gate `--leader-elect` on the replica count instead of passing it unconditionally. A new `manager.replicaCount` value (default `1`) drives both `spec.replicas` and the flag: at one replica the manager runs without leader election and rides out control-plane latency instead of crashlooping; setting `replicaCount > 1` re-enables `--leader-elect` automatically so a genuine HA deployment still coordinates. Because both derive from one value, there is no window where multiple managers run without a lease.

The same single-replica path also sets the Deployment strategy to `Recreate`. With leader election off, a default `RollingUpdate` would briefly run two managers (maxSurge) during an operator upgrade, both reconciling without lease coordination; `Recreate` closes that window at zero availability cost on one replica. Installs scaled past one replica keep `RollingUpdate`.

The arg is hardcoded in the vendored opensearch-operator 2.8.0 chart, so the change ships as `packages/system/opensearch-operator/patches/leaderElection.diff`, re-applied by the package `make update` target after `helm pull --untar`. This mirrors the existing fluxcd-operator patch mechanism so the customization survives a chart refresh. A helm-unittest suite pins both states: the default render drops `--leader-elect` and sets `strategy: Recreate`; a `replicaCount: 2` render restores `--leader-elect` and leaves the strategy at the RollingUpdate default.

### Screenshots

Not applicable — no UI change.

### Release note

```release-note
fix(opensearch-operator): disable leader election on the single-replica operator Deployment so a transient apiserver/etcd latency spike no longer crashloops the manager at install time; leader election re-enables automatically when scaled past one replica
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable replica count for the operator manager, with a default of 1.
  * Single-replica deployments now use a safer rollout strategy and skip leader election.
  * Multi-replica deployments automatically enable leader election.

* **Tests**
  * Added coverage for single- and multi-replica deployment behavior.

* **Documentation**
  * Updated configuration notes to explain replica count behavior and related deployment changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->