### PR TITLE
fix(platform): make *-rd sources depend on cozystack-engine

### DIFF
--- a/hack/check-applicationdefinition-crd-ordering.bats
+++ b/hack/check-applicationdefinition-crd-ordering.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+# Chart-wide invariant for packages/core/platform/sources:
+#
+# Every *-application PackageSource that ships a `system/*-rd` component renders
+# an ApplicationDefinition (cozystack.io/v1alpha1). That CRD is installed by the
+# application-definition-crd component of cozystack.cozystack-engine. Without an
+# explicit `dependsOn: cozystack.cozystack-engine`, a fresh install where Flux
+# happens to reconcile the *-application source before cozystack-engine fails to
+# render with `no matches for kind "ApplicationDefinition" in version
+# "cozystack.io/v1alpha1"`, which cascades into a broad install timeout.
+#
+# This invariant is generic: any future *-application source that adds a
+# system/*-rd component but forgets the cozystack-engine edge fails here, even
+# though the individual source files are not enumerated below.
+#
+# Requires: yq (mikefarah v4+), jq. Both are available on the project's CI
+# runners and on the maintainer workstation.
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
+SOURCES_DIR="$REPO_ROOT/packages/core/platform/sources"
+
+@test "every PackageSource with a system/*-rd component dependsOn cozystack.cozystack-engine" {
+  command -v yq >/dev/null || { echo "yq (mikefarah v4+) is required" >&2; exit 1; }
+  command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+  # yq streams one JSON object per source document; jq -s slurps the stream so
+  # every PackageSource variant can be evaluated as a single collection.
+  json="$(yq --output-format=json eval-all '.' "$SOURCES_DIR"/*.yaml)"
+
+  # A "-rd variant" is any variant whose components include a system/*-rd path.
+  rd_total="$(printf '%s' "$json" | jq -s '
+    [ .[]
+      | select(.kind == "PackageSource")
+      | (.spec.variants // [])[]
+      | select((.components // []) | any(.path // "" | test("^system/[a-z0-9-]+-rd$")))
+    ] | length
+  ')"
+
+  # Guard against a vacuous pass (empty glob / yq breakage): the platform ships
+  # many -rd sources, so discovering zero means this test itself is broken.
+  [ "$rd_total" -ge 1 ] || { echo "Discovered zero system/*-rd variants under $SOURCES_DIR - test is misconfigured" >&2; exit 1; }
+
+  offenders="$(printf '%s' "$json" | jq -rs '
+    [ .[]
+      | select(.kind == "PackageSource")
+      | .metadata.name as $name
+      | (.spec.variants // [])[]
+      | select((.components // []) | any(.path // "" | test("^system/[a-z0-9-]+-rd$")))
+      | select(((.dependsOn // []) | any(. == "cozystack.cozystack-engine")) | not)
+      | "\($name) [variant: \(.name)]"
+    ] | .[]
+  ')"
+
+  if [ -n "$offenders" ]; then
+    echo "PackageSources with a system/*-rd component but missing the cozystack.cozystack-engine dependsOn edge:" >&2
+    printf '%s\n' "$offenders" >&2
+    echo "Fix: add '- cozystack.cozystack-engine' to each listed variant's dependsOn (mirror sources/gateway-application.yaml)." >&2
+    exit 1
+  fi
+
+  echo "Invariant holds: all $rd_total system/*-rd PackageSource variant(s) dependsOn cozystack.cozystack-engine"
+}

--- a/hack/select-e2e.sh
+++ b/hack/select-e2e.sh
@@ -43,8 +43,21 @@ build_owners_index() {
 }
 
 # yq: PackageSource name -> sources that depend on it (reverse of dependsOn)
+#
+# Exclude cozystack.cozystack-engine as a propagation hub. Every *-application
+# source declares `dependsOn: cozystack.cozystack-engine` purely as an INSTALL
+# ORDERING edge — the app's *-rd HelmRelease must wait for the engine to
+# register the ApplicationDefinition CRD before it can reconcile. That is a
+# universal lifecycle dependency, NOT a behavioral one: a change to an engine
+# dependency (postgres-operator, keycloak, cert-manager, ...) does not alter any
+# app's runtime behavior, so it must not fan test selection out to every app.
+# Without this filter, postgres-operator -> keycloak -> cozystack-engine -> EVERY
+# app, defeating test-impact analysis. Dropping the engine reverse edges keeps
+# the engine reachable but stops it propagating selection downstream. A change to
+# the engine itself still triggers the full suite via the no-app-descendants
+# safety-net at the bottom of this script.
 build_reverse_deps() {
-  yq -rN '.metadata.name as $n | .spec.variants[]?.dependsOn[]? | select(. != null and . != "") | . + "\t" + $n' "$SOURCES_DIR"/*.yaml
+  yq -rN '.metadata.name as $n | .spec.variants[]?.dependsOn[]? | select(. != null and . != "" and . != "cozystack.cozystack-engine") | . + "\t" + $n' "$SOURCES_DIR"/*.yaml
 }
 
 OWNERS=$(build_owners_index | sort -u)

--- a/hack/select-e2e_test.bats
+++ b/hack/select-e2e_test.bats
@@ -37,6 +37,26 @@
     fi
 }
 
+@test "engine-dependency change does not fan out via the ordering edge" {
+    # cert-manager is a dependency of cozystack-engine, and every app declares
+    # dependsOn cozystack-engine purely as an INSTALL-ORDERING edge (the app's
+    # *-rd HelmRelease waits for the ApplicationDefinition CRD). That edge must
+    # not propagate test selection: a cert-manager change selects only its
+    # genuine direct dependents (postgres, harbor, ...), never unrelated apps
+    # like kafka that reach cert-manager solely through the engine.
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    echo "packages/system/cert-manager/values.yaml" > "$tmp/diff"
+    output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources")
+    echo "$output" | grep -wq postgres
+    echo "$output" | grep -wq harbor
+    if echo "$output" | grep -wq kafka; then
+        echo "cert-manager change must not fan out via engine; got: $output" >&2
+        exit 1
+    fi
+}
+
 @test "networking change triggers full suite" {
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' EXIT

--- a/packages/core/platform/sources/bootbox-application.yaml
+++ b/packages/core/platform/sources/bootbox-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.networking
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/bucket-application.yaml
+++ b/packages/core/platform/sources/bucket-application.yaml
@@ -14,6 +14,8 @@ spec:
       dependsOn:
         - cozystack.networking
         - cozystack.objectstorage-controller
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/clickhouse-application.yaml
+++ b/packages/core/platform/sources/clickhouse-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.clickhouse-operator
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/etcd-application.yaml
+++ b/packages/core/platform/sources/etcd-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.networking
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/external-dns-application.yaml
+++ b/packages/core/platform/sources/external-dns-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.networking
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/foundationdb-application.yaml
+++ b/packages/core/platform/sources/foundationdb-application.yaml
@@ -14,6 +14,8 @@ spec:
       dependsOn:
         - cozystack.networking
         - cozystack.foundationdb-operator
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/harbor-application.yaml
+++ b/packages/core/platform/sources/harbor-application.yaml
@@ -16,6 +16,8 @@ spec:
         - cozystack.postgres-operator
         - cozystack.redis-operator
         - cozystack.objectstorage-controller
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/http-cache-application.yaml
+++ b/packages/core/platform/sources/http-cache-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.networking
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/info-application.yaml
+++ b/packages/core/platform/sources/info-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.networking
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/ingress-application.yaml
+++ b/packages/core/platform/sources/ingress-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.networking
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/kafka-application.yaml
+++ b/packages/core/platform/sources/kafka-application.yaml
@@ -14,6 +14,8 @@ spec:
       dependsOn:
         - cozystack.networking
         - cozystack.kafka-operator
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/kubernetes-application.yaml
+++ b/packages/core/platform/sources/kubernetes-application.yaml
@@ -18,6 +18,8 @@ spec:
         - cozystack.capi-provider-core
         - cozystack.capi-provider-cp-kamaji
         - cozystack.capi-provider-infra-kubevirt
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/mariadb-application.yaml
+++ b/packages/core/platform/sources/mariadb-application.yaml
@@ -14,6 +14,8 @@ spec:
       dependsOn:
         - cozystack.networking
         - cozystack.mariadb-operator
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/mongodb-application.yaml
+++ b/packages/core/platform/sources/mongodb-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.networking
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/monitoring-application.yaml
+++ b/packages/core/platform/sources/monitoring-application.yaml
@@ -16,6 +16,8 @@ spec:
         - cozystack.postgres-operator
         - cozystack.grafana-operator
         - cozystack.victoria-metrics-operator
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/nats-application.yaml
+++ b/packages/core/platform/sources/nats-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.networking
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/openbao-application.yaml
+++ b/packages/core/platform/sources/openbao-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.networking
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/opensearch-application.yaml
+++ b/packages/core/platform/sources/opensearch-application.yaml
@@ -14,6 +14,8 @@ spec:
     dependsOn:
     - cozystack.networking
     - cozystack.opensearch-operator
+    # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+    - cozystack.cozystack-engine
     libraries:
     - name: cozy-lib
       path: library/cozy-lib

--- a/packages/core/platform/sources/postgres-application.yaml
+++ b/packages/core/platform/sources/postgres-application.yaml
@@ -14,6 +14,8 @@ spec:
       dependsOn:
         - cozystack.networking
         - cozystack.postgres-operator
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/qdrant-application.yaml
+++ b/packages/core/platform/sources/qdrant-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.networking
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/rabbitmq-application.yaml
+++ b/packages/core/platform/sources/rabbitmq-application.yaml
@@ -14,6 +14,8 @@ spec:
       dependsOn:
         - cozystack.networking
         - cozystack.rabbitmq-operator
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/redis-application.yaml
+++ b/packages/core/platform/sources/redis-application.yaml
@@ -14,6 +14,8 @@ spec:
       dependsOn:
         - cozystack.networking
         - cozystack.redis-operator
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/seaweedfs-application.yaml
+++ b/packages/core/platform/sources/seaweedfs-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.networking
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/tcp-balancer-application.yaml
+++ b/packages/core/platform/sources/tcp-balancer-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.networking
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/tenant-application.yaml
+++ b/packages/core/platform/sources/tenant-application.yaml
@@ -19,6 +19,8 @@ spec:
         - cozystack.info-application
         - cozystack.monitoring-application
         - cozystack.etcd-application
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/virtualprivatecloud-application.yaml
+++ b/packages/core/platform/sources/virtualprivatecloud-application.yaml
@@ -14,6 +14,8 @@ spec:
       dependsOn:
         - cozystack.networking
         - cozystack.multus
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/vm-disk-application.yaml
+++ b/packages/core/platform/sources/vm-disk-application.yaml
@@ -14,6 +14,8 @@ spec:
       dependsOn:
         - cozystack.networking
         - cozystack.kubevirt-cdi
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/vm-instance-application.yaml
+++ b/packages/core/platform/sources/vm-instance-application.yaml
@@ -14,6 +14,8 @@ spec:
       dependsOn:
         - cozystack.networking
         - cozystack.kubevirt
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/sources/vpn-application.yaml
+++ b/packages/core/platform/sources/vpn-application.yaml
@@ -13,6 +13,8 @@ spec:
     - name: default
       dependsOn:
         - cozystack.networking
+        # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
+        - cozystack.cozystack-engine
       libraries:
         - name: cozy-lib
           path: library/cozy-lib


### PR DESCRIPTION
## Problem

On an unlucky Flux reconcile order, a `*-application` PackageSource that ships a `system/*-rd` component can install before the `applicationdefinitions.cozystack.io` CRD exists. Every `*-rd` chart renders an `ApplicationDefinition` (`cozystack.io/v1alpha1`); that CRD is installed by the `application-definition-crd` component of `cozystack.cozystack-engine`. When an `*-rd` HelmRelease renders first, it hard-fails with `no matches for kind "ApplicationDefinition" in version "cozystack.io/v1alpha1"`, and that cascades into a broad install timeout — surfacing even on changes that have nothing to do with ordering, because it is a latent race.

## Fix

Add `- cozystack.cozystack-engine` to the `dependsOn` of every `*-application` source that ships a `system/*-rd` component (29 sources). `gateway-application` already carried this edge — it was added earlier for the TenantGateway CRD, the same bug class, but only for that one source. A new invariant test fails if any source with a `system/*-rd` component is missing the edge.

## Why

The ordering was previously implicit, relying on Flux happening to reconcile `cozystack-engine` before the `*-application` sources. Making the edge explicit removes the race deterministically. No dependency cycle is introduced: `cozystack-engine` depends only on `networking` and `cert-manager` (plus keycloak in its oidc variant), none of which reach back to any `*-application`.

## Test

- New generic guard `hack/check-applicationdefinition-crd-ordering.bats` (auto-discovered by `make bats-unit-tests`, runs in CI via `make unit-tests`): parses every source and fails if any PackageSource variant with a `system/*-rd` component lacks the `cozystack.cozystack-engine` edge — so future sources are covered, not just today's set.
- `helm unittest packages/core/platform`: 13 suites / 66 tests pass; the source edits do not disturb existing assertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency ordering across several platform packages to ensure related components install in the correct sequence.
  * Prevented end-to-end test selection from being overly broad when only ordering-related dependencies change.

* **Tests**
  * Added checks to catch missing dependency requirements and to verify test selection behavior stays accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->