### PR TITLE
fix(monitoring-agents): relax fluent-bit probes for loaded installs

### DIFF
--- a/packages/system/monitoring-agents/tests/fluent-bit_probes_test.yaml
+++ b/packages/system/monitoring-agents/tests/fluent-bit_probes_test.yaml
@@ -1,0 +1,53 @@
+suite: fluent-bit liveness/readiness probes carry load headroom
+
+# Regression guard for the fluent-bit crash loop on a loaded install. The
+# subchart default probes (initialDelaySeconds 0, timeoutSeconds 1,
+# failureThreshold 3) fire into a connection-refused :2020 before fluent-bit's
+# HTTP server binds — that bind happens only AFTER the kubernetes filter's
+# "testing connectivity with API server" step, which the kube-API can gate for
+# ~10s under a concurrent install. The aggressive defaults then liveness-kill
+# fluent-bit into a restart loop, timing out the HelmRelease. The umbrella
+# values relax both probes. Pin the relaxed timing AND the unchanged target
+# (httpGet path / on port http = :2020) — a wrong path/port would make the
+# probe always fail, strictly worse than the bug it fixes.
+release:
+  name: monitoring-agents
+  namespace: cozy-monitoring
+tests:
+  - it: liveness probe keeps :2020 target and gains load headroom
+    template: charts/fluent-bit/templates/daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 15
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 6
+
+  - it: readiness probe keeps :2020 target and gains load headroom
+    template: charts/fluent-bit/templates/daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 6

--- a/packages/system/monitoring-agents/values.yaml
+++ b/packages/system/monitoring-agents/values.yaml
@@ -287,9 +287,28 @@ vmagent:
 fluent-bit:
   rbac:
     eventsAccess: true
+  # Relax probe timing to survive a loaded install. Fluent-bit's HTTP server on
+  # :2020 (the probe target) does not bind until AFTER the kubernetes filter's
+  # "testing connectivity with API server" step; under concurrent install the
+  # kube-API can be unreachable for ~10s, delaying the :2020 bind, and the
+  # single-threaded HTTP server can miss a 1s timeout while the engine is busy.
+  # The subchart defaults (initialDelaySeconds 0, timeoutSeconds 1,
+  # failureThreshold 3) then liveness-kill fluent-bit into a crash loop. httpGet
+  # stays on path / port http (:2020) — same target as the subchart defaults.
+  livenessProbe:
+    httpGet:
+      path: /
+      port: http
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
   readinessProbe:
     httpGet:
       path: /
+      port: http
+    timeoutSeconds: 5
+    failureThreshold: 6
   daemonSetVolumes:
     - name: varlog
       hostPath:


### PR DESCRIPTION
## What this PR does

**Problem**

On a loaded install the `monitoring-agents` fluent-bit DaemonSet crash-loops and its HelmRelease times out (`timeout waiting for: [DaemonSet/.../monitoring-agents-fluent-bit status: 'InProgress']`), cascading into velero → backupstrategy-controller `DependencyNotReady` and failing the whole install.

Root cause: fluent-bit's HTTP server on `:2020` (the liveness/readiness target) binds only AFTER the `filter:kubernetes` "testing connectivity with API server" step. During a concurrent install the kube-API can be unreachable for ~10s (observed `connection #144 timeout after 10 seconds to: kubernetes.default.svc:443`), which delays the `:2020` bind. The vendored subchart's default probes (`initialDelaySeconds 0, timeoutSeconds 1, failureThreshold 3`) fire into a connection-refused port immediately, and the single-threaded HTTP server can't always meet a 1s timeout while the engine is busy — so liveness SIGTERMs fluent-bit (exitCode 0, not OOM) into a restart loop.

**Fix**

Relax both probes in the first-party umbrella `values.yaml` `fluent-bit:` block: `initialDelaySeconds 15, periodSeconds 10, timeoutSeconds 5, failureThreshold 6` (~75s tolerance from container start, ~60s steady-state). The `httpGet` target is unchanged — path `/` on port `http` (`:2020`). The change is values-only; the vendored subchart is not touched.

**Why load-triggered (not always-broken)**

A steady-state cluster runs the identical probe config with the DaemonSet 3/3 Ready, 0 restarts, 26 days. The probe only fails when the `:2020` bind is delayed by API unreachability under install-time load. Steady-state-stable + flaky-only-under-load = probe-too-aggressive, not a target or config error.

**Test**

Added a helm-unittest (`tests/fluent-bit_probes_test.yaml`) pinning both the relaxed timing and the preserved `:2020` httpGet target (path `/`, port `http`) on the rendered DaemonSet, so a future change that re-tightens the probes or breaks the path/port is caught.

### Screenshots

N/A — no UI changes.

### Release note

```release-note
fix(monitoring-agents): relax fluent-bit liveness/readiness probes so the DaemonSet no longer crash-loops on a loaded install when its :2020 HTTP server binds late behind a busy kube-API
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted Fluent Bit health probes to use more relaxed timing, reducing the chance of restart loops on busy installations.
  * Kept the readiness check pointed at the expected HTTP path and port while making probe behavior more stable.
* **Tests**
  * Added test coverage to verify the generated probe configuration stays consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->