### PR TITLE
test(e2e): escalate cilium leak healer to agent restart on leaked-IP reuse

### DIFF
--- a/hack/e2e-cilium-endpoint-leak-healer.sh
+++ b/hack/e2e-cilium-endpoint-leak-healer.sh
@@ -23,19 +23,36 @@
 # upstream at cilium/cilium#38313 (closed stale); no released or pre-release
 # Cilium fixes the leak and no flag disables it.
 #
-# This watchdog applies the least-disruptive known remedy: instead of
-# restarting the agent (which drops the whole node's in-memory registry), it
-# evicts only the orphaned endpoint via
-#   cilium-dbg endpoint disconnect ipv4:<X>
-# which maps to DELETE /endpoint/{id} -> RemoveEndpoint -> unexpose ->
-# removeReferencesLocked, clearing the stale IP-keyed entry. The wedged pod's
-# next CNI ADD retry then succeeds. Blast radius is one dead endpoint.
+# This watchdog heals in two tiers, least-disruptive first:
+#
+#   Tier 1 (per-endpoint, default): evict only the orphaned endpoint via
+#     cilium-dbg endpoint disconnect ipv4:<X>
+#   which maps to DELETE /endpoint/{id} -> RemoveEndpoint -> unexpose ->
+#   removeReferencesLocked, clearing the stale IP-keyed entry; or, when a
+#   reserved/infra endpoint holds the IP, delete-reschedule the wedged pod onto
+#   a free address. Blast radius is one dead endpoint or one pod.
+#
+#   Tier 2 (per-node escalation): on some variants the leak lives in agent
+#   in-memory state that `endpoint disconnect` cannot reach — the IP is no longer
+#   in the queryable endpoint registry (so Tier 1 logs "no endpoint holds ip" and
+#   no-ops) yet the agent still rejects the sandbox, and IPAM keeps re-handing the
+#   SAME IP, so a delete-rescheduled pod just re-wedges on it: an inescapable
+#   loop. When the same (node,ip) survives ESCALATE_AFTER heal cycles of Tier 1,
+#   escalate to the only remedy that clears an in-memory leak — restart the node's
+#   cilium-agent (delete its pod; the DaemonSet recreates it, rebuilding from
+#   CRDs/IPAM without the stale entry). This is heavier — it drops the node's
+#   whole in-memory endpoint registry — and a production operator would avoid it,
+#   but for a test-only, install-phase healer it is the effective, acceptable
+#   remedy. It is bounded by a per-node cap (MAX_ESCALATIONS_PER_NODE) so it can
+#   never loop-restart agents, and every action is logged loudly with its reason.
 #
 # It is READ-ONLY until it has positively confirmed an orphan: an endpoint in
 # the owning node's registry holds the disputed IP, that endpoint does not back
 # a live Running pod with that IP, and a different pod is currently wedged
 # requesting the same IP. If anything is ambiguous it logs and does nothing —
-# it never disconnects a live endpoint.
+# it never disconnects a live endpoint. The Tier-2 escalation never fires for a
+# refused (genuine duplicate-IP) case: only repeated, confirmed leak candidates
+# count toward it, so an agent restart can never mask a real product bug.
 #
 # REMOVE this script, hack/e2e-cilium-leak-healer.yaml, and the setup_file/
 # teardown_file hooks in hack/e2e-install-cozystack.bats once a fixed Cilium
@@ -44,6 +61,15 @@ set -u
 
 CILIUM_NS="${CILIUM_NS:-cozy-cilium}"
 POLL_INTERVAL="${CILIUM_HEALER_POLL_SEC:-15}"
+
+# Tier-2 escalation tuning (see header). ESCALATE_AFTER is how many consecutive
+# heal cycles the SAME (node,ip) must stay wedged under Tier-1 before the
+# cilium-agent on that node is restarted; the per-node cap bounds how many times
+# an agent may be restarted over the cluster lifetime so the watchdog can never
+# loop-restart agents.
+ESCALATE_AFTER="${CILIUM_HEALER_ESCALATE_AFTER:-3}"
+MAX_ESCALATIONS_PER_NODE="${CILIUM_HEALER_MAX_AGENT_RESTARTS:-2}"
+STATE_DIR="${CILIUM_HEALER_STATE_DIR:-/tmp/cilium-leak-healer}"
 
 log() { echo "[cilium-leak-healer $(date -u +%H:%M:%S)] $*"; }
 
@@ -54,7 +80,35 @@ agent_on_node() {
     -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
 }
 
-log "started (ns=$CILIUM_NS poll=${POLL_INTERVAL}s, in-cluster, runs for the cluster lifetime)"
+# Per-(node,ip) recurrence and per-node escalation counters, kept on the pod's
+# local filesystem. State is intentionally non-durable: if the watchdog crashes
+# and the Job restarts it, counters reset to zero, which only costs a few extra
+# heal cycles before re-escalating — never an unbounded restart loop, because the
+# per-node cap is re-derived from the (then-empty) state and the leak has either
+# cleared or recurs legibly.
+keyfrag() { printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'; }
+node_dir() { printf '%s/%s' "$STATE_DIR" "$(keyfrag "$1")"; }
+read_count() { c=$(cat "$1" 2>/dev/null); case "$c" in ''|*[!0-9]*) printf '0' ;; *) printf '%s' "$c" ;; esac; }
+
+# bump_seen NODE IP -> increments and prints the (node,ip) recurrence count.
+bump_seen() {
+  d=$(node_dir "$1"); mkdir -p "$d" 2>/dev/null || true
+  f="$d/seen-$(keyfrag "$2")"; n=$(read_count "$f"); n=$((n + 1)); echo "$n" > "$f"; printf '%s' "$n"
+}
+# reset_node_seen NODE -> clears every (node,*) recurrence counter. One agent
+# restart clears the whole node's in-memory registry, so all its IPs get a fresh
+# grace window afterwards instead of immediately re-escalating.
+reset_node_seen() { rm -f "$(node_dir "$1")"/seen-* 2>/dev/null || true; }
+# escalations NODE -> prints how many agent restarts already issued for the node.
+escalations() { read_count "$(node_dir "$1")/escalations"; }
+# record_escalation NODE -> increments the node's agent-restart counter.
+record_escalation() {
+  d=$(node_dir "$1"); mkdir -p "$d" 2>/dev/null || true
+  f="$d/escalations"; n=$(read_count "$f"); n=$((n + 1)); echo "$n" > "$f"
+}
+
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+log "started (ns=$CILIUM_NS poll=${POLL_INTERVAL}s, escalate-after=${ESCALATE_AFTER} cycles, max-agent-restarts/node=${MAX_ESCALATIONS_PER_NODE}, in-cluster, runs for the cluster lifetime)"
 
 # Endless loop: the pod is torn down with the ephemeral e2e cluster. Before
 # Cilium is serving (early install) the kubectl/exec calls simply fail and the
@@ -87,31 +141,70 @@ while true; do
     # before exposing — so any endpoint holding the IP is the stale one.)
     ep_json=$(kubectl exec -n "$CILIUM_NS" "$agent" -c cilium-agent -- \
                 cilium-dbg endpoint get "ipv4:$ip" -o json 2>/dev/null)
-    [ -n "$ep_json" ] && [ "$ep_json" != "[]" ] || \
-      { log "no endpoint holds ip=$ip on node=$node (already cleared?) for $ns/$pod"; continue; }
+    epid=""; epns=""; eppod=""
+    if [ -n "$ep_json" ] && [ "$ep_json" != "[]" ]; then
+      epid=$(printf '%s' "$ep_json" | jq -r '.[0].id // empty' 2>/dev/null)
+      epns=$(printf '%s' "$ep_json" | jq -r '.[0].status."external-identifiers"."k8s-namespace" // empty' 2>/dev/null)
+      eppod=$(printf '%s' "$ep_json" | jq -r '.[0].status."external-identifiers"."k8s-pod-name" // empty' 2>/dev/null)
 
-    epid=$(printf '%s' "$ep_json" | jq -r '.[0].id // empty' 2>/dev/null)
-    epns=$(printf '%s' "$ep_json" | jq -r '.[0].status."external-identifiers"."k8s-namespace" // empty' 2>/dev/null)
-    eppod=$(printf '%s' "$ep_json" | jq -r '.[0].status."external-identifiers"."k8s-pod-name" // empty' 2>/dev/null)
-
-    # If that endpoint claims a pod that is alive on the cluster with this IP,
-    # it is a LIVE endpoint -> a genuine duplicate-IP, NOT the leak. Refuse and
-    # shout so the real problem is visible instead of silently broken.
-    #
-    # Refuse for ANY non-terminal owner phase, not just Running: a Pending owner
-    # can already hold a live IPAM allocation (status.podIP is populated once the
-    # sandbox is created, before the pod goes Running), so disconnecting it would
-    # evict a legitimate endpoint mid-startup. Only a Succeeded/Failed owner is
-    # safely past needing its endpoint. (owner_ip == ip already gates on the pod
-    # still existing with that IP, so an empty phase from a vanished pod can't
-    # reach this branch.)
-    if [ -n "$epns" ] && [ -n "$eppod" ]; then
-      owner_ip=$(kubectl get pod -n "$epns" "$eppod" -o jsonpath='{.status.podIP}' 2>/dev/null)
-      owner_phase=$(kubectl get pod -n "$epns" "$eppod" -o jsonpath='{.status.phase}' 2>/dev/null)
-      if [ "$owner_ip" = "$ip" ] && [ "$owner_phase" != "Succeeded" ] && [ "$owner_phase" != "Failed" ]; then
-        log "REFUSE ip=$ip on node=$node: held by non-terminal pod $epns/$eppod (phase=$owner_phase; genuine duplicate IP, not the leak) — investigate"
-        continue
+      # If that endpoint claims a pod that is alive on the cluster with this IP,
+      # it is a LIVE endpoint -> a genuine duplicate-IP, NOT the leak. Refuse and
+      # shout so the real problem is visible instead of silently broken. This
+      # path `continue`s WITHOUT bumping the recurrence counter, so a genuine
+      # duplicate never accrues toward the Tier-2 agent restart.
+      #
+      # Refuse for ANY non-terminal owner phase, not just Running: a Pending owner
+      # can already hold a live IPAM allocation (status.podIP is populated once the
+      # sandbox is created, before the pod goes Running), so disconnecting it would
+      # evict a legitimate endpoint mid-startup. Only a Succeeded/Failed owner is
+      # safely past needing its endpoint. (owner_ip == ip already gates on the pod
+      # still existing with that IP, so an empty phase from a vanished pod can't
+      # reach this branch.)
+      if [ -n "$epns" ] && [ -n "$eppod" ]; then
+        owner_ip=$(kubectl get pod -n "$epns" "$eppod" -o jsonpath='{.status.podIP}' 2>/dev/null)
+        owner_phase=$(kubectl get pod -n "$epns" "$eppod" -o jsonpath='{.status.phase}' 2>/dev/null)
+        if [ "$owner_ip" = "$ip" ] && [ "$owner_phase" != "Succeeded" ] && [ "$owner_phase" != "Failed" ]; then
+          log "REFUSE ip=$ip on node=$node: held by non-terminal pod $epns/$eppod (phase=$owner_phase; genuine duplicate IP, not the leak) — investigate"
+          continue
+        fi
       fi
+    fi
+
+    # Past the REFUSE gate this is a genuine leak candidate: no endpoint holds the
+    # IP (the stale entry is outside the queryable registry; disconnect can't reach
+    # it), a reserved/infra endpoint holds it, or a stale pod endpoint holds it.
+    # The Tier-1 remedies below cannot clear a leak that lives purely in the
+    # agent's in-memory state when IPAM keeps re-handing the SAME IP — the
+    # recreated pod re-wedges on it, an inescapable loop. Track recurrence per
+    # (node,ip); once the same IP has survived ESCALATE_AFTER heal cycles,
+    # escalate (Tier 2) to the only remedy that clears an in-memory leak:
+    # restarting the node's cilium-agent. Bounded by a per-node cap so it can
+    # never loop-restart agents.
+    seen=$(bump_seen "$node" "$ip")
+    if [ "$seen" -ge "$ESCALATE_AFTER" ]; then
+      esc=$(escalations "$node")
+      if [ "$esc" -lt "$MAX_ESCALATIONS_PER_NODE" ]; then
+        log "ESCALATE node=$node agent=$agent ip=$ip wedged=$ns/$pod: leaked-IP reuse unhealed after $seen heal cycles of Tier-1 remedies (cilium/cilium#38313) -> restart cilium-agent (restart $((esc + 1))/$MAX_ESCALATIONS_PER_NODE for this node; drops its stale in-memory endpoint registry)"
+        out=$(kubectl delete pod -n "$CILIUM_NS" "$agent" --wait=false 2>&1)
+        log "  result: ${out:-<none>}"
+        record_escalation "$node"
+        # One restart clears every leaked IP on the node, so give the whole node a
+        # fresh grace window rather than immediately re-escalating each IP.
+        reset_node_seen "$node"
+      else
+        log "ESCALATION CAP reached node=$node (max=$MAX_ESCALATIONS_PER_NODE agent restarts): leaked ip=$ip for $ns/$pod still unhealed — surfacing the failure rather than restarting again (cilium/cilium#38313)"
+      fi
+      continue
+    fi
+
+    # Below the escalation threshold: apply the least-disruptive Tier-1 remedy.
+    #
+    # No endpoint holds the IP -> nothing for `endpoint disconnect` to act on (the
+    # leak, if any, is outside the queryable registry). Log and wait; if it keeps
+    # recurring on the same IP the Tier-2 escalation above takes over.
+    if [ -z "$epid" ]; then
+      log "no endpoint holds ip=$ip on node=$node (already cleared, or leak not in endpoint registry) for $ns/$pod [seen $seen/$ESCALATE_AFTER before agent restart]"
+      continue
     fi
 
     # An endpoint that holds the IP but backs no k8s pod (empty k8s identity) is
@@ -119,12 +212,12 @@ while true; do
     # Ingress endpoint — that legitimately owns the IP; the duplicate is an IPAM
     # race that handed the same pod-CIDR IP to a pod. Such endpoints both cannot
     # be disconnected ("endpoint may not be associated reserved labels") and must
-    # not be: evicting infra is wrong. The correct remedy is to reschedule the
-    # wedged pod onto a free IP by deleting it; its controller recreates it and
+    # not be: evicting infra is wrong. The correct Tier-1 remedy is to reschedule
+    # the wedged pod onto a free IP by deleting it; its controller recreates it and
     # the next CNI ADD picks a fresh IP (verified: the new pod lands on a clean
     # address while the ingress endpoint keeps the disputed one).
     if [ -z "$epns" ] || [ -z "$eppod" ]; then
-      log "HEAL node=$node ep=$epid ip=$ip held by reserved/infra endpoint (no k8s pod) -> delete wedged pod $ns/$pod"
+      log "HEAL node=$node ep=$epid ip=$ip held by reserved/infra endpoint (no k8s pod) -> delete wedged pod $ns/$pod [seen $seen/$ESCALATE_AFTER before agent restart]"
       out=$(kubectl delete pod -n "$ns" "$pod" --wait=false 2>&1)
       log "  result: ${out:-<none>}"
       continue
@@ -133,7 +226,7 @@ while true; do
     # Confirmed stale pod endpoint: endpoint $epid holds $ip, backs a pod that is
     # no longer live, and pod $ns/$pod is wedged requesting the same IP. Evict
     # only this endpoint.
-    log "HEAL node=$node agent=$agent ep=$epid ip=$ip wedged=$ns/$pod -> endpoint disconnect ipv4:$ip"
+    log "HEAL node=$node agent=$agent ep=$epid ip=$ip wedged=$ns/$pod -> endpoint disconnect ipv4:$ip [seen $seen/$ESCALATE_AFTER before agent restart]"
     out=$(kubectl exec -n "$CILIUM_NS" "$agent" -c cilium-agent -- \
             cilium-dbg endpoint disconnect "ipv4:$ip" 2>&1)
     log "  result: ${out:-<none>}"

--- a/hack/e2e-cilium-leak-healer.yaml
+++ b/hack/e2e-cilium-leak-healer.yaml
@@ -24,9 +24,12 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["get", "list", "watch"]
-  # inspect the wedged pod and the endpoint's claimed owner, and delete the
-  # wedged pod to reschedule it onto a free IP when the disputed IP is held by
-  # a reserved/infra endpoint (or a disconnect otherwise fails)
+  # inspect the wedged pod and the endpoint's claimed owner; delete the wedged
+  # pod to reschedule it onto a free IP (Tier 1, when the disputed IP is held by
+  # a reserved/infra endpoint or a disconnect otherwise fails); and delete the
+  # node's cilium-agent pod in cozy-cilium to restart it (Tier 2 escalation,
+  # which clears a stale in-memory endpoint leak the DaemonSet then rebuilds
+  # without). cluster-wide `delete` already covers cozy-cilium, so no extra verb.
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "delete"]

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -5,8 +5,11 @@
   # class): a deleted pod's endpoint is orphaned in the agent's registry, IPAM
   # re-hands its IP to a new pod, and the agent then rejects the new sandbox with
   # "IP <X> is already in use" until an agent restart. The watchdog runs as an
-  # in-cluster Job that surgically evicts only the orphaned endpoint, covering
-  # install and (the Job outlives this file) the whole app suite.
+  # in-cluster Job that first surgically evicts only the orphaned endpoint and,
+  # if the leaked IP keeps recurring (the leak is in agent in-memory state that
+  # endpoint-disconnect/delete-reschedule cannot reach), escalates to restarting
+  # that node's cilium-agent — bounded by a per-node cap. It covers install and
+  # (the Job outlives this file) the whole app suite.
   #
   # This is a real @test, NOT a bats setup_file hook: the e2e runner
   # (hack/cozytest.sh) only executes @test functions — it never invokes


### PR DESCRIPTION
## What

Add a bounded escalation tier to the E2E cilium endpoint-leak healer: when a pod stays wedged on `FailedCreatePodSandBox` "IP ipv4:<X> is already in use" for the same IP across several heal cycles, restart the cilium-agent on that node. Keep the existing per-endpoint remedies as the first tier.

## Why

The leak (cilium/cilium#38313 class) sometimes lives purely in the cilium-agent's in-memory endpoint state. The existing remedies — `cilium-dbg endpoint disconnect` and delete-rescheduling the wedged pod — cannot reach it: IPAM keeps re-handing the SAME released IP, so the recreated pod re-wedges on it, and on some variants the stale entry is not even in the queryable endpoint registry, so disconnect is a no-op. Both are inescapable loops that fail the install. The only thing that clears an in-memory leak is restarting the agent, which drops the node's endpoint registry and rebuilds it from CRDs/IPAM without the stale entry.

## How

- Track recurrence per `(node, ip)`. After `ESCALATE_AFTER` (default 3) heal cycles of a futile first-tier remedy on the same IP, restart that node's cilium-agent pod.
- Bounded by `MAX_ESCALATIONS_PER_NODE` (default 2); after the cap, log loudly and surface the failure instead of restarting again. State is per-node and resets after each restart so one restart covers every leaked IP on the node.
- A genuine duplicate-IP (endpoint backs a live owner) is refused before counting, so an agent restart can never mask a real product bug.
- RBAC unchanged: the existing cluster-wide `pods` `get/list/delete` already covers deleting a cilium-agent pod in `cozy-cilium`.

E2E-test-only resilience; no product code change. Remove alongside the rest of the healer once a fixed Cilium ships.
