### PR TITLE
fix(vm-default-images): refresh stale Alpine and openSUSE 16.0 image URLs

### DIFF
--- a/packages/system/vm-default-images/values.yaml
+++ b/packages/system/vm-default-images/values.yaml
@@ -141,7 +141,7 @@ images:
     architecture: amd64
     description: "openSUSE Leap 15.6 NoCloud image"
   - name: opensuse-leap-16.0
-    url: https://download.opensuse.org/repositories/openSUSE:/Leap:/16.0:/Images/images/Leap-16.0-Minimal-VM.x86_64-Cloud.qcow2
+    url: https://download.opensuse.org/distribution/leap/16.0/appliances/Leap-16.0-Minimal-VM.x86_64-Cloud.qcow2
     storage: 20Gi
     os:
       family: Linux
@@ -159,7 +159,7 @@ images:
     architecture: amd64
     description: "Ubuntu 20.04 LTS (Focal Fossa) cloud image"
   - name: alpine-3.21
-    url: https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/cloud/nocloud_alpine-3.21.6-x86_64-bios-cloudinit-r0.qcow2
+    url: https://dl-cdn.alpinelinux.org/alpine/v3.21/releases/cloud/nocloud_alpine-3.21.7-x86_64-bios-cloudinit-r0.qcow2
     storage: 20Gi
     os:
       family: Linux


### PR DESCRIPTION
## What this PR does

Refreshes two default golden-image download URLs in `vm-default-images` that had drifted from their canonical source. This came out of a correctness re-check of all 16 default image URLs — the other 14 use floating `current`/`latest` pointers on canonical vendor hosts and need no change.

- **alpine-3.21** — was pinned to patch `3.21.6`. Alpine's CDN now ships `3.21.7` and prunes older patches over time, so this hardcoded pin would eventually 404. Bumped to `3.21.7`. (Alpine publishes no `latest` symlink for cloud images, so a patch pin is unavoidable — it just needs to track the newest patch.)
- **opensuse-leap-16.0** — pointed at the Open Build Service staging tree (`repositories/openSUSE:/Leap:/16.0:/Images/`) rather than the canonical released-product tree. Switched to `distribution/leap/16.0/appliances/`, which serves the identical image from a more stable, official location.

Both new URLs were verified to return HTTP 200 and serve valid QCOW2 images (magic `QFI\xfb`).

> Note: `opensuse-leap-15.6` sits on the same OBS staging path, but moving it to the distribution tree would also require switching the image flavor (NoCloud → Minimal-VM Cloud, the only variant published there). That's a behavioral change, so it's intentionally left out of this PR.

### Release note

```release-note
fix(vm-default-images): refresh stale Alpine (3.21.6 → 3.21.7) and openSUSE Leap 16.0 default image URLs
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed two default virtual machine image entries to point to newer download sources.
  * Updated the openSUSE Leap 16.0 image URL to a new appliance location.
  * Bumped the Alpine 3.21 image to a newer release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->