### PR TITLE
fix(mariadb): bind metrics exporter to IPv4 for probe reachability

### DIFF
--- a/packages/apps/mariadb/Makefile
+++ b/packages/apps/mariadb/Makefile
@@ -3,6 +3,9 @@ MARIADB_BACKUP_TAG = $(shell awk '$$1 == "version:" {print $$2}' Chart.yaml)
 include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 generate:
 	cozyvalues-gen -m 'mariadb' -v values.yaml -s values.schema.json -r README.md -g ../../../api/apps/v1alpha1/mariadb/types.go
 	../../../hack/update-crd.sh

--- a/packages/apps/mariadb/templates/mariadb.yaml
+++ b/packages/apps/mariadb/templates/mariadb.yaml
@@ -43,6 +43,14 @@ spec:
     enabled: true
     exporter:
       image: prom/mysqld-exporter:v0.15.1
+      # The mariadb-operator hardcodes the exporter's liveness/readiness probe
+      # as an httpGet on port 9104, which kubelet dials over the pod's IPv4
+      # address. Bind the exporter to the IPv4 wildcard so the probe connects
+      # deterministically; the default [::] listener intermittently refuses the
+      # IPv4 connect on single-stack-IPv4 data planes, flapping the pod to
+      # NotReady and leaving the metrics Service endpoint unpopulated.
+      args:
+      - --web.listen-address=0.0.0.0:9104
       resources:
         requests:
           cpu: 50m

--- a/packages/apps/mariadb/tests/exporter_listen_address_test.yaml
+++ b/packages/apps/mariadb/tests/exporter_listen_address_test.yaml
@@ -1,0 +1,32 @@
+suite: MariaDB metrics exporter listen address
+
+# Regression cover: the mariadb-operator hardcodes the mysqld-exporter
+# liveness/readiness probe as an httpGet on port 9104, which kubelet dials
+# over the pod's IPv4 address. The exporter must therefore listen on an
+# IPv4 socket; an IPv6 wildcard ([::]) listener intermittently refuses the
+# IPv4 probe on single-stack-IPv4 data planes, flapping the pod to NotReady
+# and leaving the metrics Service endpoint unpopulated. Pin the explicit
+# IPv4 listen-address flag so the probe is reachable deterministically.
+
+templates:
+  - templates/mariadb.yaml
+
+tests:
+  - it: renders the MariaDB CR
+    release:
+      name: mariadb-test
+      namespace: tenant-test
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: MariaDB
+
+  - it: pins the exporter to the IPv4 wildcard so the kubelet probe is reachable
+    release:
+      name: mariadb-test
+      namespace: tenant-test
+    asserts:
+      - contains:
+          path: spec.metrics.exporter.args
+          content: --web.listen-address=0.0.0.0:9104


### PR DESCRIPTION
## What this PR does

The `mariadb` chart enables a Prometheus `mysqld-exporter` sidecar. The exporter binds the IPv6 wildcard `[::]:9104` by default, while mariadb-operator hardcodes the exporter's liveness/readiness probe as an `httpGet` on port 9104 that kubelet dials over the pod's IPv4 address. On a single-stack-IPv4 data plane the `[::]` listener intermittently refuses the IPv4 connect, so the probe fails roughly one second after the container starts, the pod flaps to NotReady, and the metrics Service keeps the pod IP in `notReadyAddresses` — its endpoint set never populates and Prometheus never scrapes the exporter.

This pins the exporter to the IPv4 wildcard via the only chart-side lever the operator exposes for this — `spec.metrics.exporter.args`. The operator appends user-supplied args to its defaults (it does not set `--web.listen-address` itself), so there is no duplicate flag and the DB connection arg is preserved. A `0.0.0.0:9104` socket accepts the kubelet probe deterministically, independent of the exact IPv6 `v6only` submechanism.

Conscious tradeoff: this makes the exporter IPv4-only, which is correct for cozystack's single-stack-IPv4 data plane (Cilium runs with `ipv6.enabled=false`). A future IPv6-primary deployment of this app would need `[::]` or both addresses (the exporter's `--web.listen-address` is repeatable in exporter-toolkit ≥ v0.10.0).

Adds a helm-unittest pinning the rendered `args`, plus the `test:` Makefile target so CI's chart-test discovery runs it (the chart previously shipped no tests).

### Release note

```release-note
fix(mariadb): bind the metrics exporter to IPv4 so its readiness probe is reachable and the metrics endpoint populates reliably
```
