### PR TITLE
fix(seaweedfs): raise master probe timeouts above the cluster-status backoff

### DIFF
--- a/packages/system/seaweedfs/tests/master_probe_timeout_test.yaml
+++ b/packages/system/seaweedfs/tests/master_probe_timeout_test.yaml
@@ -1,0 +1,64 @@
+suite: seaweedfs master probe timeouts
+
+# Pins the master probe timeout overrides that keep master-0 alive during raft
+# bootstrap. The master's /cluster/status handler calls topo.Leader(), which
+# backs off up to ~20s (MaxElapsedTime=20s) while the node has no leader in
+# view — e.g. a master that was briefly the initial raft leader then was demoted.
+# The subchart default 10s probe timeout is shorter than that worst case, so such
+# a master is liveness-killed into a permanent CrashLoop and the master
+# StatefulSet never reaches full readiness. Both probes must allow more than the
+# 20s backoff. The overlay overrides only timeoutSeconds and relies on Helm's
+# deep-merge to keep every other subchart probe field, so this also guards that
+# the merge does not drop the surrounding probe configuration.
+
+templates:
+  - charts/seaweedfs/templates/master/master-statefulset.yaml
+
+release:
+  name: seaweedfs
+  namespace: cozy-seaweedfs
+
+tests:
+  - it: raises both master probe timeouts above the cluster-status backoff
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.timeoutSeconds
+          value: 30
+
+  - it: preserves the other master probe fields through the deep-merge
+    asserts:
+      # liveness: only timeoutSeconds is overridden, the rest survive
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /cluster/status
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 4
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.successThreshold
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 20
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 30
+      # readiness: only timeoutSeconds is overridden, the rest survive
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /cluster/status
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 100
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.successThreshold
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 45

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -32,6 +32,19 @@ seaweedfs:
       type: "emptyDir"
     logs:
       type: ""
+    # The master's /cluster/status handler calls topo.Leader(), which backs off
+    # up to ~20s (MaxElapsedTime=20s) while the node has no leader in view — e.g.
+    # a master that was briefly the initial raft leader then was demoted during
+    # bootstrap. The default 10s probe timeout is shorter than that worst case, so
+    # such a master is liveness-killed every ~137s into a permanent CrashLoop and
+    # the master StatefulSet never reaches full readiness, timing out the install.
+    # Both probes must allow more than the 20s backoff (the volume component in
+    # this chart already uses 30s). Override only timeoutSeconds; Helm deep-merges
+    # these onto the subchart defaults, keeping enabled/path/initialDelay/etc.
+    livenessProbe:
+      timeoutSeconds: 30
+    readinessProbe:
+      timeoutSeconds: 30
   volume:
     replicas: 2
     resizeHook:


### PR DESCRIPTION
## What this PR does

The SeaweedFS master's `/cluster/status` HTTP handler calls `topo.Leader()`, which backs off exponentially up to `MaxElapsedTime=20s` while the node has no leader in view. A 3-master cluster bootstrap is a race: a master that briefly becomes the initial raft leader and is then demoted can sit with an empty leader-view for a while, so its `/cluster/status` takes up to ~20s to return (it does return 200 — just slowly). The master liveness and readiness probes both `httpGet /cluster/status:9333` with `timeoutSeconds: 10`, which is shorter than that worst case. Such a master is liveness-killed roughly every ~137s into a permanent CrashLoop (the master uses an `emptyDir` data dir, so each container restart re-reads the same raft state and re-wedges), and its readiness never succeeds — so the master StatefulSet never reaches full readiness and the `seaweedfs-system` HelmRelease install times out.

This raises both master probe `timeoutSeconds` to 30 (above the 20s backoff) via the overlay values, deep-merging onto the subchart defaults so only the timeout changes. Both probes must be raised: leaving readiness at 10s would keep the master NotReady on the same slow endpoint even if liveness no longer kills it. The volume component in this same chart already uses a 30s probe timeout, so this aligns master with that precedent. This is purely probe tuning — no raft, protocol, or storage change.

The underlying upstream behavior (`/cluster/status` slow for a master with an unhealthy raft view) is tracked upstream and is unchanged across current SeaweedFS releases, so a version bump does not address it. Switching the master to the Hashicorp raft backend is a separate, larger change (it pulls in bootstrap and storage considerations) and is intentionally out of scope here.

Operational note: on chart update each master StatefulSet rolls one pod at a time with the new timeouts (raft quorum is preserved); a platform upgrade therefore performs a short graceful roll of master pods on each instance — not a data outage.

Adds a helm-unittest pinning both master probe timeouts and guarding that the subchart's other probe fields survive the deep-merge.

### Release note

```release-note
fix(seaweedfs): raise the master liveness/readiness probe timeouts above the cluster-status leader-lookup backoff so a master with a transiently empty raft view is not killed into a permanent CrashLoop, which could time out the seaweedfs install
```
