### PR TITLE
fix(postgres): garbage-collect init-job after completion (#3055)

### DIFF
--- a/packages/apps/postgres/templates/init-job.yaml
+++ b/packages/apps/postgres/templates/init-job.yaml
@@ -20,7 +20,7 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-  ttlSecondsAfterFinished: 120
+  ttlSecondsAfterFinished: 3600
   template:
     metadata:
       name: {{ .Release.Name }}-init-job

--- a/packages/apps/postgres/templates/init-job.yaml
+++ b/packages/apps/postgres/templates/init-job.yaml
@@ -20,11 +20,6 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-  # One-shot reconciler Job: once it has applied users/databases/roles it is no
-  # longer needed. Let the Kubernetes TTL controller garbage-collect the Job and
-  # its Pod ~2 minutes after completion so it does not linger after the release
-  # is deleted (cozystack/cozystack#3055). This does not touch the Helm hook
-  # lifecycle the bootstrap.recovery path relies on.
   ttlSecondsAfterFinished: 120
   template:
     metadata:

--- a/packages/apps/postgres/templates/init-job.yaml
+++ b/packages/apps/postgres/templates/init-job.yaml
@@ -20,6 +20,12 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
+  # One-shot reconciler Job: once it has applied users/databases/roles it is no
+  # longer needed. Let the Kubernetes TTL controller garbage-collect the Job and
+  # its Pod ~2 minutes after completion so it does not linger after the release
+  # is deleted (cozystack/cozystack#3055). This does not touch the Helm hook
+  # lifecycle the bootstrap.recovery path relies on.
+  ttlSecondsAfterFinished: 120
   template:
     metadata:
       name: {{ .Release.Name }}-init-job

--- a/packages/apps/postgres/tests/init_job_cleanup_test.yaml
+++ b/packages/apps/postgres/tests/init_job_cleanup_test.yaml
@@ -3,13 +3,18 @@ suite: init-job is garbage-collected after completion
 # Locks in cozystack/cozystack#3055: the post-install/post-upgrade init Job
 # is a one-shot reconciler of users/databases/roles. Without a TTL it lingers
 # in the namespace forever after the Postgres CR is deleted (its hook-delete-policy
-# is `before-hook-creation` only, which never fires on uninstall). A native
+# is 'before-hook-creation' only, which never fires on uninstall). A native
 # ttlSecondsAfterFinished lets the Kubernetes TTL controller GC the Job and its
-# Pod ~2 minutes after it completes, regardless of Helm hook lifecycle — without
-# touching the hook-timeout semantics the recovery flow depends on.
+# Pod ~1 hour after it completes, regardless of Helm hook lifecycle — without
+# touching the hook-timeout semantics the recovery flow depends on. 1h leaves a
+# debugging window for a failed init Job before it is collected.
 
+# init-script.yaml is included alongside init-job.yaml because the Job's
+# checksum/config annotation does `include ".../init-script.yaml"`; the suite
+# must load both templates or the include fails to resolve.
 templates:
   - templates/init-job.yaml
+  - templates/init-script.yaml
 
 release:
   name: pg-test
@@ -23,21 +28,28 @@ tests:
       users:
         app:
           password: secret
+    documentSelector:
+      path: metadata.name
+      value: pg-test-init-job
     asserts:
-      - hasDocuments:
-          count: 1
       - isKind:
           of: Job
       - equal:
           path: spec.ttlSecondsAfterFinished
-          value: 120
+          value: 3600
 
   - it: "init-job is skipped entirely under bootstrap recovery"
     set:
       _cluster:
         scheduling: {}
+      users:
+        app:
+          password: secret
       bootstrap:
         enabled: true
     asserts:
       - hasDocuments:
           count: 0
+        documentSelector:
+          path: kind
+          value: Job

--- a/packages/apps/postgres/tests/init_job_cleanup_test.yaml
+++ b/packages/apps/postgres/tests/init_job_cleanup_test.yaml
@@ -9,9 +9,9 @@ suite: init-job is garbage-collected after completion
 # touching the hook-timeout semantics the recovery flow depends on. 1h leaves a
 # debugging window for a failed init Job before it is collected.
 
-# init-script.yaml is included alongside init-job.yaml because the Job's
-# checksum/config annotation does `include ".../init-script.yaml"`; the suite
-# must load both templates or the include fails to resolve.
+# Both templates are loaded so the Job's checksum/config annotation can resolve
+# its `include ".../init-script.yaml"`. Each test then pins assertions to a
+# single template via `template:` so the per-template document set is exact.
 templates:
   - templates/init-job.yaml
   - templates/init-script.yaml
@@ -20,36 +20,33 @@ release:
   name: pg-test
   namespace: tenant-test
 
+set:
+  _cluster:
+    scheduling: {}
+  users:
+    app:
+      password: secret
+
 tests:
   - it: "init-job sets ttlSecondsAfterFinished so Kubernetes GCs it after the run"
-    set:
-      _cluster:
-        scheduling: {}
-      users:
-        app:
-          password: secret
-    documentSelector:
-      path: metadata.name
-      value: pg-test-init-job
+    template: templates/init-job.yaml
     asserts:
+      - hasDocuments:
+          count: 1
       - isKind:
           of: Job
+      - equal:
+          path: metadata.name
+          value: pg-test-init-job
       - equal:
           path: spec.ttlSecondsAfterFinished
           value: 3600
 
   - it: "init-job is skipped entirely under bootstrap recovery"
+    template: templates/init-job.yaml
     set:
-      _cluster:
-        scheduling: {}
-      users:
-        app:
-          password: secret
       bootstrap:
         enabled: true
     asserts:
       - hasDocuments:
           count: 0
-        documentSelector:
-          path: kind
-          value: Job

--- a/packages/apps/postgres/tests/init_job_cleanup_test.yaml
+++ b/packages/apps/postgres/tests/init_job_cleanup_test.yaml
@@ -1,0 +1,43 @@
+suite: init-job is garbage-collected after completion
+
+# Locks in cozystack/cozystack#3055: the post-install/post-upgrade init Job
+# is a one-shot reconciler of users/databases/roles. Without a TTL it lingers
+# in the namespace forever after the Postgres CR is deleted (its hook-delete-policy
+# is `before-hook-creation` only, which never fires on uninstall). A native
+# ttlSecondsAfterFinished lets the Kubernetes TTL controller GC the Job and its
+# Pod ~2 minutes after it completes, regardless of Helm hook lifecycle — without
+# touching the hook-timeout semantics the recovery flow depends on.
+
+templates:
+  - templates/init-job.yaml
+
+release:
+  name: pg-test
+  namespace: tenant-test
+
+tests:
+  - it: "init-job sets ttlSecondsAfterFinished so Kubernetes GCs it after the run"
+    set:
+      _cluster:
+        scheduling: {}
+      users:
+        app:
+          password: secret
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Job
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 120
+
+  - it: "init-job is skipped entirely under bootstrap recovery"
+    set:
+      _cluster:
+        scheduling: {}
+      bootstrap:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## Problem

After deleting a `Postgres` app CR, the chart-managed init Job `<release>-init-job` and its completed Pod remain in the tenant namespace indefinitely (reported in #3055).

The init Job is a Helm hook (`post-install,post-upgrade`) whose only delete policy is `before-hook-creation`. That policy deletes the previous hook only right before a new one is created (next upgrade) — it never fires on `helm uninstall`. With no `hook-succeeded` and no TTL, the completed Job and Pod leak.

## Root cause

`packages/apps/postgres/templates/init-job.yaml` — the Job has no garbage-collection mechanism for its completed state.

## Fix

Add `ttlSecondsAfterFinished: 120` to the Job spec. The native Kubernetes TTL controller then GCs the Job and its Pod ~2 minutes after completion, regardless of the Helm hook lifecycle.

The init Job is a one-shot, idempotent reconciler of users/databases/roles (`init-script.yaml`) — once it has run it is not needed until the next upgrade (when Helm recreates it), so GC-ing the finished Job is safe.

This approach deliberately **does not** touch the hook-delete-policy / hook-timeout semantics, which the `bootstrap.recovery` path depends on (see the header comment in `init-job.yaml`). Under `bootstrap.enabled` the Job is skipped entirely, so the change is inert there.

## Tests

Added a `helm-unittest` suite `packages/apps/postgres/tests/init_job_cleanup_test.yaml`:
- asserts the init Job renders `spec.ttlSecondsAfterFinished: 120`
- asserts the init Job is skipped under `bootstrap.enabled: true`

Verified locally with `helm template` (TTL present on default render; Job absent under bootstrap recovery).

## Test plan
- [x] `helm template` renders `ttlSecondsAfterFinished: 120` on the init Job
- [ ] `helm unittest packages/apps/postgres` green in CI
- [ ] e2e `test-apps-postgres` green

Fixes #3055

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Postgres bootstrap init Jobs now automatically clean up after completion using a post-finish TTL.

* **Tests**
  * Added a new integration test suite to verify the init Job renders with the expected cleanup TTL, and that the init Job is skipped when bootstrap is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->