### PR TITLE
fix(mariadb): clean up orphaned operator-generated secrets (#3056)

### DIFF
--- a/packages/apps/mariadb/Makefile
+++ b/packages/apps/mariadb/Makefile
@@ -11,6 +11,10 @@ update:
 	hack/update-versions.sh
 	make generate
 
+.PHONY: test
+test:
+	helm unittest .
+
 image:
 	docker buildx build images/mariadb-backup \
 		$(call image-tags,mariadb-backup,$(MARIADB_BACKUP_TAG)) \

--- a/packages/apps/mariadb/templates/hooks/cleanup-pvc.yaml
+++ b/packages/apps/mariadb/templates/hooks/cleanup-pvc.yaml
@@ -46,15 +46,27 @@ spec:
             - /bin/sh
             - -c
             - |
+              # --ignore-not-found tolerates already-absent resources; only a
+              # genuine delete failure (RBAC/API error) must fail the hook, so
+              # track it and propagate via the final exit instead of masking
+              # errors behind `|| echo ...`.
+              cleanup_failed=0
               echo "Deleting orphaned PVCs for {{ .Release.Name }}..."
-              kubectl delete pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --ignore-not-found \
-                || echo "WARNING: PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
-              echo "PVC cleanup complete."
+              if kubectl delete pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --ignore-not-found; then
+                echo "PVC cleanup complete."
+              else
+                echo "WARNING: PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
+                cleanup_failed=1
+              fi
               echo "Deleting orphaned operator-generated Secrets for {{ .Release.Name }}..."
-              kubectl delete secret -n {{ .Release.Namespace }} \
-                {{ .Release.Name }}-metrics-password {{ .Release.Name }}-repl-password --ignore-not-found \
-                || echo "WARNING: Secret cleanup failed for {{ .Release.Name }}; orphaned Secrets may remain" >&2
-              echo "Secret cleanup complete."
+              if kubectl delete secret -n {{ .Release.Namespace }} \
+                {{ .Release.Name }}-metrics-password {{ .Release.Name }}-repl-password --ignore-not-found; then
+                echo "Secret cleanup complete."
+              else
+                echo "WARNING: Secret cleanup failed for {{ .Release.Name }}; orphaned Secrets may remain" >&2
+                cleanup_failed=1
+              fi
+              exit "${cleanup_failed}"
           volumeMounts:
             - name: tmp
               mountPath: /tmp

--- a/packages/apps/mariadb/templates/hooks/cleanup-pvc.yaml
+++ b/packages/apps/mariadb/templates/hooks/cleanup-pvc.yaml
@@ -18,16 +18,49 @@ spec:
     spec:
       serviceAccountName: {{ .Release.Name }}-cleanup
       restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: cleanup
           image: docker.io/clastix/kubectl:v1.32
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: HOME
+              value: /tmp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
           command:
             - /bin/sh
             - -c
             - |
               echo "Deleting orphaned PVCs for {{ .Release.Name }}..."
-              kubectl delete pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} || true
+              kubectl delete pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --ignore-not-found \
+                || echo "WARNING: PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
               echo "PVC cleanup complete."
+              echo "Deleting orphaned operator-generated Secrets for {{ .Release.Name }}..."
+              kubectl delete secret -n {{ .Release.Namespace }} \
+                {{ .Release.Name }}-metrics-password {{ .Release.Name }}-repl-password --ignore-not-found \
+                || echo "WARNING: Secret cleanup failed for {{ .Release.Name }}; orphaned Secrets may remain" >&2
+              echo "Secret cleanup complete."
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -51,9 +84,18 @@ metadata:
     "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
+  # PVCs are deleted by label selector, which requires list.
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "delete"]
+  # Operator-generated Secrets are deleted by name, so scope the rule to
+  # exactly those two resources (least privilege — no namespace-wide secret access).
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames:
+      - {{ .Release.Name }}-metrics-password
+      - {{ .Release.Name }}-repl-password
+    verbs: ["get", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/packages/apps/mariadb/tests/cleanup_hook_test.yaml
+++ b/packages/apps/mariadb/tests/cleanup_hook_test.yaml
@@ -1,0 +1,52 @@
+suite: post-delete cleanup hook
+
+# Locks in the post-delete cleanup behaviour. The mariadb-operator creates
+# <release>-metrics-password and <release>-repl-password Secrets as a side
+# effect of metrics/replication being enabled. These Secrets are not
+# Helm-owned and survive `helm uninstall`, so the post-delete hook must
+# sweep them (issue #3056) alongside the orphaned PVCs. The hook Role also
+# needs RBAC on secrets to do so.
+
+templates:
+  - templates/hooks/cleanup-pvc.yaml
+
+release:
+  name: mariadb-test
+  namespace: tenant-test
+
+tests:
+  - it: "cleanup Job deletes the operator-generated password Secrets by name"
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "mariadb-test-metrics-password mariadb-test-repl-password --ignore-not-found"
+
+  - it: "cleanup Role grants get/list/delete on persistentvolumeclaims"
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["persistentvolumeclaims"]
+            verbs: ["get", "list", "delete"]
+
+  - it: "cleanup Role scopes secret access to the two named secrets only (least privilege)"
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            resourceNames:
+              - mariadb-test-metrics-password
+              - mariadb-test-repl-password
+            verbs: ["get", "delete"]

--- a/packages/apps/mariadb/tests/cleanup_hook_test.yaml
+++ b/packages/apps/mariadb/tests/cleanup_hook_test.yaml
@@ -24,6 +24,18 @@ tests:
           path: spec.template.spec.containers[0].command[2]
           pattern: "mariadb-test-metrics-password mariadb-test-repl-password --ignore-not-found"
 
+  - it: "cleanup Job fails (exits non-zero) when a real delete error occurs, so orphaned resources don't pass silently"
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      # --ignore-not-found tolerates absent resources, but a genuine RBAC/API
+      # failure must propagate: the script tracks failures and exits with that
+      # status instead of masking errors behind `|| echo ...`.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'exit "\$\{cleanup_failed\}"'
+
   - it: "cleanup Role grants get/list/delete on persistentvolumeclaims"
     documentSelector:
       path: kind

--- a/packages/apps/mariadb/tests/cleanup_hook_test.yaml
+++ b/packages/apps/mariadb/tests/cleanup_hook_test.yaml
@@ -32,6 +32,15 @@ tests:
       # --ignore-not-found tolerates absent resources, but a genuine RBAC/API
       # failure must propagate: the script tracks failures and exits with that
       # status instead of masking errors behind `|| echo ...`.
+      #
+      # Assert both delete branches set the failure flag (not just the final
+      # exit), so a regression that stops flagging either path is caught.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '(?s)PVC cleanup failed for mariadb-test.*?cleanup_failed=1'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '(?s)Secret cleanup failed for mariadb-test.*?cleanup_failed=1'
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: 'exit "\$\{cleanup_failed\}"'
@@ -62,3 +71,9 @@ tests:
               - mariadb-test-metrics-password
               - mariadb-test-repl-password
             verbs: ["get", "delete"]
+      # Lock the exact rule set (PVC rule + the single scoped secrets rule).
+      # Without this, a broader unscoped `secrets` rule could be added and the
+      # `contains` checks above would still pass.
+      - lengthEqual:
+          path: rules
+          count: 2


### PR DESCRIPTION
## What this PR does

After deleting a `MariaDB` app CR with metrics and/or replication enabled, two
Secrets created by the mariadb-operator were left orphaned in the tenant
namespace:

- `<release>-metrics-password`
- `<release>-repl-password`

These are generated by the operator (`k8s.mariadb.com/v1alpha1`) as a side
effect of `metrics.enabled` / `replication.enabled`, so they are **not**
Helm-owned and survive `helm uninstall`. The existing post-delete hook
(`templates/hooks/cleanup-pvc.yaml`) only swept PVCs, leaving the Secrets behind.

This PR extends that hook to also clean them up:

- grants the cleanup `Role` RBAC on `secrets`;
- deletes both password Secrets by name with `--ignore-not-found`;
- adds a `helm-unittest` suite locking in the behaviour, plus a `test` Makefile
  target so the package's tests actually run in CI (`hack/helm-unit-tests.sh`
  only runs packages that define a `test` target).

Fixes #3056.

### Release note

```release-note
fix(mariadb): garbage-collect operator-generated metrics-password / repl-password Secrets when a MariaDB app is deleted
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MariaDB uninstall cleanup to remove leftover operator-generated password Secrets in addition to persistent volumes/claims.
  * Hardened the cleanup hook Job with stricter pod/container security settings, least-privilege Secret permissions, idempotent deletions for missing resources, and correct non-zero exit on real failures.
* **Tests**
  * Added a cleanup hook test suite validating Secret deletion behavior, failure propagation, and that cleanup RBAC grants least-privilege access only to the required Secrets.
  * Added a Helm unit test `test` target for the MariaDB chart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->