### PR TITLE
fix(clickhouse)!: clean up orphaned keeper and data PVCs on delete (#3057)

### DIFF
--- a/packages/apps/clickhouse/Makefile
+++ b/packages/apps/clickhouse/Makefile
@@ -7,6 +7,7 @@ generate:
 	cozyvalues-gen -m 'clickhouse' -v values.yaml -s values.schema.json -r README.md -g ../../../api/apps/v1alpha1/clickhouse/types.go
 	../../../hack/update-crd.sh
 
+.PHONY: test
 test:
 	helm unittest .
 

--- a/packages/apps/clickhouse/templates/chkeeper.yaml
+++ b/packages/apps/clickhouse/templates/chkeeper.yaml
@@ -64,6 +64,9 @@ spec:
 
     volumeClaimTemplates:
       - name: default
+        metadata:
+          labels:
+            app.kubernetes.io/instance: "{{ .Release.Name }}"
         spec:
           accessModes:
             - ReadWriteOnce

--- a/packages/apps/clickhouse/templates/hooks/cleanup-pvc.yaml
+++ b/packages/apps/clickhouse/templates/hooks/cleanup-pvc.yaml
@@ -8,6 +8,9 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "10"
+    # before-hook-creation only (no hook-succeeded): keep a failed cleanup Job
+    # and its logs around for post-mortem. The RBAC objects below DO carry
+    # hook-succeeded so they are reclaimed after a successful uninstall.
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
@@ -69,7 +72,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -80,7 +83,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
@@ -95,7 +98,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/packages/apps/clickhouse/templates/hooks/cleanup-pvc.yaml
+++ b/packages/apps/clickhouse/templates/hooks/cleanup-pvc.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   template:
     metadata:
@@ -46,9 +46,12 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -eu
               echo "Deleting orphaned PVCs for {{ .Release.Name }}..."
-              kubectl delete pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --ignore-not-found \
-                || echo "WARNING: PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
+              if ! kubectl delete pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --ignore-not-found; then
+                echo "ERROR: PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
+                exit 1
+              fi
               echo "PVC cleanup complete."
           volumeMounts:
             - name: tmp
@@ -65,8 +68,8 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
   annotations:
     "helm.sh/hook": post-delete
-    helm.sh/hook-weight: "0"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -77,7 +80,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
@@ -91,8 +94,8 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
   annotations:
     "helm.sh/hook": post-delete
-    helm.sh/hook-weight: "5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/packages/apps/clickhouse/templates/hooks/cleanup-pvc.yaml
+++ b/packages/apps/clickhouse/templates/hooks/cleanup-pvc.yaml
@@ -2,9 +2,9 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-cleanup
+  name: "{{ .Release.Name }}-cleanup"
   labels:
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "10"
@@ -13,10 +13,10 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
         policy.cozystack.io/allow-to-apiserver: "true"
     spec:
-      serviceAccountName: {{ .Release.Name }}-cleanup
+      serviceAccountName: "{{ .Release.Name }}-cleanup"
       restartPolicy: Never
       securityContext:
         runAsNonRoot: true
@@ -63,9 +63,9 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Release.Name }}-cleanup
+  name: "{{ .Release.Name }}-cleanup"
   labels:
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "0"
@@ -74,9 +74,9 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ .Release.Name }}-cleanup
+  name: "{{ .Release.Name }}-cleanup"
   labels:
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "5"
@@ -89,9 +89,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-cleanup
+  name: "{{ .Release.Name }}-cleanup"
   labels:
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "5"
@@ -99,7 +99,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-cleanup
+  name: "{{ .Release.Name }}-cleanup"
 subjects:
   - kind: ServiceAccount
-    name: {{ .Release.Name }}-cleanup
+    name: "{{ .Release.Name }}-cleanup"

--- a/packages/apps/clickhouse/templates/hooks/cleanup-pvc.yaml
+++ b/packages/apps/clickhouse/templates/hooks/cleanup-pvc.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        policy.cozystack.io/allow-to-apiserver: "true"
+    spec:
+      serviceAccountName: {{ .Release.Name }}-cleanup
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cleanup
+          image: docker.io/clastix/kubectl:v1.32
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: HOME
+              value: /tmp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Deleting orphaned PVCs for {{ .Release.Name }}..."
+              kubectl delete pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --ignore-not-found \
+                || echo "WARNING: PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
+              echo "PVC cleanup complete."
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    helm.sh/hook-weight: "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    helm.sh/hook-weight: "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-cleanup

--- a/packages/apps/clickhouse/tests/cleanup_pvc_test.yaml
+++ b/packages/apps/clickhouse/tests/cleanup_pvc_test.yaml
@@ -51,6 +51,11 @@ tests:
       value: Role
     asserts:
       - equal:
+          # RBAC artifacts are reclaimed on a successful uninstall (unlike the
+          # Job, which is kept for post-mortem on failure).
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+      - equal:
           path: rules[0].apiGroups[0]
           value: ""
       - equal:

--- a/packages/apps/clickhouse/tests/cleanup_pvc_test.yaml
+++ b/packages/apps/clickhouse/tests/cleanup_pvc_test.yaml
@@ -1,0 +1,73 @@
+suite: post-delete PVC cleanup hook
+
+# Verifies the post-delete hook that deletes orphaned PVCs left behind by the
+# clickhouse-keeper-operator (and the ClickHouse operator), which do not delete
+# data PVCs when their CR is removed. The cleanup Job selects PVCs by the
+# release-scoped label app.kubernetes.io/instance, which is set on both the
+# keeper volumeClaimTemplates and the main ClickHouse data/log volumeClaimTemplates.
+
+release:
+  name: ch-test
+  namespace: tenant-test
+
+set:
+  _cluster:
+    cluster-domain: cluster.local
+
+templates:
+  - templates/hooks/cleanup-pvc.yaml
+
+tests:
+  - it: "renders a post-delete cleanup Job scoped to the release"
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: metadata.name
+          value: ch-test-cleanup
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-delete
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: ch-test-cleanup
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kubectl delete pvc -n tenant-test -l app\.kubernetes\.io/instance=ch-test'
+
+  - it: "grants only get/list/delete on persistentvolumeclaims"
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - equal:
+          path: rules[0].apiGroups[0]
+          value: ""
+      - equal:
+          path: rules[0].resources[0]
+          value: persistentvolumeclaims
+      - equal:
+          path: rules[0].verbs
+          value:
+            - get
+            - list
+            - delete
+
+  - it: "binds the cleanup ServiceAccount to the cleanup Role"
+    documentSelector:
+      path: kind
+      value: RoleBinding
+    asserts:
+      - equal:
+          path: roleRef.name
+          value: ch-test-cleanup
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: ch-test-cleanup

--- a/packages/apps/clickhouse/tests/cleanup_pvc_test.yaml
+++ b/packages/apps/clickhouse/tests/cleanup_pvc_test.yaml
@@ -30,14 +30,20 @@ tests:
           path: metadata.annotations["helm.sh/hook"]
           value: post-delete
       - equal:
+          # before-hook-creation only (no hook-succeeded): a failed cleanup Job
+          # must survive so its logs are inspectable instead of being reaped.
           path: metadata.annotations["helm.sh/hook-delete-policy"]
-          value: before-hook-creation,hook-succeeded
+          value: before-hook-creation
       - equal:
           path: spec.template.spec.serviceAccountName
           value: ch-test-cleanup
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: 'kubectl delete pvc -n tenant-test -l app\.kubernetes\.io/instance=ch-test'
+      - matchRegex:
+          # The hook must surface kubectl failures (exit 1), not mask them.
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'exit 1'
 
   - it: "grants only get/list/delete on persistentvolumeclaims"
     documentSelector:

--- a/packages/core/platform/images/migrations/migrations/48
+++ b/packages/core/platform/images/migrations/migrations/48
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Migration 48 --> 49
+# Backfill the app.kubernetes.io/instance release label onto pre-existing
+# ClickHouse keeper PVCs.
+#
+# PR #3072 adds app.kubernetes.io/instance to the keeper volumeClaimTemplates and
+# a post-delete hook that garbage-collects PVCs carrying that label. But the
+# altinity clickhouse-keeper-operator only stamps volumeClaimTemplates.metadata
+# .labels onto PVCs it creates *after* the change; it never re-labels PVCs that
+# already exist. Keeper PVCs provisioned before this upgrade therefore stay
+# unlabeled, the cleanup hook's selector misses them, and they keep leaking on
+# delete (issue #3057). This migration relabels them once so the hook can reclaim
+# them. The main ClickHouse data/log PVCs have carried the label since 2025-06-03
+# (well before the migration era) and need no backfill.
+#
+# Best-effort by design: the worst case if a relabel is skipped is the
+# pre-existing leak this PR set out to fix, which is strictly no worse than the
+# status quo. A transient apiserver hiccup must therefore NOT abort the whole
+# platform upgrade, so the keeper list and per-PVC reads tolerate failure
+# (|| true) rather than exiting non-zero.
+
+set -euo pipefail
+
+# shellcheck source=lib/cozystack-version.sh
+. "$(dirname "$0")/lib/cozystack-version.sh"
+
+# This migration runs platform-wide (targetVersion bump), including on clusters
+# that never installed ClickHouse. Skip the backfill when the keeper CRD is
+# absent. The `|| true` on the list additionally keeps a transient apiserver
+# error from aborting the upgrade — there is nothing safety-critical to gate on.
+if ! kubectl get crd clickhousekeeperinstallations.clickhouse-keeper.altinity.com >/dev/null 2>&1; then
+  echo "ClickHouse keeper CRD not present; skipping keeper PVC label backfill"
+  chks=""
+else
+  # Each ClickHouseKeeperInstallation is named "<release>-keeper"; its PVCs are
+  # created from the "default" volumeClaimTemplate and named
+  # "default-chk-<release>-keeper-<cluster>-<shard>-<replica>-<ordinal>".
+  # No early-close (head) in the pipe: under pipefail a large list would SIGPIPE
+  # kubectl and abort the migration.
+  chks=$(kubectl get clickhousekeeperinstallations.clickhouse-keeper.altinity.com -A \
+    -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' || true)
+fi
+
+echo "$chks" | while read -r ns chk; do
+  [ -n "${ns:-}" ] || continue
+  release="${chk%-keeper}"
+
+  # grep exits 1 when a namespace has no matching PVCs; tolerate it so pipefail
+  # does not abort the whole migration on an empty match.
+  pvcs=$(kubectl get pvc -n "$ns" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+    | grep -E "^default-chk-${chk}-" || true)
+
+  for pvc in $pvcs; do
+    [ -n "${pvc:-}" ] || continue
+    current=$(kubectl get pvc -n "$ns" "$pvc" \
+      -o jsonpath='{.metadata.labels.app\.kubernetes\.io/instance}' 2>/dev/null || true)
+    if [ "$current" = "$release" ]; then
+      echo "PVC $ns/$pvc already labeled app.kubernetes.io/instance=$release; skipping"
+      continue
+    fi
+    echo "Labeling PVC $ns/$pvc with app.kubernetes.io/instance=$release"
+    kubectl label pvc -n "$ns" "$pvc" "app.kubernetes.io/instance=$release" --overwrite
+  done
+done
+
+# Stamp version via the shared helper so the cozystack-version ConfigMap keeps
+# the platform.cozystack.io/no-delete label. A label-less apply by the same
+# field manager would strip the label migration 42 added, dropping
+# cozystack-version out of the cozystack-no-delete-guardrail
+# ValidatingAdmissionPolicy.
+stamp_cozystack_version 49

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -6,7 +6,7 @@ sourceRef:
 migrations:
   enabled: false
   image: ghcr.io/cozystack/cozystack/platform-migrations:v1.5.0@sha256:8bf61f17e99eb4a3365394e3d97ac52a1d68cc84aa104894ecb09de25721dc1d
-  targetVersion: 48
+  targetVersion: 49
 # Bundle deployment configuration
 bundles:
   system:


### PR DESCRIPTION
## What this PR does

After deleting a `ClickHouse` app CR, data PVCs were left orphaned in the tenant
namespace and consumed storage permanently:

- the keeper PVC `default-chk-<release>-keeper-cluster1-0-0-0`, backing a
  `ClickHouseKeeperInstallation` reconciled by the clickhouse-keeper-operator;
- the main ClickHouse data / log PVCs.

The keeper operator does not delete data PVCs when the CR is removed (data-safety
default) and the CRD exposes no `persistentVolumeClaimRetentionPolicy` equivalent,
so the volumes leaked.

This adds a `post-delete` cleanup hook (modeled on the existing MariaDB hook at
`packages/apps/mariadb/templates/hooks/cleanup-pvc.yaml`) that deletes every PVC
carrying the release label `app.kubernetes.io/instance=<release>`. It also adds
that label to the keeper `volumeClaimTemplates` in `chkeeper.yaml`: the keeper
PVC previously had **no** release label (the chart set labels only on the keeper
pod template, not the PVC), so the operator never stamped one and a single
selector would have missed it — leaving the reported leak unfixed.

### Existing releases (label backfill migration)

The altinity clickhouse-keeper-operator only stamps `volumeClaimTemplates.metadata.labels`
onto PVCs it creates **after** the chart change; it never re-labels PVCs that
already exist. So for releases installed before this fix, the keeper PVC stays
unlabeled and the cleanup selector would still miss it. To close #3057 for
existing customers too, this PR adds migration `48` (`48 -> 49`,
`packages/core/platform/images/migrations/migrations/48`) that back-fills
`app.kubernetes.io/instance=<release>` onto pre-existing keeper PVCs, and bumps
`migrations.targetVersion` to `49`. The migration:

- routes its version stamp through the shared `lib/cozystack-version.sh` helper
  (`stamp_cozystack_version 49`), per the `cozystack-version-stamp.bats` convention;
- no-ops when the keeper CRD is absent, and tolerates a transient apiserver error
  on the keeper list (`|| true`) so it cannot abort a platform-wide upgrade — the
  backfill is best-effort (worst case is the pre-existing leak, no worse than today);
- is idempotent (skips PVCs already labeled).

The main ClickHouse data/log PVCs have carried `app.kubernetes.io/instance` since
2025-06-03 (well before the migration era), so they need no backfill.

### Hook failure handling

The cleanup hook does **not** mask failures: `kubectl delete` failing makes the
Job exit non-zero. The **Job** uses `helm.sh/hook-delete-policy: before-hook-creation`
only (no `hook-succeeded`) so a failed cleanup Job and its logs survive for
debugging; the **ServiceAccount/Role/RoleBinding** keep
`before-hook-creation,hook-succeeded` so the RBAC artifacts are reclaimed after a
successful uninstall instead of lingering in the namespace.

### Scope

The hook intentionally reclaims **only PVCs** of the release. Other release
state (Secrets, ConfigMaps) is owned/garbage-collected through the normal Helm
uninstall path and is out of scope here.

> [!WARNING]
> **This is destructive — deleting a ClickHouse app now permanently deletes its data.**
> The hook removes **all** PVCs of the release: the keeper PVC **and** the main
> ClickHouse data and log PVCs. After deletion nothing is left behind to recover
> data from. This is intentional and matches the existing MariaDB cleanup-hook
> behaviour and the general cozystack model (deleting a managed app reclaims its
> storage). Back up before deleting.

Fixes #3057.

### Release note

```release-note
fix(clickhouse): garbage-collect the keeper and data/log PVCs when a ClickHouse app is deleted, so no orphaned volumes are left behind. A migration back-fills the release label onto keeper PVCs from releases installed before this fix so they are cleaned up too. WARNING: deleting a ClickHouse app now permanently removes all of its PVCs (keeper + data + logs) and the data they hold.
```
