### PR TITLE
fix(openbao): garbage-collect the data PVC on delete (#3058)

### DIFF
--- a/packages/apps/openbao/Makefile
+++ b/packages/apps/openbao/Makefile
@@ -3,3 +3,7 @@ include ../../../hack/package.mk
 generate:
 	cozyvalues-gen -m 'openbao' -v values.yaml -s values.schema.json -r README.md -g ../../../api/apps/v1alpha1/openbao/types.go
 	../../../hack/update-crd.sh
+
+.PHONY: test
+test:
+	helm unittest .

--- a/packages/apps/openbao/templates/openbao.yaml
+++ b/packages/apps/openbao/templates/openbao.yaml
@@ -28,6 +28,14 @@ spec:
       server:
         podManagementPolicy: Parallel
         resources: {{- include "cozy-lib.resources.defaultingSanitize" (list .Values.resourcesPreset .Values.resources $) | nindent 10 }}
+        # Ensure the StatefulSet's data PVC is removed when the release is
+        # deleted. Without this, the upstream chart leaves the PVC orphaned
+        # (StatefulSet volumeClaimTemplates are never garbage-collected by
+        # default). Rendered onto the StatefulSet by the upstream chart from
+        # server.persistentVolumeClaimRetentionPolicy. See issue #3058.
+        persistentVolumeClaimRetentionPolicy:
+          whenDeleted: Delete
+          whenScaled: Retain
         dataStorage:
           enabled: true
           size: {{ .Values.size }}

--- a/packages/apps/openbao/tests/pvc_retention_test.yaml
+++ b/packages/apps/openbao/tests/pvc_retention_test.yaml
@@ -1,0 +1,32 @@
+suite: data PVC retention policy passthrough
+
+# Guards the fix for issue #3058: the upstream OpenBAO StatefulSet renders
+# persistentVolumeClaimRetentionPolicy from server.persistentVolumeClaimRetentionPolicy.
+# The app wrapper must pass this value through the HelmRelease so the data PVC
+# is removed on release deletion instead of being orphaned.
+
+templates:
+  - templates/openbao.yaml
+
+release:
+  name: openbao-test
+  namespace: tenant-test
+
+tests:
+  - it: "passes whenDeleted=Delete through the HelmRelease values"
+    documentSelector:
+      path: kind
+      value: HelmRelease
+    asserts:
+      - equal:
+          path: spec.values.openbao.server.persistentVolumeClaimRetentionPolicy.whenDeleted
+          value: Delete
+
+  - it: "keeps whenScaled=Retain so scale-down does not destroy raft member data"
+    documentSelector:
+      path: kind
+      value: HelmRelease
+    asserts:
+      - equal:
+          path: spec.values.openbao.server.persistentVolumeClaimRetentionPolicy.whenScaled
+          value: Retain


### PR DESCRIPTION
## What this PR does

After deleting an `OpenBAO` app CR, the StatefulSet data PVC (`data-<release>-0`)
was left orphaned in the tenant namespace, consuming storage permanently. The
OpenBAO app renders a Flux `HelmRelease` over the vendored upstream OpenBAO chart,
and StatefulSet-templated PVCs are never garbage-collected on StatefulSet deletion
by default — the chart set no `persistentVolumeClaimRetentionPolicy`.

This passes a retention policy through the HelmRelease values. The upstream chart
renders it onto the StatefulSet from `server.persistentVolumeClaimRetentionPolicy`
(verified in the vendored `server-statefulset.yaml`) — **not** from
`server.dataStorage.*`:

```yaml
server:
  persistentVolumeClaimRetentionPolicy:
    whenDeleted: Delete
    whenScaled: Retain
```

A `test` target is added to the package Makefile so the new helm-unittest suite
(asserting the passthrough) actually runs in CI — `hack/helm-unit-tests.sh` only
runs packages that define a `test` target.

> [!WARNING]
> **Deleting an OpenBAO app now permanently removes its data PVC and the data it holds.**
> This is intentional and fixes the storage leak. `whenScaled: Retain` is kept on
> purpose so scaling an HA/raft cluster down does **not** destroy a member's data —
> only full deletion of the release reclaims storage. Back up before deleting.

Fixes #3058.

### Release note

```release-note
fix(openbao): set persistentVolumeClaimRetentionPolicy so the data PVC is removed when an OpenBAO app is deleted, instead of being orphaned. WARNING: deleting an OpenBAO app now permanently removes its data PVC and the data it holds (scale-down still retains data).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable PVC retention behavior for OpenBao: storage is deleted when the release is removed and retained when scaling down.
* **Tests**
  * Added a Helm unit testing workflow to run chart/unit tests.
  * Introduced assertions to confirm PVC retention settings are correctly passed through and rendered as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->