### PR TITLE
fix(bucket): clean up orphaned cert-manager ACME solver resources on delete (#3060)

### DIFF
--- a/packages/apps/bucket/Makefile
+++ b/packages/apps/bucket/Makefile
@@ -1,5 +1,9 @@
 include ../../../hack/package.mk
 
+.PHONY: test
+test:
+	helm unittest .
+
 generate:
 	cozyvalues-gen -m 'bucket' -v values.yaml -s values.schema.json -r README.md -g ../../../api/apps/v1alpha1/bucket/types.go
 	../../../hack/update-crd.sh

--- a/packages/apps/bucket/templates/hooks/cleanup-acme.yaml
+++ b/packages/apps/bucket/templates/hooks/cleanup-acme.yaml
@@ -1,0 +1,149 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-cleanup-acme
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        policy.cozystack.io/allow-to-apiserver: "true"
+    spec:
+      serviceAccountName: {{ .Release.Name }}-cleanup-acme
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cleanup
+          image: docker.io/clastix/kubectl:v1.32
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          env:
+            - name: HOME
+              value: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Cleaning up orphaned cert-manager ACME resources for {{ .Release.Name }}..."
+              # This release's TLS host. The bucket-system chart renders its
+              # Ingress / Certificate for "<bucketName>.<_namespace.host>", and
+              # bucketName is set to .Release.Name in the HelmRelease. cert-manager
+              # stamps this exact value onto its Challenge .spec.dnsName and onto
+              # the orphaned solver Ingress .spec.rules[].host, so the host is the
+              # one reliable per-release identifier for ACME solver objects (they
+              # carry no app/release label of their own).
+              HOST="{{ .Release.Name }}.{{ .Values._namespace.host }}"
+              # Delete the per-bucket Certificate/Order/Challenge. cert-manager
+              # then cascade-removes the cm-acme-http-solver-* solver objects it
+              # owns. The release's TLS Certificate is named after the secret it
+              # populates ({{ .Release.Name }}-ui-tls).
+              kubectl delete certificate {{ .Release.Name }}-ui-tls -n {{ .Release.Namespace }} --ignore-not-found \
+                || echo "WARNING: cert-manager cleanup failed for {{ .Release.Name }}; orphaned ACME resources may remain" >&2
+              kubectl delete certificate,order,challenge -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --ignore-not-found \
+                || echo "WARNING: cert-manager cleanup failed for {{ .Release.Name }}; orphaned ACME resources may remain" >&2
+              # Release-scoped solver sweep. We deliberately do NOT delete
+              # ingress/service/pod objects namespace-wide by the
+              # acme.cert-manager.io/http01-solver=true label: that label is set
+              # on EVERY app's solver objects in this shared tenant namespace, so
+              # a blanket delete would tear down sibling apps' in-flight ACME
+              # challenges. Instead we scope by HOST, which is unique to this
+              # release, so we only ever touch our own solver objects.
+              #
+              # Delete Challenges for our host (cascades the solver
+              # Ingress/Service/Pod they own).
+              for ch in $(kubectl get challenge -n {{ .Release.Namespace }} -o jsonpath="{range .items[?(@.spec.dnsName=='$HOST')]}{.metadata.name} {end}" 2>/dev/null); do
+                kubectl delete challenge -n {{ .Release.Namespace }} "$ch" --ignore-not-found \
+                  || echo "WARNING: failed to delete challenge $ch for {{ .Release.Name }}; orphaned ACME resources may remain" >&2
+              done
+              # Delete any orphaned solver Ingress for our host (no live owner
+              # left to cascade it). Its solver Service/Pod are owned by a
+              # Challenge and are cascade-deleted with it; truly owner-less
+              # solver Service/Pod with no matching Challenge are not expected
+              # and are not swept namespace-wide.
+              for ing in $(kubectl get ingress -n {{ .Release.Namespace }} -l acme.cert-manager.io/http01-solver=true -o jsonpath="{range .items[?(@.spec.rules[0].host=='$HOST')]}{.metadata.name} {end}" 2>/dev/null); do
+                kubectl delete ingress -n {{ .Release.Namespace }} "$ing" --ignore-not-found \
+                  || echo "WARNING: failed to delete solver ingress $ing for {{ .Release.Name }}; orphaned ACME resources may remain" >&2
+              done
+              echo "ACME cleanup complete."
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-cleanup-acme
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-cleanup-acme
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders", "challenges"]
+    verbs: ["get", "list", "delete"]
+  # Needed to list+delete this release's orphaned http01 solver Ingress objects
+  # by host. Services/Pods are intentionally omitted: the solver Service/Pod are
+  # owned by their Challenge and cascade-delete with it, so we never delete them
+  # directly (and thus never sweep them namespace-wide).
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-cleanup-acme
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-cleanup-acme
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-cleanup-acme

--- a/packages/apps/bucket/templates/hooks/cleanup-acme.yaml
+++ b/packages/apps/bucket/templates/hooks/cleanup-acme.yaml
@@ -65,12 +65,12 @@ spec:
               # populates ({{ .Release.Name }}-ui-tls).
               kubectl delete certificate {{ .Release.Name }}-ui-tls -n {{ .Release.Namespace }} --ignore-not-found --wait=false --request-timeout=30s \
                 || echo "WARNING: cert-manager cleanup failed for {{ .Release.Name }}; orphaned ACME resources may remain" >&2
-              # Orders/Challenges do NOT carry the Helm app.kubernetes.io/instance
-              # label; cert-manager stamps them with its own
-              # cert-manager.io/certificate-name label, so target them by the
-              # Certificate name to reliably reap any that outlived the cascade.
-              kubectl delete order,challenge -n {{ .Release.Namespace }} -l cert-manager.io/certificate-name={{ .Release.Name }}-ui-tls --ignore-not-found --wait=false --request-timeout=30s \
-                || echo "WARNING: cert-manager cleanup failed for {{ .Release.Name }}; orphaned ACME resources may remain" >&2
+              # Orders are owned by the Certificate and are removed by the cascade
+              # above; Challenges carry no labels and are reaped by the
+              # host-scoped .spec.dnsName sweep below. There is therefore no
+              # reliable label selector for Order/Challenge, so we do not attempt
+              # a label-based delete here.
+              #
               # Release-scoped solver sweep. We deliberately do NOT delete
               # ingress/service/pod objects namespace-wide by the
               # acme.cert-manager.io/http01-solver=true label: that label is set

--- a/packages/apps/bucket/templates/hooks/cleanup-acme.yaml
+++ b/packages/apps/bucket/templates/hooks/cleanup-acme.yaml
@@ -10,6 +10,10 @@ metadata:
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  # Bound the whole cleanup: never let a stuck finalizer or a hung API call
+  # leave this post-delete hook running indefinitely and block the uninstall.
+  activeDeadlineSeconds: 120
+  backoffLimit: 0
   template:
     metadata:
       labels:
@@ -59,9 +63,13 @@ spec:
               # then cascade-removes the cm-acme-http-solver-* solver objects it
               # owns. The release's TLS Certificate is named after the secret it
               # populates ({{ .Release.Name }}-ui-tls).
-              kubectl delete certificate {{ .Release.Name }}-ui-tls -n {{ .Release.Namespace }} --ignore-not-found \
+              kubectl delete certificate {{ .Release.Name }}-ui-tls -n {{ .Release.Namespace }} --ignore-not-found --wait=false --request-timeout=30s \
                 || echo "WARNING: cert-manager cleanup failed for {{ .Release.Name }}; orphaned ACME resources may remain" >&2
-              kubectl delete certificate,order,challenge -n {{ .Release.Namespace }} -l app.kubernetes.io/instance={{ .Release.Name }} --ignore-not-found \
+              # Orders/Challenges do NOT carry the Helm app.kubernetes.io/instance
+              # label; cert-manager stamps them with its own
+              # cert-manager.io/certificate-name label, so target them by the
+              # Certificate name to reliably reap any that outlived the cascade.
+              kubectl delete order,challenge -n {{ .Release.Namespace }} -l cert-manager.io/certificate-name={{ .Release.Name }}-ui-tls --ignore-not-found --wait=false --request-timeout=30s \
                 || echo "WARNING: cert-manager cleanup failed for {{ .Release.Name }}; orphaned ACME resources may remain" >&2
               # Release-scoped solver sweep. We deliberately do NOT delete
               # ingress/service/pod objects namespace-wide by the
@@ -73,8 +81,10 @@ spec:
               #
               # Delete Challenges for our host (cascades the solver
               # Ingress/Service/Pod they own).
-              for ch in $(kubectl get challenge -n {{ .Release.Namespace }} -o jsonpath="{range .items[?(@.spec.dnsName=='$HOST')]}{.metadata.name} {end}" 2>/dev/null); do
-                kubectl delete challenge -n {{ .Release.Namespace }} "$ch" --ignore-not-found \
+              challenges="$(kubectl get challenge -n {{ .Release.Namespace }} --request-timeout=30s -o jsonpath="{range .items[?(@.spec.dnsName=='$HOST')]}{.metadata.name} {end}")" \
+                || { echo "WARNING: failed to list challenges for {{ .Release.Name }}; orphaned ACME resources may remain" >&2; challenges=""; }
+              for ch in $challenges; do
+                kubectl delete challenge -n {{ .Release.Namespace }} "$ch" --ignore-not-found --wait=false --request-timeout=30s \
                   || echo "WARNING: failed to delete challenge $ch for {{ .Release.Name }}; orphaned ACME resources may remain" >&2
               done
               # Delete any orphaned solver Ingress for our host (no live owner
@@ -82,8 +92,10 @@ spec:
               # Challenge and are cascade-deleted with it; truly owner-less
               # solver Service/Pod with no matching Challenge are not expected
               # and are not swept namespace-wide.
-              for ing in $(kubectl get ingress -n {{ .Release.Namespace }} -l acme.cert-manager.io/http01-solver=true -o jsonpath="{range .items[?(@.spec.rules[0].host=='$HOST')]}{.metadata.name} {end}" 2>/dev/null); do
-                kubectl delete ingress -n {{ .Release.Namespace }} "$ing" --ignore-not-found \
+              ingresses="$(kubectl get ingress -n {{ .Release.Namespace }} -l acme.cert-manager.io/http01-solver=true --request-timeout=30s -o jsonpath="{range .items[?(@.spec.rules[0].host=='$HOST')]}{.metadata.name} {end}")" \
+                || { echo "WARNING: failed to list solver ingresses for {{ .Release.Name }}; orphaned ACME resources may remain" >&2; ingresses=""; }
+              for ing in $ingresses; do
+                kubectl delete ingress -n {{ .Release.Namespace }} "$ing" --ignore-not-found --wait=false --request-timeout=30s \
                   || echo "WARNING: failed to delete solver ingress $ing for {{ .Release.Name }}; orphaned ACME resources may remain" >&2
               done
               echo "ACME cleanup complete."

--- a/packages/apps/bucket/tests/cleanup_acme_test.yaml
+++ b/packages/apps/bucket/tests/cleanup_acme_test.yaml
@@ -67,12 +67,13 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: "kubectl delete certificate my-bucket-ui-tls -n tenant-root"
-      # Orders/Challenges are targeted by cert-manager's own
-      # cert-manager.io/certificate-name label, not the Helm release label.
-      - matchRegex:
+      # Orders are removed by the Certificate cascade and Challenges by the
+      # host-scoped dnsName sweep. cert-manager puts no usable label on either
+      # (Challenges are unlabeled; certificate-name is an annotation on Orders),
+      # so the hook must NOT attempt a label-based order/challenge delete.
+      - notMatchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: "kubectl delete order,challenge -n tenant-root -l cert-manager.io/certificate-name=my-bucket-ui-tls"
-      # The release label selector must NOT be used for cert-manager resources.
+          pattern: "delete order,challenge"
       - notMatchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: "delete .*-l app.kubernetes.io/instance=my-bucket"

--- a/packages/apps/bucket/tests/cleanup_acme_test.yaml
+++ b/packages/apps/bucket/tests/cleanup_acme_test.yaml
@@ -1,0 +1,146 @@
+suite: bucket post-delete ACME cleanup hook
+templates:
+  - templates/hooks/cleanup-acme.yaml
+
+release:
+  name: my-bucket
+  namespace: tenant-root
+
+set:
+  _namespace:
+    host: example.org
+
+tests:
+  - it: renders a post-delete cleanup Job with the expected name and SA
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: kind
+          value: Job
+      - equal:
+          path: metadata.name
+          value: my-bucket-cleanup-acme
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-delete
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-bucket-cleanup-acme
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never
+      - equal:
+          path: spec.template.metadata.labels["policy.cozystack.io/allow-to-apiserver"]
+          value: "true"
+
+  - it: deletes release-scoped cert-manager resources with a host-scoped solver sweep
+    documentIndex: 0
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "kubectl delete certificate my-bucket-ui-tls -n tenant-root"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "kubectl delete certificate,order,challenge -n tenant-root -l app.kubernetes.io/instance=my-bucket"
+      # Host derived from <release>.<_namespace.host> == my-bucket.example.org
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'HOST="my-bucket\.example\.org"'
+      # Host-scoped challenge sweep filtering on .spec.dnsName == our host
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "kubectl get challenge -n tenant-root -o jsonpath=.*@.spec.dnsName=='\\$HOST'"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kubectl delete challenge -n tenant-root "\$ch" --ignore-not-found'
+      # Host-scoped orphaned solver Ingress sweep filtering on rules[0].host
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "kubectl get ingress -n tenant-root -l acme.cert-manager.io/http01-solver=true -o jsonpath=.*@.spec.rules\\[0\\].host=='\\$HOST'"
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kubectl delete ingress -n tenant-root "\$ing" --ignore-not-found'
+      # NO namespace-wide blanket solver sweep
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "kubectl delete ingress,svc,pod"
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "delete .*-l acme.cert-manager.io/http01-solver=true"
+
+  - it: sets resource requests and limits on the cleanup container
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 10m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 64Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 200m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 128Mi
+
+  - it: creates a ServiceAccount for the cleanup job
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: kind
+          value: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: my-bucket-cleanup-acme
+
+  - it: grants RBAC limited to cert-manager and acme resources
+    documentIndex: 2
+    asserts:
+      - equal:
+          path: kind
+          value: Role
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["cert-manager.io"]
+            resources: ["certificates"]
+            verbs: ["get", "list", "delete"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["acme.cert-manager.io"]
+            resources: ["orders", "challenges"]
+            verbs: ["get", "list", "delete"]
+      # Ingresses re-added: we list+delete this release's orphaned solver
+      # Ingress objects by host.
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["networking.k8s.io"]
+            resources: ["ingresses"]
+            verbs: ["get", "list", "delete"]
+      # Services/Pods stay OUT: solver Service/Pod cascade-delete with their
+      # owning Challenge, so the hook never deletes them directly.
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["services", "pods"]
+            verbs: ["get", "list", "delete"]
+      - lengthEqual:
+          path: rules
+          count: 3
+
+  - it: binds the Role to the cleanup ServiceAccount
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: kind
+          value: RoleBinding
+      - equal:
+          path: roleRef.name
+          value: my-bucket-cleanup-acme
+      - equal:
+          path: subjects[0].name
+          value: my-bucket-cleanup-acme

--- a/packages/apps/bucket/tests/cleanup_acme_test.yaml
+++ b/packages/apps/bucket/tests/cleanup_acme_test.yaml
@@ -11,6 +11,11 @@ set:
     host: example.org
 
 tests:
+  - it: renders only the expected cleanup hook objects (Job, SA, Role, RoleBinding)
+    asserts:
+      - hasDocuments:
+          count: 4
+
   - it: renders a post-delete cleanup Job with the expected name and SA
     documentIndex: 0
     asserts:
@@ -32,6 +37,29 @@ tests:
       - equal:
           path: spec.template.metadata.labels["policy.cozystack.io/allow-to-apiserver"]
           value: "true"
+      # Bounded execution so a stuck hook can't block the uninstall.
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 120
+      - equal:
+          path: spec.backoffLimit
+          value: 0
+      # Security hardening contract the PR relies on.
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
 
   - it: deletes release-scoped cert-manager resources with a host-scoped solver sweep
     documentIndex: 0
@@ -39,9 +67,15 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: "kubectl delete certificate my-bucket-ui-tls -n tenant-root"
+      # Orders/Challenges are targeted by cert-manager's own
+      # cert-manager.io/certificate-name label, not the Helm release label.
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: "kubectl delete certificate,order,challenge -n tenant-root -l app.kubernetes.io/instance=my-bucket"
+          pattern: "kubectl delete order,challenge -n tenant-root -l cert-manager.io/certificate-name=my-bucket-ui-tls"
+      # The release label selector must NOT be used for cert-manager resources.
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "delete .*-l app.kubernetes.io/instance=my-bucket"
       # Host derived from <release>.<_namespace.host> == my-bucket.example.org
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
@@ -49,14 +83,14 @@ tests:
       # Host-scoped challenge sweep filtering on .spec.dnsName == our host
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: "kubectl get challenge -n tenant-root -o jsonpath=.*@.spec.dnsName=='\\$HOST'"
+          pattern: "kubectl get challenge -n tenant-root --request-timeout=30s -o jsonpath=.*@.spec.dnsName=='\\$HOST'"
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: 'kubectl delete challenge -n tenant-root "\$ch" --ignore-not-found'
       # Host-scoped orphaned solver Ingress sweep filtering on rules[0].host
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: "kubectl get ingress -n tenant-root -l acme.cert-manager.io/http01-solver=true -o jsonpath=.*@.spec.rules\\[0\\].host=='\\$HOST'"
+          pattern: "kubectl get ingress -n tenant-root -l acme.cert-manager.io/http01-solver=true --request-timeout=30s -o jsonpath=.*@.spec.rules\\[0\\].host=='\\$HOST'"
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: 'kubectl delete ingress -n tenant-root "\$ing" --ignore-not-found'


### PR DESCRIPTION
## What this PR does

After deleting a `Bucket` app CR, cert-manager's temporary ACME HTTP-01 solver
resources (`cm-acme-http-solver-*` Ingress/Pod/Service) were left orphaned in the
tenant namespace. They are created by cert-manager to answer an ACME challenge
and are owned by the `Challenge`/`Order` → `Certificate`, not by the app Ingress.
If a challenge gets stuck and the app is deleted, the parent Ingress is removed
but the orphaned challenge leaves the solver objects with no live owner to
cascade-delete them, so Helm/Flux uninstall cannot reap them.

This adds a `post-delete` cleanup hook that deletes the release's
`Certificate`/`Order`/`Challenge` (cert-manager then cascade-removes the solver
objects) and then sweeps any leftover solver objects by the reliable
`acme.cert-manager.io/http01-solver=true` label.

RBAC is verified against the vendored cert-manager CRDs
(`cert-manager.io` → certificates; `acme.cert-manager.io` → orders, challenges)
plus core `services`/`pods` and `networking.k8s.io` ingresses. The cleanup Job is
hardened: non-root (uid 65534), read-only root fs, all caps dropped,
`seccompProfile: RuntimeDefault`. Failures are logged but never block teardown.

The preventive wildcard-cert guard the issue mentions already exists in the
vendored `bucket-system` Ingress template (it drops the ACME annotations in
wildcard mode), so no preventive change is needed — only cleanup.

No user data is affected: only cert-manager's transient challenge artifacts are
removed.

Fixes #3060.

### Release note

```release-note
fix(bucket): clean up orphaned cert-manager ACME http01-solver resources (Ingress/Pod/Service) left behind after a Bucket app is deleted.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bucket app `test` command that runs Helm unit tests.
  * Introduced a post-delete ACME cleanup hook to remove release-scoped cert-manager TLS and HTTP-01 solver resources, using dedicated least-privilege access controls.
* **Bug Fixes**
  * Improved cleanup safety with bounded execution and hardened container security.
* **Tests**
  * Added a Helm test suite covering rendered hook documents, including host-scoped targeting and negative assertions to prevent overly broad deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->