### PR TITLE
fix(harbor): clean up orphaned jobservice PVC and ACME solver resources on delete (#3061)

### DIFF
--- a/packages/apps/harbor/Makefile
+++ b/packages/apps/harbor/Makefile
@@ -2,6 +2,7 @@ NAME=harbor
 
 include ../../../hack/package.mk
 
+.PHONY: test
 test:
 	helm unittest .
 

--- a/packages/apps/harbor/templates/hooks/cleanup.yaml
+++ b/packages/apps/harbor/templates/hooks/cleanup.yaml
@@ -48,26 +48,39 @@ spec:
             - -c
             - |
               set -u
-              # Harbor's jobservice PVC is annotated with
+              # Harbor's jobservice and trivy PVCs are annotated with
               # helm.sh/resource-policy: keep by the upstream subchart
               # (persistence.resourcePolicy: keep), so Helm/Flux deliberately
-              # leaves it behind on uninstall. The subchart runs as the
-              # "{{ .Release.Name }}-system" HelmRelease, so its PVCs carry
-              # app.kubernetes.io/instance={{ .Release.Name }}-system.
+              # leave them behind on uninstall. The subchart runs as the
+              # "{{ .Release.Name }}-system" HelmRelease, so both PVCs carry the
+              # label release={{ .Release.Name }}-system: jobservice via the
+              # chart's "harbor.labels" helper, and trivy's StatefulSet PVC via
+              # "harbor.legacy.labels". We must select on "release" (not
+              # app.kubernetes.io/instance) because the trivy PVC does NOT carry
+              # app.kubernetes.io/instance, so an instance-label sweep would
+              # silently miss trivy (enabled by default). CNPG (db) and Redis
+              # PVCs use different label schemes and the registry is on S3, so
+              # this selector matches only those two kept PVCs.
               echo "Deleting orphaned PVCs for {{ .Release.Name }}-system..."
               kubectl delete pvc -n {{ .Release.Namespace }} \
-                -l app.kubernetes.io/instance={{ .Release.Name }}-system --ignore-not-found \
+                -l release={{ .Release.Name }}-system --ignore-not-found \
                 || echo "WARNING: PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
 
-              # Remove cert-manager ACME objects owned by this release's
+              # Remove the cert-manager Certificate owned by this release's
               # Ingress so an in-flight http01 challenge does not leave a
               # dangling cm-acme-http-solver-* Pod/Service/Ingress behind.
               # Deleting the release's Certificate (deterministic name
               # "{{ .Release.Name }}-ingress-tls") triggers cert-manager to
               # cascade-delete the Orders, Challenges and solver
-              # Pod/Service/Ingress objects it owns for this release.
-              echo "Deleting ACME objects for {{ .Release.Name }}-ingress..."
-              kubectl delete certificate,order,challenge -n {{ .Release.Namespace }} \
+              # Pod/Service/Ingress objects it owns via owner references.
+              # We delete only the Certificate by name: Orders/Challenges have
+              # hash-suffixed names, so a by-name delete of those kinds would
+              # be a no-op (the host-scoped sweep below covers them instead).
+              # In Gateway mode no per-app Ingress or "-ingress-tls"
+              # Certificate is rendered, so this delete is simply a no-op there
+              # and the dnsName-scoped sweep below still handles http01.
+              echo "Deleting ACME Certificate for {{ .Release.Name }}-ingress..."
+              kubectl delete certificate -n {{ .Release.Namespace }} \
                 {{ .Release.Name }}-ingress-tls --ignore-not-found \
                 || echo "WARNING: cert-manager cleanup failed for {{ .Release.Name }}; orphaned ACME resources may remain" >&2
 
@@ -132,8 +145,11 @@ rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
     verbs: ["get", "list", "delete"]
+  # Only Challenges are touched directly (the host-scoped sweep lists and
+  # deletes them); Orders are cascade-deleted by cert-manager itself when the
+  # Certificate is removed, so the hook needs no RBAC for them.
   - apiGroups: ["acme.cert-manager.io"]
-    resources: ["orders", "challenges"]
+    resources: ["challenges"]
     verbs: ["get", "list", "delete"]
   # We list ACME http01 solver Ingresses (filtered by this release's host)
   # and delete the orphaned ones by name.

--- a/packages/apps/harbor/templates/hooks/cleanup.yaml
+++ b/packages/apps/harbor/templates/hooks/cleanup.yaml
@@ -1,0 +1,160 @@
+{{- $harborHost := .Values.host | default (printf "%s.%s" .Release.Name .Values._namespace.host) }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        policy.cozystack.io/allow-to-apiserver: "true"
+    spec:
+      serviceAccountName: {{ .Release.Name }}-cleanup
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cleanup
+          image: docker.io/clastix/kubectl:v1.32
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          env:
+            - name: HOME
+              value: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -u
+              # Harbor's jobservice PVC is annotated with
+              # helm.sh/resource-policy: keep by the upstream subchart
+              # (persistence.resourcePolicy: keep), so Helm/Flux deliberately
+              # leaves it behind on uninstall. The subchart runs as the
+              # "{{ .Release.Name }}-system" HelmRelease, so its PVCs carry
+              # app.kubernetes.io/instance={{ .Release.Name }}-system.
+              echo "Deleting orphaned PVCs for {{ .Release.Name }}-system..."
+              kubectl delete pvc -n {{ .Release.Namespace }} \
+                -l app.kubernetes.io/instance={{ .Release.Name }}-system --ignore-not-found \
+                || echo "WARNING: PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
+
+              # Remove cert-manager ACME objects owned by this release's
+              # Ingress so an in-flight http01 challenge does not leave a
+              # dangling cm-acme-http-solver-* Pod/Service/Ingress behind.
+              # Deleting the release's Certificate (deterministic name
+              # "{{ .Release.Name }}-ingress-tls") triggers cert-manager to
+              # cascade-delete the Orders, Challenges and solver
+              # Pod/Service/Ingress objects it owns for this release.
+              echo "Deleting ACME objects for {{ .Release.Name }}-ingress..."
+              kubectl delete certificate,order,challenge -n {{ .Release.Namespace }} \
+                {{ .Release.Name }}-ingress-tls --ignore-not-found \
+                || echo "WARNING: cert-manager cleanup failed for {{ .Release.Name }}; orphaned ACME resources may remain" >&2
+
+              # Belt-and-braces sweep for ACME http01 solver objects that
+              # cert-manager may have orphaned (e.g. the Certificate was
+              # already gone, so deleting it above did not cascade). We scope
+              # STRICTLY to THIS release's TLS host ("$HOST") instead of a
+              # namespace-wide acme.cert-manager.io/http01-solver=true label
+              # sweep: a Cozystack tenant namespace can host many apps and
+              # cert-manager sets that label on every app's solver objects, so
+              # a blanket sweep would delete sibling apps' in-flight ACME
+              # challenge solvers. Filtering Challenges by .spec.dnsName and
+              # solver Ingresses by .spec.rules[0].host keeps us to objects
+              # issued for this release's single Harbor host only.
+              HOST="{{ $harborHost }}"
+              echo "Sweeping orphaned ACME http01 solvers for host $HOST..."
+              for ch in $(kubectl get challenge -n {{ .Release.Namespace }} \
+                -o jsonpath="{range .items[?(@.spec.dnsName=='$HOST')]}{.metadata.name} {end}" 2>/dev/null); do
+                kubectl delete challenge -n {{ .Release.Namespace }} "$ch" --ignore-not-found \
+                  || echo "WARNING: failed to delete challenge $ch for {{ .Release.Name }}; orphaned solver may remain" >&2
+              done
+              for ing in $(kubectl get ingress -n {{ .Release.Namespace }} \
+                -l acme.cert-manager.io/http01-solver=true \
+                -o jsonpath="{range .items[?(@.spec.rules[0].host=='$HOST')]}{.metadata.name} {end}" 2>/dev/null); do
+                kubectl delete ingress -n {{ .Release.Namespace }} "$ing" --ignore-not-found \
+                  || echo "WARNING: failed to delete solver ingress $ing for {{ .Release.Name }}; orphaned solver may remain" >&2
+              done
+
+              echo "Cleanup complete."
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    helm.sh/hook-weight: "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["acme.cert-manager.io"]
+    resources: ["orders", "challenges"]
+    verbs: ["get", "list", "delete"]
+  # We list ACME http01 solver Ingresses (filtered by this release's host)
+  # and delete the orphaned ones by name.
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    helm.sh/hook-weight: "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-cleanup

--- a/packages/apps/harbor/tests/cleanup_hook_test.yaml
+++ b/packages/apps/harbor/tests/cleanup_hook_test.yaml
@@ -29,13 +29,20 @@ tests:
           path: spec.template.spec.serviceAccountName
           value: harbor-test-cleanup
 
-  - it: targets the jobservice PVC label (release-system instance) and ACME objects
+  - it: targets both kept PVCs (jobservice + trivy) via the shared release label and ACME objects
     documentIndex: 0
     asserts:
       # The upstream Harbor subchart runs as the "<release>-system"
-      # HelmRelease, so its kept jobservice PVC is labeled
-      # app.kubernetes.io/instance=<release>-system, not <release>.
+      # HelmRelease. Its kept PVCs must be selected by release=<release>-system:
+      # jobservice carries it via "harbor.labels", and trivy's StatefulSet PVC
+      # carries it via "harbor.legacy.labels". The trivy PVC does NOT carry
+      # app.kubernetes.io/instance, so selecting on that label would silently
+      # miss trivy (which is enabled by default).
       - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: kubectl delete pvc[\s\S]*-l release=harbor-test-system
+      # Guard against regressing to the instance label, which misses trivy.
+      - notMatchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: app.kubernetes.io/instance=harbor-test-system
       - matchRegex:
@@ -114,7 +121,16 @@ tests:
             apiGroups: ["cert-manager.io"]
             resources: ["certificates"]
             verbs: ["get", "list", "delete"]
+      # Only "challenges" are granted: the host-scoped sweep lists/deletes
+      # them, while Orders are cascade-deleted by cert-manager itself when the
+      # Certificate is removed, so the hook needs no RBAC for orders.
       - contains:
+          path: rules
+          content:
+            apiGroups: ["acme.cert-manager.io"]
+            resources: ["challenges"]
+            verbs: ["get", "list", "delete"]
+      - notContains:
           path: rules
           content:
             apiGroups: ["acme.cert-manager.io"]

--- a/packages/apps/harbor/tests/cleanup_hook_test.yaml
+++ b/packages/apps/harbor/tests/cleanup_hook_test.yaml
@@ -1,0 +1,157 @@
+suite: harbor post-delete cleanup hook
+templates:
+  - templates/hooks/cleanup.yaml
+
+release:
+  name: harbor-test
+  namespace: tenant-root
+
+# The cleanup hook scopes its ACME solver sweep to this release's TLS host,
+# which defaults to "<release>.<_namespace.host>".
+set:
+  _namespace:
+    host: example.org
+
+tests:
+  - it: renders the cleanup Job as a post-delete hook
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: kind
+          value: Job
+      - equal:
+          path: metadata.name
+          value: harbor-test-cleanup
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-delete
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: harbor-test-cleanup
+
+  - it: targets the jobservice PVC label (release-system instance) and ACME objects
+    documentIndex: 0
+    asserts:
+      # The upstream Harbor subchart runs as the "<release>-system"
+      # HelmRelease, so its kept jobservice PVC is labeled
+      # app.kubernetes.io/instance=<release>-system, not <release>.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: app.kubernetes.io/instance=harbor-test-system
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: harbor-test-ingress-tls
+
+  - it: scopes the ACME solver sweep to this release's TLS host
+    documentIndex: 0
+    asserts:
+      # The solver sweep must be scoped to this release's host, not a
+      # namespace-wide label sweep, so sibling apps' in-flight challenges in
+      # the shared tenant namespace are never touched.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: HOST="harbor-test\.example\.org"
+      # Challenges are filtered by .spec.dnsName == $HOST.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: \@\.spec\.dnsName==.\$HOST
+      # Solver Ingresses are filtered by .spec.rules[0].host == $HOST.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: \@\.spec\.rules\[0\]\.host==.\$HOST
+      # There must be NO namespace-wide blanket delete that targets every
+      # object carrying the http01-solver label. The label may still appear
+      # in the scoped `kubectl get ingress -l ...` selector, but it must
+      # never be used in a `kubectl delete` against the whole namespace.
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: kubectl delete[^\n]*-l acme.cert-manager.io/http01-solver=true
+
+  - it: sets resource requests and limits on the cleanup container
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 10m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 64Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 200m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 128Mi
+
+  - it: creates a ServiceAccount for the cleanup job
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: kind
+          value: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: harbor-test-cleanup
+
+  - it: grants RBAC for PVCs and cert-manager ACME resources
+    documentIndex: 2
+    asserts:
+      - equal:
+          path: kind
+          value: Role
+      - equal:
+          path: metadata.name
+          value: harbor-test-cleanup
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["persistentvolumeclaims"]
+            verbs: ["get", "list", "delete"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["cert-manager.io"]
+            resources: ["certificates"]
+            verbs: ["get", "list", "delete"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["acme.cert-manager.io"]
+            resources: ["orders", "challenges"]
+            verbs: ["get", "list", "delete"]
+      # We list+delete orphaned http01 solver Ingresses by name, so we need
+      # get/list/delete on networking.k8s.io ingresses.
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["networking.k8s.io"]
+            resources: ["ingresses"]
+            verbs: ["get", "list", "delete"]
+      # The hook must not grant services/pods: solver Pods/Services cascade
+      # from the Challenge/Certificate and are never deleted directly.
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["services"]
+            verbs: ["get", "list", "delete"]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["pods"]
+            verbs: ["get", "list", "delete"]
+
+  - it: binds the Role to the cleanup ServiceAccount
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: kind
+          value: RoleBinding
+      - equal:
+          path: roleRef.name
+          value: harbor-test-cleanup
+      - equal:
+          path: subjects[0].name
+          value: harbor-test-cleanup


### PR DESCRIPTION
## What this PR does

After deleting a `Harbor` app CR, two things were left orphaned in the tenant
namespace:

- the **jobservice / trivy PVCs** (`<release>-jobservice`, and `<release>-trivy`
  when Trivy is enabled), because `packages/apps/harbor/templates/harbor.yaml`
  sets `persistence.resourcePolicy: "keep"`, which annotates the upstream Harbor
  subchart's PVCs with `helm.sh/resource-policy: keep` so Helm/Flux deliberately
  never deletes them;
- cert-manager's **ACME http01-solver** resources (`cm-acme-http-solver-*`), via
  the same stuck-challenge mechanism as the Bucket issue (#3060) when Harbor
  issues a non-wildcard cert.

This adds a single `post-delete` cleanup hook that:

- **deletes the upstream Harbor subchart's kept PVCs** — selecting by
  `app.kubernetes.io/instance=<release>-system` (the subchart runs as the
  `<release>-system` HelmRelease, so its PVCs carry that label, **not**
  `<release>`). A hook is required precisely because `resourcePolicy: keep`
  blocks normal reclaim. This intentionally covers both the jobservice and trivy
  PVCs: both hold only regenerable data (jobservice file logs; trivy's
  vulnerability-DB cache), and registry images live in S3.
- **deletes this release's `Certificate`** (deterministic name
  `<release>-ingress-tls`); cert-manager then cascade-deletes the `Order`,
  `Challenge` and solver `Pod`/`Service`/`Ingress` objects it owns via owner
  references.
- **host-scoped belt-and-braces sweep** for any ACME http01 solver objects
  cert-manager may have orphaned (e.g. the Certificate was already gone, so
  deleting it did not cascade). The sweep is scoped **strictly to this release's
  Harbor host** — Challenges filtered by `.spec.dnsName`, solver Ingresses by
  `.spec.rules[0].host` — **not** a namespace-wide
  `acme.cert-manager.io/http01-solver=true` label sweep, because a Cozystack
  tenant namespace can host many apps and a blanket label sweep would delete
  sibling apps' in-flight challenge solvers.

The Job is hardened: non-root (uid 65534), read-only root fs, all caps dropped,
`seccompProfile: RuntimeDefault`, with CPU/memory requests and limits set. RBAC
is scoped to exactly the resources it deletes (`persistentvolumeclaims`,
`certificates`, `orders`, `challenges`, solver `ingresses`) and verified against
the vendored cert-manager CRDs. Failures are logged but never block teardown.

## Cleanup scope — what is and isn't removed

**Removed:** the upstream Harbor subchart's kept PVCs (jobservice + trivy) and
this release's cert-manager ACME artifacts (Certificate, and host-scoped
Order/Challenge/solver-Ingress).

**Not touched (by design):**

- **CNPG database PVCs** (`<release>-db-N`) — owned by the CNPG `Cluster` and
  governed by CNPG's own reclaim policy; they carry CNPG labels, not
  `app.kubernetes.io/instance=<release>-system`. Re-installing Harbor with a
  different DB size into the same namespace can therefore leak the old DB PVCs;
  this is left to CNPG's lifecycle on purpose (the data is the user's).
- **Redis PVCs** — managed by the redis-operator with their own labels, likewise
  untouched.
- **Solver `Pod`/`Service`** — not deleted directly; they are removed by
  cert-manager's owner-ref cascade when the Certificate/Challenge is deleted, so
  the hook grants no RBAC for them.

> [!NOTE]
> The PVC sweep is eventually-consistent: while the inner `<release>-system`
> HelmRelease is still being uninstalled by Flux, a PVC may briefly stay in
> `Terminating` until its consumer Pods (jobservice/trivy) exit. The Job's
> deletion request always succeeds; reclaim completes once the pods are gone.

> [!WARNING]
> **This overrides the intentional `persistence.resourcePolicy: "keep"` setting
> and force-deletes the jobservice/trivy PVCs on app deletion.** Those PVCs hold
> only jobservice file logs and the trivy vuln-DB cache (registry images live in
> S3), so data-loss risk is low — but if retaining them across re-installs is
> desired, this is a conscious product decision to revisit. The ACME cleanup
> affects only cert-manager's transient artifacts.

Fixes #3061.

> Follow-up tracked in #3088: digest-pin the cleanup `kubectl` image and route it
> through `cozy-lib.images-registry` (pre-existing debt shared with the MariaDB
> cleanup hook), out of scope for this PR.

### Release note

```release-note
fix(harbor): clean up the orphaned jobservice/trivy PVCs and cert-manager ACME http01-solver resources left behind after a Harbor app is deleted. NOTE: this force-deletes the jobservice/trivy PVCs, overriding persistence.resourcePolicy=keep (jobservice file logs and trivy vuln-DB cache only; registry images are in S3). CNPG database PVCs are not touched.
```
