### PR TITLE
fix(kubernetes): clear kamaji datastore-secret finalizer to unblock namespace deletion (#3062)

### DIFF
--- a/packages/apps/kubernetes/templates/delete.yaml
+++ b/packages/apps/kubernetes/templates/delete.yaml
@@ -21,9 +21,30 @@ spec:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: "NoSchedule"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: kubectl
           image: docker.io/clastix/kubectl:v1.32
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: HOME
+              value: /tmp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
           command:
             - /bin/sh
             - -c
@@ -48,9 +69,49 @@ spec:
               kubectl -n {{ .Release.Namespace }} delete kamajicontrolplanes.controlplane.cluster.x-k8s.io {{ .Release.Name }} \
                 --ignore-not-found=true
 
-              echo "Step 4: Deleting TenantControlPlane {{ .Release.Name }}"
+              echo "Step 4: Deleting TenantControlPlane {{ .Release.Name }} and waiting for it to be removed"
+              # --wait=true blocks until the TenantControlPlane object is fully
+              # gone. This is required so that Kamaji's TCP finalizer-cleanup
+              # chain (which strips finalizer.kamaji.clastix.io/datastore-secret
+              # off the <release>-datastore-config Secret) has a chance to run
+              # before we fall through to Step 4b. A short --timeout keeps the
+              # hook from hanging forever if Kamaji is unreachable; Step 4b is
+              # the backstop for that case.
               kubectl -n {{ .Release.Namespace }} delete tenantcontrolplanes.kamaji.clastix.io {{ .Release.Name }} \
-                --ignore-not-found=true
+                --ignore-not-found=true --wait=true --timeout=120s \
+                || echo "WARNING: TenantControlPlane {{ .Release.Name }} did not delete within timeout; relying on the Step 4b finalizer backstop" >&2
+
+              echo "Step 4b: Clearing leftover Kamaji datastore-secret finalizer on {{ .Release.Name }}-datastore-config"
+              # Kamaji creates a per-tenant datastore connection Secret named
+              # <tcp-name>-datastore-config (tcp-name == .Release.Name) and adds
+              # the finalizer "finalizer.kamaji.clastix.io/datastore-secret" to
+              # it. That finalizer is normally removed by Kamaji as part of the
+              # TenantControlPlane deletion above. If the TCP was force-deleted,
+              # or Kamaji did not reconcile the removal in time, the finalizer
+              # stays on the Secret and blocks deletion of the entire namespace
+              # (the Secret cannot be garbage-collected, see issue #3062).
+              #
+              # By this point the TenantControlPlane is gone (Step 4 waited for
+              # it), so Kamaji no longer has any legitimate use for this Secret:
+              # the Secret has an ownerReference to the now-deleted TCP and is
+              # only awaiting garbage collection. Stripping the finalizer here is
+              # therefore safe and merely lets the GC reap it. We only patch the
+              # finalizers field of this one named Secret.
+              # Only clear the finalizer if the TenantControlPlane is actually gone.
+              # Step 4 may have timed out with the TCP still present; in that case
+              # Kamaji still legitimately owns the datastore Secret, and stripping
+              # the finalizer would interfere with its lifecycle management. Gate
+              # the patch on the TCP being confirmed absent (CodeRabbit #3078).
+              if kubectl -n {{ .Release.Namespace }} get tenantcontrolplanes.kamaji.clastix.io {{ .Release.Name }} >/dev/null 2>&1; then
+                echo "  TenantControlPlane {{ .Release.Name }} still present (deletion not complete); leaving the datastore-secret finalizer untouched"
+              elif kubectl -n {{ .Release.Namespace }} get secret {{ .Release.Name }}-datastore-config >/dev/null 2>&1; then
+                echo "  Removing finalizers from secret/{{ .Release.Name }}-datastore-config"
+                kubectl -n {{ .Release.Namespace }} patch secret {{ .Release.Name }}-datastore-config \
+                  --type=merge -p '{"metadata":{"finalizers":null}}' \
+                  || echo "WARNING: failed to clear datastore-secret finalizer for {{ .Release.Name }}; the namespace may stay in Terminating (issue #3062)" >&2
+              else
+                echo "  Secret {{ .Release.Name }}-datastore-config not present; nothing to do"
+              fi
 
               echo "Step 5: Cleaning up DataVolumes"
               kubectl -n {{ .Release.Namespace }} delete datavolumes \
@@ -64,7 +125,12 @@ spec:
                 --ignore-not-found=true
 
               echo "Cleanup completed successfully"
-
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -130,6 +196,18 @@ rules:
       - list
       - watch
       - delete
+  # Scoped to the single Kamaji datastore connection Secret so Step 4b can
+  # strip the leftover finalizer.kamaji.clastix.io/datastore-secret finalizer
+  # (issue #3062). resourceNames limits get/patch to exactly this Secret.
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - {{ .Release.Name }}-datastore-config
+    verbs:
+      - get
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/packages/apps/kubernetes/tests/delete_hook_test.yaml
+++ b/packages/apps/kubernetes/tests/delete_hook_test.yaml
@@ -1,0 +1,70 @@
+suite: pre-delete cleanup hook (issue #3062)
+
+# These tests pin the behaviour that prevents the Kamaji
+# <release>-datastore-config Secret from blocking namespace deletion:
+# the pre-delete Job must wait for the TenantControlPlane to be gone and
+# then strip the finalizer.kamaji.clastix.io/datastore-secret finalizer,
+# and the cleanup Role must be allowed to patch exactly that one Secret.
+
+templates:
+  - templates/delete.yaml
+
+release:
+  name: test-k8s
+  namespace: tenant-test
+
+values:
+  - values-ci.yaml
+
+tests:
+  - it: cleanup Role can get/patch only the datastore-config Secret
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - ""
+            resources:
+              - secrets
+            resourceNames:
+              - test-k8s-datastore-config
+            verbs:
+              - get
+              - patch
+
+  - it: pre-delete Job waits for the TenantControlPlane before clearing the Secret
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      # TCP deletion must wait so Kamaji can clear the finalizer itself first.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete tenantcontrolplanes\.kamaji\.clastix\.io test-k8s[\s\S]*--wait=true'
+
+  - it: pre-delete Job strips the leftover datastore-secret finalizer as a backstop
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'patch secret test-k8s-datastore-config'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '"finalizers":null'
+
+  - it: pre-delete Job clears the finalizer only after confirming the TenantControlPlane is gone
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      # The finalizer patch must be gated on the TCP being absent (#3078): if the
+      # Step 4 delete timed out with the TCP still alive, we must not strip the
+      # finalizer Kamaji still legitimately owns.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'get tenantcontrolplanes\.kamaji\.clastix\.io test-k8s[\s\S]*still present[\s\S]*patch secret test-k8s-datastore-config'


### PR DESCRIPTION
## What this PR does

After deleting a `Kubernetes` app CR / tenant, the secret
`<release>-datastore-config` kept the finalizer
`finalizer.kamaji.clastix.io/datastore-secret`, which was never removed —
**blocking deletion of the entire namespace** (observed stuck in `Terminating`
for 115 minutes). Kamaji adds this finalizer to the datastore connection Secret
and normally strips it as part of TenantControlPlane (TCP) deletion; if the TCP
is force-deleted or Kamaji does not reconcile in time, the finalizer hangs and
the Secret can never be garbage-collected, wedging the namespace.

This extends the existing `pre-delete` cleanup hook
(`packages/apps/kubernetes/templates/delete.yaml`):

- **Step 4** now deletes the TenantControlPlane with `--wait=true --timeout=120s`
  so Kamaji's own finalizer-cleanup chain has a chance to run before we fall
  through.
- **Step 4b (backstop)** patches `metadata.finalizers: null` on
  `<release>-datastore-config` only if it still exists. By this point the TCP is
  gone, the Secret is owner-ref'd to the deleted TCP and only awaiting GC, so
  clearing the finalizer merely lets GC reap it — it cannot strip a finalizer
  while a live TCP still needs the datastore. The Secret holds only connection
  config, not tenant data (which lives in the external etcd datastore), so no
  data is lost.
- **RBAC** adds a `secrets` rule scoped via `resourceNames` to exactly
  `<release>-datastore-config`, verbs `get`/`patch` only.

The Job is hardened: non-root (uid 65534), read-only root fs, all caps dropped,
`seccompProfile: RuntimeDefault`, writable `/tmp` for kubectl cache. Failures at
both steps are logged (the Step 4b warning explicitly mentions the namespace may
stay Terminating) but the hook still completes so it cannot itself block teardown.

This is the most impactful of the create→delete leak sweep findings: without it,
tenant teardown hangs and the create→delete cycle requires manual intervention.

Fixes #3062.

### Release note

```release-note
fix(kubernetes): clear the leftover Kamaji `finalizer.kamaji.clastix.io/datastore-secret` finalizer on the datastore-config Secret during tenant teardown, so deleting a Kubernetes app / tenant no longer leaves the namespace stuck in Terminating.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended the pre-delete cleanup workflow to more reliably remove `TenantControlPlane` and handle slow deletions with a bounded wait.
* **Security**
  * Hardened the cleanup job by running as non-root with restricted security settings, dropped capabilities, and a safe writable temp location.
* **Bug Fixes**
  * Added a conditional backstop to remove leftover `finalizers` from the relevant datastore Secret so namespace termination isn’t blocked.
* **Tests**
  * Added a YAML test suite to validate the wait-and-patch behavior and ensure the patch runs only after the `TenantControlPlane` is gone.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->