### PR TITLE
feat(tenant): recursive (hierarchical) resource quotas for sub-tenants

### DIFF
--- a/cmd/cozystack-controller/main.go
+++ b/cmd/cozystack-controller/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cozystack/cozystack/internal/controller"
 	"github.com/cozystack/cozystack/internal/controller/serviceexposure"
 	"github.com/cozystack/cozystack/internal/controller/tenantgateway"
+	"github.com/cozystack/cozystack/internal/controller/tenantquota"
 	"github.com/cozystack/cozystack/internal/telemetry"
 
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -80,6 +81,7 @@ func main() {
 	var disableTelemetry bool
 	var telemetryEndpoint string
 	var telemetryInterval string
+	var quotaBufferPercent int64
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -97,6 +99,8 @@ func main() {
 		"Endpoint for sending telemetry data")
 	flag.StringVar(&telemetryInterval, "telemetry-interval", "15m",
 		"Interval between telemetry data collection (e.g. 15m, 1h)")
+	flag.Int64Var(&quotaBufferPercent, "tenant-quota-buffer-percent", 0,
+		"Temporary buffer (e.g. 130 = +30%) added to every hierarchical tenant quota pool so workloads already over a freshly-introduced quota keep running during rollout. 0 disables it.")
 	opts := zap.Options{
 		Development: false,
 	}
@@ -242,6 +246,16 @@ func main() {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ExposureClass")
+		os.Exit(1)
+	}
+
+	if err = (&tenantquota.Reconciler{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Recorder:      mgr.GetEventRecorderFor("tenantquota-controller"),
+		BufferPercent: quotaBufferPercent,
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "TenantQuota")
 		os.Exit(1)
 	}
 

--- a/internal/controller/tenantquota/pool.go
+++ b/internal/controller/tenantquota/pool.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package tenantquota implements hierarchical (recursive) resource quotas for
+// the Cozystack tenant tree. A tenant's declared quota is the budget for its
+// whole sub-tree: a child tenant that declares its own quota carves a fixed
+// slice out of its parent's budget, while a child without a quota shares the
+// parent's remaining pool.
+//
+// The model and the "a label-selector spans many namespaces whose usage is
+// aggregated for a shared budget" mechanism are adapted from OpenShift's
+// ClusterResourceQuota controllers:
+//   - github.com/openshift/api (quota/v1)
+//   - github.com/openshift/library-go (pkg/quota/clusterquotamapping)
+//   - github.com/openshift/cluster-policy-controller (pkg/quota/clusterquotareconciliation)
+//   - github.com/openshift/apiserver-library-go (pkg/admission/quota/clusterresourcequota)
+//
+// Copyright Red Hat, Inc. and the OpenShift Authors; licensed under the Apache
+// License, Version 2.0. Like those controllers, the per-namespace quota
+// arithmetic is delegated to the upstream Kubernetes quota helpers
+// (k8s.io/apiserver/pkg/quota/v1) rather than reimplemented.
+package tenantquota
+
+import (
+	"sort"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	quota "k8s.io/apiserver/pkg/quota/v1"
+)
+
+// rootTenantNamespace is the namespace of the cluster's root tenant, which is
+// its own parent in the hierarchy.
+const rootTenantNamespace = "tenant-root"
+
+// tenantNamespacePrefix is the common prefix of every tenant namespace.
+const tenantNamespacePrefix = "tenant-"
+
+// Tenant is a snapshot of one tenant in the hierarchy: the namespace it owns
+// and its declared resourceQuotas. A nil/empty Declared marks an unbounded
+// tenant, which draws from the pool of its nearest bounded ancestor.
+type Tenant struct {
+	Namespace string
+	Declared  corev1.ResourceList
+}
+
+// parentNamespace returns the namespace owned by the parent of the tenant that
+// owns ns, or "" for the root tenant and non-tenant namespaces.
+//
+// The hierarchy is encoded in the namespace name by the tenant chart: a tenant
+// "x" created in namespace P owns namespace computeTenantNamespace(P, x) — i.e.
+// P + "-" + x, or "tenant-x" directly under root — so the parent namespace is
+// recovered by stripping the trailing "-x" segment.
+func parentNamespace(ns string) string {
+	if ns == rootTenantNamespace || !strings.HasPrefix(ns, tenantNamespacePrefix) {
+		return ""
+	}
+	segments := strings.Split(ns, "-")
+	if len(segments) == 2 {
+		return rootTenantNamespace
+	}
+	return strings.Join(segments[:len(segments)-1], "-")
+}
+
+// poolRootOf returns the namespace of the nearest ancestor tenant (inclusive of
+// ns itself) that declares a quota — the "pool root" whose budget governs ns.
+// It returns "" when no ancestor is bounded, meaning ns is governed by no pool.
+func poolRootOf(ns string, declaredByNS map[string]corev1.ResourceList) string {
+	for cur := ns; cur != ""; cur = parentNamespace(cur) {
+		if len(declaredByNS[cur]) > 0 {
+			return cur
+		}
+	}
+	return ""
+}
+
+// Pool is a budget shared by a set of namespaces: the pool root's own namespace
+// plus every unbounded descendant whose nearest bounded ancestor is the root.
+// Bounded sub-tenants are not members — they form their own pools — but their
+// declared quota is carved out of this pool's budget.
+type Pool struct {
+	Root      string
+	Budget    corev1.ResourceList // the root tenant's declared quota
+	CarvedOut corev1.ResourceList // sum of bounded sub-tenant reservations charged here
+	Available corev1.ResourceList // max(Budget-CarvedOut, 0), shared by Members
+	Members   []string            // namespaces that draw from Available
+}
+
+// ComputePools derives the pool structure for a snapshot of tenants. Each
+// bounded tenant becomes a pool root; every namespace is assigned to its
+// nearest bounded ancestor's pool; each bounded sub-tenant's declared quota is
+// charged as a carve-out against its parent pool.
+func ComputePools(tenants []Tenant) map[string]*Pool {
+	declaredByNS := make(map[string]corev1.ResourceList, len(tenants))
+	allNS := make([]string, 0, len(tenants))
+	for _, t := range tenants {
+		allNS = append(allNS, t.Namespace)
+		if len(t.Declared) > 0 {
+			declaredByNS[t.Namespace] = t.Declared
+		}
+	}
+	sort.Strings(allNS)
+
+	pools := make(map[string]*Pool, len(declaredByNS))
+	for ns, declared := range declaredByNS {
+		pools[ns] = &Pool{
+			Root:      ns,
+			Budget:    declared.DeepCopy(),
+			CarvedOut: corev1.ResourceList{},
+		}
+	}
+
+	// Membership: every namespace draws from its nearest bounded ancestor's
+	// pool (a bounded tenant's own namespace draws from its own pool).
+	for _, ns := range allNS {
+		if root := poolRootOf(ns, declaredByNS); root != "" {
+			pools[root].Members = append(pools[root].Members, ns)
+		}
+	}
+
+	// Carve-outs: a bounded sub-tenant reserves its declared budget out of the
+	// pool of its parent's nearest bounded ancestor.
+	for ns, declared := range declaredByNS {
+		if parentPool := poolRootOf(parentNamespace(ns), declaredByNS); parentPool != "" {
+			pools[parentPool].CarvedOut = quota.Add(pools[parentPool].CarvedOut, declared)
+		}
+	}
+
+	for _, p := range pools {
+		p.Available = quota.SubtractWithNonNegativeResult(p.Budget, p.CarvedOut)
+		sort.Strings(p.Members)
+	}
+	return pools
+}
+
+// Overcommitted reports the resources whose carve-outs exceed the pool budget,
+// i.e. where sub-tenants have collectively been promised more than the root
+// tenant owns. This should be prevented at admission, but a parent quota that
+// is lowered after children exist can still produce it, so the controller
+// surfaces it.
+func (p *Pool) Overcommitted() corev1.ResourceList {
+	over := quota.Subtract(p.CarvedOut, p.Budget)
+	result := corev1.ResourceList{}
+	for name, qty := range over {
+		if qty.Sign() > 0 {
+			result[name] = qty
+		}
+	}
+	return result
+}
+
+// EnforcedHard computes the per-namespace ResourceQuota hard limit that keeps
+// member namespace ns within its pool: the pool's available budget minus what
+// every other member is currently using. Restricted to the resources the pool
+// budget actually constrains.
+//
+// This realises the shared pool at runtime with plain per-namespace
+// ResourceQuotas. It is eventually consistent: concurrent admission across
+// members can briefly overshoot before the controller re-clamps — the trade-off
+// OpenShift's reconciler has and closes with its admission plugin.
+func (p *Pool) EnforcedHard(ns string, usedByNS map[string]corev1.ResourceList) corev1.ResourceList {
+	othersUsed := corev1.ResourceList{}
+	for _, member := range p.Members {
+		if member == ns {
+			continue
+		}
+		othersUsed = quota.Add(othersUsed, usedByNS[member])
+	}
+	hard := quota.SubtractWithNonNegativeResult(p.Available, othersUsed)
+	return quota.Mask(hard, quota.ResourceNames(p.Available))
+}
+
+// ScaleResourceList returns rl scaled by percent (e.g. percent=120 grows every
+// quantity by 20%). It is used to apply the temporary upgrade buffer that keeps
+// pre-existing workloads admissible while operators right-size their quotas
+// after this feature is rolled out.
+func ScaleResourceList(rl corev1.ResourceList, percent int64) corev1.ResourceList {
+	if percent == 100 || len(rl) == 0 {
+		return rl.DeepCopy()
+	}
+	out := make(corev1.ResourceList, len(rl))
+	for name, qty := range rl {
+		// MilliValue keeps sub-unit precision (e.g. CPU millicores) intact.
+		milli := qty.MilliValue() * percent / 100
+		out[name] = *resource.NewMilliQuantity(milli, qty.Format)
+	}
+	return out
+}

--- a/internal/controller/tenantquota/pool.go
+++ b/internal/controller/tenantquota/pool.go
@@ -152,10 +152,18 @@ func ComputePools(tenants []Tenant) map[string]*Pool {
 // tenant owns. This should be prevented at admission, but a parent quota that
 // is lowered after children exist can still produce it, so the controller
 // surfaces it.
+//
+// Only resources the budget actually constrains are considered: a child that
+// bounds a resource its parent leaves unbounded is allowed at admission, and an
+// unbounded budget can never be overcommitted, so such resources must not be
+// reported here.
 func (p *Pool) Overcommitted() corev1.ResourceList {
 	over := quota.Subtract(p.CarvedOut, p.Budget)
 	result := corev1.ResourceList{}
 	for name, qty := range over {
+		if _, bounded := p.Budget[name]; !bounded {
+			continue
+		}
 		if qty.Sign() > 0 {
 			result[name] = qty
 		}

--- a/internal/controller/tenantquota/pool.go
+++ b/internal/controller/tenantquota/pool.go
@@ -141,7 +141,12 @@ func ComputePools(tenants []Tenant) map[string]*Pool {
 	}
 
 	for _, p := range pools {
-		p.Available = quota.SubtractWithNonNegativeResult(p.Budget, p.CarvedOut)
+		// Restrict Available to the resources the budget actually bounds. A child
+		// may carve out a resource its parent leaves unbounded (allowed at
+		// admission); without this mask SubtractWithNonNegativeResult would
+		// surface that resource as 0 — clamping the parent pool to zero of a
+		// resource the parent never limited and blocking its workloads.
+		p.Available = quota.Mask(quota.SubtractWithNonNegativeResult(p.Budget, p.CarvedOut), quota.ResourceNames(p.Budget))
 		sort.Strings(p.Members)
 	}
 	return pools

--- a/internal/controller/tenantquota/pool_test.go
+++ b/internal/controller/tenantquota/pool_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tenantquota
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func rl(pairs map[string]string) corev1.ResourceList {
+	if pairs == nil {
+		return nil
+	}
+	out := corev1.ResourceList{}
+	for k, v := range pairs {
+		out[corev1.ResourceName(k)] = resource.MustParse(v)
+	}
+	return out
+}
+
+func quantityEqual(t *testing.T, got corev1.ResourceList, name, want string) {
+	t.Helper()
+	q := got[corev1.ResourceName(name)]
+	w := resource.MustParse(want)
+	if q.Cmp(w) != 0 {
+		t.Fatalf("%s = %s, want %s", name, q.String(), w.String())
+	}
+}
+
+func TestParentNamespace(t *testing.T) {
+	cases := map[string]string{
+		"tenant-root":        "",
+		"tenant-foo":         "tenant-root",
+		"tenant-foo-bar":     "tenant-foo",
+		"tenant-foo-bar-baz": "tenant-foo-bar",
+		"not-a-tenant":       "",
+	}
+	for in, want := range cases {
+		if got := parentNamespace(in); got != want {
+			t.Errorf("parentNamespace(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestComputePools_CarveOut(t *testing.T) {
+	// tenant-foo (cpu 10) with a bounded child bar (cpu 4) and an unbounded
+	// child qux. foo's pool: budget 10, carved 4, available 6, members
+	// {tenant-foo, tenant-foo-qux}. bar's pool: budget 4, available 4,
+	// members {tenant-foo-bar}.
+	pools := ComputePools([]Tenant{
+		{Namespace: "tenant-foo", Declared: rl(map[string]string{"cpu": "10"})},
+		{Namespace: "tenant-foo-bar", Declared: rl(map[string]string{"cpu": "4"})},
+		{Namespace: "tenant-foo-qux", Declared: nil},
+	})
+
+	foo, ok := pools["tenant-foo"]
+	if !ok {
+		t.Fatal("expected a pool rooted at tenant-foo")
+	}
+	quantityEqual(t, foo.Budget, "cpu", "10")
+	quantityEqual(t, foo.CarvedOut, "cpu", "4")
+	quantityEqual(t, foo.Available, "cpu", "6")
+	if len(foo.Members) != 2 || foo.Members[0] != "tenant-foo" || foo.Members[1] != "tenant-foo-qux" {
+		t.Fatalf("foo.Members = %v, want [tenant-foo tenant-foo-qux]", foo.Members)
+	}
+
+	bar, ok := pools["tenant-foo-bar"]
+	if !ok {
+		t.Fatal("expected a pool rooted at tenant-foo-bar")
+	}
+	quantityEqual(t, bar.Available, "cpu", "4")
+	if len(bar.Members) != 1 || bar.Members[0] != "tenant-foo-bar" {
+		t.Fatalf("bar.Members = %v, want [tenant-foo-bar]", bar.Members)
+	}
+}
+
+func TestComputePools_SharedPoolNoChildQuota(t *testing.T) {
+	// foo (cpu 10) with an unbounded child bar => they share the budget of 10.
+	pools := ComputePools([]Tenant{
+		{Namespace: "tenant-foo", Declared: rl(map[string]string{"cpu": "10"})},
+		{Namespace: "tenant-foo-bar", Declared: nil},
+	})
+	foo := pools["tenant-foo"]
+	if foo == nil {
+		t.Fatal("expected pool at tenant-foo")
+	}
+	quantityEqual(t, foo.Available, "cpu", "10")
+	if len(foo.Members) != 2 {
+		t.Fatalf("foo.Members = %v, want both foo and foo-bar", foo.Members)
+	}
+	if _, ok := pools["tenant-foo-bar"]; ok {
+		t.Fatalf("unbounded child must not form its own pool")
+	}
+}
+
+func TestComputePools_NestedUnboundedIntermediary(t *testing.T) {
+	// foo (cpu 10) -> bar (unbounded) -> baz (cpu 4, bounded).
+	// baz forms its own pool and carves 4 out of foo's pool (its nearest
+	// bounded ancestor is foo, through the unbounded bar).
+	pools := ComputePools([]Tenant{
+		{Namespace: "tenant-foo", Declared: rl(map[string]string{"cpu": "10"})},
+		{Namespace: "tenant-foo-bar", Declared: nil},
+		{Namespace: "tenant-foo-bar-baz", Declared: rl(map[string]string{"cpu": "4"})},
+	})
+	foo := pools["tenant-foo"]
+	quantityEqual(t, foo.CarvedOut, "cpu", "4")
+	quantityEqual(t, foo.Available, "cpu", "6")
+	// foo's pool members: foo itself and the unbounded bar (baz is its own pool).
+	if len(foo.Members) != 2 {
+		t.Fatalf("foo.Members = %v, want foo and foo-bar", foo.Members)
+	}
+	baz := pools["tenant-foo-bar-baz"]
+	if baz == nil {
+		t.Fatal("expected pool at tenant-foo-bar-baz")
+	}
+	quantityEqual(t, baz.Available, "cpu", "4")
+}
+
+func TestPoolEnforcedHard(t *testing.T) {
+	pools := ComputePools([]Tenant{
+		{Namespace: "tenant-foo", Declared: rl(map[string]string{"cpu": "10"})},
+		{Namespace: "tenant-foo-bar", Declared: nil},
+	})
+	foo := pools["tenant-foo"]
+	used := map[string]corev1.ResourceList{
+		"tenant-foo":     rl(map[string]string{"cpu": "3"}),
+		"tenant-foo-bar": rl(map[string]string{"cpu": "2"}),
+	}
+	// foo's own namespace may use available(10) - others(bar=2) = 8.
+	gotFoo := foo.EnforcedHard("tenant-foo", used)
+	quantityEqual(t, gotFoo, "cpu", "8")
+	// bar may use 10 - foo's 3 = 7.
+	gotBar := foo.EnforcedHard("tenant-foo-bar", used)
+	quantityEqual(t, gotBar, "cpu", "7")
+}
+
+func TestPoolEnforcedHard_ClampsAtZero(t *testing.T) {
+	pools := ComputePools([]Tenant{
+		{Namespace: "tenant-foo", Declared: rl(map[string]string{"cpu": "10"})},
+		{Namespace: "tenant-foo-bar", Declared: nil},
+	})
+	foo := pools["tenant-foo"]
+	used := map[string]corev1.ResourceList{
+		"tenant-foo-bar": rl(map[string]string{"cpu": "100"}), // overshoot
+	}
+	got := foo.EnforcedHard("tenant-foo", used)
+	quantityEqual(t, got, "cpu", "0")
+}
+
+func TestPoolOvercommitted(t *testing.T) {
+	// foo (cpu 10) with two bounded children summing to 11 => overcommitted by 1.
+	pools := ComputePools([]Tenant{
+		{Namespace: "tenant-foo", Declared: rl(map[string]string{"cpu": "10"})},
+		{Namespace: "tenant-foo-bar", Declared: rl(map[string]string{"cpu": "6"})},
+		{Namespace: "tenant-foo-baz", Declared: rl(map[string]string{"cpu": "5"})},
+	})
+	over := pools["tenant-foo"].Overcommitted()
+	quantityEqual(t, over, "cpu", "1")
+	// A within-budget pool reports nothing.
+	pools2 := ComputePools([]Tenant{
+		{Namespace: "tenant-foo", Declared: rl(map[string]string{"cpu": "10"})},
+		{Namespace: "tenant-foo-bar", Declared: rl(map[string]string{"cpu": "4"})},
+	})
+	if over2 := pools2["tenant-foo"].Overcommitted(); len(over2) != 0 {
+		t.Fatalf("expected no overcommit, got %v", over2)
+	}
+}
+
+func TestScaleResourceList(t *testing.T) {
+	got := ScaleResourceList(rl(map[string]string{"cpu": "10", "memory": "20Gi"}), 120)
+	quantityEqual(t, got, "cpu", "12")
+	quantityEqual(t, got, "memory", "24Gi")
+	// 100% is a no-op copy.
+	same := ScaleResourceList(rl(map[string]string{"cpu": "10"}), 100)
+	quantityEqual(t, same, "cpu", "10")
+}

--- a/internal/controller/tenantquota/pool_test.go
+++ b/internal/controller/tenantquota/pool_test.go
@@ -182,6 +182,20 @@ func TestPoolOvercommitted(t *testing.T) {
 	}
 }
 
+// TestPoolOvercommitted_IgnoresUnboundedResource: a child that bounds a resource
+// its parent leaves unbounded is allowed at admission, so the parent pool must
+// not be reported as overcommitted on that resource (an unbounded budget cannot
+// be overcommitted).
+func TestPoolOvercommitted_IgnoresUnboundedResource(t *testing.T) {
+	pools := ComputePools([]Tenant{
+		{Namespace: "tenant-foo", Declared: rl(map[string]string{"cpu": "10"})},
+		{Namespace: "tenant-foo-bar", Declared: rl(map[string]string{"memory": "8Gi"})},
+	})
+	if over := pools["tenant-foo"].Overcommitted(); len(over) != 0 {
+		t.Fatalf("expected no overcommit for a resource the parent does not bound, got %v", over)
+	}
+}
+
 func TestScaleResourceList(t *testing.T) {
 	got := ScaleResourceList(rl(map[string]string{"cpu": "10", "memory": "20Gi"}), 120)
 	quantityEqual(t, got, "cpu", "12")

--- a/internal/controller/tenantquota/pool_test.go
+++ b/internal/controller/tenantquota/pool_test.go
@@ -132,6 +132,26 @@ func TestComputePools_NestedUnboundedIntermediary(t *testing.T) {
 	quantityEqual(t, baz.Available, "cpu", "4")
 }
 
+// TestComputePools_CarveOutUnboundedResourceDoesNotClamp: a child carving a
+// resource its parent does not bound must not make that resource appear in the
+// parent pool's Available/EnforcedHard — otherwise the parent would be clamped
+// to zero of a resource it never limited.
+func TestComputePools_CarveOutUnboundedResourceDoesNotClamp(t *testing.T) {
+	pools := ComputePools([]Tenant{
+		{Namespace: "tenant-foo", Declared: rl(map[string]string{"cpu": "4"})},
+		{Namespace: "tenant-foo-bar", Declared: rl(map[string]string{"memory": "1Gi"})},
+	})
+	foo := pools["tenant-foo"]
+	if _, ok := foo.Available[corev1.ResourceName("memory")]; ok {
+		t.Fatalf("memory must not appear in Available (parent does not bound it), got %v", foo.Available)
+	}
+	quantityEqual(t, foo.Available, "cpu", "4")
+	hard := foo.EnforcedHard("tenant-foo", nil)
+	if _, ok := hard[corev1.ResourceName("memory")]; ok {
+		t.Fatalf("EnforcedHard must not clamp a resource the parent does not bound, got %v", hard)
+	}
+}
+
 func TestPoolEnforcedHard(t *testing.T) {
 	pools := ComputePools([]Tenant{
 		{Namespace: "tenant-foo", Declared: rl(map[string]string{"cpu": "10"})},

--- a/internal/controller/tenantquota/reconciler.go
+++ b/internal/controller/tenantquota/reconciler.go
@@ -1,0 +1,315 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tenantquota
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	appsv1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
+)
+
+const (
+	// tenantKind gates which Applications participate in hierarchical quotas.
+	tenantKind = "Tenant"
+	// chartQuotaName is the per-namespace ResourceQuota the tenant chart renders
+	// from tenant.spec.resourceQuotas (the tenant's declared budget).
+	chartQuotaName = "tenant-quota"
+	// allocatedQuotaName is the controller-owned ResourceQuota that tightens a
+	// namespace down to its share of the parent pool. Kubernetes enforces the
+	// most restrictive of all ResourceQuotas in a namespace, so this binds
+	// whenever it is below the chart quota, without the controller fighting Flux
+	// over the chart-owned object.
+	allocatedQuotaName = "tenant-quota-allocated"
+	// managedByLabel marks the controller-owned ResourceQuotas so they can be
+	// listed and garbage-collected.
+	managedByLabel = "quota.cozystack.io/managed-by"
+	managedByValue = "tenant-quota-controller"
+	// resyncInterval bounds how stale the shared-pool clamp can get if a usage
+	// update is ever missed.
+	resyncInterval = 60 * time.Second
+)
+
+// sweepKey coalesces every watch event into a single full-tree reconcile, since
+// a quota pool spans many namespaces and any change can affect siblings.
+var sweepKey = reconcile.Request{NamespacedName: types.NamespacedName{Name: "tenantquota-sweep"}}
+
+// Reconciler enforces hierarchical tenant quotas at runtime. It is the
+// reconciliation half of the design adapted from OpenShift's ClusterResourceQuota
+// controllers (see the package doc); the declaration-time gate lives in the
+// aggregated apiserver (pkg/registry/apps/application).
+type Reconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+	// BufferPercent temporarily inflates every pool budget (e.g. 120 = +20%) so
+	// that tenants already over a freshly-introduced quota keep running while
+	// operators right-size. 0 or 100 disables the buffer.
+	BufferPercent int64
+}
+
+func (r *Reconciler) bufferPercent() int64 {
+	if r.BufferPercent <= 0 {
+		return 100
+	}
+	return r.BufferPercent
+}
+
+// Reconcile rebuilds the whole tenant-quota picture: it reads every tenant's
+// declared budget and current usage, computes the pools, and writes one
+// controller-owned ResourceQuota per pool-member namespace clamping it to its
+// fair share of the pool.
+func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	tenants, err := r.snapshotTenants(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	usedByNS, err := r.snapshotUsage(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	existing, err := r.existingNamespaces(ctx)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	pools := ComputePools(tenants)
+
+	desired := map[string]corev1.ResourceList{}
+	for _, p := range pools {
+		buffered := &Pool{
+			Root:      p.Root,
+			Available: ScaleResourceList(p.Available, r.bufferPercent()),
+			Members:   p.Members,
+		}
+		for _, ns := range p.Members {
+			if !existing[ns] {
+				continue
+			}
+			desired[ns] = buffered.EnforcedHard(ns, usedByNS)
+		}
+		if over := p.Overcommitted(); len(over) > 0 {
+			logger.Info("tenant quota pool is overcommitted by sub-tenant carve-outs", "pool", p.Root, "overcommit", over)
+			r.recordOvercommit(ctx, p.Root, over)
+		}
+	}
+
+	for ns, hard := range desired {
+		if err := r.upsertAllocatedQuota(ctx, ns, hard); err != nil {
+			// A transient namespace race must not wedge the whole sweep.
+			logger.Error(err, "failed to apply allocated quota", "namespace", ns)
+		}
+	}
+	if err := r.gcAllocatedQuotas(ctx, desired); err != nil {
+		logger.Error(err, "failed to garbage-collect stale allocated quotas")
+	}
+
+	return ctrl.Result{RequeueAfter: resyncInterval}, nil
+}
+
+// snapshotTenants reads every tenant HelmRelease and projects it to the
+// hierarchy snapshot (owned namespace + declared quota).
+func (r *Reconciler) snapshotTenants(ctx context.Context) ([]Tenant, error) {
+	releases := &helmv2.HelmReleaseList{}
+	if err := r.List(ctx, releases, client.MatchingLabels{appsv1alpha1.ApplicationKindLabel: tenantKind}); err != nil {
+		return nil, err
+	}
+	tenants := make([]Tenant, 0, len(releases.Items))
+	for i := range releases.Items {
+		hr := &releases.Items[i]
+		appName := strings.TrimPrefix(hr.Name, tenantNamespacePrefix)
+		ns := ownedNamespace(hr.Namespace, appName)
+		var declared corev1.ResourceList
+		if hr.Spec.Values != nil {
+			declared = declaredFromValues(hr.Spec.Values.Raw)
+		}
+		tenants = append(tenants, Tenant{Namespace: ns, Declared: declared})
+	}
+	return tenants, nil
+}
+
+// snapshotUsage sums the current usage per namespace. Multiple ResourceQuotas
+// in a namespace each report the same usage for a given resource, so usage is
+// merged with a per-resource max (not a sum) to avoid double counting.
+func (r *Reconciler) snapshotUsage(ctx context.Context) (map[string]corev1.ResourceList, error) {
+	quotas := &corev1.ResourceQuotaList{}
+	if err := r.List(ctx, quotas); err != nil {
+		return nil, err
+	}
+	used := map[string]corev1.ResourceList{}
+	for i := range quotas.Items {
+		rq := &quotas.Items[i]
+		used[rq.Namespace] = maxResourceList(used[rq.Namespace], rq.Status.Used)
+	}
+	return used, nil
+}
+
+func (r *Reconciler) existingNamespaces(ctx context.Context) (map[string]bool, error) {
+	list := &corev1.NamespaceList{}
+	if err := r.List(ctx, list); err != nil {
+		return nil, err
+	}
+	set := make(map[string]bool, len(list.Items))
+	for i := range list.Items {
+		set[list.Items[i].Name] = true
+	}
+	return set, nil
+}
+
+func (r *Reconciler) upsertAllocatedQuota(ctx context.Context, namespace string, hard corev1.ResourceList) error {
+	rq := &corev1.ResourceQuota{ObjectMeta: metav1.ObjectMeta{Name: allocatedQuotaName, Namespace: namespace}}
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, rq, func() error {
+		if rq.Labels == nil {
+			rq.Labels = map[string]string{}
+		}
+		rq.Labels[managedByLabel] = managedByValue
+		rq.Labels["internal.cozystack.io/managed-by-cozystack"] = ""
+		rq.Spec.Hard = hard
+		return nil
+	})
+	return err
+}
+
+// gcAllocatedQuotas deletes controller-owned ResourceQuotas in namespaces that
+// are no longer pool members (e.g. a tenant gained its own quota, or was
+// deleted).
+func (r *Reconciler) gcAllocatedQuotas(ctx context.Context, desired map[string]corev1.ResourceList) error {
+	managed := &corev1.ResourceQuotaList{}
+	if err := r.List(ctx, managed, client.MatchingLabels{managedByLabel: managedByValue}); err != nil {
+		return err
+	}
+	for i := range managed.Items {
+		m := &managed.Items[i]
+		if _, keep := desired[m.Namespace]; keep {
+			continue
+		}
+		if err := r.Delete(ctx, m); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) recordOvercommit(ctx context.Context, rootNamespace string, over corev1.ResourceList) {
+	if r.Recorder == nil {
+		return
+	}
+	ns := &corev1.Namespace{}
+	if err := r.Get(ctx, types.NamespacedName{Name: rootNamespace}, ns); err != nil {
+		return
+	}
+	r.Recorder.Eventf(ns, corev1.EventTypeWarning, "QuotaOvercommitted",
+		"sub-tenant quotas exceed this tenant's budget by %s; lower a sub-tenant quota or raise this tenant's quota", resourceListString(over))
+}
+
+// SetupWithManager wires the controller. Every relevant change (a tenant
+// HelmRelease, a namespace, or a tenant ResourceQuota whose usage moved)
+// coalesces into one full-tree sweep.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	toSweep := handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []reconcile.Request {
+		return []reconcile.Request{sweepKey}
+	})
+	tenantReleases := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetLabels()[appsv1alpha1.ApplicationKindLabel] == tenantKind
+	})
+	tenantQuotas := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetName() == chartQuotaName || o.GetName() == allocatedQuotaName
+	})
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("tenantquota-controller").
+		Watches(&helmv2.HelmRelease{}, toSweep, builder.WithPredicates(tenantReleases)).
+		Watches(&corev1.Namespace{}, toSweep).
+		Watches(&corev1.ResourceQuota{}, toSweep, builder.WithPredicates(tenantQuotas)).
+		Complete(r)
+}
+
+// ownedNamespace maps a tenant HelmRelease (name "<prefix><app>" in namespace
+// hrNamespace) to the namespace that tenant owns. It mirrors
+// REST.computeTenantNamespace in the aggregated apiserver.
+func ownedNamespace(hrNamespace, appName string) string {
+	switch {
+	case hrNamespace == rootTenantNamespace && appName == "root":
+		return rootTenantNamespace
+	case hrNamespace == rootTenantNamespace:
+		return tenantNamespacePrefix + appName
+	default:
+		return hrNamespace + "-" + appName
+	}
+}
+
+// declaredFromValues extracts spec.resourceQuotas from a tenant HelmRelease's
+// values blob. Malformed values yield a nil (unbounded) quota rather than an
+// error, so one bad tenant cannot wedge the controller.
+func declaredFromValues(raw []byte) corev1.ResourceList {
+	if len(raw) == 0 {
+		return nil
+	}
+	var values struct {
+		ResourceQuotas map[string]resource.Quantity `json:"resourceQuotas"`
+	}
+	if err := json.Unmarshal(raw, &values); err != nil || len(values.ResourceQuotas) == 0 {
+		return nil
+	}
+	out := make(corev1.ResourceList, len(values.ResourceQuotas))
+	for k, q := range values.ResourceQuotas {
+		out[corev1.ResourceName(k)] = q
+	}
+	return out
+}
+
+// maxResourceList returns the per-resource maximum of a and b.
+func maxResourceList(a, b corev1.ResourceList) corev1.ResourceList {
+	out := corev1.ResourceList{}
+	for k, v := range a {
+		out[k] = v.DeepCopy()
+	}
+	for k, v := range b {
+		if cur, ok := out[k]; !ok || v.Cmp(cur) > 0 {
+			out[k] = v.DeepCopy()
+		}
+	}
+	return out
+}
+
+func resourceListString(rl corev1.ResourceList) string {
+	parts := make([]string, 0, len(rl))
+	for k, v := range rl {
+		parts = append(parts, string(k)+"="+v.String())
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/controller/tenantquota/reconciler.go
+++ b/internal/controller/tenantquota/reconciler.go
@@ -18,14 +18,12 @@ package tenantquota
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -91,19 +89,12 @@ func (r *Reconciler) bufferPercent() int64 {
 // Reconcile rebuilds the whole tenant-quota picture: it reads every tenant's
 // declared budget and current usage, computes the pools, and writes one
 // controller-owned ResourceQuota per pool-member namespace clamping it to its
-// fair share of the pool.
+// fair share of the pool. Pools that need no tightening beyond the chart-owned
+// quota (a lone tenant with no sub-tenants) are left untouched.
 func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	tenants, err := r.snapshotTenants(ctx)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	usedByNS, err := r.snapshotUsage(ctx)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	existing, err := r.existingNamespaces(ctx)
+	tenants, usedByNS, existing, err := r.snapshot(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -112,20 +103,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 
 	desired := map[string]corev1.ResourceList{}
 	for _, p := range pools {
+		if over := p.Overcommitted(); len(over) > 0 {
+			logger.Info("tenant quota pool is overcommitted by sub-tenant carve-outs", "pool", p.Root, "overcommit", over)
+			r.recordOvercommit(ctx, p.Root, over)
+		}
+		// A pool with no carve-outs and a single member is fully covered by the
+		// chart-rendered tenant-quota already; the controller adds nothing.
+		if len(p.CarvedOut) == 0 && len(p.Members) <= 1 {
+			continue
+		}
 		buffered := &Pool{
 			Root:      p.Root,
 			Available: ScaleResourceList(p.Available, r.bufferPercent()),
 			Members:   p.Members,
 		}
 		for _, ns := range p.Members {
-			if !existing[ns] {
-				continue
+			if existing[ns] {
+				desired[ns] = buffered.EnforcedHard(ns, usedByNS)
 			}
-			desired[ns] = buffered.EnforcedHard(ns, usedByNS)
-		}
-		if over := p.Overcommitted(); len(over) > 0 {
-			logger.Info("tenant quota pool is overcommitted by sub-tenant carve-outs", "pool", p.Root, "overcommit", over)
-			r.recordOvercommit(ctx, p.Root, over)
 		}
 	}
 
@@ -142,53 +137,57 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result
 	return ctrl.Result{RequeueAfter: resyncInterval}, nil
 }
 
-// snapshotTenants reads every tenant HelmRelease and projects it to the
-// hierarchy snapshot (owned namespace + declared quota).
-func (r *Reconciler) snapshotTenants(ctx context.Context) ([]Tenant, error) {
+// snapshot reads the whole picture in one pass: the tenant namespaces (from
+// tenant HelmReleases), each tenant's declared budget, current usage per
+// namespace, and the set of existing namespaces.
+//
+// A tenant's declared budget is taken from its chart-rendered "tenant-quota"
+// ResourceQuota (`.spec.hard`), not from the raw tenant.spec.resourceQuotas
+// values. The chart expands the shorthand values into the real quota resource
+// names and applies the cluster's request/limit allocation ratios
+// (cozy-lib.resources.flatten); reading the rendered object keeps the
+// controller's allocated quota in exactly the same key space, so the two
+// quotas compose correctly and the controller never has to replicate that
+// (cluster-configurable) transformation.
+func (r *Reconciler) snapshot(ctx context.Context) (tenants []Tenant, usedByNS map[string]corev1.ResourceList, existing map[string]bool, err error) {
 	releases := &helmv2.HelmReleaseList{}
-	if err := r.List(ctx, releases, client.MatchingLabels{appsv1alpha1.ApplicationKindLabel: tenantKind}); err != nil {
-		return nil, err
+	if err = r.List(ctx, releases, client.MatchingLabels{appsv1alpha1.ApplicationKindLabel: tenantKind}); err != nil {
+		return nil, nil, nil, err
 	}
-	tenants := make([]Tenant, 0, len(releases.Items))
-	for i := range releases.Items {
-		hr := &releases.Items[i]
-		appName := strings.TrimPrefix(hr.Name, tenantNamespacePrefix)
-		ns := ownedNamespace(hr.Namespace, appName)
-		var declared corev1.ResourceList
-		if hr.Spec.Values != nil {
-			declared = declaredFromValues(hr.Spec.Values.Raw)
-		}
-		tenants = append(tenants, Tenant{Namespace: ns, Declared: declared})
-	}
-	return tenants, nil
-}
 
-// snapshotUsage sums the current usage per namespace. Multiple ResourceQuotas
-// in a namespace each report the same usage for a given resource, so usage is
-// merged with a per-resource max (not a sum) to avoid double counting.
-func (r *Reconciler) snapshotUsage(ctx context.Context) (map[string]corev1.ResourceList, error) {
 	quotas := &corev1.ResourceQuotaList{}
-	if err := r.List(ctx, quotas); err != nil {
-		return nil, err
+	if err = r.List(ctx, quotas); err != nil {
+		return nil, nil, nil, err
 	}
-	used := map[string]corev1.ResourceList{}
+	declaredByNS := map[string]corev1.ResourceList{}
+	usedByNS = map[string]corev1.ResourceList{}
 	for i := range quotas.Items {
 		rq := &quotas.Items[i]
-		used[rq.Namespace] = maxResourceList(used[rq.Namespace], rq.Status.Used)
+		// Multiple ResourceQuotas in a namespace each report the same usage for
+		// a given resource, so usage is merged with a per-resource max (not a
+		// sum) to avoid double counting.
+		usedByNS[rq.Namespace] = maxResourceList(usedByNS[rq.Namespace], rq.Status.Used)
+		if rq.Name == chartQuotaName {
+			declaredByNS[rq.Namespace] = rq.Spec.Hard
+		}
 	}
-	return used, nil
-}
 
-func (r *Reconciler) existingNamespaces(ctx context.Context) (map[string]bool, error) {
-	list := &corev1.NamespaceList{}
-	if err := r.List(ctx, list); err != nil {
-		return nil, err
+	nsList := &corev1.NamespaceList{}
+	if err = r.List(ctx, nsList); err != nil {
+		return nil, nil, nil, err
 	}
-	set := make(map[string]bool, len(list.Items))
-	for i := range list.Items {
-		set[list.Items[i].Name] = true
+	existing = make(map[string]bool, len(nsList.Items))
+	for i := range nsList.Items {
+		existing[nsList.Items[i].Name] = true
 	}
-	return set, nil
+
+	tenants = make([]Tenant, 0, len(releases.Items))
+	for i := range releases.Items {
+		hr := &releases.Items[i]
+		ns := ownedNamespace(hr.Namespace, strings.TrimPrefix(hr.Name, tenantNamespacePrefix))
+		tenants = append(tenants, Tenant{Namespace: ns, Declared: declaredByNS[ns]})
+	}
+	return tenants, usedByNS, existing, nil
 }
 
 func (r *Reconciler) upsertAllocatedQuota(ctx context.Context, namespace string, hard corev1.ResourceList) error {
@@ -270,26 +269,6 @@ func ownedNamespace(hrNamespace, appName string) string {
 	default:
 		return hrNamespace + "-" + appName
 	}
-}
-
-// declaredFromValues extracts spec.resourceQuotas from a tenant HelmRelease's
-// values blob. Malformed values yield a nil (unbounded) quota rather than an
-// error, so one bad tenant cannot wedge the controller.
-func declaredFromValues(raw []byte) corev1.ResourceList {
-	if len(raw) == 0 {
-		return nil
-	}
-	var values struct {
-		ResourceQuotas map[string]resource.Quantity `json:"resourceQuotas"`
-	}
-	if err := json.Unmarshal(raw, &values); err != nil || len(values.ResourceQuotas) == 0 {
-		return nil
-	}
-	out := make(corev1.ResourceList, len(values.ResourceQuotas))
-	for k, q := range values.ResourceQuotas {
-		out[corev1.ResourceName(k)] = q
-	}
-	return out
 }
 
 // maxResourceList returns the per-resource maximum of a and b.

--- a/internal/controller/tenantquota/reconciler_test.go
+++ b/internal/controller/tenantquota/reconciler_test.go
@@ -18,12 +18,10 @@ package tenantquota
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	corev1 "k8s.io/api/core/v1"
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,23 +32,17 @@ import (
 	appsv1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
 )
 
-func tenantHR(t *testing.T, appName, namespace string, quotas map[string]string) *helmv2.HelmRelease {
-	t.Helper()
-	values := map[string]any{}
-	if len(quotas) > 0 {
-		values["resourceQuotas"] = quotas
-	}
-	raw, err := json.Marshal(values)
-	if err != nil {
-		t.Fatalf("marshal values: %v", err)
-	}
+// tenantHR builds a tenant HelmRelease named "<prefix><app>" in namespace,
+// carrying the kind label the controller selects on. Its values are irrelevant
+// to the controller (the declared budget is read from the chart-rendered
+// ResourceQuota, not the values), so they are omitted.
+func tenantHR(appName, namespace string) *helmv2.HelmRelease {
 	return &helmv2.HelmRelease{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tenantNamespacePrefix + appName,
 			Namespace: namespace,
 			Labels:    map[string]string{appsv1alpha1.ApplicationKindLabel: tenantKind},
 		},
-		Spec: helmv2.HelmReleaseSpec{Values: &apiextv1.JSON{Raw: raw}},
 	}
 }
 
@@ -58,14 +50,34 @@ func ns(name string) *corev1.Namespace {
 	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
 }
 
-func chartQuota(namespace string, used map[string]string) *corev1.ResourceQuota {
-	usedList := corev1.ResourceList{}
-	for k, v := range used {
-		usedList[corev1.ResourceName(k)] = resource.MustParse(v)
+func resourceList(pairs map[string]string) corev1.ResourceList {
+	if pairs == nil {
+		return nil
 	}
+	out := corev1.ResourceList{}
+	for k, v := range pairs {
+		out[corev1.ResourceName(k)] = resource.MustParse(v)
+	}
+	return out
+}
+
+// chartQuota builds the chart-rendered "tenant-quota" ResourceQuota for a
+// bounded tenant: spec.hard is the declared budget, status.used the current
+// usage.
+func chartQuota(namespace string, hard, used map[string]string) *corev1.ResourceQuota {
 	return &corev1.ResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{Name: chartQuotaName, Namespace: namespace},
-		Status:     corev1.ResourceQuotaStatus{Used: usedList},
+		Spec:       corev1.ResourceQuotaSpec{Hard: resourceList(hard)},
+		Status:     corev1.ResourceQuotaStatus{Used: resourceList(used)},
+	}
+}
+
+// usageQuota seeds an arbitrary ResourceQuota that only reports usage, used to
+// give an unbounded (no chart-quota) member some current usage.
+func usageQuota(namespace, name string, used map[string]string) *corev1.ResourceQuota {
+	return &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Status:     corev1.ResourceQuotaStatus{Used: resourceList(used)},
 	}
 }
 
@@ -85,8 +97,7 @@ func newReconciler(t *testing.T, objs ...client.Object) (*Reconciler, client.Cli
 func allocatedHard(t *testing.T, c client.Client, namespace, resourceName string) (string, bool) {
 	t.Helper()
 	rq := &corev1.ResourceQuota{}
-	err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: allocatedQuotaName}, rq)
-	if err != nil {
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: allocatedQuotaName}, rq); err != nil {
 		return "", false
 	}
 	q, ok := rq.Spec.Hard[corev1.ResourceName(resourceName)]
@@ -96,14 +107,30 @@ func allocatedHard(t *testing.T, c client.Client, namespace, resourceName string
 	return q.String(), true
 }
 
-// TestReconcile_SharedPool: foo (cpu 10) with an unbounded child bar. With no
-// usage, both namespaces are clamped to the full shared budget of 10.
+// TestReconcile_LoneTenantIsNoOp: a tenant with a quota but no sub-tenants is
+// already fully enforced by its chart quota, so the controller writes nothing.
+func TestReconcile_LoneTenantIsNoOp(t *testing.T) {
+	r, c := newReconciler(t,
+		tenantHR("foo", "tenant-root"),
+		ns("tenant-foo"),
+		chartQuota("tenant-foo", map[string]string{"cpu": "10"}, nil),
+	)
+	if _, err := r.Reconcile(context.Background(), sweepKey); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if _, ok := allocatedHard(t, c, "tenant-foo", "cpu"); ok {
+		t.Fatalf("lone tenant must not get a controller-owned allocated quota")
+	}
+}
+
+// TestReconcile_SharedPool: foo (cpu 10) with an unbounded child bar. They share
+// the budget, so both members get an allocated quota clamping them to it.
 func TestReconcile_SharedPool(t *testing.T) {
 	r, c := newReconciler(t,
-		tenantHR(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
-		tenantHR(t, "bar", "tenant-foo", nil),
+		tenantHR("foo", "tenant-root"),
+		tenantHR("bar", "tenant-foo"),
 		ns("tenant-foo"), ns("tenant-foo-bar"),
-		chartQuota("tenant-foo", nil),
+		chartQuota("tenant-foo", map[string]string{"cpu": "10"}, nil),
 	)
 	if _, err := r.Reconcile(context.Background(), sweepKey); err != nil {
 		t.Fatalf("reconcile: %v", err)
@@ -120,63 +147,64 @@ func TestReconcile_SharedPool(t *testing.T) {
 // member's clamp so their sum stays within the pool budget.
 func TestReconcile_SharedPoolWithUsage(t *testing.T) {
 	r, c := newReconciler(t,
-		tenantHR(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
-		tenantHR(t, "bar", "tenant-foo", nil),
+		tenantHR("foo", "tenant-root"),
+		tenantHR("bar", "tenant-foo"),
 		ns("tenant-foo"), ns("tenant-foo-bar"),
-		chartQuota("tenant-foo", map[string]string{"cpu": "4"}),     // foo using 4
-		chartQuota("tenant-foo-bar", map[string]string{"cpu": "3"}), // bar using 3
+		chartQuota("tenant-foo", map[string]string{"cpu": "10"}, map[string]string{"cpu": "4"}),
+		usageQuota("tenant-foo-bar", "some-quota", map[string]string{"cpu": "3"}),
 	)
 	if _, err := r.Reconcile(context.Background(), sweepKey); err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
-	// foo clamp = 10 - bar's 3 = 7; bar clamp = 10 - foo's 4 = 6.
-	if got, _ := allocatedHard(t, c, "tenant-foo", "cpu"); got != "7" {
+	if got, _ := allocatedHard(t, c, "tenant-foo", "cpu"); got != "7" { // 10 - bar's 3
 		t.Fatalf("tenant-foo allocated cpu = %q, want 7", got)
 	}
-	if got, _ := allocatedHard(t, c, "tenant-foo-bar", "cpu"); got != "6" {
+	if got, _ := allocatedHard(t, c, "tenant-foo-bar", "cpu"); got != "6" { // 10 - foo's 4
 		t.Fatalf("tenant-foo-bar allocated cpu = %q, want 6", got)
 	}
 }
 
 // TestReconcile_CarveOut: foo (cpu 10) with a bounded child bar (cpu 4). foo's
-// own namespace is clamped to the residual 6; bar forms its own pool of 4.
+// own namespace is clamped to the residual 6; bar is a lone pool already
+// enforced by its own chart quota, so it gets nothing extra.
 func TestReconcile_CarveOut(t *testing.T) {
 	r, c := newReconciler(t,
-		tenantHR(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
-		tenantHR(t, "bar", "tenant-foo", map[string]string{"cpu": "4"}),
+		tenantHR("foo", "tenant-root"),
+		tenantHR("bar", "tenant-foo"),
 		ns("tenant-foo"), ns("tenant-foo-bar"),
-		chartQuota("tenant-foo", nil), chartQuota("tenant-foo-bar", nil),
+		chartQuota("tenant-foo", map[string]string{"cpu": "10"}, nil),
+		chartQuota("tenant-foo-bar", map[string]string{"cpu": "4"}, nil),
 	)
 	if _, err := r.Reconcile(context.Background(), sweepKey); err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
-	if got, _ := allocatedHard(t, c, "tenant-foo", "cpu"); got != "6" {
-		t.Fatalf("tenant-foo allocated cpu = %q, want 6 (10 - 4 carve-out)", got)
+	if got, _ := allocatedHard(t, c, "tenant-foo", "cpu"); got != "6" { // 10 - 4 carve-out
+		t.Fatalf("tenant-foo allocated cpu = %q, want 6", got)
 	}
-	if got, _ := allocatedHard(t, c, "tenant-foo-bar", "cpu"); got != "4" {
-		t.Fatalf("tenant-foo-bar allocated cpu = %q, want 4", got)
+	if _, ok := allocatedHard(t, c, "tenant-foo-bar", "cpu"); ok {
+		t.Fatalf("bounded lone child tenant-foo-bar must not get an allocated quota")
 	}
 }
 
-// TestReconcile_Buffer: a 120% upgrade buffer inflates the enforced clamp.
+// TestReconcile_Buffer: the upgrade buffer inflates the enforced clamp.
 func TestReconcile_Buffer(t *testing.T) {
 	r, c := newReconciler(t,
-		tenantHR(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
-		ns("tenant-foo"),
-		chartQuota("tenant-foo", nil),
+		tenantHR("foo", "tenant-root"),
+		tenantHR("bar", "tenant-foo"),
+		ns("tenant-foo"), ns("tenant-foo-bar"),
+		chartQuota("tenant-foo", map[string]string{"cpu": "10"}, nil),
 	)
 	r.BufferPercent = 120
 	if _, err := r.Reconcile(context.Background(), sweepKey); err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
-	if got, _ := allocatedHard(t, c, "tenant-foo", "cpu"); got != "12" {
-		t.Fatalf("tenant-foo allocated cpu = %q, want 12 (10 * 120%%)", got)
+	if got, _ := allocatedHard(t, c, "tenant-foo", "cpu"); got != "12" { // 10 * 120%
+		t.Fatalf("tenant-foo allocated cpu = %q, want 12", got)
 	}
 }
 
-// TestReconcile_GarbageCollect: once a tenant gains its own quota it leaves the
-// parent pool, and a previously-written allocated quota in an unrelated
-// namespace is removed.
+// TestReconcile_GarbageCollect: a stale allocated quota in a namespace that is
+// no longer enforced is removed.
 func TestReconcile_GarbageCollect(t *testing.T) {
 	stale := &corev1.ResourceQuota{
 		ObjectMeta: metav1.ObjectMeta{
@@ -186,17 +214,16 @@ func TestReconcile_GarbageCollect(t *testing.T) {
 		},
 	}
 	r, c := newReconciler(t,
-		tenantHR(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
+		tenantHR("foo", "tenant-root"),
 		ns("tenant-foo"), ns("tenant-gone"),
-		chartQuota("tenant-foo", nil),
+		chartQuota("tenant-foo", map[string]string{"cpu": "10"}, nil),
 		stale,
 	)
 	if _, err := r.Reconcile(context.Background(), sweepKey); err != nil {
 		t.Fatalf("reconcile: %v", err)
 	}
 	rq := &corev1.ResourceQuota{}
-	err := c.Get(context.Background(), types.NamespacedName{Namespace: "tenant-gone", Name: allocatedQuotaName}, rq)
-	if err == nil {
+	if err := c.Get(context.Background(), types.NamespacedName{Namespace: "tenant-gone", Name: allocatedQuotaName}, rq); err == nil {
 		t.Fatalf("stale allocated quota in tenant-gone should have been garbage-collected")
 	}
 }

--- a/internal/controller/tenantquota/reconciler_test.go
+++ b/internal/controller/tenantquota/reconciler_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tenantquota
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	corev1 "k8s.io/api/core/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
+)
+
+func tenantHR(t *testing.T, appName, namespace string, quotas map[string]string) *helmv2.HelmRelease {
+	t.Helper()
+	values := map[string]any{}
+	if len(quotas) > 0 {
+		values["resourceQuotas"] = quotas
+	}
+	raw, err := json.Marshal(values)
+	if err != nil {
+		t.Fatalf("marshal values: %v", err)
+	}
+	return &helmv2.HelmRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tenantNamespacePrefix + appName,
+			Namespace: namespace,
+			Labels:    map[string]string{appsv1alpha1.ApplicationKindLabel: tenantKind},
+		},
+		Spec: helmv2.HelmReleaseSpec{Values: &apiextv1.JSON{Raw: raw}},
+	}
+}
+
+func ns(name string) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+func chartQuota(namespace string, used map[string]string) *corev1.ResourceQuota {
+	usedList := corev1.ResourceList{}
+	for k, v := range used {
+		usedList[corev1.ResourceName(k)] = resource.MustParse(v)
+	}
+	return &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: chartQuotaName, Namespace: namespace},
+		Status:     corev1.ResourceQuotaStatus{Used: usedList},
+	}
+}
+
+func newReconciler(t *testing.T, objs ...client.Object) (*Reconciler, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("corev1 scheme: %v", err)
+	}
+	if err := helmv2.AddToScheme(scheme); err != nil {
+		t.Fatalf("helmv2 scheme: %v", err)
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &Reconciler{Client: c, Scheme: scheme}, c
+}
+
+func allocatedHard(t *testing.T, c client.Client, namespace, resourceName string) (string, bool) {
+	t.Helper()
+	rq := &corev1.ResourceQuota{}
+	err := c.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: allocatedQuotaName}, rq)
+	if err != nil {
+		return "", false
+	}
+	q, ok := rq.Spec.Hard[corev1.ResourceName(resourceName)]
+	if !ok {
+		return "", false
+	}
+	return q.String(), true
+}
+
+// TestReconcile_SharedPool: foo (cpu 10) with an unbounded child bar. With no
+// usage, both namespaces are clamped to the full shared budget of 10.
+func TestReconcile_SharedPool(t *testing.T) {
+	r, c := newReconciler(t,
+		tenantHR(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
+		tenantHR(t, "bar", "tenant-foo", nil),
+		ns("tenant-foo"), ns("tenant-foo-bar"),
+		chartQuota("tenant-foo", nil),
+	)
+	if _, err := r.Reconcile(context.Background(), sweepKey); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got, ok := allocatedHard(t, c, "tenant-foo", "cpu"); !ok || got != "10" {
+		t.Fatalf("tenant-foo allocated cpu = %q (ok=%v), want 10", got, ok)
+	}
+	if got, ok := allocatedHard(t, c, "tenant-foo-bar", "cpu"); !ok || got != "10" {
+		t.Fatalf("tenant-foo-bar allocated cpu = %q (ok=%v), want 10", got, ok)
+	}
+}
+
+// TestReconcile_SharedPoolWithUsage: usage in one member shrinks the other
+// member's clamp so their sum stays within the pool budget.
+func TestReconcile_SharedPoolWithUsage(t *testing.T) {
+	r, c := newReconciler(t,
+		tenantHR(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
+		tenantHR(t, "bar", "tenant-foo", nil),
+		ns("tenant-foo"), ns("tenant-foo-bar"),
+		chartQuota("tenant-foo", map[string]string{"cpu": "4"}),     // foo using 4
+		chartQuota("tenant-foo-bar", map[string]string{"cpu": "3"}), // bar using 3
+	)
+	if _, err := r.Reconcile(context.Background(), sweepKey); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	// foo clamp = 10 - bar's 3 = 7; bar clamp = 10 - foo's 4 = 6.
+	if got, _ := allocatedHard(t, c, "tenant-foo", "cpu"); got != "7" {
+		t.Fatalf("tenant-foo allocated cpu = %q, want 7", got)
+	}
+	if got, _ := allocatedHard(t, c, "tenant-foo-bar", "cpu"); got != "6" {
+		t.Fatalf("tenant-foo-bar allocated cpu = %q, want 6", got)
+	}
+}
+
+// TestReconcile_CarveOut: foo (cpu 10) with a bounded child bar (cpu 4). foo's
+// own namespace is clamped to the residual 6; bar forms its own pool of 4.
+func TestReconcile_CarveOut(t *testing.T) {
+	r, c := newReconciler(t,
+		tenantHR(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
+		tenantHR(t, "bar", "tenant-foo", map[string]string{"cpu": "4"}),
+		ns("tenant-foo"), ns("tenant-foo-bar"),
+		chartQuota("tenant-foo", nil), chartQuota("tenant-foo-bar", nil),
+	)
+	if _, err := r.Reconcile(context.Background(), sweepKey); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got, _ := allocatedHard(t, c, "tenant-foo", "cpu"); got != "6" {
+		t.Fatalf("tenant-foo allocated cpu = %q, want 6 (10 - 4 carve-out)", got)
+	}
+	if got, _ := allocatedHard(t, c, "tenant-foo-bar", "cpu"); got != "4" {
+		t.Fatalf("tenant-foo-bar allocated cpu = %q, want 4", got)
+	}
+}
+
+// TestReconcile_Buffer: a 120% upgrade buffer inflates the enforced clamp.
+func TestReconcile_Buffer(t *testing.T) {
+	r, c := newReconciler(t,
+		tenantHR(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
+		ns("tenant-foo"),
+		chartQuota("tenant-foo", nil),
+	)
+	r.BufferPercent = 120
+	if _, err := r.Reconcile(context.Background(), sweepKey); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if got, _ := allocatedHard(t, c, "tenant-foo", "cpu"); got != "12" {
+		t.Fatalf("tenant-foo allocated cpu = %q, want 12 (10 * 120%%)", got)
+	}
+}
+
+// TestReconcile_GarbageCollect: once a tenant gains its own quota it leaves the
+// parent pool, and a previously-written allocated quota in an unrelated
+// namespace is removed.
+func TestReconcile_GarbageCollect(t *testing.T) {
+	stale := &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      allocatedQuotaName,
+			Namespace: "tenant-gone",
+			Labels:    map[string]string{managedByLabel: managedByValue},
+		},
+	}
+	r, c := newReconciler(t,
+		tenantHR(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
+		ns("tenant-foo"), ns("tenant-gone"),
+		chartQuota("tenant-foo", nil),
+		stale,
+	)
+	if _, err := r.Reconcile(context.Background(), sweepKey); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	rq := &corev1.ResourceQuota{}
+	err := c.Get(context.Background(), types.NamespacedName{Namespace: "tenant-gone", Name: allocatedQuotaName}, rq)
+	if err == nil {
+		t.Fatalf("stale allocated quota in tenant-gone should have been garbage-collected")
+	}
+}

--- a/packages/system/cozystack-api/templates/rbac.yaml
+++ b/packages/system/cozystack-api/templates/rbac.yaml
@@ -6,6 +6,12 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces", "secrets", "services"]
   verbs: ["get", "watch", "list"]
+# Hierarchical tenant quota admission reads the rendered ResourceQuota usage of
+# a parent tenant's pool to carve a child's allocation out of what is actually
+# left (see pkg/registry/apps/application/quota.go).
+- apiGroups: [""]
+  resources: ["resourcequotas"]
+  verbs: ["get", "watch", "list"]
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["rolebindings"]
   verbs: ["get", "watch", "list"]

--- a/packages/system/cozystack-controller/templates/rbac.yaml
+++ b/packages/system/cozystack-controller/templates/rbac.yaml
@@ -35,6 +35,15 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "list", "watch", "patch", "update"]
+# TenantQuotaReconciler manages the per-namespace "tenant-quota-allocated"
+# ResourceQuota that enforces each tenant's share of its parent pool, and emits
+# events on the tenant namespace when sub-tenant quotas overcommit the budget.
+- apiGroups: [""]
+  resources: ["resourcequotas"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
 - apiGroups: ['*']
   resources: ['*']
   verbs: ["get", "list", "watch"]

--- a/pkg/registry/apps/application/quota.go
+++ b/pkg/registry/apps/application/quota.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appsv1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
+	"github.com/cozystack/cozystack/pkg/apis/apps/validation"
+)
+
+// rootTenantNamespace is the namespace of the cluster's root tenant. The root
+// tenant is special-cased throughout the tenant hierarchy: it is its own parent
+// and its HelmRelease lives in its own namespace.
+const rootTenantNamespace = "tenant-root"
+
+// resourceQuotasField is the tenant values key holding the declared quota, kept
+// in sync with packages/apps/tenant/values.yaml (`resourceQuotas`).
+const resourceQuotasField = "resourceQuotas"
+
+// tenantValues is the minimal projection of a tenant's Helm values needed to
+// reason about hierarchical quotas. Only resourceQuotas is decoded; everything
+// else in the values blob is ignored.
+type tenantValues struct {
+	ResourceQuotas map[string]resource.Quantity `json:"resourceQuotas"`
+}
+
+// parseDeclaredQuotas extracts spec.resourceQuotas from a tenant values JSON
+// blob. The quota keys are kept verbatim as the operator writes them (e.g.
+// "cpu", "memory", "requests.storage", "count/services") — the same vocabulary
+// the parent and every child use — so they can be compared directly. The
+// `cozy-lib.resources.flatten` expansion into limits.*/requests.* is a
+// downstream rendering concern of the tenant chart and is intentionally not
+// applied here.
+func parseDeclaredQuotas(raw []byte) (map[string]resource.Quantity, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var values tenantValues
+	if err := json.Unmarshal(raw, &values); err != nil {
+		return nil, fmt.Errorf("decode tenant values: %w", err)
+	}
+	return values.ResourceQuotas, nil
+}
+
+// declaredQuotasFromHelmRelease reads resourceQuotas from a tenant HelmRelease's
+// values. A tenant Application is stored as a HelmRelease whose Spec.Values is
+// the verbatim Application spec (see ConvertApplicationToHelmRelease).
+func declaredQuotasFromHelmRelease(hr *helmv2.HelmRelease) (map[string]resource.Quantity, error) {
+	if hr.Spec.Values == nil {
+		return nil, nil
+	}
+	return parseDeclaredQuotas(hr.Spec.Values.Raw)
+}
+
+// parentTenantHelmReleaseRef maps the namespace owned by a tenant to the
+// name/namespace of that tenant's own HelmRelease. It is the inverse of
+// REST.computeTenantNamespace: a tenant created as Application "<name>" in
+// namespace C owns the workload namespace computeTenantNamespace(C, name), so
+// given the owned namespace we recover (release name, release namespace).
+//
+// Examples (prefix "tenant-"):
+//
+//	"tenant-root"        -> ("tenant-root", "tenant-root")  // root is its own parent
+//	"tenant-foo"         -> ("tenant-foo",  "tenant-root")  // foo lives in root
+//	"tenant-foo-bar"     -> ("tenant-bar",  "tenant-foo")   // bar lives in foo
+//	"tenant-foo-bar-baz" -> ("tenant-baz",  "tenant-foo-bar")
+func parentTenantHelmReleaseRef(ownedNamespace, prefix string) (name, namespace string, ok bool) {
+	if ownedNamespace == rootTenantNamespace {
+		return prefix + "root", rootTenantNamespace, true
+	}
+	if !strings.HasPrefix(ownedNamespace, prefix) {
+		return "", "", false
+	}
+	segments := strings.Split(ownedNamespace, "-")
+	last := segments[len(segments)-1]
+	// Exactly "tenant-<name>" (two segments) is a direct child of root, so its
+	// HelmRelease lives in the root namespace. Deeper names live in the
+	// namespace formed by stripping the trailing "-<name>".
+	if len(segments) == 2 {
+		return prefix + last, rootTenantNamespace, true
+	}
+	return prefix + last, strings.Join(segments[:len(segments)-1], "-"), true
+}
+
+// parentTenantDeclaredQuotas returns the declared resourceQuotas of the tenant
+// that owns childNamespace (the namespace a child Tenant CR is created in). An
+// empty result means the parent declares no quota and therefore does not
+// directly constrain the child at declaration time.
+func (r *REST) parentTenantDeclaredQuotas(ctx context.Context, childNamespace string) (map[string]resource.Quantity, error) {
+	hrName, hrNamespace, ok := parentTenantHelmReleaseRef(childNamespace, r.releaseConfig.Prefix)
+	if !ok {
+		return nil, nil
+	}
+	hr := &helmv2.HelmRelease{}
+	if err := r.c.Get(ctx, client.ObjectKey{Namespace: hrNamespace, Name: hrName}, hr); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return declaredQuotasFromHelmRelease(hr)
+}
+
+// siblingDeclaredQuotas sums, per resource, the declared quotas of every tenant
+// in namespace that already carved a slice out of the shared parent budget,
+// excluding the tenant named excludeName (so updates do not count against
+// themselves). These are the direct children of the same parent.
+func (r *REST) siblingDeclaredQuotas(ctx context.Context, namespace, excludeName string) (map[string]resource.Quantity, error) {
+	list := &helmv2.HelmReleaseList{}
+	selector := labels.SelectorFromSet(labels.Set{
+		ApplicationKindLabel:  r.kindName,
+		ApplicationGroupLabel: r.gvk.Group,
+	})
+	if err := r.c.List(ctx, list, &client.ListOptions{Namespace: namespace, LabelSelector: selector}); err != nil {
+		return nil, err
+	}
+
+	sum := map[string]resource.Quantity{}
+	for i := range list.Items {
+		hr := &list.Items[i]
+		name := strings.TrimPrefix(hr.Name, r.releaseConfig.Prefix)
+		if name == excludeName {
+			continue
+		}
+		quotas, err := declaredQuotasFromHelmRelease(hr)
+		if err != nil {
+			// A malformed sibling must not block an unrelated tenant write; skip
+			// it (the controller surfaces such tenants separately).
+			klog.Warningf("skipping sibling tenant %s/%s with unparseable quotas: %v", hr.Namespace, hr.Name, err)
+			continue
+		}
+		addQuotas(sum, quotas)
+	}
+	return sum, nil
+}
+
+// validateTenantResourceQuotas enforces hierarchical quota allocation for Tenant
+// Applications at declaration time. A child tenant's declared quota is "carved
+// out" of its parent's remaining quota and may not exceed it: for every resource
+// the parent bounds,
+//
+//	child[r] <= parent[r] - sum(other children already carved out)[r]
+//
+// A child that declares no quota of its own is always allowed here — it shares
+// the parent's pool rather than reserving a fixed slice (runtime enforcement of
+// that shared pool is the tenant quota controller's job). A parent that declares
+// no quota does not constrain its children at this layer.
+//
+// This is the deterministic, declaration-time gate against quota escalation
+// ("a tenant must not, via quota, claim more space than it was allocated"). It
+// runs inside the aggregated apiserver where Tenant writes are served, with full
+// client access to the parent and sibling HelmReleases.
+func (r *REST) validateTenantResourceQuotas(ctx context.Context, app *appsv1alpha1.Application) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if r.kindName != validation.TenantKind {
+		return allErrs
+	}
+	fldPath := field.NewPath("spec").Child(resourceQuotasField)
+
+	var raw []byte
+	if app.Spec != nil {
+		raw = app.Spec.Raw
+	}
+	childQuota, err := parseDeclaredQuotas(raw)
+	if err != nil {
+		return append(allErrs, field.Invalid(fldPath, "", err.Error()))
+	}
+	if len(childQuota) == 0 {
+		// Unbounded child: shares the parent pool, allowed at declaration time.
+		return allErrs
+	}
+
+	parentQuota, err := r.parentTenantDeclaredQuotas(ctx, app.Namespace)
+	if err != nil {
+		return append(allErrs, field.InternalError(fldPath, err))
+	}
+	if len(parentQuota) == 0 {
+		// Parent declares no quota: it does not directly constrain the child.
+		return allErrs
+	}
+
+	siblings, err := r.siblingDeclaredQuotas(ctx, app.Namespace, app.Name)
+	if err != nil {
+		return append(allErrs, field.InternalError(fldPath, err))
+	}
+
+	for _, res := range sortedQuotaKeys(parentQuota) {
+		want, requested := childQuota[res]
+		if !requested {
+			continue
+		}
+		parentLimit := parentQuota[res]
+		allocated := siblings[res] // zero value when no sibling bounds this resource
+		remaining := parentLimit.DeepCopy()
+		remaining.Sub(allocated)
+		if want.Cmp(remaining) > 0 {
+			allErrs = append(allErrs, field.Forbidden(fldPath.Key(res),
+				fmt.Sprintf("requested %s exceeds the parent tenant's remaining %q quota of %s (parent allows %s, %s already allocated to sibling tenants); a child tenant may not be granted more quota than its parent has left",
+					want.String(), res, remaining.String(), parentLimit.String(), allocated.String())))
+		}
+	}
+	return allErrs
+}
+
+// addQuotas adds src into dst in place, per resource key.
+func addQuotas(dst, src map[string]resource.Quantity) {
+	for k, v := range src {
+		if cur, ok := dst[k]; ok {
+			cur.Add(v)
+			dst[k] = cur
+		} else {
+			dst[k] = v.DeepCopy()
+		}
+	}
+}
+
+// sortedQuotaKeys returns the resource keys of a quota map in a deterministic
+// order so that admission error messages are stable.
+func sortedQuotaKeys(q map[string]resource.Quantity) []string {
+	keys := make([]string, 0, len(q))
+	for k := range q {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/registry/apps/application/quota.go
+++ b/pkg/registry/apps/application/quota.go
@@ -382,17 +382,20 @@ func (r *REST) parentPoolUsage(ctx context.Context, parentNS, excludeNS string) 
 	}
 	delete(members, excludeNS)
 
-	quotas := &corev1.ResourceQuotaList{}
-	if err := r.c.List(ctx, quotas); err != nil {
-		return nil, err
-	}
 	perNamespace := map[string]map[string]resource.Quantity{}
-	for i := range quotas.Items {
-		rq := &quotas.Items[i]
-		if !members[rq.Namespace] {
-			continue
+	for ns := range members {
+		quotas := &corev1.ResourceQuotaList{}
+		// Direct (uncached), namespace-scoped read: the aggregated apiserver
+		// must not spin up a cluster-wide ResourceQuota informer just for
+		// admission, so this goes through the watch client (r.w) rather than the
+		// cached r.c, and is scoped to the handful of pool-member namespaces.
+		if err := r.w.List(ctx, quotas, client.InNamespace(ns)); err != nil {
+			return nil, err
 		}
-		perNamespace[rq.Namespace] = maxQuotas(perNamespace[rq.Namespace], resourceListToQuotas(rq.Status.Used))
+		for i := range quotas.Items {
+			rq := &quotas.Items[i]
+			perNamespace[ns] = maxQuotas(perNamespace[ns], resourceListToQuotas(rq.Status.Used))
+		}
 	}
 
 	total := map[string]resource.Quantity{}

--- a/pkg/registry/apps/application/quota.go
+++ b/pkg/registry/apps/application/quota.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
@@ -211,6 +212,20 @@ func (r *REST) validateTenantResourceQuotas(ctx context.Context, app *appsv1alph
 		return append(allErrs, field.InternalError(fldPath, err))
 	}
 
+	// Current usage of the parent's pool (its own namespace plus its unbounded
+	// descendants). Counting it keeps the invariant — a sub-tree may never, via
+	// quota, be promised more than its root owns — holding at declaration time:
+	// without it a parent already using most of its budget could still carve a
+	// full-budget child and the two would collectively exceed the root. This is
+	// best-effort (a snapshot; concurrent writes can briefly overshoot and
+	// already-running pods are never evicted) — the tenant-quota controller is
+	// the runtime backstop.
+	childNamespace := r.computeTenantNamespace(app.Namespace, app.Name)
+	poolUsed, err := r.parentPoolUsage(ctx, app.Namespace, childNamespace)
+	if err != nil {
+		return append(allErrs, field.InternalError(fldPath, err))
+	}
+
 	for _, res := range sortedQuotaKeys(parentQuota) {
 		want, requested := childQuota[res]
 		if !requested {
@@ -218,12 +233,14 @@ func (r *REST) validateTenantResourceQuotas(ctx context.Context, app *appsv1alph
 		}
 		parentLimit := parentQuota[res]
 		allocated := siblings[res] // zero value when no sibling bounds this resource
+		used := poolUsed[renderedLimitKey(res)]
 		remaining := parentLimit.DeepCopy()
 		remaining.Sub(allocated)
+		remaining.Sub(used)
 		if want.Cmp(remaining) > 0 {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Key(res),
-				fmt.Sprintf("requested %s exceeds the parent tenant's remaining %q quota of %s (parent allows %s, %s already allocated to sibling tenants); a child tenant may not be granted more quota than its parent has left",
-					want.String(), res, remaining.String(), parentLimit.String(), allocated.String())))
+				fmt.Sprintf("requested %s exceeds the parent tenant's remaining %q quota of %s (parent allows %s, %s already allocated to sibling tenants, %s currently in use by the parent pool); a child tenant may not be granted more quota than its parent has left",
+					want.String(), res, remaining.String(), parentLimit.String(), allocated.String(), used.String())))
 		}
 	}
 	return allErrs
@@ -250,4 +267,163 @@ func sortedQuotaKeys(q map[string]resource.Quantity) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// rawQuotaKeys are the shorthand resourceQuotas keys that the tenant chart emits
+// verbatim as ResourceQuota hard keys (no limits./requests. prefix). Kept in
+// sync with cozy-lib.resources.flattenResource ($rawQuotaKeys).
+var rawQuotaKeys = map[string]struct{}{
+	"pods":                   {},
+	"services":               {},
+	"services.loadbalancers": {},
+	"services.nodeports":     {},
+	"services.clusterip":     {},
+	"configmaps":             {},
+	"secrets":                {},
+	"persistentvolumeclaims": {},
+	"replicationcontrollers": {},
+	"resourcequotas":         {},
+}
+
+// renderedLimitKey maps a shorthand resourceQuotas key (the vocabulary admission
+// works in) to the rendered ResourceQuota key that carries its limit-side
+// budget, mirroring cozy-lib.resources.flatten. The mapping is allocation-ratio
+// independent: ratios only scale the requests.* side that flatten derives from
+// the same shorthand value, so the limit-side key always holds the operator's
+// declared amount. This lets admission read a tenant's current usage from its
+// rendered ResourceQuota.status.used without replicating the chart's ratio math.
+//
+//	cpu, memory, ephemeral-storage, custom resources -> "limits.<key>"
+//	storage                                          -> "requests.storage" (no hard limits.storage)
+//	pods, services, services.loadbalancers, ...      -> "<key>" (verbatim)
+func renderedLimitKey(raw string) string {
+	if raw == "storage" {
+		return "requests.storage"
+	}
+	if _, ok := rawQuotaKeys[raw]; ok {
+		return raw
+	}
+	return "limits." + raw
+}
+
+// parentNamespaceOf returns the namespace owned by the parent of the tenant that
+// owns ns, or "" for the root tenant and non-tenant namespaces. It mirrors
+// tenantquota.parentNamespace / the inverse of computeTenantNamespace: the
+// hierarchy is encoded in the namespace name, so the parent is recovered by
+// stripping the trailing "-<name>" segment.
+func (r *REST) parentNamespaceOf(ns string) string {
+	if ns == rootTenantNamespace || !strings.HasPrefix(ns, r.releaseConfig.Prefix) {
+		return ""
+	}
+	segments := strings.Split(ns, "-")
+	if len(segments) == 2 {
+		return rootTenantNamespace
+	}
+	return strings.Join(segments[:len(segments)-1], "-")
+}
+
+// poolRootOf returns the nearest ancestor namespace (inclusive of ns) that is
+// bounded — declares its own quota — or "" when none is. That ancestor is the
+// pool root governing ns.
+func (r *REST) poolRootOf(ns string, bounded map[string]bool) string {
+	for cur := ns; cur != ""; cur = r.parentNamespaceOf(cur) {
+		if bounded[cur] {
+			return cur
+		}
+	}
+	return ""
+}
+
+// parentPoolUsage sums the current usage of the pool rooted at parentNS: the
+// parent's own namespace plus every unbounded descendant whose nearest bounded
+// ancestor is parentNS. Bounded sub-tenants are excluded — their reservations
+// are already charged as sibling carve-outs — as is excludeNS (the tenant being
+// created/updated). Usage is read from each member's ResourceQuota.status.used,
+// taking a per-resource max within a namespace to avoid double-counting the
+// chart-rendered and controller-allocated quotas, and is keyed in the rendered
+// quota key space (see renderedLimitKey). Boundedness is decided by declared
+// resourceQuotas so the result does not depend on whether Flux has rendered a
+// freshly-created tenant's quota yet.
+func (r *REST) parentPoolUsage(ctx context.Context, parentNS, excludeNS string) (map[string]resource.Quantity, error) {
+	releases := &helmv2.HelmReleaseList{}
+	selector := labels.SelectorFromSet(labels.Set{
+		ApplicationKindLabel:  r.kindName,
+		ApplicationGroupLabel: r.gvk.Group,
+	})
+	if err := r.c.List(ctx, releases, &client.ListOptions{LabelSelector: selector}); err != nil {
+		return nil, err
+	}
+
+	bounded := map[string]bool{}
+	owned := make([]string, 0, len(releases.Items))
+	for i := range releases.Items {
+		hr := &releases.Items[i]
+		name := strings.TrimPrefix(hr.Name, r.releaseConfig.Prefix)
+		ns := r.computeTenantNamespace(hr.Namespace, name)
+		owned = append(owned, ns)
+		quotas, err := declaredQuotasFromHelmRelease(hr)
+		if err != nil {
+			klog.Warningf("skipping tenant %s/%s with unparseable quotas while summing pool usage: %v", hr.Namespace, hr.Name, err)
+			continue
+		}
+		if len(quotas) > 0 {
+			bounded[ns] = true
+		}
+	}
+
+	members := map[string]bool{parentNS: true}
+	for _, ns := range owned {
+		if ns == excludeNS {
+			continue
+		}
+		if r.poolRootOf(ns, bounded) == parentNS {
+			members[ns] = true
+		}
+	}
+	delete(members, excludeNS)
+
+	quotas := &corev1.ResourceQuotaList{}
+	if err := r.c.List(ctx, quotas); err != nil {
+		return nil, err
+	}
+	perNamespace := map[string]map[string]resource.Quantity{}
+	for i := range quotas.Items {
+		rq := &quotas.Items[i]
+		if !members[rq.Namespace] {
+			continue
+		}
+		perNamespace[rq.Namespace] = maxQuotas(perNamespace[rq.Namespace], resourceListToQuotas(rq.Status.Used))
+	}
+
+	total := map[string]resource.Quantity{}
+	for _, used := range perNamespace {
+		addQuotas(total, used)
+	}
+	return total, nil
+}
+
+// resourceListToQuotas converts a corev1.ResourceList to the string-keyed quota
+// map the admission arithmetic uses.
+func resourceListToQuotas(rl corev1.ResourceList) map[string]resource.Quantity {
+	out := make(map[string]resource.Quantity, len(rl))
+	for k, v := range rl {
+		out[string(k)] = v
+	}
+	return out
+}
+
+// maxQuotas returns the per-resource maximum of dst and src as a new map.
+// Multiple ResourceQuotas in one namespace each report the same usage, so usage
+// is merged with a max (not a sum) to avoid double counting.
+func maxQuotas(dst, src map[string]resource.Quantity) map[string]resource.Quantity {
+	out := map[string]resource.Quantity{}
+	for k, v := range dst {
+		out[k] = v.DeepCopy()
+	}
+	for k, v := range src {
+		if cur, ok := out[k]; !ok || v.Cmp(cur) > 0 {
+			out[k] = v.DeepCopy()
+		}
+	}
+	return out
 }

--- a/pkg/registry/apps/application/quota_test.go
+++ b/pkg/registry/apps/application/quota_test.go
@@ -22,7 +22,9 @@ import (
 	"testing"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -79,6 +81,9 @@ func newTenantREST(t *testing.T, objects ...client.Object) *REST {
 	if err := helmv2.AddToScheme(scheme); err != nil {
 		t.Fatalf("register helmv2 scheme: %v", err)
 	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register corev1 scheme: %v", err)
+	}
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 	return &REST{
 		c: fakeClient,
@@ -113,6 +118,37 @@ func childApplication(t *testing.T, name, namespace string, quotas map[string]st
 			Namespace: namespace,
 		},
 		Spec: tenantValuesJSON(t, quotas),
+	}
+}
+
+// usageQuota builds a ResourceQuota reporting current usage (status.used) in a
+// namespace, keyed in the rendered quota key space (e.g. "limits.cpu").
+func usageQuota(t *testing.T, namespace, name string, used map[string]string) *corev1.ResourceQuota {
+	t.Helper()
+	rl := corev1.ResourceList{}
+	for k, v := range used {
+		rl[corev1.ResourceName(k)] = resource.MustParse(v)
+	}
+	return &corev1.ResourceQuota{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Status:     corev1.ResourceQuotaStatus{Used: rl},
+	}
+}
+
+func TestRenderedLimitKey(t *testing.T) {
+	cases := map[string]string{
+		"cpu":                    "limits.cpu",
+		"memory":                 "limits.memory",
+		"ephemeral-storage":      "limits.ephemeral-storage",
+		"devices.com/nvidia":     "limits.devices.com/nvidia",
+		"storage":                "requests.storage",
+		"pods":                   "pods",
+		"services.loadbalancers": "services.loadbalancers",
+	}
+	for raw, want := range cases {
+		if got := renderedLimitKey(raw); got != want {
+			t.Errorf("renderedLimitKey(%q) = %q, want %q", raw, got, want)
+		}
 	}
 }
 
@@ -263,6 +299,54 @@ func TestValidateTenantResourceQuotas_UpdateExcludesSelf(t *testing.T) {
 	if errs := r.validateTenantResourceQuotas(context.Background(), appOver); len(errs) == 0 {
 		t.Fatalf("update of own quota above parent budget should be denied")
 	}
+}
+
+// TestValidateTenantResourceQuotas_PoolUsage verifies that the parent pool's
+// current usage is carved out of the budget available to a new child, so the
+// sub-tree invariant holds at declaration time.
+func TestValidateTenantResourceQuotas_PoolUsage(t *testing.T) {
+	// foo budget cpu=10, already using 8 in its own namespace. A child asking
+	// for 10 must be denied (only 2 left); a child asking for 2 is allowed.
+	t.Run("parent usage shrinks remaining", func(t *testing.T) {
+		parent := tenantHelmRelease(t, "foo", "tenant-root", map[string]string{"cpu": "10"})
+		used := usageQuota(t, "tenant-foo", "tenant-quota", map[string]string{"limits.cpu": "8"})
+		r := newTenantREST(t, parent, used)
+
+		denied := r.validateTenantResourceQuotas(context.Background(), childApplication(t, "bar", "tenant-foo", map[string]string{"cpu": "10"}))
+		if len(denied) == 0 {
+			t.Fatalf("child cpu=10 should be denied when parent pool already uses 8 of 10")
+		}
+		allowed := r.validateTenantResourceQuotas(context.Background(), childApplication(t, "bar", "tenant-foo", map[string]string{"cpu": "2"}))
+		if len(allowed) > 0 {
+			t.Fatalf("child cpu=2 should be allowed (2 left), got: %v", allowed)
+		}
+	})
+
+	// Usage in a bounded child's own namespace (its own pool) must not count
+	// against the parent pool's remaining budget.
+	t.Run("bounded child usage excluded from parent pool", func(t *testing.T) {
+		parent := tenantHelmRelease(t, "foo", "tenant-root", map[string]string{"cpu": "10"})
+		child := tenantHelmRelease(t, "bar", "tenant-foo", map[string]string{"cpu": "4"})
+		// bar uses its full 4 in its own namespace.
+		childUsed := usageQuota(t, "tenant-foo-bar", "tenant-quota", map[string]string{"limits.cpu": "4"})
+		r := newTenantREST(t, parent, child, childUsed)
+
+		// Raising bar to 9 must still be allowed: bar's own usage is in its own
+		// pool, and as the tenant being updated it is excluded anyway.
+		if errs := r.validateTenantResourceQuotas(context.Background(), childApplication(t, "bar", "tenant-foo", map[string]string{"cpu": "9"})); len(errs) > 0 {
+			t.Fatalf("raising own quota within budget must be allowed, got: %v", errs)
+		}
+	})
+
+	// No rendered usage yet (freshly-created parent, Flux has not rendered the
+	// quota): usage degrades to zero and behaviour matches the pre-usage gate.
+	t.Run("absent usage degrades to budget-only check", func(t *testing.T) {
+		parent := tenantHelmRelease(t, "foo", "tenant-root", map[string]string{"cpu": "10"})
+		r := newTenantREST(t, parent)
+		if errs := r.validateTenantResourceQuotas(context.Background(), childApplication(t, "bar", "tenant-foo", map[string]string{"cpu": "10"})); len(errs) > 0 {
+			t.Fatalf("with no recorded usage a full-budget child must be allowed, got: %v", errs)
+		}
+	})
 }
 
 func TestParentTenantHelmReleaseRef(t *testing.T) {

--- a/pkg/registry/apps/application/quota_test.go
+++ b/pkg/registry/apps/application/quota_test.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
+	"github.com/cozystack/cozystack/pkg/config"
+)
+
+const testTenantPrefix = "tenant-"
+
+// tenantValuesJSON renders a tenant values blob carrying the given declared
+// resourceQuotas. A nil/empty map yields a blob with no quota (unbounded).
+func tenantValuesJSON(t *testing.T, quotas map[string]string) *apiextv1.JSON {
+	t.Helper()
+	values := map[string]any{}
+	if len(quotas) > 0 {
+		values["resourceQuotas"] = quotas
+	}
+	raw, err := json.Marshal(values)
+	if err != nil {
+		t.Fatalf("marshal tenant values: %v", err)
+	}
+	return &apiextv1.JSON{Raw: raw}
+}
+
+// tenantHelmRelease builds a tenant HelmRelease (as stored by the aggregated
+// apiserver) named "<prefix><name>" in namespace, with the given declared
+// quotas.
+func tenantHelmRelease(t *testing.T, name, namespace string, quotas map[string]string) *helmv2.HelmRelease {
+	t.Helper()
+	return &helmv2.HelmRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testTenantPrefix + name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				ApplicationKindLabel:  "Tenant",
+				ApplicationGroupLabel: appsv1alpha1.GroupName,
+				ApplicationNameLabel:  name,
+			},
+		},
+		Spec: helmv2.HelmReleaseSpec{
+			Values: tenantValuesJSON(t, quotas),
+		},
+	}
+}
+
+// newTenantREST wires a tenant REST handler over a fake client seeded with the
+// given HelmReleases.
+func newTenantREST(t *testing.T, objects ...client.Object) *REST {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := helmv2.AddToScheme(scheme); err != nil {
+		t.Fatalf("register helmv2 scheme: %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	return &REST{
+		c: fakeClient,
+		gvk: schema.GroupVersionKind{
+			Group:   appsv1alpha1.GroupName,
+			Version: "v1alpha1",
+			Kind:    "Tenant",
+		},
+		gvr: schema.GroupVersionResource{
+			Group:    appsv1alpha1.GroupName,
+			Version:  "v1alpha1",
+			Resource: "tenants",
+		},
+		kindName: "Tenant",
+		releaseConfig: config.ReleaseConfig{
+			Prefix: testTenantPrefix,
+		},
+	}
+}
+
+// childApplication builds a Tenant Application named name in namespace with the
+// given declared quotas.
+func childApplication(t *testing.T, name, namespace string, quotas map[string]string) *appsv1alpha1.Application {
+	t.Helper()
+	return &appsv1alpha1.Application{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.cozystack.io/v1alpha1",
+			Kind:       "Tenant",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: tenantValuesJSON(t, quotas),
+	}
+}
+
+func TestValidateTenantResourceQuotas(t *testing.T) {
+	tests := []struct {
+		name string
+		// parent owns the namespace the child is created in; its HelmRelease
+		// lives one level up.
+		parent *helmv2.HelmRelease
+		// siblings already exist in the child's namespace.
+		siblings []*helmv2.HelmRelease
+		// child being created/updated.
+		childName   string
+		childNS     string
+		childQuotas map[string]string
+		wantDenied  bool
+	}{
+		{
+			name:        "child within parent budget is allowed",
+			parent:      tenantHelmRelease(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
+			childName:   "bar",
+			childNS:     "tenant-foo",
+			childQuotas: map[string]string{"cpu": "4"},
+			wantDenied:  false,
+		},
+		{
+			name:        "child exactly at remaining is allowed",
+			parent:      tenantHelmRelease(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
+			siblings:    []*helmv2.HelmRelease{tenantHelmRelease(t, "bar", "tenant-foo", map[string]string{"cpu": "4"})},
+			childName:   "baz",
+			childNS:     "tenant-foo",
+			childQuotas: map[string]string{"cpu": "6"},
+			wantDenied:  false,
+		},
+		{
+			name:        "child exceeding remaining after sibling carve-out is denied",
+			parent:      tenantHelmRelease(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
+			siblings:    []*helmv2.HelmRelease{tenantHelmRelease(t, "bar", "tenant-foo", map[string]string{"cpu": "4"})},
+			childName:   "baz",
+			childNS:     "tenant-foo",
+			childQuotas: map[string]string{"cpu": "7"},
+			wantDenied:  true,
+		},
+		{
+			name:        "child exceeding parent total is denied",
+			parent:      tenantHelmRelease(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
+			childName:   "bar",
+			childNS:     "tenant-foo",
+			childQuotas: map[string]string{"cpu": "11"},
+			wantDenied:  true,
+		},
+		{
+			name:        "child without quota shares parent pool (allowed)",
+			parent:      tenantHelmRelease(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
+			childName:   "bar",
+			childNS:     "tenant-foo",
+			childQuotas: nil,
+			wantDenied:  false,
+		},
+		{
+			name:        "unbounded parent does not constrain child",
+			parent:      tenantHelmRelease(t, "foo", "tenant-root", nil),
+			childName:   "bar",
+			childNS:     "tenant-foo",
+			childQuotas: map[string]string{"cpu": "1000"},
+			wantDenied:  false,
+		},
+		{
+			name:        "missing parent HelmRelease does not constrain child",
+			parent:      nil,
+			childName:   "bar",
+			childNS:     "tenant-foo",
+			childQuotas: map[string]string{"cpu": "1000"},
+			wantDenied:  false,
+		},
+		{
+			name:        "per-resource enforcement denies only the over-budget resource",
+			parent:      tenantHelmRelease(t, "foo", "tenant-root", map[string]string{"cpu": "10", "memory": "20Gi"}),
+			childName:   "bar",
+			childNS:     "tenant-foo",
+			childQuotas: map[string]string{"cpu": "5", "memory": "25Gi"},
+			wantDenied:  true,
+		},
+		{
+			name:        "child bounding a resource the parent does not bound is allowed",
+			parent:      tenantHelmRelease(t, "foo", "tenant-root", map[string]string{"cpu": "10"}),
+			childName:   "bar",
+			childNS:     "tenant-foo",
+			childQuotas: map[string]string{"memory": "999Gi"},
+			wantDenied:  false,
+		},
+		{
+			name:        "deep nesting: grandchild within child budget allowed",
+			parent:      tenantHelmRelease(t, "bar", "tenant-foo", map[string]string{"cpu": "6"}),
+			childName:   "baz",
+			childNS:     "tenant-foo-bar",
+			childQuotas: map[string]string{"cpu": "5"},
+			wantDenied:  false,
+		},
+		{
+			name:        "deep nesting: grandchild exceeding child budget denied",
+			parent:      tenantHelmRelease(t, "bar", "tenant-foo", map[string]string{"cpu": "6"}),
+			childName:   "baz",
+			childNS:     "tenant-foo-bar",
+			childQuotas: map[string]string{"cpu": "7"},
+			wantDenied:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var objects []client.Object
+			if tc.parent != nil {
+				objects = append(objects, tc.parent)
+			}
+			for _, s := range tc.siblings {
+				objects = append(objects, s)
+			}
+			r := newTenantREST(t, objects...)
+
+			app := childApplication(t, tc.childName, tc.childNS, tc.childQuotas)
+			errs := r.validateTenantResourceQuotas(context.Background(), app)
+			gotDenied := len(errs) > 0
+			if gotDenied != tc.wantDenied {
+				t.Fatalf("validateTenantResourceQuotas denied=%v, want %v (errors: %v)", gotDenied, tc.wantDenied, errs)
+			}
+		})
+	}
+}
+
+// TestValidateTenantResourceQuotas_UpdateExcludesSelf verifies that raising a
+// tenant's own quota does not double-count its existing carve-out as a sibling.
+func TestValidateTenantResourceQuotas_UpdateExcludesSelf(t *testing.T) {
+	parent := tenantHelmRelease(t, "foo", "tenant-root", map[string]string{"cpu": "10"})
+	// "bar" already exists in tenant-foo with cpu=4. Raising it to cpu=9 must
+	// be allowed (only sibling carve-outs other than bar count, and there are
+	// none), not rejected as 4+9 > 10.
+	self := tenantHelmRelease(t, "bar", "tenant-foo", map[string]string{"cpu": "4"})
+	r := newTenantREST(t, parent, self)
+
+	app := childApplication(t, "bar", "tenant-foo", map[string]string{"cpu": "9"})
+	if errs := r.validateTenantResourceQuotas(context.Background(), app); len(errs) > 0 {
+		t.Fatalf("update of own quota within parent budget should be allowed, got: %v", errs)
+	}
+
+	// Raising bar above the full parent budget is still rejected.
+	appOver := childApplication(t, "bar", "tenant-foo", map[string]string{"cpu": "11"})
+	if errs := r.validateTenantResourceQuotas(context.Background(), appOver); len(errs) == 0 {
+		t.Fatalf("update of own quota above parent budget should be denied")
+	}
+}
+
+func TestParentTenantHelmReleaseRef(t *testing.T) {
+	tests := []struct {
+		owned    string
+		wantName string
+		wantNS   string
+		wantOK   bool
+	}{
+		{"tenant-root", "tenant-root", "tenant-root", true},
+		{"tenant-foo", "tenant-foo", "tenant-root", true},
+		{"tenant-foo-bar", "tenant-bar", "tenant-foo", true},
+		{"tenant-foo-bar-baz", "tenant-baz", "tenant-foo-bar", true},
+		{"not-a-tenant", "", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.owned, func(t *testing.T) {
+			name, ns, ok := parentTenantHelmReleaseRef(tc.owned, testTenantPrefix)
+			if name != tc.wantName || ns != tc.wantNS || ok != tc.wantOK {
+				t.Fatalf("parentTenantHelmReleaseRef(%q) = (%q, %q, %v), want (%q, %q, %v)",
+					tc.owned, name, ns, ok, tc.wantName, tc.wantNS, tc.wantOK)
+			}
+		})
+	}
+}

--- a/pkg/registry/apps/application/quota_test.go
+++ b/pkg/registry/apps/application/quota_test.go
@@ -87,6 +87,7 @@ func newTenantREST(t *testing.T, objects ...client.Object) *REST {
 	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
 	return &REST{
 		c: fakeClient,
+		w: fakeClient,
 		gvk: schema.GroupVersionKind{
 			Group:   appsv1alpha1.GroupName,
 			Version: "v1alpha1",

--- a/pkg/registry/apps/application/rest.go
+++ b/pkg/registry/apps/application/rest.go
@@ -189,6 +189,11 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		if nsErrs := r.validateTenantNamespaceLength(app.Namespace, app.Name); len(nsErrs) > 0 {
 			return nil, apierrors.NewInvalid(r.gvk.GroupKind(), app.Name, nsErrs)
 		}
+		// Enforce hierarchical quota allocation: a child tenant's declared
+		// quota may not exceed its parent's remaining (un-carved) quota.
+		if qErrs := r.validateTenantResourceQuotas(ctx, app); len(qErrs) > 0 {
+			return nil, apierrors.NewInvalid(r.gvk.GroupKind(), app.Name, qErrs)
+		}
 	}
 
 	// Validate that values don't contain reserved keys (starting with "_")
@@ -532,6 +537,15 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 	// Validate that values don't contain reserved keys (starting with "_")
 	if err := validateNoInternalKeys(app.Spec); err != nil {
 		return nil, false, apierrors.NewBadRequest(err.Error())
+	}
+
+	// Enforce hierarchical quota allocation on quota changes too: raising a
+	// child tenant's declared quota above its parent's remaining budget is
+	// rejected the same way as on create.
+	if r.kindName == "Tenant" {
+		if qErrs := r.validateTenantResourceQuotas(ctx, app); len(qErrs) > 0 {
+			return nil, false, apierrors.NewInvalid(r.gvk.GroupKind(), app.Name, qErrs)
+		}
 	}
 
 	r.warnLegacyPresets(app)


### PR DESCRIPTION
## What this PR does

Adds **hierarchical (recursive) resource quotas** for tenants so a tenant can no longer escalate its allocation by creating sub-tenants. Today `tenant.spec.resourceQuotas` becomes a plain per-namespace `ResourceQuota`, which ignores the tenant tree: a super-admin inside a quota'd tenant can create a sub-tenant with a larger quota — or no quota at all — and consume more than was allocated.

A tenant's declared quota is now treated as the budget for its **whole sub-tree**:

- A child that declares its own quota **carves a fixed slice** out of the parent's remaining budget (parent 10 CPU → child 4 CPU → parent has 6 left).
- A child **without** a quota **shares** the parent's remaining pool rather than being unbounded.
- A child quota that exceeds the parent's remaining budget is **rejected**.

Two cooperating layers, mirroring OpenShift's ClusterResourceQuota split (admission + reconciliation):

1. **Declaration-time gate** in the aggregated apiserver (`apps.cozystack.io` Tenant create/update): deterministically rejects a sub-tenant whose declared quota exceeds the parent's remaining budget.
2. **Runtime enforcer** in `cozystack-controller`: maintains a per-namespace `tenant-quota-allocated` ResourceQuota that clamps each pool member to its share of the parent budget, aggregating sub-tree usage so members collectively stay within the budget. Kubernetes enforces the most restrictive ResourceQuota in a namespace, so this binds without fighting Flux over the chart-rendered `tenant-quota`. Overcommitted pools (a parent quota lowered below the sum of its children) emit a `QuotaOvercommitted` event. A `--tenant-quota-buffer-percent` flag temporarily inflates pool budgets during rollout so workloads already over a freshly-introduced quota keep running.

The model and the selector-spans-namespaces / aggregated-usage approach are adapted from OpenShift's ClusterResourceQuota controllers (`openshift/api`, `library-go`, `cluster-policy-controller`, `apiserver-library-go`), Apache-2.0, Copyright Red Hat, Inc. and the OpenShift Authors; attribution is preserved in the source. The per-namespace quota arithmetic reuses the upstream Kubernetes quota helpers (`k8s.io/apiserver/pkg/quota/v1`).

No API types or the tenant chart change; the feature works with the existing `tenant.spec.resourceQuotas` field.

### Screenshots

N/A — no UI changes.

### Release note

```release-note
feat(tenant): tenant resource quotas are now hierarchical — a sub-tenant's quota is carved out of its parent's remaining budget and can no longer exceed it; sub-tenants without a quota share the parent's pool. Set `--tenant-quota-buffer-percent` on cozystack-controller for a temporary grace buffer during upgrades.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hierarchical tenant quota enforcement across tenant namespaces, including shared pool handling and configurable quota buffer support.
  * Tenant quota changes are now validated on create and update to prevent over-allocation.

* **Bug Fixes**
  * Improved quota calculations so usage, carve-outs, and nested tenant limits are applied more consistently.
  * Stale quota allocations are now cleaned up when namespaces no longer belong to an active tenant pool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->