### PR TITLE
fix(monitoring)!: clean up orphaned storage PVCs and TLS secrets on tenant module delete (#3091)

### DIFF
--- a/hack/monitoring-pvc-backfill-migration.bats
+++ b/hack/monitoring-pvc-backfill-migration.bats
@@ -1,0 +1,173 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Unit tests for packages/core/platform/images/migrations/migrations/50
+#
+# Migration 50 backfills apps.cozystack.io/application.name onto the pre-existing
+# VictoriaMetrics/VictoriaLogs storage PVCs of the monitoring module so the
+# post-delete cleanup hook (PR #3094) can reclaim storage on already-deployed
+# clusters. Its correctness property is that it must relabel EXACTLY the
+# monitoring cluster's vmstorage/vmselect/vlstorage PVCs — never a user's own
+# VMCluster, never the CNPG db PVCs — and stamp the version on a clean run.
+# helm-unittest cannot check this (it inspects rendered manifests, not the
+# operator's runtime PVCs); a mis-scoped or no-op selector is exactly the class
+# of bug this PR iterated on, so these tests pin the runtime behaviour.
+#
+# We put a fake `kubectl` on PATH that logs every call and simulates one tenant
+# namespace holding: a monitoring VMCluster (shortterm) + VLCluster (generic)
+# whose spec.managedMetadata carries application.name=monitoring-system; a user's
+# own VMCluster (custom) with no such label; plus the operator storage PVCs and
+# the CNPG db PVCs. We assert the label log:
+#   - relabels the shortterm vmstorage/vmselect and generic vlstorage PVCs;
+#   - never touches the CNPG db PVCs (grafana-db/alerta-db);
+#   - never touches the user's `custom` VMCluster PVCs (no managedMetadata label);
+#   - stamps the version (kubectl apply) on a clean run;
+#   - is a safe no-op that still stamps when the CRDs are absent.
+#
+# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
+# own line (column 0); assertions are direct shell tests, and the fake-kubectl
+# heredoc keeps every `}` off column 0. Each @test cleans up inline (no
+# EXIT/RETURN trap — see docs/agents/e2e-testing.md §3).
+#
+# Run with: hack/cozytest.sh hack/monitoring-pvc-backfill-migration.bats
+#           (or `bats hack/monitoring-pvc-backfill-migration.bats`)
+# -----------------------------------------------------------------------------
+
+HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
+REPO_ROOT="$(cd "$HACK_DIR/.." && pwd)"
+MIGRATION="$REPO_ROOT/packages/core/platform/images/migrations/migrations/50"
+
+# write_fake_kubectl <dir>
+# Emits a fake `kubectl` that logs every call to $KLOG and, when $MOCK_ABSENT=1,
+# reports the VM/VL CRDs as absent. Ordering matters: the CR appname read is
+# matched by *managedMetadata* before the generic *vmclusters*/*vlclusters* list.
+# No line below is a bare column-0 `}`, so cozytest.sh's parser leaves it intact.
+write_fake_kubectl() {
+  cat > "$1/kubectl" <<'KEOF'
+#!/bin/sh
+echo "$*" >> "$KLOG"
+case "$*" in
+  *"get crd"*)
+    [ "${MOCK_ABSENT:-}" = 1 ] && exit 1
+    exit 0
+    ;;
+  *label*pvc*)
+    exit 0
+    ;;
+  *apply*)
+    cat >/dev/null
+    exit 0
+    ;;
+  *managedMetadata*)
+    case "$*" in
+      *shortterm*|*generic*) printf 'monitoring-system' ;;
+      *) : ;;
+    esac
+    exit 0
+    ;;
+  *vmclusters*)
+    printf 'tenant-test shortterm\ntenant-test custom\n'
+    exit 0
+    ;;
+  *vlclusters*)
+    printf 'tenant-test generic\n'
+    exit 0
+    ;;
+  *"get pvc"*"items[*]"*)
+    printf 'vmstorage-db-vmstorage-shortterm-0\n'
+    printf 'cache-vmselect-shortterm-0\n'
+    printf 'vmstorage-db-vmstorage-custom-0\n'
+    printf 'vlstorage-db-vlstorage-generic-0\n'
+    printf 'grafana-db-1\n'
+    printf 'alerta-db-1\n'
+    exit 0
+    ;;
+  *"get pvc"*)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+KEOF
+  chmod +x "$1/kubectl"
+}
+
+@test "migration 50 relabels only the monitoring VM/VL storage PVCs and stamps the version" {
+  tmp=$(mktemp -d)
+  export KLOG="$tmp/kubectl.log"
+  : > "$KLOG"
+  write_fake_kubectl "$tmp"
+
+  if ! KLOG="$KLOG" PATH="$tmp:$PATH" "$MIGRATION" >"$tmp/out" 2>&1; then
+    echo "expected a clean migration run to exit zero; output:" >&2
+    cat "$tmp/out" >&2
+    rm -rf "$tmp"
+    exit 1
+  fi
+
+  # The monitoring cluster's storage PVCs must be relabeled with the exact value.
+  for pvc in vmstorage-db-vmstorage-shortterm-0 cache-vmselect-shortterm-0 vlstorage-db-vlstorage-generic-0; do
+    if ! grep -Eq "label pvc -n tenant-test $pvc apps.cozystack.io/application.name=monitoring-system --overwrite" "$KLOG"; then
+      echo "expected $pvc to be relabeled with application.name=monitoring-system" >&2
+      cat "$KLOG" >&2
+      rm -rf "$tmp"
+      exit 1
+    fi
+  done
+
+  # The CNPG db PVCs must never be touched (they are not monitoring storage).
+  if grep -Eq "label pvc.*(grafana-db|alerta-db)" "$KLOG"; then
+    echo "regression: cleanup relabeled a CNPG db PVC" >&2
+    cat "$KLOG" >&2
+    rm -rf "$tmp"
+    exit 1
+  fi
+
+  # A user's own VMCluster (no managedMetadata label) must be skipped entirely.
+  if grep -Eq "label pvc.*custom" "$KLOG"; then
+    echo "regression: relabeled a non-cozystack VMCluster's PVC" >&2
+    cat "$KLOG" >&2
+    rm -rf "$tmp"
+    exit 1
+  fi
+
+  # Positive control: the version stamp (kubectl apply) ran on a clean pass.
+  if ! grep -q apply "$KLOG"; then
+    echo "expected the version stamp (kubectl apply) to run on a clean migration" >&2
+    cat "$KLOG" >&2
+    rm -rf "$tmp"
+    exit 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "migration 50 is a safe no-op that still stamps when the VM/VL CRDs are absent" {
+  tmp=$(mktemp -d)
+  export KLOG="$tmp/kubectl.log"
+  : > "$KLOG"
+  write_fake_kubectl "$tmp"
+
+  if ! KLOG="$KLOG" MOCK_ABSENT=1 PATH="$tmp:$PATH" "$MIGRATION" >"$tmp/out" 2>&1; then
+    echo "expected the CRD-absent path to exit zero; output:" >&2
+    cat "$tmp/out" >&2
+    rm -rf "$tmp"
+    exit 1
+  fi
+
+  # No CRD -> no PVC is relabeled ...
+  if grep -q "label pvc" "$KLOG"; then
+    echo "expected no relabel when the VM/VL CRDs are absent" >&2
+    cat "$KLOG" >&2
+    rm -rf "$tmp"
+    exit 1
+  fi
+
+  # ... but the version stamp must still advance so the upgrade completes.
+  if ! grep -q apply "$KLOG"; then
+    echo "expected the version stamp to run even when the CRDs are absent" >&2
+    cat "$KLOG" >&2
+    rm -rf "$tmp"
+    exit 1
+  fi
+  rm -rf "$tmp"
+}

--- a/hack/monitoring-pvc-backfill-migration.bats
+++ b/hack/monitoring-pvc-backfill-migration.bats
@@ -1,8 +1,8 @@
 #!/usr/bin/env bats
 # -----------------------------------------------------------------------------
-# Unit tests for packages/core/platform/images/migrations/migrations/50
+# Unit tests for packages/core/platform/images/migrations/migrations/51
 #
-# Migration 50 backfills apps.cozystack.io/application.name onto the pre-existing
+# Migration 51 backfills apps.cozystack.io/application.name onto the pre-existing
 # VictoriaMetrics/VictoriaLogs storage PVCs of the monitoring module so the
 # post-delete cleanup hook (PR #3094) can reclaim storage on already-deployed
 # clusters. Its correctness property is that it must relabel EXACTLY the
@@ -34,7 +34,7 @@
 
 HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
 REPO_ROOT="$(cd "$HACK_DIR/.." && pwd)"
-MIGRATION="$REPO_ROOT/packages/core/platform/images/migrations/migrations/50"
+MIGRATION="$REPO_ROOT/packages/core/platform/images/migrations/migrations/51"
 
 # write_fake_kubectl <dir>
 # Emits a fake `kubectl` that logs every call to $KLOG and, when $MOCK_ABSENT=1,
@@ -74,7 +74,7 @@ case "$*" in
     ;;
   *"get pvc"*"items[*]"*)
     printf 'vmstorage-db-vmstorage-shortterm-0\n'
-    printf 'cache-vmselect-shortterm-0\n'
+    printf 'vmselect-cachedir-vmselect-shortterm-0\n'
     printf 'vmstorage-db-vmstorage-custom-0\n'
     printf 'vlstorage-db-vlstorage-generic-0\n'
     printf 'grafana-db-1\n'
@@ -92,7 +92,7 @@ KEOF
   chmod +x "$1/kubectl"
 }
 
-@test "migration 50 relabels only the monitoring VM/VL storage PVCs and stamps the version" {
+@test "migration 51 relabels only the monitoring VM/VL storage PVCs and stamps the version" {
   tmp=$(mktemp -d)
   export KLOG="$tmp/kubectl.log"
   : > "$KLOG"
@@ -106,7 +106,7 @@ KEOF
   fi
 
   # The monitoring cluster's storage PVCs must be relabeled with the exact value.
-  for pvc in vmstorage-db-vmstorage-shortterm-0 cache-vmselect-shortterm-0 vlstorage-db-vlstorage-generic-0; do
+  for pvc in vmstorage-db-vmstorage-shortterm-0 vmselect-cachedir-vmselect-shortterm-0 vlstorage-db-vlstorage-generic-0; do
     if ! grep -Eq "label pvc -n tenant-test $pvc apps.cozystack.io/application.name=monitoring-system --overwrite" "$KLOG"; then
       echo "expected $pvc to be relabeled with application.name=monitoring-system" >&2
       cat "$KLOG" >&2
@@ -141,7 +141,7 @@ KEOF
   rm -rf "$tmp"
 }
 
-@test "migration 50 is a safe no-op that still stamps when the VM/VL CRDs are absent" {
+@test "migration 51 is a safe no-op that still stamps when the VM/VL CRDs are absent" {
   tmp=$(mktemp -d)
   export KLOG="$tmp/kubectl.log"
   : > "$KLOG"

--- a/packages/core/platform/images/migrations/migrations/51
+++ b/packages/core/platform/images/migrations/migrations/51
@@ -1,0 +1,99 @@
+#!/bin/bash
+# Migration 51 --> 52
+# Backfill the apps.cozystack.io/application.name release label onto pre-existing
+# VictoriaMetrics / VictoriaLogs storage PVCs of the monitoring module.
+#
+# PR #3094 adds apps.cozystack.io/application.name to the VMCluster/VLCluster
+# storage volumeClaimTemplates (packages/system/monitoring) and a post-delete
+# hook that garbage-collects PVCs carrying that label. But vm-operator only
+# stamps volumeClaimTemplate.metadata.labels onto PVCs it creates *after* the
+# change; the Kubernetes StatefulSet controller applies claim-template labels
+# only at PVC creation and never re-labels existing PVCs, and vm-operator's PVC
+# reconciler is resize-only. Storage provisioned before this upgrade therefore
+# stays unlabeled, the cleanup hook's selector misses it, and it keeps leaking on
+# delete (issue #3091). This migration relabels those PVCs once so the hook can
+# reclaim them.
+#
+# The label value is read from each CR's spec.managedMetadata so we relabel only
+# cozystack-managed monitoring clusters (a user's own VMCluster carries no such
+# label and is left untouched) and always stamp the exact value the hook selects.
+#
+# Best-effort by design: the worst case if a relabel is skipped is the
+# pre-existing leak this PR set out to fix, which is strictly no worse than the
+# status quo. A transient apiserver hiccup must therefore NOT abort the whole
+# platform upgrade, so the CR list and per-PVC reads tolerate failure (|| true)
+# rather than exiting non-zero.
+
+set -euo pipefail
+
+# shellcheck source=lib/cozystack-version.sh
+. "$(dirname "$0")/lib/cozystack-version.sh"
+
+label_key="apps.cozystack.io/application.name"
+# jsonpath escapes the dots/slash in the label key.
+label_path='{.spec.managedMetadata.labels.apps\.cozystack\.io/application\.name}'
+
+# relabel_storage <crd> <pvc-name-regex>
+# For every CR of <crd> that carries the cozystack application.name label, relabel
+# its storage PVCs (matched by the StatefulSet-derived <pvc-name-regex>, with the
+# CR name spliced in) to the same value.
+relabel_storage() {
+  crd="$1"
+  pvc_regex_tmpl="$2"
+
+  # This migration runs platform-wide (targetVersion bump), including on clusters
+  # that never installed monitoring. Skip when the CRD is absent. The `|| true`
+  # on the list additionally keeps a transient apiserver error from aborting the
+  # upgrade — there is nothing safety-critical to gate on.
+  if ! kubectl get crd "$crd" >/dev/null 2>&1; then
+    echo "$crd not present; skipping monitoring PVC label backfill"
+    return 0
+  fi
+
+  crs=$(kubectl get "$crd" -A \
+    -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' || true)
+
+  echo "$crs" | while read -r ns name; do
+    [ -n "${ns:-}" ] || continue
+
+    appname=$(kubectl get "$crd" -n "$ns" "$name" -o jsonpath="$label_path" 2>/dev/null || true)
+    if [ -z "$appname" ]; then
+      echo "$crd $ns/$name has no $label_key; not a cozystack-managed cluster, skipping"
+      continue
+    fi
+
+    # Splice the CR name into the PVC regex (e.g. "(vmstorage|vmselect)-NAME-[0-9]+$").
+    pvc_regex=$(printf '%s' "$pvc_regex_tmpl" | sed "s/NAME/${name}/g")
+
+    # grep exits 1 when a namespace has no matching PVCs; tolerate it so pipefail
+    # does not abort the whole migration on an empty match.
+    pvcs=$(kubectl get pvc -n "$ns" \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+      | grep -E "$pvc_regex" || true)
+
+    for pvc in $pvcs; do
+      [ -n "${pvc:-}" ] || continue
+      current=$(kubectl get pvc -n "$ns" "$pvc" \
+        -o jsonpath="{.metadata.labels.apps\.cozystack\.io/application\.name}" 2>/dev/null || true)
+      if [ "$current" = "$appname" ]; then
+        echo "PVC $ns/$pvc already labeled $label_key=$appname; skipping"
+        continue
+      fi
+      echo "Labeling PVC $ns/$pvc with $label_key=$appname"
+      kubectl label pvc -n "$ns" "$pvc" "$label_key=$appname" --overwrite
+    done
+  done
+}
+
+# vm-operator storage PVCs are named "<claim-template>-<sts>-<ordinal>" and the
+# StatefulSet is "<component>-<cr>", so every PVC ends with
+# "<component>-<cr>-<ordinal>". The regex suffix-matches that tail, so it is
+# robust to the claim-template prefix (e.g. vmstorage-db-vmstorage-<cr>-0 and
+# vmselect-cachedir-vmselect-<cr>-0 both match on the vmselect/vmstorage arm).
+relabel_storage vmclusters.operator.victoriametrics.com '(vmstorage|vmselect)-NAME-[0-9]+$'
+# vlstorage STS PVCs are "<claim-template>-vlstorage-<cr>-<ordinal>".
+relabel_storage vlclusters.operator.victoriametrics.com 'vlstorage-NAME-[0-9]+$'
+
+# Stamp version via the shared helper so the cozystack-version ConfigMap keeps
+# the platform.cozystack.io/no-delete label.
+stamp_cozystack_version 52

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -14,7 +14,7 @@ migrations:
   # refuses to advance past a migration file missing from the image (exit 1), so
   # a stale pin fails loudly rather than silently skipping the etcd adoption.
   image: ghcr.io/cozystack/cozystack/platform-migrations:v1.5.0@sha256:8bf61f17e99eb4a3365394e3d97ac52a1d68cc84aa104894ecb09de25721dc1d
-  targetVersion: 51
+  targetVersion: 52
 # Bundle deployment configuration
 bundles:
   system:

--- a/packages/extra/monitoring/Makefile
+++ b/packages/extra/monitoring/Makefile
@@ -5,6 +5,10 @@ NAME=monitoring
 include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
 
+.PHONY: test
+test:
+	helm unittest .
+
 generate:
 	cozyvalues-gen -v values.yaml -s values.schema.json -r README.md
 	../../../hack/update-crd.sh

--- a/packages/extra/monitoring/templates/hooks/cleanup.yaml
+++ b/packages/extra/monitoring/templates/hooks/cleanup.yaml
@@ -10,6 +10,9 @@ metadata:
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  # Backstop: the deletes are best-effort and non-blocking (--wait=false), but
+  # cap the Job so it can never stall the HelmRelease teardown.
+  activeDeadlineSeconds: 120
   template:
     metadata:
       labels:
@@ -47,9 +50,9 @@ spec:
             - /bin/sh
             - -c
             - |
-              kubectl delete pvc -n {{ .Release.Namespace }} -l managed-by=vm-operator --ignore-not-found \
+              kubectl delete pvc -n {{ .Release.Namespace }} -l managed-by=vm-operator --ignore-not-found --wait=false \
                 || echo "WARNING: VM storage PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
-              kubectl delete secret -n {{ .Release.Namespace }} alerta-tls grafana-ingress-tls --ignore-not-found \
+              kubectl delete secret -n {{ .Release.Namespace }} alerta-tls grafana-ingress-tls --ignore-not-found --wait=false \
                 || echo "WARNING: TLS secret cleanup failed for {{ .Release.Name }}; orphaned secrets may remain" >&2
           volumeMounts:
             - name: tmp

--- a/packages/extra/monitoring/templates/hooks/cleanup.yaml
+++ b/packages/extra/monitoring/templates/hooks/cleanup.yaml
@@ -108,3 +108,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-cleanup
+    namespace: {{ .Release.Namespace }}

--- a/packages/extra/monitoring/templates/hooks/cleanup.yaml
+++ b/packages/extra/monitoring/templates/hooks/cleanup.yaml
@@ -50,7 +50,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              kubectl delete pvc -n {{ .Release.Namespace }} -l managed-by=vm-operator --ignore-not-found --wait=false \
+              kubectl delete pvc -n {{ .Release.Namespace }} -l managed-by=vm-operator,apps.cozystack.io/application.name={{ .Release.Name }}-system --ignore-not-found --wait=false \
                 || echo "WARNING: VM storage PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
               kubectl delete secret -n {{ .Release.Namespace }} alerta-tls grafana-ingress-tls --ignore-not-found --wait=false \
                 || echo "WARNING: TLS secret cleanup failed for {{ .Release.Name }}; orphaned secrets may remain" >&2

--- a/packages/extra/monitoring/templates/hooks/cleanup.yaml
+++ b/packages/extra/monitoring/templates/hooks/cleanup.yaml
@@ -8,11 +8,15 @@ metadata:
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    # Keep only before-hook-creation on the Job so a Failed cleanup survives for
+    # post-mortem; the SA/Role/RoleBinding keep hook-succeeded (cozystack #3072).
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   # Backstop: the deletes are best-effort and non-blocking (--wait=false), but
   # cap the Job so it can never stall the HelmRelease teardown.
   activeDeadlineSeconds: 120
+  # Best-effort cleanup: never retry.
+  backoffLimit: 0
   template:
     metadata:
       labels:
@@ -50,7 +54,7 @@ spec:
             - /bin/sh
             - -c
             - |
-              kubectl delete pvc -n {{ .Release.Namespace }} -l managed-by=vm-operator,apps.cozystack.io/application.name={{ .Release.Name }}-system --ignore-not-found --wait=false \
+              kubectl delete pvc -n {{ .Release.Namespace }} -l apps.cozystack.io/application.name={{ .Release.Name }}-system --ignore-not-found --wait=false \
                 || echo "WARNING: VM storage PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
               kubectl delete secret -n {{ .Release.Namespace }} alerta-tls grafana-ingress-tls --ignore-not-found --wait=false \
                 || echo "WARNING: TLS secret cleanup failed for {{ .Release.Name }}; orphaned secrets may remain" >&2

--- a/packages/extra/monitoring/templates/hooks/cleanup.yaml
+++ b/packages/extra/monitoring/templates/hooks/cleanup.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        policy.cozystack.io/allow-to-apiserver: "true"
+    spec:
+      serviceAccountName: {{ .Release.Name }}-cleanup
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: cleanup
+          image: docker.io/clastix/kubectl:v1.32
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: HOME
+              value: /tmp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              kubectl delete pvc -n {{ .Release.Namespace }} -l managed-by=vm-operator --ignore-not-found \
+                || echo "WARNING: VM storage PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
+              kubectl delete secret -n {{ .Release.Namespace }} alerta-tls grafana-ingress-tls --ignore-not-found \
+                || echo "WARNING: TLS secret cleanup failed for {{ .Release.Name }}; orphaned secrets may remain" >&2
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["alerta-tls", "grafana-ingress-tls"]
+    verbs: ["get", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-cleanup

--- a/packages/extra/monitoring/tests/cleanup_test.yaml
+++ b/packages/extra/monitoring/tests/cleanup_test.yaml
@@ -1,0 +1,131 @@
+suite: monitoring post-delete cleanup hook removes orphaned VM PVCs and TLS secrets
+
+release:
+  name: monitoring
+  namespace: tenant-root
+
+templates:
+  - templates/hooks/cleanup.yaml
+
+tests:
+  - it: renders the cleanup Job as a post-delete hook with the hardened pod spec
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: metadata.name
+          value: monitoring-cleanup
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-delete
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "10"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+      - equal:
+          path: spec.template.metadata.labels["policy.cozystack.io/allow-to-apiserver"]
+          value: "true"
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: monitoring-cleanup
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65534
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: cleanup
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/clastix/kubectl:v1.32
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: deletes the vm-operator storage PVCs by label
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: kubectl delete pvc -n tenant-root -l managed-by=vm-operator --ignore-not-found
+
+  - it: deletes the cert-manager TLS secrets by name
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: kubectl delete secret -n tenant-root alerta-tls grafana-ingress-tls --ignore-not-found
+
+  - it: creates the cleanup ServiceAccount as a post-delete hook
+    documentSelector:
+      path: kind
+      value: ServiceAccount
+    asserts:
+      - equal:
+          path: metadata.name
+          value: monitoring-cleanup
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-delete
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "0"
+
+  - it: grants RBAC to delete PVCs by label and the two named TLS secrets
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - equal:
+          path: metadata.name
+          value: monitoring-cleanup
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "5"
+      - equal:
+          path: rules[0].resources[0]
+          value: persistentvolumeclaims
+      - contains:
+          path: rules[0].verbs
+          content: delete
+      - equal:
+          path: rules[1].resources[0]
+          value: secrets
+      - equal:
+          path: rules[1].resourceNames
+          value:
+            - alerta-tls
+            - grafana-ingress-tls
+      - contains:
+          path: rules[1].verbs
+          content: delete
+
+  - it: binds the cleanup Role to the cleanup ServiceAccount
+    documentSelector:
+      path: kind
+      value: RoleBinding
+    asserts:
+      - equal:
+          path: metadata.name
+          value: monitoring-cleanup
+      - equal:
+          path: roleRef.name
+          value: monitoring-cleanup
+      - equal:
+          path: subjects[0].name
+          value: monitoring-cleanup

--- a/packages/extra/monitoring/tests/cleanup_test.yaml
+++ b/packages/extra/monitoring/tests/cleanup_test.yaml
@@ -22,13 +22,19 @@ tests:
       - equal:
           path: metadata.annotations["helm.sh/hook-weight"]
           value: "10"
+      # The Job keeps only before-hook-creation so a Failed cleanup survives for
+      # post-mortem; hook-succeeded stays on the SA/Role/RoleBinding (see #3072).
       - equal:
           path: metadata.annotations["helm.sh/hook-delete-policy"]
-          value: before-hook-creation,hook-succeeded
+          value: before-hook-creation
       # Backstop so a stuck delete can never stall the HelmRelease teardown.
       - equal:
           path: spec.activeDeadlineSeconds
           value: 120
+      # Best-effort, never retry.
+      - equal:
+          path: spec.backoffLimit
+          value: 0
       - equal:
           path: spec.template.metadata.labels["policy.cozystack.io/allow-to-apiserver"]
           value: "true"
@@ -62,25 +68,28 @@ tests:
       path: kind
       value: Job
     asserts:
-      # The selector must be scoped to this monitoring release, not just
-      # managed-by=vm-operator: the bare label matches every VMCluster/VLCluster
-      # in the namespace, so tearing one release down could delete another's
-      # storage. apps.cozystack.io/application.name is stamped on the VM CRs'
-      # storage.volumeClaimTemplate.metadata.labels (packages/system/monitoring),
-      # which vm-operator copies onto the PVCs via IntoSTSVolume even on v0.68.4
-      # (managedMetadata itself reaches PVCs only from v0.71.0).
+      # The selector is scoped to this release by apps.cozystack.io/application.name
+      # alone. That label is stamped on the VM/VL CRs'
+      # storage.volumeClaimTemplate.metadata.labels (packages/system/monitoring) and
+      # is copied onto the PVCs by vm-operator (IntoSTSVolume) even on v0.68.4.
+      # managed-by=vm-operator is deliberately NOT in the selector: on v0.68.4 it
+      # lives only on the StatefulSet selector/pod labels, so relying on it is
+      # fragile; application.name=<release>-system is already release-scoped and
+      # provably present on the PVC, and the CNPG db PVCs (grafana-db/alerta-db)
+      # do not carry it, so they stay untouched.
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'kubectl delete pvc -n tenant-root -l managed-by=vm-operator,apps\.cozystack\.io/application\.name=monitoring-system --ignore-not-found --wait=false'
-      # Never widen the PVC sweep beyond the vm-operator label scope.
+          pattern: 'kubectl delete pvc -n tenant-root -l apps\.cozystack\.io/application\.name=monitoring-system --ignore-not-found --wait=false'
+      # Never widen the PVC sweep beyond the release-scoped label.
       - notMatchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: kubectl delete pvc[^\n]*--all
-      # Regression guard: the PVC delete must not fall back to the release-agnostic
-      # managed-by=vm-operator selector (i.e. without the application.name scope).
+      # Regression guard: never re-introduce managed-by=vm-operator into the PVC
+      # selector — on the shipped v0.68.4 it is not stamped on the storage PVCs,
+      # so an AND with it silently matches nothing (see #3094 review).
       - notMatchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'kubectl delete pvc[^\n]*-l managed-by=vm-operator --ignore-not-found'
+          pattern: 'kubectl delete pvc[^\n]*managed-by=vm-operator'
 
   - it: deletes the cert-manager TLS secrets by name without blocking teardown
     documentSelector:

--- a/packages/extra/monitoring/tests/cleanup_test.yaml
+++ b/packages/extra/monitoring/tests/cleanup_test.yaml
@@ -57,18 +57,28 @@ tests:
           path: spec.template.spec.containers[0].securityContext.capabilities.drop
           content: ALL
 
-  - it: deletes the vm-operator storage PVCs by label without blocking teardown
+  - it: deletes the vm-operator storage PVCs scoped to this release without blocking teardown
     documentSelector:
       path: kind
       value: Job
     asserts:
+      # The selector must be scoped to this monitoring release, not just
+      # managed-by=vm-operator: the bare label matches every VMCluster/VLCluster
+      # in the namespace, so tearing one release down could delete another's
+      # storage. apps.cozystack.io/application.name is stamped on the VM CRs'
+      # managedMetadata and propagated by vm-operator onto the PVCs.
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: kubectl delete pvc -n tenant-root -l managed-by=vm-operator --ignore-not-found --wait=false
+          pattern: 'kubectl delete pvc -n tenant-root -l managed-by=vm-operator,apps\.cozystack\.io/application\.name=monitoring-system --ignore-not-found --wait=false'
       # Never widen the PVC sweep beyond the vm-operator label scope.
       - notMatchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: kubectl delete pvc[^\n]*--all
+      # Regression guard: the PVC delete must not fall back to the release-agnostic
+      # managed-by=vm-operator selector (i.e. without the application.name scope).
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kubectl delete pvc[^\n]*-l managed-by=vm-operator --ignore-not-found'
 
   - it: deletes the cert-manager TLS secrets by name without blocking teardown
     documentSelector:

--- a/packages/extra/monitoring/tests/cleanup_test.yaml
+++ b/packages/extra/monitoring/tests/cleanup_test.yaml
@@ -71,7 +71,8 @@ tests:
       # The selector is scoped to this release by apps.cozystack.io/application.name
       # alone. That label is stamped on the VM/VL CRs'
       # storage.volumeClaimTemplate.metadata.labels (packages/system/monitoring) and
-      # is copied onto the PVCs by vm-operator (IntoSTSVolume) even on v0.68.4.
+      # is copied onto the PVCs by vm-operator (IntoSTSVolume); spec.managedMetadata
+      # is not applied to PVCs, so the claim template is the only path that works.
       # managed-by=vm-operator is deliberately NOT in the selector: on v0.68.4 it
       # lives only on the StatefulSet selector/pod labels, so relying on it is
       # fragile; application.name=<release>-system is already release-scoped and

--- a/packages/extra/monitoring/tests/cleanup_test.yaml
+++ b/packages/extra/monitoring/tests/cleanup_test.yaml
@@ -66,7 +66,9 @@ tests:
       # managed-by=vm-operator: the bare label matches every VMCluster/VLCluster
       # in the namespace, so tearing one release down could delete another's
       # storage. apps.cozystack.io/application.name is stamped on the VM CRs'
-      # managedMetadata and propagated by vm-operator onto the PVCs.
+      # storage.volumeClaimTemplate.metadata.labels (packages/system/monitoring),
+      # which vm-operator copies onto the PVCs via IntoSTSVolume even on v0.68.4
+      # (managedMetadata itself reaches PVCs only from v0.71.0).
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: 'kubectl delete pvc -n tenant-root -l managed-by=vm-operator,apps\.cozystack\.io/application\.name=monitoring-system --ignore-not-found --wait=false'
@@ -151,3 +153,6 @@ tests:
       - equal:
           path: subjects[0].name
           value: monitoring-cleanup
+      - equal:
+          path: subjects[0].namespace
+          value: tenant-root

--- a/packages/extra/monitoring/tests/cleanup_test.yaml
+++ b/packages/extra/monitoring/tests/cleanup_test.yaml
@@ -25,6 +25,10 @@ tests:
       - equal:
           path: metadata.annotations["helm.sh/hook-delete-policy"]
           value: before-hook-creation,hook-succeeded
+      # Backstop so a stuck delete can never stall the HelmRelease teardown.
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 120
       - equal:
           path: spec.template.metadata.labels["policy.cozystack.io/allow-to-apiserver"]
           value: "true"
@@ -53,23 +57,31 @@ tests:
           path: spec.template.spec.containers[0].securityContext.capabilities.drop
           content: ALL
 
-  - it: deletes the vm-operator storage PVCs by label
+  - it: deletes the vm-operator storage PVCs by label without blocking teardown
     documentSelector:
       path: kind
       value: Job
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: kubectl delete pvc -n tenant-root -l managed-by=vm-operator --ignore-not-found
+          pattern: kubectl delete pvc -n tenant-root -l managed-by=vm-operator --ignore-not-found --wait=false
+      # Never widen the PVC sweep beyond the vm-operator label scope.
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: kubectl delete pvc[^\n]*--all
 
-  - it: deletes the cert-manager TLS secrets by name
+  - it: deletes the cert-manager TLS secrets by name without blocking teardown
     documentSelector:
       path: kind
       value: Job
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: kubectl delete secret -n tenant-root alerta-tls grafana-ingress-tls --ignore-not-found
+          pattern: kubectl delete secret -n tenant-root alerta-tls grafana-ingress-tls --ignore-not-found --wait=false
+      # The secret deletion must stay name-scoped — never a label or --all sweep.
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: kubectl delete secret[^\n]*(-l |--all)
 
   - it: creates the cleanup ServiceAccount as a post-delete hook
     documentSelector:

--- a/packages/system/monitoring/templates/vlogs/vlogs.yaml
+++ b/packages/system/monitoring/templates/vlogs/vlogs.yaml
@@ -22,6 +22,13 @@ spec:
     resources: {}
     storage:
       volumeClaimTemplate:
+        metadata:
+          # Stamped on the claim template so vm-operator copies it onto the
+          # storage PVCs (IntoSTSVolume) even on v0.68.4, which does not yet
+          # propagate managedMetadata to PVCs. The monitoring post-delete
+          # cleanup hook selects PVCs by this label to stay release-scoped.
+          labels:
+            apps.cozystack.io/application.name: {{ $.Release.Name }}
         spec:
           {{- with .storageClassName }}
           storageClassName: {{ . }}

--- a/packages/system/monitoring/templates/vlogs/vlogs.yaml
+++ b/packages/system/monitoring/templates/vlogs/vlogs.yaml
@@ -24,9 +24,10 @@ spec:
       volumeClaimTemplate:
         metadata:
           # Stamped on the claim template so vm-operator copies it onto the
-          # storage PVCs (IntoSTSVolume) even on v0.68.4, which does not yet
-          # propagate managedMetadata to PVCs. The monitoring post-delete
-          # cleanup hook selects PVCs by this label to stay release-scoped.
+          # storage PVCs (IntoSTSVolume). The operator does NOT apply
+          # spec.managedMetadata to PVCs, so the claim template is the only path
+          # that lands a label on them. The monitoring post-delete cleanup hook
+          # selects PVCs by this label to stay release-scoped.
           labels:
             apps.cozystack.io/application.name: {{ $.Release.Name }}
         spec:

--- a/packages/system/monitoring/templates/vm/vmcluster.yaml
+++ b/packages/system/monitoring/templates/vm/vmcluster.yaml
@@ -29,6 +29,13 @@ spec:
     cacheMountPath: /select-cache
     storage:
       volumeClaimTemplate:
+        metadata:
+          # Stamped on the claim template so vm-operator copies it onto the
+          # storage PVCs (IntoSTSVolume) even on v0.68.4, which does not yet
+          # propagate managedMetadata to PVCs. The monitoring post-delete
+          # cleanup hook selects PVCs by this label to stay release-scoped.
+          labels:
+            apps.cozystack.io/application.name: {{ $.Release.Name }}
         spec:
           {{- with .storageClassName }}
           storageClassName: {{ . }}
@@ -41,6 +48,13 @@ spec:
     resources: {}
     storage:
       volumeClaimTemplate:
+        metadata:
+          # Stamped on the claim template so vm-operator copies it onto the
+          # storage PVCs (IntoSTSVolume) even on v0.68.4, which does not yet
+          # propagate managedMetadata to PVCs. The monitoring post-delete
+          # cleanup hook selects PVCs by this label to stay release-scoped.
+          labels:
+            apps.cozystack.io/application.name: {{ $.Release.Name }}
         spec:
           {{- with .storageClassName }}
           storageClassName: {{ . }}

--- a/packages/system/monitoring/templates/vm/vmcluster.yaml
+++ b/packages/system/monitoring/templates/vm/vmcluster.yaml
@@ -31,9 +31,10 @@ spec:
       volumeClaimTemplate:
         metadata:
           # Stamped on the claim template so vm-operator copies it onto the
-          # storage PVCs (IntoSTSVolume) even on v0.68.4, which does not yet
-          # propagate managedMetadata to PVCs. The monitoring post-delete
-          # cleanup hook selects PVCs by this label to stay release-scoped.
+          # storage PVCs (IntoSTSVolume). The operator does NOT apply
+          # spec.managedMetadata to PVCs, so the claim template is the only path
+          # that lands a label on them. The monitoring post-delete cleanup hook
+          # selects PVCs by this label to stay release-scoped.
           labels:
             apps.cozystack.io/application.name: {{ $.Release.Name }}
         spec:
@@ -50,9 +51,10 @@ spec:
       volumeClaimTemplate:
         metadata:
           # Stamped on the claim template so vm-operator copies it onto the
-          # storage PVCs (IntoSTSVolume) even on v0.68.4, which does not yet
-          # propagate managedMetadata to PVCs. The monitoring post-delete
-          # cleanup hook selects PVCs by this label to stay release-scoped.
+          # storage PVCs (IntoSTSVolume). The operator does NOT apply
+          # spec.managedMetadata to PVCs, so the claim template is the only path
+          # that lands a label on them. The monitoring post-delete cleanup hook
+          # selects PVCs by this label to stay release-scoped.
           labels:
             apps.cozystack.io/application.name: {{ $.Release.Name }}
         spec:

--- a/packages/system/monitoring/tests/storage_pvc_label_test.yaml
+++ b/packages/system/monitoring/tests/storage_pvc_label_test.yaml
@@ -2,11 +2,11 @@ suite: VM/VL storage claim templates carry the release-scoping cleanup label
 
 # The extra/monitoring post-delete cleanup hook deletes orphaned VM/VL storage
 # PVCs scoped to this release via apps.cozystack.io/application.name=<release>.
-# On the shipped vm-operator v0.68.4 managedMetadata is NOT propagated to PVCs
-# (only from v0.71.0), so the label must be stamped on the claim template
-# itself — vm-operator copies volumeClaimTemplate.metadata.labels onto the PVCs
-# (IntoSTSVolume) even on v0.68.4. release.name mirrors the flux release of this
-# chart (monitoring-system), which is exactly what the hook selector expects.
+# vm-operator does NOT apply spec.managedMetadata to PVCs, so the label must be
+# stamped on the claim template itself — vm-operator copies
+# volumeClaimTemplate.metadata.labels onto the PVCs (IntoSTSVolume). release.name
+# mirrors the flux release of this chart (monitoring-system), which is exactly
+# what the hook selector expects.
 
 release:
   name: monitoring-system

--- a/packages/system/monitoring/tests/storage_pvc_label_test.yaml
+++ b/packages/system/monitoring/tests/storage_pvc_label_test.yaml
@@ -1,0 +1,49 @@
+suite: VM/VL storage claim templates carry the release-scoping cleanup label
+
+# The extra/monitoring post-delete cleanup hook deletes orphaned VM/VL storage
+# PVCs scoped to this release via apps.cozystack.io/application.name=<release>.
+# On the shipped vm-operator v0.68.4 managedMetadata is NOT propagated to PVCs
+# (only from v0.71.0), so the label must be stamped on the claim template
+# itself — vm-operator copies volumeClaimTemplate.metadata.labels onto the PVCs
+# (IntoSTSVolume) even on v0.68.4. release.name mirrors the flux release of this
+# chart (monitoring-system), which is exactly what the hook selector expects.
+
+release:
+  name: monitoring-system
+  namespace: tenant-root
+
+# Dunder values so the rest of the chart (grafana httproute etc.) renders;
+# they do not affect the VMCluster/VLCluster storage templates under test.
+set:
+  _namespace:
+    host: example.org
+    ingress: tenant-root
+  _cluster:
+    expose-ingress: ingress
+    host: example.org
+
+tests:
+  - it: stamps the cleanup label on vmstorage and vmselect claim templates
+    templates:
+      - templates/vm/vmcluster.yaml
+    documentSelector:
+      path: metadata.name
+      value: shortterm
+    asserts:
+      - equal:
+          path: spec.vmstorage.storage.volumeClaimTemplate.metadata.labels["apps.cozystack.io/application.name"]
+          value: monitoring-system
+      - equal:
+          path: spec.vmselect.storage.volumeClaimTemplate.metadata.labels["apps.cozystack.io/application.name"]
+          value: monitoring-system
+
+  - it: stamps the cleanup label on the vlstorage claim template
+    templates:
+      - templates/vlogs/vlogs.yaml
+    documentSelector:
+      path: metadata.name
+      value: generic
+    asserts:
+      - equal:
+          path: spec.vlstorage.storage.volumeClaimTemplate.metadata.labels["apps.cozystack.io/application.name"]
+          value: monitoring-system


### PR DESCRIPTION
## What this PR does

When the `monitoring` tenant module is disabled, the VictoriaMetrics/VictoriaLogs storage PVCs (created by vm-operator) and the `alerta-tls` / `grafana-ingress-tls` cert-manager secrets were left orphaned in the tenant namespace.

This adds a `post-delete` cleanup hook (`packages/extra/monitoring/templates/hooks/cleanup.yaml`) that:
- deletes the VM/VL storage PVCs scoped to this release via `-l apps.cozystack.io/application.name={{ .Release.Name }}-system`. That label is stamped on the `storage.volumeClaimTemplate.metadata.labels` of the VMCluster/VLCluster CRs (`packages/system/monitoring`); vm-operator copies claim-template labels onto the PVCs (`IntoSTSVolume`), so the selector matches and stays scoped to this monitoring release. `managed-by=vm-operator` is intentionally **not** used — vm-operator does not reliably stamp it onto the storage PVCs;
- deletes the `alerta-tls` and `grafana-ingress-tls` secrets by name (cert-manager TLS secrets carry only the cluster-wide `controller.cert-manager.io/fao=true` label, so a label sweep would be unsafe — they are removed by name).

CNPG PostgreSQL PVCs (`alerta-db-*`, `grafana-db-*`) are intentionally **not** targeted — CNPG cleans those up itself, and they do not carry `apps.cozystack.io/application.name`, so the selector leaves them untouched.

**Upgrade path:** the claim-template label only lands on PVCs created after the change, so **migration 51** (`packages/core/platform/images/migrations/migrations/51`) backfills `apps.cozystack.io/application.name` onto the pre-existing VM/VL storage PVCs of every cozystack-managed monitoring cluster, so the cleanup reclaims storage on already-deployed clusters too.

A `test` Makefile target and helm-unittest suites are added for both the cleanup hook and the claim-template label. The cleanup Job is hardened: non-root, read-only root fs, dropped capabilities, `seccompProfile: RuntimeDefault`, resource requests/limits, `activeDeadlineSeconds: 120`, `backoffLimit: 0`, `--wait=false` on both deletes; RBAC scoped to PVC get/list/delete and the two named secrets. Failures are logged but never block teardown.

> [!WARNING]
> **Disabling the monitoring module now permanently deletes its VictoriaMetrics/VictoriaLogs storage PVCs and the metrics/logs they hold.** This is intentional and fixes the storage leak. Back up before disabling if the data matters.

Fixes #3091.

### Release note

```release-note
fix(monitoring): garbage-collect the orphaned VictoriaMetrics/VictoriaLogs storage PVCs and the alerta/grafana TLS secrets left behind when a tenant's monitoring module is disabled; a migration backfills the release label onto pre-existing storage PVCs so already-deployed clusters are covered too. WARNING: disabling monitoring now permanently removes its storage PVCs and the data they hold.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Helm **post-delete** monitoring cleanup job to best-effort remove managed PVCs and two specific TLS secrets.
  * Included dedicated cleanup RBAC and hardened pod security settings for the cleanup job.
* **Tests**
  * Added Helm chart tests validating hook weight/policies, job settings, exact deletion commands, and negative cases.
  * Added a `make test` target to run Helm unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


