### PR TITLE
fix(seaweedfs)!: clean up orphaned data PVCs and cert/db secrets on tenant module delete (#3092)

### DIFF
--- a/packages/extra/seaweedfs/Makefile
+++ b/packages/extra/seaweedfs/Makefile
@@ -2,6 +2,7 @@ NAME=seaweedfs
 
 include ../../../hack/package.mk
 
+.PHONY: test
 test:
 	helm unittest .
 

--- a/packages/extra/seaweedfs/templates/hooks/cleanup.yaml
+++ b/packages/extra/seaweedfs/templates/hooks/cleanup.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+    resourceNames:
+      - {{ .Release.Name }}-s3-ingress-tls
+      - {{ .Release.Name }}-system-admin-cert
+      - {{ .Release.Name }}-system-ca-cert
+      - {{ .Release.Name }}-system-client-cert
+      - {{ .Release.Name }}-system-filer-cert
+      - {{ .Release.Name }}-system-master-cert
+      - {{ .Release.Name }}-system-volume-cert
+      - {{ .Release.Name }}-system-worker-cert
+      - {{ .Release.Name }}-system-db-secret
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-cleanup
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 120
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        policy.cozystack.io/allow-to-apiserver: "true"
+    spec:
+      serviceAccountName: {{ .Release.Name }}-cleanup
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: cleanup
+          image: docker.io/clastix/kubectl:v1.32
+          env:
+            - name: HOME
+              value: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Deleting orphaned SeaweedFS volume PVCs for {{ .Release.Name }}..."
+              kubectl delete pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/name=seaweedfs,app.kubernetes.io/instance={{ .Release.Name }}-system --ignore-not-found --wait=false \
+                || echo "WARNING: SeaweedFS PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
+              echo "Deleting orphaned SeaweedFS cert/db secrets for {{ .Release.Name }}..."
+              kubectl delete secret -n {{ .Release.Namespace }} {{ .Release.Name }}-s3-ingress-tls {{ .Release.Name }}-system-admin-cert {{ .Release.Name }}-system-ca-cert {{ .Release.Name }}-system-client-cert {{ .Release.Name }}-system-filer-cert {{ .Release.Name }}-system-master-cert {{ .Release.Name }}-system-volume-cert {{ .Release.Name }}-system-worker-cert {{ .Release.Name }}-system-db-secret --ignore-not-found --wait=false \
+                || echo "WARNING: SeaweedFS secret cleanup failed for {{ .Release.Name }}; orphaned secrets may remain" >&2
+              echo "SeaweedFS cleanup complete."

--- a/packages/extra/seaweedfs/tests/cleanup_test.yaml
+++ b/packages/extra/seaweedfs/tests/cleanup_test.yaml
@@ -1,0 +1,162 @@
+suite: seaweedfs post-delete cleanup hook removes orphaned PVCs and secrets
+templates:
+  - templates/hooks/cleanup.yaml
+
+release:
+  name: seaweedfs
+  namespace: tenant-root
+
+# After the seaweedfs module is disabled, the StatefulSet data PVCs
+# (data1-seaweedfs-system-volume-{0,1}) and the cert-manager TLS / db
+# secrets are left orphaned. The post-delete hook renders a Job (plus its
+# RBAC) that deletes the volume PVCs by label and the secrets by name.
+# All names are templated from .Release.Name: the leaked resources use the
+# {{ .Release.Name }}-system prefix because seaweedfs.yaml renders the
+# StatefulSet/cert HelmRelease as "{{ .Release.Name }}-system".
+
+tests:
+  - it: renders the cleanup ServiceAccount as a post-delete hook
+    documentSelector:
+      path: kind
+      value: ServiceAccount
+    asserts:
+      - equal:
+          path: metadata.name
+          value: seaweedfs-cleanup
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-delete
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "0"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+
+  - it: grants delete on PVCs and only the 9 named secrets
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "5"
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["persistentvolumeclaims"]
+            verbs: ["get", "list", "delete"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "delete"]
+            resourceNames:
+              - seaweedfs-s3-ingress-tls
+              - seaweedfs-system-admin-cert
+              - seaweedfs-system-ca-cert
+              - seaweedfs-system-client-cert
+              - seaweedfs-system-filer-cert
+              - seaweedfs-system-master-cert
+              - seaweedfs-system-volume-cert
+              - seaweedfs-system-worker-cert
+              - seaweedfs-system-db-secret
+
+  - it: binds the cleanup Role to the cleanup ServiceAccount
+    documentSelector:
+      path: kind
+      value: RoleBinding
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "5"
+      - equal:
+          path: roleRef.name
+          value: seaweedfs-cleanup
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: seaweedfs-cleanup
+
+  - it: renders a hardened cleanup Job with the right hook metadata
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: metadata.name
+          value: seaweedfs-cleanup
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-delete
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "10"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 120
+      - equal:
+          path: spec.template.metadata.labels["policy.cozystack.io/allow-to-apiserver"]
+          value: "true"
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: seaweedfs-cleanup
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/clastix/kubectl:v1.32
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65534
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 10m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 64Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 200m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 128Mi
+
+  - it: deletes volume PVCs by label and the named secrets in the cleanup command
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kubectl delete pvc -n tenant-root -l app\.kubernetes\.io/name=seaweedfs,app\.kubernetes\.io/instance=seaweedfs-system --ignore-not-found --wait=false'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kubectl delete secret -n tenant-root seaweedfs-s3-ingress-tls seaweedfs-system-admin-cert seaweedfs-system-ca-cert seaweedfs-system-client-cert seaweedfs-system-filer-cert seaweedfs-system-master-cert seaweedfs-system-volume-cert seaweedfs-system-worker-cert seaweedfs-system-db-secret --ignore-not-found --wait=false'
+      # The PVC selector must NOT filter by component: the volume StatefulSet sets
+      # app.kubernetes.io/component to volume / volume-<pool> / volume-<zone>[-<pool>]
+      # depending on topology, so a component clause would leave non-default pools and
+      # MultiZone PVCs orphaned (the leak this hook fixes).
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'app\.kubernetes\.io/component='


### PR DESCRIPTION
## What this PR does

When the `seaweedfs` tenant module is disabled, the SeaweedFS StatefulSet data PVCs (`data1-<release>-system-volume-*`) and a set of certificate/credential secrets were left orphaned in the tenant namespace.

This adds a `post-delete` cleanup hook (`packages/extra/seaweedfs/templates/hooks/cleanup.yaml`) that:
- deletes the volume PVCs by their release-scoped labels (`app.kubernetes.io/name=seaweedfs, app.kubernetes.io/instance=<release>-system, app.kubernetes.io/component=volume`);
- deletes the orphaned secrets by name (`<release>-s3-ingress-tls`, `<release>-system-{admin,ca,client,filer,master,volume,worker}-cert`, `<release>-system-db-secret`) — cert-manager TLS secrets carry only the cluster-wide `controller.cert-manager.io/fao=true` label, so they are removed by name rather than by an unsafe label sweep.

All names are templated from `.Release.Name` (the chart renders the StatefulSet/cert HelmRelease as `<release>-system`). CNPG PostgreSQL PVCs (`<release>-db-*`) are intentionally **not** targeted — CNPG cleans those itself.

The cleanup Job is hardened: non-root, read-only root fs, dropped capabilities, `seccompProfile: RuntimeDefault`, resource requests/limits; RBAC scoped to PVC get/list/delete and the secrets by `resourceNames`. Failures are logged but never block teardown.

> [!WARNING]
> **Disabling the seaweedfs module now permanently deletes its volume data PVCs and the object data they hold.** This is intentional and fixes the storage leak. Back up before disabling if the data matters.

Fixes #3092.

### Release note

```release-note
fix(seaweedfs): garbage-collect the orphaned SeaweedFS volume PVCs and the certificate/db secrets left behind when a tenant's seaweedfs module is disabled. WARNING: disabling seaweedfs now permanently removes its volume PVCs and the data they hold.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Helm post-delete cleanup hook for SeaweedFS to remove orphaned PersistentVolumeClaims and related certificate/database Secrets.
* **Bug Fixes**
  * Cleanup deletions now ignore missing resources to reduce hook failures.
* **Tests**
  * Added a Helm/Kubernetes test suite validating the cleanup hook behavior when the module is disabled.
* **Chores**
  * Marked the SeaweedFS Makefile `test` target as phony.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->