### PR TITLE
fix(dashboard): render error and unknown-type states instead of an infinite spinner

### DIFF
--- a/packages/system/dashboard/images/console/apps/console/src/routes/ApplicationListPage.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/ApplicationListPage.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter, Routes, Route } from "react-router"
+
+// Drive the two upstream hooks per test; the page's guards are the unit under test.
+const h = vi.hoisted(() => ({
+  defs: { data: undefined as unknown, isLoading: true },
+  instances: { data: undefined as unknown, isLoading: false },
+}))
+
+vi.mock("../lib/app-definitions.ts", () => ({
+  useApplicationDefinitions: () => h.defs,
+  useApplicationInstances: () => h.instances,
+  iconDataUrl: () => null,
+  appDisplayName: () => "App",
+}))
+vi.mock("../lib/tenant-context.tsx", () => ({
+  useTenantContext: () => ({ tenantNamespace: "tenant-test", selectedTenant: "test" }),
+}))
+
+const { ApplicationListPage } = await import("./ApplicationListPage.tsx")
+
+function renderAt(plural: string) {
+  return render(
+    <MemoryRouter initialEntries={[`/console/${plural}`]}>
+      <Routes>
+        <Route path="/console/:plural" element={<ApplicationListPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe("ApplicationListPage guards", () => {
+  it("shows the unknown-type message once defs have loaded and the plural is unrecognized", () => {
+    // Regression: previously `defsLoading || (!ad && plural)` kept the spinner
+    // up forever for an unknown plural, so this branch was unreachable.
+    h.defs = { data: { items: [] }, isLoading: false }
+    renderAt("nonexistent")
+    expect(screen.getByText("Unknown application type.")).toBeInTheDocument()
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument()
+  })
+
+  it("still shows the spinner while definitions are loading", () => {
+    h.defs = { data: undefined, isLoading: true }
+    renderAt("postgreses")
+    expect(screen.getByText("Loading…")).toBeInTheDocument()
+    expect(screen.queryByText("Unknown application type.")).not.toBeInTheDocument()
+  })
+})

--- a/packages/system/dashboard/images/console/apps/console/src/routes/ApplicationListPage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/ApplicationListPage.tsx
@@ -26,13 +26,14 @@ export function ApplicationListPage() {
   const { data, isLoading } = useApplicationInstances(ad, tenantNamespace ?? undefined)
   const items = data?.items ?? []
 
-  if (defsLoading || (!ad && plural)) {
+  if (defsLoading) {
     return (
       <div className="flex items-center gap-2 p-6 text-sm text-slate-500">
         <Spinner /> Loading…
       </div>
     )
   }
+  // defs have loaded; an unresolved plural is genuinely unknown, not pending.
   if (!ad) {
     return <div className="p-6 text-sm text-red-600">Unknown application type.</div>
   }

--- a/packages/system/dashboard/images/console/apps/console/src/routes/detail/ApplicationDetailPage.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/detail/ApplicationDetailPage.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter, Routes, Route } from "react-router"
+
+// Drive useK8sGet's result per test; the page's loading/error guards are the unit under test.
+const h = vi.hoisted(() => ({
+  get: { data: undefined as unknown, isLoading: true, error: undefined as unknown },
+}))
+
+vi.mock("@cozystack/k8s-client", () => ({
+  useK8sGet: () => h.get,
+  useK8sDelete: () => ({ mutateAsync: vi.fn() }),
+}))
+vi.mock("../../lib/app-definitions.ts", () => ({
+  useApplicationDefinitions: () => ({
+    data: { items: [{ metadata: { name: "postgres" }, spec: { application: { plural: "postgreses", kind: "Postgres" } } }] },
+  }),
+  appDisplayName: () => "Postgres",
+  iconDataUrl: () => null,
+}))
+vi.mock("../../lib/tenant-context.tsx", () => ({
+  useTenantContext: () => ({ tenantNamespace: "tenant-test" }),
+}))
+// Stub the tab tree — the loading/error branches return before any tab renders,
+// and these modules pull heavy deps (noVNC, Monaco) we don't want in jsdom.
+vi.mock("./tabs.tsx", () => ({ TabBar: () => null }))
+vi.mock("./OverviewTab.tsx", () => ({ OverviewTab: () => null }))
+vi.mock("./WorkloadsTab.tsx", () => ({ WorkloadsTab: () => null }))
+vi.mock("./ServicesTab.tsx", () => ({ ServicesTab: () => null }))
+vi.mock("./IngressesTab.tsx", () => ({ IngressesTab: () => null }))
+vi.mock("./SecretsTab.tsx", () => ({ SecretsTab: () => null }))
+vi.mock("./EventsTab.tsx", () => ({ EventsTab: () => null }))
+vi.mock("./VncTab.tsx", () => ({ VncTab: () => null }))
+vi.mock("./VMPowerControls.tsx", () => ({ VMPowerControls: () => null }))
+
+const { ApplicationDetailPage } = await import("./ApplicationDetailPage.tsx")
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/console/postgreses/demo"]}>
+      <Routes>
+        <Route path="/console/:plural/:name" element={<ApplicationDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe("ApplicationDetailPage guards", () => {
+  it("renders the not-found message on a failed GET instead of an infinite spinner", () => {
+    // Regression: previously `isLoading || !instance || !ad` ran before the
+    // error branch, so a failed GET (isLoading=false, instance=undefined) spun
+    // forever and the error branch was unreachable.
+    h.get = { data: undefined, isLoading: false, error: new Error("403 Forbidden") }
+    renderPage()
+    expect(screen.getByText("not found.", { exact: false })).toBeInTheDocument()
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument()
+  })
+
+  it("still shows the spinner while the instance is loading", () => {
+    h.get = { data: undefined, isLoading: true, error: undefined }
+    renderPage()
+    expect(screen.getByText("Loading…")).toBeInTheDocument()
+  })
+})

--- a/packages/system/dashboard/images/console/apps/console/src/routes/detail/ApplicationDetailPage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/detail/ApplicationDetailPage.tsx
@@ -69,17 +69,20 @@ export function ApplicationDetailPage() {
   })
 
   if (!plural || !name) return <Navigate to="/console" replace />
-  if (isLoading || !instance || !ad) {
-    return (
-      <div className="flex items-center gap-2 p-8 text-slate-500">
-        <Spinner /> Loading…
-      </div>
-    )
-  }
+  // Check the fetch error before the loading guard: on a failed GET, isLoading
+  // is false and instance stays undefined, so a !instance-first guard would
+  // spin forever and never reach this branch.
   if (error) {
     return (
       <div className="p-8 text-red-600">
         Application <code>{name}</code> not found.
+      </div>
+    )
+  }
+  if (isLoading || !instance || !ad) {
+    return (
+      <div className="flex items-center gap-2 p-8 text-slate-500">
+        <Spinner /> Loading…
       </div>
     )
   }


### PR DESCRIPTION
## What this PR does

Two console pages ordered their loading guard ahead of the terminal state, making the latter unreachable. Both are pre-existing upstream behaviors carried in by the cozystack-ui vendoring (#2963) and flagged as non-blocking findings in that PR's review.

- **`ApplicationDetailPage`** checked `isLoading || !instance || !ad` before `if (error)`. On a failed GET (403/404/5xx) `isLoading` is false and `instance` stays undefined, so the page rendered the loading spinner forever and never reached the "not found" branch. The error branch now runs first.
- **`ApplicationListPage`**'s `defsLoading || (!ad && plural)` guard stayed true for any unrecognized `plural` once definitions had loaded, so the "Unknown application type." branch was unreachable. The guard now only spins while definitions are loading.

## Verification

- Added co-located regression tests for the failed-GET (detail) and unknown-plural (list) paths.
- `pnpm typecheck` clean; full console suite green (`pnpm test`: 317 passed, +4 new).

```release-note
fix(dashboard): the console now shows a not-found message on a failed application GET and an unknown-type message for an unrecognized resource, instead of spinning forever
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading and error handling on application pages so users see the correct message at the right time.
  * “Unknown application type” now appears only after application definitions finish loading, instead of being masked by a loading state.
  * Application detail pages now show a “not found” message when the requested app can’t be loaded, rather than continuing to display a spinner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->