### PR TITLE
build(dashboard): pin console image builder to pnpm 11.1.2 and repoint vendor doc link

### DIFF
--- a/docs/storage-immutability.md
+++ b/docs/storage-immutability.md
@@ -10,7 +10,7 @@ Every stateful Cozystack application that exposes a `storageClass` parameter dec
 
 | Consumer | Behavior |
 | --- | --- |
-| Cozystack UI (cozystack/cozystack-ui#6) | Reads the CEL rule from the chart's `openAPISchema` and renders `storageClass` as a disabled, helper-text-annotated field on edit forms. Save-time overlay reinstates the original value before PUT. |
+| Cozystack UI (`packages/system/dashboard/images/console`) | Reads the CEL rule from the chart's `openAPISchema` and renders `storageClass` as a disabled, helper-text-annotated field on edit forms. Save-time overlay reinstates the original value before PUT. |
 | `kubectl edit` / `kubectl patch` against the cozystack aggregated apiserver | **Currently accepted** — the apiserver does not yet evaluate CEL rules embedded in `ApplicationDefinition.openAPISchema`. The change passes through but does not propagate to existing PVCs (see "Why" above), so no data corruption is possible. Apiserver enforcement is tracked in cozystack/cozystack#2657. |
 | `kubectl edit` / `kubectl patch` against native CRDs | Enforced today by the standard apiextensions apiserver. |
 

--- a/packages/system/dashboard/images/console/Containerfile
+++ b/packages/system/dashboard/images/console/Containerfile
@@ -6,7 +6,9 @@ FROM node:${NODE_VERSION} AS builder
 ARG APP_VERSION
 ENV VITE_APP_VERSION=${APP_VERSION}
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Pin to the version in package.json's packageManager field so the image build
+# matches CI and the lockfile, rather than drifting to a newer pnpm major.
+RUN corepack enable && corepack prepare pnpm@11.1.2 --activate
 
 WORKDIR /src
 


### PR DESCRIPTION
## What this PR does

Two post-vendor cleanups from the #2963 review:

- **Pin the console image builder to pnpm 11.1.2.** The `Containerfile` ran `corepack prepare pnpm@latest`, so the container build could drift to a newer pnpm major than the `pnpm@11.1.2` pinned in `package.json` and used by CI. `--frozen-lockfile` guards the lockfile, but pinning the builder makes the image build reproducible and consistent with CI.
- **Repoint a stale doc link.** `docs/storage-immutability.md` referenced the now-vendored `cozystack/cozystack-ui#6`; it now points at the in-tree console path.

## Verification

- No source change; `pnpm typecheck` + `pnpm test` unaffected.
- Builder pnpm version now matches `package.json`'s `packageManager` field.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the storage immutability documentation by updating the UI reference to an in-repo path.

* **Chores**
  * Standardized the build environment to use a specific pnpm version, helping keep installs and builds consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->