### PR TITLE
fix(dashboard): redirect to oauth2-proxy on 401 instead of failing silently

### DIFF
--- a/packages/system/dashboard/images/console/apps/console/src/__tests__/k8s-client/client.unauthorized.test.ts
+++ b/packages/system/dashboard/images/console/apps/console/src/__tests__/k8s-client/client.unauthorized.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { K8sClient, K8sApiError } from "@cozystack/k8s-client"
+
+function fakeResponse(opts: {
+  ok?: boolean
+  status?: number
+  statusText?: string
+  body?: string
+}): Response {
+  return {
+    ok: opts.ok ?? true,
+    status: opts.status ?? 200,
+    statusText: opts.statusText ?? "OK",
+    text: async () => opts.body ?? "",
+    json: async () => JSON.parse(opts.body ?? "null"),
+  } as unknown as Response
+}
+
+const unauthorized = () =>
+  fakeResponse({ ok: false, status: 401, statusText: "Unauthorized" })
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe("K8sClient onUnauthorized (401) handling", () => {
+  it("invokes onUnauthorized exactly once when a request returns 401", async () => {
+    const onUnauthorized = vi.fn()
+    vi.stubGlobal("fetch", vi.fn(async () => unauthorized()))
+    const client = new K8sClient({ onUnauthorized })
+
+    await expect(client.get("", "v1", "pods", "p", "ns")).rejects.toThrow(
+      K8sApiError,
+    )
+
+    expect(onUnauthorized).toHaveBeenCalledTimes(1)
+  })
+
+  it("invokes onUnauthorized only once across two concurrent 401s", async () => {
+    const onUnauthorized = vi.fn()
+    vi.stubGlobal("fetch", vi.fn(async () => unauthorized()))
+    const client = new K8sClient({ onUnauthorized })
+
+    // The unauthorizedHandled latch must collapse a redirect storm when many
+    // in-flight calls 401 at once into a single re-auth navigation.
+    await Promise.allSettled([
+      client.get("", "v1", "pods", "a", "ns"),
+      client.get("", "v1", "pods", "b", "ns"),
+    ])
+
+    expect(onUnauthorized).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not invoke onUnauthorized on a non-401 error", async () => {
+    const onUnauthorized = vi.fn()
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        fakeResponse({
+          ok: false,
+          status: 403,
+          statusText: "Forbidden",
+          body: JSON.stringify({ message: "forbidden" }),
+        }),
+      ),
+    )
+    const client = new K8sClient({ onUnauthorized })
+
+    await expect(client.get("", "v1", "pods", "p", "ns")).rejects.toThrow(
+      K8sApiError,
+    )
+
+    expect(onUnauthorized).not.toHaveBeenCalled()
+  })
+
+  it("does not invoke onUnauthorized on a successful response", async () => {
+    const onUnauthorized = vi.fn()
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => fakeResponse({ body: JSON.stringify({ kind: "Pod" }) })),
+    )
+    const client = new K8sClient({ onUnauthorized })
+
+    await client.get("", "v1", "pods", "p", "ns")
+
+    expect(onUnauthorized).not.toHaveBeenCalled()
+  })
+
+  it("invokes onUnauthorized when the watch stream returns 401", async () => {
+    const onUnauthorized = vi.fn()
+    vi.stubGlobal("fetch", vi.fn(async () => unauthorized()))
+    const client = new K8sClient({ onUnauthorized })
+
+    // watch() is fire-and-forget; resolve once its onError fires.
+    await new Promise<void>((resolve) => {
+      client.watch(
+        "",
+        "v1",
+        "pods",
+        "ns",
+        "0",
+        () => {},
+        () => resolve(),
+      )
+    })
+
+    expect(onUnauthorized).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("K8sClient default unauthorized handler", () => {
+  it("redirects to /oauth2/start with the current location preserved as rd", async () => {
+    // jsdom's location.assign is non-configurable, so swap the whole object.
+    const original = window.location
+    const assign = vi.fn()
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { pathname: "/apps/postgres", search: "?tab=config", hash: "#x", assign },
+    })
+    vi.stubGlobal("fetch", vi.fn(async () => unauthorized()))
+    // No onUnauthorized override -> the browser default redirect kicks in.
+    const client = new K8sClient()
+
+    try {
+      await expect(client.get("", "v1", "pods", "p", "ns")).rejects.toThrow(
+        K8sApiError,
+      )
+
+      // Relative rd (no origin) preserves the destination without tripping
+      // oauth2-proxy's open-redirect rejection.
+      expect(assign).toHaveBeenCalledTimes(1)
+      expect(assign).toHaveBeenCalledWith(
+        `/oauth2/start?rd=${encodeURIComponent("/apps/postgres?tab=config#x")}`,
+      )
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: original,
+      })
+    }
+  })
+})

--- a/packages/system/dashboard/images/console/apps/console/src/__tests__/k8s-client/client.unauthorized.test.ts
+++ b/packages/system/dashboard/images/console/apps/console/src/__tests__/k8s-client/client.unauthorized.test.ts
@@ -52,6 +52,31 @@ describe("K8sClient onUnauthorized (401) handling", () => {
     expect(onUnauthorized).toHaveBeenCalledTimes(1)
   })
 
+  it("re-arms the latch after a success so a later 401 handles again", async () => {
+    const onUnauthorized = vi.fn()
+    const responses = [
+      unauthorized(),
+      fakeResponse({ body: JSON.stringify({ kind: "Pod" }) }),
+      unauthorized(),
+    ]
+    let call = 0
+    vi.stubGlobal("fetch", vi.fn(async () => responses[call++]))
+    const client = new K8sClient({ onUnauthorized })
+
+    // A 2xx in between means the session recovered, so the next expiry is a
+    // new episode. Without the re-arm a custom in-page handler would fire
+    // once for the client's whole lifetime.
+    await expect(client.get("", "v1", "pods", "p", "ns")).rejects.toThrow(
+      K8sApiError,
+    )
+    await client.get("", "v1", "pods", "p", "ns")
+    await expect(client.get("", "v1", "pods", "p", "ns")).rejects.toThrow(
+      K8sApiError,
+    )
+
+    expect(onUnauthorized).toHaveBeenCalledTimes(2)
+  })
+
   it("does not invoke onUnauthorized on a non-401 error", async () => {
     const onUnauthorized = vi.fn()
     vi.stubGlobal(

--- a/packages/system/dashboard/images/console/apps/console/src/__tests__/k8s-client/client.unauthorized.test.ts
+++ b/packages/system/dashboard/images/console/apps/console/src/__tests__/k8s-client/client.unauthorized.test.ts
@@ -110,7 +110,7 @@ describe("K8sClient onUnauthorized (401) handling", () => {
 })
 
 describe("K8sClient default unauthorized handler", () => {
-  it("redirects to /oauth2/start with the current location preserved as rd", async () => {
+  it("redirects to /oauth2/sign_in with the current location preserved as rd", async () => {
     // jsdom's location.assign is non-configurable, so swap the whole object.
     const original = window.location
     const assign = vi.fn()
@@ -128,10 +128,12 @@ describe("K8sClient default unauthorized handler", () => {
       )
 
       // Relative rd (no origin) preserves the destination without tripping
-      // oauth2-proxy's open-redirect rejection.
+      // oauth2-proxy's open-redirect rejection. The target must stay
+      // /oauth2/sign_in: token-proxy (oidc-enabled=false) serves no
+      // /oauth2/start, so that path falls through to its catch-all.
       expect(assign).toHaveBeenCalledTimes(1)
       expect(assign).toHaveBeenCalledWith(
-        `/oauth2/start?rd=${encodeURIComponent("/apps/postgres?tab=config#x")}`,
+        `/oauth2/sign_in?rd=${encodeURIComponent("/apps/postgres?tab=config#x")}`,
       )
     } finally {
       Object.defineProperty(window, "location", {

--- a/packages/system/dashboard/images/console/packages/k8s-client/src/client.ts
+++ b/packages/system/dashboard/images/console/packages/k8s-client/src/client.ts
@@ -1,6 +1,13 @@
 export interface K8sClientConfig {
   baseUrl?: string
   getToken?: () => Promise<string>
+  onUnauthorized?: () => void
+}
+
+function defaultOnUnauthorized(): void {
+  if (typeof window === "undefined") return
+  const rd = window.location.pathname + window.location.search + window.location.hash
+  window.location.assign(`/oauth2/start?rd=${encodeURIComponent(rd)}`)
 }
 
 export class K8sApiError extends Error {
@@ -24,10 +31,19 @@ export class K8sApiError extends Error {
 export class K8sClient {
   private baseUrl: string
   private getToken?: () => Promise<string>
+  private onUnauthorized: () => void
+  private unauthorizedHandled = false
 
   constructor(config: K8sClientConfig = {}) {
     this.baseUrl = config.baseUrl ?? ""
     this.getToken = config.getToken
+    this.onUnauthorized = config.onUnauthorized ?? defaultOnUnauthorized
+  }
+
+  private handleUnauthorized(): void {
+    if (this.unauthorizedHandled) return
+    this.unauthorizedHandled = true
+    this.onUnauthorized()
   }
 
   private async request<T>(path: string, init?: RequestInit): Promise<T> {
@@ -63,6 +79,7 @@ export class K8sClient {
       } catch {
         body = `Server returned ${res.status} ${res.statusText}`
       }
+      if (res.status === 401) this.handleUnauthorized()
       throw new K8sApiError(res.status, body)
     }
 
@@ -256,6 +273,7 @@ export class K8sClient {
         })
 
         if (!res.ok) {
+          if (res.status === 401) this.handleUnauthorized()
           throw new K8sApiError(
             res.status,
             await res.json().catch(() => res.statusText),

--- a/packages/system/dashboard/images/console/packages/k8s-client/src/client.ts
+++ b/packages/system/dashboard/images/console/packages/k8s-client/src/client.ts
@@ -4,10 +4,13 @@ export interface K8sClientConfig {
   onUnauthorized?: () => void
 }
 
+// /oauth2/sign_in is the only sign-in entry both gatekeeper modes serve:
+// oauth2-proxy jumps straight to the provider there (--skip-provider-button)
+// and token-proxy renders its token form; /oauth2/start is oauth2-proxy-only.
 function defaultOnUnauthorized(): void {
   if (typeof window === "undefined") return
   const rd = window.location.pathname + window.location.search + window.location.hash
-  window.location.assign(`/oauth2/start?rd=${encodeURIComponent(rd)}`)
+  window.location.assign(`/oauth2/sign_in?rd=${encodeURIComponent(rd)}`)
 }
 
 export class K8sApiError extends Error {

--- a/packages/system/dashboard/images/console/packages/k8s-client/src/client.ts
+++ b/packages/system/dashboard/images/console/packages/k8s-client/src/client.ts
@@ -86,6 +86,10 @@ export class K8sClient {
       throw new K8sApiError(res.status, body)
     }
 
+    // A 2xx means the session is alive again, so re-arm the latch: the default
+    // handler navigates away, but a custom one may re-auth in place.
+    this.unauthorizedHandled = false
+
     if (res.status === 204) return undefined as T
     // Some endpoints (e.g. KubeVirt action subresources like
     // virtualmachines/{name}/restart) return 2xx with an empty body;
@@ -282,6 +286,7 @@ export class K8sClient {
             await res.json().catch(() => res.statusText),
           )
         }
+        this.unauthorizedHandled = false
         if (!res.body) throw new Error("No response body for watch")
 
         const reader = res.body.getReader()


### PR DESCRIPTION
## What this PR does

Re-applies cozystack/cozystack-ui#34 (by @IvanHunters) onto the in-tree console, after the UI was vendored into the monorepo (#2963) and the standalone repo is being archived. Part of the cozystack-ui retirement tracked in #3097.

When the `kc-access` cookie expires, k8s API calls return `401` and the SPA previously sat on a stale page until the user manually cleared the cache. `K8sClient` now treats `401` as an auth boundary: a one-shot top-level navigation to `/oauth2/start?rd=<current-url>` (the oauth2-proxy re-auth convention). Overridable via `K8sClientConfig.onUnauthorized`; a no-op outside the browser; an `unauthorizedHandled` latch prevents repeated redirects on concurrent 401s.

Related: #2788.

## Verification

- `pnpm typecheck` clean; full console suite green (313 passed).
- A unit regression test is a follow-up — the `k8s-client` workspace package has no test harness yet (this matches the original PR, whose verification plan was manual).

Original PR: cozystack/cozystack-ui#34 — credited via `Co-authored-by`.

```release-note
fix(dashboard): the console now redirects to oauth2-proxy re-authentication on a 401 (expired session) instead of silently showing a stale page
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional callback for handling unauthorized access.
  * Automatically redirects browser users to sign in when their session expires, preserving the current page for return.
  * Supports unauthorized handling for both standard requests and live updates.
* **Bug Fixes**
  * Prevented repeated sign-in redirects during concurrent unauthorized responses.
  * Re-enables unauthorized handling after a successful response.
* **Tests**
  * Added coverage for unauthorized requests, live updates, concurrent responses, and redirect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->