### PR TITLE
refactor(dashboard): validate the schema form before page-level checks

### DIFF
--- a/packages/system/dashboard/images/console/apps/console/src/routes/BackupCreatePage.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/BackupCreatePage.test.tsx
@@ -15,6 +15,8 @@ const h = vi.hoisted(() => ({
     strategyRef: { kind: "Strategy", name: "s3" },
     takenAt: "2024-01-01T00:00:00Z",
   },
+  // Spec the mocked SchemaForm emits into the page on mount; reset per test.
+  emitSpec: {} as unknown,
 }))
 
 vi.mock("../lib/tenant-context.tsx", () => ({
@@ -38,7 +40,7 @@ vi.mock("../components/SchemaForm.tsx", () => ({
     function MockSchemaForm({ onChange }, ref) {
       useImperativeHandle(ref, () => ({ validate: () => h.validateReturn }))
       useEffect(() => {
-        onChange(h.validSpec)
+        onChange(h.emitSpec)
       }, [onChange])
       return null
     },
@@ -60,6 +62,7 @@ describe("BackupCreatePage submit validation gate", () => {
     h.createMutateAsync.mockReset()
     h.createMutateAsync.mockResolvedValue({})
     h.validateReturn = true
+    h.emitSpec = h.validSpec
   })
 
   it("does not POST when the form fails RJSF validation", async () => {
@@ -82,5 +85,23 @@ describe("BackupCreatePage submit validation gate", () => {
     await user.click(screen.getByRole("button", { name: /create/i }))
 
     expect(h.createMutateAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it("runs RJSF validation before the page-level required-field alerts", async () => {
+    // Form is RJSF-invalid AND a page-required field is missing. The gate must
+    // fire first, so no alert() is shown — proving validate() runs before the
+    // manual checks (under the old ordering the applicationRef alert fired).
+    h.validateReturn = false
+    h.emitSpec = {}
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {})
+    const user = userEvent.setup()
+    renderPage()
+
+    await user.type(screen.getByRole("textbox"), "my-backup")
+    await user.click(screen.getByRole("button", { name: /create/i }))
+
+    expect(h.createMutateAsync).not.toHaveBeenCalled()
+    expect(alertSpy).not.toHaveBeenCalled()
+    alertSpy.mockRestore()
   })
 })

--- a/packages/system/dashboard/images/console/apps/console/src/routes/BackupCreatePage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/BackupCreatePage.tsx
@@ -80,6 +80,10 @@ export function BackupCreatePage() {
       return
     }
 
+    // Run RJSF validation before the page-level checks so schema-required
+    // fields render inline errors instead of being masked by the alerts below.
+    if (schemaFormRef.current && !schemaFormRef.current.validate()) return
+
     if (!formData.applicationRef?.kind || !formData.applicationRef?.name) {
       alert("Application reference is required")
       return
@@ -94,10 +98,6 @@ export function BackupCreatePage() {
       alert("Taken at timestamp is required")
       return
     }
-
-    // The submit button lives outside RJSF and bypasses its validation, so
-    // trigger it explicitly; an invalid spec renders errors inline and aborts.
-    if (schemaFormRef.current && !schemaFormRef.current.validate()) return
 
     const resource = {
       apiVersion: "backups.cozystack.io/v1alpha1",

--- a/packages/system/dashboard/images/console/apps/console/src/routes/BackupJobCreatePage.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/BackupJobCreatePage.test.tsx
@@ -14,6 +14,7 @@ const h = vi.hoisted(() => ({
     applicationRef: { kind: "VirtualMachine", name: "demo" },
     backupClassName: "s3",
   },
+  emitSpec: {} as unknown,
 }))
 
 vi.mock("../lib/tenant-context.tsx", () => ({
@@ -37,7 +38,7 @@ vi.mock("../components/SchemaForm.tsx", () => ({
     function MockSchemaForm({ onChange }, ref) {
       useImperativeHandle(ref, () => ({ validate: () => h.validateReturn }))
       useEffect(() => {
-        onChange(h.validSpec)
+        onChange(h.emitSpec)
       }, [onChange])
       return null
     },
@@ -59,6 +60,7 @@ describe("BackupJobCreatePage submit validation gate", () => {
     h.createMutateAsync.mockReset()
     h.createMutateAsync.mockResolvedValue({})
     h.validateReturn = true
+    h.emitSpec = h.validSpec
   })
 
   it("does not POST when the form fails RJSF validation", async () => {
@@ -81,5 +83,20 @@ describe("BackupJobCreatePage submit validation gate", () => {
     await user.click(screen.getByRole("button", { name: /create/i }))
 
     expect(h.createMutateAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it("runs RJSF validation before the page-level required-field alerts", async () => {
+    h.validateReturn = false
+    h.emitSpec = {}
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {})
+    const user = userEvent.setup()
+    renderPage()
+
+    await user.type(screen.getByRole("textbox"), "my-job")
+    await user.click(screen.getByRole("button", { name: /create/i }))
+
+    expect(h.createMutateAsync).not.toHaveBeenCalled()
+    expect(alertSpy).not.toHaveBeenCalled()
+    alertSpy.mockRestore()
   })
 })

--- a/packages/system/dashboard/images/console/apps/console/src/routes/BackupJobCreatePage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/BackupJobCreatePage.tsx
@@ -97,6 +97,10 @@ export function BackupJobCreatePage() {
       return
     }
 
+    // Run RJSF validation before the page-level checks so schema-required
+    // fields render inline errors instead of being masked by the alerts below.
+    if (schemaFormRef.current && !schemaFormRef.current.validate()) return
+
     if (!formData.applicationRef?.kind || !formData.applicationRef?.name) {
       alert("Application reference is required")
       return
@@ -106,10 +110,6 @@ export function BackupJobCreatePage() {
       alert("Backup class name is required")
       return
     }
-
-    // The submit button lives outside RJSF and bypasses its validation, so
-    // trigger it explicitly; an invalid spec renders errors inline and aborts.
-    if (schemaFormRef.current && !schemaFormRef.current.validate()) return
 
     // planRef is optional metadata recording which Plan triggered the job. The
     // dropdown ships an empty sentinel; strip it so the API never receives

--- a/packages/system/dashboard/images/console/apps/console/src/routes/BackupPlanCreatePage.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/BackupPlanCreatePage.test.tsx
@@ -14,6 +14,7 @@ const h = vi.hoisted(() => ({
     applicationRef: { kind: "VirtualMachine", name: "demo" },
     backupClassName: "s3",
   },
+  emitSpec: {} as unknown,
 }))
 
 vi.mock("../lib/tenant-context.tsx", () => ({
@@ -37,7 +38,7 @@ vi.mock("../components/SchemaForm.tsx", () => ({
     function MockSchemaForm({ onChange }, ref) {
       useImperativeHandle(ref, () => ({ validate: () => h.validateReturn }))
       useEffect(() => {
-        onChange(h.validSpec)
+        onChange(h.emitSpec)
       }, [onChange])
       return null
     },
@@ -59,6 +60,7 @@ describe("BackupPlanCreatePage submit validation gate", () => {
     h.createMutateAsync.mockReset()
     h.createMutateAsync.mockResolvedValue({})
     h.validateReturn = true
+    h.emitSpec = h.validSpec
   })
 
   it("does not POST when the form fails RJSF validation", async () => {
@@ -81,5 +83,20 @@ describe("BackupPlanCreatePage submit validation gate", () => {
     await user.click(screen.getByRole("button", { name: /create/i }))
 
     expect(h.createMutateAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it("runs RJSF validation before the page-level required-field alerts", async () => {
+    h.validateReturn = false
+    h.emitSpec = {}
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {})
+    const user = userEvent.setup()
+    renderPage()
+
+    await user.type(screen.getByRole("textbox"), "my-plan")
+    await user.click(screen.getByRole("button", { name: /create/i }))
+
+    expect(h.createMutateAsync).not.toHaveBeenCalled()
+    expect(alertSpy).not.toHaveBeenCalled()
+    alertSpy.mockRestore()
   })
 })

--- a/packages/system/dashboard/images/console/apps/console/src/routes/BackupPlanCreatePage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/BackupPlanCreatePage.tsx
@@ -102,6 +102,10 @@ export function BackupPlanCreatePage() {
       return
     }
 
+    // Run RJSF validation before the page-level checks so schema-required
+    // fields render inline errors instead of being masked by the alerts below.
+    if (schemaFormRef.current && !schemaFormRef.current.validate()) return
+
     if (!formData.applicationRef?.kind || !formData.applicationRef?.name) {
       alert("Application reference is required")
       return
@@ -111,10 +115,6 @@ export function BackupPlanCreatePage() {
       alert("Backup class name is required")
       return
     }
-
-    // The submit button lives outside RJSF and bypasses its validation, so
-    // trigger it explicitly; an invalid spec renders errors inline and aborts.
-    if (schemaFormRef.current && !schemaFormRef.current.validate()) return
 
     const resource = {
       apiVersion: "backups.cozystack.io/v1alpha1",

--- a/packages/system/dashboard/images/console/apps/console/src/routes/BackupRestoreJobCreatePage.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/BackupRestoreJobCreatePage.test.tsx
@@ -13,6 +13,7 @@ const h = vi.hoisted(() => ({
   validSpec: {
     backupRef: { name: "backup-1" },
   },
+  emitSpec: {} as unknown,
 }))
 
 vi.mock("../lib/tenant-context.tsx", () => ({
@@ -36,7 +37,7 @@ vi.mock("../components/SchemaForm.tsx", () => ({
     function MockSchemaForm({ onChange }, ref) {
       useImperativeHandle(ref, () => ({ validate: () => h.validateReturn }))
       useEffect(() => {
-        onChange(h.validSpec)
+        onChange(h.emitSpec)
       }, [onChange])
       return null
     },
@@ -58,6 +59,7 @@ describe("BackupRestoreJobCreatePage submit validation gate", () => {
     h.createMutateAsync.mockReset()
     h.createMutateAsync.mockResolvedValue({})
     h.validateReturn = true
+    h.emitSpec = h.validSpec
   })
 
   it("does not POST when the form fails RJSF validation", async () => {
@@ -80,5 +82,20 @@ describe("BackupRestoreJobCreatePage submit validation gate", () => {
     await user.click(screen.getByRole("button", { name: /create/i }))
 
     expect(h.createMutateAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it("runs RJSF validation before the page-level required-field alerts", async () => {
+    h.validateReturn = false
+    h.emitSpec = {}
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {})
+    const user = userEvent.setup()
+    renderPage()
+
+    await user.type(screen.getByRole("textbox"), "my-restore")
+    await user.click(screen.getByRole("button", { name: /create/i }))
+
+    expect(h.createMutateAsync).not.toHaveBeenCalled()
+    expect(alertSpy).not.toHaveBeenCalled()
+    alertSpy.mockRestore()
   })
 })

--- a/packages/system/dashboard/images/console/apps/console/src/routes/BackupRestoreJobCreatePage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/BackupRestoreJobCreatePage.tsx
@@ -118,6 +118,10 @@ export function BackupRestoreJobCreatePage() {
       return
     }
 
+    // Run RJSF validation before the page-level checks so schema-required
+    // fields render inline errors instead of being masked by the alerts below.
+    if (schemaFormRef.current && !schemaFormRef.current.validate()) return
+
     if (!formData.backupRef?.name) {
       alert("Backup reference is required")
       return
@@ -133,10 +137,6 @@ export function BackupRestoreJobCreatePage() {
       alert("Target reference requires both Kind and Name, or leave both empty to restore into the source application")
       return
     }
-
-    // The submit button lives outside RJSF and bypasses its validation, so
-    // trigger it explicitly; an invalid spec renders errors inline and aborts.
-    if (schemaFormRef.current && !schemaFormRef.current.validate()) return
 
     // Strip an empty targetApplicationRef so the API does not receive an empty
     // object that the API server would reject as malformed.


### PR DESCRIPTION
## What this PR does

Re-applies cozystack/cozystack-ui#26 (by @lexfrei) onto the in-tree console, after the UI was vendored into the monorepo (#2963) and the standalone repo is being archived. Part of the cozystack-ui retirement tracked in #3097.

In the four backup create pages (Backup, BackupJob, BackupPlan, BackupRestoreJob), the RJSF `SchemaForm.validate()` call now runs right after the name check and before the page-level required-field alerts. The submit button lives outside RJSF and bypasses its validation, so each page triggers `validate()` explicitly; it previously ran only after the manual alert checks, so a schema-required field left empty exited via an alert without RJSF ever rendering its inline errors. Validating first makes inline errors show consistently; the page-level alerts then cover only page-only requirements (application/backup reference, strategy, timestamp).

Scope is the validation-ordering change only — the original PR's VMDisk/StorageClass parts were obsoleted by the `DynamicOptionsWidget` refactor (#30) already present in the vendored snapshot.

## Verification

- Includes the original per-page regression tests.
- `pnpm typecheck` clean; full console suite green (317 passed).

Original PR: cozystack/cozystack-ui#26 — credited via `Co-authored-by`.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved submission validation across backup creation, backup job, backup plan, and backup restore job pages.
  * Inline required-field errors now appear before page-level alerts.
  * Invalid submissions are prevented from sending requests or triggering unnecessary alerts.

* **Tests**
  * Expanded coverage for validation order and submission blocking.
  * Improved form test scenarios for invalid and missing data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->