### PR TITLE
ci(labeler): map cozystack-ui and console scopes to area/dashboard

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -49,6 +49,8 @@ jobs:
 
               // area/dashboard
               'dashboard':           'area/dashboard',
+              'cozystack-ui':        'area/dashboard',
+              'console':             'area/dashboard',
 
               // area/database
               'postgres':            'area/database',


### PR DESCRIPTION
## What this PR does

The cozystack-ui SPA was vendored into the monorepo in #2963 and now lives under `packages/system/dashboard`. PRs touching the UI are likely to use `cozystack-ui` or `console` as their Conventional Commits scope, neither of which the PR auto-labeler recognizes today — so they fall through to `area/uncategorized`.

This maps both scopes to the existing `area/dashboard` (already described as "dashboard / UI"). No new label is introduced; `.github/labels.yml` is unchanged.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded automatic PR labeling to add the `area/dashboard` label when a PR title scope is `cozystack-ui` or `console`.
  * Existing label rules and parsing behavior remain unchanged for all other scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->