### PR TITLE
fix(platform): stamp migrations 45/46 via the cozystack-version helper

### DIFF
--- a/packages/core/platform/images/migrations/migrations/45
+++ b/packages/core/platform/images/migrations/migrations/45
@@ -39,6 +39,9 @@
 
 set -euo pipefail
 
+# shellcheck source=lib/cozystack-version.sh
+. "$(dirname "$0")/lib/cozystack-version.sh"
+
 DRY_RUN="${MIGRATION_DRY_RUN:-0}"
 FAILURES=0
 PATCHED=0
@@ -118,21 +121,9 @@ if [ "$FAILURES" -gt 0 ]; then
   exit 1
 fi
 
-# Stamp version=46. Mirror migration 43's labeled heredoc — a label-less
-# apply by the same field manager (kubectl create cm | kubectl apply)
-# would strip the platform.cozystack.io/no-delete label migration 42
-# added, dropping cozystack-version out of the
-# cozystack-no-delete-guardrail ValidatingAdmissionPolicy.
-# templates/cozystack-version.yaml only re-renders the labeled ConfigMap
-# on first install, so the label must be carried inline here.
-kubectl apply --filename - <<EOF
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cozystack-version
-  namespace: cozy-system
-  labels:
-    platform.cozystack.io/no-delete: "true"
-data:
-  version: "46"
-EOF
+# Stamp version=46. The labeled manifest lives in the shared helper so it
+# cannot drift back to a label-less apply that strips the
+# platform.cozystack.io/no-delete label migration 42 added (which would drop
+# cozystack-version out of the cozystack-no-delete-guardrail
+# ValidatingAdmissionPolicy).
+stamp_cozystack_version 46

--- a/packages/core/platform/images/migrations/migrations/46
+++ b/packages/core/platform/images/migrations/migrations/46
@@ -21,6 +21,9 @@
 
 set -euo pipefail
 
+# shellcheck source=lib/cozystack-version.sh
+. "$(dirname "$0")/lib/cozystack-version.sh"
+
 DRY_RUN="${MIGRATION_DRY_RUN:-0}"
 FAILURES=0
 PATCHED=0
@@ -107,21 +110,9 @@ fi
 kubectl annotate configmap --namespace cozy-system cozystack-version \
   "cozystack.io/migration-46-failed-tenants-" >/dev/null 2>&1 || true
 
-# Stamp version=47. Mirror migration 43's labeled heredoc — a label-less
-# apply by the same field manager (kubectl create cm | kubectl apply)
-# would strip the platform.cozystack.io/no-delete label migration 42
-# added, dropping cozystack-version out of the
-# cozystack-no-delete-guardrail ValidatingAdmissionPolicy.
-# templates/cozystack-version.yaml only re-renders the labeled ConfigMap
-# on first install, so the label must be carried inline here.
-kubectl apply --filename - <<EOF
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cozystack-version
-  namespace: cozy-system
-  labels:
-    platform.cozystack.io/no-delete: "true"
-data:
-  version: "47"
-EOF
+# Stamp version=47. The labeled manifest lives in the shared helper so it
+# cannot drift back to a label-less apply that strips the
+# platform.cozystack.io/no-delete label migration 42 added (which would drop
+# cozystack-version out of the cozystack-no-delete-guardrail
+# ValidatingAdmissionPolicy).
+stamp_cozystack_version 47


### PR DESCRIPTION
## What this PR does

Migrations 45 and 46 (added by #2931) stamp the `cozystack-version` ConfigMap
with an inline `kubectl apply` heredoc instead of sourcing
`lib/cozystack-version.sh` and calling `stamp_cozystack_version`, the way
migrations 42/43/44 do. The `cozystack-version-stamp.bats` guard forbids any
migration ≥42 from bypassing the helper, so `make bats-unit-tests` fails on
migration 45.

This only surfaces in PR CI (`make unit-tests`) — `main`-push CI does not run
the bats suite — so #2931 landed red on this test and now blocks every PR that
merges current `main`.

This routes both stamps through the helper. The helper renders a
byte-identical labeled manifest (golden-pinned in the bats suite), so the
change is behaviour-preserving: it just restores the no-label-drift guarantee
the heredoc form could silently lose.

Verified: `make bats-unit-tests` passes (was failing on migration 45), bash
syntax-check clean on both scripts.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform version stamping to keep the version record correctly labeled and consistent during upgrades.
  * Updated tenant Kubernetes resources to move from v1.30 to v1.31 as part of the migration flow.

* **Chores**
  * Standardized migration behavior by using a shared version-stamping helper for more reliable updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->