### PR TITLE
fix(etcd): pin tenant etcd to v3.5.31 to restore consistent watches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
     "config:recommended",
     ":semanticCommits"
   ],
-  "enabledManagers": ["gomod", "dockerfile", "github-actions"],
+  "enabledManagers": ["gomod", "dockerfile", "github-actions", "custom.regex"],
   "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths"],
   "labels": ["automated", "do-not-merge/hold"],
   "automerge": false,
@@ -15,6 +15,15 @@
     "enabled": true,
     "labels": ["automated", "security"]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the etcd image pinned in the extra/etcd EtcdCluster podTemplate. etcd-operator v0.4.5 bakes etcd 3.5.12 into its binary, and the chart overrides it with a hardcoded image string that the gomod/dockerfile managers cannot see. Without this manager the security-relevant pin (etcd 3.5.x releases are overwhelmingly security fixes) would silently age.",
+      "managerFilePatterns": ["/^packages/extra/etcd/templates/etcd-cluster\\.yaml$/"],
+      "matchStrings": ["image:\\s+(?<depName>quay\\.io/coreos/etcd):(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"],
+      "datasourceTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "description": "Bump indirect Go modules too. Transitive deps such as golang.org/x/crypto, golang.org/x/net and golang.org/x/sys carry OSV advisories that drive the OpenSSF Scorecard Vulnerabilities check to 0, but Renovate skips indirect gomod deps by default so they never get a PR. Grouped into one rolling PR to keep volume sane; security fixes are still split out by vulnerabilityAlerts above. Placed before the kubernetes rule on purpose: an indirect k8s.io/** dep matches both, and Renovate applies last-match-wins, so the later kubernetes rule keeps it in the kubernetes lockstep group.",

--- a/packages/extra/etcd/templates/etcd-cluster.yaml
+++ b/packages/extra/etcd/templates/etcd-cluster.yaml
@@ -51,6 +51,16 @@ spec:
     spec:
       containers:
       - name: etcd
+        # Override the etcd image strategically merged into the operator's
+        # default pod spec. etcd-operator v0.4.5 hardcodes
+        # quay.io/coreos/etcd:v3.5.12 (DefaultEtcdImage), which the
+        # kube-apiserver rejects for consistent watches: it only enables the
+        # RequestWatchProgress storage feature on etcd >= 3.5.13 / >= 3.4.31.
+        # Kubernetes >= 1.31 enables ConsistentListFromCache (locked-to-true
+        # in 1.35), so on etcd 3.5.12 every consistent watch fails inside the
+        # stream with "the required storage feature RequestWatchProgress is
+        # disabled" (HTTP 500). Pinning a >= 3.5.13 patch release restores it.
+        image: quay.io/coreos/etcd:v3.5.31
         ports:
         - name: metrics
           containerPort: 2381

--- a/packages/extra/etcd/tests/etcd-cluster_test.yaml
+++ b/packages/extra/etcd/tests/etcd-cluster_test.yaml
@@ -1,0 +1,41 @@
+suite: etcd cluster pins an etcd image new enough for consistent watches
+
+# The exact patch version is intentionally NOT asserted: the image is a
+# Renovate-tracked pin (.github/renovate.json) that bumps over time, so an
+# exact-equality assertion would turn every etcd bump PR red in CI. The
+# test encodes the durable contract instead - the etcd container image is
+# overridden to a coreos/etcd release >= 3.5.13 (the floor at which
+# kube-apiserver enables the RequestWatchProgress storage feature) and
+# never falls back to the operator default v3.5.12.
+
+release:
+  name: etcd
+  namespace: tenant-test
+
+templates:
+  - templates/etcd-cluster.yaml
+
+set:
+  _cluster: {}
+
+tests:
+  - it: overrides the operator default etcd image with a >= 3.5.13 release
+    documentSelector:
+      path: kind
+      value: EtcdCluster
+    asserts:
+      - equal:
+          path: spec.podTemplate.spec.containers[0].name
+          value: etcd
+      - matchRegex:
+          path: spec.podTemplate.spec.containers[0].image
+          pattern: ^quay\.io/coreos/etcd:v(3\.5\.(1[3-9]|[2-9][0-9]|[1-9][0-9]{2,})|3\.([6-9]|[1-9][0-9])\.[0-9]+|[4-9][0-9]*\.[0-9]+\.[0-9]+)$
+
+  - it: never falls back to the operator default v3.5.12
+    documentSelector:
+      path: kind
+      value: EtcdCluster
+    asserts:
+      - notEqual:
+          path: spec.podTemplate.spec.containers[0].image
+          value: quay.io/coreos/etcd:v3.5.12


### PR DESCRIPTION
## What this PR does

Tenant Kubernetes control planes get their etcd from the `extra/etcd` chart, which creates an `EtcdCluster` (`etcd.aenix.io/v1alpha1`) reconciled by etcd-operator v0.4.5. That operator hardcodes the etcd image to `quay.io/coreos/etcd:v3.5.12`, and the v1alpha1 CRD exposes no version field, so every tenant etcd runs 3.5.12.

kube-apiserver only enables the `RequestWatchProgress` storage feature on etcd >= 3.5.13 (or >= 3.4.31). Kubernetes >= 1.31 enables `ConsistentListFromCache` — locked-to-true in 1.35 — which depends on it. On etcd 3.5.12 every consistent watch therefore fails inside the stream with HTTP 500 (`the required storage feature RequestWatchProgress is disabled`), which breaks watch-based clients of aggregated APIs in modern (k8s 1.35) tenants.

This pins the etcd container image to a >= 3.5.13 patch release (v3.5.31) by setting `image` on the `etcd` container in the EtcdCluster's `spec.podTemplate.spec`. etcd-operator v0.4.5 strategically merges `podTemplate.spec` over its generated pod spec (matched by container name), so the override takes effect with no operator change — the same mechanism the chart already uses for the metrics port, probes, and resources. It restores consistent watches without waiting on the etcd-operator v1alpha2 migration (#2859), which is the longer-term fix.

A helm-unittest suite asserts the etcd container carries the pinned image and is no longer left on the operator default v3.5.12.

Addresses #3080.

### Upgrade impact

On merge, etcd-operator reconciles every existing tenant `EtcdCluster` and rolls its StatefulSet from 3.5.12 to 3.5.31. This is a safe in-minor rolling patch upgrade (no etcd storage-format change, quorum preserved by the operator's rolling strategy), so expect a brief, sequential etcd pod restart per tenant and no data migration.

### Release note

```release-note
fix(etcd): pin tenant etcd to v3.5.31 so kube-apiserver can enable RequestWatchProgress (consistent watches) on Kubernetes 1.35 tenants
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pinned the bundled etcd image to `quay.io/coreos/etcd:v3.5.31` to improve compatibility with Kubernetes watch-related storage behavior.
  * Prevented deployments from reverting to the older default etcd image.
* **Tests**
  * Added a new test suite to verify the template uses the expected pinned etcd image and blocks regressions.
* **Chores**
  * Updated dependency automation to recognize and manage the pinned etcd image version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
