### PR TITLE
feat(keycloak): configurable login theme via platform branding

### DIFF
--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -349,7 +349,27 @@ gateway:
 # Pod scheduling configuration
 scheduling:
   globalAppTopologySpreadConstraints: ""
-# UI branding configuration
+# UI branding configuration. The whole map is propagated verbatim into
+# _cluster.branding (the cozystack-values Secret) and consumed by the dashboard
+# (config.json) and Keycloak realm provisioning.
+#
+# Recognized keys:
+#   brandName:       realm displayName (the Keycloak login title reads it as
+#                    "Sign in to <brandName>").
+#   brandHtmlName:   realm displayNameHtml (HTML shown in the login header).
+#   loginTheme:      Keycloak login theme name; selected as the realm login
+#                    theme and used as the theme directory/name.
+#   loginThemeImage: OCI image carrying that theme under /themes/. When set
+#                    together with loginTheme, the keycloak chart mounts it via
+#                    an init container, so the theme ships without patching the
+#                    StatefulSet or the keycloak package values.
+#
+# Example:
+# branding:
+#   brandName: "Acme Platform"
+#   brandHtmlName: "<b>Acme</b> Platform"
+#   loginTheme: acme
+#   loginThemeImage: registry.example.com/acme-keycloak-theme:v1
 branding: {}
 # Container registry mirrors configuration
 #

--- a/packages/system/keycloak-configure/Makefile
+++ b/packages/system/keycloak-configure/Makefile
@@ -3,3 +3,6 @@ export NAMESPACE=cozy-keycloak
 
 include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
+
+test:
+	helm unittest .

--- a/packages/system/keycloak-configure/templates/configure-kk.yaml
+++ b/packages/system/keycloak-configure/templates/configure-kk.yaml
@@ -36,6 +36,10 @@ spec:
   {{- else if hasKey $brandingConfig "branding" }}
   displayHtmlName: {{ $brandingConfig.branding }}
   {{- end }}
+  {{- if hasKey $brandingConfig "loginTheme" }}
+  themes:
+    loginTheme: {{ $brandingConfig.loginTheme | quote }}
+  {{- end }}
   {{- end }}
   {{- with .Values.login }}
   login:

--- a/packages/system/keycloak-configure/tests/login_theme_test.yaml
+++ b/packages/system/keycloak-configure/tests/login_theme_test.yaml
@@ -1,0 +1,44 @@
+suite: keycloak realm login theme via platform branding
+
+# branding.loginTheme (delivered through _cluster.branding) must select the
+# realm login theme by rendering ClusterKeycloakRealm.spec.themes.loginTheme,
+# alongside the existing branding.brandName -> displayName path. Without this
+# the realm keeps the stock Keycloak login theme regardless of branding.
+release:
+  name: keycloak-configure
+  namespace: cozy-keycloak
+tests:
+  - it: branding loginTheme sets ClusterKeycloakRealm.spec.themes.loginTheme
+    template: templates/configure-kk.yaml
+    documentSelector:
+      path: kind
+      value: ClusterKeycloakRealm
+    set:
+      _cluster:
+        root-host: example.com
+        kube-root-ca: ""
+        branding:
+          brandName: Acme Platform
+          loginTheme: aenix
+    asserts:
+      - equal:
+          path: spec.themes.loginTheme
+          value: aenix
+      - equal:
+          path: spec.displayName
+          value: Acme Platform
+
+  - it: no loginTheme leaves the realm without a themes block
+    template: templates/configure-kk.yaml
+    documentSelector:
+      path: kind
+      value: ClusterKeycloakRealm
+    set:
+      _cluster:
+        root-host: example.com
+        kube-root-ca: ""
+        branding:
+          brandName: Acme Platform
+    asserts:
+      - notExists:
+          path: spec.themes

--- a/packages/system/keycloak/templates/sts.yaml
+++ b/packages/system/keycloak/templates/sts.yaml
@@ -6,6 +6,21 @@
 {{- $ingressHost := .Values.ingress.host | default (printf "keycloak.%s" $host) }}
 {{- $clusterDomain := (index .Values._cluster "cluster-domain") | default "cozy.local" }}
 
+{{- /*
+Effective theme list. Starts from the explicit .Values.themes and, when the
+platform branding config names a login theme (branding.loginTheme) together
+with the OCI image that carries it (branding.loginThemeImage), appends an
+auto-derived entry. This lets an operator ship a Keycloak login theme purely
+through platform branding values, without editing this chart or patching the
+StatefulSet. branding flows in via _cluster.branding (the cozystack-values
+Secret), the same path that feeds the realm displayName.
+*/}}
+{{- $branding := (.Values._cluster | default dict).branding | default dict }}
+{{- $themes := .Values.themes | default list }}
+{{- if and (hasKey $branding "loginTheme") (hasKey $branding "loginThemeImage") }}
+{{- $themes = concat $themes (list (dict "name" $branding.loginTheme "image" $branding.loginThemeImage)) }}
+{{- end }}
+
 {{- $existingPassword := lookup "v1" "Secret" "cozy-keycloak" (printf "%s-credentials" .Release.Name) }}
 {{- $password := randAlphaNum 16 -}}
 {{- if $existingPassword }}
@@ -49,9 +64,9 @@ spec:
       {{- end }}
       securityContext:
         fsGroup: 1000
-      {{- if .Values.themes }}
+      {{- if $themes }}
       {{- $themeNames := list }}
-      {{- range .Values.themes }}
+      {{- range $themes }}
       {{- if not .name }}{{ fail "theme entry missing required field: name" }}{{- end }}
       {{- if not .image }}{{ fail "theme entry missing required field: image" }}{{- end }}
       {{- $sanitized := include "keycloak.theme.sanitizedName" .name }}
@@ -61,7 +76,7 @@ spec:
       {{- $themeNames = append $themeNames $sanitized }}
       {{- end }}
       initContainers:
-        {{- range .Values.themes }}
+        {{- range $themes }}
         - name: theme-{{ include "keycloak.theme.sanitizedName" .name }}
           image: "{{ .image }}"
           imagePullPolicy: IfNotPresent
@@ -191,9 +206,9 @@ spec:
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- if or .Values.themes .Values.extraVolumeMounts }}
+          {{- if or $themes .Values.extraVolumeMounts }}
           volumeMounts:
-            {{- if .Values.themes }}
+            {{- if $themes }}
             - name: themes
               mountPath: /opt/keycloak/themes
             {{- end }}
@@ -228,9 +243,9 @@ spec:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
-      {{- if or .Values.themes .Values.extraVolumes }}
+      {{- if or $themes .Values.extraVolumes }}
       volumes:
-        {{- if .Values.themes }}
+        {{- if $themes }}
         - name: themes
           emptyDir:
             sizeLimit: 256Mi

--- a/packages/system/keycloak/tests/login_theme_test.yaml
+++ b/packages/system/keycloak/tests/login_theme_test.yaml
@@ -1,0 +1,93 @@
+suite: keycloak login theme via platform branding
+
+# branding.loginTheme + branding.loginThemeImage (delivered through
+# _cluster.branding in the cozystack-values Secret) must append a theme entry
+# to the effective theme list so the login theme image is mounted via an init
+# container without anyone editing this chart's values or the StatefulSet.
+release:
+  name: keycloak
+  namespace: cozy-keycloak
+tests:
+  - it: branding loginTheme + image adds a theme init container, volume and mount
+    template: templates/sts.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    set:
+      _cluster:
+        root-host: example.com
+        cluster-domain: cozy.local
+        branding:
+          loginTheme: aenix
+          loginThemeImage: registry.example.com/aenix-keycloak-theme:v1
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: theme-aenix
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: registry.example.com/aenix-keycloak-theme:v1
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: themes
+            emptyDir:
+              sizeLimit: 256Mi
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: themes
+            mountPath: /opt/keycloak/themes
+
+  - it: branding loginTheme without an image does not add an init container
+    template: templates/sts.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    set:
+      _cluster:
+        root-host: example.com
+        cluster-domain: cozy.local
+        branding:
+          loginTheme: aenix
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+
+  - it: no themes and no branding theme leaves the pod without theme machinery
+    template: templates/sts.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    set:
+      _cluster:
+        root-host: example.com
+        cluster-domain: cozy.local
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+      - notExists:
+          path: spec.template.spec.volumes
+
+  - it: explicit themes value still renders, with the branding theme appended after it
+    template: templates/sts.yaml
+    documentSelector:
+      path: kind
+      value: StatefulSet
+    set:
+      _cluster:
+        root-host: example.com
+        cluster-domain: cozy.local
+        branding:
+          loginTheme: aenix
+          loginThemeImage: registry.example.com/aenix-keycloak-theme:v1
+      themes:
+        - name: foo
+          image: registry.example.com/foo:1
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: theme-foo
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: theme-aenix

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -37,6 +37,12 @@ themes: []
 # Theme images must contain theme files under /themes/ directory.
 # Each theme is copied into Keycloak's /opt/keycloak/themes/ via init container.
 # If multiple themes contain files with the same path, later entries take precedence.
+#
+# In addition to this explicit list, a single login theme can be shipped through
+# platform branding values: setting branding.loginTheme (the theme name) together
+# with branding.loginThemeImage (the OCI image carrying it under /themes/) appends
+# an entry here automatically and selects it as the realm login theme. branding
+# arrives via _cluster.branding, so no per-package values plumbing is required.
 
 imagePullSecrets: []
 # - name: my-registry-secret


### PR DESCRIPTION
## What this PR does

Makes a realm's Keycloak login theme configurable through platform `branding` values, closing a gap: `branding` could set the realm display name but not its login theme, and the keycloak chart's `themes:` list was not reachable from platform values.

Two new keys under `branding` (propagated via `_cluster.branding`, the same path that already feeds `displayName`):

- `branding.loginTheme` — keycloak-configure renders it as `ClusterKeycloakRealm.spec.themes.loginTheme`, so the realm selects that login theme.
- `branding.loginThemeImage` — when set together with `loginTheme`, the keycloak chart appends `{name: loginTheme, image: loginThemeImage}` to its effective theme list, so the existing init-container mounts the theme image into `/opt/keycloak/themes/`. No StatefulSet patching or per-package values plumbing.

`loginTheme` alone (no image) still selects the theme — for themes already baked into the Keycloak image. Explicit chart `themes:` entries keep working; the branding-derived entry is appended after them.

Flow: platform `branding` → `_cluster.branding` (cozystack-values Secret) → keycloak-configure (realm loginTheme) + keycloak (theme init container). Covered by helm-unittest in both charts.

### Screenshots

No bundled UI assets — this PR adds the mechanism only; the login theme is operator-supplied via `loginThemeImage`, so the visual result depends on that image.

### Release note

```release-note
feat(keycloak): select the realm login theme and ship its theme image through platform `branding` values (`branding.loginTheme`, `branding.loginThemeImage`)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom login theme from platform branding, including automatic selection in the realm setup.
  * Theme entries can now be combined with existing theme settings and rendered in the expected order.

* **Documentation**
  * Expanded configuration guidance for branding and theme-related settings with clearer examples.

* **Tests**
  * Added coverage for login theme rendering and fallback behavior when theme settings are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->