### PR TITLE
test: make negative bats assertions fail under cozytest

### DIFF
--- a/hack/build-matrix_test.bats
+++ b/hack/build-matrix_test.bats
@@ -18,8 +18,11 @@ setup() {
 
 @test "talos and installer are excluded from the parallel matrix" {
   out=$(hack/build-matrix.sh)
-  ! echo "$out" | grep -q '"packages/core/talos"'
-  ! echo "$out" | grep -q '"packages/core/installer"'
+  # `! cmd` would be vacuous: cozytest.sh runs each @test under `set -e`, which
+  # is suppressed for a `!`-negated pipeline, so a regression that wrongly
+  # included these paths would not fail the test. Assert via `if cmd; then ...`.
+  if echo "$out" | grep -q '"packages/core/talos"'; then echo "FAIL: packages/core/talos must be excluded from the parallel matrix"; false; fi
+  if echo "$out" | grep -q '"packages/core/installer"'; then echo "FAIL: packages/core/installer must be excluded from the parallel matrix"; false; fi
 }
 
 @test "talos-only diff selects nothing (handled by the dedicated leg)" {

--- a/hack/capture-dataplane.bats
+++ b/hack/capture-dataplane.bats
@@ -53,8 +53,11 @@ E2E_CAPTURE_DATAPLANE_LIB=1
   [ "$(printf '%s\n' "$out" | grep -c .)" -eq 2 ]
   printf '%s\n' "$out" | grep -q '^tenant|app|LoadBalancer|192.0.2.50|'
   printf '%s\n' "$out" | grep -q '^tenant|db|LoadBalancer|192.0.2.51|'
-  ! printf '%s\n' "$out" | grep -q 'kube-dns'
-  ! printf '%s\n' "$out" | grep -q 'pending'
+  # `! cmd` is vacuous under cozytest's `set -e` (errexit is suppressed for a
+  # `!`-negated pipeline), so a filter regression that let these rows through
+  # would not fail the test. Assert the absence via `if cmd; then ...; false`.
+  if printf '%s\n' "$out" | grep -q 'kube-dns'; then echo "FAIL: lb_filter_services must drop the kube-dns row"; false; fi
+  if printf '%s\n' "$out" | grep -q 'pending'; then echo "FAIL: lb_filter_services must drop the pending (no external IP) row"; false; fi
 }
 
 @test "lb_first_ready_endpoint picks the first addressed endpoint that is not NotReady" {

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -85,9 +85,12 @@ EOF
   # Viewer can download
   mc cp --insecure ro-user/$BUCKET_NAME/rw-test.txt /tmp/ro-test-download.txt
 
-  # Viewer cannot upload (must fail with Access Denied)
+  # Viewer cannot upload (must fail with Access Denied). A bare `! mc cp` is
+  # vacuous under cozytest's `set -e` (errexit is suppressed for a `!` pipeline),
+  # so a real access-control regression that let the upload through would pass
+  # silently — assert via `if mc cp; then ...; false` so it fails loudly.
   echo "readonly test" > /tmp/ro-test.txt
-  ! mc cp --insecure /tmp/ro-test.txt ro-user/$BUCKET_NAME/ro-test.txt
+  if mc cp --insecure /tmp/ro-test.txt ro-user/$BUCKET_NAME/ro-test.txt; then echo "FAIL: read-only user must NOT be able to upload (bucket access-control regression)"; false; fi
 
   # --- Cleanup ---
   mc rm --insecure rw-user/$BUCKET_NAME/rw-test.txt

--- a/hack/e2e-apps/gateway.bats
+++ b/hack/e2e-apps/gateway.bats
@@ -540,8 +540,11 @@ EOF
   echo "$cozyvalues" | grep -E '^\s*gateway:\s*"tenant-test-gwparent"\s*$' >/dev/null
 
   # The child must NOT have its own gateway HelmRelease — inheritance
-  # means no separate Gateway resource for the child tenant.
-  ! kubectl -n tenant-test-gwparent-gwchild get helmrelease gateway 2>/dev/null
+  # means no separate Gateway resource for the child tenant. A bare `! kubectl`
+  # is vacuous under cozytest's `set -e` (suppressed for a `!` pipeline), so if
+  # the child wrongly got its own HelmRelease the test would still pass; assert
+  # via `if kubectl get; then ...; false`.
+  if kubectl -n tenant-test-gwparent-gwchild get helmrelease gateway 2>/dev/null; then echo "FAIL: child tenant must NOT have its own gateway HelmRelease (gateway inheritance broken)"; false; fi
 
   # Teardown child before parent, waiting out each uninstall: deleting
   # the parent while the child is still uninstalling wedges the parent's

--- a/hack/e2e-apps/kuberture.bats
+++ b/hack/e2e-apps/kuberture.bats
@@ -236,12 +236,15 @@ EOF
   # kuberture-e2e-public.cozystack.test (kuberture-e2e-public Service carries
   # external-dns.alpha.kubernetes.io/hostname=...) and must NOT see the
   # internal hostname (kuberture-e2e-internal carries only the internal prefix).
+  # A bare `! echo | grep` is vacuous under cozytest's `set -e` (errexit is
+  # suppressed for a `!` pipeline), so a leak of the wrong hostname into a probe
+  # would not fail the test; assert the absence via `if ... grep; then ...; false`.
   echo "${pub_logs}" | grep -F "${pub_host}" >/dev/null
-  ! echo "${pub_logs}" | grep -F "${int_host}" >/dev/null
+  if echo "${pub_logs}" | grep -F "${int_host}" >/dev/null; then echo "FAIL: public-prefix probe must NOT see the internal hostname ${int_host}"; false; fi
 
   # And the inverse for the internal-prefix probe.
   echo "${int_logs}" | grep -F "${int_host}" >/dev/null
-  ! echo "${int_logs}" | grep -F "${pub_host}" >/dev/null
+  if echo "${int_logs}" | grep -F "${pub_host}" >/dev/null; then echo "FAIL: internal-prefix probe must NOT see the public hostname ${pub_host}"; false; fi
 
   # _cleanup deletes the probe Pods, their SA, the ClusterRole+ClusterRoleBinding,
   # and finally the Package CR. Inlined here for the success path so a re-run

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -289,8 +289,10 @@ EOF
   # generic DNS-1035 errors and from network/auth failures).
   echo "$output" | grep -q "tenant names must"
   # And assert kubectl did NOT report creation — if validation regressed
-  # into a "warn" variant, the server could still accept the object.
-  ! echo "$output" | grep -qi "created"
+  # into a "warn" variant, the server could still accept the object. A bare
+  # `! echo | grep` is vacuous under cozytest's `set -e` (suppressed for a `!`
+  # pipeline), so the regression would slip through; assert via `if ...; false`.
+  if echo "$output" | grep -qi "created"; then echo "FAIL: kubectl reported the tenant as created — validation must reject it, not warn"; false; fi
 
   # Post-condition cleanup: even though we expect validation to reject the
   # create, removing foo-bar unconditionally keeps the cluster clean for
@@ -395,7 +397,10 @@ EOF
   version=$(kubectl get configmap cozystack-version -n cozy-system \
     -o jsonpath='{.data.version}')
   kubectl delete configmap cozystack-version -n cozy-system
-  ! kubectl get configmap cozystack-version -n cozy-system 2>/dev/null
+  # A bare `! kubectl get` is vacuous under cozytest's `set -e` (errexit is
+  # suppressed for a `!` pipeline), so a delete that silently failed would not
+  # fail the test; assert the absence via `if kubectl get; then ...; false`.
+  if kubectl get configmap cozystack-version -n cozy-system 2>/dev/null; then echo "FAIL: cozystack-version configmap must be gone after delete with the no-delete label removed"; false; fi
   # Reconstruct: declarative apply matches the chart template at
   # packages/core/platform/templates/cozystack-version.yaml — same label set
   # AND the helm.sh/resource-policy: keep annotation that pins the ConfigMap


### PR DESCRIPTION
## What this PR does

Every `*.bats` file in the repo runs through `hack/cozytest.sh`, not real bats — the e2e files via `packages/core/testing/Makefile` and the `hack/*.bats` unit tests via `make bats-unit-tests`. cozytest runs each `@test` under `set -e`, and POSIX errexit is suppressed for a pipeline beginning with `!`. So a bare `! cmd` must-not-happen assertion never fails the test: when the forbidden condition actually occurs (the command succeeds), the negated pipeline returns non-zero but errexit ignores it and the test passes anyway. Ten such assertions across six files were silently vacuous.

This converts each to `if cmd; then echo "<reason>"; false; fi`. The `if` condition is exempt from errexit (so the probe itself never aborts the test), and the `false` in the taken branch is a plain command under `set -e`, so it aborts and fails the test with a legible message when the forbidden condition holds. This is the must-not-happen inverse of the `cmd || { echo …; false; }` pattern already used in the suite (e.g. harbor.bats, per docs/agents/e2e-testing.md). Original redirections and quoting are preserved, so happy-path behavior is unchanged — only the failure path now actually fails.

Converted assertions:

- `bucket`: a read-only user must not be able to upload (access-control regression guard)
- `gateway`: a child tenant must not have its own gateway HelmRelease (inheritance)
- `kuberture`: external-dns public/internal hostname isolation
- `e2e-install-cozystack`: tenant-name validation must reject rather than warn; the version ConfigMap must be gone after delete
- `build-matrix` (unit test): talos/installer must be excluded from the parallel matrix
- `capture-dataplane` (unit test): kube-dns and pending rows must be filtered out

A separate in-flight etcd test change owns two more such assertions in `etcd.bats`; they are left out of this PR to avoid a conflicting edit.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened several end-to-end/Bats assertions to fail more explicitly when expected cluster conditions aren’t met.
  * Improved matrix validation to reliably confirm excluded components are absent.
  * Updated dataplane load balancer filtering, bucket readonly upload, and gateway inheritance checks to avoid false/ambiguous pass cases.
  * Tightened DNS hostname isolation probes and cozystack installer validations (tenant name dashes, deletion protection) with clearer “expected vs found” failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->