### PR TITLE
test: fix dead bats setup/teardown hooks under cozytest

### DIFF
--- a/hack/build-matrix_test.bats
+++ b/hack/build-matrix_test.bats
@@ -1,12 +1,10 @@
 #!/usr/bin/env bats
 # Unit tests for hack/build-matrix.sh — the CI build-matrix selector.
 #
-# Run from the repo root:  bats hack/build-matrix_test.bats
-
-setup() {
-  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
-  cd "$REPO_ROOT"
-}
+# Run via hack/cozytest.sh from the repo root (make bats-unit-tests); the
+# relative `hack/build-matrix.sh` calls below resolve against that cwd. A bats
+# setup() hook would be dead here — cozytest never invokes it — so the
+# repo-root cwd is supplied by the runner rather than a setup() cd.
 
 @test "no argument emits the full matrix" {
   out=$(hack/build-matrix.sh)

--- a/hack/e2e-apps/external-dns.bats
+++ b/hack/e2e-apps/external-dns.bats
@@ -1,6 +1,14 @@
 #!/usr/bin/env bats
 
-teardown() {
+# cozytest.sh (the e2e runner) is not real bats — it never invokes setup()/
+# teardown(). Cleanup belongs in cozy_cleanup(), which cozytest runs once at
+# suite exit and on the first failing test. Each @test already deletes its own
+# ExternalDNS inline on the success path (fail-loud); this is the failure-path
+# safety net, so a test that aborts before its inline delete does not leak the
+# ExternalDNS CR (and its HelmReleases) into the shared tenant-test namespace.
+# ExternalDNS here is a stateless Deployment with the inmemory provider, so a
+# plain delete fully reclaims it — no PVCs, finalizers, or provider records.
+cozy_cleanup() {
   kubectl -n tenant-test delete externaldns.apps.cozystack.io --all --ignore-not-found 2>/dev/null || true
 }
 

--- a/hack/e2e-apps/kuberture.bats
+++ b/hack/e2e-apps/kuberture.bats
@@ -10,28 +10,36 @@
 # multiple external-dns instances from one platform-level package.
 #
 # cozytest.sh is plain POSIX shell — no `[[ ... ]]`, no bats `run` helper,
-# no FD 3, and `teardown()` is never auto-invoked. Cleanup is inlined at the
-# end of the @test body and runs on the success path only; the e2e Makefile's
-# sandbox teardown handles the failure case.
+# no FD 3, and setup()/teardown() are never auto-invoked. Cleanup is inlined
+# at the end of the @test body (success path, fail-loud) and also wired to
+# cozy_cleanup(), the hook cozytest runs at suite exit and on the first
+# failing test, so the failure path is covered too.
 
 # Shared cleanup so the inline success-path call at the end of the @test
-# body and the teardown hook (alive only under upstream bats) cannot
-# drift apart.
+# body and the cozy_cleanup hook cannot drift apart.
 _cleanup() {
   # Probe Pods and their RBAC live outside the chart and need explicit
   # teardown — the Package delete cascade does not own them. The
   # ClusterRole/ClusterRoleBinding are cluster-scoped and would otherwise
   # leak across e2e re-runs on the same sandbox cluster.
-  kubectl delete --namespace cozy-kuberture --ignore-not-found pod/kuberture-e2e-edns-public pod/kuberture-e2e-edns-internal 2>/dev/null || true
-  kubectl delete --namespace cozy-kuberture --ignore-not-found sa/kuberture-e2e-edns-probe 2>/dev/null || true
-  kubectl delete --ignore-not-found clusterrolebinding/kuberture-e2e-edns-probe clusterrole/kuberture-e2e-edns-probe 2>/dev/null || true
-  kubectl delete package.cozystack.io cozystack.kuberture --ignore-not-found --wait=true --timeout=180s 2>/dev/null || true
+  #
+  # No `|| true`: on the success-path inline call these run under `set -e`, so
+  # a stuck finalizer or wait timeout fails the test (e2e-testing.md §4) instead
+  # of silently leaking; --ignore-not-found still covers the clean case. On the
+  # failure path cozytest wraps the cozy_cleanup hook in `|| true`, so it stays
+  # best-effort there without per-delete masking.
+  kubectl delete --namespace cozy-kuberture --ignore-not-found pod/kuberture-e2e-edns-public pod/kuberture-e2e-edns-internal
+  kubectl delete --namespace cozy-kuberture --ignore-not-found sa/kuberture-e2e-edns-probe
+  kubectl delete --ignore-not-found clusterrolebinding/kuberture-e2e-edns-probe clusterrole/kuberture-e2e-edns-probe
+  kubectl delete package.cozystack.io cozystack.kuberture --ignore-not-found --wait=true --timeout=180s
 }
 
-teardown() {
-  # Dead code under cozytest.sh — the runner never invokes it. Kept so
-  # the file still works under upstream bats (e.g. for local debugging
-  # via `bats hack/e2e-apps/kuberture.bats`).
+cozy_cleanup() {
+  # cozytest's failure-path safety net: it runs this at suite exit and on the
+  # first failing test. The @test also calls _cleanup inline on the success
+  # path; routing both through _cleanup keeps them from drifting. Without this,
+  # a failing run would leak the cluster-scoped ClusterRole/ClusterRoleBinding
+  # across e2e re-runs on the same sandbox cluster.
   _cleanup
 }
 


### PR DESCRIPTION
## What this PR does

cozytest.sh — the runner for every `*.bats` file in the repo (e2e via `packages/core/testing/Makefile`, unit tests via `make bats-unit-tests`) — is not real bats: it never invokes `setup()`/`teardown()`. Three such hooks outside `etcd.bats` were therefore dead. Cleanup ran only via each test's success-path inline delete, so a failing test leaked its resources into the shared `tenant-test` namespace — and, for kuberture, cluster-scoped RBAC that persists across sandbox re-runs.

This wires the cleanup to `cozy_cleanup()`, the hook cozytest does run (once at suite exit and on the first failing test):

- **external-dns**: dead `teardown()` → `cozy_cleanup()` deleting all ExternalDNS CRs. ExternalDNS is a stateless Deployment with the `inmemory` provider, so a plain delete fully reclaims it — no drain needed. The per-test inline deletes remain fail-loud on the success path; `cozy_cleanup` is the failure-path net.
- **kuberture**: dead `teardown()` → `cozy_cleanup()` routed through the existing `_cleanup()`, so the probe Pods, ServiceAccount, and cluster-scoped ClusterRole/ClusterRoleBinding are reclaimed on the failure path too. `_cleanup`'s per-delete `|| true` is also dropped (keeping `--ignore-not-found`): the success-path inline call now fails the test on a stuck teardown (e2e-testing.md §4), while the failure path stays best-effort via the runner's `cozy_cleanup || true` wrap.
- **build-matrix_test**: the dead `setup()` only `cd`'d to the repo root, which cozytest already runs from, so the relative `hack/build-matrix.sh` calls resolve without it — removed.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test cleanup for external-dns by switching to suite-aligned cleanup that reliably removes ExternalDNS resources even on failures or early aborts.
  * Enhanced kuberture end-to-end cleanup to remove probe components and related RBAC/package more safely, with errors handled consistently to aid diagnosis.
  * Updated test setup expectations for matrix builds so tests run correctly from the repository root without relying on a custom directory hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->