### PR TITLE
fix(seaweedfs): enforce read-only bucket access by bumping cosi-driver to v0.3.1

### DIFF
--- a/packages/system/seaweedfs/tests/cosi_image_test.yaml
+++ b/packages/system/seaweedfs/tests/cosi_image_test.yaml
@@ -1,0 +1,38 @@
+suite: seaweedfs COSI driver image pin
+
+# Pins the COSI driver image to a release that enforces read-only bucket access.
+#
+# The vendored chart default is seaweedfs-cosi-driver v0.1.2 (see
+# charts/seaweedfs/values.yaml), which hardcodes read-write S3 actions for every
+# BucketAccess and ignores the accessPolicy parameter. The chart ships a
+# -readonly BucketAccessClass with parameters.accessPolicy: readonly, so on
+# v0.1.2 a credential meant to be read-only is silently granted read-write.
+# The package values.yaml overrides cosi.image to v0.3.1, which honours
+# accessPolicy: readonly.
+#
+# This test does not set the image itself; it relies on the package values.yaml
+# override, so it goes red if that override is removed and the image falls back
+# to the vulnerable v0.1.2 — turning a silent security regression into a build
+# failure. Note: `make update` re-vendors charts/ and resets the vendored
+# default to v0.1.2 but does not touch the package values.yaml, so the override
+# (and this guard) must be preserved across any re-vendor.
+
+templates:
+  - charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+
+release:
+  name: seaweedfs
+  namespace: cozy-seaweedfs
+
+tests:
+  - it: pins the cosi-driver container to v0.3.1 (read-only access enforcement)
+    template: charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+    set:
+      seaweedfs.cosi.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: seaweedfs-cosi-driver
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/seaweedfs/seaweedfs-cosi-driver:v0.3.1

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -204,6 +204,11 @@ seaweedfs:
               topologyKey: kubernetes.io/hostname
   cosi:
     enabled: true
+    # Override the vendored chart default (v0.1.2), which hardcodes read-write
+    # S3 actions for every BucketAccess and ignores the accessPolicy parameter.
+    # v0.3.x honours accessPolicy: readonly, so a -readonly BucketAccessClass
+    # actually issues read-only (Read,List) credentials instead of read-write.
+    image: "ghcr.io/seaweedfs/seaweedfs-cosi-driver:v0.3.1"
     podLabels:
       policy.cozystack.io/allow-to-apiserver: "true"
     driverName: "seaweedfs.objectstorage.k8s.io"


### PR DESCRIPTION
## What this PR does

The SeaweedFS COSI driver shipped at `v0.1.2` hardcodes read-write S3 actions (`Read,Write,List,Tagging`) for every BucketAccess and never reads the `accessPolicy` BucketAccessClass parameter. The chart already defines a `-readonly` BucketAccessClass carrying `parameters.accessPolicy: readonly`, and the `bucket` app routes `readonly: true` users to it — but `v0.1.2` ignores the parameter, so a credential meant to be read-only is silently issued with full read-write access and can upload and delete objects. This is an access-control bug.

Upstream `seaweedfs/seaweedfs-cosi-driver` added `accessPolicy` handling in `v0.3.0`: `readonly` maps to `Read,List`, while `readwrite` and the empty default stay `Read,Write,List,Tagging`. This bumps the driver to `v0.3.1` via a `seaweedfs.cosi.image` override in the package `values.yaml`, so the override survives `make update` and the vendored chart is left untouched. The default read-write action set is unchanged, so existing read-write credentials are unaffected; only read-only grants are tightened to actually be read-only.

The `extra/seaweedfs` chart already runs `v0.3.1` with the same objectstorage-sidecar, so the driver/sidecar combination is already proven in this repo. A chart unit test pins the rendered driver image so this fix cannot silently regress on a future re-vendor.

This does not close #1921. That issue bundles two features — read-only bucket access (fixed here) and Object Lock / WORM (the `-lock` BucketClass), which is independent and out of scope here. Relates to #1921.

### Release note

```release-note
Fix SeaweedFS read-only bucket credentials being issued with read-write access; the COSI driver now honours the read-only access policy.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pin the SeaweedFS COSI driver image to `ghcr.io/seaweedfs/seaweedfs-cosi-driver:v0.3.1` to keep access behavior consistent and avoid relying on a vendored default.
  * Ensure the rendered SeaweedFS COSI deployment uses the expected container name and the pinned driver image.
* **Tests**
  * Add a YAML test suite to validate the generated COSI deployment template matches the expected container name and pinned image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->