### PR TITLE
fix(kubevirt-cdi): order behind cozystack-basics so cdi-clone-dv RoleBinding finds cozy-public

### DIFF
--- a/packages/core/platform/sources/kubevirt-cdi.yaml
+++ b/packages/core/platform/sources/kubevirt-cdi.yaml
@@ -11,8 +11,16 @@ spec:
     path: /
   variants:
   - name: default
+    # kubevirt-cdi ships the cdi-clone-dv RoleBinding INTO the cozy-public
+    # namespace, which is provisioned by cozystack-basics. Without the
+    # cozystack-basics edge the RoleBinding can race namespace creation on a
+    # fresh install and fail with `namespaces "cozy-public" not found`.
+    # Normally masked by Flux retries; becomes a hard UpgradeFailed under slow
+    # reconcile. Depend on cozystack-basics so the target namespace exists
+    # first. No cycle: cozystack-basics' deps do not depend on kubevirt-cdi.
     dependsOn:
     - cozystack.networking
+    - cozystack.cozystack-basics
     components:
     - name: kubevirt-cdi-operator
       path: system/kubevirt-cdi-operator

--- a/packages/core/platform/tests/sources_kubevirt_cdi_dependson_test.yaml
+++ b/packages/core/platform/tests/sources_kubevirt_cdi_dependson_test.yaml
@@ -1,0 +1,24 @@
+suite: kubevirt-cdi waits for the cozy-public namespace it binds into
+# Regression guard for a fresh-install ordering race: kubevirt-cdi ships the
+# cdi-clone-dv RoleBinding INTO the cozy-public namespace, which is provisioned
+# by cozystack-basics. Without the cozystack-basics edge the RoleBinding races
+# namespace creation and fails with `namespaces "cozy-public" not found`,
+# normally masked by Flux retries but a hard UpgradeFailed under slow reconcile.
+# The dependsOn edges below must stay.
+templates:
+  - templates/sources.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  - it: kubevirt-cdi dependsOn networking and cozystack-basics
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt-cdi
+    asserts:
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.networking
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.cozystack-basics


### PR DESCRIPTION
## What

Add a `cozystack.cozystack-basics` edge to the `kubevirt-cdi` `default` variant's `dependsOn` in the platform package, plus a helm-unittest regression guard.

## Why

`kubevirt-cdi` ships the `cdi-clone-dv` RoleBinding into the `cozy-public` namespace, but `cozy-public` is provisioned by `cozystack-basics`. The variant previously only depended on `cozystack.networking`, so kubevirt-cdi reconciled long before `cozystack-basics` created the namespace. On a fresh install the RoleBinding could race namespace creation and fail with `namespaces "cozy-public" not found`. Flux retries normally mask this, but under slow reconcile it surfaces as a hard `UpgradeFailed`.

This mirrors the existing `backupstrategy-controller` ordering, which already depends on `cozystack-basics` for the identical reason (it writes a Bucket into `tenant-root`).

There is no dependency cycle: `cozystack-basics`' own dependencies (`tenant-application`, `cozystack-engine`, `gateway-api-crds`) do not reach `kubevirt-cdi`.

## Notes

Surfaced via a slow-reconcile install in #3124's E2E. Does not close a specific issue.

Tradeoff: kubevirt-cdi now installs after the full `cozystack-basics` chain instead of just `networking`. Its only consumers (`vm-default-images`, `vm-disk-application`) install later still, so the added latency introduces no new ordering problem — the same correctness-over-speed tradeoff already accepted for `backupstrategy-controller`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upgrade reliability for kubevirt-cdi by enforcing correct dependency ordering before applying its RoleBinding-related resources.
  * Reduced intermittent `UpgradeFailed` outcomes during slower reconciliation scenarios.
* **Tests**
  * Added a regression test to verify kubevirt-cdi manifest `dependsOn` includes the expected prerequisites for consistent deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->