### PR TITLE
fix(velero): add startupProbe so slow startup does not crashloop the install gate

### DIFF
--- a/packages/system/velero/Makefile
+++ b/packages/system/velero/Makefile
@@ -12,3 +12,6 @@ update:
 	helm repo add tanzu https://vmware-tanzu.github.io/helm-charts
 	helm repo update tanzu
 	helm pull tanzu/velero --untar --untardir charts --version 12.0.3
+	# Render a startupProbe from .Values.startupProbe (upstream chart omits it),
+	# so a slow server start under heavy parallel install does not trip liveness.
+	patch --no-backup-if-mismatch -p4 < patches/add-startup-probe.patch

--- a/packages/system/velero/charts/velero/templates/deployment.yaml
+++ b/packages/system/velero/charts/velero/templates/deployment.yaml
@@ -199,6 +199,9 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.metrics.enabled }}
+          {{- with .Values.startupProbe }}
+          startupProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe: {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/packages/system/velero/patches/add-startup-probe.patch
+++ b/packages/system/velero/patches/add-startup-probe.patch
@@ -1,0 +1,14 @@
+diff --git a/packages/system/velero/charts/velero/templates/deployment.yaml b/packages/system/velero/charts/velero/templates/deployment.yaml
+index d2a72639a..a46d73200 100644
+--- a/packages/system/velero/charts/velero/templates/deployment.yaml
++++ b/packages/system/velero/charts/velero/templates/deployment.yaml
+@@ -199,6 +199,9 @@ spec:
+             {{- toYaml . | nindent 12 }}
+           {{- end }}
+           {{- if .Values.metrics.enabled }}
++          {{- with .Values.startupProbe }}
++          startupProbe: {{- toYaml . | nindent 12 }}
++          {{- end }}
+           {{- with .Values.livenessProbe }}
+           livenessProbe: {{- toYaml . | nindent 12 }}
+           {{- end }}

--- a/packages/system/velero/tests/velero_test.yaml
+++ b/packages/system/velero/tests/velero_test.yaml
@@ -36,3 +36,73 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # Velero binds :8085 (http-monitoring) late under a heavy parallel install, so
+  # the upstream liveness probe (initialDelaySeconds 10, ~130s total budget) would
+  # kill it mid-startup and crashloop it out of the install-gate window. A
+  # startupProbe (patched into the upstream chart, which omits one) holds liveness
+  # and readiness off until the server is up, granting 30 * 10s = 300s of startup
+  # grace while leaving steady-state liveness at the tight upstream default. Pin
+  # the startupProbe budget AND that liveness was NOT loosened, so neither
+  # silently regresses.
+  - it: gates startup with a startupProbe and keeps liveness tight
+    template: charts/velero/templates/deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: velero
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.successThreshold
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /metrics
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.port
+          value: http-monitoring
+      # No initialDelaySeconds: the first startup check fires immediately, so the
+      # full 300s budget is spent probing. Pin its absence so a future change
+      # cannot silently re-introduce a delay that eats into the grace window.
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+      # Liveness stays at the tight upstream default — the startupProbe owns the
+      # grace, so loosening liveness would only weaken steady-state crash
+      # detection. Pin the full budget (initialDelay/period/failureThreshold) so a
+      # future change cannot silently re-delay or loosen liveness.
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 5
+
+  # All three probes live behind {{- if .Values.metrics.enabled }} — :8085 only
+  # exists when metrics are on. Pin that the startupProbe follows the same gate as
+  # liveness/readiness, so disabling metrics drops all probes together and never
+  # leaves a startupProbe pointed at an unbound port.
+  - it: omits all probes (including the startupProbe) when metrics are disabled
+    template: charts/velero/templates/deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: velero
+    set:
+      velero.metrics.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe

--- a/packages/system/velero/values.yaml
+++ b/packages/system/velero/values.yaml
@@ -32,3 +32,27 @@ velero:
     # Increase timeout for item operations to 24 hours to prevent timeouts
     # during backups of very large volumes. The Velero default is 4 hours.
     defaultItemOperationTimeout: 24h
+
+  # Velero binds its metrics/health endpoint (:8085, http-monitoring) only after
+  # the server finishes loading plugins and connecting to the API server. Under a
+  # heavy parallel platform install that can take minutes, but the upstream
+  # liveness probe starts checking /metrics at initialDelaySeconds=10 and kills
+  # the container after failureThreshold=5 (~130s total) before :8085 is bound.
+  # The kubelet SIGTERMs velero (exitCode 0/Completed), it BackOff-restarts, and
+  # never escapes the loop inside the install-gate window, blocking the gate.
+  #
+  # Give the server an explicit startup budget. While the startupProbe is failing
+  # the kubelet holds off the liveness and readiness probes entirely, so steady-
+  # state liveness stays at the tight upstream default (10s / 30s / 5 failures)
+  # once startup completes. failureThreshold * periodSeconds = 30 * 10s = 300s of
+  # grace. The upstream chart does not render a startupProbe, so the velero
+  # package patches it in (patches/add-startup-probe.patch, re-applied on update).
+  startupProbe:
+    httpGet:
+      path: /metrics
+      port: http-monitoring
+      scheme: HTTP
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 30


### PR DESCRIPTION
## What

Add a `startupProbe` to the velero server container (and supply it through the package values), so a slow server start under a heavy parallel install no longer trips the liveness probe. Pin the probe with a helm-unittest regression guard.

## Why

Velero binds its metrics/health endpoint (`:8085`, `http-monitoring`) only after the server loads its plugins and connects to the API server. Under a heavy parallel platform install that can take minutes, but the upstream liveness probe starts checking `/metrics` at `initialDelaySeconds=10` and kills the container after `failureThreshold=5` (~130s total) — before `:8085` is bound. The kubelet SIGTERMs velero (exit code 0 / Completed — a graceful kill, not a crash), it BackOff-restarts, and never escapes the loop inside the install-gate window. Because `backupstrategy-controller` hard-depends on velero, this blocks the install gate.

## How

While a `startupProbe` is failing, the kubelet holds off the liveness and readiness probes entirely. So the startupProbe grants the server an explicit startup budget — `failureThreshold * periodSeconds = 30 * 10s = 300s` of grace — and then hands over to the unchanged, tight upstream liveness (`10s / 30s / 5`) for steady-state crash detection. This is strictly better than loosening liveness, which would also blunt steady-state detection for the lifetime of every pod.

The upstream velero chart (12.0.3) does not render a `startupProbe`, so the package patches the deployment template via `patches/add-startup-probe.patch`, re-applied after re-vendor by the Makefile `update` target — the same vendored-patch convention used by `seaweedfs`, `ingress-nginx`, and the existing `startupProbe` patches in `grafana-operator` and `kubevirt-cdi-operator`. The `startupProbe` value itself is supplied through the package values override.

## Notes

Surfaced as a recurring (not flaky) install failure under heavy parallel load. Does not close a specific issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable Velero `startupProbe` for the `/metrics` endpoint (`http-monitoring`) to better accommodate slow startup.
* **Bug Fixes**
  * When metrics are disabled, the rendered container no longer includes `startupProbe`, `livenessProbe`, or `readinessProbe`.
* **Tests**
  * Added invariant chart rendering tests to verify `startupProbe` behavior (including pinned timing fields) and confirm existing probe timing remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->