### PR TITLE
test(e2e): wait 10m for tenant worker MachineDeployment to match the bootstrap budget

### DIFF
--- a/hack/e2e-apps/run-kubernetes.sh
+++ b/hack/e2e-apps/run-kubernetes.sh
@@ -165,8 +165,12 @@ EOF
   # TalosConfigTemplate, which only renders once the lookup-gated Talos PKI
   # Secrets (talos-secrets, talos-ca, k8s ca, apiserver Service ClusterIP)
   # all exist; cold-start in a fresh CI sandbox pushes the time to first
-  # MachineSet scale-up past the old 1m budget.
-  kubectl wait machinedeployment kubernetes-${test_name}-md0 -n tenant-test --timeout=5m --for=jsonpath='{.status.replicas}'=2
+  # MachineSet scale-up past the old 1m budget. The talos-reconcile hook Job
+  # awaits those PKI inputs (its own wait loop budgets 10m, 120 x 5s) before it
+  # produces the TalosConfigTemplate, so a 5m test wait can give up while the
+  # product is still legitimately within budget. Use 10m to match that bootstrap
+  # budget (and the later readyReplicas wait below).
+  kubectl wait machinedeployment kubernetes-${test_name}-md0 -n tenant-test --timeout=10m --for=jsonpath='{.status.replicas}'=2
   # Get the admin kubeconfig and save it to a file
   kubectl get secret kubernetes-${test_name}-admin-kubeconfig -ojsonpath='{.data.super-admin\.conf}' -n tenant-test | base64 -d > "tenantkubeconfig-${test_name}"
 


### PR DESCRIPTION
## What this PR does

The e2e tenant-Kubernetes test waited only 5m for the tenant worker MachineDeployment (`md0`) to reach `status.replicas=2`, but the product's real bootstrap budget for that step is 10m. The MachineDeployment's `bootstrap.configRef` gates on a `TalosConfigTemplate` that the post-install talos-reconcile hook Job produces only after it observes its PKI lookup inputs (apiserver Service ClusterIP, Talos CA, Kubernetes CA, management CoreDNS). That Job's own wait loop budgets 10m for those inputs (`for i in $(seq 1 120); do … sleep 5`, i.e. 120 × 5s = 600s). On a cold-start CI sandbox the test could therefore expire at 5m while the product was still legitimately within budget, surfacing as `md0` stuck `ScalingUp: "blocked because TalosConfigTemplate does not exist"` — a false failure, not a product regression (node metrics show no resource pressure).

This raises the test wait from 5m to 10m so it matches the bootstrap budget and the later `readyReplicas=2` wait in the same script, which is already 10m. `kubernetes-latest` and `kubernetes-previous` both source this single script, so one change covers both variants. This unblocks the recurring tenant worker-VM e2e flake that has been failing the kubernetes e2e on multiple in-flight PRs.

Test-infrastructure only — no product code changes. The wait already complies with the e2e conventions (no new retries, no traps; the longer-than-5m budget is justified in-line).

### Screenshots

N/A — test-infrastructure change, no UI impact.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the wait time for Kubernetes cluster provisioning during end-to-end runs, helping avoid premature failures when nodes take longer to become ready.
  * Improved reliability of cluster setup checks by allowing more time for the expected replica count to be reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->