### PR TITLE
ci(build): make new OCIR repositories public after image push

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -107,3 +107,41 @@ jobs:
           IMAGE_TAG: main
           PUBLISH_VERSIONED: '0'
           PUBLISH_FLOATING: '0'
+
+      # A first-party image's OCIR repository is created on its FIRST push, and
+      # OCIR defaults new repositories to PRIVATE. The e2e cluster pulls these
+      # images anonymously (no pull secret), so a brand-new image's repo yields
+      # 403 until a maintainer flips it public by hand. This step flips every
+      # private cozystack/* repository public via the OCI API, so a newly
+      # introduced first-party image is pullable without manual intervention.
+      #
+      # NOTE: docker's OCIR_TOKEN is a registry auth token and CANNOT call the
+      # OCI control-plane API; repository visibility needs OCI-API auth that the
+      # maintainer provisions out of band. Until then this step is a no-op
+      # (skipped while OCIR_COMPARTMENT_OCID is empty). To enable:
+      #   1. Set repository variable OCIR_COMPARTMENT_OCID to the compartment
+      #      holding the cozystack/* repositories.
+      #   2. Grant OCI-API auth (pick one):
+      #      a) Instance principal (recommended; the runners are OCI VMs): add a
+      #         dynamic group matching the runner instances and an IAM policy
+      #         `Allow dynamic-group <dg> to manage repos in compartment <c>`;
+      #         leave OCIR_OCI_CLI_AUTH unset (defaults to instance_principal).
+      #      b) API key: set repository variable OCIR_OCI_CLI_AUTH=api_key and
+      #         add secrets OCI_CLI_USER, OCI_CLI_TENANCY, OCI_CLI_FINGERPRINT,
+      #         OCI_CLI_KEY_CONTENT, with the same `manage repos` policy on that
+      #         user's group.
+      - name: Make new OCIR repositories public
+        if: ${{ vars.OCIR_COMPARTMENT_OCID != '' }}
+        env:
+          OCI_CLI_AUTH: ${{ vars.OCIR_OCI_CLI_AUTH || 'instance_principal' }}
+          # OCIR is regional; the registry lives in iad (us-ashburn-1) regardless
+          # of the runner's own region, so target it explicitly.
+          OCI_CLI_REGION: ${{ vars.OCIR_OCI_CLI_REGION || 'us-ashburn-1' }}
+          OCIR_COMPARTMENT_OCID: ${{ vars.OCIR_COMPARTMENT_OCID }}
+          # Consumed only when OCI_CLI_AUTH=api_key; empty (and ignored) under
+          # the default instance_principal auth.
+          OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
+          OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
+          OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
+        run: hack/ocir-make-public.sh

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -356,6 +356,53 @@ jobs:
           IMAGE_TAG: pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
           PUBLISH_VERSIONED: '0'
           PUBLISH_FLOATING: '0'
+
+      # A first-party image's OCIR repository is created on its FIRST push, and
+      # OCIR defaults new repositories to PRIVATE. The e2e cluster pulls these
+      # images anonymously (no pull secret), so a brand-new image's repo yields
+      # 403 until a maintainer flips it public by hand. This step flips every
+      # private cozystack/* repository public via the OCI API, so a newly
+      # introduced first-party image is pullable without manual intervention.
+      # It runs in finalize (once, after every build/build-talos/installer push)
+      # and before e2e, so repos created upstream this run are public by then.
+      #
+      # NOTE: docker's OCIR_TOKEN is a registry auth token and CANNOT call the
+      # OCI control-plane API; repository visibility needs OCI-API auth that the
+      # maintainer provisions out of band. Until then this step is a no-op
+      # (skipped while OCIR_COMPARTMENT_OCID is empty), so current builds and
+      # fork PRs are unaffected. To enable:
+      #   1. Set repository variable OCIR_COMPARTMENT_OCID to the compartment
+      #      holding the cozystack/* repositories.
+      #   2. Grant OCI-API auth (pick one):
+      #      a) Instance principal (recommended; the runners are OCI VMs): add a
+      #         dynamic group matching the runner instances and an IAM policy
+      #         `Allow dynamic-group <dg> to manage repos in compartment <c>`;
+      #         leave OCIR_OCI_CLI_AUTH unset (defaults to instance_principal).
+      #      b) API key: set repository variable OCIR_OCI_CLI_AUTH=api_key and
+      #         add secrets OCI_CLI_USER, OCI_CLI_TENANCY, OCI_CLI_FINGERPRINT,
+      #         OCI_CLI_KEY_CONTENT, with the same `manage repos` policy on that
+      #         user's group.
+      # Fork-gated like every other privileged step in this file: repository
+      # variables (unlike secrets) ARE readable by fork PRs, and the default
+      # instance_principal auth derives from the runner — not from fork-empty
+      # secrets — so without this gate an approved fork PR could swap the script
+      # body and exercise the runner's `manage repos` IAM policy.
+      - name: Make new OCIR repositories public
+        if: ${{ vars.OCIR_COMPARTMENT_OCID != '' && !github.event.pull_request.head.repo.fork }}
+        env:
+          OCI_CLI_AUTH: ${{ vars.OCIR_OCI_CLI_AUTH || 'instance_principal' }}
+          # OCIR is regional; the registry lives in iad (us-ashburn-1) regardless
+          # of the runner's own region, so target it explicitly.
+          OCI_CLI_REGION: ${{ vars.OCIR_OCI_CLI_REGION || 'us-ashburn-1' }}
+          OCIR_COMPARTMENT_OCID: ${{ vars.OCIR_COMPARTMENT_OCID }}
+          # Consumed only when OCI_CLI_AUTH=api_key; empty (and ignored) under
+          # the default instance_principal auth.
+          OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
+          OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
+          OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
+          OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
+        run: hack/ocir-make-public.sh
+
       - name: Assemble pr.patch
         run: |
           mkdir -p _out/assets

--- a/hack/ocir-make-public.sh
+++ b/hack/ocir-make-public.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+# Make every private cozystack/* OCIR repository public via the OCI API.
+#
+# Why: a first-party image's OCIR repository is created on its FIRST push, and
+# OCIR defaults new repositories to PRIVATE. CI's e2e cluster pulls images
+# anonymously (no pull secret), so a brand-new image's repository returns 403
+# until it is flipped public. This script performs that flip idempotently for
+# the whole cozystack/ namespace, so a newly introduced first-party image needs
+# no manual intervention.
+#
+# Auth: the docker OCIR_TOKEN used for `docker login` is a registry auth token
+# and CANNOT call the OCI control-plane API. Repository visibility is set via
+# OCI-API auth (instance principal, or an API signing key in OCI_CLI_* env),
+# selected by OCI_CLI_AUTH (default: instance_principal). The caller provides
+# working auth plus an IAM `manage repos` policy on the compartment.
+#
+# Best-effort by design: a transient API/install failure emits a ::warning::
+# and exits 0 rather than failing the build — the worst case is the
+# pre-existing "new repo stays private" state, never a regression on an
+# unrelated PR.
+#
+# Env:
+#   OCIR_COMPARTMENT_OCID  (required) compartment holding the cozystack/* repos
+#   OCI_CLI_AUTH           (optional) auth method, default instance_principal
+#   OCIR_REPO_PREFIX       (optional) repo display-name prefix, default cozystack/
+#
+# Run the unit test with: hack/cozytest.sh hack/ocir-make-public_test.bats
+set -eu
+
+: "${OCIR_COMPARTMENT_OCID:?OCIR_COMPARTMENT_OCID must be set}"
+export OCI_CLI_AUTH="${OCI_CLI_AUTH:-instance_principal}"
+PREFIX="${OCIR_REPO_PREFIX:-cozystack/}"
+
+command -v jq >/dev/null 2>&1 || {
+	echo "::warning::jq not found; skipping OCIR repository visibility update"
+	exit 0
+}
+
+# Ephemeral runners may not carry the oci CLI; install under $HOME (no sudo),
+# idempotent. Install failure is non-fatal — the step is opt-in convenience.
+if ! command -v oci >/dev/null 2>&1; then
+	if curl -fsSL https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh -o /tmp/install-oci.sh \
+		&& bash /tmp/install-oci.sh --accept-all-defaults \
+			--install-dir "$HOME/.oci-cli" --exec-dir "$HOME/.oci-cli/bin" >/dev/null 2>&1; then
+		PATH="$HOME/.oci-cli/bin:$PATH"
+		export PATH
+	fi
+	rm -f /tmp/install-oci.sh
+fi
+command -v oci >/dev/null 2>&1 || {
+	echo "::warning::oci CLI unavailable; skipping OCIR repository visibility update"
+	exit 0
+}
+
+# List every repository in the compartment. Best-effort: a transient list error
+# must not fail the build.
+if ! items="$(oci artifacts container repository list \
+	--compartment-id "$OCIR_COMPARTMENT_OCID" --all 2>/tmp/ocir-list.err)"; then
+	echo "::warning::OCIR repository list failed; new repos may stay private:"
+	cat /tmp/ocir-list.err >&2 2>/dev/null || true
+	exit 0
+fi
+
+# Select private repositories under the cozystack/ display-name prefix. OCIR
+# display names are everything after <region>.ocir.io/<tenancy-namespace>/, so
+# images pushed to iad.ocir.io/<ns>/cozystack/<img> are named cozystack/<img>.
+# `// ""` guards an item without a display-name: jq would otherwise error on
+# `null | startswith`, and (no pipefail) that non-zero would abort the step,
+# defeating the best-effort design.
+ids="$(printf '%s' "$items" | jq -r --arg p "$PREFIX" \
+	'.data.items[]? | select(((.["display-name"] // "") | startswith($p)) and (.["is-public"] == false)) | .id')"
+
+if [ -z "$ids" ]; then
+	echo "No private ${PREFIX}* repositories to update."
+	exit 0
+fi
+
+echo "$ids" | while IFS= read -r id; do
+	[ -n "$id" ] || continue
+	echo "::notice::Setting OCIR repository ${id} public"
+	oci artifacts container repository update --repository-id "$id" --is-public true --force >/dev/null \
+		|| echo "::warning::Failed to set ${id} public"
+done

--- a/hack/ocir-make-public_test.bats
+++ b/hack/ocir-make-public_test.bats
@@ -1,0 +1,233 @@
+#!/usr/bin/env bats
+# Tests for hack/ocir-make-public.sh — the OCIR new-repo public-visibility flip.
+#
+# Guards that only PRIVATE repositories under the cozystack/ display-name prefix
+# are flipped public (already-public and non-cozystack repos are left alone),
+# that an empty selection is a clean no-op, that a transient list failure is
+# non-fatal, and that a missing compartment OCID aborts loudly.
+#
+# Harness note: the CI path is hack/cozytest.sh, NOT real bats. No `run`,
+# `$status`, `$output`, `skip`, or setup()/teardown(); each @test is a shell
+# function under `set -eu -x`, so a non-zero exit aborts the test (that is the
+# exit-0 assertion). A test that expects a non-zero exit must capture it with
+# `|| rc=$?`. Under `set -e`, `! cmd` is exempt from auto-exit, so "must NOT
+# have happened" checks are written as `if cmd; then exit 1; fi`. Real jq is
+# assumed present (build-dep).
+#
+# Run with: hack/cozytest.sh hack/ocir-make-public_test.bats
+
+# Write a mock `oci` CLI into $1/bin. It reads three env knobs:
+#   OCI_MOCK_LIST_JSON  JSON printed for `... repository list ...`
+#   OCI_MOCK_LIST_RC    when non-zero, the list call fails with that code
+#   OCI_MOCK_UPDATES    file the `... repository update --repository-id X ...`
+#                       call appends X to (one OCID per line) on success
+#   OCI_MOCK_UPDATE_FAIL_ID  when set, the update of that repo-id fails (and is
+#                       NOT recorded), mimicking a per-repo API error
+_make_oci_mock() {
+  d="$1"
+  mkdir -p "$d/bin"
+  cat > "$d/bin/oci" <<'EOF'
+#!/bin/sh
+mode=""
+for a in "$@"; do
+  case "$a" in
+    list) mode=list ;;
+    update) mode=update ;;
+  esac
+done
+if [ "$mode" = list ]; then
+  if [ "${OCI_MOCK_LIST_RC:-0}" -ne 0 ]; then
+    echo "mock oci: list failed" >&2
+    exit "$OCI_MOCK_LIST_RC"
+  fi
+  printf '%s' "${OCI_MOCK_LIST_JSON:-}"
+  exit 0
+fi
+if [ "$mode" = update ]; then
+  id="" prev=""
+  for a in "$@"; do
+    [ "$prev" = "--repository-id" ] && id="$a"
+    prev="$a"
+  done
+  if [ -n "${OCI_MOCK_UPDATE_FAIL_ID:-}" ] && [ "$id" = "$OCI_MOCK_UPDATE_FAIL_ID" ]; then
+    echo "mock oci: update failed for $id" >&2
+    exit 1
+  fi
+  echo "$id" >> "$OCI_MOCK_UPDATES"
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$d/bin/oci"
+}
+
+# A mixed repository listing: one new private cozystack repo (must be flipped),
+# one already-public cozystack repo (must be left), one private non-cozystack
+# repo (must be left).
+_list_json_mixed() {
+  cat <<'EOF'
+{"data":{"items":[
+  {"id":"ocid1.repo.priv-new","display-name":"cozystack/securitygroup-controller","is-public":false},
+  {"id":"ocid1.repo.pub","display-name":"cozystack/cozystack-api","is-public":true},
+  {"id":"ocid1.repo.other","display-name":"other/thing","is-public":false}
+]}}
+EOF
+}
+
+@test "flips only private cozystack/* repositories public" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  _make_oci_mock "$tmp"
+  export PATH="$tmp/bin:$PATH"
+  export OCIR_COMPARTMENT_OCID="ocid1.compartment.test"
+  export OCI_MOCK_UPDATES="$tmp/updates.txt"
+  : > "$OCI_MOCK_UPDATES"
+  export OCI_MOCK_LIST_JSON="$(_list_json_mixed)"
+
+  hack/ocir-make-public.sh > "$tmp/out" 2>&1
+
+  # The new private cozystack repo WAS flipped.
+  grep -qx 'ocid1.repo.priv-new' "$OCI_MOCK_UPDATES"
+  # The already-public cozystack repo was NOT touched.
+  if grep -qx 'ocid1.repo.pub' "$OCI_MOCK_UPDATES"; then
+    echo "BUG: already-public repo was updated" >&2; exit 1
+  fi
+  # The non-cozystack repo was NOT touched.
+  if grep -qx 'ocid1.repo.other' "$OCI_MOCK_UPDATES"; then
+    echo "BUG: non-cozystack repo was updated" >&2; exit 1
+  fi
+  # Exactly one repo flipped.
+  [ "$(wc -l < "$OCI_MOCK_UPDATES")" -eq 1 ]
+}
+
+@test "one repo's update failure is non-fatal; the rest still flip" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  _make_oci_mock "$tmp"
+  export PATH="$tmp/bin:$PATH"
+  export OCIR_COMPARTMENT_OCID="ocid1.compartment.test"
+  export OCI_MOCK_UPDATES="$tmp/updates.txt"
+  : > "$OCI_MOCK_UPDATES"
+  export OCI_MOCK_LIST_JSON='{"data":{"items":[{"id":"ocid1.repo.priv-a","display-name":"cozystack/a","is-public":false},{"id":"ocid1.repo.priv-b","display-name":"cozystack/b","is-public":false}]}}'
+  export OCI_MOCK_UPDATE_FAIL_ID="ocid1.repo.priv-a"
+
+  rc=0
+  hack/ocir-make-public.sh > "$tmp/out" 2>&1 || rc=$?
+
+  # The step does not fail the build on a per-repo error.
+  [ "$rc" -eq 0 ]
+  # The healthy repo was still flipped.
+  grep -qx 'ocid1.repo.priv-b' "$OCI_MOCK_UPDATES"
+  # The failing repo was NOT recorded (its visibility was not changed).
+  if grep -qx 'ocid1.repo.priv-a' "$OCI_MOCK_UPDATES"; then
+    echo "BUG: failed repo recorded as updated" >&2; exit 1
+  fi
+  # A warning names the repo that could not be flipped.
+  grep -q '::warning::Failed to set ocid1.repo.priv-a public' "$tmp/out"
+}
+
+@test "OCIR_REPO_PREFIX overrides the selected namespace" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  _make_oci_mock "$tmp"
+  export PATH="$tmp/bin:$PATH"
+  export OCIR_COMPARTMENT_OCID="ocid1.compartment.test"
+  export OCIR_REPO_PREFIX="custom/"
+  export OCI_MOCK_UPDATES="$tmp/updates.txt"
+  : > "$OCI_MOCK_UPDATES"
+  export OCI_MOCK_LIST_JSON='{"data":{"items":[{"id":"ocid1.repo.custom","display-name":"custom/thing","is-public":false},{"id":"ocid1.repo.cozy","display-name":"cozystack/thing","is-public":false}]}}'
+
+  hack/ocir-make-public.sh > "$tmp/out" 2>&1
+
+  # Only the custom/ repo is selected under the overridden prefix.
+  grep -qx 'ocid1.repo.custom' "$OCI_MOCK_UPDATES"
+  if grep -qx 'ocid1.repo.cozy' "$OCI_MOCK_UPDATES"; then
+    echo "BUG: cozystack/ repo selected despite prefix override" >&2; exit 1
+  fi
+  [ "$(wc -l < "$OCI_MOCK_UPDATES")" -eq 1 ]
+}
+
+@test "an item without a display-name is skipped, not fatal" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  _make_oci_mock "$tmp"
+  export PATH="$tmp/bin:$PATH"
+  export OCIR_COMPARTMENT_OCID="ocid1.compartment.test"
+  export OCI_MOCK_UPDATES="$tmp/updates.txt"
+  : > "$OCI_MOCK_UPDATES"
+  export OCI_MOCK_LIST_JSON='{"data":{"items":[{"id":"ocid1.repo.nodn","is-public":false},{"id":"ocid1.repo.ok","display-name":"cozystack/ok","is-public":false}]}}'
+
+  # Without the `// ""` jq guard the null display-name aborts the step non-zero.
+  hack/ocir-make-public.sh > "$tmp/out" 2>&1
+
+  grep -qx 'ocid1.repo.ok' "$OCI_MOCK_UPDATES"
+  if grep -qx 'ocid1.repo.nodn' "$OCI_MOCK_UPDATES"; then
+    echo "BUG: display-name-less item selected" >&2; exit 1
+  fi
+  [ "$(wc -l < "$OCI_MOCK_UPDATES")" -eq 1 ]
+}
+
+@test "missing jq is a clean no-op (warns, exit 0)" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  mkdir -p "$tmp/empty"
+  export OCIR_COMPARTMENT_OCID="ocid1.compartment.test"
+
+  # Scope the stripped PATH to the script only, so the test's own grep still
+  # works. The jq guard is reached before any external tool is needed.
+  rc=0
+  PATH="$tmp/empty" hack/ocir-make-public.sh > "$tmp/out" 2>&1 || rc=$?
+
+  [ "$rc" -eq 0 ]
+  grep -q '::warning::jq not found' "$tmp/out"
+}
+
+@test "no private cozystack/* repositories -> no updates, exit 0" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  _make_oci_mock "$tmp"
+  export PATH="$tmp/bin:$PATH"
+  export OCIR_COMPARTMENT_OCID="ocid1.compartment.test"
+  export OCI_MOCK_UPDATES="$tmp/updates.txt"
+  : > "$OCI_MOCK_UPDATES"
+  export OCI_MOCK_LIST_JSON='{"data":{"items":[{"id":"ocid1.repo.pub","display-name":"cozystack/cozystack-api","is-public":true}]}}'
+
+  hack/ocir-make-public.sh > "$tmp/out" 2>&1
+
+  [ ! -s "$OCI_MOCK_UPDATES" ]
+  grep -q 'No private cozystack/\* repositories' "$tmp/out"
+}
+
+@test "transient list failure warns and exits 0 without updating" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  _make_oci_mock "$tmp"
+  export PATH="$tmp/bin:$PATH"
+  export OCIR_COMPARTMENT_OCID="ocid1.compartment.test"
+  export OCI_MOCK_UPDATES="$tmp/updates.txt"
+  : > "$OCI_MOCK_UPDATES"
+  export OCI_MOCK_LIST_RC=1
+
+  rc=0
+  hack/ocir-make-public.sh > "$tmp/out" 2>&1 || rc=$?
+
+  [ "$rc" -eq 0 ]
+  [ ! -s "$OCI_MOCK_UPDATES" ]
+  grep -q '::warning::OCIR repository list failed' "$tmp/out"
+}
+
+@test "missing OCIR_COMPARTMENT_OCID aborts non-zero" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  _make_oci_mock "$tmp"
+  export PATH="$tmp/bin:$PATH"
+  unset OCIR_COMPARTMENT_OCID 2>/dev/null || true
+  export OCI_MOCK_UPDATES="$tmp/updates.txt"
+  : > "$OCI_MOCK_UPDATES"
+
+  rc=0
+  hack/ocir-make-public.sh > "$tmp/out" 2>&1 || rc=$?
+
+  [ "$rc" -ne 0 ]
+  [ ! -s "$OCI_MOCK_UPDATES" ]
+}


### PR DESCRIPTION
## What this PR does

A first-party image's OCIR repository is created on its first push, and OCIR defaults new repositories to private. CI's e2e cluster pulls images anonymously (no pull secret), so a brand-new image's repository returns 403 on pull until a maintainer flips it public by hand. This recently bit a newly introduced first-party controller image.

This adds `hack/ocir-make-public.sh`, invoked after every image push — from the PR `finalize` job (once, after the per-package builds and the installer build, before e2e) and from the main cache warmer. The script lists the container repositories in the configured compartment and flips every private `cozystack/*` repository public via the OCI API, so a newly introduced first-party image is pullable without manual intervention. It is idempotent (only private→public) and best-effort: a transient API or install error logs a warning and never fails the build.

### Activation (maintainer action required)

Setting a repository's visibility is an OCI control-plane operation. The token used for `docker login` to OCIR is a registry auth token and cannot call the OCI API, so this needs OCI-API auth the CI does not currently hold. Until it is provisioned the step is a no-op — skipped while the `OCIR_COMPARTMENT_OCID` repository variable is empty, and additionally gated off for fork PRs — so current builds are unaffected.

To enable:

1. Set the `OCIR_COMPARTMENT_OCID` repository variable to the compartment that holds the `cozystack/*` repositories.
2. Grant OCI-API auth, either instance principal (recommended; the runners are OCI VMs) via a dynamic group on the runner instances plus an IAM policy `Allow dynamic-group <dg> to manage repos in compartment <c>` (leave `OCIR_OCI_CLI_AUTH` at its `instance_principal` default), or an API key by setting `OCIR_OCI_CLI_AUTH=api_key` and adding the `OCI_CLI_USER`, `OCI_CLI_TENANCY`, `OCI_CLI_FINGERPRINT`, `OCI_CLI_KEY_CONTENT` secrets, with the same `manage repos` policy on that user's group.

The script ships with unit tests (`hack/ocir-make-public_test.bats`, run by `make unit-tests`) covering the selection logic, the best-effort error paths, and the input guards.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated handling to make newly created first-party container repositories public during build and PR workflows when the required settings are available.
  * Added a utility to update repository visibility in bulk for matching container repositories.

* **Tests**
  * Added coverage for repository selection, visibility updates, and failure-safe behavior in the new automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->