### PR TITLE
fix(tenant): gate VM-resource HelmReleases on victoria-metrics-operator readiness

### DIFF
--- a/packages/apps/tenant/templates/etcd.yaml
+++ b/packages/apps/tenant/templates/etcd.yaml
@@ -13,6 +13,15 @@ metadata:
     apps.cozystack.io/application.group: apps.cozystack.io
     apps.cozystack.io/application.name: etcd
 spec:
+  # This release creates a VMPodScrape resource guarded by the
+  # victoria-metrics-operator admission webhook (failurePolicy: Fail). On a cold
+  # install the operator can be briefly unavailable on :9443, so gate on its
+  # HelmRelease becoming Ready to avoid an install failure → rollback. The system
+  # monitoring components gate on the operator the same way, via a variant-level
+  # dependsOn in packages/core/platform/sources/monitoring.yaml.
+  dependsOn:
+    - name: victoria-metrics-operator
+      namespace: cozy-victoria-metrics-operator
   chartRef:
     kind: ExternalArtifact
     name: cozystack-etcd-application-default-etcd

--- a/packages/apps/tenant/templates/ingress.yaml
+++ b/packages/apps/tenant/templates/ingress.yaml
@@ -13,6 +13,15 @@ metadata:
     apps.cozystack.io/application.group: apps.cozystack.io
     apps.cozystack.io/application.name: ingress
 spec:
+  # This release creates VMPodScrape resources guarded by the
+  # victoria-metrics-operator admission webhook (failurePolicy: Fail). On a cold
+  # install the operator can be briefly unavailable on :9443, so gate on its
+  # HelmRelease becoming Ready to avoid an install failure → rollback. The system
+  # monitoring components gate on the operator the same way, via a variant-level
+  # dependsOn in packages/core/platform/sources/monitoring.yaml.
+  dependsOn:
+    - name: victoria-metrics-operator
+      namespace: cozy-victoria-metrics-operator
   chartRef:
     kind: ExternalArtifact
     name: cozystack-ingress-application-default-ingress

--- a/packages/apps/tenant/templates/monitoring.yaml
+++ b/packages/apps/tenant/templates/monitoring.yaml
@@ -13,6 +13,17 @@ metadata:
     apps.cozystack.io/application.group: apps.cozystack.io
     apps.cozystack.io/application.name: monitoring
 spec:
+  # This release (via its monitoring-system child) creates VM* custom resources
+  # guarded by the victoria-metrics-operator admission webhook (failurePolicy:
+  # Fail). On a cold install the operator can be briefly unavailable on :9443, so
+  # gate on its HelmRelease becoming Ready to avoid an install failure → rollback.
+  # Gating the parent keeps the monitoring-system child (which emits the VM* CRs)
+  # from being created until the operator is Ready. The system monitoring
+  # components gate on the operator the same way, via a variant-level dependsOn in
+  # packages/core/platform/sources/monitoring.yaml.
+  dependsOn:
+    - name: victoria-metrics-operator
+      namespace: cozy-victoria-metrics-operator
   chartRef:
     kind: ExternalArtifact
     name: cozystack-monitoring-application-default-monitoring

--- a/packages/apps/tenant/tests/vmo_webhook_dependson_test.yaml
+++ b/packages/apps/tenant/tests/vmo_webhook_dependson_test.yaml
@@ -1,0 +1,80 @@
+suite: tenant HelmReleases gate on the victoria-metrics-operator
+
+# The victoria-metrics-operator admission webhook is configured with
+# failurePolicy: Fail and rejects the VM* custom resources these tenant
+# releases create (etcd/ingress: VMPodScrape; monitoring via its
+# monitoring-system child: VMCluster/VMAlert/VLCluster/VMAlertmanager/
+# VMServiceScrape) whenever the operator pod is not yet serving on :9443.
+# On a cold install the operator can be briefly unavailable, so every tenant
+# release that creates VM* resources must depend on the operator HelmRelease
+# becoming Ready — otherwise the release reconciles too early, the webhook
+# rejects with connection refused, the install fails and rolls back. Pin the
+# dependsOn so the gate cannot regress.
+
+# Restrict rendering to the gated HelmRelease templates so the chart's
+# namespace.yaml `lookup` (which errors under helm-unittest) is not evaluated.
+templates:
+  - templates/etcd.yaml
+  - templates/ingress.yaml
+  - templates/monitoring.yaml
+  - templates/seaweedfs.yaml
+  - templates/gateway.yaml
+
+release:
+  name: tenant-test
+  namespace: tenant-test
+
+set:
+  _cluster:
+    expose-ingress: tenant-root
+    expose-external-ips: "192.0.2.10"
+    gateway-enabled: "true"
+  etcd: true
+  ingress: true
+  monitoring: true
+  seaweedfs: true
+  gateway: true
+  host: ""
+
+tests:
+  - it: etcd HR depends on the victoria-metrics-operator
+    asserts:
+      - template: templates/etcd.yaml
+        equal:
+          path: spec.dependsOn
+          value:
+            - name: victoria-metrics-operator
+              namespace: cozy-victoria-metrics-operator
+
+  - it: ingress HR depends on the victoria-metrics-operator
+    asserts:
+      - template: templates/ingress.yaml
+        equal:
+          path: spec.dependsOn
+          value:
+            - name: victoria-metrics-operator
+              namespace: cozy-victoria-metrics-operator
+
+  - it: monitoring HR depends on the victoria-metrics-operator
+    asserts:
+      - template: templates/monitoring.yaml
+        equal:
+          path: spec.dependsOn
+          value:
+            - name: victoria-metrics-operator
+              namespace: cozy-victoria-metrics-operator
+
+  # The gate is intentionally narrow: only the releases that create VM* custom
+  # resources carry it. Tenant releases that create none (seaweedfs, gateway)
+  # must not be needlessly blocked on the operator.
+  - it: seaweedfs HR carries no operator gate
+    asserts:
+      - template: templates/seaweedfs.yaml
+        notExists:
+          path: spec.dependsOn
+
+  - it: gateway HR carries no operator gate
+    asserts:
+      - template: templates/gateway.yaml
+        notExists:
+          path: spec.dependsOn


### PR DESCRIPTION
## What this PR does

The tenant `etcd`, `ingress` and `monitoring` HelmReleases create VictoriaMetrics custom resources — `VMPodScrape` directly in `etcd` and `ingress`, and `VMCluster` / `VMAlert` / `VLCluster` / `VMAlertmanager` / `VMServiceScrape` via the `monitoring-system` child that `monitoring` creates. All of these are intercepted by the `victoria-metrics-operator` validating webhook, which is configured with `failurePolicy: Fail`.

On a cold install the operator pod can be briefly unavailable on `:9443` (for example a transient API-server blip during startup leaves the webhook backend not yet serving). In that window the tenant releases reconcile, the webhook rejects their VM* resources with `connection refused`, and the releases churn through failed-install → rollback → retry. They carry `install.remediation.retries: -1` and recover eventually, but the churn can outlast a cold-install readiness deadline and surfaces as spurious install failures.

This adds a Flux `spec.dependsOn` from each of those three tenant releases to the `victoria-metrics-operator` HelmRelease in `cozy-victoria-metrics-operator`, so they wait for the operator to be Ready before creating any VM* resource. The system monitoring components already gate on the operator the same way (a variant-level `dependsOn` in the platform package sources); this brings the tenant releases to parity. `failurePolicy: Fail` is preserved — validation is unchanged.

The tenant releases are sharded (`sharding.fluxcd.io/key`) while the operator release is not. helm-controller resolves `dependsOn` through an uncached API read that bypasses the shard's watch-label-selector cache (since v1.1.0, PR fluxcd/helm-controller#1070), so the cross-shard reference is visible to the tenant shard's controller; this repo ships helm-controller v1.5.0.

A helm-unittest suite pins the gate on all three releases and asserts that the tenant releases creating no VM* resources (`seaweedfs`, `gateway`) do not carry it, documenting the intentional narrowness of the gate.

### Release note

```release-note
fix(tenant): gate tenant etcd, ingress and monitoring HelmReleases on victoria-metrics-operator readiness so they no longer fail to install when the operator's admission webhook is briefly unavailable on a cold install
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant installation reliability by adding readiness gating: etcd, ingress, and monitoring Helm releases now wait for the Victoria Metrics operator to become Ready before applying dependent resources.
  * Prevents install/rollback failures caused by temporary admission webhook unavailability during cold starts.
* **Tests**
  * Added Helm-unittest coverage to confirm the dependency gate is present only for templates that create VM* resources (and omitted for templates that don’t).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->