### PR TITLE
fix(e2e): skip cilium-agent restart for the reserved:ingress IP variant

### DIFF
--- a/hack/cilium-leak-healer_test.bats
+++ b/hack/cilium-leak-healer_test.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Unit tests for the pure decision helper in
+# hack/e2e-cilium-endpoint-leak-healer.sh -- specifically ip_is_node_ingress,
+# the gate that decides whether the disputed IP is THIS node's per-node Cilium
+# ingress IP (CiliumNode.spec.ingress.ipv4). When it matches, the healer skips
+# the futile/harmful Tier-2 agent restart; when it does not, the normal Tier-1/
+# Tier-2 flow runs unchanged.
+#
+# The match is safety-critical: a false positive would suppress a cilium-agent
+# restart that would otherwise clear a real in-memory endpoint leak, so the gate
+# must (a) require an EXACT string match and (b) NEVER match on an empty ingress
+# IP (CiliumNode absent, field unset, or RBAC denied). These tests pin exactly
+# that contract; the kubectl lookup itself needs a live cluster and is not
+# unit-testable here.
+#
+# Strategy mirrors hack/capture-dataplane.bats: the script is sourced once with
+# CILIUM_LEAK_HEALER_LIB set, which its sourcing guard honours by defining the
+# helpers and returning before the heal loop -- so no cluster is required and
+# the loop never executes. Assertions use plain `[ ... ]` / if-then-false, not a
+# `run` helper (cozytest.sh has no `run`). Mock IPs use the RFC 5737
+# documentation range (TEST-NET-1, 192.0.2.0/24).
+#
+# Run with: hack/cozytest.sh hack/cilium-leak-healer_test.bats
+# -----------------------------------------------------------------------------
+
+HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
+SCRIPT="$HACK_DIR/e2e-cilium-endpoint-leak-healer.sh"
+
+# Load the pure helpers. The guard returns before the heal loop, so this is
+# side-effect-free and needs no cluster.
+CILIUM_LEAK_HEALER_LIB=1
+# shellcheck source=/dev/null
+. "$SCRIPT"
+
+@test "ip_is_node_ingress matches when the disputed IP equals the node ingress IP" {
+  ip_is_node_ingress 192.0.2.131 192.0.2.131
+}
+
+@test "ip_is_node_ingress does not match a different IP so the Tier two restart still runs" {
+  if ip_is_node_ingress 192.0.2.55 192.0.2.131; then
+    echo "BUG: a non-ingress IP must not match the node ingress IP"
+    false
+  fi
+}
+
+@test "ip_is_node_ingress never matches an empty ingress IP so an unconfirmed lookup cannot skip a restart" {
+  if ip_is_node_ingress 192.0.2.131 ""; then
+    echo "BUG: an empty ingress IP (CiliumNode absent or RBAC denied) must never match"
+    false
+  fi
+}
+
+@test "ip_is_node_ingress never matches when both inputs are empty" {
+  if ip_is_node_ingress "" ""; then
+    echo "BUG: empty disputed IP and empty ingress IP must not be treated as a match"
+    false
+  fi
+}

--- a/hack/e2e-cilium-endpoint-leak-healer.sh
+++ b/hack/e2e-cilium-endpoint-leak-healer.sh
@@ -46,6 +46,13 @@
 #   remedy. It is bounded by a per-node cap (MAX_ESCALATIONS_PER_NODE) so it can
 #   never loop-restart agents, and every action is logged loudly with its reason.
 #
+#   Tier 2 skip: when the disputed IP is exactly the node's per-node Cilium
+#   ingress IP (CiliumNode.spec.ingress.ipv4), an agent restart cannot clear it
+#   (the agent re-derives the same ingress IP on boot) and can re-trigger the
+#   host-scope IPAM restore-window race, so the watchdog skips the restart,
+#   surfaces the case, and reschedules the wedged pod best-effort. Full mechanism
+#   is in the inline note at that gate.
+#
 # It is READ-ONLY until it has positively confirmed an orphan: an endpoint in
 # the owning node's registry holds the disputed IP, that endpoint does not back
 # a live Running pod with that IP, and a different pod is currently wedged
@@ -106,6 +113,22 @@ record_escalation() {
   d=$(node_dir "$1"); mkdir -p "$d" 2>/dev/null || true
   f="$d/escalations"; n=$(read_count "$f"); n=$((n + 1)); echo "$n" > "$f"
 }
+
+# ip_is_node_ingress IP INGRESS_IP -> success (0) iff INGRESS_IP is non-empty
+# and exactly equals IP. A pure helper so the genuine-reserved:ingress decision
+# is unit-testable without a cluster. The non-empty guard is load-bearing: an
+# empty INGRESS_IP (CiliumNode absent, field unset, or RBAC denied) must NEVER
+# match, so an unconfirmed lookup can never suppress a Tier-2 restart that would
+# clear a real in-memory leak.
+ip_is_node_ingress() { [ -n "$2" ] && [ "$1" = "$2" ]; }
+
+# Sourcing guard: hack/cilium-leak-healer_test.bats sets CILIUM_LEAK_HEALER_LIB
+# and sources this file purely to reach the pure helpers above; return before
+# the heal loop so the unit test never needs a cluster. The only executing
+# caller (the in-cluster Job) never sets this, so the guard is a no-op there.
+if [ -n "${CILIUM_LEAK_HEALER_LIB:-}" ]; then
+  return 0 2>/dev/null
+fi
 
 mkdir -p "$STATE_DIR" 2>/dev/null || true
 log "started (ns=$CILIUM_NS poll=${POLL_INTERVAL}s, escalate-after=${ESCALATE_AFTER} cycles, max-agent-restarts/node=${MAX_ESCALATIONS_PER_NODE}, in-cluster, runs for the cluster lifetime)"
@@ -168,6 +191,29 @@ while true; do
           continue
         fi
       fi
+    fi
+
+    # Genuine reserved:ingress double-allocation -> never escalate to a Tier-2
+    # agent restart. When the disputed IP is exactly THIS node's Cilium ingress
+    # IP (CiliumNode.spec.ingress.ipv4), the holder is the per-node
+    # reserved:ingress endpoint, carved from the node pod CIDR whenever Gateway
+    # API / Envoy is enabled. Restarting the agent cannot clear it (the agent
+    # re-derives the SAME ingress IP from the CiliumNode spec on every boot) and
+    # is actively harmful: the restart rebuilds the host-scope (kubernetes) IPAM
+    # bitmap empty, then re-reserves the ingress IP via a path decoupled from
+    # pod-endpoint restore, so a CNI ADD in that window can be handed the ingress
+    # IP again -- the same restore-window race that produced this wedge. (Upstream
+    # cilium host-scope IPAM + Gateway API restore-window race; no released fix as
+    # of v1.19.5.) So surface it and reschedule the wedged pod best-effort, but
+    # never count it toward or trigger the agent restart. Gated on an EXACT match
+    # (ip_is_node_ingress; an empty ingress IP never matches) so a false positive
+    # can never suppress a restart that would clear a real in-memory leak.
+    ingress_ip=$(kubectl get ciliumnode "$node" -o jsonpath='{.spec.ingress.ipv4}' 2>/dev/null)
+    if ip_is_node_ingress "$ip" "$ingress_ip"; then
+      log "SURFACE node=$node ip=$ip wedged=$ns/$pod: IP is this node's Cilium ingress IP (CiliumNode.spec.ingress.ipv4), held by the reserved:ingress endpoint -- genuine infra/pod double-allocation from the upstream host-scope IPAM + Gateway API restore-window race. Agent restart cannot clear a re-derived reserved IP and can re-trigger the race, so Tier-2 is skipped; rescheduling the wedged pod best-effort."
+      out=$(kubectl delete pod -n "$ns" "$pod" --wait=false 2>&1)
+      log "  result: ${out:-<none>}"
+      continue
     fi
 
     # Past the REFUSE gate this is a genuine leak candidate: no endpoint holds the

--- a/hack/e2e-cilium-leak-healer.yaml
+++ b/hack/e2e-cilium-leak-healer.yaml
@@ -37,6 +37,13 @@ rules:
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create"]
+  # read CiliumNode.spec.ingress.ipv4 to recognise the per-node reserved:ingress
+  # IP. When the disputed IP is exactly that, the Tier-2 agent restart is futile
+  # (the agent re-derives the same ingress IP on boot) and harmful (it can
+  # re-trigger the host-scope IPAM restore-window race), so the healer skips it.
+  - apiGroups: ["cilium.io"]
+    resources: ["ciliumnodes"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## What this PR does

The Cilium leak healer (`hack/e2e-cilium-endpoint-leak-healer.sh`, the interim CI band-aid for the Cilium endpoint-leak class) escalates an unhealed leaked-IP reuse to a Tier-2 `cilium-agent` restart. For one variant that restart is both futile and harmful.

When the disputed IP is the node's per-node Cilium ingress IP (`CiliumNode.spec.ingress.ipv4`), it is held by the `reserved:ingress` endpoint — allocated from the node pod CIDR whenever Gateway API / Envoy is enabled (`enable-envoy-config`, `daemon/infraendpoints/infra_ip_allocation.go`). Restarting the agent cannot clear it: the agent re-derives the same ingress IP from the CiliumNode spec on every boot. Worse, the restart can re-trigger the race that caused the wedge in the first place — it rebuilds the host-scope (`kubernetes` IPAM) allocation bitmap empty (`pkg/ipam/hostscope.go`; `RestoreFinished()` is a no-op), then re-reserves the ingress IP via a path decoupled from pod-endpoint restore, so a CNI ADD served in that window can be handed the ingress IP again. That is the infra-IP-vs-pod-IP double-allocation behind the "IP already in use" sandbox rejection.

This is an upstream Cilium bug in host-scope IPAM with Gateway API; no released Cilium fixes it as of v1.19.5 (the deployed version). The complete fix belongs upstream — the agent must reserve `spec.ingress.ipv4` in the host-scope allocation bitmap before the CNI server serves allocations, or reconcile it with the restored `reserved:ingress` endpoint, or source it from a dedicated range. That is tracked upstream in cilium/cilium#46799.

This PR makes the CI healer correct for that variant: it detects an exact match of the wedged IP against the node's `CiliumNode.spec.ingress.ipv4` and skips the Tier-2 restart — surfacing the case and rescheduling the wedged pod best-effort instead. The match is gated so an empty ingress IP (CiliumNode absent or RBAC denied) never matches, so a false positive can never suppress a restart that would clear a real in-memory leak. The change adds a `ciliumnodes` read to the healer RBAC and a unit test pinning the exact-match-and-non-empty contract.

### Screenshots

N/A — CI test-infrastructure change, no UI impact.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced endpoint leak healer to skip Tier-2 agent restarts when the disputed IP exactly matches a node’s reserved per-node Cilium ingress IP.
  * Added lightweight unit tests for the new IP-matching behavior.

* **Bug Fixes**
  * Prevents unnecessary remediation when the disputed IP is empty or doesn’t exactly match the node ingress IP.
  * When a match is detected, the healer deletes the affected wedged pod as a best-effort reschedule step.

* **Chores**
  * Updated healer permissions to read Cilium node ingress information cluster-wide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
