### PR TITLE
DO NOT MERGE — instrument tenant Talos bootstrap timing

### DIFF
--- a/hack/e2e-apps/kubernetes-latest.bats
+++ b/hack/e2e-apps/kubernetes-latest.bats
@@ -4,12 +4,29 @@
 # the parent shell: both run_kubernetes_test and the cozy_cleanup() hook the
 # EXIT trap calls must live there (the @test itself runs in a subshell).
 . hack/e2e-apps/run-kubernetes.sh
+# TEMPORARY DIAGNOSTIC (debug/talos-bootstrap-timing) — DO NOT MERGE.
+# Timestamped [TALOS-DEBUG] poller for tenant Talos worker-bootstrap timing.
+. hack/e2e-apps/talos-debug-poller.bash
 
 @test "Create a tenant Kubernetes control plane with latest version" {
   # 4th arg = enable_ouroboros: folds the standalone ouroboros.bats's
   # hairpin-NAT reconciliation assertions onto this cluster instead of
   # spinning up a second ~25m Kamaji bringup.
-  run_kubernetes_test 'keys | sort_by(.) | .[-1]' 'test-latest-version' '59991' 'true'
+  #
+  # TEMPORARY DIAGNOSTIC (debug/talos-bootstrap-timing) — DO NOT MERGE.
+  # Run the [TALOS-DEBUG] timing poller in the background across the whole
+  # bringup, capture run_kubernetes_test's outcome without aborting, give the
+  # poller a short post-failure tail (to see whether the TCT lands just after
+  # the md0 wait times out), stop the poller, then propagate the result.
+  _talos_debug_poller_start 'test-latest-version'
+  _k8s_rc=0
+  run_kubernetes_test 'keys | sort_by(.) | .[-1]' 'test-latest-version' '59991' 'true' || _k8s_rc=$?
+  if [ "${_k8s_rc}" -ne 0 ]; then
+    echo "[TALOS-DEBUG] run_kubernetes_test exited rc=${_k8s_rc}; ~90s post-failure capture"
+    sleep 90
+  fi
+  _talos_debug_poller_stop 'test-latest-version'
+  [ "${_k8s_rc}" -eq 0 ]
 }
 
 # Version-independent, so it runs once here (not in kubernetes-previous.bats).

--- a/hack/e2e-apps/kubernetes-previous.bats
+++ b/hack/e2e-apps/kubernetes-previous.bats
@@ -3,7 +3,20 @@
 # Sourced at file scope (see kubernetes-latest.bats) so cozytest.sh's parent
 # shell gets run_kubernetes_test + the cozy_cleanup() hook for the EXIT trap.
 . hack/e2e-apps/run-kubernetes.sh
+# TEMPORARY DIAGNOSTIC (debug/talos-bootstrap-timing) — DO NOT MERGE.
+# Timestamped [TALOS-DEBUG] poller for tenant Talos worker-bootstrap timing.
+. hack/e2e-apps/talos-debug-poller.bash
 
 @test "Create a tenant Kubernetes control plane with previous version" {
-  run_kubernetes_test 'keys | sort_by(.) | .[-2]' 'test-previous-version' '59992'
+  # TEMPORARY DIAGNOSTIC (debug/talos-bootstrap-timing) — DO NOT MERGE.
+  # See kubernetes-latest.bats for the rationale; same poller wrapper.
+  _talos_debug_poller_start 'test-previous-version'
+  _k8s_rc=0
+  run_kubernetes_test 'keys | sort_by(.) | .[-2]' 'test-previous-version' '59992' || _k8s_rc=$?
+  if [ "${_k8s_rc}" -ne 0 ]; then
+    echo "[TALOS-DEBUG] run_kubernetes_test exited rc=${_k8s_rc}; ~90s post-failure capture"
+    sleep 90
+  fi
+  _talos_debug_poller_stop 'test-previous-version'
+  [ "${_k8s_rc}" -eq 0 ]
 }

--- a/hack/e2e-apps/talos-debug-poller.bash
+++ b/hack/e2e-apps/talos-debug-poller.bash
@@ -1,0 +1,107 @@
+# TEMPORARY DIAGNOSTIC — debug/talos-bootstrap-timing — DO NOT MERGE.
+#
+# Background poller that timestamps tenant Talos worker-bootstrap timing against
+# the MANAGEMENT cluster (default kubectl context). Sourced by the kubernetes
+# e2e bats files (kubernetes-latest.bats / kubernetes-previous.bats) and wrapped
+# around the run_kubernetes_test call: started just before the install, stopped
+# after the test returns (with a post-failure capture tail). Every emitted line
+# is tagged [TALOS-DEBUG ...] for grep.
+#
+# It lives as a .bash (not .sh) file and is wired in from the two .bats files
+# rather than run-kubernetes.sh on purpose: the e2e Test-Impact-Analysis
+# (hack/select-e2e.sh) escalates any hack/e2e-apps/*.sh change to the FULL
+# suite, while editing the per-app .bats selects only that app and a non-.sh
+# helper is ignored. So this wiring runs ONLY kubernetes-latest +
+# kubernetes-previous, not every app.
+#
+# Goal: classify why the TalosConfigTemplate is late so md0 can't scale within
+# its wait budget — slow input / slow-or-stuck reconcile Job pod / pod-churn
+# (Job recreated) / TCT-eventually-lands-after-timeout. It dumps regardless of a
+# fast or slow run so even a fast sample gives the happy-path baseline.
+#
+# This whole file plus its two .bats hooks are reverted once the timeline is
+# captured. Nothing here ships.
+
+# One timestamped snapshot. All queries hit the management cluster, namespace
+# tenant-test, and are individually guarded so a transient API error or a
+# not-yet-created object never aborts the loop.
+_talos_debug_dump() {
+  tn="$1"; rel="kubernetes-${tn}"; ns="tenant-test"
+  now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  echo "[TALOS-DEBUG ts=${now} test=${tn}] ---- poll ----"
+
+  # Parent kubernetes HelmRelease: Ready/reason, attempted revision, remediation
+  # counters, and per-revision history statuses (a remediation cycle leaves
+  # failed/uninstalled entries). The churn axis at the HelmRelease level.
+  echo "[TALOS-DEBUG hr] $(kubectl get hr "${rel}" -n "${ns}" -o jsonpath='ready={.status.conditions[?(@.type=="Ready")].status} reason={.status.conditions[?(@.type=="Ready")].reason} rev={.status.lastAttemptedRevision} instFail={.status.installFailures} upgFail={.status.upgradeFailures} hist=[{range .status.history[*]}{.status},{end}]' 2>/dev/null || echo absent)"
+
+  # talos-reconcile Job(s): creationTimestamp + uid (a new uid over time = the
+  # pod-churn axis), active/succeeded/failed, backoffLimit. The Job itself is not
+  # labelled with the reconcile selector (only its pods are), so filter by name.
+  kubectl get jobs -n "${ns}" -o jsonpath='{range .items[*]}{.metadata.name}|uid={.metadata.uid}|created={.metadata.creationTimestamp}|active={.status.active}|succeeded={.status.succeeded}|failed={.status.failed}|backoffLimit={.spec.backoffLimit}{"\n"}{end}' 2>/dev/null \
+    | grep talos-reconcile | sed 's/^/[TALOS-DEBUG job] /' || true
+
+  # talos-reconcile pod(s): phase + waiting reason (Pending / ContainerCreating /
+  # ImagePullBackOff / CrashLoopBackOff) + running start + restartCount. The
+  # slow-or-stuck-pod axis. Pods carry the reconcile label.
+  kubectl get pods -n "${ns}" -l "cozystack.io/talos-reconcile=${rel}" -o jsonpath='{range .items[*]}{.metadata.name}|uid={.metadata.uid}|created={.metadata.creationTimestamp}|phase={.status.phase}|start={.status.startTime}|waiting={.status.containerStatuses[0].state.waiting.reason}|running={.status.containerStatuses[0].state.running.startedAt}|restarts={.status.containerStatuses[0].restartCount}{"\n"}{end}' 2>/dev/null \
+    | sed 's/^/[TALOS-DEBUG pod] /' || true
+
+  # The product of the Job: does the TalosConfigTemplate exist yet, and when did
+  # it first appear? (md0 status.replicas=2 is gated on this.)
+  echo "[TALOS-DEBUG tct] $(kubectl get talosconfigtemplate "${rel}-md0" -n "${ns}" -o jsonpath='present created={.metadata.creationTimestamp}' 2>/dev/null || echo absent)"
+
+  # The four runtime-wait inputs the Job blocks on.
+  echo "[TALOS-DEBUG in.svc] clusterIP=$(kubectl get svc "${rel}" -n "${ns}" -o jsonpath='{.spec.clusterIP}' 2>/dev/null || echo none)"
+  echo "[TALOS-DEBUG in.talos-ca-cert] ready=$(kubectl get certificate "${rel}-talos-ca" -n "${ns}" -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || echo none)"
+  echo "[TALOS-DEBUG in.talos-ca-secret] created=$(kubectl get secret "${rel}-talos-ca" -n "${ns}" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null || echo absent)"
+  echo "[TALOS-DEBUG in.k8s-ca-secret] created=$(kubectl get secret "${rel}-ca" -n "${ns}" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null || echo absent)"
+  echo "[TALOS-DEBUG in.coredns] clusterIP=$(kubectl get svc kube-dns -n kube-system -o jsonpath='{.spec.clusterIP}' 2>/dev/null || echo none)"
+
+  # The consumer: MachineDeployment status, its MachineSet (CAPI blocks
+  # MachineSet creation until the TCT exists), and MD/MS events (the
+  # "cannot create a new MachineSet when templates do not exist" line lands here).
+  echo "[TALOS-DEBUG md] $(kubectl get machinedeployment "${rel}-md0" -n "${ns}" -o jsonpath='replicas={.status.replicas} ready={.status.readyReplicas} phase={.status.phase}' 2>/dev/null || echo absent)"
+  kubectl get machineset -n "${ns}" -o jsonpath='{range .items[*]}{.metadata.name}|created={.metadata.creationTimestamp}|replicas={.status.replicas}{"\n"}{end}' 2>/dev/null \
+    | grep "${rel}-md0" | sed 's/^/[TALOS-DEBUG ms] /' || true
+  kubectl get events -n "${ns}" -o jsonpath='{range .items[*]}{.lastTimestamp}|{.involvedObject.kind}/{.involvedObject.name}|{.reason}|{.message}{"\n"}{end}' 2>/dev/null \
+    | grep -E "talos-reconcile|${rel}-md0" | sed 's/^/[TALOS-DEBUG ev] /' || true
+}
+
+# Start the poller in the background. Writes to a per-test artifact log under the
+# cozyreport dir AND to stdout (tee), so the timeline survives in both the
+# uploaded artifact and the raw job log.
+_talos_debug_poller_start() {
+  tn="$1"
+  _talos_debug_log="${COZY_REPORT_DIR:-_out/cozyreport}/talos-debug-${tn}.log"
+  mkdir -p "$(dirname "${_talos_debug_log}")" 2>/dev/null || true
+  rm -f "/tmp/talos-debug-stop-${tn}"
+  (
+    # cozytest.sh runs the test body under `set -eux`, which this background
+    # subshell inherits. Drop it: a best-effort diagnostic must never abort the
+    # loop on a transient query failure, and the command trace would bury the
+    # [TALOS-DEBUG] lines. Correctness is held by the per-query guards instead.
+    set +eux
+    i=0
+    # Self-cap (~40 min) so an orphaned poller — an upstream wait failing before
+    # the md0 stop-point is reached — terminates on its own well inside the CI
+    # job budget.
+    while [ ! -f "/tmp/talos-debug-stop-${tn}" ] && [ "${i}" -lt 160 ]; do
+      _talos_debug_dump "${tn}" 2>&1 | tee -a "${_talos_debug_log}" || true
+      i=$((i + 1))
+      sleep 15
+    done
+  ) &
+  TALOS_DEBUG_PID=$!
+  echo "[TALOS-DEBUG] poller started pid=${TALOS_DEBUG_PID} log=${_talos_debug_log}"
+}
+
+# Stop the poller and reap it.
+_talos_debug_poller_stop() {
+  tn="$1"
+  touch "/tmp/talos-debug-stop-${tn}" 2>/dev/null || true
+  if [ -n "${TALOS_DEBUG_PID:-}" ]; then
+    wait "${TALOS_DEBUG_PID}" 2>/dev/null || true
+  fi
+  echo "[TALOS-DEBUG] poller stopped"
+}


### PR DESCRIPTION
Throwaway diagnostic. Not for merge, not gated — close after the data is captured.

Goal: classify why the tenant worker `MachineDeployment` `md0` intermittently fails its `status.replicas=2` wait. md0 is gated on the `TalosConfigTemplate` existing; this run captures whether the template is late because an input is slow, the talos-reconcile Job pod is slow/stuck (Pending / ImagePull / CrashLoop), the Job is recreated (churn), or the template only lands after the wait times out.

What it does: a background poller (`hack/e2e-apps/talos-debug-poller.bash`) runs from just before the install through the bringup and, every ~15s, appends a timestamped `[TALOS-DEBUG ...]` block (against the management cluster) covering:

- the parent `kubernetes-<name>` HelmRelease: Ready/reason, attempted revision, install/upgrade failure counters, and per-revision history statuses (the remediation/churn axis);
- the talos-reconcile Job(s): creationTimestamp + uid (recreation = churn), active/succeeded/failed, backoffLimit;
- the Job pod(s): phase, waiting reason, running start, restartCount (the slow/stuck-pod axis);
- the `TalosConfigTemplate <rel>-md0` first-appearance timestamp;
- the four runtime-wait inputs (apiserver Service ClusterIP, talos-ca Certificate/Secret, tenant k8s-ca Secret, management CoreDNS);
- the `MachineDeployment`/`MachineSet` status and events (the "cannot create a new MachineSet when templates do not exist" line lands here).

Scope: wired in from `kubernetes-latest.bats` and `kubernetes-previous.bats` (not `run-kubernetes.sh`) so Test-Impact-Analysis runs only the two kubernetes tests, not the full suite. The md0 wait budget is unchanged so the failure window stays observable; a post-failure tail captures whether the template lands just after.

Reading the output: grep the e2e job log (or the `cozyreport` artifact) for `[TALOS-DEBUG]`. Both kubernetes-latest and kubernetes-previous run, giving two samples; md0 is bimodal (sometimes ~46s, sometimes >10m), so a fast run is the happy-path baseline and a re-run may be needed to catch a slow one.

Revert (the two `.bats` hooks + the `.bash` helper) once the timeline is captured.