### PR TITLE
fix(kubernetes): run the Talos reconcile Job in the main install phase

### DIFF
--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -36,7 +36,7 @@
        exist on first Helm render, so the gate fails, the TCT is
        skipped, and Helm's release-storage three-way merge then refuses
        to upgrade because no values changed. Both objects are now
-       produced by the post-install/post-upgrade Helm hook Job in
+       produced by the main-phase Job in
        templates/talos/talos-reconcile-job.yaml, which blocks until the
        four dependencies exist and then `kubectl apply`s deterministic
        results. The Job owns the TCT through an ownerReference to the
@@ -321,10 +321,9 @@ spec:
         protocol: TCP
     {{- /* Initial render lists only the DNS SANs because the apiserver
            Service ClusterIP is not yet allocated when Helm executes the
-           template. The talos-reconcile post-install/post-upgrade hook
-           re-patches certSANs with the live ClusterIP once Kamaji emits
-           the Service, and Kamaji then re-issues the apiserver TLS cert
-           to cover it. */}}
+           template. The talos-reconcile main-phase Job re-patches certSANs
+           with the live ClusterIP once Kamaji emits the Service, and
+           Kamaji then re-issues the apiserver TLS cert to cover it. */}}
     certSANs:
       - {{ printf "%s.%s.svc" .Release.Name .Release.Namespace }}
       - {{ printf "%s.%s.svc.%s" .Release.Name .Release.Namespace (include "kubernetes.tenantClusterDomain" .) }}
@@ -578,14 +577,15 @@ metadata:
        produce a valid Talos worker machineconfig at Helm template time
        because three of the inputs (apiserver Service ClusterIP, Talos
        CA from cert-manager, Kamaji-issued tenant CA) are created
-       asynchronously after Helm applies this manifest. The
-       talos-reconcile-job hook (templates/talos/talos-reconcile-job.yaml)
-       waits for those inputs and produces the TalosConfigTemplate with
-       a KamajiControlPlane ownerReference for natural GC. The
+       asynchronously after Helm applies this manifest. The main-phase
+       Job in templates/talos/talos-reconcile-job.yaml waits for those
+       inputs and produces the TalosConfigTemplate with a
+       KamajiControlPlane ownerReference for natural GC. That Job runs in
+       the main install phase, so it applies the template as soon as the
+       inputs appear — in parallel with the rest of the install. The
        MachineDeployment below still references the TCT name; CAPI's
        Machine controller blocks on its absence and unblocks the moment
-       the hook applies it, which happens in the same post-install/
-       post-upgrade cycle. */}}
+       the Job applies it. */}}
 ---
 {{- $context := deepCopy $ }}
 {{- $_ := set $context "group" $group }}

--- a/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
@@ -1,7 +1,7 @@
 {{- define "cozystack.defaultCiliumValues" -}}
 {{- /* Cilium runs hostNetwork on the Talos worker nodes and resolves the
        apiserver via the worker's /etc/hosts, which the talos-reconcile
-       post-install hook seeds with the Kamaji Service ClusterIP under
+       main-phase Job seeds with the Kamaji Service ClusterIP under
        <release>.<ns>.svc through machine.network.extraHostEntries. So a
        plain DNS host works here without a lookup-and-reuse race: the
        cert covers the same DNS name from chart render time, and the

--- a/packages/apps/kubernetes/templates/talos/talos-reconcile-job.yaml
+++ b/packages/apps/kubernetes/templates/talos/talos-reconcile-job.yaml
@@ -1,5 +1,5 @@
 {{- /*
-  Post-install/post-upgrade Helm hook that resolves the chart's
+  Main-phase Job (NOT a Helm hook) that resolves the chart's
   lookup-and-reuse race for TalosConfigTemplate and
   KamajiControlPlane.spec.network.certSANs.
 
@@ -18,9 +18,8 @@
   Ready but whose CAPI MachineDeployment is stuck on
   `cannot create a new MachineSet when templates do not exist` forever.
 
-  This Job runs once Helm has applied everything else in the release,
-  blocks until the four dependencies are observably present, then
-  produces both objects via `kubectl apply` (idempotent). The
+  This Job blocks until the four dependencies are observably present,
+  then produces both objects via `kubectl apply` (idempotent). The
   TalosConfigTemplate carries an ownerReference to the KamajiControlPlane
   so Kubernetes garbage-collects it through the standard owner-reference
   cascade when the chart's release is uninstalled — Helm itself does not
@@ -29,12 +28,56 @@
   field; the Kamaji controller picks up the change and re-issues the
   apiserver TLS cert with the live ClusterIP in its SAN list.
 
-  Hook weight 5 places the Job after Helm has emitted the
-  KamajiControlPlane / Talos PKI Certificate / talos-secrets but before
-  the bootstrap-token-tenant Job (weight 10), so workers see a
-  reachable apiserver, a SAN-correct TLS cert, and a populated
-  bootstrap-token Secret in the tenant kube-system the first time
-  they boot.
+  Why main phase, not a post-install hook. This Job is the only thing
+  that creates the TalosConfigTemplate (the chart no longer renders it —
+  see cluster.yaml). As a post-install hook it runs only AFTER Helm has
+  applied the release's main resources and, when Helm waits, after they
+  become Ready. But the same release also emits in-tenant addon
+  HelmReleases — notably cilium — whose readiness needs tenant worker
+  nodes, and those nodes can only be created once this Job has produced
+  the TalosConfigTemplate the worker MachineDeployment clones from. So
+  when the main-resource wait is in effect it DEADLOCKS: the install
+  waits for cilium to be Ready, cilium waits for worker nodes, the nodes
+  wait for the TalosConfigTemplate, and the template waits for this hook
+  — which never runs, because the install never finishes the wait that
+  precedes the post-install hook phase. The install times out and the
+  MachineDeployment never scales. (Observed on a failing run: the parent
+  HelmRelease stuck at `Running install action 20m`, NEITHER post-install
+  hook ever created, the cilium sub-release timing out on cilium-operator
+  — all while the four inputs were ready early. The hook never reached;
+  the inputs were not late.)
+
+  The release sets `helm-install-disable-wait` precisely to skip that
+  main-resource wait so the hooks run, but its effect is unreliable —
+  which is what makes the failure bimodal: when the wait is skipped the
+  hook runs and the template lands in ~46s; when it is not, the deadlock
+  above strands the install. Rendering this Job as an ordinary MAIN-phase
+  resource removes the dependency on both the hook phase and DisableWait.
+  The Job is created during the apply itself (not after the wait) and
+  runs on the management cluster — which has nodes, unlike the tenant
+  cilium-operator — so it produces the TalosConfigTemplate, the
+  MachineDeployment scales, workers join, cilium goes Ready, and the
+  main-resource wait (if any) closes within the install budget: the Job
+  completes in tens of seconds, node boot plus cilium readiness is a few
+  minutes. It works whether or not DisableWait takes effect. The Job's
+  RBAC, ServiceAccount and egress CiliumNetworkPolicy are main-phase too;
+  the wait loop tolerates its dependencies (and its own network policy)
+  not yet being in place, so Helm's kind-ordered apply needs no explicit
+  sequencing. The bootstrap-token Job stays a post-install hook.
+
+  Churn-free across upgrades. The Job is immutable (spec.template cannot
+  be patched), so it carries a content-hash name suffix — mirrors the
+  KubevirtMachineTemplate idiom in cluster.yaml. An identical render
+  yields the same name and Helm no-ops a Job it can never patch; any
+  change to a field that flows into the rendered Job spec (and therefore
+  into the TalosConfigTemplate it applies) yields a new name, so a fresh
+  Job re-applies the updated template and Helm prunes the superseded one.
+  Because the hash is taken over the whole rendered spec, no spec change
+  can ever land on the same name and trigger an immutable-field patch
+  error. The applied TalosConfigTemplate keeps a stable name
+  (<release>-<group>, referenced by MachineDeployment.bootstrap.configRef)
+  regardless of the Job's hash, so an unchanged render re-applies a
+  byte-identical TCT — a CAPI no-op that never rolls existing workers.
 */}}
 ---
 apiVersion: v1
@@ -44,10 +87,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -56,10 +95,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
     resources: ["services"]
@@ -81,12 +116,12 @@ rules:
     verbs: ["get", "create", "patch", "update"]
 ---
 {{- /* The tenant-root chart installs a default-deny egress policy on every
-       pod in the tenant namespace; without an explicit allow, this hook Job
+       pod in the tenant namespace; without an explicit allow, this Job
        cannot reach the management-cluster apiserver to read the Service
        ClusterIP / Secrets / KamajiControlPlane it has to reconcile. Cilium
        policies are additive, so this rule layers on top of the tenant
        default-deny without weakening it for anything else. Endpoint
-       selector is scoped to pods carrying the hook label only. */}}
+       selector is scoped to pods carrying the reconcile label only. */}}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -94,10 +129,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   endpointSelector:
     matchLabels:
@@ -123,10 +154,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -136,7 +163,7 @@ subjects:
     name: {{ .Release.Name }}-talos-reconcile
     namespace: {{ .Release.Namespace }}
 ---
-{{- /* Cluster-scoped read on the management CoreDNS Service so the hook
+{{- /* Cluster-scoped read on the management CoreDNS Service so the Job
        can look up its ClusterIP at runtime and inject it into the worker
        machineconfig as a host-level nameserver. Tenant workers run as
        KubeVirt VMs inside the management pod network; tenant in-cluster
@@ -161,10 +188,6 @@ metadata:
   name: {{ .Release.Namespace }}-{{ .Release.Name }}-talos-reconcile-coredns
   labels:
     {{- include "kubernetes.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups: [""]
     resources: ["services"]
@@ -177,10 +200,6 @@ metadata:
   name: {{ .Release.Namespace }}-{{ .Release.Name }}-talos-reconcile-coredns
   labels:
     {{- include "kubernetes.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "1"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -189,88 +208,30 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}-talos-reconcile
     namespace: {{ .Release.Namespace }}
----
-{{- $kubeletVersion := include "kubernetes.versionMap" $ | trim }}
-{{- $talosVersion := $.Values.talos.version }}
-{{- $podCIDR := "10.243.0.0/16" }}
-{{- $serviceCIDR := "10.95.0.0/16" }}
-{{- $dnsDomain := include "kubernetes.tenantClusterDomain" $ }}
-{{- /* Management cluster DNS domain. Tenant Kubernetes workers run as
-       KubeVirt VMs inside the management cluster's pod network and need
-       to resolve management-cluster service short names ("<svc>.<ns>.svc")
-       the same way an Ubuntu+kubeadm worker did via cloud-init DHCP. The
-       kubevirt-csi NFS mount path is the load-bearing case: kubelet on
-       the worker host calls `mount.nfs linstor-csi-nfs.cozy-linstor.svc`
-       (no domain suffix), and without searchDomains in /etc/resolv.conf
-       the host resolver hands that name to management CoreDNS verbatim
-       and gets NXDOMAIN.
-
-       Distinct from tenantClusterDomain ("cluster.local"), which is the
-       *tenant* kubelet --cluster-dns zone. This value is the
-       *management* cluster-domain, sourced from .Values._cluster
-       (populated by cozystack-controller from the platform config). */}}
-{{- $mgmtClusterDomain := (index .Values._cluster "cluster-domain") | default "cozy.local" }}
-{{- range $groupName, $group := .Values.nodeGroups }}
-{{- /* Mirror the kubelet-reservation computation from cluster.yaml so the
-       worker machineconfig the hook applies carries the same numbers the
-       MachineDeployment validator was happy with. Auto-computed
-       system/kube reserved memory = 5% of effective memory clamped to
-       [256Mi, 1Gi]; auto-computed system/kube reserved CPU = 5% of
-       effective CPU clamped to [50m, 500m]. instanceType lookup is
-       optional — operators that override resources.cpu / resources.memory
-       on the nodeGroup get those, otherwise the chart falls back to the
-       same static-defaults pair the cluster.yaml validator uses on a
-       no-instanceType setup. */}}
-{{- $instanceType := dict }}
-{{- if $group.instanceType }}
-{{-   $instanceType = lookup "instancetype.kubevirt.io/v1beta1" "VirtualMachineClusterInstancetype" "" $group.instanceType }}
-{{-   $instanceType = $instanceType | default dict }}
-{{- end }}
-{{- $effectiveMemory := "" }}
-{{- if and $group.resources $group.resources.memory }}
-{{-   $effectiveMemory = $group.resources.memory | toString }}
-{{- else if and $instanceType $instanceType.spec $instanceType.spec.memory $instanceType.spec.memory.guest }}
-{{-   $effectiveMemory = $instanceType.spec.memory.guest | toString }}
-{{- end }}
-{{- $effectiveCpu := "" }}
-{{- if and $group.resources $group.resources.cpu }}
-{{-   $effectiveCpu = $group.resources.cpu | toString }}
-{{- else if and $instanceType $instanceType.spec $instanceType.spec.cpu $instanceType.spec.cpu.guest }}
-{{-   $effectiveCpu = $instanceType.spec.cpu.guest | toString }}
-{{- end }}
-{{- $autoReservedMi := 256 }}
-{{- if $effectiveMemory }}
-{{-   $effectiveMemMi := divf (include "cozy-lib.resources.toFloat" $effectiveMemory | float64) 1048576.0 | int }}
-{{-   $fivePercentMi := mulf ($effectiveMemMi | float64) 0.05 | int }}
-{{-   $autoReservedMi = min (max $fivePercentMi 256) 1024 }}
-{{- end }}
-{{- $autoReservedMillicores := 50 }}
-{{- if $effectiveCpu }}
-{{-   $effectiveCpuMillicores := include "kubernetes.cpuToMillicores" $effectiveCpu | int }}
-{{-   $fivePercentMillis := mulf ($effectiveCpuMillicores | float64) 0.05 | int }}
-{{-   $autoReservedMillicores = min (max $fivePercentMillis 50) 500 }}
-{{- end }}
-{{- $kubeletOverride := $group.kubelet | default dict }}
-{{- $systemReservedMemory := $kubeletOverride.systemReservedMemory | default (printf "%dMi" $autoReservedMi) }}
-{{- $kubeReservedMemory := $kubeletOverride.kubeReservedMemory | default (printf "%dMi" $autoReservedMi) }}
-{{- $systemReservedCpu := $kubeletOverride.systemReservedCpu | default (printf "%dm" $autoReservedMillicores) }}
-{{- $kubeReservedCpu := $kubeletOverride.kubeReservedCpu | default (printf "%dm" $autoReservedMillicores) }}
-{{- $evictionHardMemory := $kubeletOverride.evictionHardMemory | default "7%" }}
-{{- $evictionSoftMemory := $kubeletOverride.evictionSoftMemory | default "10%" }}
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: {{ $.Release.Name }}-talos-reconcile-{{ $groupName }}
-  namespace: {{ $.Release.Namespace }}
-  labels:
-    {{- include "kubernetes.labels" $ | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+{{- /* Job spec rendered through a named template so the Job name can carry
+       a content hash of the whole spec (see the header comment). The dot
+       passed in is a deepCopy of the root context with the per-nodeGroup
+       computed values set on it, so $.Release / $.Values resolve as usual
+       and the loop/computed locals are read as .group, .groupName, etc. */}}
+{{- define "kubernetes.talos-reconcile-job-spec" -}}
 spec:
-  backoffLimit: 5
+  {{- /* Each pod attempt runs the ~10-minute (120 × 5s) input-wait loop, so this
+         backoffLimit sets the self-heal window to roughly 5 hours. The Job does
+         not block the install — when disable-wait is in effect Helm does not wait
+         on it, and when Helm does wait the Job completes in tens of seconds — so a
+         long retry budget costs nothing on the install path. It only governs how
+         long a Job whose inputs are unusually slow keeps retrying on its own
+         before giving up. Bounded (not infinite) so a permanently-broken input
+         eventually stops spawning pods. */}}
+  backoffLimit: 30
+  {{- /* ttlSecondsAfterFinished clears the Job (Complete or Failed) shortly after
+         it finishes, so a later reconcile can recreate and retry it. Without the
+         TTL a Failed Job would keep the same content-hash name and be a no-op on
+         every later upgrade — Helm never patches the immutable Job, so it would
+         stay Failed until deleted by hand. No churn from the TTL: the repo runs no
+         Flux drift detection, so an interval reconcile never re-applies a cleared
+         Job; only an actual upgrade does, and that re-applies the byte-identical
+         TalosConfigTemplate (a CAPI no-op). Mirrors the original hook Job's value. */}}
   ttlSecondsAfterFinished: 600
   template:
     metadata:
@@ -281,14 +242,14 @@ spec:
       serviceAccountName: {{ $.Release.Name }}-talos-reconcile
       containers:
         - name: kubectl
-          image: "{{ default ($.Files.Get "images/kubectl.tag" | trim) $.Values.images.kubectl }}"
+          image: "{{ .kubectlImage }}"
           env:
             - name: RELEASE
               value: {{ $.Release.Name | quote }}
             - name: NS
               value: {{ $.Release.Namespace | quote }}
             - name: GROUP_NAME
-              value: {{ $groupName | quote }}
+              value: {{ .groupName | quote }}
             - name: TALOS_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -336,7 +297,7 @@ spec:
               # we want here — Kamaji owns the full SAN list.
               kubectl -n "$NS" patch kamajicontrolplane "$RELEASE" --type=merge --patch "$(
                 cat <<JSON
-              {"spec":{"network":{"certSANs":["${RELEASE}.${NS}.svc","${RELEASE}.${NS}.svc.{{ $dnsDomain }}","${SVC_IP}"]}}}
+              {"spec":{"network":{"certSANs":["${RELEASE}.${NS}.svc","${RELEASE}.${NS}.svc.{{ .dnsDomain }}","${SVC_IP}"]}}}
               JSON
               )"
 
@@ -376,7 +337,7 @@ spec:
                 template:
                   spec:
                     generateType: none
-                    talosVersion: "{{ $talosVersion }}"
+                    talosVersion: "{{ .talosVersion }}"
                     data: |
                       version: v1alpha1
                       persist: true
@@ -405,9 +366,9 @@ spec:
                           nameservers:
                             - ${COREDNS_IP}
                           searchDomains:
-                            - svc.{{ $mgmtClusterDomain }}
-                            - {{ $mgmtClusterDomain }}
-                            {{- if ne $mgmtClusterDomain "cluster.local" }}
+                            - svc.{{ .mgmtClusterDomain }}
+                            - {{ .mgmtClusterDomain }}
+                            {{- if ne .mgmtClusterDomain "cluster.local" }}
                             - svc.cluster.local
                             - cluster.local
                             {{- end }}
@@ -415,10 +376,10 @@ spec:
                             - ip: ${SVC_IP}
                               aliases:
                                 - ${RELEASE}.${NS}.svc
-                                - ${RELEASE}.${NS}.svc.{{ $dnsDomain }}
+                                - ${RELEASE}.${NS}.svc.{{ .dnsDomain }}
                         ca:
                           crt: ${TALOS_CA_B64}
-                        {{- if $group.gpus }}
+                        {{- if .group.gpus }}
                         # GPU node-groups: label every node `gpu=on` so
                         # HAMi's hami-device-plugin DaemonSet (nodeSelector
                         # gpu=on) schedules and advertises nvidia.com/gpu.
@@ -431,21 +392,21 @@ spec:
                           gpu: "on"
                         {{- end }}
                         kubelet:
-                          image: ghcr.io/siderolabs/kubelet:{{ $kubeletVersion }}
+                          image: ghcr.io/siderolabs/kubelet:{{ .kubeletVersion }}
                           extraConfig:
                             systemReserved:
-                              cpu: "{{ $systemReservedCpu }}"
-                              memory: "{{ $systemReservedMemory }}"
+                              cpu: "{{ .systemReservedCpu }}"
+                              memory: "{{ .systemReservedMemory }}"
                             kubeReserved:
-                              cpu: "{{ $kubeReservedCpu }}"
-                              memory: "{{ $kubeReservedMemory }}"
+                              cpu: "{{ .kubeReservedCpu }}"
+                              memory: "{{ .kubeReservedMemory }}"
                             evictionHard:
-                              memory.available: "{{ $evictionHardMemory }}"
+                              memory.available: "{{ .evictionHardMemory }}"
                               nodefs.available: "10%"
                               imagefs.available: "15%"
                               nodefs.inodesFree: "5%"
                             evictionSoft:
-                              memory.available: "{{ $evictionSoftMemory }}"
+                              memory.available: "{{ .evictionSoftMemory }}"
                               nodefs.available: "15%"
                               imagefs.available: "20%"
                             evictionSoftGracePeriod:
@@ -456,7 +417,7 @@ spec:
                               memory.available: "256Mi"
                         install:
                           disk: /dev/vda
-                          image: factory.talos.dev/installer/{{ $.Values.talos.schematicID }}:{{ $talosVersion }}
+                          image: factory.talos.dev/installer/{{ $.Values.talos.schematicID }}:{{ .talosVersion }}
                           wipe: false
                         features:
                           rbac: true
@@ -469,11 +430,11 @@ spec:
                           endpoint: https://${RELEASE}.${NS}.svc:6443
                         clusterName: ${RELEASE}
                         network:
-                          dnsDomain: {{ $dnsDomain }}
+                          dnsDomain: {{ .dnsDomain }}
                           podSubnets:
-                            - {{ $podCIDR }}
+                            - {{ .podCIDR }}
                           serviceSubnets:
-                            - {{ $serviceCIDR }}
+                            - {{ .serviceCIDR }}
                         token: ${BOOTSTRAP_TOKEN}
                         ca:
                           crt: ${K8S_CA_B64}
@@ -503,4 +464,107 @@ spec:
             runAsUser: 65532
             seccompProfile:
               type: RuntimeDefault
+{{- end }}
+{{- $kubeletVersion := include "kubernetes.versionMap" $ | trim }}
+{{- $talosVersion := $.Values.talos.version }}
+{{- $podCIDR := "10.243.0.0/16" }}
+{{- $serviceCIDR := "10.95.0.0/16" }}
+{{- $dnsDomain := include "kubernetes.tenantClusterDomain" $ }}
+{{- /* Management cluster DNS domain. Tenant Kubernetes workers run as
+       KubeVirt VMs inside the management cluster's pod network and need
+       to resolve management-cluster service short names ("<svc>.<ns>.svc")
+       the same way an Ubuntu+kubeadm worker did via cloud-init DHCP. The
+       kubevirt-csi NFS mount path is the load-bearing case: kubelet on
+       the worker host calls `mount.nfs linstor-csi-nfs.cozy-linstor.svc`
+       (no domain suffix), and without searchDomains in /etc/resolv.conf
+       the host resolver hands that name to management CoreDNS verbatim
+       and gets NXDOMAIN.
+
+       Distinct from tenantClusterDomain ("cluster.local"), which is the
+       *tenant* kubelet --cluster-dns zone. This value is the
+       *management* cluster-domain, sourced from .Values._cluster
+       (populated by cozystack-controller from the platform config). */}}
+{{- $mgmtClusterDomain := (index .Values._cluster "cluster-domain") | default "cozy.local" }}
+{{- range $groupName, $group := .Values.nodeGroups }}
+{{- /* Mirror the kubelet-reservation computation from cluster.yaml so the
+       worker machineconfig the Job applies carries the same numbers the
+       MachineDeployment validator was happy with. Auto-computed
+       system/kube reserved memory = 5% of effective memory clamped to
+       [256Mi, 1Gi]; auto-computed system/kube reserved CPU = 5% of
+       effective CPU clamped to [50m, 500m]. instanceType lookup is
+       optional — operators that override resources.cpu / resources.memory
+       on the nodeGroup get those, otherwise the chart falls back to the
+       same static-defaults pair the cluster.yaml validator uses on a
+       no-instanceType setup. */}}
+{{- $instanceType := dict }}
+{{- if $group.instanceType }}
+{{-   $instanceType = lookup "instancetype.kubevirt.io/v1beta1" "VirtualMachineClusterInstancetype" "" $group.instanceType }}
+{{-   $instanceType = $instanceType | default dict }}
+{{- end }}
+{{- $effectiveMemory := "" }}
+{{- if and $group.resources $group.resources.memory }}
+{{-   $effectiveMemory = $group.resources.memory | toString }}
+{{- else if and $instanceType $instanceType.spec $instanceType.spec.memory $instanceType.spec.memory.guest }}
+{{-   $effectiveMemory = $instanceType.spec.memory.guest | toString }}
+{{- end }}
+{{- $effectiveCpu := "" }}
+{{- if and $group.resources $group.resources.cpu }}
+{{-   $effectiveCpu = $group.resources.cpu | toString }}
+{{- else if and $instanceType $instanceType.spec $instanceType.spec.cpu $instanceType.spec.cpu.guest }}
+{{-   $effectiveCpu = $instanceType.spec.cpu.guest | toString }}
+{{- end }}
+{{- $autoReservedMi := 256 }}
+{{- if $effectiveMemory }}
+{{-   $effectiveMemMi := divf (include "cozy-lib.resources.toFloat" $effectiveMemory | float64) 1048576.0 | int }}
+{{-   $fivePercentMi := mulf ($effectiveMemMi | float64) 0.05 | int }}
+{{-   $autoReservedMi = min (max $fivePercentMi 256) 1024 }}
+{{- end }}
+{{- $autoReservedMillicores := 50 }}
+{{- if $effectiveCpu }}
+{{-   $effectiveCpuMillicores := include "kubernetes.cpuToMillicores" $effectiveCpu | int }}
+{{-   $fivePercentMillis := mulf ($effectiveCpuMillicores | float64) 0.05 | int }}
+{{-   $autoReservedMillicores = min (max $fivePercentMillis 50) 500 }}
+{{- end }}
+{{- $kubeletOverride := $group.kubelet | default dict }}
+{{- $systemReservedMemory := $kubeletOverride.systemReservedMemory | default (printf "%dMi" $autoReservedMi) }}
+{{- $kubeReservedMemory := $kubeletOverride.kubeReservedMemory | default (printf "%dMi" $autoReservedMi) }}
+{{- $systemReservedCpu := $kubeletOverride.systemReservedCpu | default (printf "%dm" $autoReservedMillicores) }}
+{{- $kubeReservedCpu := $kubeletOverride.kubeReservedCpu | default (printf "%dm" $autoReservedMillicores) }}
+{{- $evictionHardMemory := $kubeletOverride.evictionHardMemory | default "7%" }}
+{{- $evictionSoftMemory := $kubeletOverride.evictionSoftMemory | default "10%" }}
+{{- /* Render the Job spec, then hash it to a name suffix so the immutable
+       Job is churn-free across upgrades (see the header comment). Mirrors
+       the KubevirtMachineTemplate content-hash idiom in cluster.yaml. */}}
+{{- $jobContext := deepCopy $ }}
+{{- $_ := set $jobContext "group" $group }}
+{{- $_ := set $jobContext "groupName" $groupName }}
+{{- $_ := set $jobContext "kubeletVersion" $kubeletVersion }}
+{{- $_ := set $jobContext "talosVersion" $talosVersion }}
+{{- $_ := set $jobContext "podCIDR" $podCIDR }}
+{{- $_ := set $jobContext "serviceCIDR" $serviceCIDR }}
+{{- $_ := set $jobContext "dnsDomain" $dnsDomain }}
+{{- $_ := set $jobContext "mgmtClusterDomain" $mgmtClusterDomain }}
+{{- $_ := set $jobContext "systemReservedCpu" $systemReservedCpu }}
+{{- $_ := set $jobContext "systemReservedMemory" $systemReservedMemory }}
+{{- $_ := set $jobContext "kubeReservedCpu" $kubeReservedCpu }}
+{{- $_ := set $jobContext "kubeReservedMemory" $kubeReservedMemory }}
+{{- $_ := set $jobContext "evictionHardMemory" $evictionHardMemory }}
+{{- $_ := set $jobContext "evictionSoftMemory" $evictionSoftMemory }}
+{{- $_ := set $jobContext "kubectlImage" (default ($.Files.Get "images/kubectl.tag" | trim) $.Values.images.kubectl) }}
+{{- $jobSpec := include "kubernetes.talos-reconcile-job-spec" $jobContext }}
+{{- $jobHash := $jobSpec | sha256sum | trunc 6 }}
+{{- /* Truncate the name prefix, never the hash, so the name stays within the
+       63-char DNS-label limit for long release/group names while the 6-char
+       content hash that keeps the immutable Job churn-free is always preserved.
+       A no-op for normal-length names (prefix << 56). */}}
+{{- $jobName := printf "%s-talos-reconcile-%s" $.Release.Name $groupName | trunc 56 | trimSuffix "-" }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $jobName }}-{{ $jobHash }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "kubernetes.labels" $ | nindent 4 }}
+{{ $jobSpec }}
 {{- end }}

--- a/packages/apps/kubernetes/tests/cluster_test.yaml
+++ b/packages/apps/kubernetes/tests/cluster_test.yaml
@@ -8,7 +8,7 @@ values:
 
 # With one nodeGroup (md0) the cluster.yaml template renders in this
 # order. The TalosConfigTemplate is no longer rendered here — it is
-# produced at runtime by the post-install hook in
+# produced at runtime by the main-phase Job in
 # templates/talos/talos-reconcile-job.yaml, which writes the TCT YAML
 # from a string literal in the Job's command.
 #   0: Cluster

--- a/packages/apps/kubernetes/tests/gpu_node_labels_test.yaml
+++ b/packages/apps/kubernetes/tests/gpu_node_labels_test.yaml
@@ -1,9 +1,9 @@
 suite: GPU node-group Talos worker nodeLabels tests
 
 # The TalosConfigTemplate that defines worker nodeLabels is not rendered
-# directly by helm — the kubernetes chart emits a post-install Job
+# directly by helm — the kubernetes chart emits a main-phase Job
 # (templates/talos/talos-reconcile-job.yaml) whose container command
-# carries the TCT YAML as a string literal that the hook applies at
+# carries the TCT YAML as a string literal that the Job applies at
 # runtime. helm-unittest therefore asserts on the rendered Job's script
 # via matchRegex / notMatchRegex, looking for the machine.nodeLabels
 # block GPU node-groups must inject so HAMi's hami-device-plugin

--- a/packages/apps/kubernetes/tests/kubelet_reservation_test.yaml
+++ b/packages/apps/kubernetes/tests/kubelet_reservation_test.yaml
@@ -3,12 +3,12 @@ suite: kubelet reservation validation tests
 # These tests cover the failure-path guards in cluster.yaml's per-nodeGroup
 # validation block (memory/CPU format checks, total-reserved vs effective
 # invariants, mixed-unit eviction rejection, etc.). The TalosConfigTemplate
-# is no longer rendered by cluster.yaml — the post-install hook in
+# is no longer rendered by cluster.yaml — the main-phase Job in
 # templates/talos/talos-reconcile-job.yaml produces it at runtime — so the
 # test file only asserts on the kubeadm-era validation paths that survived
 # the Talos rollover. The kubelet-reservation math used to apply
 # machine.kubelet.extraConfig is exercised separately by helm-unittest on
-# the reconcile hook template (see tests/gpu_node_labels_test.yaml for the
+# the reconcile Job template (see tests/gpu_node_labels_test.yaml for the
 # matchRegex pattern against the Job's command literal).
 
 templates:

--- a/packages/apps/kubernetes/tests/talos_templates_test.yaml
+++ b/packages/apps/kubernetes/tests/talos_templates_test.yaml
@@ -1,20 +1,26 @@
-suite: talos hook + secrets template render tests
+suite: talos main-phase Job + secrets template render tests
 
-# Minimal render-coverage for the four new talos/ templates introduced in
-# PR #2610. The TalosConfigTemplate embedded in talos-reconcile-job.yaml is
-# asserted separately by gpu_node_labels_test.yaml (matchRegex against the
-# Job's command literal); this suite covers the surrounding RBAC/Job/Secret
-# scaffolding so a future refactor breaking ServiceAccount/Role wiring is
-# caught locally before chart push. helm-unittest sees documents in source-
-# file order (not helm template's normalized render order), so the
-# documentIndex constants below follow the original template file
+# Render-coverage for the talos/ templates. The TalosConfigTemplate embedded in
+# talos-reconcile-job.yaml is asserted separately by gpu_node_labels_test.yaml
+# (matchRegex against the Job's command literal); this suite covers the
+# surrounding RBAC/Job/Secret scaffolding so a future refactor breaking
+# ServiceAccount/Role wiring is caught locally before chart push. helm-unittest
+# sees documents in source-file order (not helm template's normalized render
+# order), so the documentIndex constants below follow the original template file
 # layout — update if a top-level object is added/removed/reordered.
+#
+# The talos-reconcile resources run in the MAIN install phase (no helm.sh/hook
+# annotations) so the Job applies the TalosConfigTemplate at t0, in parallel
+# with the MachineDeployment, instead of after the install nearly finishes. The
+# Job is immutable, so it carries a content-hash name suffix (mirrors the
+# KubevirtMachineTemplate idiom in cluster.yaml) to stay churn-free on upgrade.
+# The assertions below pin both properties.
 
 values:
   - values/common.yaml
 
 tests:
-  - it: talos-reconcile-job renders the full hook RBAC stack + Job
+  - it: talos-reconcile-job renders the full RBAC stack + Job
     templates:
       - templates/talos/talos-reconcile-job.yaml
     release:
@@ -34,6 +40,31 @@ tests:
           path: metadata.name
           value: test-k8s-talos-reconcile
         documentIndex: 0
+      # Main-phase, not a hook: NONE of the talos-reconcile resources may carry
+      # helm.sh/hook. The whole set must be main-phase together — a re-hooked
+      # Role/RoleBinding (hook-delete-policy: hook-succeeded) would be deleted
+      # after the hook ran, leaving the main-phase Job permanently without
+      # permissions. Pin the absence on every document (0 SA, 1 Role,
+      # 2 CiliumNetworkPolicy, 3 RoleBinding, 4 ClusterRole, 5 ClusterRoleBinding,
+      # 6 Job).
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+        documentIndex: 0
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+        documentIndex: 1
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+        documentIndex: 2
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+        documentIndex: 3
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+        documentIndex: 4
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+        documentIndex: 5
       - isKind:
           of: ClusterRole
         documentIndex: 4
@@ -55,6 +86,181 @@ tests:
       - isKind:
           of: Job
         documentIndex: 6
+      # Main-phase Job: no hook annotations, so it is applied at t0 alongside
+      # the MachineDeployment instead of after the install nearly finishes.
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+        documentIndex: 6
+      # Content-hash name suffix keeps the immutable Job churn-free on upgrade.
+      - matchRegex:
+          path: metadata.name
+          pattern: ^test-k8s-talos-reconcile-md0-[0-9a-f]{6}$
+        documentIndex: 6
+      # TTL clears a Complete or Failed Job so a later reconcile can recreate
+      # and retry it (the release disables Helm's wait, so a failed run is
+      # invisible to Flux and would otherwise stay Failed forever).
+      - equal:
+          path: spec.ttlSecondsAfterFinished
+          value: 600
+        documentIndex: 6
+      # The Job still applies the TalosConfigTemplate with a KamajiControlPlane
+      # ownerReference (for GC) and the extraHostEntries that route workers to
+      # the apiserver Service by DNS name.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kind: TalosConfigTemplate'
+        documentIndex: 6
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kind: KamajiControlPlane'
+        documentIndex: 6
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'extraHostEntries:'
+        documentIndex: 6
+
+  # The two cases below pin the content-hash contract: a TCT-affecting change
+  # rotates the immutable Job's name (so Helm creates a fresh Job instead of
+  # failing on an immutable-field patch), while an unchanged render keeps the
+  # same name (so Helm no-ops). The two renders differ ONLY in nodeGroups.md0.gpus
+  # — everything else (release, namespace, resources, versions) is identical — so
+  # the differing suffix proves the hash tracks the rendered spec. These exact
+  # suffixes are expected to change whenever the Job spec changes; that is the
+  # signal that the Job will roll, and the fixtures are updated in lockstep.
+  - it: content-hash Job name is derived from the rendered spec (gpus unset)
+    templates:
+      - templates/talos/talos-reconcile-job.yaml
+    release:
+      name: test-k8s
+      namespace: tenant-test
+    set:
+      _cluster:
+        cluster-domain: cozy.local
+      _namespace:
+        etcd: cozy-etcd
+        ingress: nginx
+        host: example.com
+      nodeGroups:
+        md0:
+          minReplicas: 0
+          maxReplicas: 10
+          instanceType: ""
+          diskSize: 20Gi
+          roles:
+            - worker
+          resources:
+            cpu: 8
+            memory: 16Gi
+          kubelet: {}
+          gpus: []
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-k8s-talos-reconcile-md0-6ddd7d
+        documentSelector:
+          path: kind
+          value: Job
+
+  - it: content-hash Job name rotates when a TCT-affecting value changes (gpus)
+    templates:
+      - templates/talos/talos-reconcile-job.yaml
+    release:
+      name: test-k8s
+      namespace: tenant-test
+    set:
+      _cluster:
+        cluster-domain: cozy.local
+      _namespace:
+        etcd: cozy-etcd
+        ingress: nginx
+        host: example.com
+      nodeGroups:
+        md0:
+          minReplicas: 0
+          maxReplicas: 10
+          instanceType: ""
+          diskSize: 20Gi
+          roles:
+            - worker
+          resources:
+            cpu: 8
+            memory: 16Gi
+          kubelet: {}
+          gpus:
+            - name: nvidia.com/GH200
+    asserts:
+      # Only gpus changed vs the case above, yet the suffix differs (ceb45e vs
+      # 6ddd7d) — the content hash tracks the rendered spec, and the TCT the Job
+      # applies is what changed (GPU nodeLabels).
+      - equal:
+          path: metadata.name
+          value: test-k8s-talos-reconcile-md0-ceb45e
+        documentSelector:
+          path: kind
+          value: Job
+
+  - it: content-hash Job name is truncated to stay within the 63-char DNS-label limit
+    templates:
+      - templates/talos/talos-reconcile-job.yaml
+    release:
+      # release + group chosen so "<release>-talos-reconcile-<group>" alone is 61
+      # chars; adding the "-<6hexhash>" suffix would push it to 68 without the
+      # trunc-56 prefix guard, and the API server would reject the over-limit
+      # Job name.
+      name: kubernetes-pretty-long-tenant-clustername
+      namespace: tenant-test
+    set:
+      _cluster:
+        cluster-domain: cozy.local
+      _namespace:
+        etcd: cozy-etcd
+        ingress: nginx
+        host: example.com
+      nodeGroups:
+        md0:
+          minReplicas: 0
+          maxReplicas: 10
+          instanceType: ""
+          diskSize: 20Gi
+          roles:
+            - worker
+          resources:
+            cpu: 2
+            memory: 4Gi
+          kubelet: {}
+          gpus: []
+    asserts:
+      # (a) within the 63-char metadata.name / job-name label limit.
+      - matchRegex:
+          path: metadata.name
+          pattern: ^.{1,63}$
+        documentSelector:
+          path: kind
+          value: Job
+      # (b) the 6-char content hash is never truncated — it is always the suffix,
+      #     so a changed spec still rotates the name.
+      - matchRegex:
+          path: metadata.name
+          pattern: -[0-9a-f]{6}$
+        documentSelector:
+          path: kind
+          value: Job
+      # (c) trimSuffix "-" guarantees no trailing/double dash before the hash even
+      #     when trunc lands on a dash.
+      - matchRegex:
+          path: metadata.name
+          pattern: '[^-]-[0-9a-f]{6}$'
+        documentSelector:
+          path: kind
+          value: Job
+      # (d) the prefix is genuinely truncated: the full "talos-reconcile-md0" infix
+      #     would be present if trunc-56 had not fired.
+      - notMatchRegex:
+          path: metadata.name
+          pattern: talos-reconcile-md0
+        documentSelector:
+          path: kind
+          value: Job
 
   - it: bootstrap-token tenant Job renders ServiceAccount + Job
     templates:
@@ -130,7 +336,7 @@ tests:
           value: test-k8s-talos-tls-cert
         documentIndex: 3
 
-  - it: talos-secrets Secret carries the four token-component keys the reconcile hook env binds from
+  - it: talos-secrets Secret carries the four token-component keys the reconcile Job env binds from
     templates:
       - templates/talos/talos-secrets.yaml
     release:

--- a/packages/system/kubernetes-rd/cozyrds/kubernetes.yaml
+++ b/packages/system/kubernetes-rd/cozyrds/kubernetes.yaml
@@ -17,14 +17,14 @@ metadata:
     # annotation is raised, update that init deadline correspondingly.
     release.cozystack.io/helm-install-timeout: "20m"
     # The kubernetes chart emits in-tenant addon HelmReleases (cilium, coredns,
-    # csi, ingress-nginx, metrics-server, ouroboros) and ships a talos-reconcile
-    # post-install hook that produces the TalosConfigTemplate the worker
+    # csi, ingress-nginx, metrics-server, ouroboros) and a main-phase
+    # talos-reconcile Job that produces the TalosConfigTemplate the worker
     # MachineSets clone from. Without DisableWait the helm-controller waits for
-    # the addon HelmReleases to be Ready before running the hook, but those
+    # the addon HelmReleases to be Ready before the release settles, but those
     # cannot be Ready until worker nodes exist, and the workers cannot be
-    # created without the TalosConfigTemplate the hook is supposed to produce.
-    # Skip the readiness wait so the hook fires and the chicken-and-egg
-    # resolves.
+    # created without the TalosConfigTemplate the Job produces. Skip the
+    # readiness wait so the release settles and the chicken-and-egg resolves;
+    # the talos-reconcile Job runs to completion asynchronously.
     release.cozystack.io/helm-install-disable-wait: "true"
 spec:
   application:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,14 +39,15 @@ const HelmUpgradeTimeoutAnnotation = "release.cozystack.io/helm-upgrade-timeout"
 // HelmInstallDisableWaitAnnotation is the ApplicationDefinition metadata
 // annotation key that sets HelmReleaseSpec.Install.DisableWait and
 // Upgrade.DisableWait to true for a given Application kind. Use when the
-// parent chart emits child HelmReleases whose readiness depends on
-// post-install hooks of the parent (e.g. the Kubernetes Application's
-// talos-reconcile hook produces the TalosConfigTemplate that worker
-// MachineSets clone from; without DisableWait the helm-controller waits
-// for the emitted in-tenant addon HelmReleases to be Ready before
-// running the hook, but those HelmReleases can never be Ready because
-// they have no worker nodes to schedule on yet, and the hook never
-// runs).
+// parent chart emits child HelmReleases that cannot become Ready during
+// the parent's own install (e.g. the Kubernetes Application emits
+// in-tenant addon HelmReleases that have no worker nodes to schedule on
+// until the worker MachineSets come up, plus a main-phase talos-reconcile
+// Job that produces the TalosConfigTemplate those MachineSets clone from).
+// Without DisableWait the helm-controller blocks on the addon HelmReleases
+// becoming Ready, which cannot happen during install, so the release never
+// settles. DisableWait lets it settle while the addon HelmReleases and the
+// reconcile Job converge asynchronously.
 const HelmInstallDisableWaitAnnotation = "release.cozystack.io/helm-install-disable-wait"
 
 // helmTimeoutPattern mirrors the CRD validation pattern used by Flux

--- a/pkg/registry/apps/application/rest.go
+++ b/pkg/registry/apps/application/rest.go
@@ -1610,14 +1610,14 @@ func (r *REST) convertApplicationToHelmRelease(app *appsv1alpha1.Application) (*
 	// ApplicationDefinition that sets
 	// release.cozystack.io/helm-install-disable-wait: "true" gets
 	// Install.DisableWait and Upgrade.DisableWait set on the emitted
-	// HelmRelease. Required for parent charts whose post-install hooks
-	// produce resources the in-tenant child HelmReleases would
-	// otherwise wait for (e.g. the Kubernetes Application's
-	// talos-reconcile hook generates the TalosConfigTemplate the
-	// worker MachineSet clones from; without DisableWait the
-	// helm-controller blocks the hook on cilium/coredns/csi/etc.
-	// HelmReleases that themselves can never become Ready until those
-	// workers exist).
+	// HelmRelease. Required for parent charts that emit in-tenant child
+	// HelmReleases which cannot become Ready during the parent's own
+	// install (e.g. the Kubernetes Application emits cilium/coredns/csi/etc.
+	// HelmReleases that can never become Ready until worker nodes exist,
+	// plus a main-phase talos-reconcile Job that generates the
+	// TalosConfigTemplate the worker MachineSet clones from; without
+	// DisableWait the helm-controller blocks the release on those addon
+	// HelmReleases, which cannot happen during install).
 	if r.releaseConfig.HelmInstallDisableWait {
 		helmRelease.Spec.Install.DisableWait = true
 		helmRelease.Spec.Upgrade.DisableWait = true


### PR DESCRIPTION
## What this PR does

The tenant worker `MachineDeployment` `md0` intermittently never reaches `status.replicas=2`. CAPI blocks MachineSet creation until the `TalosConfigTemplate` that the deployment's `bootstrap.configRef` points to exists, and on failing installs that template is never created.

### Root cause — an ordering deadlock

The `TalosConfigTemplate` is created only by the `talos-reconcile` **post-install Helm hook** (the chart can no longer render it at template time — three of its inputs are produced asynchronously after apply). A post-install hook runs only after Helm has applied the release's main resources and, when Helm waits, after they become Ready.

But the same release also emits in-tenant addon HelmReleases — notably **cilium** — whose readiness needs tenant worker nodes, and those nodes can only be created once this hook has produced the `TalosConfigTemplate`. So when the main-resource wait is in effect, the install deadlocks: it waits for cilium to be Ready, cilium waits for worker nodes, the nodes wait for the `TalosConfigTemplate`, and the template waits for the post-install hook — which never runs, because the install never finishes the wait that precedes the hook phase. The install times out and `md0` never scales.

The release sets `helm-install-disable-wait` precisely to skip that main-resource wait so the hooks run, but its effect is unreliable — which is what makes the failure bimodal: when the wait is skipped the hook runs and the template lands in ~46s; when it is not, the deadlock strands the install.

A timestamped poller over a failing run (both `kubernetes-latest` and `kubernetes-previous`, 640 polls) captured: `TalosConfigTemplate` absent in 640/640 polls; both post-install hook Jobs (`talos-reconcile` and `bootstrap-token`) never created — the install never reached the post-install hook phase; all main resources applied (MachineDeployment, KubevirtMachineTemplate, MachineHealthCheck, WorkloadMonitor, child HelmReleases, Talos PKI/secrets) and the four hook inputs ready early and stable; the parent HelmRelease stuck at `Running 'install' action 20m` then looping into `upgrade`, with the cilium sub-release timing out on `cilium-operator` (which has no worker node to schedule on) — downstream of the missing template.

### The fix

Render the `talos-reconcile` Job and its RBAC / ServiceAccount / egress `CiliumNetworkPolicy` as ordinary **main-phase** resources instead of post-install hooks. The Job is then created during the apply itself — not after the wait — and runs on the management cluster, which has nodes (unlike the tenant `cilium-operator`). It produces the `TalosConfigTemplate`, `md0` scales, workers join, cilium goes Ready, and the main-resource wait (if any) closes within the install budget: the Job completes in tens of seconds, and node boot plus cilium readiness is a few minutes — comfortably inside the 20m install timeout. This works whether or not `helm-install-disable-wait` takes effect, so it does not depend on that annotation's reliability.

Because a main-phase Job is immutable, it carries a content-hash name suffix over its whole rendered spec (mirroring the `KubevirtMachineTemplate` idiom in `cluster.yaml`): an identical render keeps the same name and Helm no-ops it; any spec change yields a new name and a fresh Job, so no change ever lands on the same name and trips an immutable-field patch error. The applied `TalosConfigTemplate` keeps its stable `<release>-<group>` name (referenced by `bootstrap.configRef`), so an unchanged render re-applies a byte-identical template — a CAPI no-op that never rolls existing workers. The Job name is truncated to stay within the 63-char DNS-label limit while always preserving the hash. The runtime input-waits, the single `kubectl apply` of the template with a `KamajiControlPlane` ownerReference for GC, and the `extraHostEntries` are all unchanged.

`helm-install-disable-wait`'s unreliable effectiveness is a real latent issue (it explains the created-vs-never bimodality), but this fix breaks the deadlock independent of it, so that is a separate follow-up rather than a blocker here.

Supersedes #3139 (a 10-minute wait-budget bump that treated the symptom; the deadlock is structural and a larger budget would not have helped).

### Screenshots

Not applicable — no UI changes.

### Testing

helm-unittest extended to pin: no `helm.sh/hook` on any of the seven talos-reconcile documents, the content-hash name, `ttlSecondsAfterFinished`, the preserved template apply + ownerReference + extraHostEntries, the hash rotating on a spec change, and the long-name truncation staying within 63 chars. Full chart suite green (128 tests). The applied template is byte-identical to the previous hook output (verified by diff), so existing tenants are upgrade-safe.

### Release note

```release-note
fix(kubernetes): create the tenant worker TalosConfigTemplate from a main-phase Job instead of a post-install hook, so worker MachineDeployments reliably scale during install
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes addon install behavior by running reconcile work during the main chart phase, reducing readiness deadlocks and upgrade issues.
  * Added more reliable reconciliation handling with stable, change-detected job recreation and updated network access for the reconcile workload.
  * Refined chart and test guidance to match the new install flow and Helm behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->