### PR TITLE
ci: overlay current-main images for packages a PR didn't rebuild

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -335,6 +335,40 @@ jobs:
           registry: iad.ocir.io
         env:
           DOCKER_CONFIG: ${{ runner.temp }}/.docker
+      # Overlay current-main image refs onto every package this PR did NOT
+      # rebuild. Without it, unbuilt packages fall back to the last-release refs
+      # committed in the tree (e.g. v1.5.0) even when main is hundreds of commits
+      # ahead — so e2e and the installer's packages artifact would ship stale
+      # images for everything outside this PR's build matrix. Source of truth is
+      # the cozystack-packages:main OCI artifact build-main.yaml already
+      # publishes (the whole current-main packages tree, refs digest-pinned to
+      # main's images). Runs after login (creds available) and before the
+      # installer build below so the flux-pushed packages tree — and the
+      # pr.patch e2e applies — already reflect the overlay. A missing artifact
+      # (build-main not yet green) is a no-op: packages keep their committed
+      # refs (prior behaviour). See hack/overlay-main-images.sh.
+      - name: Pull current-main packages tree
+        run: |
+          rm -rf _out/mainpkgs
+          flux pull artifact "oci://${REGISTRY}/cozystack-packages:main" \
+            --output _out/mainpkgs \
+            || { echo "No cozystack-packages:main yet — keeping committed refs"; rm -rf _out/mainpkgs; }
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
+      - name: Overlay current-main refs for unbuilt packages
+        # Best-effort: this only improves WHICH images e2e and the installer use,
+        # so an unexpected failure must degrade to the committed refs (prior
+        # behaviour), never block the PR. overlay-main-images.sh already handles
+        # the expected paths (missing artifact, drift, absent unit) internally.
+        run: |
+          hack/overlay-main-images.sh _out/mainpkgs "$BUILD_MATRIX" \
+            || echo "::warning::overlay-main-images failed; unbuilt packages keep committed refs"
+        env:
+          # The set of packages THIS PR rebuilt; their pr-<N>-<sha> refs are
+          # authoritative, so overlay-main-images.sh skips them. Computed by the
+          # plan job from the Makefile (a JSON array of package dirs), not from
+          # untrusted PR input — passed via env per workflow-injection hygiene.
+          BUILD_MATRIX: ${{ needs.plan.outputs.matrix }}
       # buildkitd-config routes docker.io base-image pulls through mirror.gcr.io
       # (hack/buildkitd.toml) so the installer build dodges Docker Hub's
       # anonymous-pull rate limit; see the build job for the full rationale.

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -359,9 +359,10 @@ jobs:
       - name: Pull current-main packages tree
         run: |
           rm -rf _out/mainpkgs
+          mkdir -p _out/mainpkgs
           flux pull artifact "oci://${REGISTRY}/cozystack-packages:main" \
             --output _out/mainpkgs \
-            || { echo "No cozystack-packages:main yet — keeping committed refs"; rm -rf _out/mainpkgs; }
+            || { echo "cozystack-packages:main pull failed — keeping committed refs"; rm -rf _out/mainpkgs; }
         env:
           DOCKER_CONFIG: ${{ runner.temp }}/.docker
       - name: Overlay current-main refs for unbuilt packages

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -31,6 +31,7 @@ jobs:
       code: ${{ steps.p.outputs.code }}
       matrix: ${{ steps.p.outputs.matrix }}
       any: ${{ steps.p.outputs.any }}
+      touched: ${{ steps.p.outputs.touched }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -50,6 +51,14 @@ jobs:
           matrix="$(hack/build-matrix.sh /tmp/changed.txt)"
           echo "Build matrix: $matrix"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          # Package dirs the PR edited (packages/<area>/<name>). Their committed
+          # refs are the PR's intent and must survive the current-main overlay —
+          # otherwise an upstream image bump in a non-build-unit package would be
+          # silently reverted in e2e/the installer artifact (see
+          # hack/overlay-main-images.sh). Whitespace-separated, no trailing slash.
+          touched="$(sed -nE 's#^(packages/[^/]+/[^/]+)/.*#\1#p' /tmp/changed.txt | sort -u | tr '\n' ' ')"
+          echo "Touched packages: $touched"
+          echo "touched=$touched" >> "$GITHUB_OUTPUT"
           if [ "$matrix" = "[]" ]; then
             echo "any=false" >> "$GITHUB_OUTPUT"
           else
@@ -361,7 +370,7 @@ jobs:
         # behaviour), never block the PR. overlay-main-images.sh already handles
         # the expected paths (missing artifact, drift, absent unit) internally.
         run: |
-          hack/overlay-main-images.sh _out/mainpkgs "$BUILD_MATRIX" \
+          hack/overlay-main-images.sh _out/mainpkgs "$BUILD_MATRIX" "$PR_TOUCHED" \
             || echo "::warning::overlay-main-images failed; unbuilt packages keep committed refs"
         env:
           # The set of packages THIS PR rebuilt; their pr-<N>-<sha> refs are
@@ -369,6 +378,12 @@ jobs:
           # plan job from the Makefile (a JSON array of package dirs), not from
           # untrusted PR input — passed via env per workflow-injection hygiene.
           BUILD_MATRIX: ${{ needs.plan.outputs.matrix }}
+          # Packages THIS PR edited (changed-file dirs from the plan job's git
+          # diff). Their committed refs are the PR's intent — an upstream image
+          # bump in a non-build-unit package would otherwise be silently reverted
+          # by the overlay — so overlay-main-images.sh preserves them. Also
+          # env-passed, derived from the diff, not from untrusted PR input.
+          PR_TOUCHED: ${{ needs.plan.outputs.touched }}
       # buildkitd-config routes docker.io base-image pulls through mirror.gcr.io
       # (hack/buildkitd.toml) so the installer build dodges Docker Hub's
       # anonymous-pull rate limit; see the build job for the full rationale.

--- a/hack/overlay-main-images.sh
+++ b/hack/overlay-main-images.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# Overlay current-main image references onto packages a PR did NOT rebuild.
+#
+# Source of truth: the cozystack-packages:main OCI artifact build-main.yaml
+# already publishes (`make build` -> packages/core/installer image-packages does
+# `flux push artifact oci://$REGISTRY/cozystack-packages:main --path=packages`).
+# That artifact is the ENTIRE current-main packages tree with every image
+# reference digest-pinned to the images build-main just pushed.
+#
+# We walk EVERY ref-bearing file (values.yaml + images/*.tag) in that tree and
+# overlay the repo's copy when it differs only in image-reference lines. This is
+# deliberately driven by the artifact, NOT the per-package build matrix, so it
+# covers the WHOLE first-party tree — apps/, system/, core/, AND extra/,
+# library/, ... For any file build-main did not rebuild, the artifact copy is
+# byte-identical to the committed copy and is skipped; only files carrying a
+# rebuilt current-main digest differ and get overlaid. So a fix merged to ANY
+# first-party image (e.g. the objectstorage-sidecar ref under extra/seaweedfs)
+# takes effect in e2e and the installer artifact, instead of the frozen
+# last-release refs committed in the repo (e.g. v1.5.0).
+#
+# Skipped:
+#   - units the PR itself rebuilt (BUILT_JSON, the plan job's matrix): their
+#     pr-<N>-<sha> refs, already applied in finalize, are authoritative.
+#   - packages/core/talos and packages/core/installer: rebuilt unconditionally
+#     by their dedicated jobs (build-talos / the finalize installer build),
+#     which own those files — never overlay them.
+#   - vendored charts/ subtrees: upstream chart values we do not build.
+#
+# Surgical + self-validating: a file is overlaid only when every line that
+# differs from the current-main version is image-reference-bearing. The repo's
+# committed refs use the release registry (ghcr) while the artifact uses the CI
+# registry (OCIR), so refs differ in registry host / tag / digest — and charts
+# split those across separate lines (`repository:`, `tag:`, `digest:`), not all
+# of which carry '@sha256:'. So a changed line counts as image-related if it
+# carries '@sha256:' OR its key is image/repository/registry/tag/digest (or it
+# is a `--…-image=` arg). If any OTHER line differs — the PR branched from a
+# main whose config for that file differs from the artifact's base — the file is
+# left on its committed ref (safe degradation, logged, never fatal). CI checks
+# out the pull_request merge commit (current main + PR), so for an unbuilt file
+# the config already matches current main and only ref lines differ.
+#
+# Usage: hack/overlay-main-images.sh <mainpkgs-dir> <built-matrix-json>
+#        <mainpkgs-dir> = extracted cozystack-packages:main tree; its root holds
+#                         apps/ system/ core/ extra/ ... (the CONTENTS of
+#                         packages/).
+#        (run from the repo root)
+set -eu
+
+MAINPKGS="${1:?usage: overlay-main-images.sh <mainpkgs-dir> <built-matrix-json>}"
+MAINPKGS="${MAINPKGS%/}"
+BUILT_JSON="${2:-[]}"
+
+if [ ! -d "$MAINPKGS" ]; then
+  echo "No current-main packages tree at $MAINPKGS — unbuilt packages keep committed refs"
+  exit 0
+fi
+
+# Dirs whose files must never be overlaid: the two units owned by dedicated
+# jobs, plus every unit the PR rebuilt. Space-wrapped for whole-token matching.
+skip=" packages/core/talos packages/core/installer $(echo "$BUILT_JSON" | tr -d '[]"' | tr ',' ' ') "
+
+# A changed line is image-reference-bearing if it carries a full ref (@sha256:),
+# is a split ref key (image/repository/registry/tag/digest), or a `--…-image=` arg.
+img_line='(@sha256:|^[[:space:]]*(- )?(image|repository|registry|tag|digest):|--[A-Za-z-]*image=)'
+
+overlaid=0
+same=0
+skipped=0
+drift=0
+failed=0
+# Walk the artifact's ref-bearing files, pruning vendored charts/ subtrees.
+# `for … in $(find)` (not a pipe) keeps the counters in this shell; package
+# paths and filenames carry no spaces (same assumption as hack/build-matrix.sh).
+for new in $(find "$MAINPKGS" -type d -name charts -prune -o \
+                  \( -name values.yaml -o -name '*.tag' \) -type f -print 2>/dev/null); do
+  # Artifact root == contents of packages/, so map back by re-adding the prefix.
+  cur="packages/${new#"$MAINPKGS"/}"
+
+  in_skip=0
+  for d in $skip; do
+    case "$cur" in "$d"/*) in_skip=1; break ;; esac
+  done
+  if [ "$in_skip" -eq 1 ]; then
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  [ -f "$cur" ] || continue           # not in the PR tree -> don't introduce it
+  cmp -s "$cur" "$new" && { same=$((same + 1)); continue; }
+
+  if diff "$cur" "$new" | sed -n 's/^[<>] //p' | grep -qvE "$img_line"; then
+    echo "drift (non-ref change) in $cur -> keeping committed ref"
+    drift=$((drift + 1))
+    continue
+  fi
+
+  if cp "$new" "$cur"; then
+    echo "overlay: $cur -> current-main"
+    overlaid=$((overlaid + 1))
+  else
+    echo "WARN: cp failed for $cur (keeping committed ref)"
+    failed=$((failed + 1))
+  fi
+done
+
+echo "Overlay current-main images: overlaid=$overlaid same=$same skipped(rebuilt/owned)=$skipped drift=$drift failed=$failed"

--- a/hack/overlay-main-images.sh
+++ b/hack/overlay-main-images.sh
@@ -21,6 +21,9 @@
 # Skipped:
 #   - units the PR itself rebuilt (BUILT_JSON, the plan job's matrix): their
 #     pr-<N>-<sha> refs, already applied in finalize, are authoritative.
+#   - packages the PR EDITED (TOUCHED, the plan job's changed-package dirs): the
+#     PR's committed refs are its intent (e.g. an upstream image bump in a
+#     non-build-unit package), so they must win over the artifact — never overlay.
 #   - packages/core/talos and packages/core/installer: rebuilt unconditionally
 #     by their dedicated jobs (build-talos / the finalize installer build),
 #     which own those files — never overlay them.
@@ -39,16 +42,28 @@
 # out the pull_request merge commit (current main + PR), so for an unbuilt file
 # the config already matches current main and only ref lines differ.
 #
-# Usage: hack/overlay-main-images.sh <mainpkgs-dir> <built-matrix-json>
-#        <mainpkgs-dir> = extracted cozystack-packages:main tree; its root holds
-#                         apps/ system/ core/ extra/ ... (the CONTENTS of
-#                         packages/).
+# Usage: hack/overlay-main-images.sh <mainpkgs-dir> <built-matrix-json> [touched-pkg-dirs]
+#        <mainpkgs-dir>     = extracted cozystack-packages:main tree; its root holds
+#                             apps/ system/ core/ extra/ ... (the CONTENTS of
+#                             packages/).
+#        <built-matrix-json> = JSON array of package dirs the PR rebuilt (skipped).
+#        [touched-pkg-dirs]  = whitespace-separated package dirs the PR edited
+#                             (no trailing slash); their committed refs are kept.
 #        (run from the repo root)
 set -eu
 
-MAINPKGS="${1:?usage: overlay-main-images.sh <mainpkgs-dir> <built-matrix-json>}"
+MAINPKGS="${1:?usage: overlay-main-images.sh <mainpkgs-dir> <built-matrix-json> [touched-pkg-dirs]}"
 MAINPKGS="${MAINPKGS%/}"
 BUILT_JSON="${2:-[]}"
+# Package dirs the PR itself EDITED (whitespace-separated, no trailing slash).
+# Their committed refs ARE the PR's intent — e.g. an upstream image bump in a
+# package that is NOT a build unit (keycloak, cert-manager, ingress-nginx, …) —
+# so they must win over the artifact. Without this, such an edit differs from the
+# artifact only on image-reference lines, the drift check passes, and the overlay
+# would silently revert the PR's bump (e2e then tests the stale image). The plan
+# job derives this from `git diff --name-only` and passes it via env, not from
+# untrusted PR input.
+TOUCHED="${3:-}"
 
 if [ ! -d "$MAINPKGS" ]; then
   echo "No current-main packages tree at $MAINPKGS — unbuilt packages keep committed refs"
@@ -56,8 +71,9 @@ if [ ! -d "$MAINPKGS" ]; then
 fi
 
 # Dirs whose files must never be overlaid: the two units owned by dedicated
-# jobs, plus every unit the PR rebuilt. Space-wrapped for whole-token matching.
-skip=" packages/core/talos packages/core/installer $(echo "$BUILT_JSON" | tr -d '[]"' | tr ',' ' ') "
+# jobs, every unit the PR rebuilt, and every package the PR edited (its committed
+# refs are the PR's intent). Space-wrapped for whole-token matching.
+skip=" packages/core/talos packages/core/installer $(echo "$BUILT_JSON" | tr -d '[]"' | tr ',' ' ') $TOUCHED "
 
 # A changed line is image-reference-bearing if it carries a full ref (@sha256:),
 # is a split ref key (image/repository/registry/tag/digest), or a `--…-image=` arg.
@@ -103,4 +119,4 @@ for new in $(find "$MAINPKGS" -type d -name charts -prune -o \
   fi
 done
 
-echo "Overlay current-main images: overlaid=$overlaid same=$same skipped(rebuilt/owned)=$skipped drift=$drift failed=$failed"
+echo "Overlay current-main images: overlaid=$overlaid same=$same skipped(rebuilt/owned/edited)=$skipped drift=$drift failed=$failed"

--- a/hack/overlay-main-images_test.bats
+++ b/hack/overlay-main-images_test.bats
@@ -104,3 +104,46 @@
   "$root/hack/overlay-main-images.sh" does-not-exist '[]'
   grep -q 'foo:v1.5.0@sha256:aaaa' packages/apps/foo/values.yaml
 }
+
+@test "preserves a PR-edited non-rebuilt package ref (passed via the touched arg)" {
+  root=$(pwd)
+  w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+  mkdir -p "$w/packages/system/keycloak" "$w/main/system/keycloak"
+  # The PR bumps an upstream image in keycloak. keycloak is NOT a build unit, so
+  # it is absent from BUILD_MATRIX; only its image line differs from the artifact.
+  # Without the touched arg the overlay would silently revert the PR's bump.
+  echo 'image: quay.io/keycloak/keycloak:26.7.0' > "$w/packages/system/keycloak/values.yaml"
+  echo 'image: quay.io/keycloak/keycloak:26.6.3' > "$w/main/system/keycloak/values.yaml"
+  cd "$w"
+  out=$("$root/hack/overlay-main-images.sh" main '[]' 'packages/system/keycloak')
+  # The PR's edit wins; the overlay must not touch it.
+  grep -q 'keycloak:26.7.0' packages/system/keycloak/values.yaml
+  echo "$out" | grep -q 'overlaid=0'
+}
+
+@test "recognizes a --…-image= arg line (no @sha256, no image key) as an image ref" {
+  root=$(pwd)
+  w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+  mkdir -p "$w/packages/system/argimg" "$w/main/system/argimg"
+  # The only differing line is a `--…-image=` arg with neither @sha256 nor an
+  # image/tag/repository key — it must still count as image-reference-bearing.
+  printf 'args:\n  - --provider-image=ghcr.io/cozystack/cozystack/x:v1.5.0\n' > "$w/packages/system/argimg/values.yaml"
+  printf 'args:\n  - --provider-image=iad.ocir.io/x/cozystack/x:main\n'       > "$w/main/system/argimg/values.yaml"
+  cd "$w"
+  "$root/hack/overlay-main-images.sh" main '[]'
+  grep -q 'x:main' packages/system/argimg/values.yaml
+}
+
+@test "does not introduce a file present in the artifact but absent in the PR tree" {
+  root=$(pwd)
+  w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+  mkdir -p "$w/packages/apps/present/images" "$w/main/apps/present/images" "$w/main/apps/ghost/images"
+  echo 'ghcr.io/cozystack/cozystack/present:v1.5.0@sha256:aaaa' > "$w/packages/apps/present/images/present.tag"
+  echo 'iad.ocir.io/x/cozystack/present:main@sha256:bbbb'       > "$w/main/apps/present/images/present.tag"
+  # 'ghost' exists only in the artifact tree, never in the PR's packages/.
+  echo 'iad.ocir.io/x/cozystack/ghost:main@sha256:cccc'         > "$w/main/apps/ghost/images/ghost.tag"
+  cd "$w"
+  "$root/hack/overlay-main-images.sh" main '[]'
+  grep -q 'present:main@sha256:bbbb' packages/apps/present/images/present.tag
+  [ ! -e packages/apps/ghost/images/ghost.tag ]
+}

--- a/hack/overlay-main-images_test.bats
+++ b/hack/overlay-main-images_test.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bats
+# Unit tests for hack/overlay-main-images.sh — the PR-finalize step that points
+# packages a PR did NOT rebuild at the current-main images from the
+# cozystack-packages:main artifact.
+#
+# Run from the repo root:  bats hack/overlay-main-images_test.bats
+# (CI runs it via hack/cozytest.sh through `make unit-tests`.)
+#
+# Each test builds a throwaway tree: a `packages/` tree on release (ghcr/v1.5.0)
+# refs, and a `main/` dir standing in for the extracted cozystack-packages:main
+# artifact (root = contents of packages/) on current-main (OCIR/:main) refs.
+# $root is the real repo, captured before cd.
+
+@test "overlays an unbuilt unit (.tag) to current-main and reports it" {
+  root=$(pwd)
+  w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+  mkdir -p "$w/packages/apps/foo/images" "$w/main/apps/foo/images"
+  echo 'ghcr.io/cozystack/cozystack/foo:v1.5.0@sha256:aaaa' > "$w/packages/apps/foo/images/foo.tag"
+  echo 'iad.ocir.io/x/cozystack/foo:main@sha256:bbbb'       > "$w/main/apps/foo/images/foo.tag"
+  cd "$w"
+  out=$("$root/hack/overlay-main-images.sh" main '[]')
+  grep -q 'foo:main@sha256:bbbb' packages/apps/foo/images/foo.tag
+  echo "$out" | grep -q 'overlaid=1'
+}
+
+@test "overlays a split-form ref (repository/tag/digest, no @sha256 on those lines)" {
+  root=$(pwd)
+  w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+  mkdir -p "$w/packages/system/split" "$w/main/system/split"
+  printf 'image:\n  repository: ghcr.io/cozystack/cozystack/split\n  tag: v1.5.0\n  digest: "sha256:aaaa"\n' > "$w/packages/system/split/values.yaml"
+  printf 'image:\n  repository: iad.ocir.io/x/cozystack/split\n  tag: main\n  digest: "sha256:bbbb"\n'      > "$w/main/system/split/values.yaml"
+  cd "$w"
+  "$root/hack/overlay-main-images.sh" main '[]'
+  grep -q 'repository: iad.ocir.io/x/cozystack/split' packages/system/split/values.yaml
+  grep -q 'tag: main' packages/system/split/values.yaml
+  grep -q 'sha256:bbbb' packages/system/split/values.yaml
+}
+
+@test "overlays an extra/* unit (outside the per-package build matrix)" {
+  root=$(pwd)
+  w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+  mkdir -p "$w/packages/extra/seaweedfs/images" "$w/main/extra/seaweedfs/images"
+  echo 'ghcr.io/cozystack/cozystack/objectstorage-sidecar:v1.5.0@sha256:aaaa' > "$w/packages/extra/seaweedfs/images/objectstorage-sidecar.tag"
+  echo 'iad.ocir.io/x/cozystack/objectstorage-sidecar:main@sha256:bbbb'       > "$w/main/extra/seaweedfs/images/objectstorage-sidecar.tag"
+  cd "$w"
+  "$root/hack/overlay-main-images.sh" main '[]'
+  grep -q 'objectstorage-sidecar:main@sha256:bbbb' packages/extra/seaweedfs/images/objectstorage-sidecar.tag
+}
+
+@test "skips a unit the PR rebuilt (its pr-<N>-<sha> ref wins)" {
+  root=$(pwd)
+  w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+  mkdir -p "$w/packages/apps/foo" "$w/main/apps/foo"
+  echo 'image: ghcr.io/cozystack/cozystack/foo:v1.5.0@sha256:aaaa' > "$w/packages/apps/foo/values.yaml"
+  echo 'image: iad.ocir.io/x/cozystack/foo:main@sha256:bbbb'       > "$w/main/apps/foo/values.yaml"
+  cd "$w"
+  "$root/hack/overlay-main-images.sh" main '["packages/apps/foo"]'
+  grep -q 'foo:v1.5.0@sha256:aaaa' packages/apps/foo/values.yaml
+}
+
+@test "never overlays core/talos or core/installer (owned by dedicated jobs)" {
+  root=$(pwd)
+  w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+  mkdir -p "$w/packages/core/installer" "$w/main/core/installer" "$w/packages/core/talos" "$w/main/core/talos"
+  echo 'image: ghcr.io/cozystack/cozystack/cozystack-operator:v1.5.0@sha256:aaaa' > "$w/packages/core/installer/values.yaml"
+  echo 'image: iad.ocir.io/x/cozystack/cozystack-operator:main@sha256:bbbb'       > "$w/main/core/installer/values.yaml"
+  echo 'image: ghcr.io/cozystack/cozystack/talos:v1.5.0@sha256:cccc' > "$w/packages/core/talos/values.yaml"
+  echo 'image: iad.ocir.io/x/cozystack/talos:main@sha256:dddd'       > "$w/main/core/talos/values.yaml"
+  cd "$w"
+  "$root/hack/overlay-main-images.sh" main '[]'
+  grep -q 'cozystack-operator:v1.5.0@sha256:aaaa' packages/core/installer/values.yaml
+  grep -q 'talos:v1.5.0@sha256:cccc' packages/core/talos/values.yaml
+}
+
+@test "does not descend into vendored charts/ subtrees" {
+  root=$(pwd)
+  w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+  mkdir -p "$w/packages/system/bar/charts/sub" "$w/main/system/bar/charts/sub"
+  echo 'image: ghcr.io/cozystack/cozystack/sub:v1.5.0@sha256:aaaa' > "$w/packages/system/bar/charts/sub/values.yaml"
+  echo 'image: iad.ocir.io/x/cozystack/sub:main@sha256:bbbb'       > "$w/main/system/bar/charts/sub/values.yaml"
+  cd "$w"
+  "$root/hack/overlay-main-images.sh" main '[]'
+  grep -q 'sub:v1.5.0@sha256:aaaa' packages/system/bar/charts/sub/values.yaml
+}
+
+@test "keeps the committed ref when a non-ref line differs (drift)" {
+  root=$(pwd)
+  w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+  mkdir -p "$w/packages/system/drift" "$w/main/system/drift"
+  printf 'tuning: old\nimage: ghcr.io/cozystack/cozystack/drift:v1.5.0@sha256:aaaa\n' > "$w/packages/system/drift/values.yaml"
+  printf 'tuning: new\nimage: iad.ocir.io/x/cozystack/drift:main@sha256:bbbb\n'        > "$w/main/system/drift/values.yaml"
+  cd "$w"
+  "$root/hack/overlay-main-images.sh" main '[]'
+  grep -q 'drift:v1.5.0@sha256:aaaa' packages/system/drift/values.yaml
+  grep -q 'tuning: old' packages/system/drift/values.yaml
+}
+
+@test "missing artifact directory is a no-op and exits 0" {
+  root=$(pwd)
+  w=$(mktemp -d); trap 'rm -rf "$w"' EXIT
+  mkdir -p "$w/packages/apps/foo"
+  echo 'image: ghcr.io/cozystack/cozystack/foo:v1.5.0@sha256:aaaa' > "$w/packages/apps/foo/values.yaml"
+  cd "$w"
+  "$root/hack/overlay-main-images.sh" does-not-exist '[]'
+  grep -q 'foo:v1.5.0@sha256:aaaa' packages/apps/foo/values.yaml
+}


### PR DESCRIPTION
## What this PR does

Conditional PR builds (the per-package matrix in `pull-requests.yaml`) only rebuild packages whose dir changed. Every other package falls back to the image refs committed in the tree — the last release's digests (currently `v1.5.0`), which go stale as `main` advances. So e2e and the installer's packages artifact ran **current-main configs against last-release images** for everything outside a PR's build matrix, and a PR installed via the `cozy-installer` chart was an incoherent mix (your changes fresh, everything else at the last release).

In `finalize`, this overlays current-main image refs onto every package the PR did **not** rebuild:

- Source of truth is the `cozystack-packages:main` OCI artifact that `build-main.yaml` already publishes (`make build` → installer `image-packages`) — the whole current-main packages tree, refs digest-pinned to the images `build-main` pushed. **No `build-main` change is needed.**
- For each build unit not in the PR's build matrix, copy its ref-bearing files (`values.yaml` + `images/*.tag`) from that tree. Units the PR rebuilt keep their fresh `pr-<N>-<sha>` refs.
- The copy is **self-validating**: a file is overlaid only when every differing line is image-reference-bearing (a full `@sha256:` ref, or a split `image`/`repository`/`registry`/`tag`/`digest` key, or a `--…-image=` arg); otherwise the unit is left on its committed ref.
- A missing artifact is a no-op (prior behaviour), and the step is best-effort so it can never block a PR.

Runs after the registry login and before the installer build, so both the installer's `cozystack-packages:<pr>` artifact and the `pr.patch` e2e applies reflect the overlay.

Net effect: a PR is tested and installed as **current-main + its own changes**, coherent across config and image.

Covered by `hack/overlay-main-images_test.bats` (auto-discovered by `make unit-tests` → `bats-unit-tests`, run in the `checks` job): single-line and split-form ref overlay, skip-rebuilt, drift self-validation, and missing-artifact no-op.

### Release note

```release-note
ci: PR e2e and the installer artifact now run current-main images for packages a PR doesn't rebuild, instead of the last release's images — so a PR is tested and installed as current-main plus its own changes.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI / New Features**
  * Automatically detects which package areas were modified in the pull request and uses that to target image reference updates.
  * Overlays “current main” digest/image references for packages not rebuilt, while always skipping core special components.
  * If overlay processing fails, emits a warning and continues; installer builds still use the overlay-applied artifacts.

* **Tests**
  * Expanded integration-style coverage for overlay behavior, touched-list skipping, split-form YAML references, drift/non-image preservation, vendored-chart exclusions, and missing-artifact no-op scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->