### PR TITLE
fix(kubevirt-instancetypes): restore persistent EFI/TPM state

### DIFF
--- a/packages/system/kubevirt-instancetypes/Makefile
+++ b/packages/system/kubevirt-instancetypes/Makefile
@@ -16,12 +16,6 @@ update:
 	mkdir templates
 	kustomize build https://github.com/kubevirt/common-instancetypes/preferences?ref=$(COMMON_INSTANCETYPES_REF) > templates/preferences.yaml
 	yq -i 'select(.kind != "VirtualMachinePreference")' templates/preferences.yaml
-	# TEMPORARY (see #3005): drop persistent EFI/TPM state. With persistence on,
-	# KubeVirt creates a backend-storage PVC that is RWO on the default StorageClass,
-	# which pins the VM to its node and blocks live-migration / drain. Use `del` (not
-	# `sed -d`) so an emptied preferredTPM stays `{}` rather than null, which the
-	# KubeVirt v1.8 CRD structural schema rejects. Revert once vm-state can request RWX.
-	yq -i 'del(.spec.firmware.preferredEfi.persistent) | del(.spec.devices.preferredTPM.persistent)' templates/preferences.yaml
 	kustomize build https://github.com/kubevirt/common-instancetypes/instancetypes?ref=$(COMMON_INSTANCETYPES_REF) > templates/instancetypes.yaml
 	yq -i 'select(.kind != "VirtualMachineInstancetype")' templates/instancetypes.yaml
 	# Re-append Cozystack-local instancetypes the pinned catalog no longer ships

--- a/packages/system/kubevirt-instancetypes/templates/preferences.yaml
+++ b/packages/system/kubevirt-instancetypes/templates/preferences.yaml
@@ -1352,7 +1352,8 @@ spec:
     preferredAutoattachInputDevice: true
     preferredDiskBus: sata
     preferredInterfaceModel: e1000e
-    preferredTPM: {}
+    preferredTPM:
+      persistent: true
   features:
     preferredAcpi: {}
     preferredApic: {}
@@ -1374,6 +1375,7 @@ spec:
     preferredSmm: {}
   firmware:
     preferredEfi:
+      persistent: true
       secureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
   requirements:
@@ -1422,7 +1424,8 @@ spec:
     preferredInputBus: virtio
     preferredInputType: tablet
     preferredInterfaceModel: virtio
-    preferredTPM: {}
+    preferredTPM:
+      persistent: true
   features:
     preferredAcpi: {}
     preferredApic: {}
@@ -1444,6 +1447,7 @@ spec:
     preferredSmm: {}
   firmware:
     preferredEfi:
+      persistent: true
       secureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
   requirements:
@@ -1890,7 +1894,8 @@ spec:
     preferredAutoattachInputDevice: true
     preferredDiskBus: sata
     preferredInterfaceModel: e1000e
-    preferredTPM: {}
+    preferredTPM:
+      persistent: true
   features:
     preferredAcpi: {}
     preferredApic: {}
@@ -1912,6 +1917,7 @@ spec:
     preferredSmm: {}
   firmware:
     preferredEfi:
+      persistent: true
       secureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
   requirements:
@@ -1960,7 +1966,8 @@ spec:
     preferredInputBus: virtio
     preferredInputType: tablet
     preferredInterfaceModel: virtio
-    preferredTPM: {}
+    preferredTPM:
+      persistent: true
   features:
     preferredAcpi: {}
     preferredApic: {}
@@ -1982,6 +1989,7 @@ spec:
     preferredSmm: {}
   firmware:
     preferredEfi:
+      persistent: true
       secureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
   requirements:
@@ -2028,7 +2036,8 @@ spec:
     preferredAutoattachInputDevice: true
     preferredDiskBus: sata
     preferredInterfaceModel: e1000e
-    preferredTPM: {}
+    preferredTPM:
+      persistent: true
   features:
     preferredAcpi: {}
     preferredApic: {}
@@ -2050,6 +2059,7 @@ spec:
     preferredSmm: {}
   firmware:
     preferredEfi:
+      persistent: true
       secureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
   requirements:
@@ -2098,7 +2108,8 @@ spec:
     preferredInputBus: virtio
     preferredInputType: tablet
     preferredInterfaceModel: virtio
-    preferredTPM: {}
+    preferredTPM:
+      persistent: true
   features:
     preferredAcpi: {}
     preferredApic: {}
@@ -2120,6 +2131,7 @@ spec:
     preferredSmm: {}
   firmware:
     preferredEfi:
+      persistent: true
       secureBoot: true
   preferredTerminationGracePeriodSeconds: 3600
   requirements:


### PR DESCRIPTION
## What this PR does

Reverts #3006, restoring upstream's persistent EFI/TPM firmware state for the `windows.11` / `windows.2k22` / `windows.2k25` preferences (and their `.virtio` variants).

#3006 dropped persistent EFI/TPM to "unblock live-migration", on the assumption that an RWO Filesystem backend-storage PVC pins the VM to its node. That assumption was outdated: KubeVirt has live-migrated RWO-Filesystem backend storage since v1.4 (kubevirt/kubevirt#12629) — on migration it creates a fresh target state PVC and copies the small state blob. So persistent-EFI/TPM VMs on the default `replicated` storage live-migrate fine; the regression described in #3005 was a misdiagnosis.

Verified on a KubeVirt v1.8.2 cluster: a persistent-EFI VM with an RWO Filesystem backend PVC reports `LiveMigratable=True`, and the copy-on-target backend PVC is created when a migration starts. KubeVirt maintainers confirmed the same upstream.

This restores persistent firmware state so in-guest Microsoft UEFI CA / Secure Boot enrollment survives reboots and migrations.

### Release note

```release-note
fix(kubevirt-instancetypes): restore persistent EFI/TPM state for Windows preferences — RWO-Filesystem backend storage already live-migrates (KubeVirt v1.4+), so persistence no longer needs to be stripped
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Windows instance type preferences to keep TPM persistence enabled, improving compatibility and reducing storage-related issues.
  * Ensured firmware and TPM persistence settings are preserved during instance type preference generation for more reliable outcomes.

* **Chores**
  * Streamlined the preference generation step so instance type templates are produced consistently without removing persistence configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->