### PR TITLE
fix(ci): nest backport conflict_resolution under experimental input

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -133,4 +133,12 @@ jobs:
           label_pattern: '' # don't read labels for targets
           target_branches: ${{ steps.target.outputs.branch }}
           merge_commits: skip
-          conflict_resolution: draft_commit_conflicts
+          # conflict_resolution lives inside the experimental JSON input, not as a
+          # top-level key. Passed top-level it is silently ignored and the action
+          # falls back to the experimental default ("fail"), which on a conflict
+          # creates no PR and only comments. Nesting it here makes a conflicting
+          # backport open a draft PR with the conflict committed for manual fixup.
+          experimental: |
+            {
+              "conflict_resolution": "draft_commit_conflicts"
+            }


### PR DESCRIPTION
## What this PR does

The Automatic Backport workflow passed `conflict_resolution: draft_commit_conflicts` as a **top-level** input to `korthout/backport-action`, but the action only reads `conflict_resolution` from inside its `experimental` JSON input. Passed top-level it was silently ignored — the action run logs warn `Unexpected input(s) 'conflict_resolution'` — so it fell back to the `experimental` default of `fail`. On a cherry-pick conflict the action then created **no** pull request and only left a "Backport failed" comment on the source PR (this bit #3121 and #3119).

This moves the key into the `experimental` input, so a conflicting backport instead opens a **draft PR with the first conflict committed** for maintainers to resolve in place.

No version bump: the pinned `v3.2.1` already supports `draft_commit_conflicts` — the bug was purely the input placement.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backport pull requests now handle conflicts more reliably and open as draft PRs when conflicts are detected.
  * Improved configuration handling so the expected conflict behavior is applied consistently during backport automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->