### PR TITLE
ci(workflows): open the E2E breakpoint for maintainer-authored PRs

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -700,9 +700,15 @@ jobs:
       # ▸ Open an SSH breakpoint to the failing sandbox so maintainers can attach,
       #   inspect Talos/Cozystack state and resume with `breakpoint resume`.
       #
-      #   Gated by the `debug` or `release` label (release PRs are bot-created,
-      #   so their presence implies maintainer authorship). authorized-users is
-      #   kept as a second defense layer at the breakpoint level.
+      #   Opens when the E2E job fails AND any of: the `debug` label, the
+      #   `release` label (release PRs are bot-created, so their presence
+      #   implies maintainer authorship), or the PR author is a maintainer
+      #   (author_association is OWNER/MEMBER/COLLABORATOR). The maintainer-
+      #   authorship path needs no label and does NOT move the jobs onto
+      #   self-hosted runners — only the `debug` label flips `runs-on`, so a
+      #   maintainer PR opens the breakpoint on the default oracle-vm runner the
+      #   job already uses and simply holds that ephemeral runner. authorized-users
+      #   is kept as a second defense layer controlling who may actually SSH in.
       #
       #   Uses cozystack/breakpoint-action (fork of namespacelabs/breakpoint-action)
       #   pinned by SHA. The fork adds: pause-idle mode (initial grace period for
@@ -720,7 +726,8 @@ jobs:
           failure() &&
           vars.BREAKPOINT_ENDPOINT != '' &&
           (contains(github.event.pull_request.labels.*.name, 'debug')
-            || contains(github.event.pull_request.labels.*.name, 'release'))
+            || contains(github.event.pull_request.labels.*.name, 'release')
+            || contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
         # cozystack/breakpoint-action v2-cozy.1
         # mode: pause-idle defaults: grace-period=20m, idle-timeout=10m
         uses: cozystack/breakpoint-action@a6f3a6f87be398ad63b6577351e3398e53f578e4


### PR DESCRIPTION
## What this PR does

Decouples opening the E2E SSH breakpoint from the `debug` label.

Today, the only way to open a breakpoint on a failed feature PR is to add the `debug` label. That same label also flips every job's `runs-on` onto self-hosted runners, so you cannot get a breakpoint on the normal ephemeral runner — debugging always drags the whole pipeline onto self-hosted infrastructure.

This adds a maintainer-authorship path to the breakpoint's `if` condition: a failed PR whose author is an `OWNER`, `MEMBER`, or `COLLABORATOR` now opens the breakpoint automatically, with no label required and without moving the jobs onto self-hosted runners. The breakpoint simply holds the default `oracle-vm` ephemeral runner the job already runs on.

The existing `debug` and `release` label paths are unchanged, and the `authorized-users` list still controls who may actually SSH into an open breakpoint (second defense layer). Workflow triggers are untouched — this is purely an `if`-condition change.

### Release note

```release-note
ci(workflows): open the E2E SSH breakpoint automatically on failed maintainer-authored PRs, without requiring the `debug` label or moving the jobs onto self-hosted runners
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated E2E failure debugging so breakpoints can now open for pull requests authored by repository maintainers, not just when specific labels are applied.
  * Clarified the conditions and runner behavior for breakpoint access in the workflow documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->