### PR TITLE
fix(e2e): drain tenant VMs/PVCs between kubernetes tests to fix the node-join flake

### DIFF
--- a/hack/e2e-apps/run-kubernetes.sh
+++ b/hack/e2e-apps/run-kubernetes.sh
@@ -301,9 +301,54 @@ EOF
       sleep 5
     done
   '; then
-    # Dump debug info and fail fast — no point running LB/NFS tests without Ready nodes
-    kubectl --kubeconfig "tenantkubeconfig-${test_name}" describe nodes
-    kubectl -n tenant-test get hr
+    # Node-join failed: fewer than 2 tenant nodes became Ready inside the 12m
+    # deadline. Dump scoped diagnostics that split the failure sub-modes, then
+    # fail fast — no point running LB/NFS tests without Ready nodes.
+    #
+    # The tenant's cilium-operator HR reports "InProgress" here purely because
+    # zero worker Nodes joined, so the HelmRelease condition alone cannot tell
+    # apart (2a) the worker VM never booted (virt-launcher Pending/OOMKilled)
+    # from (2b) the VM booted fine but its kubelet never registered a Node
+    # (Talos/CSR/DNS/routing). The captures below make that distinction legible;
+    # (2b) is the failure mode a follow-up fix has to target, and it cannot be
+    # designed without this artifact. Every capture is guarded with `|| true`
+    # so a capture failure never masks the real `exit 1`.
+    echo "=== node-join failed: fewer than 2 tenant nodes Ready within 12m — diagnostics follow ==="
+    kubectl --kubeconfig "tenantkubeconfig-${test_name}" describe nodes || true
+    kubectl -n tenant-test get hr || true
+
+    # (a) Worker VM / VMI / virt-launcher state on the MANAGEMENT cluster. A VMI
+    # stuck Pending or a virt-launcher pod OOMKilled/Pending is mode 2a; a
+    # Running+Ready VMI with a healthy virt-launcher is mode 2b. This is the key
+    # split. Full resource names (not the `vm` alias) to avoid short-name
+    # ambiguity, matching cozy_wait_tenant_drained above.
+    echo "=== (a) tenant worker VM/VMI/virt-launcher state (management cluster, ns tenant-test) ==="
+    kubectl -n tenant-test get virtualmachines.kubevirt.io,virtualmachineinstances.kubevirt.io -o wide || true
+    kubectl -n tenant-test describe virtualmachineinstances.kubevirt.io || true
+    kubectl -n tenant-test get pods -l kubevirt.io=virt-launcher -o wide || true
+    kubectl -n tenant-test describe pods -l kubevirt.io=virt-launcher || true
+
+    # (c) Tenant kubelet CSRs + the talos-csr-signer sidecar log. A mode-2b node
+    # boots but blocks on a kubelet-serving/-client CSR that is never submitted
+    # or never approved; the pending CSR list (tenant cluster) plus the signer
+    # sidecar log (in the Kamaji apiserver pod on the management cluster) show
+    # which side stalled.
+    echo "=== (c) tenant CSRs + talos-csr-signer sidecar log ==="
+    kubectl --kubeconfig "tenantkubeconfig-${test_name}" get csr || true
+    kubectl -n tenant-test logs -l kamaji.clastix.io/name="kubernetes-${test_name}" \
+      -c talos-csr-signer --tail=200 --prefix || true
+
+    # (b) In-guest Talos/kubelet state from the worker VMs is intentionally NOT
+    # captured here. talosctl needs a client talosconfig for the TENANT cluster,
+    # and the runner has none: the tenant workers are provisioned with their own
+    # Talos PKI whose CA differs from the sandbox's /workspace/talosconfig (which
+    # cozyreport.sh uses to reach the MANAGEMENT nodes only), and the chart
+    # materialises no tenant client talosconfig Secret. Pointing talosctl at the
+    # worker IPs with the management talosconfig would just fail mTLS and capture
+    # nothing, so it is skipped rather than shipped as a misleading no-op. (a) +
+    # (c) carry the 2a-vs-2b split; adding real in-guest capture later requires
+    # wiring a tenant talosconfig into the runner first.
+    echo "=== (b) in-guest Talos/kubelet capture skipped: no tenant talosconfig on the runner (a/c cover the 2a-vs-2b split) ==="
     exit 1
   fi
   kubectl --kubeconfig "tenantkubeconfig-${test_name}" get nodes -o wide

--- a/hack/e2e-apps/run-kubernetes.sh
+++ b/hack/e2e-apps/run-kubernetes.sh
@@ -1,5 +1,62 @@
 . hack/e2e-apps/remediation-guard.sh
 
+# Pure exit-condition for the inter-test drain loop (cozy_wait_tenant_drained).
+# Each argument is one resource-probe capture: the stdout of a
+# `kubectl get -o name` (empty once the resource is gone) or the literal "err"
+# the loop substitutes when a probe itself fails. Returns 0 (drained) only when
+# every capture holds nothing but whitespace; any capture with a non-whitespace
+# character -- a resource name, or the "err" sentinel the loop injects on a
+# probe failure -- yields non-zero, so a transient API blip is never misread as
+# "the tenant has drained" (same guard as etcd_drain). Pure text logic,
+# unit-tested in hack/run-kubernetes-drain_test.bats.
+cozy_tenant_drained() {
+  for _capture in "$@"; do
+    case "$_capture" in
+      *[![:space:]]*) return 1 ;;
+    esac
+  done
+  return 0
+}
+
+# Block until the tenant cluster's KubeVirt compute and storage are actually
+# released, not merely triggered for deletion. Deleting the Kubernetes CR
+# returns as soon as its finalizers clear, but that only TRIGGERS teardown of
+# the CAPK worker VMs and their DataVolume-backed disk PVCs. The virt-launcher
+# pods keep their guest RAM reserved until the VMIs are gone, so without this
+# barrier the next tenant test's worker VMs begin scheduling against a sandbox
+# the previous tenant has not yet vacated -> memory starvation -> a worker VM
+# misses the node-join budget and the test flakes on worker-node-join.
+#
+# Bounded and best-effort: cozytest runs cozy_cleanup wrapped in `|| true`, and
+# this returns (loudly) on timeout, so a stuck teardown can never hang the job
+# past the deadline -- it just leaves the sandbox no worse than before this
+# wait existed. tenant-test is provisioned with etcd/monitoring/seaweedfs
+# disabled (see the Tenant in hack/e2e-install-cozystack.bats), so it carries no
+# baseline PVCs, and the e2e apps run sequentially each cleaning up after
+# itself; at cleanup time the only VMs/VMIs/PVCs in the namespace belong to the
+# tenant cluster being torn down, so a plain namespace-scoped probe is both safe
+# and accurate (the worker-disk PVCs carry no cluster-scoping label to select on).
+cozy_wait_tenant_drained() {
+  _ns=tenant-test
+  _timeout="${1:-300}"
+  _deadline=$(( $(date +%s) + _timeout ))
+  while :; do
+    _vm=$(kubectl -n "$_ns" get virtualmachines.kubevirt.io -o name 2>/dev/null) || _vm=err
+    _vmi=$(kubectl -n "$_ns" get virtualmachineinstances.kubevirt.io -o name 2>/dev/null) || _vmi=err
+    _pvc=$(kubectl -n "$_ns" get pvc -o name 2>/dev/null) || _pvc=err
+    if cozy_tenant_drained "$_vm" "$_vmi" "$_pvc"; then
+      echo "» tenant VMs/VMIs/PVCs drained from $_ns"
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$_deadline" ]; then
+      echo "» WARNING: tenant teardown did not drain within ${_timeout}s; continuing (next test may face memory/storage pressure)" >&2
+      kubectl -n "$_ns" get virtualmachines.kubevirt.io,virtualmachineinstances.kubevirt.io,pvc 2>&1 | sed 's/^/  drain-leftover: /' >&2 || true
+      return 1
+    fi
+    sleep 5
+  done
+}
+
 # Unconditional cleanup hook, invoked by cozytest.sh after this file's tests
 # (pass or fail). A failed run otherwise leaves the tenant cluster's worker-VM
 # PVCs (tens of GiB) in tenant-test, exhausting the shared tenant-quota and
@@ -13,6 +70,11 @@ cozy_cleanup() {
   kubectl -n tenant-test delete service -l cozystack-e2e.io/tenant-api-lb --ignore-not-found --wait=false 2>/dev/null || true
   kubectl -n tenant-test delete kuberneteses.apps.cozystack.io --all --ignore-not-found --wait=false 2>/dev/null || true
   kubectl -n tenant-test wait kuberneteses.apps.cozystack.io --all --for=delete --timeout=5m 2>/dev/null || true
+  # The CR delete above finalizes once the Kubernetes CR is gone, which only
+  # TRIGGERS KubeVirt VM teardown + PVC release. Block until the worker VMs,
+  # VMIs (guest RAM) and disk PVCs are actually gone so the next tenant test
+  # starts on a freed sandbox -- the root cause of the node-join flake.
+  cozy_wait_tenant_drained 300 || true
 }
 
 # Snapshot the tenant cluster (its cilium/CSI/coredns internals) on a failed run.

--- a/hack/run-kubernetes-drain_test.bats
+++ b/hack/run-kubernetes-drain_test.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Unit tests for cozy_tenant_drained in hack/e2e-apps/run-kubernetes.sh
+#
+# cozy_tenant_drained is the pure exit-condition of the inter-test drain loop
+# (cozy_wait_tenant_drained). Each argument is one resource-probe capture: the
+# stdout of a `kubectl get -o name` (empty once the resource is gone) or the
+# literal "err" the loop substitutes when a probe itself fails, so an API blip
+# is never misread as "the tenant has drained". The function returns 0 (drained)
+# only when every capture is empty/whitespace, non-zero otherwise.
+#
+# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
+# own line; there is no bats `run` or `$status`. Assertions are expressed as
+# direct shell tests that exit non-zero on failure.
+#
+# Run with: hack/cozytest.sh hack/run-kubernetes-drain_test.bats
+# -----------------------------------------------------------------------------
+
+@test "all-empty captures report drained" {
+    . hack/e2e-apps/run-kubernetes.sh
+    if ! cozy_tenant_drained "" "" ""; then
+        echo "expected drained when every capture is empty" >&2
+        exit 1
+    fi
+}
+
+@test "no arguments reports drained" {
+    . hack/e2e-apps/run-kubernetes.sh
+    if ! cozy_tenant_drained; then
+        echo "expected drained when there are no captures" >&2
+        exit 1
+    fi
+}
+
+@test "a remaining VirtualMachine reports not-drained" {
+    . hack/e2e-apps/run-kubernetes.sh
+    if cozy_tenant_drained "virtualmachine.kubevirt.io/kubernetes-test-latest-version-md0-abcde" "" ""; then
+        echo "expected not-drained while a VirtualMachine is still present" >&2
+        exit 1
+    fi
+}
+
+@test "a remaining PVC in the last capture reports not-drained" {
+    . hack/e2e-apps/run-kubernetes.sh
+    if cozy_tenant_drained "" "" "persistentvolumeclaim/disk-system-kubernetes-test-latest-version-md0-abcde"; then
+        echo "expected not-drained while a worker-disk PVC is still present" >&2
+        exit 1
+    fi
+}
+
+@test "a multi-line resource list reports not-drained" {
+    . hack/e2e-apps/run-kubernetes.sh
+    vms=$(printf 'virtualmachine.kubevirt.io/a\nvirtualmachine.kubevirt.io/b\n')
+    if cozy_tenant_drained "$vms" "" ""; then
+        echo "expected not-drained for a multi-line VirtualMachine list" >&2
+        exit 1
+    fi
+}
+
+@test "the err sentinel is never misread as drained" {
+    # A failed probe (transient API error) substitutes the literal "err". Even
+    # when every other capture is empty, an err capture MUST count as
+    # not-drained so the loop keeps polling instead of declaring victory on a
+    # blip and letting the next tenant schedule onto an un-vacated sandbox.
+    . hack/e2e-apps/run-kubernetes.sh
+    if cozy_tenant_drained "" "err" ""; then
+        echo "expected not-drained when a probe returned the err sentinel" >&2
+        exit 1
+    fi
+}
+
+@test "whitespace-only captures are treated as drained" {
+    # `kubectl get -o name` against an empty result set yields no resource
+    # names; a stray newline must not be mistaken for a live resource.
+    . hack/e2e-apps/run-kubernetes.sh
+    blank=$(printf '\n')
+    if ! cozy_tenant_drained "$blank" "" "  "; then
+        echo "expected drained when captures hold only whitespace" >&2
+        exit 1
+    fi
+}


### PR DESCRIPTION
## What this PR does

Fixes the dominant flake in the tenant-Kubernetes e2e suite, where a run fails on worker-node-join under sandbox memory/storage pressure.

The two heavy Kamaji tenant tests — `kubernetes-latest` then `kubernetes-previous` — run back-to-back in one CI sandbox, each provisioning a tenant cluster with KubeVirt worker VMs. The inter-test cleanup hook (`cozy_cleanup` in `hack/e2e-apps/run-kubernetes.sh`) deletes the tenant `Kubernetes` CR and waits only for the CR to disappear. That wait finalizes as soon as the CR's finalizers clear, which merely *triggers* teardown of the CAPK worker VMs and their DataVolume-backed disk PVCs — it does not await it. The virt-launcher pods keep their guest RAM reserved until the VMIs are gone, so the next tenant test's worker VMs begin scheduling against a sandbox the previous tenant has not yet vacated. Under the constrained sandbox this starves memory, a worker VM misses the node-join budget, and the MachineHealthCheck cannot remediate when both workers are unhealthy — so the run flakes on worker-node-join.

This adds a bounded drain barrier to `cozy_cleanup`: after deleting the CR it now blocks until the tenant's VirtualMachines, VirtualMachineInstances and disk PVCs have actually drained from the `tenant-test` namespace, so the next test starts on a freed sandbox.

The wait is bounded (5m) and best-effort: cozytest already runs `cozy_cleanup` wrapped in `|| true`, and the waiter returns loudly (warning plus a leftover dump) on timeout, so a stuck teardown can never hang the job past the deadline — it leaves the sandbox no worse than before. The probe is namespace-scoped: `tenant-test` is provisioned with etcd/monitoring/seaweedfs disabled so it carries no baseline PVCs, and the e2e apps run sequentially each cleaning up after themselves, so the only VMs/VMIs/PVCs present belong to the tenant being torn down.

The pure drain exit-condition (`cozy_tenant_drained`) is factored out and unit-tested in `hack/run-kubernetes-drain_test.bats` (runs under `make unit-tests`), including the invariant that a failed probe's `err` sentinel is never misread as a completed drain.

### Screenshots

Not applicable — e2e harness change, no UI.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes test cleanup so tenant resources are fully drained before the next test starts, reducing leftover VMs, VM instances, and PVCs.
  * Added more reliable timeout handling and clearer diagnostics when teardown or node readiness checks fail, making flaky test issues easier to identify.
* **Tests**
  * Added coverage for tenant-drain detection to verify empty, whitespace-only, multi-resource, and error scenarios behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->