### PR TITLE
fix(flux): tune source-watcher concurrency + CPU to unblock platform install under load

### DIFF
--- a/internal/fluxinstall/manifests/fluxcd.yaml
+++ b/internal/fluxinstall/manifests/fluxcd.yaml
@@ -8209,6 +8209,7 @@ spec:
             - --storage-path=/data
             - --storage-adv-addr=flux.$(RUNTIME_NAMESPACE).svc
             - --events-addr=http://localhost:9690
+            - --concurrent=20
           env:
             - name: SOURCE_CONTROLLER_LOCALHOST
               value: localhost:9790
@@ -8251,7 +8252,7 @@ spec:
             limits:
               memory: 1Gi
             requests:
-              cpu: 100m
+              cpu: 500m
               memory: 64Mi
           securityContext:
             allowPrivilegeEscalation: false

--- a/packages/core/flux-aio/Makefile
+++ b/packages/core/flux-aio/Makefile
@@ -17,6 +17,11 @@ MANIFESTS_DIR=../../../internal/fluxinstall/manifests
 update:
 	timoni bundle build -f flux-aio.cue > $(MANIFESTS_DIR)/fluxcd.yaml
 	yq eval '(select(.kind == "Namespace") | .metadata.labels."pod-security.kubernetes.io/enforce") = "privileged"' -i $(MANIFESTS_DIR)/fluxcd.yaml
+	# The flux-aio module does not expose a --concurrent flag for source-watcher; inject it here.
+	# source-watcher builds one ExternalArtifact per PackageSource component, so raise its
+	# concurrency above the binary default of 10 to match the other controllers under load.
+	# The append is guarded so a future module that emits its own --concurrent is not duplicated.
+	yq eval '(select(.kind == "Deployment" and .metadata.name == "flux").spec.template.spec.containers[] | select(.name == "source-watcher") | select(.args | contains(["--concurrent=20"]) | not).args) += ["--concurrent=20"]' -i $(MANIFESTS_DIR)/fluxcd.yaml
 	sed -i $(MANIFESTS_DIR)/fluxcd.yaml \
 		-e '/timoni/d' \
 		-e 's|\.cluster\.local\.,||g' -e 's|\.cluster\.local\,||g' -e 's|\.cluster\.local\.||g' \

--- a/packages/core/flux-aio/flux-aio.cue
+++ b/packages/core/flux-aio/flux-aio.cue
@@ -10,6 +10,20 @@ bundle: {
 			namespace: "cozy-fluxcd"
 			values: {
 				securityProfile: "privileged"
+				// source-watcher builds one ExternalArtifact per PackageSource
+				// component; on the management cluster that is ~100 concurrent
+				// builds during install. Give it CPU headroom so it is not
+				// starved by its sibling controllers in the all-in-one pod.
+				// The module has no per-controller args override for the
+				// watcher, so its --concurrent bump is applied as a post-render
+				// patch in the Makefile.
+				controllers: watcher: resources: {
+					requests: {
+						cpu:    "500m"
+						memory: "64Mi"
+					}
+					limits: memory: "1Gi"
+				}
 				tolerations: [{
 					operator: "Exists"
 					key:      "node.kubernetes.io/not-ready"

--- a/packages/system/fluxcd/values.yaml
+++ b/packages/system/fluxcd/values.yaml
@@ -19,7 +19,7 @@ flux-instance:
       patches:
         - target:
             kind: Deployment
-            name: "(kustomize-controller|helm-controller|source-controller)"
+            name: "(kustomize-controller|helm-controller|source-controller|source-watcher)"
           patch: |
             - op: add
               path: /spec/template/spec/containers/0/args/-


### PR DESCRIPTION
## What this PR does

`source-watcher` is the Flux controller that turns each `PackageSource` into an `ExternalArtifact` (one `ArtifactGenerator` per source, ~100 builds on the management cluster during install). The `cozystack-platform` HelmRelease blocks until all of those artifacts are Ready, so source-watcher's throughput sits on the install's critical path.

It was the only Flux controller left without concurrency/CPU tuning. In the bootstrap all-in-one pod it ran on the binary default (`--concurrent=10`) with the shared 100m CPU request; in the production `FluxInstance` it was absent from the reconciler patch that source-, kustomize- and helm-controller already receive. Under load its per-artifact builds finish at staggered times, leaving a random tail of not-yet-Ready artifacts that times out the platform install.

A failed run's diagnostics show the shape of this: the `cozystack-platform` HelmRelease timed out with `timeout waiting for: PackageSource/… status: 'InProgress'` (a run-to-run varying tail — e.g. `bucket-application`, `linstor-gui`, `capi-provider-core`), while its ~200 ExternalArtifacts reached Ready in a staggered trickle spread over ~60 seconds rather than together. That staggered completion of independent per-artifact builds is the signature of a throughput-limited builder, not a single all-or-nothing pull.

This raises source-watcher to `--concurrent=20` in both install paths:

- **Bootstrap all-in-one pod** (`internal/fluxinstall/manifests/fluxcd.yaml`, regenerated from `flux-aio.cue` + the `flux-aio` Makefile): `--concurrent=20` plus a 500m CPU request. The AIO pod sets no CPU limits, so the request is what drives source-watcher's proportional CPU share when the node is saturated.
- **Production `FluxInstance`** (`packages/system/fluxcd/values.yaml`): source-watcher is added to the shared reconciler patch, so it now gets the same `--concurrent=20`, `--requeue-dependency=5s` and 2000m/2048Mi limits as the other tuned controllers.

The `flux-aio` module exposes a per-controller resources override for the watcher (set via CUE) but no args override, so the bootstrap `--concurrent` bump is a guarded post-render patch in the Makefile; the embedded manifest is the product of that pipeline. source-watcher's support for both `--concurrent` and `--requeue-dependency` was confirmed against its `cmd/main.go`, and the production `op: replace` on `resources/limits` is safe because the distribution ships source-watcher with a `resources.limits` block (same shape as source-controller).

Optional follow-up, intentionally left out to keep this focused on the root cause: if the artifact-build tail still brushes the 10-minute platform HelmRelease timeout under load, the installer's HelmRelease install/upgrade timeout values give a safety margin.

### Release note

```release-note
fix(flux): tune source-watcher concurrency and CPU so the platform install does not time out under load
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the source watcher’s concurrency to improve throughput and better handle larger workloads.
  * Added higher CPU and memory settings for the watcher to support more stable operation under load.

* **Bug Fixes**
  * Updated deployment patching so the watcher receives the same configuration adjustments as other controllers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->