### PR TITLE
chore(github): needs-triage on new issues + area/{keycloak,tenant,kamaji} labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: 'kind/bug'
+labels: 'kind/bug, triage/needs-triage'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Propose a concrete, scoped improvement to Cozystack
-labels: 'kind/feature'
+labels: 'kind/feature, triage/needs-triage'
 assignees: ''
 
 ---

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -218,6 +218,18 @@
   color: 'bfd4f2'
   description: Issues or PRs related to virtualization (kubevirt, cdi, vmi, vm-import)
 
+- name: area/kamaji
+  color: 'bfd4f2'
+  description: Issues or PRs related to Kamaji (hosted control planes for tenant Kubernetes)
+
+- name: area/keycloak
+  color: 'bfd4f2'
+  description: Issues or PRs related to Keycloak (SSO / identity)
+
+- name: area/tenant
+  color: 'bfd4f2'
+  description: Issues or PRs related to the tenant chart and multi-tenancy
+
 - name: area/uncategorized
   color: 'fbca04'
   description: PR auto-labeler could not map title scope to a known area/*; please review

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -68,9 +68,16 @@ jobs:
               'etcd':                'area/database',
               'kafka':               'area/database',
               'clickhouse':          'area/database',
+              'mongodb':             'area/database',
 
               // area/extra
               'extra':               'area/extra',
+
+              // area/kamaji
+              'kamaji':              'area/kamaji',
+
+              // area/keycloak
+              'keycloak':            'area/keycloak',
 
               // area/kubernetes
               'kubernetes':          'area/kubernetes',
@@ -120,6 +127,10 @@ jobs:
               'velero':              'area/storage',
               'harbor':              'area/storage',
               'backups':             'area/storage',
+              'csi':                 'area/storage',
+
+              // area/tenant
+              'tenant':              'area/tenant',
 
               // area/testing
               'tests':               'area/testing',


### PR DESCRIPTION
## What this PR does

Two label-housekeeping changes:

1. **Auto-label new issues `triage/needs-triage`.** Both issue templates append `triage/needs-triage` to their frontmatter labels, so every issue opened through a template lands with a visible "needs triage" marker. `blank_issues_enabled: false` routes all new issues through a template, so this covers the entire intake — one label to filter the untriaged backlog and a clear signal to act on before the stale bot's 60-day clock elapses.

2. **New `area/*` labels for recurring scopes.** Three scopes recur across the PR history with no fitting `area/*` — `keycloak`, `tenant`, `kamaji` — so this adds `area/keycloak`, `area/tenant`, `area/kamaji` to `labels.yml` and maps their scopes in the auto-labeler. It also fills two gaps in existing mappings: `mongodb` → `area/database`, `csi` → `area/storage`. Existing PRs in these scopes were re-labeled off `area/uncategorized`.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Issue Management**
  * Bug reports and feature requests are now automatically marked as needing triage.
  * Added area labels for Kamaji, Keycloak, and tenants.
  * Expanded pull request auto-labeling for database, storage, Kamaji, Keycloak, and tenant changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->