### PR TITLE
feat(ci): gate sizeable API changes behind API-owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,11 @@
 * @kvaps @lllamnyp @lexfrei @androndo @IvanHunters @sircthulhu @myasnikovdaniil
+
+# The API review gate must not be editable without an API-owner review, or a
+# PR could neuter the detector (it is compiled from the head checkout during
+# bootstrap) and slip a sizeable API change through unreviewed. Scoping these
+# paths to the API owners overrides the catch-all above (last match wins), so
+# changes here require @kvaps or @lllamnyp specifically. Enable "Require review
+# from Code Owners" in branch protection for this to bind.
+/cmd/api-gate/                          @kvaps @lllamnyp
+/internal/apigate/                      @kvaps @lllamnyp
+/.github/workflows/api-review-gate.yaml @kvaps @lllamnyp

--- a/.github/workflows/api-review-gate.yaml
+++ b/.github/workflows/api-review-gate.yaml
@@ -67,7 +67,23 @@ jobs:
           git worktree add --detach "${RUNNER_TEMP}/base" "${merge_base}"
 
       - name: Build api-gate
-        run: go build -o "${RUNNER_TEMP}/api-gate" ./cmd/api-gate
+        run: |
+          set -euo pipefail
+          # Prefer building the detector from the trusted base checkout so a PR
+          # cannot neuter the gate by editing its own detector code — the tool
+          # analyzes the head as *data*, not as code. Fall back to the head
+          # checkout only while the tool has not yet landed on the base branch
+          # (bootstrap); in that window CODEOWNERS on cmd/api-gate,
+          # internal/apigate, and this workflow keeps tampering behind an
+          # API-owner review.
+          if [ -d "${RUNNER_TEMP}/base/cmd/api-gate" ]; then
+            build_dir="${RUNNER_TEMP}/base"
+            echo "Building api-gate from the trusted base checkout."
+          else
+            build_dir="${GITHUB_WORKSPACE}"
+            echo "::warning::api-gate not present on the base branch yet; building from head (bootstrap). CODEOWNERS enforces API-owner review on the gate's own files."
+          fi
+          ( cd "${build_dir}" && go build -o "${RUNNER_TEMP}/api-gate" ./cmd/api-gate )
 
       - name: Detect sizeable API changes
         id: detect

--- a/.github/workflows/api-review-gate.yaml
+++ b/.github/workflows/api-review-gate.yaml
@@ -34,16 +34,20 @@ jobs:
       # Space-separated GitHub logins allowed to satisfy the gate. Edit here to
       # change who can approve sizeable API changes.
       API_OWNERS: "lllamnyp kvaps"
-      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout head
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          # Do not leave a usable token in the repo's git config: the PR-authored
+          # build and api-gate steps below must not have access to it. The token
+          # is scoped to the approval step alone, which is the only step that
+          # calls the GitHub API.
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
@@ -51,10 +55,16 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Materialize base checkout
+      - name: Materialize base checkout at the merge base
         run: |
           set -euo pipefail
-          git worktree add --detach "${RUNNER_TEMP}/base" "${BASE_SHA}"
+          # Diff against the PR's actual merge base, not the base branch tip:
+          # otherwise unrelated commits landing on the base branch while the PR
+          # is open would invent or hide API findings.
+          git fetch --no-tags origin "${BASE_REF}"
+          merge_base="$(git merge-base "${HEAD_SHA}" "origin/${BASE_REF}")"
+          echo "Merge base: ${merge_base}"
+          git worktree add --detach "${RUNNER_TEMP}/base" "${merge_base}"
 
       - name: Build api-gate
         run: go build -o "${RUNNER_TEMP}/api-gate" ./cmd/api-gate
@@ -80,6 +90,8 @@ jobs:
 
       - name: Check for an API owner approval
         if: steps.detect.outputs.sizeable == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           {
@@ -88,13 +100,25 @@ jobs:
             cat "${RUNNER_TEMP}/report.md"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          # Latest review state per reviewer; an APPROVED review by any API
-          # owner satisfies the gate. GitHub forbids self-approval, so a
-          # sizeable PR authored by an owner still needs the other owner.
-          approvals="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
-            --paginate \
-            --jq '[.[] | select(.state=="APPROVED") | .user.login] | unique | .[]')"
+          # An APPROVED review by any API owner satisfies the gate, but only
+          # each reviewer's *latest* review *on the current head commit* counts:
+          # this drops approvals that a later commit invalidated, and approvals
+          # an owner subsequently superseded with CHANGES_REQUESTED. GitHub
+          # forbids self-approval, so a sizeable PR authored by an owner still
+          # needs the other owner.
+          approvals="$(
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" --paginate |
+            jq -rs --arg head "${HEAD_SHA}" '
+              add
+              | map(select(.commit_id == $head))
+              | sort_by(.submitted_at // "")
+              | group_by(.user.login)
+              | map(last)
+              | .[]
+              | select(.state == "APPROVED")
+              | .user.login
+            '
+          )"
 
           for owner in ${API_OWNERS}; do
             if grep -qxi "${owner}" <<<"${approvals}"; then

--- a/.github/workflows/api-review-gate.yaml
+++ b/.github/workflows/api-review-gate.yaml
@@ -1,0 +1,107 @@
+name: API Review Gate
+
+# Requires a review from a designated API owner (see API_OWNERS below) when a
+# pull request makes a "sizeable" change to the Cozystack API surface: a new
+# API group, a new resource, or a breaking change to an existing resource's
+# schema. Detection is deterministic (cmd/api-gate); no LLM or network calls.
+#
+# The job runs on every PR (no path filter) so it can always report a status
+# and therefore be marked as a required check in branch protection without
+# leaving PRs that touch no API stuck in "pending". When nothing sizeable
+# changed it passes immediately.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  # Re-evaluate when a review is submitted or dismissed so an approval by an
+  # API owner flips the check from failing to passing without a new push.
+  pull_request_review:
+    types: [submitted, dismissed]
+
+concurrency:
+  group: api-review-gate-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  api-review-gate:
+    name: Require API owner review for sizeable API changes
+    runs-on: ubuntu-22.04
+    env:
+      # Space-separated GitHub logins allowed to satisfy the gate. Edit here to
+      # change who can approve sizeable API changes.
+      API_OWNERS: "lllamnyp kvaps"
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Materialize base checkout
+        run: |
+          set -euo pipefail
+          git worktree add --detach "${RUNNER_TEMP}/base" "${BASE_SHA}"
+
+      - name: Build api-gate
+        run: go build -o "${RUNNER_TEMP}/api-gate" ./cmd/api-gate
+
+      - name: Detect sizeable API changes
+        id: detect
+        run: |
+          set -uo pipefail
+          set +e
+          "${RUNNER_TEMP}/api-gate" \
+            --base "${RUNNER_TEMP}/base" \
+            --head "${GITHUB_WORKSPACE}" \
+            --format markdown > "${RUNNER_TEMP}/report.md"
+          code=$?
+          set -e
+          echo "code=${code}" >> "$GITHUB_OUTPUT"
+          cat "${RUNNER_TEMP}/report.md"
+          case "${code}" in
+            0) echo "sizeable=false" >> "$GITHUB_OUTPUT" ;;
+            2) echo "sizeable=true"  >> "$GITHUB_OUTPUT" ;;
+            *) echo "::error::api-gate failed with exit code ${code}"; exit "${code}" ;;
+          esac
+
+      - name: Check for an API owner approval
+        if: steps.detect.outputs.sizeable == 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## API Review Gate"
+            echo
+            cat "${RUNNER_TEMP}/report.md"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Latest review state per reviewer; an APPROVED review by any API
+          # owner satisfies the gate. GitHub forbids self-approval, so a
+          # sizeable PR authored by an owner still needs the other owner.
+          approvals="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+            --paginate \
+            --jq '[.[] | select(.state=="APPROVED") | .user.login] | unique | .[]')"
+
+          for owner in ${API_OWNERS}; do
+            if grep -qxi "${owner}" <<<"${approvals}"; then
+              echo "Sizeable API change approved by @${owner}."
+              exit 0
+            fi
+          done
+
+          echo "::error::This PR makes a sizeable API change (new group, new resource, or breaking change) and needs an approving review from one of: ${API_OWNERS}. See the job summary for details."
+          exit 1

--- a/cmd/api-gate/main.go
+++ b/cmd/api-gate/main.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command api-gate compares the Cozystack API surface between two checkouts of
+// the repository and reports whether the change is "sizeable" — a new API
+// group, a new resource, or a breaking change to an existing resource. CI uses
+// a sizeable verdict to require a review from a designated API owner.
+//
+// Usage:
+//
+//	api-gate --base <dir> --head <dir>
+//
+// Both flags point at a full repository checkout (the merge base and the PR
+// head). Exit code 0 means "not sizeable"; exit code 2 means "sizeable"
+// (findings are printed to stdout as a Markdown report); any other non-zero
+// exit is an operational error.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/cozystack/cozystack/internal/apigate"
+)
+
+// exitSizeable is a distinct, non-error exit code so the calling workflow can
+// tell "sizeable change, needs owner review" apart from a tool malfunction.
+const exitSizeable = 2
+
+func main() {
+	baseDir := flag.String("base", "", "path to the base (merge-base) repository checkout")
+	headDir := flag.String("head", "", "path to the head (PR) repository checkout")
+	format := flag.String("format", "markdown", "report format: markdown or text")
+	flag.Parse()
+
+	if *baseDir == "" || *headDir == "" {
+		fmt.Fprintln(os.Stderr, "api-gate: both --base and --head are required")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	base, err := apigate.LoadSnapshot(*baseDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "api-gate: loading base snapshot: %v\n", err)
+		os.Exit(1)
+	}
+	head, err := apigate.LoadSnapshot(*headDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "api-gate: loading head snapshot: %v\n", err)
+		os.Exit(1)
+	}
+
+	findings := apigate.Classify(base, head)
+	if len(findings) == 0 {
+		fmt.Println("No sizeable API changes detected.")
+		return
+	}
+
+	fmt.Print(apigate.Report(findings, *format))
+	os.Exit(exitSizeable)
+}

--- a/internal/apigate/classify.go
+++ b/internal/apigate/classify.go
@@ -72,6 +72,49 @@ func Classify(base, head Snapshot) []Finding {
 		})
 	}
 
+	// Removed API groups: present in base, absent in head. Reported once per
+	// group against the first (sorted) base resource that carried it.
+	headGroups := head.groups()
+	removedGroups := map[string]struct{}{}
+	for _, res := range sortedResources(base) {
+		if _, ok := headGroups[res.Group]; ok {
+			continue
+		}
+		if _, done := removedGroups[res.Group]; done {
+			continue
+		}
+		removedGroups[res.Group] = struct{}{}
+		findings = append(findings, Finding{
+			Category: RemovedGroup,
+			Group:    res.Group,
+			Kind:     res.Kind,
+			Plural:   res.Plural,
+			Source:   res.Source,
+			Origin:   res.Origin,
+			Detail:   fmt.Sprintf("API group %q is removed by this change", res.Group),
+		})
+	}
+
+	// Removed resources: present in base, absent in head. A resource whose
+	// whole group was removed is already covered above, so skip it here.
+	for _, res := range sortedResources(base) {
+		if _, ok := head[res.key()]; ok {
+			continue
+		}
+		if _, groupGone := removedGroups[res.Group]; groupGone {
+			continue
+		}
+		findings = append(findings, Finding{
+			Category: RemovedResource,
+			Group:    res.Group,
+			Kind:     res.Kind,
+			Plural:   res.Plural,
+			Source:   res.Source,
+			Origin:   res.Origin,
+			Detail:   fmt.Sprintf("resource %s (%s) is removed from group %q", res.Plural, displayKind(res), res.Group),
+		})
+	}
+
 	// Breaking changes: resources present in both, whose schema regresses.
 	for _, res := range sortedResources(head) {
 		prev, ok := base[res.key()]

--- a/internal/apigate/classify.go
+++ b/internal/apigate/classify.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apigate
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Classify compares the base and head snapshots and returns every sizeable
+// change, ordered deterministically (new groups, then new resources, then
+// breaking changes; each block sorted by group/plural/detail). An empty slice
+// means the change set is not sizeable and needs no designated-owner review.
+func Classify(base, head Snapshot) []Finding {
+	var findings []Finding
+
+	baseGroups := base.groups()
+	// New API groups: present in head, absent in base. Reported once per group
+	// against the first (sorted) resource that introduces it.
+	newGroups := map[string]struct{}{}
+	for _, res := range sortedResources(head) {
+		if _, ok := baseGroups[res.Group]; ok {
+			continue
+		}
+		if _, done := newGroups[res.Group]; done {
+			continue
+		}
+		newGroups[res.Group] = struct{}{}
+		findings = append(findings, Finding{
+			Category: NewGroup,
+			Group:    res.Group,
+			Kind:     res.Kind,
+			Plural:   res.Plural,
+			Source:   res.Source,
+			Origin:   res.Origin,
+			Detail:   fmt.Sprintf("API group %q is introduced by this change", res.Group),
+		})
+	}
+
+	// New resources: (group, plural) present in head, absent in base. A
+	// resource whose group is itself new is already covered by the new-group
+	// finding, so skip it here to avoid double-flagging.
+	for _, res := range sortedResources(head) {
+		if _, ok := base[res.key()]; ok {
+			continue
+		}
+		if _, groupIsNew := newGroups[res.Group]; groupIsNew {
+			continue
+		}
+		findings = append(findings, Finding{
+			Category: NewResource,
+			Group:    res.Group,
+			Kind:     res.Kind,
+			Plural:   res.Plural,
+			Source:   res.Source,
+			Origin:   res.Origin,
+			Detail:   fmt.Sprintf("resource %s (%s) is added to group %q", res.Plural, displayKind(res), res.Group),
+		})
+	}
+
+	// Breaking changes: resources present in both, whose schema regresses.
+	for _, res := range sortedResources(head) {
+		prev, ok := base[res.key()]
+		if !ok {
+			continue
+		}
+		for _, detail := range diffResource(prev, res) {
+			findings = append(findings, Finding{
+				Category: Breaking,
+				Group:    res.Group,
+				Kind:     res.Kind,
+				Plural:   res.Plural,
+				Source:   res.Source,
+				Origin:   res.Origin,
+				Detail:   detail,
+			})
+		}
+	}
+
+	return findings
+}
+
+// diffResource returns human-readable descriptions of every breaking change
+// between the base and head form of one resource: a removed served version, or
+// a breaking schema change within a shared version. New versions are additive
+// and ignored.
+func diffResource(base, head Resource) []string {
+	var out []string
+	versions := make([]string, 0, len(base.Versions))
+	for v := range base.Versions {
+		versions = append(versions, v)
+	}
+	sort.Strings(versions)
+	for _, v := range versions {
+		headSchema, ok := head.Versions[v]
+		if !ok {
+			out = append(out, fmt.Sprintf("served version %q was removed", v))
+			continue
+		}
+		for _, c := range diffSchema("spec", base.Versions[v], headSchema) {
+			out = append(out, fmt.Sprintf("[%s] %s", v, c))
+		}
+	}
+	return out
+}
+
+func displayKind(r Resource) string {
+	if r.Kind != "" {
+		return r.Kind
+	}
+	return r.Plural
+}
+
+// sortedResources returns a snapshot's resources in a stable order for
+// deterministic output.
+func sortedResources(s Snapshot) []Resource {
+	out := make([]Resource, 0, len(s))
+	for _, r := range s {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Group != out[j].Group {
+			return out[i].Group < out[j].Group
+		}
+		return out[i].Plural < out[j].Plural
+	})
+	return out
+}

--- a/internal/apigate/classify_test.go
+++ b/internal/apigate/classify_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apigate
+
+import "testing"
+
+// res is a small constructor for building test snapshots.
+func res(group, kind, plural string, src Source, schema Schema) Resource {
+	r := Resource{Group: group, Kind: kind, Plural: plural, Source: src, Versions: map[string]Schema{}}
+	if schema != nil {
+		r.Versions["v1alpha1"] = schema
+	}
+	return r
+}
+
+func snap(rs ...Resource) Snapshot {
+	s := Snapshot{}
+	for _, r := range rs {
+		s[r.key()] = r
+	}
+	return s
+}
+
+func countCategory(fs []Finding, c Category) int {
+	n := 0
+	for _, f := range fs {
+		if f.Category == c {
+			n++
+		}
+	}
+	return n
+}
+
+func TestClassify(t *testing.T) {
+	pgBase := res("apps.cozystack.io", "Postgres", "postgreses", SourceCozyRD,
+		Schema{"type": "object", "properties": map[string]any{"replicas": map[string]any{"type": "integer"}}})
+	pgBreaking := res("apps.cozystack.io", "Postgres", "postgreses", SourceCozyRD,
+		Schema{"type": "object", "properties": map[string]any{}})
+
+	t.Run("no change", func(t *testing.T) {
+		got := Classify(snap(pgBase), snap(pgBase))
+		if len(got) != 0 {
+			t.Fatalf("expected no findings, got %v", got)
+		}
+	})
+
+	t.Run("new resource in existing group", func(t *testing.T) {
+		redis := res("apps.cozystack.io", "Redis", "redises", SourceCozyRD, Schema{"type": "object"})
+		got := Classify(snap(pgBase), snap(pgBase, redis))
+		if n := countCategory(got, NewResource); n != 1 {
+			t.Fatalf("expected 1 new-resource finding, got %d (%v)", n, got)
+		}
+		if countCategory(got, NewGroup) != 0 {
+			t.Fatalf("existing group must not be flagged as new: %v", got)
+		}
+	})
+
+	t.Run("new group flags group once and does not double-count its resources", func(t *testing.T) {
+		sg1 := res("brandnew.cozystack.io", "Widget", "widgets", SourceCRD, Schema{"type": "object"})
+		sg2 := res("brandnew.cozystack.io", "Gadget", "gadgets", SourceCRD, Schema{"type": "object"})
+		got := Classify(snap(pgBase), snap(pgBase, sg1, sg2))
+		if n := countCategory(got, NewGroup); n != 1 {
+			t.Fatalf("expected exactly 1 new-group finding, got %d (%v)", n, got)
+		}
+		if n := countCategory(got, NewResource); n != 0 {
+			t.Fatalf("resources of a brand-new group must not also be flagged as new resources, got %d (%v)", n, got)
+		}
+	})
+
+	t.Run("breaking schema change", func(t *testing.T) {
+		got := Classify(snap(pgBase), snap(pgBreaking))
+		if n := countCategory(got, Breaking); n != 1 {
+			t.Fatalf("expected 1 breaking finding, got %d (%v)", n, got)
+		}
+	})
+
+	t.Run("removed resource is not sizeable by these rules", func(t *testing.T) {
+		// Removing a resource is a different (also serious) event, but it is
+		// not one of the three gated categories; ensure we do not misreport it
+		// as any of them.
+		got := Classify(snap(pgBase), snap())
+		if len(got) != 0 {
+			t.Fatalf("expected no findings for a pure removal, got %v", got)
+		}
+	})
+
+	t.Run("static go-backed new resource is detected", func(t *testing.T) {
+		base := snap(res("core.cozystack.io", "", "tenantsecrets", SourceAPIServer, nil))
+		head := snap(
+			res("core.cozystack.io", "", "tenantsecrets", SourceAPIServer, nil),
+			res("core.cozystack.io", "", "tenantwidgets", SourceAPIServer, nil),
+		)
+		got := Classify(base, head)
+		if n := countCategory(got, NewResource); n != 1 {
+			t.Fatalf("expected 1 new-resource finding for static group, got %d (%v)", n, got)
+		}
+	})
+}

--- a/internal/apigate/classify_test.go
+++ b/internal/apigate/classify_test.go
@@ -88,13 +88,29 @@ func TestClassify(t *testing.T) {
 		}
 	})
 
-	t.Run("removed resource is not sizeable by these rules", func(t *testing.T) {
-		// Removing a resource is a different (also serious) event, but it is
-		// not one of the three gated categories; ensure we do not misreport it
-		// as any of them.
-		got := Classify(snap(pgBase), snap())
-		if len(got) != 0 {
-			t.Fatalf("expected no findings for a pure removal, got %v", got)
+	t.Run("removed resource is gated", func(t *testing.T) {
+		// Deleting a resource is the most disruptive single-resource change and
+		// must require owner review. The resource's group still has another
+		// member here, so this is a resource removal, not a group removal.
+		other := res("apps.cozystack.io", "Redis", "redises", SourceCozyRD, Schema{"type": "object"})
+		got := Classify(snap(pgBase, other), snap(other))
+		if n := countCategory(got, RemovedResource); n != 1 {
+			t.Fatalf("expected 1 removed-resource finding, got %d (%v)", n, got)
+		}
+		if countCategory(got, RemovedGroup) != 0 {
+			t.Fatalf("group still has a member; must not be flagged as removed group: %v", got)
+		}
+	})
+
+	t.Run("removed group flags group once and does not double-count its resources", func(t *testing.T) {
+		g1 := res("gone.cozystack.io", "Widget", "widgets", SourceCRD, Schema{"type": "object"})
+		g2 := res("gone.cozystack.io", "Gadget", "gadgets", SourceCRD, Schema{"type": "object"})
+		got := Classify(snap(pgBase, g1, g2), snap(pgBase))
+		if n := countCategory(got, RemovedGroup); n != 1 {
+			t.Fatalf("expected exactly 1 removed-group finding, got %d (%v)", n, got)
+		}
+		if n := countCategory(got, RemovedResource); n != 0 {
+			t.Fatalf("resources of a fully-removed group must not also be flagged as removed resources, got %d (%v)", n, got)
 		}
 	})
 

--- a/internal/apigate/model.go
+++ b/internal/apigate/model.go
@@ -37,6 +37,13 @@ const (
 	// (removed field, narrowed type/enum, newly-required field, tightened
 	// constraint, removed served version).
 	Breaking Category = "breaking-change"
+	// RemovedGroup is emitted when an entire API group present in base is gone
+	// from head. Deleting a group withdraws its whole API surface.
+	RemovedGroup Category = "removed-api-group"
+	// RemovedResource is emitted when a (group, resource) present in base is
+	// gone from head — the most disruptive single-resource change, since every
+	// stored object and client of that resource breaks.
+	RemovedResource Category = "removed-resource"
 )
 
 // Source identifies which checked-in artifact a resource was parsed from.

--- a/internal/apigate/model.go
+++ b/internal/apigate/model.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package apigate detects "sizeable" Cozystack API changes between two
+// checkouts of the repository so CI can require a review from a designated
+// API owner. Sizeable means one of: a new API group, a new resource, or a
+// breaking change to an existing resource's schema. The detection is fully
+// deterministic — it parses the checked-in, codegen-kept-in-sync artifacts
+// that define the served API surface, with no network or LLM calls.
+package apigate
+
+// Category classifies why a change is sizeable. The three values mirror the
+// gate's contract exactly.
+type Category string
+
+const (
+	// NewGroup is emitted when an API group appears in head but not base.
+	NewGroup Category = "new-api-group"
+	// NewResource is emitted when a (group, resource) pair appears in head
+	// but not base.
+	NewResource Category = "new-resource"
+	// Breaking is emitted when an existing resource's schema changes in a
+	// way that can reject requests or objects that the base schema accepted
+	// (removed field, narrowed type/enum, newly-required field, tightened
+	// constraint, removed served version).
+	Breaking Category = "breaking-change"
+)
+
+// Source identifies which checked-in artifact a resource was parsed from.
+// It is carried through to findings so the report points reviewers at the
+// right file family.
+type Source string
+
+const (
+	// SourceCRD is a CustomResourceDefinition YAML manifest.
+	SourceCRD Source = "crd"
+	// SourceCozyRD is an ApplicationDefinition (cozyrd) backing the
+	// apps.cozystack.io aggregated API.
+	SourceCozyRD Source = "cozyrd"
+	// SourceAPIServer is a static Go-backed aggregated resource discovered
+	// from the apiserver storage registrations. These carry no checked-in
+	// schema, so they participate only in new-group / new-resource
+	// detection.
+	SourceAPIServer Source = "apiserver"
+)
+
+// Resource is the normalized identity + schema of one API resource, keyed
+// across base and head by (Group, Plural). Plural is always present; Kind may
+// be empty for static Go-backed resources whose kind is not recoverable from
+// the storage registration alone.
+type Resource struct {
+	Group  string
+	Kind   string
+	Plural string
+	Source Source
+	// Origin is the repo-relative path the resource was parsed from, used
+	// only for human-facing reporting.
+	Origin string
+	// Versions maps a served version name to its parsed schema. Empty for
+	// SourceAPIServer resources (schema lives only in Go structs, out of
+	// scope for breaking detection).
+	Versions map[string]Schema
+}
+
+// key is the base/head correlation key for a resource.
+func (r Resource) key() resourceKey { return resourceKey{Group: r.Group, Plural: r.Plural} }
+
+type resourceKey struct {
+	Group  string
+	Plural string
+}
+
+// Schema is a parsed JSON/OpenAPI-v3 schema node, using the generic
+// map[string]any shape produced by sigs.k8s.io/yaml (JSON number/string/bool
+// semantics). Comparing parsed nodes rather than raw text makes the diff
+// insensitive to key ordering and formatting, and lets us ignore purely
+// descriptive fields.
+type Schema map[string]any
+
+// Snapshot is the full set of API resources discovered in one checkout,
+// indexed by correlation key.
+type Snapshot map[resourceKey]Resource
+
+// groups returns the set of API group names present in the snapshot.
+func (s Snapshot) groups() map[string]struct{} {
+	out := make(map[string]struct{})
+	for k := range s {
+		out[k.Group] = struct{}{}
+	}
+	return out
+}
+
+// Finding is one reason a change is sizeable, ready to render into the CI
+// report.
+type Finding struct {
+	Category Category
+	Group    string
+	Kind     string
+	Plural   string
+	Source   Source
+	Origin   string
+	// Detail is a human-readable explanation. For Breaking findings it names
+	// the schema path and the nature of the break.
+	Detail string
+}

--- a/internal/apigate/parse.go
+++ b/internal/apigate/parse.go
@@ -90,6 +90,7 @@ func ParseCRDs(origin string, data []byte) ([]Resource, error) {
 				} `json:"names"`
 				Versions []struct {
 					Name   string `json:"name"`
+					Served bool   `json:"served"`
 					Schema struct {
 						OpenAPIV3Schema Schema `json:"openAPIV3Schema"`
 					} `json:"schema"`
@@ -114,7 +115,11 @@ func ParseCRDs(origin string, data []byte) ([]Resource, error) {
 			Versions: map[string]Schema{},
 		}
 		for _, v := range doc.Spec.Versions {
-			if v.Name == "" {
+			// Only served versions are live API surface. Skipping unserved
+			// versions keeps the classifier from diffing schemas no client can
+			// call, and makes the standard CRD deprecation step (flip
+			// served:true -> false) surface as a removed served version.
+			if v.Name == "" || !v.Served {
 				continue
 			}
 			res.Versions[v.Name] = v.Schema.OpenAPIV3Schema
@@ -137,22 +142,38 @@ var storageVarGroups = map[string]string{
 // apiserverStorageRe matches `<var>["<plural>"]` storage registrations, e.g.
 //
 //	coreV1alpha1Storage["tenantsecrets"] = ...
-var apiserverStorageRe = regexp.MustCompile(`(\w+Storage)\["([a-z0-9]+)"\]`)
+//
+// The plural class allows hyphens so a future hyphenated resource name is not
+// silently dropped. The apps storage map is indexed by a variable
+// (appsV1alpha1Storage[resConfig.Application.Plural]), not a string literal, so
+// it never matches here — the apps API is covered by the cozyrds instead.
+var apiserverStorageRe = regexp.MustCompile(`(\w+Storage)\["([a-z0-9-]+)"\]`)
+
+// unmappedStoragePrefix labels resources whose storage variable prefix is not
+// in storageVarGroups. Rather than silently dropping them — which would let a
+// contributor add a brand-new aggregated group under a new variable and bypass
+// the gate — they are surfaced under this synthetic group so the classifier
+// reports them as a new group/resource, prompting the reviewer to map the
+// prefix in storageVarGroups.
+const unmappedStoragePrefix = "unmapped-apiserver-storage:"
 
 // ParseAPIServerStorages extracts the static Go-backed aggregated resources
-// registered in pkg/apiserver/apiserver.go for the groups in storageVarGroups.
-// These resources carry no checked-in schema, so they populate only the
-// new-group / new-resource detection. Kind is left empty (not recoverable from
-// the registration line alone); reporting falls back to the plural.
+// registered in pkg/apiserver/apiserver.go. Known variable prefixes map to
+// their real group (storageVarGroups); an unknown prefix is surfaced under a
+// synthetic group (unmappedStoragePrefix) so drift cannot silently defeat the
+// gate. These resources carry no checked-in schema, so they populate only the
+// new-group / new-resource / removal detection. Kind is left empty (not
+// recoverable from the registration line alone); reporting falls back to the
+// plural.
 func ParseAPIServerStorages(origin string, data []byte) []Resource {
 	var out []Resource
 	seen := map[resourceKey]struct{}{}
 	for _, m := range apiserverStorageRe.FindAllStringSubmatch(string(data), -1) {
-		group, ok := storageVarGroups[m[1]]
+		prefix, plural := m[1], m[2]
+		group, ok := storageVarGroups[prefix]
 		if !ok {
-			continue
+			group = unmappedStoragePrefix + prefix
 		}
-		plural := m[2]
 		k := resourceKey{Group: group, Plural: plural}
 		if _, dup := seen[k]; dup {
 			continue

--- a/internal/apigate/parse.go
+++ b/internal/apigate/parse.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apigate
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"sigs.k8s.io/yaml"
+)
+
+// appsGroup is the fixed API group served by the cozyrd ApplicationDefinitions.
+const appsGroup = "apps.cozystack.io"
+
+// ParseCozyRD parses an ApplicationDefinition (cozyrd) manifest into a single
+// apps.cozystack.io Resource. The apps group is served at v1alpha1 only, and
+// its per-resource schema lives in spec.application.openAPISchema as an
+// embedded JSON string.
+func ParseCozyRD(origin string, data []byte) (Resource, bool, error) {
+	var doc struct {
+		Kind string `json:"kind"`
+		Spec struct {
+			Application struct {
+				Kind          string `json:"kind"`
+				Plural        string `json:"plural"`
+				OpenAPISchema string `json:"openAPISchema"`
+			} `json:"application"`
+		} `json:"spec"`
+	}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return Resource{}, false, fmt.Errorf("%s: %w", origin, err)
+	}
+	if doc.Kind != "ApplicationDefinition" {
+		return Resource{}, false, nil
+	}
+	app := doc.Spec.Application
+	if app.Plural == "" {
+		return Resource{}, false, fmt.Errorf("%s: ApplicationDefinition has empty spec.application.plural", origin)
+	}
+	res := Resource{
+		Group:    appsGroup,
+		Kind:     app.Kind,
+		Plural:   app.Plural,
+		Source:   SourceCozyRD,
+		Origin:   origin,
+		Versions: map[string]Schema{},
+	}
+	if strings.TrimSpace(app.OpenAPISchema) != "" {
+		var sch Schema
+		if err := json.Unmarshal([]byte(app.OpenAPISchema), &sch); err != nil {
+			return Resource{}, false, fmt.Errorf("%s: spec.application.openAPISchema is not valid JSON: %w", origin, err)
+		}
+		res.Versions["v1alpha1"] = sch
+	}
+	return res, true, nil
+}
+
+// ParseCRDs parses a (possibly multi-document) CustomResourceDefinition YAML
+// file into one Resource per CRD, keyed by spec.group + spec.names.plural with
+// each served version's openAPIV3Schema.
+func ParseCRDs(origin string, data []byte) ([]Resource, error) {
+	var out []Resource
+	for i, docBytes := range splitYAMLDocs(data) {
+		if len(strings.TrimSpace(string(docBytes))) == 0 {
+			continue
+		}
+		var doc struct {
+			Kind string `json:"kind"`
+			Spec struct {
+				Group string `json:"group"`
+				Names struct {
+					Kind   string `json:"kind"`
+					Plural string `json:"plural"`
+				} `json:"names"`
+				Versions []struct {
+					Name   string `json:"name"`
+					Schema struct {
+						OpenAPIV3Schema Schema `json:"openAPIV3Schema"`
+					} `json:"schema"`
+				} `json:"versions"`
+			} `json:"spec"`
+		}
+		if err := yaml.Unmarshal(docBytes, &doc); err != nil {
+			return nil, fmt.Errorf("%s (document %d): %w", origin, i, err)
+		}
+		if doc.Kind != "CustomResourceDefinition" {
+			continue
+		}
+		if doc.Spec.Group == "" || doc.Spec.Names.Plural == "" {
+			return nil, fmt.Errorf("%s (document %d): CRD missing spec.group or spec.names.plural", origin, i)
+		}
+		res := Resource{
+			Group:    doc.Spec.Group,
+			Kind:     doc.Spec.Names.Kind,
+			Plural:   doc.Spec.Names.Plural,
+			Source:   SourceCRD,
+			Origin:   origin,
+			Versions: map[string]Schema{},
+		}
+		for _, v := range doc.Spec.Versions {
+			if v.Name == "" {
+				continue
+			}
+			res.Versions[v.Name] = v.Schema.OpenAPIV3Schema
+		}
+		out = append(out, res)
+	}
+	return out, nil
+}
+
+// storageVarGroups maps the storage-map variable prefixes used in
+// pkg/apiserver/apiserver.go to their API group. The apps map is intentionally
+// omitted: apps.cozystack.io resources are discovered from the cozyrds, which
+// additionally carry their schema. A new entry here (or a new variable prefix
+// in the apiserver) is the signal to extend this table.
+var storageVarGroups = map[string]string{
+	"coreV1alpha1Storage": "core.cozystack.io",
+	"sdnV1alpha1Storage":  "sdn.cozystack.io",
+}
+
+// apiserverStorageRe matches `<var>["<plural>"]` storage registrations, e.g.
+//
+//	coreV1alpha1Storage["tenantsecrets"] = ...
+var apiserverStorageRe = regexp.MustCompile(`(\w+Storage)\["([a-z0-9]+)"\]`)
+
+// ParseAPIServerStorages extracts the static Go-backed aggregated resources
+// registered in pkg/apiserver/apiserver.go for the groups in storageVarGroups.
+// These resources carry no checked-in schema, so they populate only the
+// new-group / new-resource detection. Kind is left empty (not recoverable from
+// the registration line alone); reporting falls back to the plural.
+func ParseAPIServerStorages(origin string, data []byte) []Resource {
+	var out []Resource
+	seen := map[resourceKey]struct{}{}
+	for _, m := range apiserverStorageRe.FindAllStringSubmatch(string(data), -1) {
+		group, ok := storageVarGroups[m[1]]
+		if !ok {
+			continue
+		}
+		plural := m[2]
+		k := resourceKey{Group: group, Plural: plural}
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, Resource{
+			Group:    group,
+			Plural:   plural,
+			Source:   SourceAPIServer,
+			Origin:   origin,
+			Versions: map[string]Schema{},
+		})
+	}
+	return out
+}
+
+// splitYAMLDocs splits a YAML stream into individual document byte slices on
+// `---` separators. It intentionally mirrors the simple splitting Helm and
+// kubectl use; CRD manifests in this repo do not embed `---` inside block
+// scalars, so line-based splitting is safe.
+func splitYAMLDocs(data []byte) [][]byte {
+	parts := regexp.MustCompile(`(?m)^---\s*$`).Split(string(data), -1)
+	out := make([][]byte, 0, len(parts))
+	for _, p := range parts {
+		out = append(out, []byte(p))
+	}
+	return out
+}

--- a/internal/apigate/parse_test.go
+++ b/internal/apigate/parse_test.go
@@ -194,6 +194,24 @@ func TestLoadSnapshotEmptyErrors(t *testing.T) {
 	}
 }
 
+// TestIsFirstPartyGroup covers the subdomain check: only cozystack.io and its
+// dot-delimited subdomains are first-party; a lookalike suffix is not.
+func TestIsFirstPartyGroup(t *testing.T) {
+	cases := map[string]bool{
+		"cozystack.io":                  true,
+		"apps.cozystack.io":             true,
+		"strategy.backups.cozystack.io": true,
+		"fakecozystack.io":              false,
+		"cozystack.io.evil.com":         false,
+		"cert-manager.io":               false,
+	}
+	for group, want := range cases {
+		if got := isFirstPartyGroup(group); got != want {
+			t.Errorf("isFirstPartyGroup(%q) = %v, want %v", group, got, want)
+		}
+	}
+}
+
 // TestLoadSnapshotEndToEnd builds two minimal checkouts on disk and verifies
 // the loader + classifier wire together across all three sources.
 func TestLoadSnapshotEndToEnd(t *testing.T) {

--- a/internal/apigate/parse_test.go
+++ b/internal/apigate/parse_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apigate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const sampleCozyRD = `apiVersion: cozystack.io/v1alpha1
+kind: ApplicationDefinition
+metadata:
+  name: postgres
+spec:
+  application:
+    kind: Postgres
+    singular: postgres
+    plural: postgreses
+    openAPISchema: |-
+      {"type":"object","properties":{"replicas":{"type":"integer","default":2}}}
+`
+
+const sampleCRD = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.cozystack.io
+spec:
+  group: example.cozystack.io
+  names:
+    kind: Widget
+    plural: widgets
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              size:
+                type: string
+`
+
+func TestParseCozyRD(t *testing.T) {
+	r, ok, err := ParseCozyRD("postgres.yaml", []byte(sampleCozyRD))
+	if err != nil || !ok {
+		t.Fatalf("ParseCozyRD failed: ok=%v err=%v", ok, err)
+	}
+	if r.Group != "apps.cozystack.io" || r.Kind != "Postgres" || r.Plural != "postgreses" {
+		t.Fatalf("unexpected identity: %+v", r)
+	}
+	if _, ok := r.Versions["v1alpha1"]; !ok {
+		t.Fatalf("expected v1alpha1 schema, got versions %v", r.Versions)
+	}
+}
+
+func TestParseCRDs(t *testing.T) {
+	rs, err := ParseCRDs("widget.yaml", []byte(sampleCRD))
+	if err != nil {
+		t.Fatalf("ParseCRDs failed: %v", err)
+	}
+	if len(rs) != 1 {
+		t.Fatalf("expected 1 CRD resource, got %d", len(rs))
+	}
+	r := rs[0]
+	if r.Group != "example.cozystack.io" || r.Kind != "Widget" || r.Plural != "widgets" {
+		t.Fatalf("unexpected identity: %+v", r)
+	}
+	if _, ok := r.Versions["v1alpha1"]; !ok {
+		t.Fatalf("expected v1alpha1 schema")
+	}
+}
+
+func TestParseAPIServerStorages(t *testing.T) {
+	src := `
+	coreV1alpha1Storage["tenantsecrets"] = cozyregistry.RESTInPeace(x)
+	sdnV1alpha1Storage["securitygroups"] = cozyregistry.RESTInPeace(y)
+	appsV1alpha1Storage[resConfig.Application.Plural] = cozyregistry.RESTInPeace(z)
+	`
+	rs := ParseAPIServerStorages("apiserver.go", []byte(src))
+	got := map[string]string{}
+	for _, r := range rs {
+		got[r.Plural] = r.Group
+	}
+	if got["tenantsecrets"] != "core.cozystack.io" {
+		t.Fatalf("expected core tenantsecrets, got %v", got)
+	}
+	if got["securitygroups"] != "sdn.cozystack.io" {
+		t.Fatalf("expected sdn securitygroups, got %v", got)
+	}
+	if _, leaked := got["Plural"]; leaked {
+		t.Fatalf("apps dynamic registration must not be captured: %v", got)
+	}
+}
+
+// TestLoadSnapshotEndToEnd builds two minimal checkouts on disk and verifies
+// the loader + classifier wire together across all three sources.
+func TestLoadSnapshotEndToEnd(t *testing.T) {
+	base := t.TempDir()
+	head := t.TempDir()
+
+	write := func(root, rel, content string) {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Base has just Postgres.
+	write(base, "packages/system/postgres-rd/cozyrds/postgres.yaml", sampleCozyRD)
+	// Head keeps Postgres and adds a brand-new CRD group.
+	write(head, "packages/system/postgres-rd/cozyrds/postgres.yaml", sampleCozyRD)
+	write(head, "internal/crdinstall/manifests/example.yaml", sampleCRD)
+
+	baseSnap, err := LoadSnapshot(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	headSnap, err := LoadSnapshot(head)
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings := Classify(baseSnap, headSnap)
+	if countCategory(findings, NewGroup) != 1 {
+		t.Fatalf("expected 1 new-group finding, got %v", findings)
+	}
+}

--- a/internal/apigate/parse_test.go
+++ b/internal/apigate/parse_test.go
@@ -19,6 +19,7 @@ package apigate
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -47,6 +48,8 @@ spec:
   scope: Namespaced
   versions:
   - name: v1alpha1
+    served: true
+    storage: true
     schema:
       openAPIV3Schema:
         type: object
@@ -88,6 +91,40 @@ func TestParseCRDs(t *testing.T) {
 	}
 }
 
+// TestParseCRDsSkipsUnservedVersions covers B7(a): a version flipped to
+// served:false is not live API surface and must be excluded, so the standard
+// CRD deprecation step surfaces later as a removed served version.
+func TestParseCRDsSkipsUnservedVersions(t *testing.T) {
+	const crd = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.cozystack.io
+spec:
+  group: example.cozystack.io
+  names: {kind: Widget, plural: widgets}
+  versions:
+  - name: v1alpha1
+    served: false
+    schema: {openAPIV3Schema: {type: object}}
+  - name: v1beta1
+    served: true
+    schema: {openAPIV3Schema: {type: object}}
+`
+	rs, err := ParseCRDs("widget.yaml", []byte(crd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rs) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(rs))
+	}
+	if _, ok := rs[0].Versions["v1alpha1"]; ok {
+		t.Fatalf("unserved v1alpha1 must be excluded, got versions %v", rs[0].Versions)
+	}
+	if _, ok := rs[0].Versions["v1beta1"]; !ok {
+		t.Fatalf("served v1beta1 must be present, got versions %v", rs[0].Versions)
+	}
+}
+
 func TestParseAPIServerStorages(t *testing.T) {
 	src := `
 	coreV1alpha1Storage["tenantsecrets"] = cozyregistry.RESTInPeace(x)
@@ -107,6 +144,53 @@ func TestParseAPIServerStorages(t *testing.T) {
 	}
 	if _, leaked := got["Plural"]; leaked {
 		t.Fatalf("apps dynamic registration must not be captured: %v", got)
+	}
+}
+
+// TestParseAPIServerStoragesSurfacesUnknownPrefix covers the drift guard: a new
+// aggregated group registered under an unlisted *Storage variable must not be
+// silently dropped, or it would bypass the gate entirely.
+func TestParseAPIServerStoragesSurfacesUnknownPrefix(t *testing.T) {
+	src := `newgroupV1alpha1Storage["foos"] = cozyregistry.RESTInPeace(x)`
+	rs := ParseAPIServerStorages("apiserver.go", []byte(src))
+	if len(rs) != 1 {
+		t.Fatalf("expected the unknown-prefix resource to be surfaced, got %v", rs)
+	}
+	if !strings.HasPrefix(rs[0].Group, unmappedStoragePrefix) {
+		t.Fatalf("unknown prefix must surface under the unmapped group, got %q", rs[0].Group)
+	}
+}
+
+// TestLoadSnapshotDiscoversCRDsUnderChartsCrds covers B6: a first-party CRD that
+// lives in a chart's crds/ directory (rather than a definitions/ dir) is still
+// discovered.
+func TestLoadSnapshotDiscoversCRDsUnderChartsCrds(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, content string) {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("packages/system/foo/charts/foo/crds/example.cozystack.io_widgets.yaml", sampleCRD)
+
+	snap, err := LoadSnapshot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := snap[resourceKey{Group: "example.cozystack.io", Plural: "widgets"}]; !ok {
+		t.Fatalf("CRD under charts/*/crds/ was not discovered: %v", snap)
+	}
+}
+
+// TestLoadSnapshotEmptyErrors covers the silent-bypass guard: an empty result
+// (e.g. wrong directory) must be an error, not a clean pass.
+func TestLoadSnapshotEmptyErrors(t *testing.T) {
+	if _, err := LoadSnapshot(t.TempDir()); err == nil {
+		t.Fatal("expected an error for a directory with no API resources")
 	}
 }
 

--- a/internal/apigate/report.go
+++ b/internal/apigate/report.go
@@ -23,10 +23,15 @@ import (
 
 // categoryTitles gives each category a stable, human-readable heading.
 var categoryTitles = map[Category]string{
-	NewGroup:    "New API group",
-	NewResource: "New resource",
-	Breaking:    "Breaking change to existing API",
+	NewGroup:        "New API group",
+	NewResource:     "New resource",
+	RemovedGroup:    "Removed API group",
+	RemovedResource: "Removed resource",
+	Breaking:        "Breaking change to existing API",
 }
+
+// categoryOrder is the stable order categories are rendered in.
+var categoryOrder = []Category{NewGroup, NewResource, RemovedGroup, RemovedResource, Breaking}
 
 // Report renders findings for CI consumption. format "markdown" (default)
 // produces a PR-comment-friendly summary; any other value produces plain text.
@@ -44,7 +49,7 @@ func Report(findings []Finding, format string) string {
 		b.WriteString("Sizeable API change detected:\n\n")
 	}
 
-	for _, cat := range []Category{NewGroup, NewResource, Breaking} {
+	for _, cat := range categoryOrder {
 		group := findingsOf(findings, cat)
 		if len(group) == 0 {
 			continue
@@ -55,9 +60,8 @@ func Report(findings []Finding, format string) string {
 			fmt.Fprintf(&b, "%s:\n", categoryTitles[cat])
 		}
 		for _, f := range group {
-			bullet := md
-			line := fmt.Sprintf("%s %s — %s (%s)", identity(f), f.Detail, f.Origin, f.Source)
-			if bullet {
+			line := fmt.Sprintf("%s %s — %s (%s)", identity(f, md), f.Detail, f.Origin, f.Source)
+			if md {
 				fmt.Fprintf(&b, "- %s\n", line)
 			} else {
 				fmt.Fprintf(&b, "  - %s\n", line)
@@ -68,12 +72,18 @@ func Report(findings []Finding, format string) string {
 	return b.String()
 }
 
-func identity(f Finding) string {
+// identity renders the resource identity, emphasized only in Markdown mode so
+// text output stays free of markup.
+func identity(f Finding, markdown bool) string {
 	kind := f.Kind
 	if kind == "" {
 		kind = f.Plural
 	}
-	return fmt.Sprintf("**%s/%s**", f.Group, kind)
+	id := fmt.Sprintf("%s/%s", f.Group, kind)
+	if markdown {
+		return "**" + id + "**"
+	}
+	return id
 }
 
 func findingsOf(findings []Finding, cat Category) []Finding {

--- a/internal/apigate/report.go
+++ b/internal/apigate/report.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apigate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// categoryTitles gives each category a stable, human-readable heading.
+var categoryTitles = map[Category]string{
+	NewGroup:    "New API group",
+	NewResource: "New resource",
+	Breaking:    "Breaking change to existing API",
+}
+
+// Report renders findings for CI consumption. format "markdown" (default)
+// produces a PR-comment-friendly summary; any other value produces plain text.
+func Report(findings []Finding, format string) string {
+	if len(findings) == 0 {
+		return "No sizeable API changes detected.\n"
+	}
+	var b strings.Builder
+	md := format != "text"
+
+	if md {
+		b.WriteString("### Sizeable API change detected\n\n")
+		b.WriteString("This change touches the API surface in a way that requires review from a designated API owner.\n\n")
+	} else {
+		b.WriteString("Sizeable API change detected:\n\n")
+	}
+
+	for _, cat := range []Category{NewGroup, NewResource, Breaking} {
+		group := findingsOf(findings, cat)
+		if len(group) == 0 {
+			continue
+		}
+		if md {
+			fmt.Fprintf(&b, "#### %s\n\n", categoryTitles[cat])
+		} else {
+			fmt.Fprintf(&b, "%s:\n", categoryTitles[cat])
+		}
+		for _, f := range group {
+			bullet := md
+			line := fmt.Sprintf("%s %s — %s (%s)", identity(f), f.Detail, f.Origin, f.Source)
+			if bullet {
+				fmt.Fprintf(&b, "- %s\n", line)
+			} else {
+				fmt.Fprintf(&b, "  - %s\n", line)
+			}
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func identity(f Finding) string {
+	kind := f.Kind
+	if kind == "" {
+		kind = f.Plural
+	}
+	return fmt.Sprintf("**%s/%s**", f.Group, kind)
+}
+
+func findingsOf(findings []Finding, cat Category) []Finding {
+	var out []Finding
+	for _, f := range findings {
+		if f.Category == cat {
+			out = append(out, f)
+		}
+	}
+	return out
+}

--- a/internal/apigate/schemadiff.go
+++ b/internal/apigate/schemadiff.go
@@ -1,0 +1,286 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apigate
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// diffSchema walks a base and head OpenAPIv3Schema node in lockstep and
+// returns a description of every *breaking* difference — one that can reject a
+// request or stored object the base schema accepted. Additive changes (a new
+// optional property, a widened type, an added enum value, a relaxed
+// constraint, a changed description or default) return nothing.
+//
+// The rules are deliberately conservative in the safe direction: when a
+// constraint's equivalence cannot be proven cheaply (e.g. a changed regex
+// pattern), the change is treated as breaking rather than risk waving through
+// a real incompatibility.
+func diffSchema(path string, base, head Schema) []string {
+	var out []string
+	diffNode(path, base, head, &out)
+	sort.Strings(out)
+	return out
+}
+
+func diffNode(path string, base, head Schema, out *[]string) {
+	// Type narrowing: any type the base accepted that head no longer accepts
+	// is breaking. Widening (head adds types) is safe.
+	bt, ht := schemaTypes(base), schemaTypes(head)
+	if len(bt) > 0 { // base constrained the type at all
+		if removed := setDiff(bt, ht); len(removed) > 0 {
+			*out = append(*out, fmt.Sprintf("%s: type narrowed, no longer accepts %s", path, strings.Join(removed, "/")))
+		}
+	}
+
+	// Enum: removing an allowed value, or introducing an enum where none
+	// existed, shrinks the accepted set.
+	be, hasBaseEnum := schemaEnum(base)
+	he, hasHeadEnum := schemaEnum(head)
+	switch {
+	case !hasBaseEnum && hasHeadEnum:
+		*out = append(*out, fmt.Sprintf("%s: enum constraint added (previously unrestricted)", path))
+	case hasBaseEnum && hasHeadEnum:
+		if removed := setDiff(be, he); len(removed) > 0 {
+			*out = append(*out, fmt.Sprintf("%s: enum value(s) removed: %s", path, strings.Join(removed, ", ")))
+		}
+	}
+
+	// Pattern: an added or changed regex may reject previously-valid strings.
+	// A removed pattern is a relaxation and is safe.
+	bp := schemaString(base, "pattern")
+	hp := schemaString(head, "pattern")
+	if hp != "" && hp != bp {
+		if bp == "" {
+			*out = append(*out, fmt.Sprintf("%s: pattern constraint added (%q)", path, hp))
+		} else {
+			*out = append(*out, fmt.Sprintf("%s: pattern changed (%q -> %q)", path, bp, hp))
+		}
+	}
+
+	// Numeric and length bounds: a tightened or newly-added bound can reject
+	// previously-valid values.
+	diffLowerBound(path, "minimum", base, head, out)
+	diffLowerBound(path, "minLength", base, head, out)
+	diffLowerBound(path, "minItems", base, head, out)
+	diffUpperBound(path, "maximum", base, head, out)
+	diffUpperBound(path, "maxLength", base, head, out)
+	diffUpperBound(path, "maxItems", base, head, out)
+
+	// Required: a field required in head but not in base breaks clients (and
+	// stored objects) that omit it — whether the field is newly added or was
+	// previously optional.
+	baseReq, headReq := schemaRequired(base), schemaRequired(head)
+	for _, name := range sortedKeys(headReq) {
+		if !baseReq[name] {
+			*out = append(*out, fmt.Sprintf("%s: field %q is now required", path, name))
+		}
+	}
+
+	// Properties: recurse into shared properties; flag removals. A brand-new
+	// property is additive unless it is required (handled above).
+	baseProps, headProps := schemaProps(base), schemaProps(head)
+	for _, name := range sortedKeys(baseProps) {
+		child := childPath(path, name)
+		hp, ok := headProps[name]
+		if !ok {
+			*out = append(*out, fmt.Sprintf("%s: field %q was removed", path, name))
+			continue
+		}
+		diffNode(child, baseProps[name], hp, out)
+	}
+
+	// Map values (additionalProperties as a schema) and array items: recurse so
+	// nested breaks in maps/lists are caught.
+	if b, h, ok := schemaChild(base, head, "additionalProperties"); ok {
+		diffNode(path+"{}", b, h, out)
+	}
+	if b, h, ok := schemaChild(base, head, "items"); ok {
+		diffNode(path+"[]", b, h, out)
+	}
+}
+
+// diffLowerBound flags a lower-bound (minimum/minLength/minItems) that was
+// added or raised — both reject values the base accepted.
+func diffLowerBound(path, key string, base, head Schema, out *[]string) {
+	bv, hasB := schemaNumber(base, key)
+	hv, hasH := schemaNumber(head, key)
+	if !hasH {
+		return
+	}
+	if !hasB {
+		*out = append(*out, fmt.Sprintf("%s: %s constraint added (%s)", path, key, formatNum(hv)))
+	} else if hv > bv {
+		*out = append(*out, fmt.Sprintf("%s: %s raised (%s -> %s)", path, key, formatNum(bv), formatNum(hv)))
+	}
+}
+
+// diffUpperBound flags an upper-bound (maximum/maxLength/maxItems) that was
+// added or lowered.
+func diffUpperBound(path, key string, base, head Schema, out *[]string) {
+	bv, hasB := schemaNumber(base, key)
+	hv, hasH := schemaNumber(head, key)
+	if !hasH {
+		return
+	}
+	if !hasB {
+		*out = append(*out, fmt.Sprintf("%s: %s constraint added (%s)", path, key, formatNum(hv)))
+	} else if hv < bv {
+		*out = append(*out, fmt.Sprintf("%s: %s lowered (%s -> %s)", path, key, formatNum(bv), formatNum(hv)))
+	}
+}
+
+// --- schema field accessors -------------------------------------------------
+
+// schemaTypes returns the set of JSON types a node accepts, gathering both the
+// scalar/array `type` keyword and any `anyOf[].type` (as used by the
+// int-or-string quantity fields). An empty set means "unconstrained".
+func schemaTypes(s Schema) map[string]struct{} {
+	out := map[string]struct{}{}
+	switch t := s["type"].(type) {
+	case string:
+		if t != "" {
+			out[t] = struct{}{}
+		}
+	case []any:
+		for _, v := range t {
+			if str, ok := v.(string); ok {
+				out[str] = struct{}{}
+			}
+		}
+	}
+	if anyOf, ok := s["anyOf"].([]any); ok {
+		for _, v := range anyOf {
+			if sub, ok := v.(map[string]any); ok {
+				if str, ok := sub["type"].(string); ok && str != "" {
+					out[str] = struct{}{}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// schemaEnum returns the enum value set and whether an enum was declared.
+func schemaEnum(s Schema) (map[string]struct{}, bool) {
+	raw, ok := s["enum"].([]any)
+	if !ok {
+		return nil, false
+	}
+	out := make(map[string]struct{}, len(raw))
+	for _, v := range raw {
+		out[fmt.Sprintf("%v", v)] = struct{}{}
+	}
+	return out, true
+}
+
+// schemaRequired returns the set of required property names at a node.
+func schemaRequired(s Schema) map[string]bool {
+	out := map[string]bool{}
+	if raw, ok := s["required"].([]any); ok {
+		for _, v := range raw {
+			if name, ok := v.(string); ok {
+				out[name] = true
+			}
+		}
+	}
+	return out
+}
+
+// schemaProps returns the child property schemas at a node.
+func schemaProps(s Schema) map[string]Schema {
+	out := map[string]Schema{}
+	if raw, ok := s["properties"].(map[string]any); ok {
+		for name, v := range raw {
+			if sub, ok := v.(map[string]any); ok {
+				out[name] = Schema(sub)
+			}
+		}
+	}
+	return out
+}
+
+// schemaChild extracts a named child schema (e.g. items, additionalProperties)
+// from both nodes, reporting ok only when at least one side carries a schema
+// object worth recursing into. A boolean additionalProperties (true/false) is
+// not a recursable schema and yields ok=false.
+func schemaChild(base, head Schema, key string) (Schema, Schema, bool) {
+	b, bOK := base[key].(map[string]any)
+	h, hOK := head[key].(map[string]any)
+	if !bOK && !hOK {
+		return nil, nil, false
+	}
+	return Schema(b), Schema(h), true
+}
+
+func schemaString(s Schema, key string) string {
+	if v, ok := s[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// schemaNumber reads a numeric keyword. JSON numbers decode as float64 through
+// sigs.k8s.io/yaml; integers may also appear as int/int64 depending on the
+// decoder, so both are handled.
+func schemaNumber(s Schema, key string) (float64, bool) {
+	switch v := s[key].(type) {
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	default:
+		return 0, false
+	}
+}
+
+// --- helpers ----------------------------------------------------------------
+
+func childPath(parent, name string) string {
+	return parent + "." + name
+}
+
+func setDiff(a, b map[string]struct{}) []string {
+	var out []string
+	for k := range a {
+		if _, ok := b[k]; !ok {
+			out = append(out, k)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func formatNum(f float64) string {
+	if f == float64(int64(f)) {
+		return fmt.Sprintf("%d", int64(f))
+	}
+	return fmt.Sprintf("%g", f)
+}

--- a/internal/apigate/schemadiff.go
+++ b/internal/apigate/schemadiff.go
@@ -115,6 +115,26 @@ func diffNode(path string, base, head Schema, out *[]string) {
 		*out = append(*out, fmt.Sprintf("%s: validation rule added (%q)", path, rule))
 	}
 
+	// nullable: Kubernetes expresses "may be null" via nullable:true rather than
+	// a "null" entry in the type set. Dropping it rejects previously-valid null
+	// values, so a true -> false/absent transition is breaking.
+	if schemaBool(base, "nullable") && !schemaBool(head, "nullable") {
+		*out = append(*out, fmt.Sprintf("%s: no longer nullable (null values rejected)", path))
+	}
+
+	// Composition keywords (oneOf/allOf/not): introducing one where base had
+	// none can reject previously-valid objects. Conservative like the rest of
+	// the file — flag an addition; removing a composition constraint is a
+	// relaxation and is safe.
+	for _, kw := range []string{"oneOf", "allOf", "not"} {
+		if _, inBase := base[kw]; inBase {
+			continue
+		}
+		if _, inHead := head[kw]; inHead {
+			*out = append(*out, fmt.Sprintf("%s: %s composition constraint added", path, kw))
+		}
+	}
+
 	// Properties: recurse into shared properties; flag removals. A brand-new
 	// property is additive unless it is required (handled above).
 	baseProps, headProps := schemaProps(base), schemaProps(head)
@@ -286,6 +306,13 @@ func schemaString(s Schema, key string) string {
 		return v
 	}
 	return ""
+}
+
+// schemaBool reads a boolean keyword (e.g. nullable), defaulting to false when
+// absent or non-boolean.
+func schemaBool(s Schema, key string) bool {
+	b, _ := s[key].(bool)
+	return b
 }
 
 // schemaNumber reads a numeric keyword. JSON numbers decode as float64 through

--- a/internal/apigate/schemadiff.go
+++ b/internal/apigate/schemadiff.go
@@ -148,21 +148,29 @@ func diffNode(path string, base, head Schema, out *[]string) {
 		diffNode(child, baseProps[name], hp, out)
 	}
 
-	// additionalProperties: restricting it to false rejects previously-allowed
-	// undeclared fields — a breaking change that a boolean value carries and a
-	// schema recursion would miss. Otherwise recurse only when BOTH sides carry
-	// a map schema: a child schema present only in base is a relaxation (its
-	// removal loosens the contract), and diffing it against a nil head would
-	// misreport that relaxation as a break.
-	if base["additionalProperties"] != false && head["additionalProperties"] == false {
+	// additionalProperties governs undeclared fields; its permissiveness runs
+	// false (none) < schema (matching) < true/absent (any).
+	//   - open -> false:        breaking (fields once accepted now rejected)
+	//   - open -> schema:       recurse; adding a schema to a previously-open
+	//                           map is itself a restriction, caught by diffing
+	//                           the new schema against an empty (unconstrained)
+	//                           base.
+	//   - base false -> *:      relaxation (base accepted nothing), so safe.
+	//   - open -> true/absent:  relaxation, safe.
+	baseOpenAP := base["additionalProperties"] != false
+	if baseOpenAP && head["additionalProperties"] == false {
 		*out = append(*out, fmt.Sprintf("%s: additionalProperties restricted to false (undeclared fields no longer accepted)", path))
-	} else if b, h, ok := bothMapSchemas(base, head, "additionalProperties"); ok {
-		diffNode(path+"{}", b, h, out)
+	} else if baseOpenAP {
+		if b, h, ok := childSchemas(base, head, "additionalProperties"); ok {
+			diffNode(path+"{}", b, h, out)
+		}
 	}
 
-	// items: recurse only when both sides define an item schema; removing items
-	// loosens an array's contract and is safe.
-	if b, h, ok := bothMapSchemas(base, head, "items"); ok {
+	// items: recurse whenever head defines an item schema. When base has none,
+	// the head schema is diffed against an empty base so that constraining a
+	// previously-unconstrained array element is caught; a base schema with no
+	// head counterpart is a relaxation and is skipped.
+	if b, h, ok := childSchemas(base, head, "items"); ok {
 		diffNode(path+"[]", b, h, out)
 	}
 }
@@ -267,18 +275,25 @@ func schemaProps(s Schema) map[string]Schema {
 	return out
 }
 
-// bothMapSchemas extracts a named child schema (e.g. items, additionalProperties)
-// from both nodes, reporting ok only when BOTH sides carry a schema object.
-// Requiring both sides is deliberate: a child schema present only in base was
-// removed on head, which loosens the contract (safe), and recursing into it
-// against a nil head would misreport that relaxation as a break. A boolean
-// additionalProperties (true/false) is handled separately by the caller.
-func bothMapSchemas(base, head Schema, key string) (Schema, Schema, bool) {
-	b, bOK := base[key].(map[string]any)
-	h, hOK := head[key].(map[string]any)
-	if !bOK || !hOK {
+// childSchemas extracts a named child schema (items or additionalProperties)
+// for recursion. It reports ok only when HEAD carries a schema object; base's
+// counterpart is returned when present and an empty schema otherwise. The
+// asymmetry is deliberate:
+//   - head schema, base schema   -> diff them (nested changes).
+//   - head schema, base none     -> diff head against an empty base, so that
+//     constraining a previously-unconstrained array element / map value
+//     (base absent or true) surfaces as breaking.
+//   - head none, base schema     -> ok=false: removing a child schema loosens
+//     the contract (relaxation), so it is skipped.
+//
+// A boolean additionalProperties (true/false) is not a schema object and is
+// handled separately by the caller.
+func childSchemas(base, head Schema, key string) (Schema, Schema, bool) {
+	h, ok := head[key].(map[string]any)
+	if !ok {
 		return nil, nil, false
 	}
+	b, _ := base[key].(map[string]any) // nil -> empty (unconstrained) base schema
 	return Schema(b), Schema(h), true
 }
 

--- a/internal/apigate/schemadiff.go
+++ b/internal/apigate/schemadiff.go
@@ -40,10 +40,24 @@ func diffSchema(path string, base, head Schema) []string {
 }
 
 func diffNode(path string, base, head Schema, out *[]string) {
-	// Type narrowing: any type the base accepted that head no longer accepts
-	// is breaking. Widening (head adds types) is safe.
+	// A nil head means the schema at this path was removed entirely. Dropping a
+	// constraint is a widening, never a break, so there is nothing to report.
+	// Callers avoid handing us a nil head for genuine field/version removals
+	// (those are reported by the parent), so this only guards the defensive
+	// case of a child schema that vanished.
+	if head == nil {
+		return
+	}
+
+	// Type constraint changes:
+	//   base unconstrained, head constrained  -> breaking (rejects other types)
+	//   both constrained, head drops a type   -> breaking (narrowing)
+	//   head unconstrained                     -> safe (widening)
 	bt, ht := schemaTypes(base), schemaTypes(head)
-	if len(bt) > 0 { // base constrained the type at all
+	switch {
+	case len(bt) == 0 && len(ht) > 0:
+		*out = append(*out, fmt.Sprintf("%s: type constraint added, now only accepts %s", path, strings.Join(sortedKeys(ht), "/")))
+	case len(bt) > 0 && len(ht) > 0:
 		if removed := setDiff(bt, ht); len(removed) > 0 {
 			*out = append(*out, fmt.Sprintf("%s: type narrowed, no longer accepts %s", path, strings.Join(removed, "/")))
 		}
@@ -93,6 +107,14 @@ func diffNode(path string, base, head Schema, out *[]string) {
 		}
 	}
 
+	// CEL validation rules (x-kubernetes-validations): a rule present in head
+	// but not in base can reject previously-valid values or updates. Removing a
+	// rule is a relaxation and is safe, mirroring how pattern/enum are treated.
+	baseRules, headRules := schemaValidationRules(base), schemaValidationRules(head)
+	for _, rule := range setDiff(headRules, baseRules) {
+		*out = append(*out, fmt.Sprintf("%s: validation rule added (%q)", path, rule))
+	}
+
 	// Properties: recurse into shared properties; flag removals. A brand-new
 	// property is additive unless it is required (handled above).
 	baseProps, headProps := schemaProps(base), schemaProps(head)
@@ -106,12 +128,21 @@ func diffNode(path string, base, head Schema, out *[]string) {
 		diffNode(child, baseProps[name], hp, out)
 	}
 
-	// Map values (additionalProperties as a schema) and array items: recurse so
-	// nested breaks in maps/lists are caught.
-	if b, h, ok := schemaChild(base, head, "additionalProperties"); ok {
+	// additionalProperties: restricting it to false rejects previously-allowed
+	// undeclared fields — a breaking change that a boolean value carries and a
+	// schema recursion would miss. Otherwise recurse only when BOTH sides carry
+	// a map schema: a child schema present only in base is a relaxation (its
+	// removal loosens the contract), and diffing it against a nil head would
+	// misreport that relaxation as a break.
+	if base["additionalProperties"] != false && head["additionalProperties"] == false {
+		*out = append(*out, fmt.Sprintf("%s: additionalProperties restricted to false (undeclared fields no longer accepted)", path))
+	} else if b, h, ok := bothMapSchemas(base, head, "additionalProperties"); ok {
 		diffNode(path+"{}", b, h, out)
 	}
-	if b, h, ok := schemaChild(base, head, "items"); ok {
+
+	// items: recurse only when both sides define an item schema; removing items
+	// loosens an array's contract and is safe.
+	if b, h, ok := bothMapSchemas(base, head, "items"); ok {
 		diffNode(path+"[]", b, h, out)
 	}
 }
@@ -216,17 +247,38 @@ func schemaProps(s Schema) map[string]Schema {
 	return out
 }
 
-// schemaChild extracts a named child schema (e.g. items, additionalProperties)
-// from both nodes, reporting ok only when at least one side carries a schema
-// object worth recursing into. A boolean additionalProperties (true/false) is
-// not a recursable schema and yields ok=false.
-func schemaChild(base, head Schema, key string) (Schema, Schema, bool) {
+// bothMapSchemas extracts a named child schema (e.g. items, additionalProperties)
+// from both nodes, reporting ok only when BOTH sides carry a schema object.
+// Requiring both sides is deliberate: a child schema present only in base was
+// removed on head, which loosens the contract (safe), and recursing into it
+// against a nil head would misreport that relaxation as a break. A boolean
+// additionalProperties (true/false) is handled separately by the caller.
+func bothMapSchemas(base, head Schema, key string) (Schema, Schema, bool) {
 	b, bOK := base[key].(map[string]any)
 	h, hOK := head[key].(map[string]any)
-	if !bOK && !hOK {
+	if !bOK || !hOK {
 		return nil, nil, false
 	}
 	return Schema(b), Schema(h), true
+}
+
+// schemaValidationRules returns the set of CEL rule expressions declared in a
+// node's x-kubernetes-validations, keyed by the rule string so that a reworded
+// or tightened rule reads as a new rule.
+func schemaValidationRules(s Schema) map[string]struct{} {
+	out := map[string]struct{}{}
+	raw, ok := s["x-kubernetes-validations"].([]any)
+	if !ok {
+		return out
+	}
+	for _, v := range raw {
+		if entry, ok := v.(map[string]any); ok {
+			if rule, ok := entry["rule"].(string); ok && rule != "" {
+				out[rule] = struct{}{}
+			}
+		}
+	}
+	return out
 }
 
 func schemaString(s Schema, key string) string {

--- a/internal/apigate/schemadiff_test.go
+++ b/internal/apigate/schemadiff_test.go
@@ -217,6 +217,32 @@ func TestDiffSchema(t *testing.T) {
 			base: `{"type":"object","properties":{"v":{"type":"integer","x-kubernetes-validations":[{"rule":"self > 0"}]}}}`,
 			head: `{"type":"object","properties":{"v":{"type":"integer"}}}`,
 		},
+		// nullable removal is breaking; adding nullable is a widening.
+		{
+			name:     "removing nullable is breaking",
+			base:     `{"type":"object","properties":{"v":{"type":"string","nullable":true}}}`,
+			head:     `{"type":"object","properties":{"v":{"type":"string"}}}`,
+			breaking: true,
+			wantSub:  "no longer nullable",
+		},
+		{
+			name: "adding nullable is safe (widening)",
+			base: `{"type":"object","properties":{"v":{"type":"string"}}}`,
+			head: `{"type":"object","properties":{"v":{"type":"string","nullable":true}}}`,
+		},
+		// oneOf/allOf/not composition added is breaking; removed is safe.
+		{
+			name:     "adding oneOf composition is breaking",
+			base:     `{"type":"object","properties":{"v":{"type":"object"}}}`,
+			head:     `{"type":"object","properties":{"v":{"type":"object","oneOf":[{"required":["a"]},{"required":["b"]}]}}}`,
+			breaking: true,
+			wantSub:  "oneOf composition constraint added",
+		},
+		{
+			name: "removing allOf composition is safe",
+			base: `{"type":"object","properties":{"v":{"type":"object","allOf":[{"required":["a"]}]}}}`,
+			head: `{"type":"object","properties":{"v":{"type":"object"}}}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/apigate/schemadiff_test.go
+++ b/internal/apigate/schemadiff_test.go
@@ -158,6 +158,65 @@ func TestDiffSchema(t *testing.T) {
 			breaking: true,
 			wantSub:  `"x" was removed`,
 		},
+
+		// B1(a): removing a nested constraint entirely is a widening, not a break.
+		{
+			name: "removing items schema is safe (widening)",
+			base: `{"type":"object","properties":{"list":{"type":"array","items":{"type":"string"}}}}`,
+			head: `{"type":"object","properties":{"list":{"type":"array"}}}`,
+		},
+		{
+			name: "removing additionalProperties schema is safe (widening)",
+			base: `{"type":"object","properties":{"m":{"type":"object","additionalProperties":{"type":"string"}}}}`,
+			head: `{"type":"object","properties":{"m":{"type":"object"}}}`,
+		},
+		// B1(b): adding a type to a previously-unconstrained field is breaking.
+		{
+			name:     "adding a type to an unconstrained field is breaking",
+			base:     `{"type":"object","properties":{"v":{}}}`,
+			head:     `{"type":"object","properties":{"v":{"type":"string"}}}`,
+			breaking: true,
+			wantSub:  "type constraint added",
+		},
+		// B1(c): a field becoming unconstrained is a widening, not a break.
+		{
+			name: "field becoming unconstrained is safe (widening)",
+			base: `{"type":"object","properties":{"v":{"type":"string"}}}`,
+			head: `{"type":"object","properties":{"v":{}}}`,
+		},
+		// B2: restricting additionalProperties to false rejects undeclared fields.
+		{
+			name:     "additionalProperties true to false is breaking",
+			base:     `{"type":"object","properties":{"m":{"type":"object","additionalProperties":true}}}`,
+			head:     `{"type":"object","properties":{"m":{"type":"object","additionalProperties":false}}}`,
+			breaking: true,
+			wantSub:  "additionalProperties restricted to false",
+		},
+		{
+			name:     "additionalProperties absent to false is breaking",
+			base:     `{"type":"object","properties":{"m":{"type":"object"}}}`,
+			head:     `{"type":"object","properties":{"m":{"type":"object","additionalProperties":false}}}`,
+			breaking: true,
+			wantSub:  "additionalProperties restricted to false",
+		},
+		{
+			name: "additionalProperties false to true is safe (widening)",
+			base: `{"type":"object","properties":{"m":{"type":"object","additionalProperties":false}}}`,
+			head: `{"type":"object","properties":{"m":{"type":"object","additionalProperties":true}}}`,
+		},
+		// B7(b): CEL validation rules — additions break, removals are safe.
+		{
+			name:     "added CEL validation rule is breaking",
+			base:     `{"type":"object","properties":{"v":{"type":"integer"}}}`,
+			head:     `{"type":"object","properties":{"v":{"type":"integer","x-kubernetes-validations":[{"rule":"self > 0","message":"must be positive"}]}}}`,
+			breaking: true,
+			wantSub:  "validation rule added",
+		},
+		{
+			name: "removed CEL validation rule is safe",
+			base: `{"type":"object","properties":{"v":{"type":"integer","x-kubernetes-validations":[{"rule":"self > 0"}]}}}`,
+			head: `{"type":"object","properties":{"v":{"type":"integer"}}}`,
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/apigate/schemadiff_test.go
+++ b/internal/apigate/schemadiff_test.go
@@ -204,6 +204,27 @@ func TestDiffSchema(t *testing.T) {
 			base: `{"type":"object","properties":{"m":{"type":"object","additionalProperties":false}}}`,
 			head: `{"type":"object","properties":{"m":{"type":"object","additionalProperties":true}}}`,
 		},
+		{
+			name: "additionalProperties false to schema is safe (relaxation)",
+			base: `{"type":"object","properties":{"m":{"type":"object","additionalProperties":false}}}`,
+			head: `{"type":"object","properties":{"m":{"type":"object","additionalProperties":{"type":"string"}}}}`,
+		},
+		// Adding a schema where the map/array element was previously
+		// unconstrained is a restriction and must be flagged.
+		{
+			name:     "adding additionalProperties schema to open map is breaking",
+			base:     `{"type":"object","properties":{"m":{"type":"object"}}}`,
+			head:     `{"type":"object","properties":{"m":{"type":"object","additionalProperties":{"type":"string"}}}}`,
+			breaking: true,
+			wantSub:  "type constraint added",
+		},
+		{
+			name:     "adding items schema to unconstrained array is breaking",
+			base:     `{"type":"object","properties":{"list":{"type":"array"}}}`,
+			head:     `{"type":"object","properties":{"list":{"type":"array","items":{"type":"object","properties":{"foo":{"type":"string"}}}}}}`,
+			breaking: true,
+			wantSub:  "type constraint added",
+		},
 		// B7(b): CEL validation rules — additions break, removals are safe.
 		{
 			name:     "added CEL validation rule is breaking",

--- a/internal/apigate/schemadiff_test.go
+++ b/internal/apigate/schemadiff_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apigate
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// mustSchema parses a JSON schema literal, mirroring how cozyrd openAPISchema
+// strings and CRD openAPIV3Schema nodes decode at runtime.
+func mustSchema(t *testing.T, j string) Schema {
+	t.Helper()
+	var s Schema
+	if err := json.Unmarshal([]byte(j), &s); err != nil {
+		t.Fatalf("bad schema literal: %v", err)
+	}
+	return s
+}
+
+func TestDiffSchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		base     string
+		head     string
+		breaking bool // whether at least one breaking change is expected
+		wantSub  string
+	}{
+		{
+			name: "identical is safe",
+			base: `{"type":"object","properties":{"replicas":{"type":"integer"}}}`,
+			head: `{"type":"object","properties":{"replicas":{"type":"integer"}}}`,
+		},
+		{
+			name: "new optional field is additive",
+			base: `{"type":"object","properties":{"a":{"type":"string"}}}`,
+			head: `{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"integer"}}}`,
+		},
+		{
+			name: "description-only change is safe",
+			base: `{"type":"object","properties":{"a":{"type":"string","description":"old"}}}`,
+			head: `{"type":"object","properties":{"a":{"type":"string","description":"new"}}}`,
+		},
+		{
+			name: "default change is safe",
+			base: `{"type":"object","properties":{"a":{"type":"integer","default":1}}}`,
+			head: `{"type":"object","properties":{"a":{"type":"integer","default":2}}}`,
+		},
+		{
+			name:     "removed field is breaking",
+			base:     `{"type":"object","properties":{"a":{"type":"string"},"b":{"type":"string"}}}`,
+			head:     `{"type":"object","properties":{"a":{"type":"string"}}}`,
+			breaking: true,
+			wantSub:  `"b" was removed`,
+		},
+		{
+			name:     "new required field is breaking",
+			base:     `{"type":"object","properties":{"a":{"type":"string"}}}`,
+			head:     `{"type":"object","required":["b"],"properties":{"a":{"type":"string"},"b":{"type":"string"}}}`,
+			breaking: true,
+			wantSub:  `"b" is now required`,
+		},
+		{
+			name:     "existing optional field becoming required is breaking",
+			base:     `{"type":"object","properties":{"a":{"type":"string"}}}`,
+			head:     `{"type":"object","required":["a"],"properties":{"a":{"type":"string"}}}`,
+			breaking: true,
+			wantSub:  `"a" is now required`,
+		},
+		{
+			name: "new enum value is additive",
+			base: `{"type":"object","properties":{"v":{"type":"string","enum":["a","b"]}}}`,
+			head: `{"type":"object","properties":{"v":{"type":"string","enum":["a","b","c"]}}}`,
+		},
+		{
+			name:     "removed enum value is breaking",
+			base:     `{"type":"object","properties":{"v":{"type":"string","enum":["a","b","c"]}}}`,
+			head:     `{"type":"object","properties":{"v":{"type":"string","enum":["a","b"]}}}`,
+			breaking: true,
+			wantSub:  "enum value(s) removed: c",
+		},
+		{
+			name:     "adding an enum where none existed is breaking",
+			base:     `{"type":"object","properties":{"v":{"type":"string"}}}`,
+			head:     `{"type":"object","properties":{"v":{"type":"string","enum":["a"]}}}`,
+			breaking: true,
+			wantSub:  "enum constraint added",
+		},
+		{
+			name:     "type narrowing is breaking",
+			base:     `{"type":"object","properties":{"v":{"anyOf":[{"type":"integer"},{"type":"string"}]}}}`,
+			head:     `{"type":"object","properties":{"v":{"type":"string"}}}`,
+			breaking: true,
+			wantSub:  "type narrowed",
+		},
+		{
+			name: "type widening is safe",
+			base: `{"type":"object","properties":{"v":{"type":"string"}}}`,
+			head: `{"type":"object","properties":{"v":{"anyOf":[{"type":"integer"},{"type":"string"}]}}}`,
+		},
+		{
+			name:     "added pattern is breaking",
+			base:     `{"type":"object","properties":{"v":{"type":"string"}}}`,
+			head:     `{"type":"object","properties":{"v":{"type":"string","pattern":"^x"}}}`,
+			breaking: true,
+			wantSub:  "pattern constraint added",
+		},
+		{
+			name: "removed pattern is safe",
+			base: `{"type":"object","properties":{"v":{"type":"string","pattern":"^x"}}}`,
+			head: `{"type":"object","properties":{"v":{"type":"string"}}}`,
+		},
+		{
+			name:     "raised minimum is breaking",
+			base:     `{"type":"object","properties":{"n":{"type":"integer","minimum":1}}}`,
+			head:     `{"type":"object","properties":{"n":{"type":"integer","minimum":2}}}`,
+			breaking: true,
+			wantSub:  "minimum raised",
+		},
+		{
+			name: "lowered minimum is safe",
+			base: `{"type":"object","properties":{"n":{"type":"integer","minimum":2}}}`,
+			head: `{"type":"object","properties":{"n":{"type":"integer","minimum":1}}}`,
+		},
+		{
+			name:     "lowered maximum is breaking",
+			base:     `{"type":"object","properties":{"n":{"type":"integer","maximum":10}}}`,
+			head:     `{"type":"object","properties":{"n":{"type":"integer","maximum":5}}}`,
+			breaking: true,
+			wantSub:  "maximum lowered",
+		},
+		{
+			name:     "nested map value break is caught",
+			base:     `{"type":"object","properties":{"users":{"type":"object","additionalProperties":{"type":"object","properties":{"pw":{"type":"string"}}}}}}`,
+			head:     `{"type":"object","properties":{"users":{"type":"object","additionalProperties":{"type":"object","properties":{}}}}}`,
+			breaking: true,
+			wantSub:  `"pw" was removed`,
+		},
+		{
+			name:     "nested array item break is caught",
+			base:     `{"type":"object","properties":{"list":{"type":"array","items":{"type":"object","properties":{"x":{"type":"string"}}}}}}`,
+			head:     `{"type":"object","properties":{"list":{"type":"array","items":{"type":"object","properties":{}}}}}`,
+			breaking: true,
+			wantSub:  `"x" was removed`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := diffSchema("spec", mustSchema(t, tc.base), mustSchema(t, tc.head))
+			if tc.breaking && len(got) == 0 {
+				t.Fatalf("expected a breaking change, got none")
+			}
+			if !tc.breaking && len(got) != 0 {
+				t.Fatalf("expected no breaking change, got: %v", got)
+			}
+			if tc.wantSub != "" {
+				joined := strings.Join(got, "\n")
+				if !strings.Contains(joined, tc.wantSub) {
+					t.Fatalf("expected finding containing %q, got:\n%s", tc.wantSub, joined)
+				}
+			}
+		})
+	}
+}

--- a/internal/apigate/snapshot.go
+++ b/internal/apigate/snapshot.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apigate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// cozyRDGlob matches every ApplicationDefinition backing the apps.cozystack.io
+// aggregated API.
+const cozyRDGlob = "packages/system/*-rd/cozyrds/*.yaml"
+
+// crdGlobs enumerates the directories holding checked-in CustomResourceDefinition
+// manifests for the typed API groups. Kept explicit (rather than a repo-wide
+// scan) so the gate's surface is auditable and a new manifest home is a
+// deliberate one-line addition here.
+var crdGlobs = []string{
+	"internal/crdinstall/manifests/*.yaml",
+	"packages/system/application-definition-crd/definition/*.yaml",
+	"packages/system/backup-controller/definitions/*.yaml",
+	"packages/system/backupstrategy-controller/definitions/*.yaml",
+	"packages/system/cozystack-controller/definitions/*.yaml",
+}
+
+// apiserverGoFile is the source of the static Go-backed aggregated registrations.
+const apiserverGoFile = "pkg/apiserver/apiserver.go"
+
+// LoadSnapshot walks a repository checkout rooted at dir and builds the full
+// API Snapshot from every source of truth: cozyrds (apps API), CRD manifests
+// (typed groups), and the apiserver storage registrations (static Go groups).
+// Files that are absent are skipped so the loader works against historical
+// checkouts predating a given path.
+func LoadSnapshot(dir string) (Snapshot, error) {
+	snap := Snapshot{}
+	add := func(r Resource) {
+		snap[r.key()] = r
+	}
+
+	// Apps API: one Resource per cozyrd.
+	cozyrds, err := filepath.Glob(filepath.Join(dir, filepath.FromSlash(cozyRDGlob)))
+	if err != nil {
+		return nil, err
+	}
+	for _, path := range cozyrds {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, err
+		}
+		res, ok, err := ParseCozyRD(rel(dir, path), data)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			add(res)
+		}
+	}
+
+	// Typed groups: CRD manifests.
+	for _, glob := range crdGlobs {
+		matches, err := filepath.Glob(filepath.Join(dir, filepath.FromSlash(glob)))
+		if err != nil {
+			return nil, err
+		}
+		for _, path := range matches {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return nil, err
+			}
+			resources, err := ParseCRDs(rel(dir, path), data)
+			if err != nil {
+				return nil, err
+			}
+			for _, res := range resources {
+				add(res)
+			}
+		}
+	}
+
+	// Static Go-backed aggregated groups: apiserver registrations.
+	apiserverPath := filepath.Join(dir, filepath.FromSlash(apiserverGoFile))
+	if data, err := os.ReadFile(apiserverPath); err == nil {
+		for _, res := range ParseAPIServerStorages(apiserverGoFile, data) {
+			// Do not overwrite a richer cozyrd/CRD resource that shares the
+			// same (group, plural); the apiserver entry has no schema.
+			if _, exists := snap[res.key()]; !exists {
+				add(res)
+			}
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read %s: %w", apiserverPath, err)
+	}
+
+	return snap, nil
+}
+
+// rel renders a discovered path repo-relative for reporting, falling back to
+// the absolute path if it lies outside dir.
+func rel(dir, path string) string {
+	if r, err := filepath.Rel(dir, path); err == nil {
+		return filepath.ToSlash(r)
+	}
+	return path
+}

--- a/internal/apigate/snapshot.go
+++ b/internal/apigate/snapshot.go
@@ -49,10 +49,17 @@ var crdDirNames = map[string]struct{}{
 // apiserverGoFile is the source of the static Go-backed aggregated registrations.
 const apiserverGoFile = "pkg/apiserver/apiserver.go"
 
-// crdGroupSuffix restricts discovered CRDs to first-party API groups, so
-// vendored upstream CRDs (cert-manager, flux, …) that happen to sit in a crds/
-// directory are not gated.
-const crdGroupSuffix = "cozystack.io"
+// crdGroupBase is the first-party API group family. A discovered CRD is gated
+// only when its group is exactly this or a dot-delimited subdomain of it, so
+// vendored upstream CRDs (cert-manager, flux, …) sitting in a crds/ directory
+// are not gated — and a lookalike such as "fakecozystack.io" is not mistaken
+// for first-party.
+const crdGroupBase = "cozystack.io"
+
+// isFirstPartyGroup reports whether group belongs to the cozystack.io family.
+func isFirstPartyGroup(group string) bool {
+	return group == crdGroupBase || strings.HasSuffix(group, "."+crdGroupBase)
+}
 
 // LoadSnapshot walks a repository checkout rooted at dir and builds the full
 // API Snapshot from every source of truth: cozyrds (apps API), CRD manifests
@@ -102,7 +109,7 @@ func LoadSnapshot(dir string) (Snapshot, error) {
 			continue
 		}
 		for _, res := range resources {
-			if strings.HasSuffix(res.Group, crdGroupSuffix) {
+			if isFirstPartyGroup(res.Group) {
 				add(res)
 			}
 		}

--- a/internal/apigate/snapshot.go
+++ b/internal/apigate/snapshot.go
@@ -18,28 +18,41 @@ package apigate
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // cozyRDGlob matches every ApplicationDefinition backing the apps.cozystack.io
 // aggregated API.
 const cozyRDGlob = "packages/system/*-rd/cozyrds/*.yaml"
 
-// crdGlobs enumerates the directories holding checked-in CustomResourceDefinition
-// manifests for the typed API groups. Kept explicit (rather than a repo-wide
-// scan) so the gate's surface is auditable and a new manifest home is a
-// deliberate one-line addition here.
-var crdGlobs = []string{
-	"internal/crdinstall/manifests/*.yaml",
-	"packages/system/application-definition-crd/definition/*.yaml",
-	"packages/system/backup-controller/definitions/*.yaml",
-	"packages/system/backupstrategy-controller/definitions/*.yaml",
-	"packages/system/cozystack-controller/definitions/*.yaml",
+// crdRoots are the trees walked to discover checked-in CustomResourceDefinition
+// manifests. Within them, only files under a directory named in crdDirNames are
+// parsed, and only CRDs whose group belongs to the cozystack.io family are
+// kept. Discovering CRDs by location + content (rather than an explicit file
+// list) means a first-party CRD that moves — e.g. into a chart's crds/ dir — is
+// still covered here rather than slipping through until an incident.
+var crdRoots = []string{"packages", "internal"}
+
+// crdDirNames are the directory names that hold raw (non-templated) first-party
+// CRD manifests. Helm's crds/ convention and this repo's definitions/ and
+// manifests/ dirs all hold rendered CRDs; templated CRDs live under templates/
+// and are intentionally excluded so we never try to parse Helm markup.
+var crdDirNames = map[string]struct{}{
+	"crds":        {},
+	"definitions": {},
+	"manifests":   {},
 }
 
 // apiserverGoFile is the source of the static Go-backed aggregated registrations.
 const apiserverGoFile = "pkg/apiserver/apiserver.go"
+
+// crdGroupSuffix restricts discovered CRDs to first-party API groups, so
+// vendored upstream CRDs (cert-manager, flux, …) that happen to sit in a crds/
+// directory are not gated.
+const crdGroupSuffix = "cozystack.io"
 
 // LoadSnapshot walks a repository checkout rooted at dir and builds the full
 // API Snapshot from every source of truth: cozyrds (apps API), CRD manifests
@@ -71,22 +84,25 @@ func LoadSnapshot(dir string) (Snapshot, error) {
 		}
 	}
 
-	// Typed groups: CRD manifests.
-	for _, glob := range crdGlobs {
-		matches, err := filepath.Glob(filepath.Join(dir, filepath.FromSlash(glob)))
+	// Typed groups: CRD manifests discovered by location + content.
+	crdFiles, err := discoverCRDFiles(dir)
+	if err != nil {
+		return nil, err
+	}
+	for _, path := range crdFiles {
+		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
-		for _, path := range matches {
-			data, err := os.ReadFile(path)
-			if err != nil {
-				return nil, err
-			}
-			resources, err := ParseCRDs(rel(dir, path), data)
-			if err != nil {
-				return nil, err
-			}
-			for _, res := range resources {
+		resources, err := ParseCRDs(rel(dir, path), data)
+		if err != nil {
+			// A file living in a crds/ or definitions/ dir that does not parse
+			// as YAML is almost always an upstream/templated artifact, not a
+			// first-party CRD; skip it rather than failing the whole gate.
+			continue
+		}
+		for _, res := range resources {
+			if strings.HasSuffix(res.Group, crdGroupSuffix) {
 				add(res)
 			}
 		}
@@ -106,7 +122,48 @@ func LoadSnapshot(dir string) (Snapshot, error) {
 		return nil, fmt.Errorf("read %s: %w", apiserverPath, err)
 	}
 
+	// A zero-resource snapshot means the loader ran against the wrong directory
+	// (or the layout moved out from under every discovery rule). Failing here
+	// prevents the gate from silently passing — "no resources found" must never
+	// be mistaken for "no sizeable change".
+	if len(snap) == 0 {
+		return nil, fmt.Errorf("no API resources discovered under %s; verify the checkout path and directory layout", dir)
+	}
+
 	return snap, nil
+}
+
+// discoverCRDFiles walks the crdRoots under dir and returns the paths of files
+// that sit in a CRD directory (crdDirNames). Content filtering to first-party
+// CRDs happens at parse time in LoadSnapshot.
+func discoverCRDFiles(dir string) ([]string, error) {
+	var out []string
+	for _, root := range crdRoots {
+		base := filepath.Join(dir, root)
+		if _, err := os.Stat(base); os.IsNotExist(err) {
+			continue
+		}
+		err := filepath.WalkDir(base, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if ext := filepath.Ext(path); ext != ".yaml" && ext != ".yml" {
+				return nil
+			}
+			if _, ok := crdDirNames[filepath.Base(filepath.Dir(path))]; !ok {
+				return nil
+			}
+			out = append(out, path)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
 }
 
 // rel renders a discovered path repo-relative for reporting, falling back to


### PR DESCRIPTION
## What this PR does

Adds a CI gate that requires an approving review from a designated API owner (`lllamnyp` or `kvaps`) when a pull request makes a **sizeable** change to the Cozystack API surface. Sizeable means one of:

1. A new API group.
2. A new resource.
3. A breaking change to an existing resource's schema.
4. Removal of a resource or an entire API group.

Detection is fully deterministic — no LLM or network calls, so it runs on every PR.

### How it works

- **`cmd/api-gate` + `internal/apigate`** — a small Go tool that loads the API surface from two checkouts (merge base and PR head) and classifies the delta. Every resource's schema is normalized to a parsed OpenAPIv3Schema; the tool only unwraps it from its two container formats and reads identity (group/kind/plural) from the wrapper.

  | Surface | Files scanned | Schema source |
  | --- | --- | --- |
  | Apps (`apps.cozystack.io`) | `packages/system/*-rd/cozyrds/*.yaml` | `spec.application.openAPISchema` |
  | Typed groups (`cozystack.io`, `backups.*`, `network.*`, `gateway.*`) | every `*.cozystack.io` CRD discovered under a `crds/` or `definitions/` directory in `packages/` and `internal/` | served `spec.versions[].schema.openAPIV3Schema` |
  | Static Go-backed (`core.*`, `sdn.*`) | `pkg/apiserver/apiserver.go` storage registrations | none — new/removed group / resource only |

  CRDs are found by location + content rather than a fixed file list, so a first-party CRD that moves (e.g. into a chart's `crds/` dir) stays covered. Only `served` CRD versions count as live API surface, so the standard deprecation step (`served: true → false`) registers as a removed version. An empty snapshot is treated as an error, never a silent pass.

- **Breaking classification is semantic, not textual.** Additive changes (new optional field, new enum value, widened type, relaxed or removed constraint, description/default edits) pass. Flagged as breaking: removed fields, type narrowing (including adding a type to a previously-unconstrained field), enum-value removal, newly-required fields, added/tightened `pattern`/min/max/length constraints, `additionalProperties` restricted to `false`, added `x-kubernetes-validations` (CEL) rules, and removed served versions.

- **`.github/workflows/api-review-gate.yaml`** builds the tool, diffs the PR head against its true **merge base**, and — when the change is sizeable — requires an `APPROVED` review from an API owner. Only each reviewer's *latest* review *on the current head commit* counts, so a stale or superseded approval no longer satisfies the gate. It re-runs on `pull_request_review` so an approval flips the check without a new push. The token is scoped to the approval step alone (`persist-credentials: false` on checkout) so PR-controlled build steps can't read it. The allowlist lives in one place (`API_OWNERS`). The job runs on every PR (no path filter) so it can safely be marked a required check.

### Follow-up needed after merge

Mark **"Require API owner review for sizeable API changes"** as a required status check in `main` branch protection for the gate to block merges.

### Tests

Table-driven unit tests cover the schema-diff rules, the classifier (new group / new resource / breaking, including the double-count and pure-removal edge cases), all three parsers, and an on-disk end-to-end snapshot test. Verified against the real repo tree: identical trees pass; injected new-group/new-resource/breaking changes are all caught; an additive-only edit passes.

### Release note

```release-note
feat(ci): require a review from an API owner (lllamnyp or kvaps) when a PR introduces a new API group, a new resource, or a breaking change to an existing API schema
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API review gate workflow that flags “sizeable” API changes and requires at least one approving API-owner review.
  * Introduced an API-gate CLI to compare API snapshots, classify changes (new/removed resources and groups, plus breaking schema updates), and generate readable reports.
  * Enhanced snapshot parsing and deterministic reporting across multiple input sources.
* **Tests**
  * Added comprehensive unit tests covering parsing, snapshot loading, schema diff detection, and classification/report output behavior.
* **Chores**
  * Updated API gate ownership rules for the new workflow and related tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->