### PR TITLE
fix(cozystack-api): pin the image to the build that ships the SecurityGroup API

### DIFF
--- a/packages/system/cozystack-api/values.yaml
+++ b/packages/system/cozystack-api/values.yaml
@@ -1,3 +1,3 @@
 cozystackAPI:
-  image: ghcr.io/cozystack/cozystack/cozystack-api:v1.5.0@sha256:ef50b155e419cf8f0b4d57af9fa385ecbacd5c1248f13591ffcca75c2f9f2a07
+  image: ghcr.io/cozystack/cozystack/cozystack-api:v0.0.0@sha256:e272d098cb0ab5a8bce3c3509350dce0847d752920e0effc7ecb9c97bafc24f8
   replicas: 2


### PR DESCRIPTION
## What

Pin `packages/system/cozystack-api/values.yaml` to the current main-HEAD cozystack-api build that carries the `sdn.cozystack.io` SecurityGroup API.

## Why

#2922 added the SecurityGroup API to cozystack-api, but main's committed image is still the `v1.5.0` release, which predates it. cozystack-api was only rebuilt **transiently** inside #2922's own E2E (via the per-PR digest patch) and that digest was never committed to main.

Consequence: any PR that does not itself rebuild cozystack-api installs the old apiserver, so the aggregated `v1alpha1.sdn.cozystack.io` APIService has no backing implementation and `kubectl get securitygroup` returns *"the server doesn't have a resource type"*. The **securitygroup** and **serviceexposure** e2e tests therefore fail on every unrelated PR, blocking main.

## How

The image is mirrored to ghcr from the #2922 build (amd64, digest `e272d098…`) and pinned by digest. This is a stopgap so unrelated PRs stop failing; a normal release should re-pin cozystack-api through the standard build.

Companion to the securitygroup-controller placeholder image being unpublished (same class of gap — a newly-added in-house image not committed after merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the API service to a newer container image version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->