### PR TITLE
fix(etcd): clean up orphaned data PVCs and TLS secrets on tenant module delete (#3090)

### DIFF
--- a/packages/extra/etcd/Makefile
+++ b/packages/extra/etcd/Makefile
@@ -6,5 +6,6 @@ generate:
 	cozyvalues-gen -v values.yaml -s values.schema.json -r README.md
 	../../../hack/update-crd.sh
 
+.PHONY: test
 test:
 	helm unittest .

--- a/packages/extra/etcd/templates/hooks/cleanup.yaml
+++ b/packages/extra/etcd/templates/hooks/cleanup.yaml
@@ -1,0 +1,134 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "delete"]
+  # cert-manager TLS secrets carry only the cluster-wide
+  # controller.cert-manager.io/fao label, and the two pre-install "keep"
+  # secrets carry none, so we grant delete by explicit resourceNames rather
+  # than an unsafe label sweep that could hit a sibling app's secrets.
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "delete"]
+    resourceNames:
+      - etcd-peer-ca-tls
+      - etcd-ca-tls
+      - etcd-server-tls
+      - etcd-peer-tls
+      - etcd-client-tls
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-cleanup
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-cleanup
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  activeDeadlineSeconds: 120
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        policy.cozystack.io/allow-to-apiserver: "true"
+    spec:
+      serviceAccountName: {{ .Release.Name }}-cleanup
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: cleanup
+          image: docker.io/clastix/kubectl:v1.32
+          env:
+            - name: HOME
+              value: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              # The EtcdCluster is named "etcd" (check-release-name pins the
+              # release name to "etcd"), so its StatefulSet volumeClaimTemplate
+              # PVCs are named data-etcd-<ordinal>, one per replica. The
+              # etcd-operator does not garbage-collect them on EtcdCluster
+              # deletion, so we delete them here by name (safe: no sibling
+              # workload shares the data-etcd-* prefix in a tenant namespace).
+              echo "Deleting orphaned etcd data PVCs for {{ .Release.Name }}..."
+              kubectl delete pvc -n {{ .Release.Namespace }} {{ range $i := until (int .Values.replicas) }}data-etcd-{{ $i }} {{ end }}--ignore-not-found --wait=false \
+                || echo "WARNING: etcd PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
+              # etcd-ca-tls / etcd-client-tls are pre-install "keep" secrets
+              # this chart owns; etcd-peer-ca-tls / etcd-server-tls /
+              # etcd-peer-tls are cert-manager-issued secrets with no owner
+              # reference. None are reclaimed by the uninstall, so delete them
+              # by name.
+              echo "Deleting orphaned etcd TLS secrets for {{ .Release.Name }}..."
+              kubectl delete secret -n {{ .Release.Namespace }} etcd-peer-ca-tls etcd-ca-tls etcd-server-tls etcd-peer-tls etcd-client-tls --ignore-not-found --wait=false \
+                || echo "WARNING: etcd secret cleanup failed for {{ .Release.Name }}; orphaned secrets may remain" >&2
+              echo "etcd cleanup complete."

--- a/packages/extra/etcd/templates/hooks/cleanup.yaml
+++ b/packages/extra/etcd/templates/hooks/cleanup.yaml
@@ -21,9 +21,16 @@ metadata:
     "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
+  # The Job deletes the data PVCs by their deterministic per-replica names
+  # (data-etcd-<ordinal>), so we grant delete by explicit resourceNames rather
+  # than a namespace-wide PVC delete that could hit a sibling workload's PVC.
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "delete"]
+    verbs: ["get", "delete"]
+    resourceNames:
+{{- range $i := until (int .Values.replicas) }}
+      - data-etcd-{{ $i }}
+{{- end }}
   # cert-manager TLS secrets carry only the cluster-wide
   # controller.cert-manager.io/fao label, and the two pre-install "keep"
   # secrets carry none, so we grant delete by explicit resourceNames rather

--- a/packages/extra/etcd/templates/hooks/cleanup.yaml
+++ b/packages/extra/etcd/templates/hooks/cleanup.yaml
@@ -1,3 +1,11 @@
+{{- /*
+  Clamp the replica count to at least 1 so an explicit replicas: 0 cannot
+  render an empty resourceNames list below — an empty resourceNames in an RBAC
+  rule matches ALL PVCs in the namespace (a wildcard), which would silently
+  undo the least-privilege scoping. data-etcd-0 always exists for any running
+  cluster, and the delete uses --ignore-not-found, so the clamp is safe.
+*/}}
+{{- $replicaCount := max 1 (int .Values.replicas) | int }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -28,7 +36,7 @@ rules:
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "delete"]
     resourceNames:
-{{- range $i := until (int .Values.replicas) }}
+{{- range $i := until $replicaCount }}
       - data-etcd-{{ $i }}
 {{- end }}
   # cert-manager TLS secrets carry only the cluster-wide
@@ -128,7 +136,7 @@ spec:
               # deletion, so we delete them here by name (safe: no sibling
               # workload shares the data-etcd-* prefix in a tenant namespace).
               echo "Deleting orphaned etcd data PVCs for {{ .Release.Name }}..."
-              kubectl delete pvc -n {{ .Release.Namespace }} {{ range $i := until (int .Values.replicas) }}data-etcd-{{ $i }} {{ end }}--ignore-not-found --wait=false \
+              kubectl delete pvc -n {{ .Release.Namespace }} {{ range $i := until $replicaCount }}data-etcd-{{ $i }} {{ end }}--ignore-not-found --wait=false \
                 || echo "WARNING: etcd PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
               # etcd-ca-tls / etcd-client-tls are pre-install "keep" secrets
               # this chart owns; etcd-peer-ca-tls / etcd-server-tls /

--- a/packages/extra/etcd/tests/cleanup_test.yaml
+++ b/packages/extra/etcd/tests/cleanup_test.yaml
@@ -183,3 +183,29 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: 'kubectl delete pvc -n tenant-root data-etcd-0 data-etcd-1 data-etcd-2 data-etcd-3 data-etcd-4 --ignore-not-found --wait=false'
+
+  # An explicit replicas: 0 must NOT render an empty resourceNames list — an
+  # empty resourceNames in an RBAC rule matches every PVC in the namespace
+  # (a wildcard), which would silently undo the least-privilege scoping. The
+  # $replicaCount clamp keeps at least data-etcd-0 in both the Role and command.
+  - it: clamps to one PVC name when replicas is 0 so RBAC never becomes a wildcard
+    set:
+      replicas: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["persistentvolumeclaims"]
+            verbs: ["get", "delete"]
+            resourceNames:
+              - data-etcd-0
+        documentSelector:
+          path: kind
+          value: Role
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kubectl delete pvc -n tenant-root data-etcd-0 --ignore-not-found --wait=false'
+        documentSelector:
+          path: kind
+          value: Job

--- a/packages/extra/etcd/tests/cleanup_test.yaml
+++ b/packages/extra/etcd/tests/cleanup_test.yaml
@@ -1,0 +1,167 @@
+suite: etcd post-delete cleanup hook removes orphaned PVCs and TLS secrets
+templates:
+  - templates/hooks/cleanup.yaml
+
+release:
+  name: etcd
+  namespace: tenant-root
+
+# After the etcd tenant module is disabled (etcd: false), the etcd-operator
+# StatefulSet data PVCs (data-etcd-{0,1,2}) are never garbage-collected, and
+# the five etcd-*-tls secrets are left orphaned in the tenant namespace:
+#   - etcd-ca-tls / etcd-client-tls are created by this chart as pre-install
+#     hooks with helm.sh/resource-policy: keep, so Helm deliberately keeps them.
+#   - etcd-peer-ca-tls / etcd-server-tls / etcd-peer-tls are populated by
+#     cert-manager from Certificate resources and carry no owner reference back
+#     to the chart, so they survive the uninstall.
+# The check-release-name.tpl guard pins .Release.Name to "etcd", so every
+# target name is deterministic. This post-delete hook renders a Job (plus its
+# RBAC) that deletes the data PVCs by name (one per replica) and the five
+# secrets by name.
+
+tests:
+  - it: renders the cleanup ServiceAccount as a post-delete hook
+    documentSelector:
+      path: kind
+      value: ServiceAccount
+    asserts:
+      - equal:
+          path: metadata.name
+          value: etcd-cleanup
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-delete
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "0"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+
+  - it: grants delete on PVCs and only the 5 named TLS secrets
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "5"
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["persistentvolumeclaims"]
+            verbs: ["get", "list", "delete"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["secrets"]
+            verbs: ["get", "delete"]
+            resourceNames:
+              - etcd-peer-ca-tls
+              - etcd-ca-tls
+              - etcd-server-tls
+              - etcd-peer-tls
+              - etcd-client-tls
+
+  - it: binds the cleanup Role to the cleanup ServiceAccount
+    documentSelector:
+      path: kind
+      value: RoleBinding
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "5"
+      - equal:
+          path: roleRef.name
+          value: etcd-cleanup
+      - equal:
+          path: subjects[0].kind
+          value: ServiceAccount
+      - equal:
+          path: subjects[0].name
+          value: etcd-cleanup
+
+  - it: renders a hardened cleanup Job with the right hook metadata
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: metadata.name
+          value: etcd-cleanup
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-delete
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "10"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 120
+      - equal:
+          path: spec.template.metadata.labels["policy.cozystack.io/allow-to-apiserver"]
+          value: "true"
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: etcd-cleanup
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: docker.io/clastix/kubectl:v1.32
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65534
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 10m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 64Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 200m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 128Mi
+
+  - it: deletes one data PVC per replica and the five TLS secrets by name
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kubectl delete pvc -n tenant-root data-etcd-0 data-etcd-1 data-etcd-2 --ignore-not-found --wait=false'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kubectl delete secret -n tenant-root etcd-peer-ca-tls etcd-ca-tls etcd-server-tls etcd-peer-tls etcd-client-tls --ignore-not-found --wait=false'
+
+  - it: scales the PVC list to the configured replica count
+    documentSelector:
+      path: kind
+      value: Job
+    set:
+      replicas: 5
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kubectl delete pvc -n tenant-root data-etcd-0 data-etcd-1 data-etcd-2 data-etcd-3 data-etcd-4 --ignore-not-found --wait=false'

--- a/packages/extra/etcd/tests/cleanup_test.yaml
+++ b/packages/extra/etcd/tests/cleanup_test.yaml
@@ -44,14 +44,26 @@ tests:
       value: Role
     asserts:
       - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-delete
+      - equal:
           path: metadata.annotations["helm.sh/hook-weight"]
           value: "5"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+      # PVC deletes are scoped to the deterministic per-replica names, not a
+      # namespace-wide delete, so a regression cannot reach a sibling's PVC.
       - contains:
           path: rules
           content:
             apiGroups: [""]
             resources: ["persistentvolumeclaims"]
-            verbs: ["get", "list", "delete"]
+            verbs: ["get", "delete"]
+            resourceNames:
+              - data-etcd-0
+              - data-etcd-1
+              - data-etcd-2
       - contains:
           path: rules
           content:
@@ -71,8 +83,14 @@ tests:
       value: RoleBinding
     asserts:
       - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-delete
+      - equal:
           path: metadata.annotations["helm.sh/hook-weight"]
           value: "5"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
       - equal:
           path: roleRef.name
           value: etcd-cleanup


### PR DESCRIPTION
## What this PR does

When the `etcd` tenant module is disabled (`etcd: false`), the etcd HelmRelease is pruned but two classes of resources leak into the tenant namespace (reported in #3090):

- **Data PVCs** — the etcd-operator StatefulSet `volumeClaimTemplate` PVCs `data-etcd-<ordinal>` are never garbage-collected on `EtcdCluster` deletion.
- **TLS secrets** — the five `etcd-*-tls` secrets survive the uninstall:
  - `etcd-ca-tls` / `etcd-client-tls` are created by this chart as `pre-install` hooks with `helm.sh/resource-policy: keep`, so Helm deliberately keeps them;
  - `etcd-peer-ca-tls` / `etcd-server-tls` / `etcd-peer-tls` are populated by cert-manager from `Certificate` resources and carry no owner reference back to the chart.

This adds a `post-delete` cleanup hook (`packages/extra/etcd/templates/hooks/cleanup.yaml`), modeled on the accepted seaweedfs (#3092) and monitoring (#3091) sibling fixes, that:

- deletes the data PVCs by name, one per replica (`data-etcd-0 … data-etcd-<replicas-1>`);
- deletes the five `etcd-*-tls` secrets by name.

`check-release-name` pins the release name to `etcd`, so every target name is deterministic and no sibling workload shares the `data-etcd-*` prefix in a tenant namespace — deletion by name is safe. cert-manager TLS secrets carry only the cluster-wide `controller.cert-manager.io/fao` label, so the RBAC grants `delete` by explicit `resourceNames` rather than an unsafe label sweep.

The cleanup Job is hardened: non-root, read-only root fs, dropped capabilities, `seccompProfile: RuntimeDefault`, resource requests/limits, `activeDeadlineSeconds`. Deletes use `--ignore-not-found` and failures are logged but never block teardown.

A Helm unit-test suite (`tests/cleanup_test.yaml`) asserts the hook metadata/RBAC/hardening and that the rendered commands target exactly the reported PVCs and secrets, including scaling the PVC list to the configured replica count.

> [!NOTE]
> The **stuck HelmRelease finalizer** noted in #3090 is the platform-wide sharded-helm-controller side-bug (tracked separately); it affects every `chartRef`-based tenant module identically, not just etcd. This PR fixes the PVC and secret orphans the etcd chart itself owns, matching the scope of the merged seaweedfs/monitoring fixes.

> [!WARNING]
> **Disabling the etcd module now permanently deletes its data PVCs and the etcd data they hold.** This is intentional and fixes the storage leak. Back up before disabling if the data matters.

Fixes #3090.

### Release note

```release-note
fix(etcd): garbage-collect the orphaned etcd data PVCs (data-etcd-*) and the five etcd-*-tls secrets left behind when a tenant's etcd module is disabled. WARNING: disabling etcd now permanently removes its data PVCs and the data they hold.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Helm post-delete cleanup hook for etcd that removes per-replica etcd PVCs and the related TLS secrets when a release is deleted.
  * Cleanup permissions and targets now scale with replica count, including safe handling when replicas are set to zero.
* **Tests**
  * Added Helm unit tests validating hook annotations/order, scoped RBAC, secure job hardening, and the exact deletion behavior for PVCs/secrets (including higher-replica scenarios).
* **Chores**
  * Marked the `test` make target as phony for the etcd package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->