### PR TITLE
fix(cozy-lib,harbor,mariadb): digest-pin cleanup-hook kubectl image and route it through cozy-lib.images-registry

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,14 @@
       "managerFilePatterns": ["/^packages/extra/etcd/templates/etcd-cluster\\.yaml$/"],
       "matchStrings": ["image:\\s+(?<depName>quay\\.io/coreos/etcd):(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Track and keep fresh the clastix/kubectl image digest-pinned in the post-delete cleanup hooks. The ref is assembled at render time by the cozy-lib.image helper (routed through cozy-lib.images-registry so mirrored / air-gapped installs resolve it), so it is neither a Dockerfile nor a go.mod dependency and the built-in managers cannot see it. The helm-values manager is disabled repo-wide (see enabledManagers above), so without this regex manager the digest — a supply-chain pin — would silently age.",
+      "managerFilePatterns": ["/^packages/.+/templates/hooks/.+\\.yaml$/"],
+      "matchStrings": ["clastix/kubectl:(?<currentValue>v[0-9]+\\.[0-9]+(?:\\.[0-9]+)?)@(?<currentDigest>sha256:[a-f0-9]+)"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "docker.io/clastix/kubectl"
     }
   ],
   "packageRules": [

--- a/packages/apps/harbor/templates/hooks/cleanup.yaml
+++ b/packages/apps/harbor/templates/hooks/cleanup.yaml
@@ -27,7 +27,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cleanup
-          image: docker.io/clastix/kubectl:v1.32
+          # Digest-pinned (immutable) and routed through the cluster images
+          # registry via cozy-lib.image, so mirrored / air-gapped installs
+          # resolve it and an upstream retag cannot change what runs at
+          # uninstall. The tag+digest is refreshed by the "clastix/kubectl"
+          # custom Renovate manager in .github/renovate.json (the helm-values
+          # manager is disabled repo-wide), so this pin does not silently age.
+          image: {{ include "cozy-lib.image" (list "clastix/kubectl:v1.32@sha256:b9ef7d8dbe65bcc81a46c09b8dc7543103055021c4f43287bf59e92a8f4fe05c" $) }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/packages/apps/harbor/tests/cleanup_hook_test.yaml
+++ b/packages/apps/harbor/tests/cleanup_hook_test.yaml
@@ -74,6 +74,60 @@ tests:
           path: spec.template.spec.containers[0].command[2]
           pattern: kubectl delete[^\n]*-l acme.cert-manager.io/http01-solver=true
 
+  - it: pins the cleanup image by digest and routes it through the images registry
+    documentIndex: 0
+    asserts:
+      # The image must be digest-pinned (immutable) rather than a moving tag,
+      # and must NOT hardcode docker.io so a mirrored/air-gapped registry can be
+      # prefixed via cozy-lib.image. Asserted by pattern (not an exact digest)
+      # so a Renovate tag/digest bump does not break the test.
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^clastix/kubectl:v[0-9]+\.[0-9]+(\.[0-9]+)?@sha256:[0-9a-f]{64}$
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: docker\.io
+
+  - it: prefixes the cleanup image with the cluster images registry when set
+    documentIndex: 0
+    set:
+      _cluster:
+        images-registry: registry.example.com
+    asserts:
+      # A mirrored / air-gapped install resolves the image from the internal
+      # registry; the digest pin is preserved.
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^registry\.example\.com/clastix/kubectl:v[0-9]+\.[0-9]+(\.[0-9]+)?@sha256:[0-9a-f]{64}$
+
+  - it: leaves no leading slash when the images registry is empty (default)
+    documentIndex: 0
+    asserts:
+      # With images-registry defaulting to "", the rendered ref must still be a
+      # valid image reference (no leading "/") so a standard install resolves it.
+      # The "^clastix" anchor proves there is no leading slash and no registry.
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^clastix/kubectl:v[0-9]+\.[0-9]+(\.[0-9]+)?@sha256:[0-9a-f]{64}$
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^/
+
+  - it: does not emit a double slash when the images registry has a trailing slash
+    documentIndex: 0
+    set:
+      _cluster:
+        images-registry: registry.example.com/
+    asserts:
+      # A misconfigured registry with a trailing "/" must not yield
+      # "registry.example.com//clastix/..." — the helper trims it.
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^registry\.example\.com/clastix/kubectl:v[0-9]+\.[0-9]+(\.[0-9]+)?@sha256:[0-9a-f]{64}$
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: //
+
   - it: sets resource requests and limits on the cleanup container
     documentIndex: 0
     asserts:

--- a/packages/apps/mariadb/templates/hooks/cleanup-pvc.yaml
+++ b/packages/apps/mariadb/templates/hooks/cleanup-pvc.yaml
@@ -26,7 +26,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cleanup
-          image: docker.io/clastix/kubectl:v1.32
+          # Digest-pinned (immutable) and routed through the cluster images
+          # registry via cozy-lib.image, so mirrored / air-gapped installs
+          # resolve it and an upstream retag cannot change what runs at
+          # uninstall. The tag+digest is refreshed by the "clastix/kubectl"
+          # custom Renovate manager in .github/renovate.json (the helm-values
+          # manager is disabled repo-wide), so this pin does not silently age.
+          image: {{ include "cozy-lib.image" (list "clastix/kubectl:v1.32@sha256:b9ef7d8dbe65bcc81a46c09b8dc7543103055021c4f43287bf59e92a8f4fe05c" $) }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/packages/apps/mariadb/tests/cleanup_pvc_hook_test.yaml
+++ b/packages/apps/mariadb/tests/cleanup_pvc_hook_test.yaml
@@ -1,0 +1,75 @@
+suite: mariadb post-delete cleanup hook
+templates:
+  - templates/hooks/cleanup-pvc.yaml
+
+release:
+  name: mariadb-test
+  namespace: tenant-root
+
+tests:
+  - it: renders the cleanup Job as a post-delete hook
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: kind
+          value: Job
+      - equal:
+          path: metadata.name
+          value: mariadb-test-cleanup
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-delete
+
+  - it: pins the cleanup image by digest and routes it through the images registry
+    documentIndex: 0
+    asserts:
+      # The image must be digest-pinned (immutable) rather than a moving tag,
+      # and must NOT hardcode docker.io so a mirrored/air-gapped registry can be
+      # prefixed via cozy-lib.image. Asserted by pattern (not an exact digest)
+      # so a Renovate tag/digest bump does not break the test.
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^clastix/kubectl:v[0-9]+\.[0-9]+(\.[0-9]+)?@sha256:[0-9a-f]{64}$
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: docker\.io
+
+  - it: prefixes the cleanup image with the cluster images registry when set
+    documentIndex: 0
+    set:
+      _cluster:
+        images-registry: registry.example.com
+    asserts:
+      # A mirrored / air-gapped install resolves the image from the internal
+      # registry; the digest pin is preserved.
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^registry\.example\.com/clastix/kubectl:v[0-9]+\.[0-9]+(\.[0-9]+)?@sha256:[0-9a-f]{64}$
+
+  - it: leaves no leading slash when the images registry is empty (default)
+    documentIndex: 0
+    asserts:
+      # With images-registry defaulting to "", the rendered ref must still be a
+      # valid image reference (no leading "/") so a standard install resolves it.
+      # The "^clastix" anchor proves there is no leading slash and no registry.
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^clastix/kubectl:v[0-9]+\.[0-9]+(\.[0-9]+)?@sha256:[0-9a-f]{64}$
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^/
+
+  - it: does not emit a double slash when the images registry has a trailing slash
+    documentIndex: 0
+    set:
+      _cluster:
+        images-registry: registry.example.com/
+    asserts:
+      # A misconfigured registry with a trailing "/" must not yield
+      # "registry.example.com//clastix/..." — the helper trims it.
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^registry\.example\.com/clastix/kubectl:v[0-9]+\.[0-9]+(\.[0-9]+)?@sha256:[0-9a-f]{64}$
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: //

--- a/packages/library/cozy-lib/templates/_cozyconfig.tpl
+++ b/packages/library/cozy-lib/templates/_cozyconfig.tpl
@@ -24,7 +24,28 @@ Get the images registry.
 Usage: {{ include "cozy-lib.images-registry" . }}
 */}}
 {{- define "cozy-lib.images-registry" -}}
-{{- (index .Values._cluster "images-registry") | default "" }}
+{{- (index (.Values._cluster | default dict) "images-registry") | default "" }}
+{{- end }}
+
+{{/*
+Build a fully-qualified image reference routed through the cluster images
+registry. Pass the registry-relative image path (repository + tag, ideally
+digest-pinned) and the global context.
+Usage: {{ include "cozy-lib.image" (list "clastix/kubectl:v1.32@sha256:..." $) }}
+When images-registry is set (mirrored / air-gapped installs) it is prefixed as
+"<registry>/<image>"; when empty (the default on a standard install) the image
+is returned unchanged so it resolves from its default registry — importantly
+with no leading "/", which would otherwise be an invalid reference.
+A trailing "/" on the registry and a leading "/" on the image path are trimmed
+so a misconfigured images-registry ("registry.example.com/") cannot produce a
+double slash in the rendered reference.
+*/}}
+{{- define "cozy-lib.image" -}}
+{{- include "cozy-lib.checkInput" . }}
+{{- $image := index . 0 | trimPrefix "/" }}
+{{- $ctx := index . 1 }}
+{{- $registry := include "cozy-lib.images-registry" $ctx | trimSuffix "/" }}
+{{- with $registry }}{{ . }}/{{ end }}{{ $image }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
## What this PR does

Fixes #3088.

The post-delete cleanup Jobs in the **harbor** and **mariadb** charts hardcoded the cleanup image as `docker.io/clastix/kubectl:v1.32` — a moving Docker Hub tag. This:

- **broke reproducibility / was a supply-chain risk** — `v1.32` is mutable and can be re-pushed to a different image;
- **could not be satisfied on air-gapped / mirrored clusters** — the hardcoded `docker.io` bypassed the cluster images registry, and it failed at the worst moment: during **uninstall**, when the `post-delete` hook runs and a stuck Job stalls release teardown.

### Changes

- **New canonical helper `cozy-lib.image`** (`packages/library/cozy-lib/templates/_cozyconfig.tpl`). Given a registry-relative image path and the global context, it prefixes `cozy-lib.images-registry` when set (`<registry>/<image>`) and returns the image unchanged when empty — **with no leading `/`**, so standard installs still resolve from the default registry. This establishes the previously-undefined "how to reference a cluster image" pattern (`images-registry` was defined but never consumed).
- **Digest-pinned image** in both cleanup hooks: `clastix/kubectl:v1.32@sha256:b9ef7d8dbe65bcc81a46c09b8dc7543103055021c4f43287bf59e92a8f4fe05c` (the immutable multi-arch OCI index for the `v1.32` tag; the same digest already pinned for `postgres-operator`'s webhook hook).
- **Renovate keeps the pin fresh.** The repo disables the helm-values manager (`enabledManagers`), and the ref is assembled at render time by the helper rather than being a Dockerfile / go.mod dependency, so the built-in managers can't see it. A `custom.regex` manager over the hook templates tracks `clastix/kubectl` by tag+digest — mirroring the existing `extra/etcd` manager — so the supply-chain pin doesn't silently age.
- **Hardened `cozy-lib.images-registry`** against a nil `.Values._cluster` so the helper never crashes the render — relevant precisely because this hook renders during teardown.
- **Helm unit tests** in both charts assert the rendered image for three cases: empty registry (default), registry set, and the no-leading-slash edge case. Assertions match by **pattern** (routed + digest-pinned + no leading slash) rather than an exact digest, so a Renovate bump keeps them green.

### Verification

- `helm unittest` passes for both charts (harbor: 16, mariadb: 10).
- Real `helm template` renders confirmed for both charts:
  - empty registry → `clastix/kubectl:v1.32@sha256:b9ef…`
  - `images-registry=registry.internal:5000` → `registry.internal:5000/clastix/kubectl:v1.32@sha256:b9ef…`
- The Renovate `matchStrings` regex verified to capture `currentValue=v1.32` and the digest from both hook templates.

### Note on the wider footprint

The same `docker.io/clastix/kubectl:v1.32` hardcode is already merged on `main` in several other cleanup hooks (bucket, qdrant, gateway, seaweedfs, kubernetes, tenant, dashboard, keycloak-configure) and appears in the open PRs #3170 (etcd), #3094 (monitoring), #3072 (clickhouse). This PR fixes harbor + mariadb per the issue and establishes the `cozy-lib.image` + Renovate pattern; migrating the remaining hooks is a follow-up.

### Release note

```release-note
fix(cozy-lib,harbor,mariadb): digest-pin the harbor and mariadb post-delete cleanup-hook kubectl image and route it through the cluster images registry (`cozy-lib.images-registry`) via the new `cozy-lib.image` helper, so mirrored / air-gapped installs can resolve it and uninstall no longer depends on a moving Docker Hub tag; a custom Renovate manager keeps the digest fresh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated post-delete cleanup hook Jobs to use digest-pinned container images for more secure, repeatable execution.
  * Improved image reference rendering so cleanup hooks work correctly with or without an image registry configured, avoiding invalid leading/trailing slash issues.
* **Tests**
  * Extended cleanup hook rendering tests to validate digest pinning and correct registry prefix behavior, including edge cases.
* **Chores**
  * Enhanced automated dependency detection to treat digest-pinned hook image references as stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->