### PR TITLE
fix(dashboard): show LoadBalancer external IP on the app Services tab

### DIFF
--- a/packages/system/dashboard/images/console/apps/console/src/routes/detail/ServicesTab.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/detail/ServicesTab.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { screen, waitFor, cleanup } from "@testing-library/react"
+import { K8sClient } from "@cozystack/k8s-client"
+import { renderWithK8sProvider } from "../../test-utils/render.tsx"
+import { ServicesTab } from "./ServicesTab.tsx"
+import type { ApplicationDefinition, ApplicationInstance } from "@cozystack/types"
+
+const ad: ApplicationDefinition = {
+  apiVersion: "cozystack.io/v1alpha1",
+  kind: "ApplicationDefinition",
+  metadata: { name: "http-cache" },
+  spec: {
+    application: {
+      kind: "HTTPCache",
+      plural: "httpcaches",
+      singular: "http-cache",
+      openAPISchema: "{}",
+    },
+  },
+}
+
+const instance: ApplicationInstance = {
+  apiVersion: "apps.cozystack.io/v1alpha1",
+  kind: "HTTPCache",
+  metadata: { name: "demo", namespace: "tenant-root" },
+}
+
+function makeClient(items: unknown[]) {
+  const client = new K8sClient()
+  vi.spyOn(client, "list").mockResolvedValue({
+    apiVersion: "v1",
+    kind: "List",
+    metadata: {},
+    items,
+  })
+  vi.spyOn(client, "watch").mockReturnValue(() => {})
+  return client
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe("ServicesTab external IP", () => {
+  it("shows the LoadBalancer external IP from status, not just the cluster IP", async () => {
+    const client = makeClient([
+      {
+        metadata: { name: "demo", namespace: "tenant-root" },
+        spec: { type: "LoadBalancer", clusterIP: "10.96.1.2", ports: [{ port: 80 }] },
+        status: { loadBalancer: { ingress: [{ ip: "192.0.2.50" }] } },
+      },
+    ])
+    renderWithK8sProvider(<ServicesTab ad={ad} instance={instance} />, { client })
+
+    // Regression for #3111: the assigned MetalLB IP must be surfaced, not hidden.
+    await waitFor(() => expect(screen.getByText("192.0.2.50")).toBeInTheDocument())
+    expect(screen.getByText("10.96.1.2")).toBeInTheDocument()
+  })
+
+  it("falls back to the hostname, then to Pending, for a LoadBalancer", async () => {
+    const client = makeClient([
+      {
+        metadata: { name: "by-host", namespace: "tenant-root" },
+        spec: { type: "LoadBalancer", clusterIP: "10.96.1.3", ports: [{ port: 443 }] },
+        status: { loadBalancer: { ingress: [{ hostname: "lb.example.com" }] } },
+      },
+      {
+        metadata: { name: "pending", namespace: "tenant-root" },
+        spec: { type: "LoadBalancer", clusterIP: "10.96.1.4", ports: [{ port: 443 }] },
+        status: {},
+      },
+    ])
+    renderWithK8sProvider(<ServicesTab ad={ad} instance={instance} />, { client })
+
+    await waitFor(() => expect(screen.getByText("lb.example.com")).toBeInTheDocument())
+    expect(screen.getByText("Pending")).toBeInTheDocument()
+  })
+
+  it("does not show an external IP for a ClusterIP service", async () => {
+    const client = makeClient([
+      {
+        metadata: { name: "internal", namespace: "tenant-root" },
+        spec: { type: "ClusterIP", clusterIP: "10.96.1.5", ports: [{ port: 8080 }] },
+      },
+    ])
+    renderWithK8sProvider(<ServicesTab ad={ad} instance={instance} />, { client })
+
+    await waitFor(() => expect(screen.getByText("internal")).toBeInTheDocument())
+    expect(screen.queryByText("Pending")).not.toBeInTheDocument()
+    // The External IP cell renders an em dash for non-LoadBalancer services.
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0)
+  })
+})

--- a/packages/system/dashboard/images/console/apps/console/src/routes/detail/ServicesTab.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/detail/ServicesTab.tsx
@@ -10,6 +10,12 @@ interface ServiceSpec {
   ports?: { port: number; protocol?: string; name?: string }[]
 }
 
+interface ServiceStatus {
+  loadBalancer?: {
+    ingress?: { ip?: string; hostname?: string }[]
+  }
+}
+
 export function ServicesTab({
   ad,
   instance,
@@ -18,7 +24,7 @@ export function ServicesTab({
   instance: ApplicationInstance
 }) {
   const ns = instance.metadata.namespace ?? ""
-  const { data, isLoading } = useK8sList<K8sResource<ServiceSpec>>(
+  const { data, isLoading } = useK8sList<K8sResource<ServiceSpec, ServiceStatus>>(
     { apiGroup: "", apiVersion: "v1", plural: "services", namespace: ns },
     { labelSelector: appInstanceLabel(ad, instance) },
   )
@@ -40,32 +46,43 @@ export function ServicesTab({
                 <th className="px-4 py-3">Name</th>
                 <th className="px-4 py-3">Type</th>
                 <th className="px-4 py-3">Cluster IP</th>
+                <th className="px-4 py-3">External IP</th>
                 <th className="px-4 py-3">Ports</th>
                 <th className="px-4 py-3">Age</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100">
-              {items.map((svc) => (
-                <tr key={svc.metadata.name} className="hover:bg-slate-50">
-                  <td className="px-4 py-3 font-mono text-xs text-slate-800">
-                    {svc.metadata.name}
-                  </td>
-                  <td className="px-4 py-3 text-slate-700">
-                    {svc.spec?.type ?? "ClusterIP"}
-                  </td>
-                  <td className="px-4 py-3 font-mono text-xs text-slate-600">
-                    {svc.spec?.clusterIP ?? "—"}
-                  </td>
-                  <td className="px-4 py-3 text-slate-700">
-                    {svc.spec?.ports
-                      ?.map((p) => `${p.port}/${p.protocol ?? "TCP"}`)
-                      .join(", ") ?? "—"}
-                  </td>
-                  <td className="px-4 py-3 tabular-nums text-slate-500">
-                    {formatAge(svc.metadata.creationTimestamp)}
-                  </td>
-                </tr>
-              ))}
+              {items.map((svc) => {
+                const lb = svc.status?.loadBalancer?.ingress?.[0]
+                const external =
+                  svc.spec?.type === "LoadBalancer"
+                    ? (lb?.ip ?? lb?.hostname ?? "Pending")
+                    : "—"
+                return (
+                  <tr key={svc.metadata.name} className="hover:bg-slate-50">
+                    <td className="px-4 py-3 font-mono text-xs text-slate-800">
+                      {svc.metadata.name}
+                    </td>
+                    <td className="px-4 py-3 text-slate-700">
+                      {svc.spec?.type ?? "ClusterIP"}
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs text-slate-600">
+                      {svc.spec?.clusterIP ?? "—"}
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs text-slate-700">
+                      {external}
+                    </td>
+                    <td className="px-4 py-3 text-slate-700">
+                      {svc.spec?.ports
+                        ?.map((p) => `${p.port}/${p.protocol ?? "TCP"}`)
+                        .join(", ") ?? "—"}
+                    </td>
+                    <td className="px-4 py-3 tabular-nums text-slate-500">
+                      {formatAge(svc.metadata.creationTimestamp)}
+                    </td>
+                  </tr>
+                )
+              })}
             </tbody>
           </table>
         )}


### PR DESCRIPTION
## What this PR does

For an application exposed with `external: true` (which creates a `type: LoadBalancer` Service), the app detail → **Services** tab showed the service Type and Cluster IP but not the external IP assigned by MetalLB — so there was no way to learn the connection address from the per-app view. The pre-1.4.0 dashboard showed this, so it read as a regression (reported in #2789).

Root cause: `ServicesTab.tsx` queried Services with a spec-only local type (`{ type, clusterIP, ports }`) and never read `status.loadBalancer.ingress[]`. The data was already reachable — `ExternalIpsPage.tsx` renders it — so this was a wiring gap in the per-app tab, not missing data.

Changes:
- Add a `ServiceStatus` type and extend the `useK8sList` query to `K8sResource<ServiceSpec, ServiceStatus>`.
- Add an **External IP** column: `ip ?? hostname ?? "Pending"` for `LoadBalancer` services, `—` otherwise — mirroring `ExternalIpsPage`.
- Add a co-located regression test (`ServicesTab.test.tsx`) covering the IP, hostname→Pending fallback, and the ClusterIP no-external case.

Verified: `pnpm typecheck` clean, `pnpm test` green (320 tests, incl. 3 new), `eslint` clean on the changed files.

Fixes #3111

### Screenshots
<img width="1220" height="572" alt="Снимок экрана 2026-07-02 в 14 12 11" src="https://github.com/user-attachments/assets/82cd1da8-ff81-4b95-a6bf-18729b6c85c7" />


### Release note

```release-note
fix(dashboard): show the external LoadBalancer IP on the per-app Services tab
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an **External IP** column to the service details view.
  * Load balancer services now show the external IP or hostname when available.

* **Bug Fixes**
  * Fixed the external IP display for load balancer services so it no longer misses valid IPs.
  * Improved fallback behavior by showing **Pending** when no external endpoint is assigned.
  * Non-load balancer services now show an em dash instead of misleading external IP text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->