### PR TITLE
feat(keycloak): add S3 backup for the CNPG database

### DIFF
--- a/packages/system/keycloak/templates/backup-secret.yaml
+++ b/packages/system/keycloak/templates/backup-secret.yaml
@@ -1,0 +1,18 @@
+{{/*
+  S3 credentials for the Keycloak CNPG backup. Rendered only when backups
+  are enabled with inline keys; skipped when backup.existingSecretName
+  points at a pre-provisioned Secret carrying AWS_ACCESS_KEY_ID /
+  AWS_SECRET_ACCESS_KEY.
+*/}}
+{{- if and .Values.backup.enabled .Values.backup.destinationPath (not .Values.backup.existingSecretName) }}
+{{- $accessKey := required "backup.s3AccessKey is required when backup.enabled=true and existingSecretName is unset" .Values.backup.s3AccessKey -}}
+{{- $secretKey := required "backup.s3SecretKey is required when backup.enabled=true and existingSecretName is unset" .Values.backup.s3SecretKey -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-db-backup-s3-creds
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: {{ $accessKey | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ $secretKey | quote }}
+{{- end }}

--- a/packages/system/keycloak/templates/backup.yaml
+++ b/packages/system/keycloak/templates/backup.yaml
@@ -1,13 +1,16 @@
 {{/*
   Scheduled S3 backup of the Keycloak CNPG database.
 
-  Rendered only when both backup.enabled and backup.schedule are set. The
-  Cluster's spec.backup.barmanObjectStore (see db.yaml) is what actually
-  configures WAL archiving + the object store; this ScheduledBackup drives
-  the recurring base backups. CNPG rejects an empty schedule, so the gate
-  keeps invalid manifests off the cluster.
+  Rendered only when backup.enabled, backup.destinationPath and
+  backup.schedule are all set. The destinationPath gate must match db.yaml /
+  backup-secret.yaml: without it the Cluster gets no spec.backup.barmanObjectStore,
+  so a ScheduledBackup would target a Cluster with no object store and CNPG
+  would perpetually fail it. CNPG also rejects an empty schedule.
+
+  NOTE: schedule is a 6-field cron (leading seconds field), not the 5-field
+  Kubernetes CronJob format.
 */}}
-{{- if and .Values.backup.enabled .Values.backup.schedule }}
+{{- if and .Values.backup.enabled .Values.backup.destinationPath .Values.backup.schedule }}
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:

--- a/packages/system/keycloak/templates/backup.yaml
+++ b/packages/system/keycloak/templates/backup.yaml
@@ -1,0 +1,20 @@
+{{/*
+  Scheduled S3 backup of the Keycloak CNPG database.
+
+  Rendered only when both backup.enabled and backup.schedule are set. The
+  Cluster's spec.backup.barmanObjectStore (see db.yaml) is what actually
+  configures WAL archiving + the object store; this ScheduledBackup drives
+  the recurring base backups. CNPG rejects an empty schedule, so the gate
+  keeps invalid manifests off the cluster.
+*/}}
+{{- if and .Values.backup.enabled .Values.backup.schedule }}
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: keycloak-db
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  backupOwnerReference: self
+  cluster:
+    name: keycloak-db
+{{- end }}

--- a/packages/system/keycloak/templates/db.yaml
+++ b/packages/system/keycloak/templates/db.yaml
@@ -18,6 +18,27 @@ spec:
         cnpg.io/cluster: keycloak-db
   {{- end }}
   {{- end }}
+  {{- if and .Values.backup.enabled .Values.backup.destinationPath }}
+  {{- $credSecret := .Values.backup.existingSecretName | default "keycloak-db-backup-s3-creds" }}
+  backup:
+    barmanObjectStore:
+      destinationPath: {{ .Values.backup.destinationPath | quote }}
+      {{- with .Values.backup.endpointURL }}
+      endpointURL: {{ . | quote }}
+      {{- end }}
+      s3Credentials:
+        accessKeyId:
+          name: {{ $credSecret }}
+          key: AWS_ACCESS_KEY_ID
+        secretAccessKey:
+          name: {{ $credSecret }}
+          key: AWS_SECRET_ACCESS_KEY
+      data:
+        compression: gzip
+      wal:
+        compression: gzip
+    retentionPolicy: {{ .Values.backup.retentionPolicy | quote }}
+  {{- end }}
   monitoring:
     enablePodMonitor: true
 

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -116,3 +116,25 @@ encryption:
       cpu: 50m
     limits:
       memory: 256Mi
+
+# Scheduled S3 backup of the Keycloak CNPG database (keycloak-db).
+# Disabled by default; enabling it configures WAL archiving + base backups
+# to an S3-compatible object store via CNPG Barman.
+backup:
+  # Enable S3 backups for keycloak-db.
+  enabled: false
+  # Cron schedule for recurring base backups (CNPG rejects an empty schedule).
+  schedule: "0 2 * * *"
+  # Barman retention policy for stored backups.
+  retentionPolicy: "30d"
+  # Destination prefix, e.g. s3://bucket/keycloak-db/.
+  destinationPath: ""
+  # S3-compatible endpoint URL, e.g. https://s3.example.com.
+  endpointURL: ""
+  # Inline S3 credentials (rendered into keycloak-db-backup-s3-creds), or
+  # leave empty and set existingSecretName instead.
+  s3AccessKey: ""
+  s3SecretKey: ""
+  # Reference an existing Secret carrying AWS_ACCESS_KEY_ID /
+  # AWS_SECRET_ACCESS_KEY instead of inline keys.
+  existingSecretName: ""

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -123,8 +123,9 @@ encryption:
 backup:
   # Enable S3 backups for keycloak-db.
   enabled: false
-  # Cron schedule for recurring base backups (CNPG rejects an empty schedule).
-  schedule: "0 2 * * *"
+  # Cron schedule for recurring base backups. NOTE: CNPG ScheduledBackup uses a
+  # 6-field cron (leading seconds field), not the 5-field Kubernetes format.
+  schedule: "0 0 2 * * *"
   # Barman retention policy for stored backups.
   retentionPolicy: "30d"
   # Destination prefix, e.g. s3://bucket/keycloak-db/.


### PR DESCRIPTION
## What this PR does

Adds optional scheduled S3 backups for the `keycloak-db` CloudNativePG cluster.

When `backup.enabled=true` with a `backup.destinationPath`, the Cluster gets
`spec.backup.barmanObjectStore` (gzip-compressed data + WAL streams, a
configurable `retentionPolicy`) and a `ScheduledBackup` drives recurring base
backups. S3 credentials are either inlined into a rendered
`keycloak-db-backup-s3-creds` Secret, or referenced via
`backup.existingSecretName` (a Secret carrying `AWS_ACCESS_KEY_ID` /
`AWS_SECRET_ACCESS_KEY`).

Disabled by default — no change to existing deployments; the object store
coordinates and credentials are supplied per-environment by the operator.

This is the Keycloak/Postgres half of backing up a Cozystack portal control
plane. The portal-side etcd backups (system Talos etcd + api-server etcd) live
in the companion downstream PR aenix-org/cozyportal#1008.

### Release note

```release-note
feat(keycloak): add optional S3 backups (CNPG Barman) for the Keycloak database, configurable via `backup.*` values and disabled by default.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable scheduled backups for the Keycloak CNPG database to an S3-compatible object store, including destination prefix, optional endpoint URL, retention policy, and cron schedule.
  * Backups and scheduled backup resources are only created when all required backup settings are provided, avoiding incomplete configuration.
  * Supports backup credentials via inline values (creates the needed Secret automatically) or via an existing Secret reference.
* **Documentation**
  * Added guidance on the cron schedule format required for the scheduler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->