### PR TITLE
fix(kubernetes): parallel worker VM provisioning on tenant cluster create

### DIFF
--- a/hack/e2e-apps/run-kubernetes.sh
+++ b/hack/e2e-apps/run-kubernetes.sh
@@ -349,6 +349,36 @@ EOF
     # (c) carry the 2a-vs-2b split; adding real in-guest capture later requires
     # wiring a tenant talosconfig into the runner first.
     echo "=== (b) in-guest Talos/kubelet capture skipped: no tenant talosconfig on the runner (a/c cover the 2a-vs-2b split) ==="
+
+    # (d) CAPI / CAPK / Kamaji-CP / CABPT / Kamaji / CDI / LINSTOR-CSI
+    # controller-manager logs (management cluster). Sections (a) and (c)
+    # answer WHERE the worker stalled (VMI provisioning vs kubelet CSR);
+    # (d) answers WHY the reconcile fired that late, which the object dumps
+    # alone cannot show. The primary suspect is a 5-to-10-minute gap
+    # between "Machine №1 Ready" and "MachineSet.ScalingUp to 2" on the
+    # first tenant-cluster rollout — the CAPI controllers are the only
+    # place that gap is legible. MachineDeployment.status.conditions plus
+    # capi-controller-manager reconcile events pin it down.
+    #
+    # Scoped to --since=15m: the test budget is 12m plus the pre-timeout
+    # ramp, and unbounded logs from busy reconcilers would blow past the
+    # GitHub Actions per-step log size cap. --all-containers is required
+    # because CAPI providers ship metrics / kube-rbac-proxy sidecars whose
+    # errors sometimes carry the actual reason (RBAC denial, admission
+    # webhook timeout) the primary container swallows.
+    #
+    # Guarded with `|| true` end-to-end so a controller pod that died
+    # (thereby giving us no logs to fetch) never masks the real `exit 1`.
+    echo "=== (d) CAPI / CAPK / Kamaji-CP / CABPT / CDI / LINSTOR-CSI controller logs (management cluster, last 15m) ==="
+    for ns in cozy-cluster-api cozy-kamaji cozy-kubevirt-cdi cozy-linstor; do
+      echo "--- namespace/${ns}: pod inventory ---"
+      kubectl -n "${ns}" get pods -o wide 2>&1 || true
+      for pod in $(kubectl -n "${ns}" get pods -o name 2>/dev/null); do
+        echo "--- ${pod} @ ${ns} ---"
+        kubectl -n "${ns}" logs "${pod}" --all-containers=true --prefix --timestamps --since=15m 2>&1 || true
+      done
+    done
+
     exit 1
   fi
   kubectl --kubeconfig "tenantkubeconfig-${test_name}" get nodes -o wide


### PR DESCRIPTION
## Summary

Tenant Kubernetes clusters currently take ~13 minutes to reach 2 Ready
workers even though a single worker boots in ~5. The recurring
`kubernetes-latest.bats` / `kubernetes-previous.bats` node-join
timeouts (12m budget) are the symptom; the root cause is a 5- to
10-minute gap between "Machine №1 Ready" and "MachineSet.ScalingUp to
2" on the first tenant-cluster rollout — worker provisioning happens
serially instead of in parallel.

This PR is opened as **draft** and lands in two stages:

1. Diagnostics patch (this commit) that captures controller-manager
   logs on failure, so the next CI cycle produces the reconcile
   timeline needed to pin the root cause to CAPI / CAPK / Kamaji-CP /
   CABPT / CDI / LINSTOR-CSI. Without those logs any chart-side fix
   would be guesswork.
2. Chart-side fix + `run-kubernetes.sh` wait predicate fix, appended
   as separate commits once (1) points at a specific reconciler.

## What (so far)

- `hack/e2e-apps/run-kubernetes.sh:352` — extend the existing
  node-join failure diagnostic block with section (d): 15-minute
  window of controller-manager logs across `cozy-cluster-api`,
  `cozy-kamaji`, `cozy-kubevirt-cdi`, `cozy-linstor`, timestamped,
  all-containers, guarded with `|| true`. Happy path untouched.

## Why

Sections (a) and (c) tell us WHERE the worker stalled (VMI/DV vs
tenant kubelet CSR). Neither shows WHY the reconcile fired late —
that lives in controller-manager reconcile events and rate-limiter
backoffs.

Snapshot from cozystack/cozystack#3044 CI run 28568334647
demonstrates the pattern:

\`\`\`
MachineSet.status.conditions[?type=ScalingUp]:
  lastTransitionTime: 2026-07-02T06:45:17Z
  message: \"Scaling up MachineSet to 2 replicas (actual 1)\"
\`\`\`

The first Machine had been Ready since 06:40:39 — a ~5-minute idle
gap before ScalingUp fired, with no visible reconciler activity in the
current diagnostic dump.

## Test plan

- [x] \`bash -n hack/e2e-apps/run-kubernetes.sh\` passes (shell syntax).
- [ ] E2E cycle triggered by this push produces a section (d)
      controller log dump on the next \`kubernetes-latest.bats\`
      or \`kubernetes-previous.bats\` failure.
- [ ] Root cause identified from those logs; follow-up commit applies
      the fix in \`packages/apps/kubernetes/templates/cluster.yaml\`
      strategy block and switches the \`.status.replicas\` wait to
      \`.status.readyReplicas\` in \`hack/e2e-apps/run-kubernetes.sh:275\`.
- [ ] Verified on dev3: two \`Machine\` objects created within 30s of
      each other; both nodes Ready in ~7m.
- [ ] Draft removed once \`kubernetes-latest.bats\` and
      \`kubernetes-previous.bats\` both pass on this branch.