### PR TITLE
fix(ci): catch templated CRDs and APIService-only groups in the API gate

### DIFF
--- a/internal/apigate/model.go
+++ b/internal/apigate/model.go
@@ -62,6 +62,12 @@ const (
 	// schema, so they participate only in new-group / new-resource
 	// detection.
 	SourceAPIServer Source = "apiserver"
+	// SourceAPIService is a group/version registered via a kind: APIService
+	// manifest, delegating to an aggregated apiserver that may be built
+	// entirely outside this repository (no vendored Go types, no CRD). Like
+	// SourceAPIServer, these carry no checked-in schema, so they participate
+	// only in new-group / new-resource / removal detection.
+	SourceAPIService Source = "apiservice"
 )
 
 // Resource is the normalized identity + schema of one API resource, keyed

--- a/internal/apigate/parse.go
+++ b/internal/apigate/parse.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apigate
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -87,53 +88,73 @@ func ParseCRDs(origin string, data []byte) ([]Resource, error) {
 		if len(strings.TrimSpace(string(docBytes))) == 0 {
 			continue
 		}
-		var doc struct {
-			Kind string `json:"kind"`
-			Spec struct {
-				Group string `json:"group"`
-				Names struct {
-					Kind   string `json:"kind"`
-					Plural string `json:"plural"`
-				} `json:"names"`
-				Versions []struct {
-					Name   string `json:"name"`
-					Served bool   `json:"served"`
-					Schema struct {
-						OpenAPIV3Schema Schema `json:"openAPIV3Schema"`
-					} `json:"schema"`
-				} `json:"versions"`
-			} `json:"spec"`
+		res, ok, err := crdFromDoc(origin, i, docBytes)
+		if err != nil {
+			return nil, err
 		}
-		if err := unmarshalYAMLDoc(docBytes, &doc); err != nil {
-			continue
+		if ok {
+			out = append(out, res)
 		}
-		if doc.Kind != "CustomResourceDefinition" {
-			continue
-		}
-		if doc.Spec.Group == "" || doc.Spec.Names.Plural == "" {
-			return nil, fmt.Errorf("%s (document %d): CRD missing spec.group or spec.names.plural", origin, i)
-		}
-		res := Resource{
-			Group:    doc.Spec.Group,
-			Kind:     doc.Spec.Names.Kind,
-			Plural:   doc.Spec.Names.Plural,
-			Source:   SourceCRD,
-			Origin:   origin,
-			Versions: map[string]Schema{},
-		}
-		for _, v := range doc.Spec.Versions {
-			// Only served versions are live API surface. Skipping unserved
-			// versions keeps the classifier from diffing schemas no client can
-			// call, and makes the standard CRD deprecation step (flip
-			// served:true -> false) surface as a removed served version.
-			if v.Name == "" || !v.Served {
-				continue
-			}
-			res.Versions[v.Name] = v.Schema.OpenAPIV3Schema
-		}
-		out = append(out, res)
 	}
 	return out, nil
+}
+
+// crdFromDoc attempts to parse a single YAML document as a
+// CustomResourceDefinition. ok is false whenever the document is not a CRD,
+// including when it fails to parse at all; err is non-nil only when the
+// document unambiguously claims to be a CRD (right kind) but is structurally
+// incomplete. docKind is checked first so the fuller CRD-shaped unmarshal —
+// and its cost — is paid only for documents that are actually CRDs, since
+// LoadSnapshot's content-based walk runs this against every YAML file in the
+// tree, the overwhelming majority of which are not CRDs at all.
+func crdFromDoc(origin string, i int, docBytes []byte) (Resource, bool, error) {
+	if docKind(docBytes) != "CustomResourceDefinition" {
+		return Resource{}, false, nil
+	}
+	var doc struct {
+		Spec struct {
+			Group string `json:"group"`
+			Names struct {
+				Kind   string `json:"kind"`
+				Plural string `json:"plural"`
+			} `json:"names"`
+			Versions []struct {
+				Name   string `json:"name"`
+				Served bool   `json:"served"`
+				Schema struct {
+					OpenAPIV3Schema Schema `json:"openAPIV3Schema"`
+				} `json:"schema"`
+			} `json:"versions"`
+		} `json:"spec"`
+	}
+	if err := unmarshalYAMLDoc(docBytes, &doc); err != nil {
+		// docKind above already parsed this document successfully, so this
+		// would be surprising; tolerate it like any other unparseable
+		// document rather than erroring.
+		return Resource{}, false, nil
+	}
+	if doc.Spec.Group == "" || doc.Spec.Names.Plural == "" {
+		return Resource{}, false, fmt.Errorf("%s (document %d): CRD missing spec.group or spec.names.plural", origin, i)
+	}
+	res := Resource{
+		Group:    doc.Spec.Group,
+		Kind:     doc.Spec.Names.Kind,
+		Plural:   doc.Spec.Names.Plural,
+		Source:   SourceCRD,
+		Origin:   origin,
+		Versions: map[string]Schema{},
+	}
+	for _, v := range doc.Spec.Versions {
+		// Only served versions are live API surface. Skipping unserved
+		// versions keeps the classifier from diffing schemas no client can
+		// call, and makes the standard CRD deprecation step (flip
+		// served:true -> false) surface as a removed served version.
+		if v.Name == "" || !v.Served {
+			continue
+		}
+		res.Versions[v.Name] = v.Schema.OpenAPIV3Schema
+	}
+	return res, true, nil
 }
 
 // storageVarGroups maps the storage-map variable prefixes used in
@@ -221,29 +242,40 @@ func ParseAPIServices(origin string, data []byte) []Resource {
 		if len(strings.TrimSpace(string(docBytes))) == 0 {
 			continue
 		}
-		var doc struct {
-			Kind string `json:"kind"`
-			Spec struct {
-				Group   string `json:"group"`
-				Version string `json:"version"`
-			} `json:"spec"`
+		if res, ok := apiServiceFromDoc(origin, docBytes); ok {
+			out = append(out, res)
 		}
-		if err := unmarshalYAMLDoc(docBytes, &doc); err != nil {
-			continue
-		}
-		if doc.Kind != "APIService" || doc.Spec.Group == "" || doc.Spec.Version == "" {
-			continue
-		}
-		out = append(out, Resource{
-			Group:    doc.Spec.Group,
-			Kind:     "(aggregated apiserver)",
-			Plural:   apiServicePlural,
-			Source:   SourceAPIService,
-			Origin:   origin,
-			Versions: map[string]Schema{doc.Spec.Version: {}},
-		})
 	}
 	return out
+}
+
+// apiServiceFromDoc attempts to parse a single YAML document as an
+// APIService. See crdFromDoc for why docKind is checked before the fuller
+// unmarshal.
+func apiServiceFromDoc(origin string, docBytes []byte) (Resource, bool) {
+	if docKind(docBytes) != "APIService" {
+		return Resource{}, false
+	}
+	var doc struct {
+		Spec struct {
+			Group   string `json:"group"`
+			Version string `json:"version"`
+		} `json:"spec"`
+	}
+	if err := unmarshalYAMLDoc(docBytes, &doc); err != nil {
+		return Resource{}, false
+	}
+	if doc.Spec.Group == "" || doc.Spec.Version == "" {
+		return Resource{}, false
+	}
+	return Resource{
+		Group:    doc.Spec.Group,
+		Kind:     "(aggregated apiserver)",
+		Plural:   apiServicePlural,
+		Source:   SourceAPIService,
+		Origin:   origin,
+		Versions: map[string]Schema{doc.Spec.Version: {}},
+	}, true
 }
 
 // helmDirectiveLine matches a line that is entirely Go-template/Helm markup
@@ -269,12 +301,52 @@ func unmarshalYAMLDoc(doc []byte, out any) error {
 	return yaml.Unmarshal(helmDirectiveLine.ReplaceAll(doc, nil), out)
 }
 
+// docKind cheaply extracts a YAML document's top-level kind field, without
+// paying for a full CRD- or APIService-shaped unmarshal on documents that
+// are neither. LoadSnapshot's discovery walk scans every .yaml/.yml file
+// under packages/ and internal/ rather than a curated directory allowlist
+// (see discoverYAMLFiles), so the overwhelming majority of documents it
+// sees are not API manifests at all; probing kind first, once, keeps that
+// walk cheap.
+// mightBeAPIManifest is a cheap fast-reject shared by docKind (per document)
+// and LoadSnapshot (per whole file, before even splitting it into
+// documents). Both kinds this package looks for (crdFromDoc,
+// apiServiceFromDoc) appear as their own kind name verbatim in a valid
+// manifest; content containing neither substring cannot be either kind. This
+// is the overwhelming majority of what a content-based walk across the whole
+// tree sees — Deployments, Services, plain values trees, and everything else
+// that is neither a CRD nor an APIService — so rejecting on a raw substring
+// scan avoids the cost of the `---` split, the YAML parse attempt, and (for
+// a document that isn't valid strict YAML at all — an ordinary Helm
+// template) the further regex-stripped retry in unmarshalYAMLDoc.
+func mightBeAPIManifest(data []byte) bool {
+	return bytes.Contains(data, []byte("CustomResourceDefinition")) || bytes.Contains(data, []byte("APIService"))
+}
+
+func docKind(docBytes []byte) string {
+	if !mightBeAPIManifest(docBytes) {
+		return ""
+	}
+	var probe struct {
+		Kind string `json:"kind"`
+	}
+	if err := unmarshalYAMLDoc(docBytes, &probe); err != nil {
+		return ""
+	}
+	return probe.Kind
+}
+
+// yamlDocSeparator matches a `---` document-separator line. Compiled once at
+// package init rather than per splitYAMLDocs call, since LoadSnapshot's
+// content-based walk now runs this against every YAML file in the tree.
+var yamlDocSeparator = regexp.MustCompile(`(?m)^---\s*$`)
+
 // splitYAMLDocs splits a YAML stream into individual document byte slices on
 // `---` separators. It intentionally mirrors the simple splitting Helm and
 // kubectl use; CRD manifests in this repo do not embed `---` inside block
 // scalars, so line-based splitting is safe.
 func splitYAMLDocs(data []byte) [][]byte {
-	parts := regexp.MustCompile(`(?m)^---\s*$`).Split(string(data), -1)
+	parts := yamlDocSeparator.Split(string(data), -1)
 	out := make([][]byte, 0, len(parts))
 	for _, p := range parts {
 		out = append(out, []byte(p))

--- a/internal/apigate/parse.go
+++ b/internal/apigate/parse.go
@@ -73,7 +73,14 @@ func ParseCozyRD(origin string, data []byte) (Resource, bool, error) {
 
 // ParseCRDs parses a (possibly multi-document) CustomResourceDefinition YAML
 // file into one Resource per CRD, keyed by spec.group + spec.names.plural with
-// each served version's openAPIV3Schema.
+// each served version's openAPIV3Schema. CRD discovery is content-based (any
+// file under the walked roots, regardless of directory name — see
+// discoverYAMLFiles), so a single file routinely mixes genuine CRD documents
+// with unrendered Helm markup (a `{{- if }}` guard, an `{{ include }}` call)
+// in neighboring documents of the same `---`-delimited stream. A document
+// that fails to parse as YAML is therefore skipped on its own rather than
+// aborting the whole file, so a real CRD sharing a file with templated
+// documents is still found.
 func ParseCRDs(origin string, data []byte) ([]Resource, error) {
 	var out []Resource
 	for i, docBytes := range splitYAMLDocs(data) {
@@ -97,8 +104,8 @@ func ParseCRDs(origin string, data []byte) ([]Resource, error) {
 				} `json:"versions"`
 			} `json:"spec"`
 		}
-		if err := yaml.Unmarshal(docBytes, &doc); err != nil {
-			return nil, fmt.Errorf("%s (document %d): %w", origin, i, err)
+		if err := unmarshalYAMLDoc(docBytes, &doc); err != nil {
+			continue
 		}
 		if doc.Kind != "CustomResourceDefinition" {
 			continue
@@ -188,6 +195,78 @@ func ParseAPIServerStorages(origin string, data []byte) []Resource {
 		})
 	}
 	return out
+}
+
+// apiServicePlural is the sentinel Plural used for SourceAPIService
+// resources. An APIService does not describe an individual resource the way
+// a CRD or cozyrd does — it registers a whole (group, version) pair, served
+// by whatever aggregated apiserver binary the group's registration points
+// at, which may be built entirely outside this repository (no vendored Go
+// types, no checked-in CRD). The literal is namespaced with "$" so it can
+// never collide with a real plural name.
+const apiServicePlural = "$apiservice"
+
+// ParseAPIServices parses a (possibly multi-document) YAML file for
+// kind: APIService manifests, surfacing one schema-less Resource per
+// first-party (group, version) registration. Like ParseAPIServerStorages,
+// these resources carry no checked-in schema, so they participate only in
+// new-group / new-resource / removal detection via the shared
+// empty-Versions mechanism — diffResource has nothing to iterate, so no
+// Breaking finding is ever produced from one of these alone. Documents that
+// fail to parse (Helm markup sharing a file with a real APIService, as with
+// ParseCRDs) are skipped rather than failing the file.
+func ParseAPIServices(origin string, data []byte) []Resource {
+	var out []Resource
+	for _, docBytes := range splitYAMLDocs(data) {
+		if len(strings.TrimSpace(string(docBytes))) == 0 {
+			continue
+		}
+		var doc struct {
+			Kind string `json:"kind"`
+			Spec struct {
+				Group   string `json:"group"`
+				Version string `json:"version"`
+			} `json:"spec"`
+		}
+		if err := unmarshalYAMLDoc(docBytes, &doc); err != nil {
+			continue
+		}
+		if doc.Kind != "APIService" || doc.Spec.Group == "" || doc.Spec.Version == "" {
+			continue
+		}
+		out = append(out, Resource{
+			Group:    doc.Spec.Group,
+			Kind:     "(aggregated apiserver)",
+			Plural:   apiServicePlural,
+			Source:   SourceAPIService,
+			Origin:   origin,
+			Versions: map[string]Schema{doc.Spec.Version: {}},
+		})
+	}
+	return out
+}
+
+// helmDirectiveLine matches a line that is entirely Go-template/Helm markup
+// (`{{- if ... }}`, `{{- end }}`, `{{- /* comment */ -}}`), including its
+// trailing newline.
+var helmDirectiveLine = regexp.MustCompile(`(?m)^[ \t]*\{\{-?[^\n]*-?\}\}[ \t]*\r?\n?`)
+
+// unmarshalYAMLDoc decodes one `---`-delimited document, tolerating Helm
+// directive lines that share a document with otherwise-valid YAML. The
+// convention this repo's charts use for a raw CRD/APIService body is to wrap
+// the whole manifest in a single `{{- if }}...{{- end }}` block; the `{{- if
+// }}` half is naturally its own document (nothing precedes it since it opens
+// the block before a `---`), but the closing `{{- end }}` has no `---` before
+// it and so lands in the same document as the manifest itself — plain
+// yaml.Unmarshal rejects that whole document as invalid. Stripping
+// whole-line directives before decoding recovers the manifest; a document
+// that still fails after stripping is genuinely not YAML and is left to the
+// caller to skip.
+func unmarshalYAMLDoc(doc []byte, out any) error {
+	if err := yaml.Unmarshal(doc, out); err == nil {
+		return nil
+	}
+	return yaml.Unmarshal(helmDirectiveLine.ReplaceAll(doc, nil), out)
 }
 
 // splitYAMLDocs splits a YAML stream into individual document byte slices on

--- a/internal/apigate/parse_test.go
+++ b/internal/apigate/parse_test.go
@@ -402,6 +402,99 @@ spec: {group: metrics.k8s.io, version: v1beta1}
 	}
 }
 
+// TestLoadSnapshotSkipsOversizedFiles guards the size cap added alongside
+// content-based discovery: since every .yaml/.yml file in the tree is now a
+// candidate (no directory allowlist), an untrusted PR head checkout could
+// otherwise force an unbounded read/parse of a pathologically large file. A
+// first-party CRD past maxYAMLFileSize must be excluded from discovery.
+func TestLoadSnapshotSkipsOversizedFiles(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, content string) {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	padding := strings.Repeat("# padding\n", (maxYAMLFileSize/len("# padding\n"))+1)
+	write("packages/system/oversized/crds/widgets.yaml", padding+sampleCRD)
+	// A small, legitimate resource so the empty-snapshot guard doesn't fire
+	// for an unrelated reason.
+	write("packages/system/postgres-rd/cozyrds/postgres.yaml", sampleCozyRD)
+
+	snap, err := LoadSnapshot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := snap[resourceKey{Group: "example.cozystack.io", Plural: "widgets"}]; ok {
+		t.Fatalf("CRD in a file past maxYAMLFileSize must be excluded: %v", snap)
+	}
+}
+
+// TestLoadSnapshotMergesAPIServiceOriginAcrossFiles covers the traceability
+// fix: when a group's versions are registered via several sibling APIService
+// objects in different files (the real-world shape — one object per
+// version), the merged resource's Origin must mention every contributing
+// file, not just the first one encountered.
+func TestLoadSnapshotMergesAPIServiceOriginAcrossFiles(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, content string) {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("packages/system/cozyplane/templates/apiserver-v1alpha1.yaml", `apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata: {name: v1alpha1.sdn.cozystack.io}
+spec: {group: sdn.cozystack.io, version: v1alpha1}
+`)
+	write("packages/system/cozyplane/templates/apiserver-v1beta1.yaml", `apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata: {name: v1beta1.sdn.cozystack.io}
+spec: {group: sdn.cozystack.io, version: v1beta1}
+`)
+
+	snap, err := LoadSnapshot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := snap[resourceKey{Group: "sdn.cozystack.io", Plural: apiServicePlural}]
+	if !ok {
+		t.Fatalf("APIService group was not discovered: %v", snap)
+	}
+	for _, want := range []string{
+		"packages/system/cozyplane/templates/apiserver-v1alpha1.yaml",
+		"packages/system/cozyplane/templates/apiserver-v1beta1.yaml",
+	} {
+		if !strings.Contains(res.Origin, want) {
+			t.Fatalf("expected Origin to mention %q, got %q", want, res.Origin)
+		}
+	}
+}
+
+// BenchmarkLoadSnapshotRealTree tracks LoadSnapshot's wall-clock cost against
+// this repository's own checkout — the actual worst case the CI gate runs
+// against on every PR. Content-based discovery (see discoverYAMLFiles) scans
+// every .yaml/.yml file under packages/ and internal/, not a curated
+// directory allowlist, so this is meant to catch a future change that
+// reintroduces redundant per-file work (e.g. splitting or parsing the same
+// file's documents more than once). Run with:
+//
+//	go test ./internal/apigate/ -run '^$' -bench LoadSnapshotRealTree
+func BenchmarkLoadSnapshotRealTree(b *testing.B) {
+	for b.Loop() {
+		if _, err := LoadSnapshot("../.."); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // TestLoadSnapshotEmptyErrors covers the silent-bypass guard: an empty result
 // (e.g. wrong directory) must be an error, not a clean pass.
 func TestLoadSnapshotEmptyErrors(t *testing.T) {

--- a/internal/apigate/parse_test.go
+++ b/internal/apigate/parse_test.go
@@ -125,6 +125,68 @@ spec:
 	}
 }
 
+// TestParseCRDsToleratesTemplatedNeighborDocument reproduces the cozyplane
+// bug: a real CRD living in a chart's templates/ dir, guarded by a
+// `{{- if }}` block that is not valid YAML on its own. The malformed
+// neighbor document must not take the real CRD down with it.
+func TestParseCRDsToleratesTemplatedNeighborDocument(t *testing.T) {
+	const doc = `{{- /* CRDs are installed only in CRD mode */ -}}
+{{- if not .Values.apiserver.enabled }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: vpcs.sdn.cozystack.io
+spec:
+  group: sdn.cozystack.io
+  names: {kind: VPC, plural: vpcs}
+  versions:
+  - name: v1alpha1
+    served: true
+    schema: {openAPIV3Schema: {type: object}}
+{{- end }}
+`
+	rs, err := ParseCRDs("templates/crds.yaml", []byte(doc))
+	if err != nil {
+		t.Fatalf("ParseCRDs failed: %v", err)
+	}
+	if len(rs) != 1 || rs[0].Plural != "vpcs" {
+		t.Fatalf("expected the CRD sharing the file with templated markup to survive, got %v", rs)
+	}
+}
+
+// TestParseAPIServices covers the new APIService source: a first-party group
+// registration is surfaced as a schema-less resource, and a non-APIService or
+// incomplete document is ignored.
+func TestParseAPIServices(t *testing.T) {
+	const doc = `apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  name: v1alpha1.sdn.cozystack.io
+spec:
+  group: sdn.cozystack.io
+  version: v1alpha1
+  groupPriorityMinimum: 1000
+  versionPriority: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cozyplane-apiserver
+`
+	rs := ParseAPIServices("apiserver.yaml", []byte(doc))
+	if len(rs) != 1 {
+		t.Fatalf("expected exactly 1 APIService resource, got %v", rs)
+	}
+	r := rs[0]
+	if r.Group != "sdn.cozystack.io" || r.Source != SourceAPIService || r.Plural != apiServicePlural {
+		t.Fatalf("unexpected APIService resource: %+v", r)
+	}
+	if _, ok := r.Versions["v1alpha1"]; !ok {
+		t.Fatalf("expected v1alpha1 in versions, got %v", r.Versions)
+	}
+}
+
 func TestParseAPIServerStorages(t *testing.T) {
 	src := `
 	coreV1alpha1Storage["tenantsecrets"] = cozyregistry.RESTInPeace(x)
@@ -183,6 +245,160 @@ func TestLoadSnapshotDiscoversCRDsUnderChartsCrds(t *testing.T) {
 	}
 	if _, ok := snap[resourceKey{Group: "example.cozystack.io", Plural: "widgets"}]; !ok {
 		t.Fatalf("CRD under charts/*/crds/ was not discovered: %v", snap)
+	}
+}
+
+// TestLoadSnapshotDiscoversCRDUnderTemplatesDir reproduces the real gap found
+// in the cozyplane PR: a raw CRD document guarded by `{{- if }}`, sitting in a
+// chart's templates/ dir (not crds/), must still be discovered — directory
+// name is no longer the discovery signal, file content is.
+func TestLoadSnapshotDiscoversCRDUnderTemplatesDir(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, content string) {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("packages/system/cozyplane/templates/crds.yaml", `{{- if not .Values.apiserver.enabled }}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: vpcs.sdn.cozystack.io
+spec:
+  group: sdn.cozystack.io
+  names: {kind: VPC, plural: vpcs}
+  versions:
+  - name: v1alpha1
+    served: true
+    schema: {openAPIV3Schema: {type: object}}
+{{- end }}
+`)
+
+	snap, err := LoadSnapshot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := snap[resourceKey{Group: "sdn.cozystack.io", Plural: "vpcs"}]; !ok {
+		t.Fatalf("CRD under templates/ was not discovered: %v", snap)
+	}
+}
+
+// TestLoadSnapshotDiscoversAPIServiceAndTripsNewGroup covers the other half of
+// the cozyplane gap: a group served only by an aggregated apiserver (no CRD,
+// no cozyrd, no apiserver.go entry) — its schema lives entirely outside this
+// repo, but the group's first appearance must still require review. Versions
+// registered via separate sibling APIService objects (one per version, the
+// real-world shape) must merge onto the same resource.
+func TestLoadSnapshotDiscoversAPIServiceAndTripsNewGroup(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, content string) {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("packages/system/cozyplane/templates/apiserver-v1alpha1.yaml", `apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata: {name: v1alpha1.sdn.cozystack.io}
+spec: {group: sdn.cozystack.io, version: v1alpha1}
+`)
+	write("packages/system/cozyplane/templates/apiserver-v1beta1.yaml", `apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata: {name: v1beta1.sdn.cozystack.io}
+spec: {group: sdn.cozystack.io, version: v1beta1}
+`)
+
+	// A minimal but non-empty base, unrelated to sdn.cozystack.io.
+	baseRoot := t.TempDir()
+	writeBase := func(rel, content string) {
+		p := filepath.Join(baseRoot, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeBase("packages/system/postgres-rd/cozyrds/postgres.yaml", sampleCozyRD)
+
+	base, err := LoadSnapshot(baseRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	head, err := LoadSnapshot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key := resourceKey{Group: "sdn.cozystack.io", Plural: apiServicePlural}
+	res, ok := head[key]
+	if !ok {
+		t.Fatalf("APIService group was not discovered: %v", head)
+	}
+	if _, ok := res.Versions["v1alpha1"]; !ok {
+		t.Fatalf("expected v1alpha1 merged in, got %v", res.Versions)
+	}
+	if _, ok := res.Versions["v1beta1"]; !ok {
+		t.Fatalf("expected v1beta1 from the sibling APIService object merged in, got %v", res.Versions)
+	}
+
+	if countCategory(Classify(base, head), NewGroup) != 1 {
+		t.Fatalf("expected the APIService-only group to trip NewGroup, got %v", Classify(base, head))
+	}
+}
+
+// TestLoadSnapshotIgnoresThirdPartyManifestsUnderTemplates guards against the
+// content-based walk becoming too permissive: a vendored CRD and APIService
+// for a non-cozystack.io group, sitting in the exact same templates/ shape,
+// must still be filtered out.
+func TestLoadSnapshotIgnoresThirdPartyManifestsUnderTemplates(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, content string) {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("packages/system/cert-manager/templates/crds.yaml", `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata: {name: certificates.cert-manager.io}
+spec:
+  group: cert-manager.io
+  names: {kind: Certificate, plural: certificates}
+  versions:
+  - name: v1
+    served: true
+    schema: {openAPIV3Schema: {type: object}}
+`)
+	write("packages/system/metrics/templates/apiservice.yaml", `apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata: {name: v1beta1.metrics.k8s.io}
+spec: {group: metrics.k8s.io, version: v1beta1}
+`)
+	// Give the checkout a first-party resource so LoadSnapshot's
+	// empty-snapshot guard doesn't fire for an unrelated reason.
+	write("packages/system/postgres-rd/cozyrds/postgres.yaml", sampleCozyRD)
+
+	snap, err := LoadSnapshot(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := snap[resourceKey{Group: "cert-manager.io", Plural: "certificates"}]; ok {
+		t.Fatalf("vendored third-party CRD must not be discovered: %v", snap)
+	}
+	if _, ok := snap[resourceKey{Group: "metrics.k8s.io", Plural: apiServicePlural}]; ok {
+		t.Fatalf("vendored third-party APIService must not be discovered: %v", snap)
 	}
 }
 

--- a/internal/apigate/snapshot.go
+++ b/internal/apigate/snapshot.go
@@ -19,6 +19,7 @@ package apigate
 import (
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,22 +30,15 @@ import (
 const cozyRDGlob = "packages/system/*-rd/cozyrds/*.yaml"
 
 // crdRoots are the trees walked to discover checked-in CustomResourceDefinition
-// manifests. Within them, only files under a directory named in crdDirNames are
-// parsed, and only CRDs whose group belongs to the cozystack.io family are
-// kept. Discovering CRDs by location + content (rather than an explicit file
-// list) means a first-party CRD that moves — e.g. into a chart's crds/ dir — is
-// still covered here rather than slipping through until an incident.
+// and APIService manifests. Every .yaml/.yml file under them is a candidate;
+// filtering to the resources we actually care about is content-based (does
+// this document parse, and does it have the right kind and a first-party
+// group?) rather than directory-based. A directory-name allowlist (crds/,
+// definitions/, manifests/, ...) was tried first and missed a real CRD that
+// shipped inside a chart's templates/ dir behind a `{{- if }}` guard — the
+// convention a contributor uses for a chart layout is not a reliable signal,
+// so content sniffing replaces it entirely.
 var crdRoots = []string{"packages", "internal"}
-
-// crdDirNames are the directory names that hold raw (non-templated) first-party
-// CRD manifests. Helm's crds/ convention and this repo's definitions/ and
-// manifests/ dirs all hold rendered CRDs; templated CRDs live under templates/
-// and are intentionally excluded so we never try to parse Helm markup.
-var crdDirNames = map[string]struct{}{
-	"crds":        {},
-	"definitions": {},
-	"manifests":   {},
-}
 
 // apiserverGoFile is the source of the static Go-backed aggregated registrations.
 const apiserverGoFile = "pkg/apiserver/apiserver.go"
@@ -63,9 +57,10 @@ func isFirstPartyGroup(group string) bool {
 
 // LoadSnapshot walks a repository checkout rooted at dir and builds the full
 // API Snapshot from every source of truth: cozyrds (apps API), CRD manifests
-// (typed groups), and the apiserver storage registrations (static Go groups).
-// Files that are absent are skipped so the loader works against historical
-// checkouts predating a given path.
+// (typed groups), the apiserver storage registrations (static Go groups), and
+// APIService manifests (groups delegated to an aggregated apiserver, possibly
+// built outside this repo entirely). Files that are absent are skipped so the
+// loader works against historical checkouts predating a given path.
 func LoadSnapshot(dir string) (Snapshot, error) {
 	snap := Snapshot{}
 	add := func(r Resource) {
@@ -91,27 +86,57 @@ func LoadSnapshot(dir string) (Snapshot, error) {
 		}
 	}
 
-	// Typed groups: CRD manifests discovered by location + content.
-	crdFiles, err := discoverCRDFiles(dir)
+	// Typed groups (CRD manifests) and APIService-backed groups: both are
+	// discovered by content from the same file walk. APIService resources
+	// are accumulated separately and merged by group below, since a group's
+	// versions are commonly registered as several sibling APIService objects
+	// (one per version) rather than a single document listing all of them.
+	yamlFiles, err := discoverYAMLFiles(dir)
 	if err != nil {
 		return nil, err
 	}
-	for _, path := range crdFiles {
+	apiServices := map[resourceKey]Resource{}
+	for _, path := range yamlFiles {
 		data, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
-		resources, err := ParseCRDs(rel(dir, path), data)
+		origin := rel(dir, path)
+
+		resources, err := ParseCRDs(origin, data)
 		if err != nil {
-			// A file living in a crds/ or definitions/ dir that does not parse
-			// as YAML is almost always an upstream/templated artifact, not a
-			// first-party CRD; skip it rather than failing the whole gate.
+			// A file that does not parse as YAML at all (not even one
+			// tolerated document) is almost always an upstream/templated
+			// artifact, not a first-party CRD; skip it rather than failing
+			// the whole gate.
 			continue
 		}
 		for _, res := range resources {
 			if isFirstPartyGroup(res.Group) {
 				add(res)
 			}
+		}
+
+		for _, res := range ParseAPIServices(origin, data) {
+			if !isFirstPartyGroup(res.Group) {
+				continue
+			}
+			key := resourceKey{Group: res.Group, Plural: res.Plural}
+			existing, ok := apiServices[key]
+			if !ok {
+				apiServices[key] = res
+				continue
+			}
+			maps.Copy(existing.Versions, res.Versions)
+		}
+	}
+	for key, res := range apiServices {
+		// Do not overwrite a richer cozyrd/CRD/apiserver-storage resource
+		// that shares the same key; apiServicePlural is reserved and cannot
+		// collide with a real plural, so in practice this only guards
+		// against processing the same merged group twice.
+		if _, exists := snap[key]; !exists {
+			add(res)
 		}
 	}
 
@@ -140,10 +165,10 @@ func LoadSnapshot(dir string) (Snapshot, error) {
 	return snap, nil
 }
 
-// discoverCRDFiles walks the crdRoots under dir and returns the paths of files
-// that sit in a CRD directory (crdDirNames). Content filtering to first-party
-// CRDs happens at parse time in LoadSnapshot.
-func discoverCRDFiles(dir string) ([]string, error) {
+// discoverYAMLFiles walks the crdRoots under dir and returns the path of
+// every .yaml/.yml file found. Filtering to the CRD / APIService documents we
+// actually care about happens at parse time in LoadSnapshot.
+func discoverYAMLFiles(dir string) ([]string, error) {
 	var out []string
 	for _, root := range crdRoots {
 		base := filepath.Join(dir, root)
@@ -158,9 +183,6 @@ func discoverCRDFiles(dir string) ([]string, error) {
 				return nil
 			}
 			if ext := filepath.Ext(path); ext != ".yaml" && ext != ".yml" {
-				return nil
-			}
-			if _, ok := crdDirNames[filepath.Base(filepath.Dir(path))]; !ok {
 				return nil
 			}
 			out = append(out, path)

--- a/internal/apigate/snapshot.go
+++ b/internal/apigate/snapshot.go
@@ -87,10 +87,15 @@ func LoadSnapshot(dir string) (Snapshot, error) {
 	}
 
 	// Typed groups (CRD manifests) and APIService-backed groups: both are
-	// discovered by content from the same file walk. APIService resources
-	// are accumulated separately and merged by group below, since a group's
-	// versions are commonly registered as several sibling APIService objects
-	// (one per version) rather than a single document listing all of them.
+	// discovered by content from the same file walk, splitting each file's
+	// documents exactly once and probing each document's kind exactly once
+	// (docKind) before deciding which of the two shapes to try — the walk
+	// now scans every YAML file under packages/ and internal/ rather than a
+	// curated directory allowlist, so most documents are neither and this
+	// keeps the common case cheap. APIService resources are accumulated
+	// separately and merged by group below, since a group's versions are
+	// commonly registered as several sibling APIService objects (one per
+	// version) rather than a single document listing all of them.
 	yamlFiles, err := discoverYAMLFiles(dir)
 	if err != nil {
 		return nil, err
@@ -101,33 +106,48 @@ func LoadSnapshot(dir string) (Snapshot, error) {
 		if err != nil {
 			return nil, err
 		}
-		origin := rel(dir, path)
-
-		resources, err := ParseCRDs(origin, data)
-		if err != nil {
-			// A file that does not parse as YAML at all (not even one
-			// tolerated document) is almost always an upstream/templated
-			// artifact, not a first-party CRD; skip it rather than failing
-			// the whole gate.
+		if !mightBeAPIManifest(data) {
+			// Whole file contains neither marker substring anywhere, so no
+			// document within it can be a CRD or an APIService either;
+			// skip the `---` split (a regexp pass over the full file) too.
 			continue
 		}
-		for _, res := range resources {
-			if isFirstPartyGroup(res.Group) {
-				add(res)
-			}
-		}
+		origin := rel(dir, path)
 
-		for _, res := range ParseAPIServices(origin, data) {
-			if !isFirstPartyGroup(res.Group) {
+		for i, docBytes := range splitYAMLDocs(data) {
+			if len(strings.TrimSpace(string(docBytes))) == 0 {
 				continue
 			}
-			key := resourceKey{Group: res.Group, Plural: res.Plural}
-			existing, ok := apiServices[key]
-			if !ok {
-				apiServices[key] = res
-				continue
+			switch docKind(docBytes) {
+			case "CustomResourceDefinition":
+				res, ok, err := crdFromDoc(origin, i, docBytes)
+				if err != nil {
+					// A document unambiguously claiming to be a first-party
+					// CRD but structurally incomplete; skip just this
+					// document rather than losing any other resource that
+					// shares its file.
+					continue
+				}
+				if ok && isFirstPartyGroup(res.Group) {
+					add(res)
+				}
+			case "APIService":
+				res, ok := apiServiceFromDoc(origin, docBytes)
+				if !ok || !isFirstPartyGroup(res.Group) {
+					continue
+				}
+				key := resourceKey{Group: res.Group, Plural: res.Plural}
+				existing, ok := apiServices[key]
+				if !ok {
+					apiServices[key] = res
+					continue
+				}
+				maps.Copy(existing.Versions, res.Versions)
+				if existing.Origin != res.Origin {
+					existing.Origin += ", " + res.Origin
+				}
+				apiServices[key] = existing
 			}
-			maps.Copy(existing.Versions, res.Versions)
 		}
 	}
 	for key, res := range apiServices {
@@ -165,9 +185,19 @@ func LoadSnapshot(dir string) (Snapshot, error) {
 	return snap, nil
 }
 
+// maxYAMLFileSize bounds how large a single discovered file is read and
+// parsed. Discovery is now content-based across every YAML file in the tree
+// (no directory allowlist — see crdRoots), so this walk runs against
+// untrusted PR head checkouts with no other size guard; real chart
+// CRD/APIService manifests in this repo are well under a megabyte, so this
+// is generous headroom, not a tight fit, and only bounds a pathological or
+// adversarial file.
+const maxYAMLFileSize = 8 << 20 // 8 MiB
+
 // discoverYAMLFiles walks the crdRoots under dir and returns the path of
-// every .yaml/.yml file found. Filtering to the CRD / APIService documents we
-// actually care about happens at parse time in LoadSnapshot.
+// every .yaml/.yml file found, up to maxYAMLFileSize. Filtering to the CRD /
+// APIService documents we actually care about happens at parse time in
+// LoadSnapshot.
 func discoverYAMLFiles(dir string) ([]string, error) {
 	var out []string
 	for _, root := range crdRoots {
@@ -183,6 +213,13 @@ func discoverYAMLFiles(dir string) ([]string, error) {
 				return nil
 			}
 			if ext := filepath.Ext(path); ext != ".yaml" && ext != ".yml" {
+				return nil
+			}
+			info, err := d.Info()
+			if err != nil {
+				return err
+			}
+			if info.Size() > maxYAMLFileSize {
 				return nil
 			}
 			out = append(out, path)


### PR DESCRIPTION
## What this PR does

Closes two coverage gaps found while shadow-observing the API-owner-review gate (#3167) against real PRs in the first hours after merge:

1. **CRD discovery was gated on directory name** (`crds/`, `definitions/`, `manifests/`), so a CRD shipped inside a chart's `templates/` dir — a valid, existing convention when the CRD is wrapped in a `{{- if }}` guard — was invisible to the gate. This was not hypothetical: `#3149` (cozyplane) adds four brand-new CRDs (`VPC`, `VPCBinding`, `VPCPeering`, `Port`) exactly this way, and none of them tripped a review requirement.
2. **Groups served only by an external aggregated apiserver had no representation at all.** The same `#3149` also registers `sdn.cozystack.io` via a `kind: APIService` pointing at a prebuilt image built outside this repository — no CRD, no vendored Go types, nothing to diff.

### Fix

- CRD/APIService discovery is now content-based: every `.yaml`/`.yml` file under `packages/` and `internal/` is a candidate, and whether it's kept depends on whether it parses into the right `kind` with a first-party group — not which directory it sits in.
- Both parsers now tolerate a Helm directive line (`{{- if }}`, `{{- end }}`, a comment block) sharing a `---`-delimited document with otherwise-valid YAML, rather than dropping the whole document. This matters because the closing `{{- end }}` of a wrapping conditional has no `---` before it, so it lands in the same document as the manifest it closes.
- Added a fourth resource source, `SourceAPIService`, for `kind: APIService` manifests registering a first-party group. Like the existing static Go-backed groups, these carry no checked-in schema, so they participate only in new-group / new-resource / removal detection — never a fabricated breaking-change diff against a schema this repo can't see.

Verified against the real `feat/cozyplane` branch: the gate now reports all four new CRDs, plus the removal of the old `securitygroups`/`APIService` registration for the same group — a full API-surface migration that was previously invisible end to end.

### Release note

```release-note
fix(ci): the API-owner-review gate now discovers CRDs and APIService registrations by content instead of directory name, closing a gap where a CRD or an externally-served aggregated API group could ship without triggering the required review.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discovery now includes Kubernetes APIService registrations, enabling detection of groups/versions exposed only via aggregated APIService manifests, including merging versions across multiple templates.
* **Bug Fixes**
  * Improved YAML parsing and snapshot loading for Helm-like multi-document streams: invalid neighboring documents no longer halt discovery, and template directives are handled more reliably.
  * Snapshot discovery is now content-based and skips oversized YAML files (8 MiB cap), while excluding third-party CRDs/APIService manifests under templates.
* **Tests**
  * Added coverage for CRDs/APIService discovery under `templates/`, tolerant parsing of templated neighbor documents, correct third-party exclusions, merging behavior, and runtime benchmarking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->