### PR TITLE
fix(ci): build api-gate detector from base tip when merge base predates it

### DIFF
--- a/.github/workflows/api-review-gate.yaml
+++ b/.github/workflows/api-review-gate.yaml
@@ -69,16 +69,30 @@ jobs:
       - name: Build api-gate
         run: |
           set -euo pipefail
-          # Prefer building the detector from the trusted base checkout so a PR
-          # cannot neuter the gate by editing its own detector code — the tool
-          # analyzes the head as *data*, not as code. Fall back to the head
-          # checkout only while the tool has not yet landed on the base branch
-          # (bootstrap); in that window CODEOWNERS on cmd/api-gate,
-          # internal/apigate, and this workflow keeps tampering behind an
-          # API-owner review.
+          # Build the detector from a trusted checkout so a PR cannot neuter the
+          # gate by editing its own detector code — the tool analyzes the head as
+          # *data*, not as code. This selection stays inline in the workflow (an
+          # API-owner-protected file that is always present) rather than in a
+          # helper script: a helper would be read from the untrusted PR head,
+          # which both breaks PRs whose head predates the helper and lets a PR
+          # steer the selection.
+          #
+          # Precedence: prefer the merge-base checkout; when the merge base
+          # predates the commit that introduced the gate (cmd/api-gate absent
+          # there and in the equally old head) fall back to the base branch tip,
+          # which is equally trusted (protected branch, not PR-authored) and
+          # current — this unblocks PRs whose merge base is older than the gate
+          # without forcing a rebase. Bootstrap from head only while the tool
+          # exists nowhere on the base branch yet; in that window CODEOWNERS on
+          # cmd/api-gate, internal/apigate, and this workflow keeps tampering
+          # behind an API-owner review.
           if [ -d "${RUNNER_TEMP}/base/cmd/api-gate" ]; then
             build_dir="${RUNNER_TEMP}/base"
-            echo "Building api-gate from the trusted base checkout."
+            echo "Building api-gate from the trusted merge-base checkout."
+          elif git cat-file -e "origin/${BASE_REF}:cmd/api-gate" 2>/dev/null; then
+            git worktree add --detach "${RUNNER_TEMP}/base-tip" "origin/${BASE_REF}"
+            build_dir="${RUNNER_TEMP}/base-tip"
+            echo "Building api-gate from the ${BASE_REF} tip; the merge base predates the gate."
           else
             build_dir="${GITHUB_WORKSPACE}"
             echo "::warning::api-gate not present on the base branch yet; building from head (bootstrap). CODEOWNERS enforces API-owner review on the gate's own files."


### PR DESCRIPTION
## What this PR does

The `API Review Gate` required check builds the `cmd/api-gate` detector from the PR's merge-base checkout so a PR cannot neuter the detector by editing its own code. When a PR's merge base predates the commit that introduced the gate (`fa871249c`), `cmd/api-gate` is absent from both the merge base and the equally old head, so the head fallback also fails to build and the check errors out before evaluating any API content. This red-blocks every open PR whose merge base is older than the gate, and neither a re-run nor an approving review clears it.

This adds the base branch tip (`origin/<base>`) as an intermediate build source: prefer the merge-base checkout, fall back to the base tip when the merge base lacks the tool, and bootstrap from the head only while the tool exists nowhere on the base branch yet. The base tip is a protected, non-PR-authored branch, so it preserves the "analyze the head as data, not code" property. The API surface is still diffed against the merge base; only where the detector binary is compiled changes. This unblocks the pre-gate backlog without forcing every affected PR to rebase.

The selection is kept inline in the workflow rather than in a helper script: a helper would be read from the untrusted PR head, which both reintroduces the failure for heads that predate the helper and lets a PR steer the selection away from the trusted build.

Closes #3192

### Screenshots

N/A — CI-only change, no user-facing UI.

### Release note

```release-note
fix(ci): API Review Gate now builds its detector from the base branch tip when the PR merge base predates the gate, so pre-gate PRs stop failing the check without needing a rebase.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build selection logic for the API review gate to use the most appropriate trusted source when compiling checks.
  * Updated fallback behavior so the build process is more reliable when the target tool is missing in some branches.
  * Clarified status messages during the build process to better reflect which source is being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->