### PR TITLE
fix(cert-manager): raise cainjector memory limit to unblock caBundle injection

### DIFF
--- a/packages/system/cert-manager/Makefile
+++ b/packages/system/cert-manager/Makefile
@@ -3,6 +3,9 @@ export NAMESPACE=cozy-$(NAME)
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	helm repo add jetstack https://charts.jetstack.io

--- a/packages/system/cert-manager/tests/cainjector_resources_test.yaml
+++ b/packages/system/cert-manager/tests/cainjector_resources_test.yaml
@@ -1,0 +1,30 @@
+suite: cert-manager cainjector resources
+
+# Pins the cainjector memory sizing that keeps CA injection working on a full
+# cozystack install. cainjector loads all ValidatingWebhookConfigurations,
+# APIServices and CRDs into its informer caches at startup; on a large cluster
+# that working set exceeds the old 128Mi limit, so the single leader-elected
+# cainjector Pod is OOMKilled during cache population and CrashLoops before it
+# ever injects a caBundle. Every webhook then keeps an empty caBundle and
+# admission calls fail with "x509: certificate signed by unknown authority"
+# (failurePolicy: Fail). This guards the override in values.yaml against a
+# blanket resource change or a `make update` silently lowering it again.
+
+templates:
+  - charts/cert-manager/templates/cainjector-deployment.yaml
+
+release:
+  name: cert-manager
+  namespace: cozy-cert-manager
+
+tests:
+  - it: sizes the cainjector memory limit above the OOM floor
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi

--- a/packages/system/cert-manager/values.yaml
+++ b/packages/system/cert-manager/values.yaml
@@ -15,13 +15,23 @@ cert-manager:
         cpu: 10m
         memory: 32Mi
   cainjector:
+    # cainjector loads all ValidatingWebhookConfigurations, APIServices and CRDs
+    # into its informer caches at startup. On a full cozystack install that
+    # working set exceeds 128Mi, so cainjector is OOMKilled during cache
+    # population and CrashLoops before it ever injects a caBundle. Because it
+    # runs as a single leader-elected replica, that stalls CA injection for the
+    # whole cluster: webhook ValidatingWebhookConfigurations keep an empty
+    # caBundle and every admission call fails with
+    # "x509: certificate signed by unknown authority" (failurePolicy: Fail).
+    # Size the limit to the controller's 512Mi and lift the request off the
+    # OOM floor so injection completes deterministically.
     resources:
       limits:
         cpu: 200m
-        memory: 128Mi
+        memory: 512Mi
       requests:
         cpu: 10m
-        memory: 32Mi
+        memory: 128Mi
   startupapicheck:
     resources:
       limits:


### PR DESCRIPTION
## What this PR does

cert-manager's cainjector loads every ValidatingWebhookConfiguration,
MutatingWebhookConfiguration, APIService and CRD into its informer caches at
startup. On a full cozystack install that working set exceeds the 128Mi memory
limit the package sets today, so the single leader-elected cainjector Pod is
OOMKilled (exit 137) during cache population and enters CrashLoopBackOff before
it ever runs a reconcile.

Because cainjector is the component that injects the issuing CA into webhook
`clientConfig.caBundle` (via `cert-manager.io/inject-ca-from`), a cainjector
that never completes a reconcile leaves those caBundles empty. With
`failurePolicy: Fail`, the apiserver then rejects every call to an affected
webhook with `x509: certificate signed by unknown authority` — even though the
cert-manager PKI chain is healthy and the webhook Pods serve a valid cert. In
practice this intermittently blocks `Ingress` creation in tenant namespaces
(the ingress-nginx admission webhook), which stalls dependent HelmReleases and
fails installs.

It behaves as a flake because it is a memory race: on a lighter run cainjector
fits under 128Mi, injects the caBundle within seconds and everything works; on
a heavier run (more CRDs/webhooks resident, slower leader election) peak startup
memory crosses 128Mi and it is OOMKilled before the first injection, stalling CA
injection cluster-wide for as long as it CrashLoops.

Fix: raise the cainjector memory limit to 512Mi (matching the cert-manager
controller in the same values file) and lift the request from 32Mi to 128Mi so
injection completes deterministically instead of racing the OOM floor. A
helm-unittest pins the sizing so a blanket resource change or a `make update`
cannot silently lower it again. The webhook and controller resources are left
unchanged — only cainjector exhibited the OOM.

### Screenshots

N/A — no UI changes.

### Release note

```release-note
fix(cert-manager): raise cainjector memory limit so CA injection into webhook caBundles no longer fails under memory pressure (previously surfaced as intermittent "x509: certificate signed by unknown authority" admission errors)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased cainjector memory settings for cert-manager, helping it run more reliably during startup and cache population.
  * Added automated chart tests to verify the cainjector resource settings stay within the expected range.

* **Bug Fixes**
  * Reduced the risk of cainjector being OOM-killed, improving stability and consistency of CA injection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->