### PR TITLE
fix(snapshot-controller): add startupProbe as defense-in-depth against slow HTTPS bind on snapshot-validation-webhook

### DIFF
--- a/packages/system/snapshot-controller/Makefile
+++ b/packages/system/snapshot-controller/Makefile
@@ -3,11 +3,19 @@ export NAMESPACE=cozy-$(NAME)
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	helm repo add piraeus-charts https://piraeus.io/helm-charts/
 	helm repo update piraeus-charts
-	helm pull piraeus-charts/snapshot-controller --untar --untardir charts
+	# Pin the vendored version — running `helm pull` without --version would
+	# grab whatever is latest on the piraeus-charts repo and break
+	# `patches/webhook-startup-probe.diff` (the templates layout changed
+	# between v3.x and v5.x). Bumping this pin is a deliberate step that
+	# must regenerate the patch against the new upstream.
+	helm pull piraeus-charts/snapshot-controller --untar --untardir charts --version 3.0.5
 	# cozystack: re-apply local mods carried as patches/*.diff so an upstream
 	# chart bump does not silently revert them. Each diff is byte-consistent
 	# with the vendored tree and applied against the freshly-pulled upstream.

--- a/packages/system/snapshot-controller/Makefile
+++ b/packages/system/snapshot-controller/Makefile
@@ -8,3 +8,8 @@ update:
 	helm repo add piraeus-charts https://piraeus.io/helm-charts/
 	helm repo update piraeus-charts
 	helm pull piraeus-charts/snapshot-controller --untar --untardir charts
+	# cozystack: re-apply local mods carried as patches/*.diff so an upstream
+	# chart bump does not silently revert them. Each diff is byte-consistent
+	# with the vendored tree and applied against the freshly-pulled upstream.
+	# See cozystack/cozystack#3203 for the startup-probe fix rationale.
+	patch --no-backup-if-mismatch -p1 < patches/webhook-startup-probe.diff

--- a/packages/system/snapshot-controller/Makefile
+++ b/packages/system/snapshot-controller/Makefile
@@ -10,8 +10,8 @@ update:
 	rm -rf charts
 	helm repo add piraeus-charts https://piraeus.io/helm-charts/
 	helm repo update piraeus-charts
-	# Pin the vendored version — running `helm pull` without --version would
-	# grab whatever is latest on the piraeus-charts repo and break
+	# Pin the vendored version. Running `helm pull` without a --version pin
+	# would grab whatever is latest on the piraeus-charts repo and break
 	# `patches/webhook-startup-probe.diff` (the templates layout changed
 	# between v3.x and v5.x). Bumping this pin is a deliberate step that
 	# must regenerate the patch against the new upstream.

--- a/packages/system/snapshot-controller/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
+++ b/packages/system/snapshot-controller/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
@@ -50,6 +50,27 @@ spec:
           volumeMounts:
             - mountPath: /etc/snapshot-validation
               name: tls-config
+          # cozystack: startupProbe grants the webhook container up to ~10 minutes
+          # (periodSeconds * failureThreshold) to bind its HTTPS listener on
+          # :8443 before liveness begins gating. Two things eat into that budget
+          # under first-install load on the E2E sandbox:
+          #   1) cert-manager issuing the Certificate CR whose Secret the pod
+          #      mounts as tls-config — observed at 8+ minutes when cainjector
+          #      / cert-manager are backlogged (see cozystack/cozystack#3203).
+          #   2) the webhook binary's own startup after the Secret is present.
+          # Without a startupProbe the kubelet applies the (non-configurable in
+          # the upstream chart) liveness defaults `periodSeconds=10,
+          # failureThreshold=3`, giving the pod only ~30s from start to bind
+          # :8443 — insufficient under load and the root of the E2E flake
+          # cascading through this HR into piraeus/linstor and ~20 downstream
+          # operators.
+          startupProbe:
+            httpGet:
+              path: /readyz
+              port: https
+              scheme: HTTPS
+            periodSeconds: 10
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /readyz

--- a/packages/system/snapshot-controller/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
+++ b/packages/system/snapshot-controller/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
@@ -56,7 +56,7 @@ spec:
           # (kubelet defaults periodSeconds=10 failureThreshold=3 = ~30s from
           # container Started to first liveness kill), which is insufficient
           # on a loaded E2E sandbox and cascades into install-wide failure
-          # via `snapshot-controller` HR → piraeus / linstor / ~20 downstream
+          # via `snapshot-controller` HR through piraeus, linstor, and ~20
           # operators. See cozystack/cozystack#3203.
           #
           # Budget: 5s * 45 = 225s. Sized to comfortably clear the actual

--- a/packages/system/snapshot-controller/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
+++ b/packages/system/snapshot-controller/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
@@ -50,27 +50,35 @@ spec:
           volumeMounts:
             - mountPath: /etc/snapshot-validation
               name: tls-config
-          # cozystack: startupProbe grants the webhook container up to ~10 minutes
-          # (periodSeconds * failureThreshold) to bind its HTTPS listener on
-          # :8443 before liveness begins gating. Two things eat into that budget
-          # under first-install load on the E2E sandbox:
-          #   1) cert-manager issuing the Certificate CR whose Secret the pod
-          #      mounts as tls-config — observed at 8+ minutes when cainjector
-          #      / cert-manager are backlogged (see cozystack/cozystack#3203).
-          #   2) the webhook binary's own startup after the Secret is present.
-          # Without a startupProbe the kubelet applies the (non-configurable in
-          # the upstream chart) liveness defaults `periodSeconds=10,
-          # failureThreshold=3`, giving the pod only ~30s from start to bind
-          # :8443 — insufficient under load and the root of the E2E flake
-          # cascading through this HR into piraeus/linstor and ~20 downstream
-          # operators.
+          # cozystack: startupProbe covers the post-Started window where the
+          # webhook binary is coming up but has not yet bound `:8443` — the
+          # upstream chart hard-codes liveness without any startup grace
+          # (kubelet defaults periodSeconds=10 failureThreshold=3 = ~30s from
+          # container Started to first liveness kill), which is insufficient
+          # on a loaded E2E sandbox and cascades into install-wide failure
+          # via `snapshot-controller` HR → piraeus / linstor / ~20 downstream
+          # operators. See cozystack/cozystack#3203.
+          #
+          # Budget: 5s * 45 = 225s. Sized to comfortably clear the actual
+          # bind-time on a loaded sandbox (single-digit-second range in the
+          # healthy case) while staying well inside the operator's default
+          # 10m HR install timeout (--helmrelease-install-timeout in
+          # cmd/cozystack-operator/main.go). A larger budget would race the
+          # HR timeout.
+          #
+          # This fix covers the "container Started, still binding :8443"
+          # window. It does NOT cover a separate class of failure where the
+          # container self-exits (e.g. cert-mount race producing an empty
+          # tls-config volume); that would need an initContainer that waits
+          # for the Certificate's Secret to have non-empty tls.crt/tls.key.
+          # Filed as a follow-up on cozystack/cozystack#3203.
           startupProbe:
             httpGet:
               path: /readyz
               port: https
               scheme: HTTPS
-            periodSeconds: 10
-            failureThreshold: 60
+            periodSeconds: 5
+            failureThreshold: 45
           livenessProbe:
             httpGet:
               path: /readyz

--- a/packages/system/snapshot-controller/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
+++ b/packages/system/snapshot-controller/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
@@ -51,7 +51,7 @@ spec:
             - mountPath: /etc/snapshot-validation
               name: tls-config
           # cozystack: startupProbe covers the post-Started window where the
-          # webhook binary is coming up but has not yet bound `:8443` — the
+          # webhook binary is coming up but has not yet bound `:8443`. The
           # upstream chart hard-codes liveness without any startup grace
           # (kubelet defaults periodSeconds=10 failureThreshold=3 = ~30s from
           # container Started to first liveness kill), which is insufficient

--- a/packages/system/snapshot-controller/patches/webhook-startup-probe.diff
+++ b/packages/system/snapshot-controller/patches/webhook-startup-probe.diff
@@ -1,5 +1,5 @@
 diff --git a/charts/snapshot-controller/templates/deployment_validation_webhook.yaml b/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
-index ad24b32..e24c88b 100644
+index ad24b32..adaa03f 100644
 --- a/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
 +++ b/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
 @@ -50,6 +50,35 @@ spec:
@@ -12,7 +12,7 @@ index ad24b32..e24c88b 100644
 +          # (kubelet defaults periodSeconds=10 failureThreshold=3 = ~30s from
 +          # container Started to first liveness kill), which is insufficient
 +          # on a loaded E2E sandbox and cascades into install-wide failure
-+          # via `snapshot-controller` HR → piraeus / linstor / ~20 downstream
++          # via `snapshot-controller` HR through piraeus, linstor, and ~20
 +          # operators. See cozystack/cozystack#3203.
 +          #
 +          # Budget: 5s * 45 = 225s. Sized to comfortably clear the actual

--- a/packages/system/snapshot-controller/patches/webhook-startup-probe.diff
+++ b/packages/system/snapshot-controller/patches/webhook-startup-probe.diff
@@ -1,32 +1,40 @@
 diff --git a/charts/snapshot-controller/templates/deployment_validation_webhook.yaml b/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
-index ad24b32..30fa46e 100644
+index ad24b32..e24c88b 100644
 --- a/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
 +++ b/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
-@@ -50,6 +50,27 @@ spec:
+@@ -50,6 +50,35 @@ spec:
            volumeMounts:
              - mountPath: /etc/snapshot-validation
                name: tls-config
-+          # cozystack: startupProbe grants the webhook container up to ~10 minutes
-+          # (periodSeconds * failureThreshold) to bind its HTTPS listener on
-+          # :8443 before liveness begins gating. Two things eat into that budget
-+          # under first-install load on the E2E sandbox:
-+          #   1) cert-manager issuing the Certificate CR whose Secret the pod
-+          #      mounts as tls-config — observed at 8+ minutes when cainjector
-+          #      / cert-manager are backlogged (see cozystack/cozystack#3203).
-+          #   2) the webhook binary's own startup after the Secret is present.
-+          # Without a startupProbe the kubelet applies the (non-configurable in
-+          # the upstream chart) liveness defaults `periodSeconds=10,
-+          # failureThreshold=3`, giving the pod only ~30s from start to bind
-+          # :8443 — insufficient under load and the root of the E2E flake
-+          # cascading through this HR into piraeus/linstor and ~20 downstream
-+          # operators.
++          # cozystack: startupProbe covers the post-Started window where the
++          # webhook binary is coming up but has not yet bound `:8443` — the
++          # upstream chart hard-codes liveness without any startup grace
++          # (kubelet defaults periodSeconds=10 failureThreshold=3 = ~30s from
++          # container Started to first liveness kill), which is insufficient
++          # on a loaded E2E sandbox and cascades into install-wide failure
++          # via `snapshot-controller` HR → piraeus / linstor / ~20 downstream
++          # operators. See cozystack/cozystack#3203.
++          #
++          # Budget: 5s * 45 = 225s. Sized to comfortably clear the actual
++          # bind-time on a loaded sandbox (single-digit-second range in the
++          # healthy case) while staying well inside the operator's default
++          # 10m HR install timeout (--helmrelease-install-timeout in
++          # cmd/cozystack-operator/main.go). A larger budget would race the
++          # HR timeout.
++          #
++          # This fix covers the "container Started, still binding :8443"
++          # window. It does NOT cover a separate class of failure where the
++          # container self-exits (e.g. cert-mount race producing an empty
++          # tls-config volume); that would need an initContainer that waits
++          # for the Certificate's Secret to have non-empty tls.crt/tls.key.
++          # Filed as a follow-up on cozystack/cozystack#3203.
 +          startupProbe:
 +            httpGet:
 +              path: /readyz
 +              port: https
 +              scheme: HTTPS
-+            periodSeconds: 10
-+            failureThreshold: 60
++            periodSeconds: 5
++            failureThreshold: 45
            livenessProbe:
              httpGet:
                path: /readyz

--- a/packages/system/snapshot-controller/patches/webhook-startup-probe.diff
+++ b/packages/system/snapshot-controller/patches/webhook-startup-probe.diff
@@ -1,0 +1,32 @@
+diff --git a/charts/snapshot-controller/templates/deployment_validation_webhook.yaml b/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
+index ad24b32..30fa46e 100644
+--- a/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
++++ b/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
+@@ -50,6 +50,27 @@ spec:
+           volumeMounts:
+             - mountPath: /etc/snapshot-validation
+               name: tls-config
++          # cozystack: startupProbe grants the webhook container up to ~10 minutes
++          # (periodSeconds * failureThreshold) to bind its HTTPS listener on
++          # :8443 before liveness begins gating. Two things eat into that budget
++          # under first-install load on the E2E sandbox:
++          #   1) cert-manager issuing the Certificate CR whose Secret the pod
++          #      mounts as tls-config — observed at 8+ minutes when cainjector
++          #      / cert-manager are backlogged (see cozystack/cozystack#3203).
++          #   2) the webhook binary's own startup after the Secret is present.
++          # Without a startupProbe the kubelet applies the (non-configurable in
++          # the upstream chart) liveness defaults `periodSeconds=10,
++          # failureThreshold=3`, giving the pod only ~30s from start to bind
++          # :8443 — insufficient under load and the root of the E2E flake
++          # cascading through this HR into piraeus/linstor and ~20 downstream
++          # operators.
++          startupProbe:
++            httpGet:
++              path: /readyz
++              port: https
++              scheme: HTTPS
++            periodSeconds: 10
++            failureThreshold: 60
+           livenessProbe:
+             httpGet:
+               path: /readyz

--- a/packages/system/snapshot-controller/patches/webhook-startup-probe.diff
+++ b/packages/system/snapshot-controller/patches/webhook-startup-probe.diff
@@ -1,5 +1,5 @@
 diff --git a/charts/snapshot-controller/templates/deployment_validation_webhook.yaml b/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
-index ad24b32..adaa03f 100644
+index ad24b32..3ac9bd6 100644
 --- a/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
 +++ b/charts/snapshot-controller/templates/deployment_validation_webhook.yaml
 @@ -50,6 +50,35 @@ spec:
@@ -7,7 +7,7 @@ index ad24b32..adaa03f 100644
              - mountPath: /etc/snapshot-validation
                name: tls-config
 +          # cozystack: startupProbe covers the post-Started window where the
-+          # webhook binary is coming up but has not yet bound `:8443` — the
++          # webhook binary is coming up but has not yet bound `:8443`. The
 +          # upstream chart hard-codes liveness without any startup grace
 +          # (kubelet defaults periodSeconds=10 failureThreshold=3 = ~30s from
 +          # container Started to first liveness kill), which is insufficient

--- a/packages/system/snapshot-controller/tests/webhook_startup_probe_test.yaml
+++ b/packages/system/snapshot-controller/tests/webhook_startup_probe_test.yaml
@@ -1,0 +1,51 @@
+suite: cozy-snapshot-controller webhook startup-probe cozystack patch
+release:
+  name: snapshot-controller
+  namespace: cozy-snapshot-controller
+tests:
+  # cozystack carries a `patches/webhook-startup-probe.diff` on the vendored
+  # piraeus-charts/snapshot-controller v3.0.5 subchart because the upstream
+  # `deployment_validation_webhook.yaml` hard-codes the liveness and readiness
+  # probes without any `initialDelaySeconds` or `startupProbe` and does NOT
+  # expose them via values, so a slow cert-manager Certificate issuance under
+  # E2E-sandbox load cascades into the whole install failing through this HR
+  # (see cozystack/cozystack#3203). If a future `make update` bump re-pulls
+  # upstream and the local diff drops off — or an upstream refactor renames /
+  # replaces this Deployment — these asserts catch it before the flake
+  # returns.
+  - it: webhook Deployment carries a startupProbe that grants ~10 minutes for HTTPS listener bind
+    template: charts/snapshot-controller/templates/deployment_validation_webhook.yaml
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].startupProbe
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.port
+          value: https
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.scheme
+          value: HTTPS
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 10
+      # periodSeconds * failureThreshold = startup budget. 10 * 60 = 600s ≈
+      # 10 minutes, deliberately generous to cover cert-manager Certificate
+      # issuance latency under first-install cert-manager burst.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 60
+
+  # Liveness / readiness stay as upstream renders them — startupProbe covers
+  # the slow-start window, once it passes the kubelet gates on the normal
+  # probes at their default cadence.
+  - it: webhook Deployment still renders liveness and readiness on the same HTTPS endpoint
+    template: charts/snapshot-controller/templates/deployment_validation_webhook.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz

--- a/packages/system/snapshot-controller/tests/webhook_startup_probe_test.yaml
+++ b/packages/system/snapshot-controller/tests/webhook_startup_probe_test.yaml
@@ -13,7 +13,7 @@ tests:
   # upstream and the local diff drops off — or an upstream refactor renames /
   # replaces this Deployment — these asserts catch it before the flake
   # returns.
-  - it: webhook Deployment carries a startupProbe that grants ~10 minutes for HTTPS listener bind
+  - it: webhook Deployment carries a startupProbe covering the HTTPS-listener bind window
     template: charts/snapshot-controller/templates/deployment_validation_webhook.yaml
     asserts:
       - exists:
@@ -27,25 +27,41 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].startupProbe.httpGet.scheme
           value: HTTPS
+      # Budget = periodSeconds * failureThreshold. Pinning both exact values
+      # locks the total (5 * 45 = 225s) as a regression sentinel — a chart
+      # bump that silently zeroed one of them would still fall out here.
+      # Bumping the budget deliberately requires a matching test update; the
+      # comment on the patched template covers why it must stay inside the
+      # operator's 10m HR install timeout.
       - equal:
           path: spec.template.spec.containers[0].startupProbe.periodSeconds
-          value: 10
-      # periodSeconds * failureThreshold = startup budget. 10 * 60 = 600s ≈
-      # 10 minutes, deliberately generous to cover cert-manager Certificate
-      # issuance latency under first-install cert-manager burst.
+          value: 5
       - equal:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
-          value: 60
+          value: 45
 
-  # Liveness / readiness stay as upstream renders them — startupProbe covers
-  # the slow-start window, once it passes the kubelet gates on the normal
-  # probes at their default cadence.
-  - it: webhook Deployment still renders liveness and readiness on the same HTTPS endpoint
+  # Liveness / readiness must survive the patch unchanged — startupProbe
+  # covers the slow-start window, and once it passes the kubelet gates on
+  # the normal probes at their default cadence. If an upstream refactor
+  # renamed the port or dropped the scheme, this catches the drift.
+  - it: webhook Deployment leaves upstream liveness and readiness intact on the same HTTPS endpoint
     template: charts/snapshot-controller/templates/deployment_validation_webhook.yaml
     asserts:
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /readyz
       - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: https
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.scheme
+          value: HTTPS
+      - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
           value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: https
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: HTTPS

--- a/packages/system/snapshot-controller/tests/webhook_startup_probe_test.yaml
+++ b/packages/system/snapshot-controller/tests/webhook_startup_probe_test.yaml
@@ -10,8 +10,8 @@ tests:
   # expose them via values, so a slow cert-manager Certificate issuance under
   # E2E-sandbox load cascades into the whole install failing through this HR
   # (see cozystack/cozystack#3203). If a future `make update` bump re-pulls
-  # upstream and the local diff drops off — or an upstream refactor renames /
-  # replaces this Deployment — these asserts catch it before the flake
+  # upstream and the local diff drops off, or an upstream refactor renames
+  # or replaces this Deployment, these asserts catch it before the flake
   # returns.
   - it: webhook Deployment carries a startupProbe covering the HTTPS-listener bind window
     template: charts/snapshot-controller/templates/deployment_validation_webhook.yaml
@@ -28,7 +28,7 @@ tests:
           path: spec.template.spec.containers[0].startupProbe.httpGet.scheme
           value: HTTPS
       # Budget = periodSeconds * failureThreshold. Pinning both exact values
-      # locks the total (5 * 45 = 225s) as a regression sentinel — a chart
+      # locks the total (5 * 45 = 225s) as a regression sentinel: a chart
       # bump that silently zeroed one of them would still fall out here.
       # Bumping the budget deliberately requires a matching test update; the
       # comment on the patched template covers why it must stay inside the
@@ -40,7 +40,7 @@ tests:
           path: spec.template.spec.containers[0].startupProbe.failureThreshold
           value: 45
 
-  # Liveness / readiness must survive the patch unchanged — startupProbe
+  # Liveness / readiness must survive the patch unchanged. startupProbe
   # covers the slow-start window, and once it passes the kubelet gates on
   # the normal probes at their default cadence. If an upstream refactor
   # renamed the port or dropped the scheme, this catches the drift.


### PR DESCRIPTION
## Summary

Refs #3203 (partial hardening — see [Scope](#scope) below).

Carries a cozystack-standard vendored-chart patch on `piraeus-charts/snapshot-controller` v3.0.5 that adds a `startupProbe` to the `snapshot-validation-webhook` Deployment. The upstream chart hard-codes the liveness / readiness probes without any startup grace and does not expose them via `values.yaml`, so under one specific pathway of the failure documented in #3203 — the webhook binary is `Started` but has not yet bound `:8443` — the kubelet's default liveness (`periodSeconds=10 failureThreshold=3` ≈ 30s) kills the container before it can serve. `startupProbe` widens that specific window.

## Scope

This PR is **defense-in-depth for one subset** of the failure documented in #3203. It is not a root-cause fix.

- **What this covers.** The narrow window where the container is `Started`, the mounted `tls-config` volume has a usable cert, but the binary has not yet bound `:8443`. Without a `startupProbe`, the kubelet's default liveness kills the container inside ~30s. With this patch, that window widens to ~225 seconds (`periodSeconds: 5 × failureThreshold: 45`).
- **What this does NOT cover.**
  - Pre-`Started` cert-manager latency, where `snapshot-validation-webhook-tls` is absent and the pod sits in Pending with `FailedMount`. The kubelet does not evaluate any probe against a container that has not been `Started`, so `startupProbe` has no effect on this phase. That latency is being addressed by [#3199](https://github.com/cozystack/cozystack/pull/3199) (cainjector memory bump) on the cert-manager side.
  - Post-`Started` self-exit. The pod events in the #3203 evidence show `Exit Code: 2`, which is a process self-exit, not a kubelet-initiated `SIGTERM` (which would be `143`). Cross-referencing kubelet events shows a mismatch between the liveness-failure count and the observed restart count — some restarts are self-exits, not probe kills. A probe of any shape cannot keep a self-exiting process alive; that class needs a different fix (e.g. an initContainer that blocks main container start until the mounted Secret carries non-empty `tls.crt` / `tls.key`), which is out of scope for this change and remains tracked in #3203.
- **HR install-timeout interaction.** The operator's default HR install timeout (`--helmrelease-install-timeout` in `cmd/cozystack-operator/main.go`) is 10 minutes and has no per-component override. If cert-manager takes ~8 minutes to issue the `Certificate` (the observed worst case), only ~2 minutes remain within the HR install window even before this probe budget begins to count. On that trajectory no probe fixes the failure. This PR does not change the HR timeout; addressing it is a separate change.

Given the above, this PR is intentionally scoped as `Refs #3203`, not `Fixes`. The tracking issue stays open until the pre-`Started` cert-manager path and the post-`Started` self-exit path are both addressed.

## Why `startupProbe` (in the window it actually governs)

Bumping `initialDelaySeconds` on the existing `livenessProbe` would need to be sized for worst-case tail latency, which produces a fragile value that either misses the tail or delays failure detection in the healthy case. `startupProbe` is the k8s-native pattern for "container has a slow but bounded startup, don't hand over to liveness until it's up" — once it passes, the kubelet transitions to the normal `livenessProbe` and `readinessProbe` at their default cadence and steady-state health-checking is unchanged.

Chosen values `periodSeconds: 5 × failureThreshold: 45 = 225s`:

- Comfortably clears the actual bind time on a loaded sandbox once the binary is `Started` (single-digit-second range in the healthy case, tens of seconds under contention).
- Stays well inside the operator's 10-minute HR install timeout so the probe budget does not race the outer wait. A larger probe budget would encroach on that limit.

## Files touched

- `packages/system/snapshot-controller/charts/snapshot-controller/templates/deployment_validation_webhook.yaml` — add `startupProbe` block. Comment inline documents the scope boundary above.
- `packages/system/snapshot-controller/patches/webhook-startup-probe.diff` — new file (first patch on this package). Byte-consistent with the vendored tree: verified by re-applying against a fresh `helm pull piraeus-charts/snapshot-controller --version 3.0.5` and running `diff -qr` (empty output).
- `packages/system/snapshot-controller/Makefile` — add `test:` target so the new unit tests run in CI (mirrors `vpa/Makefile`, `harbor/Makefile`), pin `--version 3.0.5` on `helm pull` (an unpinned pull would grab `latest` and the templates layout changed between v3.x and v5.x), and re-apply `patches/webhook-startup-probe.diff` after the pull so a future upstream bump does not silently revert the fix.
- `packages/system/snapshot-controller/tests/webhook_startup_probe_test.yaml` — new file (first helm-unittest on this package). Asserts `startupProbe` shape (endpoint, port, scheme, `periodSeconds`, `failureThreshold`) and that `livenessProbe` / `readinessProbe` still render on the same HTTPS `/readyz` endpoint. Guards against an upstream refactor renaming or replacing the Deployment silently dropping the fix.

## Testing

- `make -C packages/system/snapshot-controller test` — 2/2 unit tests pass.
- `helm template test packages/system/snapshot-controller/charts/snapshot-controller` — renders the `startupProbe` as expected.
- `make update` idempotency — re-pulling upstream v3.0.5 and re-applying `patches/webhook-startup-probe.diff` produces a chart tree byte-identical to what is committed.

## Release note

```release-note
fix(snapshot-controller): add a `startupProbe` to the snapshot-validation-webhook Deployment so the container gets a wider grace before liveness kicks in when its HTTPS listener is slow to bind. Defense-in-depth against one class of E2E install flake; the cert-manager Certificate issuance latency and any post-`Started` self-exit paths are tracked separately in #3203.
```
