### PR TITLE
fix(cozystack-basics): normalize tenant hostname VAP comparisons with lowerAscii

### DIFF
--- a/hack/e2e-chainsaw/gateway/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/gateway/chainsaw-test.yaml
@@ -132,6 +132,16 @@ metadata:
   name: gateway-foreign-hostname-rejected
 spec:
   steps:
+  # No mixed-case-apex counterpart here, unlike the Route and Ingress suites.
+  # Deliberate: this policy applies the same rule as the Route one — own apex
+  # or a dot-bounded subdomain of it, with no outside-root branch — so a
+  # Gateway probe would re-exercise the same two comparisons that
+  # route-hostname-policy already drives against a mixed-case apex at runtime,
+  # in both directions. The two differ only in how the apex reaches the
+  # comparison: a `variables.tenantHost` binding here, the label inlined there.
+  # Because that binding is what this suite does NOT cover, both of its
+  # comparisons are pinned operand-by-operand in
+  # tests/gateway-hostname-policy_test.yaml instead.
   - name: foreign-listener-hostname-denied
     try:
     - script:
@@ -502,6 +512,140 @@ spec:
                 port: 443
           EOF
           kubectl -n "$ns" delete httproute route-hostname-allow-probe --ignore-not-found
+        check:
+          ($error == null): true
+  # Case-insensitivity. The route hostname is always lowercase — the CRD's
+  # hostname pattern permits only lowercase, so an uppercase hostname is rejected
+  # before the VAP runs — but the apex operand is the namespace.cozystack.io/host
+  # label VALUE, and Kubernetes permits uppercase in a label value. Under a
+  # mixed-case apex a lowercase in-apex route must still be admitted, so the VAP
+  # normalizes both operands with .lowerAscii(). Pre-fix it compares
+  # "probe.case-probe.route.invalid" against "Case-Probe.route.invalid", misses,
+  # and denies a legitimate route — this step is red pre-fix, green post-fix.
+  # A mixed-case apex is the only runtime shape that exercises the
+  # normalization.
+  #
+  # The apex here does not need to sit under the platform root: unlike the
+  # Ingress policy this VAP compares against the tenant apex only and has no
+  # outside-root branch, so a reserved .invalid apex (RFC 2606) keeps the case
+  # host-independent and unable to collide with a dev cluster's real apex.
+  #
+  # The mixed-case apex goes on a throwaway tenant-* namespace rather than on
+  # tenant-test: relabelling the shared namespace would leave it mixed-case for
+  # every later test if a restore were missed. The tenant-* prefix is what makes
+  # the VAP's matchCondition fire, and the runner is a trusted caller for the
+  # host-label immutability VAP, so the labelled CREATE is admitted (see
+  # untrusted-sa-cannot-set-host-label-at-create above). Applied declaratively:
+  # an admission denial fails the apply, and Chainsaw auto-cleanup deletes the
+  # route and the namespace.
+  - name: mixed-case-apex-route-allowed
+    try:
+    # Pre-clean a namespace left by an interrupted prior run: a leftover
+    # tenant-case-probe stuck in Terminating fails the apply below, and because
+    # the label here is a fixed literal a surviving namespace would otherwise be
+    # silently reused rather than rebuilt.
+    - script:
+        content: |
+          set -eu
+          kubectl delete namespace tenant-case-probe --ignore-not-found --wait=true --timeout=60s
+        check:
+          ($error == null): true
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: tenant-case-probe
+            labels:
+              namespace.cozystack.io/host: Case-Probe.route.invalid
+    # Guard against a vacuous pass: re-read the persisted label. Had anything
+    # normalized it to lowercase, the route below would be admitted with or
+    # without the fix and the step would stop proving case-insensitivity.
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: tenant-case-probe
+            labels:
+              namespace.cozystack.io/host: Case-Probe.route.invalid
+    - apply:
+        resource:
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: HTTPRoute
+          metadata:
+            name: route-hostname-case-probe
+            namespace: tenant-case-probe
+          spec:
+            hostnames:
+            - "probe.case-probe.route.invalid"
+            rules:
+            - backendRefs:
+              - name: kubernetes
+                namespace: default
+                port: 443
+  # The deny half of the mixed-case apex, pairing with the step above the way
+  # foreign-apex-route-denied pairs with own-apex-route-allowed. The allow half
+  # alone only proves the normalized match does not UNDER-admit; over-admission
+  # is the direction that hijacks a hostname, and normalizing both operands is
+  # exactly the edit that can widen a match by accident. Reuses the namespace
+  # the previous step created — Chainsaw cleans up at test scope, not step
+  # scope. Scripted rather than an apply/expect pair because the grep for
+  # "ValidatingAdmissionPolicy" is what proves the VAP did the denying: a bare
+  # "the apply failed" assertion would be satisfied by a typo in the manifest.
+  - name: mixed-case-apex-route-denied
+    try:
+    - script:
+        content: |
+          set -eu
+          # deny <case> <name> reads a manifest on stdin and expects the VAP to
+          # reject it, mirroring the deny() helper in the Ingress suite below.
+          deny() {
+            kubectl -n tenant-case-probe delete httproute "$2" --ignore-not-found >/dev/null
+            out=$(kubectl apply -n tenant-case-probe -f - 2>&1) && rc=0 || rc=$?
+            echo "case=$1 rc=$rc"
+            if [ "$rc" -eq 0 ]; then
+              kubectl -n tenant-case-probe delete httproute "$2" --ignore-not-found
+              echo "BUG: admission accepted $1: $out" >&2
+              exit 1
+            fi
+            echo "$out" | grep -qi "ValidatingAdmissionPolicy"
+          }
+          # A wholly foreign apex stays denied once both operands are lowercased.
+          deny foreign-apex route-case-foreign-probe <<'EOF'
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: HTTPRoute
+          metadata:
+            name: route-case-foreign-probe
+          spec:
+            hostnames:
+            - "evil.other.invalid"
+            rules:
+            - backendRefs:
+              - name: kubernetes
+                namespace: default
+                port: 443
+          EOF
+          # Dot-boundary guard under the mixed-case apex: "evilcase-probe.route.invalid"
+          # ends with the lowercased apex "case-probe.route.invalid" but is NOT a
+          # subdomain of it. The CEL only denies it because the suffix test is
+          # endsWith("." + apex); drop that leading dot and this hostname is
+          # admitted and hijacks the apex. This is the only case in this suite
+          # that would notice.
+          deny prefix-adjacent route-case-adjacent-probe <<'EOF'
+          apiVersion: gateway.networking.k8s.io/v1
+          kind: HTTPRoute
+          metadata:
+            name: route-case-adjacent-probe
+          spec:
+            hostnames:
+            - "evilcase-probe.route.invalid"
+            rules:
+            - backendRefs:
+              - name: kubernetes
+                namespace: default
+                port: 443
+          EOF
         check:
           ($error == null): true
 ---
@@ -1048,6 +1192,151 @@ spec:
           kubectl -n "$ns" delete ingress ingress-ownapex-wildcard-probe --ignore-not-found
         check:
           ($error == null): true
+  # Case-insensitivity. spec.rules[].host and spec.tls[].hosts[] are always
+  # lowercase — the apiserver's host validation permits only lowercase, so an
+  # uppercase host is rejected before the VAP runs — but the apex operand is the
+  # namespace.cozystack.io/host label VALUE, and Kubernetes permits uppercase in
+  # a label value. Under a mixed-case apex a lowercase in-apex Ingress must
+  # still be admitted, so the VAP normalizes both operands with .lowerAscii().
+  # Ingress is the default publish path and carries the most complex CEL (a
+  # rule-host and a tls-host branch), so it gets its own runtime guard beside
+  # the route one; both branches are exercised at once because the tls branch
+  # denies on its own.
+  #
+  # The probe apex is derived as Case-Probe.<root> rather than hardcoded, and it
+  # has to sit UNDER the platform root to mean anything: the outside-root branch
+  # admits any non-wildcard host outside the root apex whatever the tenant apex
+  # says, so a probe on an unrelated domain would be admitted pre-fix and prove
+  # nothing. Under the root that escape is closed — pre-fix the own-apex branch
+  # misses on case and the outside-root branch is excluded, so admission denies
+  # and this step is red; post-fix the own-apex branch matches and it is green.
+  #
+  # The mixed-case apex goes on a throwaway tenant-* namespace rather than on
+  # tenant-test, for the same reason as the route case. Built in a script since
+  # it needs ${root} interpolation, so the namespace is torn down in finally
+  # rather than by Chainsaw auto-cleanup. That teardown is also why the allow and
+  # deny halves share ONE step here while the route case splits them in two:
+  # finally runs at step scope, so a second step would find the namespace gone.
+  # The route namespace is applied declaratively and reclaimed at test scope, so
+  # it survives into its own deny step.
+  - name: mixed-case-apex-allowed-and-denied
+    try:
+    - script:
+        content: |
+          set -eu
+          root=$(kubectl get namespace tenant-root -o jsonpath='{.metadata.labels.namespace\.cozystack\.io/host}')
+          [ -n "$root" ] || { echo "SETUP FAILURE: tenant-root lacks the namespace.cozystack.io/host label" >&2; exit 1; }
+          apex="Case-Probe.${root}"
+          host="probe.case-probe.${root}"
+          # Guard against a vacuous pass: the probe apex must really be
+          # mixed-case. An all-lowercase apex would admit the Ingress with or
+          # without the fix — this catches a later edit that lowercases the
+          # literal above, which the persisted-label check below cannot see.
+          [ "$apex" != "$(echo "$apex" | tr '[:upper:]' '[:lower:]')" ] || { echo "SETUP FAILURE: probe apex '$apex' is not mixed-case" >&2; exit 1; }
+          # Pre-clean a namespace left behind by an interrupted prior run.
+          kubectl delete namespace tenant-ingress-case-probe --ignore-not-found --wait=true --timeout=60s
+          kubectl apply -f - <<EOF
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: tenant-ingress-case-probe
+            labels:
+              namespace.cozystack.io/host: ${apex}
+          EOF
+          # Second vacuous-pass guard: re-read the persisted label, in case
+          # anything normalized the value on the way in.
+          got=$(kubectl get namespace tenant-ingress-case-probe -o jsonpath='{.metadata.labels.namespace\.cozystack\.io/host}')
+          [ "$got" = "$apex" ] || { echo "SETUP FAILURE: apex label persisted as '$got', want '$apex'" >&2; exit 1; }
+          kubectl apply -n tenant-ingress-case-probe -f - <<EOF
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: ingress-hostname-case-probe
+          spec:
+            tls:
+            - hosts:
+              - "${host}"
+              secretName: noop-tls
+            rules:
+            - host: "${host}"
+              http:
+                paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: noop
+                      port:
+                        number: 80
+          EOF
+          # The deny half, pairing with the allow above the way
+          # foreign-and-adjacent-hosts-denied pairs with own-apex-allowed. The
+          # allow half alone only proves the normalized match does not
+          # UNDER-admit; over-admission is what hijacks a hostname, and
+          # normalizing both operands is exactly the edit that can widen a match
+          # by accident.
+          deny() {
+            kubectl -n tenant-ingress-case-probe delete ingress "$2" --ignore-not-found >/dev/null
+            out=$(kubectl apply -n tenant-ingress-case-probe -f - 2>&1) && rc=0 || rc=$?
+            echo "case=$1 rc=$rc"
+            if [ "$rc" -eq 0 ]; then
+              kubectl -n tenant-ingress-case-probe delete ingress "$2" --ignore-not-found
+              echo "BUG: admission accepted $1: $out" >&2
+              exit 1
+            fi
+            echo "$out" | grep -qi "ValidatingAdmissionPolicy"
+          }
+          # Under the platform root but outside the probe's own apex: the
+          # own-apex branch must miss on more than case, and the outside-root
+          # branch must stay closed under the root.
+          deny foreign-apex-host ingress-case-foreign-probe <<EOF
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: ingress-case-foreign-probe
+          spec:
+            rules:
+            - host: "dashboard.${root}"
+              http:
+                paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: noop
+                      port:
+                        number: 80
+          EOF
+          # Dot-boundary guard on the normalized path: "evilcase-probe.<root>"
+          # ends with the lowercased apex "case-probe.<root>" without being a
+          # subdomain of it. Only endsWith("." + apex) denies it; drop that
+          # leading dot and the apex is hijackable.
+          deny prefix-adjacent ingress-case-adjacent-probe <<EOF
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: ingress-case-adjacent-probe
+          spec:
+            rules:
+            - host: "evilcase-probe.${root}"
+              http:
+                paths:
+                - path: /
+                  pathType: Prefix
+                  backend:
+                    service:
+                      name: noop
+                      port:
+                        number: 80
+          EOF
+        check:
+          ($error == null): true
+    finally:
+    - delete:
+        ref:
+          apiVersion: v1
+          kind: Namespace
+          name: tenant-ingress-case-probe
   # Static accepts — concrete external domains outside the platform root apex
   # on both spec.rules[].host and spec.tls[].hosts. Declarative apply; Chainsaw
   # auto-cleanup deletes the probes.

--- a/packages/system/cozystack-basics/templates/gateway-hostname-policy.yaml
+++ b/packages/system/cozystack-basics/templates/gateway-hostname-policy.yaml
@@ -27,13 +27,26 @@ spec:
          ? namespaceObject.metadata.labels["namespace.cozystack.io/host"]
          : ""
   validations:
+  # Both operands of the hostname match are normalized with .lowerAscii():
+  # the listener hostname is already lowercase (the CRD pattern permits
+  # nothing else), but tenantHost
+  # comes from the namespace.cozystack.io/host label value, which
+  # Kubernetes permits to carry uppercase. Unlike the Ingress policy this
+  # one never compares against the platform root-host.
+  #
+  # The leading `tenantHost == "" ||` makes this policy fail OPEN when the
+  # host label is absent or empty, unlike its fail-closed siblings. That is
+  # the platform's documented fail-open exception, with its compensating
+  # control and its limits — see docs/security/threat-model.md. Changing
+  # that posture is a security-model decision, not a side effect of
+  # normalizing case, so the behavior is left as it was and pinned by test.
   - expression: >-
       variables.tenantHost == "" ||
       !has(object.spec.listeners) ||
       object.spec.listeners.all(l,
         !has(l.hostname) ||
-        l.hostname == variables.tenantHost ||
-        l.hostname.endsWith("." + variables.tenantHost)
+        l.hostname.lowerAscii() == variables.tenantHost.lowerAscii() ||
+        l.hostname.lowerAscii().endsWith("." + variables.tenantHost.lowerAscii())
       )
     messageExpression: >-
       "Gateway listener hostname must equal " + variables.tenantHost +

--- a/packages/system/cozystack-basics/templates/ingress-hostname-policy.yaml
+++ b/packages/system/cozystack-basics/templates/ingress-hostname-policy.yaml
@@ -43,11 +43,27 @@
   has() then walks into metadata.labels safely. See the feedback memory
   cel-has-field-only.md.
 
-  Case handling: kube-apiserver validates spec.rules[].host and
-  spec.tls[].hosts[] as DNS-1123 subdomains (lowercase only), so the
-  apex/subdomain string comparisons below need no case normalization — a
-  mixed-case host is rejected by built-in validation and never reaches a
-  created state, so casing cannot be used to sidestep the comparisons.
+  Case handling: every comparison below normalizes both operands with
+  .lowerAscii(), and for this policy that is load-bearing rather than
+  hardening. The resource-side host is always lowercase — kube-apiserver
+  permits only lowercase in spec.rules[].host and spec.tls[].hosts[],
+  wildcards included, and rejects the rest before this VAP runs — but BOTH apex operands can carry
+  uppercase: the namespace.cozystack.io/host label VALUE (Kubernetes
+  permits uppercase in a label value) and the templated root-host, a
+  free-form platform value that nothing validates for case.
+
+  An uppercase root-host is the dangerous direction. The outside-root
+  branch below admits a host lying entirely outside the platform apex,
+  and it decides that by comparing the lowercase host against this
+  templated literal. Un-normalized, that comparison can never match, the
+  exclusion silently stops excluding, and the policy degenerates into
+  "admit any non-wildcard host" — every non-wildcard platform-apex name a
+  tenant asks for is granted, including the root apex itself. Only the
+  anti-wildcard gate still holds.
+
+  A mixed-case apex LABEL is the milder direction: it wrongly denies a
+  tenant its own legitimate in-apex hostname rather than granting it
+  someone else's.
 
   Defense-in-depth contract: this VAP is fail-closed. A tenant-*
   namespace without `namespace.cozystack.io/host` is rejected (not
@@ -60,7 +76,7 @@
 {{- /* Also gate on the ValidatingAdmissionPolicy API (GA since Kubernetes 1.30; the management cluster requires 1.33+), so a cluster without it does not get an unrenderable resource. Same guard as packages/core/platform/templates/deletion-protection.yaml. */}}
 {{- if and $rootHost (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy") }}
 {{- $A := `namespaceObject.metadata.labels["namespace.cozystack.io/host"]` }}
-{{- $celValidator := printf `(namespaceObject == null || !has(namespaceObject.metadata.labels) || !("namespace.cozystack.io/host" in namespaceObject.metadata.labels)) ? false : (!has(object.spec.defaultBackend) && (!has(object.spec.rules) || object.spec.rules.all(r, has(r.host) && r.host != "" && (r.host == %s || r.host.endsWith("." + %s) || (!r.host.startsWith("*.") && !(r.host == %q || r.host.endsWith(%q)))))) && (!has(object.spec.tls) || object.spec.tls.all(t, !has(t.hosts) || t.hosts.all(h, h != "" && (h == %s || h.endsWith("." + %s) || (!h.startsWith("*.") && !(h == %q || h.endsWith(%q))))))))` $A $A $rootHost (printf ".%s" $rootHost) $A $A $rootHost (printf ".%s" $rootHost) -}}
+{{- $celValidator := printf `(namespaceObject == null || !has(namespaceObject.metadata.labels) || !("namespace.cozystack.io/host" in namespaceObject.metadata.labels)) ? false : (!has(object.spec.defaultBackend) && (!has(object.spec.rules) || object.spec.rules.all(r, has(r.host) && r.host != "" && (r.host.lowerAscii() == %s.lowerAscii() || r.host.lowerAscii().endsWith("." + %s.lowerAscii()) || (!r.host.lowerAscii().startsWith("*.") && !(r.host.lowerAscii() == %q.lowerAscii() || r.host.lowerAscii().endsWith(%q.lowerAscii())))))) && (!has(object.spec.tls) || object.spec.tls.all(t, !has(t.hosts) || t.hosts.all(h, h != "" && (h.lowerAscii() == %s.lowerAscii() || h.lowerAscii().endsWith("." + %s.lowerAscii()) || (!h.lowerAscii().startsWith("*.") && !(h.lowerAscii() == %q.lowerAscii() || h.lowerAscii().endsWith(%q.lowerAscii()))))))))` $A $A $rootHost (printf ".%s" $rootHost) $A $A $rootHost (printf ".%s" $rootHost) -}}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy

--- a/packages/system/cozystack-basics/templates/route-hostname-policy.yaml
+++ b/packages/system/cozystack-basics/templates/route-hostname-policy.yaml
@@ -35,7 +35,14 @@
   label is absent is an in-flight namespace creation that hasn't
   finished labelling yet — in which case the caller should retry.
 */}}
-{{- $celValidator := `(namespaceObject == null || !has(namespaceObject.metadata.labels) || !("namespace.cozystack.io/host" in namespaceObject.metadata.labels)) ? false : (!has(object.spec.hostnames) || object.spec.hostnames.all(h, h == namespaceObject.metadata.labels["namespace.cozystack.io/host"] || h.endsWith("." + namespaceObject.metadata.labels["namespace.cozystack.io/host"])))` -}}
+{{- /*
+  Both operands of the hostname comparison are normalized with
+  .lowerAscii() as defense-in-depth: the route hostname is already
+  lowercase (the CRD pattern permits nothing else), but the apex operand is the
+  namespace.cozystack.io/host label value, which Kubernetes permits to
+  carry uppercase.
+*/}}
+{{- $celValidator := `(namespaceObject == null || !has(namespaceObject.metadata.labels) || !("namespace.cozystack.io/host" in namespaceObject.metadata.labels)) ? false : (!has(object.spec.hostnames) || object.spec.hostnames.all(h, h.lowerAscii() == namespaceObject.metadata.labels["namespace.cozystack.io/host"].lowerAscii() || h.lowerAscii().endsWith("." + namespaceObject.metadata.labels["namespace.cozystack.io/host"].lowerAscii())))` -}}
 {{- /* Render only where the ValidatingAdmissionPolicy API is served (GA since Kubernetes 1.30; the management cluster requires 1.33+). Same guard as packages/core/platform/templates/deletion-protection.yaml. */}}
 {{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy" }}
 ---

--- a/packages/system/cozystack-basics/tests/gateway-hostname-policy_test.yaml
+++ b/packages/system/cozystack-basics/tests/gateway-hostname-policy_test.yaml
@@ -75,11 +75,52 @@ tests:
       - documentIndex: 0
         matchRegex:
           path: spec.validations[0].expression
-          pattern: 'l\.hostname\.endsWith'
+          pattern: 'l\.hostname\.lowerAscii\(\)\.endsWith'
       - documentIndex: 0
         matchRegex:
           path: spec.validations[0].expression
           pattern: 'variables\.tenantHost'
+      # Both operands normalized with lowerAscii() — tenantHost comes from
+      # the label value, which may carry uppercase even though the listener
+      # hostname is lowercase-only. Unlike the Ingress policy this one never
+      # compares against the platform root host, so the normalization here
+      # only stops a mixed-case apex from wrongly denying a tenant its own
+      # listener.
+      #
+      # Both comparisons are pinned as whole operand PAIRS. This policy has
+      # no runtime probe of its own — it relies on these renderings — so a
+      # pattern matching a lone `.lowerAscii()` somewhere in the expression
+      # would let either operand lose its normalization unnoticed.
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'l\.hostname\.lowerAscii\(\) == variables\.tenantHost\.lowerAscii\(\)'
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'l\.hostname\.lowerAscii\(\)\.endsWith\("\." \+ variables\.tenantHost\.lowerAscii\(\)\)'
+
+  - it: cozystack-gateway-hostname-policy admits any listener hostname when the host label is absent or empty
+    # Pins the documented fail-open exception, so that changing it has to be
+    # a deliberate act rather than a silent one. The leading
+    # `tenantHost == "" ||` admits a Gateway with any listener hostname when
+    # the namespace.cozystack.io/host label is absent or empty — the
+    # opposite of the sibling Route and Ingress policies, which fail closed
+    # on the same input. docs/security/threat-model.md records this as the
+    # platform's one fail-open exception and states that the Gateway-side
+    # guarantee is conditional on the label being present; the compensating
+    # control is that the platform sets the label at tenant creation and the
+    # host-label policy keeps it immutable. This test asserts the shape the
+    # threat model describes, so that a change to the posture shows up here
+    # and gets made against that document rather than by accident.
+    asserts:
+      # Anchored: the empty-host short-circuit must be the FIRST operand, and
+      # `||` is what makes it admit. Rewriting it to the siblings' fail-closed
+      # `tenantHost == "" ? false :` breaks this pattern, which is the point.
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: '^variables\.tenantHost == "" \|\|'
 
   - it: cozystack-gateway-hostname-policy Binding is fail-closed (validationActions Deny)
     asserts:

--- a/packages/system/cozystack-basics/tests/ingress-hostname-policy_test.yaml
+++ b/packages/system/cozystack-basics/tests/ingress-hostname-policy_test.yaml
@@ -94,6 +94,80 @@ tests:
           path: spec.validations[0].expression
           pattern: 'namespace\.cozystack\.io/host'
 
+  - it: normalizes both operands of every comparison with lowerAscii
+    # The resource-side host is already lowercase, but the apex
+    # operand is the namespace.cozystack.io/host label VALUE, which
+    # Kubernetes permits to carry uppercase.
+    #
+    # Each pattern pins a whole operand PAIR, not a lone `.lowerAscii()`
+    # anywhere in the expression: the apex label appears four times here
+    # (equality and endsWith, on the rules[].host and tls[].hosts[]
+    # branches), so a pattern that merely looks for a normalized label
+    # still matches when one of the four loses its normalization. Pin the
+    # exact comparison each time, so dropping any single operand is caught.
+    asserts:
+      # rules[].host — exact apex match, then dot-bounded subdomain.
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'r\.host\.lowerAscii\(\) == namespaceObject\.metadata\.labels\["namespace\.cozystack\.io/host"\]\.lowerAscii\(\)'
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'r\.host\.lowerAscii\(\)\.endsWith\("\." \+ namespaceObject\.metadata\.labels\["namespace\.cozystack\.io/host"\]\.lowerAscii\(\)\)'
+      # tls[].hosts[] — the same two comparisons, denying on their own.
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'h\.lowerAscii\(\) == namespaceObject\.metadata\.labels\["namespace\.cozystack\.io/host"\]\.lowerAscii\(\)'
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'h\.lowerAscii\(\)\.endsWith\("\." \+ namespaceObject\.metadata\.labels\["namespace\.cozystack\.io/host"\]\.lowerAscii\(\)\)'
+      # The templated root-host literal, on both branches.
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: '"example\.org"\.lowerAscii\(\)'
+
+  - it: normalizes an uppercase templated root apex so the outside-root escape stays closed
+    # _cluster.root-host is a free-form platform value with no lowercase
+    # validation, so an operator can set Example.ORG. The outside-root branch
+    # admits any non-wildcard host that is NOT under the root apex, and it
+    # compares against this templated literal. Un-normalized, the comparison
+    # never matches a real (lowercase) host, the exclusion silently stops
+    # excluding, and the policy degenerates into "admit any non-wildcard host"
+    # — a tenant could then take a hostname under the platform apex that
+    # belongs to another tenant. Rendering with an uppercase root is the only
+    # way to pin that; every other case here renders the lowercase default and
+    # would pass either way.
+    set:
+      _cluster:
+        root-host: Example.ORG
+    asserts:
+      # All four occurrences are pinned as whole operand pairs — equality and
+      # endsWith, on the rules[].host and tls[].hosts[] branches. A pattern
+      # that merely looks for a normalized root literal somewhere would still
+      # match with one of the four stripped: leaving the suffix operands
+      # normalized while dropping the equality ones makes the outside-root
+      # branch admit the bare root apex itself.
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'r\.host\.lowerAscii\(\) == "Example\.ORG"\.lowerAscii\(\)'
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'r\.host\.lowerAscii\(\)\.endsWith\("\.Example\.ORG"\.lowerAscii\(\)\)'
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'h\.lowerAscii\(\) == "Example\.ORG"\.lowerAscii\(\)'
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'h\.lowerAscii\(\)\.endsWith\("\.Example\.ORG"\.lowerAscii\(\)\)'
+
   - it: allows a hostname outside the platform root apex (external custom domain)
     # Narrow rule: a tenant may route its own domain that lies entirely
     # outside the platform root apex (templated from _cluster.root-host).
@@ -104,11 +178,11 @@ tests:
       - documentIndex: 0
         matchRegex:
           path: spec.validations[0].expression
-          pattern: '!\(r\.host == "example\.org" \|\| r\.host\.endsWith\("\.example\.org"\)\)'
+          pattern: '!\(r\.host\.lowerAscii\(\) == "example\.org"\.lowerAscii\(\) \|\| r\.host\.lowerAscii\(\)\.endsWith\("\.example\.org"\.lowerAscii\(\)\)\)'
       - documentIndex: 0
         matchRegex:
           path: spec.validations[0].expression
-          pattern: '!\(h == "example\.org" \|\| h\.endsWith\("\.example\.org"\)\)'
+          pattern: '!\(h\.lowerAscii\(\) == "example\.org"\.lowerAscii\(\) \|\| h\.lowerAscii\(\)\.endsWith\("\.example\.org"\.lowerAscii\(\)\)\)'
 
   - it: does not let a wildcard use the outside-root path (would match the platform apex)
     # A wildcard on the root's parent label (e.g. *.org when root is
@@ -120,11 +194,11 @@ tests:
       - documentIndex: 0
         matchRegex:
           path: spec.validations[0].expression
-          pattern: '!r\.host\.startsWith\("\*\."\) && !\(r\.host == "example\.org"'
+          pattern: '!r\.host\.lowerAscii\(\)\.startsWith\("\*\."\) && !\(r\.host\.lowerAscii\(\) == "example\.org"\.lowerAscii\(\)'
       - documentIndex: 0
         matchRegex:
           path: spec.validations[0].expression
-          pattern: '!h\.startsWith\("\*\."\) && !\(h == "example\.org"'
+          pattern: '!h\.lowerAscii\(\)\.startsWith\("\*\."\) && !\(h\.lowerAscii\(\) == "example\.org"\.lowerAscii\(\)'
 
   - it: allows a wildcard under the own apex (own-apex path is not wildcard-gated)
     # The !startsWith("*.") gate applies ONLY to the outside-root branch.
@@ -137,11 +211,11 @@ tests:
       - documentIndex: 0
         matchRegex:
           path: spec.validations[0].expression
-          pattern: 'r\.host\.endsWith\("\." \+ namespaceObject\.metadata\.labels\["namespace\.cozystack\.io/host"\]\) \|\| \(!r\.host\.startsWith\("\*\."\)'
+          pattern: 'r\.host\.lowerAscii\(\)\.endsWith\("\." \+ namespaceObject\.metadata\.labels\["namespace\.cozystack\.io/host"\]\.lowerAscii\(\)\) \|\| \(!r\.host\.lowerAscii\(\)\.startsWith\("\*\."\)'
       - documentIndex: 0
         matchRegex:
           path: spec.validations[0].expression
-          pattern: 'h\.endsWith\("\." \+ namespaceObject\.metadata\.labels\["namespace\.cozystack\.io/host"\]\) \|\| \(!h\.startsWith\("\*\."\)'
+          pattern: 'h\.lowerAscii\(\)\.endsWith\("\." \+ namespaceObject\.metadata\.labels\["namespace\.cozystack\.io/host"\]\.lowerAscii\(\)\) \|\| \(!h\.lowerAscii\(\)\.startsWith\("\*\."\)'
 
   - it: rejects a hostless or empty-host catch-all rule
     # A legacy Ingress rule with no .host (absent OR empty string) matches

--- a/packages/system/cozystack-basics/tests/route-hostname-policy_test.yaml
+++ b/packages/system/cozystack-basics/tests/route-hostname-policy_test.yaml
@@ -60,6 +60,33 @@ tests:
           path: spec.validations[0].expression
           pattern: 'namespace\.cozystack\.io/host'
 
+  - it: normalizes both operands of every comparison with lowerAscii
+    # The route hostname is already lowercase, but the apex operand
+    # is the namespace.cozystack.io/host label VALUE, which Kubernetes
+    # permits to carry uppercase.
+    #
+    # Both comparisons are pinned as whole operand pairs, for HTTPRoute
+    # (doc 0) and TLSRoute (doc 2), which share one CEL validator: a pattern
+    # matching a lone `.lowerAscii()` somewhere in the expression still
+    # matches when one operand loses its normalization.
+    asserts:
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'h\.lowerAscii\(\) == namespaceObject\.metadata\.labels\["namespace\.cozystack\.io/host"\]\.lowerAscii\(\)'
+      - documentIndex: 0
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'h\.lowerAscii\(\)\.endsWith\("\." \+ namespaceObject\.metadata\.labels\["namespace\.cozystack\.io/host"\]\.lowerAscii\(\)\)'
+      - documentIndex: 2
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'h\.lowerAscii\(\) == namespaceObject\.metadata\.labels\["namespace\.cozystack\.io/host"\]\.lowerAscii\(\)'
+      - documentIndex: 2
+        matchRegex:
+          path: spec.validations[0].expression
+          pattern: 'h\.lowerAscii\(\)\.endsWith\("\." \+ namespaceObject\.metadata\.labels\["namespace\.cozystack\.io/host"\]\.lowerAscii\(\)\)'
+
   - it: validation actions are Deny so requests fail closed
     asserts:
       - documentIndex: 1


### PR DESCRIPTION
## What this PR does

The Ingress, Gateway, and Route hostname `ValidatingAdmissionPolicy` objects compare tenant hostnames against the tenant apex with case-sensitive CEL. The resource-side host is always lowercase — the apiserver's hostname validation permits nothing else — but both apex operands can carry uppercase: the `namespace.cozystack.io/host` label value, which Kubernetes permits to carry uppercase and which the tenant chart writes verbatim from `tenant.spec.host`, and the templated `_cluster.root-host`, a free-form platform value that nothing validates for case.

A mixed-case apex label wrongly denies a tenant its own legitimate lowercase in-apex hostname. An uppercase `_cluster.root-host` is the dangerous direction: the Ingress outside-root exclusion compares a lowercase host against the uppercase literal, never matches, so the exclusion stops excluding and the policy admits any non-wildcard host — every non-wildcard platform-apex name a tenant asks for, including a hostname belonging to another tenant and the root apex itself. Only the anti-wildcard gate still holds.

This normalizes both operands of every hostname comparison with `.lowerAscii()` (host, apex label, and the templated root-host literal) across all three policies, so the match follows DNS case semantics. There is no behavior change in the default all-lowercase configuration.

The Gateway policy's fail-open on an absent or empty host label is deliberately left as it was: that is the platform's one documented fail-open exception in `docs/security/threat-model.md`, so changing the posture is a security-model decision rather than a side effect of normalizing case. Its current shape is pinned by a test.

Test coverage:

- helm-unittest pins each comparison as a whole operand pair — equality and `endsWith`, across the rule-host and tls-host branches — so dropping the normalization from any single operand is caught. A pattern matching a lone `.lowerAscii()` would not: the apex appears four times in the Ingress expression, so stripping one operand still leaves three matches.
- A rendering case with `_cluster.root-host: Example.ORG` pins the outside-root escape shut; it is red pre-fix.
- e2e probes set a mixed-case apex on an isolated throwaway namespace and assert both halves of the match: a lowercase in-apex HTTPRoute and Ingress are still admitted (red pre-fix, green post-fix), while a foreign apex and a hostname ending with the apex without a dot boundary are still denied. Vacuous-pass guards re-read the persisted label and assert the probe apex really is mixed-case.

Normalizing the apex at the write site — the tenant namespace template and `_cluster.root-host` — is tracked separately in #3328. It would not remove the need for this change: the host label is settable out-of-band by a trusted caller, so these policies must not assume the apex arrives normalized.

Closes #3205.

### Screenshots

N/A (no UI changes).

### Release note

```release-note
fix(cozystack-basics): tenant hostname admission policies now compare against the tenant apex and the platform root apex case-insensitively. This closes a bypass where an uppercase `_cluster.root-host` made the Ingress policy's outside-root exclusion stop matching, so the policy admitted any non-wildcard host — including a hostname under the platform apex belonging to another tenant, and the root apex itself.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hostname validation now consistently matches case-insensitively across Gateway, Ingress, HTTPRoute, and TLSRoute.
  * Mixed-case tenant and apex hostnames are accepted when they meet the intended domain boundaries.
  * Foreign domains and prefix-adjacent hostnames remain correctly rejected; validation behaves as documented when the tenant host is empty.

* **Tests**
  * Expanded unit and e2e coverage for case-insensitive hostname rendering and boundary rejections across the supported resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
