### PR TITLE
test(e2e): wait for LINSTOR pool free capacity between tenant Kubernetes tests

### DIFF
--- a/hack/e2e-apps/run-kubernetes.sh
+++ b/hack/e2e-apps/run-kubernetes.sh
@@ -57,6 +57,68 @@ cozy_wait_tenant_drained() {
   done
 }
 
+# Block until every ZFS storage pool on every LINSTOR satellite reports at
+# least _min_free_gib of FreeCapacity. Motivation is proven from a
+# cozyreport artefact captured by hack/cozyreport.sh (see PR #3044 run
+# 28751310913, LINSTOR satellite ErrorReport 6A4AADFD-349B2-000000):
+# tearing down a tenant Kubernetes worker with a `replicated` (autoPlace=3,
+# DRBD) 20 GiB root disk removes the PVC from the API within seconds, but
+# the ZFS `zvol destroy` on each satellite lags behind by tens of seconds
+# as DRBD adjusts, unref counts drain and ZFS batch-destroys the datasets.
+# cozy_wait_tenant_drained above only waits on the API-level PVC delete,
+# not on the physical satellite space return; if the next tenant test
+# starts inside that window it hits `zfs create -V ...` failing with
+# `cannot create '...': out of space`, LINSTOR-CSI then retries autoplace,
+# each retry racing the still-being-torn-down previous placement and
+# stretching worker-Machine bringup past the MHC nodeStartupTimeout.
+#
+# Two 20 GiB replicated worker targets (60 GiB total per satellite, since
+# autoPlace=3 places one replica per node) plus two 21 GiB CDI scratch
+# PVCs (worst case both landing on the same node via the local
+# storageClass) yields a ~82 GiB per-satellite peak footprint; 90 GiB
+# default threshold covers that with margin. Bounded and best-effort like
+# cozy_wait_tenant_drained: caller wraps in `|| true`, timeout returns
+# loudly.
+cozy_wait_linstor_pool_free() {
+  _min_free_gib="${1:-90}"
+  _timeout="${2:-300}"
+  _min_free_kib=$(( _min_free_gib * 1024 * 1024 ))
+  _deadline=$(( $(date +%s) + _timeout ))
+  while :; do
+    # jq lives inside the controller pod (Debian-bookworm base, `sh` is
+    # dash — keep the heredoc POSIX-safe). LINSTOR's `--machine-readable`
+    # output for `sp l` on LINSTOR 1.33.x is a one-element outer array
+    # whose sole element is a flat array of storage-pool objects; each
+    # pool object exposes free_capacity at the top level in KiB. Filter
+    # to ZFS variants (both `ZFS` and `ZFS_THIN`) so DISKLESS
+    # placeholders (whose free_capacity is a Long.MAX_VALUE sentinel)
+    # and any future non-ZFS driver are skipped. Also guard against
+    # OFFLINE satellites, whose pool objects omit free_capacity entirely
+    # (StoragePool schema marks it optional) — without the null guard
+    # `sort -n` would rank the string "null" ahead of real numbers and
+    # the loop would silently poll to timeout. Emit
+    # `<free_capacity_kib>:<node>` lines so a single sort yields the
+    # smallest pool and its owner in one round-trip.
+    _min_line=$(kubectl -n cozy-linstor exec deploy/linstor-controller -- sh -c '
+      linstor --machine-readable sp l 2>/dev/null |
+      jq -r "first | .[] | select((.provider_kind | test(\"^ZFS\")) and .free_capacity != null) | \"\(.free_capacity):\(.node_name)\"" |
+      sort -n | head -n 1
+    ' 2>/dev/null) || _min_line=""
+    _min_kib="${_min_line%%:*}"
+    _min_node="${_min_line#*:}"
+    if [ -n "$_min_kib" ] && [ "$_min_kib" -ge "$_min_free_kib" ] 2>/dev/null; then
+      echo "» LINSTOR ZFS pool free: smallest satellite ${_min_node} has $(( _min_kib / 1024 / 1024 )) GiB (>= ${_min_free_gib} GiB threshold)"
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$_deadline" ]; then
+      echo "» WARNING: LINSTOR ZFS pool free did not reach ${_min_free_gib} GiB on every satellite within ${_timeout}s (smallest observed: ${_min_kib:-unknown} KiB on ${_min_node:-unknown}); continuing (next test may face zfs create out-of-space)" >&2
+      kubectl -n cozy-linstor exec deploy/linstor-controller -- linstor --no-color sp l 2>&1 | sed 's/^/  linstor-pool: /' >&2 || true
+      return 1
+    fi
+    sleep 5
+  done
+}
+
 # Unconditional cleanup hook, invoked by cozytest.sh after this file's tests
 # (pass or fail). A failed run otherwise leaves the tenant cluster's worker-VM
 # PVCs (tens of GiB) in tenant-test, exhausting the shared tenant-quota and
@@ -75,6 +137,10 @@ cozy_cleanup() {
   # VMIs (guest RAM) and disk PVCs are actually gone so the next tenant test
   # starts on a freed sandbox -- the root cause of the node-join flake.
   cozy_wait_tenant_drained 300 || true
+  # PVC removal at the API level does not imply the satellite ZFS pool has
+  # reclaimed the space (see comment on cozy_wait_linstor_pool_free above);
+  # wait for FreeCapacity to return before yielding to the next tenant test.
+  cozy_wait_linstor_pool_free 90 300 || true
 }
 
 # Snapshot the tenant cluster (its cilium/CSI/coredns internals) on a failed run.


### PR DESCRIPTION
## What this PR does

Adds a companion `cozy_wait_linstor_pool_free` helper to `hack/e2e-apps/run-kubernetes.sh` and calls it from `cozy_cleanup` right after `cozy_wait_tenant_drained`. The helper polls LINSTOR for the smallest ZFS pool `FreeCapacity` across every satellite and blocks until it reaches a per-satellite threshold (default 90 GiB), bounded to 300 s with a loud warning on timeout.

### Root cause (proven)

`kubernetes-previous.bats` intermittently failed with `zfs create -V 20976048KB data/pvc-... returned with exitcode 1: cannot create '...': out of space` on a satellite that measured **132 GiB free 35 minutes later** — so this is not an absolute capacity issue but a timing race.

Root cause is captured in the cozyreport artefact of run 28751310913 (PR #3044), satellite ErrorReport `6A4AADFD-349B2-000000`. The previous tenant Kubernetes test's `cozy_wait_tenant_drained` gate returned as soon as its PVCs disappeared from the API, but the satellite-side ZFS `zvol destroy` for the just-deleted replicated (autoPlace=3, DRBD) 20 GiB worker disks lagged tens of seconds behind that signal as DRBD adjusted, unref counts drained, and ZFS batch-destroyed the datasets. The next tenant test's `CreateVolume` landed inside that window, LINSTOR-CSI retried autoplace against the still-being-torn-down previous placement (`Do not place with resource: pvc-<same-uid>` implicit anti-collocation, no CSI bug), and worker Machine bringup stretched past the MHC `nodeStartupTimeout` budget with no cluster-side fault.

The proximate observation (`zfs create out of space`) surfaced only because of PR #3209 which teaches `hack/cozyreport.sh` to bundle satellite ErrorReports into the artefact. Without that, the root cause was ambiguous between several plausible LINSTOR internal races and I nearly opened a wrong upstream issue.

### Threshold rationale

Two 20 GiB replicated worker targets = 60 GiB per satellite (autoPlace=3 places one replica per node) plus two 21 GiB CDI scratch PVCs (worst case both landing on the same node via the `local` storageClass) = ~82 GiB per-satellite peak footprint. 90 GiB default threshold covers that with margin.

### Scope

`hack/e2e-apps/run-kubernetes.sh` only. E2E-scope, no product or chart change. Threshold and timeout are function args with sensible defaults; caller can override.

### Verified

`jq` expression against a live LINSTOR 1.33.2 cluster:

```
$ kubectl -n cozy-linstor exec deploy/linstor-controller -- sh -c 'linstor --machine-readable sp l 2>/dev/null | jq -r "first | .[] | select((.provider_kind | test(\"^ZFS\")) and .free_capacity != null) | \"\(.free_capacity):\(.node_name)\"" | sort -n'
3088864:talos-5jt-iq3
42483036:talos-te2-p24
197991872:talos-6cn-cgg
```

Matches `linstor sp l` output exactly (2.95 GiB / 40.51 GiB / 188.82 GiB). ZFS-only filter excludes DISKLESS `Long.MAX_VALUE` sentinel; `and .free_capacity != null` guard prevents OFFLINE satellite pool objects (whose `free_capacity` is optional per REST schema) from ranking as `null` in the sort and hanging the loop.

Contract mirrors `cozy_wait_tenant_drained`: bounded deadline, `|| true` at the call site, loud timeout warning that includes the smallest observed pool and its satellite. Timeout can never wedge the suite worse than the status quo.

### Release note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup reliability by waiting for storage capacity to be released before finishing teardown, reducing cases where resources appear deleted but storage is still unavailable.
  * Made teardown more resilient with a configurable timeout to avoid premature completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->