### PR TITLE
ci(pr-labeler): drop 'edited' trigger to stop bot PR re-run churn

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -2,7 +2,11 @@ name: PR Auto-Label
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, synchronize]
+    # Note: 'edited' is intentionally omitted. It fires on every PR body edit,
+    # which causes long-lived bot PRs (e.g. Renovate) to re-run this job dozens
+    # of times on an unchanged commit. Labels are re-applied on the next push
+    # (synchronize) or reopen instead.
+    types: [opened, reopened, synchronize]
 
 # Top-level token defaults to read-only; jobs request the minimum extra scopes.
 permissions:


### PR DESCRIPTION
## Problem

The **PR Auto-Label** workflow (`.github/workflows/pr-labeler.yaml`) triggers on `pull_request_target` with `types: [opened, edited, reopened, synchronize]`.

The `edited` action fires on every PR title **and body** edit. Long-lived bot PRs — notably Renovate — repeatedly edit their own description on schedule (rebase checkbox, changelog tables, dependency-dashboard state). Each body edit re-runs the `label` job against an **unchanged commit**.

Example: on #2998 (a Renovate PR) the `label` job has run **~48 times**, all on the same head SHA, from Jun 22 through today. It shows up on the /checks page as a wall of duplicate labeler runs.

## Change

Drop `edited` from the trigger types:

```yaml
on:
  pull_request_target:
    types: [opened, reopened, synchronize]
```

## Trade-off

Labels derived from the PR title are re-applied on the next push (`synchronize`) or on reopen. A **title-only** edit made between pushes will no longer trigger an immediate relabel — an acceptable trade for eliminating the constant bot-driven churn. (Title edits are rare and the next push catches up.)

No behavior change for the common case: label-on-open and label-on-push both still work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pull request labeling behavior so labels are refreshed on new commits or when a PR is reopened, while avoiding unnecessary updates from body-only edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->