### PR TITLE
test(e2e): capture per-node network diagnostics in cozyreport

### DIFF
--- a/hack/capture-dataplane.bats
+++ b/hack/capture-dataplane.bats
@@ -1,15 +1,21 @@
 #!/usr/bin/env bats
 # -----------------------------------------------------------------------------
 # Unit tests for the pure decision/parsing helpers in
-# hack/e2e-capture-dataplane.sh -- specifically the LoadBalancer-datapath
-# section, which fires for a Service type=LoadBalancer whose external IP is
-# unreachable while its backend stays Ready (the NotReady-pod path never sees
-# this case). Only the pure logic is unit-testable here:
+# hack/e2e-capture-dataplane.sh. Only the pure logic is unit-testable here:
 #
+# LoadBalancer-datapath section (fires for a Service type=LoadBalancer whose
+# external IP is unreachable while its backend stays Ready -- the NotReady-pod
+# path never sees this case):
 #   - lb_filter_services      -- keep only LoadBalancer rows with an ingress IP;
 #   - lb_first_ready_endpoint -- pick the first addressed, non-NotReady endpoint;
 #   - lb_announcer_node       -- the speaker node of the most recent announce;
 #   - lb_capture_decision     -- capture only when every probe failed.
+#
+# Baseline per-node capture (--baseline mode, invoked by cozyreport.sh):
+#   - _diag_prunable          -- drop only empty files and this script's own
+#                                "DIAG-SKIP:" absence markers, never a real
+#                                kubectl exec failure (a broken capture must stay
+#                                distinguishable from a node that lacked the tool).
 #
 # The kubectl exec / tcpdump capture itself is not unit-testable (it needs a
 # live cluster); these tests pin the derivations that decide WHICH node to
@@ -224,4 +230,64 @@ E2E_CAPTURE_DATAPLANE_LIB=1
 
   [ "$captured" -eq 2 ]
   [ "$dropped" -eq 1 ]
+}
+
+# --------------------------------------------------------------------------- #
+# _diag_prunable -- the baseline-capture pruning predicate. It must drop empty  #
+# files and this script's own "DIAG-SKIP:" absence markers, but KEEP a genuine  #
+# kubectl exec failure so a broken capture stays distinguishable from an absent  #
+# tool (PR review blocker B2). Mock inputs use real kubectl failure text.       #
+# --------------------------------------------------------------------------- #
+
+@test "diag prunable drops an empty capture file" {
+  f="$(mktemp)"
+  : > "$f"
+  if _diag_prunable "$f"; then rm -f "$f"; else rm -f "$f"; echo "FAIL: empty file must be prunable"; false; fi
+}
+
+@test "diag prunable drops a lone DIAG SKIP absence marker" {
+  f="$(mktemp)"
+  printf 'DIAG-SKIP: iptables-save not present in cni-server\n' > "$f"
+  if _diag_prunable "$f"; then rm -f "$f"; else rm -f "$f"; echo "FAIL: DIAG-SKIP stub must be prunable"; false; fi
+}
+
+@test "diag prunable keeps a kubectl Error from server exec failure" {
+  f="$(mktemp)"
+  printf 'Error from server (BadRequest): pod does not have a host assigned\n' > "$f"
+  if _diag_prunable "$f"; then rm -f "$f"; echo "FAIL: a capture failure must be kept, not pruned"; false; fi
+  rm -f "$f"
+}
+
+@test "diag prunable keeps a container not found OCI runtime exec failure" {
+  f="$(mktemp)"
+  printf 'error: unable to upgrade connection: container not found (cilium-agent)\n' > "$f"
+  if _diag_prunable "$f"; then rm -f "$f"; echo "FAIL: an exec failure must be kept, not pruned"; false; fi
+  rm -f "$f"
+}
+
+@test "diag prunable keeps a real multi line capture" {
+  f="$(mktemp)"
+  printf 'Chain INPUT policy ACCEPT\ntarget prot source destination\nACCEPT all anywhere anywhere\n' > "$f"
+  if _diag_prunable "$f"; then rm -f "$f"; echo "FAIL: a real capture must be kept"; false; fi
+  rm -f "$f"
+}
+
+@test "diag prunable keeps a legit one line capture that contains the word error" {
+  f="$(mktemp)"
+  printf 'flow verdict FORWARDED reason error none\n' > "$f"
+  if _diag_prunable "$f"; then rm -f "$f"; echo "FAIL: a real one-line capture must be kept even if it contains the word error"; false; fi
+  rm -f "$f"
+}
+
+@test "diag prunable keeps a multi line file even when the first line is a DIAG SKIP" {
+  f="$(mktemp)"
+  printf 'DIAG-SKIP: header\nreal capture line follows\nand another\n' > "$f"
+  if _diag_prunable "$f"; then rm -f "$f"; echo "FAIL: a multi-line file must be kept even if line 1 is DIAG-SKIP"; false; fi
+  rm -f "$f"
+}
+
+@test "diag prunable drops a DIAG SKIP marker that lacks a trailing newline" {
+  f="$(mktemp)"
+  printf 'DIAG-SKIP: iptables-save not present in cni-server' > "$f"
+  if _diag_prunable "$f"; then rm -f "$f"; else rm -f "$f"; echo "FAIL: a newline-less DIAG-SKIP marker must still be prunable"; false; fi
 }

--- a/hack/cozyreport.sh
+++ b/hack/cozyreport.sh
@@ -348,6 +348,135 @@ if [ -f /workspace/talosconfig ]; then
   done
 fi
 
+# -- per-node network diagnostics
+#
+# kubelet -> pod probe failures (readiness/liveness `dial tcp <podIP>:<port>:
+# connect: connection refused` on a pod whose stdout log confirms the server
+# is bound) are recurrent baseline flakes in the multi-CNI sandbox (kube-ovn
+# + cilium + multus). Cozyreport at end-of-job carries CiliumEndpoint
+# `state: ready`, the pod-side listener log, and the kube-ovn CNI ADD trace
+# for the pod IP -- all of which say the path should work -- but omits the
+# host-side networking state that would prove or disprove the drop. Without
+# it, the pod either (a) is silently on stale conntrack from a previous
+# incarnation with the same IP, (b) is blocked by a hostFirewall or Cilium
+# policy drop that only Hubble sees, or (c) hits a kube-ovn OVS flow race
+# between the kube-ovn-cni ADD and the kernel-side iptables NAT chain.
+# All three leave signature in per-node artefacts a cozyreport that only
+# captures pod-scoped state cannot recover.
+#
+# Every source below is a DaemonSet pod that already runs on the node with
+# hostNetwork and the required binary preinstalled: `iptables-save` +
+# `conntrack` live in `kube-ovn-cni` (`cni-server` container), OVS flows
+# live in `ovs-ovn` (`openvswitch` container), and `hubble observe` +
+# `cilium-dbg endpoint list` live in `cilium` (`cilium-agent`). Optional
+# binaries are `command -v` probed inline so an image without the tool
+# leaves a single "not present" line instead of an OCI runtime error
+# masquerading as a diagnostic capture. Every exec is wrapped in
+# `timeout 30 kubectl exec ...` (matching the upper bound the sibling
+# `hack/e2e-capture-dataplane.sh` uses for the heaviest captures) so a
+# wedged agent (bpf-map iteration stall, hubble ring-buffer replay,
+# ovn-controller lock) cannot hang the surrounding cozyreport run.
+# Files that end up empty or contain only a known error-signature line
+# are dropped so the artefact tree carries only real captures.
+#
+# `timeout(1)` from coreutils is a hard dependency of this block. Skip
+# the whole section on runners without it rather than filling the tree
+# with `sh: 1: timeout: not found` stubs.
+if ! command -v timeout >/dev/null 2>&1; then
+  echo "  timeout(1) not present -- skipping per-node network diagnostics"
+else
+echo "Collecting per-node network diagnostics..."
+DIR=$REPORT_DIR/net-diag
+mkdir -p "$DIR"
+
+# _keep_if_useful <file>
+# Drop the capture file if it is empty or its content is a known "no
+# useful data" signature (missing binary, container exec error). This
+# stops error-text stubs from pretending to be real captures. A file
+# with real data (dozens/hundreds of lines) is left untouched; a
+# single-line "not present" / "OCI runtime" / "command terminated"
+# stub gets removed so the artefact tree carries only real captures.
+_keep_if_useful() {
+  _f="$1"
+  if [ ! -s "$_f" ]; then
+    rm -f "$_f"
+    return
+  fi
+  if [ "$(wc -l < "$_f" 2>/dev/null)" -le 1 ] && \
+     grep --extended-regexp --quiet "not (present|enabled|found)|socket missing|OCI runtime|executable file not found|command terminated|error:|Error from server" "$_f" 2>/dev/null; then
+    rm -f "$_f"
+  fi
+}
+
+for pod in $(kubectl -n cozy-kubeovn get pods -l app=kube-ovn-cni -o name 2>/dev/null); do
+  node=$(kubectl -n cozy-kubeovn get "$pod" -o jsonpath='{.spec.nodeName}' 2>/dev/null)
+  [ -z "$node" ] && node=$(basename "$pod")
+  # `iptables-save` dumps every table (filter/nat/mangle/raw) as a single
+  # text blob; the whole thing lands in one file per node so an operator
+  # can grep across chains without unpacking per-table splits.
+  timeout 30 kubectl -n cozy-kubeovn exec "$pod" --container=cni-server -- \
+    sh -c 'command -v iptables-save >/dev/null 2>&1 && iptables-save || echo "iptables-save not present in cni-server"' \
+    > "$DIR/$node-iptables.txt" 2>&1 || true
+  _keep_if_useful "$DIR/$node-iptables.txt"
+  # `conntrack -L` lists the kernel conntrack table (5-tuple + state +
+  # bytes). `head -n 5000` bounds output so a node with heavy tenant
+  # traffic does not push megabytes of connections into the artefact.
+  # NOTE: conntrack iterates the kernel hash table in bucket order, not
+  # by connection age, so the truncation is not a guaranteed FIFO of
+  # recent entries — an operator chasing a specific 5-tuple should grep
+  # for the podIP/port rather than assume the tail is missing.
+  timeout 30 kubectl -n cozy-kubeovn exec "$pod" --container=cni-server -- \
+    sh -c 'command -v conntrack >/dev/null 2>&1 && conntrack -L 2>/dev/null | head -n 5000 || echo "conntrack not present in cni-server"' \
+    > "$DIR/$node-conntrack.txt" 2>&1 || true
+  _keep_if_useful "$DIR/$node-conntrack.txt"
+done
+
+for pod in $(kubectl -n cozy-kubeovn get pods -l app=ovs -o name 2>/dev/null); do
+  node=$(kubectl -n cozy-kubeovn get "$pod" -o jsonpath='{.spec.nodeName}' 2>/dev/null)
+  [ -z "$node" ] && node=$(basename "$pod")
+  # `ovs-ofctl dump-flows br-int` is the OVS side of the kube-ovn
+  # datapath. Distinguishes a CNI ADD that finished from an ovn-controller
+  # that has not programmed the pod's flow into OVS yet — the flow race
+  # the block-comment above cites as failure mode (c).
+  timeout 30 kubectl -n cozy-kubeovn exec "$pod" --container=openvswitch -- \
+    sh -c 'command -v ovs-ofctl >/dev/null 2>&1 && ovs-ofctl dump-flows br-int || echo "ovs-ofctl not present in openvswitch"' \
+    > "$DIR/$node-ovs-flows.txt" 2>&1 || true
+  _keep_if_useful "$DIR/$node-ovs-flows.txt"
+done
+
+for pod in $(kubectl -n cozy-cilium get pods -l app.kubernetes.io/name=cilium-agent -o name 2>/dev/null); do
+  node=$(kubectl -n cozy-cilium get "$pod" -o jsonpath='{.spec.nodeName}' 2>/dev/null)
+  [ -z "$node" ] && node=$(basename "$pod")
+  # `hubble observe --last N` prints the recent flow log from the local
+  # cilium-agent ring buffer, including verdicts (FORWARDED / DROPPED /
+  # ERROR) with the reason field. Probe for both the binary AND the
+  # hubble unix socket -- the CLI is present in every recent cilium
+  # image, but hubble observability itself is optional (feature flag
+  # `hubble.enabled` in the cilium chart), so the socket may not exist
+  # even when the CLI does. Sized so a probe-drop cascade over a
+  # 5-minute window still fits, and a healthy node's log stays small.
+  timeout 30 kubectl -n cozy-cilium exec "$pod" --container=cilium-agent -- \
+    sh -c 'command -v hubble >/dev/null 2>&1 && [ -S /var/run/cilium/hubble.sock ] && hubble observe --last 2000 --output=compact 2>&1 || echo "hubble not enabled or socket missing in cilium-agent"' \
+    > "$DIR/$node-hubble-flows.txt" 2>&1 || true
+  _keep_if_useful "$DIR/$node-hubble-flows.txt"
+  # `cilium-dbg endpoint list` gives the per-endpoint policy state
+  # (identity, security policies, state, controllers), which resolves
+  # the question "was the drop a policy decision or a datapath race"
+  # that hubble alone doesn't disambiguate.
+  timeout 30 kubectl -n cozy-cilium exec "$pod" --container=cilium-agent -- \
+    sh -c 'command -v cilium-dbg >/dev/null 2>&1 && cilium-dbg endpoint list || echo "cilium-dbg not present in cilium-agent"' \
+    > "$DIR/$node-cilium-endpoints.txt" 2>&1 || true
+  _keep_if_useful "$DIR/$node-cilium-endpoints.txt"
+done
+
+# Drop the parent directory if no artefact landed (e.g. neither kube-ovn
+# nor cilium was present on the cluster the report is run against, or
+# every capture was pruned by `_keep_if_useful`).
+if [ -z "$(ls -A "$DIR" 2>/dev/null)" ]; then
+  rmdir "$DIR" 2>/dev/null || true
+fi
+fi
+
 # -- finalization
 
 echo "Generating summary..."

--- a/hack/cozyreport.sh
+++ b/hack/cozyreport.sh
@@ -350,132 +350,24 @@ fi
 
 # -- per-node network diagnostics
 #
-# kubelet -> pod probe failures (readiness/liveness `dial tcp <podIP>:<port>:
-# connect: connection refused` on a pod whose stdout log confirms the server
-# is bound) are recurrent baseline flakes in the multi-CNI sandbox (kube-ovn
-# + cilium + multus). Cozyreport at end-of-job carries CiliumEndpoint
-# `state: ready`, the pod-side listener log, and the kube-ovn CNI ADD trace
-# for the pod IP -- all of which say the path should work -- but omits the
-# host-side networking state that would prove or disprove the drop. Without
-# it, the pod either (a) is silently on stale conntrack from a previous
-# incarnation with the same IP, (b) is blocked by a hostFirewall or Cilium
-# policy drop that only Hubble sees, or (c) hits a kube-ovn OVS flow race
-# between the kube-ovn-cni ADD and the kernel-side iptables NAT chain.
-# All three leave signature in per-node artefacts a cozyreport that only
-# captures pod-scoped state cannot recover.
+# Baseline host-side + CNI data-plane state (iptables, kernel conntrack, OVS
+# flows, cilium endpoints + drop events) for every node, captured on every
+# report. cozyreport otherwise carries only pod-scoped state (CiliumEndpoint,
+# listener log, CNI ADD trace), which cannot prove or disprove a host-side
+# kubelet->local-pod "connection refused" transient (stale conntrack on a reused
+# podIP, a policy drop, or a kube-ovn OVS flow race). Delegated to
+# hack/e2e-capture-dataplane.sh --baseline so the CNI topology knowledge
+# (namespaces, DaemonSet selectors, container names, the conntrack CLI->/proc
+# fallback) has a single source of truth shared with the failure-triggered
+# capture cozytest.sh runs, rather than a divergent second copy here.
 #
-# Every source below is a DaemonSet pod that already runs on the node with
-# hostNetwork and the required binary preinstalled: `iptables-save` +
-# `conntrack` live in `kube-ovn-cni` (`cni-server` container), OVS flows
-# live in `ovs-ovn` (`openvswitch` container), and `hubble observe` +
-# `cilium-dbg endpoint list` live in `cilium` (`cilium-agent`). Optional
-# binaries are `command -v` probed inline so an image without the tool
-# leaves a single "not present" line instead of an OCI runtime error
-# masquerading as a diagnostic capture. Every exec is wrapped in
-# `timeout 30 kubectl exec ...` (matching the upper bound the sibling
-# `hack/e2e-capture-dataplane.sh` uses for the heaviest captures) so a
-# wedged agent (bpf-map iteration stall, hubble ring-buffer replay,
-# ovn-controller lock) cannot hang the surrounding cozyreport run.
-# Files that end up empty or contain only a known error-signature line
-# are dropped so the artefact tree carries only real captures.
-#
-# `timeout(1)` from coreutils is a hard dependency of this block. Skip
-# the whole section on runners without it rather than filling the tree
-# with `sh: 1: timeout: not found` stubs.
-if ! command -v timeout >/dev/null 2>&1; then
-  echo "  timeout(1) not present -- skipping per-node network diagnostics"
-else
+# Diagnostic-only: never mutates the cluster, best-effort (|| true). The whole
+# capture is wrapped in an aggregate `timeout -k` so a wedged API server or agent
+# cannot cost the entire cozyreport artefact -- matching the wrapper cozytest.sh
+# puts around the same script (5 bounded execs x N nodes has no aggregate bound
+# otherwise).
 echo "Collecting per-node network diagnostics..."
-DIR=$REPORT_DIR/net-diag
-mkdir -p "$DIR"
-
-# _keep_if_useful <file>
-# Drop the capture file if it is empty or its content is a known "no
-# useful data" signature (missing binary, container exec error). This
-# stops error-text stubs from pretending to be real captures. A file
-# with real data (dozens/hundreds of lines) is left untouched; a
-# single-line "not present" / "OCI runtime" / "command terminated"
-# stub gets removed so the artefact tree carries only real captures.
-_keep_if_useful() {
-  _f="$1"
-  if [ ! -s "$_f" ]; then
-    rm -f "$_f"
-    return
-  fi
-  if [ "$(wc -l < "$_f" 2>/dev/null)" -le 1 ] && \
-     grep --extended-regexp --quiet "not (present|enabled|found)|socket missing|OCI runtime|executable file not found|command terminated|error:|Error from server" "$_f" 2>/dev/null; then
-    rm -f "$_f"
-  fi
-}
-
-for pod in $(kubectl -n cozy-kubeovn get pods -l app=kube-ovn-cni -o name 2>/dev/null); do
-  node=$(kubectl -n cozy-kubeovn get "$pod" -o jsonpath='{.spec.nodeName}' 2>/dev/null)
-  [ -z "$node" ] && node=$(basename "$pod")
-  # `iptables-save` dumps every table (filter/nat/mangle/raw) as a single
-  # text blob; the whole thing lands in one file per node so an operator
-  # can grep across chains without unpacking per-table splits.
-  timeout 30 kubectl -n cozy-kubeovn exec "$pod" --container=cni-server -- \
-    sh -c 'command -v iptables-save >/dev/null 2>&1 && iptables-save || echo "iptables-save not present in cni-server"' \
-    > "$DIR/$node-iptables.txt" 2>&1 || true
-  _keep_if_useful "$DIR/$node-iptables.txt"
-  # `conntrack -L` lists the kernel conntrack table (5-tuple + state +
-  # bytes). `head -n 5000` bounds output so a node with heavy tenant
-  # traffic does not push megabytes of connections into the artefact.
-  # NOTE: conntrack iterates the kernel hash table in bucket order, not
-  # by connection age, so the truncation is not a guaranteed FIFO of
-  # recent entries — an operator chasing a specific 5-tuple should grep
-  # for the podIP/port rather than assume the tail is missing.
-  timeout 30 kubectl -n cozy-kubeovn exec "$pod" --container=cni-server -- \
-    sh -c 'command -v conntrack >/dev/null 2>&1 && conntrack -L 2>/dev/null | head -n 5000 || echo "conntrack not present in cni-server"' \
-    > "$DIR/$node-conntrack.txt" 2>&1 || true
-  _keep_if_useful "$DIR/$node-conntrack.txt"
-done
-
-for pod in $(kubectl -n cozy-kubeovn get pods -l app=ovs -o name 2>/dev/null); do
-  node=$(kubectl -n cozy-kubeovn get "$pod" -o jsonpath='{.spec.nodeName}' 2>/dev/null)
-  [ -z "$node" ] && node=$(basename "$pod")
-  # `ovs-ofctl dump-flows br-int` is the OVS side of the kube-ovn
-  # datapath. Distinguishes a CNI ADD that finished from an ovn-controller
-  # that has not programmed the pod's flow into OVS yet — the flow race
-  # the block-comment above cites as failure mode (c).
-  timeout 30 kubectl -n cozy-kubeovn exec "$pod" --container=openvswitch -- \
-    sh -c 'command -v ovs-ofctl >/dev/null 2>&1 && ovs-ofctl dump-flows br-int || echo "ovs-ofctl not present in openvswitch"' \
-    > "$DIR/$node-ovs-flows.txt" 2>&1 || true
-  _keep_if_useful "$DIR/$node-ovs-flows.txt"
-done
-
-for pod in $(kubectl -n cozy-cilium get pods -l app.kubernetes.io/name=cilium-agent -o name 2>/dev/null); do
-  node=$(kubectl -n cozy-cilium get "$pod" -o jsonpath='{.spec.nodeName}' 2>/dev/null)
-  [ -z "$node" ] && node=$(basename "$pod")
-  # `hubble observe --last N` prints the recent flow log from the local
-  # cilium-agent ring buffer, including verdicts (FORWARDED / DROPPED /
-  # ERROR) with the reason field. Probe for both the binary AND the
-  # hubble unix socket -- the CLI is present in every recent cilium
-  # image, but hubble observability itself is optional (feature flag
-  # `hubble.enabled` in the cilium chart), so the socket may not exist
-  # even when the CLI does. Sized so a probe-drop cascade over a
-  # 5-minute window still fits, and a healthy node's log stays small.
-  timeout 30 kubectl -n cozy-cilium exec "$pod" --container=cilium-agent -- \
-    sh -c 'command -v hubble >/dev/null 2>&1 && [ -S /var/run/cilium/hubble.sock ] && hubble observe --last 2000 --output=compact 2>&1 || echo "hubble not enabled or socket missing in cilium-agent"' \
-    > "$DIR/$node-hubble-flows.txt" 2>&1 || true
-  _keep_if_useful "$DIR/$node-hubble-flows.txt"
-  # `cilium-dbg endpoint list` gives the per-endpoint policy state
-  # (identity, security policies, state, controllers), which resolves
-  # the question "was the drop a policy decision or a datapath race"
-  # that hubble alone doesn't disambiguate.
-  timeout 30 kubectl -n cozy-cilium exec "$pod" --container=cilium-agent -- \
-    sh -c 'command -v cilium-dbg >/dev/null 2>&1 && cilium-dbg endpoint list || echo "cilium-dbg not present in cilium-agent"' \
-    > "$DIR/$node-cilium-endpoints.txt" 2>&1 || true
-  _keep_if_useful "$DIR/$node-cilium-endpoints.txt"
-done
-
-# Drop the parent directory if no artefact landed (e.g. neither kube-ovn
-# nor cilium was present on the cluster the report is run against, or
-# every capture was pruned by `_keep_if_useful`).
-if [ -z "$(ls -A "$DIR" 2>/dev/null)" ]; then
-  rmdir "$DIR" 2>/dev/null || true
-fi
-fi
+timeout -k 30 300 "$SCRIPT_DIR/e2e-capture-dataplane.sh" --baseline "$REPORT_DIR/net-diag" || true
 
 # -- finalization
 

--- a/hack/e2e-capture-dataplane.sh
+++ b/hack/e2e-capture-dataplane.sh
@@ -200,6 +200,30 @@ lb_budget_ok() {
   if [ "$1" -lt "$2" ]; then echo yes; else echo no; fi
 }
 
+# _diag_prunable <file> -- true (exit 0) when <file> holds no real capture and
+# should be dropped from the artefact tree: it is empty, OR its only content is a
+# single "DIAG-SKIP: ..." absence marker this script emits for an expected-missing
+# tool/feature. A genuine capture is kept (one line or many), and a kubectl exec
+# FAILURE ("Error from server", "OCI runtime", "command terminated", "container
+# not found") is ALSO kept -- those are never DIAG-SKIP lines, so a broken capture
+# stays distinguishable from a node that simply lacked the tool. Pure (reads only
+# the file); unit-tested in hack/capture-dataplane.bats.
+_diag_prunable() {
+  _dp_f="$1"
+  [ -s "$_dp_f" ] || return 0
+  _dp_lines=$(wc -l < "$_dp_f" 2>/dev/null | tr -d ' ')
+  [ "${_dp_lines:-0}" -le 1 ] || return 1
+  # `read` returns non-zero on a final line without a trailing newline but still
+  # assigns the partial line, so do NOT blank _dp_line on that non-zero exit --
+  # else a newline-less "DIAG-SKIP:" marker would be kept instead of pruned.
+  _dp_line=""
+  IFS= read -r _dp_line < "$_dp_f" 2>/dev/null || true
+  case "$_dp_line" in
+    "DIAG-SKIP: "*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 # Sourcing guard: hack/capture-dataplane.bats sets E2E_CAPTURE_DATAPLANE_LIB and
 # sources this file purely to reach the helpers above; return before touching $1
 # or running any capture so the unit test never needs a cluster. The script's
@@ -209,7 +233,18 @@ if [ -n "${E2E_CAPTURE_DATAPLANE_LIB:-}" ]; then
   return 0 2>/dev/null
 fi
 
-OUT="${1:?Usage: e2e-capture-dataplane.sh <output-dir>}"
+# --baseline: capture a per-node BASELINE snapshot for EVERY node on EVERY
+# cozyreport (not just the failed-pod / unreachable-LB paths below). cozyreport.sh
+# invokes this mode so the host-side + CNI data-plane knowledge (namespaces,
+# DaemonSet selectors, container names, the conntrack CLI->/proc fallback) lives
+# here once instead of being forked into a second script.
+BASELINE=0
+if [ "${1:-}" = "--baseline" ]; then
+  BASELINE=1
+  shift
+fi
+
+OUT="${1:?Usage: e2e-capture-dataplane.sh [--baseline] <output-dir>}"
 
 CILIUM_NS="${COZY_CILIUM_NS:-cozy-cilium}"
 KUBEOVN_NS="${COZY_KUBEOVN_NS:-cozy-kubeovn}"
@@ -239,6 +274,92 @@ command -v kubectl >/dev/null 2>&1 || exit 0
 mkdir -p "$OUT" 2>/dev/null || exit 0
 
 log() { echo "[capture-dataplane] $*"; }
+
+# pod_on_node <ns> <label> <node> -> first matching pod name (empty if none).
+# Defined up here (ahead of the NotReady-pod / LB paths that also use it) so the
+# --baseline dispatch below can reach it.
+pod_on_node() {
+  kubectl get pod -n "$1" -l "$2" --field-selector "spec.nodeName=$3" \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+# _diag_prune <file> -- acting wrapper around the pure _diag_prunable predicate:
+# drop <file> when it carries no real capture.
+_diag_prune() { if _diag_prunable "$1"; then rm -f "$1"; fi; }
+
+# capture_baseline -- per-node BASELINE host-side + CNI data-plane snapshot for
+# EVERY node, run on EVERY cozyreport. The failed-pod / unreachable-LB paths
+# below only fire on an already-broken cluster, so a self-healing host->local-pod
+# transient that recovers before the report leaves no host-side trace otherwise.
+# One file per (node, capture); each is pruned by _diag_prune iff empty or a lone
+# "DIAG-SKIP:" absence marker -- a genuine kubectl exec FAILURE is never a
+# DIAG-SKIP line, so it is always kept (a missing capture must stay
+# distinguishable from a broken one). Every exec is timeout-bounded; the
+# aggregate wall-clock bound is the `timeout -k` wrapper at the cozyreport.sh
+# call site.
+capture_baseline() {
+  for _bn in $(kubectl get nodes \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null); do
+    [ -n "$_bn" ] || continue
+    _cni=$(pod_on_node "$KUBEOVN_NS" app=kube-ovn-cni "$_bn")
+    _ovs=$(pod_on_node "$KUBEOVN_NS" app=ovs "$_bn")
+    _agent=$(pod_on_node "$CILIUM_NS" k8s-app=cilium "$_bn")
+
+    if [ -n "$_cni" ]; then
+      # iptables-save: every table (filter/nat/mangle/raw) in one blob -- the
+      # only capture genuinely new vs the failed-pod path.
+      timeout 25 kubectl exec -n "$KUBEOVN_NS" "$_cni" -c cni-server -- \
+        sh -c 'command -v iptables-save >/dev/null 2>&1 && iptables-save || echo "DIAG-SKIP: iptables-save not present in cni-server"' \
+        > "$OUT/$_bn-iptables.txt" 2>&1 || true
+      _diag_prune "$OUT/$_bn-iptables.txt"
+
+      # Kernel conntrack table (bounded). Prefer the conntrack CLI; fall back to
+      # /proc/net/nf_conntrack when the image lacks it (the same fallback the
+      # failed-pod path carries), and DIAG-SKIP only when BOTH are absent.
+      timeout 25 kubectl exec -n "$KUBEOVN_NS" "$_cni" -c cni-server -- \
+        sh -c 'if command -v conntrack >/dev/null 2>&1; then conntrack -L 2>/dev/null | head -n 5000; elif [ -r /proc/net/nf_conntrack ]; then head -n 5000 /proc/net/nf_conntrack; else echo "DIAG-SKIP: no conntrack CLI and no /proc/net/nf_conntrack in cni-server"; fi' \
+        > "$OUT/$_bn-conntrack.txt" 2>&1 || true
+      _diag_prune "$OUT/$_bn-conntrack.txt"
+    fi
+
+    if [ -n "$_ovs" ]; then
+      # OVS side of the kube-ovn datapath -- a CNI ADD that finished vs an
+      # ovn-controller that has not programmed the pod's flow into OVS yet.
+      timeout 25 kubectl exec -n "$KUBEOVN_NS" "$_ovs" -c openvswitch -- \
+        ovs-ofctl dump-flows br-int > "$OUT/$_bn-ovs-flows.txt" 2>&1 || true
+      _diag_prune "$OUT/$_bn-ovs-flows.txt"
+    fi
+
+    if [ -n "$_agent" ]; then
+      # Per-endpoint policy state (identity, policy, controllers).
+      timeout 25 kubectl exec -n "$CILIUM_NS" "$_agent" -c cilium-agent -- \
+        cilium-dbg endpoint list > "$OUT/$_bn-cilium-endpoints.txt" 2>&1 || true
+      _diag_prune "$OUT/$_bn-cilium-endpoints.txt"
+
+      # Bounded drop-event capture. Replaces a hubble capture that can never
+      # produce output on cozystack (hubble.enabled:false in packages/system/
+      # cilium/values.yaml, so /var/run/cilium/hubble.sock is never created);
+      # `cilium-dbg monitor --type drop` needs no Hubble. Nested timeouts: inner
+      # `timeout 8` self-terminates the stream if the agent ships coreutils, the
+      # outer `timeout 12` on the exec is the hard backstop if it does not.
+      timeout 12 kubectl exec -n "$CILIUM_NS" "$_agent" -c cilium-agent -- \
+        sh -c 'timeout 8 cilium-dbg monitor --type drop 2>&1 || true' \
+        > "$OUT/$_bn-cilium-drops.txt" 2>&1 || true
+      _diag_prune "$OUT/$_bn-cilium-drops.txt"
+    fi
+  done
+
+  # Drop the parent dir if nothing real landed (neither kube-ovn nor cilium
+  # present, or every capture pruned).
+  [ -n "$(ls -A "$OUT" 2>/dev/null)" ] || rmdir "$OUT" 2>/dev/null || true
+}
+
+# --baseline short-circuits the failed-pod / LB paths below.
+if [ "$BASELINE" = "1" ]; then
+  log "capturing per-node baseline network diagnostics -> $OUT"
+  capture_baseline
+  exit 0
+fi
 
 # Affected = scheduled (has nodeName), has a podIP (so an endpoint exists to
 # inspect), Ready!=True, and not already terminal. That is the superset of the
@@ -274,12 +395,6 @@ if [ -n "$central" ]; then
 else
   log "no ovn-central pod in $KUBEOVN_NS -- skipping OVN logical-flow dump"
 fi
-
-# pod_on_node <ns> <label> <node> -> first matching pod name (empty if none).
-pod_on_node() {
-  kubectl get pod -n "$1" -l "$2" --field-selector "spec.nodeName=$3" \
-    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
-}
 
 # Per-node captures are node-global (every pod on a node shares one cilium-agent
 # / ovs / cni-server), so run them once per node and reuse across that node's


### PR DESCRIPTION
## What this PR does

Extends `hack/cozyreport.sh` with a `net-diag` section that captures per-satellite-node network state from the DaemonSet pods already running on the node: `iptables-save` + `conntrack -L` (from `kube-ovn-cni` `cni-server`), `ovs-ofctl dump-flows br-int` (from `ovs-ovn` `openvswitch`), and `hubble observe` + `cilium-dbg endpoint list` (from `cilium` `cilium-agent`). Follows #3209 (LINSTOR ErrorReport bundles) as the second half of closing the "cozyreport is blind to the host-networking path" gap surfaced by the PR #3044 vlselect flake investigation.

### Why

Recurrent baseline flake in the sandbox: `vlselect-generic-*` on one satellite fails every livenessProbe with `dial tcp <podIP>:9471: connect: connection refused` for 49 s, while an identical sibling replica on another satellite runs clean. Cozyreport at end-of-job carries `CiliumEndpoint state: ready`, the pod-side listener log confirming the HTTP server bound at 0.0.0.0:9471 within 5 ms of start, and the kube-ovn CNI ADD trace completing for the pod IP — all say the path SHOULD work. Attribution of the drop to a specific host-side cause (stale conntrack from a previous pod that shared the IP, a Cilium policy drop that only Hubble sees, or an OVS-flow race between the CNI ADD and the iptables NAT chain) is not possible from the artefact because none of the host-side networking state is captured. Talos-side kubelet logs also come out as one-line stubs (`error constructing client: failed to determine endpoints` — separate cozyreport bug), so kubelet-view evidence is unavailable too. This PR closes exactly that observability gap.

### Scope

`hack/cozyreport.sh` only, +129 lines under a new `net-diag` module block. E2E-diagnostic-only, no product-side change, no chart change.

### Verified

Every load-bearing claim cross-checked against a live production cluster and the chart templates in-tree:

- **Label selectors** match the actual DaemonSets: `app=kube-ovn-cni` (`ovncni-ds.yaml`), `app=ovs` (`ovsovn-ds.yaml`, not accidentally matched by `app=ovs-dpdk`), `app.kubernetes.io/name=cilium-agent` (only the agent, not operator/envoy/pre-flight/etc.).
- **Container names** (`cni-server`, `openvswitch`, `cilium-agent`) match the pod specs.
- **Tools** confirmed present: `iptables-save`, `conntrack`, `ip` in `cni-server`; `ovs-ofctl` in `openvswitch`; `hubble`, `cilium-dbg` in `cilium-agent`.
- **Hubble socket path** `/var/run/cilium/hubble.sock` matches `hubble.socketPath` in the cilium chart values.
- **Timeout choice** `timeout 30` matches the upper bound the sibling `hack/e2e-capture-dataplane.sh` uses for heavy captures.
- **`_keep_if_useful` pruning** drops empty files AND single-line "not present / not found / OCI runtime / socket missing / error:" stubs, so an image without an optional tool leaves nothing (not a stub-as-diagnostic).
- **`timeout(1)` availability** guarded at block entry: whole section skipped cleanly on runners without it.

### Related

- #3209 (merged, LINSTOR ErrorReport bundles) — same class of gap in the other direction. This PR complements it.
- #3210 (merged, LINSTOR pool free-capacity wait) — root cause fix that came out of the diagnostic gains from #3209.

### Release note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional per-node network diagnostics section to report collection to capture deeper host-side connectivity dataplane evidence when available.
  * Diagnostics are captured in a best-effort, time-bounded way so report generation continues even if captures fail.
  * Empty or placeholder diagnostic outputs are automatically pruned, preventing clutter and removing uninformative sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->