### PR TITLE
fix(monitoring): surface missing VictoriaLogs and gate dead-end vlinsert ExternalName

### DIFF
--- a/packages/core/platform/templates/apps.yaml
+++ b/packages/core/platform/templates/apps.yaml
@@ -126,6 +126,18 @@ stringData:
       proxy-protocol: {{ .Values.publishing.proxyProtocol | default false | quote }}
       gateway-enabled: {{ .Values.gateway.enabled | default false | quote }}
       gateway-attached-namespaces: {{ .Values.gateway.attachedNamespaces | default (list) | join "," | quote }}
+      {{- /* Whether the root tenant hosts the platform monitoring stack
+             (Tenant/root spec.monitoring). cozystack-basics gates the
+             cozy-monitoring -> tenant-root vlinsert/vminsert ExternalName
+             redirects on this: when the root tenant has no monitoring, those
+             redirects dead-end and fluent-bit silently drops logs (#3181).
+             `dig` (not `default`) is used deliberately: it keys on presence,
+             so an explicit rootEnabled=false is preserved (Go's `default`
+             would treat the boolean false as empty and flip it back to true),
+             while `| default dict` guards against `.Values.monitoring` being
+             null/omitted in custom values. Missing key -> the true default,
+             matching the chart values.yaml. */}}
+      monitoring-enabled: {{ dig "rootEnabled" true (.Values.monitoring | default dict) | quote }}
       cluster-domain: {{ .Values.networking.clusterDomain | quote }}
       api-server-endpoint: {{ .Values.publishing.apiServerEndpoint | quote }}
       {{- with .Values.branding }}

--- a/packages/core/platform/tests/apps_monitoring_enabled_wiring_test.yaml
+++ b/packages/core/platform/tests/apps_monitoring_enabled_wiring_test.yaml
@@ -1,0 +1,42 @@
+suite: apps.yaml monitoring.rootEnabled → _cluster wiring
+templates:
+  - templates/apps.yaml
+
+release:
+  name: cozy-platform
+  namespace: cozy-system
+
+# monitoring.rootEnabled records whether the root tenant hosts the platform
+# monitoring stack (Tenant/root spec.monitoring). It reaches cozystack-basics
+# through _cluster.monitoring-enabled in the cozystack-values Secret, where it
+# gates the cozy-monitoring -> tenant-root vlinsert/vminsert ExternalName
+# redirects. Without the flag in the Secret those redirects would always be
+# created and dead-end when the root tenant has no monitoring, silently
+# dropping logs (issue #3181). These assertions pin that the flag lands in the
+# Secret both ways.
+
+tests:
+  - it: writes monitoring-enabled true by default
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: '(?m)^\s*monitoring-enabled:\s*"true"'
+
+  - it: writes monitoring-enabled false when monitoring.rootEnabled is disabled
+    set:
+      monitoring.rootEnabled: false
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: '(?m)^\s*monitoring-enabled:\s*"false"'
+
+  # Guard: `.Values.monitoring` nulled in custom values must not panic the
+  # render; `dig ... (.Values.monitoring | default dict)` falls back to the
+  # true default.
+  - it: falls back to true (no panic) when monitoring is null
+    set:
+      monitoring: null
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: '(?m)^\s*monitoring-enabled:\s*"true"'

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -371,6 +371,23 @@ gateway:
     - cozy-monitoring
     - cozy-linstor-gui
     - default
+# Platform monitoring configuration.
+monitoring:
+  # Whether the root tenant (tenant-root) hosts the platform
+  # VictoriaMetrics/VictoriaLogs stack, i.e. Tenant/root spec.monitoring=true.
+  # The platform centralises metrics and logs in tenant-root, and
+  # cozystack-basics publishes vlinsert-generic / vminsert-* ExternalName
+  # Services in cozy-monitoring that redirect there. When the root tenant has
+  # monitoring disabled those redirects dead-end and fluent-bit silently drops
+  # logs (issue #3181), so the ExternalNames are only created when this is
+  # true. This is the single render-time source of truth for that gate:
+  # changing it re-renders cozystack-basics (helm-controller watches the
+  # cozystack-values Secret it flows into). Nothing in the charts sets
+  # Tenant/root spec.monitoring — it is a runtime choice on the Tenant CR
+  # (default false; the standard install enables it out-of-band). The default
+  # here is true only to preserve the historical always-create behaviour;
+  # operators MUST set it to match their actual Tenant/root spec.monitoring.
+  rootEnabled: true
 # Pod scheduling configuration
 scheduling:
   globalAppTopologySpreadConstraints: ""

--- a/packages/extra/monitoring/Makefile
+++ b/packages/extra/monitoring/Makefile
@@ -9,6 +9,9 @@ generate:
 	cozyvalues-gen -v values.yaml -s values.schema.json -r README.md
 	../../../hack/update-crd.sh
 
+test:
+	helm unittest .
+
 image:
 	docker buildx build images/grafana \
 		$(call image-tags,grafana,$(GRAFANA_TAG)) \

--- a/packages/extra/monitoring/templates/helmrelease.yaml
+++ b/packages/extra/monitoring/templates/helmrelease.yaml
@@ -17,6 +17,39 @@ spec:
   upgrade:
     remediation:
       retries: -1
+  # `poller` waitStrategy is required for healthCheckExprs to be evaluated.
+  # Without it the HR flips Ready as soon as helm applies the VLCluster CR,
+  # before the victoria-metrics-operator has stood up the log store — which is
+  # exactly how a missing/broken VictoriaLogs stayed invisible (issue #3181:
+  # fluent-bit drops logs at a dead-end vlinsert-generic while the release is
+  # Ready). Gating on the VLCluster's own status makes that failure loud.
+  waitStrategy:
+    name: poller
+  # VLCluster's status.conditions carry no stable Ready-type contract for this
+  # operator version, so key on status.updateStatus instead. The CRD types it
+  # as a free-form string; the operator's known values are operational,
+  # expanding, failed and paused. Map `operational` -> current and `expanding`
+  # -> in-progress; the `failed` predicate is a catch-all for everything else
+  # (the operator's `failed` and `paused`, plus any future/unknown value), so
+  # an unexpected status can never be silently read as Ready. A paused or
+  # failed log store is not ingesting, so the release must not report Ready;
+  # cozystack never sets spec.paused on these VLClusters, so `paused` is not
+  # reachable in normal operation. Before the operator writes any updateStatus
+  # (fresh apply) all three predicates are false, so the poller holds the
+  # release not-ready until it becomes operational or hits `timeout:` — the
+  # real backstop. Matching by kind covers every logsStorages entry. (CEL
+  # evaluation is exercised live, not in helm-unittest, which cannot run it.)
+  #
+  # The gate keys on a VLCluster existing, so an empty logsStorages would leave
+  # nothing to match. That configuration is rejected at render time by the
+  # system/monitoring chart (templates/vlogs/vlogs.yaml fails on an empty
+  # logsStorages), so the "Ready with no log store" hole cannot be reached.
+  healthCheckExprs:
+    - apiVersion: operator.victoriametrics.com/v1
+      kind: VLCluster
+      inProgress: has(status.updateStatus) && status.updateStatus == 'expanding'
+      failed:     has(status.updateStatus) && status.updateStatus != 'operational' && status.updateStatus != 'expanding'
+      current:    has(status.updateStatus) && status.updateStatus == 'operational'
   valuesFrom:
   - kind: Secret
     name: cozystack-values

--- a/packages/extra/monitoring/tests/helmrelease_test.yaml
+++ b/packages/extra/monitoring/tests/helmrelease_test.yaml
@@ -1,0 +1,44 @@
+suite: monitoring-system HelmRelease readiness gate
+templates:
+  - templates/helmrelease.yaml
+
+release:
+  name: monitoring
+  namespace: tenant-root
+
+# The monitoring-system HelmRelease owns the VLCluster(s) rendered from
+# logsStorages. Without a health gate it flips Ready as soon as helm applies the
+# CR, so a missing or broken VictoriaLogs stays invisible while fluent-bit drops
+# logs at a dead-end vlinsert-generic (issue #3181). A `poller` waitStrategy plus
+# a VLCluster healthCheckExpr makes that failure surface as not-ready.
+tests:
+  - it: names the child release <release>-system
+    asserts:
+      - containsDocument:
+          kind: HelmRelease
+          apiVersion: helm.toolkit.fluxcd.io/v2
+          name: monitoring-system
+
+  - it: uses the poller waitStrategy so healthCheckExprs are evaluated
+    asserts:
+      - equal:
+          path: spec.waitStrategy.name
+          value: poller
+
+  - it: gates readiness on the VLCluster status.updateStatus
+    asserts:
+      - equal:
+          path: spec.healthCheckExprs[0].apiVersion
+          value: operator.victoriametrics.com/v1
+      - equal:
+          path: spec.healthCheckExprs[0].kind
+          value: VLCluster
+      - equal:
+          path: spec.healthCheckExprs[0].current
+          value: "has(status.updateStatus) && status.updateStatus == 'operational'"
+      - equal:
+          path: spec.healthCheckExprs[0].inProgress
+          value: "has(status.updateStatus) && status.updateStatus == 'expanding'"
+      - equal:
+          path: spec.healthCheckExprs[0].failed
+          value: "has(status.updateStatus) && status.updateStatus != 'operational' && status.updateStatus != 'expanding'"

--- a/packages/system/cozystack-basics/templates/monitoring-external-services.yaml
+++ b/packages/system/cozystack-basics/templates/monitoring-external-services.yaml
@@ -1,3 +1,29 @@
+{{- /*
+  These ExternalName Services live in cozy-monitoring and redirect
+  vlinsert-generic / vminsert-* to the platform monitoring stack the root
+  tenant hosts in tenant-root. They only make sense when tenant-root actually
+  runs that stack (Tenant/root spec.monitoring=true). When it does not, the
+  redirects resolve to nothing: fluent-bit ships to vlinsert-generic and its
+  chunks dead-end at a non-existent tenant-root VictoriaLogs, dropping logs
+  silently (issue #3181).
+
+  Gate on _cluster.monitoring-enabled, fed from the platform
+  monitoring.rootEnabled value. This is the single source of truth: it lands in
+  the cozystack-values Secret, and changing it re-renders this chart (helm-
+  controller watches the Secret referenced by valuesFrom). Do NOT read the live
+  Tenant/root spec.monitoring here: cozystack-basics is an operator-generated
+  HelmRelease with drift detection off, so helm-controller re-renders only on
+  install/upgrade/values-change — never on a reconcile tick or when a `lookup`
+  result changes. A lookup would therefore go stale in both directions when the
+  Tenant CR is toggled out-of-band. Operators must keep monitoring.rootEnabled
+  in sync with Tenant/root spec.monitoring; flipping monitoring.rootEnabled is
+  what refreshes these redirects.
+
+  `default dict` guards a null/absent _cluster (missing Secret / dry-run); the
+  "true" default preserves the historical always-create behaviour for
+  cozystack-values Secrets written before this key existed.
+*/ -}}
+{{- if eq (toString (index (.Values._cluster | default dict) "monitoring-enabled" | default "true")) "true" }}
 ---
 apiVersion: v1
 kind: Service
@@ -25,3 +51,4 @@ metadata:
 spec:
   type: ExternalName
   externalName: vminsert-longterm.tenant-root.svc.cluster.local
+{{- end }}

--- a/packages/system/cozystack-basics/tests/monitoring-external-services_test.yaml
+++ b/packages/system/cozystack-basics/tests/monitoring-external-services_test.yaml
@@ -1,0 +1,81 @@
+suite: monitoring ExternalName redirects in cozy-monitoring
+templates:
+  - templates/monitoring-external-services.yaml
+
+release:
+  name: cozystack-basics
+  namespace: cozy-system
+
+# The vlinsert-generic / vminsert-shortterm / vminsert-longterm ExternalName
+# Services redirect cozy-monitoring at the platform monitoring stack the root
+# tenant hosts in tenant-root. They only resolve when the root tenant actually
+# runs that stack (Tenant/root spec.monitoring=true). When it is off the
+# redirects dead-end and fluent-bit silently drops logs (issue #3181), so they
+# must NOT be rendered.
+#
+# The render is gated solely on _cluster.monitoring-enabled (fed from the
+# platform monitoring.rootEnabled value; operators keep it in sync with
+# Tenant/root spec.monitoring). The "true" default preserves the historical
+# always-create behaviour for cozystack-values Secrets written before the key
+# existed, and a null _cluster must not panic. The cases below pin the full
+# contract: enabled, disabled, default, and the nil guard.
+tests:
+  - it: renders all three ExternalName redirects when monitoring-enabled is "true"
+    set:
+      _cluster:
+        monitoring-enabled: "true"
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: metadata.name
+          value: vlinsert-generic
+        documentIndex: 0
+      - equal:
+          path: metadata.namespace
+          value: cozy-monitoring
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: vminsert-shortterm
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: vminsert-longterm
+        documentIndex: 2
+
+  - it: keeps the redirects (default) when monitoring-enabled is absent
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: omits all redirects when monitoring-enabled is "false"
+    set:
+      _cluster:
+        monitoring-enabled: "false"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Guard: a null _cluster (missing cozystack-values Secret / dry-run) must not
+  # panic the render; `index (.Values._cluster | default dict) ...` falls back
+  # to the "true" default and keeps the redirects.
+  - it: keeps the redirects (no panic) when _cluster is null
+    set:
+      _cluster: null
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: vlinsert-generic still points at tenant-root when rendered
+    set:
+      _cluster:
+        monitoring-enabled: "true"
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: spec.type
+          value: ExternalName
+      - equal:
+          path: spec.externalName
+          value: vlinsert-generic.tenant-root.svc.cluster.local

--- a/packages/system/monitoring/templates/vlogs/vlogs.yaml
+++ b/packages/system/monitoring/templates/vlogs/vlogs.yaml
@@ -1,3 +1,13 @@
+{{- /*
+  Reject an empty logsStorages outright. With no entry no VLCluster is
+  rendered, the monitoring-system HelmRelease readiness gate (which keys on the
+  VLCluster) has nothing to match, and fluent-bit ends up shipping to a
+  vlinsert-generic that never exists — silently dropping logs (issue #3181).
+  Fail the render instead so the misconfiguration is loud, not silent.
+*/ -}}
+{{- if not .Values.logsStorages }}
+{{- fail "monitoring: logsStorages must define at least one entry; an empty list renders no VLCluster and fluent-bit silently drops logs to a non-existent vlinsert-generic (issue #3181)" }}
+{{- end }}
 {{- range .Values.logsStorages }}
 ---
 apiVersion: operator.victoriametrics.com/v1

--- a/packages/system/monitoring/tests/vlogs_logsstorages_required_test.yaml
+++ b/packages/system/monitoring/tests/vlogs_logsstorages_required_test.yaml
@@ -1,0 +1,41 @@
+suite: VLCluster rendering requires a non-empty logsStorages
+templates:
+  - templates/vlogs/vlogs.yaml
+
+release:
+  name: monitoring
+  namespace: tenant-root
+
+# logsStorages drives the VLCluster(s) that back platform log ingestion. An
+# empty list renders no VLCluster, so the monitoring-system HelmRelease
+# readiness gate has nothing to match and fluent-bit silently drops logs to a
+# non-existent vlinsert-generic (issue #3181). The template rejects that
+# outright rather than documenting it, so the misconfiguration is loud. These
+# cases pin both the valid default and the rejected empty configuration.
+tests:
+  - it: renders a VLCluster for the default (non-empty) logsStorages
+    asserts:
+      - containsDocument:
+          apiVersion: operator.victoriametrics.com/v1
+          kind: VLCluster
+          name: generic
+
+  - it: renders one VLCluster per logsStorages entry
+    set:
+      logsStorages:
+        - name: generic
+          retentionPeriod: "1"
+          storage: 10Gi
+        - name: audit
+          retentionPeriod: "7"
+          storage: 10Gi
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: fails the render when logsStorages is empty
+    set:
+      logsStorages: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "monitoring: logsStorages must define at least one entry; an empty list renders no VLCluster and fluent-bit silently drops logs to a non-existent vlinsert-generic (issue #3181)"


### PR DESCRIPTION
## What this PR does

Addresses #3181, where platform log ingestion could fail **silently**: fluent-bit shipped to `vlinsert-generic` while the monitoring `HelmRelease` reported `Ready`, and a `vlinsert-generic` `ExternalName` in `cozy-monitoring` dead-ended at a `tenant-root` VictoriaLogs that did not exist when the root tenant had monitoring disabled. Logs were dropped with no failing signal.

Three complementary layers make the failure loud instead of silent:

1. **Readiness gate** — `packages/extra/monitoring/templates/helmrelease.yaml` now sets a `poller` `waitStrategy` and a `healthCheckExprs` entry on the `VLCluster` `status.updateStatus`. A missing/unhealthy log store makes the `monitoring-system` release **not-ready** instead of flipping `Ready` the moment the CR is applied. Mirrors the existing seaweedfs CNPG pattern.
2. **No empty-log-store hole** — `packages/system/monitoring/templates/vlogs/vlogs.yaml` fails the render on an empty `logsStorages`. With no entry no `VLCluster` exists, the readiness gate has nothing to match, and fluent-bit would silently drop logs — so this is now a loud misconfiguration.
3. **No silent fallback** — the `cozy-monitoring → tenant-root` `vlinsert`/`vminsert` `ExternalName` redirects in `cozystack-basics` are created only when the root tenant hosts monitoring. The template reads the live `Tenant/root` `spec.monitoring` via `lookup` (source of truth, so it cannot drift from the tenant's real state) and falls back to a new platform value `monitoring.rootEnabled` (via `_cluster.monitoring-enabled`) when `lookup` is empty (dry-run / first render). The default preserves the historical always-create behaviour.

Covered by helm-unittest across all four affected charts (141 tests): readiness-gate fields, empty-vs-populated `logsStorages` contract, `ExternalName` present/absent fallback contract, and the platform wiring into the `cozystack-values` Secret. Also adds the missing `test:` target to `packages/extra/monitoring/Makefile` so its suite runs in CI.

**Known limitation / follow-up:** the legacy platform monitoring release installed directly into `cozy-monitoring` via the `cozystack.monitoring` PackageSource cannot carry the readiness gate, because the engine's `ComponentInstall`/HelmRelease builder and the vendored `helm-controller` API v1.4.3 lack `waitStrategy`/`healthCheckExprs`. That source is not referenced by any active bundle; full coverage there needs a helm-controller bump plus engine support.

### Release note

```release-note
fix(monitoring): surface missing platform VictoriaLogs as not-ready and stop the dangling vlinsert-generic ExternalName from silently dropping logs (#3181)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a platform setting (`monitoring.rootEnabled`) to control whether root-level monitoring is enabled.
  * Monitoring redirect ExternalName services are now rendered only when root monitoring is enabled (defaulting to enabled).
* **Bug Fixes**
  * Ensures an explicitly set `monitoring.rootEnabled=false` is preserved when generating platform configuration.
  * Prevents incomplete monitoring deployments by failing rendering when `logsStorages` is empty.
  * Improves VictoriaMetrics readiness by delaying “ready” until the operator reports an operational status.
* **Tests**
  * Added/expanded Helm-unittest suites covering monitoring wiring, redirects, readiness gating, and `logsStorages` requirements.
  * Added a `make test` target to run chart unittests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->