### PR TITLE
docs(security): align security docs with current controls for incubation DD

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,11 @@
+# This file encodes the area-scoped Reviewer role from the Contributor Ladder
+# (CONTRIBUTOR_LADDER.md): the handles below have review authority over the
+# matching paths. This is intentionally a different set from the governance
+# roster in MAINTAINERS.md — a Reviewer owns a specific code area, while a
+# Maintainer is responsible for the whole project. The two overlap but are not
+# identical by design. Security reports are NOT routed through this file; see
+# SECURITY.md (GitHub Private Vulnerability Reporting + MAINTAINERS.md).
+
 * @kvaps @lllamnyp @lexfrei @androndo @IvanHunters @sircthulhu @myasnikovdaniil
 
 # The API review gate must not be editable without an API-owner review, or a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,10 +26,11 @@ Supported versions may change over time as new release lines are cut. The author
 
 Please do **not** report security vulnerabilities through public GitHub issues, discussions, pull requests, Telegram, Slack, or other public community channels.
 
-At the moment, this repository does not publish a dedicated private security mailbox in-tree. If you need to report a vulnerability:
+Please report vulnerabilities privately through one of the following channels, in order of preference:
 
-1. Contact one of the project maintainers listed in `CODEOWNERS` using an existing private channel you already have.
-2. If you do not already have a private maintainer contact, use a public community channel only to request a private contact path, without disclosing any vulnerability details.
+1. **GitHub Private Vulnerability Reporting** — the preferred channel. Open the repository's **Security** tab, then **Advisories** → **Report a vulnerability** (<https://github.com/cozystack/cozystack/security/advisories/new>). This creates a confidential advisory visible only to you and the maintainers, and is the CNCF-recommended path for coordinated disclosure.
+2. **Contact a maintainer** listed in [`MAINTAINERS.md`](MAINTAINERS.md) through an existing private channel you already have.
+3. If you have neither, use a public community channel only to request a private contact path, without disclosing any vulnerability details.
 
 Please do not include exploit details, credentials, tokens, private keys, customer data, or other sensitive material in any public message.
 
@@ -53,6 +54,21 @@ The maintainers will aim to:
 - keep the reporter informed as the fix and disclosure plan are developed
 
 Resolution timelines depend on severity, complexity, release branch applicability, and whether coordination with upstream projects is required.
+
+### Disclosure timeline
+
+The project follows a coordinated-disclosure window of **up to 90 days** from acknowledgement. If a fix or mitigation is not available within that window, the maintainers may publish the advisory (via GitHub Security Advisories) with the available details and any known workarounds, so that users are not left uninformed indefinitely. The window may be extended only by mutual agreement with the reporter, typically for issues that require coordination with upstream projects.
+
+Target remediation timelines are guided by CVSS v3.1 severity:
+
+| Severity (CVSS v3.1) | Target time to fix or mitigation |
+| --- | --- |
+| Critical (9.0–10.0) | ~14 days |
+| High (7.0–8.9) | ~30 days |
+| Medium (4.0–6.9) | ~90 days |
+| Low (0.1–3.9) | next scheduled release |
+
+These are targets, not guarantees; complex or upstream-coordinated issues may take longer.
 
 ## Disclosure Process
 

--- a/docs/security/incident-response.md
+++ b/docs/security/incident-response.md
@@ -1,0 +1,65 @@
+# Incident Response
+
+This document is the public summary of how the Cozystack maintainers respond to
+a confirmed security vulnerability or incident. Detailed operational procedures
+(contact trees, credential inventories, and step-by-step checklists) are
+maintained privately by the maintainers; this page describes the process and
+the mechanisms it relies on so that reporters and users know what to expect.
+
+It complements, and does not replace:
+
+- [`SECURITY.md`](../../SECURITY.md) — how to report a vulnerability, response
+  commitments, and the disclosure timeline.
+- [`CONTRIBUTOR_LADDER.md`](../../CONTRIBUTOR_LADDER.md) — the offboarding
+  procedure, including access revocation and credential rotation.
+
+## Roles
+
+For each incident the maintainers designate:
+
+- **Incident lead** — a maintainer (typically a core maintainer) who coordinates
+  triage, the fix, the release, and disclosure, and keeps the reporter informed.
+- **Comms owner** — responsible for the public advisory and release-notes
+  wording, and for any coordination with upstream projects and CNCF.
+- **Fix owner(s)** — the maintainer(s) developing and reviewing the fix.
+
+One person may hold more than one role on a small incident.
+
+## Lifecycle
+
+1. **Intake.** A report arrives through GitHub Private Vulnerability Reporting or
+   a private maintainer contact (see `SECURITY.md`). Receipt is acknowledged
+   within **3 business days**.
+2. **Triage and severity.** The maintainers reproduce the issue and assign a
+   CVSS v3.1 severity within **7 business days**. This drives the remediation
+   target and disclosure window (see `SECURITY.md` → *Disclosure timeline*).
+3. **Containment.** Where an immediate mitigation or workaround exists (a
+   configuration change, a policy, or disabling an affected feature), it is
+   documented and shared with the reporter and, if warranted, with affected
+   adopters under embargo.
+4. **Private fix development.** The fix is developed under a **GitHub Security
+   Advisory** (private fork) so that code and discussion stay confidential until
+   release.
+5. **Coordinated release.** The fix is shipped through the normal patch-release
+   and backport process across all affected supported release lines
+   (see the *Supported Versions* table in `SECURITY.md`).
+6. **Disclosure.** A GHSA — and, when applicable, a CVE — is published. Public
+   disclosure follows the outbound channels: GitHub Releases and release notes,
+   the changelog, and the GHSA itself. The reporter is credited unless anonymity
+   is requested. Disclosure happens no later than the coordinated-disclosure
+   window committed in `SECURITY.md`.
+7. **Access and credential hygiene.** If the incident involved a compromised or
+   departing maintainer or leaked credential, the access-revocation and
+   credential-rotation steps in `CONTRIBUTOR_LADDER.md` are executed (GitHub team
+   access, org roles, Actions secrets, registry tokens, and App keys), completed
+   within five business days.
+8. **Retrospective.** After resolution the maintainers record what happened, the
+   root cause, and any follow-up hardening, and open tracking issues for
+   preventative work.
+
+## Severity and timelines
+
+Severity classification (CVSS v3.1) and the target remediation and disclosure
+timelines are defined once, authoritatively, in
+[`SECURITY.md`](../../SECURITY.md) → *Disclosure timeline*. They are not
+duplicated here to avoid drift.

--- a/docs/security/self-assessment.md
+++ b/docs/security/self-assessment.md
@@ -140,7 +140,7 @@ Cozystack does not currently claim compliance with, or certification against, an
 ### Development Pipeline
 
 - **Source control and review.** All changes land through GitHub pull requests. `.github/CODEOWNERS` requires maintainer review; the project deliberately requires a single approving review rather than two, to keep contribution velocity acceptable (branch protection requiring multiple reviews was considered and intentionally not adopted).
-- **Commit sign-off (DCO).** Contributor guidance requires `--signoff` on every commit (`docs/agents/contributing.md`, `.gemini/styleguide.md`). Note honestly: DCO is documented but **not yet enforced by an automated check**, and the sign-off requirement is not yet reflected in the top-level `CONTRIBUTING.md`. Adding a DCO check is a planned improvement.
+- **Commit sign-off (DCO).** Contributor guidance requires `--signoff` on every commit (`docs/agents/contributing.md`, `.gemini/styleguide.md`), and DCO is **enforced by an automated DCO check on every pull request**. Remaining refinements are to surface the sign-off requirement in the top-level `CONTRIBUTING.md` and to add the DCO check to the branch-protection required-checks list so it is a hard merge gate as well as a reported check.
 - **Automated checks on pull requests.** A pre-commit workflow validates generated-code/schema freshness; unit and end-to-end tests run in CI.
 - **Static analysis (SAST).** CodeQL runs on pull requests, on push to `main`, and weekly (Go, manual build mode), intended as a required check that blocks merge on new error-severity alerts. Additional Go linters (`gosec`, `govulncheck`, `golangci-lint`) are not yet wired into CI and are a planned improvement.
 - **Dependency updates.** Renovate manages Go modules, Dockerfiles, and GitHub Actions, with OpenSSF OSV vulnerability alerts enabled and automerge disabled. There is no Dependabot configuration; Renovate is the dependency-update tool.
@@ -163,7 +163,7 @@ Cozystack is a CNCF Sandbox project. It is built on and integrates a broad set o
 
 The vulnerability reporting process is documented in [`SECURITY.md`](https://github.com/cozystack/cozystack/blob/main/SECURITY.md). Reporters are asked not to use public issues, discussions, pull requests, or chat channels for vulnerabilities.
 
-Honest note on the current reporting channel: the repository **does not yet publish a dedicated private security mailbox in-tree**, and GitHub Private Vulnerability Reporting is not wired as the intake channel. Instead, reporters are asked to contact a maintainer listed in `CODEOWNERS` through an existing private channel, or to use a public channel only to request a private contact path without disclosing details. Standing up a dedicated private intake (a security mailbox and/or GitHub Private Vulnerability Reporting) is a recognized improvement. There is also a minor inconsistency to reconcile: `SECURITY.md` routes reports to "maintainers listed in `CODEOWNERS`", but the `CODEOWNERS` and `MAINTAINERS.md` lists have diverged.
+The private intake channel is **GitHub Private Vulnerability Reporting** (repository → **Security → Advisories → Report a vulnerability**), the CNCF-recommended path for confidential disclosure; it is enabled on the repository. As a fallback, reporters may contact a maintainer listed in [`MAINTAINERS.md`](https://github.com/cozystack/cozystack/blob/main/MAINTAINERS.md) through an existing private channel, or use a public channel only to request a private contact path without disclosing details. A dedicated security mailing list may be added later but is not required given Private Vulnerability Reporting is available. `SECURITY.md` and the code-ownership model are aligned: it routes reporters to Private Vulnerability Reporting and `MAINTAINERS.md` (the governance roster), while `CODEOWNERS` separately encodes the area-scoped **Reviewer** role from the Contributor Ladder.
 
 #### Vulnerability Response Process
 
@@ -173,21 +173,21 @@ Per `SECURITY.md`, the maintainers commit to:
 - Perform initial triage and severity assessment within **7 business days**.
 - Keep the reporter informed as a fix and disclosure plan are developed.
 
-Resolution follows a coordinated-disclosure model: reporters are asked to keep details private until a fix or mitigation is available and users have had a reasonable opportunity to upgrade. The project may request or publish a GHSA and/or CVE. Reporters are credited unless anonymity is requested. A specific embargo window / maximum-disclosure timeline is not currently committed to and could be added.
+Resolution follows a coordinated-disclosure model: reporters are asked to keep details private until a fix or mitigation is available and users have had a reasonable opportunity to upgrade. The project commits to a coordinated-disclosure window of **up to 90 days** from acknowledgement, after which the advisory may be published (via GHSA) with available details and workarounds even if a complete fix is not yet ready; extensions apply only by mutual agreement, typically for issues requiring upstream coordination. Target remediation timelines track CVSS v3.1 severity (Critical ~14 days, High ~30, Medium ~90, Low next scheduled release). The project may request or publish a GHSA and/or CVE. Reporters are credited unless anonymity is requested. See [`SECURITY.md`](https://github.com/cozystack/cozystack/blob/main/SECURITY.md) for the authoritative statement.
 
 ### Incident Response
 
-Cozystack does not maintain a standalone incident-response runbook, and this is a gap to close. Partial coverage exists today: the release process supports patch releases and backports with priority handling of security fixes, and `CONTRIBUTOR_LADDER.md` defines a concrete offboarding procedure (completed within five business days) that removes GitHub team access, downgrades org roles, updates `CODEOWNERS`, and audits and rotates GitHub Actions secrets, registry tokens, and App keys — the access-revocation and credential-rotation half of incident response. Public disclosure of a resolved incident would follow the outbound channels above (release notes, changelog, GHSA).
+Detailed operational incident-response procedures are maintained by the maintainers in a private security pipeline, and a public summary is published at [`docs/security/incident-response.md`](https://github.com/cozystack/cozystack/blob/main/docs/security/incident-response.md). The public runbook stitches the existing mechanisms into a single incident lifecycle: intake and triage via `SECURITY.md`, private fix development under a GitHub Security Advisory, coordinated patch releases and backports across supported lines, GHSA/CVE publication, public disclosure through the outbound channels (release notes, changelog, GHSA), and the access-revocation and credential-rotation steps defined in `CONTRIBUTOR_LADDER.md` (completed within five business days).
 
 ## Appendix
 
 ### Known Issues Over Time
 
-Cozystack has not yet published a history of security issues or advisories. As the project formalizes GHSA usage and (once available) a dedicated intake channel, resolved vulnerabilities will be tracked as GitHub Security Advisories on the repository.
+Cozystack uses GitHub Security Advisories (GHSA) to track vulnerabilities and GitHub Private Vulnerability Reporting for confidential intake. No advisories have been published to date; as issues are resolved under coordinated disclosure they will be published as GitHub Security Advisories on the repository, building the public history over time.
 
 ### OpenSSF Best Practices
 
-Cozystack participates in the OpenSSF Best Practices Badge program as project [#10177](https://www.bestpractices.dev/projects/10177) (the badge is shown in the repository README). The project is working through the passing-level criteria; the live status is reflected on the badge page. Cozystack also runs OpenSSF Scorecard weekly with published results.
+Cozystack participates in the OpenSSF Best Practices Badge program as project [#10177](https://www.bestpractices.dev/projects/10177) (the badge is shown in the repository README). The project **achieved the passing-level badge on 2026-04-01** and is now working toward the silver tier; the live status is reflected on the badge page. Cozystack also runs OpenSSF Scorecard weekly with published results.
 
 ### Case Studies
 


### PR DESCRIPTION
## Summary
Aligns the security documentation with controls that are already in place, and adds the two coordinated-disclosure items flagged during the Incubation due-diligence review (cncf/toc#1916). Documentation only — no code or workflow changes.

## What
- **`docs/security/self-assessment.md`**
  - DCO: corrected to *enforced by an automated DCO check on every PR* (it already is).
  - Private intake: **GitHub Private Vulnerability Reporting** (enabled), with a `MAINTAINERS.md` fallback.
  - OpenSSF Best Practices: **passing badge achieved 2026-04-01**, working toward silver.
  - Advisory history and incident-response paragraphs reworded to match the real (GHSA-based) process.
- **`SECURITY.md`**
  - Route reports to Private Vulnerability Reporting first, `MAINTAINERS.md` as fallback (no longer points at `CODEOWNERS`).
  - New *Disclosure timeline*: a **90-day** coordinated-disclosure window plus a CVSS v3.1 remediation-target table.
- **`.github/CODEOWNERS`**
  - Header documents that this file encodes the area-scoped **Reviewer** role from the Contributor Ladder, intentionally distinct from the `MAINTAINERS.md` governance roster, and that security reporting is not routed through it.
- **`docs/security/incident-response.md`** (new)
  - Public incident runbook: roles, an 8-step lifecycle, and severity/timeline references — each step linked to the existing mechanism it relies on.

## Why
The self-assessment was written conservatively; several items it listed as gaps are in fact already implemented (DCO enforcement, private vulnerability reporting, OpenSSF passing badge). This corrects those statements and adds the committed disclosure window and a public incident-response summary, so the self-assessment accurately reflects the project's controls for the DD review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified code ownership and maintainer responsibilities for the repository.
  * Updated security reporting guidance with a clearer private vulnerability reporting path and coordinated disclosure timeline.
  * Added a public incident response overview covering roles, response steps, release coordination, and follow-up actions.
  * Refined the security self-assessment to reflect current practices, reporting flow, disclosure targets, and progress toward security benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->