### PR TITLE
ci(actions): pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -69,7 +69,7 @@ jobs:
           fi
 
       - name: Login to OCIR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.OCIR_USER }}
           password: ${{ secrets.OCIR_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
       # isolated buildkit so it never contends with PR builds on the shared one.
       - name: Set up Buildx (docker-container driver)
         id: buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
         with:
           driver: docker-container
         env:

--- a/.github/workflows/ui-test.yaml
+++ b/.github/workflows/ui-test.yaml
@@ -24,17 +24,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           # The monorepo root has no package.json; read the pnpm version from
           # the console workspace manifest (packageManager field).
           package_json_file: packages/system/dashboard/images/console/package.json
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## What this PR does

Pins the remaining floating version tags in the `build-main` and `ui-test` workflows to immutable commit SHAs, keeping the original tag in a trailing comment.

This is a supply-chain hardening change: a mutable tag such as `@v4` can be force-repointed (by a compromised or malicious upstream) to arbitrary code, whereas a commit SHA is immutable. Most workflows in this repository were already SHA-pinned — this closes the last gap so that every third-party action is referenced by digest.

Actions pinned in this PR:

- `build-main.yaml`: `actions/checkout`, `docker/login-action`, `docker/setup-buildx-action`
- `ui-test.yaml`: `actions/checkout`, `pnpm/action-setup`, `actions/setup-node`

Each SHA is the exact commit the tag currently resolves to, so there is **no functional change**. The trailing `# vX` comment records the original tag; Renovate's `github-actions` manager understands this format and can keep the pins updated automatically.

> Note: `.github/renovate.json` currently sets `enabledManagers: ["gomod"]`, so the `github-actions` manager is not active yet. For Renovate to auto-maintain these (and the other already-pinned) action digests, that manager needs to be enabled — suggested as a separate follow-up.

### Screenshots

N/A — CI-only change, no user-facing or UI impact.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to use fixed, version-pinned action releases for build and UI test steps.
  * This helps make automated builds and tests more consistent and reliable over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->