### PR TITLE
chore(codeowners): scope CODEOWNERS to per-area reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,12 @@
 *                                            @kvaps @lllamnyp
 
 # --- All packages: general owners (overridden by the specific areas below) ---
-/packages/                                   @lexfrei @IvanHunters @myasnikovdaniil
+/packages/                                   @lexfrei @IvanHunters @myasnikovdaniil @sircthulhu
+
+# --- Go source: general owners (specific cmd/pkg areas overridden below) ---
+/cmd/                                        @kvaps @lllamnyp @sircthulhu
+/internal/                                   @kvaps @lllamnyp @sircthulhu
+/pkg/                                        @kvaps @lllamnyp @sircthulhu
 
 # --- Apps: default owners (specific apps overridden below) ---
 /packages/apps/                              @lexfrei @IvanHunters @myasnikovdaniil @scooby87
@@ -53,6 +58,11 @@
 /cmd/cozystack-api/                          @IvanHunters @kvaps @lllamnyp
 /cmd/cozystack-controller/                   @IvanHunters @kvaps @lllamnyp
 /cmd/lineage-controller-webhook/             @IvanHunters @kvaps @lllamnyp
+
+# --- Keycloak ---
+/packages/system/keycloak/                   @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil
+/packages/system/keycloak-operator/          @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil
+/packages/system/keycloak-configure/         @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil
 
 # --- CLI tooling ---
 /cmd/cozypkg/                                @lexfrei @IvanHunters @myasnikovdaniil

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,79 @@
 # Maintainer is responsible for the whole project. The two overlap but are not
 # identical by design. Security reports are NOT routed through this file; see
 # SECURITY.md (GitHub Private Vulnerability Reporting + MAINTAINERS.md).
+#
+# Ordering matters: CODEOWNERS applies the LAST matching pattern, so entries go
+# from broad to specific. The API review gate block stays last so it cannot be
+# overridden. Enable "Require review from Code Owners" in branch protection for
+# these to bind.
 
-* @kvaps @lllamnyp @lexfrei @androndo @IvanHunters @sircthulhu @myasnikovdaniil
+# --- Default: architects own anything not scoped below ---
+*                                            @kvaps @lllamnyp
+
+# --- All packages: general owners (overridden by the specific areas below) ---
+/packages/                                   @lexfrei @IvanHunters @myasnikovdaniil
+
+# --- Apps: default owners (specific apps overridden below) ---
+/packages/apps/                              @lexfrei @IvanHunters @myasnikovdaniil @scooby87
+/packages/apps/kubernetes/                   @IvanHunters @kvaps
+/packages/apps/vm-instance/                  @scooby87 @lllamnyp @kvaps @myasnikovdaniil
+/packages/apps/vm-disk/                      @scooby87 @lllamnyp @kvaps @myasnikovdaniil
+/packages/apps/vpc/                          @kvaps @lllamnyp
+
+# --- Extra apps ---
+/packages/extra/                             @kvaps @lllamnyp @IvanHunters
+
+# --- Virtualization (system side) ---
+/packages/system/kubevirt/                   @scooby87 @lllamnyp @kvaps @myasnikovdaniil
+/packages/system/kubevirt-cdi/               @scooby87 @lllamnyp @kvaps @myasnikovdaniil
+/packages/system/kubevirt-cdi-operator/      @scooby87 @lllamnyp @kvaps @myasnikovdaniil
+/packages/system/kubevirt-operator/          @scooby87 @lllamnyp @kvaps @myasnikovdaniil
+/packages/system/kubevirt-instancetypes/     @scooby87 @lllamnyp @kvaps @myasnikovdaniil
+/packages/system/kubevirt-csi-node/          @scooby87 @lllamnyp @kvaps @myasnikovdaniil
+/packages/system/vm-default-images/          @scooby87 @lllamnyp @kvaps @myasnikovdaniil
+
+# --- Backups ---
+/packages/system/backup-controller/          @androndo @lllamnyp
+/packages/system/backupstrategy-controller/  @androndo @lllamnyp
+/packages/system/velero/                     @androndo @lllamnyp
+/cmd/backup-controller/                      @androndo @lllamnyp
+/cmd/backupstrategy-controller/              @androndo @lllamnyp
+
+# --- cozystack-api / controller / lineage webhook ---
+/packages/system/cozystack-api/              @IvanHunters @kvaps @lllamnyp
+/packages/system/cozystack-controller/       @IvanHunters @kvaps @lllamnyp
+/packages/system/lineage-controller-webhook/ @IvanHunters @kvaps @lllamnyp
+/cmd/cozystack-api/                          @IvanHunters @kvaps @lllamnyp
+/cmd/cozystack-controller/                   @IvanHunters @kvaps @lllamnyp
+/cmd/lineage-controller-webhook/             @IvanHunters @kvaps @lllamnyp
+
+# --- CLI tooling ---
+/cmd/cozypkg/                                @lexfrei @IvanHunters @myasnikovdaniil
+/tools/                                      @lexfrei @IvanHunters @myasnikovdaniil
+
+# --- API surface (architects) ---
+/api/                                        @kvaps @lllamnyp
+
+# --- Docs ---
+/docs/                                       @lexfrei @myasnikovdaniil
+
+# --- CI / automation ---
+/.github/                                    @myasnikovdaniil @sircthulhu
+/hack/                                       @myasnikovdaniil @sircthulhu
+/Makefile                                    @myasnikovdaniil @sircthulhu
+/.pre-commit-config.yaml                     @myasnikovdaniil @sircthulhu
+
+# --- Governance, licensing, project docs ---
+/LICENSE                                     @tym83 @kvaps
+/GOVERNANCE.md                               @tym83 @kvaps
+/MAINTAINERS.md                              @tym83 @kvaps
+/CONTRIBUTOR_LADDER.md                       @tym83 @kvaps
+/CODE_OF_CONDUCT.md                          @tym83 @kvaps
+/CONTRIBUTING.md                             @tym83 @kvaps
+/SECURITY.md                                 @tym83 @kvaps
+/ADOPTERS.md                                 @tym83 @kvaps
+/README.md                                   @tym83 @kvaps
+/.github/CODEOWNERS                          @kvaps @lllamnyp
 
 # The API review gate must not be editable without an API-owner review, or a
 # PR could neuter the detector (it is compiled from the head checkout during

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,9 @@
 # --- Extra apps ---
 /packages/extra/                             @kvaps @lllamnyp @IvanHunters
 
+# --- Core (installer / platform / talos / flux-aio) ---
+/packages/core/                              @lllamnyp @kvaps @myasnikovdaniil @IvanHunters @lexfrei
+
 # --- Virtualization (system side) ---
 /packages/system/kubevirt/                   @scooby87 @lllamnyp @kvaps @myasnikovdaniil
 /packages/system/kubevirt-cdi/               @scooby87 @lllamnyp @kvaps @myasnikovdaniil
@@ -55,8 +58,12 @@
 /cmd/cozypkg/                                @lexfrei @IvanHunters @myasnikovdaniil
 /tools/                                      @lexfrei @IvanHunters @myasnikovdaniil
 
-# --- API surface (architects) ---
+# --- API surface (architects): API types, aggregated apiserver, registry ---
 /api/                                        @kvaps @lllamnyp
+/pkg/apis/                                   @kvaps @lllamnyp
+/pkg/apiserver/                              @kvaps @lllamnyp
+/pkg/registry/                               @kvaps @lllamnyp
+/pkg/generated/                              @kvaps @lllamnyp
 
 # --- Docs ---
 /docs/                                       @lexfrei @myasnikovdaniil

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,10 +69,10 @@
 /docs/                                       @lexfrei @myasnikovdaniil
 
 # --- CI / automation ---
-/.github/                                    @myasnikovdaniil @sircthulhu
-/hack/                                       @myasnikovdaniil @sircthulhu
-/Makefile                                    @myasnikovdaniil @sircthulhu
-/.pre-commit-config.yaml                     @myasnikovdaniil @sircthulhu
+/.github/                                    @myasnikovdaniil @lexfrei
+/hack/                                       @myasnikovdaniil @lexfrei
+/Makefile                                    @myasnikovdaniil @lexfrei
+/.pre-commit-config.yaml                     @myasnikovdaniil @lexfrei
 
 # --- Governance, licensing, project docs ---
 /LICENSE                                     @tym83 @kvaps

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,8 +8,14 @@
 #
 # Ordering matters: CODEOWNERS applies the LAST matching pattern, so entries go
 # from broad to specific. The API review gate block stays last so it cannot be
-# overridden. Enable "Require review from Code Owners" in branch protection for
-# these to bind.
+# overridden.
+#
+# "Require review from Code Owners" is already enabled on main, so these rules
+# gate merges from the moment this file lands — they are not an intention to be
+# tightened later. That makes an unhonoured owner worse than a wrong one: GitHub
+# ignores a handle without write access, so scoping a path to someone who lacks
+# it carves that path out from under the catch-all and leaves it gating on
+# nobody, without reporting anything.
 
 # --- Default: architects own anything not scoped below ---
 *                                            @kvaps @lllamnyp
@@ -126,8 +132,8 @@
 # PR could neuter the detector (it is compiled from the head checkout during
 # bootstrap) and slip a sizeable API change through unreviewed. Scoping these
 # paths to the API owners overrides the catch-all above (last match wins), so
-# changes here require @kvaps or @lllamnyp specifically. Enable "Require review
-# from Code Owners" in branch protection for this to bind.
+# changes here require @kvaps or @lllamnyp specifically. This is in force today,
+# not pending a branch-protection change.
 /cmd/api-gate/                          @kvaps @lllamnyp
 /internal/apigate/                      @kvaps @lllamnyp
 /.github/workflows/api-review-gate.yaml @kvaps @lllamnyp

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,6 +51,20 @@
 /cmd/backup-controller/                      @androndo @lllamnyp
 /cmd/backupstrategy-controller/              @androndo @lllamnyp
 
+# --- Flux ---
+/packages/system/fluxcd/                     @kingdonb @kvaps @lllamnyp
+/packages/system/fluxcd-operator/            @kingdonb @kvaps @lllamnyp
+
+# --- GPU ---
+/packages/system/hami/                       @lexfrei @kvaps
+/packages/system/gpu-operator/               @lexfrei @kvaps
+/dashboards/gpu/                             @lexfrei @kvaps
+
+# --- Storage and metrics plumbing ---
+/packages/system/metrics-server/             @nbykov0 @IvanHunters
+/packages/system/seaweedfs/                  @nbykov0 @IvanHunters
+/packages/extra/seaweedfs/                   @nbykov0 @sircthulhu
+
 # --- cozystack-api / controller / lineage webhook ---
 /packages/system/cozystack-api/              @IvanHunters @kvaps @lllamnyp
 /packages/system/cozystack-controller/       @IvanHunters @kvaps @lllamnyp

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,73 +14,85 @@
 # --- Default: architects own anything not scoped below ---
 *                                            @kvaps @lllamnyp
 
+# --- Dashboards, examples, tests (largest fall-throughs to the default) ---
+/dashboards/                                 @myasnikovdaniil @IvanHunters
+/examples/                                   @lllamnyp @myasnikovdaniil
+/examples/backups/                           @androndo @lllamnyp
+/test/                                       @myasnikovdaniil
+
 # --- All packages: general owners (overridden by the specific areas below) ---
 /packages/                                   @lexfrei @IvanHunters @myasnikovdaniil @sircthulhu
 
 # --- Go source: general owners (specific cmd/pkg areas overridden below) ---
-/cmd/                                        @kvaps @lllamnyp @sircthulhu
-/internal/                                   @kvaps @lllamnyp @sircthulhu
-/pkg/                                        @kvaps @lllamnyp @sircthulhu
+/cmd/                                        @kvaps @lllamnyp @sircthulhu @lexfrei
+/internal/                                   @kvaps @lllamnyp @sircthulhu @lexfrei
+/pkg/                                        @kvaps @lllamnyp @sircthulhu @lexfrei
 
 # --- Apps: default owners (specific apps overridden below) ---
 /packages/apps/                              @lexfrei @IvanHunters @myasnikovdaniil @scooby87
-/packages/apps/kubernetes/                   @IvanHunters @kvaps
 /packages/apps/vm-instance/                  @scooby87 @lllamnyp @kvaps @myasnikovdaniil
 /packages/apps/vm-disk/                      @scooby87 @lllamnyp @kvaps @myasnikovdaniil
 /packages/apps/vpc/                          @kvaps @lllamnyp
 
+# --- Managed Kubernetes: app chart, node pools, resource definitions, control plane, CAPI ---
+/packages/apps/kubernetes/                   @IvanHunters @kvaps @myasnikovdaniil @lexfrei
+/packages/apps/kubernetes-nodes/             @IvanHunters @kvaps @myasnikovdaniil @lexfrei
+/packages/system/kubernetes-rd/              @IvanHunters @kvaps @myasnikovdaniil @lexfrei
+/packages/system/kubernetes-nodes-rd/        @IvanHunters @kvaps @myasnikovdaniil @lexfrei
+/packages/system/kamaji/                     @IvanHunters @kvaps @myasnikovdaniil @lexfrei
+/packages/system/capi-operator/              @IvanHunters @kvaps @myasnikovdaniil @lexfrei
+/packages/system/capi-providers-core/        @IvanHunters @kvaps @myasnikovdaniil @lexfrei
+/packages/system/capi-providers-bootstrap/   @IvanHunters @kvaps @myasnikovdaniil @lexfrei
+/packages/system/capi-providers-cpprovider/  @IvanHunters @kvaps @myasnikovdaniil @lexfrei
+/packages/system/capi-providers-infraprovider/ @IvanHunters @kvaps @myasnikovdaniil @lexfrei
+
 # --- Extra apps ---
-/packages/extra/                             @kvaps @lllamnyp @IvanHunters
+/packages/extra/                             @kvaps @lllamnyp @IvanHunters @lexfrei @myasnikovdaniil
 
 # --- Core (installer / platform / talos / flux-aio) ---
 /packages/core/                              @lllamnyp @kvaps @myasnikovdaniil @IvanHunters @lexfrei
 
 # --- Virtualization (system side) ---
-/packages/system/kubevirt/                   @scooby87 @lllamnyp @kvaps @myasnikovdaniil
-/packages/system/kubevirt-cdi/               @scooby87 @lllamnyp @kvaps @myasnikovdaniil
+/packages/system/kubevirt/                   @scooby87 @lllamnyp @kvaps @lexfrei
+/packages/system/kubevirt-cdi/               @scooby87 @lllamnyp @kvaps
 /packages/system/kubevirt-cdi-operator/      @scooby87 @lllamnyp @kvaps @myasnikovdaniil
-/packages/system/kubevirt-operator/          @scooby87 @lllamnyp @kvaps @myasnikovdaniil
+/packages/system/kubevirt-operator/          @scooby87 @lllamnyp @kvaps @myasnikovdaniil @IvanHunters
 /packages/system/kubevirt-instancetypes/     @scooby87 @lllamnyp @kvaps @myasnikovdaniil
 /packages/system/kubevirt-csi-node/          @scooby87 @lllamnyp @kvaps @myasnikovdaniil
 /packages/system/vm-default-images/          @scooby87 @lllamnyp @kvaps @myasnikovdaniil
 
 # --- Backups ---
-/packages/system/backup-controller/          @androndo @lllamnyp
+/packages/system/backup-controller/          @androndo @lllamnyp @lexfrei
 /packages/system/backupstrategy-controller/  @androndo @lllamnyp
-/packages/system/velero/                     @androndo @lllamnyp
+/packages/system/velero/                     @androndo @lllamnyp @lexfrei
 /cmd/backup-controller/                      @androndo @lllamnyp
 /cmd/backupstrategy-controller/              @androndo @lllamnyp
 
 # --- Flux ---
-/packages/system/fluxcd/                     @kingdonb @kvaps @lllamnyp
-/packages/system/fluxcd-operator/            @kingdonb @kvaps @lllamnyp
+/packages/system/fluxcd/                     @kingdonb @kvaps @lllamnyp @myasnikovdaniil
+/packages/system/fluxcd-operator/            @kingdonb @kvaps @lllamnyp @myasnikovdaniil
 
 # --- GPU ---
 /packages/system/hami/                       @lexfrei @kvaps
 /packages/system/gpu-operator/               @lexfrei @kvaps
 /dashboards/gpu/                             @lexfrei @kvaps
 
-# --- Storage and metrics plumbing ---
-/packages/system/metrics-server/             @nbykov0 @IvanHunters
-/packages/system/seaweedfs/                  @nbykov0 @IvanHunters
-/packages/extra/seaweedfs/                   @nbykov0 @sircthulhu
+# --- SeaweedFS ---
+/packages/system/seaweedfs/                  @IvanHunters @lexfrei @myasnikovdaniil
+/packages/extra/seaweedfs/                   @sircthulhu @lexfrei @myasnikovdaniil
 
 # --- cozystack-api / controller / lineage webhook ---
-/packages/system/cozystack-api/              @IvanHunters @kvaps @lllamnyp
-/packages/system/cozystack-controller/       @IvanHunters @kvaps @lllamnyp
-/packages/system/lineage-controller-webhook/ @IvanHunters @kvaps @lllamnyp
-/cmd/cozystack-api/                          @IvanHunters @kvaps @lllamnyp
-/cmd/cozystack-controller/                   @IvanHunters @kvaps @lllamnyp
-/cmd/lineage-controller-webhook/             @IvanHunters @kvaps @lllamnyp
+/packages/system/cozystack-api/              @IvanHunters @kvaps @lllamnyp @lexfrei
+/packages/system/cozystack-controller/       @IvanHunters @kvaps @lllamnyp @lexfrei
+/packages/system/lineage-controller-webhook/ @IvanHunters @kvaps @lllamnyp @lexfrei
+/cmd/cozystack-api/                          @IvanHunters @kvaps @lllamnyp @lexfrei
+/cmd/cozystack-controller/                   @IvanHunters @kvaps @lllamnyp @lexfrei
+/cmd/lineage-controller-webhook/             @IvanHunters @kvaps @lllamnyp @lexfrei
 
 # --- Keycloak ---
 /packages/system/keycloak/                   @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil
 /packages/system/keycloak-operator/          @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil
 /packages/system/keycloak-configure/         @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil
-
-# --- CLI tooling ---
-/cmd/cozypkg/                                @lexfrei @IvanHunters @myasnikovdaniil
-/tools/                                      @lexfrei @IvanHunters @myasnikovdaniil
 
 # --- API surface (architects): API types, aggregated apiserver, registry ---
 /api/                                        @kvaps @lllamnyp


### PR DESCRIPTION
## What this PR does

Replaces the single catch-all owner line in `.github/CODEOWNERS` with area-scoped reviewer ownership, so each part of the tree routes to the people who actually own it (per the Contributor Ladder), instead of requiring the whole roster on every change.

Highlights:
- Architects (`@kvaps @lllamnyp`) are the default owner and own the API surface (`/api/`) and the VPC app.
- CI / automation → `@myasnikovdaniil @sircthulhu`; backups → `@androndo @lllamnyp`; virtualization (kubevirt, vm-instance/disk) → `@scooby87 @lllamnyp @kvaps @myasnikovdaniil`.
- `cozystack-api` / controller / lineage webhook → `@IvanHunters @kvaps @lllamnyp`.
- General packages / apps / CLI ownership → `@lexfrei @IvanHunters @myasnikovdaniil` (+ `@scooby87` for apps), with `kubernetes` and `extra` scoped separately.
- Flux → `@kingdonb`; GPU (hami, gpu-operator, GPU dashboards) → `@lexfrei`; metrics-server and seaweedfs → `@nbykov0`.
- Governance / licensing files → `@tym83 @kvaps`.

Ordering follows "last match wins" (broad → specific). The API review gate block is kept last so it cannot be overridden. This is review-routing only — no runtime/functional change — and only binds once "Require review from Code Owners" is enabled in branch protection.

This file is what the CNCF Incubation review reads as "code ownership", so it is paired with #3462, which documents the same people in `MAINTAINERS.md` and introduces the Reviewers table the ladder already defined. Merging one without the other leaves the two describing different projects, which is the gap both PRs exist to close. Three of the people named here — `@kingdonb`, `@matthieu-robin`, `@mattia-eleuteri` — hold only read access today, and a CODEOWNERS entry for someone without write is silently ignored by GitHub, so the org-side permission changes have to land alongside.

### Screenshots

N/A — governance/config change, no user-facing or UI impact.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

Walked the trigger map against the diff: no row matches. The change touches only `.github/CODEOWNERS` — no package, no `values.schema.json`, no `ApplicationDefinition`, no platform variant, no release asset, no node prerequisite. Every path named here was checked against current `main`; all 65 exist.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CODEOWNERS from a single catch-all to an ordered, path-scoped reviewer mapping.
  * Clarified “last matching pattern wins” behavior and ensured the API review gate rules remain last to avoid overrides.
  * Expanded explicit ownership coverage across dashboards/examples, packages and Go components, apps, platform/infrastructure modules, CI/automation, and governance/licensing documentation (including SECURITY).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->