### PR TITLE
fix(apps/kubernetes): bump tenant Cilium HR install timeout 10m -> 15m

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
@@ -44,7 +44,12 @@ spec:
   targetNamespace: cozy-cilium
   storageNamespace: cozy-cilium
   interval: 5m
-  timeout: 10m
+  # 15m matches the tenant Kubernetes install budget and gives image pull
+  # onto a fresh Talos worker VM enough headroom on slow CI runners: the
+  # Cilium container image lives in the OCIR mirror and the tenant node
+  # has no image cache on first boot; the 10m timeout raced the pull
+  # about half the time (~13m wall-clock, see cozystack/cozystack#3229).
+  timeout: 15m
   install:
     createNamespace: true
     remediation:


### PR DESCRIPTION
## Summary

The tenant Cilium HR's install timeout races the container image pull to a fresh Talos worker VM on CI runners. Bump `spec.timeout` on `packages/apps/kubernetes/templates/helmreleases/cilium.yaml` from 10m to 15m — aligned with the tenant Kubernetes install budget the rest of the stack already uses.

## Root cause (from CI artifact analysis)

Reproduced on E2E run [28843794670](https://github.com/cozystack/cozystack/actions/runs/28843794670) (job 85543970802) — the same failure signature seen on 6+ open PRs at time of writing, tracked in #3229.

Cozyreport artifact from that run, looking at `snapshots/kubernetes-previous/tenantkubeconfig-test-previous-version/namespaces/cozy-cilium/v1/pod/cilium-*.yaml`:

```yaml
initContainerStatuses:
- name: config
  state: {waiting: {reason: PodInitializing}}
  imageID: ""                               # kubelet is still pulling
- name: mount-cgroup
  state: {waiting: {reason: PodInitializing}}
  imageID: ""
- name: apply-sysctl-overwrites
  state: {waiting: {reason: PodInitializing}}
  imageID: ""
- name: mount-bpf-fs
  state: {waiting: {reason: PodInitializing}}
  imageID: ""
- name: clean-cilium-state
  state: {waiting: {reason: PodInitializing}}
  imageID: ""
```

`cilium-agent` `current.log` and `previous.log` are **zero bytes** — the container never entered running phase because every init container was still waiting for `iad.ocir.io/idyksih5sir9/cozystack/cilium:main@sha256:16e9a5cd3b3614571329a309fc283f5a43e7522bef91d1ff539545c0ec1bc857` to land. The HR's 10m install `timeout` fires, helm-controller uninstalls, retries via `retries: -1`, next install races the pull again.

The failure is *not* version-scoped:

| Test | k8s minor | Wall-clock | Result |
| --- | --- | --- | --- |
| kubernetes-latest | v1.35.6 | 13:10 | ✅ (~30s under 12m `until nodes Ready` bats budget) |
| kubernetes-previous | v1.34.9 | 13:52 | ❌ (82s over) |

Both tests sit right on the edge; whichever races the pull first wins. Cilium's own startup work (once running) completes in seconds, so 15m is pure headroom for slow first-time image pull on a runner without a warm mirror cache. Matches the 15m budget the outer tenant HR and the monitoring cozyrds annotation already use elsewhere.

## Alternative fixes considered

- **Pre-pull Cilium image on the Talos node.** Requires either a systemd unit in the Talos machineconfig or a warm-up DaemonSet — much larger change surface for the same effect.
- **Move the image to a closer / faster mirror.** Out of scope for the tenant chart; would touch cluster-level registry config.
- **Bump Cilium chart.** Doesn't help — the container hasn't even started; the newer chart's binary would face the same pull latency.

## Test plan

- [ ] Existing `kubernetes-latest` and `kubernetes-previous` E2E tests both pass on the next CI run against this branch.
- [ ] Verify no downstream helm-controller behaviour change from the 5m bump (spec.timeout only controls `helm install --wait` deadline; interval and reconcile cadence unchanged).

Closes #3229.

## Release note

```release-note
fix(apps/kubernetes): raise Cilium HelmRelease install timeout to 15m so first-time image pull on a fresh Talos worker node has enough headroom on CI runners without a warm mirror cache.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the timeout for Cilium installation and upgrade reconciliation, helping long-running deployments complete more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->