### PR TITLE
test(e2e): disable KVM nested virtualization (CVE-2026-53359)

### DIFF
--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -133,6 +133,10 @@ machine:
     - name: zfs
     - name: spl
   install:
+    # On Talos >1.11 the base defaults grubUseUKICmdline: true (UKI cmdline),
+    # which Talos rejects together with extraKernelArgs and which ignores them
+    # anyway; pin false so the kvm args land on the Talos-built cmdline.
+    grubUseUKICmdline: false
     extraKernelArgs:
     # CVE-2026-53359: disable KVM nested virtualization (guest-to-host escape mitigation)
     - kvm_intel.nested=0

--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -132,6 +132,11 @@ machine:
         - usermode_helper=disabled
     - name: zfs
     - name: spl
+  install:
+    extraKernelArgs:
+    # CVE-2026-53359: disable KVM nested virtualization (guest-to-host escape mitigation)
+    - kvm_intel.nested=0
+    - kvm_amd.nested=0
   registries:
     mirrors:
       docker.io:


### PR DESCRIPTION
## What this PR does

Disables KVM nested virtualization in the E2E Talos machine-config patch to mitigate **CVE-2026-53359** ("Januscape"), a guest-to-host escape in the Linux KVM/x86 shadow MMU (a use-after-free in `kvm_mmu_get_child_sp()` caused by shadow-page role confusion).

The vulnerable code path is only reachable when a guest is allowed to use nested virtualization (i.e. the guest is given the `vmx`/`svm` CPU feature and runs its own nested guest). Setting `kvm_intel.nested=0` and `kvm_amd.nested=0` on the host removes the attack surface entirely, independent of the node kernel patch level.

The bug was fixed upstream in commit `81ccda30b4e8` and in stable kernels `6.12.95` / `6.6.144` / `6.1.177` / `6.18.38` / `7.1.3` (2026-07-04); as of this PR no released Talos ships a fixed kernel yet, so disabling nested virtualization is the reliable mitigation. Both args are set so a single config works on Intel and AMD hosts — the non-matching one is silently ignored.

Part of a coordinated set of PRs (see Related PRs below).

### Release note

```release-note
test(e2e): disable KVM nested virtualization to mitigate CVE-2026-53359 (Januscape guest-to-host escape)
```

## Related PRs

Coordinated **CVE-2026-53359** (Januscape) nested-virtualization mitigation across Cozystack repos:

- cozystack/cozystack#3234 — E2E Talos machine-config
- cozystack/talm#224 — Talos `cozystack`/`generic` presets (canonical source)
- cozystack/website#602 — install docs (all versions)
- cozystack/ccp#17 — Talos bootstrap/upgrade skills (prescribe + verify, survives upgrades)
- cozystack/ansible-cozystack#60 — generic Ubuntu/RHEL/SUSE hosts (modprobe.d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cluster preparation defaults to disable nested virtualization on both Intel and AMD systems, improving boot-time consistency.
* **Security**
  * Updated boot-time configuration to apply new kernel command-line parameters related to virtualization behavior.
  * Adjusted UKI command-line handling during cluster setup to align with the hardened configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->