### PR TITLE
fix(keycloak): point HTTPRoute backends at the service port

### DIFF
--- a/packages/system/keycloak/templates/httproute.yaml
+++ b/packages/system/keycloak/templates/httproute.yaml
@@ -36,11 +36,11 @@ spec:
         value: /.well-known
     backendRefs:
     - name: keycloak-http
-      port: 80
+      port: 8080
   {{- else }}
   - backendRefs:
     - name: keycloak-http
-      port: 80
+      port: 8080
   {{- end }}
 {{- if $adminHost }}
 ---
@@ -62,6 +62,6 @@ spec:
   rules:
   - backendRefs:
     - name: keycloak-http
-      port: 80
+      port: 8080
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

With `gateway-enabled: "true"`, every Keycloak hostname answers 503 from envoy. The `keycloak-http` Service exposes a single port, 8080:

```yaml
ports:
  - name: http
    port: 8080
```

but all three HTTPRoute backendRefs in `packages/system/keycloak/templates/httproute.yaml` reference `port: 80`. Gateway API resolves a backendRef against the Service's declared ports, so no backend resolves and the route serves 503. The Ingress template is unaffected because it references the port by name (`http`).

Observed live on the freedom dev cluster: all Keycloak hosts returned 503 via the Gateway; hand-patching the route's backend port to 8080 restored service.

## Change

Point the three backendRefs (public route, its no-adminHost variant, and the admin route) at port 8080.

Verified with `helm template -s templates/httproute.yaml` (with and without `ingress.adminHost`): both routes render with `port: 8080`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Keycloak HTTP routing so both the main and admin routes forward traffic to the correct backend service port (from 80 to 8080), improving reliability and access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->