### PR TITLE
docs(readme): add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![GitHub Release](https://img.shields.io/github/release/cozystack/cozystack.svg?style=flat)](https://github.com/cozystack/cozystack/releases/latest)
 [![GitHub Commit](https://img.shields.io/github/commit-activity/y/cozystack/cozystack)](https://github.com/cozystack/cozystack/graphs/contributors)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10177/badge)](https://www.bestpractices.dev/projects/10177)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/cozystack/cozystack/badge)](https://securityscorecards.dev/viewer/?uri=github.com/cozystack/cozystack)
 
 # Cozystack
 


### PR DESCRIPTION
## What this PR does

Adds the OpenSSF Scorecard badge to the README, next to the existing OpenSSF Best Practices badge. The `scorecard.yml` workflow already publishes results to the public securityscorecards.dev dataset, so the badge surfaces the project's live supply-chain security score directly in the README.

### Release note

```release-note
docs(readme): add OpenSSF Scorecard badge
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an OpenSSF Scorecard badge to the README, linking to the repository’s security scorecard page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->