### PR TITLE
feat(keycloak): add Vault Kubernetes and AppRole auth for the encryption proxy

### DIFF
--- a/packages/system/keycloak/templates/proxy.yaml
+++ b/packages/system/keycloak/templates/proxy.yaml
@@ -113,17 +113,38 @@ spec:
               value: {{ .Values.encryption.lenient | quote }}
             {{- if eq $backend "vault-transit" }}
             {{- $vault := $kms.vault | default dict }}
+            {{- $auth := $vault.auth | default "token" }}
+            {{- if and (ne $auth "token") (ne $auth "approle") }}
+            {{- fail (printf "encryption.kms.vault.auth must be 'token' or 'approle', got %q" $auth) }}
+            {{- end }}
             - name: KKP_VAULT_ADDR
               value: {{ required "encryption.kms.vault.address is required when kms.backend=vault-transit" $vault.address | quote }}
             - name: KKP_VAULT_KEY_NAME
               value: {{ required "encryption.kms.vault.keyName is required when kms.backend=vault-transit" $vault.keyName | quote }}
             - name: KKP_VAULT_MOUNT
               value: {{ $vault.mount | default "transit" | quote }}
+            {{- if eq $auth "approle" }}
+            {{- $appRole := $vault.appRole | default dict }}
+            {{- $secretName := required "encryption.kms.vault.appRole.secretName is required when vault.auth=approle" $appRole.secretName }}
+            - name: KKP_VAULT_APPROLE_MOUNT
+              value: {{ $appRole.mount | default "approle" | quote }}
+            - name: KKP_VAULT_ROLE_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ $appRole.roleIdKey | default "role-id" }}
+            - name: KKP_VAULT_SECRET_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $secretName }}
+                  key: {{ $appRole.secretIdKey | default "secret-id" }}
+            {{- else }}
             - name: KKP_VAULT_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "encryption.kms.vault.tokenSecretName is required when kms.backend=vault-transit" $vault.tokenSecretName }}
+                  name: {{ required "encryption.kms.vault.tokenSecretName is required when vault.auth=token" $vault.tokenSecretName }}
                   key: token
+            {{- end }}
             {{- else }}
             - name: KKP_KEK
               valueFrom:

--- a/packages/system/keycloak/templates/proxy.yaml
+++ b/packages/system/keycloak/templates/proxy.yaml
@@ -114,8 +114,8 @@ spec:
             {{- if eq $backend "vault-transit" }}
             {{- $vault := $kms.vault | default dict }}
             {{- $auth := $vault.auth | default "token" }}
-            {{- if and (ne $auth "token") (ne $auth "approle") }}
-            {{- fail (printf "encryption.kms.vault.auth must be 'token' or 'approle', got %q" $auth) }}
+            {{- if and (ne $auth "token") (ne $auth "approle") (ne $auth "kubernetes") }}
+            {{- fail (printf "encryption.kms.vault.auth must be 'token', 'approle', or 'kubernetes', got %q" $auth) }}
             {{- end }}
             - name: KKP_VAULT_ADDR
               value: {{ required "encryption.kms.vault.address is required when kms.backend=vault-transit" $vault.address | quote }}
@@ -138,6 +138,15 @@ spec:
                 secretKeyRef:
                   name: {{ $secretName }}
                   key: {{ $appRole.secretIdKey | default "secret-id" }}
+            {{- else if eq $auth "kubernetes" }}
+            {{- $k8s := $vault.kubernetes | default dict }}
+            # The proxy logs in with its own ServiceAccount token (auto-mounted
+            # at the standard in-pod path); bind the Vault role to this pod's
+            # ServiceAccount + namespace. No credential is stored in a Secret.
+            - name: KKP_VAULT_KUBERNETES_ROLE
+              value: {{ required "encryption.kms.vault.kubernetes.role is required when vault.auth=kubernetes" $k8s.role | quote }}
+            - name: KKP_VAULT_KUBERNETES_MOUNT
+              value: {{ $k8s.mount | default "kubernetes" | quote }}
             {{- else }}
             - name: KKP_VAULT_TOKEN
               valueFrom:

--- a/packages/system/keycloak/templates/proxy.yaml
+++ b/packages/system/keycloak/templates/proxy.yaml
@@ -14,6 +14,10 @@
 {{- /* The proxy needs its ServiceAccount token only for Vault Kubernetes auth. */}}
 {{- $vaultAuth := (($kms.vault | default dict).auth | default "token") }}
 {{- $k8sAuth := and (eq $backend "vault-transit") (eq $vaultAuth "kubernetes") }}
+{{- $replicas := .Values.encryption.replicas | default 1 | int }}
+{{- if and (gt $replicas 1) (not .Values.encryption.deksetSecretName) }}
+{{- fail "encryption.replicas > 1 requires encryption.deksetSecretName (a shared wrapped DEK set); otherwise replicas would encrypt deterministic columns under different keys" }}
+{{- end }}
 {{- if eq $backend "static" }}
 {{- /*
   Static KMS: a self-generated 32-byte KEK kept in a Secret. Generated once
@@ -52,10 +56,11 @@ metadata:
   labels:
     app: keycloak-kms-proxy
 spec:
-  # Single replica: HA needs a shared wrapped DEK set (KKP_DEKSET_FILE) so
-  # every replica encrypts deterministic columns with the same key. Tracked
-  # as a follow-up.
-  replicas: 1
+  # Defaults to a single replica. HA (replicas > 1) requires a shared wrapped
+  # DEK set (encryption.deksetSecretName → KKP_DEKSET_FILE) so every replica
+  # encrypts deterministic columns under the same key; the guard above enforces
+  # that.
+  replicas: {{ $replicas }}
   selector:
     matchLabels:
       app: keycloak-kms-proxy
@@ -176,6 +181,15 @@ spec:
                   name: keycloak-kms-proxy-kek
                   key: kek
             {{- end }}
+            {{- if .Values.encryption.deksetSecretName }}
+            # Wrapped DEK set minted by the backfill tool. Required to run more
+            # than one replica AND to migrate an existing populated database
+            # (the proxy must reuse the DEK that encrypt-rows wrapped with);
+            # without it the proxy mints an ephemeral DEK usable only on a fresh
+            # database.
+            - name: KKP_DEKSET_FILE
+              value: /etc/kkp/dekset/{{ .Values.encryption.deksetSecretKey | default "dekset.json" }}
+            {{- end }}
           {{- with .Values.encryption.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -188,6 +202,18 @@ spec:
             tcpSocket:
               port: postgres
             periodSeconds: 15
+          {{- if .Values.encryption.deksetSecretName }}
+          volumeMounts:
+            - name: dekset
+              mountPath: /etc/kkp/dekset
+              readOnly: true
+          {{- end }}
+      {{- if .Values.encryption.deksetSecretName }}
+      volumes:
+        - name: dekset
+          secret:
+            secretName: {{ .Values.encryption.deksetSecretName }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/packages/system/keycloak/templates/proxy.yaml
+++ b/packages/system/keycloak/templates/proxy.yaml
@@ -11,6 +11,9 @@
 {{- if and (ne $backend "static") (ne $backend "vault-transit") }}
 {{- fail (printf "encryption.kms.backend must be 'static' or 'vault-transit', got %q" $backend) }}
 {{- end }}
+{{- /* The proxy needs its ServiceAccount token only for Vault Kubernetes auth. */}}
+{{- $vaultAuth := (($kms.vault | default dict).auth | default "token") }}
+{{- $k8sAuth := and (eq $backend "vault-transit") (eq $vaultAuth "kubernetes") }}
 {{- if eq $backend "static" }}
 {{- /*
   Static KMS: a self-generated 32-byte KEK kept in a Secret. Generated once
@@ -32,6 +35,16 @@ data:
   kek: {{ $kek | quote }}
 ---
 {{- end }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-kms-proxy
+  labels:
+    app: keycloak-kms-proxy
+# Dedicated identity for the proxy (never the namespace default SA). Its token
+# is only mounted for Vault Kubernetes auth; other modes don't need it.
+automountServiceAccountToken: {{ $k8sAuth }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -51,6 +64,8 @@ spec:
       labels:
         app: keycloak-kms-proxy
     spec:
+      serviceAccountName: keycloak-kms-proxy
+      automountServiceAccountToken: {{ $k8sAuth }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -140,9 +155,9 @@ spec:
                   key: {{ $appRole.secretIdKey | default "secret-id" }}
             {{- else if eq $auth "kubernetes" }}
             {{- $k8s := $vault.kubernetes | default dict }}
-            # The proxy logs in with its own ServiceAccount token (auto-mounted
-            # at the standard in-pod path); bind the Vault role to this pod's
-            # ServiceAccount + namespace. No credential is stored in a Secret.
+            # The proxy logs in with its own ServiceAccount token; bind the
+            # Vault role to system:serviceaccount:<namespace>:keycloak-kms-proxy.
+            # No credential is stored in a Secret.
             - name: KKP_VAULT_KUBERNETES_ROLE
               value: {{ required "encryption.kms.vault.kubernetes.role is required when vault.auth=kubernetes" $k8s.role | quote }}
             - name: KKP_VAULT_KUBERNETES_MOUNT

--- a/packages/system/keycloak/tests/encryption_test.yaml
+++ b/packages/system/keycloak/tests/encryption_test.yaml
@@ -151,6 +151,13 @@ tests:
           content:
             name: KKP_VAULT_ADDR
             value: https://vault.vault.svc:8200
+      # Token auth must not leak AppRole env vars. any:true matches on the
+      # element name alone (helm-unittest otherwise deep-equals whole elements).
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: KKP_VAULT_ROLE_ID
 
   - it: does not generate a static KEK Secret for the Vault backend
     template: templates/proxy.yaml
@@ -258,8 +265,12 @@ tests:
               secretKeyRef:
                 name: keycloak-vault-approle
                 key: secret-id
+      # AppRole must not store a long-lived token. any:true matches on the
+      # element name alone (helm-unittest otherwise deep-equals whole elements,
+      # so a name-only content would never match the valueFrom entry).
       - notContains:
           path: spec.template.spec.containers[0].env
+          any: true
           content:
             name: KKP_VAULT_TOKEN
 

--- a/packages/system/keycloak/tests/encryption_test.yaml
+++ b/packages/system/keycloak/tests/encryption_test.yaml
@@ -220,3 +220,75 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "encryption.kms.vault.tokenSecretName is required"
+
+  - it: authenticates via AppRole when vault.auth=approle
+    template: templates/proxy.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      encryption.enabled: true
+      encryption.kms.backend: vault-transit
+      encryption.kms.vault.address: https://vault.vault.svc:8200
+      encryption.kms.vault.keyName: keycloak
+      encryption.kms.vault.auth: approle
+      encryption.kms.vault.appRole.secretName: keycloak-vault-approle
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KKP_VAULT_APPROLE_MOUNT
+            value: approle
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KKP_VAULT_ROLE_ID
+            valueFrom:
+              secretKeyRef:
+                name: keycloak-vault-approle
+                key: role-id
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KKP_VAULT_SECRET_ID
+            valueFrom:
+              secretKeyRef:
+                name: keycloak-vault-approle
+                key: secret-id
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KKP_VAULT_TOKEN
+
+  - it: requires appRole.secretName when vault.auth=approle
+    template: templates/proxy.yaml
+    set:
+      encryption.enabled: true
+      encryption.kms.backend: vault-transit
+      encryption.kms.vault.address: https://vault.vault.svc:8200
+      encryption.kms.vault.keyName: keycloak
+      encryption.kms.vault.auth: approle
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - failedTemplate:
+          errorPattern: "encryption.kms.vault.appRole.secretName is required"
+
+  - it: rejects an unsupported vault auth method
+    template: templates/proxy.yaml
+    set:
+      encryption.enabled: true
+      encryption.kms.backend: vault-transit
+      encryption.kms.vault.address: https://vault.vault.svc:8200
+      encryption.kms.vault.keyName: keycloak
+      encryption.kms.vault.auth: k8s
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - failedTemplate:
+          errorPattern: "encryption.kms.vault.auth must be 'token' or 'approle'"

--- a/packages/system/keycloak/tests/encryption_test.yaml
+++ b/packages/system/keycloak/tests/encryption_test.yaml
@@ -511,3 +511,22 @@ tests:
       - equal:
           path: spec.replicas
           value: 2
+
+  - it: honors a custom deksetSecretKey
+    template: templates/proxy.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      encryption.enabled: true
+      encryption.deksetSecretName: keycloak-kms-proxy-dekset
+      encryption.deksetSecretKey: custom.json
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KKP_DEKSET_FILE
+            value: /etc/kkp/dekset/custom.json

--- a/packages/system/keycloak/tests/encryption_test.yaml
+++ b/packages/system/keycloak/tests/encryption_test.yaml
@@ -289,6 +289,59 @@ tests:
       - failedTemplate:
           errorPattern: "encryption.kms.vault.appRole.secretName is required"
 
+  - it: authenticates via Kubernetes when vault.auth=kubernetes
+    template: templates/proxy.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      encryption.enabled: true
+      encryption.kms.backend: vault-transit
+      encryption.kms.vault.address: https://vault.vault.svc:8200
+      encryption.kms.vault.keyName: keycloak
+      encryption.kms.vault.auth: kubernetes
+      encryption.kms.vault.kubernetes.role: keycloak-proxy
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KKP_VAULT_KUBERNETES_ROLE
+            value: keycloak-proxy
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KKP_VAULT_KUBERNETES_MOUNT
+            value: kubernetes
+      # No credential env vars for the other modes must leak in.
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: KKP_VAULT_TOKEN
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: KKP_VAULT_ROLE_ID
+
+  - it: requires kubernetes.role when vault.auth=kubernetes
+    template: templates/proxy.yaml
+    set:
+      encryption.enabled: true
+      encryption.kms.backend: vault-transit
+      encryption.kms.vault.address: https://vault.vault.svc:8200
+      encryption.kms.vault.keyName: keycloak
+      encryption.kms.vault.auth: kubernetes
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - failedTemplate:
+          errorPattern: "encryption.kms.vault.kubernetes.role is required"
+
   - it: rejects an unsupported vault auth method
     template: templates/proxy.yaml
     set:
@@ -296,10 +349,10 @@ tests:
       encryption.kms.backend: vault-transit
       encryption.kms.vault.address: https://vault.vault.svc:8200
       encryption.kms.vault.keyName: keycloak
-      encryption.kms.vault.auth: k8s
+      encryption.kms.vault.auth: bogus
       _cluster:
         root-host: example.org
         cluster-domain: cozy.local
     asserts:
       - failedTemplate:
-          errorPattern: "encryption.kms.vault.auth must be 'token' or 'approle'"
+          errorPattern: "encryption.kms.vault.auth must be 'token', 'approle', or 'kubernetes'"

--- a/packages/system/keycloak/tests/encryption_test.yaml
+++ b/packages/system/keycloak/tests/encryption_test.yaml
@@ -433,3 +433,81 @@ tests:
       - equal:
           path: spec.template.spec.automountServiceAccountToken
           value: true
+
+  - it: mints an ephemeral DEK (no dekset) by default
+    template: templates/proxy.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      encryption.enabled: true
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          any: true
+          content:
+            name: KKP_DEKSET_FILE
+      - notExists:
+          path: spec.template.spec.volumes
+
+  - it: mounts the wrapped DEK set when deksetSecretName is set
+    template: templates/proxy.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      encryption.enabled: true
+      encryption.deksetSecretName: keycloak-kms-proxy-dekset
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KKP_DEKSET_FILE
+            value: /etc/kkp/dekset/dekset.json
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: dekset
+            mountPath: /etc/kkp/dekset
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: dekset
+            secret:
+              secretName: keycloak-kms-proxy-dekset
+
+  - it: rejects HA (replicas > 1) without a dekset
+    template: templates/proxy.yaml
+    set:
+      encryption.enabled: true
+      encryption.replicas: 2
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - failedTemplate:
+          errorPattern: "encryption.replicas > 1 requires encryption.deksetSecretName"
+
+  - it: allows HA when a shared dekset is provided
+    template: templates/proxy.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      encryption.enabled: true
+      encryption.replicas: 2
+      encryption.deksetSecretName: keycloak-kms-proxy-dekset
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2

--- a/packages/system/keycloak/tests/encryption_test.yaml
+++ b/packages/system/keycloak/tests/encryption_test.yaml
@@ -37,7 +37,7 @@ tests:
                 name: keycloak-db-app
                 key: "host"
 
-  - it: renders three documents (KEK Secret + Deployment + Service) when enabled
+  - it: renders four documents (KEK Secret + ServiceAccount + Deployment + Service) when enabled
     template: templates/proxy.yaml
     set:
       encryption.enabled: true
@@ -46,7 +46,7 @@ tests:
         cluster-domain: cozy.local
     asserts:
       - hasDocuments:
-          count: 3
+          count: 4
 
   - it: deploys the proxy wired to the static KEK and the CNPG backend
     template: templates/proxy.yaml
@@ -171,8 +171,9 @@ tests:
         root-host: example.org
         cluster-domain: cozy.local
     asserts:
+      # ServiceAccount + Deployment + Service (no KEK Secret for Vault).
       - hasDocuments:
-          count: 2
+          count: 3
 
   - it: rejects an unsupported kms backend at render time
     template: templates/proxy.yaml
@@ -356,3 +357,56 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "encryption.kms.vault.auth must be 'token', 'approle', or 'kubernetes'"
+
+  - it: creates a dedicated proxy ServiceAccount
+    template: templates/proxy.yaml
+    documentSelector:
+      path: kind
+      value: ServiceAccount
+    set:
+      encryption.enabled: true
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - equal:
+          path: metadata.name
+          value: keycloak-kms-proxy
+
+  - it: runs the proxy under its ServiceAccount with the token off by default
+    template: templates/proxy.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      encryption.enabled: true
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: keycloak-kms-proxy
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+
+  - it: mounts the ServiceAccount token only for Kubernetes auth
+    template: templates/proxy.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    set:
+      encryption.enabled: true
+      encryption.kms.backend: vault-transit
+      encryption.kms.vault.address: https://vault.vault.svc:8200
+      encryption.kms.vault.keyName: keycloak
+      encryption.kms.vault.auth: kubernetes
+      encryption.kms.vault.kubernetes.role: keycloak-proxy
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true

--- a/packages/system/keycloak/tests/encryption_test.yaml
+++ b/packages/system/keycloak/tests/encryption_test.yaml
@@ -358,7 +358,7 @@ tests:
       - failedTemplate:
           errorPattern: "encryption.kms.vault.auth must be 'token', 'approle', or 'kubernetes'"
 
-  - it: creates a dedicated proxy ServiceAccount
+  - it: creates a dedicated proxy ServiceAccount with the token off by default
     template: templates/proxy.yaml
     documentSelector:
       path: kind
@@ -372,6 +372,29 @@ tests:
       - equal:
           path: metadata.name
           value: keycloak-kms-proxy
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: enables the ServiceAccount token on the SA object for Kubernetes auth
+    template: templates/proxy.yaml
+    documentSelector:
+      path: kind
+      value: ServiceAccount
+    set:
+      encryption.enabled: true
+      encryption.kms.backend: vault-transit
+      encryption.kms.vault.address: https://vault.vault.svc:8200
+      encryption.kms.vault.keyName: keycloak
+      encryption.kms.vault.auth: kubernetes
+      encryption.kms.vault.kubernetes.role: keycloak-proxy
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: true
 
   - it: runs the proxy under its ServiceAccount with the token off by default
     template: templates/proxy.yaml

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -92,7 +92,7 @@ extraEnv: []
 #     MUST be part of the backup set. For production prefer kms.backend=vault-transit.
 encryption:
   enabled: false
-  image: ghcr.io/cozystack/keycloak-kms-proxy:v0.1.0
+  image: ghcr.io/cozystack/keycloak-kms-proxy:v0.2.0
   # Encrypted field set: "" = full default set (username, email, names,
   # PII attributes, credentials), "email-only", or "disabled" (passthrough).
   fields: ""
@@ -113,8 +113,6 @@ encryption:
       #     (RECOMMENDED: no credential is stored; the kubelet rotates the token).
       #   "approle" — the proxy logs in via AppRole and re-authenticates on demand.
       #   "token" — a long-lived Vault token in a Secret.
-      # "kubernetes"/"approle" require a keycloak-kms-proxy image that supports
-      # them (> v0.1.0); bump encryption.image accordingly.
       auth: token
       # token auth: existing Secret holding the Vault token under key "token".
       tokenSecretName: ""

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -92,7 +92,7 @@ extraEnv: []
 #     MUST be part of the backup set. For production prefer kms.backend=vault-transit.
 encryption:
   enabled: false
-  image: ghcr.io/cozystack/keycloak-kms-proxy:0.2.0
+  image: ghcr.io/cozystack/keycloak-kms-proxy:0.2.1
   # Encrypted field set: "" = full default set (username, email, names,
   # PII attributes, credentials), "email-only", or "disabled" (passthrough).
   fields: ""

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -108,13 +108,21 @@ encryption:
       address: ""       # e.g. https://vault.vault.svc:8200
       keyName: ""       # Transit key name
       mount: transit    # Transit mount path
-      # Vault authentication: "token" (a long-lived token in a Secret) or
-      # "approle" (the proxy logs in via AppRole and re-authenticates on demand,
-      # so no long-lived token is stored). AppRole requires a keycloak-kms-proxy
-      # image that supports it (> v0.1.0); bump encryption.image accordingly.
+      # Vault authentication mode:
+      #   "kubernetes" — the proxy logs in with its own ServiceAccount token
+      #     (RECOMMENDED: no credential is stored; the kubelet rotates the token).
+      #   "approle" — the proxy logs in via AppRole and re-authenticates on demand.
+      #   "token" — a long-lived Vault token in a Secret.
+      # "kubernetes"/"approle" require a keycloak-kms-proxy image that supports
+      # them (> v0.1.0); bump encryption.image accordingly.
       auth: token
       # token auth: existing Secret holding the Vault token under key "token".
       tokenSecretName: ""
+      # kubernetes auth: the Vault role bound to this pod's ServiceAccount +
+      # namespace. The SA token is auto-mounted, so no Secret is needed.
+      kubernetes:
+        role: ""                # Vault Kubernetes auth role
+        mount: kubernetes       # Kubernetes auth mount path
       # approle auth: existing Secret holding the AppRole role id and secret id.
       appRole:
         mount: approle          # AppRole auth mount path

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -92,7 +92,7 @@ extraEnv: []
 #     MUST be part of the backup set. For production prefer kms.backend=vault-transit.
 encryption:
   enabled: false
-  image: ghcr.io/cozystack/keycloak-kms-proxy:v0.2.0
+  image: ghcr.io/cozystack/keycloak-kms-proxy:0.2.0
   # Encrypted field set: "" = full default set (username, email, names,
   # PII attributes, credentials), "email-only", or "disabled" (passthrough).
   fields: ""

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -99,6 +99,16 @@ encryption:
   # Bootstrap window only: downgrades fail-loud rules to passthrough so the
   # Keycloak Liquibase migrations can complete. MUST be false in steady state.
   lenient: false
+  # Number of proxy replicas. >1 requires deksetSecretName (a shared wrapped
+  # DEK set) so every replica encrypts deterministic columns under one key.
+  replicas: 1
+  # Existing Secret holding the wrapped DEK set (dekset.json) minted by the
+  # proxy's backfill tool (`cmd/backfill generate-dekset`). REQUIRED to migrate
+  # an existing populated database — the proxy must reuse the DEK the backfill
+  # encrypted rows with — and to run more than one replica. When empty the proxy
+  # mints an ephemeral DEK at startup, which is only safe on a fresh, empty DB.
+  deksetSecretName: ""
+  deksetSecretKey: dekset.json
   kms:
     # "static" — a self-generated 32-byte KEK kept in a Secret (works on any
     # cluster, suitable for evaluation). "vault-transit" — the KEK lives in

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -108,8 +108,19 @@ encryption:
       address: ""       # e.g. https://vault.vault.svc:8200
       keyName: ""       # Transit key name
       mount: transit    # Transit mount path
-      # Existing Secret holding the Vault token under key "token".
+      # Vault authentication: "token" (a long-lived token in a Secret) or
+      # "approle" (the proxy logs in via AppRole and re-authenticates on demand,
+      # so no long-lived token is stored). AppRole requires a keycloak-kms-proxy
+      # image that supports it (> v0.1.0); bump encryption.image accordingly.
+      auth: token
+      # token auth: existing Secret holding the Vault token under key "token".
       tokenSecretName: ""
+      # approle auth: existing Secret holding the AppRole role id and secret id.
+      appRole:
+        mount: approle          # AppRole auth mount path
+        secretName: ""          # Secret with the role id / secret id
+        roleIdKey: role-id      # key in secretName holding the role id
+        secretIdKey: secret-id  # key in secretName holding the secret id
   resources:
     requests:
       memory: 128Mi

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -118,8 +118,10 @@ encryption:
       auth: token
       # token auth: existing Secret holding the Vault token under key "token".
       tokenSecretName: ""
-      # kubernetes auth: the Vault role bound to this pod's ServiceAccount +
-      # namespace. The SA token is auto-mounted, so no Secret is needed.
+      # kubernetes auth: bind the Vault role to the proxy's dedicated
+      # ServiceAccount — system:serviceaccount:<namespace>:keycloak-kms-proxy
+      # (created by this chart). No Secret is needed; the SA token is mounted
+      # into the proxy pod only in this mode.
       kubernetes:
         role: ""                # Vault Kubernetes auth role
         mount: kubernetes       # Kubernetes auth mount path


### PR DESCRIPTION
## What this PR does

Makes the optional `keycloak-kms-proxy` PII-encryption feature production-usable.

**Vault auth** — new `encryption.kms.vault.auth` switch:
- `kubernetes` — **recommended**. The proxy logs in with its own dedicated ServiceAccount (`keycloak-kms-proxy`; bind the Vault role to `system:serviceaccount:<ns>:keycloak-kms-proxy`), so no credential is stored in a Secret.
- `approle` — `KKP_VAULT_ROLE_ID` / `KKP_VAULT_SECRET_ID` from `encryption.kms.vault.appRole.secretName`.
- `token` (default, unchanged) — Vault token from `tokenSecretName`.

The proxy pod runs under a dedicated ServiceAccount (never the namespace default), with its token mounted only for Kubernetes auth.

**Shared DEK set** — `encryption.deksetSecretName` → `KKP_DEKSET_FILE` (mounted read-only), and `encryption.replicas` is now configurable. Without a dekset the proxy mints an ephemeral DEK (only safe on a fresh, empty database, single replica). A shared wrapped DEK set — minted by the proxy's backfill tool — is required to migrate an existing populated Keycloak and to run HA; a guard rejects `replicas > 1` without one.

Render-time validation requires each mode's settings and rejects unknown values. helm-unittest covers all auth modes, the ServiceAccount/token toggle, and the dekset/replicas paths. Uses `keycloak-kms-proxy` v0.2.0.

### Release note

```release-note
feat(keycloak): Vault Kubernetes/AppRole auth, a dedicated ServiceAccount, and a shared DEK set (migration + HA) for the optional PII-encryption proxy
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Keycloak KMS proxy Vault authentication to support **token**, **AppRole**, and **Kubernetes** modes.
  * Added **multi-replica/HA** support via configurable DEK-set reuse, including selecting a custom DEK-set key.
  * Introduced a dedicated proxy ServiceAccount with **conditional token automount** for Kubernetes auth.
* **Bug Fixes**
  * Added stricter validation for missing/unsupported Vault auth settings.
  * Prevented Vault credential environment variables from leaking across auth modes.
  * Updated rendering behavior and test expectations for proxy resources (including KEK/ServiceAccount documents).
* **Chores**
  * Updated the Keycloak KMS proxy container image version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->