### PR TITLE
fix(talos): bump Talos to v1.13.6 (CVE-2026-53359)

### DIFF
--- a/packages/core/talos/images/talos/profiles/initramfs.yaml
+++ b/packages/core/talos/images/talos/profiles/initramfs.yaml
@@ -3,24 +3,24 @@
 arch: amd64
 platform: metal
 secureboot: false
-version: v1.13.5
+version: v1.13.6
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz
   initramfs:
     path: /usr/install/amd64/initramfs.xz
   baseInstaller:
-    imageRef: "ghcr.io/siderolabs/installer:v1.13.5"
+    imageRef: "ghcr.io/siderolabs/installer:v1.13.6"
   systemExtensions:
-    - imageRef: ghcr.io/siderolabs/amd-ucode:20260519@sha256:4727bcdcd647ec48f4c3870559c2321a437e657ce993342ddb1ce3da6d91e827
-    - imageRef: ghcr.io/siderolabs/amdgpu:20260519-v1.13.5@sha256:c343cf183a792821f01bc77237aca499d9815b45ad2d09e6b7f22b518cb0c883
-    - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260519@sha256:1f4b3e79f6606b06ef4ca686bd36770bd78e89caf6020e318dda2a37634bf06b
-    - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260519@sha256:e02a67edc3d55676ef9c6381d48a173c40f17bac0cf1d3dd3f5f258813203ac8
-    - imageRef: ghcr.io/siderolabs/i915:20260519-v1.13.5@sha256:3f8f8d45e4f543c6670bb65a269d841ed972ec6e5b1b5a7140c4f2cfe84c8990
-    - imageRef: ghcr.io/siderolabs/intel-ucode:20260512@sha256:4b7edc20e8eebbe288bc1add0f6e3dc1bc86285e084ca5814e8b650ac479f148
-    - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260519@sha256:8c3a6e40d79f9d5a27b06dd785ccc140f76d228ede2562950dfac53ceb4518eb
-    - imageRef: ghcr.io/siderolabs/drbd:9.3.2-v1.13.5@sha256:aecfdaeb280d26be0e748af93514ad989a66ce707d4d9ac5d72fcc284604658b
-    - imageRef: ghcr.io/siderolabs/zfs:2.4.3-v1.13.5@sha256:de38940fea680ffc12d85f4d57210a1ef4fab873a7e51d86e62d3280e04b9ec1
+    - imageRef: ghcr.io/siderolabs/amd-ucode:20260622@sha256:ceab0ca292cd2a33e21c2ff4acc3afa01e8dea37f763aec1b7ae77784edfff7a
+    - imageRef: ghcr.io/siderolabs/amdgpu:20260622-v1.13.6@sha256:ca397e6f681b0567fb9905c8020c8dcee4b2ade5852389651b4007fc18a16316
+    - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260622@sha256:46dee9e025c972a29cd7e9d0a15f665e71e581627f9372a75607153e1221f44e
+    - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260622@sha256:977558ad5f00a4d6058e3f7f0756e68cbb2596621f155fec931261ff2dd330b6
+    - imageRef: ghcr.io/siderolabs/i915:20260622-v1.13.6@sha256:0936458e210b6997812826103f800e5bbcae2f7428a5c50031e58a4626c8eb02
+    - imageRef: ghcr.io/siderolabs/intel-ucode:20260512@sha256:bda9d1fcd5658427cf4c3db00bb830e3d93056d24b1ee1c0bd9dc6072f68ac56
+    - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260622@sha256:b4e05d55d6d27d57c85a29c33e199444c80aacc72a2e9b5b7344391d46f1eade
+    - imageRef: ghcr.io/siderolabs/drbd:9.3.2-v1.13.6@sha256:4a6f77f4e3fde41f3656f72d7d68380356afbb289254af8263a154cf7b70598e
+    - imageRef: ghcr.io/siderolabs/zfs:2.4.3-v1.13.6@sha256:3389808471eb857096cdf47a645b30b3e954bef0a9cb5d13a45b185796f606b6
 output:
   kind: initramfs
   imageOptions: {}

--- a/packages/core/talos/images/talos/profiles/installer.yaml
+++ b/packages/core/talos/images/talos/profiles/installer.yaml
@@ -3,24 +3,24 @@
 arch: amd64
 platform: metal
 secureboot: false
-version: v1.13.5
+version: v1.13.6
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz
   initramfs:
     path: /usr/install/amd64/initramfs.xz
   baseInstaller:
-    imageRef: "ghcr.io/siderolabs/installer:v1.13.5"
+    imageRef: "ghcr.io/siderolabs/installer:v1.13.6"
   systemExtensions:
-    - imageRef: ghcr.io/siderolabs/amd-ucode:20260519@sha256:4727bcdcd647ec48f4c3870559c2321a437e657ce993342ddb1ce3da6d91e827
-    - imageRef: ghcr.io/siderolabs/amdgpu:20260519-v1.13.5@sha256:c343cf183a792821f01bc77237aca499d9815b45ad2d09e6b7f22b518cb0c883
-    - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260519@sha256:1f4b3e79f6606b06ef4ca686bd36770bd78e89caf6020e318dda2a37634bf06b
-    - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260519@sha256:e02a67edc3d55676ef9c6381d48a173c40f17bac0cf1d3dd3f5f258813203ac8
-    - imageRef: ghcr.io/siderolabs/i915:20260519-v1.13.5@sha256:3f8f8d45e4f543c6670bb65a269d841ed972ec6e5b1b5a7140c4f2cfe84c8990
-    - imageRef: ghcr.io/siderolabs/intel-ucode:20260512@sha256:4b7edc20e8eebbe288bc1add0f6e3dc1bc86285e084ca5814e8b650ac479f148
-    - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260519@sha256:8c3a6e40d79f9d5a27b06dd785ccc140f76d228ede2562950dfac53ceb4518eb
-    - imageRef: ghcr.io/siderolabs/drbd:9.3.2-v1.13.5@sha256:aecfdaeb280d26be0e748af93514ad989a66ce707d4d9ac5d72fcc284604658b
-    - imageRef: ghcr.io/siderolabs/zfs:2.4.3-v1.13.5@sha256:de38940fea680ffc12d85f4d57210a1ef4fab873a7e51d86e62d3280e04b9ec1
+    - imageRef: ghcr.io/siderolabs/amd-ucode:20260622@sha256:ceab0ca292cd2a33e21c2ff4acc3afa01e8dea37f763aec1b7ae77784edfff7a
+    - imageRef: ghcr.io/siderolabs/amdgpu:20260622-v1.13.6@sha256:ca397e6f681b0567fb9905c8020c8dcee4b2ade5852389651b4007fc18a16316
+    - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260622@sha256:46dee9e025c972a29cd7e9d0a15f665e71e581627f9372a75607153e1221f44e
+    - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260622@sha256:977558ad5f00a4d6058e3f7f0756e68cbb2596621f155fec931261ff2dd330b6
+    - imageRef: ghcr.io/siderolabs/i915:20260622-v1.13.6@sha256:0936458e210b6997812826103f800e5bbcae2f7428a5c50031e58a4626c8eb02
+    - imageRef: ghcr.io/siderolabs/intel-ucode:20260512@sha256:bda9d1fcd5658427cf4c3db00bb830e3d93056d24b1ee1c0bd9dc6072f68ac56
+    - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260622@sha256:b4e05d55d6d27d57c85a29c33e199444c80aacc72a2e9b5b7344391d46f1eade
+    - imageRef: ghcr.io/siderolabs/drbd:9.3.2-v1.13.6@sha256:4a6f77f4e3fde41f3656f72d7d68380356afbb289254af8263a154cf7b70598e
+    - imageRef: ghcr.io/siderolabs/zfs:2.4.3-v1.13.6@sha256:3389808471eb857096cdf47a645b30b3e954bef0a9cb5d13a45b185796f606b6
 output:
   kind: installer
   imageOptions: {}

--- a/packages/core/talos/images/talos/profiles/iso.yaml
+++ b/packages/core/talos/images/talos/profiles/iso.yaml
@@ -3,24 +3,24 @@
 arch: amd64
 platform: metal
 secureboot: false
-version: v1.13.5
+version: v1.13.6
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz
   initramfs:
     path: /usr/install/amd64/initramfs.xz
   baseInstaller:
-    imageRef: "ghcr.io/siderolabs/installer:v1.13.5"
+    imageRef: "ghcr.io/siderolabs/installer:v1.13.6"
   systemExtensions:
-    - imageRef: ghcr.io/siderolabs/amd-ucode:20260519@sha256:4727bcdcd647ec48f4c3870559c2321a437e657ce993342ddb1ce3da6d91e827
-    - imageRef: ghcr.io/siderolabs/amdgpu:20260519-v1.13.5@sha256:c343cf183a792821f01bc77237aca499d9815b45ad2d09e6b7f22b518cb0c883
-    - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260519@sha256:1f4b3e79f6606b06ef4ca686bd36770bd78e89caf6020e318dda2a37634bf06b
-    - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260519@sha256:e02a67edc3d55676ef9c6381d48a173c40f17bac0cf1d3dd3f5f258813203ac8
-    - imageRef: ghcr.io/siderolabs/i915:20260519-v1.13.5@sha256:3f8f8d45e4f543c6670bb65a269d841ed972ec6e5b1b5a7140c4f2cfe84c8990
-    - imageRef: ghcr.io/siderolabs/intel-ucode:20260512@sha256:4b7edc20e8eebbe288bc1add0f6e3dc1bc86285e084ca5814e8b650ac479f148
-    - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260519@sha256:8c3a6e40d79f9d5a27b06dd785ccc140f76d228ede2562950dfac53ceb4518eb
-    - imageRef: ghcr.io/siderolabs/drbd:9.3.2-v1.13.5@sha256:aecfdaeb280d26be0e748af93514ad989a66ce707d4d9ac5d72fcc284604658b
-    - imageRef: ghcr.io/siderolabs/zfs:2.4.3-v1.13.5@sha256:de38940fea680ffc12d85f4d57210a1ef4fab873a7e51d86e62d3280e04b9ec1
+    - imageRef: ghcr.io/siderolabs/amd-ucode:20260622@sha256:ceab0ca292cd2a33e21c2ff4acc3afa01e8dea37f763aec1b7ae77784edfff7a
+    - imageRef: ghcr.io/siderolabs/amdgpu:20260622-v1.13.6@sha256:ca397e6f681b0567fb9905c8020c8dcee4b2ade5852389651b4007fc18a16316
+    - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260622@sha256:46dee9e025c972a29cd7e9d0a15f665e71e581627f9372a75607153e1221f44e
+    - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260622@sha256:977558ad5f00a4d6058e3f7f0756e68cbb2596621f155fec931261ff2dd330b6
+    - imageRef: ghcr.io/siderolabs/i915:20260622-v1.13.6@sha256:0936458e210b6997812826103f800e5bbcae2f7428a5c50031e58a4626c8eb02
+    - imageRef: ghcr.io/siderolabs/intel-ucode:20260512@sha256:bda9d1fcd5658427cf4c3db00bb830e3d93056d24b1ee1c0bd9dc6072f68ac56
+    - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260622@sha256:b4e05d55d6d27d57c85a29c33e199444c80aacc72a2e9b5b7344391d46f1eade
+    - imageRef: ghcr.io/siderolabs/drbd:9.3.2-v1.13.6@sha256:4a6f77f4e3fde41f3656f72d7d68380356afbb289254af8263a154cf7b70598e
+    - imageRef: ghcr.io/siderolabs/zfs:2.4.3-v1.13.6@sha256:3389808471eb857096cdf47a645b30b3e954bef0a9cb5d13a45b185796f606b6
 output:
   kind: iso
   imageOptions: {}

--- a/packages/core/talos/images/talos/profiles/kernel.yaml
+++ b/packages/core/talos/images/talos/profiles/kernel.yaml
@@ -3,24 +3,24 @@
 arch: amd64
 platform: metal
 secureboot: false
-version: v1.13.5
+version: v1.13.6
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz
   initramfs:
     path: /usr/install/amd64/initramfs.xz
   baseInstaller:
-    imageRef: "ghcr.io/siderolabs/installer:v1.13.5"
+    imageRef: "ghcr.io/siderolabs/installer:v1.13.6"
   systemExtensions:
-    - imageRef: ghcr.io/siderolabs/amd-ucode:20260519@sha256:4727bcdcd647ec48f4c3870559c2321a437e657ce993342ddb1ce3da6d91e827
-    - imageRef: ghcr.io/siderolabs/amdgpu:20260519-v1.13.5@sha256:c343cf183a792821f01bc77237aca499d9815b45ad2d09e6b7f22b518cb0c883
-    - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260519@sha256:1f4b3e79f6606b06ef4ca686bd36770bd78e89caf6020e318dda2a37634bf06b
-    - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260519@sha256:e02a67edc3d55676ef9c6381d48a173c40f17bac0cf1d3dd3f5f258813203ac8
-    - imageRef: ghcr.io/siderolabs/i915:20260519-v1.13.5@sha256:3f8f8d45e4f543c6670bb65a269d841ed972ec6e5b1b5a7140c4f2cfe84c8990
-    - imageRef: ghcr.io/siderolabs/intel-ucode:20260512@sha256:4b7edc20e8eebbe288bc1add0f6e3dc1bc86285e084ca5814e8b650ac479f148
-    - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260519@sha256:8c3a6e40d79f9d5a27b06dd785ccc140f76d228ede2562950dfac53ceb4518eb
-    - imageRef: ghcr.io/siderolabs/drbd:9.3.2-v1.13.5@sha256:aecfdaeb280d26be0e748af93514ad989a66ce707d4d9ac5d72fcc284604658b
-    - imageRef: ghcr.io/siderolabs/zfs:2.4.3-v1.13.5@sha256:de38940fea680ffc12d85f4d57210a1ef4fab873a7e51d86e62d3280e04b9ec1
+    - imageRef: ghcr.io/siderolabs/amd-ucode:20260622@sha256:ceab0ca292cd2a33e21c2ff4acc3afa01e8dea37f763aec1b7ae77784edfff7a
+    - imageRef: ghcr.io/siderolabs/amdgpu:20260622-v1.13.6@sha256:ca397e6f681b0567fb9905c8020c8dcee4b2ade5852389651b4007fc18a16316
+    - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260622@sha256:46dee9e025c972a29cd7e9d0a15f665e71e581627f9372a75607153e1221f44e
+    - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260622@sha256:977558ad5f00a4d6058e3f7f0756e68cbb2596621f155fec931261ff2dd330b6
+    - imageRef: ghcr.io/siderolabs/i915:20260622-v1.13.6@sha256:0936458e210b6997812826103f800e5bbcae2f7428a5c50031e58a4626c8eb02
+    - imageRef: ghcr.io/siderolabs/intel-ucode:20260512@sha256:bda9d1fcd5658427cf4c3db00bb830e3d93056d24b1ee1c0bd9dc6072f68ac56
+    - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260622@sha256:b4e05d55d6d27d57c85a29c33e199444c80aacc72a2e9b5b7344391d46f1eade
+    - imageRef: ghcr.io/siderolabs/drbd:9.3.2-v1.13.6@sha256:4a6f77f4e3fde41f3656f72d7d68380356afbb289254af8263a154cf7b70598e
+    - imageRef: ghcr.io/siderolabs/zfs:2.4.3-v1.13.6@sha256:3389808471eb857096cdf47a645b30b3e954bef0a9cb5d13a45b185796f606b6
 output:
   kind: kernel
   imageOptions: {}

--- a/packages/core/talos/images/talos/profiles/metal.yaml
+++ b/packages/core/talos/images/talos/profiles/metal.yaml
@@ -3,24 +3,24 @@
 arch: amd64
 platform: metal
 secureboot: false
-version: v1.13.5
+version: v1.13.6
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz
   initramfs:
     path: /usr/install/amd64/initramfs.xz
   baseInstaller:
-    imageRef: "ghcr.io/siderolabs/installer:v1.13.5"
+    imageRef: "ghcr.io/siderolabs/installer:v1.13.6"
   systemExtensions:
-    - imageRef: ghcr.io/siderolabs/amd-ucode:20260519@sha256:4727bcdcd647ec48f4c3870559c2321a437e657ce993342ddb1ce3da6d91e827
-    - imageRef: ghcr.io/siderolabs/amdgpu:20260519-v1.13.5@sha256:c343cf183a792821f01bc77237aca499d9815b45ad2d09e6b7f22b518cb0c883
-    - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260519@sha256:1f4b3e79f6606b06ef4ca686bd36770bd78e89caf6020e318dda2a37634bf06b
-    - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260519@sha256:e02a67edc3d55676ef9c6381d48a173c40f17bac0cf1d3dd3f5f258813203ac8
-    - imageRef: ghcr.io/siderolabs/i915:20260519-v1.13.5@sha256:3f8f8d45e4f543c6670bb65a269d841ed972ec6e5b1b5a7140c4f2cfe84c8990
-    - imageRef: ghcr.io/siderolabs/intel-ucode:20260512@sha256:4b7edc20e8eebbe288bc1add0f6e3dc1bc86285e084ca5814e8b650ac479f148
-    - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260519@sha256:8c3a6e40d79f9d5a27b06dd785ccc140f76d228ede2562950dfac53ceb4518eb
-    - imageRef: ghcr.io/siderolabs/drbd:9.3.2-v1.13.5@sha256:aecfdaeb280d26be0e748af93514ad989a66ce707d4d9ac5d72fcc284604658b
-    - imageRef: ghcr.io/siderolabs/zfs:2.4.3-v1.13.5@sha256:de38940fea680ffc12d85f4d57210a1ef4fab873a7e51d86e62d3280e04b9ec1
+    - imageRef: ghcr.io/siderolabs/amd-ucode:20260622@sha256:ceab0ca292cd2a33e21c2ff4acc3afa01e8dea37f763aec1b7ae77784edfff7a
+    - imageRef: ghcr.io/siderolabs/amdgpu:20260622-v1.13.6@sha256:ca397e6f681b0567fb9905c8020c8dcee4b2ade5852389651b4007fc18a16316
+    - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260622@sha256:46dee9e025c972a29cd7e9d0a15f665e71e581627f9372a75607153e1221f44e
+    - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260622@sha256:977558ad5f00a4d6058e3f7f0756e68cbb2596621f155fec931261ff2dd330b6
+    - imageRef: ghcr.io/siderolabs/i915:20260622-v1.13.6@sha256:0936458e210b6997812826103f800e5bbcae2f7428a5c50031e58a4626c8eb02
+    - imageRef: ghcr.io/siderolabs/intel-ucode:20260512@sha256:bda9d1fcd5658427cf4c3db00bb830e3d93056d24b1ee1c0bd9dc6072f68ac56
+    - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260622@sha256:b4e05d55d6d27d57c85a29c33e199444c80aacc72a2e9b5b7344391d46f1eade
+    - imageRef: ghcr.io/siderolabs/drbd:9.3.2-v1.13.6@sha256:4a6f77f4e3fde41f3656f72d7d68380356afbb289254af8263a154cf7b70598e
+    - imageRef: ghcr.io/siderolabs/zfs:2.4.3-v1.13.6@sha256:3389808471eb857096cdf47a645b30b3e954bef0a9cb5d13a45b185796f606b6
 output:
   kind: image
   imageOptions: { diskSize: 1306525696, diskFormat: raw }

--- a/packages/core/talos/images/talos/profiles/nocloud.yaml
+++ b/packages/core/talos/images/talos/profiles/nocloud.yaml
@@ -3,24 +3,24 @@
 arch: amd64
 platform: nocloud
 secureboot: false
-version: v1.13.5
+version: v1.13.6
 input:
   kernel:
     path: /usr/install/amd64/vmlinuz
   initramfs:
     path: /usr/install/amd64/initramfs.xz
   baseInstaller:
-    imageRef: "ghcr.io/siderolabs/installer:v1.13.5"
+    imageRef: "ghcr.io/siderolabs/installer:v1.13.6"
   systemExtensions:
-    - imageRef: ghcr.io/siderolabs/amd-ucode:20260519@sha256:4727bcdcd647ec48f4c3870559c2321a437e657ce993342ddb1ce3da6d91e827
-    - imageRef: ghcr.io/siderolabs/amdgpu:20260519-v1.13.5@sha256:c343cf183a792821f01bc77237aca499d9815b45ad2d09e6b7f22b518cb0c883
-    - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260519@sha256:1f4b3e79f6606b06ef4ca686bd36770bd78e89caf6020e318dda2a37634bf06b
-    - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260519@sha256:e02a67edc3d55676ef9c6381d48a173c40f17bac0cf1d3dd3f5f258813203ac8
-    - imageRef: ghcr.io/siderolabs/i915:20260519-v1.13.5@sha256:3f8f8d45e4f543c6670bb65a269d841ed972ec6e5b1b5a7140c4f2cfe84c8990
-    - imageRef: ghcr.io/siderolabs/intel-ucode:20260512@sha256:4b7edc20e8eebbe288bc1add0f6e3dc1bc86285e084ca5814e8b650ac479f148
-    - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260519@sha256:8c3a6e40d79f9d5a27b06dd785ccc140f76d228ede2562950dfac53ceb4518eb
-    - imageRef: ghcr.io/siderolabs/drbd:9.3.2-v1.13.5@sha256:aecfdaeb280d26be0e748af93514ad989a66ce707d4d9ac5d72fcc284604658b
-    - imageRef: ghcr.io/siderolabs/zfs:2.4.3-v1.13.5@sha256:de38940fea680ffc12d85f4d57210a1ef4fab873a7e51d86e62d3280e04b9ec1
+    - imageRef: ghcr.io/siderolabs/amd-ucode:20260622@sha256:ceab0ca292cd2a33e21c2ff4acc3afa01e8dea37f763aec1b7ae77784edfff7a
+    - imageRef: ghcr.io/siderolabs/amdgpu:20260622-v1.13.6@sha256:ca397e6f681b0567fb9905c8020c8dcee4b2ade5852389651b4007fc18a16316
+    - imageRef: ghcr.io/siderolabs/bnx2-bnx2x:20260622@sha256:46dee9e025c972a29cd7e9d0a15f665e71e581627f9372a75607153e1221f44e
+    - imageRef: ghcr.io/siderolabs/intel-ice-firmware:20260622@sha256:977558ad5f00a4d6058e3f7f0756e68cbb2596621f155fec931261ff2dd330b6
+    - imageRef: ghcr.io/siderolabs/i915:20260622-v1.13.6@sha256:0936458e210b6997812826103f800e5bbcae2f7428a5c50031e58a4626c8eb02
+    - imageRef: ghcr.io/siderolabs/intel-ucode:20260512@sha256:bda9d1fcd5658427cf4c3db00bb830e3d93056d24b1ee1c0bd9dc6072f68ac56
+    - imageRef: ghcr.io/siderolabs/qlogic-firmware:20260622@sha256:b4e05d55d6d27d57c85a29c33e199444c80aacc72a2e9b5b7344391d46f1eade
+    - imageRef: ghcr.io/siderolabs/drbd:9.3.2-v1.13.6@sha256:4a6f77f4e3fde41f3656f72d7d68380356afbb289254af8263a154cf7b70598e
+    - imageRef: ghcr.io/siderolabs/zfs:2.4.3-v1.13.6@sha256:3389808471eb857096cdf47a645b30b3e954bef0a9cb5d13a45b185796f606b6
 output:
   kind: image
   imageOptions: { diskSize: 1306525696, diskFormat: raw }


### PR DESCRIPTION
## What this PR does

Bumps the platform Talos profiles from v1.13.5 to v1.13.6.

CVE-2026-53359 and CVE-2026-46113 are related KVM x86 shadow-paging use-after-free bugs that let a guest escape to the host, and the fix is complete only once both upstream patches (`81ccda30b4e8`, `0cb2af2ea66a`) are applied. On the 6.18 stable line CVE-2026-46113 landed in 6.18.30 and CVE-2026-53359 in 6.18.38. Talos v1.13.5 runs Linux 6.18.36, so it carries only the first of the two. Talos v1.13.6 runs Linux 6.18.38 and carries both.

Nested virtualization stays enabled. The bugs are fixed in the kernel, so there is no reason to take the feature away from workloads that rely on it — bumping the kernel is the complete fix.

Profiles are regenerated with `hack/gen-profiles.sh v1.13.6`. Alongside the Talos version and the installer reference, this refreshes the pinned system-extension digests: the firmware extensions move from the 20260519 to the 20260622 build, and `intel-ucode` keeps its `20260512` tag but resolves to a new digest because upstream re-pushed that tag as an OCI image index (identical config and layer blobs underneath).

References: [Talos v1.13.6 release notes](https://github.com/siderolabs/talos/releases/tag/v1.13.6) (`Linux: 6.18.38`)

### Screenshots

Not applicable, no UI changes.

### Release note

```release-note
fix(talos): bump Talos Linux to v1.13.6, which ships Linux 6.18.38 with the kernel fixes for the CVE-2026-53359 and CVE-2026-46113 KVM guest-to-host escapes
```
