### PR TITLE
fix(keycloak): bump keycloak-kms-proxy to 0.2.1

### DIFF
--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -92,7 +92,7 @@ extraEnv: []
 #     MUST be part of the backup set. For production prefer kms.backend=vault-transit.
 encryption:
   enabled: false
-  image: ghcr.io/cozystack/keycloak-kms-proxy:v0.1.0
+  image: ghcr.io/cozystack/keycloak-kms-proxy:0.2.1
   # Encrypted field set: "" = full default set (username, email, names,
   # PII attributes, credentials), "email-only", or "disabled" (passthrough).
   fields: ""


### PR DESCRIPTION
## What this PR does

Bumps the `keycloak-kms-proxy` image in the keycloak system package to [v0.2.1](https://github.com/cozystack/keycloak-kms-proxy/releases/tag/v0.2.1).

v0.2.1 fixes silent ciphertext passthrough on the proxy read path: pgjdbc's server-prepared statements (the Describe-statement flow and warm Bind/Execute reuse) never produce a RowDescription during Execute, so the decrypt plan was never built and raw `$KKP$` envelopes reached Keycloak — breaking the verify-email flow and leaking ciphertext into `id_token` email claims. The release also tracks simple-protocol queries and Sync boundaries (result-queue desyncs), and adds fail-loud metrics (`kkp_ciphertext_passthrough_total`, `kkp_double_encrypted_total`) so any undecrypted PII leaving the proxy is alertable.

The previous default also pointed at a non-existent `v`-prefixed image tag (`v0.1.0`) — the kms-proxy release workflow publishes semver tags without the prefix, so pulling the proxy with chart defaults could never succeed.

### Screenshots

N/A — no UI changes.

### Release note

```release-note
fix(keycloak): keycloak-kms-proxy bumped to 0.2.1 — fixes undecrypted PII passthrough on server-prepared statements (verify-email / id_token) and the broken default image tag
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Keycloak KMS proxy image to a newer version for deployments with database encryption enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->