### PR TITLE
feat(keycloak): add ingress.rootRedirect for the login host root

### DIFF
--- a/packages/system/keycloak/templates/httproute.yaml
+++ b/packages/system/keycloak/templates/httproute.yaml
@@ -18,6 +18,22 @@ spec:
   hostnames:
   - {{ $ingressHost | quote }}
   rules:
+  {{- with .Values.ingress.rootRedirect }}
+  # rootRedirect set: the bare "/" on the login hostname 302-redirects here
+  # (e.g. the product dashboard) instead of reaching Keycloak, whose root
+  # redirects to the admin console. Only the exact "/" is redirected — every
+  # OIDC path below still reaches Keycloak. Most useful with adminHost, which
+  # already narrows the login route off "/".
+  - matches:
+    - path:
+        type: Exact
+        value: /
+    filters:
+    - type: RequestRedirect
+      requestRedirect:
+        hostname: {{ . | quote }}
+        statusCode: 302
+  {{- end }}
   {{- if $adminHost }}
   # adminHost is set: the public (login) hostname exposes only the
   # OIDC/login paths. The admin console and Administration REST API are

--- a/packages/system/keycloak/tests/root_redirect_test.yaml
+++ b/packages/system/keycloak/tests/root_redirect_test.yaml
@@ -1,0 +1,69 @@
+suite: login root redirect (ingress.rootRedirect)
+
+release:
+  name: keycloak
+  namespace: cozy-keycloak
+
+# ingress.rootRedirect is an opt-in option. When set, the bare "/" of the
+# login hostname 302-redirects to the given hostname (e.g. the product
+# dashboard) instead of reaching Keycloak, whose root redirects to the admin
+# console. Only the exact "/" is redirected; the OIDC paths still reach
+# Keycloak. It applies to the Gateway API HTTPRoute.
+tests:
+  - it: no root redirect rule when rootRedirect is empty (default)
+    template: templates/httproute.yaml
+    documentSelector:
+      path: metadata.name
+      value: keycloak
+    set:
+      _cluster:
+        root-host: example.com
+        gateway-enabled: "true"
+        expose-ingress: cozy-gateway
+      ingress:
+        adminHost: kc-admin.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      # First rule is the (scoped) backend, not a redirect.
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: keycloak-http
+      - notExists:
+          path: spec.rules[0].filters
+
+  - it: adds exact / -> RequestRedirect when rootRedirect is set
+    template: templates/httproute.yaml
+    documentSelector:
+      path: metadata.name
+      value: keycloak
+    set:
+      _cluster:
+        root-host: example.com
+        gateway-enabled: "true"
+        expose-ingress: cozy-gateway
+      ingress:
+        adminHost: kc-admin.example.com
+        rootRedirect: dashboard.example.com
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: Exact
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestRedirect
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.hostname
+          value: dashboard.example.com
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.statusCode
+          value: 302
+      # OIDC paths still reach Keycloak on the following rule.
+      - equal:
+          path: spec.rules[1].backendRefs[0].name
+          value: keycloak-http

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -21,6 +21,13 @@ ingress:
   # the network/path separation here is what restricts access.
   # If left empty, the admin console stays on the main hostname (default).
   adminHost: ""
+  # Optional: hostname to 302-redirect the bare "/" of the login hostname to
+  # (e.g. "dashboard.example.com"). Without it, "/" reaches Keycloak and
+  # redirects to the admin console — undesirable on a public login host.
+  # Only the exact "/" is redirected; OIDC paths still reach Keycloak. Best
+  # combined with adminHost (which narrows the login route off "/"). Applies
+  # to the Gateway API HTTPRoute (gateway-enabled); empty disables it.
+  rootRedirect: ""
   annotations:
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-expires: "86400"


### PR DESCRIPTION
## What this PR does

Adds an opt-in `ingress.rootRedirect` value to the Keycloak chart. When set, the bare `/` of the login hostname 302-redirects to the given hostname (e.g. the product dashboard) via the Gateway API `HTTPRoute`.

With `ingress.adminHost` set, the login route is already narrowed to the OIDC paths (`/realms`, `/resources`, `/.well-known`) and no longer serves `/`. Hitting the bare `/` on the login host then reaches Keycloak's root, which 302-redirects to the **admin console** — undesirable on a public login hostname. `rootRedirect` sends `/` to a product page instead.

- Only the **exact** `/` is redirected; every OIDC path still reaches Keycloak.
- Renders an extra `HTTPRoute` rule (exact `/` → `RequestRedirect`, 302) ahead of the backend rule. Combined with `adminHost` (which narrows the login route off `/`) there is no competing backend for `/`, so it works even on gateways that don't prefer exact-over-prefix matches.
- Opt-in: empty by default (no behaviour change). Gateway API path only (`gateway-enabled`).
- Covered by `tests/root_redirect_test.yaml`; full keycloak suite passes (33 tests).

### Release note

```release-note
feat(keycloak): add `ingress.rootRedirect` to 302-redirect the bare `/` of the login hostname (e.g. to a product dashboard) instead of exposing Keycloak's admin-console redirect there.
```