### PR TITLE
fix(e2e): gate LINSTOR node-list probe on a ready controller endpoint

### DIFF
--- a/hack/e2e-post-install-prep.sh
+++ b/hack/e2e-post-install-prep.sh
@@ -44,13 +44,50 @@ wait_for() {
   done
 }
 
+# controller_reachable: true only while the linstor-controller Service has at
+# least one *ready* endpoint. The linstor CLI below dials that Service
+# (linstor+ssl://linstor-controller:3371), and a ClusterIP is routable only once
+# its Service has a ready backend -- otherwise the dial fails with
+# "[Errno 113] No route to host" (EHOSTUNREACH). In the core Endpoints object the
+# ready set is .subsets[].addresses (peers not yet ready sit in
+# .subsets[].notReadyAddresses), so a non-empty addresses list is exactly
+# ">=1 ready backend". Missing object / API error -> empty -> not reachable.
+controller_reachable() {
+  [ -n "$(kubectl get endpoints linstor-controller -n cozy-linstor \
+    -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null)" ]
+}
+
 wait_for "linstor HelmRelease to be Ready" \
   helmrelease/linstor -n cozy-linstor --for=condition=Ready
 wait_for "linstor-controller Deployment to be Available" \
   deployment/linstor-controller -n cozy-linstor --for=condition=available
 
-echo "[post-install-prep] waiting for 3 LINSTOR nodes Online"
-timeout 300 sh -ec 'until [ $(kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor node list | grep -c Online) -eq 3 ]; do sleep 2; done'
+# Wait for 3 satellites to register Online, but gate every probe on a ready
+# controller Service endpoint. The "Deployment Available" check above is a
+# one-shot gate that goes stale: the controller carries
+# reloader.stakater.com/auto=true and mounts the cert-manager-issued API-TLS
+# Secret (see packages/system/linstor/templates/cluster.yaml). When cert-manager
+# (re)writes that Secret during bring-up, reloader rolls the single-replica
+# controller, dropping its Service to zero ready endpoints *after* Available
+# already passed. A blind CLI dial into that window is what surfaced as the
+# tolerated "[Errno 113] No route to host" churn. Probing only while the Service
+# is routable removes that churn at the root -- a mid-loop reload re-waits for
+# the endpoint instead of erroring -- while "Online == 3" stays the real
+# satellite-convergence assertion. The dedicated 300s budget is preserved from
+# the previous `timeout 300`; `set -e` is disabled inside an until-condition, so
+# a not-yet-reachable controller does not abort the script.
+echo "[post-install-prep] waiting for linstor-controller endpoint + 3 LINSTOR nodes Online"
+node_deadline=$(( $(date +%s) + 300 ))
+until controller_reachable \
+  && [ "$(kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor node list 2>/dev/null | grep -c Online)" -eq 3 ]; do
+  if [ "$(date +%s)" -ge "$node_deadline" ]; then
+    echo "[post-install-prep] timed out waiting for linstor-controller endpoint + 3 LINSTOR nodes Online" >&2
+    kubectl get endpoints linstor-controller -n cozy-linstor -o wide >&2 || true
+    kubectl get pods -n cozy-linstor -o wide >&2 || true
+    exit 1
+  fi
+  sleep 2
+done
 
 echo "[post-install-prep] creating LINSTOR storage pools (parallel across nodes)"
 created_pools=$(kubectl exec -n cozy-linstor deploy/linstor-controller -- linstor sp l -s data --pastable | awk '$2 == "data" {printf " " $4} END{printf " "}')


### PR DESCRIPTION
## What this PR does

The E2E `Install Cozystack` step runs `hack/e2e-post-install-prep.sh` in the background, which waits for 3 LINSTOR satellites to come Online by dialing the `linstor-controller` Service (`linstor+ssl://linstor-controller:3371`) from the controller pod. That probe was gated only by a one-shot `kubectl wait deployment/linstor-controller --for=condition=available`, which goes stale. The controller carries `reloader.stakater.com/auto=true` and mounts the cert-manager-issued API-TLS Secret (`packages/system/linstor/templates/cluster.yaml`), so when cert-manager (re)writes that Secret during bring-up, reloader rolls the single-replica controller. The roll drops the Service to zero ready endpoints *after* `Available` already passed, and a dial into that window fails with `[Errno 113] No route to host` (EHOSTUNREACH — the state of a ClusterIP whose Service has no ready backend). The blind `until` loop then churned the CLI on that error, tolerating a real un-Ready-controller race instead of gating on it.

This gates every probe on the `linstor-controller` Service actually having a ready endpoint (a non-empty `Endpoints .subsets[].addresses`), so the CLI only dials a routable controller and a mid-loop reload re-waits for the endpoint instead of erroring. The `Online == 3` satellite-convergence check stays the real readiness assertion, and the dedicated 300s budget is preserved from the previous `timeout 300`; on timeout the loop now dumps the controller endpoints and pods for diagnostics before failing, per the E2E diagnostics convention.

Evidence for the mechanism: the same single `Error: Unable to connect to linstor+ssl://linstor-controller:3371: [Errno 113] No route to host` line appears exactly once per install across multiple runs and is immediately recovered by the retry — consistent with one reloader-driven controller roll during initial bring-up, not a persistent outage.

Scoped to the LINSTOR readiness path in `hack/e2e-post-install-prep.sh` only; no change to install ordering, dependencies, or timeouts.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the LINSTOR startup readiness check to wait more reliably for the service to become reachable before verifying node status.
  * Made the node-online verification more resilient by handling transient connectivity errors and enforcing a clearer timeout.
  * Added extra diagnostic output when readiness does not complete in time, helping with troubleshooting failed installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->