### PR TITLE
ci(e2e): move install gate to 32vCPU runner to end CPU oversubscription

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -490,8 +490,22 @@ jobs:
 
   e2e:
     name: "E2E Tests"
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-24cpu-96gb-x86-64' }}
-    #runs-on: [oracle-vm-32cpu-128gb-x86-64]
+    # The sandbox boots three QEMU guests (hack/e2e-prepare-cluster.bats), each
+    # with `-smp 8 -m 24576`, so the guests alone demand 24 vCPU and 72 GiB.
+    # On the 24-vCPU runner that is a 1:1 CPU commit with zero host headroom for
+    # QEMU's own emulation/IO threads, vhost-net, the host iptables MASQUERADE
+    # every guest image pull traverses, containerd, the kernel and the runner
+    # agent. During "Install Cozystack" (all platform operators + image pulls
+    # across three nodes at once) the guest vCPUs contend with those host threads
+    # and lose cycles to CPU steal, so in-guest kubelet/apiserver readiness and
+    # liveness probes miss their deadlines ("context deadline exceeded"). A
+    # HelmRelease then flips InProgress -> Failed and its dependents cascade to
+    # DependencyNotReady — on a different component each run, the signature of
+    # resource thrash rather than a product bug. The 32-vCPU / 128 GiB class
+    # keeps the guests' 24 vCPU / 72 GiB unchanged (no slower install) while
+    # leaving 8 vCPU (25%) and 56 GiB of host headroom, which removes the
+    # oversubscription that starves the probes.
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-32cpu-128gb-x86-64' }}
     timeout-minutes: 180
     permissions:
       contents: read


### PR DESCRIPTION
## What this PR does

The E2E `Install Cozystack` gate flakes intermittently: a platform HelmRelease/Deployment sticks `InProgress` → `Failed` and its dependents cascade to `DependencyNotReady`, on a **different component each run** (observed: opensearch-operator-controller-manager, monitoring-agents-kube-state-metrics, kamaji readiness "context deadline exceeded"). That non-determinism is the signature of host resource thrash, not a product bug.

**Measured envelope.** The sandbox boots three QEMU guests (`hack/e2e-prepare-cluster.bats`), each `-smp 8 -m 24576`:

| Resource | Guests demand | 24-vCPU runner (current) | 32-vCPU runner (this PR) |
| --- | --- | --- | --- |
| vCPU | 3 × 8 = 24 | 24 → 0 host headroom | 32 → 8 (25%) headroom |
| RAM | 3 × 24 = 72 GiB | 96 GiB → 24 GiB headroom | 128 GiB → 56 GiB headroom |

On the 24-vCPU runner the guests alone pin all 24 host vCPUs, leaving nothing for QEMU's own emulation/IO threads, vhost-net, the host `iptables MASQUERADE` every guest image pull traverses, containerd, the kernel and the runner agent. Under the peak concurrency of the platform install the guest vCPUs contend with those host threads and lose cycles to CPU steal, so in-guest kubelet/apiserver readiness/liveness probes miss their deadlines and the HelmRelease flips. Across sampled failed runs the symptom is always a probe/readiness timeout with `DependencyNotReady`, never `OOMKilled`/`Evicted`/`MemoryPressure` — CPU steal, not memory, is the binding constraint (RAM already keeps 24 GiB of headroom).

**Fix.** Move the job to the `oracle-vm-32cpu-128gb-x86-64` class (already referenced in-repo as the commented alternative). Guest sizing is unchanged (24 vCPU / 72 GiB), so the CPU-bound install does not slow down, while the host keeps 8 vCPU + 56 GiB of headroom that absorbs the emulation/network overhead the probes were starving against.

This is deliberately **not** a retry or timeout bump (forbidden by `docs/agents/e2e-testing.md`): the install gate keeps its teeth, runs once, and still fails loud on a genuine product bug. It removes the harness oversubscription that manufactured false failures, and is complementary to the per-component probe-hardening work and to the in-sandbox image-mirror change (which relieves the distinct storage-import axis).

**Trade-off / caveat.** The 32-vCPU class costs more per E2E run and adds load to that runner pool — an infra/cost decision for maintainers. A zero-cost alternative (drop guest `-smp` to 6 → 18 vCPU / 6 host headroom on the existing runner) was considered and rejected as primary: it cuts guest compute 25% on an already CPU-bound install and could trade steal-flakes for wall-clock-timeout flakes, unverifiable without a CI run.

### Screenshots

N/A — CI-only change, no user-facing surface.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the default runner size for end-to-end pull request checks.
  * Added clearer workflow guidance to reduce flaky readiness and liveness failures during installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->