### PR TITLE
feat(talos-log-collector): add talos-log-collector package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ build: build-deps
 	make -C packages/system/kubeovn-plunger image
 	make -C packages/system/dashboard image
 	make -C packages/system/metallb image
+	make -C packages/system/talos-log-collector image
 	make -C packages/system/kamaji image
 	make -C packages/system/capi-providers-cpprovider image
 	make -C packages/system/multus image

--- a/packages/core/platform/sources/talos-log-collector.yaml
+++ b/packages/core/platform/sources/talos-log-collector.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: cozystack.io/v1alpha1
+kind: PackageSource
+metadata:
+  name: cozystack.talos-log-collector
+spec:
+  sourceRef:
+    kind: OCIRepository
+    name: cozystack-packages
+    namespace: cozy-system
+    path: /
+  variants:
+  - name: default
+    dependsOn:
+    - cozystack.networking
+    components:
+    - name: talos-log-collector
+      path: system/talos-log-collector
+      install:
+        namespace: cozy-talos-log-collector
+        releaseName: talos-log-collector
+        privileged: true

--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -226,5 +226,6 @@ cozystack-platform HelmRelease never becomes Ready. */}}
 {{include "cozystack.platform.package.default" (list "cozystack.bootbox" $) }}
 {{- end }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.hetzner-robotlb" $) }}
+{{include "cozystack.platform.package.optional.default" (list "cozystack.talos-log-collector" $) }}
 
 {{- end }}

--- a/packages/system/talos-log-collector/Chart.yaml
+++ b/packages/system/talos-log-collector/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: cozy-talos-log-collector
+description: Node-local Vector DaemonSet that receives Talos machine and kernel logs over loopback and forwards them to the in-cluster VictoriaLogs
+type: application
+version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process
+appVersion: "0.56.0"

--- a/packages/system/talos-log-collector/Makefile
+++ b/packages/system/talos-log-collector/Makefile
@@ -1,0 +1,27 @@
+export NAME=talos-log-collector
+export NAMESPACE=cozy-$(NAME)
+
+include ../../../hack/common-envs.mk
+include ../../../hack/package.mk
+
+test:
+	helm unittest .
+
+update:
+	ver=$$(curl -sSL "https://api.github.com/repos/vectordotdev/vector/releases" | jq -r '[.[] | select(.prerelease == false) | .tag_name | select(startswith("v0."))][0]' | sed 's/^v//') && \
+	$(SED_INPLACE) "/ARG VERSION/ s|=.*|=$${ver}-alpine|g" images/vector/Dockerfile
+
+image:
+	docker buildx build images/vector \
+		$(call image-tags,vector,v$(COZYSTACK_VERSION)) \
+		$(call cache-args,vector) \
+		--metadata-file images/vector.json \
+		$(BUILDX_ARGS)
+	REPOSITORY="$(REGISTRY)/vector" \
+		yq -i '.image.repository = strenv(REPOSITORY)' values.yaml
+	TAG=$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/vector.json -o json -r) \
+		yq -i '.image.tag = strenv(TAG)' values.yaml
+	rm -f images/vector.json
+
+generate:
+	cozyvalues-gen -v values.yaml -s values.schema.json -r README.md

--- a/packages/system/talos-log-collector/Makefile
+++ b/packages/system/talos-log-collector/Makefile
@@ -9,7 +9,8 @@ test:
 
 update:
 	ver=$$(curl -sSL "https://api.github.com/repos/vectordotdev/vector/releases" | jq -r '[.[] | select(.prerelease == false) | .tag_name | select(startswith("v0."))][0]' | sed 's/^v//') && \
-	$(SED_INPLACE) "/ARG VERSION/ s|=.*|=$${ver}-alpine|g" images/vector/Dockerfile
+	$(SED_INPLACE) "/ARG VERSION/ s|=.*|=$${ver}-alpine|g" images/vector/Dockerfile && \
+	VERSION="$${ver}" yq -i '.appVersion = strenv(VERSION)' Chart.yaml
 
 image:
 	docker buildx build images/vector \

--- a/packages/system/talos-log-collector/Makefile
+++ b/packages/system/talos-log-collector/Makefile
@@ -18,10 +18,8 @@ image:
 		$(call cache-args,vector) \
 		--metadata-file images/vector.json \
 		$(BUILDX_ARGS)
-	REPOSITORY="$(REGISTRY)/vector" \
-		yq -i '.image.repository = strenv(REPOSITORY)' values.yaml
-	TAG=$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/vector.json -o json -r) \
-		yq -i '.image.tag = strenv(TAG)' values.yaml
+	echo "$(REGISTRY)/vector:$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/vector.json -o json -r)" \
+		> images/vector.tag
 	rm -f images/vector.json
 
 generate:

--- a/packages/system/talos-log-collector/README.md
+++ b/packages/system/talos-log-collector/README.md
@@ -5,9 +5,11 @@ forwards them to the in-cluster VictoriaLogs.
 
 Talos keeps its system and kernel (kmsg) logs inside the OS and does not write
 them to a host file that the default Fluent Bit `tail` input could read, so
-those logs are never picked up by `monitoring-agents`. This package runs a
-Vector receiver on every node; Talos pushes its logs into it over the node
-loopback, and Vector forwards them to the tenant VictoriaLogs
+those logs are never picked up by `monitoring-agents`. Fluent Bit there is
+tail-only and the vendored chart offers no way to add a loopback TCP receiver,
+so extending it is not an option; this package runs a dedicated Vector receiver
+on every node instead. Talos pushes its logs into it over the node loopback,
+and Vector forwards them to the tenant VictoriaLogs
 (`vlinsert-generic.<target>.svc`) next to the container, audit and event logs
 already collected by `monitoring-agents`.
 
@@ -17,14 +19,25 @@ Vector runs as a DaemonSet on the pod network, so cluster DNS resolves the
 vlinsert service. It listens on a TCP socket published on the node loopback via
 a `hostPort` bound to `hostIP: 127.0.0.1`. Because the pod is not on the host
 network, the outbound path to vlinsert keeps working; the inbound loopback
-socket is provided by the hostPort. `machine.logging` already forwards the
-runtime kernel (kmsg) stream as the `kernel` service (verified on Talos v1.12),
-so no separate `KmsgLogConfig` is needed for runtime kernel logs.
+socket is provided by the hostPort.
+
+Talos exposes its logs through two independent config paths, and both must
+point at this socket to collect everything:
+
+- `machine.logging.destinations` forwards the JSON-lines **service** logs
+  (kubelet, etcd, apid and the other machine services).
+- A `KmsgLogConfig` document forwards the **kernel** (kmsg) stream, including
+  driver messages such as DRBD. `machine.logging.destinations` does not carry
+  kmsg: Talos builds the kmsg destination list only from `KmsgLogConfig`
+  documents and the `talos.logging.kernel=` kernel argument, so without one the
+  kernel logs never leave the node. Both endpoints may point at the same
+  socket; `KmsgLogConfig` only supports the `json_lines` format.
 
 ## Talos configuration (required)
 
 This package deploys only the receiver. Each Talos node must be told to push
-its logs to the loopback socket. Add this to the machine config and apply it:
+both its service logs and its kernel logs to the loopback socket. Add this to
+the machine config and apply it:
 
 ```yaml
 machine:
@@ -32,7 +45,15 @@ machine:
     destinations:
       - endpoint: "tcp://127.0.0.1:5170/"
         format: "json_lines"
+---
+apiVersion: v1alpha1
+kind: KmsgLogConfig
+name: talos-log-collector
+url: "tcp://127.0.0.1:5170/"
 ```
+
+> Omitting the `KmsgLogConfig` document collects service logs only; kernel
+> (kmsg) logs, including the DRBD messages, will silently never arrive.
 
 > Early-boot kernel panics, before the network is up, are not captured by any
 > in-cluster collector. Use the node BMC serial console for those.
@@ -62,7 +83,7 @@ machine:
 | `image.tag`        | Image tag (digest-pinned by the build).                                                  | `string`   | `0.56.0-alpine@sha256:0eb66216f5f9322264e2ba83f4606428ef77a2cd4dea619a5bea610ac80ccc43` |
 | `image.pullPolicy` | Image pull policy.                                                                       | `string`   | `IfNotPresent`                                                                          |
 | `resources`        | Compute resources for the collector.                                                     | `object`   | `{}`                                                                                    |
-| `resources.cpu`    | CPU request and limit.                                                                   | `quantity` | `100m`                                                                                  |
+| `resources.cpu`    | CPU request.                                                                             | `quantity` | `100m`                                                                                  |
 | `resources.memory` | Memory request and limit.                                                                | `quantity` | `128Mi`                                                                                 |
 
 

--- a/packages/system/talos-log-collector/README.md
+++ b/packages/system/talos-log-collector/README.md
@@ -78,17 +78,13 @@ url: "tcp://127.0.0.1:5170/"
 
 ### Common parameters
 
-| Name               | Description                                                                              | Type       | Value                                                                                   |
-| ------------------ | ---------------------------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------- |
-| `logLevel`         | Vector log verbosity (trace, debug, info, warn, error).                                  | `string`   | `warn`                                                                                  |
-| `listenPort`       | TCP port bound on the node loopback (127.0.0.1) where Talos machine.logging pushes logs. | `int`      | `5170`                                                                                  |
-| `image`            | Vector container image.                                                                  | `object`   | `{}`                                                                                    |
-| `image.repository` | Image repository.                                                                        | `string`   | `ghcr.io/cozystack/cozystack/vector`                                                    |
-| `image.tag`        | Image tag (digest-pinned by the build).                                                  | `string`   | `0.56.0-alpine@sha256:0eb66216f5f9322264e2ba83f4606428ef77a2cd4dea619a5bea610ac80ccc43` |
-| `image.pullPolicy` | Image pull policy.                                                                       | `string`   | `IfNotPresent`                                                                          |
-| `resources`        | Compute resources for the collector.                                                     | `object`   | `{}`                                                                                    |
-| `resources.cpu`    | CPU request.                                                                             | `quantity` | `100m`                                                                                  |
-| `resources.memory` | Memory request and limit.                                                                | `quantity` | `128Mi`                                                                                 |
+| Name               | Description                                                                              | Type       | Value   |
+| ------------------ | ---------------------------------------------------------------------------------------- | ---------- | ------- |
+| `logLevel`         | Vector log verbosity (trace, debug, info, warn, error).                                  | `string`   | `warn`  |
+| `listenPort`       | TCP port bound on the node loopback (127.0.0.1) where Talos machine.logging pushes logs. | `int`      | `5170`  |
+| `resources`        | Compute resources for the collector.                                                     | `object`   | `{}`    |
+| `resources.cpu`    | CPU request.                                                                             | `quantity` | `100m`  |
+| `resources.memory` | Memory request and limit.                                                                | `quantity` | `128Mi` |
 
 
 ### VictoriaLogs destination

--- a/packages/system/talos-log-collector/README.md
+++ b/packages/system/talos-log-collector/README.md
@@ -55,6 +55,10 @@ url: "tcp://127.0.0.1:5170/"
 > Omitting the `KmsgLogConfig` document collects service logs only; kernel
 > (kmsg) logs, including the DRBD messages, will silently never arrive.
 
+> Kernel (kmsg) records carry no wall-clock timestamp (only a monotonic
+> clock), so VictoriaLogs stamps them with the ingest time rather than the
+> `talos-time` used for service logs.
+
 > Early-boot kernel panics, before the network is up, are not captured by any
 > in-cluster collector. Use the node BMC serial console for those.
 
@@ -89,8 +93,8 @@ url: "tcp://127.0.0.1:5170/"
 
 ### VictoriaLogs destination
 
-| Name            | Description                                                                  | Type     | Value         |
-| --------------- | ---------------------------------------------------------------------------- | -------- | ------------- |
-| `global`        | Platform-injected global values.                                             | `object` | `{}`          |
-| `global.target` | Tenant whose VictoriaLogs (vlinsert-generic.<target>.svc) receives the logs. | `string` | `tenant-root` |
+| Name            | Description                                                                                                                       | Type     | Value         |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| `global`        | Global values block; `target` selects the destination tenant.                                                                     | `object` | `{}`          |
+| `global.target` | Tenant whose VictoriaLogs (vlinsert-generic.<target>.svc) receives the logs. Defaults to tenant-root; override via bundle values. | `string` | `tenant-root` |
 

--- a/packages/system/talos-log-collector/README.md
+++ b/packages/system/talos-log-collector/README.md
@@ -1,0 +1,75 @@
+# Talos Log Collector
+
+A node-local Vector DaemonSet that receives Talos machine and kernel logs and
+forwards them to the in-cluster VictoriaLogs.
+
+Talos keeps its system and kernel (kmsg) logs inside the OS and does not write
+them to a host file that the default Fluent Bit `tail` input could read, so
+those logs are never picked up by `monitoring-agents`. This package runs a
+Vector receiver on every node; Talos pushes its logs into it over the node
+loopback, and Vector forwards them to the tenant VictoriaLogs
+(`vlinsert-generic.<target>.svc`) next to the container, audit and event logs
+already collected by `monitoring-agents`.
+
+## How it works
+
+Vector runs as a DaemonSet on the pod network, so cluster DNS resolves the
+vlinsert service. It listens on a TCP socket published on the node loopback via
+a `hostPort` bound to `hostIP: 127.0.0.1`. Because the pod is not on the host
+network, the outbound path to vlinsert keeps working; the inbound loopback
+socket is provided by the hostPort. `machine.logging` already forwards the
+runtime kernel (kmsg) stream as the `kernel` service (verified on Talos v1.12),
+so no separate `KmsgLogConfig` is needed for runtime kernel logs.
+
+## Talos configuration (required)
+
+This package deploys only the receiver. Each Talos node must be told to push
+its logs to the loopback socket. Add this to the machine config and apply it:
+
+```yaml
+machine:
+  logging:
+    destinations:
+      - endpoint: "tcp://127.0.0.1:5170/"
+        format: "json_lines"
+```
+
+> Early-boot kernel panics, before the network is up, are not captured by any
+> in-cluster collector. Use the node BMC serial console for those.
+
+## Notes
+
+- The package is opt-in via `bundles.enabledPackages` and stays inert until the
+  Talos machine config above is applied on the nodes.
+- If the target tenant has no VictoriaLogs (vlinsert) yet, Vector's sink retries
+  and backpressures the source: the pod stays Running, but Talos logs are
+  dropped until vlinsert exists.
+- Teardown: removing the package from `bundles.enabledPackages` does not
+  uninstall it (Package CRs carry `helm.sh/resource-policy: keep`). Delete it
+  explicitly with
+  `kubectl delete package.cozystack.io cozystack.talos-log-collector`.
+
+## Parameters
+
+### Common parameters
+
+| Name               | Description                                                                              | Type       | Value                                                                                   |
+| ------------------ | ---------------------------------------------------------------------------------------- | ---------- | --------------------------------------------------------------------------------------- |
+| `logLevel`         | Vector log verbosity (trace, debug, info, warn, error).                                  | `string`   | `warn`                                                                                  |
+| `listenPort`       | TCP port bound on the node loopback (127.0.0.1) where Talos machine.logging pushes logs. | `int`      | `5170`                                                                                  |
+| `image`            | Vector container image.                                                                  | `object`   | `{}`                                                                                    |
+| `image.repository` | Image repository.                                                                        | `string`   | `ghcr.io/cozystack/cozystack/vector`                                                    |
+| `image.tag`        | Image tag (digest-pinned by the build).                                                  | `string`   | `0.56.0-alpine@sha256:0eb66216f5f9322264e2ba83f4606428ef77a2cd4dea619a5bea610ac80ccc43` |
+| `image.pullPolicy` | Image pull policy.                                                                       | `string`   | `IfNotPresent`                                                                          |
+| `resources`        | Compute resources for the collector.                                                     | `object`   | `{}`                                                                                    |
+| `resources.cpu`    | CPU request and limit.                                                                   | `quantity` | `100m`                                                                                  |
+| `resources.memory` | Memory request and limit.                                                                | `quantity` | `128Mi`                                                                                 |
+
+
+### VictoriaLogs destination
+
+| Name            | Description                                                                  | Type     | Value         |
+| --------------- | ---------------------------------------------------------------------------- | -------- | ------------- |
+| `global`        | Platform-injected global values.                                             | `object` | `{}`          |
+| `global.target` | Tenant whose VictoriaLogs (vlinsert-generic.<target>.svc) receives the logs. | `string` | `tenant-root` |
+

--- a/packages/system/talos-log-collector/images/vector.tag
+++ b/packages/system/talos-log-collector/images/vector.tag
@@ -1,0 +1,1 @@
+ghcr.io/cozystack/cozystack/vector:0.56.0-alpine@sha256:0eb66216f5f9322264e2ba83f4606428ef77a2cd4dea619a5bea610ac80ccc43

--- a/packages/system/talos-log-collector/images/vector/Dockerfile
+++ b/packages/system/talos-log-collector/images/vector/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1.2
+#
+# Pure mirror of the upstream Vector image, re-hosted in the cozystack
+# registry and pinned by digest via `make image` (same pattern as metallb).
+ARG VERSION=0.56.0-alpine
+
+FROM timberio/vector:${VERSION}

--- a/packages/system/talos-log-collector/templates/_helpers.tpl
+++ b/packages/system/talos-log-collector/templates/_helpers.tpl
@@ -1,0 +1,4 @@
+{{- define "talos-log-collector.labels" -}}
+app.kubernetes.io/name: talos-log-collector
+app.kubernetes.io/part-of: talos-log-collector
+{{- end }}

--- a/packages/system/talos-log-collector/templates/configmap.yaml
+++ b/packages/system/talos-log-collector/templates/configmap.yaml
@@ -22,11 +22,13 @@ data:
         source: |
           .log_source = "talos_system"
           .node = get_env_var("VECTOR_SELF_NODE_NAME") ?? "unknown"
+          .tenant = "{{ .Values.global.target | default "tenant-root" }}"
+          .cluster = "root-cluster"
     sinks:
       victorialogs:
         type: http
         inputs: [tag]
-        uri: "http://vlinsert-generic.{{ .Values.global.target }}.svc:9481/insert/jsonline?_stream_fields=node,log_source,talos-service,facility&_msg_field=msg&_time_field=talos-time"
+        uri: "http://vlinsert-generic.{{ .Values.global.target | default "tenant-root" }}.svc:9481/insert/jsonline?_stream_fields=node,log_source,talos-service,facility,tenant,cluster&_msg_field=msg&_time_field=talos-time"
         method: post
         compression: gzip
         encoding:

--- a/packages/system/talos-log-collector/templates/configmap.yaml
+++ b/packages/system/talos-log-collector/templates/configmap.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: talos-log-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "talos-log-collector.labels" . | nindent 4 }}
+data:
+  vector.yaml: |
+    data_dir: /vector-data
+    sources:
+      talos:
+        type: socket
+        mode: tcp
+        address: 0.0.0.0:{{ .Values.listenPort }}
+        decoding:
+          codec: json
+    transforms:
+      tag:
+        type: remap
+        inputs: [talos]
+        source: |
+          .log_source = "talos_system"
+          .node = get_env_var("VECTOR_SELF_NODE_NAME") ?? "unknown"
+    sinks:
+      victorialogs:
+        type: http
+        inputs: [tag]
+        uri: "http://vlinsert-generic.{{ .Values.global.target }}.svc:9481/insert/jsonline?_stream_fields=node,log_source,talos-service,facility&_msg_field=msg&_time_field=talos-time"
+        method: post
+        compression: gzip
+        encoding:
+          codec: json
+        framing:
+          method: newline_delimited
+        request:
+          headers:
+            Content-Type: application/x-ndjson
+            AccountID: "0"
+            ProjectID: "0"

--- a/packages/system/talos-log-collector/templates/daemonset.yaml
+++ b/packages/system/talos-log-collector/templates/daemonset.yaml
@@ -39,8 +39,8 @@ spec:
           type: RuntimeDefault
       containers:
       - name: vector
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "{{ $.Files.Get "images/vector.tag" | trim }}"
+        imagePullPolicy: IfNotPresent
         args: ["--config", "/etc/vector/vector.yaml"]
         livenessProbe:
           tcpSocket:

--- a/packages/system/talos-log-collector/templates/daemonset.yaml
+++ b/packages/system/talos-log-collector/templates/daemonset.yaml
@@ -25,6 +25,11 @@ spec:
       # socket into the pod via portmap. This keeps the receiver off the host
       # network (no node-wide pod exposure, no host-DNS handling) while still
       # accepting node-loopback traffic.
+      # The loopback hostPort relies on the portmap CNI plugin (chained ahead of
+      # Cilium on the kubeovn-cilium* variants). Cilium's own eBPF hostPort
+      # implementation cannot bind a hostPort to 127.0.0.1, so on the plain
+      # cilium/cilium-generic/cilium-kilo variants (not selected by any bundle
+      # today) this receiver would silently stop receiving.
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -37,6 +42,11 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: ["--config", "/etc/vector/vector.yaml"]
+        livenessProbe:
+          tcpSocket:
+            port: talos
+          initialDelaySeconds: 10
+          periodSeconds: 30
         env:
         - name: VECTOR_SELF_NODE_NAME
           valueFrom:

--- a/packages/system/talos-log-collector/templates/daemonset.yaml
+++ b/packages/system/talos-log-collector/templates/daemonset.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: talos-log-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "talos-log-collector.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: talos-log-collector
+  template:
+    metadata:
+      labels:
+        {{- include "talos-log-collector.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: talos-log-collector
+      priorityClassName: system-node-critical
+      # No hostNetwork: the pod stays on the pod network, so the outbound sink
+      # resolves vlinsert-generic.<target>.svc through cluster DNS with no extra
+      # config. Talos machine.logging pushes to 127.0.0.1:<listenPort>; the
+      # hostPort below, bound to hostIP 127.0.0.1, publishes that loopback
+      # socket into the pod via portmap. This keeps the receiver off the host
+      # network (no node-wide pod exposure, no host-DNS handling) while still
+      # accepting node-loopback traffic.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: vector
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: ["--config", "/etc/vector/vector.yaml"]
+        env:
+        - name: VECTOR_SELF_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: VECTOR_LOG
+          value: {{ .Values.logLevel | quote }}
+        ports:
+        - name: talos
+          containerPort: {{ .Values.listenPort }}
+          hostPort: {{ .Values.listenPort }}
+          hostIP: 127.0.0.1
+          protocol: TCP
+        resources:
+          requests:
+            cpu: {{ .Values.resources.cpu }}
+            memory: {{ .Values.resources.memory }}
+          limits:
+            memory: {{ .Values.resources.memory }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: config
+          mountPath: /etc/vector
+        - name: data
+          mountPath: /vector-data
+      tolerations:
+      - effect: NoSchedule
+        operator: Exists
+      - effect: NoExecute
+        operator: Exists
+      volumes:
+      - name: config
+        configMap:
+          name: talos-log-collector
+      - name: data
+        emptyDir: {}

--- a/packages/system/talos-log-collector/templates/networkpolicy.yaml
+++ b/packages/system/talos-log-collector/templates/networkpolicy.yaml
@@ -1,11 +1,16 @@
+# Vector binds 0.0.0.0:<listenPort> inside the pod netns and exposes it as a
+# containerPort, so the pod IP is reachable from every pod in the cluster. Any
+# workload could open <podIP>:<listenPort> and inject forged JSON lines that the
+# pipeline stamps with log_source=talos_system and the real node name, straight
+# into VictoriaLogs. This policy is load-bearing, not defence-in-depth: it is
+# the only thing restricting the receiver to the node-local push path (Talos
+# reaches it on 127.0.0.1:<listenPort>; portmap DNATs to the pod and SNATs the
+# source to the node, so legitimate traffic arrives as the host). A CNI that
+# does not enforce NetworkPolicy (e.g. the noop networking variant, or a BYO CNI
+# without policy support) leaves the socket unprotected regardless.
 {{- if .Capabilities.APIVersions.Has "cilium.io/v2/CiliumNetworkPolicy" }}
----
-# Talos reaches the receiver on 127.0.0.1:<listenPort>; portmap DNATs that to
-# the pod and SNATs the source to the node, so legitimate traffic arrives as
-# the "host" entity. Restrict ingress on the listen port to host only, so other
-# pods on the pod network cannot inject spoofed talos_system log lines.
-# Defense-in-depth and Cilium-only: even without this policy the loopback
-# hostPort is not reachable from the pod network, so its absence is safe.
+# Cilium is present: restrict ingress on the listen port to the host entity, so
+# only the node-local push path is allowed and other pods are denied.
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -24,4 +29,25 @@ spec:
     - ports:
       - port: "{{ .Values.listenPort }}"
         protocol: TCP
+{{- else }}
+# No Cilium CRD: fall back to a CNI-agnostic default-deny-ingress policy so the
+# socket is never offered without protection. This denies ingress from the pod
+# network (the injection path) while node-local host traffic keeps flowing, the
+# same way liveness/readiness probes from the node are not blocked by a
+# default-deny policy; the portmap hostPort path arrives as node-local host
+# traffic.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: talos-log-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "talos-log-collector.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: talos-log-collector
+  policyTypes:
+  - Ingress
+  ingress: []
 {{- end }}

--- a/packages/system/talos-log-collector/templates/networkpolicy.yaml
+++ b/packages/system/talos-log-collector/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if .Capabilities.APIVersions.Has "cilium.io/v2/CiliumNetworkPolicy" }}
+---
+# Talos reaches the receiver on 127.0.0.1:<listenPort>; portmap DNATs that to
+# the pod and SNATs the source to the node, so legitimate traffic arrives as
+# the "host" entity. Restrict ingress on the listen port to host only, so other
+# pods on the pod network cannot inject spoofed talos_system log lines.
+# Defense-in-depth and Cilium-only: even without this policy the loopback
+# hostPort is not reachable from the pod network, so its absence is safe.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: talos-log-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "talos-log-collector.labels" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: talos-log-collector
+  ingress:
+  - fromEntities:
+    - host
+    toPorts:
+    - ports:
+      - port: "{{ .Values.listenPort }}"
+        protocol: TCP
+{{- end }}

--- a/packages/system/talos-log-collector/templates/networkpolicy.yaml
+++ b/packages/system/talos-log-collector/templates/networkpolicy.yaml
@@ -32,10 +32,13 @@ spec:
 {{- else }}
 # No Cilium CRD: fall back to a CNI-agnostic default-deny-ingress policy so the
 # socket is never offered without protection. This denies ingress from the pod
-# network (the injection path) while node-local host traffic keeps flowing, the
-# same way liveness/readiness probes from the node are not blocked by a
-# default-deny policy; the portmap hostPort path arrives as node-local host
-# traffic.
+# network (the injection path, whose source is a real pod IP). The node-local
+# push path (portmap SNATs the source to the node) keeps flowing on CNIs that
+# exempt node-local/health traffic from policy enforcement, as the mainstream
+# policy CNIs do; a CNI that instead enforces policy on node-local traffic would
+# also block this push path, so on such a CNI keep Cilium or open the port
+# explicitly. The only non-Cilium variant shipped today is noop, which does not
+# enforce NetworkPolicy at all, so this fallback is inert there.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/packages/system/talos-log-collector/templates/serviceaccount.yaml
+++ b/packages/system/talos-log-collector/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: talos-log-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "talos-log-collector.labels" . | nindent 4 }}
+automountServiceAccountToken: false

--- a/packages/system/talos-log-collector/tests/talos-log-collector_test.yaml
+++ b/packages/system/talos-log-collector/tests/talos-log-collector_test.yaml
@@ -2,7 +2,8 @@ suite: talos-log-collector receive/forward wiring
 
 # Pins the surface this package owns:
 #   - the DaemonSet pulls the first-party vector image from the cozystack
-#     registry (repository is the load-bearing ref re-pinned by `make image`);
+#     registry (the load-bearing ref lives in images/vector.tag, re-pinned by
+#     `make image`);
 #   - Talos logs are received on the node loopback via hostPort+hostIP (the pod
 #     stays on the pod network for the sink; the loopback socket is published
 #     via portmap), NOT via hostNetwork;

--- a/packages/system/talos-log-collector/tests/talos-log-collector_test.yaml
+++ b/packages/system/talos-log-collector/tests/talos-log-collector_test.yaml
@@ -1,0 +1,129 @@
+suite: talos-log-collector receive/forward wiring
+
+# Pins the surface this package owns:
+#   - the DaemonSet pulls the first-party vector image from the cozystack
+#     registry (repository is the load-bearing ref re-pinned by `make image`);
+#   - Talos logs are received on the node loopback via hostPort+hostIP (the pod
+#     stays on the pod network for the sink; the loopback socket is published
+#     via portmap), NOT via hostNetwork;
+#   - the collector runs on every node (tolerate everything, node-critical);
+#   - logs are forwarded to the tenant VictoriaLogs vlinsert on port 9481, and
+#     the destination tenant (global.target) plumbs through verbatim.
+
+templates:
+  - templates/daemonset.yaml
+  - templates/configmap.yaml
+  - templates/serviceaccount.yaml
+  - templates/networkpolicy.yaml
+
+tests:
+  - it: "DaemonSet pulls the first-party vector image from the cozystack registry"
+    template: templates/daemonset.yaml
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: "^ghcr\\.io/cozystack/cozystack/vector:"
+
+  - it: "receives Talos logs on node loopback via hostPort, not hostNetwork"
+    template: templates/daemonset.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.hostNetwork
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].hostIP
+          value: 127.0.0.1
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].hostPort
+          value: 5170
+
+  - it: "runs on every node and is node-critical"
+    template: templates/daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: system-node-critical
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            effect: NoSchedule
+            operator: Exists
+
+  - it: "forwards to the tenant VictoriaLogs vlinsert on 9481"
+    template: templates/configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["vector.yaml"]
+          pattern: "vlinsert-generic\\.tenant-root\\.svc:9481"
+
+  - it: "destination tenant is overridable via global.target"
+    template: templates/configmap.yaml
+    set:
+      global:
+        target: tenant-ktj
+    asserts:
+      - matchRegex:
+          path: data["vector.yaml"]
+          pattern: "vlinsert-generic\\.tenant-ktj\\.svc:9481"
+
+  - it: "listenPort drives the DaemonSet host/container ports"
+    template: templates/daemonset.yaml
+    set:
+      listenPort: 6000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 6000
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].hostPort
+          value: 6000
+
+  - it: "listenPort drives the Vector socket address"
+    template: templates/configmap.yaml
+    set:
+      listenPort: 6000
+    asserts:
+      - matchRegex:
+          path: data["vector.yaml"]
+          pattern: "address: 0\\.0\\.0\\.0:6000"
+
+  - it: "container runs unprivileged and non-root"
+    template: templates/daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: "ServiceAccount disables token automount"
+    template: templates/serviceaccount.yaml
+    asserts:
+      - equal:
+          path: automountServiceAccountToken
+          value: false
+
+  - it: "NetworkPolicy restricts ingress to the host entity on the listen port"
+    template: templates/networkpolicy.yaml
+    capabilities:
+      apiVersions:
+        - cilium.io/v2/CiliumNetworkPolicy
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: CiliumNetworkPolicy
+      - equal:
+          path: spec.ingress[0].fromEntities[0]
+          value: host
+      - equal:
+          path: spec.ingress[0].toPorts[0].ports[0].port
+          value: "5170"

--- a/packages/system/talos-log-collector/tests/talos-log-collector_test.yaml
+++ b/packages/system/talos-log-collector/tests/talos-log-collector_test.yaml
@@ -49,6 +49,11 @@ tests:
           content:
             effect: NoSchedule
             operator: Exists
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            effect: NoExecute
+            operator: Exists
 
   - it: "forwards to the tenant VictoriaLogs vlinsert on 9481"
     template: templates/configmap.yaml
@@ -56,6 +61,19 @@ tests:
       - matchRegex:
           path: data["vector.yaml"]
           pattern: "vlinsert-generic\\.tenant-root\\.svc:9481"
+
+  - it: "stamps tenant and cluster on records and streams them (parity with monitoring-agents)"
+    template: templates/configmap.yaml
+    asserts:
+      - matchRegex:
+          path: data["vector.yaml"]
+          pattern: '\.tenant = "tenant-root"'
+      - matchRegex:
+          path: data["vector.yaml"]
+          pattern: '\.cluster = "root-cluster"'
+      - matchRegex:
+          path: data["vector.yaml"]
+          pattern: "_stream_fields=node,log_source,talos-service,facility,tenant,cluster"
 
   - it: "destination tenant is overridable via global.target"
     template: templates/configmap.yaml
@@ -127,3 +145,43 @@ tests:
       - equal:
           path: spec.ingress[0].toPorts[0].ports[0].port
           value: "5170"
+
+  - it: "falls back to a CNI-agnostic default-deny NetworkPolicy when the Cilium CRD is absent"
+    template: templates/networkpolicy.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: NetworkPolicy
+      - isAPIVersion:
+          of: networking.k8s.io/v1
+      - equal:
+          path: spec.podSelector.matchLabels["app.kubernetes.io/name"]
+          value: talos-log-collector
+      - contains:
+          path: spec.policyTypes
+          content: Ingress
+      - isNullOrEmpty:
+          path: spec.ingress
+
+  - it: "cpu is a request only; memory is request and limit"
+    template: templates/daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 128Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 128Mi
+      - notExists:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+
+  - it: "has a tcpSocket liveness probe on the listen port"
+    template: templates/daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: talos

--- a/packages/system/talos-log-collector/tests/talos-log-collector_test.yaml
+++ b/packages/system/talos-log-collector/tests/talos-log-collector_test.yaml
@@ -147,6 +147,18 @@ tests:
           path: spec.ingress[0].toPorts[0].ports[0].port
           value: "5170"
 
+  - it: "Cilium NetworkPolicy ingress port follows the listenPort override"
+    template: templates/networkpolicy.yaml
+    capabilities:
+      apiVersions:
+        - cilium.io/v2/CiliumNetworkPolicy
+    set:
+      listenPort: 6000
+    asserts:
+      - equal:
+          path: spec.ingress[0].toPorts[0].ports[0].port
+          value: "6000"
+
   - it: "falls back to a CNI-agnostic default-deny NetworkPolicy when the Cilium CRD is absent"
     template: templates/networkpolicy.yaml
     asserts:

--- a/packages/system/talos-log-collector/values.schema.json
+++ b/packages/system/talos-log-collector/values.schema.json
@@ -1,0 +1,85 @@
+{
+  "title": "Chart Values",
+  "type": "object",
+  "properties": {
+    "logLevel": {
+      "description": "Vector log verbosity (trace, debug, info, warn, error).",
+      "type": "string",
+      "default": "warn"
+    },
+    "listenPort": {
+      "description": "TCP port bound on the node loopback (127.0.0.1) where Talos machine.logging pushes logs.",
+      "type": "integer",
+      "default": 5170
+    },
+    "image": {
+      "description": "Vector container image.",
+      "type": "object",
+      "default": {},
+      "properties": {
+        "pullPolicy": {
+          "description": "Image pull policy.",
+          "type": "string",
+          "default": "IfNotPresent"
+        },
+        "repository": {
+          "description": "Image repository.",
+          "type": "string",
+          "default": "ghcr.io/cozystack/cozystack/vector"
+        },
+        "tag": {
+          "description": "Image tag (digest-pinned by the build).",
+          "type": "string",
+          "default": "0.56.0-alpine@sha256:0eb66216f5f9322264e2ba83f4606428ef77a2cd4dea619a5bea610ac80ccc43"
+        }
+      }
+    },
+    "resources": {
+      "description": "Compute resources for the collector.",
+      "type": "object",
+      "default": {},
+      "properties": {
+        "cpu": {
+          "description": "CPU request and limit.",
+          "default": "100m",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "x-kubernetes-int-or-string": true
+        },
+        "memory": {
+          "description": "Memory request and limit.",
+          "default": "128Mi",
+          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "x-kubernetes-int-or-string": true
+        }
+      }
+    },
+    "global": {
+      "description": "Platform-injected global values.",
+      "type": "object",
+      "default": {},
+      "properties": {
+        "target": {
+          "description": "Tenant whose VictoriaLogs (vlinsert-generic.\u003ctarget\u003e.svc) receives the logs.",
+          "type": "string",
+          "default": "tenant-root"
+        }
+      }
+    }
+  }
+}

--- a/packages/system/talos-log-collector/values.schema.json
+++ b/packages/system/talos-log-collector/values.schema.json
@@ -21,28 +21,6 @@
       "maximum": 65535,
       "minimum": 1
     },
-    "image": {
-      "description": "Vector container image.",
-      "type": "object",
-      "default": {},
-      "properties": {
-        "pullPolicy": {
-          "description": "Image pull policy.",
-          "type": "string",
-          "default": "IfNotPresent"
-        },
-        "repository": {
-          "description": "Image repository.",
-          "type": "string",
-          "default": "ghcr.io/cozystack/cozystack/vector"
-        },
-        "tag": {
-          "description": "Image tag (digest-pinned by the build).",
-          "type": "string",
-          "default": "0.56.0-alpine@sha256:0eb66216f5f9322264e2ba83f4606428ef77a2cd4dea619a5bea610ac80ccc43"
-        }
-      }
-    },
     "resources": {
       "description": "Compute resources for the collector.",
       "type": "object",

--- a/packages/system/talos-log-collector/values.schema.json
+++ b/packages/system/talos-log-collector/values.schema.json
@@ -5,12 +5,21 @@
     "logLevel": {
       "description": "Vector log verbosity (trace, debug, info, warn, error).",
       "type": "string",
-      "default": "warn"
+      "default": "warn",
+      "enum": [
+        "trace",
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ]
     },
     "listenPort": {
       "description": "TCP port bound on the node loopback (127.0.0.1) where Talos machine.logging pushes logs.",
       "type": "integer",
-      "default": 5170
+      "default": 5170,
+      "maximum": 65535,
+      "minimum": 1
     },
     "image": {
       "description": "Vector container image.",
@@ -40,7 +49,7 @@
       "default": {},
       "properties": {
         "cpu": {
-          "description": "CPU request and limit.",
+          "description": "CPU request.",
           "default": "100m",
           "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
           "anyOf": [

--- a/packages/system/talos-log-collector/values.schema.json
+++ b/packages/system/talos-log-collector/values.schema.json
@@ -79,12 +79,12 @@
       }
     },
     "global": {
-      "description": "Platform-injected global values.",
+      "description": "Global values block; `target` selects the destination tenant.",
       "type": "object",
       "default": {},
       "properties": {
         "target": {
-          "description": "Tenant whose VictoriaLogs (vlinsert-generic.\u003ctarget\u003e.svc) receives the logs.",
+          "description": "Tenant whose VictoriaLogs (vlinsert-generic.\u003ctarget\u003e.svc) receives the logs. Defaults to tenant-root; override via bundle values.",
           "type": "string",
           "default": "tenant-root"
         }

--- a/packages/system/talos-log-collector/values.yaml
+++ b/packages/system/talos-log-collector/values.yaml
@@ -17,17 +17,6 @@ logLevel: warn
 ## @maximum 65535
 listenPort: 5170
 
-## @typedef {struct} Image - Vector container image.
-## @field {string} [repository] - Image repository.
-## @field {string} [tag] - Image tag (digest-pinned by the build).
-## @field {string} [pullPolicy] - Image pull policy.
-
-## @param {Image} [image] - Vector container image.
-image:
-  repository: ghcr.io/cozystack/cozystack/vector
-  tag: 0.56.0-alpine@sha256:0eb66216f5f9322264e2ba83f4606428ef77a2cd4dea619a5bea610ac80ccc43
-  pullPolicy: IfNotPresent
-
 ## @typedef {struct} Resources - Compute resources for the collector.
 ## @field {quantity} [cpu] - CPU request.
 ## @field {quantity} [memory] - Memory request and limit.

--- a/packages/system/talos-log-collector/values.yaml
+++ b/packages/system/talos-log-collector/values.yaml
@@ -2,10 +2,19 @@
 ## @section Common parameters
 ##
 
-## @param {string} [logLevel] - Vector log verbosity (trace, debug, info, warn, error).
+## @enum {string} LogLevel - Vector log verbosity.
+## @value trace
+## @value debug
+## @value info
+## @value warn
+## @value error
+
+## @param {LogLevel} [logLevel] - Vector log verbosity (trace, debug, info, warn, error).
 logLevel: warn
 
 ## @param {int} [listenPort] - TCP port bound on the node loopback (127.0.0.1) where Talos machine.logging pushes logs.
+## @minimum 1
+## @maximum 65535
 listenPort: 5170
 
 ## @typedef {struct} Image - Vector container image.
@@ -20,7 +29,7 @@ image:
   pullPolicy: IfNotPresent
 
 ## @typedef {struct} Resources - Compute resources for the collector.
-## @field {quantity} [cpu] - CPU request and limit.
+## @field {quantity} [cpu] - CPU request.
 ## @field {quantity} [memory] - Memory request and limit.
 
 ## @param {Resources} [resources] - Compute resources for the collector.

--- a/packages/system/talos-log-collector/values.yaml
+++ b/packages/system/talos-log-collector/values.yaml
@@ -41,9 +41,9 @@ resources:
 ## @section VictoriaLogs destination
 ##
 
-## @typedef {struct} Global - Platform-injected global values.
-## @field {string} [target] - Tenant whose VictoriaLogs (vlinsert-generic.<target>.svc) receives the logs.
+## @typedef {struct} Global - Global values block; `target` selects the destination tenant.
+## @field {string} [target] - Tenant whose VictoriaLogs (vlinsert-generic.<target>.svc) receives the logs. Defaults to tenant-root; override via bundle values.
 
-## @param {Global} [global] - Platform-injected global values.
+## @param {Global} [global] - Global values block; `target` selects the destination tenant.
 global:
   target: tenant-root

--- a/packages/system/talos-log-collector/values.yaml
+++ b/packages/system/talos-log-collector/values.yaml
@@ -1,0 +1,40 @@
+##
+## @section Common parameters
+##
+
+## @param {string} [logLevel] - Vector log verbosity (trace, debug, info, warn, error).
+logLevel: warn
+
+## @param {int} [listenPort] - TCP port bound on the node loopback (127.0.0.1) where Talos machine.logging pushes logs.
+listenPort: 5170
+
+## @typedef {struct} Image - Vector container image.
+## @field {string} [repository] - Image repository.
+## @field {string} [tag] - Image tag (digest-pinned by the build).
+## @field {string} [pullPolicy] - Image pull policy.
+
+## @param {Image} [image] - Vector container image.
+image:
+  repository: ghcr.io/cozystack/cozystack/vector
+  tag: 0.56.0-alpine@sha256:0eb66216f5f9322264e2ba83f4606428ef77a2cd4dea619a5bea610ac80ccc43
+  pullPolicy: IfNotPresent
+
+## @typedef {struct} Resources - Compute resources for the collector.
+## @field {quantity} [cpu] - CPU request and limit.
+## @field {quantity} [memory] - Memory request and limit.
+
+## @param {Resources} [resources] - Compute resources for the collector.
+resources:
+  cpu: 100m
+  memory: 128Mi
+
+##
+## @section VictoriaLogs destination
+##
+
+## @typedef {struct} Global - Platform-injected global values.
+## @field {string} [target] - Tenant whose VictoriaLogs (vlinsert-generic.<target>.svc) receives the logs.
+
+## @param {Global} [global] - Platform-injected global values.
+global:
+  target: tenant-root


### PR DESCRIPTION
## What this PR does

Adds `talos-log-collector`, an optional system package: a node-local Vector
DaemonSet that receives Talos machine and kernel logs and forwards them to the
tenant VictoriaLogs (vlinsert), alongside the container/audit/event logs
already collected by monitoring-agents.

Talos keeps system and kernel (kmsg) logs inside the OS and does not write them
to a host file the Fluent Bit `tail` input could read, so these logs are
currently never collected. Vector receives them over the node loopback
(Talos pushes to 127.0.0.1:5170). Talos exposes the two streams through
independent config paths, and both must point at the loopback socket:
`machine.logging.destinations` forwards the JSON-lines service logs, and a
`KmsgLogConfig` document forwards the kernel (kmsg) stream (including DRBD
kmsg). The node-side setup for both is in the README.

Design notes:
- The pod stays on the pod network so cluster DNS resolves vlinsert with no
  extra config. Talos pushes to 127.0.0.1:5170; a `hostPort` bound to
  `hostIP: 127.0.0.1` publishes that loopback socket into the pod via portmap,
  keeping the receiver off the host network (no node-wide pod exposure).
- The receiver binds inside the pod netns, so a NetworkPolicy is load-bearing:
  a CiliumNetworkPolicy restricts ingress to the host entity when Cilium is
  present, otherwise a default-deny-ingress `networking.k8s.io/v1` fallback
  keeps the socket protected on non-Cilium variants.
- Runs non-root, read-only root filesystem, all capabilities dropped.
- Optional package (opt-in via `bundles.enabledPackages`): inert until each
  Talos node is configured to push logs. Node-side setup is in the README.

Verified end-to-end on a Talos v1.12 dev cluster: service and kernel logs
(including DRBD kmsg) reach VictoriaLogs; pods run non-root with 0 restarts.

### Release note

```release-note
feat(talos-log-collector): add talos-log-collector package to collect Talos machine and kernel logs into VictoriaLogs
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional node-local Talos log collector (via system bundle packages) that forwards Talos service and kernel logs over loopback to the platform log ingestion endpoint.
  * Introduced the collector Helm chart (Vector-based) with configurable log level, loopback TCP receive port, digest-pinned image, default resources, and routing target.
  * Added conditional Cilium network policy support with a safe deny-by-default fallback.
* **Security**
  * Hardened the collector to run non-root with reduced privileges, read-only filesystem, and dropped Linux capabilities (and disabled service account token automount).
* **Documentation**
  * Documented configuration requirements (including kernel log enablement), operational behavior, and teardown steps.
* **Build & Release**
  * Extended the build to include building the collector’s image.
* **Tests**
  * Added Helm rendering/contract tests covering daemonset, configmap, service account, and network policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->