### PR TITLE
fix(platform): make etcd v1alpha2 adoption (migration 50) robust in-cluster

### DIFF
--- a/hack/migration-50-etcd-adopt.bats
+++ b/hack/migration-50-etcd-adopt.bats
@@ -289,3 +289,53 @@ lineno() {
   ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }
+
+@test "cert SAN check is exact: a superstring dnsName does not skip the re-issue patch" {
+  prep
+  # The Certificate's spec.dnsNames already carries *.etcd.<ns>.svc.cluster.local,
+  # which CONTAINS the native wildcard *.etcd.<ns>.svc as a substring but is not
+  # an exact match. A substring match (the bug) would treat the wildcard as
+  # already present and skip the patch; the exact match must still re-issue.
+  export FAKE_CERTS=1
+  export FAKE_CERT_SUPERSTRING=1
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  # Both Certificates are still patched despite the substring-only SAN.
+  grep -qF -- "PATCH-CERT etcd-server" "$FAKE_CMDLOG"
+  grep -qF -- "PATCH-CERT etcd-peer" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "etcd-migrate authenticates via a synthesized in-cluster kubeconfig at kubernetes.default.svc" {
+  prep
+  # etcd-migrate only reads a kubeconfig FILE (no in-cluster SA fallback), so the
+  # script synthesizes one from the mounted ServiceAccount. Point the SA dir at a
+  # fixture and capture the written kubeconfig.
+  sa="$WORK/sa"; mkdir -p "$sa"
+  printf 'faketoken'   > "$sa/token"
+  printf 'fakeca'      > "$sa/ca.crt"
+  printf 'cozy-system' > "$sa/namespace"
+  export ETCD_ADOPT_SA_DIR="$sa"
+  export ETCD_MIGRATE_KUBECONFIG="$WORK/in-cluster.kubeconfig"
+  # A bare IPv6 host that must NOT end up in the (unbracketed, invalid) server URL.
+  export KUBERNETES_SERVICE_HOST="fd00::1"
+  export KUBERNETES_SERVICE_PORT="443"
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  # Both the dry-run and --apply invocations carry --kubeconfig=<synthesized>.
+  [ "$(grep -cF -- "--kubeconfig=$WORK/in-cluster.kubeconfig" "$FAKE_CMDLOG")" -ge 2 ]
+  # The kubeconfig is IP-family-agnostic (DNS name, not the bare IPv6 host) and
+  # authenticates via the SA token file + CA.
+  [ -s "$ETCD_MIGRATE_KUBECONFIG" ]
+  grep -qF -- "server: https://kubernetes.default.svc" "$ETCD_MIGRATE_KUBECONFIG"
+  ! grep -qF -- "fd00::1" "$ETCD_MIGRATE_KUBECONFIG"
+  grep -qF -- "tokenFile: $sa/token" "$ETCD_MIGRATE_KUBECONFIG"
+  grep -qF -- "certificate-authority: $sa/ca.crt" "$ETCD_MIGRATE_KUBECONFIG"
+  rm -rf "$WORK"
+}

--- a/hack/testdata/migration-50/kubectl
+++ b/hack/testdata/migration-50/kubectl
@@ -69,6 +69,20 @@ case "$args" in
     cert="$(arg_after certificate.cert-manager.io "$@")"
     : > "$state_dir/reissued-${cert}-tls"
     log "PATCH-CERT $cert"; exit 0 ;;
+  # jsonpath '{.spec.dnsNames[*]}' probe used by _san_present: emit a
+  # SPACE-separated SAN list (matches real kubectl jsonpath[*] output), NOT the
+  # -o json blob below. FAKE_CERT_SUPERSTRING=1 injects a longer SAN that
+  # CONTAINS the native wildcard as a substring (*.etcd.<ns>.svc inside
+  # *.etcd.<ns>.svc.cluster.local) but is not an exact match — exercises the
+  # exact-match guard (a substring match would wrongly skip the re-issue patch).
+  *"get certificate.cert-manager.io"*"dnsNames"*)
+    ns="$(arg_after -n "$@")"
+    if [ "${FAKE_CERT_SUPERSTRING:-0}" = "1" ]; then
+      printf 'etcd etcd.%s.svc *.etcd.%s.svc.cluster.local\n' "$ns" "$ns"
+    else
+      printf 'etcd etcd.%s.svc\n' "$ns"
+    fi
+    exit 0 ;;
   *"get certificate.cert-manager.io"*"-o json"*)
     ns="$(arg_after -n "$@")"
     printf '{"spec":{"dnsNames":["etcd","etcd.%s.svc"]}}\n' "$ns"; exit 0 ;;

--- a/packages/core/platform/images/migrations/migrations/50
+++ b/packages/core/platform/images/migrations/migrations/50
@@ -114,6 +114,33 @@ CREDS_TENANT_LABEL="internal.cozystack.io/tenantresource"
 # templates declare only the short forms, so adding FQDN SANs here would be
 # stripped on the next HelmRelease reconcile — adoption and chart output must
 # converge to the same fixed point on the cert SANs.
+# _san_present <ns> <secret> <cert> <native>
+# Returns 0 iff <native> is present in the issued Secret's cert-manager.io/alt-names
+# annotation OR the Certificate's spec.dnsNames (the source of truth for the SANs
+# cert-manager will issue). ROBUSTNESS: a plain `kubectl get ... 2>/dev/null` can
+# transiently return an EMPTY string on an API hiccup (discovery refresh, apiserver
+# blip, throttling), which is indistinguishable from "SAN genuinely absent" and
+# makes a correctly-configured cert look missing — the failure mode that wedges the
+# cert wait below. Neither field is ever legitimately empty on a real object, so we
+# treat an empty read from BOTH sources as a transient error and retry, only
+# trusting a non-empty read to decide presence/absence.
+_san_present() {
+  local ns="$1" secret="$2" cert="$3" native="$4" a d try
+  for try in 1 2 3 4 5; do
+    a=$(kubectl -n "$ns" get secret "$secret" \
+          -o jsonpath='{.metadata.annotations.cert-manager\.io/alt-names}' 2>/dev/null || true)
+    d=$(kubectl -n "$ns" get certificate.cert-manager.io "$cert" \
+          -o jsonpath='{.spec.dnsNames}' 2>/dev/null || true)
+    if [ -n "$a" ] || [ -n "$d" ]; then
+      printf '%s' "$a" | tr ',' '\n' | grep -qxF "$native" && return 0
+      printf '%s' "$d" | tr ',' '\n' | grep -qF  "$native" && return 0
+      return 1
+    fi
+    sleep 1
+  done
+  return 1
+}
+
 ensure_wildcard_sans() {
   local ns="$1" name="$2"
   local native="*.${name}.${ns}.svc"
@@ -129,9 +156,7 @@ ensure_wildcard_sans() {
       echo "  - ${ns}/${cert}: Certificate not found; skipping (operator-managed or already pruned)"
       continue
     fi
-    if kubectl -n "$ns" get secret "$secret" \
-         -o jsonpath='{.metadata.annotations.cert-manager\.io/alt-names}' 2>/dev/null \
-         | tr ',' '\n' | grep -qxF "$native"; then
+    if _san_present "$ns" "$secret" "$cert" "$native"; then
       echo "  - ${ns}/${cert}: native wildcard already present; nothing to do"
       continue
     fi
@@ -148,9 +173,7 @@ ensure_wildcard_sans() {
     # Wait for cert-manager to re-issue the Secret with the new SANs.
     local i
     for i in $(seq 1 30); do
-      if kubectl -n "$ns" get secret "$secret" \
-           -o jsonpath='{.metadata.annotations.cert-manager\.io/alt-names}' 2>/dev/null \
-           | tr ',' '\n' | grep -qxF "$native"; then
+      if _san_present "$ns" "$secret" "$cert" "$native"; then
         echo "    ${ns}/${secret}: re-issued with native wildcard"
         break
       fi
@@ -331,9 +354,39 @@ if [ "$LEGACY_COUNT" -gt 0 ]; then
     -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null)
 fi
 
+# etcd-migrate (unlike kubectl) does NOT fall back to the in-cluster
+# ServiceAccount: it only reads a kubeconfig FILE (-k/--kubeconfig, default
+# /root/.kube/config), which does not exist in this Job pod. Synthesize one from
+# the mounted ServiceAccount so etcd-migrate authenticates as the hook SA.
+ETCD_MIGRATE_KUBECONFIG="/tmp/in-cluster.kubeconfig"
+_sa_dir="/var/run/secrets/kubernetes.io/serviceaccount"
+if [ ! -f "$ETCD_MIGRATE_KUBECONFIG" ] && [ -f "$_sa_dir/token" ]; then
+  cat > "$ETCD_MIGRATE_KUBECONFIG" <<KUBECONFIG_EOF
+apiVersion: v1
+kind: Config
+clusters:
+- name: in-cluster
+  cluster:
+    certificate-authority: ${_sa_dir}/ca.crt
+    server: https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT:-443}
+contexts:
+- name: in-cluster
+  context:
+    cluster: in-cluster
+    user: sa
+    namespace: $(cat "$_sa_dir/namespace")
+current-context: in-cluster
+users:
+- name: sa
+  user:
+    tokenFile: ${_sa_dir}/token
+KUBECONFIG_EOF
+fi
+
 # Always show the plan first.
 echo "=== etcd-migrate dry-run ==="
 etcd-migrate \
+  --kubeconfig="${ETCD_MIGRATE_KUBECONFIG}" \
   --new-controller="${ETCD_OPERATOR_NS}/${ETCD_OPERATOR_DEPLOY}" \
   --skip-controller-check || true
 
@@ -379,6 +432,7 @@ if [ "$LEGACY_COUNT" -gt 0 ]; then
   # 0 is still the LEGACY operator, so resolveAgentImage would otherwise bake the
   # wrong (aenix) image into the snapshot Job.
   etcd-migrate --apply --yes \
+    --kubeconfig="${ETCD_MIGRATE_KUBECONFIG}" \
     --new-controller="${ETCD_OPERATOR_NS}/${ETCD_OPERATOR_DEPLOY}" \
     --skip-controller-check \
     --agent-image="${ETCD_OPERATOR_IMAGE}" \

--- a/packages/core/platform/images/migrations/migrations/50
+++ b/packages/core/platform/images/migrations/migrations/50
@@ -129,12 +129,40 @@ _san_present() {
   for try in 1 2 3 4 5; do
     a=$(kubectl -n "$ns" get secret "$secret" \
           -o jsonpath='{.metadata.annotations.cert-manager\.io/alt-names}' 2>/dev/null || true)
+    # {.spec.dnsNames[*]} yields a SPACE-separated list (one SAN per token);
+    # {.spec.dnsNames} would be a bracketed JSON blob that tr ',' cannot split,
+    # forcing a substring match. Split on spaces and match EXACTLY (grep -qxF) —
+    # same as the Secret annotation above — so a wildcard that is a substring of
+    # a longer SAN (e.g. *.etcd.<ns>.svc inside *.etcd.<ns>.svc.cluster.local)
+    # cannot false-positive and skip the patch.
     d=$(kubectl -n "$ns" get certificate.cert-manager.io "$cert" \
-          -o jsonpath='{.spec.dnsNames}' 2>/dev/null || true)
+          -o jsonpath='{.spec.dnsNames[*]}' 2>/dev/null || true)
     if [ -n "$a" ] || [ -n "$d" ]; then
       printf '%s' "$a" | tr ',' '\n' | grep -qxF "$native" && return 0
-      printf '%s' "$d" | tr ',' '\n' | grep -qF  "$native" && return 0
+      printf '%s' "$d" | tr ' ' '\n' | grep -qxF "$native" && return 0
       return 1
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# _secret_has_san: exact-match check that $native is listed in the ISSUED
+# Secret's cert-manager alt-names annotation — the authoritative record of what
+# cert-manager has actually issued. Unlike _san_present it does NOT consult the
+# Certificate spec.dnsNames: after we patch the spec below, the spec carries the
+# wildcard immediately, but the Secret is only re-issued once cert-manager
+# reconciles; the wait loop must gate on the SECRET, not on the value we just
+# wrote. Same empty-read retry rationale as _san_present (a real issued Secret
+# never has an empty alt-names annotation), and the same exact grep -qxF match.
+_secret_has_san() {
+  local ns="$1" secret="$2" native="$3" a try
+  for try in 1 2 3 4 5; do
+    a=$(kubectl -n "$ns" get secret "$secret" \
+          -o jsonpath='{.metadata.annotations.cert-manager\.io/alt-names}' 2>/dev/null || true)
+    if [ -n "$a" ]; then
+      printf '%s' "$a" | tr ',' '\n' | grep -qxF "$native"
+      return
     fi
     sleep 1
   done
@@ -173,8 +201,8 @@ ensure_wildcard_sans() {
     # Wait for cert-manager to re-issue the Secret with the new SANs.
     local i
     for i in $(seq 1 30); do
-      if _san_present "$ns" "$secret" "$cert" "$native"; then
-        echo "    ${ns}/${secret}: re-issued with native wildcard"
+      if _secret_has_san "$ns" "$secret" "$native"; then
+        echo "    ${ns}/${secret}: re-issued Secret now carries the native wildcard"
         break
       fi
       [ "$i" = "30" ] && { echo "    ERROR: ${ns}/${secret} not re-issued with ${native} in time" >&2; exit 1; }
@@ -358,9 +386,14 @@ fi
 # ServiceAccount: it only reads a kubeconfig FILE (-k/--kubeconfig, default
 # /root/.kube/config), which does not exist in this Job pod. Synthesize one from
 # the mounted ServiceAccount so etcd-migrate authenticates as the hook SA.
-ETCD_MIGRATE_KUBECONFIG="/tmp/in-cluster.kubeconfig"
-_sa_dir="/var/run/secrets/kubernetes.io/serviceaccount"
+ETCD_MIGRATE_KUBECONFIG="${ETCD_MIGRATE_KUBECONFIG:-/tmp/in-cluster.kubeconfig}"
+_sa_dir="${ETCD_ADOPT_SA_DIR:-/var/run/secrets/kubernetes.io/serviceaccount}"
 if [ ! -f "$ETCD_MIGRATE_KUBECONFIG" ] && [ -f "$_sa_dir/token" ]; then
+  # server is the in-cluster DNS name, NOT https://$KUBERNETES_SERVICE_HOST:PORT:
+  # on an IPv6-only cluster KUBERNETES_SERVICE_HOST is a bare IPv6 address that
+  # would need bracketing to be a valid URL. kubernetes.default.svc is
+  # IP-family-agnostic, resolves in-cluster, and is validated by the mounted SA
+  # CA — the same server URL kubectl itself synthesizes in-cluster.
   cat > "$ETCD_MIGRATE_KUBECONFIG" <<KUBECONFIG_EOF
 apiVersion: v1
 kind: Config
@@ -368,7 +401,7 @@ clusters:
 - name: in-cluster
   cluster:
     certificate-authority: ${_sa_dir}/ca.crt
-    server: https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT:-443}
+    server: https://kubernetes.default.svc
 contexts:
 - name: in-cluster
   context:


### PR DESCRIPTION
Migration 50 (etcd.aenix.io -> etcd-operator.cozystack.io/v1alpha2 adoption) had two defects that blocked every in-cluster 1.5 -> 1.6 upgrade on a cluster with an existing etcd:

1. Cert-SAN wait treated transient kubectl failures as "SAN absent". ensure_wildcard_sans checked/awaited the wildcard SAN with `kubectl get ... 2>/dev/null | grep`, so any transient GET failure (API discovery refresh, apiserver blip, throttling) produced an empty string indistinguishable from a genuine absence -> false miss, and the 120s wait never recovered. Replace the two ad-hoc checks with a _san_present helper that retries on an empty read (a real Certificate/Secret never has empty dnsNames/alt-names) and accepts the native wildcard from EITHER the issued Secret's cert-manager.io/alt-names annotation OR the Certificate spec.dnsNames (the source of truth for what cert-manager will issue).

2. etcd-migrate had no kubeconfig in-cluster. etcd-migrate only reads a kubeconfig file (-k/--kubeconfig, default /root/.kube/config) and, unlike kubectl, does not fall back to the mounted in-cluster ServiceAccount. The hook Job set no KUBECONFIG and passed no --kubeconfig, so both the dry-run and --apply aborted with "error building kubeconfig: stat /root/.kube/config: no such file". Synthesize an in-cluster kubeconfig from the mounted ServiceAccount and pass --kubeconfig to both etcd-migrate invocations.

Verified end-to-end on a 1.5.2 -> 1.6.0-rc.1 upgrade: the adoption now completes in-place (pods never restarted, data intact) and the cluster reaches readyMembers=3 / Available=True.

Refs: #3243, #3255

<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does


### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of wildcard SAN detection by validating against both cert-manager sources and retrying when reads are temporarily empty.
  * Updated Secret-based SAN presence checks to retry on missing annotation data and require an exact match for the native wildcard.
  * Fixed migration authentication by generating a kubeconfig for `etcd-migrate` from the hook Pod’s ServiceAccount credentials, including during dry-run and apply.
* **Tests**
  * Added end-to-end coverage for exact wildcard SAN matching behavior and kubeconfig generation/authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->