### PR TITLE
fix(etcd): against bugs to v1alpha2 transition

### DIFF
--- a/packages/extra/etcd/templates/etcd-cluster.yaml
+++ b/packages/extra/etcd/templates/etcd-cluster.yaml
@@ -275,3 +275,50 @@ spec:
     app.kubernetes.io/managed-by: etcd-operator
     app.kubernetes.io/name: etcd
   version: {{ $.Chart.Version }}
+---
+# Transitional headless Service backing the LEGACY per-pod DNS names.
+#
+# `etcd-migrate` adopts legacy clusters IN PLACE — the existing Pods are never
+# recreated, so they keep their original `spec.subdomain: etcd-headless` (and
+# hostname etcd-<i>). Their stable DNS name therefore stays
+# `etcd-<i>.etcd-headless.<ns>.svc`, which the v1alpha2 operator dials for
+# MemberList/health until the members are eventually rolled onto its native
+# `<member>.etcd.<ns>.svc` domain (served by the operator-owned `etcd` Service).
+#
+# The v1alpha2 operator only creates the native `etcd` Service, and the legacy
+# `etcd-headless` Service (previously owned by the old operator) is pruned during
+# the transition. Without a Service named `etcd-headless`, the adopted Pods'
+# `etcd-<i>.etcd-headless.<ns>.svc` records stop resolving (`no such host`),
+# MemberList fails, and status.readyMembers never populates — the cluster never
+# goes Ready even though the etcd processes are healthy and in quorum. This is
+# the DNS counterpart of the legacy `*.etcd-headless.<ns>.svc` wildcard kept in
+# the server/peer cert SANs above for the same transition window.
+#
+# Selector mirrors the operator's native `etcd` Service
+# (etcd-operator.cozystack.io/cluster), so this resolves the same member Pods;
+# publishNotReadyAddresses keeps peer discovery working while a member is not
+# yet Ready. Safe to remove — together with the legacy cert SAN — once the
+# members have been rolled onto the native `etcd` subdomain.
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: etcd
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    cozystack.io/service: etcd
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    etcd-operator.cozystack.io/cluster: etcd
+  ports:
+  - name: client
+    port: 2379
+    targetPort: 2379
+    protocol: TCP
+  - name: peer
+    port: 2380
+    targetPort: 2380
+    protocol: TCP

--- a/packages/system/etcd-operator/templates/pre-upgrade-selector-fix.yaml
+++ b/packages/system/etcd-operator/templates/pre-upgrade-selector-fix.yaml
@@ -1,0 +1,145 @@
+{{- /*
+Pre-upgrade selector migration for the controller-manager Deployment.
+
+1.6 replaced the upstream etcd-operator chart with the cozystack-authored one
+(#2859), changing the Deployment's spec.selector.matchLabels:
+
+  1.5: {app.kubernetes.io/instance: etcd-operator, app.kubernetes.io/name: etcd-operator}
+  1.6: {app.kubernetes.io/name: etcd-operator, control-plane: controller-manager}
+
+spec.selector is immutable, so `helm upgrade` cannot patch the existing
+Deployment and the whole HelmRelease upgrade fails ("field is immutable") — the
+operator (and the v1alpha2 CRDs it serves) never come up, which blocks the etcd
+v1alpha2 adoption. Fresh installs use the new selector directly and are
+unaffected, so fresh-install CI does not catch it. See cozystack/cozystack#3242.
+
+This pre-upgrade hook deletes the Deployment ONLY when its live selector is the
+pre-1.6 one (i.e. lacks control-plane=controller-manager), so Helm recreates it
+cleanly with the new selector. It is a no-op when the selector already matches
+(rc.1 -> later upgrades) and never runs on a fresh install (pre-upgrade only).
+Keeping the selector stable in the chart is NOT an option: rc.1 already shipped
+the new selector, so aligning it back would merely move the immutable break to
+rc.1 -> next.
+*/}}
+{{- $name := "etcd-operator-selector-fix" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: etcd-operator
+    app.kubernetes.io/component: selector-fix-hook
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed,before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: etcd-operator
+    app.kubernetes.io/component: selector-fix-hook
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed,before-hook-creation
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: etcd-operator
+    app.kubernetes.io/component: selector-fix-hook
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: etcd-operator
+    app.kubernetes.io/component: selector-fix-hook
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "0"
+    # Keep a failed Job's Pod around for `kubectl logs`; reap the whole hook
+    # bundle on success. before-hook-creation clears a prior run first.
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+spec:
+  activeDeadlineSeconds: 120
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: etcd-operator
+        app.kubernetes.io/component: selector-fix-hook
+    spec:
+      serviceAccountName: {{ $name }}
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      # writable HOME so kubectl can create its discovery cache under
+      # readOnlyRootFilesystem=true (kubectl 1.30+ aborts otherwise).
+      volumes:
+        - name: home
+          emptyDir: {}
+      containers:
+        - name: selector-fix
+          image: "{{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}"
+          imagePullPolicy: {{ .Values.kubectlImage.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: HOME
+              value: /tmp
+          volumeMounts:
+            - name: home
+              mountPath: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              ns="{{ .Release.Namespace }}"
+              name=etcd-operator-controller-manager
+              if ! kubectl -n "$ns" get deployment "$name" >/dev/null 2>&1; then
+                echo "[selector-fix] Deployment $name absent; nothing to do."
+                exit 0
+              fi
+              cp="$(kubectl -n "$ns" get deployment "$name" \
+                    -o jsonpath='{.spec.selector.matchLabels.control-plane}' 2>/dev/null || true)"
+              if [ "$cp" = "controller-manager" ]; then
+                echo "[selector-fix] Deployment $name already has the v1.6 selector; nothing to do."
+                exit 0
+              fi
+              echo "[selector-fix] Deployment $name has a pre-1.6 spec.selector (immutable); deleting so the chart recreates it with the current selector."
+              kubectl -n "$ns" delete deployment "$name" --wait=true --timeout=90s
+              echo "[selector-fix] Deleted; the chart will recreate $name."

--- a/packages/system/etcd-operator/values.yaml
+++ b/packages/system/etcd-operator/values.yaml
@@ -20,18 +20,38 @@ resources:
     memory: 64Mi
   limits:
     cpu: 500m
-    memory: 128Mi
+    # Cold-start floor. This is the limit a freshly-created Pod runs under until
+    # the VPA admission webhook has had a chance to rewrite it (see vpa below).
+    # The manager's steady-state working set is ~250Mi (the VPA's own
+    # recommendation), so a 128Mi floor OOMKills the operator on any start where
+    # the webhook does not mutate the Pod in time — e.g. a Deployment recreated
+    # out of band, or the webhook briefly unavailable during an upgrade. Keep
+    # this at or above the observed working set so the operator never depends on
+    # VPA timing merely to avoid a crash loop; the VPA still scales it further
+    # under real load up to maxAllowed.
+    memory: 256Mi
 
 vpa:
   enabled: true
   updateMode: Auto
   minAllowed:
     cpu: 100m
-    memory: 128Mi
+    # Matches the cold-start limit floor above so the VPA never recommends BELOW
+    # the manager's ~250Mi working set.
+    memory: 256Mi
   # maxAllowed is the VPA's scaling CEILING, deliberately well above the static
-  # resources.limits above (128Mi): with updateMode: Auto the VPA rewrites the
+  # resources.limits above (256Mi): with updateMode: Auto the VPA rewrites the
   # Pod's request/limit up to this bound under real load. Do NOT "align" it down
-  # to the 128Mi limit — that would cap the autoscaler's headroom.
+  # to the 256Mi limit — that would cap the autoscaler's headroom.
   maxAllowed:
     cpu: 1000m
     memory: 1Gi
+
+# Image for the pre-upgrade selector-migration hook Job (see
+# templates/pre-upgrade-selector-fix.yaml). Only needs a kubectl binary. Pinned
+# by digest for reproducibility; clastix/kubectl is already used elsewhere in
+# cozystack (Kamaji).
+kubectlImage:
+  repository: docker.io/clastix/kubectl
+  tag: v1.32
+  pullPolicy: IfNotPresent


### PR DESCRIPTION
## What this PR does

Completes the etcd `v1alpha2` transition (#2859) by fixing the three remaining blockers that surface on an **in-cluster 1.5 → 1.6 upgrade** of a cluster that already has an etcd. Fresh installs use the new shapes directly and are unaffected, so fresh-install CI does not catch these. Scope is limited to the etcd charts; the sibling migration-script fixes (#3243 cert-SAN wait, #3255 in-cluster kubeconfig) are in #3261.

### 1. Keep the legacy `etcd-headless` Service alive during adoption — `packages/extra/etcd`
`etcd-migrate` adopts legacy clusters **in place**: the Pods are never recreated, so they keep their original `spec.subdomain: etcd-headless` and are dialed at `etcd-<i>.etcd-headless.<ns>.svc` until they eventually roll onto the operator's native `<member>.etcd.<ns>.svc` domain. The v1alpha2 operator only creates the native `etcd` Service, and the legacy `etcd-headless` Service (previously owned by the old operator) is pruned during the transition — so those per-pod names stop resolving (`no such host`), the operator's `MemberList` fails, and `status.readyMembers` never populates. The `EtcdCluster` then never goes `Ready` even though the etcd processes are healthy and in quorum.

We ship a chart-managed transitional headless `etcd-headless` Service (selector mirrors the operator's native `etcd` Service via `etcd-operator.cozystack.io/cluster`, `publishNotReadyAddresses: true`). This is the DNS counterpart of the legacy `*.etcd-headless.<ns>.svc` wildcard already kept in the server/peer cert SANs for the same transition window — the TLS half of the compat was done, the DNS half was missing. Safe to remove, together with that SAN, once members have rolled onto the native subdomain.

### 2. Survive the immutable controller-Deployment selector on upgrade — `packages/system/etcd-operator` (#3242)
#2859 replaced the upstream etcd-operator chart with the cozystack-authored one, changing `Deployment.spec.selector.matchLabels` (`{instance,name}` → `{name,control-plane}`). `spec.selector` is immutable, so `helm upgrade` cannot patch the existing Deployment and the whole HelmRelease upgrade fails (`field is immutable`) — the operator and the v1alpha2 CRDs it serves never come up, which blocks the etcd adoption.

A **pre-upgrade hook** (`templates/pre-upgrade-selector-fix.yaml`: ServiceAccount + Role + RoleBinding + Job) deletes the Deployment **only** when its live selector is the pre-1.6 one (lacks `control-plane=controller-manager`), so Helm recreates it cleanly. It is a no-op when the selector already matches (rc.1 → later upgrades) and never runs on a fresh install (pre-upgrade only). Keeping the selector stable in the chart is not viable — rc.1 already shipped the new selector, which would only move the immutable break to rc.1 → next.

### 3. Raise the operator's memory cold-start floor — `packages/system/etcd-operator`
The controller manager's steady-state working set is ~250Mi (the VPA's own recommendation); the static `limits.memory: 128Mi` OOMKills a Pod that starts before the VPA admission webhook rewrites it (e.g. a Deployment recreated out of band, or the webhook briefly unavailable during an upgrade). Raise the floor to `256Mi` (and VPA `minAllowed` to match) as defense in depth so the operator never depends on VPA timing merely to avoid crashing; the VPA still scales it further under load up to `maxAllowed`.

### Verification
- `helm unittest` (etcd-operator) green; both charts render cleanly (`helm template`).
- Behaviours 1 & 2 were reproduced and their fixes confirmed live on a 1.5.2 → 1.6.0-rc.1 adoption (3-node cluster) — recreating the `etcd-headless` Service took the adopted cluster to `readyMembers=3 / Available=True`. The authoritative regression guard is the 1.5 → 1.6 e2e upgrade path.

### Release note

```release-note
fix(etcd): complete the v1alpha2 transition on in-cluster 1.5→1.6 upgrades — keep the legacy etcd-headless Service alive so adopted members stay resolvable, delete the pre-1.6 operator Deployment via a pre-upgrade hook to get past the immutable selector, and raise the operator's memory floor so it does not OOM before the VPA scales it.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compatibility service for etcd pods to preserve legacy per-pod DNS access during upgrades.
  * Introduced an automated upgrade step to help recover from selector mismatches and keep upgrades moving.

* **Bug Fixes**
  * Improved etcd-operator upgrade reliability by handling immutable deployment selector changes automatically.
  * Increased the controller manager’s baseline memory to reduce cold-start issues and align resource recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
