### PR TITLE
fix(etcd): complete v1alpha2 transition for in-cluster 1.5→1.6 upgrades

### DIFF
--- a/docs/operations/backup-classes.md
+++ b/docs/operations/backup-classes.md
@@ -27,7 +27,7 @@ The FoundationDB strategy CR is rendered by the chart so admins can reference it
 
 ### Endpoint format per driver
 
-Different operators expect different endpoint shapes; the strategy templates rendered by `backupstrategy-controller` adapt the single `backupStorage.endpoint` value (a full URL like `http://seaweedfs-s3.tenant-root.svc:8333`) to each consumer's contract:
+Different operators expect different endpoint shapes; the strategy templates rendered by `backupstrategy-controller` resolve one S3 endpoint (via the `backupstrategy-controller.endpoint` helper) and adapt it to each consumer's contract. For a provisioned bucket (`provisionBucket: true`, the default) the endpoint is **derived from the COSI bucket's system-credentials Secret** (`backupStorage.systemSecretName`) and forced to `https://` — the external S3 ingress with an ACME cert, the only endpoint the backup operators can verify. SeaweedFS's in-cluster S3 serves TLS on `:8333` behind the self-signed "SeaweedFS CA", and the Etcd Strategy S3 schema has no `caCert` field, so the in-cluster endpoint cannot be targeted directly. The `backupStorage.endpoint` chart value (a full URL like `http://seaweedfs-s3.tenant-root.svc:8333`) is the **fallback**, used for external S3 (`provisionBucket: false`) and for offline `helm template`/pre-reconcile renders where the Secret lookup returns nothing. The resolved endpoint is adapted per consumer:
 
 | Driver | Strategy template field | Form |
 |--------|-------------------------|------|
@@ -38,7 +38,7 @@ Different operators expect different endpoint shapes; the strategy templates ren
 | Velero          | `BackupStorageLocation.spec.config.s3Url` | full URL (scheme preserved) |
 | ClickHouse sidecar | `S3_ENDPOINT` env | bare host:port (from projected Secret) |
 
-The projected `cozy-backups-creds.endpoint` key is **stripped of scheme** so chart-emitted sidecars (ClickHouse) consume it directly. Drivers that need the full URL pull from `backupStorage.endpoint` in chart values, not from the Secret.
+The projected `cozy-backups-creds.endpoint` key is **stripped of scheme** so chart-emitted sidecars (ClickHouse) consume it directly. Drivers that need the full URL receive the resolved endpoint described above — derived from the COSI system Secret (forced `https://`) for a provisioned bucket, or the `backupStorage.endpoint` fallback for external S3.
 
 VM-driven (Velero) backups land in the same `cozy-backups` bucket under the `velero/` prefix. A `BackupStorageLocation` named `cozy-default` is shipped by the `backupstrategy-controller` chart (`packages/system/backupstrategy-controller/templates/velero-bsl.yaml`) so endpoint/bucket/region come from the same `backupStorage` values block used by Strategy CRs and the projector.
 
@@ -135,7 +135,7 @@ spec:
 | `provisionBucket` | Toggle creation of the in-cluster `apps.cozystack.io/Bucket` CR. Set `false` for external S3 (see [Disabling the platform-managed bucket](#disabling-the-platform-managed-bucket)). |
 | `bucketName` | K8s name of the Bucket CR + lookup key for the COSI BucketClaim. The actual S3 bucket name is the COSI-assigned UUID, surfaced through `BucketClaim.status.bucketName`. |
 | `bucketNameOverride` | Escape hatch for offline `helm template` renders — bypasses the live-cluster BucketClaim lookup. Leave empty in production. |
-| `endpoint` | S3 endpoint baked into every default strategy CR + the Velero BSL. Switching to `https://` silently enables TLS in the MariaDB strategy — ensure the CA bundle is reachable to the relevant operator/driver Pods before flipping it. |
+| `endpoint` | **Fallback** S3 endpoint. For a provisioned bucket the strategy CRs + Velero BSL derive the endpoint from the COSI system Secret (external ACME ingress, forced `https://`) instead; this value is used only for external S3 (`provisionBucket: false`) and offline renders. For external S3, switching it to `https://` enables TLS in the MariaDB/FoundationDB strategies — ensure the CA bundle is reachable to the relevant operator/driver Pods first. |
 | `region` | Re-projected into `cozy-backups-creds` on the next reconcile. Pod-restart required for chart-emitted clients consuming the region via env (ClickHouse sidecar today). |
 | `forcePathStyle` | Path-style addressing; SeaweedFS S3 requires it, AWS S3 typically doesn't. |
 | `systemSecretName` | Name of the human-friendly Secret produced by the Bucket app (or pre-created manually for external S3). The projector also accepts the raw COSI Secret format. |

--- a/hack/migration-50-etcd-adopt.bats
+++ b/hack/migration-50-etcd-adopt.bats
@@ -289,3 +289,53 @@ lineno() {
   ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }
+
+@test "cert SAN check is exact: a superstring dnsName does not skip the re-issue patch" {
+  prep
+  # The Certificate's spec.dnsNames already carries *.etcd.<ns>.svc.cluster.local,
+  # which CONTAINS the native wildcard *.etcd.<ns>.svc as a substring but is not
+  # an exact match. A substring match (the bug) would treat the wildcard as
+  # already present and skip the patch; the exact match must still re-issue.
+  export FAKE_CERTS=1
+  export FAKE_CERT_SUPERSTRING=1
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  # Both Certificates are still patched despite the substring-only SAN.
+  grep -qF -- "PATCH-CERT etcd-server" "$FAKE_CMDLOG"
+  grep -qF -- "PATCH-CERT etcd-peer" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "etcd-migrate authenticates via a synthesized in-cluster kubeconfig at kubernetes.default.svc" {
+  prep
+  # etcd-migrate only reads a kubeconfig FILE (no in-cluster SA fallback), so the
+  # script synthesizes one from the mounted ServiceAccount. Point the SA dir at a
+  # fixture and capture the written kubeconfig.
+  sa="$WORK/sa"; mkdir -p "$sa"
+  printf 'faketoken'   > "$sa/token"
+  printf 'fakeca'      > "$sa/ca.crt"
+  printf 'cozy-system' > "$sa/namespace"
+  export ETCD_ADOPT_SA_DIR="$sa"
+  export ETCD_MIGRATE_KUBECONFIG="$WORK/in-cluster.kubeconfig"
+  # A bare IPv6 host that must NOT end up in the (unbracketed, invalid) server URL.
+  export KUBERNETES_SERVICE_HOST="fd00::1"
+  export KUBERNETES_SERVICE_PORT="443"
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  # Both the dry-run and --apply invocations carry --kubeconfig=<synthesized>.
+  [ "$(grep -cF -- "--kubeconfig=$WORK/in-cluster.kubeconfig" "$FAKE_CMDLOG")" -ge 2 ]
+  # The kubeconfig is IP-family-agnostic (DNS name, not the bare IPv6 host) and
+  # authenticates via the SA token file + CA.
+  [ -s "$ETCD_MIGRATE_KUBECONFIG" ]
+  grep -qF -- "server: https://kubernetes.default.svc" "$ETCD_MIGRATE_KUBECONFIG"
+  ! grep -qF -- "fd00::1" "$ETCD_MIGRATE_KUBECONFIG"
+  grep -qF -- "tokenFile: $sa/token" "$ETCD_MIGRATE_KUBECONFIG"
+  grep -qF -- "certificate-authority: $sa/ca.crt" "$ETCD_MIGRATE_KUBECONFIG"
+  rm -rf "$WORK"
+}

--- a/hack/testdata/migration-50/kubectl
+++ b/hack/testdata/migration-50/kubectl
@@ -69,6 +69,20 @@ case "$args" in
     cert="$(arg_after certificate.cert-manager.io "$@")"
     : > "$state_dir/reissued-${cert}-tls"
     log "PATCH-CERT $cert"; exit 0 ;;
+  # jsonpath '{.spec.dnsNames[*]}' probe used by _san_present: emit a
+  # SPACE-separated SAN list (matches real kubectl jsonpath[*] output), NOT the
+  # -o json blob below. FAKE_CERT_SUPERSTRING=1 injects a longer SAN that
+  # CONTAINS the native wildcard as a substring (*.etcd.<ns>.svc inside
+  # *.etcd.<ns>.svc.cluster.local) but is not an exact match — exercises the
+  # exact-match guard (a substring match would wrongly skip the re-issue patch).
+  *"get certificate.cert-manager.io"*"dnsNames"*)
+    ns="$(arg_after -n "$@")"
+    if [ "${FAKE_CERT_SUPERSTRING:-0}" = "1" ]; then
+      printf 'etcd etcd.%s.svc *.etcd.%s.svc.cluster.local\n' "$ns" "$ns"
+    else
+      printf 'etcd etcd.%s.svc\n' "$ns"
+    fi
+    exit 0 ;;
   *"get certificate.cert-manager.io"*"-o json"*)
     ns="$(arg_after -n "$@")"
     printf '{"spec":{"dnsNames":["etcd","etcd.%s.svc"]}}\n' "$ns"; exit 0 ;;

--- a/packages/core/platform/images/migrations/migrations/50
+++ b/packages/core/platform/images/migrations/migrations/50
@@ -114,6 +114,33 @@ CREDS_TENANT_LABEL="internal.cozystack.io/tenantresource"
 # templates declare only the short forms, so adding FQDN SANs here would be
 # stripped on the next HelmRelease reconcile — adoption and chart output must
 # converge to the same fixed point on the cert SANs.
+# _san_present <ns> <secret> <cert> <native>
+# Returns 0 iff <native> is present in the issued Secret's cert-manager.io/alt-names
+# annotation OR the Certificate's spec.dnsNames (the source of truth for the SANs
+# cert-manager will issue). ROBUSTNESS: a plain `kubectl get ... 2>/dev/null` can
+# transiently return an EMPTY string on an API hiccup (discovery refresh, apiserver
+# blip, throttling), which is indistinguishable from "SAN genuinely absent" and
+# makes a correctly-configured cert look missing — the failure mode that wedges the
+# cert wait below. Neither field is ever legitimately empty on a real object, so we
+# treat an empty read from BOTH sources as a transient error and retry, only
+# trusting a non-empty read to decide presence/absence.
+_san_present() {
+  local ns="$1" secret="$2" cert="$3" native="$4" a d try
+  for try in 1 2 3 4 5; do
+    a=$(kubectl -n "$ns" get secret "$secret" \
+          -o jsonpath='{.metadata.annotations.cert-manager\.io/alt-names}' 2>/dev/null || true)
+    d=$(kubectl -n "$ns" get certificate.cert-manager.io "$cert" \
+          -o jsonpath='{.spec.dnsNames}' 2>/dev/null || true)
+    if [ -n "$a" ] || [ -n "$d" ]; then
+      printf '%s' "$a" | tr ',' '\n' | grep -qxF "$native" && return 0
+      printf '%s' "$d" | tr ',' '\n' | grep -qF  "$native" && return 0
+      return 1
+    fi
+    sleep 1
+  done
+  return 1
+}
+
 ensure_wildcard_sans() {
   local ns="$1" name="$2"
   local native="*.${name}.${ns}.svc"
@@ -129,9 +156,7 @@ ensure_wildcard_sans() {
       echo "  - ${ns}/${cert}: Certificate not found; skipping (operator-managed or already pruned)"
       continue
     fi
-    if kubectl -n "$ns" get secret "$secret" \
-         -o jsonpath='{.metadata.annotations.cert-manager\.io/alt-names}' 2>/dev/null \
-         | tr ',' '\n' | grep -qxF "$native"; then
+    if _san_present "$ns" "$secret" "$cert" "$native"; then
       echo "  - ${ns}/${cert}: native wildcard already present; nothing to do"
       continue
     fi
@@ -148,9 +173,7 @@ ensure_wildcard_sans() {
     # Wait for cert-manager to re-issue the Secret with the new SANs.
     local i
     for i in $(seq 1 30); do
-      if kubectl -n "$ns" get secret "$secret" \
-           -o jsonpath='{.metadata.annotations.cert-manager\.io/alt-names}' 2>/dev/null \
-           | tr ',' '\n' | grep -qxF "$native"; then
+      if _san_present "$ns" "$secret" "$cert" "$native"; then
         echo "    ${ns}/${secret}: re-issued with native wildcard"
         break
       fi
@@ -331,9 +354,39 @@ if [ "$LEGACY_COUNT" -gt 0 ]; then
     -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' 2>/dev/null)
 fi
 
+# etcd-migrate (unlike kubectl) does NOT fall back to the in-cluster
+# ServiceAccount: it only reads a kubeconfig FILE (-k/--kubeconfig, default
+# /root/.kube/config), which does not exist in this Job pod. Synthesize one from
+# the mounted ServiceAccount so etcd-migrate authenticates as the hook SA.
+ETCD_MIGRATE_KUBECONFIG="/tmp/in-cluster.kubeconfig"
+_sa_dir="/var/run/secrets/kubernetes.io/serviceaccount"
+if [ ! -f "$ETCD_MIGRATE_KUBECONFIG" ] && [ -f "$_sa_dir/token" ]; then
+  cat > "$ETCD_MIGRATE_KUBECONFIG" <<KUBECONFIG_EOF
+apiVersion: v1
+kind: Config
+clusters:
+- name: in-cluster
+  cluster:
+    certificate-authority: ${_sa_dir}/ca.crt
+    server: https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT:-443}
+contexts:
+- name: in-cluster
+  context:
+    cluster: in-cluster
+    user: sa
+    namespace: $(cat "$_sa_dir/namespace")
+current-context: in-cluster
+users:
+- name: sa
+  user:
+    tokenFile: ${_sa_dir}/token
+KUBECONFIG_EOF
+fi
+
 # Always show the plan first.
 echo "=== etcd-migrate dry-run ==="
 etcd-migrate \
+  --kubeconfig="${ETCD_MIGRATE_KUBECONFIG}" \
   --new-controller="${ETCD_OPERATOR_NS}/${ETCD_OPERATOR_DEPLOY}" \
   --skip-controller-check || true
 
@@ -379,6 +432,7 @@ if [ "$LEGACY_COUNT" -gt 0 ]; then
   # 0 is still the LEGACY operator, so resolveAgentImage would otherwise bake the
   # wrong (aenix) image into the snapshot Job.
   etcd-migrate --apply --yes \
+    --kubeconfig="${ETCD_MIGRATE_KUBECONFIG}" \
     --new-controller="${ETCD_OPERATOR_NS}/${ETCD_OPERATOR_DEPLOY}" \
     --skip-controller-check \
     --agent-image="${ETCD_OPERATOR_IMAGE}" \

--- a/packages/core/platform/images/migrations/migrations/50
+++ b/packages/core/platform/images/migrations/migrations/50
@@ -129,12 +129,40 @@ _san_present() {
   for try in 1 2 3 4 5; do
     a=$(kubectl -n "$ns" get secret "$secret" \
           -o jsonpath='{.metadata.annotations.cert-manager\.io/alt-names}' 2>/dev/null || true)
+    # {.spec.dnsNames[*]} yields a SPACE-separated list (one SAN per token);
+    # {.spec.dnsNames} would be a bracketed JSON blob that tr ',' cannot split,
+    # forcing a substring match. Split on spaces and match EXACTLY (grep -qxF) —
+    # same as the Secret annotation above — so a wildcard that is a substring of
+    # a longer SAN (e.g. *.etcd.<ns>.svc inside *.etcd.<ns>.svc.cluster.local)
+    # cannot false-positive and skip the patch.
     d=$(kubectl -n "$ns" get certificate.cert-manager.io "$cert" \
-          -o jsonpath='{.spec.dnsNames}' 2>/dev/null || true)
+          -o jsonpath='{.spec.dnsNames[*]}' 2>/dev/null || true)
     if [ -n "$a" ] || [ -n "$d" ]; then
       printf '%s' "$a" | tr ',' '\n' | grep -qxF "$native" && return 0
-      printf '%s' "$d" | tr ',' '\n' | grep -qF  "$native" && return 0
+      printf '%s' "$d" | tr ' ' '\n' | grep -qxF "$native" && return 0
       return 1
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# _secret_has_san: exact-match check that $native is listed in the ISSUED
+# Secret's cert-manager alt-names annotation — the authoritative record of what
+# cert-manager has actually issued. Unlike _san_present it does NOT consult the
+# Certificate spec.dnsNames: after we patch the spec below, the spec carries the
+# wildcard immediately, but the Secret is only re-issued once cert-manager
+# reconciles; the wait loop must gate on the SECRET, not on the value we just
+# wrote. Same empty-read retry rationale as _san_present (a real issued Secret
+# never has an empty alt-names annotation), and the same exact grep -qxF match.
+_secret_has_san() {
+  local ns="$1" secret="$2" native="$3" a try
+  for try in 1 2 3 4 5; do
+    a=$(kubectl -n "$ns" get secret "$secret" \
+          -o jsonpath='{.metadata.annotations.cert-manager\.io/alt-names}' 2>/dev/null || true)
+    if [ -n "$a" ]; then
+      printf '%s' "$a" | tr ',' '\n' | grep -qxF "$native"
+      return
     fi
     sleep 1
   done
@@ -173,8 +201,8 @@ ensure_wildcard_sans() {
     # Wait for cert-manager to re-issue the Secret with the new SANs.
     local i
     for i in $(seq 1 30); do
-      if _san_present "$ns" "$secret" "$cert" "$native"; then
-        echo "    ${ns}/${secret}: re-issued with native wildcard"
+      if _secret_has_san "$ns" "$secret" "$native"; then
+        echo "    ${ns}/${secret}: re-issued Secret now carries the native wildcard"
         break
       fi
       [ "$i" = "30" ] && { echo "    ERROR: ${ns}/${secret} not re-issued with ${native} in time" >&2; exit 1; }
@@ -358,9 +386,14 @@ fi
 # ServiceAccount: it only reads a kubeconfig FILE (-k/--kubeconfig, default
 # /root/.kube/config), which does not exist in this Job pod. Synthesize one from
 # the mounted ServiceAccount so etcd-migrate authenticates as the hook SA.
-ETCD_MIGRATE_KUBECONFIG="/tmp/in-cluster.kubeconfig"
-_sa_dir="/var/run/secrets/kubernetes.io/serviceaccount"
+ETCD_MIGRATE_KUBECONFIG="${ETCD_MIGRATE_KUBECONFIG:-/tmp/in-cluster.kubeconfig}"
+_sa_dir="${ETCD_ADOPT_SA_DIR:-/var/run/secrets/kubernetes.io/serviceaccount}"
 if [ ! -f "$ETCD_MIGRATE_KUBECONFIG" ] && [ -f "$_sa_dir/token" ]; then
+  # server is the in-cluster DNS name, NOT https://$KUBERNETES_SERVICE_HOST:PORT:
+  # on an IPv6-only cluster KUBERNETES_SERVICE_HOST is a bare IPv6 address that
+  # would need bracketing to be a valid URL. kubernetes.default.svc is
+  # IP-family-agnostic, resolves in-cluster, and is validated by the mounted SA
+  # CA — the same server URL kubectl itself synthesizes in-cluster.
   cat > "$ETCD_MIGRATE_KUBECONFIG" <<KUBECONFIG_EOF
 apiVersion: v1
 kind: Config
@@ -368,7 +401,7 @@ clusters:
 - name: in-cluster
   cluster:
     certificate-authority: ${_sa_dir}/ca.crt
-    server: https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT:-443}
+    server: https://kubernetes.default.svc
 contexts:
 - name: in-cluster
   context:

--- a/packages/extra/etcd/templates/etcd-cluster.yaml
+++ b/packages/extra/etcd/templates/etcd-cluster.yaml
@@ -275,3 +275,50 @@ spec:
     app.kubernetes.io/managed-by: etcd-operator
     app.kubernetes.io/name: etcd
   version: {{ $.Chart.Version }}
+---
+# Transitional headless Service backing the LEGACY per-pod DNS names.
+#
+# `etcd-migrate` adopts legacy clusters IN PLACE — the existing Pods are never
+# recreated, so they keep their original `spec.subdomain: etcd-headless` (and
+# hostname etcd-<i>). Their stable DNS name therefore stays
+# `etcd-<i>.etcd-headless.<ns>.svc`, which the v1alpha2 operator dials for
+# MemberList/health until the members are eventually rolled onto its native
+# `<member>.etcd.<ns>.svc` domain (served by the operator-owned `etcd` Service).
+#
+# The v1alpha2 operator only creates the native `etcd` Service, and the legacy
+# `etcd-headless` Service (previously owned by the old operator) is pruned during
+# the transition. Without a Service named `etcd-headless`, the adopted Pods'
+# `etcd-<i>.etcd-headless.<ns>.svc` records stop resolving (`no such host`),
+# MemberList fails, and status.readyMembers never populates — the cluster never
+# goes Ready even though the etcd processes are healthy and in quorum. This is
+# the DNS counterpart of the legacy `*.etcd-headless.<ns>.svc` wildcard kept in
+# the server/peer cert SANs above for the same transition window.
+#
+# Selector mirrors the operator's native `etcd` Service
+# (etcd-operator.cozystack.io/cluster), so this resolves the same member Pods;
+# publishNotReadyAddresses keeps peer discovery working while a member is not
+# yet Ready. Safe to remove — together with the legacy cert SAN — once the
+# members have been rolled onto the native `etcd` subdomain.
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: etcd
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    cozystack.io/service: etcd
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    etcd-operator.cozystack.io/cluster: etcd
+  ports:
+  - name: client
+    port: 2379
+    targetPort: 2379
+    protocol: TCP
+  - name: peer
+    port: 2380
+    targetPort: 2380
+    protocol: TCP

--- a/packages/extra/etcd/tests/etcd-cluster_test.yaml
+++ b/packages/extra/etcd/tests/etcd-cluster_test.yaml
@@ -38,3 +38,40 @@ tests:
       - notEqual:
           path: spec.version
           value: "3.5.12"
+
+  - it: ships the transitional etcd-headless Service that keeps legacy per-pod DNS resolving during v1alpha2 adoption
+    # Adopted Pods keep their legacy `etcd-<i>.etcd-headless.<ns>.svc` DNS (never
+    # recreated), which the operator dials for MemberList until members roll onto
+    # the native domain. It must be headless, publish not-ready addresses (so
+    # peer discovery works before a member is Ready), select the operator's
+    # member Pods, and expose the client/peer ports.
+    documentSelector:
+      path: kind
+      value: Service
+    asserts:
+      - equal:
+          path: metadata.name
+          value: etcd-headless
+      - equal:
+          path: spec.clusterIP
+          value: None
+      - equal:
+          path: spec.publishNotReadyAddresses
+          value: true
+      - equal:
+          path: spec.selector["etcd-operator.cozystack.io/cluster"]
+          value: etcd
+      - contains:
+          path: spec.ports
+          content:
+            name: client
+            port: 2379
+            targetPort: 2379
+            protocol: TCP
+      - contains:
+          path: spec.ports
+          content:
+            name: peer
+            port: 2380
+            targetPort: 2380
+            protocol: TCP

--- a/packages/system/backupstrategy-controller/templates/_helpers.tpl
+++ b/packages/system/backupstrategy-controller/templates/_helpers.tpl
@@ -60,3 +60,44 @@
      BucketClaim CAN come into existence even on the first install. */}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+  Resolve the S3 endpoint URL (scheme included) shared by every default
+  Strategy CR (CNPG/Etcd/MariaDB/FDB), the Velero BSL, and the controller
+  Deployment env.
+
+  Why not just use .Values.backupStorage.endpoint: Cozystack ships SeaweedFS
+  with global.seaweedfs.enableSecurity=true, so its in-cluster S3 Service
+  serves TLS on :8333 fronted by the self-signed "SeaweedFS CA". The static
+  default endpoint (http://seaweedfs-s3...svc:8333) therefore hits a TLS
+  listener over plaintext and every backup upload fails the handshake. The
+  Etcd Strategy's S3 schema has no caCert/insecureSkipVerify field, so it
+  cannot target the self-signed in-cluster endpoint at all — it needs a
+  trusted-cert endpoint. The COSI-provisioned bucket exposes exactly that: the
+  external S3 ingress (ACME cert), advertised in the bucket's system
+  credentials Secret (backupStorage.systemSecretName) — the same Secret the
+  projector already consumes. We read the bucket host from there and force the
+  https:// scheme (the S3 ingress is always TLS).
+
+  Failure semantics mirror bucketName:
+    - provisionBucket: false → external S3, the admin-configured
+      .Values.backupStorage.endpoint is authoritative. Return it as-is.
+    - provisionBucket: true + system Secret present → return
+      https://<bucket-host>.
+    - provisionBucket: true + Secret missing (offline `helm template`/unit
+      render, or pre-reconcile install where lookup returns nil) → fall back
+      to .Values.backupStorage.endpoint. On a live deploy Flux re-renders on
+      spec.interval once the Secret exists, promoting the derived endpoint.
+*/}}
+{{- define "backupstrategy-controller.endpoint" -}}
+{{- if not .Values.backupStorage.provisionBucket -}}
+{{- .Values.backupStorage.endpoint -}}
+{{- else -}}
+{{- $secret := lookup "v1" "Secret" .Values.backupStorage.namespace .Values.backupStorage.systemSecretName -}}
+{{- if and $secret $secret.data (index $secret.data "endpoint") -}}
+{{- printf "https://%s" (b64dec (index $secret.data "endpoint") | trimPrefix "https://" | trimPrefix "http://") -}}
+{{- else -}}
+{{- .Values.backupStorage.endpoint -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/packages/system/backupstrategy-controller/templates/_helpers.tpl
+++ b/packages/system/backupstrategy-controller/templates/_helpers.tpl
@@ -88,6 +88,12 @@
       render, or pre-reconcile install where lookup returns nil) → fall back
       to .Values.backupStorage.endpoint. On a live deploy Flux re-renders on
       spec.interval once the Secret exists, promoting the derived endpoint.
+
+  Normalization of the decoded value: trim first (a trailing newline in the
+  Secret data would otherwise ride into the URL and break it), then strip any
+  leftover scheme before re-forcing https://. The producer already writes a
+  bare host, so the trimPrefix pair is belt-and-suspenders and never fires
+  today — kept as insurance against a future producer that emits a scheme.
 */}}
 {{- define "backupstrategy-controller.endpoint" -}}
 {{- if not .Values.backupStorage.provisionBucket -}}
@@ -95,7 +101,7 @@
 {{- else -}}
 {{- $secret := lookup "v1" "Secret" .Values.backupStorage.namespace .Values.backupStorage.systemSecretName -}}
 {{- if and $secret $secret.data (index $secret.data "endpoint") -}}
-{{- printf "https://%s" (b64dec (index $secret.data "endpoint") | trimPrefix "https://" | trimPrefix "http://") -}}
+{{- printf "https://%s" (b64dec (index $secret.data "endpoint") | trim | trimPrefix "https://" | trimPrefix "http://") -}}
 {{- else -}}
 {{- .Values.backupStorage.endpoint -}}
 {{- end -}}

--- a/packages/system/backupstrategy-controller/templates/deployment.yaml
+++ b/packages/system/backupstrategy-controller/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - name: BACKUP_STORAGE_CREDS_SECRET_NAME
           value: cozy-backups-creds
         - name: BACKUP_STORAGE_ENDPOINT
-          value: {{ .Values.backupStorage.endpoint | quote }}
+          value: {{ include "backupstrategy-controller.endpoint" . | quote }}
         - name: BACKUP_STORAGE_REGION
           value: {{ .Values.backupStorage.region | quote }}
         - name: BACKUP_STORAGE_FORCE_PATH_STYLE

--- a/packages/system/backupstrategy-controller/templates/strategy-cnpg-default.yaml
+++ b/packages/system/backupstrategy-controller/templates/strategy-cnpg-default.yaml
@@ -9,7 +9,7 @@ spec:
     serverName: {{ printf "{{ .Application.metadata.namespace }}-{{ .Application.metadata.name }}" | quote }}
     barmanObjectStore:
       destinationPath: {{ printf "s3://%s/{{ .Application.metadata.namespace }}/{{ .Application.metadata.name }}/" $bucketName | quote }}
-      endpointURL: {{ .Values.backupStorage.endpoint | quote }}
+      endpointURL: {{ include "backupstrategy-controller.endpoint" . | quote }}
       retentionPolicy: "30d"
       s3Credentials:
         secretRef:

--- a/packages/system/backupstrategy-controller/templates/strategy-etcd-default.yaml
+++ b/packages/system/backupstrategy-controller/templates/strategy-etcd-default.yaml
@@ -9,7 +9,7 @@ spec:
     destination:
       s3:
         bucket: {{ $bucketName | quote }}
-        endpoint: {{ .Values.backupStorage.endpoint | quote }}
+        endpoint: {{ include "backupstrategy-controller.endpoint" . | quote }}
         key: {{ printf "{{ .Application.metadata.namespace }}/{{ .Application.metadata.name }}/" | quote }}
         region: {{ .Values.backupStorage.region | quote }}
         forcePathStyle: {{ .Values.backupStorage.forcePathStyle }}

--- a/packages/system/backupstrategy-controller/templates/strategy-foundationdb-default.yaml
+++ b/packages/system/backupstrategy-controller/templates/strategy-foundationdb-default.yaml
@@ -1,5 +1,6 @@
-{{- $endpointHost := .Values.backupStorage.endpoint | trimPrefix "https://" | trimPrefix "http://" -}}
-{{- $secureConn := ternary "1" "0" (hasPrefix "https://" .Values.backupStorage.endpoint) -}}
+{{- $endpoint := include "backupstrategy-controller.endpoint" . -}}
+{{- $endpointHost := $endpoint | trimPrefix "https://" | trimPrefix "http://" -}}
+{{- $secureConn := ternary "1" "0" (hasPrefix "https://" $endpoint) -}}
 {{- $bucketName := include "backupstrategy-controller.bucketName" . -}}
 {{- if $bucketName -}}
 apiVersion: strategy.backups.cozystack.io/v1alpha1

--- a/packages/system/backupstrategy-controller/templates/strategy-mariadb-default.yaml
+++ b/packages/system/backupstrategy-controller/templates/strategy-mariadb-default.yaml
@@ -1,4 +1,5 @@
-{{- $endpointHost := .Values.backupStorage.endpoint | trimPrefix "https://" | trimPrefix "http://" -}}
+{{- $endpoint := include "backupstrategy-controller.endpoint" . -}}
+{{- $endpointHost := $endpoint | trimPrefix "https://" | trimPrefix "http://" -}}
 {{- $bucketName := include "backupstrategy-controller.bucketName" . -}}
 {{- if $bucketName -}}
 apiVersion: strategy.backups.cozystack.io/v1alpha1
@@ -20,6 +21,6 @@ spec:
           name: cozy-backups-creds
           key: AWS_SECRET_ACCESS_KEY
         tls:
-          enabled: {{ hasPrefix "https://" .Values.backupStorage.endpoint }}
+          enabled: {{ hasPrefix "https://" $endpoint }}
     compression: gzip
 {{- end -}}

--- a/packages/system/backupstrategy-controller/templates/velero-bsl.yaml
+++ b/packages/system/backupstrategy-controller/templates/velero-bsl.yaml
@@ -30,6 +30,6 @@ spec:
   config:
     region: {{ .Values.backupStorage.region | quote }}
     s3ForcePathStyle: {{ .Values.backupStorage.forcePathStyle | quote }}
-    s3Url: {{ .Values.backupStorage.endpoint | quote }}
+    s3Url: {{ include "backupstrategy-controller.endpoint" . | quote }}
 {{- end }}
 {{- end }}

--- a/packages/system/backupstrategy-controller/tests/endpoint_form_test.yaml
+++ b/packages/system/backupstrategy-controller/tests/endpoint_form_test.yaml
@@ -1,13 +1,25 @@
 suite: endpoint scheme → per-driver derivations (TLS / secure_connection / scheme stripping)
 
-# backupStorage.endpoint is a single URL adapted per driver. MariaDB and
-# FoundationDB want a bare host:port and derive their secure flag from the
-# scheme, so flipping http<->https must flip tls.enabled / secure_connection
-# without leaking the scheme into the host fields.
+# The S3 endpoint is resolved by the "backupstrategy-controller.endpoint"
+# helper and shared by every driver: CNPG/Etcd want a full URL (scheme
+# included), MariaDB/FoundationDB want a bare host:port and derive their secure
+# flag from the scheme, and the Velero BSL wants a full URL. Flipping
+# http<->https must flip tls.enabled / secure_connection without leaking the
+# scheme into the host fields, and must reach every consumer identically.
+#
+# NOTE: the provisionBucket:true derivation (read the external ACME endpoint
+# from the COSI system Secret and force https://) uses `lookup`, which returns
+# nothing under `helm template` / helm-unittest. These offline tests therefore
+# exercise the FALLBACK path — where the helper returns
+# .Values.backupStorage.endpoint verbatim — which is exactly what runs on the
+# pre-reconcile first install and for external S3 (provisionBucket:false).
 
 templates:
+  - templates/strategy-etcd-default.yaml
+  - templates/strategy-cnpg-default.yaml
   - templates/strategy-mariadb-default.yaml
   - templates/strategy-foundationdb-default.yaml
+  - templates/velero-bsl.yaml
 
 release:
   name: t
@@ -18,10 +30,22 @@ set:
   backupStorage.bucketNameOverride: test-bucket
 
 tests:
-  - it: "https endpoint: MariaDB TLS on, FDB secure_connection=1, scheme stripped from host fields"
+  - it: "https endpoint: full URL reaches CNPG/Etcd/Velero; MariaDB TLS on, FDB secure_connection=1, scheme stripped from host fields"
     set:
       backupStorage.endpoint: https://s3.example.com:8333
     asserts:
+      - equal:
+          path: spec.template.destination.s3.endpoint
+          value: https://s3.example.com:8333
+        template: templates/strategy-etcd-default.yaml
+      - equal:
+          path: spec.template.barmanObjectStore.endpointURL
+          value: https://s3.example.com:8333
+        template: templates/strategy-cnpg-default.yaml
+      - equal:
+          path: spec.config.s3Url
+          value: https://s3.example.com:8333
+        template: templates/velero-bsl.yaml
       - equal:
           path: spec.template.storage.s3.endpoint
           value: s3.example.com:8333
@@ -39,10 +63,14 @@ tests:
           content: secure_connection=1
         template: templates/strategy-foundationdb-default.yaml
 
-  - it: "http endpoint: MariaDB TLS off, FDB secure_connection=0"
+  - it: "http endpoint: MariaDB TLS off, FDB secure_connection=0, Etcd keeps scheme"
     set:
       backupStorage.endpoint: http://s3.example.com:8333
     asserts:
+      - equal:
+          path: spec.template.destination.s3.endpoint
+          value: http://s3.example.com:8333
+        template: templates/strategy-etcd-default.yaml
       - equal:
           path: spec.template.storage.s3.tls.enabled
           value: false
@@ -51,3 +79,18 @@ tests:
           path: spec.template.blobStoreConfiguration.urlParameters
           content: secure_connection=0
         template: templates/strategy-foundationdb-default.yaml
+
+  - it: "external S3 (provisionBucket:false): endpoint is used verbatim (no derivation)"
+    set:
+      backupStorage.provisionBucket: false
+      backupStorage.bucketName: ext-bucket
+      backupStorage.endpoint: https://minio.example.internal:9000
+    asserts:
+      - equal:
+          path: spec.template.destination.s3.endpoint
+          value: https://minio.example.internal:9000
+        template: templates/strategy-etcd-default.yaml
+      - equal:
+          path: spec.config.s3Url
+          value: https://minio.example.internal:9000
+        template: templates/velero-bsl.yaml

--- a/packages/system/backupstrategy-controller/values.yaml
+++ b/packages/system/backupstrategy-controller/values.yaml
@@ -47,11 +47,26 @@ backupStorage:
   # name independent of .bucketName above, and the BucketClaim status
   # is the only authoritative source.
   bucketNameOverride: ""
-  # endpoint is wired into every default Strategy CR at chart-render time.
-  # Switching to an https:// URL silently enables TLS in the MariaDB
-  # strategy (tls.enabled is computed from the scheme). Make sure the CA
-  # bundle is reachable to the operator (mariadb's tls.caSecretKeyRef, the
-  # FDB pod ca-cert volume, Velero's BSL caCert field) before flipping it.
+  # endpoint is the S3 endpoint URL shared by every default Strategy CR, the
+  # Velero BSL and the controller Deployment. For a provisioned bucket
+  # (provisionBucket: true, the default) it is NOT used verbatim: the
+  # "backupstrategy-controller.endpoint" helper derives the real endpoint from
+  # the COSI bucket's system credentials Secret (backupStorage.systemSecretName)
+  # and forces https://, because Cozystack's SeaweedFS runs with
+  # enableSecurity=true and serves TLS on :8333 behind the self-signed
+  # "SeaweedFS CA". The COSI-advertised endpoint is the external S3 ingress
+  # (ACME cert), which every consumer can verify — unlike the in-cluster
+  # service, whose CA is not plumbed to the backup operators and which the Etcd
+  # Strategy's S3 schema (no caCert field) cannot target at all.
+  #
+  # This value is the FALLBACK, used only when the derivation cannot run:
+  #   - provisionBucket: false (external S3) — set it to your S3 endpoint,
+  #     scheme included; it is used verbatim (the MariaDB/FDB strategies compute
+  #     their secure flag from the scheme, so https:// enables TLS there — make
+  #     the CA bundle reachable to those operators before pointing at a
+  #     self-signed external endpoint);
+  #   - offline `helm template` / unit renders and the pre-reconcile first
+  #     install, where the Secret lookup returns nothing.
   endpoint: http://seaweedfs-s3.tenant-root.svc.cozy.local:8333
   # region is re-projected into cozy-backups-creds on the next reconcile
   # (1-minute tick for system namespaces, on-demand for tenant namespaces).

--- a/packages/system/etcd-operator/templates/pre-upgrade-selector-fix.yaml
+++ b/packages/system/etcd-operator/templates/pre-upgrade-selector-fix.yaml
@@ -1,0 +1,145 @@
+{{- /*
+Pre-upgrade selector migration for the controller-manager Deployment.
+
+1.6 replaced the upstream etcd-operator chart with the cozystack-authored one
+(#2859), changing the Deployment's spec.selector.matchLabels:
+
+  1.5: {app.kubernetes.io/instance: etcd-operator, app.kubernetes.io/name: etcd-operator}
+  1.6: {app.kubernetes.io/name: etcd-operator, control-plane: controller-manager}
+
+spec.selector is immutable, so `helm upgrade` cannot patch the existing
+Deployment and the whole HelmRelease upgrade fails ("field is immutable") — the
+operator (and the v1alpha2 CRDs it serves) never come up, which blocks the etcd
+v1alpha2 adoption. Fresh installs use the new selector directly and are
+unaffected, so fresh-install CI does not catch it. See cozystack/cozystack#3242.
+
+This pre-upgrade hook deletes the Deployment ONLY when its live selector is the
+pre-1.6 one (i.e. lacks control-plane=controller-manager), so Helm recreates it
+cleanly with the new selector. It is a no-op when the selector already matches
+(rc.1 -> later upgrades) and never runs on a fresh install (pre-upgrade only).
+Keeping the selector stable in the chart is NOT an option: rc.1 already shipped
+the new selector, so aligning it back would merely move the immutable break to
+rc.1 -> next.
+*/}}
+{{- $name := "etcd-operator-selector-fix" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: etcd-operator
+    app.kubernetes.io/component: selector-fix-hook
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed,before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: etcd-operator
+    app.kubernetes.io/component: selector-fix-hook
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed,before-hook-creation
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: etcd-operator
+    app.kubernetes.io/component: selector-fix-hook
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: etcd-operator
+    app.kubernetes.io/component: selector-fix-hook
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "0"
+    # Keep a failed Job's Pod around for `kubectl logs`; reap the whole hook
+    # bundle on success. before-hook-creation clears a prior run first.
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+spec:
+  activeDeadlineSeconds: 120
+  backoffLimit: 1
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: etcd-operator
+        app.kubernetes.io/component: selector-fix-hook
+    spec:
+      serviceAccountName: {{ $name }}
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      # writable HOME so kubectl can create its discovery cache under
+      # readOnlyRootFilesystem=true (kubectl 1.30+ aborts otherwise).
+      volumes:
+        - name: home
+          emptyDir: {}
+      containers:
+        - name: selector-fix
+          image: "{{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}"
+          imagePullPolicy: {{ .Values.kubectlImage.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: HOME
+              value: /tmp
+          volumeMounts:
+            - name: home
+              mountPath: /tmp
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -eu
+              ns="{{ .Release.Namespace }}"
+              name=etcd-operator-controller-manager
+              if ! kubectl -n "$ns" get deployment "$name" >/dev/null 2>&1; then
+                echo "[selector-fix] Deployment $name absent; nothing to do."
+                exit 0
+              fi
+              cp="$(kubectl -n "$ns" get deployment "$name" \
+                    -o jsonpath='{.spec.selector.matchLabels.control-plane}' 2>/dev/null || true)"
+              if [ "$cp" = "controller-manager" ]; then
+                echo "[selector-fix] Deployment $name already has the v1.6 selector; nothing to do."
+                exit 0
+              fi
+              echo "[selector-fix] Deployment $name has a pre-1.6 spec.selector (immutable); deleting so the chart recreates it with the current selector."
+              kubectl -n "$ns" delete deployment "$name" --wait=true --timeout=90s
+              echo "[selector-fix] Deleted; the chart will recreate $name."

--- a/packages/system/etcd-operator/templates/pre-upgrade-selector-fix.yaml
+++ b/packages/system/etcd-operator/templates/pre-upgrade-selector-fix.yaml
@@ -119,6 +119,16 @@ spec:
         - name: selector-fix
           image: {{ $img | quote }}
           imagePullPolicy: {{ .Values.kubectlImage.pullPolicy }}
+          # Small fixed budget for a one-shot kubectl get/delete; values mirror
+          # the postgres-operator webhook-ready hook that runs the same image,
+          # so the hook Pod schedules predictably without over-reserving.
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/packages/system/etcd-operator/templates/pre-upgrade-selector-fix.yaml
+++ b/packages/system/etcd-operator/templates/pre-upgrade-selector-fix.yaml
@@ -22,6 +22,8 @@ the new selector, so aligning it back would merely move the immutable break to
 rc.1 -> next.
 */}}
 {{- $name := "etcd-operator-selector-fix" }}
+{{- $img := printf "%s:%s" .Values.kubectlImage.repository .Values.kubectlImage.tag }}
+{{- with .Values.kubectlImage.digest }}{{- $img = printf "%s@%s" $img . }}{{- end }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -101,6 +103,11 @@ spec:
       restartPolicy: Never
       securityContext:
         runAsNonRoot: true
+        # clastix/kubectl's image user is the non-numeric name `nonroot`, which
+        # the kubelet cannot verify against runAsNonRoot; pin a numeric UID so
+        # the Pod passes admission (matches postgres-operator's webhook-ready
+        # hook running the same image).
+        runAsUser: 65532
         seccompProfile:
           type: RuntimeDefault
       # writable HOME so kubectl can create its discovery cache under
@@ -110,7 +117,7 @@ spec:
           emptyDir: {}
       containers:
         - name: selector-fix
-          image: "{{ .Values.kubectlImage.repository }}:{{ .Values.kubectlImage.tag }}"
+          image: {{ $img | quote }}
           imagePullPolicy: {{ .Values.kubectlImage.pullPolicy }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/packages/system/etcd-operator/tests/deployment_test.yaml
+++ b/packages/system/etcd-operator/tests/deployment_test.yaml
@@ -89,3 +89,13 @@ tests:
             containerPort: 8080
             protocol: TCP
           any: true
+
+  - it: "cold-start memory limit floor is at/above the manager working set so the Pod is not OOMKilled before VPA mutates it"
+    # A freshly-created Pod runs under resources.limits until the VPA admission
+    # webhook rewrites it; a 128Mi floor OOMKills the ~250Mi manager on any start
+    # the webhook does not mutate in time (Deployment recreated out of band, or
+    # webhook briefly down during an upgrade). Keep the floor at/above 256Mi.
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 256Mi

--- a/packages/system/etcd-operator/tests/selector-fix-hook_test.yaml
+++ b/packages/system/etcd-operator/tests/selector-fix-hook_test.yaml
@@ -1,0 +1,120 @@
+suite: pre-upgrade selector-fix hook — hook wiring, RBAC scope, security context, image
+
+# 1.6 changed the controller Deployment's immutable spec.selector (#3242); this
+# pre-upgrade hook deletes a pre-1.6 Deployment so Helm recreates it with the new
+# selector. Pin the parts that are easy to break and fail closed on a real
+# cluster:
+#   - it is a pre-upgrade hook, RBAC (weight -5) before the Job (weight 0);
+#   - the Role is namespaced and grants only get/list/delete on deployments;
+#   - the Job runs the digest-pinned kubectl image as a NUMERIC non-root user.
+# The last one is load-bearing: clastix/kubectl's image user is the non-numeric
+# name `nonroot`, which the kubelet cannot verify against runAsNonRoot, so
+# runAsNonRoot WITHOUT a numeric runAsUser fails admission and the hook never
+# runs — silently blocking the very upgrade it exists to unblock.
+
+templates:
+  - templates/pre-upgrade-selector-fix.yaml
+
+release:
+  name: etcd-operator
+  namespace: cozy-etcd-operator
+
+tests:
+  - it: renders four hook objects (SA + Role + RoleBinding + Job)
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: every rendered object is a pre-upgrade hook
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      - documentIndex: 2
+        equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      - documentIndex: 3
+        equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+
+  - it: RBAC (weight -5) is created before the Job (weight 0)
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: kind
+          value: ServiceAccount
+      - documentIndex: 1
+        equal:
+          path: kind
+          value: Role
+      - documentIndex: 2
+        equal:
+          path: kind
+          value: RoleBinding
+      - documentIndex: 3
+        equal:
+          path: kind
+          value: Job
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-5"
+      - documentIndex: 3
+        equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "0"
+
+  - it: the Role is least-privilege — namespaced get/list/delete on deployments only, never a wildcard verb
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: rules[0].apiGroups[0]
+          value: apps
+      - equal:
+          path: rules[0].resources[0]
+          value: deployments
+      - contains:
+          path: rules[0].verbs
+          content: get
+      - contains:
+          path: rules[0].verbs
+          content: list
+      - contains:
+          path: rules[0].verbs
+          content: delete
+      - notContains:
+          path: rules[0].verbs
+          content: "*"
+
+  - it: the Job runs as a NUMERIC non-root user so the nonroot-image passes the kubelet runAsNonRoot check
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.runAsUser
+          value: 65532
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
+
+  - it: the kubectl image is digest-pinned (reproducible across the fleet)
+    documentIndex: 3
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^docker\.io/clastix/kubectl:v1\.32@sha256:[0-9a-f]{64}$

--- a/packages/system/etcd-operator/tests/selector-fix-hook_test.yaml
+++ b/packages/system/etcd-operator/tests/selector-fix-hook_test.yaml
@@ -112,6 +112,22 @@ tests:
           path: spec.template.spec.containers[0].securityContext.capabilities.drop
           content: ALL
 
+  - it: the container declares resource requests and limits so the hook Pod schedules predictably
+    documentIndex: 3
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 10m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 32Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 100m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 64Mi
+
   - it: the kubectl image is digest-pinned (reproducible across the fleet)
     documentIndex: 3
     asserts:

--- a/packages/system/etcd-operator/values.yaml
+++ b/packages/system/etcd-operator/values.yaml
@@ -48,10 +48,14 @@ vpa:
     memory: 1Gi
 
 # Image for the pre-upgrade selector-migration hook Job (see
-# templates/pre-upgrade-selector-fix.yaml). Only needs a kubectl binary. Pinned
-# by digest for reproducibility; clastix/kubectl is already used elsewhere in
-# cozystack (Kamaji).
+# templates/pre-upgrade-selector-fix.yaml). Only needs a kubectl binary. The tag
+# is digest-pinned so an upstream retag does not change what runs across the
+# fleet; refresh by resolving the current manifest-list digest
+# (`docker manifest inspect docker.io/clastix/kubectl:v1.32`) and updating
+# `digest` below. Same image the postgres-operator webhook-ready hook pins.
+# renovate: datasource=docker depName=docker.io/clastix/kubectl
 kubectlImage:
   repository: docker.io/clastix/kubectl
   tag: v1.32
+  digest: sha256:b9ef7d8dbe65bcc81a46c09b8dc7543103055021c4f43287bf59e92a8f4fe05c
   pullPolicy: IfNotPresent

--- a/packages/system/etcd-operator/values.yaml
+++ b/packages/system/etcd-operator/values.yaml
@@ -20,18 +20,38 @@ resources:
     memory: 64Mi
   limits:
     cpu: 500m
-    memory: 128Mi
+    # Cold-start floor. This is the limit a freshly-created Pod runs under until
+    # the VPA admission webhook has had a chance to rewrite it (see vpa below).
+    # The manager's steady-state working set is ~250Mi (the VPA's own
+    # recommendation), so a 128Mi floor OOMKills the operator on any start where
+    # the webhook does not mutate the Pod in time — e.g. a Deployment recreated
+    # out of band, or the webhook briefly unavailable during an upgrade. Keep
+    # this at or above the observed working set so the operator never depends on
+    # VPA timing merely to avoid a crash loop; the VPA still scales it further
+    # under real load up to maxAllowed.
+    memory: 256Mi
 
 vpa:
   enabled: true
   updateMode: Auto
   minAllowed:
     cpu: 100m
-    memory: 128Mi
+    # Matches the cold-start limit floor above so the VPA never recommends BELOW
+    # the manager's ~250Mi working set.
+    memory: 256Mi
   # maxAllowed is the VPA's scaling CEILING, deliberately well above the static
-  # resources.limits above (128Mi): with updateMode: Auto the VPA rewrites the
+  # resources.limits above (256Mi): with updateMode: Auto the VPA rewrites the
   # Pod's request/limit up to this bound under real load. Do NOT "align" it down
-  # to the 128Mi limit — that would cap the autoscaler's headroom.
+  # to the 256Mi limit — that would cap the autoscaler's headroom.
   maxAllowed:
     cpu: 1000m
     memory: 1Gi
+
+# Image for the pre-upgrade selector-migration hook Job (see
+# templates/pre-upgrade-selector-fix.yaml). Only needs a kubectl binary. Pinned
+# by digest for reproducibility; clastix/kubectl is already used elsewhere in
+# cozystack (Kamaji).
+kubectlImage:
+  repository: docker.io/clastix/kubectl
+  tag: v1.32
+  pullPolicy: IfNotPresent


### PR DESCRIPTION
Consolidates the etcd `v1alpha2` transition fix for **in-cluster 1.5 → 1.6 upgrades** into a single PR, rebased on current `main`. Supersedes #3265 and #3261 — their commits are carried here (authorship preserved), so those PRs can be closed once this lands. Fresh installs use the new shapes directly and are unaffected, so fresh-install CI does not catch these; the 1.5 → 1.6 e2e upgrade path is the authoritative regression guard.

## What this PR does

### 1. Keep the legacy `etcd-headless` Service alive during adoption — `packages/extra/etcd`
`etcd-migrate` adopts legacy clusters **in place**: the Pods keep their original `spec.subdomain: etcd-headless` and are dialed at `etcd-<i>.etcd-headless.<ns>.svc` until they roll onto the operator's native `<member>.etcd.<ns>.svc` domain. The v1alpha2 operator only creates the native `etcd` Service and the legacy `etcd-headless` Service is pruned, so those per-pod names stop resolving (`no such host`), `MemberList` fails, and `status.readyMembers` never populates — the `EtcdCluster` never goes `Ready` even though etcd is healthy and in quorum. We ship a chart-managed transitional headless `etcd-headless` Service (selector mirrors the operator's native `etcd` Service via `etcd-operator.cozystack.io/cluster`, `publishNotReadyAddresses: true`) — the DNS counterpart of the legacy `*.etcd-headless.<ns>.svc` SAN already kept for this window. Removable together with that SAN once members roll onto the native subdomain.

### 2. Survive the immutable controller-Deployment selector on upgrade — `packages/system/etcd-operator` (#3242)
#2859 replaced the upstream etcd-operator chart with the cozystack-authored one, changing `Deployment.spec.selector.matchLabels`. `spec.selector` is immutable, so `helm upgrade` cannot patch the existing Deployment and the whole HelmRelease upgrade fails (`field is immutable`). A **pre-upgrade hook** (`templates/pre-upgrade-selector-fix.yaml`: ServiceAccount + Role + RoleBinding + Job) deletes the Deployment **only** when its live selector is the pre-1.6 one, so Helm recreates it cleanly. No-op when the selector already matches, never runs on fresh install.

### 3. Raise the operator's memory cold-start floor — `packages/system/etcd-operator`
Steady-state working set is ~250Mi; the static `limits.memory: 128Mi` OOMKills a Pod that starts before the VPA admission webhook rewrites it. Raise the floor to `256Mi` (and VPA `minAllowed` to match) as defense in depth so the operator never depends on VPA timing to avoid crashing.

### 4. Make migration 50 (etcd adoption) robust in-cluster — `packages/core/platform/images/migrations/migrations/50` (was #3261)
Exact server/peer cert-SAN match, Secret-gated wait on the adoption Secret, and in-cluster (IPv6-safe) kubeconfig handling, so the migration script drives the adoption reliably from inside the cluster. Covered by `hack/migration-50-etcd-adopt.bats`.

### 5. Hardening / review fixes (this PR's original scope)
- **Hook `runAsUser: 65532`.** `pre-upgrade-selector-fix.yaml` set `runAsNonRoot: true` but no numeric `runAsUser`; `clastix/kubectl`'s image user is the non-numeric name `nonroot`, which the kubelet cannot verify against `runAsNonRoot` — so the hook Pod fails admission and silently blocks the very upgrade it exists to unblock. Adds `runAsUser: 65532`, matching the postgres-operator webhook-ready hook that runs the same image.
- **Digest-pin the kubectl image.** The values comment claimed digest-pinning but shipped a floating `v1.32` tag. Reuses the digest postgres-operator vendors, adds the `renovate` annotation, and templates `repo:tag@digest`.
- **Tests.** `etcd-operator/tests/selector-fix-hook_test.yaml` (hook wiring, weight ordering, namespaced least-privilege RBAC, numeric-non-root security context, digest-pinned image), `etcd-operator/tests/deployment_test.yaml` (256Mi cold-start floor), `extra/etcd/tests/etcd-cluster_test.yaml` (transitional `etcd-headless` Service). Each assertion was mutation-tested.

### 6. Derive the default S3 endpoint from the provisioned bucket — `packages/system/backupstrategy-controller`
Derive the default S3 endpoint (and per-driver scheme / TLS / `secure_connection`) from the provisioned bucket Secret instead of requiring it to be hand-set, so etcd (and other) backup strategies get a working endpoint by default. Docs in `docs/operations/backup-classes.md`; covered by `tests/endpoint_form_test.yaml`.

### Verification
- `helm unittest` green on current `main`: etcd-operator **18/18**, extra/etcd **18/18**, backupstrategy-controller **11/11**.
- Behaviours 1 & 2 were reproduced and confirmed live on a 1.5.2 → 1.6.0-rc.1 adoption (3-node cluster) — recreating the `etcd-headless` Service took the adopted cluster to `readyMembers=3 / Available=True`.

```release-note
fix(etcd): complete the v1alpha2 transition on in-cluster 1.5→1.6 upgrades — keep the legacy etcd-headless Service alive so adopted members stay resolvable, delete the pre-1.6 operator Deployment via a pre-upgrade hook to get past the immutable selector, raise the operator's memory floor so it does not OOM before the VPA scales it, and make the etcd adoption migration robust in-cluster.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved backup storage endpoint handling across supported backup drivers, including provisioned and external S3 storage.
  * Added compatibility support for legacy etcd pod discovery during migration.
  * Added an automated upgrade safeguard for etcd operator deployments.

* **Bug Fixes**
  * Improved certificate SAN detection and etcd migration authentication.
  * Increased the etcd operator’s minimum startup memory to prevent early restarts.

* **Documentation**
  * Clarified backup endpoint, TLS, and driver-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->