### PR TITLE
fix(apps/kubernetes): make pre-delete hook steps 3/5/6 fire-and-forget (#3271)

### DIFF
--- a/packages/apps/kubernetes/templates/delete.yaml
+++ b/packages/apps/kubernetes/templates/delete.yaml
@@ -90,8 +90,20 @@ spec:
               fi
 
               echo "Step 3: Deleting KamajiControlPlane {{ .Release.Name }}"
+              # Fire-and-forget (--wait=false): unlike the child HelmReleases in
+              # Step 2 — whose Flux finalizer only clears once helm-controller can
+              # uninstall INSIDE the tenant cluster (impossible with no Ready
+              # nodes) — the KamajiControlPlane is finalized by the Kamaji/CAPI
+              # controllers in THIS management cluster, so its teardown does not
+              # depend on tenant node health and cannot hang on the nodeless
+              # condition (#3271). kubectl delete defaults to --wait=true; waiting
+              # here would only block this hook on the same TCP teardown that
+              # Step 4 already handles with a bounded wait + Step 4b backstop — an
+              # unbounded wait here would run first and defeat that backstop. So
+              # trigger deletion and move on; Step 4 owns the bounded TCP wait.
               kubectl -n {{ .Release.Namespace }} delete kamajicontrolplanes.controlplane.cluster.x-k8s.io {{ .Release.Name }} \
-                --ignore-not-found=true
+                --ignore-not-found=true --wait=false \
+                || echo "WARNING: failed to trigger deletion of KamajiControlPlane {{ .Release.Name }}; Step 4 will still attempt the TenantControlPlane" >&2
 
               echo "Step 4: Deleting TenantControlPlane {{ .Release.Name }} and waiting for it to be removed"
               # --wait=true blocks until the TenantControlPlane object is fully
@@ -138,15 +150,38 @@ spec:
               fi
 
               echo "Step 5: Cleaning up DataVolumes"
+              # Fire-and-forget (--wait=false): DataVolumes and their backing PVCs
+              # live in THIS management cluster and are finalized by CDI and the
+              # CSI driver here, independent of tenant node health — so, like
+              # Step 3, deletion cannot hang on the nodeless condition (#3271).
+              # kubectl delete defaults to --wait=true, which would block this
+              # hook until every worker-disk PVC is physically reclaimed; under
+              # storage pressure that can exceed the parent Helm uninstall budget
+              # and wedge the whole teardown. Deleting the Kubernetes CR only
+              # TRIGGERS this reclaim anyway — the actual VM/PVC drain is waited
+              # on separately and best-effort by the caller (e.g. the e2e
+              # cozy_wait_tenant_drained barrier), NOT on the CR-finalization
+              # path. Do NOT force-clear a stuck PVC/DataVolume finalizer here:
+              # that would orphan the LINSTOR backing volume. A genuinely wedged
+              # PVC is a storage-layer problem and surfaces honestly as a
+              # Terminating namespace rather than being masked.
               kubectl -n {{ .Release.Namespace }} delete datavolumes \
                 -l "cluster.x-k8s.io/cluster-name={{ .Release.Name }}" \
-                --ignore-not-found=true
+                --ignore-not-found=true --wait=false \
+                || echo "WARNING: failed to trigger deletion of DataVolumes for {{ .Release.Name }}" >&2
 
               echo "Step 6: Cleaning up LoadBalancer Services"
+              # Fire-and-forget (--wait=false): these LoadBalancer Services are
+              # reconciled by the management cluster's LB controller (MetalLB /
+              # kube-vip), so their teardown does not depend on tenant node
+              # health. kubectl delete defaults to --wait=true; there is nothing
+              # to wait for on the CR-finalization path here — trigger the delete
+              # and let the LB controller release the address asynchronously.
               kubectl -n {{ .Release.Namespace }} delete services \
                 -l "cluster.x-k8s.io/cluster-name={{ .Release.Name }}" \
                 --field-selector spec.type=LoadBalancer \
-                --ignore-not-found=true
+                --ignore-not-found=true --wait=false \
+                || echo "WARNING: failed to trigger deletion of LoadBalancer Services for {{ .Release.Name }}" >&2
 
               echo "Cleanup completed successfully"
           volumeMounts:

--- a/packages/apps/kubernetes/tests/delete_hook_test.yaml
+++ b/packages/apps/kubernetes/tests/delete_hook_test.yaml
@@ -68,3 +68,62 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: 'get tenantcontrolplanes\.kamaji\.clastix\.io test-k8s[\s\S]*still present[\s\S]*patch secret test-k8s-datastore-config'
+
+  # ---- issue #3271: the hook must not hang teardown on a nodeless tenant ----
+
+  # The patterns below anchor --wait=false / --wait=true to each command's OWN
+  # continuation lines (`\\?\s+`), not a loose `[\s\S]*?` gap: a loose gap would
+  # match a *later* step's flag and pass even if this step's were removed
+  # (verified: such a pattern survives mutation, i.e. it is vacuous).
+
+  - it: Step 2 keeps a bounded wait and force-clears child HR finalizers on timeout (#3271)
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      # Child HelmReleases carry a Flux finalizer that only clears once
+      # helm-controller can uninstall INSIDE the tenant — impossible with no
+      # Ready nodes. So Step 2 must stay bounded (not an unbounded --wait) and
+      # force-clear the leftover finalizer so teardown proceeds.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete helmreleases\.helm\.toolkit\.fluxcd\.io \\?\s+-l "cozystack\.io/target-cluster-name=test-k8s" \\?\s+--ignore-not-found=true --wait=true --timeout=120s'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'Force-clearing finalizers on \$hr'
+
+  - it: Step 3 deletes the KamajiControlPlane fire-and-forget, never an unbounded wait (#3271)
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      # The KCP is finalized by mgmt-cluster controllers, so its deletion cannot
+      # hang on tenant node health — trigger it and let Step 4 own the bounded
+      # TCP wait. An unbounded wait here would run first and defeat Step 4/4b.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete kamajicontrolplanes\.controlplane\.cluster\.x-k8s\.io test-k8s \\?\s+--ignore-not-found=true --wait=false'
+
+  - it: Step 5 deletes DataVolumes fire-and-forget so a stuck PVC cannot wedge the Job (#3271)
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete datavolumes \\?\s+-l "cluster\.x-k8s\.io/cluster-name=test-k8s" \\?\s+--ignore-not-found=true --wait=false'
+      # It must NOT force-clear a stuck PVC/DataVolume finalizer — that would
+      # orphan the LINSTOR backing volume. Only the child-HR (Step 2) and the
+      # Kamaji datastore Secret (Step 4b) are ever finalizer-stripped.
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete datavolumes[\s\S]*?patch[\s\S]*?finalizers'
+
+  - it: Step 6 deletes LoadBalancer Services fire-and-forget (#3271)
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete services \\?\s+-l "cluster\.x-k8s\.io/cluster-name=test-k8s" \\?\s+--field-selector spec\.type=LoadBalancer \\?\s+--ignore-not-found=true --wait=false'


### PR DESCRIPTION
## What this PR does

Completes the fix for #3271. The tenant Kubernetes pre-delete hook (`packages/apps/kubernetes/templates/delete.yaml`, Job `<release>-pre-cleanup`) could hang teardown when the tenant cluster has **no working nodes** (LINSTOR/ZFS exhaustion, worker VMs that never joined, or a nodeGroup at `minReplicas: 0`).

The Step 2 child-HelmRelease wait was already bounded in #2826, but the remaining teardown steps still inherited `kubectl delete`'s default `--wait=true` with no timeout:

- **Step 3** — delete `KamajiControlPlane`
- **Step 5** — delete `DataVolumes`
- **Step 6** — delete LoadBalancer `Services`

### Why these three are different from Step 2

Step 2's child HelmReleases carry a Flux finalizer that only clears once helm-controller can uninstall **inside the tenant cluster** — impossible with no Ready nodes — so Step 2 genuinely needs its bounded wait + finalizer force-clear (unchanged here).

Steps 3/5/6 target resources finalized by controllers in **this management cluster** (Kamaji/CAPI, CDI + the CSI driver, the LB controller). Their teardown does not depend on tenant node health, so there is nothing to wait for on the `Kubernetes`-CR finalization path — the default wait only hurt:

- Step 5's unbounded wait blocked the pre-cleanup Job until every worker-disk PVC was physically reclaimed; under storage pressure (the exact #3271 failure mode) that exceeds the parent Helm uninstall budget and wedges teardown.
- Step 3's unbounded wait ran ahead of Step 4 on the same TenantControlPlane teardown, so it could defeat Step 4's bounded wait + Step 4b datastore-secret backstop (added for #3062 / #3078).

### The change

Make Steps 3/5/6 `--wait=false` (fire-and-forget) and non-fatal (`|| echo WARNING`), so the Job completes promptly, the parent Helm uninstall succeeds, and the CR finalizes. The actual VM/PVC drain is waited on separately and best-effort by the caller (the e2e `cozy_wait_tenant_drained` barrier in `hack/e2e-chainsaw/_lib/run-kubernetes.sh`), not on the CR-finalization path — this restores the layering the kubernetes e2e harness was built around.

Deliberately **not** force-clearing a stuck PVC/DataVolume finalizer: that would orphan the LINSTOR backing volume. A genuinely wedged PVC is a storage-layer problem and surfaces honestly as a `Terminating` namespace rather than being masked.

### Tests

Adds four behavioural cases to `tests/delete_hook_test.yaml` pinning the fire-and-forget behaviour of Steps 3/5/6 and the retained bounded-wait + force-clear of Step 2. The regex assertions are anchored to each command's own continuation lines (a loose `[\s\S]*?` gap matches a later step's flag and passes vacuously) — each assertion was mutation-verified to fail when its step's `--wait=false` is removed. Full `kubernetes` chart unittest suite: 180/180. Rendered hook passes `shellcheck -s sh`.

### Release note

```release-note
fix(apps/kubernetes): the tenant Kubernetes pre-delete hook no longer hangs teardown when the tenant cluster has no working nodes. The KamajiControlPlane, DataVolume, and LoadBalancer Service cleanup steps now trigger deletion without blocking on it, so deleting a broken or nodeless tenant completes within a bounded time instead of leaving the namespace stuck Terminating.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant deletion reliability by preventing cleanup operations from blocking indefinitely.
  * Added bounded waiting for resource finalization and non-blocking deletion for control planes, storage volumes, and load balancer services.
  * Prevented forced finalizer removal from storage volumes, reducing the risk of orphaned backing resources.
  * Added coverage for nodeless tenant teardown scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->