### PR TITLE
test(e2e): diff-driven install selector select-install.sh

### DIFF
--- a/hack/select-install.sh
+++ b/hack/select-install.sh
@@ -1,0 +1,161 @@
+#!/bin/sh
+# Given the E2E app suite(s) about to run, emit the minimal set of packages that
+# must be INSTALLED for those suites — the forward dependency closure over the
+# PackageSource graph. This is the install-side companion to select-e2e.sh:
+# select-e2e.sh picks WHICH Chainsaw suites run (reverse dependency walk);
+# select-install.sh picks WHAT must be up for them (forward dependency walk).
+#
+# Usage:
+#   hack/select-install.sh <suites> [<sources-dir>]
+#   hack/select-install.sh --validate [<sources-dir>]
+#
+# Defaults: sources-dir = packages/core/platform/sources
+#
+# <suites>: whitespace-separated suite names, i.e. the output of select-e2e.sh
+#           (e.g. "postgres harbor"). "-" reads the list from stdin.
+#
+# Output (closure mode): space-separated PackageSource names (cozystack.*) that
+#   the run must enable, seeds + all transitive dependsOn. Empty when <suites>
+#   is empty.
+#
+# --validate: check the whole graph — every dependsOn target resolves to a real
+#   PackageSource, and there are no dependency cycles. Exit non-zero on either.
+#
+# Unlike select-e2e.sh's reverse walk, the forward walk KEEPS the
+# cozystack.cozystack-engine edge: every *-application declares
+# `dependsOn: cozystack.cozystack-engine` because the app's *-rd HelmRelease
+# needs the engine to register the ApplicationDefinition CRD before it can
+# reconcile. For test SELECTION that edge is noise (it would fan every app out
+# to every other); for INSTALL it is a genuine prerequisite that must be up.
+set -eu
+
+SOURCES_DIR="packages/core/platform/sources"
+MODE="closure"
+SUITES=""
+
+if [ "${1:-}" = "--validate" ]; then
+  MODE="validate"
+  SOURCES_DIR="${2:-$SOURCES_DIR}"
+else
+  suites_arg="${1?usage: select-install.sh <suites> [sources-dir] | --validate [sources-dir]}"
+  SOURCES_DIR="${2:-$SOURCES_DIR}"
+  if [ "$suites_arg" = "-" ]; then
+    SUITES="$(cat)"
+  else
+    SUITES="$suites_arg"
+  fi
+fi
+
+# suite name -> owning PackageSource. Prints:
+#   - a "cozystack.*" name         the suite's primary install target
+#   - "-"                          the suite targets a core-platform feature that
+#                                  has no separately-enabled package (always
+#                                  present via the base install), e.g.
+#                                  serviceexposure (ExposureClass/ServiceExposure
+#                                  live in packages/core/platform)
+#   - nothing                      no mapping is known (caller warns)
+# Most suites follow the <suite>-application convention; a bare-<suite> fallback
+# and the explicit cases cover suites whose source is named differently. Kept in
+# lockstep with select-e2e.sh's src_to_suites() and the hack/e2e-chainsaw/ dirs.
+#
+# Note: a suite may exercise MORE than one package (e.g. securitygroup also
+# stands up a Kubernetes app). Only the primary package is mapped here; the
+# forward closure covers its own deps, and the full-suite fallback covers the
+# rest. Modelling multi-package suites is deferred to the test-minimal work.
+suite_to_source() {
+  case "$1" in
+    kubernetes-latest|kubernetes-previous|kubernetes-oidc-system|kubernetes-oidc-customconfig)
+      echo cozystack.kubernetes-application ; return ;;
+    vminstance) echo cozystack.vm-instance-application ; return ;;
+    securitygroup) echo cozystack.securitygroup-controller ; return ;;
+    serviceexposure) echo - ; return ;;
+  esac
+  for cand in "cozystack.$1-application" "cozystack.$1"; do
+    if echo "$NODES" | grep -Fxq "$cand"; then echo "$cand"; return; fi
+  done
+}
+
+# yq: forward edges — "owner<TAB>dep", one per variant dependsOn entry.
+build_forward_deps() {
+  yq -rN '.metadata.name as $n | .spec.variants[]?.dependsOn[]? | select(. != null and . != "") | $n + "\t" + .' "$SOURCES_DIR"/*.yaml
+}
+
+NODES="$(yq -rN '.metadata.name | select(. != null and . != "")' "$SOURCES_DIR"/*.yaml | sort -u)"
+FORWARD="$(build_forward_deps | sort -u)"
+
+# forward deps of a single node
+deps_of() {
+  echo "$FORWARD" | awk -v s="$1" -F'\t' '$1==s {print $2}'
+}
+
+if [ "$MODE" = "validate" ]; then
+  rc=0
+
+  # 1. Reachability: every dependsOn target must be a real PackageSource.
+  echo "$FORWARD" | awk -F'\t' '{print $2}' | sort -u | while IFS= read -r dep; do
+    [ -z "$dep" ] && continue
+    if ! echo "$NODES" | grep -Fxq "$dep"; then
+      owners="$(echo "$FORWARD" | awk -v x="$dep" -F'\t' '$2==x {print $1}' | paste -sd ',' -)"
+      echo "select-install: dangling dependency '$dep' (referenced by: $owners) has no PackageSource" >&2
+      echo dangling
+    fi
+  done | grep -q dangling && rc=1
+
+  # 2. Cycles: from every node with outgoing edges, walk forward; if the walk
+  #    returns to its start, the graph has a cycle through it.
+  owners_list="$(echo "$FORWARD" | awk -F'\t' '{print $1}' | sort -u)"
+  for start in $owners_list; do
+    visited=""
+    frontier="$(deps_of "$start")"
+    while [ -n "$frontier" ]; do
+      next=""
+      for f in $frontier; do
+        if [ "$f" = "$start" ]; then
+          echo "select-install: dependency cycle detected involving '$start'" >&2
+          rc=1
+          next=""
+          break
+        fi
+        case " $visited " in *" $f "*) continue ;; esac
+        visited="$visited $f"
+        next="$next $(deps_of "$f")"
+      done
+      frontier="$next"
+    done
+  done
+
+  [ "$rc" = 0 ] && echo "select-install: graph OK ($(echo "$NODES" | grep -c .) sources)" >&2
+  exit "$rc"
+fi
+
+# Closure mode: map suites to seed sources, then take the forward closure.
+seeds=""
+for suite in $SUITES; do
+  [ -z "$suite" ] && continue
+  src="$(suite_to_source "$suite")"
+  case "$src" in
+    "-") continue ;;  # core-platform feature — nothing separate to enable
+    "")  echo "select-install: warning: suite '$suite' has no known PackageSource mapping; skipping" >&2 ; continue ;;
+  esac
+  if echo "$NODES" | grep -Fxq "$src"; then
+    case " $seeds " in *" $src "*) ;; *) seeds="$seeds $src" ;; esac
+  else
+    echo "select-install: warning: suite '$suite' -> '$src' not found; skipping" >&2
+  fi
+done
+
+[ -z "$seeds" ] && exit 0
+
+all="$seeds"
+while :; do
+  new=""
+  for s in $all; do
+    for d in $(deps_of "$s"); do
+      case " $all $new " in *" $d "*) ;; *) new="$new $d" ;; esac
+    done
+  done
+  [ -z "$new" ] && break
+  all="$all $new"
+done
+
+echo "$all" | tr ' ' '\n' | grep -v '^$' | sort -u | paste -sd ' ' -

--- a/hack/select-install.sh
+++ b/hack/select-install.sh
@@ -7,19 +7,26 @@
 #
 # Usage:
 #   hack/select-install.sh <suites> [<sources-dir>]
-#   hack/select-install.sh --validate [<sources-dir>]
+#   hack/select-install.sh --validate [<sources-dir> [<suites-dir>]]
 #
 # Defaults: sources-dir = packages/core/platform/sources
+#           suites-dir  = hack/e2e-chainsaw
 #
 # <suites>: whitespace-separated suite names, i.e. the output of select-e2e.sh
 #           (e.g. "postgres harbor"). "-" reads the list from stdin.
 #
 # Output (closure mode): space-separated PackageSource names (cozystack.*) that
-#   the run must enable, seeds + all transitive dependsOn. Empty when <suites>
-#   is empty.
+#   the run must enable, seeds + the engine + all transitive dependsOn. Empty
+#   when <suites> is empty. A suite with no known mapping is a HARD ERROR (fail
+#   closed) — a silently-skipped suite would install nothing and let the test
+#   pass vacuously or fail later on a missing CRD.
 #
-# --validate: check the whole graph — every dependsOn target resolves to a real
-#   PackageSource, and there are no dependency cycles. Exit non-zero on either.
+# --validate: check the whole graph AND the suite mapping — every dependsOn
+#   target resolves to a real PackageSource, there are no dependency cycles, and
+#   every Chainsaw suite under <suites-dir> resolves via suite_to_source() to a
+#   real PackageSource or to "-". Exit non-zero on any failure. The graph lives
+#   next to the packages and cannot drift from the suite directories; the
+#   hand-maintained suite mapping is the only part that can, so it is guarded here.
 #
 # Unlike select-e2e.sh's reverse walk, the forward walk KEEPS the
 # cozystack.cozystack-engine edge: every *-application declares
@@ -27,17 +34,21 @@
 # needs the engine to register the ApplicationDefinition CRD before it can
 # reconcile. For test SELECTION that edge is noise (it would fan every app out
 # to every other); for INSTALL it is a genuine prerequisite that must be up.
+# Suites backed by a system package (e.g. securitygroup) carry no such edge, so
+# the engine is seeded explicitly for any non-empty closure (see below).
 set -eu
 
 SOURCES_DIR="packages/core/platform/sources"
+SUITES_DIR="hack/e2e-chainsaw"
 MODE="closure"
 SUITES=""
 
 if [ "${1:-}" = "--validate" ]; then
   MODE="validate"
   SOURCES_DIR="${2:-$SOURCES_DIR}"
+  SUITES_DIR="${3:-$SUITES_DIR}"
 else
-  suites_arg="${1?usage: select-install.sh <suites> [sources-dir] | --validate [sources-dir]}"
+  suites_arg="${1?usage: select-install.sh <suites> [sources-dir] | --validate [sources-dir [suites-dir]]}"
   SOURCES_DIR="${2:-$SOURCES_DIR}"
   if [ "$suites_arg" = "-" ]; then
     SUITES="$(cat)"
@@ -53,15 +64,18 @@ fi
 #                                  present via the base install), e.g.
 #                                  serviceexposure (ExposureClass/ServiceExposure
 #                                  live in packages/core/platform)
-#   - nothing                      no mapping is known (caller warns)
+#   - nothing                      no mapping is known (caller fails closed)
 # Most suites follow the <suite>-application convention; a bare-<suite> fallback
 # and the explicit cases cover suites whose source is named differently. Kept in
-# lockstep with select-e2e.sh's src_to_suites() and the hack/e2e-chainsaw/ dirs.
+# lockstep with select-e2e.sh's src_to_suites() and the hack/e2e-chainsaw/ dirs;
+# --validate asserts every suite dir still resolves here.
 #
-# Note: a suite may exercise MORE than one package (e.g. securitygroup also
-# stands up a Kubernetes app). Only the primary package is mapped here; the
-# forward closure covers its own deps, and the full-suite fallback covers the
-# rest. Modelling multi-package suites is deferred to the test-minimal work.
+# Note: a suite may exercise fixtures or selectors that name other app kinds
+# (e.g. securitygroup's SecurityGroup references Postgres/Kubernetes by kind and
+# name as selectors — it does not stand those apps up). Only the primary package
+# is mapped here; the forward closure covers its own deps, the seeded engine
+# covers the aggregated *.cozystack.io APIs, and the full-suite fallback covers
+# the rest. Modelling multi-package suites is deferred to the test-minimal work.
 suite_to_source() {
   case "$1" in
     kubernetes-latest|kubernetes-previous|kubernetes-oidc-system|kubernetes-oidc-customconfig)
@@ -76,6 +90,10 @@ suite_to_source() {
 }
 
 # yq: forward edges — "owner<TAB>dep", one per variant dependsOn entry.
+# NOTE: this unions dependsOn across ALL spec.variants[] rather than the single
+# variant actually installed (e.g. cozystack.networking has 6 variants; only 5
+# declare gateway-api-crds). That OVER-selects, never under-selects, so the
+# emitted set is a safe superset of the true minimal set for the chosen variant.
 build_forward_deps() {
   yq -rN '.metadata.name as $n | .spec.variants[]?.dependsOn[]? | select(. != null and . != "") | $n + "\t" + .' "$SOURCES_DIR"/*.yaml
 }
@@ -86,6 +104,13 @@ FORWARD="$(build_forward_deps | sort -u)"
 # forward deps of a single node
 deps_of() {
   echo "$FORWARD" | awk -v s="$1" -F'\t' '$1==s {print $2}'
+}
+
+# all Chainsaw suite names under a suites-dir (dirs holding chainsaw-test.yaml),
+# discovered exactly like select-e2e.sh.
+discover_suites() {
+  find "$1" -mindepth 2 -maxdepth 2 -name chainsaw-test.yaml 2>/dev/null \
+    | sed -e 's,/chainsaw-test\.yaml$,,' -e 's,.*/,,' | sort
 }
 
 if [ "$MODE" = "validate" ]; then
@@ -124,27 +149,71 @@ if [ "$MODE" = "validate" ]; then
     done
   done
 
+  # 3. Suite mapping: every Chainsaw suite dir must resolve to a real source or
+  #    "-". The suite universe is auto-discovered while suite_to_source() is
+  #    hand-maintained, so this is the part that actually drifts. A missing
+  #    suites dir is itself a failure — otherwise a moved/misspelled path would
+  #    make discovery yield nothing and silently pass this whole check.
+  if [ ! -d "$SUITES_DIR" ]; then
+    echo "select-install: suites dir '$SUITES_DIR' does not exist" >&2
+    rc=1
+  else
+    for suite in $(discover_suites "$SUITES_DIR"); do
+      src="$(suite_to_source "$suite")"
+      if [ -z "$src" ]; then
+        echo "select-install: suite '$suite' has no PackageSource mapping (add it to suite_to_source)" >&2
+        rc=1
+      elif [ "$src" != "-" ] && ! echo "$NODES" | grep -Fxq "$src"; then
+        echo "select-install: suite '$suite' maps to '$src', not a PackageSource in $SOURCES_DIR" >&2
+        rc=1
+      fi
+    done
+  fi
+
   [ "$rc" = 0 ] && echo "select-install: graph OK ($(echo "$NODES" | grep -c .) sources)" >&2
   exit "$rc"
 fi
 
 # Closure mode: map suites to seed sources, then take the forward closure.
 seeds=""
+map_rc=0
 for suite in $SUITES; do
   [ -z "$suite" ] && continue
   src="$(suite_to_source "$suite")"
   case "$src" in
     "-") continue ;;  # core-platform feature — nothing separate to enable
-    "")  echo "select-install: warning: suite '$suite' has no known PackageSource mapping; skipping" >&2 ; continue ;;
+    "")
+      # Fail closed: a suite that maps to nothing must abort, not silently emit
+      # an empty set. Collect every bad suite so one run reports them all.
+      echo "select-install: error: suite '$suite' has no known PackageSource mapping (add it to suite_to_source)" >&2
+      map_rc=1
+      continue ;;
   esac
   if echo "$NODES" | grep -Fxq "$src"; then
     case " $seeds " in *" $src "*) ;; *) seeds="$seeds $src" ;; esac
   else
-    echo "select-install: warning: suite '$suite' -> '$src' not found; skipping" >&2
+    echo "select-install: error: suite '$suite' -> '$src' is not a PackageSource in $SOURCES_DIR" >&2
+    map_rc=1
   fi
 done
+[ "$map_rc" = 0 ] || exit "$map_rc"
 
 [ -z "$seeds" ] && exit 0
+
+# Any non-empty install set needs the engine up: it registers the
+# ApplicationDefinition CRD every *-rd HelmRelease reconciles against, and its
+# cozystack-api component serves the aggregated *.cozystack.io APIs some suites
+# exercise (e.g. securitygroup -> sdn.cozystack.io). *-application sources carry
+# a dependsOn edge to it; system-package-backed suites reach it via no edge, so
+# seed it explicitly here. Its absence from the graph is a hard error — nothing
+# can install without it.
+engine="cozystack.cozystack-engine"
+if echo "$NODES" | grep -Fxq "$engine"; then
+  case " $seeds " in *" $engine "*) ;; *) seeds="$seeds $engine" ;; esac
+else
+  echo "select-install: error: required engine PackageSource '$engine' not found in $SOURCES_DIR" >&2
+  exit 1
+fi
 
 all="$seeds"
 while :; do

--- a/hack/select-install_test.bats
+++ b/hack/select-install_test.bats
@@ -5,18 +5,19 @@
 # cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
 # own line; there is no bats `run` or `$status`. Each test runs as a shell
 # function under `set -eu -x`, so assertions are direct shell tests that exit
-# non-zero on failure. setup()/teardown() are not honored — each test creates
-# and cleans its own scratch dir. To assert a NON-zero exit, invert with `if`
-# so `set -e` doesn't abort the test.
+# non-zero on failure. setup()/teardown() are not honored; per-test `trap ...
+# EXIT` cleanup IS honored. To assert a NON-zero exit, invert with `if` so
+# `set -e` doesn't abort the test.
+#
+# Tests that only READ the production sources call the script directly (it
+# defaults sources-dir to packages/core/platform/sources); only the tests that
+# build a synthetic graph or suite tree use a scratch dir.
 #
 # Run with: hack/cozytest.sh hack/select-install_test.bats
 # -----------------------------------------------------------------------------
 
 @test "single app selects its forward dependency closure" {
-    tmp=$(mktemp -d)
-    trap 'rm -rf "$tmp"' EXIT
-    cp -r packages/core/platform/sources "$tmp/sources"
-    output=$(hack/select-install.sh "postgres" "$tmp/sources")
+    output=$(hack/select-install.sh "postgres")
     echo "$output" | grep -wq cozystack.postgres-application
     echo "$output" | grep -wq cozystack.postgres-operator
     echo "$output" | grep -wq cozystack.networking
@@ -25,10 +26,7 @@
 }
 
 @test "closure is transitive (deps of deps are pulled in)" {
-    tmp=$(mktemp -d)
-    trap 'rm -rf "$tmp"' EXIT
-    cp -r packages/core/platform/sources "$tmp/sources"
-    output=$(hack/select-install.sh "postgres" "$tmp/sources")
+    output=$(hack/select-install.sh "postgres")
     # cert-manager is a 2-hop dep (via postgres-operator and via the engine)
     echo "$output" | grep -wq cozystack.cert-manager
     # gateway-api-crds is a 3-hop dep (postgres-application -> networking -> gateway-api-crds)
@@ -36,10 +34,7 @@
 }
 
 @test "app pulls its direct operator dependencies" {
-    tmp=$(mktemp -d)
-    trap 'rm -rf "$tmp"' EXIT
-    cp -r packages/core/platform/sources "$tmp/sources"
-    output=$(hack/select-install.sh "harbor" "$tmp/sources")
+    output=$(hack/select-install.sh "harbor")
     echo "$output" | grep -wq cozystack.harbor-application
     echo "$output" | grep -wq cozystack.postgres-operator
     echo "$output" | grep -wq cozystack.redis-operator
@@ -47,77 +42,81 @@
 }
 
 @test "kubernetes suites map back to the kubernetes application source" {
-    tmp=$(mktemp -d)
-    trap 'rm -rf "$tmp"' EXIT
-    cp -r packages/core/platform/sources "$tmp/sources"
-    output=$(hack/select-install.sh "kubernetes-latest" "$tmp/sources")
+    output=$(hack/select-install.sh "kubernetes-latest")
     echo "$output" | grep -wq cozystack.kubernetes-application
 }
 
 @test "multiple suites union their closures" {
-    tmp=$(mktemp -d)
-    trap 'rm -rf "$tmp"' EXIT
-    cp -r packages/core/platform/sources "$tmp/sources"
-    output=$(hack/select-install.sh "postgres kafka" "$tmp/sources")
+    output=$(hack/select-install.sh "postgres kafka")
     echo "$output" | grep -wq cozystack.postgres-application
     echo "$output" | grep -wq cozystack.kafka-application
 }
 
+@test "suite list can be read from stdin with -" {
+    output=$(printf '%s\n' "postgres kafka" | hack/select-install.sh -)
+    echo "$output" | grep -wq cozystack.postgres-application
+    echo "$output" | grep -wq cozystack.kafka-application
+    echo "$output" | grep -wq cozystack.cozystack-engine
+}
+
 @test "empty suites select nothing" {
-    tmp=$(mktemp -d)
-    trap 'rm -rf "$tmp"' EXIT
-    cp -r packages/core/platform/sources "$tmp/sources"
-    output=$(hack/select-install.sh "" "$tmp/sources")
+    output=$(hack/select-install.sh "")
     [ -z "$output" ]
 }
 
-@test "unknown suite is skipped, not fatal" {
-    tmp=$(mktemp -d)
-    trap 'rm -rf "$tmp"' EXIT
-    cp -r packages/core/platform/sources "$tmp/sources"
-    output=$(hack/select-install.sh "definitely-not-an-app" "$tmp/sources" 2>/dev/null)
-    [ -z "$output" ]
+@test "unmapped suites are a hard error, all reported, no partial output" {
+    # Fail closed: a suite that maps to nothing must abort, not silently emit an
+    # empty set (which would install nothing and let the run pass vacuously).
+    # Also lock the contract that EVERY bad suite is reported in one run (not
+    # just the first) and that no partial closure leaks to stdout.
+    out=$(mktemp); err=$(mktemp)
+    trap 'rm -f "$out" "$err"' EXIT
+    if hack/select-install.sh "bad-one postgres bad-two" >"$out" 2>"$err"; then
+        echo "expected a non-zero exit for unmapped suites" >&2
+        exit 1
+    fi
+    grep -q "bad-one" "$err"
+    grep -q "bad-two" "$err"
+    [ ! -s "$out" ]
 }
 
 @test "suite whose source omits the -application suffix resolves via fallback" {
-    tmp=$(mktemp -d)
-    trap 'rm -rf "$tmp"' EXIT
-    cp -r packages/core/platform/sources "$tmp/sources"
     # kuberture's PackageSource is cozystack.kuberture (no -application suffix)
-    output=$(hack/select-install.sh "kuberture" "$tmp/sources")
+    output=$(hack/select-install.sh "kuberture")
     echo "$output" | grep -wq cozystack.kuberture
 }
 
-@test "suite with an irregular source name maps via explicit override" {
-    tmp=$(mktemp -d)
-    trap 'rm -rf "$tmp"' EXIT
-    cp -r packages/core/platform/sources "$tmp/sources"
-    output=$(hack/select-install.sh "securitygroup" "$tmp/sources")
+@test "securitygroup closure includes the engine that serves sdn.cozystack.io" {
+    # Regression for the under-selection bug: the securitygroup suite applies
+    # sdn.cozystack.io/v1alpha1, served by the aggregated apiserver
+    # (a cozystack-engine component). The forward walk from the controller can't
+    # reach the engine, so it must be seeded. Assert the controller AND the
+    # engine AND the engine's stable prerequisites — asserting only the
+    # controller (a single member) is what let the bug through.
+    output=$(hack/select-install.sh "securitygroup")
     echo "$output" | grep -wq cozystack.securitygroup-controller
+    echo "$output" | grep -wq cozystack.cozystack-engine
+    echo "$output" | grep -wq cozystack.cert-manager
+    echo "$output" | grep -wq cozystack.networking
+    echo "$output" | grep -wq cozystack.gateway-api-crds
 }
 
 @test "core-platform suite contributes no package and emits no warning" {
-    tmp=$(mktemp -d)
-    trap 'rm -rf "$tmp"' EXIT
-    cp -r packages/core/platform/sources "$tmp/sources"
     # serviceexposure is a core-platform CRD; nothing to enable, no warning.
-    err=$(hack/select-install.sh "serviceexposure" "$tmp/sources" 2>&1 1>/dev/null)
+    err=$(hack/select-install.sh "serviceexposure" 2>&1 1>/dev/null)
     [ -z "$err" ]
-    output=$(hack/select-install.sh "serviceexposure" "$tmp/sources" 2>/dev/null)
+    output=$(hack/select-install.sh "serviceexposure" 2>/dev/null)
     [ -z "$output" ]
 }
 
-@test "validate passes on the real source graph" {
-    tmp=$(mktemp -d)
-    trap 'rm -rf "$tmp"' EXIT
-    cp -r packages/core/platform/sources "$tmp/sources"
-    hack/select-install.sh --validate "$tmp/sources"
+@test "validate passes on the real source graph and suite mapping" {
+    hack/select-install.sh --validate
 }
 
 @test "validate detects a dangling dependency" {
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' EXIT
-    mkdir -p "$tmp/sources"
+    mkdir -p "$tmp/sources" "$tmp/suites"
     cat > "$tmp/sources/foo-application.yaml" <<'YAML'
 apiVersion: cozystack.io/v1alpha1
 kind: PackageSource
@@ -129,7 +128,8 @@ spec:
       dependsOn:
         - cozystack.does-not-exist
 YAML
-    if hack/select-install.sh --validate "$tmp/sources" 2>/dev/null; then
+    # empty suites-dir isolates this to the graph check
+    if hack/select-install.sh --validate "$tmp/sources" "$tmp/suites" 2>/dev/null; then
         echo "expected validation to fail on a dangling dependency" >&2
         exit 1
     fi
@@ -138,7 +138,7 @@ YAML
 @test "validate detects a dependency cycle" {
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' EXIT
-    mkdir -p "$tmp/sources"
+    mkdir -p "$tmp/sources" "$tmp/suites"
     cat > "$tmp/sources/a.yaml" <<'YAML'
 apiVersion: cozystack.io/v1alpha1
 kind: PackageSource
@@ -161,8 +161,52 @@ spec:
       dependsOn:
         - cozystack.a
 YAML
-    if hack/select-install.sh --validate "$tmp/sources" 2>/dev/null; then
+    # empty suites-dir isolates this to the graph check
+    if hack/select-install.sh --validate "$tmp/sources" "$tmp/suites" 2>/dev/null; then
         echo "expected validation to fail on a dependency cycle" >&2
+        exit 1
+    fi
+}
+
+@test "validate detects a suite directory with no source mapping" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    mkdir -p "$tmp/suites/totally-unmapped-suite"
+    : > "$tmp/suites/totally-unmapped-suite/chainsaw-test.yaml"
+    # real graph (so graph checks pass); the only failure is the unmapped suite
+    if hack/select-install.sh --validate packages/core/platform/sources "$tmp/suites" 2>/dev/null; then
+        echo "expected validation to fail on an unmapped suite dir" >&2
+        exit 1
+    fi
+}
+
+@test "validate fails when the suites dir does not exist" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    # real graph passes the graph checks; a missing suites dir must still FAIL
+    # (find would yield nothing and silently pass the mapping check otherwise).
+    if hack/select-install.sh --validate packages/core/platform/sources "$tmp/does-not-exist" 2>/dev/null; then
+        echo "expected validate to fail on a missing suites dir" >&2
+        exit 1
+    fi
+}
+
+@test "closure fails closed when the engine PackageSource is absent" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    mkdir -p "$tmp/sources"
+    # a lone app source, with no cozystack.cozystack-engine in the graph
+    cat > "$tmp/sources/foo-application.yaml" <<'YAML'
+apiVersion: cozystack.io/v1alpha1
+kind: PackageSource
+metadata:
+  name: cozystack.foo-application
+spec:
+  variants:
+    - name: default
+YAML
+    if hack/select-install.sh "foo" "$tmp/sources" 2>/dev/null; then
+        echo "expected a non-zero exit when the engine source is missing" >&2
         exit 1
     fi
 }

--- a/hack/select-install_test.bats
+++ b/hack/select-install_test.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Unit tests for hack/select-install.sh
+#
+# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
+# own line; there is no bats `run` or `$status`. Each test runs as a shell
+# function under `set -eu -x`, so assertions are direct shell tests that exit
+# non-zero on failure. setup()/teardown() are not honored — each test creates
+# and cleans its own scratch dir. To assert a NON-zero exit, invert with `if`
+# so `set -e` doesn't abort the test.
+#
+# Run with: hack/cozytest.sh hack/select-install_test.bats
+# -----------------------------------------------------------------------------
+
+@test "single app selects its forward dependency closure" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    output=$(hack/select-install.sh "postgres" "$tmp/sources")
+    echo "$output" | grep -wq cozystack.postgres-application
+    echo "$output" | grep -wq cozystack.postgres-operator
+    echo "$output" | grep -wq cozystack.networking
+    # engine edge is KEPT on the install walk (unlike select-e2e.sh)
+    echo "$output" | grep -wq cozystack.cozystack-engine
+}
+
+@test "closure is transitive (deps of deps are pulled in)" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    output=$(hack/select-install.sh "postgres" "$tmp/sources")
+    # cert-manager is a 2-hop dep (via postgres-operator and via the engine)
+    echo "$output" | grep -wq cozystack.cert-manager
+    # gateway-api-crds is a 3-hop dep (postgres-application -> networking -> gateway-api-crds)
+    echo "$output" | grep -wq cozystack.gateway-api-crds
+}
+
+@test "app pulls its direct operator dependencies" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    output=$(hack/select-install.sh "harbor" "$tmp/sources")
+    echo "$output" | grep -wq cozystack.harbor-application
+    echo "$output" | grep -wq cozystack.postgres-operator
+    echo "$output" | grep -wq cozystack.redis-operator
+    echo "$output" | grep -wq cozystack.objectstorage-controller
+}
+
+@test "kubernetes suites map back to the kubernetes application source" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    output=$(hack/select-install.sh "kubernetes-latest" "$tmp/sources")
+    echo "$output" | grep -wq cozystack.kubernetes-application
+}
+
+@test "multiple suites union their closures" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    output=$(hack/select-install.sh "postgres kafka" "$tmp/sources")
+    echo "$output" | grep -wq cozystack.postgres-application
+    echo "$output" | grep -wq cozystack.kafka-application
+}
+
+@test "empty suites select nothing" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    output=$(hack/select-install.sh "" "$tmp/sources")
+    [ -z "$output" ]
+}
+
+@test "unknown suite is skipped, not fatal" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    output=$(hack/select-install.sh "definitely-not-an-app" "$tmp/sources" 2>/dev/null)
+    [ -z "$output" ]
+}
+
+@test "suite whose source omits the -application suffix resolves via fallback" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    # kuberture's PackageSource is cozystack.kuberture (no -application suffix)
+    output=$(hack/select-install.sh "kuberture" "$tmp/sources")
+    echo "$output" | grep -wq cozystack.kuberture
+}
+
+@test "suite with an irregular source name maps via explicit override" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    output=$(hack/select-install.sh "securitygroup" "$tmp/sources")
+    echo "$output" | grep -wq cozystack.securitygroup-controller
+}
+
+@test "core-platform suite contributes no package and emits no warning" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    # serviceexposure is a core-platform CRD; nothing to enable, no warning.
+    err=$(hack/select-install.sh "serviceexposure" "$tmp/sources" 2>&1 1>/dev/null)
+    [ -z "$err" ]
+    output=$(hack/select-install.sh "serviceexposure" "$tmp/sources" 2>/dev/null)
+    [ -z "$output" ]
+}
+
+@test "validate passes on the real source graph" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+    hack/select-install.sh --validate "$tmp/sources"
+}
+
+@test "validate detects a dangling dependency" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    mkdir -p "$tmp/sources"
+    cat > "$tmp/sources/foo-application.yaml" <<'YAML'
+apiVersion: cozystack.io/v1alpha1
+kind: PackageSource
+metadata:
+  name: cozystack.foo-application
+spec:
+  variants:
+    - name: default
+      dependsOn:
+        - cozystack.does-not-exist
+YAML
+    if hack/select-install.sh --validate "$tmp/sources" 2>/dev/null; then
+        echo "expected validation to fail on a dangling dependency" >&2
+        exit 1
+    fi
+}
+
+@test "validate detects a dependency cycle" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    mkdir -p "$tmp/sources"
+    cat > "$tmp/sources/a.yaml" <<'YAML'
+apiVersion: cozystack.io/v1alpha1
+kind: PackageSource
+metadata:
+  name: cozystack.a
+spec:
+  variants:
+    - name: default
+      dependsOn:
+        - cozystack.b
+YAML
+    cat > "$tmp/sources/b.yaml" <<'YAML'
+apiVersion: cozystack.io/v1alpha1
+kind: PackageSource
+metadata:
+  name: cozystack.b
+spec:
+  variants:
+    - name: default
+      dependsOn:
+        - cozystack.a
+YAML
+    if hack/select-install.sh --validate "$tmp/sources" 2>/dev/null; then
+        echo "expected validation to fail on a dependency cycle" >&2
+        exit 1
+    fi
+}


### PR DESCRIPTION
## What this PR does

Adds `hack/select-install.sh` — the install-side companion to `hack/select-e2e.sh`. Where `select-e2e.sh` picks *which* Chainsaw suites run for a diff (a reverse dependency walk), `select-install.sh` picks *what must be installed* for those suites: the forward `dependsOn` closure over the `PackageSource` graph.

Given the suite names `select-e2e.sh` emits, it maps each back to its `*-application` `PackageSource` and walks `spec.variants[].dependsOn` forward to the transitive closure — the minimal set of packages to enable instead of provisioning the full `isp-full` platform. A `postgres` chart change, for example, resolves to 9 of 97 sources.

Design notes:

- Reuses the real `PackageSource` graph in `packages/core/platform/sources/` — no parallel dependency-declaration files to keep in sync.
- Unlike `select-e2e.sh`'s reverse walk, the forward walk **keeps** the `cozystack.cozystack-engine` edge: for test *selection* it is noise (it would fan every app out to every other), but for *install* it is a genuine prerequisite (the app's `*-rd` HelmRelease needs the engine to register the ApplicationDefinition CRD). Because that edge lives only on `*-application` sources, a suite backed by a **system** package (e.g. `securitygroup`, whose `SecurityGroup` in `sdn.cozystack.io` is served by the aggregated `cozystack-api` — a `cozystack-engine` component) can't reach the engine via the walk, so the engine is **seeded explicitly for any non-empty closure** (and a graph missing it is a hard error).
- `--validate` mode checks the whole graph — every `dependsOn` target resolves to a real `PackageSource` (reachability) and there are no dependency cycles — **and** the suite mapping: every `hack/e2e-chainsaw/*/` suite resolves to a real `PackageSource` or to `-` (a missing suites dir is itself a failure). The graph lives next to the packages and can't drift from the suite dirs; the hand-maintained mapping is the only part that can, so this is the cheap CI guard.
- Suite→source mapping follows the `<suite>-application` convention with a bare-`<suite>` fallback, plus explicit cases for the irregular names (`kubernetes`/`vminstance`/`securitygroup`) and for core-platform features that have no separately-enabled package (`serviceexposure`, whose `ExposureClass`/`ServiceExposure` CRDs live in `packages/core/platform`). A suite may reference other app kinds by selector without standing them up (e.g. `securitygroup`'s `SecurityGroup` names `Postgres`/`Kubernetes` as selectors only) — only the primary package is mapped here; the forward closure and the seeded engine cover its prerequisites, and full multi-package modelling is left to the `test-minimal` follow-up. A suite with no known mapping is a **hard error** (fail closed), not a silent skip.

Includes a 17-case unit suite (`hack/select-install_test.bats`) covering single-app closure, transitivity, multi-suite union, stdin input, the kubernetes/irregular/core-platform suite mappings, the `securitygroup` engine-seed regression, empty input, fail-closed unmapped suites (all reported, no partial output), the missing-engine hard error, and the `--validate` failure modes (dangling dep, cycle, unmapped suite dir, missing suites dir). It is auto-discovered by `make unit-tests` (`BATS_UNIT_FILES` globs `hack/*.bats`).

Verified end-to-end against real git diffs across six path types (app chart, shared operator, docs-only, per-suite Chainsaw edit, library, shared e2e helper): a `postgres` chart change scopes the install to 9 of 97 sources; the full-suite fallback to 39 of 97.

This is Track A of #2847 (diff-driven & scenario-based E2E); tracked in #3278. Consuming the output — a `test-minimal` platform variant/bundle plus wiring into the `pull-requests.yaml` install step — is a deliberate follow-up, since it depends on a platform-variant design decision.

### Screenshots

Not applicable — CI/tooling-only change.

### Release note

```release-note
test(e2e): add hack/select-install.sh to compute the minimal package install set for a diff-scoped E2E run (forward PackageSource dependency closure), with a --validate graph-consistency mode
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tool to select the minimal package set required for one or more end-to-end test suites.
  * Supports combining multiple suites, resolving transitive dependencies, and handling unmapped or empty suite selections.
  * Added validation for missing dependencies and circular dependency definitions.

* **Tests**
  * Added coverage for package selection, dependency resolution, suite mappings, empty selections, and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
