### PR TITLE
fix(apps/vpn): remove invalid foo field from urls Secret

### DIFF
--- a/packages/apps/vpn/templates/secret.yaml
+++ b/packages/apps/vpn/templates/secret.yaml
@@ -59,8 +59,6 @@ kind: Secret
 metadata:
   name: {{ .Release.Name }}-urls
 type: Opaque
-foo: |
-  {{ toJson $passwords }}
 stringData:
   {{- range $user, $u := .Values.users }}
   "{{ $user }}": "ss://{{ regexReplaceAll "=" (replace "/" "_" (replace "+" "-" (printf "chacha20-ietf-poly1305:%s" (index $passwords $user) | b64enc))) "" }}@{{ $.Values.host | default (printf "%s.%s" $.Release.Name $host) }}:40000/?outline=1#{{ $.Release.Name }}"


### PR DESCRIPTION
## What this PR does

Removes a leftover debug field `foo` from the `<release>-urls` Secret template in the VPN app chart.

The `foo` field is not part of the `core/v1` Secret schema (which only allows `data`, `stringData`, `type`, `immutable`, and `metadata`). It went unnoticed under client-side apply, but under server-side apply the stricter schema validation rejects it with:

```text
.foo: field not declared in schema
```

As a result, any VPN application upgrade fails and the release is left in `UpgradeFailed` state.

### Release note

```release-note
fix(apps/vpn): remove invalid `foo` field from the urls Secret that broke Helm upgrades under server-side apply
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-user Shadowsocks connection links to the VPN secret.
  * Links include the configured encryption method, host, port, and connection name for easier client setup.

* **Bug Fixes**
  * Removed obsolete serialized password data from the VPN secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->