### PR TITLE
fix(seaweedfs): adopt legacy workloads in place across the 4.31 rename

### DIFF
--- a/docs/operations/seaweedfs-431-rename-recovery.md
+++ b/docs/operations/seaweedfs-431-rename-recovery.md
@@ -1,0 +1,197 @@
+# SeaweedFS 4.31 rename — audit & recovery
+
+This runbook covers clusters affected by the SeaweedFS chart-rename regression introduced when the vendored chart was bumped from `4.0.405` to `4.31.0` (Cozystack v1.5.0). Use it to classify each tenant, and to recover the ones that need an operator before they can be upgraded.
+
+## Background
+
+Before 4.31 the chart named workloads after the chart (`seaweedfs-*`), ignoring the release name. 4.31 names them after the release, and the data-plane HelmRelease is `<name>-system`, so every StatefulSet wanted to become `seaweedfs-system-*`. StatefulSet names are immutable, so the upgrade could not rename in place — Helm stood up a second, duplicate set beside the running one. Depending on cluster size the duplicate either deadlocks or splits:
+
+- **D-wedged** — with as many nodes as master replicas, the new masters cannot schedule (hard pod anti-affinity against the old masters). The new set stays `Pending`/`CrashLoopBackOff`, the old set keeps serving. No data at risk.
+- **D-split** — with more nodes than masters, the new (empty) set comes up. Both sets carry identical pod labels, so the `seaweedfs-s3` Service load-balances across them, and both filers write to the **same `seaweedfs-db` Postgres** metadata store while pointing at different volume servers. This is a data-integrity incident, not just a duplicate: reads of existing objects through the new endpoint miss, new writes land on empty volumes, and the two master sets hand out volume IDs from independent sequences into one shared metadata table.
+
+The fix pins `fullnameOverride: seaweedfs` in `system/seaweedfs` values, so workloads are always named after the chart, exactly as they were before 4.31. Upgrading past the bump therefore **adopts the running set and its volumes in place**.
+
+One class cannot be adopted that way: a tenant installed **fresh on 1.5.x**, whose data was written under the release-based names and lives on `data1-seaweedfs-system-volume-*` PVCs. Pinning the chart name there would rename the workloads *away* from that data. Helm cannot move data between PVCs, so `extra/seaweedfs` refuses to render for such a tenant and points here. Re-bind its volumes (below) before upgrading.
+
+## Step 1 — Audit the fleet (read-only)
+
+Run per cluster (`KUBECONFIG` pointed at each). It mutates nothing. Classification is driven by the **PVCs**, because they hold the data and outlive any workload.
+
+```sh
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%-28s %-10s %s\n' NAMESPACE CLASS NOTE
+printf '%-28s %-10s %s\n' --------- ----- ----
+# A volume PVC is data1-<fullname>-volume[-<pool|zone>]-N. Pre-4.31 <fullname> was
+# always the chart name, so legacy data is data1-seaweedfs-volume-*. On 4.31 it is
+# the release name, plus the chart name when the release does not contain it:
+# seaweedfs-system-* for the default instance, <name>-system-seaweedfs-* otherwise.
+nss=$(kubectl get pvc -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' \
+        | awk '$2 ~ /^data1-.*volume/ && $2 ~ /seaweedfs/ {print $1}' | sort -u)
+[ -z "${nss}" ] && { echo "(no SeaweedFS volume PVCs found)"; exit 0; }
+for ns in ${nss}; do
+  pvcs=$(kubectl get pvc -n "$ns" -o name | sed 's|persistentvolumeclaim/||')
+  legacy=$(echo "$pvcs" | grep -cE '^data1-seaweedfs-volume' || true)
+  system=$(echo "$pvcs" | grep -E '^data1-.*volume' | grep -E 'seaweedfs' | grep -vE '^data1-seaweedfs-volume' | grep -c . || true)
+  running_new=$(kubectl get pods -n "$ns" \
+      -l app.kubernetes.io/name=seaweedfs,app.kubernetes.io/component=volume \
+      --field-selector=status.phase=Running -o name 2>/dev/null \
+      | grep -vc '/seaweedfs-volume-' || true)
+  if [ "$legacy" -gt 0 ] && [ "$system" -gt 0 ]; then
+    if [ "${running_new:-0}" -gt 0 ]; then
+      printf '%-28s %-10s %s\n' "$ns" "D-split" "DANGER: duplicate volume servers Running — audit before upgrading"
+    else
+      printf '%-28s %-10s %s\n' "$ns" "D-wedged" "duplicate set never served; upgrade adopts the legacy set"
+    fi
+  elif [ "$legacy" -gt 0 ]; then
+    printf '%-28s %-10s %s\n' "$ns" "L" "pre-1.5 naming; upgrade adopts in place, nothing to do"
+  else
+    printf '%-28s %-10s %s\n' "$ns" "S" "fresh 1.5.x install; re-bind volumes (Step 2) BEFORE upgrading"
+  fi
+done
+```
+
+Act on the classes in this order: resolve every **D-split** and every **S** tenant first (both need an operator), then upgrade. **L** and **D-wedged** need nothing.
+
+## Step 2 — `S` tenants: re-bind the volumes before upgrading
+
+The data is on `data1-seaweedfs-system-volume-N`; the fixed chart expects `data1-seaweedfs-volume-N`. Rather than copying objects, re-point the same PersistentVolume at a PVC with the new name. Nothing is written or moved; only the claim is renamed. Expect downtime for this tenant's S3.
+
+```sh
+ns=<tenant>
+
+# 1. Stop the operator from fighting the change.
+app=<seaweedfs-instance-name>   # the SeaweedFS resource name; `seaweedfs` unless you renamed it
+kubectl -n "$ns" patch helmrelease "${app}-system" --type merge -p '{"spec":{"suspend":true}}'
+# Select the renamed workloads precisely. An S tenant has only the renamed set,
+# but exclude the pre-4.31 chart-named seaweedfs-master/-filer/-volume[-<key>]
+# anyway so the same selector is reused in Step 3, where both sets coexist.
+# seaweedfs-system-* and <name>-system-seaweedfs-* are kept.
+renamed_sts() {
+  kubectl -n "$ns" get sts -l app.kubernetes.io/name=seaweedfs -o name \
+    | sed 's|statefulset.apps/||' | grep -vE '^seaweedfs-(master|filer|volume)($|-)'
+}
+for sts in $(renamed_sts); do
+  kubectl -n "$ns" scale sts "$sts" --replicas=0
+done
+kubectl -n "$ns" scale deploy -l app.kubernetes.io/name=seaweedfs,app.kubernetes.io/component=s3 --replicas=0
+
+# 2. For every volume PVC: protect its PV, then re-bind it under the new name.
+for pvc in $(kubectl -n "$ns" get pvc -o name | sed 's|persistentvolumeclaim/||' \
+               | grep -E '^data1-.*volume' | grep seaweedfs | grep -vE '^data1-seaweedfs-volume'); do
+  # data1-<renamed>-volume[-<key>]-N  ->  data1-seaweedfs-volume[-<key>]-N
+  new_pvc=$(echo "$pvc" | sed -E 's/^data1-.*-volume-/data1-seaweedfs-volume-/')
+  pv=$(kubectl -n "$ns" get pvc "$pvc" -o jsonpath='{.spec.volumeName}')
+  sc=$(kubectl -n "$ns" get pvc "$pvc" -o jsonpath='{.spec.storageClassName}')
+  size=$(kubectl -n "$ns" get pvc "$pvc" -o jsonpath='{.spec.resources.requests.storage}')
+  # Remember the PV's own reclaim policy: it is restored verbatim below, so a volume
+  # the cluster deliberately set to Retain does not silently come back as Delete.
+  reclaim=$(kubectl get pv "$pv" -o jsonpath='{.spec.persistentVolumeReclaimPolicy}')
+
+  # Keep the PV (and the data) when the claim goes away.
+  kubectl patch pv "$pv" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+  kubectl -n "$ns" delete pvc "$pvc"
+  # A Released PV cannot be re-bound until its old claimRef is cleared.
+  kubectl patch pv "$pv" --type json -p '[{"op":"remove","path":"/spec/claimRef"}]'
+
+  kubectl -n "$ns" apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${new_pvc}
+  namespace: ${ns}
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: ${sc}
+  volumeName: ${pv}
+  resources:
+    requests:
+      storage: ${size}
+EOF
+  # Restore the PV's original reclaim policy now that the new claim owns it.
+  kubectl patch pv "$pv" -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"${reclaim}\"}}"
+done
+
+# 3. Confirm every new claim is Bound to its original PV before going further.
+kubectl -n "$ns" get pvc -o custom-columns=NAME:.metadata.name,STATUS:.status.phase,VOLUME:.spec.volumeName
+
+# 4. Drop the old workloads; the fixed chart will recreate them under the chart name.
+for sts in $(renamed_sts); do kubectl -n "$ns" delete sts "$sts" --ignore-not-found; done
+kubectl -n "$ns" get deploy -l app.kubernetes.io/name=seaweedfs -o name | sed 's|deployment.apps/||' \
+  | grep -vE '^seaweedfs-(s3|objectstorage-provisioner)$' \
+  | xargs -r -I{} kubectl -n "$ns" delete deploy {} --ignore-not-found
+kubectl -n "$ns" patch helmrelease "${app}-system" --type merge -p '{"spec":{"suspend":false}}'
+```
+
+Then upgrade. The filer metadata lives in the shared `seaweedfs-db` Postgres and is name-independent, and the volume IDs travel with the volumes themselves, so the adopted cluster comes back with its objects intact.
+
+The loop handles pools and zones (their PVC names carry the pool/zone key) and both renamed shapes: `data1-seaweedfs-system-volume-*` for the default instance, and `data1-<name>-system-seaweedfs-volume-*` for an instance running under another name, because 4.31's name helper appends the chart name when the release name does not contain it.
+
+## Step 3 — `D-split` tenants: stop the split before upgrading
+
+Do **not** upgrade first and do not delete the duplicate PVCs — they may hold objects written through the split endpoint.
+
+1. Take the live duplicate out of the `seaweedfs-s3` Service rotation so nothing else is written to it. Select the renamed set precisely — the pre-4.31 chart-named `seaweedfs-master/-filer/-volume[-<key>]` is the authoritative set and must keep serving:
+
+   ```sh
+   ns=<tenant>
+   kubectl -n "$ns" get sts -l app.kubernetes.io/name=seaweedfs -o name | sed 's|statefulset.apps/||' \
+     | grep -vE '^seaweedfs-(master|filer|volume)($|-)' \
+     | xargs -r -I{} kubectl -n "$ns" scale sts {} --replicas=0
+   # The renamed s3 Deployment is the one whose pod template is NOT the chart-named set;
+   # scale every seaweedfs s3 Deployment except the adopted `seaweedfs-s3`.
+   kubectl -n "$ns" get deploy -l app.kubernetes.io/name=seaweedfs,app.kubernetes.io/component=s3 -o name \
+     | sed 's|deployment.apps/||' | grep -v '^seaweedfs-s3$' \
+     | xargs -r -I{} kubectl -n "$ns" scale deploy {} --replicas=0
+   ```
+
+2. Confirm the legacy set (`seaweedfs-*`) is the authoritative one and is serving.
+3. Audit what the split wrote: enumerate filer entries whose fids resolve only on the duplicate volume servers (objects PUT while both sets were live). Export anything that must survive, then re-upload it through the authoritative endpoint.
+4. Only then upgrade, and clean up the duplicate as in Step 4.
+
+## Step 4 — Upgrade, then clear the leftovers
+
+Upgrade the cluster to a Cozystack version carrying the fix. On reconcile the `seaweedfs-system` release renders the chart-based names, adopts the running workloads and their volumes, and drops the duplicate `seaweedfs-system-*` StatefulSets and Deployments (they are no longer part of the release).
+
+Helm does not delete PVCs it did not template, and cert-manager Secrets have no owner reference, so the duplicate's volumes and certificates survive the upgrade as inert leftovers. Remove them by hand once the tenant is verified healthy:
+
+```sh
+ns=<tenant>
+# Duplicate volume PVCs, BY NAME. Never by label: the live data PVCs carry the
+# same app.kubernetes.io/instance=seaweedfs-system label and would match too.
+kubectl -n "$ns" get pvc -o name | sed 's|persistentvolumeclaim/||' | grep -E '^data1-.*volume' \
+  | grep seaweedfs | grep -vE '^data1-seaweedfs-volume' | xargs -r -I{} kubectl -n "$ns" delete pvc {}
+# Orphaned certificate/db secrets of the duplicate set. cert-manager names them
+# <fullname>-<comp>-cert, so the renamed set's are everything matching the cert/db
+# suffix EXCEPT the adopted chart-named seaweedfs-<comp>-cert / seaweedfs-db-secret.
+# This covers the default (seaweedfs-system-*) and any non-default (<name>-system-
+# seaweedfs-*) instance without hardcoding the name.
+kubectl -n "$ns" get secret -o name | sed 's|secret/||' \
+  | grep -E '(-cert|-db-secret)$' | grep seaweedfs \
+  | grep -vE '^seaweedfs-(admin|ca|client|filer|master|volume|worker)-cert$|^seaweedfs-db-secret$' \
+  | xargs -r -I{} kubectl -n "$ns" delete secret {} --ignore-not-found
+```
+
+Never delete `data1-seaweedfs-volume-*` — those are the live data PVCs of the adopted set.
+
+If a tenant's `seaweedfs-system` HelmRelease was suspended during triage, resume it so the fix can reconcile:
+
+```sh
+kubectl -n <tenant> patch helmrelease seaweedfs-system --type merge -p '{"spec":{"suspend":false}}'
+kubectl -n <tenant> annotate helmrelease seaweedfs-system reconcile.fluxcd.io/requestedAt="$(date +%s)" --overwrite
+```
+
+## Step 5 — Verify
+
+```sh
+ns=<tenant>
+# Exactly one set, named after the chart, healthy.
+kubectl -n "$ns" get sts -l app.kubernetes.io/name=seaweedfs
+# All three HelmReleases Ready.
+kubectl -n "$ns" get helmrelease seaweedfs seaweedfs-system seaweedfs-db
+# S3 endpoints resolve only to the adopted set's ready pods.
+kubectl -n "$ns" get endpoints seaweedfs-s3
+# Objects are readable through S3 (bucket list via any tenant bucket).
+```
+
+A recovered tenant has a single `seaweedfs-*` set, all three HelmReleases `Ready`, no `seaweedfs-system-*` StatefulSets, and no `data1-seaweedfs-system-volume-*` PVCs left behind.

--- a/packages/extra/seaweedfs/templates/hooks/cleanup.yaml
+++ b/packages/extra/seaweedfs/templates/hooks/cleanup.yaml
@@ -1,3 +1,14 @@
+{{- /* The 4.31 chart names the fresh-install secrets after seaweedfs.fullname of
+     the child `<name>-system` release: `seaweedfs-system` for the default
+     instance, `<name>-system-seaweedfs` for a non-default one (the helper appends
+     the chart name when the release name does not contain it). Compute it here so
+     the cleanup covers both without hardcoding the default. */ -}}
+{{- $childRelease := printf "%s-system" .Release.Name }}
+{{- $renamedFull := $childRelease }}
+{{- if not (contains "seaweedfs" $childRelease) }}
+{{-   $renamedFull = printf "%s-seaweedfs" $childRelease }}
+{{- end }}
+{{- $renamedFull = $renamedFull | trunc 63 | trimSuffix "-" }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -29,14 +40,27 @@ rules:
     verbs: ["get", "delete"]
     resourceNames:
       - {{ .Release.Name }}-s3-ingress-tls
-      - {{ .Release.Name }}-system-admin-cert
-      - {{ .Release.Name }}-system-ca-cert
-      - {{ .Release.Name }}-system-client-cert
-      - {{ .Release.Name }}-system-filer-cert
-      - {{ .Release.Name }}-system-master-cert
-      - {{ .Release.Name }}-system-volume-cert
-      - {{ .Release.Name }}-system-worker-cert
-      - {{ .Release.Name }}-system-db-secret
+      # Renamed 4.31 naming (a tenant installed fresh on 1.5.x kept these).
+      - {{ $renamedFull }}-admin-cert
+      - {{ $renamedFull }}-ca-cert
+      - {{ $renamedFull }}-client-cert
+      - {{ $renamedFull }}-filer-cert
+      - {{ $renamedFull }}-master-cert
+      - {{ $renamedFull }}-volume-cert
+      - {{ $renamedFull }}-worker-cert
+      - {{ $renamedFull }}-db-secret
+      # Adopted chart-based naming: before 4.31 the chart ignored the release name,
+      # so these are seaweedfs-* for every release, and system/seaweedfs pins that
+      # name back. Only one of the two schemes exists on a given tenant; listing
+      # both keeps the delete exhaustive.
+      - seaweedfs-admin-cert
+      - seaweedfs-ca-cert
+      - seaweedfs-client-cert
+      - seaweedfs-filer-cert
+      - seaweedfs-master-cert
+      - seaweedfs-volume-cert
+      - seaweedfs-worker-cert
+      - seaweedfs-db-secret
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -118,6 +142,6 @@ spec:
               kubectl delete pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/name=seaweedfs,app.kubernetes.io/instance={{ .Release.Name }}-system --ignore-not-found --wait=false \
                 || echo "WARNING: SeaweedFS PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
               echo "Deleting orphaned SeaweedFS cert/db secrets for {{ .Release.Name }}..."
-              kubectl delete secret -n {{ .Release.Namespace }} {{ .Release.Name }}-s3-ingress-tls {{ .Release.Name }}-system-admin-cert {{ .Release.Name }}-system-ca-cert {{ .Release.Name }}-system-client-cert {{ .Release.Name }}-system-filer-cert {{ .Release.Name }}-system-master-cert {{ .Release.Name }}-system-volume-cert {{ .Release.Name }}-system-worker-cert {{ .Release.Name }}-system-db-secret --ignore-not-found --wait=false \
+              kubectl delete secret -n {{ .Release.Namespace }} {{ .Release.Name }}-s3-ingress-tls {{ $renamedFull }}-admin-cert {{ $renamedFull }}-ca-cert {{ $renamedFull }}-client-cert {{ $renamedFull }}-filer-cert {{ $renamedFull }}-master-cert {{ $renamedFull }}-volume-cert {{ $renamedFull }}-worker-cert {{ $renamedFull }}-db-secret seaweedfs-admin-cert seaweedfs-ca-cert seaweedfs-client-cert seaweedfs-filer-cert seaweedfs-master-cert seaweedfs-volume-cert seaweedfs-worker-cert seaweedfs-db-secret --ignore-not-found --wait=false \
                 || echo "WARNING: SeaweedFS secret cleanup failed for {{ .Release.Name }}; orphaned secrets may remain" >&2
               echo "SeaweedFS cleanup complete."

--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -98,6 +98,70 @@
 {{- $solver := (index .Values._cluster "solver") | default "http01" }}
 {{- $clusterIssuer := (index .Values._cluster "issuer-name") | default "letsencrypt-prod" }}
 {{- $wildcardSecret := (index .Values._cluster "wildcard-secret-name") | default "" }}
+{{- /* Refuse to rename a running SeaweedFS away from its data.
+
+   Before 4.31 the chart named workloads after the CHART, ignoring the release
+   name, so every instance ran as `seaweedfs-*` with its data on
+   `data1-seaweedfs-volume-*`. 4.31 names them after the release instead, so the
+   upgrade could not rename in place (StatefulSet names are immutable) and Helm
+   stood up a second, empty set while the data stayed put. system/seaweedfs pins
+   the chart-based name back, so those workloads and volumes are adopted in place.
+
+   Two states cannot be adopted and stop the render instead:
+
+   - FRESH on 1.5.x: only the renamed volumes exist, so the data was written under
+     them. Adopting the chart-based name would rename the workloads AWAY from that
+     data and bring up an empty cluster beside it. Helm cannot move data between
+     PVCs, so the operator is sent to the PV re-bind runbook (Step 2).
+   - D-split: both sets exist AND the renamed volume servers are live, so they may
+     hold objects written through the split endpoint. Adopting the chart-based set
+     would strand those. The operator is sent to reconcile the split first (Step 3).
+     A duplicate that never served (D-wedged: zero ready replicas) is safe to adopt
+     and renders through.
+
+   The renamed volumes are matched by SHAPE rather than by reconstructing the
+   name: a volume PVC is always `data1-<fullname>-volume[-<pool|zone>]-N`, and
+   `<fullname>` is `seaweedfs` only for the adopted naming. Reconstructing it
+   instead would have to replay the chart's fullname helper AND its 56-character
+   component truncation, and would silently miss a tenant whose name is long or
+   does not contain the chart name.
+
+   PVCs hold the data and outlive any workload, but carry no chart labels, so they
+   are matched on the name shape and must mention the chart to avoid tripping over
+   an unrelated `data1-*-volume-*` claim. StatefulSets do carry the labels, so they
+   are matched on those, which also covers a tenant whose PVCs are not provisioned
+   yet and one whose name the chart truncated past the chart name; the renamed
+   volume StatefulSet is also where the D-split liveness signal is read. */}}
+{{- $legacyData := false }}
+{{- $systemData := false }}
+{{- $systemRunning := false }}
+{{- range (lookup "v1" "PersistentVolumeClaim" .Release.Namespace "").items | default list }}
+{{-   if and (hasPrefix "data1-" .metadata.name) (contains "-volume" .metadata.name) (contains "seaweedfs" .metadata.name) }}
+{{-     if hasPrefix "data1-seaweedfs-volume" .metadata.name }}
+{{-       $legacyData = true }}
+{{-     else }}
+{{-       $systemData = true }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- range (lookup "apps/v1" "StatefulSet" .Release.Namespace "").items | default list }}
+{{-   if and (eq (dig "app.kubernetes.io/name" "" (.metadata.labels | default dict)) "seaweedfs") (contains "volume" .metadata.name) }}
+{{-     if hasPrefix "seaweedfs-volume" .metadata.name }}
+{{-       $legacyData = true }}
+{{-     else }}
+{{-       $systemData = true }}
+{{-       if gt (int (dig "status" "readyReplicas" 0 .)) 0 }}
+{{-         $systemRunning = true }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- if and $legacyData $systemData $systemRunning }}
+{{-   fail (printf "SeaweedFS %s in namespace %s is running two live SeaweedFS sets (D-split): the renamed set has ready volume servers alongside the adopted set, and both write to the shared seaweedfs-db metadata. Rendering would adopt the chart-named set and strand the objects the renamed set wrote. Stop the split and reconcile the two sets before upgrading — see docs/operations/seaweedfs-431-rename-recovery.md (Step 3)." .Release.Name .Release.Namespace) }}
+{{- end }}
+{{- if and $systemData (not $legacyData) }}
+{{-   fail (printf "SeaweedFS %s in namespace %s keeps its data on volumes named after the Helm release (this tenant was installed on Cozystack 1.5.x). Workloads are named seaweedfs-*, so rendering would rename them away from that data and bring up an empty cluster. Re-bind the existing PVs onto the data1-seaweedfs-volume-* PVC names before upgrading — see docs/operations/seaweedfs-431-rename-recovery.md" .Release.Name .Release.Namespace) }}
+{{- end }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/packages/extra/seaweedfs/tests/cleanup_named_test.yaml
+++ b/packages/extra/seaweedfs/tests/cleanup_named_test.yaml
@@ -1,0 +1,48 @@
+suite: seaweedfs cleanup hook covers a non-default instance name
+
+# SeaweedFS is a user-creatable kind, so an instance can run under a name other
+# than `seaweedfs`. On delete, the post-delete hook must remove that instance's
+# secrets under BOTH schemes it could carry: the adopted chart-based `seaweedfs-*`
+# and the renamed `seaweedfs.fullname`-based names. For a non-default release the
+# fullname helper appends the chart name, so a fresh-1.5.x `archive` instance's
+# secrets are `archive-system-seaweedfs-*` — not `archive-system-*`. This pins
+# that the hook derives the renamed name instead of hardcoding the default.
+
+templates:
+  - templates/hooks/cleanup.yaml
+
+release:
+  name: archive
+  namespace: tenant-root
+
+set: &values
+  topology: Simple
+  replicationFactor: 2
+  _namespace:
+    host: example.org
+    ingress: tenant-root
+  _cluster:
+    issuer-name: letsencrypt-prod
+    solver: http01
+
+tests:
+  - it: grants delete on the renamed (archive-system-seaweedfs-*) and adopted (seaweedfs-*) secrets
+    set: *values
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - contains:
+          path: rules[1].resourceNames
+          content: archive-system-seaweedfs-ca-cert
+      - contains:
+          path: rules[1].resourceNames
+          content: archive-system-seaweedfs-db-secret
+      # The adopted chart-based scheme is the same for every instance.
+      - contains:
+          path: rules[1].resourceNames
+          content: seaweedfs-ca-cert
+      # The old hardcoded default name must NOT appear for a non-default instance.
+      - notContains:
+          path: rules[1].resourceNames
+          content: archive-system-ca-cert

--- a/packages/extra/seaweedfs/tests/cleanup_test.yaml
+++ b/packages/extra/seaweedfs/tests/cleanup_test.yaml
@@ -10,9 +10,13 @@ release:
 # (data1-seaweedfs-system-volume-{0,1}) and the cert-manager TLS / db
 # secrets are left orphaned. The post-delete hook renders a Job (plus its
 # RBAC) that deletes the volume PVCs by label and the secrets by name.
-# All names are templated from .Release.Name: the leaked resources use the
-# {{ .Release.Name }}-system prefix because seaweedfs.yaml renders the
-# StatefulSet/cert HelmRelease as "{{ .Release.Name }}-system".
+# Secrets are cleaned under BOTH naming schemes: the native
+# {{ .Release.Name }}-system-* prefix (fresh installs) and the adopted
+# chart-name-based seaweedfs-* prefix (clusters upgraded past the 4.31
+# rename, where seaweedfs.yaml pins fullnameOverride=seaweedfs). Only one
+# set exists on a given cluster; the hook lists both so cleanup stays
+# exhaustive. PVCs are deleted by the app.kubernetes.io/instance label,
+# which is {{ .Release.Name }}-system under either naming.
 
 tests:
   - it: renders the cleanup ServiceAccount as a post-delete hook
@@ -33,7 +37,7 @@ tests:
           path: metadata.annotations["helm.sh/hook-delete-policy"]
           value: before-hook-creation,hook-succeeded
 
-  - it: grants delete on PVCs and only the 9 named secrets
+  - it: grants delete on PVCs and only the named secrets under both naming schemes
     documentSelector:
       path: kind
       value: Role
@@ -63,6 +67,14 @@ tests:
               - seaweedfs-system-volume-cert
               - seaweedfs-system-worker-cert
               - seaweedfs-system-db-secret
+              - seaweedfs-admin-cert
+              - seaweedfs-ca-cert
+              - seaweedfs-client-cert
+              - seaweedfs-filer-cert
+              - seaweedfs-master-cert
+              - seaweedfs-volume-cert
+              - seaweedfs-worker-cert
+              - seaweedfs-db-secret
 
   - it: binds the cleanup Role to the cleanup ServiceAccount
     documentSelector:
@@ -152,7 +164,7 @@ tests:
           pattern: 'kubectl delete pvc -n tenant-root -l app\.kubernetes\.io/name=seaweedfs,app\.kubernetes\.io/instance=seaweedfs-system --ignore-not-found --wait=false'
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'kubectl delete secret -n tenant-root seaweedfs-s3-ingress-tls seaweedfs-system-admin-cert seaweedfs-system-ca-cert seaweedfs-system-client-cert seaweedfs-system-filer-cert seaweedfs-system-master-cert seaweedfs-system-volume-cert seaweedfs-system-worker-cert seaweedfs-system-db-secret --ignore-not-found --wait=false'
+          pattern: 'kubectl delete secret -n tenant-root seaweedfs-s3-ingress-tls seaweedfs-system-admin-cert seaweedfs-system-ca-cert seaweedfs-system-client-cert seaweedfs-system-filer-cert seaweedfs-system-master-cert seaweedfs-system-volume-cert seaweedfs-system-worker-cert seaweedfs-system-db-secret seaweedfs-admin-cert seaweedfs-ca-cert seaweedfs-client-cert seaweedfs-filer-cert seaweedfs-master-cert seaweedfs-volume-cert seaweedfs-worker-cert seaweedfs-db-secret --ignore-not-found --wait=false'
       # The PVC selector must NOT filter by component: the volume StatefulSet sets
       # app.kubernetes.io/component to volume / volume-<pool> / volume-<zone>[-<pool>]
       # depending on topology, so a component clause would leave non-default pools and

--- a/packages/extra/seaweedfs/tests/fullname_override_named_test.yaml
+++ b/packages/extra/seaweedfs/tests/fullname_override_named_test.yaml
@@ -1,0 +1,167 @@
+suite: seaweedfs naming guard for a non-default instance name
+
+# SeaweedFS is a user-creatable kind, so an instance can run under a name other
+# than `seaweedfs`. Two things follow, and the guard has to get both right:
+#   - Before 4.31 the chart ignored the release name, so such an instance ALSO
+#     stored its data on the chart-named data1-seaweedfs-volume-* PVCs.
+#   - On 4.31 the fullname helper appends the chart name when the release name
+#     does not contain it, so a fresh 1.5.x `archive` wrote its data to
+#     data1-archive-system-seaweedfs-volume-*, NOT data1-archive-system-volume-*.
+
+templates:
+  - templates/seaweedfs.yaml
+
+release:
+  name: archive
+  namespace: tenant-root
+
+set: &values
+  topology: Simple
+  replicationFactor: 2
+  _namespace:
+    host: example.org
+    ingress: tenant-root
+  _cluster:
+    issuer-name: letsencrypt-prod
+    solver: http01
+
+tests:
+  - it: adopts a pre-4.31 instance whose data is on the chart-named PVCs
+    set: *values
+    kubernetesProvider:
+      scheme:
+        "v1/PersistentVolumeClaim":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+        "apps/v1/StatefulSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "statefulsets"
+          namespaced: true
+      objects:
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-root
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: unrelated-app
+            namespace: tenant-root
+    documentSelector:
+      path: kind
+      value: HelmRelease
+    asserts:
+      - equal:
+          path: metadata.name
+          value: archive-system
+
+  - it: refuses to render when this release's data is on its renamed volumes
+    set: *values
+    kubernetesProvider:
+      scheme:
+        "v1/PersistentVolumeClaim":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+        "apps/v1/StatefulSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "statefulsets"
+          namespaced: true
+      objects:
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-archive-system-seaweedfs-volume-0
+            namespace: tenant-root
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: unrelated-app
+            namespace: tenant-root
+    asserts:
+      - failedTemplate:
+          errorPattern: "SeaweedFS archive in namespace tenant-root keeps its data on volumes named after the Helm release"
+
+  - it: catches a long instance name whose renamed workloads the chart truncated
+    set: *values
+    kubernetesProvider:
+      scheme:
+        "v1/PersistentVolumeClaim":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+        "apps/v1/StatefulSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "statefulsets"
+          namespaced: true
+      objects:
+        # 4.31 truncates <fullname> to 56 chars before appending -volume, so a long
+        # name loses the chart name from its tail and the PVC name alone no longer
+        # identifies it. The StatefulSet still carries the chart labels, so the
+        # guard sees it there.
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: archive-system-a-very-long-instance-name-that-gets-trunca-volume
+            namespace: tenant-root
+            labels:
+              app.kubernetes.io/name: seaweedfs
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: unrelated-app-data-0
+            namespace: tenant-root
+    asserts:
+      - failedTemplate:
+          errorPattern: "keeps its data on volumes named after the Helm release"
+
+  - it: ignores an unrelated data1-*-volume-* PVC belonging to another app
+    set: *values
+    kubernetesProvider:
+      scheme:
+        "v1/PersistentVolumeClaim":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+        "apps/v1/StatefulSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "statefulsets"
+          namespaced: true
+      objects:
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-clickhouse-volume-0
+            namespace: tenant-root
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: clickhouse-volume
+            namespace: tenant-root
+            labels:
+              app.kubernetes.io/name: clickhouse
+    documentSelector:
+      path: kind
+      value: HelmRelease
+    asserts:
+      - equal:
+          path: metadata.name
+          value: archive-system

--- a/packages/extra/seaweedfs/tests/fullname_override_test.yaml
+++ b/packages/extra/seaweedfs/tests/fullname_override_test.yaml
@@ -1,0 +1,322 @@
+suite: seaweedfs legacy-naming guard
+
+# system/seaweedfs pins the chart-based name, so workloads keep their pre-4.31
+# names (`seaweedfs-master`, `data1-seaweedfs-volume-N`) and an upgrade past the
+# 4.31 rename adopts the running set in place.
+#
+# Two states stop the render instead of adopting: a tenant installed FRESH on
+# 1.5.x (only the renamed volumes exist → PV re-bind, Step 2), and a D-split
+# tenant (both sets present AND the renamed volume servers are live → reconcile
+# the split, Step 3). A duplicate that never served (D-wedged, zero ready
+# replicas) renders through and is adopted.
+#
+# Two helm-unittest quirks the mocks work around:
+#   - The template LISTs both PVCs and StatefulSets, so every mocked provider
+#     must register both list kinds — a fake client errors on an unregistered
+#     LIST rather than returning empty.
+#   - status.readyReplicas is quoted ("1"/"0"): the fake client cannot deep-copy
+#     a bare Go int in a mocked object's status, and the template's `int` coerces
+#     the string back either way.
+
+templates:
+  - templates/seaweedfs.yaml
+
+release:
+  name: seaweedfs
+  namespace: tenant-root
+
+set: &values
+  topology: Simple
+  replicationFactor: 2
+  _namespace:
+    host: example.org
+    ingress: tenant-root
+  _cluster:
+    issuer-name: letsencrypt-prod
+    solver: http01
+
+tests:
+  - it: renders for a net-new install (no SeaweedFS data in the namespace)
+    set: *values
+    kubernetesProvider:
+      scheme:
+        "v1/PersistentVolumeClaim":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+        "apps/v1/StatefulSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "statefulsets"
+          namespaced: true
+      objects:
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: unrelated-app-data-0
+            namespace: tenant-root
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: unrelated-app
+            namespace: tenant-root
+    documentSelector:
+      path: kind
+      value: HelmRelease
+    asserts:
+      - equal:
+          path: metadata.name
+          value: seaweedfs-system
+      # The chart-based name is pinned in system/seaweedfs values, not re-pinned here.
+      - notExists:
+          path: spec.values.seaweedfs.fullnameOverride
+
+  - it: renders for a cluster whose data is on the legacy seaweedfs-* PVCs
+    set: *values
+    kubernetesProvider:
+      scheme:
+        "v1/PersistentVolumeClaim":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+        "apps/v1/StatefulSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "statefulsets"
+          namespaced: true
+      objects:
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-root
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: unrelated-app-data-0
+            namespace: tenant-root
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: unrelated-app
+            namespace: tenant-root
+    documentSelector:
+      path: kind
+      value: HelmRelease
+    asserts:
+      - equal:
+          path: metadata.name
+          value: seaweedfs-system
+
+  - it: renders on a D-wedged cluster (duplicate present but never served) — adopts the legacy set
+    set: *values
+    kubernetesProvider:
+      scheme:
+        "v1/PersistentVolumeClaim":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+        "apps/v1/StatefulSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "statefulsets"
+          namespaced: true
+      objects:
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-root
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-0
+            namespace: tenant-root
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: unrelated-app-data-0
+            namespace: tenant-root
+        # The duplicate volume set exists but never scheduled (anti-affinity):
+        # zero ready replicas, so its PVCs are empty and adoption is safe.
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-system-volume
+            namespace: tenant-root
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "0"
+    documentSelector:
+      path: kind
+      value: HelmRelease
+    asserts:
+      - equal:
+          path: metadata.name
+          value: seaweedfs-system
+
+  - it: refuses to render on a D-split cluster (duplicate volume servers are live)
+    set: *values
+    kubernetesProvider:
+      scheme:
+        "v1/PersistentVolumeClaim":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+        "apps/v1/StatefulSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "statefulsets"
+          namespaced: true
+      objects:
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-root
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-0
+            namespace: tenant-root
+        # The duplicate volume set is live: it may hold objects written through
+        # the split endpoint, so adoption would strand them.
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-system-volume
+            namespace: tenant-root
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "1"
+    asserts:
+      - failedTemplate:
+          errorPattern: "is running two live SeaweedFS sets.*Stop the split"
+
+  - it: renders for a zoned legacy cluster (volume StatefulSets are per zone)
+    set: *values
+    kubernetesProvider:
+      scheme:
+        "v1/PersistentVolumeClaim":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+        "apps/v1/StatefulSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "statefulsets"
+          namespaced: true
+      objects:
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-zone-a-0
+            namespace: tenant-root
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: unrelated-app-data-0
+            namespace: tenant-root
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: unrelated-app
+            namespace: tenant-root
+    documentSelector:
+      path: kind
+      value: HelmRelease
+    asserts:
+      - equal:
+          path: metadata.name
+          value: seaweedfs-system
+
+  - it: refuses to render when the data lives only on seaweedfs-system-* PVCs
+    set: *values
+    kubernetesProvider:
+      scheme:
+        "v1/PersistentVolumeClaim":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+        "apps/v1/StatefulSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "statefulsets"
+          namespaced: true
+      objects:
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-0
+            namespace: tenant-root
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: unrelated-app-data-0
+            namespace: tenant-root
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: unrelated-app
+            namespace: tenant-root
+    asserts:
+      - failedTemplate:
+          errorPattern: "keeps its data on volumes named after the Helm release.*Re-bind"
+
+  - it: refuses to render on a seaweedfs-system-* cluster detected by its StatefulSet
+    set: *values
+    kubernetesProvider:
+      scheme:
+        "v1/PersistentVolumeClaim":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+        "apps/v1/StatefulSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "statefulsets"
+          namespaced: true
+      objects:
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-system-volume
+            namespace: tenant-root
+            labels:
+              app.kubernetes.io/name: seaweedfs
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: unrelated-app-data-0
+            namespace: tenant-root
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: unrelated-app
+            namespace: tenant-root
+    asserts:
+      - failedTemplate:
+          errorPattern: "keeps its data on volumes named after the Helm release.*Re-bind"

--- a/packages/system/seaweedfs/tests/fullname_override_test.yaml
+++ b/packages/system/seaweedfs/tests/fullname_override_test.yaml
@@ -1,0 +1,62 @@
+suite: seaweedfs workload naming is pinned to the chart name
+
+# Upstream chart 4.31 names workloads after the Helm release (`seaweedfs.fullname`)
+# instead of after the chart (`seaweedfs.name`, pre-4.31). The shipped release is
+# `seaweedfs-system`, so the bump silently renamed every StatefulSet/Deployment to
+# `seaweedfs-system-*`. Those names are immutable, so an upgrade cannot rename in
+# place — Helm brings up a second, duplicate set beside the running one while the
+# data stays on the original `data1-seaweedfs-volume-*` PVCs.
+#
+# values.yaml pins `fullnameOverride: seaweedfs` so the rendered names stay
+# chart-based regardless of the release name, matching the convention already used
+# by other system packages (cozy-proxy, flux-operator, linstor-scheduler, ...).
+# These tests pin that contract: names must NOT follow the release name.
+
+release:
+  name: seaweedfs-system
+  namespace: tenant-root
+
+tests:
+  - it: names the master StatefulSet after the chart, not the release
+    template: charts/seaweedfs/templates/master/master-statefulset.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: seaweedfs-master
+      - equal:
+          path: spec.serviceName
+          value: seaweedfs-master
+
+  - it: names the volume StatefulSet after the chart, so its data PVCs keep the legacy names
+    template: charts/seaweedfs/templates/volume/volume-statefulset.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: seaweedfs-volume
+      # Together with the StatefulSet name this yields data1-seaweedfs-volume-N —
+      # the PVC names the running clusters already hold their data on.
+      - equal:
+          path: spec.volumeClaimTemplates[0].metadata.name
+          value: data1
+
+  - it: names the filer StatefulSet after the chart
+    template: charts/seaweedfs/templates/filer/filer-statefulset.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: seaweedfs-filer
+
+  - it: keeps the selector labels release-scoped so adopted pods keep matching
+    template: charts/seaweedfs/templates/master/master-statefulset.yaml
+    asserts:
+      # A StatefulSet selector is immutable: in-place adoption only works because
+      # 4.31 left these labels identical to 4.05.
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: seaweedfs
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+          value: seaweedfs-system
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: master

--- a/packages/system/seaweedfs/tests/s3_service_name_consumers_test.yaml
+++ b/packages/system/seaweedfs/tests/s3_service_name_consumers_test.yaml
@@ -13,9 +13,12 @@ suite: seaweedfs s3 consumers resolve the renamed s3 service
 # `seaweedfs-system-s3` while the real service is `seaweedfs-s3`. With no
 # matching endpoints, ingress-nginx returns 503 and COSI cannot reach S3.
 #
-# All tests render under the real release name so name != fullname, the exact
-# condition that exposes the bug. The all-in-one case documents the other
-# ternary branch, which is unchanged and correct.
+# values.yaml now pins fullnameOverride: seaweedfs, which makes name == fullname
+# and would hide this bug by accident. So each test re-creates the original
+# condition explicitly (fullnameOverride: seaweedfs-system => name != fullname)
+# and keeps guarding the divergence itself, independent of what the shipped
+# default happens to be. The all-in-one case documents the other ternary branch,
+# which is unchanged and correct.
 
 templates:
   - charts/seaweedfs/templates/s3/s3-service.yaml
@@ -31,6 +34,7 @@ tests:
   - it: s3 service is named with the name helper, not componentName
     template: charts/seaweedfs/templates/s3/s3-service.yaml
     set:
+      seaweedfs.fullnameOverride: seaweedfs-system
       seaweedfs.s3.enabled: true
     asserts:
       - equal:
@@ -40,6 +44,7 @@ tests:
   - it: s3 ingress backend points at the s3 service, not a fullname-derived name
     template: charts/seaweedfs/templates/s3/s3-ingress.yaml
     set:
+      seaweedfs.fullnameOverride: seaweedfs-system
       seaweedfs.s3.enabled: true
       seaweedfs.s3.ingress.enabled: true
       seaweedfs.s3.ingress.host: s3.example.com
@@ -51,6 +56,7 @@ tests:
   - it: all-in-one ingress backend still resolves to the all-in-one service
     template: charts/seaweedfs/templates/s3/s3-ingress.yaml
     set:
+      seaweedfs.fullnameOverride: seaweedfs-system
       seaweedfs.allInOne.enabled: true
       seaweedfs.allInOne.s3.enabled: true
       seaweedfs.s3.ingress.enabled: true
@@ -63,6 +69,7 @@ tests:
   - it: iceberg ingress backend points at the s3 service too
     template: charts/seaweedfs/templates/s3/s3-iceberg-ingress.yaml
     set:
+      seaweedfs.fullnameOverride: seaweedfs-system
       seaweedfs.s3.enabled: true
       seaweedfs.s3.icebergPort: 8334
       seaweedfs.s3.icebergIngress.enabled: true
@@ -75,6 +82,7 @@ tests:
   - it: COSI in-cluster ENDPOINT resolves the s3 service when ingress is disabled
     template: charts/seaweedfs/templates/cosi/cosi-deployment.yaml
     set:
+      seaweedfs.fullnameOverride: seaweedfs-system
       seaweedfs.cosi.enabled: true
       seaweedfs.s3.enabled: true
       seaweedfs.s3.ingress.enabled: false
@@ -88,6 +96,7 @@ tests:
   - it: COSI in-cluster ENDPOINT (filer S3 mode) targets the s3 service on the filer s3 port
     template: charts/seaweedfs/templates/cosi/cosi-deployment.yaml
     set:
+      seaweedfs.fullnameOverride: seaweedfs-system
       seaweedfs.cosi.enabled: true
       seaweedfs.s3.enabled: false
       seaweedfs.filer.s3.enabled: true

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -11,6 +11,17 @@ global:
     monitoring:
       enabled: true
 seaweedfs:
+  # Decouple the workload names from the Helm release name. Upstream 4.31 started
+  # naming resources after the release, and the data-plane release is
+  # `<name>-system`, so every StatefulSet was renamed to `<name>-system-*`. Those
+  # names are immutable, so Helm could not rename in place — it stood up a second,
+  # empty set beside the running one while the data stayed on `data1-seaweedfs-volume-*`.
+  # Pinning the chart name restores the pre-4.31 names, so the running workloads
+  # and their volumes are adopted across the bump. extra/seaweedfs does NOT override
+  # this per release — it relies on this pin — and guards the one case the pin
+  # cannot serve (a tenant installed fresh on 1.5.x, whose data is on the renamed
+  # volumes) by refusing to render.
+  fullnameOverride: seaweedfs
   master:
     # 30 GB per volume × 10 GiB PVC = 0 → rounded to 1 maxVolume per
     # volume server. With defaultReplication=001 (one replica on a


### PR DESCRIPTION
## What this PR does

Fixes a v1.5.0 upgrade regression where a tenant ends up with **two** SeaweedFS workload sets.

**Root cause.** v1.5.0 bumped the vendored SeaweedFS chart `4.0.405 → 4.31.0`. Upstream changed resource naming: before 4.31 the chart named workloads after the **chart** (`seaweedfs-*`, ignoring the release name), and 4.31 names them after the **release**. The data-plane release is `<name>-system`, so every StatefulSet wanted to become `seaweedfs-system-*`. StatefulSet names are immutable, so Helm could not rename in place — it stood up a second, empty set beside the running one while the data stayed on the original `data1-seaweedfs-volume-*` PVCs. Where the node count let both sets run, they shared one `seaweedfs-s3` Service (identical pod labels) and one `seaweedfs-db` filer metadata database, so the empty set answered reads and the two master sets mixed volume IDs from independent sequences into one metadata table.

**Fix.** Pin `fullnameOverride` in `system/seaweedfs` values so the rendered names stop following the release name, which is the convention already used by `cozy-proxy`, `flux-operator`, `grafana-operator`, `linstor-scheduler` and `victoria-metrics-operator`. The names go back to what every pre-1.5 cluster already runs, so the upgrade adopts the running workloads **and their volumes** in place. No data migration, no platform migration.

**The one case that cannot be adopted.** A tenant installed *fresh* on 1.5.x wrote its data under the renamed workloads, so its volumes are not the chart-named ones. Pinning the chart name there would rename the workloads *away* from that data and bring up an empty cluster beside it. Helm cannot move data between PVCs, so `extra/seaweedfs` refuses to render for such a tenant and points at the recovery runbook, which re-binds the existing PVs onto the adopted PVC names (no copying — the claim is renamed, the volume is not touched). The guard is fail-closed: it fires only when renamed volumes are present and no adopted ones are.

Two naming subtleties the guard has to respect, both verified by rendering the shipped 1.5 chart:

- Before 4.31 the chart ignored the release name, so an instance running under a non-default name (`SeaweedFS` is a user-creatable kind) *also* stored its data on `data1-seaweedfs-volume-*`. Such a tenant is adopted, not blocked.
- On 4.31 the fullname helper appends the chart name when the release name does not contain it, and the component helper truncates to 56 characters. A fresh 1.5.x instance named `archive` therefore wrote to `data1-archive-system-seaweedfs-volume-*`, and a long name loses the chart name from its tail entirely. The guard matches volumes by shape and by the chart labels on the StatefulSet instead of reconstructing those names, so both are caught.

**On the duplicate set.** Once the fix reconciles, the `seaweedfs-system-*` StatefulSets and Deployments are no longer part of the release and Helm removes them on its own. What it cannot remove — PVCs it did not template, and cert-manager Secrets that carry no owner reference — is inert, and the runbook clears it explicitly. A pre-upgrade migration was considered and dropped: it would duplicate what Helm already does, while its only unique action (deleting PVCs) cannot distinguish "the duplicate never served" from "it served and is currently down", and any transient delete failure under `set -e` would fail the platform's pre-upgrade hook and block delivery of this very fix.

## Testing

`helm unittest` — `system/seaweedfs` 21 tests, `extra/seaweedfs` 17 tests. The guard's `lookup` branches are covered by mocking the Kubernetes provider (the pattern already used in `core/platform` and `system/cozystack-api`): adopted-only, renamed-only, both sets, zoned volumes, a non-default instance name, a truncated long name, and an unrelated `data1-*-volume-*` PVC that must not trip the guard. The s3-consumer suite now re-creates the name/fullname divergence explicitly, so it keeps guarding that regression regardless of the shipped default.

The remaining regression test for this class of bug is an upgrade E2E (seed a pre-4.31 named set, upgrade, assert a single set with data intact) — no fresh-install E2E or `helm template` can reproduce an upgrade over pre-existing state. That belongs in the chainsaw upgrade lane and is a follow-up.

### Screenshots

N/A — no UI changes.

### Release note

```release-note
fix(seaweedfs): adopt existing SeaweedFS workloads and volumes in place when upgrading past the 4.31 chart rename, instead of standing up a second, empty cluster beside them
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audit & recovery runbook for SeaweedFS 4.31 rename impacts.
* **Bug Fixes**
  * Stabilized SeaweedFS workload/PVC naming across upgrades, including non-default instance names.
  * Added preflight safeguards to prevent upgrade scenarios that could split or wedge existing data.
  * Updated post-delete cleanup to remove secrets from both legacy and current naming schemes.
* **Tests**
  * Expanded Helm unit coverage for naming guards, cleanup behavior, and S3 service name consumers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->