### PR TITLE
fix(fluxcd): omit empty distribution.artifact in FluxInstance for guest clusters

### DIFF
--- a/packages/system/fluxcd/Makefile
+++ b/packages/system/fluxcd/Makefile
@@ -8,4 +8,5 @@ apply-locally:
 
 update:
 	rm -rf charts
-	helm pull oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance --untar --untardir charts
+	helm pull oci://ghcr.io/controlplaneio-fluxcd/charts/flux-instance --version 0.50.0 --untar --untardir charts
+	patch --no-backup-if-mismatch -p1 < patches/guard-distribution-artifact.diff

--- a/packages/system/fluxcd/charts/flux-instance/templates/instance.yaml
+++ b/packages/system/fluxcd/charts/flux-instance/templates/instance.yaml
@@ -16,7 +16,9 @@ spec:
   distribution:
     version: {{ .Values.instance.distribution.version | quote }}
     registry: {{ .Values.instance.distribution.registry }}
+    {{- if .Values.instance.distribution.artifact }}
     artifact: {{ .Values.instance.distribution.artifact }}
+    {{- end }}
     {{- if .Values.instance.distribution.artifactPullSecret }}
     artifactPullSecret: {{ .Values.instance.distribution.artifactPullSecret }}
     {{- end }}

--- a/packages/system/fluxcd/patches/guard-distribution-artifact.diff
+++ b/packages/system/fluxcd/patches/guard-distribution-artifact.diff
@@ -1,0 +1,22 @@
+# Upstream bug: flux-instance's instance.yaml renders spec.distribution.artifact
+# unconditionally, unlike the sibling optional fields (artifactPullSecret,
+# imagePullSecret, variant). The umbrella's empty default then renders as
+# `artifact: null`, which the FluxInstance CRD rejects (type: string,
+# pattern ^oci://.*$, and the field is optional). Guard it like its siblings.
+#
+# Chart source: https://github.com/controlplaneio-fluxcd/charts (flux-instance)
+# Not yet reported upstream; drop this hunk once upstream guards the field.
+diff --git a/charts/flux-instance/templates/instance.yaml b/charts/flux-instance/templates/instance.yaml
+index f1f58309e..5217c24d9 100644
+--- a/charts/flux-instance/templates/instance.yaml
++++ b/charts/flux-instance/templates/instance.yaml
+@@ -16,7 +16,9 @@ spec:
+   distribution:
+     version: {{ .Values.instance.distribution.version | quote }}
+     registry: {{ .Values.instance.distribution.registry }}
++    {{- if .Values.instance.distribution.artifact }}
+     artifact: {{ .Values.instance.distribution.artifact }}
++    {{- end }}
+     {{- if .Values.instance.distribution.artifactPullSecret }}
+     artifactPullSecret: {{ .Values.instance.distribution.artifactPullSecret }}
+     {{- end }}


### PR DESCRIPTION
## What this PR does

Guest Kubernetes clusters (`apps/kubernetes`) with the `fluxcd` addon enabled never became
`Ready`. The `flux-instance` template renders `spec.distribution.artifact` unconditionally,
unlike the sibling optional fields (`artifactPullSecret`, `imagePullSecret`, `variant`, which
are all `{{- if }}`-guarded). The umbrella default is empty (`artifact: ""`) so the operator
uses its embedded manifests, which is the intended air-gapped default (#964, and the upstream
recommendation). But an empty value renders as YAML `null`, and the flux-operator v0.50.0 CRD
types `distribution.artifact` as a non-nullable `string` (pattern `^oci://.*$`), so the API
rejects the `FluxInstance`.

Result: the addon's HelmRelease looped install/uninstall (`remediation.retries: -1`), the
parent `kubernetes` release stayed `InProgress`, and the cluster CR was stuck `Ready=Unknown`.

This guards the field so an empty value is omitted entirely. Behaviour:

- empty (default) -> field omitted -> operator falls back to embedded manifests: **air-gapped
  default preserved**, and the CRD accepts it (artifact is not in `distribution.required`);
- non-empty -> renders as before; `valuesOverride` still applies.

The template is a vendored subchart (`make update` runs `helm pull`), so the change is carried
as `patches/guard-distribution-artifact.diff` and applied by the `update` target, matching the
convention of the sibling `fluxcd-operator` package (`patch -p1 < patches/*.diff`).

Verified with `helm template packages/system/fluxcd`:

- default values -> no `artifact:` line (before this PR: `artifact: null`);
- `--set flux-instance.instance.distribution.artifact=oci://example.com/x:1` -> renders.

The affected path is off by default (`addons.fluxcd.enabled: false`) and not exercised by the
in-repo CI values, which is why default e2e stayed green.

Closes #3283

### Release note

```release-note
fix(fluxcd): guest Kubernetes clusters with the fluxcd addon enabled no longer fail to install; an empty distribution artifact is now omitted so the operator uses its embedded manifests (air-gapped default preserved) instead of rendering an invalid null
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Flux instance configuration from including an empty distribution artifact value, which could cause validation failures.
  * Improved the generated FluxInstance manifest so the artifact field is omitted entirely when no distribution artifact is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->