### PR TITLE
fix(platform): route OIDC backend calls through the in-cluster Keycloak by default

### DIFF
--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -328,16 +328,60 @@ EOF
 }
 
 @test "Keycloak OIDC stack is healthy" {
-  # keycloakInternalUrl makes oauth2-proxy skip OIDC discovery and route
-  # backend calls (token/jwks/userinfo/logout) through the in-cluster
-  # keycloak Service. Without it the dashboard gatekeeper crashloops on
-  # DNS lookup of keycloak.example.org -- the e2e host placeholder does
-  # not resolve, and under Flux v2.8 kstatus the gatekeeper Deployment
-  # then flips to Failed and stalls the dashboard HelmRelease.
-  kubectl patch package cozystack.cozystack-platform --type merge -p '{"spec":{"components":{"platform":{"values":{"authentication":{"oidc":{"enabled":true,"keycloakInternalUrl":"http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy"}}}}}}}'
+  # Only oidc.enabled is set here: keycloakInternalUrl defaults to the in-cluster
+  # keycloak Service, which makes oauth2-proxy skip OIDC discovery and route the
+  # backend calls (token/jwks/userinfo/logout) through that Service.
+  kubectl patch package cozystack.cozystack-platform --type merge -p '{"spec":{"components":{"platform":{"values":{"authentication":{"oidc":{"enabled":true}}}}}}}'
 
   timeout 120 sh -ec 'until kubectl get hr -n cozy-keycloak keycloak keycloak-configure keycloak-operator >/dev/null 2>&1; do sleep 1; done'
   kubectl wait hr/keycloak hr/keycloak-configure hr/keycloak-operator -n cozy-keycloak --timeout=20m --for=condition=ready
+
+  # Enabling OIDC swaps the dashboard's token-proxy container for oauth2-proxy,
+  # so the dashboard is the consumer that proves the internal-URL default works.
+  # The install-time `kubectl wait hr --all -A` ran before this test flipped the
+  # flag and only ever saw the token-proxy shape, so nothing has re-checked the
+  # dashboard on the OIDC path.
+  #
+  # Waiting on hr/dashboard directly would be vacuous: it is still Ready=True
+  # from the token-proxy install, so `--for=condition=ready` returns instantly
+  # against the stale condition, before Flux has even consumed the patched
+  # values. Gate on an observable that exists ONLY on the OIDC path instead --
+  # the auth-proxy container appearing in the gatekeeper Deployment -- which is
+  # reached only after the new values are rendered.
+  timeout 600 sh -ec 'until kubectl get deploy/incloud-web-gatekeeper -n cozy-dashboard -o jsonpath="{.spec.template.spec.containers[*].name}" 2>/dev/null | grep -qw auth-proxy; do sleep 5; done' || {
+    echo "=== gatekeeper never re-rendered with the auth-proxy container after enabling OIDC ==="
+    echo "=== the patched values likely never reached the dashboard HelmRelease ==="
+    kubectl get package cozystack.cozystack-platform -o yaml 2>&1 || true
+    kubectl get hr/dashboard -n cozy-dashboard -o yaml 2>&1 || true
+    kubectl get deploy/incloud-web-gatekeeper -n cozy-dashboard -o yaml 2>&1 || true
+    false
+  }
+
+  # Then wait for the ROLLOUT, not for condition=available. The Deployment has
+  # replicas: 1 and maxUnavailable: 25%, which rounds down to 0, so Kubernetes
+  # keeps the old token-proxy pod up while the new one starts: Available stays
+  # True on the strength of the OLD ReplicaSet even as the new auth-proxy pod
+  # crashloops. `rollout status` is the check that only succeeds once the
+  # UPDATED pod is available.
+  #
+  # That is what gives this case teeth: were the default to regress to the
+  # external hostname, oauth2-proxy would do OIDC discovery against
+  # keycloak.example.org -- the e2e host placeholder does not resolve -- and
+  # crashloop, failing the rollout instead of shipping the regression.
+  kubectl rollout status deploy/incloud-web-gatekeeper -n cozy-dashboard --timeout=10m || {
+    echo "=== deploy/incloud-web-gatekeeper rollout did not complete after enabling OIDC ==="
+    kubectl get deploy/incloud-web-gatekeeper -n cozy-dashboard -o yaml 2>&1 || true
+    echo "=== cozy-dashboard pods ==="
+    kubectl get pods -n cozy-dashboard -o wide 2>&1 || true
+    echo "=== auth-proxy logs ==="
+    kubectl logs -n cozy-dashboard -l app.kubernetes.io/name=gatekeeper --all-containers --tail=50 2>&1 || true
+    false
+  }
+
+  # Not the vacuous wait described above: past the rollout gate the HelmRelease
+  # has necessarily been re-reconciled, so Ready here means the whole upgrade
+  # converged -- not just the one Deployment this test watched.
+  kubectl wait hr/dashboard -n cozy-dashboard --timeout=10m --for=condition=ready
 }
 
 @test "Aggregated API rejects Tenant name with dashes" {

--- a/packages/core/platform/tests/apps_oidc_keycloak_internal_url_test.yaml
+++ b/packages/core/platform/tests/apps_oidc_keycloak_internal_url_test.yaml
@@ -1,0 +1,53 @@
+suite: apps.yaml OIDC keycloak-internal-url platform → tenant value wiring
+templates:
+  - templates/apps.yaml
+
+release:
+  name: cozy-platform
+  namespace: cozy-system
+
+# authentication.oidc.keycloakInternalUrl rides the _cluster channel as
+# keycloak-internal-url and is read by the dashboard and linstor-gui
+# gatekeepers (packages/system/{dashboard,linstor-gui}/templates/gatekeeper.yaml).
+# A non-empty value switches oauth2-proxy to --skip-oidc-discovery and sends
+# the backend calls (token, jwks, userinfo, logout) straight to the Keycloak
+# Service, so the dashboard no longer depends on the root ingress serving the
+# external Keycloak hostname before it can start. The default must therefore be
+# the in-cluster Service address, and an operator override — including an
+# override back to "" — must still reach the consumers untouched.
+
+tests:
+  - it: writes the in-cluster keycloak Service address by default
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'keycloak-internal-url:\s*"http://keycloak-http\.cozy-keycloak\.svc:8080/realms/cozy"'
+
+  - it: writes the in-cluster default even when OIDC is enabled
+    set:
+      authentication.oidc.enabled: true
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'oidc-enabled:\s*"true"'
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'keycloak-internal-url:\s*"http://keycloak-http\.cozy-keycloak\.svc:8080/realms/cozy"'
+
+  - it: honors an operator override pointing at a non-standard keycloak placement
+    set:
+      authentication.oidc.enabled: true
+      authentication.oidc.keycloakInternalUrl: http://keycloak.example.test:8080/realms/other
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'keycloak-internal-url:\s*"http://keycloak\.example\.test:8080/realms/other"'
+
+  - it: keeps the empty-string escape hatch, restoring external OIDC discovery
+    set:
+      authentication.oidc.enabled: true
+      authentication.oidc.keycloakInternalUrl: ""
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: 'keycloak-internal-url:\s*""'

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -330,11 +330,21 @@ authentication:
     enabled: false
     insecureSkipVerify: false
     keycloakExtraRedirectUri: ""
-    # Internal URL to access KeyCloak realm for backend-to-backend requests (bypasses external DNS).
-    # When set, oauth2-proxy uses --skip-oidc-discovery and routes all backend calls (token, jwks,
-    # userinfo, logout) through this URL while keeping browser redirects on the external URL.
-    # Example: http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy
-    keycloakInternalUrl: ""
+    # In-cluster URL of the KeyCloak realm, used for backend-to-backend requests. oauth2-proxy runs
+    # with --skip-oidc-discovery and sends every backend call (token, jwks, userinfo, logout) to this
+    # URL, while browser-facing redirects keep pointing at the external host.
+    #
+    # This is the default path: the bundled KeyCloak is the only supported provider, so those calls
+    # have no reason to leave the cluster. Taking the external hostname instead would route them
+    # through public DNS and the root ingress — which does not serve yet on a fresh install, leaving
+    # the dashboard permanently down.
+    #
+    # The keycloak-http Service has no TLS listener, so these backend calls travel as plaintext HTTP
+    # between pods, as keycloak-configure's own admin calls to the same address already do.
+    #
+    # Override only for a KeyCloak that does not live at the standard in-cluster address. Setting it
+    # to an empty string restores full OIDC discovery against the external issuer.
+    keycloakInternalUrl: "http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy"
 # Gateway API configuration
 gateway:
   # Enable Gateway API support across the platform. When true:

--- a/packages/system/dashboard/tests/gatekeeper_test.yaml
+++ b/packages/system/dashboard/tests/gatekeeper_test.yaml
@@ -51,6 +51,34 @@ tests:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8000
 
+  # authentication.oidc.enabled defaults to false while keycloakInternalUrl now
+  # defaults to the in-cluster Service, so THIS pair — OIDC off, internal URL
+  # set — is what most clusters actually render. The internal-URL block is
+  # nested inside the oidc-enabled guard, so it cannot leak into the
+  # token-proxy branch today; pin that, because a refactor which hoists the
+  # block out would otherwise ship silently.
+  - it: oidc-enabled=false ignores a set keycloak-internal-url
+    set:
+      _cluster:
+        root-host: example.org
+        oidc-enabled: "false"
+        keycloak-internal-url: http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy
+      tokenProxy:
+        image: example.invalid/token-proxy:test
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: token-proxy
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --skip-oidc-discovery
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --redeem-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/token
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --oidc-jwks-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/certs
+
   - it: oidc-enabled=true renders auth-proxy with /ping probes and no startupProbe
     set:
       _cluster:
@@ -74,3 +102,106 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 8000
+
+  # keycloak-internal-url arrives on the _cluster channel from
+  # authentication.oidc.keycloakInternalUrl in packages/core/platform. Its
+  # default is the in-cluster Keycloak Service, so the value asserted below is
+  # what a stock cluster ships: oauth2-proxy skips OIDC discovery and talks to
+  # the Service for token/jwks/userinfo/logout, which keeps the dashboard
+  # independent of the root ingress serving keycloak.<host> at startup. The
+  # browser-facing URLs (redirect, login) must stay on the external host —
+  # routing them to a cluster-internal address would send the user's browser to
+  # an unreachable URL.
+  - it: default in-cluster keycloak URL skips discovery and keeps browser URLs external
+    set:
+      _cluster:
+        root-host: example.org
+        oidc-enabled: "true"
+        keycloak-internal-url: http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --skip-oidc-discovery
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --redeem-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/token
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --oidc-jwks-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/certs
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --validate-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/userinfo
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --backend-logout-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/logout?id_token_hint={id_token}
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --redirect-url=https://dashboard.example.org/oauth2/callback
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --login-url=https://keycloak.example.org/realms/cozy/protocol/openid-connect/auth
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --oidc-issuer-url=https://keycloak.example.org/realms/cozy
+
+  - it: an explicit keycloak-internal-url override wins over the default
+    set:
+      _cluster:
+        root-host: example.org
+        oidc-enabled: "true"
+        keycloak-internal-url: http://keycloak.example.test:8080/realms/other
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --skip-oidc-discovery
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --redeem-url=http://keycloak.example.test:8080/realms/other/protocol/openid-connect/token
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --oidc-jwks-url=http://keycloak.example.test:8080/realms/other/protocol/openid-connect/certs
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --validate-url=http://keycloak.example.test:8080/realms/other/protocol/openid-connect/userinfo
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --redeem-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/token
+
+  # The escape hatch: an operator who sets keycloakInternalUrl back to "" gets
+  # the historical shape — full OIDC discovery against the external issuer, no
+  # backend URLs pinned. It must keep working, so pin it.
+  #
+  # --skip-oidc-discovery carries the whole meaning here. All five in-cluster
+  # args live inside one {{- if $keycloakInternalUrl }} block in the template,
+  # so its absence structurally guarantees the absence of the other four; the
+  # notContains assertions below then pin the regression that actually threatens
+  # this branch — the in-cluster default leaking back in. Asserting an arg count
+  # instead would couple this OIDC test to every unrelated gatekeeper flag.
+  - it: empty keycloak-internal-url restores external OIDC discovery
+    set:
+      _cluster:
+        root-host: example.org
+        oidc-enabled: "true"
+        keycloak-internal-url: ""
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --skip-oidc-discovery
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --oidc-issuer-url=https://keycloak.example.org/realms/cozy
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --backend-logout-url=https://keycloak.example.org/realms/cozy/protocol/openid-connect/logout?id_token_hint={id_token}
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --redeem-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/token
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --oidc-jwks-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/certs
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --validate-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/userinfo
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --backend-logout-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/logout?id_token_hint={id_token}

--- a/packages/system/linstor-gui/tests/ingress_auth_test.yaml
+++ b/packages/system/linstor-gui/tests/ingress_auth_test.yaml
@@ -79,6 +79,22 @@ tests:
       - hasDocuments:
           count: 0
 
+  # authentication.oidc.enabled defaults to false while keycloakInternalUrl now
+  # defaults to the in-cluster Service, so THIS pair — OIDC off, internal URL
+  # set — is what most clusters actually render. A non-empty internal URL must
+  # not conjure a gatekeeper on a cluster that never asked for OIDC.
+  - it: a set keycloak-internal-url does not render a gatekeeper while OIDC is disabled
+    template: templates/gatekeeper.yaml
+    set:
+      _cluster:
+        root-host: example.org
+        oidc-enabled: "false"
+        keycloak-internal-url: http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy
+        expose-services: "linstor-gui"
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: renders an oauth2-proxy Deployment pointing at the cluster Keycloak realm
     template: templates/gatekeeper.yaml
     set:
@@ -123,6 +139,113 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
           value: true
+
+  # keycloak-internal-url arrives on the _cluster channel from
+  # authentication.oidc.keycloakInternalUrl in packages/core/platform, whose
+  # default is the in-cluster Keycloak Service. A stock cluster therefore
+  # renders --skip-oidc-discovery with the backend calls (token, jwks,
+  # userinfo, logout) aimed at the Service, so the proxy does not need the
+  # external keycloak.<host> ingress to be serving before it can start. The
+  # browser-facing URLs (redirect, login) must stay on the external host.
+  - it: default in-cluster keycloak URL skips discovery and keeps browser URLs external
+    template: templates/gatekeeper.yaml
+    set:
+      _cluster:
+        root-host: dev10.example.org
+        oidc-enabled: "true"
+        keycloak-internal-url: http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy
+        expose-services: "linstor-gui"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --skip-oidc-discovery
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --redeem-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/token
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --oidc-jwks-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/certs
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --validate-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/userinfo
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --backend-logout-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/logout?id_token_hint={id_token}
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --redirect-url=https://linstor-gui.dev10.example.org/oauth2/callback
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --login-url=https://keycloak.dev10.example.org/realms/cozy/protocol/openid-connect/auth
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --oidc-issuer-url=https://keycloak.dev10.example.org/realms/cozy
+
+  - it: an explicit keycloak-internal-url override wins over the default
+    template: templates/gatekeeper.yaml
+    set:
+      _cluster:
+        root-host: dev10.example.org
+        oidc-enabled: "true"
+        keycloak-internal-url: http://keycloak.example.test:8080/realms/other
+        expose-services: "linstor-gui"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --skip-oidc-discovery
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --redeem-url=http://keycloak.example.test:8080/realms/other/protocol/openid-connect/token
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --oidc-jwks-url=http://keycloak.example.test:8080/realms/other/protocol/openid-connect/certs
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --validate-url=http://keycloak.example.test:8080/realms/other/protocol/openid-connect/userinfo
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --redeem-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/token
+
+  # The escape hatch: setting keycloakInternalUrl back to "" must keep
+  # rendering the historical shape — full OIDC discovery against the external
+  # issuer, no backend URLs pinned.
+  #
+  # --skip-oidc-discovery carries the whole meaning here. All five in-cluster
+  # args live inside one {{- if $keycloakInternalUrl }} block in the template,
+  # so its absence structurally guarantees the absence of the other four; the
+  # notContains assertions below then pin the regression that actually threatens
+  # this branch — the in-cluster default leaking back in. Asserting an arg count
+  # instead would couple this OIDC test to every unrelated gatekeeper flag.
+  - it: empty keycloak-internal-url restores external OIDC discovery
+    template: templates/gatekeeper.yaml
+    set:
+      _cluster:
+        root-host: dev10.example.org
+        oidc-enabled: "true"
+        keycloak-internal-url: ""
+        expose-services: "linstor-gui"
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --skip-oidc-discovery
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --oidc-issuer-url=https://keycloak.dev10.example.org/realms/cozy
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --backend-logout-url=https://keycloak.dev10.example.org/realms/cozy/protocol/openid-connect/logout?id_token_hint={id_token}
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --redeem-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/token
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --oidc-jwks-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/certs
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --validate-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/userinfo
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --backend-logout-url=http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy/protocol/openid-connect/logout?id_token_hint={id_token}
 
   - it: creates client + cookie Secrets and a KeycloakClient CRD
     template: templates/keycloakclient.yaml


### PR DESCRIPTION
## What this PR does

Defaults `authentication.oidc.keycloakInternalUrl` to `http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy` instead of an empty string.

With the empty default, oauth2-proxy performed OIDC discovery against the external Keycloak hostname. That request resolves through public DNS and lands on the root ingress controller, which does not serve yet on a fresh install: the root tenant's IngressClass only exists once `tenant-root` is ready, and `tenant-root` is still reconciling while the dashboard starts. Discovery has nothing to talk to, the gatekeeper fails, and the dashboard never comes up — with no obvious diagnosis for a first-time installer.

The bundled Keycloak is the only supported provider (the external hostname is templated as `keycloak.<host>` and the realm is fixed), so backend-to-backend calls have no reason to leave the cluster. The new default is the same Service address `keycloak-configure` already uses for its own backend calls. The dashboard and linstor-gui gatekeepers then run with `--skip-oidc-discovery` and send token, jwks, userinfo and logout requests straight to the Service, while browser-facing redirects stay on the external host.

Both gatekeeper templates already branch on the value being non-empty, so neither needed a change. The value stays overridable for a Keycloak that does not live at the standard in-cluster address, and setting it back to `""` restores the previous external-discovery behaviour.

Token validation is unaffected: Keycloak pins `KC_HOSTNAME` to the external URL, so tokens redeemed over the internal Service still carry the external `iss` and match the unchanged `--oidc-issuer-url`.

### Upgrade behaviour

Existing OIDC clusters that never set `keycloakInternalUrl` pick up the new default on upgrade: their gatekeepers roll once and move to the internal path. Clusters that set the value explicitly — including to `""` — keep exactly what they configured.

### Security posture

The backend leg (token redemption, which carries the gatekeeper's Keycloak client secret, plus jwks/userinfo/logout) now travels as plaintext HTTP between pods rather than HTTPS to the ingress. This is stated in the `values.yaml` comment rather than left implicit. The `keycloak-http` Service has no TLS listener, so in-cluster HTTPS is not an available alternative, and `keycloak-configure` already sends Keycloak *admin* credentials over that identical address — anyone positioned to read this traffic can already reach a strictly more powerful secret. The externally reachable front door (browser to oauth2-proxy) is unchanged.

### Testing

helm-unittest coverage across all three affected charts: the default landing on the `_cluster` channel, both gatekeepers rendering the in-cluster backend URLs while keeping browser URLs external, an explicit override winning, the empty-string escape hatch still rendering the external-discovery shape, and OIDC-disabled clusters (now the common case of "OIDC off, internal URL set") ignoring the value entirely.

The E2E OIDC case previously applied this exact URL as a manual workaround. It now sets only `oidc.enabled` and asserts the consequence: it waits for the `auth-proxy` container to appear in the gatekeeper Deployment, then gates on `kubectl rollout status`. Readiness alone would prove nothing there — the HelmRelease is still `Ready` from the token-proxy install, and with `replicas: 1` and `maxUnavailable: 25%` (which rounds down to 0) the Deployment keeps the old ReplicaSet `Available` while a new pod crashloops. Only the rollout catches a regression back to external discovery.

Follow-up: the OIDC documentation in the website repo still frames `keycloakInternalUrl` as an optional tweak "for self-signed certificates or restricted external access". It is now the default path and needs a separate docs PR.

Closes #3288

### Screenshots

No UI changes.

### Release note

```release-note
fix(platform): `authentication.oidc.keycloakInternalUrl` now defaults to the in-cluster Keycloak Service (`http://keycloak-http.cozy-keycloak.svc:8080/realms/cozy`). OIDC backend calls from the dashboard and linstor-gui gatekeepers no longer leave the cluster, so enabling OIDC on a fresh install no longer leaves the dashboard down while the root ingress is not yet serving. Existing clusters that never set the value pick up the new default and roll their gatekeepers once. Set the value explicitly to point at a non-standard Keycloak placement, or to an empty string to restore external OIDC discovery.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OIDC-enabled applications now use the internal Keycloak service for backend authentication by default, improving reliability and avoiding unnecessary external discovery.
  - Browser redirects and login flows continue using the external Keycloak address.
  - Operators can provide a custom internal Keycloak URL or set it to an empty value to restore external OIDC discovery.

- **Bug Fixes**
  - Dashboard and Linstor GUI authentication now correctly apply internal Keycloak settings only when OIDC is enabled.
  - Dashboard upgrades now wait for authentication components to become ready before completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->