### PR TITLE
docs(harbor): fix SeaweedFS discovery key described as annotation

### DIFF
--- a/packages/apps/harbor/README.md
+++ b/packages/apps/harbor/README.md
@@ -4,7 +4,7 @@ Harbor is an open-source trusted cloud-native registry project that stores, sign
 
 ## Prerequisites
 
-The Cozystack Harbor app stores its registry data exclusively in S3-compatible object storage: the chart pins the registry backend to S3 and exposes no filesystem option. That bucket is provisioned through COSI (`objectstorage.k8s.io`) from a SeaweedFS deployment, so before deploying Harbor the tenant must have SeaweedFS available — enabled on the same tenant or inherited from a parent tenant (the resolved class is propagated down the tenant tree, surfaced as the `namespace.cozystack.io/seaweedfs` namespace annotation).
+The Cozystack Harbor app stores its registry data exclusively in S3-compatible object storage: the chart pins the registry backend to S3 and exposes no filesystem option. That bucket is provisioned through COSI (`objectstorage.k8s.io`) from a SeaweedFS deployment, so before deploying Harbor the tenant must have SeaweedFS available — enabled on the same tenant or inherited from a parent tenant (the resolved class is propagated down the tenant tree, surfaced as the `namespace.cozystack.io/seaweedfs` namespace label).
 
 Enable it by setting `seaweedfs: true` on the tenant (or a parent tenant):
 


### PR DESCRIPTION
## What this PR does

Corrects a factual error in the Harbor app's prerequisites documentation.

The prerequisites section described the resolved SeaweedFS class as being surfaced on the tenant namespace as the `namespace.cozystack.io/seaweedfs` **annotation**. It is a **label**. `packages/apps/tenant/templates/namespace.yaml` renders that key under `metadata.labels` — in the block commented "Labels for network policies", alongside the sibling `namespace.cozystack.io/etcd`, `/ingress`, `/gateway`, `/monitoring` and `/host` keys. No annotation of that name exists anywhere in the tree.

Why the wrong noun matters: it sends an operator to the wrong field at exactly the moment they are already debugging. The README documents that a Harbor release which cannot provision its registry bucket stays unreconciled waiting on `BucketInfo`, and the natural check is to confirm the tenant chain actually resolved a SeaweedFS class. Following the text and inspecting `.metadata.annotations` returns nothing even on a perfectly healthy tenant, which invites the conclusion that the tenant chain is misconfigured and sends the investigation away from the real cause.

The change is one word. I checked the rest of the tree for the same error class — grepping for `namespace.cozystack.io/` together with "annotation" across all of `packages/` and then across the whole repository — and this README was the only occurrence. `packages/extra/gateway/README.md` already describes the sibling keys correctly as labels.

Note on the file being partially generated: `packages/apps/harbor/README.md` has a `generate:` target in its Makefile that runs `cozyvalues-gen ... -r README.md`, but that generator only rewrites the `## Parameters` tables from the `@param` comments in `values.yaml`. The corrected sentence lives in the hand-maintained prose section, which the generator preserves verbatim — confirmed by running cozyvalues-gen v1.6.0 (the version CI pins) against a copy of the package: the corrected wording survives regeneration byte-for-byte, so this introduces no codegen drift. Editing the README directly is the correct fix here; there is no separate upstream source to change.

Downstream consequence worth flagging for reviewers: the cozystack website generates the Harbor app page from this README, so the published v1.5 Harbor page currently carries the same error. It will be corrected when the site re-syncs from this file.

### Screenshots

Not applicable — documentation-only change, no UI surface.

### Release note

```release-note
docs(harbor): fix SeaweedFS discovery key in prerequisites — it is the `namespace.cozystack.io/seaweedfs` namespace label, previously documented as an annotation
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Harbor prerequisites to clarify that the resolved SeaweedFS class is exposed through a namespace label.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->