### PR TITLE
fix(kubernetes): re-pin deleted centos:stream9 digest for kubevirt-csi-driver

### DIFF
--- a/packages/apps/kubernetes/images/kubevirt-csi-driver/Dockerfile
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver/Dockerfile
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
     -ldflags "-X kubevirt.io/csi-driver/pkg/service.VendorVersion=0.2.0" \
     -o kubevirt-csi-driver .
 
-FROM quay.io/centos/centos:stream9@sha256:0c9db821f54b244ec5e487056fe782e939db026240f52bc89e1d3a509dca7e8b
+FROM quay.io/centos/centos:stream9@sha256:a93e3316b14a226863327f35110909569ec554fc9e092bc307282cf00e17e3d0
 
 RUN dnf install -y e2fsprogs xfsprogs nfs-utils && dnf clean all
 


### PR DESCRIPTION
## What this PR does

`packages/apps/kubernetes/images/kubevirt-csi-driver/Dockerfile` pins its runtime base image to `quay.io/centos/centos:stream9` by digest. `stream9` is a rolling tag, and upstream deleted the pinned digest (`sha256:0c9db821…`) when it published a fresh stream9 build. As a result `make image-kubevirt-csi-driver` now fails with `not found` on every build — open PRs and `main` alike (the `Build packages/apps/kubernetes` job goes red before E2E even starts).

Re-pin to the current live `stream9` digest (`sha256:a93e3316…`, verified pullable and multi-arch: amd64/arm64/ppc64le/s390x). No Dockerfile logic changes.

## Known limitation and follow-up

This is an emergency CI unblock, **not** a durable fix. `stream9` is a rolling, garbage-collected tag: upstream deletes old digests on every rebuild, so the same `not found` breakage will recur the next time CentOS rolls the tag faster than the pin is bumped. This is the same operation Renovate's weekly (non-automerged) digest PR performs.

A durable fix is out of scope for this hotfix and left as follow-up:
- mirror the base image into cozystack's own registry so old digests are not GC'd, or
- move to an immutable-digest base such as UBI9 (`registry.access.redhat.com/ubi9`), or
- enable automerge / tighten the schedule for the digest-only Renovate group so future rolls are absorbed automatically.

### Downstream repositories

- [x] No downstream repository is affected by this change

<!-- Runtime base-image digest of an internal component image; no API, values, CRD, or chart-interface surface changes. -->

### Release note

```release-note
fix(kubernetes): restore the kubevirt-csi-driver image build after upstream deleted the pinned centos:stream9 base image digest
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kubernetes CSI driver’s runtime base image to a newer verified version.
  * Runtime behavior and application functionality remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->