### PR TITLE
fix(keycloak): use barman-capable system image when backups enabled

### DIFF
--- a/packages/system/keycloak/templates/db.yaml
+++ b/packages/system/keycloak/templates/db.yaml
@@ -6,7 +6,19 @@ spec:
   instances: 2
   {{- $existingCluster := lookup "postgresql.cnpg.io/v1" "Cluster" .Release.Namespace "keycloak-db" }}
   {{- $image := dig "spec" "imageName" "ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie" $existingCluster }}
-  imageName: {{ if regexMatch ":17\\." $image }}ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie{{ else if regexMatch ":[0-9]+\\.[0-9]+$" $image }}{{ printf "%s-standard-trixie" $image }}{{ else }}{{ $image }}{{ end }}
+  {{- /*
+    Backups use the in-tree (native) barmanObjectStore, whose barman-cloud-*
+    binaries ship ONLY in the CNPG `system` image variant. The `standard`
+    variant (default since #2342) omits them, so with `standard` a base backup
+    fails `barman-cloud-backup: executable file not found` and WAL archiving
+    cannot run. When backups are enabled, pin the barman-capable `system`
+    variant; otherwise keep `standard`.
+    TEMPORARY: `system` is deprecated in CNPG 1.27 (removed in 1.29). Remove this
+    once Postgres backups move to the Barman Cloud Plugin — see #3300.
+  */}}
+  {{- $backupOn := and .Values.backup.enabled (not (empty .Values.backup.destinationPath)) }}
+  {{- $variant := ternary "system" "standard" $backupOn }}
+  imageName: {{ if regexMatch ":17\\." $image }}ghcr.io/cloudnative-pg/postgresql:17.7-{{ $variant }}-trixie{{ else if regexMatch ":[0-9]+\\.[0-9]+$" $image }}{{ printf "%s-%s-trixie" $image $variant }}{{ else }}{{ $image }}{{ end }}
   storage:
     size: 20Gi
   {{- if .Values._cluster.scheduling }}

--- a/packages/system/keycloak/tests/db_backup_image_test.yaml
+++ b/packages/system/keycloak/tests/db_backup_image_test.yaml
@@ -1,0 +1,53 @@
+suite: keycloak-db image variant tracks backup enablement
+
+# Native barmanObjectStore backups need the barman-cloud-* binaries, which
+# ship only in the CNPG `system` image variant (see templates/db.yaml). The
+# image-variant switch MUST be pinned to `system` exactly when the
+# barmanObjectStore block renders, otherwise a base backup fails with
+# `barman-cloud-backup: executable file not found` (#3300). This suite locks
+# that gate: input (backup.enabled + backup.destinationPath) -> rendered
+# spec.imageName, and asserts the object-store block co-renders with `system`.
+release:
+  name: keycloak
+  namespace: cozy-keycloak
+templates:
+  - templates/db.yaml
+tests:
+  - it: defaults (backups off) render the standard image and no object store
+    set:
+      _cluster: {}
+    asserts:
+      - equal:
+          path: spec.imageName
+          value: ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie
+      - notExists:
+          path: spec.backup.barmanObjectStore
+
+  - it: backups enabled with a destination pin the barman-capable system image
+    set:
+      _cluster: {}
+      backup:
+        enabled: true
+        destinationPath: s3://bucket/keycloak-db/
+    asserts:
+      - equal:
+          path: spec.imageName
+          value: ghcr.io/cloudnative-pg/postgresql:17.7-system-trixie
+      # the variant switch and the object-store gate must agree — system image
+      # is present exactly when the barmanObjectStore renders.
+      - equal:
+          path: spec.backup.barmanObjectStore.destinationPath
+          value: s3://bucket/keycloak-db/
+
+  - it: enabled with an empty destinationPath stays standard (two-part gate)
+    set:
+      _cluster: {}
+      backup:
+        enabled: true
+        destinationPath: ""
+    asserts:
+      - equal:
+          path: spec.imageName
+          value: ghcr.io/cloudnative-pg/postgresql:17.7-standard-trixie
+      - notExists:
+          path: spec.backup.barmanObjectStore


### PR DESCRIPTION
## Problem

The Keycloak DB backup added in #3174 uses the in-tree **native** `spec.backup.barmanObjectStore`, whose `barman-cloud-*` binaries ship **only** in the CloudNativePG **`system`** image variant. Since #2342 `keycloak-db` is pinned to the **`standard`** variant (`17.7-standard-trixie`), which omits those binaries — so with backups enabled:

```
LastBackupFailed: exec: "barman-cloud-backup": executable file not found in $PATH
```

Base backups fail and WAL archiving can't run (the latter also risks WAL accumulation blocking recycling). This is the keycloak facet of #3300.

## Fix

In `templates/db.yaml`, pin the barman-capable **`system`** variant **only when backups are enabled** (`backup.enabled` + `backup.destinationPath`); otherwise keep `standard`. One-line variant switch, gated, fully documented inline.

## Verification

On a freedom-portal cluster (CNPG 1.27, PostgreSQL 17.7):
- `standard-trixie` + native barman → `barman-cloud-backup: executable file not found` (base backup fails).
- `system-trixie` + native barman → CNPG `Backup` **completed**, `LastBackupSucceeded=True`, `ContinuousArchiving=True`, WAL archived to S3 (`barman-cloud-wal-archive` runs).

`helm unittest` 48/48 pass (incl. new `tests/db_backup_image_test.yaml` locking the variant gate: backups off → `standard`, on+destination → `system`, on+empty-destination → `standard`); `helm template` shows `standard-trixie` with backups off and `system-trixie` with backups on.

## Note for air-gapped installs

Enabling backups now pulls a new tag, `ghcr.io/cloudnative-pg/postgresql:17.7-system-trixie`, reachable via a runtime `backup.enabled` flip. Mirrors that only carry `17.7-standard-trixie` must also mirror `17.7-system-trixie`, otherwise the first base backup fails on image pull.

## Temporary bridge

`system` is **deprecated** in CNPG 1.27 (removed in 1.29). This is a stopgap so keycloak backups work today; it should be **removed once Postgres backups migrate to the Barman Cloud Plugin — see #3300** (which covers the same issue for the `cozy-default-cnpg` strategy and `apps/postgres`).

Refs #3300, #2342, #3174.

### Release note

```release-note
fix(keycloak): pin the barman-capable CNPG `system` image for keycloak-db when backups are enabled
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Keycloak database backup compatibility by dynamically selecting the correct PostgreSQL image variant when backups are enabled and a non-empty backup destination path is configured.
  * If the backup destination path is missing or empty, deployments continue using the standard database image and omit the backup object-store destination settings.
* **Tests**
  * Added Helm test coverage to verify database image variant rendering based on backup enablement and destination path configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
