### PR TITLE
fix(backups/postgres): purge stale recovery cluster on repeat in-place restore

### DIFF
--- a/internal/backupcontroller/cnpgstrategy_controller.go
+++ b/internal/backupcontroller/cnpgstrategy_controller.go
@@ -314,16 +314,46 @@ func cnpgBackupDeadlineExceeded(startedAt *metav1.Time) bool {
 // destructive step:
 //  1. The RestoreJob already records that we've purged
 //     (restoreCondTargetPurged=True). Normal idempotent path.
-//  2. The live Cluster already has spec.bootstrap.recovery populated. This
-//     only happens when an earlier reconcile purged successfully but the
+//  2. The live Cluster is a freshly-recovered one that THIS restore's own
+//     purge + chart re-render produced (see cnpgClusterFreshlyRecovered).
+//     This only happens when an earlier reconcile purged successfully but the
 //     status-condition write failed; the chart has since re-rendered the
 //     Cluster with our restore-shaped values. Re-purging here would delete
 //     the Cluster CNPG is actively bootstrapping from S3.
-func cnpgPurgeNeeded(purgedCondition, liveClusterHasRecovery bool) bool {
+//
+// A live Cluster that carries spec.bootstrap.recovery but predates this
+// RestoreJob is NOT a skip signal: it is leftover from an earlier, already-
+// completed restore and still holds the old data. Skipping the purge on it
+// (the previous behaviour, which keyed only on "has recovery bootstrap") made
+// a repeat in-place restore a silent no-op - the job reported Succeeded while
+// the PVC, disk, and data were never touched.
+func cnpgPurgeNeeded(purgedCondition, liveClusterFreshlyRecovered bool) bool {
 	if purgedCondition {
 		return false
 	}
-	return !liveClusterHasRecovery
+	return !liveClusterFreshlyRecovered
+}
+
+// cnpgClusterFreshlyRecovered reports whether a live cnpg.io Cluster that
+// carries spec.bootstrap.recovery was produced by THIS RestoreJob's own purge
+// + chart re-render (its creationTimestamp is at or after the job's StartedAt)
+// rather than being left over from an earlier, already-completed restore.
+//
+// Only the former is safe to skip re-purging. A leftover recovery Cluster from
+// a prior restore predates StartedAt and still holds the prior data, so it must
+// be purged for the new restore to re-bootstrap from the backup. The fresh
+// Cluster in the status-write-race case is always created after StartedAt (the
+// job sets StartedAt on its first reconcile, long before it purges and the
+// chart re-renders), so the timestamp comparison cleanly separates the two.
+//
+// Returns false when freshness cannot be determined (no recovery bootstrap, or
+// a missing timestamp): the caller then proceeds to purge, which is the safe
+// default for any pre-existing, non-fresh Cluster.
+func cnpgClusterFreshlyRecovered(hasRecovery bool, clusterCreatedAt, restoreStartedAt *metav1.Time) bool {
+	if !hasRecovery || clusterCreatedAt == nil || restoreStartedAt == nil {
+		return false
+	}
+	return !clusterCreatedAt.Time.Before(restoreStartedAt.Time)
 }
 
 // applyClusterBarmanObjectStore SSA-patches the live CNPG Cluster's
@@ -614,12 +644,18 @@ func (r *RestoreJobReconciler) reconcileCNPGRestore(ctx context.Context, restore
 	// check the live Cluster for bootstrap.recovery: if present, the chart
 	// has already re-rendered after a previous purge, and we must NOT delete
 	// it again.
-	hasRecovery, err := r.clusterHasRecoveryBootstrap(ctx, target.Namespace, clusterName)
+	hasRecovery, clusterCreatedAt, err := r.recoveryBootstrapClusterState(ctx, target.Namespace, clusterName)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	purgedCondition := apimeta.IsStatusConditionTrue(restoreJob.Status.Conditions, restoreCondTargetPurged)
-	if cnpgPurgeNeeded(purgedCondition, hasRecovery) {
+	// Only skip the destructive purge for a recovery Cluster THIS restore just
+	// produced (created at/after StartedAt). A recovery Cluster left over from
+	// an earlier completed restore predates StartedAt and still holds the old
+	// data, so it must be purged - otherwise a repeat in-place restore silently
+	// no-ops.
+	freshlyRecovered := cnpgClusterFreshlyRecovered(hasRecovery, clusterCreatedAt, restoreJob.Status.StartedAt)
+	if cnpgPurgeNeeded(purgedCondition, freshlyRecovered) {
 		// Gate the destructive flow on the source cluster having shipped
 		// the backup's required WALs to object storage. archive_command runs
 		// on the source primary; once we delete the Cluster + PVCs, any
@@ -1126,11 +1162,15 @@ func (r *RestoreJobReconciler) cnpgClusterHealthy(ctx context.Context, namespace
 	return cluster.Status.Phase == cnpgClusterHealthyPhase, nil
 }
 
-// clusterHasRecoveryBootstrap returns true when the live cnpg.io Cluster's
-// spec.bootstrap.recovery is populated - the signal that the chart has
-// re-rendered with our restore-shaped values and the operator is using the
-// recovery bootstrap path. Treats a missing Cluster as "not yet" rather
-// than an error so the caller can keep polling while HelmRelease catches up.
+// recoveryBootstrapClusterState fetches the live cnpg.io Cluster and reports
+// whether its spec.bootstrap.recovery is populated - the signal that the chart
+// has re-rendered with our restore-shaped values and the operator is using the
+// recovery bootstrap path - together with the Cluster's creationTimestamp. The
+// caller pairs the timestamp with the RestoreJob's StartedAt (via
+// cnpgClusterFreshlyRecovered) to tell a Cluster this restore just produced
+// apart from one left over by an earlier completed restore. Treats a missing
+// Cluster as "not yet" rather than an error so the caller can keep polling
+// while HelmRelease catches up.
 //
 // A Cluster carrying DeletionTimestamp is also treated as "not yet": that is
 // the in-flight purge case, where r.Delete has fired but cnpg.io's
@@ -1143,18 +1183,22 @@ func (r *RestoreJobReconciler) cnpgClusterHealthy(ctx context.Context, namespace
 // drops the change and the cluster ends up with the original initdb spec.
 // Holding here forces the caller to requeue until the old CR is fully GC'd
 // and the chart re-creates a fresh one.
-func (r *RestoreJobReconciler) clusterHasRecoveryBootstrap(ctx context.Context, namespace, clusterName string) (bool, error) {
+func (r *RestoreJobReconciler) recoveryBootstrapClusterState(ctx context.Context, namespace, clusterName string) (hasRecovery bool, createdAt *metav1.Time, err error) {
 	cluster := &cnpgtypes.Cluster{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: clusterName}, cluster); err != nil {
 		if apierrors.IsNotFound(err) {
-			return false, nil
+			return false, nil, nil
 		}
-		return false, err
+		return false, nil, err
 	}
 	if !cluster.DeletionTimestamp.IsZero() {
-		return false, nil
+		return false, nil, nil
 	}
-	return cluster.Spec.Bootstrap != nil && cluster.Spec.Bootstrap.Recovery != nil, nil
+	if cluster.Spec.Bootstrap == nil || cluster.Spec.Bootstrap.Recovery == nil {
+		return false, nil, nil
+	}
+	created := cluster.CreationTimestamp
+	return true, &created, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/backupcontroller/cnpgstrategy_controller.go
+++ b/internal/backupcontroller/cnpgstrategy_controller.go
@@ -336,8 +336,9 @@ func cnpgPurgeNeeded(purgedCondition, liveClusterFreshlyRecovered bool) bool {
 
 // cnpgClusterFreshlyRecovered reports whether a live cnpg.io Cluster that
 // carries spec.bootstrap.recovery was produced by THIS RestoreJob's own purge
-// + chart re-render (its creationTimestamp is at or after the job's StartedAt)
-// rather than being left over from an earlier, already-completed restore.
+// + chart re-render (its creationTimestamp is strictly after the job's
+// StartedAt) rather than being left over from an earlier, already-completed
+// restore.
 //
 // Only the former is safe to skip re-purging. A leftover recovery Cluster from
 // a prior restore predates StartedAt and still holds the prior data, so it must
@@ -346,6 +347,21 @@ func cnpgPurgeNeeded(purgedCondition, liveClusterFreshlyRecovered bool) bool {
 // job sets StartedAt on its first reconcile, long before it purges and the
 // chart re-renders), so the timestamp comparison cleanly separates the two.
 //
+// The comparison is strict (created > started), so an exact tie resolves to
+// "not fresh" and the caller purges. That matches the conservative default
+// below: the only classification that must never be wrong is calling a stale
+// leftover "fresh" (which reintroduces the silent no-op), and a fresh Cluster
+// is always created well after StartedAt (see above), never exactly at it.
+//
+// An identity-based alternative was considered - recording the purged Cluster's
+// UID on the TargetPurged condition and comparing UIDs on later reconciles -
+// which is immune to clock skew. It was rejected because it leans on the same
+// status write that the status-write-race path (the whole reason this skip
+// exists) assumes can fail, so it cannot cover that case; the timestamp
+// comparison needs no extra persisted state and the fresh-vs-stale gap
+// (a full purge + re-render cycle) always dwarfs any plausible control-plane
+// clock skew.
+//
 // Returns false when freshness cannot be determined (no recovery bootstrap, or
 // a missing timestamp): the caller then proceeds to purge, which is the safe
 // default for any pre-existing, non-fresh Cluster.
@@ -353,7 +369,7 @@ func cnpgClusterFreshlyRecovered(hasRecovery bool, clusterCreatedAt, restoreStar
 	if !hasRecovery || clusterCreatedAt == nil || restoreStartedAt == nil {
 		return false
 	}
-	return !clusterCreatedAt.Time.Before(restoreStartedAt.Time)
+	return clusterCreatedAt.After(restoreStartedAt.Time)
 }
 
 // applyClusterBarmanObjectStore SSA-patches the live CNPG Cluster's

--- a/internal/backupcontroller/cnpgstrategy_controller_test.go
+++ b/internal/backupcontroller/cnpgstrategy_controller_test.go
@@ -641,11 +641,11 @@ func TestCNPGClusterFreshlyRecovered(t *testing.T) {
 			want:        false,
 		},
 		{
-			name:        "recovery cluster created exactly at start: fresh (boundary)",
+			name:        "recovery cluster created exactly at start: not fresh (conservative tie -> purge)",
 			hasRecovery: true,
 			createdAt:   &started,
 			startedAt:   &started,
-			want:        true,
+			want:        false,
 		},
 		{
 			name:        "missing cluster creation timestamp: not fresh",
@@ -1596,6 +1596,149 @@ func TestReconcileCNPGRestore_MissingStrategyFailsClosedAfterDeadline(t *testing
 	if !strings.Contains(final.Status.Message, "missing-strategy") {
 		t.Errorf("failure message should name the missing strategy, got %q", final.Status.Message)
 	}
+}
+
+// TestReconcileCNPGRestore_RepeatInPlacePurgesStaleRecoveryCluster is the
+// reconcile-level regression test for #3311. The pure-function tests
+// (TestCNPGPurgeNeeded / TestCNPGClusterFreshlyRecovered) lock in the truth
+// table, but the bug lived at the call site: a repeat in-place restore fed the
+// purge decision the wrong signal and skipped the destructive purge, so the
+// job reported Succeeded against untouched data. This drives the real
+// reconcileCNPGRestore path with a fake client and asserts the destructive
+// purge actually fires for a stale leftover recovery Cluster - and, in the
+// mirror case, that a Cluster this restore just re-created is NOT re-purged
+// (the status-write-race protection the guard was originally built for).
+func TestReconcileCNPGRestore_RepeatInPlacePurgesStaleRecoveryCluster(t *testing.T) {
+	const (
+		ns          = "tenant"
+		appName     = "app"
+		clusterName = "postgres-app"
+		cnpgBkName  = "cnpgbk"
+	)
+	apiGroup := backupsv1alpha1.DefaultApplicationAPIGroup
+	strategyGroup := strategyv1alpha1.GroupVersion.Group
+	ctx := context.Background()
+
+	// startedAt anchors the discriminator: a stale leftover Cluster predates
+	// it, a freshly-recovered one postdates it.
+	startedAt := metav1.NewTime(time.Now())
+
+	mkBackupArtifact := func(t *testing.T) *backupsv1alpha1.Backup {
+		t.Helper()
+		snap, err := marshalCNPGBackupSnapshot(newPostgresApp(appName, ns), nil)
+		if err != nil {
+			t.Fatalf("marshal snapshot: %v", err)
+		}
+		return &backupsv1alpha1.Backup{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "bk"},
+			Spec: backupsv1alpha1.BackupSpec{
+				ApplicationRef: corev1.TypedLocalObjectReference{APIGroup: &apiGroup, Kind: postgresAppKind, Name: appName},
+				StrategyRef:    corev1.TypedLocalObjectReference{APIGroup: &strategyGroup, Kind: strategyv1alpha1.CNPGStrategyKind, Name: "cnpg-strategy"},
+				DriverMetadata: map[string]string{
+					cnpgServerNameKey:      appName,
+					cnpgDestinationPathKey: "s3://bucket/" + appName + "/",
+					cnpgBackupNameKey:      cnpgBkName,
+				},
+			},
+			Status: backupsv1alpha1.BackupStatus{UnderlyingResources: snap},
+		}
+	}
+	strategy := &strategyv1alpha1.CNPG{
+		ObjectMeta: metav1.ObjectMeta{Name: "cnpg-strategy"},
+		Spec: strategyv1alpha1.CNPGSpec{
+			Template: strategyv1alpha1.CNPGTemplate{
+				BarmanObjectStore: strategyv1alpha1.BarmanObjectStoreTemplate{DestinationPath: "s3://bucket/"},
+			},
+		},
+	}
+	// A completed cnpg.io/Backup with endWal set clears the WAL-archive gate
+	// so the reconcile can reach the purge step.
+	cnpgBackup := &cnpgtypes.Backup{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: cnpgBkName},
+		Spec:       cnpgtypes.BackupSpec{Cluster: cnpgtypes.ClusterReference{Name: clusterName}},
+		Status:     cnpgtypes.BackupStatus{Phase: cnpgBackupPhaseComplete, EndWal: "000000010000000000000003"},
+	}
+	mkRecoveryCluster := func(created metav1.Time) *cnpgtypes.Cluster {
+		return &cnpgtypes.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: clusterName, CreationTimestamp: created},
+			Spec: cnpgtypes.ClusterSpec{
+				Bootstrap: &cnpgtypes.BootstrapConfiguration{
+					Recovery: &cnpgtypes.RecoverySource{Source: appName},
+				},
+			},
+		}
+	}
+	mkClusterPVC := func() *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: clusterName + "-1", Labels: map[string]string{cnpgClusterLabel: clusterName}},
+		}
+	}
+	mkRestoreJob := func() *backupsv1alpha1.RestoreJob {
+		sa := startedAt
+		return &backupsv1alpha1.RestoreJob{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "rj"},
+			Spec:       backupsv1alpha1.RestoreJobSpec{BackupRef: corev1.LocalObjectReference{Name: "bk"}},
+			Status:     backupsv1alpha1.RestoreJobStatus{StartedAt: &sa, Phase: backupsv1alpha1.RestoreJobPhaseRunning},
+		}
+	}
+
+	t.Run("stale leftover recovery cluster from a prior restore is purged", func(t *testing.T) {
+		backup := mkBackupArtifact(t)
+		// creationTimestamp an hour before StartedAt: leftover from a prior restore.
+		stale := metav1.NewTime(startedAt.Add(-time.Hour))
+		c := newCNPGStrategyTestClient(t, backup, mkRestoreJob(), strategy, cnpgBackup,
+			newPostgresApp(appName, ns), mkRecoveryCluster(stale), mkClusterPVC())
+		r := &RestoreJobReconciler{Client: c, Interface: dynamicfake.NewSimpleDynamicClient(testCNPGScheme(t))}
+
+		rj := &backupsv1alpha1.RestoreJob{}
+		if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: "rj"}, rj); err != nil {
+			t.Fatalf("get seeded RestoreJob: %v", err)
+		}
+		if _, err := r.reconcileCNPGRestore(ctx, rj, backup); err != nil {
+			t.Fatalf("reconcileCNPGRestore: %v", err)
+		}
+
+		// The stale Cluster (and its labelled PVC) must have been purged.
+		err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: clusterName}, &cnpgtypes.Cluster{})
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("expected stale Cluster to be purged (NotFound), got err=%v", err)
+		}
+		pvcs := &corev1.PersistentVolumeClaimList{}
+		if err := c.List(ctx, pvcs, client.InNamespace(ns), client.MatchingLabels{cnpgClusterLabel: clusterName}); err != nil {
+			t.Fatalf("list PVCs: %v", err)
+		}
+		if len(pvcs.Items) != 0 {
+			t.Fatalf("expected cluster PVCs purged, still have %d", len(pvcs.Items))
+		}
+	})
+
+	t.Run("freshly-recovered cluster from this restore is not re-purged", func(t *testing.T) {
+		backup := mkBackupArtifact(t)
+		// creationTimestamp a minute after StartedAt: this restore's own re-render.
+		fresh := metav1.NewTime(startedAt.Add(time.Minute))
+		c := newCNPGStrategyTestClient(t, backup, mkRestoreJob(), strategy, cnpgBackup,
+			newPostgresApp(appName, ns), mkRecoveryCluster(fresh))
+		r := &RestoreJobReconciler{Client: c, Interface: dynamicfake.NewSimpleDynamicClient(testCNPGScheme(t))}
+
+		rj := &backupsv1alpha1.RestoreJob{}
+		if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: "rj"}, rj); err != nil {
+			t.Fatalf("get seeded RestoreJob: %v", err)
+		}
+		if _, err := r.reconcileCNPGRestore(ctx, rj, backup); err != nil {
+			t.Fatalf("reconcileCNPGRestore: %v", err)
+		}
+
+		// The freshly-recovered Cluster must survive - re-purging it would
+		// destroy the recovery this restore just started (the status-write-race
+		// protection the guard was built for).
+		got := &cnpgtypes.Cluster{}
+		if err := c.Get(ctx, client.ObjectKey{Namespace: ns, Name: clusterName}, got); err != nil {
+			t.Fatalf("expected freshly-recovered Cluster to survive, got err=%v", err)
+		}
+		if !got.DeletionTimestamp.IsZero() {
+			t.Fatalf("freshly-recovered Cluster must not be marked for deletion")
+		}
+	})
 }
 
 // newCNPGStrategyTestClient returns a fake client.Client wired up with

--- a/internal/backupcontroller/cnpgstrategy_controller_test.go
+++ b/internal/backupcontroller/cnpgstrategy_controller_test.go
@@ -549,43 +549,122 @@ func TestBuildPostgresAppRestorePatch_NoSecretRefIsSkipped(t *testing.T) {
 // freshly-recovered Cluster on a status-update failure. The controller used
 // to rely solely on a Status condition: if the post-purge Status().Update
 // raced or failed, the next reconcile would re-purge the just-restored
-// Cluster, destroying recovery progress. Cross-checking the live Cluster's
-// bootstrap.recovery makes the second purge a no-op.
+// Cluster, destroying recovery progress. Cross-checking that the live
+// Cluster is a *freshly-recovered* one (bootstrap.recovery + created after
+// the job started) makes that second purge a no-op - while still purging a
+// stale recovery Cluster left over from an earlier completed restore, so a
+// repeat in-place restore is not a silent no-op.
 func TestCNPGPurgeNeeded(t *testing.T) {
 	cases := []struct {
-		name            string
-		purgedCondition bool
-		hasRecovery     bool
-		want            bool
+		name                        string
+		purgedCondition             bool
+		liveClusterFreshlyRecovered bool
+		want                        bool
 	}{
 		{
-			name:            "fresh restore, old cluster still in place: purge",
-			purgedCondition: false,
-			hasRecovery:     false,
-			want:            true,
+			name:                        "fresh restore, old cluster still in place: purge",
+			purgedCondition:             false,
+			liveClusterFreshlyRecovered: false,
+			want:                        true,
 		},
 		{
-			name:            "purge already recorded: skip",
-			purgedCondition: true,
-			hasRecovery:     false,
-			want:            false,
+			name:                        "purge already recorded: skip",
+			purgedCondition:             true,
+			liveClusterFreshlyRecovered: false,
+			want:                        false,
 		},
 		{
-			name:            "live cluster already recovered (status write raced): skip - the bug fix",
-			purgedCondition: false,
-			hasRecovery:     true,
-			want:            false,
+			name:                        "live cluster freshly recovered by this restore (status write raced): skip",
+			purgedCondition:             false,
+			liveClusterFreshlyRecovered: true,
+			want:                        false,
 		},
 		{
-			name:            "both true: skip (post-purge steady state)",
-			purgedCondition: true,
-			hasRecovery:     true,
-			want:            false,
+			name:                        "stale recovery cluster from a previous completed restore: purge (repeat-restore fix)",
+			purgedCondition:             false,
+			liveClusterFreshlyRecovered: false,
+			want:                        true,
+		},
+		{
+			name:                        "both true: skip (post-purge steady state)",
+			purgedCondition:             true,
+			liveClusterFreshlyRecovered: true,
+			want:                        false,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := cnpgPurgeNeeded(tc.purgedCondition, tc.hasRecovery)
+			got := cnpgPurgeNeeded(tc.purgedCondition, tc.liveClusterFreshlyRecovered)
+			if got != tc.want {
+				t.Errorf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestCNPGClusterFreshlyRecovered locks in the signal that separates a
+// recovery Cluster THIS restore just produced from one left over by an
+// earlier completed restore. The repeat-in-place-restore bug was exactly a
+// stale recovery Cluster (created before StartedAt) being mistaken for a
+// freshly-recovered one and skipping the purge.
+func TestCNPGClusterFreshlyRecovered(t *testing.T) {
+	started := metav1.NewTime(time.Now())
+	after := metav1.NewTime(started.Add(time.Minute))
+	before := metav1.NewTime(started.Add(-time.Hour))
+
+	cases := []struct {
+		name        string
+		hasRecovery bool
+		createdAt   *metav1.Time
+		startedAt   *metav1.Time
+		want        bool
+	}{
+		{
+			name:        "no recovery bootstrap: not fresh",
+			hasRecovery: false,
+			createdAt:   &after,
+			startedAt:   &started,
+			want:        false,
+		},
+		{
+			name:        "recovery cluster created after start (our own purge re-render): fresh",
+			hasRecovery: true,
+			createdAt:   &after,
+			startedAt:   &started,
+			want:        true,
+		},
+		{
+			name:        "recovery cluster created before start (leftover from previous restore): not fresh",
+			hasRecovery: true,
+			createdAt:   &before,
+			startedAt:   &started,
+			want:        false,
+		},
+		{
+			name:        "recovery cluster created exactly at start: fresh (boundary)",
+			hasRecovery: true,
+			createdAt:   &started,
+			startedAt:   &started,
+			want:        true,
+		},
+		{
+			name:        "missing cluster creation timestamp: not fresh",
+			hasRecovery: true,
+			createdAt:   nil,
+			startedAt:   &started,
+			want:        false,
+		},
+		{
+			name:        "missing job start timestamp: not fresh",
+			hasRecovery: true,
+			createdAt:   &after,
+			startedAt:   nil,
+			want:        false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := cnpgClusterFreshlyRecovered(tc.hasRecovery, tc.createdAt, tc.startedAt)
 			if got != tc.want {
 				t.Errorf("got %v want %v", got, tc.want)
 			}
@@ -898,7 +977,7 @@ func TestApplyClusterBarmanObjectStore_NotFoundOnMissingCluster(t *testing.T) {
 	}
 }
 
-// TestClusterHasRecoveryBootstrap_TerminatingCluster locks in the
+// TestRecoveryBootstrapClusterState_TerminatingCluster locks in the
 // DeletionTimestamp guard. Without it, a Cluster CR mid-deletion (after
 // purgeExistingCluster fired r.Delete but cnpg.io's finalizers haven't
 // drained yet) would get treated as "still has bootstrap" by the
@@ -907,7 +986,7 @@ func TestApplyClusterBarmanObjectStore_NotFoundOnMissingCluster(t *testing.T) {
 // might SSA-merge the chart's bootstrap.recovery onto the terminating
 // CR and cnpg-operator's bootstrap-immutability check would drop the
 // change, leaving the cluster on the original initdb spec.
-func TestClusterHasRecoveryBootstrap_TerminatingCluster(t *testing.T) {
+func TestRecoveryBootstrapClusterState_TerminatingCluster(t *testing.T) {
 	now := metav1.Now()
 	t.Run("terminating cluster reports not-yet-recovered", func(t *testing.T) {
 		cluster := &cnpgtypes.Cluster{
@@ -925,18 +1004,22 @@ func TestClusterHasRecoveryBootstrap_TerminatingCluster(t *testing.T) {
 		}
 		c := newCNPGStrategyTestClient(t, cluster)
 		r := &RestoreJobReconciler{Client: c}
-		got, err := r.clusterHasRecoveryBootstrap(context.Background(), "tenant", "postgres-app")
+		got, createdAt, err := r.recoveryBootstrapClusterState(context.Background(), "tenant", "postgres-app")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got {
 			t.Fatalf("expected false for terminating cluster, got true")
 		}
+		if createdAt != nil {
+			t.Fatalf("expected nil createdAt for terminating cluster, got %v", createdAt)
+		}
 	})
 
-	t.Run("live recovery cluster reports recovered", func(t *testing.T) {
+	t.Run("live recovery cluster reports recovered with creation timestamp", func(t *testing.T) {
+		created := metav1.NewTime(time.Now().Add(-time.Hour))
 		cluster := &cnpgtypes.Cluster{
-			ObjectMeta: metav1.ObjectMeta{Namespace: "tenant", Name: "postgres-app"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: "tenant", Name: "postgres-app", CreationTimestamp: created},
 			Spec: cnpgtypes.ClusterSpec{
 				Bootstrap: &cnpgtypes.BootstrapConfiguration{
 					Recovery: &cnpgtypes.RecoverySource{Source: "pg-src"},
@@ -945,24 +1028,30 @@ func TestClusterHasRecoveryBootstrap_TerminatingCluster(t *testing.T) {
 		}
 		c := newCNPGStrategyTestClient(t, cluster)
 		r := &RestoreJobReconciler{Client: c}
-		got, err := r.clusterHasRecoveryBootstrap(context.Background(), "tenant", "postgres-app")
+		got, createdAt, err := r.recoveryBootstrapClusterState(context.Background(), "tenant", "postgres-app")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if !got {
 			t.Fatalf("expected true for live recovery cluster, got false")
 		}
+		if createdAt == nil {
+			t.Fatalf("expected non-nil createdAt for live recovery cluster")
+		}
 	})
 
 	t.Run("missing cluster reports not-yet", func(t *testing.T) {
 		c := newCNPGStrategyTestClient(t)
 		r := &RestoreJobReconciler{Client: c}
-		got, err := r.clusterHasRecoveryBootstrap(context.Background(), "tenant", "postgres-app")
+		got, createdAt, err := r.recoveryBootstrapClusterState(context.Background(), "tenant", "postgres-app")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got {
 			t.Fatalf("expected false for missing cluster, got true")
+		}
+		if createdAt != nil {
+			t.Fatalf("expected nil createdAt for missing cluster, got %v", createdAt)
 		}
 	})
 }


### PR DESCRIPTION
## What this PR does

Fixes a silent data-integrity failure in the CNPG backup driver: a repeat in-place PostgreSQL `RestoreJob` into a target that was already restored once reported `Succeeded` but did nothing. The PVC was untouched (same uid), no `*-full-recovery` pods appeared, and the database kept its pre-restore contents.

Root cause: the restore patch sets `spec.bootstrap.enabled=true` on the Postgres app and never resets it, so the chart keeps rendering `spec.bootstrap.recovery` on the live cnpg.io Cluster. On a second `RestoreJob` the re-purge guard (`cnpgPurgeNeeded`) saw that leftover `bootstrap.recovery` and treated it as "an earlier reconcile of this restore already purged", skipping the destructive Cluster + PVC purge. That guard was meant only to avoid re-purging a freshly-recovered Cluster when the post-purge status write races, but it could not tell that case apart from a Cluster left over by a previous completed restore.

The fix distinguishes the two by the live Cluster's `creationTimestamp` relative to the `RestoreJob`'s `StartedAt`:

- created after `StartedAt`: freshly recovered by this restore's own purge, so it is skipped (unchanged behaviour for the status-write-race path);
- created at or before `StartedAt`: leftover from an earlier completed restore, so it is purged and the restore re-bootstraps from the backup.

Design note: an identity-based alternative (record the purged Cluster's UID on the `TargetPurged` condition and compare UIDs on later reconciles) was considered and rejected. It is immune to clock skew but leans on the same status write that the status-write-race path assumes can fail, so it cannot cover the exact case the skip exists for. The timestamp comparison needs no extra persisted state, and the fresh-vs-stale gap (a full purge plus chart re-render cycle) always dwarfs any plausible control-plane clock skew. The comparison is strict, so an exact-second tie resolves to purge (the conservative direction).

### Tests

- New `cnpgClusterFreshlyRecovered` unit test: fresh / stale / boundary / missing-timestamp cases.
- `TestCNPGPurgeNeeded` extended with the repeat-restore (stale recovery cluster) case that reproduced the bug.
- `recoveryBootstrapClusterState` test updated to assert the returned `creationTimestamp`.
- New reconcile-level regression test driving `reconcileCNPGRestore` end to end: a stale leftover recovery Cluster is purged, a freshly-recovered Cluster is not re-purged.

Bug report: #3311

### Screenshots

Not applicable (no UI changes).

### Downstream repositories

The diff touches only `internal/backupcontroller` (operator reconcile logic); no API types, CRDs, chart values, or docs change, so no downstream repository is affected.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(postgres): a repeat in-place restore no longer silently succeeds without restoring; a recovery cluster left over from an earlier completed restore is now purged so the restore re-bootstraps from the backup
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repeat in-place restore handling by distinguishing newly recovered clusters from stale recovery remnants.
  * Stale recovery clusters are now purged when appropriate, preventing restores from silently reusing outdated data.
  * Freshly recovered clusters are preserved instead of being purged again.
  * Improved handling of clusters that are terminating or missing during restore processing.

* **Tests**
  * Expanded regression coverage for restore retries, recovery timing, and purge decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->