### PR TITLE
fix(bucket): retry the release until COSI provisions the BucketInfo Secret

### DIFF
--- a/hack/e2e-chainsaw/bucket/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/bucket/chainsaw-test.yaml
@@ -14,6 +14,13 @@ spec:
       apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: bucket-test
+  # The child release renders the -credentials Secrets and fails its render
+  # until the COSI BucketInfo Secrets exist (#3247), so on a hang this is
+  # where the retry loop and its failure message are visible.
+  - describe:
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: bucket-test-system
   - describe:
       apiVersion: objectstorage.k8s.io/v1alpha1
       kind: BucketClaim
@@ -76,6 +83,54 @@ spec:
           status:
             accessGranted: true
 
+  # The human-friendly -credentials Secrets are rendered by the child
+  # (bucket-system) release from the COSI BucketInfo Secrets. The COSI
+  # driver provisions those asynchronously, so the child release fails its
+  # render (and is retried by remediation) until they appear — a bucket is
+  # only done when the child release converges to Ready and both projected
+  # Secrets exist (#3247: they used to stay missing forever when the COSI
+  # Secret appeared after the release's last render).
+  - name: wait-credentials-projected
+    try:
+    - assert:
+        timeout: 6m
+        resource:
+          apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: bucket-test-system
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+    - assert:
+        timeout: 2m
+        resource:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: bucket-test-admin-credentials
+            labels:
+              apps.cozystack.io/user-secret: "true"
+          data:
+            (accessKey != null): true
+            (secretKey != null): true
+            (endpoint != null): true
+            (bucketName != null): true
+    - assert:
+        timeout: 2m
+        resource:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: bucket-test-viewer-credentials
+            labels:
+              apps.cozystack.io/user-secret: "true"
+          data:
+            (accessKey != null): true
+            (secretKey != null): true
+            (endpoint != null): true
+            (bucketName != null): true
+
   - name: verify-s3-access
     try:
     - script:
@@ -85,16 +140,15 @@ spec:
           workdir=$(mktemp -d)
           trap '[ -n "${pf_pid:-}" ] && kill "$pf_pid" 2>/dev/null || true; rm -rf "$workdir"' EXIT
 
-          # Extract credentials for both users
-          kubectl -n "$NAMESPACE" get secret bucket-test-admin \
-            -o jsonpath='{.data.BucketInfo}' | base64 -d > "$workdir/admin.json"
-          kubectl -n "$NAMESPACE" get secret bucket-test-viewer \
-            -o jsonpath='{.data.BucketInfo}' | base64 -d > "$workdir/viewer.json"
-          ADMIN_ACCESS_KEY=$(jq -r '.spec.secretS3.accessKeyID' "$workdir/admin.json")
-          ADMIN_SECRET_KEY=$(jq -r '.spec.secretS3.accessSecretKey' "$workdir/admin.json")
-          VIEWER_ACCESS_KEY=$(jq -r '.spec.secretS3.accessKeyID' "$workdir/viewer.json")
-          VIEWER_SECRET_KEY=$(jq -r '.spec.secretS3.accessSecretKey' "$workdir/viewer.json")
-          BUCKET_NAME=$(jq -r '.spec.bucketName' "$workdir/admin.json")
+          # Extract credentials for both users from the projected -credentials
+          # Secrets (not the raw COSI BucketInfo), so this step proves the
+          # user-facing Secrets carry working keys (#3247).
+          sec() { kubectl -n "$NAMESPACE" get secret "$1" -o "jsonpath={.data.$2}" | base64 -d; }
+          ADMIN_ACCESS_KEY=$(sec bucket-test-admin-credentials accessKey)
+          ADMIN_SECRET_KEY=$(sec bucket-test-admin-credentials secretKey)
+          VIEWER_ACCESS_KEY=$(sec bucket-test-viewer-credentials accessKey)
+          VIEWER_SECRET_KEY=$(sec bucket-test-viewer-credentials secretKey)
+          BUCKET_NAME=$(sec bucket-test-admin-credentials bucketName)
 
           # Port-forward to the S3 endpoint; cleaned up by the trap
           kubectl port-forward service/seaweedfs-s3 -n tenant-root 8333:8333 >/dev/null 2>&1 &

--- a/packages/system/bucket/templates/user-credentials.yaml
+++ b/packages/system/bucket/templates/user-credentials.yaml
@@ -1,8 +1,27 @@
+{{- /*
+The per-user BucketInfo Secret (<bucketName>-<user>) is provisioned by the
+COSI driver asynchronously, some time after the BucketAccess is granted.
+Helm re-evaluates `lookup` only during a real install/upgrade attempt, so
+skipping a missing Secret here silently means the -credentials Secret is
+never created once the release settles: nothing triggers another render
+after the COSI Secret finally appears (#3247). Failing the render instead
+keeps the release in remediation (the parent HelmRelease sets
+install/upgrade retries to -1), so helm-controller keeps re-rendering
+until the COSI Secret exists and the credentials materialise. It also
+makes a bucket whose credentials are not usable yet report not-Ready
+instead of Ready.
+*/}}
 {{- range $name, $user := .Values.users }}
 {{- $secretName := printf "%s-%s" $.Values.bucketName $name }}
 {{- $existingSecret := lookup "v1" "Secret" $.Release.Namespace $secretName }}
-{{- if $existingSecret }}
-{{- $bucketInfo := fromJson (b64dec (index $existingSecret.data "BucketInfo")) }}
+{{- if not $existingSecret }}
+{{- fail (printf "COSI BucketInfo Secret %s/%s for bucket user %q is not provisioned yet; the release is retried until the object storage driver creates it" $.Release.Namespace $secretName $name) }}
+{{- end }}
+{{- $bucketInfoRaw := index $existingSecret.data "BucketInfo" }}
+{{- if not $bucketInfoRaw }}
+{{- fail (printf "Secret %s/%s exists but has no BucketInfo key; expected a COSI-provisioned BucketAccess credentials Secret" $.Release.Namespace $secretName) }}
+{{- end }}
+{{- $bucketInfo := fromJson (b64dec $bucketInfoRaw) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,5 +35,4 @@ stringData:
   secretKey: {{ index $bucketInfo.spec.secretS3 "accessSecretKey" | quote }}
   endpoint: {{ index $bucketInfo.spec.secretS3 "endpoint" | trimPrefix "https://" | trimPrefix "http://" | quote }}
   bucketName: {{ index $bucketInfo.spec "bucketName" | quote }}
-{{- end }}
 {{- end }}

--- a/packages/system/bucket/tests/user_credentials_test.yaml
+++ b/packages/system/bucket/tests/user_credentials_test.yaml
@@ -1,0 +1,115 @@
+suite: bucket user credentials (COSI lookup gate)
+templates:
+  - templates/user-credentials.yaml
+
+release:
+  name: mybucket
+  namespace: tenant-test
+
+# The COSI driver provisions the per-user BucketInfo Secret asynchronously,
+# after the BucketAccess is granted. Helm re-evaluates `lookup` only during a
+# real install/upgrade attempt, so a silent skip on a missing Secret left the
+# -credentials Secret permanently uncreated once the release settled (#3247).
+# The template now fails the render instead, so helm-controller remediation
+# (retries: -1 on the HelmRelease) keeps re-rendering until the COSI Secret
+# appears.
+
+kubernetesProvider:
+  scheme:
+    "v1/Secret":
+      gvr:
+        group: ""
+        version: "v1"
+        resource: "secrets"
+      namespaced: true
+  objects:
+    - kind: Secret
+      apiVersion: v1
+      metadata:
+        name: mybucket-writer
+        namespace: tenant-test
+      data:
+        BucketInfo: eyJhcGlWZXJzaW9uIjoib2JqZWN0c3RvcmFnZS5rOHMuaW8vdjFhbHBoYTEiLCJraW5kIjoiQnVja2V0SW5mbyIsIm1ldGFkYXRhIjp7Im5hbWUiOiJteWJ1Y2tldC13cml0ZXIifSwic3BlYyI6eyJidWNrZXROYW1lIjoiYnVja2V0LWNsYWltLTRhM2YiLCJhdXRoZW50aWNhdGlvblR5cGUiOiJLRVkiLCJwcm90b2NvbHMiOlsiczMiXSwic2VjcmV0UzMiOnsiZW5kcG9pbnQiOiJodHRwczovL3MzLmV4YW1wbGUub3JnOjgzMzMiLCJyZWdpb24iOiJ1cy1lYXN0LTEiLCJhY2Nlc3NLZXlJRCI6IlRFU1RBQ0NFU1NLRVkiLCJhY2Nlc3NTZWNyZXRLZXkiOiJURVNUU0VDUkVUS0VZIn19fQ==
+    - kind: Secret
+      apiVersion: v1
+      metadata:
+        name: mybucket-plain
+        namespace: tenant-test
+      data:
+        BucketInfo: eyJhcGlWZXJzaW9uIjoib2JqZWN0c3RvcmFnZS5rOHMuaW8vdjFhbHBoYTEiLCJraW5kIjoiQnVja2V0SW5mbyIsIm1ldGFkYXRhIjp7Im5hbWUiOiJteWJ1Y2tldC1wbGFpbiJ9LCJzcGVjIjp7ImJ1Y2tldE5hbWUiOiJidWNrZXQtY2xhaW0tOWIyYyIsImF1dGhlbnRpY2F0aW9uVHlwZSI6IktFWSIsInByb3RvY29scyI6WyJzMyJdLCJzZWNyZXRTMyI6eyJlbmRwb2ludCI6Imh0dHA6Ly9zZWF3ZWVkZnMtczMudGVuYW50LXJvb3Quc3ZjOjgzMzMiLCJyZWdpb24iOiJ1cy1lYXN0LTEiLCJhY2Nlc3NLZXlJRCI6IlBMQUlOS0VZIiwiYWNjZXNzU2VjcmV0S2V5IjoiUExBSU5TRUNSRVQifX19
+    - kind: Secret
+      apiVersion: v1
+      metadata:
+        name: mybucket-legacy
+        namespace: tenant-test
+      data:
+        unrelated: Zm9v
+
+tests:
+  - it: renders a credentials Secret per user once the COSI Secrets exist
+    set:
+      bucketName: mybucket
+      users:
+        plain: {}
+        writer: {}
+    asserts:
+      - hasDocuments:
+          count: 2
+      # map iteration is key-sorted: plain first, writer second
+      - equal:
+          path: metadata.name
+          value: mybucket-plain-credentials
+        documentIndex: 0
+      - equal:
+          path: stringData.endpoint
+          value: seaweedfs-s3.tenant-root.svc:8333
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: mybucket-writer-credentials
+        documentIndex: 1
+      - equal:
+          path: metadata.labels["apps.cozystack.io/user-secret"]
+          value: "true"
+        documentIndex: 1
+      - equal:
+          path: stringData.accessKey
+          value: TESTACCESSKEY
+        documentIndex: 1
+      - equal:
+          path: stringData.secretKey
+          value: TESTSECRETKEY
+        documentIndex: 1
+      - equal:
+          path: stringData.endpoint
+          value: s3.example.org:8333
+        documentIndex: 1
+      - equal:
+          path: stringData.bucketName
+          value: bucket-claim-4a3f
+        documentIndex: 1
+
+  - it: fails the render while a user's COSI Secret is not provisioned yet
+    set:
+      bucketName: mybucket
+      users:
+        reader: {}
+    asserts:
+      - failedTemplate:
+          errorPattern: "COSI BucketInfo Secret tenant-test/mybucket-reader for bucket user \"reader\" is not provisioned yet"
+
+  - it: fails the render when the Secret exists but carries no BucketInfo key
+    set:
+      bucketName: mybucket
+      users:
+        legacy: {}
+    asserts:
+      - failedTemplate:
+          errorPattern: "Secret tenant-test/mybucket-legacy exists but has no BucketInfo key"
+
+  - it: renders nothing for a bucket without users
+    set:
+      bucketName: mybucket
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## What this PR does

Fixes #3247. The `-credentials` Secret rendered by `system/bucket` (`packages/system/bucket/templates/user-credentials.yaml`) was gated on a Helm `lookup` of the COSI-provisioned BucketInfo Secret. COSI provisions that Secret asynchronously, after the BucketAccess is granted, and Helm re-evaluates `lookup` only during a real install/upgrade attempt — so when the COSI Secret appeared after the release's last render, the `-credentials` Secret was silently skipped and never created (nothing triggers another render; the release is otherwise unchanged). Consumers such as the platform backup flow (`backupstrategy-controller` projecting `bucket-cozy-backups-system-credentials`) then hang forever in `CredentialsProjectionPending`.

The fix makes the render **fail** instead of silently skipping while the COSI Secret is missing. The parent HelmRelease (rendered by `apps/bucket`) already sets `install`/`upgrade` remediation `retries: -1`, so helm-controller keeps retrying — and each retry re-renders, re-evaluating the `lookup` — until the COSI Secret exists and the credentials materialise. This is the "bounded requeue re-render" option from #3247, implemented with machinery already in place; no controller changes, no new images, and it works on the currently pinned Flux 2.8.x.

Side effects, both intentional:
- A bucket whose credentials are not usable yet reports **not-Ready** (with an explicit message naming the missing Secret) instead of Ready-with-missing-credentials.
- A COSI Secret that exists but carries no `BucketInfo` key fails with a clear message instead of a cryptic `b64dec` nil error.

Why not the other #3247 options: an event-driven projection in cozystack-controller needs a watch on `objectstorage.k8s.io` CRDs that don't exist yet when the controller starts on fresh bootstraps (plus cache/RBAC surface); replacing the lookup with `valuesFrom` + `targetPath` cannot carry the BucketInfo JSON through helm-controller's `--set` parsing — `literal: true` fixes that but only exists since helm-controller 1.6 (Flux 2.9), while the platform pins Flux 2.8.x. This chart-only fix can later be superseded by the `valuesFrom literal` approach after a Flux bump.

## Tests

- `helm-unittest` suite for the gate (`kubernetesProvider`-mocked lookup): renders one Secret per user with trimmed endpoint once the COSI Secrets exist; fails with the retry message while one is missing; fails on a Secret without `BucketInfo`; renders nothing for a user-less bucket.
- The bucket chainsaw e2e now asserts the child `bucket-test-system` release converges to Ready and both projected `-credentials` Secrets exist, and the S3 access check (`mc`) authenticates with keys taken from the projected Secrets instead of the raw COSI BucketInfo — proving end-to-end that the user-facing Secrets carry working credentials.

`make -C packages/system/bucket test` passes. `helm lint` failure on `_namespace.host` is pre-existing on main (chart has no defaults for the platform-injected `_namespace`).

### Downstream repositories

- [x] No downstream repository is affected by this change

### Release note

```release-note
fix(bucket): the human-friendly `<bucket>-<user>-credentials` Secret is now created reliably even when the COSI driver provisions the bucket after the release's first reconcile. The bucket release reports not-Ready (and is retried automatically) until the credentials exist, instead of settling Ready with the Secret silently missing. If you previously created a `<bucket>-<user>-credentials` Secret manually to work around #3247, delete it (or annotate it for Helm adoption with `meta.helm.sh/release-name=<bucket>-system`, `meta.helm.sh/release-namespace=<namespace>` and label `app.kubernetes.io/managed-by=Helm`) before upgrading, otherwise the release upgrade fails with a resource-ownership conflict.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)