### PR TITLE
fix(ouroboros): render controller rollout strategy in every mode

### DIFF
--- a/packages/system/ouroboros/Makefile
+++ b/packages/system/ouroboros/Makefile
@@ -26,8 +26,8 @@ include ../../../hack/package.mk
 # and update both lines below; resolve the new image digest with
 #   crane digest ghcr.io/lexfrei/ouroboros:<new-tag>
 # and update values.yaml.
-OUROBOROS_CHART_VERSION ?= 0.8.0
-OUROBOROS_CHART_DIGEST ?= sha256:b57255ef65a8eace361bf0e4eb93637e6a45315bc7744746b2e16ffa5bdd3744
+OUROBOROS_CHART_VERSION ?= 0.8.1
+OUROBOROS_CHART_DIGEST ?= sha256:40fd5b639ff73594989856076eab5dfbd0dfab8ee16d1cab915756e24b54458b
 
 test:
 	helm unittest .
@@ -38,6 +38,11 @@ update:
 	# version. A digest mismatch (someone bumped DIGEST without
 	# bumping VERSION, or vice versa) trips the assert and aborts.
 	helm pull oci://ghcr.io/lexfrei/charts/ouroboros@$(OUROBOROS_CHART_DIGEST) --untar --untardir charts
+	# Pulling by digest also leaves an empty directory named after the
+	# digest ref next to the untarred chart. Git ignores empty directories
+	# so it never shows as drift, which is exactly why it lingers
+	# unnoticed; drop it so `make update` leaves the tree clean.
+	rm -rf "charts/ouroboros@$(OUROBOROS_CHART_DIGEST)"
 	@actual_version=$$(awk '/^version:/ {print $$2}' charts/ouroboros/Chart.yaml | tr -d '"'); \
 	if [ "$$actual_version" != "$(OUROBOROS_CHART_VERSION)" ]; then \
 	  echo "ERROR: pulled chart Chart.yaml version=$$actual_version but Makefile OUROBOROS_CHART_VERSION=$(OUROBOROS_CHART_VERSION). Bump both in lockstep."; \

--- a/packages/system/ouroboros/charts/ouroboros/Chart.yaml
+++ b/packages/system/ouroboros/charts/ouroboros/Chart.yaml
@@ -2,7 +2,7 @@ annotations:
   artifacthub.io/category: networking
   artifacthub.io/license: BSD-3-Clause
 apiVersion: v2
-appVersion: 0.8.0
+appVersion: 0.8.1
 description: In-cluster controller + TCP proxy that fixes hairpin-NAT for Ingress
   controllers behind PROXY-protocol
 home: https://github.com/lexfrei/ouroboros
@@ -22,4 +22,4 @@ name: ouroboros
 sources:
 - https://github.com/lexfrei/ouroboros
 type: application
-version: 0.8.0
+version: 0.8.1

--- a/packages/system/ouroboros/charts/ouroboros/templates/controller-deployment.yaml
+++ b/packages/system/ouroboros/charts/ouroboros/templates/controller-deployment.yaml
@@ -13,14 +13,54 @@ metadata:
     {{- include "ouroboros.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controller.replicaCount }}
-  {{- if eq $mode "external-dns" }}
-  # Recreate strategy: external-dns mode has no leader-election, so the
-  # default RollingUpdate (maxSurge=25% rounds to 1 with replicaCount=1)
-  # would briefly run two reconcilers during chart upgrades and produce
-  # the exact Get-Update race the replicaCount > 1 chart-fail prevents.
+  {{- /* The controller has no leader-election in any mode and no serving
+         path (no ports, no probes), so surging a second pod during a
+         rollout buys no availability anywhere. In external-dns mode it
+         actively hurts: that reconciler Updates DNSEndpoints with no
+         conflict retry, so two overlapping reconcilers race on
+         Get->Update. The coredns paths wrap Get->Update in
+         RetryOnConflict and converge instead, which is why only
+         external-dns rejects replicaCount > 1 above — that asymmetry is
+         deliberate, do not extend the guard to coredns. The default
+         maxSurge=25% rounds to 1 on a single replica and keeps the old
+         pod fully live and reconciling until the new one reports Ready.
+
+         maxSurge=0 is deliberately NOT claimed to be Recreate-equivalent
+         exclusivity: the surge budget counts rs.Spec.Replicas (desired),
+         not live pods, so once the old ReplicaSet's desired count hits 0
+         the new pod is created even though the old one may still be
+         Terminating. rolloutRecreate gates scale-up on oldPodsRunning;
+         the rolling path has no equivalent. What maxSurge=0 does
+         guarantee is enough here: the old pod is sent SIGTERM at
+         scale-down, before the new pod is created, and SIGTERM cancels
+         the reconciler context (see signalContext in cmd/ouroboros), so
+         the old reconciler has stopped well before the new pod finishes
+         starting and syncing its caches. Overlapping *reconcile* is what
+         matters, and that window is effectively nil. Nothing is lost by
+         the gap either: CoreDNS keeps serving the last written Corefile,
+         and the controller reconciles from scratch at startup.
+
+         Rendered for every mode on purpose. While this block was gated
+         on external-dns, switching controller.mode on a live release
+         mutated spec.strategy, adding type: Recreate on top of the
+         rollingUpdate block that the apiserver defaults onto any
+         Deployment created without one:
+           spec.strategy.rollingUpdate: Forbidden: may not be specified
+           when strategy `type` is 'Recreate'
+         That rejection fires only under server-side apply, so a
+         `helm upgrade` does not reproduce it — DeploymentSpec.Strategy
+         carries patchStrategy:"retainKeys", so a client-side strategic
+         merge clears rollingUpdate on the way through. Server-side apply
+         has no such retainKeys step and the two fields collide; Flux's
+         helm-controller applies server-side by default. Rendering the
+         same RollingUpdate block in every mode means a mode switch
+         changes no strategy field at all, so the combination cannot
+         arise on any transition. */}}
   strategy:
-    type: Recreate
-  {{- end }}
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels:
       {{- include "ouroboros.selectorLabels" . | nindent 6 }}

--- a/packages/system/ouroboros/charts/ouroboros/values.yaml
+++ b/packages/system/ouroboros/charts/ouroboros/values.yaml
@@ -112,7 +112,7 @@ controller:
     # Renovate-cut bump to a brand-new tag may temporarily render an image
     # reference that 404s on pull until Google's mirror picks it up.
     repository: mirror.gcr.io/alpine/kubectl
-    tag: "1.36.0"
+    tag: "1.36.1"
     pullPolicy: IfNotPresent
   # -- Informer resync period. Doubles as the worst-case event-to-reconcile
   # latency when the underlying Ingress watch silently dies (kamaji-managed
@@ -242,7 +242,7 @@ externalDns:
     # Renovate-cut bump to a brand-new tag may temporarily render an image
     # reference that 404s on pull until Google's mirror picks it up.
     repository: mirror.gcr.io/alpine/kubectl
-    tag: "1.36.0"
+    tag: "1.36.1"
     pullPolicy: IfNotPresent
 
 # -- Optional /etc/hosts DaemonSet (alt to CoreDNS).

--- a/packages/system/ouroboros/tests/controller_test.yaml
+++ b/packages/system/ouroboros/tests/controller_test.yaml
@@ -47,6 +47,77 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --log-level=info
 
+  # The upstream chart owns this contract and tests it across every mode;
+  # these pins exist because cozystack is the kind of consumer the
+  # contract protects — helm-controller applies server-side, and
+  # server-side apply is the only path on which a mode-gated strategy
+  # breaks. Up to chart 0.8.0 the strategy was rendered only in
+  # external-dns mode, as type: Recreate. Switching a live release into
+  # that mode laid Recreate on top of the rollingUpdate block the
+  # apiserver defaults onto any Deployment created without one, and the
+  # apiserver rejected it with "spec.strategy.rollingUpdate: Forbidden:
+  # may not be specified when strategy `type` is 'Recreate'". A
+  # client-side helm upgrade clears rollingUpdate via retainKeys and
+  # never reproduces it, so no local render catches a regression here.
+  #
+  # cozystack pins coredns on the host and coredns-import for tenants,
+  # and configures external-dns nowhere, so the break is not reachable
+  # from any shipped configuration — this is a latent break and the pins
+  # are defence in depth for a user-settable value. All three modes are
+  # asserted, external-dns included: it is the only mode that ever
+  # rendered Recreate, so a bump that re-gates the block would slip past
+  # a coredns-only suite unnoticed.
+  - it: renders a no-surge RollingUpdate strategy, never Recreate — the mode-switch upgrade path is server-side-apply-only and breaks on any other shape
+    template: charts/ouroboros/templates/controller-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 0
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+
+  - it: renders that same strategy in coredns-import mode — the mode tenants actually run
+    template: charts/ouroboros/templates/controller-deployment.yaml
+    set:
+      ouroboros:
+        controller:
+          mode: coredns-import
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 0
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+
+  # The mode that rendered type: Recreate up to 0.8.0, and the only one a
+  # transition into which could trip the rejection. A re-gate that
+  # restored Recreate here while leaving the coredns paths on
+  # RollingUpdate would satisfy every other case in this file.
+  - it: renders that same strategy in external-dns mode — the one mode that previously rendered Recreate
+    template: charts/ouroboros/templates/controller-deployment.yaml
+    set:
+      ouroboros:
+        controller:
+          mode: external-dns
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: RollingUpdate
+      - equal:
+          path: spec.strategy.rollingUpdate.maxSurge
+          value: 0
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+
   - it: writes into the kube-system/coredns Corefile by default (host mode)
     template: charts/ouroboros/templates/controller-deployment.yaml
     asserts:

--- a/packages/system/ouroboros/tests/cozystack_overrides_test.yaml
+++ b/packages/system/ouroboros/tests/cozystack_overrides_test.yaml
@@ -40,4 +40,4 @@ tests:
       # a Makefile bump that forgets to bump the tag (or vice versa).
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/lexfrei/ouroboros:0.8.0@sha256:9fe97093056d0bd05db667831a2a6270087ee648634d594e104c2d73f8aaa8ad
+          value: ghcr.io/lexfrei/ouroboros:0.8.1@sha256:cf285fe6f1eff6ac34e45871d4eef9c2f3ef590d76a6fc272019a9387519891d

--- a/packages/system/ouroboros/values.yaml
+++ b/packages/system/ouroboros/values.yaml
@@ -6,7 +6,7 @@ ouroboros:
     # Air-gapped operators must mirror both this image and the OCI chart
     # at oci://ghcr.io/lexfrei/charts/ouroboros separately. Bump the tag
     # here together with OUROBOROS_CHART_VERSION in the Makefile.
-    tag: 0.8.0@sha256:9fe97093056d0bd05db667831a2a6270087ee648634d594e104c2d73f8aaa8ad
+    tag: 0.8.1@sha256:cf285fe6f1eff6ac34e45871d4eef9c2f3ef590d76a6fc272019a9387519891d
   controller:
     # Host scenario default: mutate the live kube-system/coredns Corefile
     # directly. The host CoreDNS on cozystack is Talos-managed and its


### PR DESCRIPTION
## What this PR does

Bumps the ouroboros chart and controller image to 0.8.1, which fixes a latent upgrade break in the controller Deployment's rollout strategy, and pins the fixed contract from the cozystack side.

Up to chart 0.8.0 the controller Deployment rendered a rollout strategy **only** in `external-dns` mode, as `type: Recreate`, and rendered no strategy block at all in the other modes. The apiserver defaults a `rollingUpdate` block onto any Deployment created without one, so switching a live release into `external-dns` laid `Recreate` on top of that defaulted block, and the apiserver rejected the object:

```
spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
```

0.8.1 renders the same `RollingUpdate` block, with no surge, in every mode. The strategy no longer changes when `controller.mode` does, so the rejected combination cannot arise on any transition. Rendering `Recreate` unconditionally would not have worked: existing `coredns`-mode releases already carry the defaulted `rollingUpdate` block and would hit the identical rejection on their first upgrade. Always-`RollingUpdate` is upgrade-safe from both existing states, and rollback works for the same reason.

**Reachability, stated plainly:** this is a latent break, not an active one. The host pins `coredns` and tenants pin `coredns-import`, neither of which rendered a strategy in 0.8.0, and no shipped configuration selects `external-dns`. But `controller.mode` is a documented, user-settable value that the tenant wrapper exposes through `valuesOverride`, so the transition is reachable by configuration rather than only in theory.

**Why it went unnoticed:** the break only surfaces under server-side apply, which helm-controller uses by default. `DeploymentSpec.Strategy` carries `patchStrategy:"retainKeys"`, so a client-side strategic merge clears `rollingUpdate` on the way through and a plain `helm upgrade` never reproduces it. Only the upgrade breaks, never the install, so nothing catches it at render time either.

**Why no surge, in every mode:** the controller has no leader-election in any mode and no serving path — no ports, no probes — so surging a second pod buys no availability anywhere. In `external-dns` mode it also removes a real hazard: that reconciler `Update`s DNSEndpoints with no conflict retry, so two overlapping reconcilers race on Get→Update. The `coredns` paths wrap Get→Update in `RetryOnConflict` and converge instead, which is why only `external-dns` rejects `replicaCount > 1`; that asymmetry is deliberate and is now called out in the template so it does not get tidied away later. The upstream comment is explicit that `maxSurge: 0` is *not* Recreate-equivalent exclusivity — the surge budget counts desired replicas, not live pods — and rests the argument on what is actually guaranteed: the old pod's SIGTERM precedes the new pod's creation, and SIGTERM cancels the reconciler context. The proxy Deployment is untouched and keeps its default rolling surge, as the data-path component.

The fix was made upstream in `lexfrei/ouroboros` and released as v0.8.1 rather than patched into the vendored tree here, since `make update` regenerates `charts/` wholesale. The vendored chart in this PR is a verbatim `make update` pull of the published 0.8.1 artifact, byte-identical to the registry.

Chart manifest digest and controller image digest are bumped in lockstep with the version, as the package Makefile requires. 0.8.1 also carries an upstream Renovate bump of the cleanup-hook kubectl image to 1.36.1 (verified to resolve, multi-arch).

The `update` target additionally drops the empty digest-named directory that `helm pull` leaves beside the untarred chart when pulling by digest. Git ignores empty directories, which is exactly why it lingered unnoticed.

### Testing

`make -C packages/system/ouroboros test` → 17/17 pass. The three new cases pin the rendered strategy on `coredns`, `coredns-import` and `external-dns`. `external-dns` is included deliberately: it is the only mode that ever rendered `Recreate`, so a future bump that re-gated the block would slip past a coredns-only suite. Verified by re-gating the bug surgically against the new suite — it fails on exactly that case, and passes without it. Upstream additionally tests this contract across every mode in its own suite.

### Screenshots

Not applicable — no UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff file by file. The diff touches only `packages/system/ouroboros/`: the package Makefile's version and digest pins, the vendored chart (regenerated), the image pin in `values.yaml`, and the package's own tests. It adds, renames and removes no package under `packages/apps/` or `packages/extra/`; touches no `packages/core/platform/values.yaml` key, no platform variant, bundle or component; changes no `ApplicationDefinition`, no `values.schema.json`, no version enum, no `release.prefix`; touches nothing under `hack/`, no namespace, and no node prerequisite. No trigger matches.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(ouroboros): render the controller rollout strategy in every controller.mode. Up to chart 0.8.0 the strategy was rendered only in external-dns mode, as type: Recreate, so switching a live release into that mode applied Recreate on top of the rollingUpdate block the apiserver defaults onto a Deployment created without one, and the upgrade was rejected with "spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'". The rejection only occurs under server-side apply, which helm-controller uses by default. The strategy is now identical across all modes, so a mode switch changes no strategy field.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated Ouroboros to version 0.8.1 with refreshed, pinned images.
  * Improved controller rollouts using a consistent rolling-update strategy across supported modes.
  * Updated cleanup hook tooling to version 1.36.1.

* **Bug Fixes**
  * Prevented leftover chart directories from accumulating during chart updates.
  * Improved deployment behavior by limiting rollout disruption while maintaining controller availability.

* **Tests**
  * Added coverage validating rollout behavior across all supported controller modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->