### PR TITLE
fix(ci): resolve nightly packages digest without image-specific skopeo ops

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -83,13 +83,22 @@ jobs:
         id: resolve
         run: |
           set -eu
-          # Pin :main to its current digest first, then read the revision
-          # annotation and pull the baked tree from that SAME digest below, so a
-          # concurrent build-main push of :main cannot make us check out commit A
-          # while mirroring tree B.
-          packages_ref="$(skopeo inspect --format '{{.Digest}}' "docker://${SRC_REGISTRY}/cozystack-packages:main")"
-          rev="$(skopeo inspect --raw "docker://${SRC_REGISTRY}/cozystack-packages@${packages_ref}" \
-            | yq -r '.annotations["org.opencontainers.image.revision"] // ""' -p json 2>/dev/null || true)"
+          # Fetch the :main manifest ONCE and derive BOTH its digest and the
+          # revision annotation from those exact bytes, then pull the baked tree
+          # from that SAME digest below, so a concurrent build-main push of :main
+          # cannot make us check out commit A while mirroring tree B.
+          #
+          # --raw is mandatory here: cozystack-packages is a Flux OCI artifact
+          # (config mediaType application/vnd.cncf.flux.config.v1+json), not a
+          # container image, so a plain `skopeo inspect` attempts an
+          # image-specific operation and fatals on it. `manifest-digest` hashes
+          # the manifest bytes, which is exactly what the registry addresses it
+          # by — no image-specific parsing involved.
+          manifest="${RUNNER_TEMP}/cozystack-packages-main.json"
+          skopeo inspect --raw "docker://${SRC_REGISTRY}/cozystack-packages:main" > "$manifest"
+          packages_ref="$(skopeo manifest-digest "$manifest")"
+          rev="$(yq -r '.annotations["org.opencontainers.image.revision"] // ""' -p json "$manifest" 2>/dev/null || true)"
+          rm -f "$manifest"
           # revision is "<git-describe>:<sha>"; take the sha.
           sha="${rev##*:}"
           # The sha flows into `actions/checkout` ref: — validate it is a bare
@@ -118,7 +127,12 @@ jobs:
       # Pull the digest-vendored tree build-main baked (but never committed).
       # Pinned to the digest resolved above, not the mutable :main tag.
       - name: Pull baked package tree
-        run: flux pull artifact "oci://${SRC_REGISTRY}/cozystack-packages@${{ steps.resolve.outputs.packages_ref }}" --output _baked
+        run: |
+          set -eu
+          # `flux pull artifact` rejects an --output path that does not already
+          # exist ("invalid output path"), so create it first.
+          rm -rf _baked && mkdir -p _baked
+          flux pull artifact "oci://${SRC_REGISTRY}/cozystack-packages@${{ steps.resolve.outputs.packages_ref }}" --output _baked
 
       # Copy every cozystack-owned component image OCIR -> GHCR by digest and
       # rewrite the baked tree's image hosts to GHCR (digests untouched).
@@ -239,6 +253,9 @@ jobs:
           PACKAGES_DIGEST: ${{ needs.mirror.outputs.packages_digest }}
         run: |
           set -eu
+          # `flux pull artifact` rejects an --output path that does not already
+          # exist ("invalid output path"), so create it first.
+          rm -rf _rw && mkdir -p _rw
           flux pull artifact "oci://${DST_REGISTRY}/cozystack-packages:${VERSION}" --output _rw
           cp -r _rw/. packages/
           yq -i ".cozystackOperator.platformSourceUrl = \"oci://${DST_REGISTRY}/cozystack-packages\"" packages/core/installer/values.yaml


### PR DESCRIPTION
## What this PR does

The Nightly workflow has **never completed a run**. Every scheduled run since `NIGHTLY_ENABLED` was set has failed in `mirror` at "Resolve source commit and version", ~80s in, with:

```
level=fatal msg="unsupported image-specific operation on artifact with type \"application/vnd.cncf.flux.config.v1+json\""
```

Nothing has ever been published — `cozy-installer:nightly` and `cozystack-packages:nightly` both 404 on GHCR, and `cozystack-nocloud` does not exist.

This fixes that failure and the next two behind it.

### 1. The digest lookup could never have worked

`cozystack-packages` is a **Flux OCI artifact** (config mediaType `application/vnd.cncf.flux.config.v1+json`), not a container image. A plain `skopeo inspect` parses the config blob as an image config and fatals on it, so `skopeo inspect --format '{{.Digest}}'` was never viable against this ref — the `--raw` call on the very next line already acknowledged this.

Replaced with `skopeo inspect --raw` + `skopeo manifest-digest`, which hashes the manifest bytes — exactly what the registry addresses the artifact by, with no image-specific parsing.

This also collapses two registry fetches into one: the digest and the `org.opencontainers.image.revision` annotation now come from the **same bytes**, which strengthens the race the original comment describes — there is no longer any window between pinning the tag and reading it.

### 2. `flux pull artifact` rejects a non-existent output path (×2)

`flux pull artifact --output _baked` fails with `invalid output path "_baked": no such file or directory`. `_baked` is neither tracked nor created by anything. `pull-requests.yaml` does `rm -rf` + `mkdir -p` first; `nightly.yaml` omitted it. Since the workflow always died at step 1, this was never reached.

Same bug for `_rw` in the e2e staging step. Both now create the directory first.

## Verification

- Reproduced the original fatal against the live artifact with skopeo 1.22.2.
- Ran the fixed resolve step end-to-end against the real registry: returns the digest the registry reports, and a `sha` that matches the current `main` HEAD.
- Reproduced the `_baked` failure and confirmed the fix extracts the tree.
- `actionlint` clean; `zizmor --offline` clean; `shellcheck` clean on changed lines.

Also checked and **not** changed, each disproven rather than assumed:

- `skopeo copy --multi-arch all` on a Flux artifact — works; `copy` is mediaType-agnostic.
- The `awk -F@ '/artifact successfully pushed/'` digest capture — matches current flux CLI output, and is the same idiom `packages/core/installer/Makefile` already uses in production.
- `nightly-mirror.sh`'s `inspect --format Digest` — all mirrored refs there are genuine image manifests, so it is correct as written.
- `make -C packages/core/talos talos-nocloud` — exists and is CI-proven via `tags.yaml`.

## Honest scope

This fixes the `mirror` job's blockers. It does **not** promise a green nightly on the first run: every step after `mirror` is still unproven, having never executed. The most likely next wall is `build-disk` — `cozystack-nocloud` is a brand-new package, so the first `oras push` creates it, and the follow-up `oras tag` can hit `403 permission_denied` until the package is linked (the risk the workflow already documents in-line). The first-ever full e2e run may well surface its own issues.

Reviewing that follow-on separately seems better than growing this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly artifact mirroring and staging reliability.
  * Prevented artifact pull failures by ensuring required output directories are created before use.
  * Enhanced retrieval of artifact version and source revision metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->