### PR TITLE
fix(bucket): project user credentials once COSI provisions the BucketInfo Secret

### DIFF
--- a/hack/e2e-chainsaw/bucket/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/bucket/chainsaw-test.yaml
@@ -14,6 +14,13 @@ spec:
       apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: bucket-test
+  # The child release projects the -credentials Secrets from the COSI
+  # BucketInfo Secrets (#3247), so on a hang this is where a stuck or
+  # never-triggered upgrade is visible.
+  - describe:
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: bucket-test-system
   - describe:
       apiVersion: objectstorage.k8s.io/v1alpha1
       kind: BucketClaim
@@ -76,6 +83,58 @@ spec:
           status:
             accessGranted: true
 
+  # The human-friendly -credentials Secrets are projected by the child
+  # (bucket-test-system) release from the COSI BucketInfo Secrets. The COSI
+  # driver provisions those asynchronously — usually after the child's first
+  # render — and the projection only happens because the parent lists the
+  # BucketInfo Secrets in the child's valuesFrom, which makes helm-controller
+  # re-render the child when they appear (#3247: before that wiring the
+  # -credentials Secrets stayed missing forever). The 6m budget covers the
+  # interval-based fallback reconcile (child interval is 5m) in case the
+  # watch event is missed; the watch path converges in seconds.
+  - name: wait-credentials-projected
+    try:
+    - assert:
+        timeout: 6m
+        resource:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: bucket-test-admin-credentials
+            labels:
+              apps.cozystack.io/user-secret: "true"
+          data:
+            (accessKey != null): true
+            (secretKey != null): true
+            (endpoint != null): true
+            (bucketName != null): true
+    - assert:
+        timeout: 6m
+        resource:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: bucket-test-viewer-credentials
+            labels:
+              apps.cozystack.io/user-secret: "true"
+          data:
+            (accessKey != null): true
+            (secretKey != null): true
+            (endpoint != null): true
+            (bucketName != null): true
+    # A projected Secret alone is not the regression guard: the child release
+    # must also have settled Ready, or remediation is still churning.
+    - assert:
+        timeout: 2m
+        resource:
+          apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: bucket-test-system
+          status:
+            (conditions[?type == 'Ready']):
+            - status: "True"
+
   - name: verify-s3-access
     try:
     - script:
@@ -85,16 +144,15 @@ spec:
           workdir=$(mktemp -d)
           trap '[ -n "${pf_pid:-}" ] && kill "$pf_pid" 2>/dev/null || true; rm -rf "$workdir"' EXIT
 
-          # Extract credentials for both users
-          kubectl -n "$NAMESPACE" get secret bucket-test-admin \
-            -o jsonpath='{.data.BucketInfo}' | base64 -d > "$workdir/admin.json"
-          kubectl -n "$NAMESPACE" get secret bucket-test-viewer \
-            -o jsonpath='{.data.BucketInfo}' | base64 -d > "$workdir/viewer.json"
-          ADMIN_ACCESS_KEY=$(jq -r '.spec.secretS3.accessKeyID' "$workdir/admin.json")
-          ADMIN_SECRET_KEY=$(jq -r '.spec.secretS3.accessSecretKey' "$workdir/admin.json")
-          VIEWER_ACCESS_KEY=$(jq -r '.spec.secretS3.accessKeyID' "$workdir/viewer.json")
-          VIEWER_SECRET_KEY=$(jq -r '.spec.secretS3.accessSecretKey' "$workdir/viewer.json")
-          BUCKET_NAME=$(jq -r '.spec.bucketName' "$workdir/admin.json")
+          # Extract credentials for both users from the projected -credentials
+          # Secrets (not the raw COSI BucketInfo), so this step proves the
+          # user-facing Secrets carry working keys (#3247).
+          sec() { kubectl -n "$NAMESPACE" get secret "$1" -o "jsonpath={.data.$2}" | base64 -d; }
+          ADMIN_ACCESS_KEY=$(sec bucket-test-admin-credentials accessKey)
+          ADMIN_SECRET_KEY=$(sec bucket-test-admin-credentials secretKey)
+          VIEWER_ACCESS_KEY=$(sec bucket-test-viewer-credentials accessKey)
+          VIEWER_SECRET_KEY=$(sec bucket-test-viewer-credentials secretKey)
+          BUCKET_NAME=$(sec bucket-test-admin-credentials bucketName)
 
           # Port-forward to the S3 endpoint; cleaned up by the trap
           kubectl port-forward service/seaweedfs-s3 -n tenant-root 8333:8333 >/dev/null 2>&1 &

--- a/hack/e2e-chainsaw/bucket/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/bucket/chainsaw-test.yaml
@@ -89,9 +89,10 @@ spec:
   # render — and the projection only happens because the parent lists the
   # BucketInfo Secrets in the child's valuesFrom, which makes helm-controller
   # re-render the child when they appear (#3247: before that wiring the
-  # -credentials Secrets stayed missing forever). The 6m budget covers the
-  # interval-based fallback reconcile (child interval is 5m) in case the
-  # watch event is missed; the watch path converges in seconds.
+  # -credentials Secrets stayed missing forever). The 6m budget covers one
+  # full release interval (5m): helm-controller 1.5 re-composes valuesFrom
+  # per reconcile rather than watching the Secret, so the worst case is the
+  # Secret appearing just after a reconcile, plus the upgrade itself.
   - name: wait-credentials-projected
     try:
     - assert:

--- a/packages/apps/bucket/templates/helmrelease.yaml
+++ b/packages/apps/bucket/templates/helmrelease.yaml
@@ -20,6 +20,26 @@ spec:
   valuesFrom:
   - kind: Secret
     name: cozystack-values
+  {{- /*
+  The per-user COSI BucketInfo Secrets are referenced only to make
+  helm-controller watch them: `lookup` in the child chart's
+  user-credentials.yaml is never re-evaluated once the release settles, so
+  without this reference a Secret the COSI driver provisions after the last
+  render would never be projected into <bucket>-<user>-credentials (#3247).
+  helm-controller re-composes valuesFrom on every reconcile and reacts to
+  watched Secret events, so the Secret appearing (or rotating) triggers an
+  upgrade, which re-runs the lookup. BucketInfo is a JSON object, so its
+  keys (apiVersion/kind/metadata/spec) merge into the child's values root;
+  the chart does not read them. Scoping the payload under targetPath is not
+  an option before Flux 2.9: targetPath goes through Helm's strvals parser,
+  which cannot carry JSON, and `literal` needs helm-controller >= 1.6.
+  */}}
+  {{- range $name, $user := .Values.users }}
+  - kind: Secret
+    name: {{ $.Release.Name }}-{{ $name }}
+    valuesKey: BucketInfo
+    optional: true
+  {{- end }}
   values:
     bucketName: {{ .Release.Name }}
     users: {{ .Values.users | toJson }}

--- a/packages/apps/bucket/templates/helmrelease.yaml
+++ b/packages/apps/bucket/templates/helmrelease.yaml
@@ -26,9 +26,11 @@ spec:
   user-credentials.yaml is never re-evaluated once the release settles, so
   without this reference a Secret the COSI driver provisions after the last
   render would never be projected into <bucket>-<user>-credentials (#3247).
-  helm-controller re-composes valuesFrom on every reconcile and reacts to
-  watched Secret events, so the Secret appearing (or rotating) triggers an
-  upgrade, which re-runs the lookup. BucketInfo is a JSON object, so its
+  helm-controller re-composes valuesFrom on every reconcile, so the Secret
+  appearing (or rotating) changes the composed values digest and triggers
+  an upgrade, which re-runs the lookup. Convergence is bounded by the
+  release interval below — helm-controller 1.5 (Flux 2.8) does not watch
+  valuesFrom references. BucketInfo is a JSON object, so its
   keys (apiVersion/kind/metadata/spec) merge into the child's values root;
   the chart does not read them. Scoping the payload under targetPath is not
   an option before Flux 2.9: targetPath goes through Helm's strvals parser,

--- a/packages/apps/bucket/tests/helmrelease_test.yaml
+++ b/packages/apps/bucket/tests/helmrelease_test.yaml
@@ -1,0 +1,57 @@
+suite: bucket child release COSI Secret watch wiring
+templates:
+  - templates/helmrelease.yaml
+
+release:
+  name: my-bucket
+  namespace: tenant-root
+
+set:
+  _namespace:
+    host: example.org
+
+tests:
+  # The child release only re-renders (and so only projects the -credentials
+  # Secrets, see #3247) because every per-user COSI BucketInfo Secret is a
+  # watched valuesFrom reference. optional is load-bearing: the Secret does
+  # not exist until the COSI driver grants the BucketAccess.
+  - it: references each user's COSI BucketInfo Secret in valuesFrom as an optional watch trigger
+    set:
+      users:
+        admin: {}
+        viewer:
+          readonly: true
+    asserts:
+      - contains:
+          path: spec.valuesFrom
+          content:
+            kind: Secret
+            name: my-bucket-admin
+            valuesKey: BucketInfo
+            optional: true
+      - contains:
+          path: spec.valuesFrom
+          content:
+            kind: Secret
+            name: my-bucket-viewer
+            valuesKey: BucketInfo
+            optional: true
+      - contains:
+          path: spec.valuesFrom
+          content:
+            kind: Secret
+            name: cozystack-values
+      - lengthEqual:
+          path: spec.valuesFrom
+          count: 3
+
+  - it: keeps only cozystack-values in valuesFrom when the bucket has no users
+    asserts:
+      - lengthEqual:
+          path: spec.valuesFrom
+          count: 1
+      - contains:
+          path: spec.valuesFrom
+          content:
+            kind: Secret
+            name: cozystack-values

--- a/packages/system/bucket/templates/user-credentials.yaml
+++ b/packages/system/bucket/templates/user-credentials.yaml
@@ -4,8 +4,9 @@ COSI driver asynchronously, some time after the BucketAccess is granted, so
 the lookup below legitimately comes up empty on early renders and the
 -credentials Secret is skipped. Re-rendering is guaranteed by the parent
 release (apps/bucket), which lists every BucketInfo Secret in this
-release's valuesFrom: helm-controller watches those references and upgrades
-this release as soon as one appears or changes, re-running the lookup and
+release's valuesFrom: helm-controller re-composes them on every reconcile
+and upgrades this release on the first reconcile after one appears or
+changes (bounded by the release interval), re-running the lookup and
 materialising the -credentials Secret (#3247). Skipping — rather than
 failing the render — is deliberate: the platform's built-in cozy-backups
 bucket exists on clusters where tenant-root has no seaweedfs (and thus no

--- a/packages/system/bucket/templates/user-credentials.yaml
+++ b/packages/system/bucket/templates/user-credentials.yaml
@@ -1,8 +1,26 @@
+{{- /*
+The per-user BucketInfo Secret (<bucketName>-<user>) is provisioned by the
+COSI driver asynchronously, some time after the BucketAccess is granted, so
+the lookup below legitimately comes up empty on early renders and the
+-credentials Secret is skipped. Re-rendering is guaranteed by the parent
+release (apps/bucket), which lists every BucketInfo Secret in this
+release's valuesFrom: helm-controller watches those references and upgrades
+this release as soon as one appears or changes, re-running the lookup and
+materialising the -credentials Secret (#3247). Skipping — rather than
+failing the render — is deliberate: the platform's built-in cozy-backups
+bucket exists on clusters where tenant-root has no seaweedfs (and thus no
+BucketClass) yet, and a failing render would keep that release, and with it
+every fresh install, permanently not-Ready.
+*/}}
 {{- range $name, $user := .Values.users }}
 {{- $secretName := printf "%s-%s" $.Values.bucketName $name }}
 {{- $existingSecret := lookup "v1" "Secret" $.Release.Namespace $secretName }}
 {{- if $existingSecret }}
-{{- $bucketInfo := fromJson (b64dec (index $existingSecret.data "BucketInfo")) }}
+{{- $bucketInfoRaw := index $existingSecret.data "BucketInfo" }}
+{{- if not $bucketInfoRaw }}
+{{- fail (printf "Secret %s/%s exists but has no BucketInfo key; expected a COSI-provisioned BucketAccess credentials Secret" $.Release.Namespace $secretName) }}
+{{- end }}
+{{- $bucketInfo := fromJson (b64dec $bucketInfoRaw) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/packages/system/bucket/tests/user_credentials_test.yaml
+++ b/packages/system/bucket/tests/user_credentials_test.yaml
@@ -1,0 +1,88 @@
+suite: bucket user -credentials projection
+templates:
+  - templates/user-credentials.yaml
+
+release:
+  name: my-bucket-system
+  namespace: tenant-root
+
+set:
+  bucketName: my-bucket
+  users:
+    admin: {}
+
+tests:
+  # The COSI driver provisions the BucketInfo Secret asynchronously; until it
+  # exists the template must skip (not fail) so the release — and a fresh
+  # platform install carrying the built-in cozy-backups bucket — stays Ready.
+  # Re-rendering once the Secret appears is the parent release's job (it lists
+  # the Secret in this release's valuesFrom as a watch trigger, see #3247).
+  - it: renders nothing while the COSI BucketInfo Secret is missing
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: projects accessKey, secretKey, endpoint and bucketName once the COSI Secret exists
+    kubernetesProvider:
+      scheme:
+        "v1/Secret":
+          gvr:
+            version: v1
+            resource: secrets
+          namespaced: true
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: my-bucket-admin
+            namespace: tenant-root
+          data:
+            BucketInfo: eyJhcGlWZXJzaW9uIjoib2JqZWN0c3RvcmFnZS5rOHMuaW8vdjFhbHBoYTEiLCJraW5kIjoiQnVja2V0SW5mbyIsInNwZWMiOnsiYnVja2V0TmFtZSI6Im15LWJ1Y2tldC1yZWFsIiwic2VjcmV0UzMiOnsiYWNjZXNzS2V5SUQiOiJBSzEyMyIsImFjY2Vzc1NlY3JldEtleSI6IlNLNDU2IiwiZW5kcG9pbnQiOiJodHRwczovL3MzLmV4YW1wbGUub3JnIn19fQ==
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Secret
+      - equal:
+          path: metadata.name
+          value: my-bucket-admin-credentials
+      - equal:
+          path: metadata.labels["apps.cozystack.io/user-secret"]
+          value: "true"
+      - equal:
+          path: stringData.accessKey
+          value: AK123
+      - equal:
+          path: stringData.secretKey
+          value: SK456
+      # The https:// scheme is stripped so consumers can prepend their own.
+      - equal:
+          path: stringData.endpoint
+          value: s3.example.org
+      - equal:
+          path: stringData.bucketName
+          value: my-bucket-real
+
+  # A Secret with the right name but no BucketInfo payload is a broken COSI
+  # driver, not an in-progress provision — fail loudly instead of projecting
+  # an empty credential.
+  - it: fails the render when the Secret exists without a BucketInfo key
+    kubernetesProvider:
+      scheme:
+        "v1/Secret":
+          gvr:
+            version: v1
+            resource: secrets
+          namespaced: true
+      objects:
+        - apiVersion: v1
+          kind: Secret
+          metadata:
+            name: my-bucket-admin
+            namespace: tenant-root
+          data:
+            unrelated: dW5yZWxhdGVk
+    asserts:
+      - failedTemplate:
+          errorPattern: has no BucketInfo key


### PR DESCRIPTION
## What this PR does

Fixes #3247: the human-friendly `<bucket>-<user>-credentials` Secret was never created when the COSI driver provisioned the BucketInfo Secret after the bucket release's first render. `user-credentials.yaml` reads the BucketInfo Secret with `lookup`, and Helm only re-evaluates `lookup` during a real install/upgrade attempt — once the release settled Ready with the Secret still missing, nothing ever triggered another render, so the credentials stayed missing forever.

The fix makes the parent release (`apps/bucket`) list every per-user COSI BucketInfo Secret in the child release's `valuesFrom` with `optional: true`. helm-controller re-composes `valuesFrom` on every reconcile, so the Secret appearing (or rotating) changes the composed values digest and triggers an upgrade of the child release within one release interval (5m — helm-controller 1.5 / Flux 2.8 does not watch `valuesFrom` references), which re-runs the `lookup` and projects the credentials. The template keeps skipping while the Secret is missing, and only fails the render for the genuinely broken state of a BucketInfo Secret without a `BucketInfo` key.

This supersedes #3320, which failed the render while the COSI Secret was missing and relied on `retries: -1` remediation to converge. That approach deadlocks every fresh install: the platform's built-in `cozy-backups` bucket is created by `backupstrategy-controller` unconditionally, but its BucketClass only exists once seaweedfs is enabled in `tenant-root`, so the bucket child releases stayed permanently not-Ready and the install gate (`kubectl wait hr --all -A`) could never pass — see the [E2E failure](https://github.com/cozystack/cozystack/actions/runs/29492957760) on that PR. Carrying the BucketInfo payload itself through `valuesFrom` instead of `lookup` remains impossible before Flux 2.9: `targetPath` goes through Helm's strvals parser, which cannot carry JSON, and `literal: true` needs helm-controller >= 1.6 while we pin Flux 2.8.x.

The bucket Chainsaw suite now asserts the regression directly: both `-credentials` Secrets must appear with all four keys and the child release must settle Ready, and the S3 round-trip reads its keys from the projected Secrets instead of the raw BucketInfo. On `main` without the fix the new asserts time out, because the Secrets never appear. Helm-unittest covers the template pair: the skip-while-missing path, the projection path against a faked BucketInfo Secret, the no-`BucketInfo`-key failure, and the `valuesFrom` wiring per user.

Operational note for existing clusters: a `<bucket>-<user>-credentials` Secret that was created by hand (as a workaround for #3247) is adopted and overwritten by the first triggered upgrade — verified live on Flux 2.8 / helm-controller v1.5.0, where the upgrade stamped the Helm ownership metadata onto the pre-existing Secret and replaced its stale keys with the real BucketInfo ones. Unlike #3320, whose remediation went through the install path and its stricter ownership check, this fix only ever drives upgrades, so no manual deletion or adoption is required; if an older toolchain does fail with an invalid-ownership error, deleting the hand-made Secret (or adding the `meta.helm.sh` annotations and `app.kubernetes.io/managed-by: Helm` label) unblocks it.

Verified live on a dev cluster (Flux 2.8, helm-controller v1.5.0): a standalone child release with this `valuesFrom` wiring settles Ready with no credentials while the COSI Secret is missing; after applying the BucketClaim/BucketAccess the COSI Secret appeared in ~4s and the `-credentials` Secret was projected 4m49s later on the first interval reconcile (release v1 → v2, projected keys match the BucketInfo payload).

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(bucket): create the <bucket>-<user>-credentials Secret even when the COSI driver provisions the BucketInfo Secret after the release first settles (#3247)
```
