### PR TITLE
fix(migrations): derive the etcd-adoption snapshot target from the projected bucket creds

### DIFF
--- a/hack/migration-50-etcd-adopt.bats
+++ b/hack/migration-50-etcd-adopt.bats
@@ -49,6 +49,10 @@ prep() {
   export FAKE_STRATEGY=1
   export FAKE_CREDS=1
   export FAKE_V2_CRD=0
+  export FAKE_CLAIM_CRD=1
+  # One healthy claim provisioned into the bucket the projected creds advertise:
+  # the COSI path. Tests override this to model external S3 / stale claims.
+  export FAKE_CLAIMS="tenant-root bucket-cozy-backups cozy-backups-7f3a -"
   # The baked-CRD dir must exist for the script's `-d` guard; the fake kubectl
   # logs the apply without reading it, so an empty dir is enough.
   export ETCD_CRD_DIR="$WORK/etcd-operator-crds"
@@ -77,6 +81,9 @@ lineno() {
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   echo "$apply" | grep -qF -- "--backup-s3-endpoint=https://s3.example.com"
   ! echo "$apply" | grep -qF -- "seaweedfs-s3.tenant-root.svc.cozy.local:8333"
+  # https is forced because a BucketClaim is provisioned into exactly the bucket
+  # the creds advertise, not because the projected endpoint happens to exist.
+  grep -qF -- "BUCKETCLAIM-LIST" "$FAKE_CMDLOG"
   echo "$apply" | grep -qF -- "--backup-s3-bucket=cozy-backups-7f3a"
   echo "$apply" | grep -qF -- "--backup-s3-credentials-secret=cozy-backups-creds"
   echo "$apply" | grep -qF -- "--backup-s3-region=us-east-1"
@@ -189,7 +196,9 @@ lineno() {
 
 @test "no resolvable destination hard-fails without scaling or adopting" {
   prep
-  # Neither source resolves: no Strategy CR AND no projected coordinates.
+  # Neither source resolves the bucket: the projector dropped bucketName (its
+  # source Secret did not carry one) and the Strategy CR that would supply it
+  # never rendered.
   export FAKE_STRATEGY=0
   export FAKE_CREDS_COORDS=0
   rc=0
@@ -229,20 +238,296 @@ lineno() {
   rm -rf "$WORK"
 }
 
-@test "external S3 (no projected endpoint) keeps the Strategy CR endpoint verbatim" {
+@test "external S3 (no COSI at all) keeps the Strategy CR endpoint scheme verbatim" {
   prep
-  # provisionBucket: false — the admin's .Values.backupStorage.endpoint is
-  # authoritative and may legitimately be plaintext against a private store, so
-  # the CR's scheme must survive: we must not force https on a non-COSI target.
-  export FAKE_CREDS_COORDS=0
+  # provisionBucket: false on a cluster with no SeaweedFS/COSI at all
+  # (docs/operations/backup-classes.md describes exactly this flip), so the
+  # BucketClaim CRD itself is absent and every claim query fails the way real
+  # kubectl fails on an unknown resource type. That must classify as external
+  # and must NOT abort the script under `set -euo pipefail`.
+  #
+  # The projector still writes a bare `endpoint` here (it always does), so the
+  # endpoint's PRESENCE cannot signal this case. The admin's
+  # .Values.backupStorage.endpoint is authoritative and may legitimately be
+  # plaintext against a private store, so its scheme must survive. Forcing https
+  # would be a total upgrade block: the snapshot is mandatory and
+  # ETCD_ADOPT_SKIP_BACKUP is not plumbed through templates/migration-hook.yaml,
+  # so the operator would have no escape.
+  export FAKE_CLAIM_CRD=0
+  export FAKE_CLAIMS=""
+  export FAKE_CREDS_ENDPOINT="minio.internal:9000"
+  # The healthy external shape: the admin's backupStorage.bucketName (which the
+  # CR renders) and their source Secret name the same bucket. The disagreeing
+  # shape is covered separately by the CR-wholesale test above.
+  export FAKE_CREDS_BUCKET="minio-bucket"
+  export FAKE_STRATEGY_BUCKET="minio-bucket"
+  export FAKE_STRATEGY_ENDPOINT="http://minio.internal:9000"
   rc=0
   bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"
   cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
-  echo "$apply" | grep -qF -- "--backup-s3-endpoint=http://seaweedfs-s3.tenant-root.svc.cozy.local:8333"
+  echo "$apply" | grep -qF -- "--backup-s3-endpoint=http://minio.internal:9000"
+  # The projected bare host must NOT be promoted to https.
+  ! echo "$apply" | grep -qF -- "https://minio.internal:9000"
+  echo "$apply" | grep -qF -- "--backup-s3-bucket=minio-bucket"
+  # A missing CRD is answered, not retried: the list is never even attempted.
+  ! grep -qF -- "BUCKETCLAIM-LIST" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "external S3 takes every coordinate from the CR, never a Secret/CR hybrid" {
+  prep
+  # The projector copies bucketName straight from the admin's source Secret and
+  # never from backupStorage.bucketName, so the two can disagree outright (a
+  # stale projection, or a Secret that simply names a different bucket). Taking
+  # the CR's endpoint while keeping the Secret's bucket/region would assemble a
+  # pairing nothing else in the system produces and could snapshot into a bucket
+  # the platform's own backups never touch. The CR renders backupStorage.* and
+  # already points at these same creds, so CR coordinates + these creds is what
+  # this cluster's real BackupJobs use — take all four from it.
+  export FAKE_CLAIM_CRD=0
+  export FAKE_CLAIMS=""
+  export FAKE_CREDS_ENDPOINT="minio.internal:9000"
+  export FAKE_CREDS_BUCKET="stale-secret-bucket"
+  export FAKE_CREDS_REGION="eu-west-9"
+  export FAKE_CREDS_FPS="false"
+  export FAKE_STRATEGY_ENDPOINT="http://minio.internal:9000"
+  export FAKE_STRATEGY_BUCKET="platform-bucket"
+  export FAKE_STRATEGY_REGION="us-east-1"
+  export FAKE_STRATEGY_FPS="true"
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  [ "$rc" -eq 0 ]
+  apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
+  echo "$apply" | grep -qF -- "--backup-s3-endpoint=http://minio.internal:9000"
+  echo "$apply" | grep -qF -- "--backup-s3-bucket=platform-bucket"
+  echo "$apply" | grep -qF -- "--backup-s3-region=us-east-1"
+  echo "$apply" | grep -qF -- "--backup-s3-force-path-style"
+  # Not one projected coordinate may leak into the external destination.
+  ! echo "$apply" | grep -qF -- "stale-secret-bucket"
+  ! echo "$apply" | grep -qF -- "eu-west-9"
+  rm -rf "$WORK"
+}
+
+@test "COSI keeps the projected bucket even when the Strategy CR names another" {
+  prep
+  # Guard, not a bite: the CR-wholesale rule above is scoped to external S3. On
+  # the COSI path the projected bucket is the COSI-assigned name, which the CR
+  # can only reproduce through a live BucketClaim lookup that may never have run
+  # (the very race this hook works around) — and bucketNameOverride immunity
+  # depends on preferring the Secret. A future "simplify both paths to the CR"
+  # must fail here.
+  export FAKE_STRATEGY_BUCKET="cr-bucket-should-lose"
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  [ "$rc" -eq 0 ]
+  apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   echo "$apply" | grep -qF -- "--backup-s3-bucket=cozy-backups-7f3a"
+  ! echo "$apply" | grep -qF -- "cr-bucket-should-lose"
+  rm -rf "$WORK"
+}
+
+@test "external S3 with a stale Terminating BucketClaim still keeps the CR scheme" {
+  prep
+  # The regression the name-keyed probe shipped: provisionBucket: false, but a
+  # leftover BucketClaim is wedged Terminating — its cosi bucketclaim-protection
+  # finalizer outlives the uninstalled COSI controller, so `kubectl get` on the
+  # NAME keeps returning 0 forever. An existence-keyed probe reads that as COSI
+  # and forces https on the admin's plaintext store, wedging the upgrade with no
+  # escape hatch. Matching on .status.bucketName instead: the stale claim names
+  # the OLD bucket, which cannot match the bucket the creds advertise.
+  export FAKE_CLAIMS="tenant-root bucket-cozy-backups bucket-0bb5096a-stale 2026-07-17T09:00:00Z"
+  export FAKE_CREDS_ENDPOINT="minio.internal:9000"
+  export FAKE_CREDS_BUCKET="minio-bucket"
+  export FAKE_STRATEGY_BUCKET="minio-bucket"
+  export FAKE_STRATEGY_ENDPOINT="http://minio.internal:9000"
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
+  echo "$apply" | grep -qF -- "--backup-s3-endpoint=http://minio.internal:9000"
+  ! echo "$apply" | grep -qF -- "https://minio.internal:9000"
+  rm -rf "$WORK"
+}
+
+@test "COSI with overridden bucket coordinates is still detected (no hardcoded names)" {
+  prep
+  # backupStorage.namespace / .bucketName are supported Package-CR overrides
+  # (docs/operations/backup-classes.md), and this hook cannot see chart values —
+  # nothing plumbs them into the migration Job's env. So the claim may sit in any
+  # namespace under any name. Keying on the COSI-assigned .status.bucketName,
+  # which is what the projector republishes, makes the probe independent of both.
+  # A name-keyed probe would miss this claim, misclassify the cluster as
+  # external, and fall back to the v1.5.x plaintext CR — the original P0.
+  export FAKE_CLAIMS="tenant-custom bucket-my-backups cozy-backups-7f3a -"
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
+  echo "$apply" | grep -qF -- "--backup-s3-endpoint=https://s3.example.com"
+  ! echo "$apply" | grep -qF -- "seaweedfs-s3.tenant-root.svc.cozy.local:8333"
+  rm -rf "$WORK"
+}
+
+@test "COSI is detected on a big multi-tenant cluster (match not last in the claim list)" {
+  prep
+  # Every other test runs with a single BucketClaim, which is exactly why a
+  # first-match-exit consumer looks green: it only misbehaves once the rendered
+  # list outgrows one pipe write (~8KB) AND the match is not the last line.
+  # `kubectl get -A` sorts by namespace, so tenant-root lands mid-list on a real
+  # cluster; this puts the match FIRST, the worst case.
+  #
+  # A `jq -r ... | grep -qxF` probe SIGPIPEs jq here (rc 141) and `set -o
+  # pipefail` surfaces that instead of grep's 0, so the match reads as "not
+  # COSI" -> external -> the v1.5.x plaintext :8333 CR endpoint -> the snapshot
+  # fails and the upgrade is blocked, on precisely the large clusters that can
+  # least afford it. Worse, it is a race: backoffLimit 3 can classify the same
+  # cluster differently on each retry.
+  export FAKE_CREDS_BUCKET="bucket-0bb5096a-956e-4630-91f4-e1d265de5f51"
+  export FAKE_CLAIMS="tenant-root bucket-cozy-backups bucket-0bb5096a-956e-4630-91f4-e1d265de5f51 -"
+  export FAKE_CLAIM_FILLER=300
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  [ "$rc" -eq 0 ]
+  apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
+  echo "$apply" | grep -qF -- "--backup-s3-endpoint=https://s3.example.com"
+  echo "$apply" | grep -qF -- "--backup-s3-bucket=bucket-0bb5096a-956e-4630-91f4-e1d265de5f51"
+  # The v1.5.x CR endpoint must never be what a large cluster falls back to.
+  ! echo "$apply" | grep -qF -- "seaweedfs-s3.tenant-root.svc.cozy.local:8333"
+  rm -rf "$WORK"
+}
+
+@test "a TERMINATING claim on the matching bucket is ambiguous: refuse, do not guess" {
+  prep
+  # The state neither reading survives: an admin moved COSI -> external S3
+  # REUSING the bucket name (backup continuity), and the old claim is wedged
+  # Terminating because COSI is gone. Reading the corpse as ownership forces
+  # https on a plaintext store; reading it as "external" would, on a cluster
+  # that is still COSI with a mid-recreate claim, resurrect the plaintext-:8333
+  # P0. Both are wrong half the time and both fail as a confusing handshake
+  # error, so the guess buys nothing — refuse and name the ambiguity.
+  export FAKE_CLAIMS="tenant-root bucket-cozy-backups minio-bucket 2026-07-17T09:00:00Z"
+  export FAKE_CREDS_BUCKET="minio-bucket"
+  export FAKE_CREDS_ENDPOINT="minio.internal:9000"
+  export FAKE_STRATEGY_ENDPOINT="http://minio.internal:9000"
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  cat "$FAKE_CMDLOG"
+  [ "$rc" -ne 0 ]
+  grep -qF -- "TERMINATING BucketClaim" "$WORK/out"
+  grep -qF -- "could not determine" "$WORK/out"
+  # It must not have silently taken either branch.
+  ! grep -qF -- "treating as external S3" "$WORK/out"
+  ! grep -qF -- "forcing https" "$WORK/out"
+  # Nothing destructive ran.
+  ! grep -qF -- "SCALE 0" "$FAKE_CMDLOG"
+  ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
+  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "a LIVE claim wins over an unrelated Terminating one (ambiguity is not over-applied)" {
+  prep
+  # Guard, not a bite: the refusal above must fire ONLY when the match is
+  # exclusively Terminating. A healthy COSI cluster that also carries some dead
+  # claim must still resolve normally — an over-broad "any Terminating claim is
+  # ambiguous" rule would wedge ordinary upgrades.
+  export FAKE_CLAIMS="tenant-root bucket-cozy-backups cozy-backups-7f3a -
+tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  [ "$rc" -eq 0 ]
+  apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
+  echo "$apply" | grep -qF -- "--backup-s3-endpoint=https://s3.example.com"
+  ! grep -qF -- "TERMINATING BucketClaim" "$WORK/out"
+  rm -rf "$WORK"
+}
+
+@test "an uninterpretable claim list fails loud rather than reading as external" {
+  prep
+  # No producer emits this — kubectl always renders a List with an items array —
+  # but without a shape gate every unexpected document reads as "no claim owns
+  # the bucket" = external = the plaintext-:8333 P0, silently. Refuse instead.
+  export FAKE_CLAIM_LIST_SHAPE=items-not-array
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  [ "$rc" -ne 0 ]
+  grep -qF -- "unexpected BucketClaim list shape" "$WORK/out"
+  ! grep -qF -- "treating as external S3" "$WORK/out"
+  ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
+  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "an unreadable BucketClaim API fails loud instead of guessing external S3" {
+  prep
+  # A transient CRD read error is NOT the same answer as "the CRD is absent".
+  # Treating it as absent classifies a COSI cluster as external and snapshots to
+  # the unreachable v1.5 in-cluster endpoint — the original P0, resurrected by an
+  # apiserver blip. Refuse to classify instead: a loud failure is recoverable
+  # (the Job retries), a wrong classification is not.
+  export FAKE_CLAIM_CRD=error
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  cat "$FAKE_CMDLOG"
+  [ "$rc" -ne 0 ]
+  grep -qF -- "could not determine" "$WORK/out"
+  grep -qF -- "refusing to adopt" "$WORK/out"
+  # It must NOT have silently taken the external path.
+  ! grep -qF -- "treating as external S3" "$WORK/out"
+  # Nothing destructive ran.
+  ! grep -qF -- "SCALE 0" "$FAKE_CMDLOG"
+  ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
+  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "an unreadable claim LIST fails loud rather than classifying as external" {
+  prep
+  # Same reasoning one level down: the CRD exists (COSI is installed), so a
+  # failing list read cannot mean "no COSI here".
+  export FAKE_CLAIM_LIST_ERR=1
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  [ "$rc" -ne 0 ]
+  grep -qF -- "could not determine" "$WORK/out"
+  ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
+  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "COSI without a projected endpoint falls back to the CR, never a bare https://" {
+  prep
+  # Defensive: the projector cannot produce this (it fails
+  # ReasonSourceMalformed rather than omit the endpoint), but forcing the scheme
+  # onto an empty host yields the literal "https://", which is non-empty and so
+  # sails through the final resolution guard and reaches etcd-migrate as a
+  # destination. origin/main degraded to the CR here; so must this.
+  export FAKE_CREDS_ENDPOINT=""
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
+  # No scheme-only endpoint reaches etcd-migrate...
+  ! echo "$apply" | grep -qE -- "--backup-s3-endpoint=https://( |$)"
+  # ...and the CR supplies the real one instead.
+  echo "$apply" | grep -qF -- "--backup-s3-endpoint=http://seaweedfs-s3.tenant-root.svc.cozy.local:8333"
   rm -rf "$WORK"
 }
 
@@ -292,7 +577,8 @@ lineno() {
   # The narrowing the reviewer asked for: a cluster with legacy etcd but no
   # resolvable backup target (backups disabled / external S3 without staged
   # creds / SeaweedFS not ready) is no longer a total upgrade block when the
-  # operator opts into skipping the snapshot.
+  # operator opts into skipping the snapshot. Resolution is not even attempted,
+  # so this passes regardless of why the target would be unresolvable.
   export FAKE_STRATEGY=0
   export FAKE_CREDS_COORDS=0
   export ETCD_ADOPT_SKIP_BACKUP=1

--- a/hack/migration-50-etcd-adopt.bats
+++ b/hack/migration-50-etcd-adopt.bats
@@ -71,8 +71,12 @@ lineno() {
   [ "$rc" -eq 0 ]
 
   # --apply carries the platform-derived S3 destination, NOT --skip-backup.
+  # The endpoint is derived from the projected Secret's bare host and forced to
+  # https, NOT taken from the Strategy CR — the CR is rendered by the version we
+  # are upgrading FROM and its plaintext in-cluster default cannot be reached.
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
-  echo "$apply" | grep -qF -- "--backup-s3-endpoint=http://seaweedfs-s3.tenant-root.svc.cozy.local:8333"
+  echo "$apply" | grep -qF -- "--backup-s3-endpoint=https://s3.example.com"
+  ! echo "$apply" | grep -qF -- "seaweedfs-s3.tenant-root.svc.cozy.local:8333"
   echo "$apply" | grep -qF -- "--backup-s3-bucket=cozy-backups-7f3a"
   echo "$apply" | grep -qF -- "--backup-s3-credentials-secret=cozy-backups-creds"
   echo "$apply" | grep -qF -- "--backup-s3-region=us-east-1"
@@ -185,7 +189,9 @@ lineno() {
 
 @test "no resolvable destination hard-fails without scaling or adopting" {
   prep
+  # Neither source resolves: no Strategy CR AND no projected coordinates.
   export FAKE_STRATEGY=0
+  export FAKE_CREDS_COORDS=0
   rc=0
   bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"
@@ -196,6 +202,47 @@ lineno() {
   ! grep -qF -- "SCALE 0" "$FAKE_CMDLOG"
   ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
   ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "absent Strategy CR still resolves from the projected coordinates" {
+  prep
+  # The v1.5.x shape where strategy-etcd-default.yaml never rendered: its
+  # `if $bucketName` guard lookup raced the BucketClaim the same chart creates,
+  # and helm lookup does not re-run on reconcile. Before deriving coordinates
+  # from the projected Secret this was a total upgrade block with no reachable
+  # escape (ETCD_ADOPT_SKIP_BACKUP is not plumbed through the migration hook).
+  export FAKE_STRATEGY=0
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  ! grep -qF -- "refusing to adopt" "$WORK/out"
+  apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
+  echo "$apply" | grep -qF -- "--backup-s3-endpoint=https://s3.example.com"
+  echo "$apply" | grep -qF -- "--backup-s3-bucket=cozy-backups-7f3a"
+  echo "$apply" | grep -qF -- "--backup-s3-region=us-east-1"
+  echo "$apply" | grep -qF -- "--backup-s3-force-path-style"
+  ! echo "$apply" | grep -qF -- "--skip-backup"
+  grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "external S3 (no projected endpoint) keeps the Strategy CR endpoint verbatim" {
+  prep
+  # provisionBucket: false — the admin's .Values.backupStorage.endpoint is
+  # authoritative and may legitimately be plaintext against a private store, so
+  # the CR's scheme must survive: we must not force https on a non-COSI target.
+  export FAKE_CREDS_COORDS=0
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
+  echo "$apply" | grep -qF -- "--backup-s3-endpoint=http://seaweedfs-s3.tenant-root.svc.cozy.local:8333"
+  echo "$apply" | grep -qF -- "--backup-s3-bucket=cozy-backups-7f3a"
   rm -rf "$WORK"
 }
 
@@ -247,6 +294,7 @@ lineno() {
   # creds / SeaweedFS not ready) is no longer a total upgrade block when the
   # operator opts into skipping the snapshot.
   export FAKE_STRATEGY=0
+  export FAKE_CREDS_COORDS=0
   export ETCD_ADOPT_SKIP_BACKUP=1
   rc=0
   bash "$MIG" >"$WORK/out" 2>&1 || rc=$?

--- a/hack/migration-50-etcd-adopt.bats
+++ b/hack/migration-50-etcd-adopt.bats
@@ -207,6 +207,12 @@ lineno() {
   cat "$FAKE_CMDLOG"
   [ "$rc" -ne 0 ]
   grep -qF -- "refusing to adopt" "$WORK/out"
+  # The refusal must tell the operator how to actually take the hatch. Naming
+  # ETCD_ADOPT_SKIP_BACKUP alone was unactionable advice for the entire life of
+  # this migration: nothing can set a var on a Helm-hook Job, so the message has
+  # to name the Package CR path that renders it.
+  grep -qF -- "package.cozystack.io cozystack.cozystack-platform" "$WORK/out"
+  grep -qF -- "etcdAdoptSkipBackup: true" "$WORK/out"
   # Nothing destructive must have run: no scale-down, no --apply, no version stamp.
   ! grep -qF -- "SCALE 0" "$FAKE_CMDLOG"
   ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
@@ -569,6 +575,41 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   # Adoption still runs and stamps: scale down -> --apply -> scale up -> stamp.
   grep -qF -- "SCALE 0" "$FAKE_CMDLOG"
   grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "ETCD_ADOPT_SKIP_BACKUP=true is honoured, not silently ignored" {
+  prep
+  # The platform renders this var through migrations.etcdAdoptSkipBackup and
+  # always emits "1", but an operator setting it by hand will reasonably type
+  # "true". An exact match on "1" would accept that, show it in the Job spec and
+  # do nothing — a safety valve that is set but silently ignored is worse than
+  # one that was never offered, because the operator believes they opted in.
+  export ETCD_ADOPT_SKIP_BACKUP=true
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  [ "$rc" -eq 0 ]
+  apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
+  echo "$apply" | grep -qF -- "--skip-backup"
+  ! echo "$apply" | grep -qF -- "--backup-s3-endpoint"
+  ! grep -qF -- "STAGE " "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "an unrecognised ETCD_ADOPT_SKIP_BACKUP value does NOT skip the snapshot" {
+  prep
+  # Skipping the snapshot on live etcd must require an affirmative answer. A
+  # typo, a stray value, or a future template bug rendering something unexpected
+  # must fall back to the safe side and still take the snapshot.
+  export ETCD_ADOPT_SKIP_BACKUP=banana
+  rc=0
+  bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"
+  [ "$rc" -eq 0 ]
+  apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
+  ! echo "$apply" | grep -qF -- "--skip-backup"
+  echo "$apply" | grep -qF -- "--backup-s3-endpoint=https://s3.example.com"
   rm -rf "$WORK"
 }
 

--- a/hack/testdata/migration-50/kubectl
+++ b/hack/testdata/migration-50/kubectl
@@ -22,13 +22,27 @@ state_dir="${FAKE_CMDLOG%/*}"
 # arg_after KEY -- echoes the token following KEY in the argument vector.
 arg_after() { k="$1"; shift; p=""; for a in "$@"; do [ "$p" = "$k" ] && { printf '%s' "$a"; return; }; p="$a"; done; }
 
-# Strategy CR JSON (rendered with real S3 coordinates by the backupstrategy-
-# controller; forcePathStyle true => the script must add --backup-s3-force-path-style).
+# Strategy CR JSON as the version being upgraded FROM rendered it. The endpoint
+# is the static v1.5.x default: plaintext against SeaweedFS's :8333 TLS listener,
+# i.e. unusable. The script must NOT take its endpoint from here when the
+# projected Secret advertises the real one. FAKE_STRATEGY=0 models the other
+# v1.5.x shape, where the CR was never rendered at all (its template is guarded
+# by a bucketName lookup that races the BucketClaim on first install).
 strategy_json='{"spec":{"template":{"destination":{"s3":{"endpoint":"http://seaweedfs-s3.tenant-root.svc.cozy.local:8333","bucket":"cozy-backups-7f3a","region":"us-east-1","forcePathStyle":true}}}}}'
 # cozy-backups-creds as eagerly projected into cozy-velero (carries owner/anno
 # metadata the stage copy must strip, plus the AWS_* keys). It also carries a
 # tenantresource label here so the test can prove the stage copy strips it.
-creds_json='{"apiVersion":"v1","kind":"Secret","metadata":{"name":"cozy-backups-creds","namespace":"cozy-velero","resourceVersion":"123","uid":"abc","ownerReferences":[{"name":"projector"}],"labels":{"internal.cozystack.io/tenantresource":"true"},"annotations":{"reconcile.io/x":"y"}},"data":{"AWS_ACCESS_KEY_ID":"QUtJQUVYQU1QTEU=","AWS_SECRET_ACCESS_KEY":"c2VjcmV0a2V5"}}'
+#
+# The projector writes the COSI bucket's own coordinates alongside the AWS_*
+# keys: endpoint (a BARE HOST — the external, ACME-certed S3 ingress),
+# bucketName, region, forcePathStyle. Those describe the live bucket regardless
+# of which version rendered the charts, so they are what resolve_platform_backup_args
+# must prefer. FAKE_CREDS_COORDS=0 drops them to model the admin-managed
+# external-S3 case (provisionBucket: false), where the Strategy CR stays
+# authoritative and its scheme must be preserved verbatim.
+creds_coords='"endpoint":"czMuZXhhbXBsZS5jb20=","bucketName":"Y296eS1iYWNrdXBzLTdmM2E=","region":"dXMtZWFzdC0x","forcePathStyle":"dHJ1ZQ==",'
+[ "${FAKE_CREDS_COORDS:-1}" = "1" ] || creds_coords=''
+creds_json='{"apiVersion":"v1","kind":"Secret","metadata":{"name":"cozy-backups-creds","namespace":"cozy-velero","resourceVersion":"123","uid":"abc","ownerReferences":[{"name":"projector"}],"labels":{"internal.cozystack.io/tenantresource":"true"},"annotations":{"reconcile.io/x":"y"}},"data":{'"$creds_coords"'"AWS_ACCESS_KEY_ID":"QUtJQUVYQU1QTEU=","AWS_SECRET_ACCESS_KEY":"c2VjcmV0a2V5"}}'
 
 emit_clusters_name() { printf '%s\n' "${FAKE_CLUSTERS:-}" | while read -r ns name; do [ -n "$ns" ] && printf 'etcdcluster.etcd.aenix.io/%s\n' "$name"; done; }
 emit_clusters_jsonpath() { printf '%s\n' "${FAKE_CLUSTERS:-}" | while read -r ns name; do [ -n "$ns" ] && printf '%s %s\n' "$ns" "$name"; done; }

--- a/hack/testdata/migration-50/kubectl
+++ b/hack/testdata/migration-50/kubectl
@@ -8,7 +8,42 @@
 #   FAKE_LEGACY_CRD   "1" => the etcd.aenix.io CRD exists (default 1)
 #   FAKE_CLUSTERS     newline list of "<ns> <name>" legacy clusters
 #   FAKE_STRATEGY     "1" => the cozy-default-etcd Strategy CR resolves (default 1)
+#   FAKE_STRATEGY_ENDPOINT  the CR's s3.endpoint (default: the v1.5.x plaintext
+#                            seaweedfs default)
+#   FAKE_STRATEGY_BUCKET    the CR's s3.bucket (default cozy-backups-7f3a)
+#   FAKE_STRATEGY_REGION    the CR's s3.region (default us-east-1)
+#   FAKE_STRATEGY_FPS       the CR's s3.forcePathStyle (default true)
 #   FAKE_CREDS        "1" => cozy-backups-creds (with AWS_* keys) exists (default 1)
+#   FAKE_CREDS_ENDPOINT     the projected `endpoint` value; always a BARE host.
+#                            Set to the EMPTY string to drop the key entirely
+#                            (default s3.example.com)
+#   FAKE_CREDS_BUCKET       the projected `bucketName` value (default
+#                            cozy-backups-7f3a). Copied from the admin's source
+#                            Secret on the external path, so it can disagree
+#                            with the CR's bucket outright.
+#   FAKE_CREDS_REGION       the projected `region` value (default us-east-1)
+#   FAKE_CREDS_FPS          the projected `forcePathStyle` value (default true)
+#   FAKE_CLAIM_CRD    "1"     => the bucketclaims.objectstorage.k8s.io CRD
+#                                exists, i.e. COSI is installed (default 1)
+#                     "0"     => genuinely absent: `--ignore-not-found -o name`
+#                                prints nothing at rc=0
+#                     "error" => the read FAILS (rc!=0) -- a transient API
+#                                error, which is NOT the same answer as absent
+#   FAKE_CLAIM_LIST_ERR "1" => the cluster-wide claim list read fails (default 0)
+#   FAKE_CLAIM_LIST_SHAPE   emit an unexpected list document instead of a List:
+#                            "items-not-array" | "no-items" | "not-json"
+#                            (default: a well-formed List). No real producer
+#                            emits these; they pin that an uninterpretable list
+#                            is never silently read as "no claim" = external.
+#   FAKE_CLAIMS       newline list of BucketClaims, one per line, as
+#                     "<ns> <name> <status.bucketName|-> <deletionTimestamp|->"
+#                     (default: one healthy claim provisioned into the same
+#                     bucket the projected Secret advertises => COSI path)
+#   FAKE_CLAIM_FILLER N synthetic extra claims appended AFTER FAKE_CLAIMS, with
+#                     realistically long bucket-<uuid> status names (default 0).
+#                     Models a big multi-tenant cluster: the FAKE_CLAIMS entries
+#                     stay FIRST, i.e. the matching claim is NOT last, which is
+#                     the position a first-match-exit consumer gets wrong.
 #   FAKE_CERTS        "1" => server/peer cert-manager Certificates exist and
 #                            initially LACK the native wildcard SAN (default 0,
 #                            i.e. no Certificate -> ensure_wildcard_sans skips)
@@ -22,27 +57,84 @@ state_dir="${FAKE_CMDLOG%/*}"
 # arg_after KEY -- echoes the token following KEY in the argument vector.
 arg_after() { k="$1"; shift; p=""; for a in "$@"; do [ "$p" = "$k" ] && { printf '%s' "$a"; return; }; p="$a"; done; }
 
-# Strategy CR JSON as the version being upgraded FROM rendered it. The endpoint
-# is the static v1.5.x default: plaintext against SeaweedFS's :8333 TLS listener,
-# i.e. unusable. The script must NOT take its endpoint from here when the
-# projected Secret advertises the real one. FAKE_STRATEGY=0 models the other
-# v1.5.x shape, where the CR was never rendered at all (its template is guarded
-# by a bucketName lookup that races the BucketClaim on first install).
-strategy_json='{"spec":{"template":{"destination":{"s3":{"endpoint":"http://seaweedfs-s3.tenant-root.svc.cozy.local:8333","bucket":"cozy-backups-7f3a","region":"us-east-1","forcePathStyle":true}}}}}'
+b64() { printf '%s' "$1" | base64 | tr -d '\n'; }
+
+# Strategy CR JSON as the version being upgraded FROM rendered it. The default
+# endpoint is the static v1.5.x one: plaintext against SeaweedFS's :8333 TLS
+# listener, i.e. unusable. The script must NOT take its endpoint from here on the
+# COSI path. FAKE_STRATEGY=0 models the other v1.5.x shape, where the CR was
+# never rendered at all (its template is guarded by a bucketName lookup that
+# races the BucketClaim on first install) — a shape reachable ONLY under
+# provisionBucket: true, since the lookup is skipped entirely for external S3.
+strategy_endpoint="${FAKE_STRATEGY_ENDPOINT:-http://seaweedfs-s3.tenant-root.svc.cozy.local:8333}"
+strategy_json='{"spec":{"template":{"destination":{"s3":{"endpoint":"'"$strategy_endpoint"'","bucket":"'"${FAKE_STRATEGY_BUCKET:-cozy-backups-7f3a}"'","region":"'"${FAKE_STRATEGY_REGION:-us-east-1}"'","forcePathStyle":'"${FAKE_STRATEGY_FPS:-true}"'}}}}}'
 # cozy-backups-creds as eagerly projected into cozy-velero (carries owner/anno
 # metadata the stage copy must strip, plus the AWS_* keys). It also carries a
 # tenantresource label here so the test can prove the stage copy strips it.
 #
-# The projector writes the COSI bucket's own coordinates alongside the AWS_*
-# keys: endpoint (a BARE HOST — the external, ACME-certed S3 ingress),
-# bucketName, region, forcePathStyle. Those describe the live bucket regardless
-# of which version rendered the charts, so they are what resolve_platform_backup_args
-# must prefer. FAKE_CREDS_COORDS=0 drops them to model the admin-managed
-# external-S3 case (provisionBucket: false), where the Strategy CR stays
-# authoritative and its scheme must be preserved verbatim.
-creds_coords='"endpoint":"czMuZXhhbXBsZS5jb20=","bucketName":"Y296eS1iYWNrdXBzLTdmM2E=","region":"dXMtZWFzdC0x","forcePathStyle":"dHJ1ZQ==",'
+# The projector ALWAYS writes a bare-host `endpoint`: it scheme-strips it and
+# refuses to project (ReasonSourceMalformed) when it would be empty, so there is
+# no reachable state in which it is missing — that is why its presence cannot
+# discriminate COSI from external S3, and why the BucketClaim data does. The
+# empty FAKE_CREDS_ENDPOINT (drop the key) models NO reachable projector state;
+# it exists only to pin the defensive CR fallback.
+# bucketName/region/forcePathStyle ARE droppable: the projector's setOrDelete
+# deletes a key whose value is empty. FAKE_CREDS_COORDS=0 models that.
+creds_endpoint_key=''
+[ -z "${FAKE_CREDS_ENDPOINT-s3.example.com}" ] \
+  || creds_endpoint_key='"endpoint":"'"$(b64 "${FAKE_CREDS_ENDPOINT-s3.example.com}")"'",'
+creds_coords='"bucketName":"'"$(b64 "${FAKE_CREDS_BUCKET:-cozy-backups-7f3a}")"'","region":"'"$(b64 "${FAKE_CREDS_REGION:-us-east-1}")"'","forcePathStyle":"'"$(b64 "${FAKE_CREDS_FPS:-true}")"'",'
 [ "${FAKE_CREDS_COORDS:-1}" = "1" ] || creds_coords=''
-creds_json='{"apiVersion":"v1","kind":"Secret","metadata":{"name":"cozy-backups-creds","namespace":"cozy-velero","resourceVersion":"123","uid":"abc","ownerReferences":[{"name":"projector"}],"labels":{"internal.cozystack.io/tenantresource":"true"},"annotations":{"reconcile.io/x":"y"}},"data":{'"$creds_coords"'"AWS_ACCESS_KEY_ID":"QUtJQUVYQU1QTEU=","AWS_SECRET_ACCESS_KEY":"c2VjcmV0a2V5"}}'
+creds_json='{"apiVersion":"v1","kind":"Secret","metadata":{"name":"cozy-backups-creds","namespace":"cozy-velero","resourceVersion":"123","uid":"abc","ownerReferences":[{"name":"projector"}],"labels":{"internal.cozystack.io/tenantresource":"true"},"annotations":{"reconcile.io/x":"y"}},"data":{'"$creds_endpoint_key$creds_coords"'"AWS_ACCESS_KEY_ID":"QUtJQUVYQU1QTEU=","AWS_SECRET_ACCESS_KEY":"c2VjcmV0a2V5"}}'
+
+# BucketClaims as data. The COSI driver assigns .status.bucketName and the
+# projector republishes exactly that as the `bucketName` key, so the DEFAULT
+# claim is provisioned into the same bucket the creds advertise => COSI path.
+# A claim whose status names a DIFFERENT bucket (a stale/Terminating leftover)
+# must not classify the cluster as COSI, which is why the probe matches on
+# status rather than on the claim's existence.
+FAKE_CLAIMS="${FAKE_CLAIMS-tenant-root bucket-cozy-backups cozy-backups-7f3a -}"
+
+# claims_all emits FAKE_CLAIMS followed by FAKE_CLAIM_FILLER synthetic claims.
+# Filler status names are full-length bucket-<uuid> strings because it is the
+# BYTE SIZE of the rendered list, not the claim count, that pushes a streaming
+# consumer past a pipe write boundary.
+claims_all() {
+  printf '%s\n' "$FAKE_CLAIMS"
+  local i=1 n="${FAKE_CLAIM_FILLER:-0}"
+  while [ "$i" -le "$n" ]; do
+    printf 'tenant-f%04d bucket-f%04d bucket-%08x-956e-4630-91f4-e1d265de5f51 -\n' "$i" "$i" "$i"
+    i=$((i + 1))
+  done
+}
+
+# claims_json renders claims_all as a real `kubectl get -A -o json` List.
+claims_json() {
+  local first=1 out='{"apiVersion":"v1","kind":"List","items":[' ns name bn dts item
+  while read -r ns name bn dts; do
+    [ -n "${ns:-}" ] || continue
+    item='{"apiVersion":"objectstorage.k8s.io/v1alpha1","kind":"BucketClaim","metadata":{"namespace":"'"$ns"'","name":"'"$name"'","finalizers":["cosi.objectstorage.k8s.io/bucketclaim-protection"]'
+    [ "${dts:--}" = "-" ] || item="$item"',"deletionTimestamp":"'"$dts"'"'
+    item="$item"'}'
+    if [ "${bn:--}" = "-" ]; then item="$item"',"status":{}}'; else item="$item"',"status":{"bucketName":"'"$bn"'"}}'; fi
+    [ "$first" = 1 ] && { out="$out$item"; first=0; } || out="$out,$item"
+  done < <(claims_all)
+  printf '%s]}\n' "$out"
+}
+
+# claim_exists <ns> <name> -- 0 iff FAKE_CLAIMS lists that claim, regardless of
+# its status. Models the name-keyed single GET, which succeeds for a Terminating
+# claim too (the bucketclaim-protection finalizer keeps the object around).
+claim_exists() {
+  local want_ns="$1" want_name="$2" ns name bn dts
+  while read -r ns name bn dts; do
+    [ -n "${ns:-}" ] || continue
+    [ "$ns" = "$want_ns" ] && [ "$name" = "$want_name" ] && return 0
+  done <<EOF
+$FAKE_CLAIMS
+EOF
+  return 1
+}
 
 emit_clusters_name() { printf '%s\n' "${FAKE_CLUSTERS:-}" | while read -r ns name; do [ -n "$ns" ] && printf 'etcdcluster.etcd.aenix.io/%s\n' "$name"; done; }
 emit_clusters_jsonpath() { printf '%s\n' "${FAKE_CLUSTERS:-}" | while read -r ns name; do [ -n "$ns" ] && printf '%s %s\n' "$ns" "$name"; done; }
@@ -67,6 +159,39 @@ case "$args" in
   *"etcds.strategy.backups.cozystack.io"*)
     [ "${FAKE_STRATEGY:-1}" = "1" ] || exit 1
     printf '%s\n' "$strategy_json"; exit 0 ;;
+
+  # COSI presence. With --ignore-not-found real kubectl distinguishes a genuinely
+  # absent CRD (rc=0, no output) from a failed read (rc!=0) — the script must
+  # treat only the former as "external".
+  *"get crd bucketclaims.objectstorage.k8s.io"*)
+    log "CLAIM-CRD-PROBE"
+    case "${FAKE_CLAIM_CRD:-1}" in
+      1) printf 'customresourcedefinition.apiextensions.k8s.io/bucketclaims.objectstorage.k8s.io\n'; exit 0 ;;
+      0) exit 0 ;;   # --ignore-not-found: absent is a rc=0 empty answer
+      *) exit 1 ;;   # transient read error
+    esac ;;
+
+  # Cluster-wide claim list: the data the probe matches the projected bucketName
+  # against.
+  *"bucketclaims.objectstorage.k8s.io"*"-A"*)
+    log "BUCKETCLAIM-LIST"
+    [ "${FAKE_CLAIM_LIST_ERR:-0}" = "1" ] && exit 1
+    [ "${FAKE_CLAIM_CRD:-1}" = "1" ] || exit 1
+    case "${FAKE_CLAIM_LIST_SHAPE:-}" in
+      items-not-array) printf '{"items":"oops"}\n'; exit 0 ;;
+      no-items)        printf '{"apiVersion":"v1","kind":"List"}\n'; exit 0 ;;
+      not-json)        printf 'definitely not json\n'; exit 0 ;;
+    esac
+    claims_json; exit 0 ;;
+
+  # Name-keyed single GET. Nothing in the migration issues this any more; kept so
+  # the pre-fix script can still be driven against this fixture to prove the new
+  # tests bite.
+  *"bucketclaims.objectstorage.k8s.io"*)
+    log "BUCKETCLAIM-GET"
+    [ "${FAKE_CLAIM_CRD:-1}" = "1" ] || exit 1
+    claim_exists "$(arg_after -n "$@")" "$(arg_after bucketclaims.objectstorage.k8s.io "$@")" || exit 1
+    printf 'bucketclaim.objectstorage.k8s.io/x\n'; exit 0 ;;
 
   *"get secret cozy-backups-creds"*)   # both-keys validation probe AND stage source
     [ "${FAKE_CREDS:-1}" = "1" ] || exit 1

--- a/packages/core/platform/images/migrations/migrations/50
+++ b/packages/core/platform/images/migrations/migrations/50
@@ -29,7 +29,46 @@ DRY_RUN="${MIGRATION_DRY_RUN:-0}"
 # than turn "no backup storage" into a total upgrade block, an operator who
 # accepts adopting live etcd WITHOUT a snapshot can set ETCD_ADOPT_SKIP_BACKUP=1
 # to pass etcd-migrate's --skip-backup. Default 0 keeps the fail-loud behaviour.
+# The platform renders this from migrations.etcdAdoptSkipBackup
+# (templates/migration-hook.yaml), which is the only route an operator has:
+# nothing else can set a var on a Helm-hook Job. Keep the two in lockstep —
+# an unreachable hatch is what the failure messages below used to advertise.
 SKIP_BACKUP="${ETCD_ADOPT_SKIP_BACKUP:-0}"
+
+# _is_true accepts the spellings an operator can plausibly arrive at. The
+# platform renders this var through migrations.etcdAdoptSkipBackup and always
+# emits "1"/"0", so the extra spellings are for the hand-set paths (running this
+# image directly, or a Job edited in place) where "true" is the natural thing to
+# type. A safety valve that is set but silently ignored is the worst outcome
+# here — worse than one that is not offered at all — so recognise the obvious
+# spellings rather than only the documented one. Everything else, including
+# typos, stays false: skipping the snapshot must need an affirmative answer.
+_is_true() {
+  case "$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')" in
+    1 | true | yes) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# _print_skip_backup_hatch spells out how to actually take the hatch. Naming the
+# env var alone is useless advice: this Job is a Helm hook rendered by the
+# platform chart, so an operator cannot set the variable directly and nothing
+# they can edit survives the next render. The Package CR is the only supported
+# route (it is cluster-scoped; the platform chart's own values sit under
+# components.platform). Deliberately not sold as a quick fix — it is a values
+# change plus a re-reconcile, and it must be reverted afterwards.
+_print_skip_backup_hatch() {
+  echo "    kubectl edit package.cozystack.io cozystack.cozystack-platform" >&2
+  echo "    spec:" >&2
+  echo "      components:" >&2
+  echo "        platform:" >&2
+  echo "          values:" >&2
+  echo "            migrations:" >&2
+  echo "              etcdAdoptSkipBackup: true" >&2
+  echo "    Flux then re-renders the platform chart and re-runs this hook, which adopts" >&2
+  echo "    every legacy etcd WITHOUT a snapshot. Set it back to false once the upgrade" >&2
+  echo "    completes, or the next etcd migration will skip its snapshot too." >&2
+}
 
 # Shared cozystack-version stamp helper. Every migration >= 42 must stamp via
 # this (labeled, no-delete-guarded) helper rather than a hand-rolled apply — the
@@ -571,10 +610,11 @@ fi
 # ETCD_ADOPT_SKIP_BACKUP=1 escape hatch; any inbound ETCD_MIGRATE_BACKUP_ARGS is
 # overwritten here on purpose (it can never suppress the snapshot).
 if [ "$LEGACY_COUNT" -gt 0 ]; then
-  if [ "$SKIP_BACKUP" = "1" ]; then
-    echo "WARNING: ETCD_ADOPT_SKIP_BACKUP=1 — adopting live etcd WITHOUT a pre-adoption" >&2
-    echo "  safety snapshot, by explicit operator request. A botched adoption on a" >&2
-    echo "  tenant control-plane etcd is UNRECOVERABLE with no snapshot." >&2
+  if _is_true "$SKIP_BACKUP"; then
+    echo "WARNING: migrations.etcdAdoptSkipBackup is set — adopting live etcd WITHOUT a" >&2
+    echo "  pre-adoption safety snapshot, by explicit operator request. A botched adoption" >&2
+    echo "  on a tenant control-plane etcd is UNRECOVERABLE with no snapshot. Reset the" >&2
+    echo "  flag to false once this upgrade is through." >&2
     ETCD_MIGRATE_BACKUP_ARGS="--skip-backup"
   else
     echo "Resolving platform-managed S3 snapshot target ('${PLATFORM_STRATEGY}' strategy)..."
@@ -590,7 +630,8 @@ if [ "$LEGACY_COUNT" -gt 0 ]; then
       echo "  cozy-backups Bucket and the backupstrategy-controller are healthy, then re-run." >&2
       echo "  If this cluster intentionally has no backup storage (backups disabled," >&2
       echo "  external S3 without staged creds, or SeaweedFS not yet ready) and you accept" >&2
-      echo "  adopting live etcd WITHOUT a snapshot, re-run with ETCD_ADOPT_SKIP_BACKUP=1." >&2
+      echo "  adopting live etcd WITHOUT a snapshot, take the escape hatch:" >&2
+      _print_skip_backup_hatch
       exit 1
     fi
   fi
@@ -659,7 +700,7 @@ if [ "$LEGACY_COUNT" -gt 0 ]; then
   # etcd-migrate's per-namespace snapshot Job mounts PLATFORM_CREDS_SECRET there.
   # Skipped entirely when ETCD_ADOPT_SKIP_BACKUP=1 (no snapshot Job runs, so no
   # creds are needed) — adoption below still proceeds.
-  if [ "$SKIP_BACKUP" != "1" ]; then
+  if ! _is_true "$SKIP_BACKUP"; then
     echo "=== staging snapshot credentials ('${PLATFORM_CREDS_SECRET}') into adopted namespaces ==="
     while read -r ns name; do
       [ -n "$ns" ] || continue

--- a/packages/core/platform/images/migrations/migrations/50
+++ b/packages/core/platform/images/migrations/migrations/50
@@ -211,12 +211,120 @@ ensure_wildcard_sans() {
   done
 }
 
-# secret_val echoes one base64 key from a Secret JSON blob, whitespace-trimmed.
+# secret_val echoes one base64 key from a Secret JSON blob, whitespace-stripped.
 # A trailing newline in the Secret data would otherwise ride into a URL and
-# break it (the same normalization backupstrategy-controller.endpoint applies).
+# break it. Stricter than the `trim` backupstrategy-controller.endpoint applies
+# (edges only): every key read through here is a host, bucket, region or bool,
+# none of which may contain interior whitespace, so stripping it all cannot
+# discard a meaningful value.
 secret_val() {
   printf '%s' "$1" | jq -r --arg k "$2" '.data[$k] // ""' \
     | base64 -d 2>/dev/null | tr -d '[:space:]'
+}
+
+# _cosi_bucket_claimed <bucket> returns 0 iff <bucket> is the S3 bucket some
+# BucketClaim was provisioned into, i.e. the projected credentials describe a
+# COSI bucket rather than an admin-managed external one.
+#
+# Keyed on DATA, not on names: the COSI driver assigns the bucket name and
+# publishes it as BucketClaim .status.bucketName, which is the very value the
+# projector republishes as the `bucketName` key (packages/system/bucket
+# user-credentials.yaml reads BucketInfo spec.bucketName; live-verified equal on
+# a real stand). Matching that makes the probe independent of
+# backupStorage.namespace / .bucketName, which are supported Package-CR
+# overrides this hook cannot see — a claim-name lookup would miss a renamed
+# bucket and misclassify the cluster as external.
+#
+# Data-keying also disposes of the common stale claim: one wedged Terminating
+# (the cosi bucketclaim-protection finalizer outlives an uninstalled COSI
+# controller) whose status carries some OTHER bucket simply does not match.
+#
+# Four-way, because "definitely not COSI", "could not read" and "cannot tell"
+# must never collapse into one answer: guessing "external" on an unreadable API
+# sends a COSI cluster to the v1.5.x plaintext CR endpoint, which is the very P0
+# this hook exists to avoid. Callers must fail loud on 2, and this function
+# prints the specific reason it could not answer.
+#   0 -> a LIVE claim owns the bucket: COSI-provisioned
+#   1 -> definitively unowned: admin-managed external S3
+#   2 -> undeterminable; reason already logged
+#
+# A TERMINATING claim on the MATCHING bucket is treated as ambiguous. It is
+# reachable two ways with opposite answers: an admin who moved COSI -> external
+# S3 reusing the bucket name (external; the claim is a corpse COSI is not around
+# to reap), or a still-COSI cluster whose claim is mid-recreate (COSI). Both
+# readings fail loudly-but-confusingly when wrong — a handshake error against
+# the wrong scheme — so neither buys reliability, and reading it as "external"
+# specifically resurrects the plaintext-:8333 P0.
+#
+# Refusing is a judgement call, not a proof that the two are indistinguishable:
+# comparing the projected host against the CR's would separate them today (reuse
+# -> same host; a v1.5.x mid-recreate -> ACME ingress vs the seaweedfs default).
+# But that leans on the CR being present AND still carrying the v1.5.x default —
+# precisely what this function exists not to trust — so it is a heuristic, and
+# an irreversible live-etcd adoption is the wrong place to spend one. Refuse and
+# let the operator resolve the claim (idempotent: re-run after).
+_cosi_bucket_claimed() {
+  local want="$1" crd claims verdict try
+  # `--ignore-not-found -o name` separates a genuinely absent CRD (rc=0, no
+  # output -> definitive, so it costs no retries and external clusters pay
+  # nothing) from a real read error (rc!=0 -> retry, then refuse).
+  crd=""
+  for try in 1 2 3; do
+    if crd=$(kubectl get crd bucketclaims.objectstorage.k8s.io \
+               --ignore-not-found -o name 2>/dev/null); then
+      [ -n "$crd" ] || return 1
+      break
+    fi
+    if [ "$try" = "3" ]; then
+      echo "  cannot read the BucketClaim CRD (API error): COSI presence unknown" >&2
+      return 2
+    fi
+    sleep 1
+  done
+
+  for try in 1 2 3; do
+    if claims=$(kubectl get bucketclaims.objectstorage.k8s.io -A -o json 2>/dev/null); then
+      # ONE jq process, and nothing downstream that can exit early. A
+      # `jq -r ... | grep -qxF` pipe is unusable here: grep exits on the first
+      # match and SIGPIPEs jq, and `set -o pipefail` reports the RIGHTMOST
+      # non-zero status — jq's 141 — so a MATCH is returned as a failure. It is
+      # a race on the list outgrowing one stdio write (~8KB, i.e. a few hundred
+      # claims) with only a last-line match safe, so it surfaces exactly on the
+      # big multi-tenant clusters this must not misjudge. `any` streams inside
+      # jq: immune to both list size and match position.
+      #
+      # The shape gate is deliberate: without it every unexpected document
+      # (null, items absent/null/not-a-list) silently reads as "no match" =
+      # external = the plaintext P0. No producer emits those — kubectl always
+      # renders a List with an items array — so the gate only ever fires on
+      # something we genuinely cannot interpret, and that must not be an answer.
+      verdict=$(printf '%s' "$claims" | jq -r --arg w "$want" '
+        if (.items | type) != "array" or any(.items[]; type != "object") then "malformed"
+        elif any(.items[]; ((.status?.bucketName? // "") == $w)
+                           and ((.metadata?.deletionTimestamp? // "") == "")) then "cosi"
+        elif any(.items[]; (.status?.bucketName? // "") == $w) then "terminating"
+        else "external"
+        end' 2>/dev/null) || verdict="malformed"
+      case "$verdict" in
+        cosi)     return 0 ;;
+        external) return 1 ;;
+        terminating)
+          echo "  bucket '${want}' is claimed ONLY by a TERMINATING BucketClaim: cannot tell a" >&2
+          echo "  COSI bucket mid-teardown (endpoint = the TLS S3 ingress) from an external" >&2
+          echo "  store that reuses the name (endpoint = whatever the admin configured)." >&2
+          echo "  Resolve the claim — let COSI reap it, or clear its finalizer — then re-run." >&2
+          return 2 ;;
+        *)
+          echo "  unexpected BucketClaim list shape; refusing to interpret it" >&2
+          return 2 ;;
+      esac
+    fi
+    if [ "$try" = "3" ]; then
+      echo "  cannot list BucketClaims (API error): bucket ownership unknown" >&2
+      return 2
+    fi
+    sleep 1
+  done
 }
 
 # resolve_platform_backup_args echoes the etcd-migrate --backup-s3-* flags for
@@ -238,6 +346,9 @@ secret_val() {
 #      that same chart, so on first render the lookup is empty and the Strategy
 #      is silently skipped. Helm lookup only runs at install/upgrade time, so a
 #      cluster that reached 1.5.x in one hop never grows the CR on reconcile.
+#      Reachable ONLY under provisionBucket: true — the helper short-circuits to
+#      .Values.backupStorage.bucketName (non-empty) before the lookup when it is
+#      false, which is what makes the CR a sound fallback on the external path.
 #   2. Present, carrying the static default http://seaweedfs-s3...svc:8333.
 #      Cozystack ships SeaweedFS with enableSecurity=true, so :8333 is a TLS
 #      listener — plaintext against it fails the handshake and every snapshot
@@ -256,7 +367,12 @@ secret_val() {
 # The Strategy CR remains the fallback for the admin-managed external-S3 case
 # (provisionBucket: false), where .Values.backupStorage.endpoint is
 # authoritative and may legitimately be plaintext against a private object
-# store. That path is detected by the absence of a projected endpoint.
+# store. That path is keyed off whether a BucketClaim actually claims the
+# projected bucket (_cosi_bucket_claimed), NOT off a missing projected endpoint:
+# the projector never omits the endpoint — it substitutes
+# BACKUP_STORAGE_ENDPOINT and fails ReasonSourceMalformed when both sources are
+# empty (credentials_projector.go), so a projected Secret always carries one and
+# its presence discriminates nothing.
 resolve_platform_backup_args() {
   local creds ep bucket region fps
   # The credentials Secret must already exist with BOTH AWS keys so the snapshot
@@ -272,16 +388,66 @@ resolve_platform_backup_args() {
   region=$(secret_val "$creds" region)
   fps=$(secret_val "$creds" forcePathStyle)
 
-  if [ -n "$ep" ]; then
-    # Projected (COSI) endpoint: a bare host fronted by the always-TLS S3
-    # ingress. Strip any scheme a future producer might emit, then force https.
-    ep="${ep#https://}"; ep="${ep#http://}"
-    ep="https://${ep}"
+  # An empty bucket cannot be matched against a claim, so it is classified
+  # external and resolved wholly from the CR — what origin/main did.
+  local cosi=1
+  if [ -n "$bucket" ]; then
+    cosi=0; _cosi_bucket_claimed "$bucket" || cosi=$?
+  fi
+  if [ "$cosi" = "2" ]; then
+    echo "  ERROR: could not determine whether bucket '${bucket}' is COSI-provisioned" >&2
+    echo "  (reason above). Refusing to guess the endpoint scheme: a wrong guess snapshots" >&2
+    echo "  to an unreachable endpoint and the adoption fails anyway, so the guess buys" >&2
+    echo "  nothing. Resolve the condition above and re-run — this migration is idempotent." >&2
+    return 1
   fi
 
-  # Fall back to the Strategy CR for anything the projected Secret did not
-  # supply — notably the external-S3 case, which has no projected endpoint.
-  if [ -z "$ep" ] || [ -z "$bucket" ]; then
+  # `[ -n "$ep" ]` guards the forcing itself, not just the classification: an
+  # empty projected endpoint must degrade to the CR fallback below, never to a
+  # scheme-only "https://" that would satisfy the non-empty check at the end and
+  # be passed to etcd-migrate as a destination.
+  if [ "$cosi" = "0" ]; then
+    echo "  bucket '${bucket}' is claimed by a BucketClaim: COSI-provisioned, forcing https" >&2
+    if [ -n "$ep" ]; then
+      # Projected (COSI) endpoint: a bare host fronted by the always-TLS S3
+      # ingress. Strip any scheme a future producer might emit, then force https.
+      ep="${ep#https://}"; ep="${ep#http://}"
+      ep="https://${ep}"
+    fi
+  else
+    # External S3: take EVERY coordinate from the Strategy CR, not just the
+    # endpoint. The CR renders .Values.backupStorage.* and points at this same
+    # cozy-backups-creds (strategy-etcd-default.yaml credentialsSecretRef), so
+    # CR coordinates + these credentials is exactly what this cluster's regular
+    # etcd BackupJobs already use — the one combination proven to work here, and
+    # the bucket an operator will look in for the snapshot. Keeping the Secret's
+    # bucket while taking the CR's endpoint would invent a pairing nothing else
+    # in the system produces: the projector copies bucketName straight from the
+    # admin-managed source Secret and never from backupStorage.bucketName, so
+    # the two can disagree outright. (region can only disagree if the source
+    # Secret overrides it; forcePathStyle is always the platform value on both
+    # sides and cannot.) If CR-bucket + these creds really did not go together,
+    # the cluster's own backups would already be failing — a pre-existing
+    # misconfiguration to fix, not to route around by snapshotting somewhere
+    # nothing else writes.
+    #
+    # Relying on the CR wholesale is safe on this path and only this path:
+    # bucketName short-circuits to .Values.backupStorage.bucketName before the
+    # BucketClaim lookup that races on the COSI path, so `if $bucketName` always
+    # passes and the CR is guaranteed present. The scheme in particular survives
+    # nowhere else — the projector strips it off the host.
+    echo "  no BucketClaim claims bucket '${bucket:-<unset>}': treating as external S3," >&2
+    echo "  taking every coordinate from the '${PLATFORM_STRATEGY}' Strategy CR verbatim" >&2
+    ep=""; bucket=""; region=""; fps=""
+  fi
+
+  # Fill from the Strategy CR: every coordinate on the external-S3 path above,
+  # and on the COSI path only what the projector dropped because its source
+  # Secret did not carry it (setOrDelete deletes an empty value rather than
+  # writing it). The COSI path keeps the projected bucket on purpose — it is the
+  # COSI-assigned name, which the CR can only reproduce via a live lookup that
+  # may not have run.
+  if [ -z "$ep" ] || [ -z "$bucket" ] || [ -z "$region" ] || [ -z "$fps" ]; then
     local cr
     cr=$(kubectl get etcds.strategy.backups.cozystack.io "$PLATFORM_STRATEGY" -o json 2>/dev/null) || cr=""
     if [ -n "$cr" ]; then
@@ -416,6 +582,8 @@ if [ "$LEGACY_COUNT" -gt 0 ]; then
       echo "  -> safety snapshot: ${ETCD_MIGRATE_BACKUP_ARGS}"
     else
       echo "ERROR: refusing to adopt live etcd without a safety snapshot." >&2
+      echo "  See the classification logged above: a bucket claimed by a BucketClaim is" >&2
+      echo "  resolved from the projected Secret, anything else from the Strategy CR." >&2
       echo "  Could not resolve the platform backup target: the '${PLATFORM_STRATEGY}'" >&2
       echo "  strategy and a projected '${PLATFORM_CREDS_SECRET}' Secret (AWS_ACCESS_KEY_ID/" >&2
       echo "  AWS_SECRET_ACCESS_KEY) in '${PLATFORM_CREDS_NS}' are required. Ensure the" >&2

--- a/packages/core/platform/images/migrations/migrations/50
+++ b/packages/core/platform/images/migrations/migrations/50
@@ -211,30 +211,88 @@ ensure_wildcard_sans() {
   done
 }
 
+# secret_val echoes one base64 key from a Secret JSON blob, whitespace-trimmed.
+# A trailing newline in the Secret data would otherwise ride into a URL and
+# break it (the same normalization backupstrategy-controller.endpoint applies).
+secret_val() {
+  printf '%s' "$1" | jq -r --arg k "$2" '.data[$k] // ""' \
+    | base64 -d 2>/dev/null | tr -d '[:space:]'
+}
+
 # resolve_platform_backup_args echoes the etcd-migrate --backup-s3-* flags for
 # the platform-managed safety snapshot, or returns non-zero if the target
-# cannot be resolved (no cozy-default etcd strategy, or no projected creds).
-# Read-only — safe in dry-run. The authoritative endpoint/bucket/region come
-# from the live cozy-default-etcd Strategy CR (rendered with real coordinates
-# by the backupstrategy-controller), so this never drifts from the bucket the
-# regular backups use.
+# cannot be resolved. Read-only — safe in dry-run.
+#
+# The coordinates come from the PROJECTED CREDENTIALS SECRET, not from the live
+# cozy-default-etcd Strategy CR, because this runs as a PRE-upgrade hook: every
+# chart-rendered resource on the cluster still belongs to the version we are
+# upgrading FROM, and cannot be trusted to describe a reachable target.
+#
+# On a v1.5.x cluster the live Strategy CR is wrong in one of two ways, and the
+# platform upgrade is gated behind this snapshot, so neither can self-heal
+# first (the fixed backupstrategy-controller chart only reconciles AFTER the
+# upgrade this hook blocks):
+#
+#   1. Absent. strategy-etcd-default.yaml is guarded by `if $bucketName`, whose
+#      helper `lookup`s the BucketClaim status. The BucketClaim is created by
+#      that same chart, so on first render the lookup is empty and the Strategy
+#      is silently skipped. Helm lookup only runs at install/upgrade time, so a
+#      cluster that reached 1.5.x in one hop never grows the CR on reconcile.
+#   2. Present, carrying the static default http://seaweedfs-s3...svc:8333.
+#      Cozystack ships SeaweedFS with enableSecurity=true, so :8333 is a TLS
+#      listener — plaintext against it fails the handshake and every snapshot
+#      dies. The Etcd Strategy's S3 schema has no caCert/insecureSkipVerify, so
+#      the self-signed in-cluster endpoint is unusable at ANY scheme; a trusted
+#      -cert endpoint is required.
+#
+# PLATFORM_CREDS_SECRET is produced by the projector from the COSI-provisioned
+# bucket's system credentials — bucket provisioning, not chart values — so it
+# describes the live bucket regardless of the version that rendered the chart.
+# It advertises the external S3 ingress (ACME cert) as a bare host, and that
+# ingress is always TLS, so we force https:// exactly as the 1.6 chart helper
+# backupstrategy-controller.endpoint does. We already had to read this Secret
+# for the AWS keys, so this adds no new dependency.
+#
+# The Strategy CR remains the fallback for the admin-managed external-S3 case
+# (provisionBucket: false), where .Values.backupStorage.endpoint is
+# authoritative and may legitimately be plaintext against a private object
+# store. That path is detected by the absence of a projected endpoint.
 resolve_platform_backup_args() {
-  local cr ep bucket region fps
-  cr=$(kubectl get etcds.strategy.backups.cozystack.io "$PLATFORM_STRATEGY" -o json 2>/dev/null) || return 1
-  [ -n "$cr" ] || return 1
-  ep=$(printf '%s' "$cr"     | jq -r '.spec.template.destination.s3.endpoint // ""')
-  bucket=$(printf '%s' "$cr" | jq -r '.spec.template.destination.s3.bucket // ""')
-  region=$(printf '%s' "$cr" | jq -r '.spec.template.destination.s3.region // ""')
-  fps=$(printf '%s' "$cr"    | jq -r '.spec.template.destination.s3.forcePathStyle // false')
-  [ -n "$ep" ] && [ -n "$bucket" ] || return 1
+  local creds ep bucket region fps
   # The credentials Secret must already exist with BOTH AWS keys so the snapshot
   # agent can authenticate. Validate both up front: a Secret missing one key
   # would otherwise abort etcd-migrate AFTER the operator/cert mutations have
   # begun (creds staged, operator scaled to 0).
-  local creds
   creds=$(kubectl -n "$PLATFORM_CREDS_NS" get secret "$PLATFORM_CREDS_SECRET" -o json 2>/dev/null) || return 1
   printf '%s' "$creds" | jq -e '(.data.AWS_ACCESS_KEY_ID // "")     | length > 0' >/dev/null 2>&1 || return 1
   printf '%s' "$creds" | jq -e '(.data.AWS_SECRET_ACCESS_KEY // "") | length > 0' >/dev/null 2>&1 || return 1
+
+  ep=$(secret_val "$creds" endpoint)
+  bucket=$(secret_val "$creds" bucketName)
+  region=$(secret_val "$creds" region)
+  fps=$(secret_val "$creds" forcePathStyle)
+
+  if [ -n "$ep" ]; then
+    # Projected (COSI) endpoint: a bare host fronted by the always-TLS S3
+    # ingress. Strip any scheme a future producer might emit, then force https.
+    ep="${ep#https://}"; ep="${ep#http://}"
+    ep="https://${ep}"
+  fi
+
+  # Fall back to the Strategy CR for anything the projected Secret did not
+  # supply — notably the external-S3 case, which has no projected endpoint.
+  if [ -z "$ep" ] || [ -z "$bucket" ]; then
+    local cr
+    cr=$(kubectl get etcds.strategy.backups.cozystack.io "$PLATFORM_STRATEGY" -o json 2>/dev/null) || cr=""
+    if [ -n "$cr" ]; then
+      [ -n "$ep" ]     || ep=$(printf '%s' "$cr"     | jq -r '.spec.template.destination.s3.endpoint // ""')
+      [ -n "$bucket" ] || bucket=$(printf '%s' "$cr" | jq -r '.spec.template.destination.s3.bucket // ""')
+      [ -n "$region" ] || region=$(printf '%s' "$cr" | jq -r '.spec.template.destination.s3.region // ""')
+      [ -n "$fps" ]    || fps=$(printf '%s' "$cr"    | jq -r '.spec.template.destination.s3.forcePathStyle // false')
+    fi
+  fi
+  [ -n "$ep" ] && [ -n "$bucket" ] || return 1
+
   local args="--backup-s3-endpoint=${ep} --backup-s3-bucket=${bucket}"
   args="${args} --backup-s3-credentials-secret=${PLATFORM_CREDS_SECRET}"
   args="${args} --backup-s3-key=${SNAPSHOT_KEY_PREFIX}"

--- a/packages/core/platform/templates/migration-hook.yaml
+++ b/packages/core/platform/templates/migration-hook.yaml
@@ -2,6 +2,20 @@
 {{- $shouldRunMigrationHook := false }}
 {{- $currentVersion := 0 }}
 {{- $targetVersion := .Values.migrations.targetVersion | int }}
+{{- /*
+  Resolve migrations.etcdAdoptSkipBackup to the exact string migration 50
+  matches. Two hazards, both silent:
+    - the key is absent on a Platform Package that predates it, so `dig` supplies
+      the default rather than letting the whole platform render fail;
+    - the script tests for "1", so a bare bool renders "true" and the hatch is
+      accepted, displayed in the Job spec, and ignored. Normalise through a
+      string so a bool, a quoted "true" out of the Package CR's Values JSON, or
+      a numeric 1 all land on the same answer.
+  Anything unrecognised (nil, garbage) resolves to "0": taking the hatch must
+  require an affirmative spelling, never a typo.
+*/}}
+{{- $skipBackupRaw := dig "etcdAdoptSkipBackup" false .Values.migrations }}
+{{- $skipBackup := has (lower (printf "%v" $skipBackupRaw)) (list "1" "true" "yes") }}
 {{- $configMap := lookup "v1" "ConfigMap" .Release.Namespace "cozystack-version" }}
 {{- if $configMap }}
   {{- $currentVersion = dig "data" "version" "0" $configMap | int }}
@@ -38,6 +52,11 @@ spec:
               value: {{ $currentVersion | quote }}
             - name: TARGET_VERSION
               value: {{ $targetVersion | quote }}
+            # Always emitted, including the "0" default, so the Job spec states
+            # the cluster's safety posture outright: an operator reading the Job
+            # can see whether the snapshot was skipped without diffing values.
+            - name: ETCD_ADOPT_SKIP_BACKUP
+              value: {{ $skipBackup | ternary "1" "0" | quote }}
       restartPolicy: Never
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/packages/core/platform/tests/migration_hook_skip_backup_test.yaml
+++ b/packages/core/platform/tests/migration_hook_skip_backup_test.yaml
@@ -1,0 +1,139 @@
+suite: migrations.etcdAdoptSkipBackup reaches the migration Job as the value the script matches
+templates:
+  - templates/migration-hook.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+# The Job only renders when the cozystack-version ConfigMap reports a version
+# BELOW migrations.targetVersion. Under plain `helm template` (and therefore
+# `helm lint`/CI) lookup returns nil and the whole hook is skipped, so the env
+# block is unreachable without mocking the ConfigMap — which is precisely why
+# this template had no coverage and shipped an unreachable escape hatch.
+kubernetesProvider:
+  scheme:
+    "v1/ConfigMap":
+      gvr:
+        version: "v1"
+        resource: "configmaps"
+      namespaced: true
+  objects:
+    - kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: cozystack-version
+        namespace: cozy-system
+      data:
+        version: "52"
+tests:
+  # The trap this suite exists for: migration 50 tests the env var against the
+  # literal string "1". A bare bool renders "true", which the script does not
+  # match, so the hatch would appear in the Job spec and silently do nothing —
+  # the worst outcome for a safety valve an operator reaches for when stuck.
+  # Assert the RENDERED VALUE, never merely that the var exists.
+  - it: renders ETCD_ADOPT_SKIP_BACKUP=1 (not "true") when the flag is enabled
+    set:
+      migrations:
+        enabled: true
+        etcdAdoptSkipBackup: true
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[3].name
+          value: ETCD_ADOPT_SKIP_BACKUP
+      - equal:
+          path: spec.template.spec.containers[0].env[3].value
+          value: "1"
+
+  - it: renders ETCD_ADOPT_SKIP_BACKUP=0 when the flag is explicitly disabled
+    set:
+      migrations:
+        enabled: true
+        etcdAdoptSkipBackup: false
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[3].value
+          value: "0"
+
+  # A Platform Package predating this knob carries no such key. The chart's own
+  # values.yaml supplies the default on merge, but the template must not depend
+  # on that: a nil here would fail the render of the ENTIRE platform chart and
+  # brick every upgrade — far worse than the hatch being unavailable.
+  - it: renders cleanly and OFF when the key is absent entirely (pre-existing Package CR)
+    set:
+      migrations:
+        enabled: true
+        etcdAdoptSkipBackup: null
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[3].value
+          value: "0"
+
+  # Values arrive as JSON from the Package CR, where a quoted "true" is an easy
+  # mistake. It must take the hatch rather than silently render "0".
+  - it: accepts a stringified true from the Package CR Values JSON
+    set:
+      migrations:
+        enabled: true
+        etcdAdoptSkipBackup: "true"
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[3].value
+          value: "1"
+
+  # The dangerous direction must require an affirmative spelling: anything
+  # unrecognised resolves to "0" rather than being treated as truthy.
+  - it: treats an unrecognised value as OFF, never as an accidental skip
+    set:
+      migrations:
+        enabled: true
+        etcdAdoptSkipBackup: "banana"
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[3].value
+          value: "0"
+
+  # The pre-existing env contract must survive: the script reads all four.
+  - it: keeps NAMESPACE/CURRENT_VERSION/TARGET_VERSION alongside the new var
+    set:
+      migrations:
+        enabled: true
+        etcdAdoptSkipBackup: true
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: NAMESPACE
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: CURRENT_VERSION
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "52"
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: TARGET_VERSION
+
+  - it: emits no Job at all when migrations are disabled
+    set:
+      migrations:
+        enabled: false
+        etcdAdoptSkipBackup: true
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -15,6 +15,24 @@ migrations:
   # a stale pin fails loudly rather than silently skipping the etcd adoption.
   image: ghcr.io/cozystack/cozystack/platform-migrations:v1.5.0@sha256:8bf61f17e99eb4a3365394e3d97ac52a1d68cc84aa104894ecb09de25721dc1d
   targetVersion: 53
+  # Adopt legacy etcd clusters onto the v1alpha2 operator WITHOUT the mandatory
+  # pre-adoption safety snapshot (migration 50). Leave false unless migration 50
+  # has actually refused to proceed and you accept the risk: adoption rewires
+  # ownership of LIVE etcd storage, and a botched adoption on a tenant
+  # control-plane etcd is UNRECOVERABLE with no snapshot.
+  #
+  # Migration 50 refuses when it cannot resolve, or cannot trust, a snapshot
+  # destination — backups disabled, an external S3 whose credentials were never
+  # staged, SeaweedFS not ready at upgrade time, or a bucket it cannot classify.
+  # Those are individually-supported configurations, so rather than leave such a
+  # cluster permanently unable to upgrade, this flag lets an operator proceed
+  # deliberately. Prefer fixing the condition the migration names in its log:
+  # the migration is idempotent, so re-running after the fix is the safe path,
+  # and this flag is the last resort when there is nothing to fix.
+  #
+  # Reset it to false once the upgrade is through, or the next platform upgrade
+  # that adds an etcd migration will skip its snapshot too.
+  etcdAdoptSkipBackup: false
 # Bundle deployment configuration
 bundles:
   system:


### PR DESCRIPTION
## What this PR does

Migration 50 takes a mandatory S3 safety snapshot before adopting live etcd onto the v1alpha2 operator. It is a **`pre-upgrade` hook**, so every chart-rendered resource it reads still belongs to the version being upgraded **from**. It resolved the snapshot target from the live `cozy-default-etcd` Strategy CR — and on a v1.5.x cluster that CR cannot be trusted to describe a reachable target. The platform upgrade is gated behind the snapshot, so nothing can self-heal first: the corrected `backupstrategy-controller.endpoint` helper only reconciles **after** the upgrade this hook blocks.

### Two failure modes, both a hard block

**1. The Strategy CR does not exist.** `strategy-etcd-default.yaml` is guarded by `{{- if $bucketName -}}`, whose helper `lookup`s the BucketClaim's `.status.bucketName`. That BucketClaim is created by the *same chart*, so on first render the lookup is empty and the Strategy is silently skipped. Helm `lookup` only runs at install/upgrade time, so a cluster that reached 1.5.x in one hop never grows the CR on reconcile — a forced reconcile does not produce it.

**2. The Strategy CR exists carrying `http://seaweedfs-s3.tenant-root.svc.cozy.local:8333`** (the static v1.5.x `backupStorage.endpoint` default). Cozystack ships SeaweedFS with `enableSecurity=true`, so `:8333` is a **TLS listener** — plaintext against it fails the handshake and every snapshot dies. Fixing the *scheme* is not sufficient: as `backupstrategy-controller.endpoint` documents, the Etcd Strategy's S3 schema has no `caCert`/`insecureSkipVerify`, so the self-signed in-cluster endpoint is unusable at **any** scheme. A trusted-cert endpoint is required.

## The fix

Take the coordinates from `cozy-backups-creds` instead. The projector writes it from the **COSI-provisioned bucket's system credentials** — bucket provisioning, not chart values — so it describes the live bucket regardless of which version rendered the charts. It carries `endpoint`, `bucketName`, `region` and `forcePathStyle` alongside the AWS keys, and `resolve_platform_backup_args` already read this Secret to validate those keys, so preferring it adds no new dependency.

Both modes disappear: mode 1 because the CR is no longer needed, mode 2 because its endpoint is ignored.

### Classifying COSI vs. external S3

The projected endpoint is a bare host fronted by the always-TLS S3 ingress, so on the platform-managed path we force `https://` — exactly what `backupstrategy-controller.endpoint` does. But the admin-managed external-S3 case (`provisionBucket: false`) must keep `.Values.backupStorage.endpoint` verbatim, since it may legitimately be plaintext against a private store. The two therefore have to be told apart.

**Endpoint presence cannot do that.** `ProjectBackupCredentials` substitutes `BACKUP_STORAGE_ENDPOINT` when the source Secret is silent and then *fails loud* rather than projecting an endpoint-less Secret, so a projected `endpoint` key is **always** present and **always** scheme-stripped — for external S3 too. Classifying on its absence would force `https://` onto a plaintext external store and never consult the CR, which is a regression against a supported, documented configuration.

Instead the hook asks whether the bucket the credentials name is one **COSI actually provisioned**: it matches the projected `bucketName` against `.status.bucketName` of any BucketClaim. That is keyed on data rather than names, so it is independent of `backupStorage.namespace` / `.bucketName` / `bucketNameOverride` — all supported Package-CR overrides the hook cannot see — and a claim-name lookup would misclassify a renamed bucket as external.

Resolution is then:

| cluster state | endpoint | other coordinates |
|---|---|---|
| a **live** BucketClaim claims the bucket | projected host, forced `https://` | projected Secret |
| **no** claim claims the bucket (external S3) | Strategy CR, scheme verbatim | Strategy CR |
| only a **Terminating** claim claims it | refuse | — |
| BucketClaim API unreadable | refuse | — |

On the external path every coordinate comes from the CR, never a Secret/CR hybrid: `strategy-etcd-default.yaml` pairs `bucket` with `credentialsSecretRef: cozy-backups-creds`, so CR coordinates plus the projected credentials is exactly the pairing the cluster's real etcd BackupJobs already use.

### Deliberate behaviour changes

Two states now refuse where `main` proceeded. Both are cases where the classifier cannot read its input, and adopting live etcd is irreversible, so it fails closed with an actionable message rather than guessing:

- **A Terminating BucketClaim on the projected bucket.** Reachable via COSI → external reusing a retained bucket name, where the `bucketclaim-protection` finalizer wedges the corpse permanently. Both readings are reachable and guessing wrong in either direction also ends in a block — just with a confusing TLS/handshake error instead of a precise one. Remedy: let COSI reap the claim, or clear its finalizer, then re-run (migration 50 is idempotent).
- **A sustained BucketClaim API read failure** on a cluster that has COSI installed. A genuinely absent CRD is still a definitive, zero-cost "external" answer and costs no retries.

### The escape hatch is now reachable

The script has always supported `ETCD_ADOPT_SKIP_BACKUP=1` for clusters that intentionally have no backup storage, but `migration-hook.yaml` passed no such variable, so the failure paths advised an action the platform made impossible. It is now plumbed as `migrations.etcdAdoptSkipBackup`, an explicit opt-in defaulting to off, and the operator-facing messages name that knob rather than a variable nobody can set. It also unblocks the two refuse states above.

The template normalises to the exact string the script matches: a bare bool renders `true`, which the script's `= "1"` test would accept into the Job spec and then silently ignore — the worst outcome for a valve reached for under duress. Anything unrecognised resolves to `"0"`, so taking the hatch requires an affirmative spelling and never a typo. A Platform Package predating the key renders cleanly as off.

The script's own check was widened alongside it to accept `1|true|yes` case-insensitively, so a hand-run image honours what an operator actually types. That is a behaviour change beyond plumbing, and it has a cost worth naming: if the template's normalisation were ever dropped, a raw bool would previously have failed safe (snapshot taken) and now fails unsafe (snapshot skipped). The rendered value is pinned by a unit test to prevent that.

`migration-hook.yaml` had no test coverage at all before this: the Job renders only when a `lookup` of `cozystack-version` reports a version below target, and `lookup` returns nil under `helm template`, so lint and CI never rendered the Job. That is structurally why an unreachable escape hatch shipped unnoticed. The new suite mocks the ConfigMap so the Job is rendered and its env asserted by value.

## Tests

The bats fixture modelled `cozy-backups-creds` as carrying only the AWS keys, and test 1 asserted the broken plaintext endpoint **as expected output** — written against the implementation rather than the requirement, against a mock that did not match a real cluster, which is why this shipped green. The fixture now models what the projector and COSI really produce.

Added, each verified to fail before the corresponding fix and pass after:

- platform path derives `https://` from the projected coordinates, and the in-cluster host never appears
- absent Strategy CR still resolves (mode 1)
- external S3 keeps the CR endpoint's scheme verbatim
- external S3 takes **every** coordinate from the CR, never a Secret/CR hybrid
- overridden bucket coordinates still classify as COSI
- a large multi-tenant claim list still classifies correctly (the match must not depend on list size or position)
- a Terminating claim on the projected bucket refuses, and never scales or adopts
- an unreadable BucketClaim CRD / list refuses
- a live claim wins over an unrelated Terminating one
- COSI keeps the projected bucket even when the CR names another
- the skip-backup hatch is honoured, and an unrecognised value does not skip

Suite: 15 → 28, plus a new helm-unittest suite covering the hook's rendered env (chart: 81 → 88 tests).

## Validation

Reproduced end-to-end on a throwaway 3-node stand (fresh v1.4.5 → v1.5.3 → this branch's build). Before: mode 1, version stamp stuck, `cozy-backups` Bucket Ready, `backupstrategy-controller` Ready, creds projected, **zero** Strategy CRs. After: the stamp advanced and the hook completed, with endpoint, bucket, region and path-style all derived from the projected Secret and no Strategy CR in existence. Failure was safe in both cases — it refuses before any mutation: etcd stayed 3/3 Running, the legacy CR un-adopted, no scale-down. The derived `https://` endpoint reproduces the 1.6 chart helper's own output byte-for-byte, and the projected `bucketName` equals the BucketClaim's `.status.bucketName` on a live stand.

## Follow-ups this PR deliberately does not do

- **Fix the `if $bucketName` lookup race** in `strategy-etcd-default.yaml`, so the Strategy exists at all on affected clusters. This PR makes migration 50 independent of it, but the missing CR likely means **default etcd backups are silently broken on 1.5.x clusters**, upgrade or not — the backup e2e is `.disabled`, so CI cannot see it. Possibly related to #3256. Worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backup destination for migration 50 adoption can now derive from projected credentials when available.
  * Added `migrations.etcdAdoptSkipBackup` to control whether the migration job skips pre-adoption snapshot safety checks.
* **Bug Fixes**
  * Improved COSI vs external S3 classification and endpoint normalization; clearer failures when destination can’t be resolved.
  * `ETCD_ADOPT_SKIP_BACKUP` now honors true/false and rejects unrecognized values (does not skip by accident).
* **Tests**
  * Expanded end-to-end coverage for projected vs external S3 behavior, precedence rules, and non-destructive failure scenarios.
  * Added migration hook tests validating `ETCD_ADOPT_SKIP_BACKUP` env-var mapping and defaulting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->