### PR TITLE
fix(seaweedfs): close the 4.31 rename fallout on the 1.5.x→1.6 upgrade path

### DIFF
--- a/docs/operations/seaweedfs-431-rename-recovery.md
+++ b/docs/operations/seaweedfs-431-rename-recovery.md
@@ -2,6 +2,8 @@
 
 This runbook covers clusters affected by the SeaweedFS chart-rename regression introduced when the vendored chart was bumped from `4.0.405` to `4.31.0` (Cozystack v1.5.0). Use it to classify each tenant, and to recover the ones that need an operator before they can be upgraded.
 
+**Scope — the default instance name is assumed throughout.** The supported way to run SeaweedFS is the tenant module: the tenant chart creates the instance under the fixed name `seaweedfs` (`packages/apps/tenant/templates/seaweedfs.yaml` hardcodes it; a tenant only enables or disables the module). Every shell selector below assumes that name. The API does not yet enforce it, so an instance created directly against `seaweedfses.apps.cozystack.io` under another name can exist — the audit script still classifies it (its release is `<name>-system`), but **do not run the shell loops here against it: escalate instead**, because the name-based `grep seaweedfs` filters cannot see claims whose names the chart truncated (instance names of roughly 30+ characters), and the chart guard's reconstruction does not cover the zone/pool volume components of long-named instances. One accepted limit applies even to default-named instances: a zone or pool **key** of roughly 40+ characters pushes `seaweedfs-system-volume-<key>` past the chart's truncation limit and similarly out of the guard's reconstruction — do not use keys that long.
+
 ## Background
 
 Before 4.31 the chart named workloads after the chart (`seaweedfs-*`), ignoring the release name. 4.31 names them after the release, and the data-plane HelmRelease is `<name>-system`, so every StatefulSet wanted to become `seaweedfs-system-*`. StatefulSet names are immutable, so the upgrade could not rename in place — Helm stood up a second, duplicate set beside the running one. Depending on cluster size the duplicate either deadlocks or splits:
@@ -63,21 +65,48 @@ It reports one class per SeaweedFS instance, matching exactly what the chart's g
 | `S` | Only the release-named generation — installed fresh on 1.5.x, or a long instance name. | Step 2, before upgrading. |
 | `MIXED` | Both generations. The chart **refuses**. | Below. |
 
-For `MIXED` it also names which generation is **original**, from two independent durable signals: the naming scheme revision 1 of the `<name>-system` release was installed with, and the age of each generation's **PersistentVolumes** measured against that release's `first_deployed`. It reads PV timestamps, never claim timestamps — Step 2 deletes each release-named claim and recreates it under the chart name against the same PV, so claim age is not durable and inverts for a tenant interrupted mid-re-bind. Such a tenant has both generations sitting at `first_deployed`, and the audit reports `MID-REBIND`: finish Step 2, do not run Step 2a.
+For `MIXED` it also names which generation is **original**, from two independent durable signals: the naming scheme revision 1 of the `<name>-system` release was installed with, and each generation's **PersistentVolume** creation timestamps. It reads PV timestamps, never claim timestamps — Step 2 deletes each release-named claim and recreates it under the chart name against the same PV, so claim age is not durable and inverts for a tenant interrupted mid-re-bind. The direction rule is **relative, never a clock**: a generation is the candidate duplicate only when *every* one of its bound PVs is strictly newer than every bound PV of the other generation — the same precondition Step 2a enforces. A tenant interrupted mid-re-bind has both generations on original-vintage PVs, so their ranges **overlap** and the audit names no candidate: finish Step 2, do not run Step 2a.
 
 **Read the audit's own warning.** "Original" is not "the other one is empty", and the gap is exactly where it matters. A duplicate that never scheduled (safe to delete) and one that served writes and later crashed or was scaled down (holds unique objects, deleting destroys them) are **identical on every durable signal** — same revision-1 scheme, same `first_deployed` deltas. The audit narrows the question to one generation; it does not answer it. Before deleting anything, establish that the candidate is empty:
 
+Empty means: no volume files (`.dat`/`.idx`/`.vif`) in any data directory. Do **not** `kubectl exec` into the candidate's own pods to check — a wedged duplicate's pods never start, so a check that needs the pod running is unexecutable exactly for the class where it matters most. Mount the claims instead:
+
 ```sh
 ns=<tenant>
-# The candidate's volume servers hold no volume files: an empty /data, no .dat/.idx.
-# Run per replica. If a server cannot be started, you cannot conclude it is empty.
-kubectl -n "$ns" exec <candidate-volume-pod> -- sh -c 'ls -la /data; du -sh /data'
-# Cross-check against the cluster's own accounting: no volumes attributed to the
-# candidate's servers.
-kubectl -n "$ns" exec <master-pod> -- weed shell -c "volume.list"
+# 1. Stop the candidate's workloads so its RWO claims can be mounted elsewhere.
+#    Reversible, and it is Step 3's first action anyway (Step 2a's for S-damaged).
+# 2. A candidate claim still Pending has no PV and therefore no data — empty by
+#    construction; skip it.
+# 3. Mount each BOUND candidate claim read-only in a scratch pod:
+pvc=<candidate-volume-claim>     # e.g. data1-seaweedfs-system-volume-0; repeat per claim
+kubectl -n "$ns" apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: swfs-emptiness-check
+spec:
+  restartPolicy: Never
+  containers:
+  - name: inspect
+    image: busybox:1.37
+    command: ["sh", "-c", "ls -laR /data; echo '--- volume file count:'; find /data \( -name '*.dat' -o -name '*.idx' -o -name '*.vif' \) | wc -l"]
+    volumeMounts:
+    - { name: data, mountPath: /data, readOnly: true }
+  volumes:
+  - name: data
+    persistentVolumeClaim: { claimName: ${pvc}, readOnly: true }
+EOF
+kubectl -n "$ns" wait --for=jsonpath='{.status.phase}'=Succeeded pod/swfs-emptiness-check --timeout=120s
+kubectl -n "$ns" logs swfs-emptiness-check      # empty = volume file count 0
+kubectl -n "$ns" delete pod swfs-emptiness-check
+
+# Cross-check against the cluster's own accounting, on the AUTHORITATIVE set's
+# running master (exec is fine there — that set is serving): no volumes may be
+# attributed to the candidate's servers.
+kubectl -n "$ns" exec <authoritative-master-pod> -- weed shell -c "volume.list"
 ```
 
-If the candidate's servers cannot be inspected, or the two views disagree, **stop and escalate**. Both generations holding real data is recoverable; deleting the wrong one is not.
+If a candidate claim cannot be inspected, or the two views disagree, **stop and escalate**. Both generations holding real data is recoverable; deleting the wrong one is not.
 
 **D-wedged** — a duplicate that never scheduled — is `MIXED` too, and the chart refuses it like any other duplicate. On main it rendered through, because a duplicate reading `readyReplicas: 0` was taken as proof it never served. That is not proof: a duplicate that served writes and later crashed or was scaled down reads identically. Confirm emptiness as above, then remove it via Step 3 **before** upgrading.
 

--- a/docs/operations/seaweedfs-431-rename-recovery.md
+++ b/docs/operations/seaweedfs-431-rename-recovery.md
@@ -11,7 +11,7 @@ Before 4.31 the chart named workloads after the chart (`seaweedfs-*`), ignoring 
 
 The fix pins `fullnameOverride: seaweedfs` in `system/seaweedfs` values, so workloads are always named after the chart, exactly as they were before 4.31. Upgrading past the bump therefore **adopts the running set and its volumes in place**.
 
-One class cannot be adopted that way: a tenant installed **fresh on 1.5.x**, whose data was written under the release-based names and lives on `data1-seaweedfs-system-volume-*` PVCs. Pinning the chart name there would rename the workloads *away* from that data. Helm cannot move data between PVCs, so `extra/seaweedfs` refuses to render for such a tenant and points here. Re-bind its volumes (below) before upgrading.
+One class cannot be adopted that way: a tenant installed **fresh on 1.5.x**, whose data was written under the release-based names and lives on `data1-seaweedfs-system-volume-*` PVCs. Pinning the chart name there would rename the workloads *away* from that data. Helm cannot move data between PVCs, so the charts refuse to render for such a tenant and point here. The **enforcing** guard lives in `system/seaweedfs` (`templates/naming-guard.yaml`) — the `<name>-system` HelmRelease pulls that chart straight from a platform-managed ExternalArtifact, so a platform upgrade re-renders it directly and nothing else stands between the upgrade and the tenant's workloads; `extra/seaweedfs` carries a sibling copy so the refusal is also visible on the SeaweedFS application itself. Re-bind the tenant's volumes (below) before upgrading.
 
 ## Step 1 — Audit the fleet (read-only)
 
@@ -30,15 +30,26 @@ nss=$(kubectl get pvc -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "
         | awk '$2 ~ /^data1-.*volume/ && $2 ~ /seaweedfs/ {print $1}' | sort -u)
 [ -z "${nss}" ] && { echo "(no SeaweedFS volume PVCs found)"; exit 0; }
 for ns in ${nss}; do
-  pvcs=$(kubectl get pvc -n "$ns" -o name | sed 's|persistentvolumeclaim/||')
+  # name<TAB>creationTimestamp — the AGE ordering below tells a genuine D tenant
+  # from an S tenant that an unguarded upgrade already damaged.
+  pvcs=$(kubectl get pvc -n "$ns" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.creationTimestamp}{"\n"}{end}')
   legacy=$(echo "$pvcs" | grep -cE '^data1-seaweedfs-volume' || true)
   system=$(echo "$pvcs" | grep -E '^data1-.*volume' | grep -E 'seaweedfs' | grep -vE '^data1-seaweedfs-volume' | grep -c . || true)
+  legacy_oldest=$(echo "$pvcs" | grep -E '^data1-seaweedfs-volume' | cut -f2 | sort | head -1)
+  system_oldest=$(echo "$pvcs" | grep -E '^data1-.*volume' | grep -E 'seaweedfs' | grep -vE '^data1-seaweedfs-volume' | cut -f2 | sort | head -1)
   running_new=$(kubectl get pods -n "$ns" \
       -l app.kubernetes.io/name=seaweedfs,app.kubernetes.io/component=volume \
       --field-selector=status.phase=Running -o name 2>/dev/null \
       | grep -vc '/seaweedfs-volume-' || true)
   if [ "$legacy" -gt 0 ] && [ "$system" -gt 0 ]; then
-    if [ "${running_new:-0}" -gt 0 ]; then
+    # PVCs are never recreated in place, so the OLDER generation is where the
+    # data was born. Renamed older ⇒ a fresh-1.5.x tenant that an unguarded
+    # 1.6.0 upgrade already hit: the chart-named set is the NEWER, EMPTY one.
+    # That tenant is S (recover via Step 2a + Step 2), NEVER D-split — the
+    # D-split procedure would quiesce the set that holds all the data.
+    if [ "$system_oldest" \< "$legacy_oldest" ]; then
+      printf '%-28s %-10s %s\n' "$ns" "S-damaged" "renamed volumes are OLDER: data born there, chart-named set is empty (Step 2a, then Step 2)"
+    elif [ "${running_new:-0}" -gt 0 ]; then
       printf '%-28s %-10s %s\n' "$ns" "D-split" "DANGER: duplicate volume servers Running — audit before upgrading"
     else
       printf '%-28s %-10s %s\n' "$ns" "D-wedged" "duplicate set never served; upgrade adopts the legacy set"
@@ -51,7 +62,16 @@ for ns in ${nss}; do
 done
 ```
 
-Act on the classes in this order: resolve every **D-split** and every **S** tenant first (both need an operator), then upgrade. **L** and **D-wedged** need nothing.
+Act on the classes in this order: resolve every **D-split**, **S** and **S-damaged** tenant first (all need an operator), then upgrade. **L** needs nothing.
+
+**D-wedged** normally needs nothing — but on a cluster with no spare nodes (nodes ≤ replicas) the adoption rollout can stall: the wedged duplicate pods are still *scheduled*, carry the same labels as the adopted set (including `app.kubernetes.io/instance`), and their hard pod anti-affinity blocks the adopted set's rolled pods from landing anywhere (observed as `seaweedfs-filer-1`/`seaweedfs-master-2` stuck Pending on `didn't match pod anti-affinity rules`, wedging the `<name>-system` HelmRelease in upgrade/rollback loops). If that happens, scale the duplicate down first — it never served, so this is safe:
+
+```sh
+ns=<tenant>
+kubectl -n "$ns" get sts -l app.kubernetes.io/name=seaweedfs -o name | sed 's|statefulset.apps/||' \
+  | grep -vE '^seaweedfs-(master|filer|volume)($|-)' \
+  | xargs -r -I{} kubectl -n "$ns" scale sts {} --replicas=0
+```
 
 ## Step 2 — `S` tenants: re-bind the volumes before upgrading
 
@@ -126,6 +146,29 @@ kubectl -n "$ns" patch helmrelease "${app}-system" --type merge -p '{"spec":{"su
 Then upgrade. The filer metadata lives in the shared `seaweedfs-db` Postgres and is name-independent, and the volume IDs travel with the volumes themselves, so the adopted cluster comes back with its objects intact.
 
 The loop handles pools and zones (their PVC names carry the pool/zone key) and both renamed shapes: `data1-seaweedfs-system-volume-*` for the default instance, and `data1-<name>-system-seaweedfs-volume-*` for an instance running under another name, because 4.31's name helper appends the chart name when the release name does not contain it.
+
+## Step 2a — `S-damaged` tenants: remove the empty chart-named set first
+
+An `S` tenant that an unguarded 1.6.0 upgrade already reached has an extra problem: the upgrade **created** chart-named workloads (`seaweedfs-master/-filer/-volume`, an s3 Deployment) and **empty** `data1-seaweedfs-volume-*` PVCs beside the live renamed set, and deleted the renamed `<fullname>-s3` Service (only `seaweedfs-s3` remains — its endpoints may still resolve to the renamed set's pods because both sets carry identical labels, which is luck, not design: if the chart-named pods ever become Ready, the Service splits reads across a live set and an empty one).
+
+Verify the direction before touching anything — the chart-named PVCs must be the **newer** generation (compare `kubectl get pvc -o custom-columns=NAME:.metadata.name,CREATED:.metadata.creationTimestamp`), matching the `S-damaged` audit row. Then clear the empty chart-named set so Step 2 can re-bind onto those names:
+
+```sh
+ns=<tenant>
+app=<seaweedfs-instance-name>
+kubectl -n "$ns" patch helmrelease "${app}-system" --type merge -p '{"spec":{"suspend":true}}'
+# The chart-named workloads were created by the aborted upgrade and never held
+# data. Delete them so the re-bind can take over their names.
+kubectl -n "$ns" delete sts seaweedfs-master seaweedfs-filer --ignore-not-found
+kubectl -n "$ns" get sts -o name | sed 's|statefulset.apps/||' | grep -E '^seaweedfs-volume($|-)' \
+  | xargs -r -I{} kubectl -n "$ns" delete sts {}
+# The EMPTY chart-named claims block Step 2's re-bind (same names). Double-check
+# each is the newer, never-served generation before deleting.
+kubectl -n "$ns" get pvc -o name | sed 's|persistentvolumeclaim/||' | grep -E '^data1-seaweedfs-volume' \
+  | xargs -r -I{} kubectl -n "$ns" delete pvc {}
+```
+
+Leave the HelmRelease suspended and continue with Step 2 (skip its suspend line; the renamed StatefulSets it scales down are the ones holding the data, exactly as in a plain `S` tenant). Do NOT scale down or delete anything named `*-system-*` before its volumes are re-bound.
 
 ## Step 3 — `D-split` tenants: stop the split before upgrading
 

--- a/docs/operations/seaweedfs-431-rename-recovery.md
+++ b/docs/operations/seaweedfs-431-rename-recovery.md
@@ -6,12 +6,19 @@ This runbook covers clusters affected by the SeaweedFS chart-rename regression i
 
 Before 4.31 the chart named workloads after the chart (`seaweedfs-*`), ignoring the release name. 4.31 names them after the release, and the data-plane HelmRelease is `<name>-system`, so every StatefulSet wanted to become `seaweedfs-system-*`. StatefulSet names are immutable, so the upgrade could not rename in place — Helm stood up a second, duplicate set beside the running one. Depending on cluster size the duplicate either deadlocks or splits:
 
-- **D-wedged** — with as many nodes as master replicas, the new masters cannot schedule (hard pod anti-affinity against the old masters). The new set stays `Pending`/`CrashLoopBackOff`, the old set keeps serving. No data at risk.
+- **D-wedged** — with as many nodes as master replicas, the new masters cannot schedule (hard pod anti-affinity against the old masters). The new set stays `Pending`/`CrashLoopBackOff`, the old set keeps serving. Usually no data at risk — but "usually" is not something a Helm render can verify (a duplicate that served writes and later crashed or was scaled down is indistinguishable from one that never started), so the chart refuses these too rather than adopt on an assumption.
 - **D-split** — with more nodes than masters, the new (empty) set comes up. Both sets carry identical pod labels, so the `seaweedfs-s3` Service load-balances across them, and both filers write to the **same `seaweedfs-db` Postgres** metadata store while pointing at different volume servers. This is a data-integrity incident, not just a duplicate: reads of existing objects through the new endpoint miss, new writes land on empty volumes, and the two master sets hand out volume IDs from independent sequences into one shared metadata table.
 
 The fix pins `fullnameOverride: seaweedfs` in `system/seaweedfs` values, so workloads are always named after the chart, exactly as they were before 4.31. Upgrading past the bump therefore **adopts the running set and its volumes in place**.
 
-One class cannot be adopted that way: a tenant installed **fresh on 1.5.x**, whose data was written under the release-based names and lives on `data1-seaweedfs-system-volume-*` PVCs. Pinning the chart name there would rename the workloads *away* from that data. Helm cannot move data between PVCs, so the charts refuse to render for such a tenant and point here. The **enforcing** guard lives in `system/seaweedfs` (`templates/naming-guard.yaml`) — the `<name>-system` HelmRelease pulls that chart straight from a platform-managed ExternalArtifact, so a platform upgrade re-renders it directly and nothing else stands between the upgrade and the tenant's workloads; `extra/seaweedfs` carries a sibling copy so the refusal is also visible on the SeaweedFS application itself. Re-bind the tenant's volumes (below) before upgrading.
+Two states cannot be adopted that way, and the charts refuse to render for both rather than guess:
+
+- A tenant installed **fresh on 1.5.x**, whose data was written under the release-based names and lives on `data1-seaweedfs-system-volume-*` PVCs. Pinning the chart name there would rename the workloads *away* from that data, and Helm cannot move data between PVCs. Re-bind its volumes (Step 2) before upgrading.
+- A tenant where **both** naming generations exist. One of them is an empty duplicate and one holds the data — but nothing durable in the object graph says which. Claim timestamps are not evidence: Step 2's own re-bind deletes and recreates claims, so a tenant interrupted mid-recovery has a brand-new claim holding real data. StatefulSets are recreated by the adoption hook. `readyReplicas: 0` does not prove a duplicate never served. Rendering would adopt the chart-named set, so a wrong guess strands or destroys data. Step 1 classifies these with signals a template does not have; once the empty generation is deleted, exactly one remains and the render proceeds on its own.
+
+The **enforcing** guard lives in `system/seaweedfs` (`templates/naming-guard.yaml`) — the `<name>-system` HelmRelease pulls that chart straight from a platform-managed ExternalArtifact, so a platform upgrade re-renders it directly and nothing else stands between the upgrade and the tenant's workloads; `extra/seaweedfs` carries a sibling copy so the refusal is also visible on the SeaweedFS application itself.
+
+A tenant upgrading **1.4.x straight to 1.6 never renames**, so it only ever has one generation and is unaffected by any of this. Duplicates exist only on tenants that passed through 1.5.x.
 
 ## Step 0 — `seaweedfs-db` ownership check (read-only, do this FIRST)
 
@@ -41,63 +48,40 @@ A tenant with a SeaweedFS instance but **no `seaweedfs-db` row** has already had
 
 ## Step 1 — Audit the fleet (read-only)
 
-Run per cluster (`KUBECONFIG` pointed at each). It mutates nothing. Classification is driven by the **PVCs**, because they hold the data and outlive any workload.
-
 ```sh
-#!/usr/bin/env bash
-set -euo pipefail
-printf '%-28s %-10s %s\n' NAMESPACE CLASS NOTE
-printf '%-28s %-10s %s\n' --------- ----- ----
-# A volume PVC is data1-<fullname>-volume[-<pool|zone>]-N. Pre-4.31 <fullname> was
-# always the chart name, so legacy data is data1-seaweedfs-volume-*. On 4.31 it is
-# the release name, plus the chart name when the release does not contain it:
-# seaweedfs-system-* for the default instance, <name>-system-seaweedfs-* otherwise.
-nss=$(kubectl get pvc -A -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{"\n"}{end}' \
-        | awk '$2 ~ /^data1-.*volume/ && $2 ~ /seaweedfs/ {print $1}' | sort -u)
-[ -z "${nss}" ] && { echo "(no SeaweedFS volume PVCs found)"; exit 0; }
-for ns in ${nss}; do
-  # name<TAB>creationTimestamp — the AGE ordering below tells a genuine D tenant
-  # from an S tenant that an unguarded upgrade already damaged.
-  pvcs=$(kubectl get pvc -n "$ns" -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.creationTimestamp}{"\n"}{end}')
-  legacy=$(echo "$pvcs" | grep -cE '^data1-seaweedfs-volume' || true)
-  system=$(echo "$pvcs" | grep -E '^data1-.*volume' | grep -E 'seaweedfs' | grep -vE '^data1-seaweedfs-volume' | grep -c . || true)
-  legacy_oldest=$(echo "$pvcs" | grep -E '^data1-seaweedfs-volume' | cut -f2 | sort | head -1)
-  system_oldest=$(echo "$pvcs" | grep -E '^data1-.*volume' | grep -E 'seaweedfs' | grep -vE '^data1-seaweedfs-volume' | cut -f2 | sort | head -1)
-  running_new=$(kubectl get pods -n "$ns" \
-      -l app.kubernetes.io/name=seaweedfs,app.kubernetes.io/component=volume \
-      --field-selector=status.phase=Running -o name 2>/dev/null \
-      | grep -vc '/seaweedfs-volume-' || true)
-  if [ "$legacy" -gt 0 ] && [ "$system" -gt 0 ]; then
-    # PVCs are never recreated in place, so the OLDER generation is where the
-    # data was born. Renamed older ⇒ a fresh-1.5.x tenant that an unguarded
-    # 1.6.0 upgrade already hit: the chart-named set is the NEWER, EMPTY one.
-    # That tenant is S (recover via Step 2a + Step 2), NEVER D-split — the
-    # D-split procedure would quiesce the set that holds all the data.
-    if [ "$system_oldest" \< "$legacy_oldest" ]; then
-      printf '%-28s %-10s %s\n' "$ns" "S-damaged" "renamed volumes are OLDER: data born there, chart-named set is empty (Step 2a, then Step 2)"
-    elif [ "${running_new:-0}" -gt 0 ]; then
-      printf '%-28s %-10s %s\n' "$ns" "D-split" "DANGER: duplicate volume servers Running — audit before upgrading"
-    else
-      printf '%-28s %-10s %s\n' "$ns" "D-wedged" "duplicate set never served; upgrade adopts the legacy set"
-    fi
-  elif [ "$legacy" -gt 0 ]; then
-    printf '%-28s %-10s %s\n' "$ns" "L" "pre-1.5 naming; upgrade adopts in place, nothing to do"
-  else
-    printf '%-28s %-10s %s\n' "$ns" "S" "fresh 1.5.x install; re-bind volumes (Step 2) BEFORE upgrading"
-  fi
-done
+hack/seaweedfs-naming-audit.sh                 # whole cluster
+hack/seaweedfs-naming-audit.sh tenant-foo      # or named namespaces
 ```
 
-Act on the classes in this order: resolve every **D-split**, **S** and **S-damaged** tenant first (all need an operator), then upgrade. **L** needs nothing.
+It mutates nothing. Earlier revisions of this runbook inlined the classification as a shell snippet here; it is a tested script now (`hack/seaweedfs-naming-audit.bats`), because it is what the chart's refusal hands you to and acting on it deletes PVCs. Two inline versions shipped wrong — one whose selector matched both generations at once and so inverted its own primary rule, one that could not see a long instance name at all — so it is not a snippet any more.
 
-**D-wedged** normally needs nothing — but on a cluster with no spare nodes (nodes ≤ replicas) the adoption rollout can stall: the wedged duplicate pods are still *scheduled*, carry the same labels as the adopted set (including `app.kubernetes.io/instance`), and their hard pod anti-affinity blocks the adopted set's rolled pods from landing anywhere (observed as `seaweedfs-filer-1`/`seaweedfs-master-2` stuck Pending on `didn't match pod anti-affinity rules`, wedging the `<name>-system` HelmRelease in upgrade/rollback loops). If that happens, scale the duplicate down first — it never served, so this is safe:
+It reports one class per SeaweedFS instance, matching exactly what the chart's guard decides:
+
+| CLASS | Meaning | Action |
+|---|---|---|
+| `L` | Only the chart-named generation. | None. The upgrade adopts it in place. |
+| `S` | Only the release-named generation — installed fresh on 1.5.x, or a long instance name. | Step 2, before upgrading. |
+| `MIXED` | Both generations. The chart **refuses**. | Below. |
+
+For `MIXED` it also names which generation is **original**, from two independent durable signals: the naming scheme revision 1 of the `<name>-system` release was installed with, and the age of each generation's **PersistentVolumes** measured against that release's `first_deployed`. It reads PV timestamps, never claim timestamps — Step 2 deletes each release-named claim and recreates it under the chart name against the same PV, so claim age is not durable and inverts for a tenant interrupted mid-re-bind. Such a tenant has both generations sitting at `first_deployed`, and the audit reports `MID-REBIND`: finish Step 2, do not run Step 2a.
+
+**Read the audit's own warning.** "Original" is not "the other one is empty", and the gap is exactly where it matters. A duplicate that never scheduled (safe to delete) and one that served writes and later crashed or was scaled down (holds unique objects, deleting destroys them) are **identical on every durable signal** — same revision-1 scheme, same `first_deployed` deltas. The audit narrows the question to one generation; it does not answer it. Before deleting anything, establish that the candidate is empty:
 
 ```sh
 ns=<tenant>
-kubectl -n "$ns" get sts -l app.kubernetes.io/name=seaweedfs -o name | sed 's|statefulset.apps/||' \
-  | grep -vE '^seaweedfs-(master|filer|volume)($|-)' \
-  | xargs -r -I{} kubectl -n "$ns" scale sts {} --replicas=0
+# The candidate's volume servers hold no volume files: an empty /data, no .dat/.idx.
+# Run per replica. If a server cannot be started, you cannot conclude it is empty.
+kubectl -n "$ns" exec <candidate-volume-pod> -- sh -c 'ls -la /data; du -sh /data'
+# Cross-check against the cluster's own accounting: no volumes attributed to the
+# candidate's servers.
+kubectl -n "$ns" exec <master-pod> -- weed shell -c "volume.list"
 ```
+
+If the candidate's servers cannot be inspected, or the two views disagree, **stop and escalate**. Both generations holding real data is recoverable; deleting the wrong one is not.
+
+**D-wedged** — a duplicate that never scheduled — is `MIXED` too, and the chart refuses it like any other duplicate. On main it rendered through, because a duplicate reading `readyReplicas: 0` was taken as proof it never served. That is not proof: a duplicate that served writes and later crashed or was scaled down reads identically. Confirm emptiness as above, then remove it via Step 3 **before** upgrading.
+
+On a cluster with no spare nodes (nodes ≤ replicas) a wedged duplicate also blocks the adoption rollout even once the render passes: its pods are still *scheduled*, carry the same labels as the adopted set (including `app.kubernetes.io/instance`), and their hard pod anti-affinity keeps the adopted set's rolled pods from landing anywhere (observed as `seaweedfs-filer-1`/`seaweedfs-master-2` stuck Pending on `didn't match pod anti-affinity rules`, wedging the `<name>-system` HelmRelease in upgrade/rollback loops). Step 3 removes it, which resolves that too.
 
 ## Step 2 — `S` tenants: re-bind the volumes before upgrading
 
@@ -130,9 +114,14 @@ for pvc in $(kubectl -n "$ns" get pvc -o name | sed 's|persistentvolumeclaim/||'
   pv=$(kubectl -n "$ns" get pvc "$pvc" -o jsonpath='{.spec.volumeName}')
   sc=$(kubectl -n "$ns" get pvc "$pvc" -o jsonpath='{.spec.storageClassName}')
   size=$(kubectl -n "$ns" get pvc "$pvc" -o jsonpath='{.spec.resources.requests.storage}')
-  # Remember the PV's own reclaim policy: it is restored verbatim below, so a volume
-  # the cluster deliberately set to Retain does not silently come back as Delete.
+  # Stash the PV's own reclaim policy ON THE PV before changing it, so a volume the
+  # cluster deliberately set to Retain does not silently come back as Delete -- and
+  # so the record survives this loop being interrupted, which a shell variable would
+  # not. Step 5 restores it from the annotation once the tenant is verified healthy.
   reclaim=$(kubectl get pv "$pv" -o jsonpath='{.spec.persistentVolumeReclaimPolicy}')
+  if [ -z "$(kubectl get pv "$pv" -o jsonpath='{.metadata.annotations.cozystack\.io/original-reclaim-policy}')" ]; then
+    kubectl annotate pv "$pv" "cozystack.io/original-reclaim-policy=${reclaim}"
+  fi
 
   # Keep the PV (and the data) when the claim goes away.
   kubectl patch pv "$pv" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
@@ -140,12 +129,20 @@ for pvc in $(kubectl -n "$ns" get pvc -o name | sed 's|persistentvolumeclaim/||'
   # A Released PV cannot be re-bound until its old claimRef is cleared.
   kubectl patch pv "$pv" --type json -p '[{"op":"remove","path":"/spec/claimRef"}]'
 
+  # The labels matter: the post-delete cleanup hook selects volume PVCs by
+  # app.kubernetes.io/name + instance, and StatefulSet reconciliation does NOT
+  # retrofit claim-template labels onto an existing PVC. A claim recreated without
+  # them is invisible to that hook forever, so a recovered tenant would leak its
+  # volumes on a later app deletion.
   kubectl -n "$ns" apply -f - <<EOF
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ${new_pvc}
   namespace: ${ns}
+  labels:
+    app.kubernetes.io/name: seaweedfs
+    app.kubernetes.io/instance: ${app}-system
 spec:
   accessModes: ["ReadWriteOnce"]
   storageClassName: ${sc}
@@ -154,8 +151,10 @@ spec:
     requests:
       storage: ${size}
 EOF
-  # Restore the PV's original reclaim policy now that the new claim owns it.
-  kubectl patch pv "$pv" -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"${reclaim}\"}}"
+  # NOTE: the reclaim policy stays Retain until Step 5. Restoring it here (as this
+  # runbook used to) re-arms Delete while the tenant is still mid-recovery, which is
+  # what turned a later mis-step into permanent data loss: on a Delete-policy
+  # StorageClass, deleting the claim takes the PV and the bytes with it.
 done
 
 # 3. Confirm every new claim is Bound to its original PV before going further.
@@ -177,52 +176,109 @@ The loop handles pools and zones (their PVC names carry the pool/zone key) and b
 
 An `S` tenant that an unguarded 1.6.0 upgrade already reached has an extra problem: the upgrade **created** chart-named workloads (`seaweedfs-master/-filer/-volume`, an s3 Deployment) and **empty** `data1-seaweedfs-volume-*` PVCs beside the live renamed set, and deleted the renamed `<fullname>-s3` Service (only `seaweedfs-s3` remains — its endpoints may still resolve to the renamed set's pods because both sets carry identical labels, which is luck, not design: if the chart-named pods ever become Ready, the Service splits reads across a live set and an empty one).
 
-Verify the direction before touching anything — the chart-named PVCs must be the **newer** generation (compare `kubectl get pvc -o custom-columns=NAME:.metadata.name,CREATED:.metadata.creationTimestamp`), matching the `S-damaged` audit row. Then clear the empty chart-named set so Step 2 can re-bind onto those names:
+> **STOP if you are resuming an interrupted Step 2.** This step deletes every `data1-seaweedfs-volume-*` claim. If Step 2 already re-bound some of them, those claims hold your data and are bound to the original PVs — deleting them is the data-loss path this step used to be reachable through by misclassification. Finish Step 2 instead. The check below refuses in that case, but read the Step 1 classification first and be sure.
+
+Verify the direction before touching anything. The chart-named generation must be the **newer** one, judged on the **PV** ages (claims are recreated by Step 2's re-bind, so their timestamps prove nothing). The precondition below refuses unless every chart-named claim is bound to a PV strictly newer than every release-named PV:
 
 ```sh
+#!/usr/bin/env bash
+set -euo pipefail
 ns=<tenant>
 app=<seaweedfs-instance-name>
+
+# PRECONDITION. Every chart-named claim must be bound to a PV strictly newer than
+# every release-named PV. A chart-named claim sitting on an OLD PV means Step 2
+# already re-bound it: it holds data, and this step would delete it.
+pv_age() { kubectl get pv "$(kubectl -n "$ns" get pvc "$1" -o jsonpath='{.spec.volumeName}')" \
+             -o jsonpath='{.metadata.creationTimestamp}'; }
+newest_release_pv=""
+for pvc in $(kubectl -n "$ns" get pvc -o name | sed 's|persistentvolumeclaim/||' \
+               | grep -E '^data1-.*volume' | grep seaweedfs | grep -vE '^data1-seaweedfs-volume'); do
+  a=$(pv_age "$pvc"); [ "$a" \> "$newest_release_pv" ] && newest_release_pv="$a"
+done
+[ -n "$newest_release_pv" ] || { echo "REFUSING: no release-named volumes found; this is not an S-damaged tenant"; exit 1; }
+for pvc in $(kubectl -n "$ns" get pvc -o name | sed 's|persistentvolumeclaim/||' | grep -E '^data1-seaweedfs-volume'); do
+  a=$(pv_age "$pvc")
+  if [ ! "$a" \> "$newest_release_pv" ]; then
+    echo "REFUSING: $pvc is bound to a PV created $a, NOT newer than the newest release-named PV ($newest_release_pv)."
+    echo "That claim is not an empty duplicate — Step 2 has most likely already re-bound it. Finish Step 2; do not run this step."
+    exit 1
+  fi
+done
+echo "ok: every chart-named claim is bound to a strictly newer PV — safe to clear the duplicate"
+
 kubectl -n "$ns" patch helmrelease "${app}-system" --type merge -p '{"spec":{"suspend":true}}'
 # The chart-named workloads were created by the aborted upgrade and never held
 # data. Delete them so the re-bind can take over their names.
 kubectl -n "$ns" delete sts seaweedfs-master seaweedfs-filer --ignore-not-found
 kubectl -n "$ns" get sts -o name | sed 's|statefulset.apps/||' | grep -E '^seaweedfs-volume($|-)' \
   | xargs -r -I{} kubectl -n "$ns" delete sts {}
-# The EMPTY chart-named claims block Step 2's re-bind (same names). Double-check
-# each is the newer, never-served generation before deleting.
+# The EMPTY chart-named claims block Step 2's re-bind (same names).
 kubectl -n "$ns" get pvc -o name | sed 's|persistentvolumeclaim/||' | grep -E '^data1-seaweedfs-volume' \
   | xargs -r -I{} kubectl -n "$ns" delete pvc {}
 ```
 
 Leave the HelmRelease suspended and continue with Step 2 (skip its suspend line; the renamed StatefulSets it scales down are the ones holding the data, exactly as in a plain `S` tenant). Do NOT scale down or delete anything named `*-system-*` before its volumes are re-bound.
 
-## Step 3 — `D-split` tenants: stop the split before upgrading
+## Step 3 — `MIXED` tenants: remove the duplicate before upgrading
 
-Do **not** upgrade first and do not delete the duplicate PVCs — they may hold objects written through the split endpoint.
+The chart refuses while both generations exist, so the duplicate must be **gone before** the upgrade, not cleaned up after it. Do not skip to Step 4: it cannot run until this is done.
 
-1. Take the live duplicate out of the `seaweedfs-s3` Service rotation so nothing else is written to it. Select the renamed set precisely — the pre-4.31 chart-named `seaweedfs-master/-filer/-volume[-<key>]` is the authoritative set and must keep serving:
+Do **not** start by deleting PVCs. If the duplicate ever served, they may hold objects written through the split endpoint.
+
+1. **Take the duplicate out of service** so nothing else is written to it. Select it precisely — the generation Step 1 named as ORIGINAL is authoritative and must keep serving. For the common case (chart-named original, release-named duplicate):
 
    ```sh
    ns=<tenant>
    kubectl -n "$ns" get sts -l app.kubernetes.io/name=seaweedfs -o name | sed 's|statefulset.apps/||' \
      | grep -vE '^seaweedfs-(master|filer|volume)($|-)' \
      | xargs -r -I{} kubectl -n "$ns" scale sts {} --replicas=0
-   # The renamed s3 Deployment is the one whose pod template is NOT the chart-named set;
-   # scale every seaweedfs s3 Deployment except the adopted `seaweedfs-s3`.
+   # The renamed s3 Deployment is the one that is NOT the chart-named `seaweedfs-s3`.
    kubectl -n "$ns" get deploy -l app.kubernetes.io/name=seaweedfs,app.kubernetes.io/component=s3 -o name \
      | sed 's|deployment.apps/||' | grep -v '^seaweedfs-s3$' \
      | xargs -r -I{} kubectl -n "$ns" scale deploy {} --replicas=0
    ```
 
-2. Confirm the legacy set (`seaweedfs-*`) is the authoritative one and is serving.
-3. Audit what the split wrote: enumerate filer entries whose fids resolve only on the duplicate volume servers (objects PUT while both sets were live). Export anything that must survive, then re-upload it through the authoritative endpoint.
-4. Only then upgrade, and clean up the duplicate as in Step 4.
+   If Step 1 named the **release-named** generation as original, this tenant is `S-damaged`: the duplicate is the chart-named set. Use **Step 2a** instead, then Step 2 — the selectors are inverted there.
+
+2. **Confirm the authoritative set is serving**, and that the duplicate is out of the `seaweedfs-s3` endpoints:
+
+   ```sh
+   kubectl -n "$ns" get endpoints seaweedfs-s3 -o yaml
+   ```
+
+3. **If the duplicate ever served, escalate.** Step 1's emptiness check is what decides this. Recovering objects that exist only on a duplicate is not a procedure this runbook can give you: both master sets allocate volume IDs from independent sequences into one shared `seaweedfs-db`, so a fid written through the split endpoint can collide with a fid on the authoritative set, and there is no supported tool that reconciles two volume-ID spaces against one metadata store. Do not improvise it. Involve someone who can plan a per-object export, and treat the tenant as an incident.
+
+4. **Delete the duplicate's StatefulSets, Deployments and PVCs.** Only once (3) is settled, and only for a duplicate confirmed empty (or whose contents have been exported):
+
+   ```sh
+   ns=<tenant>
+   # StatefulSets and Deployments of the duplicate generation.
+   kubectl -n "$ns" get sts -l app.kubernetes.io/name=seaweedfs -o name | sed 's|statefulset.apps/||' \
+     | grep -vE '^seaweedfs-(master|filer|volume)($|-)' \
+     | xargs -r -I{} kubectl -n "$ns" delete sts {}
+   kubectl -n "$ns" get deploy -l app.kubernetes.io/name=seaweedfs -o name | sed 's|deployment.apps/||' \
+     | grep -vE '^seaweedfs-(s3|objectstorage-provisioner)$' \
+     | xargs -r -I{} kubectl -n "$ns" delete deploy {}
+   # Duplicate volume PVCs, BY NAME. Never by label: the live data PVCs carry the
+   # same app.kubernetes.io/instance=<name>-system label and would match too.
+   kubectl -n "$ns" get pvc -o name | sed 's|persistentvolumeclaim/||' | grep -E '^data1-.*volume' \
+     | grep seaweedfs | grep -vE '^data1-seaweedfs-volume' | xargs -r -I{} kubectl -n "$ns" delete pvc {}
+   ```
+
+   Never delete `data1-seaweedfs-volume-*` here — those are the live data PVCs of the authoritative set. (For an `S-damaged` tenant it is the other way round; that is Step 2a's job, and it has its own precondition check.)
+
+5. **Re-run the audit.** The tenant must now read `L` (or `S`, if you are on the Step 2 path). Only then upgrade.
+
+   ```sh
+   hack/seaweedfs-naming-audit.sh "$ns"
+   ```
 
 ## Step 4 — Upgrade, then clear the leftovers
 
-Upgrade the cluster to a Cozystack version carrying the fix. On reconcile the `seaweedfs-system` release renders the chart-based names, adopts the running workloads and their volumes, and drops the duplicate `seaweedfs-system-*` StatefulSets and Deployments (they are no longer part of the release).
+Every tenant must read `L` or `S` in the audit before you start: the chart refuses to render while both generations exist, so a `MIXED` tenant does not upgrade at all — Steps 2/2a/3 come first, not after. Once the fleet is clean, upgrade to a Cozystack version carrying the fix. On reconcile the `<name>-system` release renders the chart-based names and adopts the running workloads and their volumes in place.
 
-Helm does not delete PVCs it did not template, and cert-manager Secrets have no owner reference, so the duplicate's volumes and certificates survive the upgrade as inert leftovers. Remove them by hand once the tenant is verified healthy:
+A duplicate's StatefulSets and PVCs are removed in Step 3, before the upgrade. What can still be left behind afterwards are objects no release templated and nothing owns: cert-manager Secrets have no owner reference, and PVCs Helm never templated are never GC'd. Remove those once the tenant is verified healthy:
 
 ```sh
 ns=<tenant>
@@ -284,3 +340,16 @@ kubectl -n "$ns" get endpoints seaweedfs-s3
 ```
 
 A recovered tenant has a single `seaweedfs-*` set, all three HelmReleases `Ready`, no `seaweedfs-system-*` StatefulSets, and no `data1-seaweedfs-system-volume-*` PVCs left behind.
+
+Only once that is true, restore the reclaim policy Step 2 stashed on each PV. Until this runs the volumes are `Retain`, which is deliberate: it is what makes an accidental claim deletion during recovery survivable.
+
+```sh
+ns=<tenant>
+for pvc in $(kubectl -n "$ns" get pvc -o name | sed 's|persistentvolumeclaim/||' | grep -E '^data1-seaweedfs-volume'); do
+  pv=$(kubectl -n "$ns" get pvc "$pvc" -o jsonpath='{.spec.volumeName}')
+  orig=$(kubectl get pv "$pv" -o jsonpath='{.metadata.annotations.cozystack\.io/original-reclaim-policy}')
+  [ -n "$orig" ] || continue
+  kubectl patch pv "$pv" -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"${orig}\"}}"
+  kubectl annotate pv "$pv" cozystack.io/original-reclaim-policy-
+done
+```

--- a/docs/operations/seaweedfs-431-rename-recovery.md
+++ b/docs/operations/seaweedfs-431-rename-recovery.md
@@ -13,6 +13,32 @@ The fix pins `fullnameOverride: seaweedfs` in `system/seaweedfs` values, so work
 
 One class cannot be adopted that way: a tenant installed **fresh on 1.5.x**, whose data was written under the release-based names and lives on `data1-seaweedfs-system-volume-*` PVCs. Pinning the chart name there would rename the workloads *away* from that data. Helm cannot move data between PVCs, so the charts refuse to render for such a tenant and point here. The **enforcing** guard lives in `system/seaweedfs` (`templates/naming-guard.yaml`) — the `<name>-system` HelmRelease pulls that chart straight from a platform-managed ExternalArtifact, so a platform upgrade re-renders it directly and nothing else stands between the upgrade and the tenant's workloads; `extra/seaweedfs` carries a sibling copy so the refusal is also visible on the SeaweedFS application itself. Re-bind the tenant's volumes (below) before upgrading.
 
+## Step 0 — `seaweedfs-db` ownership check (read-only, do this FIRST)
+
+Unrelated to the rename, but it lands on the same upgrade and it destroys data rather than duplicating it, so clear it before anything else.
+
+The v1.5.0 db split moved the CNPG `Cluster/seaweedfs-db` — the filer metadata store, i.e. the index for every object in the tenant's S3 — out of the `<name>-system` release into its own `<name>-db` release. Migration 43 performs the hand-over: it re-owns the Cluster to `<name>-db` and stamps `helm.sh/resource-policy: keep` so the `<name>-system` upgrade, whose chart no longer renders the Cluster, does not delete it as a removed resource. **Migration 43 shipped comparing the owning release name against the literal `seaweedfs-system`**, so it only ever fired for an instance named `seaweedfs`. `SeaweedFS` is a user-creatable kind: an instance named `foo` is owned by `foo-system`, was skipped, and had its Cluster pruned — CNPG takes the PVC with it.
+
+The prune is not a one-shot. Helm computes deletions by diffing the **last deployed** revision against the new manifest, so a tenant whose `<name>-system` last succeeded on a pre-split revision recomputes the same deletion on *every* upgrade attempt — including attempts that fail for unrelated reasons and never become the new deployed revision. Such a tenant re-deletes the Cluster each time `<name>-db` recreates it.
+
+Migration 43 is fixed to match the `-system` suffix, and migration 53 re-runs the hand-over for clusters that already ran the hardcoded version. Both are pre-upgrade hooks, so they land before `<name>-system` re-renders. Audit anyway — a Cluster already deleted cannot be recovered by either:
+
+```sh
+kubectl get cluster.postgresql.cnpg.io -A \
+  -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name,OWNER:.metadata.annotations.meta\.helm\.sh/release-name,KEEP:.metadata.annotations.helm\.sh/resource-policy'
+```
+
+Read the rows for `NAME=seaweedfs-db`:
+
+| OWNER | KEEP | Meaning |
+|---|---|---|
+| `<name>-db` | `keep` | Handed over. Nothing to do. |
+| `<name>-db` | *(none)* | Installed fresh on ≥1.5.0. Safe: `<name>-system` never rendered the Cluster, so it is not in that release's prune baseline. |
+| `<name>-system` | *(none)* | **At risk.** Migration 53 hands it over on the next upgrade. Do not reconcile `<name>-system` before the migration runs. |
+| *(no row at all)* | | **Already lost** — see below. |
+
+A tenant with a SeaweedFS instance but **no `seaweedfs-db` row** has already had its metadata deleted. Its S3 returns 500 and its objects are unreachable even though the volume PVCs still hold the bytes. Nothing in this runbook or in any migration can rebuild that index: the Cluster and its PVC are gone. Restore the `seaweedfs-db` Postgres from a backup, or treat the tenant's object storage as lost. Note that `<name>-db` may report **Ready** while this is true — it rendered its Cluster successfully and a later `<name>-system` prune removed it; Flux has not re-checked. Trust the `kubectl get cluster` output, not the HelmRelease status.
+
 ## Step 1 — Audit the fleet (read-only)
 
 Run per cluster (`KUBECONFIG` pointed at each). It mutates nothing. Classification is driven by the **PVCs**, because they hold the data and outlive any workload.

--- a/docs/operations/seaweedfs-431-rename-recovery.md
+++ b/docs/operations/seaweedfs-431-rename-recovery.md
@@ -217,6 +217,26 @@ kubectl -n "$ns" get secret -o name | sed 's|secret/||' \
 
 Never delete `data1-seaweedfs-volume-*` — those are the live data PVCs of the adopted set.
 
+The same 4.31 bump also renamed the tenant's four **cluster-scoped** RBAC objects, and those leftovers are cluster-wide rather than namespaced. Pre-4.31 they were named after the per-namespace service account (`<tenant>-seaweedfs-*`); 4.31 named them after the Helm release, which is identical in every tenant, so the fleet collided on one object. The fix puts them back on the service account name, which is where a 1.4.x tenant's objects already are — those are adopted in place and need no cleanup. A tenant that passed **through** 1.5.x, however, leaves behind whatever name that release used, and because more than one tenant claimed it, it may not be pruned by any release's manifest:
+
+```sh
+# Stale shared/renamed cluster-scoped RBAC. The go-forward names all start with a
+# tenant namespace; anything on the release-based names is a leftover. The fourth
+# pre-4.31 object is matched separately: 4.31 renamed the master-rw BINDING from
+# upstream's username-shaped system:serviceaccount:<sa>:default to <sa>-rw-crb, so
+# the old one carries neither suffix and no tenant prefix.
+kubectl get clusterrole,clusterrolebinding \
+  -o custom-columns='KIND:.kind,NAME:.metadata.name,OWNER:.metadata.annotations.meta\.helm\.sh/release-name,NS:.metadata.annotations.meta\.helm\.sh/release-namespace' \
+  | grep -E 'objectstorage-provisioner|-rw-cr|^\S+\s+system:serviceaccount:.*:default' \
+  | grep -vE '^\S+\s+tenant-'
+```
+
+A `system:serviceaccount:<tenant>-seaweedfs:default` row is the pre-4.31 master-rw binding. It is superseded by `<tenant>-seaweedfs-rw-crb` and is pruned automatically by the tenant's own upgrade (it is in that release's manifest), so it should not survive — if it does, the tenant has not upgraded yet.
+
+Each surviving row is inert once every tenant is upgraded and verified — no release renders those names any more. Confirm the tenant listed in `OWNER`/`NS` is healthy on the go-forward names first, then delete by name. Do not delete anything named `<tenant>-seaweedfs-*`: those are live.
+
+**During** a rolling fleet upgrade there is a window, and it is worth expecting rather than debugging: Helm prunes by name without checking ownership, so the first tenant to reconcile onto the fixed chart deletes the shared `seaweedfs-objectstorage-provisioner` / `seaweedfs-rw-cr` objects that a not-yet-upgraded tenant is still bound through. Those tenants' COSI provisioners get 403s on bucket operations until they reconcile onto their own per-namespace RBAC. Existing buckets keep serving — S3 traffic does not go through the provisioner — so this is a provisioning outage, not a data-plane one, and it closes on its own as the remaining tenants reconcile.
+
 If a tenant's `seaweedfs-system` HelmRelease was suspended during triage, resume it so the fix can reconcile:
 
 ```sh

--- a/docs/operations/seaweedfs-431-rename-recovery.md
+++ b/docs/operations/seaweedfs-431-rename-recovery.md
@@ -149,11 +149,11 @@ for pvc in $(kubectl -n "$ns" get pvc -o name | sed 's|persistentvolumeclaim/||'
   # not. Step 5 restores it from the annotation once the tenant is verified healthy.
   reclaim=$(kubectl get pv "$pv" -o jsonpath='{.spec.persistentVolumeReclaimPolicy}')
   if [ -z "$(kubectl get pv "$pv" -o jsonpath='{.metadata.annotations.cozystack\.io/original-reclaim-policy}')" ]; then
-    kubectl annotate pv "$pv" "cozystack.io/original-reclaim-policy=${reclaim}"
+    kubectl annotate pv "$pv" "cozystack.io/original-reclaim-policy=${reclaim}" || { echo "FAILED to record the original reclaim policy on $pv; aborting before any PVC is deleted" >&2; break; }
   fi
 
   # Keep the PV (and the data) when the claim goes away.
-  kubectl patch pv "$pv" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+  kubectl patch pv "$pv" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}' || { echo "FAILED to set Retain on $pv; aborting before deleting its PVC" >&2; break; }
   kubectl -n "$ns" delete pvc "$pvc"
   # A Released PV cannot be re-bound until its old claimRef is cleared.
   kubectl patch pv "$pv" --type json -p '[{"op":"remove","path":"/spec/claimRef"}]'
@@ -378,7 +378,6 @@ for pvc in $(kubectl -n "$ns" get pvc -o name | sed 's|persistentvolumeclaim/||'
   pv=$(kubectl -n "$ns" get pvc "$pvc" -o jsonpath='{.spec.volumeName}')
   orig=$(kubectl get pv "$pv" -o jsonpath='{.metadata.annotations.cozystack\.io/original-reclaim-policy}')
   [ -n "$orig" ] || continue
-  kubectl patch pv "$pv" -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"${orig}\"}}"
-  kubectl annotate pv "$pv" cozystack.io/original-reclaim-policy-
+  kubectl patch pv "$pv" -p "{\"spec\":{\"persistentVolumeReclaimPolicy\":\"${orig}\"}}" && kubectl annotate pv "$pv" cozystack.io/original-reclaim-policy-
 done
 ```

--- a/hack/migration-seaweedfs-db-adopt.bats
+++ b/hack/migration-seaweedfs-db-adopt.bats
@@ -34,19 +34,26 @@
 # These drive the real migration scripts end-to-end against a fake kubectl
 # (hack/testdata/migration-seaweedfs-db/), mocking only the cluster boundary.
 #
-# SHELL. Production runs these under /bin/sh = busybox ash (the migrations image
-# is FROM alpine, run-migrations.sh is #!/bin/sh), where `set -euo pipefail` and
-# errexit-in-function semantics differ from bash. Asserting fail-closed in a shell
-# that never runs it would be asserting nothing, so the scripts are invoked here
-# via `sh` rather than `bash`, and the fake kubectl is POSIX sh. On a developer box
-# /bin/sh is often bash, so this alone does not PROVE ash compatibility — that was
-# verified directly against the production base image, and can be re-run with:
+# SHELL. Production runs these under /bin/sh = busybox ash: the migrations image
+# is FROM alpine, and run-migrations.sh execs `/migrations/<n>` BY PATH, so the
+# kernel honours the `#!/bin/sh` shebang. `set -euo pipefail` and
+# errexit-in-function semantics differ from bash, and pipefail is load-bearing —
+# lib/cozystack-version.sh pipes the rendered manifest into `kubectl apply`, so
+# without it a failed render stamps the version from empty input. Asserting
+# fail-closed in a shell that never runs it would be asserting nothing.
 #
-#   docker run --rm -v "$PWD/packages/core/platform/images/migrations/migrations:/m:ro" \
-#     alpine:3.24 sh -c 'for f in /m/43 /m/53 /m/lib/*.sh; do ash -n "$f" || exit 1; done'
+# So these tests do not invoke the migrations through the runner's shell at all:
+# run_migration() executes them by path inside the image's own pinned base, read
+# from the migrations Dockerfile. Same base image, same interpreter, same
+# invocation form — production, rather than an approximation of it. This needs a
+# working docker; there is deliberately no host-shell fallback, because every
+# fallback available is a shell production never uses.
 #
-# (busybox 1.37.0 on alpine:3.24 supports `set -o pipefail`, and every script here
-# passes `ash -n`; the fail-closed path was exercised end-to-end under it.)
+# What that replaced was `sh "$MIG_DIR/<n>"`, which is neither production nor
+# bash: on the GitHub ubuntu runner /bin/sh is dash, which has no `set -o
+# pipefail` and aborts on line 1 with "set: Illegal option -o pipefail" before
+# the script does any work, while on a developer box /bin/sh is often bash, which
+# runs green and proves nothing about ash.
 #
 # cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
 # own line; there is no bats `run`/`$status`/`setup`. Assertions are direct
@@ -58,13 +65,55 @@
 FAKEBIN="$PWD/hack/testdata/migration-seaweedfs-db"
 MIG_DIR="$PWD/packages/core/platform/images/migrations/migrations"
 
-# prep resets PATH/env to a clean scenario. Tests set FAKE_* afterwards.
+# The production base image, read out of the migrations Dockerfile rather than
+# repeated here, so the interpreter under test cannot drift from the one the
+# migrations actually ship on when that pin is bumped.
+ALPINE=$(sed -n 's/^FROM \(alpine:[^ ]*\).*$/\1/p' \
+  "$PWD/packages/core/platform/images/migrations/Dockerfile" | head -1)
+
+# run_migration <n> -- run migrations/<n> the way run-migrations.sh does.
+#
+# By path, not `sh <file>`: that is what makes the shebang, and therefore the
+# interpreter, part of what is under test. The fake kubectl goes on PATH inside
+# the container and $WORK is bind-mounted, so $FAKE_CMDLOG is the same file the
+# assertions read back on the host. --network none because nothing here may
+# reach a real cluster; --user keeps $WORK removable by the test afterwards.
+#
+# The explicit `return` is load-bearing: cozytest.sh's awk generator rewrites
+# every bare `}` in column 0 into `return 0` + `}`, so a helper that falls off
+# its own end returns 0 no matter what it ran, and every fail-closed assertion
+# below would pass vacuously. Capture the status and return it by hand.
+run_migration() {
+  _run_migration_rc=0
+  docker run --rm --network none \
+    --user "$(id -u):$(id -g)" \
+    -v "$MIG_DIR:/migrations:ro" \
+    -v "$FAKEBIN:/fakebin:ro" \
+    -v "$WORK:/work" \
+    -e PATH=/fakebin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    -e FAKE_CMDLOG=/work/cmdlog \
+    -e NAMESPACE="${NAMESPACE-}" \
+    -e FAKE_CLUSTERS="${FAKE_CLUSTERS-}" \
+    -e FAKE_LIST_FAIL="${FAKE_LIST_FAIL-}" \
+    -e FAKE_GET_FAIL="${FAKE_GET_FAIL-}" \
+    -e FAKE_ANNOTATE_FAIL="${FAKE_ANNOTATE_FAIL-}" \
+    "$ALPINE" "/migrations/$1" || _run_migration_rc=$?
+  return "$_run_migration_rc"
+}
+
+# prep resets env to a clean scenario. Tests set FAKE_* afterwards.
 prep() {
+  # Fail here rather than at the first docker run, so the reason is legible.
+  docker info >/dev/null 2>&1 || {
+    echo "docker is required: these tests run the migrations inside $ALPINE," >&2
+    echo "the base image of the migrations image, so that they exercise busybox" >&2
+    echo "ash — the interpreter run-migrations.sh actually gives them." >&2
+    return 1
+  }
   chmod +x "$FAKEBIN/kubectl"
   WORK=$(mktemp -d)
   export FAKE_CMDLOG="$WORK/cmdlog"
   : > "$FAKE_CMDLOG"
-  export PATH="$FAKEBIN:$PATH"
   export NAMESPACE=cozy-system
   export FAKE_CLUSTERS=""
   unset FAKE_LIST_FAIL FAKE_GET_FAIL FAKE_ANNOTATE_FAIL || true
@@ -76,7 +125,7 @@ prep() {
   prep
   export FAKE_CLUSTERS="tenant-root seaweedfs-system -"
   rc=0
-  sh "$MIG_DIR/43" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 43 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   grep -qF -- "ANNOTATE tenant-root release-name=seaweedfs-db resource-policy=keep" "$FAKE_CMDLOG"
@@ -93,7 +142,7 @@ prep() {
   prep
   export FAKE_CLUSTERS="tenant-named foo-system -"
   rc=0
-  sh "$MIG_DIR/43" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 43 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   grep -qF -- "ANNOTATE tenant-named release-name=foo-db resource-policy=keep" "$FAKE_CMDLOG"
@@ -104,7 +153,7 @@ prep() {
   prep
   export FAKE_CLUSTERS="tenant-named foo-system -"
   rc=0
-  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   grep -qF -- "ANNOTATE tenant-named release-name=foo-db resource-policy=keep" "$FAKE_CMDLOG"
@@ -120,7 +169,7 @@ tenant-dsplit seaweedfs-system -
 tenant-l seaweedfs-system -
 tenant-named foo-system -"
   rc=0
-  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   grep -qF -- "ANNOTATE tenant-root release-name=seaweedfs-db resource-policy=keep" "$FAKE_CMDLOG"
@@ -142,7 +191,7 @@ tenant-named foo-system -"
   prep
   export FAKE_CLUSTERS="tenant-named foo-db -"
   rc=0
-  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   grep -qF -- "ANNOTATE tenant-named release-name=<unset> resource-policy=keep" "$FAKE_CMDLOG"
@@ -153,7 +202,7 @@ tenant-named foo-system -"
   prep
   export FAKE_CLUSTERS="tenant-fresh seaweedfs-db -"
   rc=0
-  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   grep -qF -- "ANNOTATE tenant-fresh release-name=<unset> resource-policy=keep" "$FAKE_CMDLOG"
@@ -165,7 +214,7 @@ tenant-named foo-system -"
   export FAKE_CLUSTERS="tenant-root seaweedfs-db keep
 tenant-named foo-db keep"
   rc=0
-  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
@@ -179,7 +228,7 @@ tenant-named foo-db keep"
   # an unowned SeaweedFS database must not pass silently.
   export FAKE_CLUSTERS="tenant-manual - -"
   rc=0
-  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
@@ -191,7 +240,7 @@ tenant-named foo-db keep"
   prep
   export FAKE_CLUSTERS="tenant-x some-other-release -"
   rc=0
-  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
@@ -206,7 +255,7 @@ tenant-named foo-db keep"
   # meant to protect it.
   export FAKE_CLUSTERS="tenant-weird -system -"
   rc=0
-  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
@@ -221,7 +270,7 @@ tenant-named foo-db keep"
   export FAKE_CLUSTERS="tenant-named foo-system -"
   export FAKE_LIST_FAIL="Error from server (Timeout): the server was unable to return a response in the time allotted"
   rc=0
-  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   # Must propagate: the Job retries rather than advancing the version.
   [ "$rc" -ne 0 ]
@@ -235,7 +284,7 @@ tenant-named foo-db keep"
   export FAKE_CLUSTERS="tenant-named foo-system -"
   export FAKE_GET_FAIL="Error from server (Forbidden): clusters.postgresql.cnpg.io \"seaweedfs-db\" is forbidden"
   rc=0
-  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -ne 0 ]
   grep -qF -- "cannot read the Helm owner" "$WORK/out"
@@ -248,7 +297,7 @@ tenant-named foo-db keep"
   export FAKE_CLUSTERS="tenant-named foo-system -"
   export FAKE_ANNOTATE_FAIL="Error from server (Conflict): the object has been modified"
   rc=0
-  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -ne 0 ]
   ! grep -q 'STAMP' "$FAKE_CMDLOG"
@@ -262,7 +311,7 @@ tenant-named foo-db keep"
   prep
   export FAKE_LIST_FAIL="error: the server doesn't have a resource type \"cluster\" in group \"postgresql.cnpg.io\""
   rc=0
-  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   grep -qF -- "resource type is not served" "$WORK/out"
@@ -275,7 +324,7 @@ tenant-named foo-db keep"
   prep
   export FAKE_CLUSTERS=""
   rc=0
-  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"

--- a/hack/migration-seaweedfs-db-adopt.bats
+++ b/hack/migration-seaweedfs-db-adopt.bats
@@ -1,0 +1,284 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Unit tests for the SeaweedFS db-split hand-over shared by platform migrations
+# 43 (original) and 53 (repair) — lib/seaweedfs-db-adopt.sh.
+#
+# The 1.5.0 split (PR #2601) moved Cluster/seaweedfs-db out of the <name>-system
+# release into a new <name>-db release. The hand-over must, before <name>-system
+# next renders, re-own the Cluster to <name>-db AND stamp
+# helm.sh/resource-policy: keep — otherwise the <name>-system upgrade prunes the
+# Cluster as a removed resource, CNPG takes its PVC with it, and the tenant's
+# filer metadata (all of its S3) is gone.
+#
+# Three properties are pinned here, each of which shipped broken:
+#
+#  1. INSTANCE NAME. Migration 43 compared the owner against the literal
+#     "seaweedfs-system". `SeaweedFS` is user-creatable, so an instance named
+#     `foo` is owned by `foo-system` and was silently skipped. Observed live:
+#     four default-named tenants carry release-name=seaweedfs-db + keep and their
+#     Clusters survived; the one tenant running `foo` has no Cluster at all.
+#
+#  2. OWNERSHIP IS NOT SAFETY. A Cluster already owned by <name>-db can still
+#     need keep: where the hand-over was skipped, <name>-system prunes it and
+#     <name>-db RECREATES it under its own ownership with no keep, while
+#     <name>-system's prune baseline still lists it. Live proof that the shape is
+#     real: tenant-l and tenant-root are <name>-db-owned and their <name>-system
+#     deployed revision still contains the Cluster — only keep saves them.
+#
+#  3. FAIL CLOSED. Migrations never re-run, so a swallowed error permanently
+#     leaves at-risk tenants exposed. `for ns in $(kubectl ...)` does not trip
+#     errexit: on failure the loop runs zero times and the script stamps the
+#     version anyway. Only "the resource type is not served" (no CNPG at all) and
+#     "gone between scan and read" may be treated as empty.
+#
+# These drive the real migration scripts end-to-end against a fake kubectl
+# (hack/testdata/migration-seaweedfs-db/), mocking only the cluster boundary.
+#
+# SHELL. Production runs these under /bin/sh = busybox ash (the migrations image
+# is FROM alpine, run-migrations.sh is #!/bin/sh), where `set -euo pipefail` and
+# errexit-in-function semantics differ from bash. Asserting fail-closed in a shell
+# that never runs it would be asserting nothing, so the scripts are invoked here
+# via `sh` rather than `bash`, and the fake kubectl is POSIX sh. On a developer box
+# /bin/sh is often bash, so this alone does not PROVE ash compatibility — that was
+# verified directly against the production base image, and can be re-run with:
+#
+#   docker run --rm -v "$PWD/packages/core/platform/images/migrations/migrations:/m:ro" \
+#     alpine:3.24 sh -c 'for f in /m/43 /m/53 /m/lib/*.sh; do ash -n "$f" || exit 1; done'
+#
+# (busybox 1.37.0 on alpine:3.24 supports `set -o pipefail`, and every script here
+# passes `ash -n`; the fail-closed path was exercised end-to-end under it.)
+#
+# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
+# own line; there is no bats `run`/`$status`/`setup`. Assertions are direct
+# shell tests that exit non-zero on failure.
+#
+# Run with: hack/cozytest.sh hack/migration-seaweedfs-db-adopt.bats
+# -----------------------------------------------------------------------------
+
+FAKEBIN="$PWD/hack/testdata/migration-seaweedfs-db"
+MIG_DIR="$PWD/packages/core/platform/images/migrations/migrations"
+
+# prep resets PATH/env to a clean scenario. Tests set FAKE_* afterwards.
+prep() {
+  chmod +x "$FAKEBIN/kubectl"
+  WORK=$(mktemp -d)
+  export FAKE_CMDLOG="$WORK/cmdlog"
+  : > "$FAKE_CMDLOG"
+  export PATH="$FAKEBIN:$PATH"
+  export NAMESPACE=cozy-system
+  export FAKE_CLUSTERS=""
+  unset FAKE_LIST_FAIL FAKE_GET_FAIL FAKE_ANNOTATE_FAIL || true
+}
+
+# --- 1. instance name -------------------------------------------------------
+
+@test "hands over a default-named instance (seaweedfs-system -> seaweedfs-db)" {
+  prep
+  export FAKE_CLUSTERS="tenant-root seaweedfs-system -"
+  rc=0
+  sh "$MIG_DIR/43" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  grep -qF -- "ANNOTATE tenant-root release-name=seaweedfs-db resource-policy=keep" "$FAKE_CMDLOG"
+  # Migration 43 stamps 44 — asserting the number, not a bare "STAMP": a wrong
+  # version would loop run-migrations.sh forever.
+  grep -qF -- "STAMP 44" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+# THE original regression. Unfixed (owner compared against the literal
+# "seaweedfs-system") this namespace is skipped entirely: no ANNOTATE line, and
+# the Cluster is left with no keep for the foo-system upgrade to prune.
+@test "hands over a NON-default instance name (foo-system -> foo-db)" {
+  prep
+  export FAKE_CLUSTERS="tenant-named foo-system -"
+  rc=0
+  sh "$MIG_DIR/43" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  grep -qF -- "ANNOTATE tenant-named release-name=foo-db resource-policy=keep" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "migration 53 repairs a non-default instance the hardcoded 43 skipped, and stamps 54" {
+  prep
+  export FAKE_CLUSTERS="tenant-named foo-system -"
+  rc=0
+  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  grep -qF -- "ANNOTATE tenant-named release-name=foo-db resource-policy=keep" "$FAKE_CMDLOG"
+  grep -qF -- "STAMP 54" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "handles a mixed fleet: every -system owner is handed over, in its own namespace" {
+  prep
+  # The shape of the upgrade stand: default-named tenants plus one `foo`.
+  export FAKE_CLUSTERS="tenant-root seaweedfs-system -
+tenant-dsplit seaweedfs-system -
+tenant-l seaweedfs-system -
+tenant-named foo-system -"
+  rc=0
+  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  grep -qF -- "ANNOTATE tenant-root release-name=seaweedfs-db resource-policy=keep" "$FAKE_CMDLOG"
+  grep -qF -- "ANNOTATE tenant-dsplit release-name=seaweedfs-db resource-policy=keep" "$FAKE_CMDLOG"
+  grep -qF -- "ANNOTATE tenant-l release-name=seaweedfs-db resource-policy=keep" "$FAKE_CMDLOG"
+  grep -qF -- "ANNOTATE tenant-named release-name=foo-db resource-policy=keep" "$FAKE_CMDLOG"
+  [ "$(grep -c 'ANNOTATE' "$FAKE_CMDLOG")" -eq 4 ]
+  rm -rf "$WORK"
+}
+
+# --- 2. ownership is not safety --------------------------------------------
+
+# A <name>-db-owned Cluster WITHOUT keep is exposed, not done: <name>-system's
+# prune baseline may still list the Cluster (live on the stand for tenant-l and
+# tenant-root), in which case its next reconcile deletes it. Skipping on
+# ownership alone — the shape the previous revision of this helper shipped —
+# leaves the database to be pruned.
+@test "protects a <name>-db-owned Cluster that is still missing keep" {
+  prep
+  export FAKE_CLUSTERS="tenant-named foo-db -"
+  rc=0
+  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  grep -qF -- "ANNOTATE tenant-named release-name=<unset> resource-policy=keep" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "protects a default-named <name>-db-owned Cluster that is still missing keep" {
+  prep
+  export FAKE_CLUSTERS="tenant-fresh seaweedfs-db -"
+  rc=0
+  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  grep -qF -- "ANNOTATE tenant-fresh release-name=<unset> resource-policy=keep" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "idempotent: a Cluster already owned by <name>-db AND carrying keep is left alone" {
+  prep
+  export FAKE_CLUSTERS="tenant-root seaweedfs-db keep
+tenant-named foo-db keep"
+  rc=0
+  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  grep -qF -- "STAMP 54" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "leaves a Cluster with no Helm owner annotation alone, but says so" {
+  prep
+  # Not Helm-managed. Guessing an owner would be worse than doing nothing, but
+  # an unowned SeaweedFS database must not pass silently.
+  export FAKE_CLUSTERS="tenant-manual - -"
+  rc=0
+  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  grep -qF -- "carries no meta.helm.sh/release-name" "$WORK/out"
+  rm -rf "$WORK"
+}
+
+@test "leaves a Cluster owned by an unrelated release alone" {
+  prep
+  export FAKE_CLUSTERS="tenant-x some-other-release -"
+  rc=0
+  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  grep -qF -- "owned by unrelated release" "$WORK/out"
+  rm -rf "$WORK"
+}
+
+@test "refuses a release literally named -system rather than annotating owner -db" {
+  prep
+  # "${current%-system}" would be empty, yielding release-name=-db, which no
+  # release will ever claim: the Cluster would be orphaned by the very step
+  # meant to protect it.
+  export FAKE_CLUSTERS="tenant-weird -system -"
+  rc=0
+  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  grep -qF -- "no instance name" "$WORK/out"
+  rm -rf "$WORK"
+}
+
+# --- 3. fail closed ---------------------------------------------------------
+
+@test "a failing fleet scan aborts the migration instead of stamping past it" {
+  prep
+  export FAKE_CLUSTERS="tenant-named foo-system -"
+  export FAKE_LIST_FAIL="Error from server (Timeout): the server was unable to return a response in the time allotted"
+  rc=0
+  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  # Must propagate: the Job retries rather than advancing the version.
+  [ "$rc" -ne 0 ]
+  grep -qF -- "refusing to stamp past an unverified fleet" "$WORK/out"
+  ! grep -q 'STAMP' "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "an unreadable owner annotation aborts rather than being read as not-Helm-managed" {
+  prep
+  export FAKE_CLUSTERS="tenant-named foo-system -"
+  export FAKE_GET_FAIL="Error from server (Forbidden): clusters.postgresql.cnpg.io \"seaweedfs-db\" is forbidden"
+  rc=0
+  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -ne 0 ]
+  grep -qF -- "cannot read the Helm owner" "$WORK/out"
+  ! grep -q 'STAMP' "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "a failed hand-over aborts rather than stamping a half-migrated fleet" {
+  prep
+  export FAKE_CLUSTERS="tenant-named foo-system -"
+  export FAKE_ANNOTATE_FAIL="Error from server (Conflict): the object has been modified"
+  rc=0
+  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -ne 0 ]
+  ! grep -q 'STAMP' "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+# The fail-open that IS load-bearing: a cluster with no CNPG at all must not be
+# blocked from upgrading. "The server doesn't have a resource type" is the only
+# list failure allowed to mean "nothing to do".
+@test "a cluster with no CNPG resource type stamps cleanly without annotating" {
+  prep
+  export FAKE_LIST_FAIL="error: the server doesn't have a resource type \"cluster\" in group \"postgresql.cnpg.io\""
+  rc=0
+  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  grep -qF -- "resource type is not served" "$WORK/out"
+  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  grep -qF -- "STAMP 54" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "an empty fleet stamps without annotating" {
+  prep
+  export FAKE_CLUSTERS=""
+  rc=0
+  sh "$MIG_DIR/53" >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  grep -qF -- "STAMP 54" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}

--- a/hack/seaweedfs-guard-parity.bats
+++ b/hack/seaweedfs-guard-parity.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# The SeaweedFS naming guard exists in two copies:
+#
+#   packages/system/seaweedfs/templates/naming-guard.yaml   (ENFORCING — the
+#     <name>-system HelmRelease pulls this chart from a platform-managed
+#     ExternalArtifact, so a platform upgrade re-renders it directly and nothing
+#     else stands between the upgrade and the tenant's workloads)
+#   packages/extra/seaweedfs/templates/seaweedfs.yaml       (sibling — warns on
+#     the SeaweedFS application itself, where the operator looks first)
+#
+# They cannot be shared: the two packages are separate charts and neither depends
+# on cozy-lib, so there is no library either could include the classifier from.
+# They were kept in sync by a comment saying "keep the two classifications in
+# sync" — and this whole branch exists because the guard lived in the wrong
+# chart. Silent drift between the copies is the same failure class, so pin it.
+#
+# Only the DETECTION block is compared: the two `fail` messages differ by design
+# ("SeaweedFS release <name>" vs "SeaweedFS <name>", matching each chart's voice)
+# and the branch structure is asserted separately. It is the detection — which
+# objects establish which generation — that must never diverge.
+#
+# The block starts at the reconstruction, not at the flag declarations: the line
+# above it is deliberately different per chart (system/ IS the <name>-system
+# release; extra/ is <name> and derives the child), and that is the ONLY sanctioned
+# difference. Both are asserted separately below.
+#
+# Run with: hack/cozytest.sh hack/seaweedfs-guard-parity.bats
+# -----------------------------------------------------------------------------
+
+SYS="$PWD/packages/system/seaweedfs/templates/naming-guard.yaml"
+EXTRA="$PWD/packages/extra/seaweedfs/templates/seaweedfs.yaml"
+
+# detection_block <file> -- the generation-detection lines, from the first flag
+# declaration through the two derived generation booleans.
+detection_block() {
+  sed -n '/\$renamedVol := include/,/\$systemGen := or/p' "$1"
+}
+
+@test "both charts detect naming generations with byte-identical logic" {
+  a=$(mktemp); b=$(mktemp)
+  detection_block "$SYS"   > "$a"
+  detection_block "$EXTRA" > "$b"
+  # Non-empty: a sed range that matched nothing would make this test vacuous.
+  [ -s "$a" ]
+  [ -s "$b" ]
+  diff -u "$a" "$b"
+  rm -f "$a" "$b"
+}
+
+@test "each chart feeds the reconstruction the <name>-system release name" {
+  # system/seaweedfs IS that release; extra/seaweedfs is <name> and must derive it.
+  # Getting this wrong silently reconstructs the wrong prefix, so neither
+  # generation matches and the guard renders through.
+  grep -qF -- '$sysRelease := .Release.Name' "$SYS"
+  grep -qF -- '$sysRelease := printf "%s-system" .Release.Name' "$EXTRA"
+}
+
+@test "both charts reconstruct the renamed prefix rather than prefix-matching alone" {
+  # An instance legitimately named `seaweedfs-volume` renders release-named objects
+  # (seaweedfs-volume-system-volume, data1-seaweedfs-volume-system-volume-0) that
+  # ALSO satisfy the chart-named prefixes. Release-named must be tested FIRST,
+  # against a reconstructed prefix, or live storage reads as legacy.
+  for f in "$SYS" "$EXTRA"; do
+    grep -qF -- '$renamedVol := include "seaweedfs.renamedVolumePrefix" $sysRelease' "$f"
+    # release-named branch precedes the chart-named fallback in both scans
+    pv=$(grep -n 'hasPrefix (printf "data1-%s" $renamedVol)' "$f" | cut -d: -f1)
+    lv=$(grep -n 'hasPrefix "data1-seaweedfs-volume"' "$f" | cut -d: -f1)
+    [ -n "$pv" ] && [ -n "$lv" ] && [ "$pv" -lt "$lv" ]
+    ps=$(grep -n 'hasPrefix $renamedVol .metadata.name' "$f" | cut -d: -f1)
+    ls=$(grep -n 'hasPrefix "seaweedfs-volume" .metadata.name' "$f" | cut -d: -f1)
+    [ -n "$ps" ] && [ -n "$ls" ] && [ "$ps" -lt "$ls" ]
+  done
+}
+
+@test "both charts derive the generation flags from PVC and StatefulSet evidence" {
+  # The OR is load-bearing: a tenant whose PVCs are not provisioned yet is only
+  # visible through its label-matched StatefulSet.
+  for f in "$SYS" "$EXTRA"; do
+    grep -qF -- '$legacyGen := or $legacyPVC $legacySTS' "$f"
+    grep -qF -- '$systemGen := or $systemPVC $systemSTS' "$f"
+  done
+}
+
+@test "both charts refuse when both generations are present" {
+  for f in "$SYS" "$EXTRA"; do
+    grep -qF -- 'if and $legacyGen $systemGen' "$f"
+    grep -qF -- 'has BOTH naming generations present' "$f"
+  done
+}
+
+@test "both charts refuse a release-named-only tenant (class S)" {
+  for f in "$SYS" "$EXTRA"; do
+    grep -qF -- 'else if $systemGen' "$f"
+    grep -qF -- 'keeps its data on volumes named after the Helm release' "$f"
+  done
+}
+
+@test "neither chart classifies on mutable claim timestamps or liveness" {
+  # The premise "PVCs are never recreated in place" is false: the runbook's own
+  # Step 2 re-bind deletes and recreates each claim, so a tenant interrupted
+  # part-way through reads as the exact inverse of the truth — and the step the
+  # old classification pointed at deletes the claim Step 2 just re-bound.
+  # readyReplicas is likewise only a snapshot, not proof a duplicate never
+  # served. Neither may come back as a discriminator.
+  for f in "$SYS" "$EXTRA"; do
+    ! grep -qF -- 'creationTimestamp' "$f"
+    ! grep -qF -- 'readyReplicas' "$f"
+    ! grep -qF -- '$systemOldest' "$f"
+    ! grep -qF -- '$legacyOldest' "$f"
+  done
+}
+
+@test "both charts gate the guard behind the same cluster-view canary" {
+  for f in "$SYS" "$EXTRA"; do
+    grep -qF -- '$canary := lookup "v1" "Namespace" "" .Release.Namespace' "$f"
+    grep -qF -- 'refusing to upgrade blind' "$f"
+  done
+}

--- a/hack/seaweedfs-naming-audit.bats
+++ b/hack/seaweedfs-naming-audit.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Unit tests for hack/seaweedfs-naming-audit.sh.
+#
+# The chart's naming guard refuses whenever both naming generations exist, so the
+# audit IS the classifier — it is what an operator acts on, and acting on it
+# deletes PVCs. Two earlier revisions of this classification shipped as an
+# untested shell snippet inside the runbook, and both were wrong in ways that
+# routed a live tenant into the step that strands its data:
+#
+#   - a selector `^data1-(.*seaweedfs.*)-volume` also matched the CHART-named
+#     claims, so the release-named age range spanned both generations, every
+#     tenant read as "ranges overlap / mid-rebind", and a genuine S-damaged tenant
+#     was routed AWAY from Step 2a (which would have been correct) into Step 2,
+#     which deletes its data claim;
+#   - matching claims by name with `grep seaweedfs` cannot see a long instance
+#     name, whose claims the chart truncates past `seaweedfs`, so such a tenant
+#     read as "L — nothing to do" while the chart refused it.
+#
+# Moving the classifier into a file with tests is the point. These drive it
+# against a fake kubectl, mocking only the cluster boundary.
+#
+# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its own
+# line; there is no bats `run`/`$status`/`setup`.
+#
+# Run with: hack/cozytest.sh hack/seaweedfs-naming-audit.bats
+# -----------------------------------------------------------------------------
+
+SEAWEEDFS_AUDIT_LIB=1
+export SEAWEEDFS_AUDIT_LIB
+# shellcheck source=seaweedfs-naming-audit.sh
+. "$PWD/hack/seaweedfs-naming-audit.sh"
+
+@test "reconstructs the renamed volume prefix for a default instance" {
+  [ "$(renamed_volume_prefix seaweedfs-system)" = "seaweedfs-system-volume" ]
+}
+
+@test "reconstructs the renamed volume prefix for a non-default instance" {
+  # The release name does not contain the chart name, so 4.31 appends it.
+  [ "$(renamed_volume_prefix foo-system)" = "foo-system-seaweedfs-volume" ]
+}
+
+@test "reconstructs the truncated prefix for a long instance name" {
+  # componentName cuts the fullname to 62-len("volume")=56 before appending, so
+  # `seaweedfs` falls off the tail — the case a `grep seaweedfs` name match cannot
+  # see, and the reason this is reconstructed rather than pattern-matched.
+  got=$(renamed_volume_prefix archive-of-quarterly-financial-statements-x1-system)
+  [ "$got" = "archive-of-quarterly-financial-statements-x1-system-seaw-volume" ]
+  # 56 chars of fullname + "-volume"
+  [ "${#got}" -eq 63 ]
+}
+
+@test "reconstructs a distinct prefix for an instance named seaweedfs-volume" {
+  # The pathological case: this instance's RELEASE-named objects
+  # (seaweedfs-volume-system-volume, data1-seaweedfs-volume-system-volume-0) also
+  # satisfy the CHART-named prefixes. The reconstruction must return the
+  # release-named prefix so the release-named branch can be tested first.
+  got=$(renamed_volume_prefix seaweedfs-volume-system)
+  [ "$got" = "seaweedfs-volume-system-volume" ]
+  # It must NOT collide with the chart-named prefix.
+  [ "$got" != "seaweedfs-volume" ]
+}
+
+@test "the reconstructed prefix never equals the chart-named prefix" {
+  # If it did, both generations would match one branch and the guard/audit could
+  # not separate them at all.
+  for r in seaweedfs-system foo-system seaweedfs-volume-system a-system; do
+    [ "$(renamed_volume_prefix "$r")" != "seaweedfs-volume" ]
+  done
+}
+
+@test "the audit's reconstruction agrees with the chart helper it mirrors" {
+  # hack/seaweedfs-naming-audit.sh and
+  # packages/system/seaweedfs/templates/_naming.tpl reimplement the same two
+  # upstream helpers in two languages. If they drift, the audit classifies a
+  # tenant differently from the render that refuses it, and the operator is
+  # working from a different picture than the chart. Render the chart helper
+  # through helm and compare it to this script's output, release by release.
+  chart=$(mktemp -d)
+  printf 'apiVersion: v2\nname: probe\nversion: 0.0.0\n' > "$chart/Chart.yaml"
+  mkdir -p "$chart/templates"
+  cp packages/system/seaweedfs/templates/_naming.tpl "$chart/templates/"
+  cat > "$chart/templates/out.yaml" <<'EOF'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: probe
+data:
+{{- range $r := list "seaweedfs-system" "foo-system" "seaweedfs-volume-system" "archive-of-quarterly-financial-statements-x1-system" "a-system" }}
+  {{ $r }}: {{ include "seaweedfs.renamedVolumePrefix" $r }}
+{{- end }}
+EOF
+  helm template probe "$chart" 2>/dev/null | sed -n 's/^  \([a-z0-9-]*-system\): \(.*\)$/\1=\2/p' > "$chart/rendered"
+  [ -s "$chart/rendered" ]
+  [ "$(wc -l < "$chart/rendered")" -eq 5 ]
+  while IFS='=' read -r rel expected; do
+    [ -n "$rel" ] || continue
+    got=$(renamed_volume_prefix "$rel")
+    echo "chart: $rel -> $expected ; audit: $got"
+    [ "$got" = "$expected" ]
+  done < "$chart/rendered"
+  rm -rf "$chart"
+}

--- a/hack/seaweedfs-naming-audit.bats
+++ b/hack/seaweedfs-naming-audit.bats
@@ -69,6 +69,43 @@ export SEAWEEDFS_AUDIT_LIB
   done
 }
 
+@test "clean duplicate: release-named PVs all strictly newer => legacy is original" {
+  # A tenant that passed through the 4.31 rename: legacy PVs at install time,
+  # duplicate PVs provisioned by the bad upgrade much later.
+  [ "$(classify_mixed_direction 1000 1010 5000 5020)" = "legacy-original" ]
+}
+
+@test "S-damaged: chart-named PVs all strictly newer => release-named is original" {
+  # Installed fresh on 1.5.x (release-named PVs first); an unguarded 1.6 upgrade
+  # then created empty chart-named claims beside them.
+  [ "$(classify_mixed_direction 5000 5020 1000 1010)" = "renamed-original" ]
+}
+
+@test "interrupted Step 2 re-bind: overlapping vintages => no candidate" {
+  # Step 2 re-binds release-named claims onto their ORIGINAL PVs under chart
+  # names, one claim at a time. Interrupted part-way, BOTH generations sit on
+  # original-vintage PVs, so the ranges interleave. The old absolute-window
+  # classifier fell through to a coin flip here and its advice deleted the
+  # un-re-bound claims; the relative rule must refuse instead.
+  [ "$(classify_mixed_direction 1000 1010 1005 1015)" = "overlap" ]
+}
+
+@test "a tie is overlap, not a candidate" {
+  # Second-resolution timestamps: a duplicate provisioned within the same second
+  # as the newest original PV is not STRICTLY newer. Refusing is recoverable;
+  # naming the wrong candidate is not.
+  [ "$(classify_mixed_direction 1000 1010 1010 1020)" = "overlap" ]
+}
+
+@test "direction needs no clock: vintages far from any anchor still classify" {
+  # The shipped StorageClasses are WaitForFirstConsumer, so PVs appear at
+  # pod-SCHEDULE time — on a cold cluster minutes after first_deployed. The rule
+  # must not care: only the two generations' ranges relative to EACH OTHER count.
+  # (The previous classifier anchored a 120s window on first_deployed and
+  # misclassified exactly this case.)
+  [ "$(classify_mixed_direction 100000 100600 200000 200600)" = "legacy-original" ]
+}
+
 @test "the audit's reconstruction agrees with the chart helper it mirrors" {
   # hack/seaweedfs-naming-audit.sh and
   # packages/system/seaweedfs/templates/_naming.tpl reimplement the same two

--- a/hack/seaweedfs-naming-audit.sh
+++ b/hack/seaweedfs-naming-audit.sh
@@ -13,15 +13,27 @@
 #   sh.helm.release.v1.<name>-system.v1  — the manifest of revision 1 names either
 #       seaweedfs-master (born pre-4.31) or <release>-master (born 4.31). Exact, but
 #       revision 1 may have been pruned by Helm's history limit.
-#   info.first_deployed                  — on EVERY retained revision, so it survives
-#       pruning. The generation whose PersistentVolumes were created at first_deployed
-#       is the original; the other was provisioned later, by the bad upgrade.
+#   PersistentVolume creation timestamps — the original generation's PVs predate the
+#       duplicate's, which were provisioned later by the bad upgrade. Compared only
+#       against each other (see the relative rule below); info.first_deployed is
+#       printed as context but decides nothing.
 #
 # PV timestamps, not PVC ones: runbook Step 2 deletes each release-named claim and
 # recreates it under the chart name against the SAME PV, so claim age is not durable
 # and inverts for a tenant interrupted mid-re-bind. The PV survives and keeps its
-# creationTimestamp. A tenant mid-re-bind shows BOTH generations at first_deployed,
-# which this reports as MID-REBIND rather than as a duplicate.
+# creationTimestamp.
+#
+# Direction is decided by a RELATIVE rule, never a clock window: a generation is
+# the candidate duplicate only when EVERY one of its bound PVs is strictly newer
+# than every bound PV of the other generation — the same precondition runbook
+# Step 2a enforces before deleting anything. Overlapping vintages mean an
+# interrupted Step 2 re-bind (both generations on original PVs) or interleaved
+# provisioning, and the audit refuses to name a candidate. An absolute window
+# measured from first_deployed was tried first and is unsound: the shipped
+# StorageClasses are WaitForFirstConsumer, so PVs appear at pod-SCHEDULE time,
+# and ordinary cold-cluster latency puts even the original generation's PVs
+# minutes past first_deployed — which pushed a mid-rebind tenant into the branch
+# whose advice deletes the un-re-bound claims.
 #
 # IMPORTANT — what this does NOT tell you. "Which generation is original" is not
 # "the other one is empty". A duplicate that never scheduled (safe to delete) and one
@@ -110,6 +122,27 @@ pv_epoch() {
   date -u -d "$(printf '%s' "$t" | cut -c1-19)" +%s 2>/dev/null
 }
 
+# classify_mixed_direction <lmin> <lmax> <rmin> <rmax> -- direction of a MIXED
+# tenant, from the bound-PV creation-epoch ranges of the chart-named (l*) and
+# release-named (r*) generations. Prints one of:
+#
+#   legacy-original   every release-named PV strictly newer -> it is the candidate
+#                     duplicate (runbook Step 3)
+#   renamed-original  every chart-named PV strictly newer -> S-damaged, the
+#                     chart-named set is the candidate duplicate (Step 2a, then 2)
+#   overlap           vintages interleave or touch -> no candidate. An interrupted
+#                     Step 2 re-bind puts BOTH generations on original-vintage PVs.
+#
+# Purely relative — no clock, no window, no first_deployed. Ties (second-resolution
+# timestamps) count as overlap: refusing a candidate is recoverable, naming the
+# wrong one is not.
+classify_mixed_direction() {
+  if [ "$3" -gt "$2" ]; then printf 'legacy-original'
+  elif [ "$1" -gt "$4" ]; then printf 'renamed-original'
+  else printf 'overlap'
+  fi
+}
+
 audit_ns() {
   ns="$1"
   for rel in $(system_releases "$ns"); do
@@ -150,28 +183,37 @@ audit_ns() {
       printf '%-24s %-14s %-8s   revision 1 was installed with the %s names => the %s generation is ORIGINAL\n' \
         "" "" "" "$scheme" "$scheme"
     fi
-    if [ -n "$fd" ]; then
-      lmin=""; rmin=""
-      for p in $legacy_pvcs;  do e=$(pv_epoch "$ns" "$p"); [ -n "$e" ] || continue; d=$((e - fd)); { [ -z "$lmin" ] || [ "$d" -lt "$lmin" ]; } && lmin=$d; done
-      for p in $renamed_pvcs; do e=$(pv_epoch "$ns" "$p"); [ -n "$e" ] || continue; d=$((e - fd)); { [ -z "$rmin" ] || [ "$d" -lt "$rmin" ]; } && rmin=$d; done
-      printf '%-24s %-14s %-8s   oldest PV vs first_deployed: chart-named %ss, release-named %ss\n' \
-        "" "" "" "${lmin:-?}" "${rmin:-?}"
-      if [ -n "$lmin" ] && [ -n "$rmin" ]; then
-        if [ "$lmin" -le "$MIDREBIND_WINDOW" ] && [ "$rmin" -le "$MIDREBIND_WINDOW" ]; then
-          printf '%-24s %-14s %-8s   BOTH at first_deployed => MID-REBIND, not a duplicate. Finish Step 2; do NOT run Step 2a.\n' "" "" ""
-        elif [ "$lmin" -lt "$rmin" ]; then
-          printf '%-24s %-14s %-8s   chart-named is original => the release-named set is the candidate duplicate\n' "" "" ""
-        else
-          printf '%-24s %-14s %-8s   release-named is original => the chart-named set is the candidate duplicate (Step 2a, then Step 2)\n' "" "" ""
-        fi
-      fi
+    lmin=""; lmax=""; rmin=""; rmax=""
+    for p in $legacy_pvcs; do
+      e=$(pv_epoch "$ns" "$p"); [ -n "$e" ] || continue
+      { [ -z "$lmin" ] || [ "$e" -lt "$lmin" ]; } && lmin=$e
+      { [ -z "$lmax" ] || [ "$e" -gt "$lmax" ]; } && lmax=$e
+    done
+    for p in $renamed_pvcs; do
+      e=$(pv_epoch "$ns" "$p"); [ -n "$e" ] || continue
+      { [ -z "$rmin" ] || [ "$e" -lt "$rmin" ]; } && rmin=$e
+      { [ -z "$rmax" ] || [ "$e" -gt "$rmax" ]; } && rmax=$e
+    done
+    if [ -n "$fd" ] && [ -n "$lmin" ] && [ -n "$rmin" ]; then
+      printf '%-24s %-14s %-8s   oldest PV vs first_deployed: chart-named +%ss, release-named +%ss (context only, not the rule)\n' \
+        "" "" "" "$((lmin - fd))" "$((rmin - fd))"
+    fi
+    if [ -n "$lmin" ] && [ -n "$rmin" ]; then
+      case $(classify_mixed_direction "$lmin" "$lmax" "$rmin" "$rmax") in
+        legacy-original)
+          printf '%-24s %-14s %-8s   every release-named PV is strictly newer => chart-named is ORIGINAL, the release-named set is the candidate duplicate (Step 3)\n' "" "" "" ;;
+        renamed-original)
+          printf '%-24s %-14s %-8s   every chart-named PV is strictly newer => release-named is ORIGINAL, the chart-named set is the candidate duplicate (Step 2a, then Step 2)\n' "" "" "" ;;
+        overlap)
+          printf '%-24s %-14s %-8s   PV vintages OVERLAP => no candidate. An interrupted Step 2 re-bind looks exactly like this (both generations on original PVs). Finish Step 2 if one is in progress; otherwise escalate. Do NOT run Step 2a.\n' "" "" "" ;;
+      esac
+    else
+      printf '%-24s %-14s %-8s   a generation has no bound PVs (Pending claims, or StatefulSets only) => direction cannot be established from PV ages. Resolve the Pending claims or classify by hand.\n' "" "" ""
     fi
     printf '%-24s %-14s %-8s   CANDIDATE ONLY: "original" does not mean the other set is EMPTY. A duplicate that\n' "" "" ""
     printf '%-24s %-14s %-8s   served writes and later crashed looks identical here. Verify emptiness before deleting.\n' "" "" ""
   done
 }
-
-MIDREBIND_WINDOW="${MIDREBIND_WINDOW:-120}"
 
 main() {
   printf '%-24s %-14s %-8s %s\n' NAMESPACE RELEASE CLASS NOTE

--- a/hack/seaweedfs-naming-audit.sh
+++ b/hack/seaweedfs-naming-audit.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# SeaweedFS 4.31 rename — fleet audit (READ-ONLY).
+#
+# Classifies every SeaweedFS tenant into the three states the chart's naming guard
+# (packages/system/seaweedfs/templates/naming-guard.yaml) decides between:
+#
+#   L      exactly the chart-named generation -> the upgrade adopts it. Nothing to do.
+#   S      exactly the release-named generation -> re-bind first (runbook Step 2).
+#   MIXED  both generations -> the chart REFUSES; an operator must remove the empty one.
+#
+# For MIXED it also reports which generation is ORIGINAL, from durable evidence:
+#
+#   sh.helm.release.v1.<name>-system.v1  — the manifest of revision 1 names either
+#       seaweedfs-master (born pre-4.31) or <release>-master (born 4.31). Exact, but
+#       revision 1 may have been pruned by Helm's history limit.
+#   info.first_deployed                  — on EVERY retained revision, so it survives
+#       pruning. The generation whose PersistentVolumes were created at first_deployed
+#       is the original; the other was provisioned later, by the bad upgrade.
+#
+# PV timestamps, not PVC ones: runbook Step 2 deletes each release-named claim and
+# recreates it under the chart name against the SAME PV, so claim age is not durable
+# and inverts for a tenant interrupted mid-re-bind. The PV survives and keeps its
+# creationTimestamp. A tenant mid-re-bind shows BOTH generations at first_deployed,
+# which this reports as MID-REBIND rather than as a duplicate.
+#
+# IMPORTANT — what this does NOT tell you. "Which generation is original" is not
+# "the other one is empty". A duplicate that never scheduled (safe to delete) and one
+# that served writes and later crashed (holds unique objects) are identical on every
+# durable signal — same revision-1 scheme, same first_deployed deltas. Establishing
+# emptiness needs the duplicate's volume files and the filer's volume list, which this
+# script does not inspect. It narrows the question; it does not answer it.
+#
+# Usage:  hack/seaweedfs-naming-audit.sh [namespace...]
+#         KUBECONFIG=<file> hack/seaweedfs-naming-audit.sh
+# Exit:   0 always (audit only). Nothing is mutated.
+set -uo pipefail
+
+# renamed_volume_prefix <release> -- reconstruct the name 4.31 gives the volume
+# component of <release>. Mirrors seaweedfs.fullname + seaweedfs.componentName
+# (see packages/system/seaweedfs/templates/_naming.tpl, which the chart's guard
+# uses for exactly the same purpose): the fullname gains -seaweedfs when the
+# release name does not already contain it, is capped at 63, and componentName
+# then cuts it to (62 - len("volume")) = 56 before appending -volume.
+renamed_volume_prefix() {
+  release="$1"
+  case "$release" in
+    *seaweedfs*) full="$release" ;;
+    *)           full="${release}-seaweedfs" ;;
+  esac
+  full=$(printf '%s' "$full" | cut -c1-63 | sed 's/-$//')
+  printf '%s-volume' "$(printf '%s' "$full" | cut -c1-56 | sed 's/-$//')"
+}
+
+# release_json <ns> <release> [rev] -- decode a Helm release secret.
+# Helm stores base64(gzip(json)) in Secret.data.release, and Kubernetes base64s
+# the data value again, hence the two decodes.
+release_json() {
+  kubectl get secret -n "$1" "sh.helm.release.v1.$2.v${3:-1}" -o jsonpath='{.data.release}' 2>/dev/null \
+    | base64 -d 2>/dev/null | base64 -d 2>/dev/null | gunzip 2>/dev/null
+}
+
+# revisions <ns> <release> -- retained revision numbers, oldest first.
+revisions() {
+  kubectl get secret -n "$1" -l "name=$2,owner=helm" \
+    -o jsonpath='{range .items[*]}{.metadata.labels.version}{"\n"}{end}' 2>/dev/null | sort -n
+}
+
+# system_releases <ns> -- the SeaweedFS <name>-system Helm releases in a namespace.
+# Filtering on the `-system` suffix alone is not enough: every Cozystack app has a
+# <name>-system release (ingress-nginx-system, bucket-*-system, ...), and since the
+# generation scan below matches PVCs by NAME across the whole namespace, an
+# unrelated release in a namespace that happens to run SeaweedFS would be reported
+# as a SeaweedFS tenant. Confirm the chart.
+system_releases() {
+  for rel in $(kubectl get secret -n "$1" \
+                 -o jsonpath='{range .items[?(@.type=="helm.sh/release.v1")]}{.metadata.labels.name}{"\n"}{end}' 2>/dev/null \
+               | grep -E -- '-system$' | sort -u); do
+    for rev in $(revisions "$1" "$rel"); do
+      chart=$(release_json "$1" "$rel" "$rev" | sed -n 's/.*"name":"\(cozy-seaweedfs\)".*/\1/p' | head -1)
+      if [ -n "$chart" ]; then printf '%s\n' "$rel"; fi
+      break
+    done
+  done
+}
+
+# first_deployed <ns> <release> -- epoch seconds of the release's first install,
+# from any retained revision (the field is identical on all of them).
+first_deployed() {
+  for rev in $(revisions "$1" "$2"); do
+    ts=$(release_json "$1" "$2" "$rev" | sed -n 's/.*"first_deployed":"\([^"]*\)".*/\1/p' | head -1)
+    if [ -n "$ts" ]; then date -u -d "$(printf '%s' "$ts" | cut -c1-19)" +%s 2>/dev/null; return; fi
+  done
+}
+
+# rev1_scheme <ns> <release> -- "legacy" | "renamed" | "" (revision 1 pruned).
+rev1_scheme() {
+  m=$(release_json "$1" "$2" 1)
+  [ -n "$m" ] || return 0
+  if printf '%s' "$m" | grep -q 'name: seaweedfs-master'; then printf 'legacy'
+  elif printf '%s' "$m" | grep -qE "name: $2(-seaweedfs)?-master"; then printf 'renamed'
+  fi
+}
+
+# pv_epoch <ns> <pvc> -- creation epoch of the PV the claim is BOUND to.
+pv_epoch() {
+  pv=$(kubectl get pvc -n "$1" "$2" -o jsonpath='{.spec.volumeName}' 2>/dev/null)
+  [ -n "$pv" ] || return 0
+  t=$(kubectl get pv "$pv" -o jsonpath='{.metadata.creationTimestamp}' 2>/dev/null)
+  [ -n "$t" ] || return 0
+  date -u -d "$(printf '%s' "$t" | cut -c1-19)" +%s 2>/dev/null
+}
+
+audit_ns() {
+  ns="$1"
+  for rel in $(system_releases "$ns"); do
+    prefix=$(renamed_volume_prefix "$rel")
+    legacy_pvcs=""; renamed_pvcs=""
+    for pvc in $(kubectl get pvc -n "$ns" -o name 2>/dev/null | sed 's|persistentvolumeclaim/||'); do
+      case "$pvc" in
+        "data1-${prefix}"*)      renamed_pvcs="$renamed_pvcs $pvc" ;;
+        data1-seaweedfs-volume*) legacy_pvcs="$legacy_pvcs $pvc" ;;
+      esac
+    done
+    legacy_sts=""; renamed_sts=""
+    for sts in $(kubectl get sts -n "$ns" -l app.kubernetes.io/name=seaweedfs -o name 2>/dev/null | sed 's|statefulset.apps/||'); do
+      case "$sts" in
+        "${prefix}"*)      renamed_sts="$renamed_sts $sts" ;;
+        seaweedfs-volume*) legacy_sts="$legacy_sts $sts" ;;
+      esac
+    done
+    has_legacy=0; has_renamed=0
+    [ -n "$legacy_pvcs$legacy_sts" ] && has_legacy=1
+    [ -n "$renamed_pvcs$renamed_sts" ] && has_renamed=1
+    [ "$has_legacy" = 0 ] && [ "$has_renamed" = 0 ] && continue
+
+    if [ "$has_legacy" = 1 ] && [ "$has_renamed" = 0 ]; then
+      printf '%-24s %-14s %-8s %s\n' "$ns" "$rel" "L" "chart-named only; the upgrade adopts it, nothing to do"
+      continue
+    fi
+    if [ "$has_renamed" = 1 ] && [ "$has_legacy" = 0 ]; then
+      printf '%-24s %-14s %-8s %s\n' "$ns" "$rel" "S" "release-named only; re-bind the volumes (Step 2) BEFORE upgrading"
+      continue
+    fi
+
+    # Both generations. Report which is ORIGINAL from durable evidence.
+    fd=$(first_deployed "$ns" "$rel")
+    scheme=$(rev1_scheme "$ns" "$rel")
+    printf '%-24s %-14s %-8s %s\n' "$ns" "$rel" "MIXED" "both generations; the chart REFUSES until one is removed"
+    if [ -n "$scheme" ]; then
+      printf '%-24s %-14s %-8s   revision 1 was installed with the %s names => the %s generation is ORIGINAL\n' \
+        "" "" "" "$scheme" "$scheme"
+    fi
+    if [ -n "$fd" ]; then
+      lmin=""; rmin=""
+      for p in $legacy_pvcs;  do e=$(pv_epoch "$ns" "$p"); [ -n "$e" ] || continue; d=$((e - fd)); { [ -z "$lmin" ] || [ "$d" -lt "$lmin" ]; } && lmin=$d; done
+      for p in $renamed_pvcs; do e=$(pv_epoch "$ns" "$p"); [ -n "$e" ] || continue; d=$((e - fd)); { [ -z "$rmin" ] || [ "$d" -lt "$rmin" ]; } && rmin=$d; done
+      printf '%-24s %-14s %-8s   oldest PV vs first_deployed: chart-named %ss, release-named %ss\n' \
+        "" "" "" "${lmin:-?}" "${rmin:-?}"
+      if [ -n "$lmin" ] && [ -n "$rmin" ]; then
+        if [ "$lmin" -le "$MIDREBIND_WINDOW" ] && [ "$rmin" -le "$MIDREBIND_WINDOW" ]; then
+          printf '%-24s %-14s %-8s   BOTH at first_deployed => MID-REBIND, not a duplicate. Finish Step 2; do NOT run Step 2a.\n' "" "" ""
+        elif [ "$lmin" -lt "$rmin" ]; then
+          printf '%-24s %-14s %-8s   chart-named is original => the release-named set is the candidate duplicate\n' "" "" ""
+        else
+          printf '%-24s %-14s %-8s   release-named is original => the chart-named set is the candidate duplicate (Step 2a, then Step 2)\n' "" "" ""
+        fi
+      fi
+    fi
+    printf '%-24s %-14s %-8s   CANDIDATE ONLY: "original" does not mean the other set is EMPTY. A duplicate that\n' "" "" ""
+    printf '%-24s %-14s %-8s   served writes and later crashed looks identical here. Verify emptiness before deleting.\n' "" "" ""
+  done
+}
+
+MIDREBIND_WINDOW="${MIDREBIND_WINDOW:-120}"
+
+main() {
+  printf '%-24s %-14s %-8s %s\n' NAMESPACE RELEASE CLASS NOTE
+  printf '%-24s %-14s %-8s %s\n' --------- ------- ----- ----
+  if [ "$#" -gt 0 ]; then
+    for ns in "$@"; do audit_ns "$ns"; done
+  else
+    for ns in $(kubectl get ns -o name 2>/dev/null | sed 's|namespace/||'); do audit_ns "$ns"; done
+  fi
+}
+
+# Sourced by hack/seaweedfs-naming-audit.bats to exercise the classifier directly.
+[ "${SEAWEEDFS_AUDIT_LIB:-0}" = "1" ] || main "$@"

--- a/hack/seaweedfs-naming-audit.sh
+++ b/hack/seaweedfs-naming-audit.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # SeaweedFS 4.31 rename — fleet audit (READ-ONLY).
 #
 # Classifies every SeaweedFS tenant into the three states the chart's naming guard
@@ -45,7 +45,15 @@
 # Usage:  hack/seaweedfs-naming-audit.sh [namespace...]
 #         KUBECONFIG=<file> hack/seaweedfs-naming-audit.sh
 # Exit:   0 always (audit only). Nothing is mutated.
-set -uo pipefail
+#
+# POSIX sh, deliberately. hack/seaweedfs-naming-audit.bats sources this file, and
+# cozytest.sh sources the converted test into its own /bin/sh — which is dash on
+# the CI runner. A bash shebang would not save it: `.` runs the file's contents in
+# the caller's shell and the shebang is just a comment. Keeping the script POSIX
+# is what makes the tested shell and the executed shell the same one; anything
+# bash-only here is untested in CI and unavailable at run time. `pipefail` in
+# particular is not POSIX and dash 0.5.12 (Ubuntu) rejects it outright.
+set -u
 
 # renamed_volume_prefix <release> -- reconstruct the name 4.31 gives the volume
 # component of <release>. Mirrors seaweedfs.fullname + seaweedfs.componentName

--- a/hack/testdata/migration-seaweedfs-db/kubectl
+++ b/hack/testdata/migration-seaweedfs-db/kubectl
@@ -1,0 +1,101 @@
+#!/bin/sh
+# Fake kubectl for hack/migration-seaweedfs-db-adopt.bats. It serves only the
+# calls lib/seaweedfs-db-adopt.sh makes; behaviour is driven by FAKE_* env and
+# every invocation is appended to $FAKE_CMDLOG so the test can assert on which
+# namespaces were acted on and with which annotations.
+#
+#   FAKE_CMDLOG    file to append a one-line record of each call to
+#   FAKE_CLUSTERS  newline list of "<ns> <release-name> <resource-policy>" — one
+#                  per namespace holding a Cluster/seaweedfs-db. Use "-" for
+#                  either annotation to model it being ABSENT (jsonpath prints
+#                  nothing and exits 0).
+#   FAKE_LIST_FAIL      non-empty => the -A fleet scan exits 1 with this as stderr
+#   FAKE_GET_FAIL       non-empty => the per-namespace get exits 1 with this stderr
+#   FAKE_ANNOTATE_FAIL  non-empty => `annotate` exits 1 (a failed hand-over)
+#
+# The failure knobs exist because the point of the helper is that a kubectl error
+# must ABORT the migration rather than let it stamp the version and never run
+# again. A fake that can only succeed cannot test that.
+set -u
+
+log() { [ -n "${FAKE_CMDLOG:-}" ] && printf '%s\n' "$*" >> "$FAKE_CMDLOG"; }
+log "KUBECTL $*"
+
+args="$*"
+
+# arg_after KEY -- echoes the token following KEY in the argument vector.
+arg_after() { k="$1"; shift; p=""; for a in "$@"; do [ "$p" = "$k" ] && { printf '%s' "$a"; return; }; p="$a"; done; }
+
+# field <ns> <rel|keep> -- echo that annotation for the FAKE_CLUSTERS row of ns.
+field() {
+  printf '%s\n' "${FAKE_CLUSTERS:-}" | while read -r n rel keep; do
+    if [ "$n" = "$1" ]; then
+      case "$2" in
+        rel)  [ "${rel:--}" = "-" ]  || printf '%s' "$rel" ;;
+        keep) [ "${keep:--}" = "-" ] || printf '%s' "$keep" ;;
+      esac
+      break
+    fi
+  done
+}
+
+case "$args" in
+  # Version stamp: kubectl apply --filename -
+  *"apply --filename -"*)
+    manifest=$(cat)
+    # Record the version actually stamped. A migration that stamped the wrong
+    # number would loop the runner forever, and asserting a bare "STAMP" would
+    # not notice.
+    v=$(printf '%s\n' "$manifest" | sed -n 's/^  version: "\{0,1\}\([0-9]\{1,\}\)"\{0,1\}$/\1/p' | head -1)
+    log "STAMP ${v:-unknown}"
+    exit 0
+    ;;
+
+  # Fleet scan: list namespaces holding a Cluster named seaweedfs-db.
+  *"get cluster.postgresql.cnpg.io -A"*)
+    if [ -n "${FAKE_LIST_FAIL:-}" ]; then
+      printf '%s\n' "$FAKE_LIST_FAIL" >&2
+      exit 1
+    fi
+    printf '%s\n' "${FAKE_CLUSTERS:-}" | while read -r ns rel keep; do
+      [ -n "$ns" ] && printf '%s\n' "$ns"
+    done
+    exit 0
+    ;;
+
+  # Per-namespace read of an annotation.
+  *"get cluster.postgresql.cnpg.io seaweedfs-db"*)
+    if [ -n "${FAKE_GET_FAIL:-}" ]; then
+      printf '%s\n' "$FAKE_GET_FAIL" >&2
+      exit 1
+    fi
+    ns=$(arg_after -n "$@")
+    case "$args" in
+      *"resource-policy"*) field "$ns" keep ;;
+      *)                   field "$ns" rel ;;
+    esac
+    exit 0
+    ;;
+
+  # The hand-over itself.
+  *"annotate cluster.postgresql.cnpg.io seaweedfs-db"*)
+    if [ -n "${FAKE_ANNOTATE_FAIL:-}" ]; then
+      printf '%s\n' "$FAKE_ANNOTATE_FAIL" >&2
+      exit 1
+    fi
+    ns=$(arg_after -n "$@")
+    rel=""
+    keep=""
+    for a in "$@"; do
+      case "$a" in
+        meta.helm.sh/release-name=*) rel="${a#meta.helm.sh/release-name=}" ;;
+        helm.sh/resource-policy=*)   keep="${a#helm.sh/resource-policy=}" ;;
+      esac
+    done
+    log "ANNOTATE $ns release-name=${rel:-<unset>} resource-policy=${keep:-<unset>}"
+    exit 0
+    ;;
+esac
+
+log "UNHANDLED $args"
+exit 0

--- a/packages/core/platform/images/migrations/migrations/43
+++ b/packages/core/platform/images/migrations/migrations/43
@@ -1,34 +1,33 @@
 #!/bin/sh
 # Migration 43 --> 44
-# Adopt existing Cluster/seaweedfs-db resources into the new seaweedfs-db
+# Adopt existing Cluster/seaweedfs-db resources into the new <name>-db
 # HelmRelease introduced in this release.
 #
-# Pre-split, the CNPG Cluster lived inside the seaweedfs-system Helm release.
-# Splitting moves it to a new release named seaweedfs-db. We rewrite the
-# helm ownership annotations so Helm adopts the existing Cluster instead of
-# erroring on the next reconcile, and stamp helm.sh/resource-policy: keep
-# so the seaweedfs-system upgrade (which no longer renders the Cluster) does
-# not delete it during the transition.
+# Pre-split, the CNPG Cluster lived inside the <name>-system Helm release.
+# Splitting moves it to a new release named <name>-db. We rewrite the helm
+# ownership annotations so Helm adopts the existing Cluster instead of erroring
+# on the next reconcile, and stamp helm.sh/resource-policy: keep so the
+# <name>-system upgrade (which no longer renders the Cluster) does not delete it
+# during the transition.
+#
+# The hand-over itself lives in lib/seaweedfs-db-adopt.sh, shared with migration
+# 53. This migration originally compared the owning release name against the
+# literal "seaweedfs-system", which silently skipped every instance NOT named
+# `seaweedfs`: SeaweedFS is a user-creatable kind, so an instance `foo` is owned
+# by `foo-system`. Those tenants got no `keep`, and the <name>-system upgrade
+# pruned their Cluster — taking the filer metadata, and with it all of the
+# tenant's S3. The shared helper matches the `-system` SUFFIX instead, covering
+# every instance name; migration 53 repairs clusters that already ran the
+# hardcoded version.
 
 set -euo pipefail
 
 # shellcheck source=lib/cozystack-version.sh
 . "$(dirname "$0")/lib/cozystack-version.sh"
+# shellcheck source=lib/seaweedfs-db-adopt.sh
+. "$(dirname "$0")/lib/seaweedfs-db-adopt.sh"
 
-# Iterate every namespace that has a Cluster named "seaweedfs-db".
-for ns in $(kubectl get cluster.postgresql.cnpg.io -A \
-              -o jsonpath='{range .items[?(@.metadata.name=="seaweedfs-db")]}{.metadata.namespace}{"\n"}{end}'); do
-  current=$(kubectl get cluster.postgresql.cnpg.io seaweedfs-db -n "$ns" \
-    -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>/dev/null || true)
-  if [ "$current" = "seaweedfs-system" ]; then
-    echo "Re-annotating Cluster/seaweedfs-db in $ns: seaweedfs-system -> seaweedfs-db"
-    kubectl annotate cluster.postgresql.cnpg.io seaweedfs-db -n "$ns" \
-      meta.helm.sh/release-name=seaweedfs-db \
-      helm.sh/resource-policy=keep \
-      --overwrite
-    # release-namespace stays the same (tenant namespace, e.g. tenant-root)
-  fi
-done
+adopt_seaweedfs_db_clusters
 
 # Stamp version. The labeled manifest lives in the shared helper so it cannot
 # drift back to a label-less apply that strips platform.cozystack.io/no-delete.

--- a/packages/core/platform/images/migrations/migrations/53
+++ b/packages/core/platform/images/migrations/migrations/53
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Migration 53 --> 54
+# Repair the 1.5.0 db-split hand-over for SeaweedFS instances whose name is not
+# the default `seaweedfs`.
+#
+# Migration 43 performs the hand-over of Cluster/seaweedfs-db from the
+# <name>-system release to the <name>-db release introduced by the split (PR
+# #2601, v1.5.0). It matched the owning release name against the literal
+# "seaweedfs-system", so it only ever fired for an instance named `seaweedfs`.
+# `SeaweedFS` is a user-creatable kind: an instance named `foo` is owned by
+# release `foo-system` and was skipped. Such a tenant kept
+# meta.helm.sh/release-name: <name>-system and never received
+# helm.sh/resource-policy: keep, so the <name>-system upgrade — whose post-split
+# chart no longer renders the Cluster — deleted it as a removed resource. CNPG
+# takes the PVC with the Cluster, so the filer metadata, and with it every object
+# in that tenant's S3, is unreachable.
+#
+# Migration 43 is fixed in place, which covers clusters upgrading from before 43.
+# Migrations never re-run, so any cluster already at version >= 44 ran the
+# hardcoded version and is still exposed: this migration re-checks the fleet and
+# performs the hand-over for any Cluster/seaweedfs-db still owned by a
+# <name>-system release. Running as a pre-upgrade hook, it lands before the
+# platform applies the new artifacts and therefore before <name>-system
+# re-renders, closing the window on THIS upgrade.
+#
+# The prune is not a one-shot: Helm diffs the LAST DEPLOYED revision against the
+# new manifest, so a tenant whose <name>-system last succeeded on a pre-split
+# revision recomputes the same deletion on EVERY upgrade attempt, including ones
+# that fail for unrelated reasons. Such a tenant re-deletes the Cluster each time
+# <name>-db recreates it. Stamping `keep` breaks that loop even when the
+# <name>-system upgrade itself stays wedged.
+#
+# Idempotent (a Cluster already owned by <name>-db is left alone), so it is a
+# no-op on a correctly migrated cluster and on fresh installs.
+#
+# LIMIT — this migration cannot recover a Cluster that is ALREADY deleted. There
+# is nothing left to re-annotate: the PVC went with it. Such a tenant needs its
+# filer metadata restored from a backup; see
+# docs/operations/seaweedfs-431-rename-recovery.md.
+
+set -euo pipefail
+
+# shellcheck source=lib/cozystack-version.sh
+. "$(dirname "$0")/lib/cozystack-version.sh"
+# shellcheck source=lib/seaweedfs-db-adopt.sh
+. "$(dirname "$0")/lib/seaweedfs-db-adopt.sh"
+
+adopt_seaweedfs_db_clusters
+
+# Stamp version via the shared helper so the cozystack-version ConfigMap keeps
+# the platform.cozystack.io/no-delete label.
+stamp_cozystack_version 54

--- a/packages/core/platform/images/migrations/migrations/lib/seaweedfs-db-adopt.sh
+++ b/packages/core/platform/images/migrations/migrations/lib/seaweedfs-db-adopt.sh
@@ -1,0 +1,178 @@
+# shellcheck shell=sh
+# Shared helper for handing Cluster/seaweedfs-db over to the <name>-db release.
+#
+# The 1.5.0 db split (PR #2601) moved the CNPG Cluster carrying SeaweedFS filer
+# metadata out of the <name>-system Helm release into a new <name>-db release.
+# The Cluster object itself did not move — only its ownership had to. Two things
+# must be true BEFORE <name>-system next renders, and they are independent:
+#
+#   meta.helm.sh/release-name=<name>-db   so <name>-db ADOPTS the existing
+#                                         Cluster instead of failing its install
+#                                         on Helm's ownership check;
+#   helm.sh/resource-policy=keep          so the <name>-system upgrade, whose new
+#                                         chart no longer renders the Cluster,
+#                                         does not GARBAGE-COLLECT it as a
+#                                         removed resource.
+#
+# Without `keep` the Cluster is deleted, CNPG takes its PVC with it, and the
+# tenant's filer metadata — hence all of its S3 — is gone. Data loss, not outage.
+#
+# The window is not a one-shot. Helm prunes by diffing the LAST DEPLOYED revision
+# against the new manifest, so as long as <name>-system's last successful revision
+# is a pre-split one that still contains the Cluster, EVERY subsequent upgrade
+# attempt — including ones that fail for unrelated reasons and never become the
+# new "deployed" revision — re-computes the same deletion. A tenant whose
+# <name>-system is wedged therefore re-deletes the Cluster on every retry, racing
+# <name>-db, which keeps recreating it. `keep` is what breaks that loop, and it
+# must stay for as long as that pre-split revision remains the prune baseline
+# (i.e. until <name>-system upgrades successfully at least once). Clearing it
+# again is deferred to the 1.7 batch migrations.
+#
+# Ownership is therefore NOT a proxy for safety. A Cluster can already be owned by
+# <name>-db and still need `keep`: where the hand-over was skipped, <name>-system
+# prunes the Cluster and <name>-db simply RECREATES it under its own ownership
+# with no keep — while <name>-system's prune baseline still lists it, so the next
+# reconcile deletes it again. Both shapes are live on the upgrade stand:
+# tenant-l and tenant-root are <name>-db-owned WITH keep and their <name>-system
+# deployed revision (rev 1) still contains the Cluster, so only keep saves them;
+# tenant-fresh is <name>-db-owned WITHOUT keep because it was installed after the
+# split and its <name>-system never rendered a Cluster. Telling those two apart
+# needs the release's deployed manifest, which this script cannot read cheaply or
+# reliably. The costs are asymmetric: stamping keep where it was not needed leaves
+# an orphan on app delete (which the extra/seaweedfs cleanup hook reclaims);
+# missing one loses the database. So keep is stamped on every Cluster owned by
+# either side of the split.
+#
+# Migration 43 shipped this logic with the owning release name hardcoded to
+# "seaweedfs-system", which is only correct for an instance named `seaweedfs`.
+# `SeaweedFS` is a user-creatable kind, so an instance named e.g. `foo` is owned
+# by `foo-system` and was silently skipped: no re-own, no keep, Cluster pruned.
+# Matching on the `-system` SUFFIX instead covers every instance name, so this
+# helper is sourced by both migration 43 (the original hand-over, for clusters
+# that have not run it yet) and migration 53 (repair, for clusters that already
+# ran the hardcoded version).
+#
+# Idempotent: a Cluster already owned by <name>-db AND carrying keep is left
+# alone, so re-running is a no-op and both migrations can safely fire on the same
+# cluster.
+#
+# FAILS CLOSED. Migrations never re-run, so a transient error swallowed here would
+# permanently leave at-risk tenants exposed with no later migration to catch them.
+# Every kubectl failure is fatal EXCEPT the two that genuinely mean "nothing to
+# do": the CNPG resource type not being served at all (a cluster without CNPG),
+# and a Cluster disappearing between the scan and the read. A non-zero return
+# aborts the migration before it stamps the version, so the Job retries.
+#
+# Sourced, not executed:
+#   . "$(dirname "$0")/lib/seaweedfs-db-adopt.sh"
+
+# _sdb_is_absent_err <file>
+# True when a kubectl error means the thing simply is not there, as opposed to the
+# API being unreachable, forbidden, throttled, or not yet established. Kept
+# deliberately narrow: anything unrecognised is treated as fatal.
+_sdb_is_absent_err() {
+  grep -qiE "server doesn't have a resource type|server could not find the requested resource|could not find the requested resource|not found" "$1"
+}
+
+# adopt_seaweedfs_db_clusters
+# Re-own and/or protect every Cluster/seaweedfs-db the split left exposed.
+# Returns non-zero (aborting the migration) on any error that is not "absent".
+adopt_seaweedfs_db_clusters() {
+  _sdb_err=$(mktemp)
+
+  # Fleet scan. Assigning inside `if !` keeps errexit from firing so the exit
+  # status can be inspected — `for ns in $(kubectl ...)` would silently iterate
+  # zero times on failure and let the caller stamp the version regardless, which
+  # is the whole bug this guard exists for.
+  if ! _sdb_namespaces=$(kubectl get cluster.postgresql.cnpg.io -A \
+        -o jsonpath='{range .items[?(@.metadata.name=="seaweedfs-db")]}{.metadata.namespace}{"\n"}{end}' \
+        2>"$_sdb_err"); then
+    if _sdb_is_absent_err "$_sdb_err"; then
+      echo "CNPG Cluster resource type is not served on this cluster — no SeaweedFS databases to hand over"
+      rm -f "$_sdb_err"
+      return 0
+    fi
+    echo "FATAL: cannot list Cluster/seaweedfs-db across namespaces; refusing to stamp past an unverified fleet:" >&2
+    cat "$_sdb_err" >&2
+    rm -f "$_sdb_err"
+    return 1
+  fi
+
+  for ns in $_sdb_namespaces; do
+    [ -n "$ns" ] || continue
+
+    if ! _sdb_current=$(kubectl get cluster.postgresql.cnpg.io seaweedfs-db -n "$ns" \
+          -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>"$_sdb_err"); then
+      if _sdb_is_absent_err "$_sdb_err"; then
+        echo "Cluster/seaweedfs-db in $ns disappeared between scan and read — skipping"
+        continue
+      fi
+      echo "FATAL: cannot read the Helm owner of Cluster/seaweedfs-db in $ns:" >&2
+      cat "$_sdb_err" >&2
+      rm -f "$_sdb_err"
+      return 1
+    fi
+
+    if ! _sdb_keep=$(kubectl get cluster.postgresql.cnpg.io seaweedfs-db -n "$ns" \
+          -o jsonpath='{.metadata.annotations.helm\.sh/resource-policy}' 2>"$_sdb_err"); then
+      if _sdb_is_absent_err "$_sdb_err"; then
+        echo "Cluster/seaweedfs-db in $ns disappeared between scan and read — skipping"
+        continue
+      fi
+      echo "FATAL: cannot read the resource-policy of Cluster/seaweedfs-db in $ns:" >&2
+      cat "$_sdb_err" >&2
+      rm -f "$_sdb_err"
+      return 1
+    fi
+
+    case "$_sdb_current" in
+      # No Helm ownership annotation at all — distinct from "unreadable", which is
+      # fatal above. Guessing an owner would be worse than doing nothing, but a
+      # SeaweedFS database that nobody owns is worth saying out loud.
+      "")
+        echo "WARNING: Cluster/seaweedfs-db in $ns carries no meta.helm.sh/release-name — not Helm-managed, leaving it alone. If this tenant runs SeaweedFS, verify by hand that its database is not about to be pruned." >&2
+        ;;
+
+      # Owned by the data-plane release: this is the hand-over. The instance name
+      # is whatever precedes -system, so `foo-system` -> `foo-db` exactly as
+      # `seaweedfs-system` -> `seaweedfs-db`.
+      *-system)
+        _sdb_instance="${_sdb_current%-system}"
+        # A release literally named "-system" has no instance name; refusing is
+        # safer than annotating an owner of "-db" that no release will claim.
+        if [ -z "$_sdb_instance" ]; then
+          echo "WARNING: Cluster/seaweedfs-db in $ns is owned by a release named '$_sdb_current' with no instance name — skipping" >&2
+          continue
+        fi
+        echo "Re-annotating Cluster/seaweedfs-db in $ns: $_sdb_current -> ${_sdb_instance}-db (+keep)"
+        kubectl annotate cluster.postgresql.cnpg.io seaweedfs-db -n "$ns" \
+          meta.helm.sh/release-name="${_sdb_instance}-db" \
+          helm.sh/resource-policy=keep \
+          --overwrite
+        # release-namespace stays the same (the tenant namespace); both releases
+        # live there, so the ownership check only needed release-name rewritten.
+        ;;
+
+      # Already owned by the db release. Ownership is correct, but that does NOT
+      # imply it is protected — see the note above. Stamp keep if it is missing.
+      *-db)
+        if [ "$_sdb_keep" = "keep" ]; then
+          echo "Cluster/seaweedfs-db in $ns already handed over to $_sdb_current and protected — nothing to do"
+        else
+          echo "Protecting Cluster/seaweedfs-db in $ns: owned by $_sdb_current but missing helm.sh/resource-policy=keep"
+          kubectl annotate cluster.postgresql.cnpg.io seaweedfs-db -n "$ns" \
+            helm.sh/resource-policy=keep \
+            --overwrite
+        fi
+        ;;
+
+      # Owned by some unrelated release. Not ours to touch.
+      *)
+        echo "WARNING: Cluster/seaweedfs-db in $ns is owned by unrelated release '$_sdb_current' — leaving it alone" >&2
+        ;;
+    esac
+  done
+
+  rm -f "$_sdb_err"
+  return 0
+}

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -14,7 +14,7 @@ migrations:
   # refuses to advance past a migration file missing from the image (exit 1), so
   # a stale pin fails loudly rather than silently skipping the etcd adoption.
   image: ghcr.io/cozystack/cozystack/platform-migrations:v1.5.0@sha256:8bf61f17e99eb4a3365394e3d97ac52a1d68cc84aa104894ecb09de25721dc1d
-  targetVersion: 53
+  targetVersion: 54
   # Adopt legacy etcd clusters onto the v1alpha2 operator WITHOUT the mandatory
   # pre-adoption safety snapshot (migration 50). Leave false unless migration 50
   # has actually refused to proceed and you accept the risk: adoption rewires

--- a/packages/extra/seaweedfs/Makefile
+++ b/packages/extra/seaweedfs/Makefile
@@ -5,6 +5,22 @@ include ../../../hack/package.mk
 .PHONY: test
 test:
 	helm unittest .
+	$(MAKE) test-guard-fail-closed
+
+# Sibling of the same target in packages/system/seaweedfs: this chart's copy of
+# the naming guard must also refuse an UPGRADE it cannot see the cluster for.
+# helm-unittest 1.0.3 ignores release.isUpgrade, so tests/guard_fail_closed_test.yaml
+# can only cover the render-through side and passes with or without the canary —
+# the refusal needs a real renderer.
+.PHONY: test-guard-fail-closed
+test-guard-fail-closed:
+	@out=$$(helm template seaweedfs . -n tenant-root --is-upgrade \
+	  --set topology=Simple --set replicationFactor=2 \
+	  --set _namespace.host=example.org --set _namespace.ingress=tenant-root \
+	  --set _cluster.issuer-name=letsencrypt-prod --set _cluster.solver=http01 2>&1); \
+	echo "$$out" | grep -q 'refusing to upgrade blind' \
+	  || { echo "FAIL: a blind upgrade rendered instead of refusing (naming-guard canary is not firing)"; echo "$$out" | head -5; exit 1; }
+	@echo "ok: naming guard refuses a blind upgrade"
 
 generate:
 	cozyvalues-gen -v values.yaml -s values.schema.json -r README.md

--- a/packages/extra/seaweedfs/templates/_naming.tpl
+++ b/packages/extra/seaweedfs/templates/_naming.tpl
@@ -22,7 +22,21 @@
 
    The guard deliberately does NOT call seaweedfs.fullname directly: that helper
    reads .Values.fullnameOverride, which this chart PINS to `seaweedfs`, so it
-   returns the chart-named generation — the opposite of what is wanted here. */}}
+   returns the chart-named generation — the opposite of what is wanted here.
+
+   ACCEPTED LIMIT — zone/pool volume components. MultiZone (and Simple-with-
+   pools) tenants get per-group components with suffix `volume-<key>`, cut at
+   (62 - len(suffix)), i.e. SHORTER than the 56 this helper reconstructs. The
+   prefixes only diverge when the fullname exceeds that shorter cut: for the
+   supported instance (the tenant module hardcodes the name `seaweedfs`,
+   fullname 16 chars) that takes a zone/pool key of ~40+ characters, and for
+   the default `volume` group it can never happen (its suffix IS the 56 cut).
+   A guard prefix that diverges means a release-named zone component the guard
+   cannot see. Decided 2026-07-17 (1.6 triage): accepted and documented in
+   docs/operations/seaweedfs-431-rename-recovery.md (Scope) rather than
+   reconstructed per-key — instance names are fixed by the tenant module and
+   absurd keys are the only reachable trigger. Revisit if instance naming is
+   ever opened up or a key-length clamp lands in extra/seaweedfs. */}}
 {{- define "seaweedfs.renamedVolumePrefix" -}}
 {{- $release := . -}}
 {{- $full := $release -}}

--- a/packages/extra/seaweedfs/templates/_naming.tpl
+++ b/packages/extra/seaweedfs/templates/_naming.tpl
@@ -1,0 +1,34 @@
+{{- /* seaweedfs.renamedVolumePrefix — reconstruct the name 4.31 gives the volume
+   component of the `<name>-system` release, i.e. the RELEASE-NAMED generation the
+   fullnameOverride pin exists to avoid.
+
+   Input: the `<name>-system` release name, as a bare string.
+     {{ include "seaweedfs.renamedVolumePrefix" "foo-system" }} -> foo-system-seaweedfs-volume
+
+   This replays two upstream helpers, so it must track them if the vendored chart
+   changes (hack/seaweedfs-guard-parity.bats pins the two copies of the guard
+   against each other; charts/seaweedfs/templates/shared/_helpers.tpl is the
+   source of truth for the rules below):
+
+     seaweedfs.fullname      — with no fullnameOverride, the release name, plus
+                               `-<chart name>` when the release name does not
+                               already contain it; truncated to 63.
+     seaweedfs.componentName — truncates the fullname to (62 - len(suffix)) before
+                               appending `-<suffix>`, so for `volume` the fullname
+                               is cut to 56. An instance name >= ~40 chars
+                               therefore loses `seaweedfs` from the tail, which is
+                               why a `contains "seaweedfs"` name filter cannot see
+                               its claims and this reconstruction can.
+
+   The guard deliberately does NOT call seaweedfs.fullname directly: that helper
+   reads .Values.fullnameOverride, which this chart PINS to `seaweedfs`, so it
+   returns the chart-named generation — the opposite of what is wanted here. */}}
+{{- define "seaweedfs.renamedVolumePrefix" -}}
+{{- $release := . -}}
+{{- $full := $release -}}
+{{- if not (contains "seaweedfs" $release) -}}
+{{-   $full = printf "%s-seaweedfs" $release -}}
+{{- end -}}
+{{- $full = $full | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-volume" ($full | trunc 56 | trimSuffix "-") -}}
+{{- end -}}

--- a/packages/extra/seaweedfs/templates/hooks/cleanup.yaml
+++ b/packages/extra/seaweedfs/templates/hooks/cleanup.yaml
@@ -182,8 +182,25 @@ spec:
               # but still installs. Deleting on name alone would take a different
               # app's database.
               echo "Deleting SeaweedFS filer-metadata database for {{ .Release.Name }}..."
-              owner=$(kubectl get cluster.postgresql.cnpg.io -n {{ .Release.Namespace }} seaweedfs-db \
-                        -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>/dev/null || true)
+              # Reading ownership must FAIL the Job on error, not fall through. `|| true`
+              # would turn a Forbidden, a timeout or any API error into an empty owner,
+              # take the "nothing to reclaim" branch below, and let the Job complete —
+              # orphaning the keep-protected Cluster this hook exists to reclaim, with
+              # nothing else that will ever collect it. Only a genuine NotFound counts
+              # as absence; every other failure aborts so the Job retries.
+              owner_err=/tmp/seaweedfs-db-owner-err
+              if owner=$(kubectl get cluster.postgresql.cnpg.io -n {{ .Release.Namespace }} seaweedfs-db \
+                          -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>"$owner_err"); then
+                :
+              elif grep -qi 'not found' "$owner_err"; then
+                owner=""
+              else
+                cat "$owner_err" >&2
+                echo "ERROR: failed to read Cluster/seaweedfs-db ownership for {{ .Release.Name }}; refusing to assume it is absent. Failing so the Job retries." >&2
+                rm -f "$owner_err"
+                exit 1
+              fi
+              rm -f "$owner_err"
               if [ -z "$owner" ]; then
                 echo "No Cluster/seaweedfs-db owned by a Helm release here; nothing to reclaim."
               elif [ "$owner" != "{{ .Release.Name }}-db" ]; then

--- a/packages/extra/seaweedfs/templates/hooks/cleanup.yaml
+++ b/packages/extra/seaweedfs/templates/hooks/cleanup.yaml
@@ -35,6 +35,29 @@ rules:
   - apiGroups: [""]
     resources: ["persistentvolumeclaims"]
     verbs: ["get", "list", "delete"]
+  {{- if not (eq .Values.topology "Client") }}
+  # The filer-metadata database. Platform migration 43/53 stamps
+  # helm.sh/resource-policy=keep on it so a <name>-system upgrade cannot prune it
+  # (that prune is a data-loss bug), but `keep` is permanent and also stops the
+  # <name>-db release's own uninstall from removing it — so deleting the app
+  # would leave the CNPG Cluster, its Postgres pods and its PVCs behind with
+  # nothing owning them. Reclaim it explicitly here instead.
+  #
+  # Gated exactly as templates/seaweedfs-db.yaml gates the <name>-db HelmRelease.
+  # The Cluster name is hardcoded `seaweedfs-db` by the db chart for every
+  # instance, so it is NOT this release's to delete unless this release owns the
+  # db: a Client instance renders no <name>-db at all and shares another app's
+  # filer, and a second Simple instance in the same namespace loses the ownership
+  # race but still installs. Ungated, deleting either would take a DIFFERENT app's
+  # database, and CNPG takes its PVC with it via ownerReferences. The Job
+  # re-checks the ownership annotation at run time; this gate only stops the
+  # permission from being granted at all where it can never be legitimate.
+  - apiGroups: ["postgresql.cnpg.io"]
+    resources: ["clusters"]
+    verbs: ["get", "delete"]
+    resourceNames:
+      - seaweedfs-db
+  {{- end }}
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "delete"]
@@ -141,6 +164,38 @@ spec:
               echo "Deleting orphaned SeaweedFS volume PVCs for {{ .Release.Name }}..."
               kubectl delete pvc -n {{ .Release.Namespace }} -l app.kubernetes.io/name=seaweedfs,app.kubernetes.io/instance={{ .Release.Name }}-system --ignore-not-found --wait=false \
                 || echo "WARNING: SeaweedFS PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
+              {{- if not (eq .Values.topology "Client") }}
+              # The filer-metadata database. Platform migration 43/53 stamps
+              # helm.sh/resource-policy=keep on this Cluster so a <name>-system
+              # upgrade cannot prune it — that prune destroys the tenant's S3
+              # index — but `keep` is permanent and also survives the <name>-db
+              # release's own uninstall, so without this the Cluster, its
+              # Postgres pods and its PVCs outlive the app that owned them. The
+              # PVCs carry ownerReferences to the Cluster, so deleting it
+              # garbage-collects them; they are NOT matched by the label selector
+              # above (they are labelled cnpg.io/cluster=seaweedfs-db).
+              #
+              # The Cluster name is hardcoded `seaweedfs-db` for every instance,
+              # so confirm THIS release owns it before deleting. A Client instance
+              # renders no <name>-db and shares another app's filer; a second
+              # Simple instance in the same namespace loses Helm's ownership race
+              # but still installs. Deleting on name alone would take a different
+              # app's database.
+              echo "Deleting SeaweedFS filer-metadata database for {{ .Release.Name }}..."
+              owner=$(kubectl get cluster.postgresql.cnpg.io -n {{ .Release.Namespace }} seaweedfs-db \
+                        -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}' 2>/dev/null || true)
+              if [ -z "$owner" ]; then
+                echo "No Cluster/seaweedfs-db owned by a Helm release here; nothing to reclaim."
+              elif [ "$owner" != "{{ .Release.Name }}-db" ]; then
+                echo "REFUSING to delete Cluster/seaweedfs-db: owned by '$owner', not {{ .Release.Name }}-db. Another SeaweedFS app owns this database; leaving it alone." >&2
+              else
+                # A failure here must FAIL the Job: the Cluster is keep-protected, so
+                # nothing else will ever reclaim it, and hook-delete-policy would
+                # otherwise remove the only cleanup Job while the orphan remains.
+                kubectl delete cluster.postgresql.cnpg.io -n {{ .Release.Namespace }} seaweedfs-db --ignore-not-found --wait=false \
+                  || { echo "ERROR: failed to delete Cluster/seaweedfs-db for {{ .Release.Name }}; it is keep-protected and will be orphaned. Failing so the Job retries." >&2; exit 1; }
+              fi
+              {{- end }}
               echo "Deleting orphaned SeaweedFS cert/db secrets for {{ .Release.Name }}..."
               kubectl delete secret -n {{ .Release.Namespace }} {{ .Release.Name }}-s3-ingress-tls {{ $renamedFull }}-admin-cert {{ $renamedFull }}-ca-cert {{ $renamedFull }}-client-cert {{ $renamedFull }}-filer-cert {{ $renamedFull }}-master-cert {{ $renamedFull }}-volume-cert {{ $renamedFull }}-worker-cert {{ $renamedFull }}-db-secret seaweedfs-admin-cert seaweedfs-ca-cert seaweedfs-client-cert seaweedfs-filer-cert seaweedfs-master-cert seaweedfs-volume-cert seaweedfs-worker-cert seaweedfs-db-secret --ignore-not-found --wait=false \
                 || echo "WARNING: SeaweedFS secret cleanup failed for {{ .Release.Name }}; orphaned secrets may remain" >&2

--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -107,7 +107,7 @@
    stood up a second, empty set while the data stayed put. system/seaweedfs pins
    the chart-based name back, so those workloads and volumes are adopted in place.
 
-   Two states cannot be adopted and stop the render instead:
+   These states cannot be adopted and stop the render instead:
 
    - FRESH on 1.5.x: only the renamed volumes exist, so the data was written under
      them. Adopting the chart-based name would rename the workloads AWAY from that
@@ -116,8 +116,9 @@
    - D-split: both sets exist AND the renamed volume servers are live, so they may
      hold objects written through the split endpoint. Adopting the chart-based set
      would strand those. The operator is sent to reconcile the split first (Step 3).
-     A duplicate that never served (D-wedged: zero ready replicas) is safe to adopt
-     and renders through.
+     A duplicate that never served (D-wedged: zero ready replicas) is refused the
+     same way: readyReplicas is a snapshot, not proof it never served, so it cannot
+     be told apart from D-split and is never adopted blind (see the note below).
 
    The renamed volumes are matched by SHAPE rather than by reconstructing the
    name: a volume PVC is always `data1-<fullname>-volume[-<pool|zone>]-N`, and

--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -131,36 +131,76 @@
    an unrelated `data1-*-volume-*` claim. StatefulSets do carry the labels, so they
    are matched on those, which also covers a tenant whose PVCs are not provisioned
    yet and one whose name the chart truncated past the chart name; the renamed
-   volume StatefulSet is also where the D-split liveness signal is read. */}}
-{{- $legacyData := false }}
-{{- $systemData := false }}
+   volume StatefulSet is also where the D-split liveness signal is read.
+
+   Telling S from D when BOTH PVC generations exist is done by AGE: PVCs are never
+   recreated in place (StatefulSets are, by the adoption hook, so their timestamps
+   are useless), so the OLDER volume-PVC generation is where the data was born.
+   Release-named older → a fresh-1.5.x tenant that an unguarded upgrade already
+   damaged by creating the empty chart-named set: still class S; reporting it as
+   D-split would send the operator to quiesce the set that holds ALL the data.
+
+   This copy of the guard warns on the SeaweedFS application itself, where the
+   operator looks first. The ENFORCING copy lives in system/seaweedfs
+   (templates/naming-guard.yaml): the <name>-system HelmRelease pulls its chart
+   from a platform-managed ExternalArtifact, so a platform upgrade re-renders
+   THAT chart directly without ever re-rendering this one. Keep the two
+   classifications in sync.
+
+   Fail-closed: lookup errors abort the render, but a client-side render returns
+   nothing — the release namespace is used as a canary, and an upgrade that
+   cannot see the cluster refuses instead of misclassifying. */}}
+{{- $canary := lookup "v1" "Namespace" "" .Release.Namespace }}
+{{- if and (not $canary) .Release.IsUpgrade }}
+{{-   fail (printf "SeaweedFS naming-migration guard for %s in namespace %s: cannot see the cluster (lookup returned nothing for the release namespace itself). This render decides whether workloads are renamed away from live data, so refusing to upgrade blind. Renders applied by helm-controller always see the cluster; if templating by hand, render server-side." .Release.Name .Release.Namespace) }}
+{{- end }}
+{{- if $canary }}
+{{- $legacyPVC := false }}
+{{- $systemPVC := false }}
+{{- $legacyOldest := "" }}
+{{- $systemOldest := "" }}
+{{- $legacySTS := false }}
+{{- $systemSTS := false }}
 {{- $systemRunning := false }}
 {{- range (lookup "v1" "PersistentVolumeClaim" .Release.Namespace "").items | default list }}
 {{-   if and (hasPrefix "data1-" .metadata.name) (contains "-volume" .metadata.name) (contains "seaweedfs" .metadata.name) }}
+{{-     $ts := dig "metadata" "creationTimestamp" "" . }}
 {{-     if hasPrefix "data1-seaweedfs-volume" .metadata.name }}
-{{-       $legacyData = true }}
+{{-       $legacyPVC = true }}
+{{-       if and $ts (or (not $legacyOldest) (lt $ts $legacyOldest)) }}
+{{-         $legacyOldest = $ts }}
+{{-       end }}
 {{-     else }}
-{{-       $systemData = true }}
+{{-       $systemPVC = true }}
+{{-       if and $ts (or (not $systemOldest) (lt $ts $systemOldest)) }}
+{{-         $systemOldest = $ts }}
+{{-       end }}
 {{-     end }}
 {{-   end }}
 {{- end }}
 {{- range (lookup "apps/v1" "StatefulSet" .Release.Namespace "").items | default list }}
 {{-   if and (eq (dig "app.kubernetes.io/name" "" (.metadata.labels | default dict)) "seaweedfs") (contains "volume" .metadata.name) }}
 {{-     if hasPrefix "seaweedfs-volume" .metadata.name }}
-{{-       $legacyData = true }}
+{{-       $legacySTS = true }}
 {{-     else }}
-{{-       $systemData = true }}
+{{-       $systemSTS = true }}
 {{-       if gt (int (dig "status" "readyReplicas" 0 .)) 0 }}
 {{-         $systemRunning = true }}
 {{-       end }}
 {{-     end }}
 {{-   end }}
 {{- end }}
-{{- if and $legacyData $systemData $systemRunning }}
-{{-   fail (printf "SeaweedFS %s in namespace %s is running two live SeaweedFS sets (D-split): the renamed set has ready volume servers alongside the adopted set, and both write to the shared seaweedfs-db metadata. Rendering would adopt the chart-named set and strand the objects the renamed set wrote. Stop the split and reconcile the two sets before upgrading — see docs/operations/seaweedfs-431-rename-recovery.md (Step 3)." .Release.Name .Release.Namespace) }}
+{{- if or $systemPVC $systemSTS }}
+{{-   if and $systemPVC (not $legacyPVC) }}
+{{-     fail (printf "SeaweedFS %s in namespace %s keeps its data on volumes named after the Helm release (this tenant was installed on Cozystack 1.5.x). Workloads are named seaweedfs-*, so rendering would rename them away from that data and bring up an empty cluster. Re-bind the existing PVs onto the data1-seaweedfs-volume-* PVC names before upgrading — see docs/operations/seaweedfs-431-rename-recovery.md (Step 2)." .Release.Name .Release.Namespace) }}
+{{-   else if and $systemPVC $legacyPVC $systemOldest $legacyOldest (lt $systemOldest $legacyOldest) }}
+{{-     fail (printf "SeaweedFS %s in namespace %s keeps its data on the release-named volume PVCs (created %s, OLDER than the chart-named data1-seaweedfs-volume-* claims created %s) — a fresh 1.5.x install that a previous unguarded upgrade already damaged by creating the empty chart-named set. Classify as S, never as D-split — do NOT quiesce the release-named set, it holds all the data. Remove the empty chart-named set, then re-bind the PVs — see docs/operations/seaweedfs-431-rename-recovery.md (Step 2a, then Step 2)." .Release.Name .Release.Namespace $systemOldest $legacyOldest) }}
+{{-   else if and (not $systemPVC) (not $legacyPVC) (not $legacySTS) }}
+{{-     fail (printf "SeaweedFS %s in namespace %s runs release-named workloads (fresh 1.5.x install; volume PVCs not matchable by name — likely a long instance name the chart truncated). Rendering the chart-based names would rename the workloads away from their data. Re-bind the volumes first — see docs/operations/seaweedfs-431-rename-recovery.md (Step 2)." .Release.Name .Release.Namespace) }}
+{{-   else if $systemRunning }}
+{{-     fail (printf "SeaweedFS %s in namespace %s is running two live SeaweedFS sets (D-split): the renamed set has ready volume servers alongside the adopted set, and both write to the shared seaweedfs-db metadata. Rendering would adopt the chart-named set and strand the objects the renamed set wrote. Stop the split and reconcile the two sets before upgrading — see docs/operations/seaweedfs-431-rename-recovery.md (Step 3)." .Release.Name .Release.Namespace) }}
+{{-   end }}
 {{- end }}
-{{- if and $systemData (not $legacyData) }}
-{{-   fail (printf "SeaweedFS %s in namespace %s keeps its data on volumes named after the Helm release (this tenant was installed on Cozystack 1.5.x). Workloads are named seaweedfs-*, so rendering would rename them away from that data and bring up an empty cluster. Re-bind the existing PVs onto the data1-seaweedfs-volume-* PVC names before upgrading — see docs/operations/seaweedfs-431-rename-recovery.md" .Release.Name .Release.Namespace) }}
 {{- end }}
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease

--- a/packages/extra/seaweedfs/templates/seaweedfs.yaml
+++ b/packages/extra/seaweedfs/templates/seaweedfs.yaml
@@ -129,23 +129,25 @@
    PVCs hold the data and outlive any workload, but carry no chart labels, so they
    are matched on the name shape and must mention the chart to avoid tripping over
    an unrelated `data1-*-volume-*` claim. StatefulSets do carry the labels, so they
-   are matched on those, which also covers a tenant whose PVCs are not provisioned
-   yet and one whose name the chart truncated past the chart name; the renamed
-   volume StatefulSet is also where the D-split liveness signal is read.
+   are matched on those, which is also the ONLY signal for a tenant whose PVCs are
+   not provisioned yet and for one whose instance name is long enough that the
+   chart truncated `seaweedfs` off the PVC names. Either establishes a generation's
+   presence, so the two are OR-ed.
 
-   Telling S from D when BOTH PVC generations exist is done by AGE: PVCs are never
-   recreated in place (StatefulSets are, by the adoption hook, so their timestamps
-   are useless), so the OLDER volume-PVC generation is where the data was born.
-   Release-named older → a fresh-1.5.x tenant that an unguarded upgrade already
-   damaged by creating the empty chart-named set: still class S; reporting it as
-   D-split would send the operator to quiesce the set that holds ALL the data.
+   Two generations present is UNDECIDABLE from inside a render and this guard does
+   not guess — see the long note in system/seaweedfs/templates/naming-guard.yaml.
+   In short: the release history DOES record birth order durably, but birth order
+   is the wrong question. It says which generation is original; adoption needs to
+   know whether the other one is EMPTY, and D-wedged and D-split are identical on
+   every durable signal.
 
    This copy of the guard warns on the SeaweedFS application itself, where the
    operator looks first. The ENFORCING copy lives in system/seaweedfs
    (templates/naming-guard.yaml): the <name>-system HelmRelease pulls its chart
    from a platform-managed ExternalArtifact, so a platform upgrade re-renders
    THAT chart directly without ever re-rendering this one. Keep the two
-   classifications in sync.
+   classifications in sync — they are deliberately identical, and
+   hack/seaweedfs-guard-parity.bats fails the build if they drift.
 
    Fail-closed: lookup errors abort the render, but a client-side render returns
    nothing — the release namespace is used as a canary, and an upgrade that
@@ -155,51 +157,37 @@
 {{-   fail (printf "SeaweedFS naming-migration guard for %s in namespace %s: cannot see the cluster (lookup returned nothing for the release namespace itself). This render decides whether workloads are renamed away from live data, so refusing to upgrade blind. Renders applied by helm-controller always see the cluster; if templating by hand, render server-side." .Release.Name .Release.Namespace) }}
 {{- end }}
 {{- if $canary }}
+{{- /* extra/seaweedfs is the `<name>` release; the renamed generation is named
+   after its CHILD `<name>-system` release, so derive it. This one line is the only
+   difference from the copy in system/seaweedfs. */}}
+{{- $sysRelease := printf "%s-system" .Release.Name }}
+{{- $renamedVol := include "seaweedfs.renamedVolumePrefix" $sysRelease }}
 {{- $legacyPVC := false }}
 {{- $systemPVC := false }}
-{{- $legacyOldest := "" }}
-{{- $systemOldest := "" }}
 {{- $legacySTS := false }}
 {{- $systemSTS := false }}
-{{- $systemRunning := false }}
 {{- range (lookup "v1" "PersistentVolumeClaim" .Release.Namespace "").items | default list }}
-{{-   if and (hasPrefix "data1-" .metadata.name) (contains "-volume" .metadata.name) (contains "seaweedfs" .metadata.name) }}
-{{-     $ts := dig "metadata" "creationTimestamp" "" . }}
-{{-     if hasPrefix "data1-seaweedfs-volume" .metadata.name }}
-{{-       $legacyPVC = true }}
-{{-       if and $ts (or (not $legacyOldest) (lt $ts $legacyOldest)) }}
-{{-         $legacyOldest = $ts }}
-{{-       end }}
-{{-     else }}
-{{-       $systemPVC = true }}
-{{-       if and $ts (or (not $systemOldest) (lt $ts $systemOldest)) }}
-{{-         $systemOldest = $ts }}
-{{-       end }}
-{{-     end }}
+{{-   if hasPrefix (printf "data1-%s" $renamedVol) .metadata.name }}
+{{-     $systemPVC = true }}
+{{-   else if hasPrefix "data1-seaweedfs-volume" .metadata.name }}
+{{-     $legacyPVC = true }}
 {{-   end }}
 {{- end }}
 {{- range (lookup "apps/v1" "StatefulSet" .Release.Namespace "").items | default list }}
-{{-   if and (eq (dig "app.kubernetes.io/name" "" (.metadata.labels | default dict)) "seaweedfs") (contains "volume" .metadata.name) }}
-{{-     if hasPrefix "seaweedfs-volume" .metadata.name }}
-{{-       $legacySTS = true }}
-{{-     else }}
+{{-   if eq (dig "app.kubernetes.io/name" "" (.metadata.labels | default dict)) "seaweedfs" }}
+{{-     if hasPrefix $renamedVol .metadata.name }}
 {{-       $systemSTS = true }}
-{{-       if gt (int (dig "status" "readyReplicas" 0 .)) 0 }}
-{{-         $systemRunning = true }}
-{{-       end }}
+{{-     else if hasPrefix "seaweedfs-volume" .metadata.name }}
+{{-       $legacySTS = true }}
 {{-     end }}
 {{-   end }}
 {{- end }}
-{{- if or $systemPVC $systemSTS }}
-{{-   if and $systemPVC (not $legacyPVC) }}
-{{-     fail (printf "SeaweedFS %s in namespace %s keeps its data on volumes named after the Helm release (this tenant was installed on Cozystack 1.5.x). Workloads are named seaweedfs-*, so rendering would rename them away from that data and bring up an empty cluster. Re-bind the existing PVs onto the data1-seaweedfs-volume-* PVC names before upgrading — see docs/operations/seaweedfs-431-rename-recovery.md (Step 2)." .Release.Name .Release.Namespace) }}
-{{-   else if and $systemPVC $legacyPVC $systemOldest $legacyOldest (lt $systemOldest $legacyOldest) }}
-{{-     fail (printf "SeaweedFS %s in namespace %s keeps its data on the release-named volume PVCs (created %s, OLDER than the chart-named data1-seaweedfs-volume-* claims created %s) — a fresh 1.5.x install that a previous unguarded upgrade already damaged by creating the empty chart-named set. Classify as S, never as D-split — do NOT quiesce the release-named set, it holds all the data. Remove the empty chart-named set, then re-bind the PVs — see docs/operations/seaweedfs-431-rename-recovery.md (Step 2a, then Step 2)." .Release.Name .Release.Namespace $systemOldest $legacyOldest) }}
-{{-   else if and (not $systemPVC) (not $legacyPVC) (not $legacySTS) }}
-{{-     fail (printf "SeaweedFS %s in namespace %s runs release-named workloads (fresh 1.5.x install; volume PVCs not matchable by name — likely a long instance name the chart truncated). Rendering the chart-based names would rename the workloads away from their data. Re-bind the volumes first — see docs/operations/seaweedfs-431-rename-recovery.md (Step 2)." .Release.Name .Release.Namespace) }}
-{{-   else if $systemRunning }}
-{{-     fail (printf "SeaweedFS %s in namespace %s is running two live SeaweedFS sets (D-split): the renamed set has ready volume servers alongside the adopted set, and both write to the shared seaweedfs-db metadata. Rendering would adopt the chart-named set and strand the objects the renamed set wrote. Stop the split and reconcile the two sets before upgrading — see docs/operations/seaweedfs-431-rename-recovery.md (Step 3)." .Release.Name .Release.Namespace) }}
-{{-   end }}
+{{- $legacyGen := or $legacyPVC $legacySTS }}
+{{- $systemGen := or $systemPVC $systemSTS }}
+{{- if and $legacyGen $systemGen }}
+{{-   fail (printf "SeaweedFS %s in namespace %s has BOTH naming generations present: the chart-named set (seaweedfs-volume / data1-seaweedfs-volume-*) AND the release-named set this chart no longer uses. One of them is an empty duplicate and one holds the data, and which is which cannot be established from inside a Helm render — claim timestamps are mutable (the Step 2 re-bind recreates claims), StatefulSets are recreated by the adoption hook, and a duplicate with zero ready replicas may still have served writes. Rendering would adopt the chart-named set, so guessing wrong strands or destroys the data. Refusing instead. Classify the tenant and delete the EMPTY generation so exactly one remains — this render then adopts the survivor with no further action. See docs/operations/seaweedfs-431-rename-recovery.md (Step 1 classifies; Step 2/2a/3 recover). If you are part-way through Step 2's re-bind, finish it." .Release.Name .Release.Namespace) }}
+{{- else if $systemGen }}
+{{-   fail (printf "SeaweedFS %s in namespace %s keeps its data on volumes named after the Helm release — a tenant installed fresh on Cozystack 1.5.x (or one whose instance name is long enough that the chart truncated the volume PVC names, leaving only its StatefulSets to match on). Workloads are named seaweedfs-*, so rendering would rename them away from that data and bring up an empty cluster. Helm cannot move data between PVCs. Re-bind the existing PVs onto the data1-seaweedfs-volume-* PVC names before upgrading — see docs/operations/seaweedfs-431-rename-recovery.md (Step 2)." .Release.Name .Release.Namespace) }}
 {{- end }}
 {{- end }}
 apiVersion: helm.toolkit.fluxcd.io/v2

--- a/packages/extra/seaweedfs/tests/cleanup_client_test.yaml
+++ b/packages/extra/seaweedfs/tests/cleanup_client_test.yaml
@@ -1,0 +1,58 @@
+suite: seaweedfs cleanup hook does not reclaim another app's database
+
+# templates/seaweedfs-db.yaml gates the <name>-db HelmRelease on
+# `topology != "Client"`: a Client instance renders NO database of its own and
+# points at another app's filer. The cleanup hook reclaims Cluster/seaweedfs-db —
+# a name the db chart hardcodes for every instance — so if it is not gated the
+# same way, deleting a Client deletes the SERVER's filer metadata, and CNPG takes
+# the PVC with it via ownerReferences. Total S3 loss for an app the operator never
+# touched.
+#
+# These fail on an ungated hook: it renders the Role granting delete on
+# clusters/seaweedfs-db and the delete command for a release that owns no database.
+
+templates:
+  - templates/hooks/cleanup.yaml
+
+release:
+  name: s3-remote
+  namespace: tenant-root
+
+tests:
+  - it: grants no cnpg RBAC to a Client instance
+    set: &client
+      topology: Client
+      filer:
+        grpcHost: seaweedfs-filer.tenant-other.svc
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["postgresql.cnpg.io"]
+            resources: ["clusters"]
+            verbs: ["get", "delete"]
+            resourceNames:
+              - seaweedfs-db
+
+  - it: does not delete any database in a Client instance's cleanup command
+    set: *client
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete cluster\.postgresql\.cnpg\.io'
+      # Its own PVC/secret cleanup must still run.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kubectl delete pvc -n tenant-root'

--- a/packages/extra/seaweedfs/tests/cleanup_named_test.yaml
+++ b/packages/extra/seaweedfs/tests/cleanup_named_test.yaml
@@ -33,16 +33,16 @@ tests:
       value: Role
     asserts:
       - contains:
-          path: rules[1].resourceNames
+          path: rules[2].resourceNames
           content: archive-system-seaweedfs-ca-cert
       - contains:
-          path: rules[1].resourceNames
+          path: rules[2].resourceNames
           content: archive-system-seaweedfs-db-secret
       # The adopted chart-based scheme is the same for every instance.
       - contains:
-          path: rules[1].resourceNames
+          path: rules[2].resourceNames
           content: seaweedfs-ca-cert
       # The old hardcoded default name must NOT appear for a non-default instance.
       - notContains:
-          path: rules[1].resourceNames
+          path: rules[2].resourceNames
           content: archive-system-ca-cert

--- a/packages/extra/seaweedfs/tests/cleanup_test.yaml
+++ b/packages/extra/seaweedfs/tests/cleanup_test.yaml
@@ -51,6 +51,20 @@ tests:
             apiGroups: [""]
             resources: ["persistentvolumeclaims"]
             verbs: ["get", "list", "delete"]
+      # Migration 43/53 stamps helm.sh/resource-policy=keep on the CNPG Cluster
+      # so a <name>-system upgrade cannot prune the filer metadata. `keep` is
+      # permanent and also survives the <name>-db release's own uninstall, so
+      # without an explicit reclaim here, deleting the app orphans the Cluster,
+      # its Postgres pods and its PVCs (which the PVC selector above does not
+      # match — they are labelled cnpg.io/cluster=seaweedfs-db).
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["postgresql.cnpg.io"]
+            resources: ["clusters"]
+            verbs: ["get", "delete"]
+            resourceNames:
+              - seaweedfs-db
       - contains:
           path: rules
           content:
@@ -172,3 +186,34 @@ tests:
       - notMatchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: 'app\.kubernetes\.io/component='
+      # The filer-metadata database must be reclaimed too. Migration 43/53 stamps
+      # helm.sh/resource-policy=keep on the Cluster so a <name>-system upgrade
+      # cannot prune it (that prune destroys the tenant's S3 index), but keep is
+      # permanent and also survives the <name>-db release's own uninstall — so
+      # deleting the app would leave the Cluster, its Postgres pods and its PVCs
+      # with nothing owning them. The PVCs carry ownerReferences to the Cluster,
+      # so deleting it garbage-collects them; the label selector above does not
+      # match them (they are labelled cnpg.io/cluster=seaweedfs-db).
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kubectl delete cluster\.postgresql\.cnpg\.io -n tenant-root seaweedfs-db --ignore-not-found --wait=false'
+      # The Cluster name is hardcoded `seaweedfs-db` for EVERY instance, so name
+      # alone is not ownership. Deleting on name would take a different SeaweedFS
+      # app's database (a Client shares another app's filer; a second Simple
+      # instance loses Helm's ownership race but still installs), and CNPG takes
+      # the PVC with it. The Job must re-check the owner annotation at run time.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'REFUSING to delete Cluster/seaweedfs-db: owned by'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: '\$owner" != "seaweedfs-db"'
+      # A failed reclaim must FAIL the Job: the Cluster is keep-protected, so
+      # nothing else reclaims it, and hook-delete-policy would drop the only
+      # cleanup Job. `|| echo` would swallow it into exit zero.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'Failing so the Job retries.*\n.*exit 1|exit 1'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete cluster\.postgresql\.cnpg\.io[^|]*\|\| echo'

--- a/packages/extra/seaweedfs/tests/cleanup_test.yaml
+++ b/packages/extra/seaweedfs/tests/cleanup_test.yaml
@@ -217,3 +217,13 @@ tests:
       - notMatchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: 'delete cluster\.postgresql\.cnpg\.io[^|]*\|\| echo'
+      # Reading ownership must ALSO fail closed. `|| true` on the get would turn a
+      # Forbidden or timeout into an empty owner, take the "nothing to reclaim"
+      # branch, and orphan the keep-protected Cluster. Only a genuine NotFound is
+      # treated as absence; every other error aborts the Job.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'failed to read Cluster/seaweedfs-db ownership'
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "release-name.}' 2>/dev/null \\|\\| true"

--- a/packages/extra/seaweedfs/tests/fullname_override_named_test.yaml
+++ b/packages/extra/seaweedfs/tests/fullname_override_named_test.yaml
@@ -7,6 +7,9 @@ suite: seaweedfs naming guard for a non-default instance name
 #   - On 4.31 the fullname helper appends the chart name when the release name
 #     does not contain it, so a fresh 1.5.x `archive` wrote its data to
 #     data1-archive-system-seaweedfs-volume-*, NOT data1-archive-system-volume-*.
+#
+# The guard only runs when it can see the cluster (the release namespace is its
+# canary), so every provider registers v1/Namespace and includes the namespace.
 
 templates:
   - templates/seaweedfs.yaml
@@ -29,7 +32,13 @@ tests:
   - it: adopts a pre-4.31 instance whose data is on the chart-named PVCs
     set: *values
     kubernetesProvider:
-      scheme:
+      scheme: &scheme
+        "v1/Namespace":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "namespaces"
+          namespaced: false
         "v1/PersistentVolumeClaim":
           gvr:
             group: ""
@@ -43,11 +52,17 @@ tests:
             resource: "statefulsets"
           namespaced: true
       objects:
+        - &ns
+          kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: tenant-root
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
             name: data1-seaweedfs-volume-0
             namespace: tenant-root
+            creationTimestamp: "2025-11-02T10:00:00Z"
         - kind: StatefulSet
           apiVersion: apps/v1
           metadata:
@@ -64,25 +79,15 @@ tests:
   - it: refuses to render when this release's data is on its renamed volumes
     set: *values
     kubernetesProvider:
-      scheme:
-        "v1/PersistentVolumeClaim":
-          gvr:
-            group: ""
-            version: "v1"
-            resource: "persistentvolumeclaims"
-          namespaced: true
-        "apps/v1/StatefulSet":
-          gvr:
-            group: "apps"
-            version: "v1"
-            resource: "statefulsets"
-          namespaced: true
+      scheme: *scheme
       objects:
+        - *ns
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
             name: data1-archive-system-seaweedfs-volume-0
             namespace: tenant-root
+            creationTimestamp: "2026-06-20T07:01:59Z"
         - kind: StatefulSet
           apiVersion: apps/v1
           metadata:
@@ -92,23 +97,46 @@ tests:
       - failedTemplate:
           errorPattern: "SeaweedFS archive in namespace tenant-root keeps its data on volumes named after the Helm release"
 
+  - it: refuses with class S when the renamed volumes are older than the chart-named ones
+    set: *values
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        # A fresh-1.5.x `archive` that an unguarded upgrade already damaged: the
+        # renamed volumes are older (the data was born there) and the chart-named
+        # set is the newer, empty one. Must be S (Step 2a), never D-split.
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-archive-system-seaweedfs-volume-0
+            namespace: tenant-root
+            creationTimestamp: "2026-06-20T07:01:59Z"
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-root
+            creationTimestamp: "2026-06-20T08:28:58Z"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: archive-system-seaweedfs-volume
+            namespace: tenant-root
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "1"
+    asserts:
+      - failedTemplate:
+          errorPattern: "never as D-split.*Step 2a"
+
   - it: catches a long instance name whose renamed workloads the chart truncated
     set: *values
     kubernetesProvider:
-      scheme:
-        "v1/PersistentVolumeClaim":
-          gvr:
-            group: ""
-            version: "v1"
-            resource: "persistentvolumeclaims"
-          namespaced: true
-        "apps/v1/StatefulSet":
-          gvr:
-            group: "apps"
-            version: "v1"
-            resource: "statefulsets"
-          namespaced: true
+      scheme: *scheme
       objects:
+        - *ns
         # 4.31 truncates <fullname> to 56 chars before appending -volume, so a long
         # name loses the chart name from its tail and the PVC name alone no longer
         # identifies it. The StatefulSet still carries the chart labels, so the
@@ -127,25 +155,14 @@ tests:
             namespace: tenant-root
     asserts:
       - failedTemplate:
-          errorPattern: "keeps its data on volumes named after the Helm release"
+          errorPattern: "runs release-named workloads.*Re-bind"
 
   - it: ignores an unrelated data1-*-volume-* PVC belonging to another app
     set: *values
     kubernetesProvider:
-      scheme:
-        "v1/PersistentVolumeClaim":
-          gvr:
-            group: ""
-            version: "v1"
-            resource: "persistentvolumeclaims"
-          namespaced: true
-        "apps/v1/StatefulSet":
-          gvr:
-            group: "apps"
-            version: "v1"
-            resource: "statefulsets"
-          namespaced: true
+      scheme: *scheme
       objects:
+        - *ns
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:

--- a/packages/extra/seaweedfs/tests/fullname_override_named_test.yaml
+++ b/packages/extra/seaweedfs/tests/fullname_override_named_test.yaml
@@ -97,7 +97,7 @@ tests:
       - failedTemplate:
           errorPattern: "SeaweedFS archive in namespace tenant-root keeps its data on volumes named after the Helm release"
 
-  - it: refuses with class S when the renamed volumes are older than the chart-named ones
+  - it: refuses when both generations exist (was S-damaged)
     set: *values
     kubernetesProvider:
       scheme: *scheme
@@ -129,33 +129,39 @@ tests:
             readyReplicas: "1"
     asserts:
       - failedTemplate:
-          errorPattern: "never as D-split.*Step 2a"
+          errorPattern: "has BOTH naming generations present"
 
   - it: catches a long instance name whose renamed workloads the chart truncated
+    # Instance `archive-of-quarterly-financial-statements-x1` -> child release
+    # archive-of-quarterly-financial-statements-x1-system -> the fullname gains
+    # `-seaweedfs` (the release name does not contain it) and is 61 chars, so
+    # componentName cuts it to 56 before appending `-volume`: the chart name is gone
+    # from the tail and both the workload and its claims read
+    # ...-x1-system-seaw-volume. A `contains "seaweedfs"` name filter cannot see
+    # either of them; the reconstructed prefix matches both exactly.
+    release:
+      name: archive-of-quarterly-financial-statements-x1
+      namespace: tenant-root
     set: *values
     kubernetesProvider:
       scheme: *scheme
       objects:
         - *ns
-        # 4.31 truncates <fullname> to 56 chars before appending -volume, so a long
-        # name loses the chart name from its tail and the PVC name alone no longer
-        # identifies it. The StatefulSet still carries the chart labels, so the
-        # guard sees it there.
         - kind: StatefulSet
           apiVersion: apps/v1
           metadata:
-            name: archive-system-a-very-long-instance-name-that-gets-trunca-volume
+            name: archive-of-quarterly-financial-statements-x1-system-seaw-volume
             namespace: tenant-root
             labels:
               app.kubernetes.io/name: seaweedfs
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
-            name: unrelated-app-data-0
+            name: data1-archive-of-quarterly-financial-statements-x1-system-seaw-volume-0
             namespace: tenant-root
     asserts:
       - failedTemplate:
-          errorPattern: "runs release-named workloads.*Re-bind"
+          errorPattern: "keeps its data on volumes named after the Helm release"
 
   - it: ignores an unrelated data1-*-volume-* PVC belonging to another app
     set: *values

--- a/packages/extra/seaweedfs/tests/fullname_override_test.yaml
+++ b/packages/extra/seaweedfs/tests/fullname_override_test.yaml
@@ -123,13 +123,18 @@ tests:
           path: metadata.name
           value: seaweedfs-system
 
-  - it: renders on a D-wedged cluster (duplicate present but never served) — adopts the legacy set
+  # Was: "renders on a D-wedged cluster — adopts the legacy set". A duplicate
+  # reading zero ready replicas used to be treated as proof it never served, so
+  # this rendered through. readyReplicas is only a snapshot: a duplicate that
+  # crashed, was scaled down, or lost readiness AFTER serving writes looks
+  # identical, and adopting the legacy set would strand whatever it wrote. Both
+  # generations present is now refused regardless of liveness.
+  - it: refuses when both generations exist and the duplicate reads zero ready (was D-wedged, adopted)
     set: *values
     kubernetesProvider:
       scheme: *scheme
       objects:
         - *ns
-        # The legacy volumes predate the duplicate: the data was born on them.
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
@@ -147,8 +152,6 @@ tests:
           metadata:
             name: unrelated-app-data-0
             namespace: tenant-root
-        # The duplicate volume set exists but never scheduled (anti-affinity):
-        # zero ready replicas, so its PVCs are empty and adoption is safe.
         - kind: StatefulSet
           apiVersion: apps/v1
           metadata:
@@ -158,15 +161,11 @@ tests:
               app.kubernetes.io/name: seaweedfs
           status:
             readyReplicas: "0"
-    documentSelector:
-      path: kind
-      value: HelmRelease
     asserts:
-      - equal:
-          path: metadata.name
-          value: seaweedfs-system
+      - failedTemplate:
+          errorPattern: "has BOTH naming generations present"
 
-  - it: refuses to render on a D-split cluster (duplicate volume servers are live)
+  - it: refuses when both generations exist and the duplicate is live (was D-split)
     set: *values
     kubernetesProvider:
       scheme: *scheme
@@ -197,9 +196,9 @@ tests:
             readyReplicas: "1"
     asserts:
       - failedTemplate:
-          errorPattern: "is running two live SeaweedFS sets.*Stop the split"
+          errorPattern: "has BOTH naming generations present"
 
-  - it: refuses with class S when the renamed volumes are OLDER (tenant damaged by an unguarded upgrade)
+  - it: refuses when both generations exist and the renamed volumes are older (was S-damaged)
     set: *values
     kubernetesProvider:
       scheme: *scheme
@@ -242,7 +241,7 @@ tests:
             readyReplicas: "0"
     asserts:
       - failedTemplate:
-          errorPattern: "never as D-split.*Step 2a"
+          errorPattern: "has BOTH naming generations present"
 
   - it: renders for a zoned legacy cluster (volume StatefulSets are per zone)
     set: *values
@@ -323,4 +322,4 @@ tests:
             namespace: tenant-root
     asserts:
       - failedTemplate:
-          errorPattern: "runs release-named workloads.*Re-bind"
+          errorPattern: "keeps its data on volumes named after the Helm release"

--- a/packages/extra/seaweedfs/tests/fullname_override_test.yaml
+++ b/packages/extra/seaweedfs/tests/fullname_override_test.yaml
@@ -4,16 +4,24 @@ suite: seaweedfs legacy-naming guard
 # names (`seaweedfs-master`, `data1-seaweedfs-volume-N`) and an upgrade past the
 # 4.31 rename adopts the running set in place.
 #
-# Two states stop the render instead of adopting: a tenant installed FRESH on
-# 1.5.x (only the renamed volumes exist → PV re-bind, Step 2), and a D-split
-# tenant (both sets present AND the renamed volume servers are live → reconcile
+# Three states stop the render instead of adopting: a tenant installed FRESH on
+# 1.5.x (only the renamed volumes exist → PV re-bind, Step 2), a tenant an
+# unguarded upgrade already damaged (BOTH generations exist but the renamed
+# volumes are OLDER — the data was born there and the chart-named set is the
+# empty one → Step 2a + Step 2), and a D-split tenant (both sets present, the
+# legacy volumes are older, AND the renamed volume servers are live → reconcile
 # the split, Step 3). A duplicate that never served (D-wedged, zero ready
 # replicas) renders through and is adopted.
 #
+# The guard only runs when it can see the cluster: the release namespace is its
+# canary. Every test that exercises classification therefore registers
+# v1/Namespace and provides the release namespace object; the fail-closed
+# behaviour of the canary itself is covered in guard_fail_closed_test.yaml.
+#
 # Two helm-unittest quirks the mocks work around:
-#   - The template LISTs both PVCs and StatefulSets, so every mocked provider
-#     must register both list kinds — a fake client errors on an unregistered
-#     LIST rather than returning empty.
+#   - The template GETs the namespace and LISTs both PVCs and StatefulSets, so
+#     every mocked provider must register all three kinds — a fake client errors
+#     on an unregistered kind rather than returning empty.
 #   - status.readyReplicas is quoted ("1"/"0"): the fake client cannot deep-copy
 #     a bare Go int in a mocked object's status, and the template's `int` coerces
 #     the string back either way.
@@ -39,7 +47,13 @@ tests:
   - it: renders for a net-new install (no SeaweedFS data in the namespace)
     set: *values
     kubernetesProvider:
-      scheme:
+      scheme: &scheme
+        "v1/Namespace":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "namespaces"
+          namespaced: false
         "v1/PersistentVolumeClaim":
           gvr:
             group: ""
@@ -53,6 +67,11 @@ tests:
             resource: "statefulsets"
           namespaced: true
       objects:
+        - &ns
+          kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: tenant-root
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
@@ -77,25 +96,15 @@ tests:
   - it: renders for a cluster whose data is on the legacy seaweedfs-* PVCs
     set: *values
     kubernetesProvider:
-      scheme:
-        "v1/PersistentVolumeClaim":
-          gvr:
-            group: ""
-            version: "v1"
-            resource: "persistentvolumeclaims"
-          namespaced: true
-        "apps/v1/StatefulSet":
-          gvr:
-            group: "apps"
-            version: "v1"
-            resource: "statefulsets"
-          namespaced: true
+      scheme: *scheme
       objects:
+        - *ns
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
             name: data1-seaweedfs-volume-0
             namespace: tenant-root
+            creationTimestamp: "2025-11-02T10:00:00Z"
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
@@ -117,30 +126,22 @@ tests:
   - it: renders on a D-wedged cluster (duplicate present but never served) — adopts the legacy set
     set: *values
     kubernetesProvider:
-      scheme:
-        "v1/PersistentVolumeClaim":
-          gvr:
-            group: ""
-            version: "v1"
-            resource: "persistentvolumeclaims"
-          namespaced: true
-        "apps/v1/StatefulSet":
-          gvr:
-            group: "apps"
-            version: "v1"
-            resource: "statefulsets"
-          namespaced: true
+      scheme: *scheme
       objects:
+        - *ns
+        # The legacy volumes predate the duplicate: the data was born on them.
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
             name: data1-seaweedfs-volume-0
             namespace: tenant-root
+            creationTimestamp: "2025-11-02T10:00:00Z"
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
             name: data1-seaweedfs-system-volume-0
             namespace: tenant-root
+            creationTimestamp: "2026-06-20T12:00:00Z"
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
@@ -168,30 +169,21 @@ tests:
   - it: refuses to render on a D-split cluster (duplicate volume servers are live)
     set: *values
     kubernetesProvider:
-      scheme:
-        "v1/PersistentVolumeClaim":
-          gvr:
-            group: ""
-            version: "v1"
-            resource: "persistentvolumeclaims"
-          namespaced: true
-        "apps/v1/StatefulSet":
-          gvr:
-            group: "apps"
-            version: "v1"
-            resource: "statefulsets"
-          namespaced: true
+      scheme: *scheme
       objects:
+        - *ns
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
             name: data1-seaweedfs-volume-0
             namespace: tenant-root
+            creationTimestamp: "2025-11-02T10:00:00Z"
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
             name: data1-seaweedfs-system-volume-0
             namespace: tenant-root
+            creationTimestamp: "2026-06-20T12:00:00Z"
         # The duplicate volume set is live: it may hold objects written through
         # the split endpoint, so adoption would strand them.
         - kind: StatefulSet
@@ -207,28 +199,63 @@ tests:
       - failedTemplate:
           errorPattern: "is running two live SeaweedFS sets.*Stop the split"
 
+  - it: refuses with class S when the renamed volumes are OLDER (tenant damaged by an unguarded upgrade)
+    set: *values
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        # Mirrors a fresh-1.5.x tenant that an unguarded 1.6 upgrade already hit:
+        # the data was born on the renamed volumes (older), and the upgrade
+        # created the chart-named set (newer, EMPTY). The renamed set is live —
+        # which a presence-only guard misreads as D-split, sending the operator
+        # to quiesce the set that holds all the data.
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-0
+            namespace: tenant-root
+            creationTimestamp: "2026-06-20T07:01:59Z"
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-root
+            creationTimestamp: "2026-06-20T08:28:58Z"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-system-volume
+            namespace: tenant-root
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "1"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-volume
+            namespace: tenant-root
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "0"
+    asserts:
+      - failedTemplate:
+          errorPattern: "never as D-split.*Step 2a"
+
   - it: renders for a zoned legacy cluster (volume StatefulSets are per zone)
     set: *values
     kubernetesProvider:
-      scheme:
-        "v1/PersistentVolumeClaim":
-          gvr:
-            group: ""
-            version: "v1"
-            resource: "persistentvolumeclaims"
-          namespaced: true
-        "apps/v1/StatefulSet":
-          gvr:
-            group: "apps"
-            version: "v1"
-            resource: "statefulsets"
-          namespaced: true
+      scheme: *scheme
       objects:
+        - *ns
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
             name: data1-seaweedfs-volume-zone-a-0
             namespace: tenant-root
+            creationTimestamp: "2025-11-02T10:00:00Z"
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
@@ -250,30 +277,15 @@ tests:
   - it: refuses to render when the data lives only on seaweedfs-system-* PVCs
     set: *values
     kubernetesProvider:
-      scheme:
-        "v1/PersistentVolumeClaim":
-          gvr:
-            group: ""
-            version: "v1"
-            resource: "persistentvolumeclaims"
-          namespaced: true
-        "apps/v1/StatefulSet":
-          gvr:
-            group: "apps"
-            version: "v1"
-            resource: "statefulsets"
-          namespaced: true
+      scheme: *scheme
       objects:
+        - *ns
         - kind: PersistentVolumeClaim
           apiVersion: v1
           metadata:
             name: data1-seaweedfs-system-volume-0
             namespace: tenant-root
-        - kind: PersistentVolumeClaim
-          apiVersion: v1
-          metadata:
-            name: unrelated-app-data-0
-            namespace: tenant-root
+            creationTimestamp: "2026-06-20T07:01:59Z"
         - kind: StatefulSet
           apiVersion: apps/v1
           metadata:
@@ -286,20 +298,12 @@ tests:
   - it: refuses to render on a seaweedfs-system-* cluster detected by its StatefulSet
     set: *values
     kubernetesProvider:
-      scheme:
-        "v1/PersistentVolumeClaim":
-          gvr:
-            group: ""
-            version: "v1"
-            resource: "persistentvolumeclaims"
-          namespaced: true
-        "apps/v1/StatefulSet":
-          gvr:
-            group: "apps"
-            version: "v1"
-            resource: "statefulsets"
-          namespaced: true
+      scheme: *scheme
       objects:
+        - *ns
+        # No volume PVCs are visible at all (e.g. not provisioned yet, or a long
+        # name truncated the chart name out of them); the renamed StatefulSet
+        # alone is enough to refuse.
         - kind: StatefulSet
           apiVersion: apps/v1
           metadata:
@@ -319,4 +323,4 @@ tests:
             namespace: tenant-root
     asserts:
       - failedTemplate:
-          errorPattern: "keeps its data on volumes named after the Helm release.*Re-bind"
+          errorPattern: "runs release-named workloads.*Re-bind"

--- a/packages/extra/seaweedfs/tests/fullname_override_test.yaml
+++ b/packages/extra/seaweedfs/tests/fullname_override_test.yaml
@@ -4,14 +4,18 @@ suite: seaweedfs legacy-naming guard
 # names (`seaweedfs-master`, `data1-seaweedfs-volume-N`) and an upgrade past the
 # 4.31 rename adopts the running set in place.
 #
-# Three states stop the render instead of adopting: a tenant installed FRESH on
-# 1.5.x (only the renamed volumes exist → PV re-bind, Step 2), a tenant an
-# unguarded upgrade already damaged (BOTH generations exist but the renamed
-# volumes are OLDER — the data was born there and the chart-named set is the
-# empty one → Step 2a + Step 2), and a D-split tenant (both sets present, the
-# legacy volumes are older, AND the renamed volume servers are live → reconcile
-# the split, Step 3). A duplicate that never served (D-wedged, zero ready
-# replicas) renders through and is adopted.
+# Any tenant with BOTH naming generations present stops the render instead of
+# adopting — which set is the empty duplicate cannot be told from inside a render,
+# so the guard refuses and sends the operator to classify. The recovery path
+# differs by case: a tenant an unguarded upgrade already damaged (the renamed
+# volumes are OLDER — the data was born there and the chart-named set is the empty
+# one → Step 2a + Step 2), and a D-split tenant (the legacy volumes are older AND
+# the renamed volume servers are live → reconcile the split, Step 3). A duplicate
+# that never served (D-wedged, zero ready replicas) is refused the same way:
+# readyReplicas is a snapshot, not proof it never served, so it is indistinguishable
+# from D-split and cannot be adopted blind. A tenant installed FRESH on 1.5.x (only
+# the renamed volumes exist, no second generation) is refused separately → PV
+# re-bind, Step 2.
 #
 # The guard only runs when it can see the cluster: the release namespace is its
 # canary. Every test that exercises classification therefore registers

--- a/packages/extra/seaweedfs/tests/guard_fail_closed_test.yaml
+++ b/packages/extra/seaweedfs/tests/guard_fail_closed_test.yaml
@@ -1,0 +1,42 @@
+suite: seaweedfs naming guard skips cleanly without a cluster view
+
+# The guard classifies a tenant by looking up its PVCs and StatefulSets. A
+# failed API call already aborts the render (Helm propagates lookup errors),
+# but a CLIENT-SIDE render (helm template, --dry-run=client) silently returns
+# nothing — which, unguarded, would render the chart-based names over a class-S
+# tenant. The release namespace is the canary: it always exists for a real
+# install or upgrade, so when it cannot be seen, an UPGRADE refuses rather than
+# classify blind, while an install without cluster access (CI lint, unittest
+# with no provider — this test) skips the guard: it never touches live data.
+#
+# The refusal branch cannot be modelled here: helm-unittest 1.0.3 ignores
+# release.isUpgrade (.Release.IsUpgrade renders false regardless). Verify it
+# with a real renderer instead:
+#   helm template packages/extra/seaweedfs --is-upgrade ... 2>&1 \
+#     | grep 'refusing to upgrade blind'
+
+templates:
+  - templates/seaweedfs.yaml
+
+release:
+  name: seaweedfs
+  namespace: tenant-root
+
+tests:
+  - it: still renders a client-side install (no cluster view, no data at risk)
+    set:
+      topology: Simple
+      replicationFactor: 2
+      _namespace:
+        host: example.org
+        ingress: tenant-root
+      _cluster:
+        issuer-name: letsencrypt-prod
+        solver: http01
+    documentSelector:
+      path: kind
+      value: HelmRelease
+    asserts:
+      - equal:
+          path: metadata.name
+          value: seaweedfs-system

--- a/packages/system/seaweedfs/Makefile
+++ b/packages/system/seaweedfs/Makefile
@@ -19,5 +19,6 @@ update:
 	patch --no-backup-if-mismatch -p4 < patches/cosi-bucket-class-lock-readonly.patch
 	patch --no-backup-if-mismatch -p4 < patches/s3-service-name.patch
 	patch --no-backup-if-mismatch -p4 < patches/s3-service-name-consumers.patch
+	patch --no-backup-if-mismatch -p4 < patches/cluster-scoped-names-per-namespace.patch
 	#patch --no-backup-if-mismatch -p4 < patches/retention-policy-delete.yaml
 

--- a/packages/system/seaweedfs/Makefile
+++ b/packages/system/seaweedfs/Makefile
@@ -5,6 +5,20 @@ include ../../../hack/package.mk
 
 test:
 	helm unittest .
+	$(MAKE) test-guard-fail-closed
+
+# The naming guard refuses to render an UPGRADE that cannot see the cluster
+# (templates/naming-guard.yaml): a client-side lookup silently returns nothing,
+# which would classify a class-S tenant as net-new and rename its workloads away
+# from its data. helm-unittest 1.0.3 ignores release.isUpgrade, so .Release.IsUpgrade
+# always renders false there and the refusal branch gets NO unit coverage — the
+# suite passes with or without the canary. Verify with a real renderer instead.
+.PHONY: test-guard-fail-closed
+test-guard-fail-closed:
+	@out=$$(helm template seaweedfs-system . -n tenant-root --is-upgrade 2>&1); \
+	echo "$$out" | grep -q 'refusing to upgrade blind' \
+	  || { echo "FAIL: a blind upgrade rendered instead of refusing (naming-guard canary is not firing)"; echo "$$out" | head -5; exit 1; }
+	@echo "ok: naming guard refuses a blind upgrade"
 
 update:
 	rm -rf charts

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
@@ -4,7 +4,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "seaweedfs.fullname" . }}-objectstorage-provisioner
+  name: {{ include "seaweedfs.serviceAccountName" . }}-objectstorage-provisioner
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -53,7 +53,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "seaweedfs.fullname" . }}-objectstorage-provisioner
+  name: {{ include "seaweedfs.serviceAccountName" . }}-objectstorage-provisioner
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -65,6 +65,6 @@ subjects:
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ include "seaweedfs.fullname" . }}-objectstorage-provisioner
+  name: {{ include "seaweedfs.serviceAccountName" . }}-objectstorage-provisioner
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/cluster-role.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/cluster-role.yaml
@@ -5,7 +5,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "seaweedfs.fullname" . }}-rw-cr
+  name: {{ include "seaweedfs.serviceAccountName" . }}-rw-cr
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -19,7 +19,7 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "seaweedfs.fullname" . }}-rw-crb
+  name: {{ include "seaweedfs.serviceAccountName" . }}-rw-crb
   labels:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
@@ -32,5 +32,5 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "seaweedfs.fullname" . }}-rw-cr
+  name: {{ include "seaweedfs.serviceAccountName" . }}-rw-cr
 {{- end }}

--- a/packages/system/seaweedfs/patches/cluster-scoped-names-per-namespace.patch
+++ b/packages/system/seaweedfs/patches/cluster-scoped-names-per-namespace.patch
@@ -1,0 +1,60 @@
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
+index b5c103575..a6e5b761e 100644
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
+@@ -4,7 +4,7 @@
+ kind: ClusterRole
+ apiVersion: rbac.authorization.k8s.io/v1
+ metadata:
+-  name: {{ include "seaweedfs.fullname" . }}-objectstorage-provisioner
++  name: {{ include "seaweedfs.serviceAccountName" . }}-objectstorage-provisioner
+   labels:
+     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+@@ -53,7 +53,7 @@ rules:
+ kind: ClusterRoleBinding
+ apiVersion: rbac.authorization.k8s.io/v1
+ metadata:
+-  name: {{ include "seaweedfs.fullname" . }}-objectstorage-provisioner
++  name: {{ include "seaweedfs.serviceAccountName" . }}-objectstorage-provisioner
+   labels:
+     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+@@ -65,6 +65,6 @@ subjects:
+     namespace: {{ .Release.Namespace }}
+ roleRef:
+   kind: ClusterRole
+-  name: {{ include "seaweedfs.fullname" . }}-objectstorage-provisioner
++  name: {{ include "seaweedfs.serviceAccountName" . }}-objectstorage-provisioner
+   apiGroup: rbac.authorization.k8s.io
+ {{- end }}
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/cluster-role.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/cluster-role.yaml
+index 14d09f999..e31c2d5f2 100644
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/cluster-role.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/cluster-role.yaml
+@@ -5,7 +5,7 @@
+ kind: ClusterRole
+ apiVersion: rbac.authorization.k8s.io/v1
+ metadata:
+-  name: {{ include "seaweedfs.fullname" . }}-rw-cr
++  name: {{ include "seaweedfs.serviceAccountName" . }}-rw-cr
+   labels:
+     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+@@ -19,7 +19,7 @@ rules:
+ kind: ClusterRoleBinding
+ apiVersion: rbac.authorization.k8s.io/v1
+ metadata:
+-  name: {{ include "seaweedfs.fullname" . }}-rw-crb
++  name: {{ include "seaweedfs.serviceAccountName" . }}-rw-crb
+   labels:
+     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+@@ -32,5 +32,5 @@ subjects:
+ roleRef:
+   apiGroup: rbac.authorization.k8s.io
+   kind: ClusterRole
+-  name: {{ include "seaweedfs.fullname" . }}-rw-cr
++  name: {{ include "seaweedfs.serviceAccountName" . }}-rw-cr
+ {{- end }}
+\ No newline at end of file

--- a/packages/system/seaweedfs/templates/_naming.tpl
+++ b/packages/system/seaweedfs/templates/_naming.tpl
@@ -22,7 +22,21 @@
 
    The guard deliberately does NOT call seaweedfs.fullname directly: that helper
    reads .Values.fullnameOverride, which this chart PINS to `seaweedfs`, so it
-   returns the chart-named generation — the opposite of what is wanted here. */}}
+   returns the chart-named generation — the opposite of what is wanted here.
+
+   ACCEPTED LIMIT — zone/pool volume components. MultiZone (and Simple-with-
+   pools) tenants get per-group components with suffix `volume-<key>`, cut at
+   (62 - len(suffix)), i.e. SHORTER than the 56 this helper reconstructs. The
+   prefixes only diverge when the fullname exceeds that shorter cut: for the
+   supported instance (the tenant module hardcodes the name `seaweedfs`,
+   fullname 16 chars) that takes a zone/pool key of ~40+ characters, and for
+   the default `volume` group it can never happen (its suffix IS the 56 cut).
+   A guard prefix that diverges means a release-named zone component the guard
+   cannot see. Decided 2026-07-17 (1.6 triage): accepted and documented in
+   docs/operations/seaweedfs-431-rename-recovery.md (Scope) rather than
+   reconstructed per-key — instance names are fixed by the tenant module and
+   absurd keys are the only reachable trigger. Revisit if instance naming is
+   ever opened up or a key-length clamp lands in extra/seaweedfs. */}}
 {{- define "seaweedfs.renamedVolumePrefix" -}}
 {{- $release := . -}}
 {{- $full := $release -}}

--- a/packages/system/seaweedfs/templates/_naming.tpl
+++ b/packages/system/seaweedfs/templates/_naming.tpl
@@ -1,0 +1,34 @@
+{{- /* seaweedfs.renamedVolumePrefix — reconstruct the name 4.31 gives the volume
+   component of the `<name>-system` release, i.e. the RELEASE-NAMED generation the
+   fullnameOverride pin exists to avoid.
+
+   Input: the `<name>-system` release name, as a bare string.
+     {{ include "seaweedfs.renamedVolumePrefix" "foo-system" }} -> foo-system-seaweedfs-volume
+
+   This replays two upstream helpers, so it must track them if the vendored chart
+   changes (hack/seaweedfs-guard-parity.bats pins the two copies of the guard
+   against each other; charts/seaweedfs/templates/shared/_helpers.tpl is the
+   source of truth for the rules below):
+
+     seaweedfs.fullname      — with no fullnameOverride, the release name, plus
+                               `-<chart name>` when the release name does not
+                               already contain it; truncated to 63.
+     seaweedfs.componentName — truncates the fullname to (62 - len(suffix)) before
+                               appending `-<suffix>`, so for `volume` the fullname
+                               is cut to 56. An instance name >= ~40 chars
+                               therefore loses `seaweedfs` from the tail, which is
+                               why a `contains "seaweedfs"` name filter cannot see
+                               its claims and this reconstruction can.
+
+   The guard deliberately does NOT call seaweedfs.fullname directly: that helper
+   reads .Values.fullnameOverride, which this chart PINS to `seaweedfs`, so it
+   returns the chart-named generation — the opposite of what is wanted here. */}}
+{{- define "seaweedfs.renamedVolumePrefix" -}}
+{{- $release := . -}}
+{{- $full := $release -}}
+{{- if not (contains "seaweedfs" $release) -}}
+{{-   $full = printf "%s-seaweedfs" $release -}}
+{{- end -}}
+{{- $full = $full | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-volume" ($full | trunc 56 | trimSuffix "-") -}}
+{{- end -}}

--- a/packages/system/seaweedfs/templates/cluster-scoped-rbac-guard.yaml
+++ b/packages/system/seaweedfs/templates/cluster-scoped-rbac-guard.yaml
@@ -1,0 +1,69 @@
+{{- /* Cluster-scoped RBAC uniqueness guard.
+
+   ClusterRoles and ClusterRoleBindings are CLUSTER-scoped: exactly one object can
+   carry a given name, cluster-wide. This chart is installed once per tenant, so
+   every cluster-scoped name it renders must be unique per install.
+
+   That is in direct tension with the adoption pin. `seaweedfs.fullnameOverride`
+   is pinned to `seaweedfs` (see values.yaml and templates/naming-guard.yaml) so
+   the NAMESPACED workloads keep their pre-4.31 chart-based names and are adopted
+   in place across the bump — which means `seaweedfs.fullname` is, by
+   construction, the SAME string in every tenant. Naming a cluster-scoped object
+   after it makes every tenant fight over one object.
+
+   Upstream 4.31 did exactly that: it switched the four cluster-scoped names from
+   global.serviceAccountName to seaweedfs.fullname. Pre-4.31 they were
+   `<global.serviceAccountName>-{objectstorage-provisioner,rw-cr}`, and Cozystack
+   sets that value to `<namespace>-seaweedfs` (extra/seaweedfs), so they were
+   unique per tenant. patches/cluster-scoped-names-per-namespace.patch puts them
+   back on the service account name — restoring the pre-4.31 names byte-for-byte
+   and, with them, per-tenant uniqueness.
+
+   Uniqueness therefore rests on a VALUE, so assert it instead of trusting it:
+   the name must carry the release namespace. Without this, a tenant that stops
+   setting the value per namespace silently re-collides — no error, no ownership
+   conflict, just one ClusterRoleBinding whose subject flips to whichever tenant
+   reconciled last while every other tenant's COSI provisioner loses its RBAC.
+   That failure is invisible until a bucket operation fails, which is why the
+   collision survived two releases.
+
+   Checked only when the render can see the cluster (same namespace canary as
+   naming-guard.yaml): system/seaweedfs's own values.yaml carries a static
+   PLACEHOLDER serviceAccountName that only extra/seaweedfs overrides per
+   release, so a client-side render (CI lint, helm unittest) legitimately sees
+   the placeholder and touches no live RBAC.
+
+   The compat shim must run first. extra/seaweedfs sets the OLD flat key
+   global.serviceAccountName, and seaweedfs.compat is what folds it into the
+   canonical global.seaweedfs.serviceAccountName (the flat key wins when
+   present). Every subchart template includes the shim before reading, and this
+   guard has to read the same value the subchart will, or it compares against
+   this chart's placeholder default and refuses every real upgrade. Including
+   the shim rather than re-deriving the precedence here is deliberate: a second
+   copy of that rule would be free to drift from the one that actually names the
+   objects. It is idempotent and output-free, so calling it here is safe. */}}
+{{- include "seaweedfs.compat" . -}}
+
+{{- $canary := lookup "v1" "Namespace" "" .Release.Namespace }}
+{{- if $canary }}
+{{-   $sa := include "seaweedfs.serviceAccountName" . }}
+{{- /* Equality, not a prefix or substring test. extra/seaweedfs sets exactly
+   `<namespace>-seaweedfs`, so that is what to assert. Anything looser accepts a
+   value belonging to a DIFFERENT namespace: `contains` lets namespace `tenant-a`
+   through on `tenant-ab-seaweedfs`, and `hasPrefix "tenant-a-"` still lets it
+   through on `tenant-a-b-seaweedfs` — which is also the natural value for
+   namespace `tenant-a-b`, i.e. two namespaces would accept one string and
+   collide on the very object this guard exists to keep unique.
+
+   This asserts the VALUE the names are built from, not the rendered names — it
+   cannot catch the chart being reverted to name them after the pinned fullname.
+   tests/cluster_scoped_names_test.yaml covers that axis, by asserting that two
+   tenants render two different names.
+
+   (The comment marker must be exactly `{{- /*`: Go's lexer looks for `/*` at a
+   fixed offset past the trim marker, so `{{-   /*` lexes as a command and fails
+   with `unexpected "/" in command`.) */}}
+{{-   if ne $sa (printf "%s-seaweedfs" .Release.Namespace) }}
+{{-     fail (printf "SeaweedFS release %s in namespace %s would render cluster-scoped RBAC named %q, which is not this namespace's own <namespace>-seaweedfs and so is not unique per tenant. Every SeaweedFS instance pins the same fullname, so ClusterRole/ClusterRoleBinding names are taken from global.seaweedfs.serviceAccountName, which extra/seaweedfs must set per namespace. With a shared name only one tenant can own the object, and the ClusterRoleBinding's subject flips to whichever tenant reconciled last — silently revoking every other tenant's COSI provisioner." .Release.Name .Release.Namespace $sa) }}
+{{-   end }}
+{{- end }}

--- a/packages/system/seaweedfs/templates/naming-guard.yaml
+++ b/packages/system/seaweedfs/templates/naming-guard.yaml
@@ -1,0 +1,111 @@
+{{- /* Naming-migration guard — the ENFORCING copy.
+
+   Before 4.31 the vendored chart named workloads after the CHART, ignoring the
+   release name, so every instance ran as `seaweedfs-*` with its data on
+   `data1-seaweedfs-volume-*`. 4.31 names them after the release; values.yaml pins
+   `fullnameOverride: seaweedfs` so an upgrade past the bump adopts the running
+   set and its volumes in place. Two states cannot be adopted, and this template
+   stops the render instead of letting Helm stand up a second, empty set:
+
+   - class S — a tenant installed fresh on 1.5.x keeps its data on the
+     release-named `data1-<release>[-seaweedfs]-volume-*` PVCs. Rendering the
+     pinned names would rename the workloads AWAY from that data. → runbook Step 2.
+   - class D-split — both naming generations exist and the release-named volume
+     servers are LIVE, so they may hold objects written through the split
+     endpoint. Adopting the chart-named set would strand those. → runbook Step 3.
+     A duplicate that never served (D-wedged: zero ready replicas) is safe to
+     adopt and renders through.
+
+   extra/seaweedfs carries the same classification for its own render, but that
+   render is NOT in the path of a platform upgrade: this chart reaches
+   helm-controller through an ExternalArtifact, so a platform bump upgrades the
+   `<name>-system` release directly from the new artifact without ever
+   re-rendering extra/seaweedfs. The only render guaranteed to sit between a
+   platform upgrade and the tenant's workloads is THIS one. (v1.6 regression:
+   the guard lived only in extra/seaweedfs, so upgrading a fresh-1.5.x tenant
+   created an empty chart-named set beside its live data.)
+
+   Telling S from D when BOTH PVC generations exist is done by AGE: PVCs are
+   never recreated in place (StatefulSets are, by the adoption hook, so their
+   timestamps are useless), so the OLDER volume-PVC generation is where the data
+   was born. Legacy older → genuine D (adopt, or Step 3 if the duplicate is
+   live). Release-named older → the tenant is a fresh-1.5.x install that a
+   previous (unguarded) upgrade already damaged by creating the empty chart-named
+   set: still class S, and the D-split runbook step would quiesce the set that
+   holds ALL the data — so it must NOT be reported as D-split.
+
+   Fail-closed: `lookup` errors abort the render (Helm propagates API errors),
+   but a client-side render (`helm template`, --dry-run=client) silently returns
+   nothing. The release namespace itself is used as a canary: it always exists
+   for any real install/upgrade, so an empty canary means the render cannot see
+   the cluster — refuse on upgrade rather than misclassify, and skip the guard
+   for client-side installs (CI lint/unittest), which never touch live data. */}}
+
+{{- /* The classification below and the whole adoption scheme assume chart-based
+   workload names. Refuse to render at all if the pin is ever lifted. */}}
+{{- if ne (dig "fullnameOverride" "" (.Values.seaweedfs | default dict)) "seaweedfs" }}
+{{-   fail (printf "system/seaweedfs must pin seaweedfs.fullnameOverride=seaweedfs (got %q): workload adoption across the 4.31 rename and the naming-migration guard are both built on chart-based names. Do not lift the pin without a data-migration plan." (dig "fullnameOverride" "" (.Values.seaweedfs | default dict))) }}
+{{- end }}
+
+{{- $canary := lookup "v1" "Namespace" "" .Release.Namespace }}
+{{- if and (not $canary) .Release.IsUpgrade }}
+{{-   fail (printf "SeaweedFS naming-migration guard for release %s in namespace %s: cannot see the cluster (lookup returned nothing for the release namespace itself). This render decides whether workloads are renamed away from live data, so refusing to upgrade blind. Renders applied by helm-controller always see the cluster; if templating by hand, render server-side." .Release.Name .Release.Namespace) }}
+{{- end }}
+{{- if $canary }}
+
+{{- /* PVCs hold the data and outlive any workload, but carry no chart labels, so
+   they are matched on the name shape — `data1-<fullname>-volume[-<pool|zone>]-N`
+   — and must mention the chart to avoid tripping over an unrelated
+   `data1-*-volume-*` claim. StatefulSets do carry the labels, so they are
+   matched on those, which also covers a tenant whose PVCs are not provisioned
+   yet and one whose name the chart truncated past the chart name; the renamed
+   volume StatefulSet is also where the D-split liveness signal is read. */}}
+{{- $legacyPVC := false }}
+{{- $systemPVC := false }}
+{{- $legacyOldest := "" }}
+{{- $systemOldest := "" }}
+{{- $legacySTS := false }}
+{{- $systemSTS := false }}
+{{- $systemRunning := false }}
+{{- range (lookup "v1" "PersistentVolumeClaim" .Release.Namespace "").items | default list }}
+{{-   if and (hasPrefix "data1-" .metadata.name) (contains "-volume" .metadata.name) (contains "seaweedfs" .metadata.name) }}
+{{-     $ts := dig "metadata" "creationTimestamp" "" . }}
+{{-     if hasPrefix "data1-seaweedfs-volume" .metadata.name }}
+{{-       $legacyPVC = true }}
+{{-       if and $ts (or (not $legacyOldest) (lt $ts $legacyOldest)) }}
+{{-         $legacyOldest = $ts }}
+{{-       end }}
+{{-     else }}
+{{-       $systemPVC = true }}
+{{-       if and $ts (or (not $systemOldest) (lt $ts $systemOldest)) }}
+{{-         $systemOldest = $ts }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- range (lookup "apps/v1" "StatefulSet" .Release.Namespace "").items | default list }}
+{{-   if and (eq (dig "app.kubernetes.io/name" "" (.metadata.labels | default dict)) "seaweedfs") (contains "volume" .metadata.name) }}
+{{-     if hasPrefix "seaweedfs-volume" .metadata.name }}
+{{-       $legacySTS = true }}
+{{-     else }}
+{{-       $systemSTS = true }}
+{{-       if gt (int (dig "status" "readyReplicas" 0 .)) 0 }}
+{{-         $systemRunning = true }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+
+{{- if or $systemPVC $systemSTS }}
+{{-   if and $systemPVC (not $legacyPVC) }}
+{{-     fail (printf "SeaweedFS release %s in namespace %s keeps its data on volumes named after the Helm release (installed fresh on Cozystack 1.5.x). This chart pins the pre-4.31 chart-based names, so rendering would rename the workloads away from that data and stand up an empty cluster beside it. Re-bind the existing PVs onto the data1-seaweedfs-volume-* PVC names first — docs/operations/seaweedfs-431-rename-recovery.md (Step 2)." .Release.Name .Release.Namespace) }}
+{{-   else if and $systemPVC $legacyPVC $systemOldest $legacyOldest (lt $systemOldest $legacyOldest) }}
+{{-     fail (printf "SeaweedFS release %s in namespace %s keeps its data on the release-named volume PVCs (created %s, OLDER than the chart-named data1-seaweedfs-volume-* claims created %s) — a fresh 1.5.x install that a previous unguarded upgrade already damaged by creating the empty chart-named set. Classify as S, never as D-split — do NOT quiesce the release-named set, it holds all the data. Remove the empty chart-named set, then re-bind the PVs — see docs/operations/seaweedfs-431-rename-recovery.md (Step 2a, then Step 2)." .Release.Name .Release.Namespace $systemOldest $legacyOldest) }}
+{{-   else if and (not $systemPVC) (not $legacyPVC) (not $legacySTS) }}
+{{-     fail (printf "SeaweedFS release %s in namespace %s runs release-named workloads (fresh 1.5.x install; volume PVCs not matchable by name — likely a long instance name the chart truncated). Rendering the chart-based names would rename the workloads away from their data. Re-bind the volumes first — docs/operations/seaweedfs-431-rename-recovery.md (Step 2)." .Release.Name .Release.Namespace) }}
+{{-   else if $systemRunning }}
+{{-     fail (printf "SeaweedFS release %s in namespace %s is running two live SeaweedFS sets (D-split): the renamed set has ready volume servers alongside the adopted set, and both write to the shared seaweedfs-db metadata. Rendering would adopt the chart-named set and strand the objects the renamed set wrote. Stop the split and reconcile the two sets before upgrading — docs/operations/seaweedfs-431-rename-recovery.md (Step 3)." .Release.Name .Release.Namespace) }}
+{{-   end }}
+{{- end }}
+
+{{- end }}

--- a/packages/system/seaweedfs/templates/naming-guard.yaml
+++ b/packages/system/seaweedfs/templates/naming-guard.yaml
@@ -4,17 +4,16 @@
    release name, so every instance ran as `seaweedfs-*` with its data on
    `data1-seaweedfs-volume-*`. 4.31 names them after the release; values.yaml pins
    `fullnameOverride: seaweedfs` so an upgrade past the bump adopts the running
-   set and its volumes in place. Two states cannot be adopted, and this template
-   stops the render instead of letting Helm stand up a second, empty set:
+   set and its volumes in place. This template stops the render instead of letting
+   Helm rename workloads away from live data, or adopt the wrong one of two sets:
 
-   - class S — a tenant installed fresh on 1.5.x keeps its data on the
-     release-named `data1-<release>[-seaweedfs]-volume-*` PVCs. Rendering the
-     pinned names would rename the workloads AWAY from that data. → runbook Step 2.
-   - class D-split — both naming generations exist and the release-named volume
-     servers are LIVE, so they may hold objects written through the split
-     endpoint. Adopting the chart-named set would strand those. → runbook Step 3.
-     A duplicate that never served (D-wedged: zero ready replicas) is safe to
-     adopt and renders through.
+   - exactly the legacy generation (or nothing) — decidable, and adoption is
+     correct. Renders.
+   - exactly the release-named generation — a tenant installed fresh on 1.5.x,
+     whose data is on `data1-<release>[-seaweedfs]-volume-*`. Rendering the pinned
+     names would rename the workloads AWAY from that data. Refuses → runbook Step 2.
+   - BOTH generations — undecidable from inside a render, so it refuses rather
+     than guess. See the classification note below. → runbook Step 1, then 2/2a/3.
 
    extra/seaweedfs carries the same classification for its own render, but that
    render is NOT in the path of a platform upgrade: this chart reaches
@@ -24,15 +23,6 @@
    platform upgrade and the tenant's workloads is THIS one. (v1.6 regression:
    the guard lived only in extra/seaweedfs, so upgrading a fresh-1.5.x tenant
    created an empty chart-named set beside its live data.)
-
-   Telling S from D when BOTH PVC generations exist is done by AGE: PVCs are
-   never recreated in place (StatefulSets are, by the adoption hook, so their
-   timestamps are useless), so the OLDER volume-PVC generation is where the data
-   was born. Legacy older → genuine D (adopt, or Step 3 if the duplicate is
-   live). Release-named older → the tenant is a fresh-1.5.x install that a
-   previous (unguarded) upgrade already damaged by creating the empty chart-named
-   set: still class S, and the D-split runbook step would quiesce the set that
-   holds ALL the data — so it must NOT be reported as D-split.
 
    Fail-closed: `lookup` errors abort the render (Helm propagates API errors),
    but a client-side render (`helm template`, --dry-run=client) silently returns
@@ -53,59 +43,112 @@
 {{- end }}
 {{- if $canary }}
 
-{{- /* PVCs hold the data and outlive any workload, but carry no chart labels, so
-   they are matched on the name shape — `data1-<fullname>-volume[-<pool|zone>]-N`
-   — and must mention the chart to avoid tripping over an unrelated
-   `data1-*-volume-*` claim. StatefulSets do carry the labels, so they are
-   matched on those, which also covers a tenant whose PVCs are not provisioned
-   yet and one whose name the chart truncated past the chart name; the renamed
-   volume StatefulSet is also where the D-split liveness signal is read. */}}
+{{- /* Two naming GENERATIONS can exist in a namespace:
+     legacy — the pre-4.31 chart-based names (`seaweedfs-volume[-<key>]`,
+              `data1-seaweedfs-volume[-<key>]-N`), which this chart pins and renders;
+     system — the 4.31 release-based names (`<release>[-seaweedfs]-volume`,
+              `data1-<release>[-seaweedfs]-volume-N`).
+
+   The release-named generation is matched by RECONSTRUCTING the name 4.31 would
+   give this release's volume component, and the chart-named one by the pinned
+   name — release-named checked FIRST, because the two prefixes can nest.
+   Overlapping prefixes alone are not safe: for an instance legitimately named
+   `seaweedfs-volume`, the release-named StatefulSet `seaweedfs-volume-system-volume`
+   and claim `data1-seaweedfs-volume-system-volume-0` BOTH satisfy the chart-named
+   prefixes, so a prefix-only guard reads live release-named storage as legacy and
+   renders onto the empty chart-named claims, stranding the real generation.
+
+   Reconstructing also removes the blind spot a name match alone has: 4.31's
+   componentName truncates the fullname to 56 chars before appending `-volume`, so
+   an instance name >= ~40 chars loses `seaweedfs` from its claim names and a
+   `contains "seaweedfs"` filter cannot see them. The reconstructed prefix carries
+   the same truncation, so it matches those claims exactly.
+
+   PVCs hold the data and outlive any workload but carry no chart labels, so they
+   are matched on name alone. StatefulSets DO carry the labels, and are the only
+   signal for a tenant whose PVCs are not provisioned yet. Either establishes a
+   generation's presence, so the two are OR-ed. */}}
+{{- /* This chart IS the `<name>-system` release, so its own release name is what
+   4.31 named the renamed generation after. extra/seaweedfs is the `<name>` release
+   and derives the child instead; that one line is the only difference between the
+   two copies of the block below. */}}
+{{- $sysRelease := .Release.Name }}
+{{- $renamedVol := include "seaweedfs.renamedVolumePrefix" $sysRelease }}
 {{- $legacyPVC := false }}
 {{- $systemPVC := false }}
-{{- $legacyOldest := "" }}
-{{- $systemOldest := "" }}
 {{- $legacySTS := false }}
 {{- $systemSTS := false }}
-{{- $systemRunning := false }}
 {{- range (lookup "v1" "PersistentVolumeClaim" .Release.Namespace "").items | default list }}
-{{-   if and (hasPrefix "data1-" .metadata.name) (contains "-volume" .metadata.name) (contains "seaweedfs" .metadata.name) }}
-{{-     $ts := dig "metadata" "creationTimestamp" "" . }}
-{{-     if hasPrefix "data1-seaweedfs-volume" .metadata.name }}
-{{-       $legacyPVC = true }}
-{{-       if and $ts (or (not $legacyOldest) (lt $ts $legacyOldest)) }}
-{{-         $legacyOldest = $ts }}
-{{-       end }}
-{{-     else }}
-{{-       $systemPVC = true }}
-{{-       if and $ts (or (not $systemOldest) (lt $ts $systemOldest)) }}
-{{-         $systemOldest = $ts }}
-{{-       end }}
-{{-     end }}
+{{-   if hasPrefix (printf "data1-%s" $renamedVol) .metadata.name }}
+{{-     $systemPVC = true }}
+{{-   else if hasPrefix "data1-seaweedfs-volume" .metadata.name }}
+{{-     $legacyPVC = true }}
 {{-   end }}
 {{- end }}
 {{- range (lookup "apps/v1" "StatefulSet" .Release.Namespace "").items | default list }}
-{{-   if and (eq (dig "app.kubernetes.io/name" "" (.metadata.labels | default dict)) "seaweedfs") (contains "volume" .metadata.name) }}
-{{-     if hasPrefix "seaweedfs-volume" .metadata.name }}
-{{-       $legacySTS = true }}
-{{-     else }}
+{{-   if eq (dig "app.kubernetes.io/name" "" (.metadata.labels | default dict)) "seaweedfs" }}
+{{-     if hasPrefix $renamedVol .metadata.name }}
 {{-       $systemSTS = true }}
-{{-       if gt (int (dig "status" "readyReplicas" 0 .)) 0 }}
-{{-         $systemRunning = true }}
-{{-       end }}
+{{-     else if hasPrefix "seaweedfs-volume" .metadata.name }}
+{{-       $legacySTS = true }}
 {{-     end }}
 {{-   end }}
 {{- end }}
+{{- $legacyGen := or $legacyPVC $legacySTS }}
+{{- $systemGen := or $systemPVC $systemSTS }}
 
-{{- if or $systemPVC $systemSTS }}
-{{-   if and $systemPVC (not $legacyPVC) }}
-{{-     fail (printf "SeaweedFS release %s in namespace %s keeps its data on volumes named after the Helm release (installed fresh on Cozystack 1.5.x). This chart pins the pre-4.31 chart-based names, so rendering would rename the workloads away from that data and stand up an empty cluster beside it. Re-bind the existing PVs onto the data1-seaweedfs-volume-* PVC names first — docs/operations/seaweedfs-431-rename-recovery.md (Step 2)." .Release.Name .Release.Namespace) }}
-{{-   else if and $systemPVC $legacyPVC $systemOldest $legacyOldest (lt $systemOldest $legacyOldest) }}
-{{-     fail (printf "SeaweedFS release %s in namespace %s keeps its data on the release-named volume PVCs (created %s, OLDER than the chart-named data1-seaweedfs-volume-* claims created %s) — a fresh 1.5.x install that a previous unguarded upgrade already damaged by creating the empty chart-named set. Classify as S, never as D-split — do NOT quiesce the release-named set, it holds all the data. Remove the empty chart-named set, then re-bind the PVs — see docs/operations/seaweedfs-431-rename-recovery.md (Step 2a, then Step 2)." .Release.Name .Release.Namespace $systemOldest $legacyOldest) }}
-{{-   else if and (not $systemPVC) (not $legacyPVC) (not $legacySTS) }}
-{{-     fail (printf "SeaweedFS release %s in namespace %s runs release-named workloads (fresh 1.5.x install; volume PVCs not matchable by name — likely a long instance name the chart truncated). Rendering the chart-based names would rename the workloads away from their data. Re-bind the volumes first — docs/operations/seaweedfs-431-rename-recovery.md (Step 2)." .Release.Name .Release.Namespace) }}
-{{-   else if $systemRunning }}
-{{-     fail (printf "SeaweedFS release %s in namespace %s is running two live SeaweedFS sets (D-split): the renamed set has ready volume servers alongside the adopted set, and both write to the shared seaweedfs-db metadata. Rendering would adopt the chart-named set and strand the objects the renamed set wrote. Stop the split and reconcile the two sets before upgrading — docs/operations/seaweedfs-431-rename-recovery.md (Step 3)." .Release.Name .Release.Namespace) }}
-{{-   end }}
+{{- /* Exactly one generation is decidable; two is not.
+
+   This guard used to try to tell the cases apart by comparing PVC creation
+   timestamps — older generation wins, because "PVCs are never recreated in
+   place". That premise is false, and the runbook itself is the counter-example:
+   Step 2's re-bind DELETES each release-named claim and re-creates it under the
+   chart name against the same PV. A tenant interrupted part-way through that
+   loop has a chart-named claim created SECONDS ago holding real data, beside a
+   release-named claim with the original timestamp also holding real data — the
+   exact inversion of the rule. The guard then reported S-damaged and sent the
+   operator to a step that deletes the claim Step 2 had just re-bound.
+
+   A durable signal for BIRTH ORDER does exist, and it is worth naming so nobody
+   re-derives the broken one: the release history. `sh.helm.release.v1.<name>-
+   system.v1` records the naming scheme the tenant was installed under (its
+   manifest names either `seaweedfs-master` or `<release>-master`), and
+   `info.first_deployed` — present on every retained revision, so it survives
+   history pruning — anchors the PV creationTimestamps that Step 2's re-bind
+   preserves. On the upgrade stand that classifies every tenant correctly,
+   including reporting "no duplicate, mid-rebind" for the interrupted-Step-2 case,
+   because there BOTH generations sit at first_deployed.
+
+   This render still cannot read it — the release is base64(gzip(json)) in a
+   Secret and Go templates have no gunzip — but that is NOT the reason the guard
+   refuses. Birth order is the wrong question. It says which generation is
+   ORIGINAL; adoption needs to know whether the OTHER one is EMPTY, and those come
+   apart exactly where it matters:
+
+     D-wedged  — duplicate never scheduled, holds nothing  -> adopting is safe
+     D-split   — duplicate served writes, holds unique objects -> adopting strands them
+
+   Both are born pre-4.31, so the history signal is IDENTICAL for both (verified:
+   tenant-root and tenant-dsplit have the same rev-1 scheme and the same
+   first_deployed deltas — ~10s legacy vs ~35min release-named — yet one duplicate
+   served and the other did not). The only thing that separated them was
+   readyReplicas, which is a snapshot and not evidence: a duplicate that crashed,
+   was scaled down, or lost readiness after serving reads exactly like one that
+   never started.
+
+   So this render does not guess. Two generations => refuse, and let an operator
+   establish emptiness with context the template does not have (the duplicate's
+   volume files, the filer's volume list). Once the empty generation is gone
+   exactly one remains, which IS decidable, and the render proceeds on its own.
+
+   The cost is bounded: a duplicate only exists on a tenant that passed through
+   the broken 4.31 rename in 1.5.x, i.e. one that is already damaged and already
+   needs an operator. A 1.4.x tenant upgrading straight to 1.6 never renames, so
+   it only ever has the legacy generation and renders untouched. */}}
+{{- if and $legacyGen $systemGen }}
+{{-   fail (printf "SeaweedFS release %s in namespace %s has BOTH naming generations present: the chart-named set (seaweedfs-volume / data1-seaweedfs-volume-*) AND the release-named set this chart no longer uses. One of them is an empty duplicate and one holds the data, and which is which cannot be established from inside a Helm render — claim timestamps are mutable (the Step 2 re-bind recreates claims), StatefulSets are recreated by the adoption hook, and a duplicate with zero ready replicas may still have served writes. Rendering would adopt the chart-named set, so guessing wrong strands or destroys the data. Refusing instead. Classify the tenant and delete the EMPTY generation so exactly one remains — this render then adopts the survivor with no further action. See docs/operations/seaweedfs-431-rename-recovery.md (Step 1 classifies; Step 2/2a/3 recover). If you are part-way through Step 2's re-bind, finish it." .Release.Name .Release.Namespace) }}
+{{- else if $systemGen }}
+{{-   fail (printf "SeaweedFS release %s in namespace %s keeps its data on volumes named after the Helm release — a tenant installed fresh on Cozystack 1.5.x (or one whose instance name is long enough that the chart truncated the volume PVC names, leaving only its StatefulSets to match on). This chart pins the pre-4.31 chart-based names, so rendering would rename the workloads away from that data and stand up an empty cluster beside it. Helm cannot move data between PVCs. Re-bind the existing PVs onto the data1-seaweedfs-volume-* PVC names first — docs/operations/seaweedfs-431-rename-recovery.md (Step 2)." .Release.Name .Release.Namespace) }}
 {{- end }}
 
 {{- end }}

--- a/packages/system/seaweedfs/tests/cluster_scoped_names_test.yaml
+++ b/packages/system/seaweedfs/tests/cluster_scoped_names_test.yaml
@@ -1,0 +1,138 @@
+suite: seaweedfs cluster-scoped RBAC names stay unique per tenant
+
+# ClusterRoles and ClusterRoleBindings are CLUSTER-scoped: exactly one object can
+# carry a given name, cluster-wide. Every SeaweedFS instance pins the same
+# `fullnameOverride: seaweedfs` (#3282 — that pin is what adopts the running
+# NAMESPACED workloads across the 4.31 rename), so `seaweedfs.fullname` is
+# identical in every tenant and must never name a cluster-scoped object.
+#
+# Upstream 4.31 switched these four names from global.serviceAccountName (which
+# Cozystack sets per namespace) to seaweedfs.fullname, which is how five tenants
+# ended up fighting over ONE ClusterRole. patches/cluster-scoped-names-per-
+# namespace.patch puts them back on the service account name, restoring the
+# pre-4.31 names byte-for-byte.
+#
+# These assertions fail on unpatched code: it renders `seaweedfs-*` for every
+# namespace, so the two namespaces below produce the SAME name instead of two.
+
+templates:
+  - charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
+  - charts/seaweedfs/templates/shared/cluster-role.yaml
+
+release:
+  name: seaweedfs-system
+  namespace: tenant-root
+
+tests:
+  - it: names the COSI ClusterRole/Binding after the per-namespace service account
+    template: charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
+    set:
+      global.seaweedfs.serviceAccountName: tenant-root-seaweedfs
+    asserts:
+      # ClusterRole — pre-4.31 name, restored.
+      - equal:
+          path: metadata.name
+          value: tenant-root-seaweedfs-objectstorage-provisioner
+        documentIndex: 0
+      # ClusterRoleBinding — same name, and its roleRef must follow the rename or
+      # the binding would point at another tenant's ClusterRole.
+      - equal:
+          path: metadata.name
+          value: tenant-root-seaweedfs-objectstorage-provisioner
+        documentIndex: 1
+      - equal:
+          path: roleRef.name
+          value: tenant-root-seaweedfs-objectstorage-provisioner
+        documentIndex: 1
+      # The subject was ALREADY per-namespace (cosi-provisioner-sa-name.patch);
+      # it is what the cluster-scoped names are now aligned with.
+      - equal:
+          path: subjects[0].name
+          value: tenant-root-seaweedfs-objectstorage-provisioner
+        documentIndex: 1
+      - equal:
+          path: subjects[0].namespace
+          value: tenant-root
+        documentIndex: 1
+
+  - it: names the master-rw ClusterRole/Binding after the per-namespace service account
+    template: charts/seaweedfs/templates/shared/cluster-role.yaml
+    set:
+      global.seaweedfs.serviceAccountName: tenant-root-seaweedfs
+    asserts:
+      - equal:
+          path: metadata.name
+          value: tenant-root-seaweedfs-rw-cr
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: tenant-root-seaweedfs-rw-crb
+        documentIndex: 1
+      - equal:
+          path: roleRef.name
+          value: tenant-root-seaweedfs-rw-cr
+        documentIndex: 1
+      - equal:
+          path: subjects[0].name
+          value: tenant-root-seaweedfs
+        documentIndex: 1
+
+  # THE regression test. A second tenant, running an instance under a DIFFERENT
+  # name (`foo` -> release foo-system), must not collide with tenant-root above.
+  # Unpatched, both render `seaweedfs-objectstorage-provisioner` / `seaweedfs-rw-cr`
+  # — observed live as one ClusterRole annotated to a single owning tenant while
+  # four others silently lost their COSI RBAC.
+  - it: renders a different cluster-scoped name for a different tenant (collision regression)
+    template: charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
+    release:
+      name: foo-system
+      namespace: tenant-named
+    set:
+      global.seaweedfs.serviceAccountName: tenant-named-seaweedfs
+    asserts:
+      - equal:
+          path: metadata.name
+          value: tenant-named-seaweedfs-objectstorage-provisioner
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: tenant-named-seaweedfs-objectstorage-provisioner
+        documentIndex: 1
+      - equal:
+          path: roleRef.name
+          value: tenant-named-seaweedfs-objectstorage-provisioner
+        documentIndex: 1
+
+  - it: renders a different master-rw name for a different tenant (collision regression)
+    template: charts/seaweedfs/templates/shared/cluster-role.yaml
+    release:
+      name: foo-system
+      namespace: tenant-named
+    set:
+      global.seaweedfs.serviceAccountName: tenant-named-seaweedfs
+    asserts:
+      - equal:
+          path: metadata.name
+          value: tenant-named-seaweedfs-rw-cr
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: tenant-named-seaweedfs-rw-crb
+        documentIndex: 1
+
+  # The pin must NOT leak into cluster-scoped names, and must NOT be lifted from
+  # namespaced ones. Guards the two halves against each other.
+  - it: keeps the cluster-scoped name independent of the pinned fullname
+    template: charts/seaweedfs/templates/cosi/cosi-cluster-role.yaml
+    set:
+      global.seaweedfs.serviceAccountName: tenant-root-seaweedfs
+      seaweedfs.fullnameOverride: seaweedfs
+    asserts:
+      - notMatchRegex:
+          path: metadata.name
+          pattern: "^seaweedfs-"
+        documentIndex: 0
+      - notMatchRegex:
+          path: metadata.name
+          pattern: "^seaweedfs-system-"
+        documentIndex: 0

--- a/packages/system/seaweedfs/tests/cluster_scoped_rbac_guard_test.yaml
+++ b/packages/system/seaweedfs/tests/cluster_scoped_rbac_guard_test.yaml
@@ -1,0 +1,177 @@
+suite: seaweedfs cluster-scoped RBAC uniqueness guard
+
+# Companion to cluster_scoped_names_test.yaml: that suite pins the NAMES the
+# chart renders, this one pins the guard that refuses when those names would not
+# be unique per tenant.
+#
+# The guard reads global.seaweedfs.serviceAccountName and requires it to carry
+# the release namespace, because the pinned fullname is identical in every tenant
+# and so cannot be what distinguishes a cluster-scoped object. It runs only when
+# the render can see the cluster (namespace canary, same as naming-guard.yaml) —
+# system/seaweedfs's values.yaml default is a placeholder that only
+# extra/seaweedfs overrides per release, so a client-side render must not trip.
+
+templates:
+  - templates/cluster-scoped-rbac-guard.yaml
+
+release:
+  name: seaweedfs-system
+  namespace: tenant-fresh
+
+tests:
+  - it: renders for a client-side install with no cluster view (CI lint, unittest)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders when the cluster-scoped RBAC name carries the namespace
+    set:
+      global:
+        seaweedfs:
+          serviceAccountName: tenant-fresh-seaweedfs
+    kubernetesProvider:
+      scheme: &scheme
+        "v1/Namespace":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "namespaces"
+          namespaced: false
+      objects:
+        - &ns
+          kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: tenant-fresh
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # M2 REGRESSION — the compat shim. Production does NOT set the canonical
+  # global.seaweedfs.serviceAccountName that the other cases here use:
+  # extra/seaweedfs sets the OLD FLAT key global.serviceAccountName, which only
+  # `include "seaweedfs.compat"` folds into the canonical path (and the flat key
+  # wins when present). Without that include the guard reads this chart's
+  # placeholder default and refuses EVERY real upgrade on EVERY cluster — a bug
+  # that only `helm upgrade --dry-run=server` caught, because every mock set the
+  # canonical key. This case sets the key production actually sets.
+  - it: accepts the flat global.serviceAccountName that extra/seaweedfs actually sets
+    set:
+      global:
+        serviceAccountName: tenant-fresh-seaweedfs
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # The shim must not become a way to bypass the guard: a flat key that is not
+  # per-namespace is still refused.
+  - it: refuses a flat global.serviceAccountName that is not per-namespace
+    set:
+      global:
+        serviceAccountName: seaweedfs
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+    asserts:
+      - failedTemplate:
+          errorPattern: "not unique per tenant"
+
+  # A substring match accepts `tenant-ab-seaweedfs` for namespace `tenant-a`; a
+  # prefix match still accepts `tenant-a-b-seaweedfs`, which is ALSO the natural
+  # value for namespace `tenant-a-b` — so two namespaces would accept one string
+  # and collide on the object this guard exists to keep unique. Only equality with
+  # `<namespace>-seaweedfs` — the value extra/seaweedfs actually sets — is safe.
+  - it: refuses a service account from a namespace that only shares a prefix
+    release:
+      name: seaweedfs-system
+      namespace: tenant-a
+    set:
+      global:
+        seaweedfs:
+          serviceAccountName: tenant-ab-seaweedfs
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: tenant-a
+    asserts:
+      - failedTemplate:
+          errorPattern: "not unique per tenant"
+
+  # The prefix variant: `tenant-a-b-seaweedfs` starts with `tenant-a-` but belongs
+  # to namespace tenant-a-b. hasPrefix passes this; equality does not.
+  - it: refuses a service account whose namespace merely extends this one
+    release:
+      name: seaweedfs-system
+      namespace: tenant-a
+    set:
+      global:
+        seaweedfs:
+          serviceAccountName: tenant-a-b-seaweedfs
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: tenant-a
+    asserts:
+      - failedTemplate:
+          errorPattern: "not unique per tenant"
+
+  # The regression this guard exists for: the bare chart default (or any value
+  # that is the same string in every tenant) collides cluster-wide.
+  - it: refuses when the RBAC name would be identical in every tenant
+    set:
+      global:
+        seaweedfs:
+          serviceAccountName: seaweedfs
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+    asserts:
+      - failedTemplate:
+          errorPattern: "not unique per tenant"
+
+  # The placeholder shipped in system/seaweedfs/values.yaml is namespace-shaped
+  # but belongs to no real namespace — it must not be mistaken for a valid value
+  # once the render can see the cluster.
+  - it: refuses when the value is the shipped placeholder, not this namespace
+    set:
+      global:
+        seaweedfs:
+          serviceAccountName: tenant-foo-seaweedfs
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+    asserts:
+      - failedTemplate:
+          errorPattern: "not unique per tenant"
+
+  - it: refuses for a non-default instance name whose SA is not per-namespace
+    release:
+      name: foo-system
+      namespace: tenant-named
+    set:
+      global:
+        seaweedfs:
+          serviceAccountName: seaweedfs
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: tenant-named
+    asserts:
+      - failedTemplate:
+          errorPattern: "not unique per tenant"

--- a/packages/system/seaweedfs/tests/naming_guard_test.yaml
+++ b/packages/system/seaweedfs/tests/naming_guard_test.yaml
@@ -462,6 +462,90 @@ tests:
       - failedTemplate:
           errorPattern: "has BOTH naming generations present"
 
+  # ---------------------------------------------------------------------------
+  # MultiZone (and Simple-with-pools) tenants have NO plain `volume` component —
+  # extra/seaweedfs sets volume.enabled=false and renders one component per zone
+  # key, suffix `volume-<key>`. For the supported instance (the tenant module
+  # hardcodes the name `seaweedfs`, fullname 16 chars) nothing is truncated, so
+  # the reconstructed prefix `seaweedfs-system-volume` must prefix-match every
+  # zone component. These pin that. The reconstruction does NOT cover zone
+  # components of long-named instances or ~40+ char zone keys — an accepted,
+  # documented limit (_naming.tpl, runbook Scope), deliberately not tested.
+  # ---------------------------------------------------------------------------
+
+  - it: renders for a legacy-only MultiZone tenant (zone components adopt in place)
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-md-0
+            namespace: tenant-fresh
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-volume-md
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: refuses class S for a MultiZone tenant with only zone components (fresh 1.5.x)
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        # No plain `volume` component exists on a MultiZone tenant — the zone
+        # objects are the ONLY release-named evidence, so if the prefix match
+        # missed them this tenant would render and be renamed away from its data.
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-md-0
+            namespace: tenant-fresh
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-system-volume-md
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+    asserts:
+      - failedTemplate:
+          errorPattern: "keeps its data on volumes named after the Helm release"
+
+  - it: refuses both-generations for a MultiZone tenant
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-md-0
+            namespace: tenant-fresh
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-md-0
+            namespace: tenant-fresh
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-system-volume-md
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "0"
+    asserts:
+      - failedTemplate:
+          errorPattern: "has BOTH naming generations present"
+
   - it: ignores unrelated data1-*-volume-* claims of other apps
     kubernetesProvider:
       scheme: *scheme

--- a/packages/system/seaweedfs/tests/naming_guard_test.yaml
+++ b/packages/system/seaweedfs/tests/naming_guard_test.yaml
@@ -4,11 +4,18 @@ suite: seaweedfs naming-migration guard (enforcing copy)
 # HelmRelease pulls it from a platform-managed ExternalArtifact, so bumping the
 # platform upgrades the release directly — extra/seaweedfs (which carries a
 # sibling copy of this guard for operator visibility) is NOT in that path.
-# v1.6 regression: the guard lived only in extra/seaweedfs, so upgrading a
-# tenant installed fresh on 1.5.x (class S: data on the release-named
-# data1-<release>[-seaweedfs]-volume-* PVCs) stood up an empty chart-named set
-# beside its live data. These tests pin the enforcement where the rename
-# actually happens.
+#
+# The guard decides between exactly three outcomes:
+#   legacy generation only (or nothing) -> render (adoption is correct)
+#   release-named generation only       -> refuse, class S (runbook Step 2)
+#   BOTH generations                    -> refuse, undecidable (runbook Step 1)
+#
+# It used to tell the both-generations cases apart by comparing PVC
+# creationTimestamps ("PVCs are never recreated in place, so the older generation
+# is where the data was born"). That premise is false — the runbook's own Step 2
+# re-bind DELETES each release-named claim and recreates it under the chart name
+# against the same PV — and acting on the wrong answer deletes live data. The
+# guard no longer guesses; the tests below pin that.
 #
 # The guard reads the cluster through lookup with the release namespace as its
 # canary, so classification tests register v1/Namespace + v1/PersistentVolumeClaim
@@ -30,9 +37,8 @@ tests:
 
   # NOTE: the fail-closed refusal (client-side UPGRADE with no cluster view)
   # cannot be modelled here — helm-unittest 1.0.3 ignores release.isUpgrade, so
-  # .Release.IsUpgrade always renders false. Verify with a real renderer:
-  #   helm template packages/system/seaweedfs --is-upgrade 2>&1 \
-  #     | grep 'refusing to upgrade blind'
+  # .Release.IsUpgrade always renders false. The chart's `make test` target
+  # covers it with a real renderer (helm template --is-upgrade).
 
   - it: refuses to render if the fullnameOverride pin is ever lifted
     set:
@@ -83,7 +89,7 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: renders for a legacy tenant (data on the chart-named PVCs, adopt in place)
+  - it: renders for a legacy-only tenant (data on the chart-named PVCs, adopt in place)
     kubernetesProvider:
       scheme: *scheme
       objects:
@@ -93,12 +99,13 @@ tests:
           metadata:
             name: data1-seaweedfs-volume-0
             namespace: tenant-fresh
-            creationTimestamp: "2025-11-02T10:00:00Z"
         - kind: StatefulSet
           apiVersion: apps/v1
           metadata:
-            name: unrelated-app
+            name: seaweedfs-volume
             namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
     asserts:
       - hasDocuments:
           count: 0
@@ -113,7 +120,6 @@ tests:
           metadata:
             name: data1-seaweedfs-system-volume-0
             namespace: tenant-fresh
-            creationTimestamp: "2026-06-20T07:01:59Z"
         - kind: StatefulSet
           apiVersion: apps/v1
           metadata:
@@ -121,123 +127,9 @@ tests:
             namespace: tenant-fresh
             labels:
               app.kubernetes.io/name: seaweedfs
-          status:
-            readyReplicas: "1"
     asserts:
       - failedTemplate:
           errorPattern: "keeps its data on volumes named after the Helm release.*Step 2"
-
-  - it: refuses class S when a previous unguarded upgrade already created the empty chart-named set
-    kubernetesProvider:
-      scheme: *scheme
-      objects:
-        - *ns
-        # Exactly the observed damage: system volumes older (the data), chart-named
-        # volumes newer (created empty by the upgrade), renamed set still serving.
-        # A presence-only classification calls this D-split and sends the operator
-        # to quiesce the set that holds ALL the data.
-        - kind: PersistentVolumeClaim
-          apiVersion: v1
-          metadata:
-            name: data1-seaweedfs-system-volume-0
-            namespace: tenant-fresh
-            creationTimestamp: "2026-06-20T07:01:59Z"
-        - kind: PersistentVolumeClaim
-          apiVersion: v1
-          metadata:
-            name: data1-seaweedfs-volume-0
-            namespace: tenant-fresh
-            creationTimestamp: "2026-06-20T08:28:58Z"
-        - kind: StatefulSet
-          apiVersion: apps/v1
-          metadata:
-            name: seaweedfs-system-volume
-            namespace: tenant-fresh
-            labels:
-              app.kubernetes.io/name: seaweedfs
-          status:
-            readyReplicas: "1"
-        - kind: StatefulSet
-          apiVersion: apps/v1
-          metadata:
-            name: seaweedfs-volume
-            namespace: tenant-fresh
-            labels:
-              app.kubernetes.io/name: seaweedfs
-          status:
-            readyReplicas: "0"
-    asserts:
-      - failedTemplate:
-          errorPattern: "never as D-split.*Step 2a"
-
-  - it: renders for a D-wedged tenant (legacy volumes older, duplicate never served)
-    kubernetesProvider:
-      scheme: *scheme
-      objects:
-        - *ns
-        - kind: PersistentVolumeClaim
-          apiVersion: v1
-          metadata:
-            name: data1-seaweedfs-volume-0
-            namespace: tenant-fresh
-            creationTimestamp: "2025-11-02T10:00:00Z"
-        - kind: PersistentVolumeClaim
-          apiVersion: v1
-          metadata:
-            name: data1-seaweedfs-system-volume-0
-            namespace: tenant-fresh
-            creationTimestamp: "2026-06-20T12:00:00Z"
-        - kind: StatefulSet
-          apiVersion: apps/v1
-          metadata:
-            name: seaweedfs-system-volume
-            namespace: tenant-fresh
-            labels:
-              app.kubernetes.io/name: seaweedfs
-          status:
-            readyReplicas: "0"
-        - kind: StatefulSet
-          apiVersion: apps/v1
-          metadata:
-            name: seaweedfs-volume
-            namespace: tenant-fresh
-            labels:
-              app.kubernetes.io/name: seaweedfs
-          status:
-            readyReplicas: "1"
-    asserts:
-      - hasDocuments:
-          count: 0
-
-  - it: refuses a genuine D-split (legacy volumes older AND the duplicate is live)
-    kubernetesProvider:
-      scheme: *scheme
-      objects:
-        - *ns
-        - kind: PersistentVolumeClaim
-          apiVersion: v1
-          metadata:
-            name: data1-seaweedfs-volume-0
-            namespace: tenant-fresh
-            creationTimestamp: "2025-11-02T10:00:00Z"
-        - kind: PersistentVolumeClaim
-          apiVersion: v1
-          metadata:
-            name: data1-seaweedfs-system-volume-0
-            namespace: tenant-fresh
-            creationTimestamp: "2026-06-20T12:00:00Z"
-        - kind: StatefulSet
-          apiVersion: apps/v1
-          metadata:
-            name: seaweedfs-system-volume
-            namespace: tenant-fresh
-            labels:
-              app.kubernetes.io/name: seaweedfs
-          status:
-            readyReplicas: "1"
-    asserts:
-      - failedTemplate:
-          errorPattern: "is running two live SeaweedFS sets.*Step 3"
 
   - it: refuses class S for a non-default instance name (foo-system release)
     release:
@@ -254,8 +146,11 @@ tests:
           metadata:
             name: data1-foo-system-seaweedfs-volume-0
             namespace: tenant-fresh
-            creationTimestamp: "2026-06-20T07:01:59Z"
-        - kind: StatefulSet
+        # The fake client builds its list kinds from the objects present, so a
+        # suite that LISTs StatefulSets must include at least one or the lookup
+        # errors instead of returning empty.
+        - &unrelated_sts
+          kind: StatefulSet
           apiVersion: apps/v1
           metadata:
             name: unrelated-app
@@ -263,6 +158,309 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "keeps its data on volumes named after the Helm release"
+
+  # ---------------------------------------------------------------------------
+  # Both generations present => refuse. Four shapes the old timestamp classifier
+  # routed FOUR different ways; all four get the same answer now.
+  # ---------------------------------------------------------------------------
+
+  # Old code: legacy older + duplicate live -> "D-split" (Step 3). Now: refuse.
+  - it: refuses when both generations exist and the duplicate is live (was D-split)
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2025-11-02T10:00:00Z"
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2026-06-20T12:00:00Z"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-system-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "1"
+    asserts:
+      - failedTemplate:
+          errorPattern: "has BOTH naming generations present"
+
+  # B5 REGRESSION. Old code: legacy older + zero ready replicas -> "D-wedged",
+  # which rendered THROUGH and adopted. readyReplicas is only a snapshot: a
+  # duplicate that crashed, was scaled down, or lost readiness AFTER serving
+  # writes reads identically to one that never served. Adoption would strand
+  # whatever it wrote.
+  - it: refuses when both generations exist and the duplicate reads zero ready (was D-wedged, adopted)
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2025-11-02T10:00:00Z"
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2026-06-20T12:00:00Z"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-system-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "0"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "1"
+    asserts:
+      - failedTemplate:
+          errorPattern: "has BOTH naming generations present"
+
+  # Old code: release-named older -> "S-damaged" (Step 2a). Now: refuse.
+  - it: refuses when both generations exist and the release-named claims are older (was S-damaged)
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2026-06-20T07:01:59Z"
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2026-06-20T08:28:58Z"
+        - *unrelated_sts
+    asserts:
+      - failedTemplate:
+          errorPattern: "has BOTH naming generations present"
+
+  # B1 REGRESSION — the data-loss path. A tenant interrupted part-way through the
+  # runbook's Step 2 re-bind: data1-seaweedfs-volume-0 was DELETED and RECREATED
+  # against its original PV seconds ago, so it is the NEWEST claim while holding
+  # real data; data1-seaweedfs-system-volume-1 has not been re-bound yet, so it
+  # keeps the ORIGINAL timestamp and also holds real data. The old timestamp rule
+  # read "release-named older" and reported S-damaged, sending the operator to
+  # Step 2a — which deletes data1-seaweedfs-volume-*, i.e. the claim Step 2 had
+  # just re-bound, with the PV's reclaim policy already restored to Delete.
+  - it: refuses a tenant interrupted mid Step-2 re-bind rather than calling it S-damaged
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        # Not yet re-bound: original claim, original timestamp, real data.
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-1
+            namespace: tenant-fresh
+            creationTimestamp: "2026-06-20T07:01:59Z"
+        # Already re-bound by Step 2: brand-new claim, ORIGINAL PV, real data.
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2026-07-17T09:30:00Z"
+        - *unrelated_sts
+    asserts:
+      - failedTemplate:
+          errorPattern: "has BOTH naming generations present"
+
+  # ---------------------------------------------------------------------------
+  # B2 REGRESSION — long instance name. seaweedfs.componentName truncates the
+  # fullname to 56 chars before appending -volume, so an instance name >= ~40
+  # chars drops `seaweedfs` off the PVC name and the name match cannot see it.
+  # The StatefulSet is label-matched and still can, which is why the generation
+  # flags OR the two signals instead of keying off the PVC evidence alone.
+  # ---------------------------------------------------------------------------
+
+  - it: refuses both-generations for a long instance name whose PVC names were truncated
+    release:
+      name: archive-of-quarterly-financial-statements-x1-system
+      namespace: tenant-fresh
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        # The renamed volume PVC, truncated past the chart name: unmatchable.
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-archive-of-quarterly-financial-statements-x1-system-seaw-volume-0
+            namespace: tenant-fresh
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-fresh
+        # Only the label-matched StatefulSet reveals the renamed generation. Old
+        # code fell through to the D-split branch here, sending the operator to
+        # quiesce the set holding the data — the exact misclassification the
+        # parent commit exists to remove.
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: archive-of-quarterly-financial-statements-x1-system-seaw-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "1"
+    asserts:
+      - failedTemplate:
+          errorPattern: "has BOTH naming generations present"
+
+  - it: refuses a truncated long instance name whose duplicate reads zero ready (rendered unguarded before)
+    release:
+      name: archive-of-quarterly-financial-statements-x1-system
+      namespace: tenant-fresh
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-archive-of-quarterly-financial-statements-x1-system-seaw-volume-0
+            namespace: tenant-fresh
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-fresh
+        # Old code: no branch fired at all here — it rendered through and adopted
+        # the empty chart-named set. Blocker fully open.
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: archive-of-quarterly-financial-statements-x1-system-seaw-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "0"
+    asserts:
+      - failedTemplate:
+          errorPattern: "has BOTH naming generations present"
+
+  - it: refuses class S for a truncated long instance name with no legacy generation
+    release:
+      name: archive-of-quarterly-financial-statements-x1-system
+      namespace: tenant-fresh
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-archive-of-quarterly-financial-statements-x1-system-seaw-volume-0
+            namespace: tenant-fresh
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: archive-of-quarterly-financial-statements-x1-system-seaw-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+    asserts:
+      - failedTemplate:
+          errorPattern: "keeps its data on volumes named after the Helm release"
+
+  # ---------------------------------------------------------------------------
+  # An instance legitimately named `seaweedfs-volume`. Its release is
+  # seaweedfs-volume-system, which CONTAINS "seaweedfs", so 4.31 names its volume
+  # workloads seaweedfs-volume-system-volume and its claims
+  # data1-seaweedfs-volume-system-volume-N. Both satisfy the chart-named prefixes
+  # ("seaweedfs-volume" / "data1-seaweedfs-volume"), so a prefix-only guard reads
+  # this tenant's LIVE release-named storage as legacy, sees no release-named
+  # generation, renders, and stands an empty cluster on data1-seaweedfs-volume-*
+  # while the real data is stranded. Reconstructing the renamed prefix and testing
+  # it FIRST is what separates them.
+  # ---------------------------------------------------------------------------
+
+  - it: refuses class S for an instance named seaweedfs-volume (release-named storage is not legacy)
+    release:
+      name: seaweedfs-volume-system
+      namespace: tenant-fresh
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-system-volume-0
+            namespace: tenant-fresh
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-volume-system-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+    asserts:
+      - failedTemplate:
+          errorPattern: "keeps its data on volumes named after the Helm release"
+
+  - it: refuses both-generations for an instance named seaweedfs-volume
+    release:
+      name: seaweedfs-volume-system
+      namespace: tenant-fresh
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        # Live release-named storage...
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-system-volume-0
+            namespace: tenant-fresh
+        # ...beside a genuine chart-named duplicate.
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-fresh
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-volume-system-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+    asserts:
+      - failedTemplate:
+          errorPattern: "has BOTH naming generations present"
 
   - it: ignores unrelated data1-*-volume-* claims of other apps
     kubernetesProvider:

--- a/packages/system/seaweedfs/tests/naming_guard_test.yaml
+++ b/packages/system/seaweedfs/tests/naming_guard_test.yaml
@@ -1,0 +1,286 @@
+suite: seaweedfs naming-migration guard (enforcing copy)
+
+# This chart is what a platform upgrade actually re-renders: the <name>-system
+# HelmRelease pulls it from a platform-managed ExternalArtifact, so bumping the
+# platform upgrades the release directly — extra/seaweedfs (which carries a
+# sibling copy of this guard for operator visibility) is NOT in that path.
+# v1.6 regression: the guard lived only in extra/seaweedfs, so upgrading a
+# tenant installed fresh on 1.5.x (class S: data on the release-named
+# data1-<release>[-seaweedfs]-volume-* PVCs) stood up an empty chart-named set
+# beside its live data. These tests pin the enforcement where the rename
+# actually happens.
+#
+# The guard reads the cluster through lookup with the release namespace as its
+# canary, so classification tests register v1/Namespace + v1/PersistentVolumeClaim
+# + apps/v1/StatefulSet and include the namespace object. readyReplicas is quoted
+# ("1"/"0") because the fake client cannot deep-copy a bare Go int.
+
+templates:
+  - templates/naming-guard.yaml
+
+release:
+  name: seaweedfs-system
+  namespace: tenant-fresh
+
+tests:
+  - it: renders for a client-side install with no cluster view (CI lint, unittest)
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # NOTE: the fail-closed refusal (client-side UPGRADE with no cluster view)
+  # cannot be modelled here — helm-unittest 1.0.3 ignores release.isUpgrade, so
+  # .Release.IsUpgrade always renders false. Verify with a real renderer:
+  #   helm template packages/system/seaweedfs --is-upgrade 2>&1 \
+  #     | grep 'refusing to upgrade blind'
+
+  - it: refuses to render if the fullnameOverride pin is ever lifted
+    set:
+      seaweedfs:
+        fullnameOverride: something-else
+    asserts:
+      - failedTemplate:
+          errorPattern: "must pin seaweedfs.fullnameOverride=seaweedfs"
+
+  - it: renders for a net-new tenant (namespace visible, no SeaweedFS data)
+    kubernetesProvider:
+      scheme: &scheme
+        "v1/Namespace":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "namespaces"
+          namespaced: false
+        "v1/PersistentVolumeClaim":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+        "apps/v1/StatefulSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "statefulsets"
+          namespaced: true
+      objects:
+        - &ns
+          kind: Namespace
+          apiVersion: v1
+          metadata:
+            name: tenant-fresh
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: unrelated-app-data-0
+            namespace: tenant-fresh
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: unrelated-app
+            namespace: tenant-fresh
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders for a legacy tenant (data on the chart-named PVCs, adopt in place)
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2025-11-02T10:00:00Z"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: unrelated-app
+            namespace: tenant-fresh
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: refuses class S — data only on release-named volumes (fresh 1.5.x install)
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2026-06-20T07:01:59Z"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-system-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "1"
+    asserts:
+      - failedTemplate:
+          errorPattern: "keeps its data on volumes named after the Helm release.*Step 2"
+
+  - it: refuses class S when a previous unguarded upgrade already created the empty chart-named set
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        # Exactly the observed damage: system volumes older (the data), chart-named
+        # volumes newer (created empty by the upgrade), renamed set still serving.
+        # A presence-only classification calls this D-split and sends the operator
+        # to quiesce the set that holds ALL the data.
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2026-06-20T07:01:59Z"
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2026-06-20T08:28:58Z"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-system-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "1"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "0"
+    asserts:
+      - failedTemplate:
+          errorPattern: "never as D-split.*Step 2a"
+
+  - it: renders for a D-wedged tenant (legacy volumes older, duplicate never served)
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2025-11-02T10:00:00Z"
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2026-06-20T12:00:00Z"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-system-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "0"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "1"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: refuses a genuine D-split (legacy volumes older AND the duplicate is live)
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2025-11-02T10:00:00Z"
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-system-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2026-06-20T12:00:00Z"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-system-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: seaweedfs
+          status:
+            readyReplicas: "1"
+    asserts:
+      - failedTemplate:
+          errorPattern: "is running two live SeaweedFS sets.*Step 3"
+
+  - it: refuses class S for a non-default instance name (foo-system release)
+    release:
+      name: foo-system
+      namespace: tenant-fresh
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        # 4.31 appends the chart name when the release name does not contain it:
+        # a fresh 1.5.x `foo` wrote to data1-foo-system-seaweedfs-volume-*.
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-foo-system-seaweedfs-volume-0
+            namespace: tenant-fresh
+            creationTimestamp: "2026-06-20T07:01:59Z"
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: unrelated-app
+            namespace: tenant-fresh
+    asserts:
+      - failedTemplate:
+          errorPattern: "keeps its data on volumes named after the Helm release"
+
+  - it: ignores unrelated data1-*-volume-* claims of other apps
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - *ns
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-clickhouse-volume-0
+            namespace: tenant-fresh
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: clickhouse-volume
+            namespace: tenant-fresh
+            labels:
+              app.kubernetes.io/name: clickhouse
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -18,9 +18,12 @@ seaweedfs:
   # empty set beside the running one while the data stayed on `data1-seaweedfs-volume-*`.
   # Pinning the chart name restores the pre-4.31 names, so the running workloads
   # and their volumes are adopted across the bump. extra/seaweedfs does NOT override
-  # this per release — it relies on this pin — and guards the one case the pin
-  # cannot serve (a tenant installed fresh on 1.5.x, whose data is on the renamed
-  # volumes) by refusing to render.
+  # this per release — it relies on this pin. The cases the pin cannot serve (a
+  # tenant installed fresh on 1.5.x, whose data is on the renamed volumes, and a
+  # live D-split duplicate) refuse to render in templates/naming-guard.yaml — the
+  # guard MUST live in this chart, because a platform upgrade re-renders this
+  # chart directly from its ExternalArtifact without re-rendering extra/seaweedfs.
+  # The guard also refuses to render at all if this pin is ever lifted.
   fullnameOverride: seaweedfs
   master:
     # 30 GB per volume × 10 GiB PVC = 0 → rounded to 1 maxVolume per


### PR DESCRIPTION
## What this PR does

Cozystack v1.5.0 bumped the vendored SeaweedFS chart 4.0.405 → 4.31.0, which renamed every workload after the Helm release (`<name>-system-*`). StatefulSet names are immutable, so upgrades through 1.5.x stood up a second, empty set beside the running one instead of renaming. #3282 pinned `fullnameOverride: seaweedfs` so 1.6 adopts running workloads in place — this PR closes the remaining holes on that adoption path, found by driving a disposable 3-node cluster through a real v1.4.5 → v1.5.3 → main upgrade with SeaweedFS tenants planted in every reachable state.

- **The naming guard moves into `packages/system/seaweedfs`** — the render a platform upgrade actually re-renders: the `<name>-system` HelmRelease pulls this chart from a platform-managed ExternalArtifact, so the previous guard in `extra/seaweedfs` was never in the path. Upgrading a fresh-1.5.x tenant therefore created an empty chart-named set beside its live data and flipped the guard's own legacy-data signal. `extra/` keeps a sibling copy for operator visibility; a bats parity suite pins the two detection blocks byte-identical.
- **The guard refuses instead of guessing when both naming generations exist.** Nothing durable distinguishes a duplicate that never served from one that served and crashed: claim timestamps invert during the recovery runbook's own re-bind, `readyReplicas: 0` is a snapshot, and Helm birth order answers "which generation is original", not "is the other one empty". Exactly one generation present is decidable, and the render proceeds (or refuses as class S) on its own.
- **Cluster-scoped RBAC is named per namespace again.** 4.31 named four cluster-scoped objects after the release — identical for every tenant — so all tenants collided on one ClusterRole/ClusterRoleBinding and only the last-reconciled tenant's COSI provisioner kept its RBAC. Names return to `global.seaweedfs.serviceAccountName`; three of four are byte-identical to pre-4.31 and adopt in place.
- **The `seaweedfs-db` hand-over runs for every instance name.** Migration 43 compared the owning release against the literal `seaweedfs-system`, so an instance named `foo` was skipped and its CNPG Cluster — the filer metadata for every object in that tenant's S3 — was pruned on the next reconcile, PVC included. The comparison now matches the `-system` suffix (shared `lib/seaweedfs-db-adopt.sh`), and new migration 53 re-runs the hand-over for clusters already past 43, before anything re-renders.
- **`hack/seaweedfs-naming-audit.sh` + `docs/operations/seaweedfs-431-rename-recovery.md`** — what the guard's refusal points operators at: read-only classification (`L` / `S` / `MIXED`, naming the candidate duplicate from relative PV vintage, never a clock window) and the recovery procedures.

**Scope.** The supported SeaweedFS deployment is the tenant module, which hardcodes the instance name (`packages/apps/tenant/templates/seaweedfs.yaml`); a tenant only enables or disables it. The runbook and its selectors are scoped to that name; instances created directly against the API under other names are classified by the audit but routed to escalation. Zone/pool keys of ~40 or more characters fall outside the guard's reconstruction — an accepted limit, recorded in `_naming.tpl` and the runbook.

**Upgrade impact.** 1.4.x → 1.6: no manual steps — one generation, adopted in place. 1.5.x → 1.6 with SeaweedFS: migration 53 protects every `seaweedfs-db` first; then the upgrade **refuses** for any tenant holding both naming generations until the operator resolves the duplicate. This is deliberate — which generation holds the data is not decidable from inside a render, and guessing wrong destroys it. Release notes should present the refusal as expected behavior.

**Testing.** 55 chart unit tests across both packages (including new MultiZone zone-component guard cases — the suite previously had no zone shapes), 11 audit bats, 8 guard-parity bats, migration bats. Validated end-to-end on a disposable 3-node cluster driven v1.4.5 → v1.5.3 → main with five tenants covering: never-saw-4.31 (renders untouched), fresh-1.5.x (refused as class S), wedged duplicate, split duplicate, and a non-default-named instance (its database survives only with this fix). The audit classifies all five correctly, and its two independent signals — revision-1 birth scheme and relative PV vintage — agree on every MIXED tenant.

Related: #3282 (fullnameOverride pin), #3335 (etcd adoption backup gate — separate, also required for the 1.5.x→1.6 path).

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change

Walked the trigger map against the diff: no package added/renamed under `packages/{apps,extra}/`, the `packages/core/platform/values.yaml` change is only the migrations `targetVersion` bump (no `spec.components.platform.values.*` key changes), no variant/bundle/component changes, no asset renames, no ApplicationDefinition semantic changes.

### Release note

```release-note
fix(seaweedfs): the 1.6 upgrade no longer renames a SeaweedFS instance away from its data. The naming guard now runs in the chart a platform upgrade actually re-renders and refuses when both pre- and post-4.31 naming generations exist; hack/seaweedfs-naming-audit.sh and docs/operations/seaweedfs-431-rename-recovery.md guide recovery, and the refusal is expected for tenants that passed through 1.5.x. Cluster-scoped COSI RBAC is named per namespace again (the 4.31 release-based names collided across tenants), and the seaweedfs-db hand-over runs for every instance name — previously an instance not named `seaweedfs` had its filer metadata database pruned on upgrade; new migration 53 repairs clusters that already ran the old hand-over.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fail-closed upgrade protections for SeaweedFS naming migrations (mixed/damaged classification), including safer behavior when cluster visibility is limited.
  * Added cluster-scoped RBAC uniqueness safeguards to prevent cross-tenant name collisions during rendering.
  * Improved SeaweedFS database adoption/repair migrations and strengthened post-delete cleanup ownership checks.
* **Bug Fixes**
  * Hardened SeaweedFS 4.31 rename recovery and PV rebind flow, including reclaim policy preservation and long/non-default instance-name edge cases.
* **Documentation**
  * Expanded the SeaweedFS 4.31 rename-recovery runbook with clarified auditing, verification, and escalation.
* **Tests**
  * Added/expanded integration and Helm rendering tests for the above scenarios and refusal/fail-closed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->