### PR TITLE
feat(nats): publish ca.crt-only trust anchor to tenants

### DIFF
--- a/hack/check-nats-rd-secrets.bats
+++ b/hack/check-nats-rd-secrets.bats
@@ -14,8 +14,12 @@
 # happens to occupy the name.
 #
 # These assertions exist because both halves are one edit away from breaking
-# with a fully green chart suite: helm-unittest covers the chart templates, and
-# neither the ResourceDefinition nor the dashboard Role is a chart template.
+# with a fully green chart suite, for two different reasons. The
+# ResourceDefinition is rendered, by the nats-rd chart inlining cozyrds/*, but
+# that chart carries neither a tests directory nor the test target
+# hack/helm-unit-tests.sh looks for, and no packages/system/*-rd package does.
+# The dashboard Role is rendered by a chart that has both, and no suite under
+# packages/apps/nats/tests/ asserts on it.
 #
 # The grants are asserted as WHITELISTS against rendered output rather than as
 # a blacklist of forbidden names over source text. A blacklist grepping for
@@ -27,11 +31,26 @@ REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
 COZYRDS="$REPO_ROOT/packages/system/nats-rd/cozyrds/nats.yaml"
 CHART="$REPO_ROOT/packages/apps/nats"
 
-# Secret names the tenant is allowed to hold by NAME. Credentials only: the
-# trust anchor is reached by label, through the tenantsecrets API.
-EXPECTED_RD_NAMES='nats-{{ .name }}-credentials'
-EXPECTED_ROLE_NAMES='nats-test-credentials'
+# The complete set of grants the tenant holds, asserted as one value rather than
+# per-dimension: a name whitelist alone passes an added label selector, and a
+# label whitelist alone passes an added name. Either dimension can reach a
+# key-bearing Secret -- controller.cert-manager.io/fao is stamped on both of
+# them, so a selector on it is a one-line grant of the CA private key.
+EXPECTED_RD_INCLUDE='[{"resourceNames":["nats-{{ .name }}-credentials"]},{"matchLabels":{"internal.cozystack.io/tenant-ca":"true"}}]'
 
+# The dashboard template's entire RBAC output: every rule of the Role, and the
+# kinds it renders. Asserted whole rather than filtered down to the rules that mention
+# secrets, because every filter admits the spelling it did not anticipate: a rule
+# with no resourceNames names no Secret, a rule with resources ["*"] names no
+# resource, and a ClusterRole is not a Role. Each of those reaches both
+# key-bearing Secrets. There is no filter that is right for all of them, and one
+# comparison against the whole output needs none.
+EXPECTED_ROLE_RULES='[{"apiGroups":[""],"resources":["services"],"resourceNames":["nats-test"],"verbs":["get","list","watch"]},{"apiGroups":[""],"resources":["secrets"],"resourceNames":["nats-test-credentials"],"verbs":["get","list","watch"]},{"apiGroups":["cozystack.io"],"resources":["workloadmonitors"],"resourceNames":["nats-test"],"verbs":["get","list","watch"]}]'
+EXPECTED_RBAC_KINDS='["Role","RoleBinding"]'
+
+# Subsumed by the whitelist below, which cannot match without this entry. Kept
+# because the runner stops at the first failing test, so this one fires first
+# and says what the loss costs rather than printing two JSON blobs to diff.
 @test "nats-rd cozyrds selects the key-free tenant-CA projection by label" {
   if [ ! -f "$COZYRDS" ]; then
     echo "ResourceDefinition not found at $COZYRDS -- did it move?" >&2
@@ -49,28 +68,26 @@ EXPECTED_ROLE_NAMES='nats-test-credentials'
   fi
 }
 
-@test "nats-rd cozyrds grants no Secret by name except the credentials Secret" {
+@test "nats-rd cozyrds grants nothing beyond the credentials Secret and the trust anchor" {
   if [ ! -f "$COZYRDS" ]; then
     echo "ResourceDefinition not found at $COZYRDS -- did it move?" >&2
     exit 1
   fi
 
-  names=$(yq eval \
-    '[.spec.secrets.include[].resourceNames // [] | .[]] | sort | join(",")' \
-    "$COZYRDS") || exit 1
+  include=$(yq eval --output-format=json --indent=0 '.spec.secrets.include' "$COZYRDS") || exit 1
 
-  if [ "$names" != "$EXPECTED_RD_NAMES" ]; then
-    echo "Unexpected resourceNames in nats-rd spec.secrets.include: $names" >&2
-    echo "Expected exactly: $EXPECTED_RD_NAMES" >&2
+  if [ "$include" != "$EXPECTED_RD_INCLUDE" ]; then
+    echo "Unexpected nats-rd spec.secrets.include: $include" >&2
+    echo "Expected exactly: $EXPECTED_RD_INCLUDE" >&2
     echo "nats-<name>-ca holds the CA private key and nats-<name>-tls the server key;" >&2
-    echo "neither may be granted to a tenant." >&2
+    echo "neither may be granted to a tenant, by name or by label." >&2
     exit 1
   fi
 }
 
 # Asserted against RENDERED output, so the spelling used in the template --
 # quoted, helper-derived, or otherwise -- cannot smuggle a name past the check.
-@test "nats dashboard Role grants no Secret by name except the credentials Secret" {
+@test "nats dashboard Role renders exactly the grants it is supposed to" {
   if [ ! -d "$CHART" ]; then
     echo "Chart not found at $CHART -- did it move?" >&2
     exit 1
@@ -87,24 +104,30 @@ EXPECTED_ROLE_NAMES='nats-test-credentials'
     exit 1
   }
 
-  names=$(printf '%s\n' "$rendered" | yq eval \
-    '[select(.kind == "Role") | .rules[] | select(.resources[] == "secrets") | .resourceNames[]] | sort | join(",")' \
-    -) || exit 1
+  # eval-all aggregates the documents into one result, so the Role may sit at any
+  # position among them.
+  kinds=$(printf '%s\n' "$rendered" | yq eval-all --output-format=json --indent=0 \
+    '[.kind]' -) || exit 1
 
-  # Fail closed: an empty result means the Role stopped granting Secrets at all,
-  # or the render silently produced nothing. Either way this guard is no longer
-  # observing what it claims to observe.
-  if [ -z "$names" ]; then
-    echo "No secrets grant found in the rendered dashboard Role -- guard is blind." >&2
+  if [ "$kinds" != "$EXPECTED_RBAC_KINDS" ]; then
+    echo "Unexpected RBAC kinds rendered by the nats dashboard template: $kinds" >&2
+    echo "Expected exactly: $EXPECTED_RBAC_KINDS" >&2
+    echo "A ClusterRole here would grant across namespaces and is not covered by" >&2
+    echo "the rule comparison below, which reads the namespaced Role." >&2
     exit 1
   fi
 
-  if [ "$names" != "$EXPECTED_ROLE_NAMES" ]; then
-    echo "Unexpected Secret grants in the nats dashboard Role: $names" >&2
-    echo "Expected exactly: $EXPECTED_ROLE_NAMES" >&2
+  # Fails closed on an empty list: a Role that stopped granting anything, or a
+  # render that silently produced nothing, does not match the expected rules.
+  rules=$(printf '%s\n' "$rendered" | yq eval-all --output-format=json --indent=0 \
+    '[select(.kind == "Role") | .rules[]]' -) || exit 1
+
+  if [ "$rules" != "$EXPECTED_ROLE_RULES" ]; then
+    echo "Unexpected rules in the nats dashboard Role: $rules" >&2
+    echo "Expected exactly: $EXPECTED_ROLE_RULES" >&2
     echo "nats-<release>-ca holds the CA PRIVATE KEY and nats-<release>-tls the" >&2
     echo "server private key. The trust anchor reaches the tenant as the key-free" >&2
-    echo "<release>.tenant-ca projection via tenantsecrets, not by a name grant." >&2
+    echo "<release>.tenant-ca projection via tenantsecrets, not by a Role grant." >&2
     exit 1
   fi
 }

--- a/hack/check-nats-rd-secrets.bats
+++ b/hack/check-nats-rd-secrets.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+# Unit test: the nats trust anchor reaches tenants as a key-free projection, and
+# the two key-BEARING Secrets the chart creates never do.
+#
+# The chart issues nats-<name>-ca (CA certificate AND CA private key, the latter
+# under tls.key) and nats-<name>-tls (server certificate AND server private key).
+# Neither may be handed to a tenant: read access to the CA key would let the
+# holder issue certificates for anything rather than merely verify the server.
+#
+# What a client actually needs is ca.crt alone. That is delivered by the
+# CA-extraction controller as the key-free <release>.tenant-ca projection,
+# selected here by LABEL rather than by name. The label is stamped only on an
+# object the controller itself produced, whereas a name grant conveys whatever
+# happens to occupy the name.
+#
+# These assertions exist because both halves are one edit away from breaking
+# with a fully green chart suite: helm-unittest covers the chart templates, and
+# neither the ResourceDefinition nor the dashboard Role is a chart template.
+#
+# The grants are asserted as WHITELISTS against rendered output rather than as
+# a blacklist of forbidden names over source text. A blacklist grepping for
+# "{{ .Release.Name }}-ca" is defeated by quoting the scalar, by $.Release.Name,
+# or by a fullname helper -- all of which grant the CA private key while the
+# guard stays green.
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
+COZYRDS="$REPO_ROOT/packages/system/nats-rd/cozyrds/nats.yaml"
+CHART="$REPO_ROOT/packages/apps/nats"
+
+# Secret names the tenant is allowed to hold by NAME. Credentials only: the
+# trust anchor is reached by label, through the tenantsecrets API.
+EXPECTED_RD_NAMES='nats-{{ .name }}-credentials'
+EXPECTED_ROLE_NAMES='nats-test-credentials'
+
+@test "nats-rd cozyrds selects the key-free tenant-CA projection by label" {
+  if [ ! -f "$COZYRDS" ]; then
+    echo "ResourceDefinition not found at $COZYRDS -- did it move?" >&2
+    exit 1
+  fi
+
+  count=$(yq eval \
+    '[.spec.secrets.include[] | select(.matchLabels."internal.cozystack.io/tenant-ca" == "true")] | length' \
+    "$COZYRDS") || exit 1
+
+  if [ "$count" -lt 1 ]; then
+    echo 'nats-rd does not select internal.cozystack.io/tenant-ca: "true"' >&2
+    echo "Without it the tenant cannot read ca.crt and TLS verification is impossible." >&2
+    exit 1
+  fi
+}
+
+@test "nats-rd cozyrds grants no Secret by name except the credentials Secret" {
+  if [ ! -f "$COZYRDS" ]; then
+    echo "ResourceDefinition not found at $COZYRDS -- did it move?" >&2
+    exit 1
+  fi
+
+  names=$(yq eval \
+    '[.spec.secrets.include[].resourceNames // [] | .[]] | sort | join(",")' \
+    "$COZYRDS") || exit 1
+
+  if [ "$names" != "$EXPECTED_RD_NAMES" ]; then
+    echo "Unexpected resourceNames in nats-rd spec.secrets.include: $names" >&2
+    echo "Expected exactly: $EXPECTED_RD_NAMES" >&2
+    echo "nats-<name>-ca holds the CA private key and nats-<name>-tls the server key;" >&2
+    echo "neither may be granted to a tenant." >&2
+    exit 1
+  fi
+}
+
+# Asserted against RENDERED output, so the spelling used in the template --
+# quoted, helper-derived, or otherwise -- cannot smuggle a name past the check.
+@test "nats dashboard Role grants no Secret by name except the credentials Secret" {
+  if [ ! -d "$CHART" ]; then
+    echo "Chart not found at $CHART -- did it move?" >&2
+    exit 1
+  fi
+
+  # stderr is deliberately not discarded: when the render breaks, helm's own
+  # message is the only thing that says why, and a CI red showing just
+  # "helm template failed" sends the reader back here to rerun it by hand.
+  rendered=$(helm template nats-test "$CHART" \
+    --namespace tenant-test \
+    --set '_cluster.cluster-domain=cozy.local' \
+    --show-only templates/dashboard-resourcemap.yaml) || {
+    echo "helm template failed for $CHART" >&2
+    exit 1
+  }
+
+  names=$(printf '%s\n' "$rendered" | yq eval \
+    '[select(.kind == "Role") | .rules[] | select(.resources[] == "secrets") | .resourceNames[]] | sort | join(",")' \
+    -) || exit 1
+
+  # Fail closed: an empty result means the Role stopped granting Secrets at all,
+  # or the render silently produced nothing. Either way this guard is no longer
+  # observing what it claims to observe.
+  if [ -z "$names" ]; then
+    echo "No secrets grant found in the rendered dashboard Role -- guard is blind." >&2
+    exit 1
+  fi
+
+  if [ "$names" != "$EXPECTED_ROLE_NAMES" ]; then
+    echo "Unexpected Secret grants in the nats dashboard Role: $names" >&2
+    echo "Expected exactly: $EXPECTED_ROLE_NAMES" >&2
+    echo "nats-<release>-ca holds the CA PRIVATE KEY and nats-<release>-tls the" >&2
+    echo "server private key. The trust anchor reaches the tenant as the key-free" >&2
+    echo "<release>.tenant-ca projection via tenantsecrets, not by a name grant." >&2
+    exit 1
+  fi
+}

--- a/packages/apps/nats/README.md
+++ b/packages/apps/nats/README.md
@@ -64,7 +64,7 @@ When TLS is on, the chart issues a self-signed CA and a server certificate from 
 
 **Retrieving the CA certificate** for client verification:
 
-The trust anchor is published as `nats-<name>.tenant-ca`: an object holding `ca.crt` and nothing else, delivered to tenants through the `core.cozystack.io/tenantsecrets` API that the base tenant roles already grant.
+The trust anchor is published as `nats-<name>.tenant-ca`: an object holding `ca.crt` and nothing else, delivered to tenants through the `core.cozystack.io/tenantsecrets` API that the base tenant roles already grant. It exists only while TLS is on, because that is the only state in which the chart issues a CA to publish.
 
 ```bash
 kubectl --context <ctx> --namespace <tenant> \

--- a/packages/apps/nats/README.md
+++ b/packages/apps/nats/README.md
@@ -56,3 +56,22 @@ Presets follow a cloud-style `<series>.<size>` naming convention. Five series co
 
 See [`docs/operations/resource-presets.md`](../../../docs/operations/resource-presets.md) for the full size matrix and the legacy-to-instance-type mapping.
 
+### tls
+
+`tls.enabled` is tri-state. Left unset it follows `external`, so TLS is enabled automatically for a NATS instance exposed outside the cluster and disabled for one that is not. Setting it explicitly overrides that in either direction.
+
+When TLS is on, the chart issues a self-signed CA and a server certificate from it, and NATS serves the client port on `:4222` with the server certificate.
+
+**Retrieving the CA certificate** for client verification:
+
+The trust anchor is published as `nats-<name>.tenant-ca`: an object holding `ca.crt` and nothing else, delivered to tenants through the `core.cozystack.io/tenantsecrets` API that the base tenant roles already grant.
+
+```bash
+kubectl --context <ctx> --namespace <tenant> \
+  get tenantsecret nats-<name>.tenant-ca \
+  --output jsonpath='{.data.ca\.crt}' | base64 --decode
+```
+
+`nats-<name>.tenant-ca` is the only object that hands over the CA certificate without also handing over a private key, which is why it exists. The chart's own `nats-<name>-ca` Secret stores the CA **private key** under `tls.key` alongside the certificate — read access to it would let the holder issue certificates for anything, so it is never granted to a tenant. The same applies to `nats-<name>-tls`, which holds the server's private key.
+
+It is reached through `tenantsecrets` rather than by reading the Secret directly, and that is deliberate: `tenantsecrets` surfaces only objects the platform has vouched for, whereas a direct grant on the name would convey whatever happens to occupy that name.

--- a/packages/apps/nats/templates/tenant-projection.yaml
+++ b/packages/apps/nats/templates/tenant-projection.yaml
@@ -1,4 +1,5 @@
 {{- /* Gated on the same condition as certmanager.yaml: the source Secret only exists when TLS is on. */}}
+{{- /* cert-manager writes the certificate of a selfSigned isCA Certificate to ca.crt as well as to tls.crt, and ca.crt is the key the trust-anchor contract names. */}}
 {{- if eq (include "nats.tls.enabled" .) "true" }}
 ---
 apiVersion: internal.cozystack.io/v1alpha1

--- a/packages/apps/nats/templates/tenant-projection.yaml
+++ b/packages/apps/nats/templates/tenant-projection.yaml
@@ -1,0 +1,13 @@
+{{- /* Gated on the same condition as certmanager.yaml: the source Secret only exists when TLS is on. */}}
+{{- if eq (include "nats.tls.enabled" .) "true" }}
+---
+apiVersion: internal.cozystack.io/v1alpha1
+kind: TenantProjection
+metadata:
+  name: {{ .Release.Name }}-ca
+spec:
+  projections:
+    - type: CACert
+      sourceSecretName: {{ .Release.Name }}-ca
+      sourceKey: ca.crt
+{{- end }}

--- a/packages/apps/nats/tests/certmanager_test.yaml
+++ b/packages/apps/nats/tests/certmanager_test.yaml
@@ -139,6 +139,34 @@ tests:
           value: my-nats-ca
 
   ###################################################
+  # CA Secret carries trust-anchor publish labels   #
+  ###################################################
+
+  - it: CA certificate publishes ca.crt to tenants via secretTemplate labels
+    set:
+      tls:
+        enabled: true
+      external: false
+    documentIndex: 1
+    asserts:
+      - equal:
+          path: spec.secretTemplate.labels["internal.cozystack.io/publish-ca-cert"]
+          value: "true"
+      - equal:
+          path: spec.secretTemplate.labels["internal.cozystack.io/publish-ca-cert-release"]
+          value: my-nats
+
+  - it: leaf certificate does NOT carry publish-ca-cert labels
+    set:
+      tls:
+        enabled: true
+      external: false
+    documentIndex: 3
+    asserts:
+      - notExists:
+          path: spec.secretTemplate.labels["internal.cozystack.io/publish-ca-cert"]
+
+  ###################################################
   # SAN coverage (internal, tls.enabled=true)       #
   ###################################################
 

--- a/packages/apps/nats/tests/certmanager_test.yaml
+++ b/packages/apps/nats/tests/certmanager_test.yaml
@@ -139,32 +139,47 @@ tests:
           value: my-nats-ca
 
   ###################################################
-  # CA Secret carries trust-anchor publish labels   #
+  # Key-bearing Secrets stay invisible to tenants   #
   ###################################################
 
-  - it: CA certificate publishes ca.crt to tenants via secretTemplate labels
+  # Both Certificates below mint a private key: the CA Secret stores the CA key
+  # under tls.key, the leaf Secret the server key. The nats ResourceDefinition
+  # grants tenants read access to Secrets matching
+  # internal.cozystack.io/tenant-ca, so stamping either visibility label here
+  # would hand that key to every tenant subject. Only the controller-authored
+  # projection may carry them.
+  #
+  # Selected by the Secret each Certificate writes rather than by position: a
+  # documentIndex would follow the slot, so reordering this template would let
+  # a labelled key-bearing Certificate slide out from under the assertion and
+  # pass green.
+  - it: the key-bearing CA Secret is never marked tenant-readable
     set:
       tls:
         enabled: true
       external: false
-    documentIndex: 1
-    asserts:
-      - equal:
-          path: spec.secretTemplate.labels["internal.cozystack.io/publish-ca-cert"]
-          value: "true"
-      - equal:
-          path: spec.secretTemplate.labels["internal.cozystack.io/publish-ca-cert-release"]
-          value: my-nats
-
-  - it: leaf certificate does NOT carry publish-ca-cert labels
-    set:
-      tls:
-        enabled: true
-      external: false
-    documentIndex: 3
+    documentSelector:
+      path: spec.secretName
+      value: my-nats-ca
     asserts:
       - notExists:
-          path: spec.secretTemplate.labels["internal.cozystack.io/publish-ca-cert"]
+          path: spec.secretTemplate.labels["internal.cozystack.io/tenant-ca"]
+      - notExists:
+          path: spec.secretTemplate.labels["internal.cozystack.io/tenantresource"]
+
+  - it: the key-bearing leaf Secret is never marked tenant-readable
+    set:
+      tls:
+        enabled: true
+      external: false
+    documentSelector:
+      path: spec.secretName
+      value: my-nats-tls
+    asserts:
+      - notExists:
+          path: spec.secretTemplate.labels["internal.cozystack.io/tenant-ca"]
+      - notExists:
+          path: spec.secretTemplate.labels["internal.cozystack.io/tenantresource"]
 
   ###################################################
   # SAN coverage (internal, tls.enabled=true)       #

--- a/packages/apps/nats/tests/certmanager_test.yaml
+++ b/packages/apps/nats/tests/certmanager_test.yaml
@@ -145,9 +145,15 @@ tests:
   # Both Certificates below mint a private key: the CA Secret stores the CA key
   # under tls.key, the leaf Secret the server key. The nats ResourceDefinition
   # grants tenants read access to Secrets matching
-  # internal.cozystack.io/tenant-ca, so stamping either visibility label here
-  # would hand that key to every tenant subject. Only the controller-authored
-  # projection may carry them.
+  # internal.cozystack.io/tenant-ca, so only the controller-authored projection
+  # may carry that label.
+  #
+  # A stamp here does not by itself reach a tenant today: tenantsecrets serves
+  # only objects the lineage webhook marked tenantresource=true, and it resolves
+  # lineage from ownerReferences or the Flux helm labels, neither of which a
+  # cert-manager Secret carries while enableCertificateOwnerRef stays false.
+  # These assertions become load-bearing the moment either of those changes, and
+  # the second gate is not one this chart controls.
   #
   # Selected by the Secret each Certificate writes rather than by position: a
   # documentIndex would follow the slot, so reordering this template would let

--- a/packages/apps/nats/tests/tenant_projection_test.yaml
+++ b/packages/apps/nats/tests/tenant_projection_test.yaml
@@ -35,11 +35,19 @@ tests:
           path: metadata.name
           value: my-nats-ca
 
-  - it: declares a CACert projection of the chart's CA
+  # The list length is asserted alongside the entry: hasDocuments counts
+  # documents, not list entries, so a second entry naming tls.key as its source
+  # renders inside this same document and leaves every other assertion here
+  # untouched. The controller refuses a multi-entry sentinel outright, which
+  # makes that a silent loss of the anchor rather than a leak.
+  - it: declares exactly one projection, of the chart's CA
     set:
       tls:
         enabled: true
     asserts:
+      - lengthEqual:
+          path: spec.projections
+          count: 1
       - equal:
           path: spec.projections[0].type
           value: CACert

--- a/packages/apps/nats/tests/tenant_projection_test.yaml
+++ b/packages/apps/nats/tests/tenant_projection_test.yaml
@@ -1,0 +1,115 @@
+suite: nats TenantProjection sentinel
+
+# The chart renders one TenantProjection per TLS-enabled release: the
+# declaration that tells the CA-extraction controller to lift ca.crt out of the
+# key-bearing <release>-ca into the tenant-readable <release>.tenant-ca
+# projection.
+#
+# The load-bearing invariant is the ABSENCE of ownerReferences. The sentinel must
+# carry none — it owns the projection, and it is itself owned only through the
+# helm.toolkit.fluxcd.io/name label Flux stamps, which is how the lineage webhook
+# resolves the application. An ownerReference here would short-circuit that walk
+# and silently break the tenant's read path (pkg/lineage/lineage.go).
+
+release:
+  name: my-nats
+  namespace: tenant-test
+
+templates:
+  - templates/tenant-projection.yaml
+
+tests:
+  - it: renders exactly one TenantProjection named after the release
+    set:
+      tls:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: TenantProjection
+      - equal:
+          path: apiVersion
+          value: internal.cozystack.io/v1alpha1
+      - equal:
+          path: metadata.name
+          value: my-nats-ca
+
+  - it: declares a CACert projection of the chart's CA
+    set:
+      tls:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.projections[0].type
+          value: CACert
+      - equal:
+          path: spec.projections[0].sourceSecretName
+          value: my-nats-ca
+      - equal:
+          path: spec.projections[0].sourceKey
+          value: ca.crt
+
+  # The one load-bearing invariant: an ownerReference here would short-circuit
+  # the lineage walk before it reaches the helm-label fallback, so the tenant
+  # would silently lose the anchor.
+  - it: carries no ownerReferences, so the lineage walk reaches the helm label
+    set:
+      tls:
+        enabled: true
+    asserts:
+      - notExists:
+          path: metadata.ownerReferences
+
+  # Not an invariant — conformance to the shape the merged engines share. An
+  # explicit namespace would pin the sentinel outside the release, and chart
+  # labels would compete with the Flux label that is the whole attribution
+  # path. Pinned separately so a failure here is not read as a lineage break.
+  - it: omits namespace and chart-added labels, matching the shared shape
+    set:
+      tls:
+        enabled: true
+    asserts:
+      - notExists:
+          path: metadata.namespace
+      - notExists:
+          path: metadata.labels
+
+  # The nats CA exists only while TLS is on. An ungated sentinel would sit
+  # Ready=False/SourceNotFound forever on every plaintext release.
+  #
+  # The gate must track the chart's effective TLS state, not the raw
+  # tls.enabled value: leaving it unset means "follow external". A naive
+  # `if .Values.tls.enabled` still passes the two explicit cases below while
+  # silently publishing no anchor to exactly the releases most likely to need
+  # one, so both implied legs are pinned too.
+  - it: renders the sentinel when TLS is implied by external access
+    set:
+      external: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: renders nothing when TLS is implied off by external being false
+    set:
+      external: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders nothing when TLS is explicitly disabled despite external access
+    set:
+      external: true
+      tls:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders nothing when TLS is disabled
+    set:
+      tls:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/packages/system/nats-rd/cozyrds/nats.yaml
+++ b/packages/system/nats-rd/cozyrds/nats.yaml
@@ -31,6 +31,11 @@ spec:
     include:
       - resourceNames:
           - nats-{{ .name }}-credentials
+      # The key-free trust anchor the CA-extraction controller publishes. This
+      # is the single, engine-agnostic selector every converged engine shares;
+      # it carries no per-release name templating.
+      - matchLabels:
+          internal.cozystack.io/tenant-ca: "true"
   services:
     exclude: []
     include:


### PR DESCRIPTION
## What this PR does

Converges nats onto the key-free CA trust-anchor contract. A TLS-enabled nats release renders a `TenantProjection` sentinel naming the chart's cert-manager CA Secret as its source, and the nats ResourceDefinition selects the resulting `<release>.tenant-ca` object by label. The projection is built by the CA extraction controller in `internal/controller/cacert`, which parses the source certificate and re-encodes it into a single `ca.crt` key, so a tenant that enables TLS gets something to verify the server against without ever getting a private key. No key-bearing Secret is granted to a tenant, by name or by label.

`packages/apps/nats/templates/certmanager.yaml` is not touched. An earlier draft of this change stamped publish labels onto the CA `Certificate`'s `secretTemplate`; the controller that shipped consumes a sentinel object instead, so the chart now declares its source rather than marking it. The functional change is one new template and one `matchLabels` entry in the ResourceDefinition.

The sentinel is gated on the chart's effective TLS state, which is tri-state: left unset it follows `external`. That gate is the single divergence from the postgres implementation of the same contract, and it exists because the nats CA is only issued while TLS resolves true. An ungated sentinel would sit `Ready=False/SourceNotFound` forever on every plaintext release.

The CA extraction controller is already on main, so this is live on merge rather than dormant until a follow-up lands. The `do-not-merge/hold` label predates that and no longer guards anything.

## Verified against a running cluster

The premise this rests on is that cert-manager populates `ca.crt` on the Secret of a `selfSigned`, `isCA: true` Certificate. Nothing in this repository witnesses it: `hack/e2e-chainsaw/` has no nats suite, and nats appears in no e2e workflow, so every unit test here encodes the same assumption the chart encodes and the two cannot catch each other being wrong. I closed it against a live cluster instead, running cert-manager v1.20.2, the version this repo ships, on two independent nats releases:

- `nats-<name>-ca`, the chart's CA Secret, holds `ca.crt`, `tls.crt` and `tls.key`. The declared source key exists.
- `nats-<name>.tenant-ca`, the projection, holds exactly one key, `ca.crt`.
- The projection's SHA-256 certificate fingerprint equals the source's, so it carries that CA and not some other certificate.
- The projection carries `internal.cozystack.io/tenant-ca: "true"` and `internal.cozystack.io/tenantresource: "true"`. The second is stamped by the lineage webhook, computed from the ResourceDefinition selector this PR adds, so its presence means the whole chain held.
- `kubectl get tenantsecret nats-<name>-ca` returns NotFound. The key-bearing Secret is not served through the tenant API.

What is still missing is an automated regression witness for that premise. Adding one means a new chainsaw suite for nats, which has no e2e coverage of any kind today, and that is a larger change than this one.

## What the tests pin

61 helm-unittest cases and 3 bats cases. The sentinel's absence of `ownerReferences` (an owner would short-circuit the lineage walk before it reaches the Flux label the attribution depends on), the length of `spec.projections` as well as its single entry (the controller refuses a multi-entry sentinel, so a second entry is a silent loss of the anchor rather than a leak), both implied legs of the tri-state TLS gate, and `notExists` on either visibility label for both key-bearing Certificates.

The bats guard covers the two grant surfaces nothing else asserts on. The ResourceDefinition is rendered, by the `nats-rd` chart inlining `cozyrds/*`, but that chart has neither a tests directory nor the `test` target `hack/helm-unit-tests.sh` looks for, and no `packages/system/*-rd` package does. The dashboard Role is rendered by a chart that has both, and no suite under `packages/apps/nats/tests/` asserts on it.

Both are compared whole rather than filtered down to the entries that mention a Secret, because every such filter admits the spelling it did not anticipate. A name whitelist passes an added label selector, and `controller.cert-manager.io/fao` is stamped on both key-bearing Secrets, so a selector on it is a one-line grant of the CA private key. On the Role side, a rule with no `resourceNames` names no Secret, a rule with `resources: ["*"]` names no resource, and a ClusterRole is not a Role, while all three grant read access to the CA key. Comparing the rendered output whole needs no filter and leaves no spelling to find.

## Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff, file by file. No trigger fires, and no follow-up PR is owed.

`packages/apps/nats/templates/tenant-projection.yaml` is a new template and `packages/apps/nats/tests/` holds chart tests. No package is added, renamed or removed; `values.yaml` and `values.schema.json` are untouched, so neither the hand-written Terraform schema, its version enums, nor its restated defaults have anything to track. `kind`, `plural` and `release.prefix` are unchanged, and no output Secret or Service is renamed, so the provider's concatenated name lookups still resolve.

`packages/system/nats-rd/cozyrds/nats.yaml` is edited in place rather than renamed, so the ccp external-app skill's dependency-contract anchor still resolves. The provider offers no typed access to the new projection, which is the position it already holds for every Secret it does not model, and not a break.

`packages/apps/nats/README.md` is covered by the one automated path that does exist: `nats` is present in the website `Makefile` `APPS` list, so the docs bot regenerates the managed-apps reference page from this `README.md` on the next stable tag. This is the silent-skip failure mode the trigger map warns about, so I checked the list rather than assuming; an app missing from it gets no page at all, which is what happened to `opensearch`.

`hack/check-nats-rd-secrets.bats` is a new file, not a move or a rename, and it changes no make target's contract: `Makefile` globs `hack/*.bats` into `BATS_UNIT_FILES` automatically. The ccp skills anchor on `hack/package.mk` and `hack/common-envs.mk`, neither of which is touched.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

Part of #2814.

### Release note

```release-note
feat(nats): expose the CA certificate to tenants as a key-free `<release>.tenant-ca` Secret
```
