### PR TITLE
feat(qdrant): publish ca.crt-only trust anchor to tenants

### DIFF
--- a/hack/check-qdrant-rd-secrets.bats
+++ b/hack/check-qdrant-rd-secrets.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+# Unit test: the qdrant ResourceDefinition hands tenants the key-free trust
+# anchor and nothing else.
+#
+# The chart issues qdrant-<name>-ca (CA certificate AND CA private key, the
+# latter under tls.key) and qdrant-<name>-tls (server certificate AND server
+# private key). Neither may reach a tenant: read access to the CA key would
+# let the holder issue certificates for anything rather than merely verify the
+# server. What a client actually needs is ca.crt alone, delivered by the
+# CA-extraction controller as the key-free <release>.tenant-ca projection and
+# selected by LABEL rather than by name, because a name grant conveys whatever
+# happens to occupy that name.
+#
+# Asserted against the RENDERED chart, not against cozyrds/qdrant.yaml on
+# disk. templates/cozyrd.yaml globs cozyrds/* and emits each match through
+# .Files.Get, so what ships is the render: reading one source file would miss
+# a second file in that directory, and a dotfile the glob picks up. Helm
+# ignores dotfiles only under templates/, so one here does ship.
+#
+# This lives in bats rather than helm-unittest because packages/system/
+# qdrant-rd has no `test:` target, and hack/helm-unit-tests.sh skips any
+# package without one. If that package ever grows one, this belongs there.
+#
+# spec.secrets is compared WHOLE rather than probed for known-bad names.
+# Three ways this breaks are invisible to a name-by-name check:
+#
+#   - a name added under a different spelling, or via a helper;
+#   - an include with NO resourceNames and NO matchLabels, which restricts
+#     nothing;
+#   - a SECOND matchLabels include selecting a label the key-bearing Secrets
+#     also carry. cert-manager stamps controller.cert-manager.io/fao on the
+#     Secrets it creates, both of these among them, so one such entry grants
+#     the CA private key while every name in the file stays correct.
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
+CHART="$REPO_ROOT/packages/system/qdrant-rd"
+
+# The complete tenant-visible Secret surface. The API key by name; the trust
+# anchor by label. Nothing else.
+EXPECTED_SECRETS='{"exclude":[],"include":[{"resourceNames":["qdrant-{{ .name }}-apikey"]},{"matchLabels":{"internal.cozystack.io/tenant-ca":"true"}}]}'
+
+# Order within include is meaningless -- the matcher ORs across entries -- so
+# the array is sorted before comparing, and a missing exclude is normalized to
+# the empty list it means. Neither can hide a grant: sort preserves every
+# entry (it is not unique), and exclude only ever narrows.
+#
+# Kept as a filter string rather than a shell function because hack/cozytest.sh
+# inserts `return 0` before any line that is exactly `}`. A helper whose own
+# last command decides the outcome returns 0 regardless -- and whether a
+# wrapper propagates a failure at all then depends on the shell running it.
+# Repeating the helm invocation inline in each test costs two lines and owes
+# nothing to that.
+NORMALIZE='{exclude: (.exclude // []), include: (.include | sort)}'
+
+# Every document count below uses `yq eval-all`, never `yq eval`. `eval` runs
+# the expression once PER DOCUMENT, so `[.] | length` reports 1 per document
+# rather than the number of documents -- it prints "1" for a single document,
+# "1\n1" for two, and "1" for empty input, which would make a count check here
+# pass on exactly the cases it exists to catch. `eval-all` folds the stream
+# into one expression. Empty input still yields 1, since yq synthesizes a null
+# document, so emptiness is checked separately before counting.
+
+@test "qdrant-rd renders exactly one ApplicationDefinition" {
+  # stderr is deliberately not discarded: when the render breaks, helm's own
+  # message is the only thing that says why.
+  rendered=$(helm template qdrant-rd "$CHART") || return 1
+
+  # Fail closed: an empty render makes every assertion below vacuous, and yq
+  # cannot distinguish it from one document.
+  if [ -z "$rendered" ]; then
+    echo "helm template produced no output for $CHART -- guard is blind." >&2
+    return 1
+  fi
+
+  count=$(printf '%s\n' "$rendered" | yq eval-all '[.] | length' -) || return 1
+
+  if [ "$count" != "1" ]; then
+    echo "Expected exactly 1 rendered document from $CHART, got: $count" >&2
+    echo "templates/cozyrd.yaml globs cozyrds/*, so every file there -- including" >&2
+    echo "a dotfile -- ships its own tenant grants. Extend this suite before" >&2
+    echo "adding one." >&2
+    return 1
+  fi
+}
+
+@test "qdrant-rd selects the key-free tenant-CA projection by label" {
+  rendered=$(helm template qdrant-rd "$CHART") || return 1
+
+  if [ -z "$rendered" ]; then
+    echo "helm template produced no output for $CHART -- guard is blind." >&2
+    return 1
+  fi
+
+  count=$(printf '%s\n' "$rendered" | yq eval-all \
+    '[.. | select(has("secrets")) | .secrets.include[] | select(.matchLabels."internal.cozystack.io/tenant-ca" == "true")] | length' \
+    -) || return 1
+
+  if [ "$count" -lt 1 ]; then
+    echo 'qdrant-rd does not select internal.cozystack.io/tenant-ca: "true"' >&2
+    echo "Without it the tenant cannot read ca.crt and TLS verification is impossible." >&2
+    return 1
+  fi
+}
+
+# Whole-structure comparison. Anything added to the tenant's Secret surface --
+# by name, by label, or by an unrestricted entry -- changes this string.
+@test "qdrant-rd exposes no Secret beyond the API key and the trust anchor" {
+  rendered=$(helm template qdrant-rd "$CHART") || return 1
+
+  if [ -z "$rendered" ]; then
+    echo "helm template produced no output for $CHART -- guard is blind." >&2
+    return 1
+  fi
+
+  # eval-all again: with `eval`, a second rendered document would emit a
+  # second JSON object and the comparison below would run on a concatenation.
+  actual=$(printf '%s\n' "$rendered" \
+    | yq eval-all --output-format=json '[.. | select(has("secrets")) | .secrets]' - \
+    | jq --sort-keys --compact-output "if length == 1 then .[0] else . end | $NORMALIZE") || return 1
+
+  expected=$(printf '%s' "$EXPECTED_SECRETS" \
+    | jq --sort-keys --compact-output "$NORMALIZE") || return 1
+
+  # Fail closed: an empty or null result means spec.secrets stopped being
+  # readable at this path, so the guard is no longer observing what it claims.
+  if [ -z "$actual" ] || [ "$actual" = "null" ]; then
+    echo "spec.secrets is missing or unreadable in the rendered ResourceDefinition -- guard is blind." >&2
+    return 1
+  fi
+
+  if [ "$actual" != "$expected" ]; then
+    echo "Unexpected tenant Secret surface in the rendered qdrant-rd spec.secrets:" >&2
+    echo "  actual:   $actual" >&2
+    echo "  expected: $expected" >&2
+    echo "qdrant-<name>-ca holds the CA PRIVATE KEY and qdrant-<name>-tls the" >&2
+    echo "server private key. Neither may be granted to a tenant, by name or by" >&2
+    echo "a label they also carry -- cert-manager stamps its own labels on both." >&2
+    return 1
+  fi
+}

--- a/packages/apps/qdrant/README.md
+++ b/packages/apps/qdrant/README.md
@@ -54,3 +54,17 @@ This setting is ignored if the corresponding `resources` value is set.
 Presets follow a cloud-style `<series>.<size>` naming convention. Five series cover the full CPU-to-memory ratio range (`t1` 1:0.5, `c1` 1:1, `s1` 1:2, `u1` 1:4, `m1` 1:8) and each series ships eight sizes (`nano` through `4xlarge`). The legacy flat names (`nano`, `micro`, `small`, `medium`, `large`, `xlarge`, `2xlarge`) remain accepted as deprecated aliases of their 1:1 instance-type equivalents.
 
 See [`docs/operations/resource-presets.md`](../../../docs/operations/resource-presets.md) for the full size matrix and the legacy-to-instance-type mapping.
+
+### tls
+
+With TLS on, the chart issues the server certificate from a self-signed CA it creates per release. The trust anchor for verifying that certificate is published as `qdrant-<name>.tenant-ca`, where `<name>` is the name of the `Qdrant` resource: an object holding `ca.crt` and nothing else, delivered to tenants through the `core.cozystack.io/tenantsecrets` API that the base tenant roles already grant.
+
+```bash
+kubectl --context <ctx> --namespace <tenant> \
+  get tenantsecret qdrant-<name>.tenant-ca \
+  --output jsonpath='{.data.ca\.crt}' | base64 --decode
+```
+
+It is the only object that hands over the CA certificate without also handing over a private key, which is why it exists. The `qdrant-<name>-ca` Secret the chart creates stores the CA **private key** alongside the certificate — read access to it would let the holder issue certificates for anything, so it is never granted to a tenant.
+
+It is reached through `tenantsecrets` rather than by reading the Secret directly, and that is deliberate: `tenantsecrets` surfaces only objects the platform has vouched for (those the application's definition selects), whereas a direct grant on the name would convey whatever happens to occupy that name.

--- a/packages/apps/qdrant/templates/tenant-projection.yaml
+++ b/packages/apps/qdrant/templates/tenant-projection.yaml
@@ -1,0 +1,13 @@
+{{- /* Gated on the same condition as certmanager.yaml: the source Secret only exists when TLS is on. */}}
+{{- if eq (include "qdrant.tls.enabled" .) "true" }}
+---
+apiVersion: internal.cozystack.io/v1alpha1
+kind: TenantProjection
+metadata:
+  name: {{ .Release.Name }}-ca
+spec:
+  projections:
+    - type: CACert
+      sourceSecretName: {{ .Release.Name }}-ca
+      sourceKey: ca.crt
+{{- end }}

--- a/packages/apps/qdrant/tests/certmanager_test.yaml
+++ b/packages/apps/qdrant/tests/certmanager_test.yaml
@@ -107,6 +107,56 @@ tests:
           value: false
         documentIndex: 3
 
+  ###################################################
+  # Key-bearing Secrets stay invisible to tenants   #
+  ###################################################
+
+  # Both Certificates below mint a private key. The qdrant ResourceDefinition
+  # grants tenants read access to Secrets matching
+  # internal.cozystack.io/tenant-ca, so stamping either label here would hand
+  # the tenant a signing key. Only the controller-authored projection may
+  # carry them.
+  #
+  # Selected by the Secret each Certificate writes rather than by position: a
+  # documentIndex would follow the slot, so reordering this template would let
+  # a labelled key-bearing Certificate slide out from under the assertion and
+  # pass green.
+  - it: the key-bearing CA Secret is never marked tenant-readable
+    release:
+      name: test-qdrant
+      namespace: tenant-test
+    set:
+      tls:
+        enabled: true
+      _cluster:
+        cluster-domain: cozy.local
+    documentSelector:
+      path: spec.secretName
+      value: test-qdrant-ca
+    asserts:
+      - notExists:
+          path: spec.secretTemplate.labels["internal.cozystack.io/tenant-ca"]
+      - notExists:
+          path: spec.secretTemplate.labels["internal.cozystack.io/tenantresource"]
+
+  - it: the key-bearing leaf Secret is never marked tenant-readable
+    release:
+      name: test-qdrant
+      namespace: tenant-test
+    set:
+      tls:
+        enabled: true
+      _cluster:
+        cluster-domain: cozy.local
+    documentSelector:
+      path: spec.secretName
+      value: test-qdrant-tls
+    asserts:
+      - notExists:
+          path: spec.secretTemplate.labels["internal.cozystack.io/tenant-ca"]
+      - notExists:
+          path: spec.secretTemplate.labels["internal.cozystack.io/tenantresource"]
+
   - it: leaf cert has server auth and client auth EKU
     release:
       name: test-qdrant

--- a/packages/apps/qdrant/tests/certmanager_test.yaml
+++ b/packages/apps/qdrant/tests/certmanager_test.yaml
@@ -111,11 +111,27 @@ tests:
   # Key-bearing Secrets stay invisible to tenants   #
   ###################################################
 
-  # Both Certificates below mint a private key. The qdrant ResourceDefinition
-  # grants tenants read access to Secrets matching
-  # internal.cozystack.io/tenant-ca, so stamping either label here would hand
-  # the tenant a signing key. Only the controller-authored projection may
-  # carry them.
+  # Both Certificates below mint a private key. Neither may carry the labels
+  # the tenant read path selects on; only the controller-authored projection
+  # may.
+  #
+  # That path has two gates and this label is the second one. tenantsecrets
+  # serves Secrets labelled internal.cozystack.io/tenantresource=true, and the
+  # lineage webhook sets that by matching the Secret against the application
+  # definition's spec.secrets selectors, one of which is the tenant-ca label
+  # below. It only gets that far for a Secret whose owner it can resolve:
+  # pkg/lineage walks ownerReferences, then falls back to a
+  # helm.toolkit.fluxcd.io/name label, and returns no owner otherwise, in
+  # which case the webhook stamps nothing at all. A Secret cert-manager writes
+  # has neither while enableCertificateOwnerRef is false, which is how
+  # cert-manager ships here, so the label on its own is inert today.
+  #
+  # It stops being inert under --enable-certificate-owner-ref, which puts an
+  # ownerReference to the Certificate on the Secret, and the Certificate does
+  # carry the Flux label the walk needs. Same if a secretTemplate ever copies
+  # that label across. So the guard is not protecting against today's config;
+  # it is keeping a cluster flag from being what decides whether the CA
+  # private key is tenant-readable.
   #
   # Selected by the Secret each Certificate writes rather than by position: a
   # documentIndex would follow the slot, so reordering this template would let

--- a/packages/apps/qdrant/tests/dashboard-resourcemap_test.yaml
+++ b/packages/apps/qdrant/tests/dashboard-resourcemap_test.yaml
@@ -1,0 +1,338 @@
+suite: qdrant dashboard resourcemap tests
+
+# The Role bound here is what a tenant subject can actually read. Two of the
+# Secrets this chart creates must never appear in it: <release>-ca carries the
+# CA private key under tls.key, <release>-tls the server key. Read access to
+# the former is enough to issue certificates for anything.
+#
+# So the rules array is pinned WHOLE rather than checked for known-bad names.
+# A name-by-name check misses a rule that grants secrets with NO resourceNames
+# at all, which is not a narrow grant but an unrestricted one — "an empty set
+# means that everything is allowed" — and so adds no name to notice while
+# granting every Secret in the namespace. Pinning the whole array also makes
+# the template's spelling irrelevant, since the assertion runs on rendered
+# output.
+#
+# Pinning one document is not enough, because a grant need not live in it. A
+# second RBAC object rendered beside it reaches the same subjects, and a
+# selector addressing the Role looks straight past it. So each permutation
+# also pins the document COUNT, catching an added object, and pins the kind in
+# every slot, catching a substituted one — a count alone is satisfied by
+# swapping the WorkloadMonitor for a binding onto cluster-admin. The
+# RoleBinding is pinned across the same permutations for the same reason: its
+# roleRef is one conditional away from pointing at cluster-admin.
+#
+# Documents are addressed by kind rather than by index. An index follows the
+# slot, so inserting a document above the Role would quietly move these
+# assertions onto something else and pass green. A second Role, or none, makes
+# the selector error rather than silently pick a first match.
+#
+# What this does NOT reach, and why it is a guard rather than a proof:
+#
+#   - a grant rendered from a DIFFERENT template file, since the suite-level
+#     `templates` key scopes what is rendered;
+#   - a grant behind a `.Capabilities` check this suite does not declare.
+#     helm-unittest populates `.Capabilities`, but its default APIVersions set
+#     is empty, so `.Capabilities.APIVersions.Has "cert-manager.io/v1"` is
+#     false here and true on any cluster running cert-manager;
+#   - a grant comparing a value against a third point not sampled, e.g.
+#     `replicas` greater than two or `resourcesPreset` equal to one specific
+#     preset. The permutations below sample each value at the points that
+#     change behaviour — for `tls.enabled`, a tri-state, that means all three
+#     — which settles presence and boolean gates and nothing more.
+
+templates:
+  - templates/dashboard-resourcemap.yaml
+
+release:
+  name: test-qdrant
+  namespace: tenant-test
+
+tests:
+  ###################################################
+  # The document set: nothing added, nothing swapped
+  ###################################################
+
+  # The baseline. A grant that renders only while a value is unset shows up
+  # here and in no other permutation.
+  - it: renders three documents with default values
+    asserts: &documentSet
+      - hasDocuments:
+          count: 3
+
+  - it: renders three documents with TLS enabled
+    set: &tlsOn
+      tls:
+        enabled: true
+    asserts: *documentSet
+
+  - it: renders three documents with TLS implied by external access
+    set: &externalOn
+      external: true
+    asserts: *documentSet
+
+  # Every value a tenant can set, plus the two the platform injects, moved off
+  # their defaults at once, so a grant gated on the presence of any single one
+  # renders here.
+  - it: renders three documents with every settable value set
+    set: &allValues
+      replicas: 2
+      resources:
+        cpu: 500m
+        memory: 1Gi
+      resourcesPreset: u1.large
+      size: 20Gi
+      storageClass: replicated
+      external: true
+      tls:
+        enabled: true
+      _namespace:
+        host: example.com
+      _cluster:
+        cluster-domain: cozy.local
+    asserts: *documentSet
+
+  # Chart.yaml carries version 0.0.0, and it stays 0.0.0 on the path that
+  # ships: the installer pushes packages/ verbatim as an OCI artifact, and the
+  # `helm package --version` target that would stamp a real version has no
+  # caller. Sampling a second version costs one test and means a grant gated
+  # on .Chart.Version cannot hide if that ever changes.
+  - it: renders three documents with a different chart version
+    chart: &packagedChart
+      version: 1.2.3
+    asserts: *documentSet
+
+  # tls.enabled is tri-state: unset means "follow external", so an explicit
+  # false is a distinct state from leaving it out, and a grant gated on it
+  # renders in neither case above.
+  - it: renders three documents with TLS explicitly disabled
+    set: &tlsOff
+      tls:
+        enabled: false
+    asserts: *documentSet
+
+  - it: renders three documents with TLS explicitly disabled despite external access
+    set: &externalTlsOff
+      external: true
+      tls:
+        enabled: false
+    asserts: *documentSet
+
+  # helm-controller upgrades whenever the release is not up to date, so any
+  # values or chart change puts a release on the upgrade path. A grant behind
+  # .Release.IsUpgrade is live on essentially every release while rendering
+  # false in every case above.
+  - it: renders three documents on upgrade
+    release: &upgraded
+      name: test-qdrant
+      namespace: tenant-test
+      upgrade: true
+    asserts: *documentSet
+
+  # The WorkloadMonitor itself. Without this the count above is satisfied by
+  # any replacement, including one binding the tenant to cluster-admin.
+  - it: keeps the WorkloadMonitor as the third document with default values
+    documentSelector: &workloadMonitor
+      path: kind
+      value: WorkloadMonitor
+    asserts: &workloadMonitorPinned
+      - equal:
+          path: metadata.name
+          value: test-qdrant
+
+  - it: keeps the WorkloadMonitor with TLS enabled
+    set: *tlsOn
+    documentSelector: *workloadMonitor
+    asserts: *workloadMonitorPinned
+
+  - it: keeps the WorkloadMonitor with TLS implied by external access
+    set: *externalOn
+    documentSelector: *workloadMonitor
+    asserts: *workloadMonitorPinned
+
+  - it: keeps the WorkloadMonitor with every settable value set
+    set: *allValues
+    documentSelector: *workloadMonitor
+    asserts: *workloadMonitorPinned
+
+  - it: keeps the WorkloadMonitor with a different chart version
+    chart: *packagedChart
+    documentSelector: *workloadMonitor
+    asserts: *workloadMonitorPinned
+
+  - it: keeps the WorkloadMonitor with TLS explicitly disabled
+    set: *tlsOff
+    documentSelector: *workloadMonitor
+    asserts: *workloadMonitorPinned
+
+  - it: keeps the WorkloadMonitor with TLS explicitly disabled despite external access
+    set: *externalTlsOff
+    documentSelector: *workloadMonitor
+    asserts: *workloadMonitorPinned
+
+  - it: keeps the WorkloadMonitor on upgrade
+    release: *upgraded
+    documentSelector: *workloadMonitor
+    asserts: *workloadMonitorPinned
+
+  ###################################################
+  # The grant itself
+  ###################################################
+
+  - it: names the dashboard Role after the release
+    documentSelector: &role
+      path: kind
+      value: Role
+    asserts:
+      - equal:
+          path: apiVersion
+          value: rbac.authorization.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: test-qdrant-dashboard-resources
+
+  # Default values leave tls.enabled unset and external false, which the
+  # chart's helper resolves to TLS off, so the CA Secret does not exist here.
+  # Pinned to catch a grant that renders only while a value is unset.
+  - it: grants no Secret beyond the API key with default values
+    documentSelector: *role
+    asserts: &pinnedRules
+      - equal:
+          path: rules
+          value:
+            - apiGroups: [""]
+              resources: [services]
+              resourceNames: [test-qdrant, test-qdrant-headless]
+              verbs: [get, list, watch]
+            - apiGroups: [""]
+              resources: [secrets]
+              resourceNames: [test-qdrant-apikey]
+              verbs: [get, list, watch]
+            - apiGroups: [cozystack.io]
+              resources: [workloadmonitors]
+              resourceNames: [test-qdrant]
+              verbs: [get, list, watch]
+
+  # The case that matters. With TLS on the chart mints <release>-ca and
+  # <release>-tls, so this is the permutation where a leaked grant has
+  # something to leak. A grant added inside the same `if` that creates the CA
+  # renders only here, and would sail past a check that runs on defaults.
+  - it: grants no Secret beyond the API key with TLS enabled
+    set: *tlsOn
+    documentSelector: *role
+    asserts: *pinnedRules
+
+  # TLS is also reachable by implication: leaving tls.enabled unset makes it
+  # follow external. Pinned separately because a grant gated on `external`
+  # rather than on the TLS helper renders in neither case above.
+  - it: grants no Secret beyond the API key with TLS implied by external access
+    set: *externalOn
+    documentSelector: *role
+    asserts: *pinnedRules
+
+  - it: grants no Secret beyond the API key with every settable value set
+    set: *allValues
+    documentSelector: *role
+    asserts: *pinnedRules
+
+  - it: grants no Secret beyond the API key with a different chart version
+    chart: *packagedChart
+    documentSelector: *role
+    asserts: *pinnedRules
+
+  - it: grants no Secret beyond the API key with TLS explicitly disabled
+    set: *tlsOff
+    documentSelector: *role
+    asserts: *pinnedRules
+
+  - it: grants no Secret beyond the API key with TLS explicitly disabled despite external access
+    set: *externalTlsOff
+    documentSelector: *role
+    asserts: *pinnedRules
+
+  - it: grants no Secret beyond the API key on upgrade
+    release: *upgraded
+    documentSelector: *role
+    asserts: *pinnedRules
+
+  ###################################################
+  # The binding: who the Role is handed to
+  ###################################################
+
+  # Pinning the Role's rules is worth nothing if the binding points somewhere
+  # else, so roleRef and the subject list are pinned across the same
+  # permutations. A conditional swapping roleRef for cluster-admin renders in
+  # exactly the case a default-values check would miss.
+  - it: binds the tenant subjects to the dashboard Role with default values
+    documentSelector: &roleBinding
+      path: kind
+      value: RoleBinding
+    asserts: &roleBindingPinned
+      - equal:
+          path: roleRef
+          value:
+            kind: Role
+            name: test-qdrant-dashboard-resources
+            apiGroup: rbac.authorization.k8s.io
+      - equal:
+          path: subjects
+          value:
+            - kind: ServiceAccount
+              name: tenant-test
+              namespace: tenant-test
+            - kind: Group
+              name: tenant-test-admin
+              apiGroup: rbac.authorization.k8s.io
+            - kind: Group
+              name: tenant-test-super-admin
+              apiGroup: rbac.authorization.k8s.io
+            - kind: Group
+              name: tenant-test-use
+              apiGroup: rbac.authorization.k8s.io
+            - kind: ServiceAccount
+              name: tenant-root
+              namespace: tenant-root
+            - kind: Group
+              name: tenant-root-admin
+              apiGroup: rbac.authorization.k8s.io
+            - kind: Group
+              name: tenant-root-super-admin
+              apiGroup: rbac.authorization.k8s.io
+            - kind: Group
+              name: tenant-root-use
+              apiGroup: rbac.authorization.k8s.io
+
+  - it: binds the tenant subjects to the dashboard Role with TLS enabled
+    set: *tlsOn
+    documentSelector: *roleBinding
+    asserts: *roleBindingPinned
+
+  - it: binds the tenant subjects to the dashboard Role with TLS implied by external access
+    set: *externalOn
+    documentSelector: *roleBinding
+    asserts: *roleBindingPinned
+
+  - it: binds the tenant subjects to the dashboard Role with every settable value set
+    set: *allValues
+    documentSelector: *roleBinding
+    asserts: *roleBindingPinned
+
+  - it: binds the tenant subjects to the dashboard Role with a different chart version
+    chart: *packagedChart
+    documentSelector: *roleBinding
+    asserts: *roleBindingPinned
+
+  - it: binds the tenant subjects to the dashboard Role with TLS explicitly disabled
+    set: *tlsOff
+    documentSelector: *roleBinding
+    asserts: *roleBindingPinned
+
+  - it: binds the tenant subjects to the dashboard Role with TLS explicitly disabled despite external access
+    set: *externalTlsOff
+    documentSelector: *roleBinding
+    asserts: *roleBindingPinned
+
+  - it: binds the tenant subjects to the dashboard Role on upgrade
+    release: *upgraded
+    documentSelector: *roleBinding
+    asserts: *roleBindingPinned

--- a/packages/apps/qdrant/tests/tenant_projection_test.yaml
+++ b/packages/apps/qdrant/tests/tenant_projection_test.yaml
@@ -1,0 +1,118 @@
+suite: qdrant TenantProjection sentinel
+
+# The chart renders one TenantProjection per TLS-enabled release: the
+# declaration that tells the CA-extraction controller to lift ca.crt out of the
+# key-bearing <release>-ca into the tenant-readable <release>.tenant-ca
+# projection.
+#
+# The load-bearing invariant is the ABSENCE of ownerReferences. The sentinel must
+# carry none — it owns the projection, and it is itself owned only through the
+# helm.toolkit.fluxcd.io/name label Flux stamps, which is how the lineage webhook
+# resolves the application. An ownerReference here would short-circuit that walk
+# and silently break the tenant's read path (pkg/lineage/lineage.go).
+
+release:
+  name: test-qdrant
+  namespace: tenant-test
+
+templates:
+  - templates/tenant-projection.yaml
+
+tests:
+  - it: renders exactly one TenantProjection named after the release
+    set:
+      tls:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: TenantProjection
+      - equal:
+          path: apiVersion
+          value: internal.cozystack.io/v1alpha1
+      - equal:
+          path: metadata.name
+          value: test-qdrant-ca
+
+  - it: declares a CACert projection of the chart's CA
+    set:
+      tls:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.projections[0].type
+          value: CACert
+      - equal:
+          path: spec.projections[0].sourceSecretName
+          value: test-qdrant-ca
+      - equal:
+          path: spec.projections[0].sourceKey
+          value: ca.crt
+
+  # The one genuine invariant. pkg/lineage/lineage.go returns early once a
+  # ownerReferences is present, so the helm-label fallback that resolves the
+  # application is never reached: the projection never gets tenantresource=true
+  # and the tenant silently loses the anchor. Adding one breaks the read path
+  # with no error anywhere.
+  - it: carries no ownerReferences
+    set:
+      tls:
+        enabled: true
+    asserts:
+      - notExists:
+          path: metadata.ownerReferences
+
+  # Not invariants — conformance to the shared sentinel shape. Setting either
+  # would be functionally harmless here (the release namespace is where Helm
+  # puts it either way, and Flux stamps its own label at apply time), but every
+  # engine's sentinel is meant to be the same eight lines, so a local
+  # embellishment is a divergence to catch at review rather than in six copies.
+  - it: matches the shared sentinel shape
+    set:
+      tls:
+        enabled: true
+    asserts:
+      - notExists:
+          path: metadata.namespace
+      - notExists:
+          path: metadata.labels
+
+  # Unlike CNPG, qdrant's CA exists only while TLS is on. An ungated sentinel
+  # would sit Ready=False/SourceNotFound forever on every plaintext release.
+  #
+  # The gate must track the chart's effective TLS state, not the raw
+  # tls.enabled value: leaving it unset means "follow external". A naive
+  # `if .Values.tls.enabled` still passes the two explicit cases below while
+  # silently publishing no anchor to exactly the releases most likely to need
+  # one, so both implied legs are pinned too.
+  - it: renders the sentinel when TLS is implied by external access
+    set:
+      external: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: renders nothing when TLS is implied off by external being false
+    set:
+      external: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders nothing when TLS is explicitly disabled despite external access
+    set:
+      external: true
+      tls:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders nothing when TLS is disabled
+    set:
+      tls:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/packages/system/qdrant-rd/cozyrds/qdrant.yaml
+++ b/packages/system/qdrant-rd/cozyrds/qdrant.yaml
@@ -33,6 +33,11 @@ spec:
     include:
       - resourceNames:
           - qdrant-{{ .name }}-apikey
+      # The key-free trust anchor the CA-extraction controller publishes. This
+      # is the single, engine-agnostic selector every converged engine shares;
+      # it carries no per-release name templating.
+      - matchLabels:
+          internal.cozystack.io/tenant-ca: "true"
   services:
     exclude: []
     include:


### PR DESCRIPTION
## What this PR does

Converges qdrant onto the key-free CA trust-anchor contract (#2814), the same way #3340 does it for nats. The chart declares a `TenantProjection` sentinel naming its cert-manager CA Secret. The CA-extraction controller reads that declaration and publishes a key-free copy, `ca.crt` and nothing else, as `<release>.tenant-ca`. The qdrant ResourceDefinition selects that projection by label so it shows up in the tenant's secret list. No key-bearing Secret gains a tenant-visible label.

The sentinel is gated on the chart's TLS condition. Engines whose operator mints a CA unconditionally do not need that, but qdrant only has a CA while TLS is on, and an ungated sentinel would sit `Ready=False`/`SourceNotFound` on every plaintext release.

This was held while the CA-extraction controller was still open. That controller landed in #3407, so the sentinel is honoured as soon as this merges and the hold is gone.

Tests pin the invariants that otherwise fail silently. The sentinel carries no `ownerReferences`, so the lineage walk falls through to the Flux release label. Neither key-bearing Certificate stamps a tenant-visible label on its Secret. The two objects that decide which Secrets a tenant may actually read, the dashboard Role with its binding and the ResourceDefinition, are pinned whole rather than checked for known-bad names: a rule granting secrets with no `resourceNames` is unrestricted rather than narrow, and a label selector can reach a key-bearing Secret while every name in the file stays correct, so neither adds a name for a probe to notice.

Part of #2814.

### Follow-ups

What this PR does not do, and where each belongs instead.

- nats converges the same contract in #3340 and has no `dashboard-resourcemap_test.yaml`, so the dashboard Role pin belongs there too. Tracked in #3701 along with postgres, which already carries the label selector with no guard behind it.
- The qdrant e2e fixture runs plaintext (`hack/e2e-chainsaw/qdrant/qdrant.yaml` sets `external: false`), so nothing in CI walks the path from the sentinel to `tenantsecrets`. postgres has a `verify-tenant-ca-projection` step to copy.
- `hack/check-qdrant-rd-secrets.bats` is engine-agnostic apart from two literals, the chart path and the expected Secret set. The third copy of it is the point to parameterise over `packages/system/*-rd/cozyrds/` instead of copying again.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff, file by file. Nothing needs a manual follow-up, but not for the reason a values-only walk would give: the website reference page for an app is regenerated from that package's `README.md`, and this PR does change it. `qdrant` is in the app list hardcoded in the website `Makefile`, so the docs bot picks the new section up on the next stable tag and there is nothing to open by hand. The Terraform provider's schema is hand-written against `values.schema.json`, which is untouched, and the provider offers no typed access to the new projection, the same position it holds for every other Secret it does not model. No package is added, renamed or removed, and the `cozyrds` file is edited in place rather than renamed, so the ccp dependency-contract anchor still resolves.

User-facing documentation for consuming the trust anchor ships with the chart README, matching #3340.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
feat(qdrant): expose the CA certificate to tenants as a key-free `<release>.tenant-ca` Secret
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant environments can securely access the Qdrant TLS CA certificate without receiving the private key.
  * TLS CA access is automatically enabled when TLS or external access is configured.

* **Documentation**
  * Expanded TLS guidance explains certificate validation and provides commands for retrieving the tenant CA certificate.

* **Tests**
  * Added coverage for TLS projections, secret visibility, dashboard resources, and secure fail-closed secret exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



