### PR TITLE
fix(cilium): bump vendored chart to v1.19.6

### DIFF
--- a/hack/e2e-cilium-endpoint-leak-healer.sh
+++ b/hack/e2e-cilium-endpoint-leak-healer.sh
@@ -203,8 +203,8 @@ while true; do
     # bitmap empty, then re-reserves the ingress IP via a path decoupled from
     # pod-endpoint restore, so a CNI ADD in that window can be handed the ingress
     # IP again -- the same restore-window race that produced this wedge. (Upstream
-    # cilium host-scope IPAM + Gateway API restore-window race; no released fix as
-    # of v1.19.5.) So surface it and reschedule the wedged pod best-effort, but
+    # cilium host-scope IPAM + Gateway API restore-window race; no released fix
+    # known to address it.) So surface it and reschedule the wedged pod best-effort, but
     # never count it toward or trigger the agent restart. Gated on an EXACT match
     # (ip_is_node_ingress; an empty ingress IP never matches) so a false positive
     # can never suppress a restart that would clear a real in-memory leak.

--- a/internal/controller/tenantgateway/reconciler.go
+++ b/internal/controller/tenantgateway/reconciler.go
@@ -865,11 +865,25 @@ func (r *Reconciler) renderGateway(tgw *gatewayv1alpha1.TenantGateway, dynHostna
 	// (cilium#45559). In practice only TLSRoute attaches to a Passthrough
 	// listener, but listing HTTPRoute here is harmless — Gateway API
 	// rejects any HTTPRoute that references a Passthrough sectionName.
-	// NOTE: on Cilium 1.19.x each tls-<svc> listener will surface
+	// NOTE: each tls-<svc> listener surfaces
 	// ResolvedRefs=False/InvalidRouteKinds on the raw Gateway object
 	// (cosmetic — Accepted, Programmed, traffic, and TenantGateway
-	// readiness are all unaffected); removable once Cilium 1.20 /
-	// cilium#45693 ships.
+	// readiness are all unaffected). It is self-inflicted: Cilium emits it
+	// from the supportedKinds length check in operator/pkg/gateway-api/
+	// gateway_reconcile.go (len(supportedKinds) != len(AllowedRoutes.Kinds)),
+	// which fires because port443Kinds puts two kinds on a listener whose
+	// protocol supports one. That check is byte-identical in v1.19.5 and
+	// v1.19.6, so the noise does not clear on its own.
+	// Whether port443Kinds is still needed at all is a separate question,
+	// and this bump reopens it: cilium#45693 ("fix allowedRoute namespace
+	// and kind restrictions on multi-listener") is backported to 1.19 and
+	// present in v1.19.6, where CheckGatewayRouteKindAllowed now filters
+	// listeners by sectionName and port instead of scanning every listener
+	// last-one-wins — the collapse this workaround exists to defeat.
+	// Dropping it is its own change: it needs a cluster check, and the
+	// two-kind set is pinned by TestReconcile_Port443ListenersShareKinds.
+	// Tracked in cozystack#3087, whose "once Cilium >=1.20" premise the
+	// 1.19 backport has already overtaken.
 	// The corresponding TLSRoute templates (cozystack-api, vm-exportproxy,
 	// cdi-uploadproxy) attach to these listeners by sectionName.
 	for _, svc := range tgw.Spec.TLSPassthroughServices {

--- a/packages/system/cilium/charts/cilium/Chart.yaml
+++ b/packages/system/cilium/charts/cilium/Chart.yaml
@@ -76,7 +76,7 @@ annotations:
     Cilium Gateway Class Config\n  description: |\n    CiliumGatewayClassConfig defines
     a configuration for Gateway API GatewayClass.\n"
 apiVersion: v2
-appVersion: 1.19.5
+appVersion: 1.19.6
 description: eBPF-based Networking, Security, and Observability
 home: https://cilium.io/
 icon: https://cdn.jsdelivr.net/gh/cilium/cilium@main/Documentation/images/logo-solo.svg
@@ -92,4 +92,4 @@ kubeVersion: '>= 1.21.0-0'
 name: cilium
 sources:
 - https://github.com/cilium/cilium
-version: 1.19.5
+version: 1.19.6

--- a/packages/system/cilium/charts/cilium/README.md
+++ b/packages/system/cilium/charts/cilium/README.md
@@ -1,6 +1,6 @@
 # cilium
 
-![Version: 1.19.5](https://img.shields.io/badge/Version-1.19.5-informational?style=flat-square) ![AppVersion: 1.19.5](https://img.shields.io/badge/AppVersion-1.19.5-informational?style=flat-square)
+![Version: 1.19.6](https://img.shields.io/badge/Version-1.19.6-informational?style=flat-square) ![AppVersion: 1.19.6](https://img.shields.io/badge/AppVersion-1.19.6-informational?style=flat-square)
 
 Cilium is open source software for providing and transparently securing
 network connectivity and loadbalancing between application workloads such as
@@ -175,7 +175,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.tproxy | bool | `false` | Configure the eBPF-based TPROXY (beta) to reduce reliance on iptables rules for implementing Layer 7 policy. Note this is incompatible with netkit (`bpf.datapathMode=netkit`, `bpf.datapathMode=netkit-l2`). |
 | bpf.vlanBypass | list | `[]` | Configure explicitly allowed VLAN id's for bpf logic bypass. [0] will allow all VLAN id's without any filtering. |
 | bpfClockProbe | bool | `false` | Enable BPF clock source probing for more efficient tick retrieval. |
-| certgen | object | `{"affinity":{},"annotations":{"cronJob":{},"job":{}},"cronJob":{"failedJobsHistoryLimit":1,"successfulJobsHistoryLimit":3},"extraVolumeMounts":[],"extraVolumes":[],"generateCA":true,"image":{"digest":"sha256:f107522ed4dcea62f918b8eb836142875a9b3e3cb2b2d728dc680f76cdbde6cf","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.4.5","useDigest":true},"nodeSelector":{},"podLabels":{},"priorityClassName":"","resources":{},"tolerations":[],"ttlSecondsAfterFinished":null}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
+| certgen | object | `{"affinity":{},"annotations":{"cronJob":{},"job":{}},"cronJob":{"failedJobsHistoryLimit":1,"successfulJobsHistoryLimit":3},"extraVolumeMounts":[],"extraVolumes":[],"generateCA":true,"image":{"digest":"sha256:511cedee817713fdf72db7e32fffb4b90da7747661b95180064f18198877626c","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.4.6","useDigest":true},"nodeSelector":{},"podLabels":{},"priorityClassName":"","resources":{},"tolerations":[],"ttlSecondsAfterFinished":null}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
 | certgen.affinity | object | `{}` | Affinity for certgen |
 | certgen.annotations | object | `{"cronJob":{},"job":{}}` | Annotations to be added to the hubble-certgen initial Job and CronJob |
 | certgen.cronJob.failedJobsHistoryLimit | int | `1` | The number of failed finished jobs to keep |
@@ -214,7 +214,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.extraVolumeMounts | list | `[]` | Additional clustermesh-apiserver volumeMounts. |
 | clustermesh.apiserver.extraVolumes | list | `[]` | Additional clustermesh-apiserver volumes. |
 | clustermesh.apiserver.healthPort | int | `9880` | TCP port for the clustermesh-apiserver health API. |
-| clustermesh.apiserver.image | object | `{"digest":"sha256:5ed9334b2254315740f9e2a8b6645bf69920f79ef14f436931579d2038784f9b","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/clustermesh-apiserver","tag":"v1.19.5","useDigest":true}` | Clustermesh API server image. |
+| clustermesh.apiserver.image | object | `{"digest":"sha256:accab5fe6ab7134fcd6f916acc9e4c785382a022128ae5495ec4a45fbe18c9a6","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/clustermesh-apiserver","tag":"v1.19.6","useDigest":true}` | Clustermesh API server image. |
 | clustermesh.apiserver.kvstoremesh.enabled | bool | `true` | Enable KVStoreMesh. KVStoreMesh caches the information retrieved from the remote clusters in the local etcd instance (deprecated - KVStoreMesh will always be enabled once the option is removed). |
 | clustermesh.apiserver.kvstoremesh.extraArgs | list | `[]` | Additional KVStoreMesh arguments. |
 | clustermesh.apiserver.kvstoremesh.extraEnv | list | `[]` | Additional KVStoreMesh environment variables. |
@@ -470,7 +470,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.httpRetryCount | int | `3` | Maximum number of retries for each HTTP request |
 | envoy.httpUpstreamLingerTimeout | string | `nil` | Time in seconds to block Envoy worker thread while an upstream HTTP connection is closing. If set to 0, the connection is closed immediately (with TCP RST). If set to -1, the connection is closed asynchronously in the background. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:326f872e19ce8aa45170efbf583b3f301586ba3feead14b864676d4baf3b45ed","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.36.8-1781157951-a7f42a3390781539911b5b9107881b35ecc4e752","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:767101fb8a5e38f055778cb43b7aa8eed80450b37f8121effac3d9de9e06dc99","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.36.9-1782267392-edeb3f2af56c37c407efa1f63f0b32f595399bbc","useDigest":true}` | Envoy container image. |
 | envoy.initContainers | list | `[]` | Init containers added to the cilium Envoy DaemonSet. |
 | envoy.initialFetchTimeoutSeconds | int | `30` | Time in seconds after which the initial fetch on an xDS stream is considered timed out |
 | envoy.livenessProbe.enabled | bool | `true` | Enable liveness probe for cilium-envoy |
@@ -615,7 +615,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.extraVolumes | list | `[]` | Additional hubble-relay volumes. |
 | hubble.relay.gops.enabled | bool | `true` | Enable gops for hubble-relay |
 | hubble.relay.gops.port | int | `9893` | Configure gops listen port for hubble-relay |
-| hubble.relay.image | object | `{"digest":"sha256:24409bfa1bca075c92acb26ba4b49cd573d99d68d5370f7cc825078185222a0c","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-relay","tag":"v1.19.5","useDigest":true}` | Hubble-relay container image. |
+| hubble.relay.image | object | `{"digest":"sha256:6782a49e3f28eba015701c4410a5ec7fa096fe9a562f879b4372dbecd827ea44","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-relay","tag":"v1.19.6","useDigest":true}` | Hubble-relay container image. |
 | hubble.relay.listenHost | string | `""` | Host to listen to. Specify an empty string to bind to all the interfaces. |
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |
 | hubble.relay.logOptions | object | `{"format":null,"level":null}` | Logging configuration for hubble-relay. |
@@ -733,7 +733,7 @@ contributors across the globe, there is almost always someone available to help.
 | identityAllocationMode | string | `"crd"` | Method to use for identity allocation (`crd`, `kvstore` or `doublewrite-readkvstore` / `doublewrite-readcrd` for migrating between identity backends). |
 | identityChangeGracePeriod | string | `"5s"` | Time to wait before using new identity on endpoint identity change. |
 | identityManagementMode | string | `"agent"` | Control whether CiliumIdentities are created by the agent ("agent"), the operator ("operator") or both ("both"). "Both" should be used only to migrate between "agent" and "operator". Operator-managed identities is a beta feature. |
-| image | object | `{"digest":"sha256:20fbbc14ac20b55a292c0dcda5571bf31cde30a7dbc68c29db3e709390ab0732","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.19.5","useDigest":true}` | Agent container image. |
+| image | object | `{"digest":"sha256:0df5b2750b64c49843aba1d649e9eaf61467cb0645ad3171db6f6962c095ac92","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.19.6","useDigest":true}` | Agent container image. |
 | imagePullSecrets | list | `[]` | Configure image pull secrets for pulling container images |
 | ingressController.default | bool | `false` | Set cilium ingress controller to be the default ingress controller This will let cilium ingress controller route entries without ingress class set |
 | ingressController.defaultSecretName | string | `nil` | Default secret name for ingresses without .spec.tls[].secretName set. |
@@ -885,7 +885,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.hostNetwork | bool | `true` | HostNetwork setting |
 | operator.identityGCInterval | string | `"15m0s"` | Interval for identity garbage collection. |
 | operator.identityHeartbeatTimeout | string | `"30m0s"` | Timeout for identity heartbeats. |
-| operator.image | object | `{"alibabacloudDigest":"sha256:c9706343dde700804c2f50c09a2f8291797c707d1747fd50f70c939c23747c16","awsDigest":"sha256:b8473618e8d2bf8a610da445c8c37e1d1e8221aecd05989456d87a7588d66707","azureDigest":"sha256:8600299cb121f9df00fd32b93fa74de89ed49dd3a67e3d7301c07325c04c77f8","genericDigest":"sha256:be848a365776e07d0c5a895eda7aec928ddc52a5a1fa2f432fd7a286609e1db4","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/operator","suffix":"","tag":"v1.19.5","useDigest":true}` | cilium-operator image. |
+| operator.image | object | `{"alibabacloudDigest":"sha256:031e332cdec61a9ebaca42f044e7e2f5b876ba96ac0ccf1d42acd5954779efaf","awsDigest":"sha256:546d13ac511cf82441b5e9e99e03d0e054b788513ceb1a883e620b8284d5ccc3","azureDigest":"sha256:e555430b7f5e4c407daab1afbec3c431ec016a53f1f1b848f67b9242cd3adedd","genericDigest":"sha256:0db4ca4e06969d8904ee036617795d0e9c3228cf7b8d902ba74fc2bb98d2d665","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/operator","suffix":"","tag":"v1.19.6","useDigest":true}` | cilium-operator image. |
 | operator.nodeGCInterval | string | `"5m0s"` | Interval for cilium node garbage collection. |
 | operator.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | operator.podAnnotations | object | `{}` | Annotations to be added to cilium-operator pods |
@@ -943,11 +943,11 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-preflight |
 | preflight.annotations | object | `{}` | Annotations to be added to all top-level preflight objects (resources under templates/cilium-preflight) |
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
-| preflight.envoy.image | object | `{"digest":"sha256:326f872e19ce8aa45170efbf583b3f301586ba3feead14b864676d4baf3b45ed","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.36.8-1781157951-a7f42a3390781539911b5b9107881b35ecc4e752","useDigest":true}` | Envoy pre-flight image. |
+| preflight.envoy.image | object | `{"digest":"sha256:767101fb8a5e38f055778cb43b7aa8eed80450b37f8121effac3d9de9e06dc99","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.36.9-1782267392-edeb3f2af56c37c407efa1f63f0b32f595399bbc","useDigest":true}` | Envoy pre-flight image. |
 | preflight.extraEnv | list | `[]` | Additional preflight environment variables. |
 | preflight.extraVolumeMounts | list | `[]` | Additional preflight volumeMounts. |
 | preflight.extraVolumes | list | `[]` | Additional preflight volumes. |
-| preflight.image | object | `{"digest":"sha256:20fbbc14ac20b55a292c0dcda5571bf31cde30a7dbc68c29db3e709390ab0732","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.19.5","useDigest":true}` | Cilium pre-flight image. |
+| preflight.image | object | `{"digest":"sha256:0df5b2750b64c49843aba1d649e9eaf61467cb0645ad3171db6f6962c095ac92","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.19.6","useDigest":true}` | Cilium pre-flight image. |
 | preflight.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |
 | preflight.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |

--- a/packages/system/cilium/charts/cilium/templates/cilium-configmap.yaml
+++ b/packages/system/cilium/charts/cilium/templates/cilium-configmap.yaml
@@ -830,9 +830,7 @@ data:
   enable-nat46x64-gateway: {{ .Values.nat46x64Gateway.enabled | quote }}
 {{- end }}
 
-{{- if and .Values.hostFirewall .Values.hostFirewall.enabled }}
   enable-host-firewall: {{ .Values.hostFirewall.enabled | quote }}
-{{- end}}
 
 {{- if hasKey .Values "devices" }}
   # List of devices used to attach bpf_host.o (implements BPF NodePort,

--- a/packages/system/cilium/charts/cilium/values.yaml
+++ b/packages/system/cilium/charts/cilium/values.yaml
@@ -247,10 +247,10 @@ image:
   # @schema
   override: ~
   repository: "quay.io/cilium/cilium"
-  tag: "v1.19.5"
+  tag: "v1.19.6"
   pullPolicy: "IfNotPresent"
   # cilium-digest
-  digest: sha256:20fbbc14ac20b55a292c0dcda5571bf31cde30a7dbc68c29db3e709390ab0732
+  digest: sha256:0df5b2750b64c49843aba1d649e9eaf61467cb0645ad3171db6f6962c095ac92
   useDigest: true
 # -- Scheduling configurations for cilium pods
 scheduling:
@@ -1350,8 +1350,8 @@ certgen:
     # @schema
     override: ~
     repository: "quay.io/cilium/certgen"
-    tag: "v0.4.5"
-    digest: "sha256:f107522ed4dcea62f918b8eb836142875a9b3e3cb2b2d728dc680f76cdbde6cf"
+    tag: "v0.4.6"
+    digest: "sha256:511cedee817713fdf72db7e32fffb4b90da7747661b95180064f18198877626c"
     useDigest: true
     pullPolicy: "IfNotPresent"
   # @schema
@@ -1699,9 +1699,9 @@ hubble:
       # @schema
       override: ~
       repository: "quay.io/cilium/hubble-relay"
-      tag: "v1.19.5"
+      tag: "v1.19.6"
       # hubble-relay-digest
-      digest: sha256:24409bfa1bca075c92acb26ba4b49cd573d99d68d5370f7cc825078185222a0c
+      digest: sha256:6782a49e3f28eba015701c4410a5ec7fa096fe9a562f879b4372dbecd827ea44
       useDigest: true
       pullPolicy: "IfNotPresent"
     # -- Specifies the resources for the hubble-relay pods
@@ -2719,9 +2719,9 @@ envoy:
     # @schema
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.36.8-1781157951-a7f42a3390781539911b5b9107881b35ecc4e752"
+    tag: "v1.36.9-1782267392-edeb3f2af56c37c407efa1f63f0b32f595399bbc"
     pullPolicy: "IfNotPresent"
-    digest: "sha256:326f872e19ce8aa45170efbf583b3f301586ba3feead14b864676d4baf3b45ed"
+    digest: "sha256:767101fb8a5e38f055778cb43b7aa8eed80450b37f8121effac3d9de9e06dc99"
     useDigest: true
   # -- Init containers added to the cilium Envoy DaemonSet.
   initContainers: []
@@ -3104,15 +3104,15 @@ operator:
     # @schema
     override: ~
     repository: "quay.io/cilium/operator"
-    tag: "v1.19.5"
+    tag: "v1.19.6"
     # operator-generic-digest
-    genericDigest: sha256:be848a365776e07d0c5a895eda7aec928ddc52a5a1fa2f432fd7a286609e1db4
+    genericDigest: sha256:0db4ca4e06969d8904ee036617795d0e9c3228cf7b8d902ba74fc2bb98d2d665
     # operator-azure-digest
-    azureDigest: sha256:8600299cb121f9df00fd32b93fa74de89ed49dd3a67e3d7301c07325c04c77f8
+    azureDigest: sha256:e555430b7f5e4c407daab1afbec3c431ec016a53f1f1b848f67b9242cd3adedd
     # operator-aws-digest
-    awsDigest: sha256:b8473618e8d2bf8a610da445c8c37e1d1e8221aecd05989456d87a7588d66707
+    awsDigest: sha256:546d13ac511cf82441b5e9e99e03d0e054b788513ceb1a883e620b8284d5ccc3
     # operator-alibabacloud-digest
-    alibabacloudDigest: sha256:c9706343dde700804c2f50c09a2f8291797c707d1747fd50f70c939c23747c16
+    alibabacloudDigest: sha256:031e332cdec61a9ebaca42f044e7e2f5b876ba96ac0ccf1d42acd5954779efaf
     useDigest: true
     pullPolicy: "IfNotPresent"
     suffix: ""
@@ -3437,9 +3437,9 @@ preflight:
     # @schema
     override: ~
     repository: "quay.io/cilium/cilium"
-    tag: "v1.19.5"
+    tag: "v1.19.6"
     # cilium-digest
-    digest: sha256:20fbbc14ac20b55a292c0dcda5571bf31cde30a7dbc68c29db3e709390ab0732
+    digest: sha256:0df5b2750b64c49843aba1d649e9eaf61467cb0645ad3171db6f6962c095ac92
     useDigest: true
     pullPolicy: "IfNotPresent"
   envoy:
@@ -3450,9 +3450,9 @@ preflight:
       # @schema
       override: ~
       repository: "quay.io/cilium/cilium-envoy"
-      tag: "v1.36.8-1781157951-a7f42a3390781539911b5b9107881b35ecc4e752"
+      tag: "v1.36.9-1782267392-edeb3f2af56c37c407efa1f63f0b32f595399bbc"
       pullPolicy: "IfNotPresent"
-      digest: "sha256:326f872e19ce8aa45170efbf583b3f301586ba3feead14b864676d4baf3b45ed"
+      digest: "sha256:767101fb8a5e38f055778cb43b7aa8eed80450b37f8121effac3d9de9e06dc99"
       useDigest: true
   # -- The priority class to use for the preflight pod.
   priorityClassName: ""
@@ -3696,9 +3696,9 @@ clustermesh:
       # @schema
       override: ~
       repository: "quay.io/cilium/clustermesh-apiserver"
-      tag: "v1.19.5"
+      tag: "v1.19.6"
       # clustermesh-apiserver-digest
-      digest: sha256:5ed9334b2254315740f9e2a8b6645bf69920f79ef14f436931579d2038784f9b
+      digest: sha256:accab5fe6ab7134fcd6f916acc9e4c785382a022128ae5495ec4a45fbe18c9a6
       useDigest: true
       pullPolicy: "IfNotPresent"
     # -- TCP port for the clustermesh-apiserver health API.

--- a/packages/system/cilium/images/cilium/Dockerfile
+++ b/packages/system/cilium/images/cilium/Dockerfile
@@ -1,4 +1,4 @@
-ARG VERSION=v1.19.5@sha256:20fbbc14ac20b55a292c0dcda5571bf31cde30a7dbc68c29db3e709390ab0732
+ARG VERSION=v1.19.6@sha256:0df5b2750b64c49843aba1d649e9eaf61467cb0645ad3171db6f6962c095ac92
 
 FROM quay.io/cilium/cilium:${VERSION} AS upstream
 


### PR DESCRIPTION
## What this PR does

Refreshes the vendored upstream Cilium chart and the agent image build from v1.19.5 to v1.19.6 via `make update`.

The motivating fix is cilium#42159: on v1.19.5, `CheckGatewayAllowedForNamespace` early-returns `false` on the first namespace-selector miss instead of continuing to later listeners, so platform app HTTPRoutes (Keycloak, dashboard, and others) attaching to a shared tenant Gateway are wrongly rejected with `NotAllowedByListeners`. v1.19.6 carries the upstream fix (cilium#45693, 1.19 backport cilium#46826).

The bump also picks up the upstream host-firewall config fix (cilium#44748): `enable-host-firewall` is now emitted unconditionally, so toggling `hostFirewall.enabled` from true to false no longer leaves a stale value in the live ConfigMap. Rendering the package both ways puts a number on what that changes here: the default variant emits `"true"` before and after, and the only rendered difference across both variants is the kilo one, where the key goes from absent to `"false"`. That is Cilium's own default, so the behaviour is unchanged and only the explicitness is new.

The IPv6-passthrough BPF patch (pass IPv6 to the kernel stack when the IPv6 datapath is disabled under host firewall) applies cleanly to v1.19.6 `bpf/bpf_host.c` with no offset or fuzz and is carried unchanged.

One thing worth knowing before reading this diff for completeness: the agent image and the operator image move on separate clocks. `packages/system/cilium/values.yaml` pins the first-party agent image by digest, and a chart bump does not repin it (the previous bump to v1.19.5 left it alone as well), so the agent keeps running its last build until that image is rebuilt. The fix this PR exists for lives in the operator, in `operator/pkg/gateway-api/gateway_reconcile.go`, and the operator image is pinned by the vendored chart. Rendering the package on both sides shows `operator-generic` going v1.19.5 to v1.19.6 while the agent image stays put, so the motivating fix ships with this change regardless of when the agent is next rebuilt.

Areas worth exercising on a running cluster: Gateway API multi-listener cross-namespace HTTPRoute attachment; host-firewall with the IPv6 datapath disabled (node IPv6 / ICMPv6 ND); and the `hostFirewall.enabled` true→false ConfigMap behavior on the kilo variant.

### Release note

```release-note
fix(cilium): bump to v1.19.6, fixing Gateway API HTTPRoute attachment on shared Gateways (cilium#42159)
fix(cilium): enforce Gateway API listener allowedRoutes.kinds — a route kind not listed on a listener is now rejected instead of accepted with a NotAllowedByListeners condition (cilium#45693); tenant GRPCRoute/TCPRoute/UDPRoute that attached to a shared Gateway under v1.19.5's broken-open behaviour will stop attaching (no first-party routes affected)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the Cilium platform release to **1.19.6**.
  * Refreshed bundled container images (Cilium, Envoy, Hubble Relay, Cluster Mesh API, Certgen, Cilium Operator, and preflight) with updated tags/digests to match **1.19.6**.
  * Updated Helm chart metadata and documentation to reflect **1.19.6**.
  * Made host firewall config rendering consistent with the enabled setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
