### PR TITLE
fix(mariadb): derive my.cnf sizing from the instance's own resources

### DIFF
--- a/packages/apps/mariadb/templates/_tuning.tpl
+++ b/packages/apps/mariadb/templates/_tuning.tpl
@@ -1,0 +1,137 @@
+{{/*
+  Derive my.cnf sizing from the instance's own CPU, memory and volume.
+
+  Every value below is either a memory allocation or a thread count, so it
+  belongs to the pod rather than to the host the config was first written
+  for. Settings that encode durability or storage behaviour — flush method,
+  flush_log_at_trx_commit, io_capacity, fast_shutdown — are deliberately not
+  derived here: the chart cannot infer them from the pod's size.
+
+  join_buffer_size is the one allocation left hardcoded, at the 2M the chart
+  has always shipped, eight times the server's own default. It is per-join
+  rather than per-connection and is left for a change that can measure the
+  effect; on a small instance it is the largest allocation this helper does
+  not account for.
+
+  The memory limit is read through the same cozy-lib helper that fills the
+  MariaDB CR's resource stanza, so `resources` overrides and `resourcesPreset`
+  resolve exactly as they do there.
+
+  Two version constraints shape the clamps, both checked against every server
+  this chart ships (10.6.24, 10.11.15, 11.4.9, 11.8.5):
+
+  - InnoDB refuses to start when innodb_buffer_pool_size is too small at the
+    default 16K page size. The exact minimum moved: 10.6 demands 5 MiB, the
+    later lines 6 MiB. The 8Mi floor clears both.
+  - On the 10.6 line the buffer pool is allocated in innodb_buffer_pool_chunk_size
+    units, which default to 128 MiB there, and a request above one chunk is
+    rounded *up* to a whole number of chunks. Rounding the computed size down to
+    a 128 MiB multiple keeps 10.6 from being handed more buffer pool than its
+    memory limit allows. It is a no-op on the other shipped versions: 10.8
+    autosized the chunk to a 64th of the pool, and 10.11.12, 11.4.6 and 11.8.2
+    deprecated and ignore it outright, all at or below 10.11.15, 11.4.9 and
+    11.8.5. Rounding down unconditionally costs those versions a little pool
+    whenever the memory limit is at least 256 MiB and not a multiple of it —
+    the rounding applies to half the limit, and below one whole chunk it does
+    not fire at all — in exchange for one effective size across every version
+    the chart ships.
+
+  Where the clamps sit relative to what the chart used to ship, since an
+  upgrade moves an existing instance onto them:
+
+  - Most caps are the previously shipped value, so an instance large enough to
+    reach one is sized as it is today.
+  - key_buffer_size is capped at 128M against the 1024M shipped before, and
+    floored at 8M against the server's own 128M default. Both ends are
+    deliberate — see the key cache note below — and both lower the allocation
+    on every instance.
+  - The IO threads floor at 2 against a server default of 4, so a one-core
+    instance gets fewer than an untuned server would start. That is the point:
+    the floor follows the CPU limit, not the host.
+  - The buffer pool has no cap at all: it is the setting this whole helper
+    exists to derive, and pinning it to the old 60G would keep the largest
+    instances sized for a host they do not run on. An instance with 128Gi or
+    more of memory is the single case where anything here goes up rather than
+    down, to half of a limit the instance already has.
+*/}}
+{{- define "mariadb.tuning" }}
+{{-   $mib := 1048576 }}
+{{-   $resources := include "cozy-lib.resources.defaultingSanitize" (list .Values.resourcesPreset .Values.resources $) | fromYaml }}
+{{-   $memB := include "cozy-lib.resources.toFloat" $resources.limits.memory | float64 | int64 }}
+{{-   $cpu := include "cozy-lib.resources.toFloat" $resources.limits.cpu | float64 }}
+{{-   $volB := include "cozy-lib.resources.toFloat" (.Values.size | toString) | float64 | int64 }}
+{{-   $memMi := div $memB $mib }}
+{{-   $cores := ceil $cpu | int64 }}
+
+{{/*
+  Buffer pool: half of the memory limit. The classic "70-80% of RAM" advice
+  assumes a dedicated host where the remainder is page cache and overshooting
+  merely swaps. Under a cgroup limit the same budget also has to cover the
+  per-connection buffers, temp tables, the key cache and mysqld's own heap,
+  and exceeding it is an OOM kill rather than swapping, so half is the share
+  that leaves room for everything else.
+*/}}
+{{-   $poolB := div $memB 2 }}
+{{-   if ge $poolB (mul 128 $mib) }}
+{{-     $poolB = mul (div $poolB (mul 128 $mib)) (mul 128 $mib) }}
+{{-   end }}
+{{-   $poolB = max $poolB (mul 8 $mib) }}
+
+{{/*
+  Redo log: bounded by the buffer pool it buffers dirty pages for, and by a
+  small fraction of the data volume it is preallocated on. The floor is the
+  server's own 96M default; the ceiling is the 4096M the chart shipped before.
+  Changing this on an existing database is safe on every shipped version —
+  InnoDB replays the existing log during crash recovery and only then rewrites
+  it at the new size, after both a clean and an unclean shutdown.
+*/}}
+{{-   $logB := min $poolB (div $volB 20) }}
+{{-   $logB = min (max $logB (mul 96 $mib)) (mul 4096 $mib) }}
+
+{{/*
+  MyISAM key cache. Allocated eagerly at startup, and close to dead weight
+  here because MariaDB's own system tables are Aria rather than MyISAM, so it
+  is held to a small share of memory and never above the 128M server default.
+*/}}
+{{-   $keyB := min (max (div $memB 32) (mul 8 $mib)) (mul 128 $mib) }}
+
+{{/*
+  Connections and the per-connection buffers behind them. The floor is stock
+  MariaDB's own 151, so the chart is never more restrictive than an untuned
+  server; the ceiling is the 4096 shipped before.
+*/}}
+{{-   $maxConnections := min (max (div $memMi 4) 151) 4096 }}
+
+{{/*
+  tmp_table_size only takes effect up to max_heap_table_size, which the chart
+  does not set and which defaults to 16M, so today this scales a value whose
+  effective ceiling is its own floor. It is derived anyway so that raising
+  max_heap_table_size later is a one-line change rather than a re-derivation,
+  and because the 512M shipped before was inert for exactly the same reason.
+*/}}
+{{-   $tmpTableB := min (max (div $memB 32) (mul 16 $mib)) (mul 512 $mib) }}
+{{-   $readRndB := min (max (div $memB 256) 262144) (mul 16 $mib) }}
+{{-   $tableOpenCache := min (max (mul $memMi 4) 2000) 40714 }}
+
+{{/*
+  Thread counts follow the CPU limit; ceilings are the previously shipped
+  values. Only the IO threads are live today: thread_pool_size applies solely
+  under thread_handling=pool-of-threads, and the chart leaves the server on its
+  default of one-thread-per-connection, so this — like the 24 shipped before —
+  is carried for the day the chart switches rather than for effect now.
+*/}}
+{{-   $threadPoolSize := min (max $cores 1) 24 }}
+{{-   $ioThreads := min (max $cores 2) 12 }}
+
+{{-   dict
+        "bufferPoolSizeMi" (div $poolB $mib)
+        "logFileSizeMi"    (div $logB $mib)
+        "keyBufferSizeMi"  (div $keyB $mib)
+        "tmpTableSizeMi"   (div $tmpTableB $mib)
+        "readRndBufferKi"  (div $readRndB 1024)
+        "maxConnections"   $maxConnections
+        "tableOpenCache"   $tableOpenCache
+        "threadPoolSize"   $threadPoolSize
+        "ioThreads"        $ioThreads
+      | toYaml }}
+{{- end }}

--- a/packages/apps/mariadb/templates/config.yaml
+++ b/packages/apps/mariadb/templates/config.yaml
@@ -1,4 +1,5 @@
 ---
+{{- $tuning := include "mariadb.tuning" $ | fromYaml }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,29 +8,26 @@ data:
   config: |
     [mysqld]
     sql-mode=NO_ENGINE_SUBSTITUTION
-    max_connections=4096
+    max_connections={{ $tuning.maxConnections }}
     default_authentication_plugin=mysql_native_password
     #innodb_buffer_pool_dump_at_shutdown=1
-    innodb_buffer_pool_instances=48
-    innodb_buffer_pool_size=60G
+    innodb_buffer_pool_size={{ $tuning.bufferPoolSizeMi }}M
     innodb_fast_shutdown=0
     innodb_flush_method=O_DIRECT_NO_FSYNC
     innodb_flush_log_at_trx_commit=2
     innodb_io_capacity=10000
     innodb_io_capacity_max=50000
     #innodb_log_buffer_size=128M
-    innodb_log_file_size=4096M
-    #innodb_log_files_in_group=6
-    innodb_thread_concurrency=24
+    innodb_log_file_size={{ $tuning.logFileSizeMi }}M
     join_buffer_size=2M
-    key_buffer_size=1024M
-    read_rnd_buffer_size=16M
+    key_buffer_size={{ $tuning.keyBufferSizeMi }}M
+    read_rnd_buffer_size={{ $tuning.readRndBufferKi }}K
     #sync_binlog=0
-    table_open_cache=40714
+    table_open_cache={{ $tuning.tableOpenCache }}
     table_definition_cache=4000
-    thread_pool_size=24
-    tmp_table_size=512M
+    thread_pool_size={{ $tuning.threadPoolSize }}
+    tmp_table_size={{ $tuning.tmpTableSizeMi }}M
     master_info_repository=TABLE
     relay_log_info_repository=TABLE
-    innodb_read_io_threads=12
-    innodb_write_io_threads=12
+    innodb_read_io_threads={{ $tuning.ioThreads }}
+    innodb_write_io_threads={{ $tuning.ioThreads }}

--- a/packages/apps/mariadb/tests/my_cnf_resource_scaling_test.yaml
+++ b/packages/apps/mariadb/tests/my_cnf_resource_scaling_test.yaml
@@ -1,0 +1,241 @@
+suite: MariaDB my.cnf resource scaling
+
+# The shipped my.cnf used to hardcode sizing for a large bare-metal host —
+# a 60G buffer pool, a 4 GiB redo log, a 1 GiB MyISAM key cache and 4096
+# connections — while the chart defaults to t1.nano (250m CPU / 128Mi RAM)
+# and a 10Gi volume. Every memory allocation and thread count in the file
+# now derives from the instance's own CPU and memory limits, so a small
+# instance asks for memory it actually has and does not preallocate a redo
+# log worth 40% of its default volume.
+
+templates:
+  - templates/config.yaml
+
+tests:
+  - it: renders a single my.cnf ConfigMap
+    release:
+      name: mariadb-test
+      namespace: tenant-test
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+
+  # t1.nano — the chart default: 250m CPU, 128Mi memory, 10Gi volume.
+  - it: sizes every allocation to the instance on the default t1.nano preset
+    release:
+      name: mariadb-test
+      namespace: tenant-test
+    asserts:
+      # 50% of the 128Mi memory limit.
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_buffer_pool_size=64M$
+      # min(buffer pool, 5% of the 10Gi volume) lifted to the 96M server default.
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_log_file_size=96M$
+      # memory/4 lifted to the 151 stock MariaDB default.
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^max_connections=151$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^key_buffer_size=8M$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^tmp_table_size=16M$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^read_rnd_buffer_size=512K$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^table_open_cache=2000$
+      # 250m of CPU must not spawn 24 pool threads.
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^thread_pool_size=1$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_read_io_threads=2$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_write_io_threads=2$
+
+  # The exact values the old hardcoded file shipped. None of them may come
+  # back for a nano instance, whatever the formulas are rewritten to.
+  - it: never emits the hardcoded large-host sizing on a nano instance
+    release:
+      name: mariadb-test
+      namespace: tenant-test
+    asserts:
+      - notMatchRegex:
+          path: data.config
+          pattern: innodb_buffer_pool_size=60G
+      - notMatchRegex:
+          path: data.config
+          pattern: innodb_log_file_size=4096M
+      - notMatchRegex:
+          path: data.config
+          pattern: key_buffer_size=1024M
+      - notMatchRegex:
+          path: data.config
+          pattern: max_connections=4096
+      - notMatchRegex:
+          path: data.config
+          pattern: tmp_table_size=512M
+
+  # innodb_buffer_pool_instances and innodb_thread_concurrency were removed
+  # from the server in 10.6, below the oldest version this chart ships. Both
+  # only produce a "was removed. It does nothing now" warning on every start.
+  - it: omits variables the shipped server versions have removed
+    release:
+      name: mariadb-test
+      namespace: tenant-test
+    asserts:
+      - notMatchRegex:
+          path: data.config
+          pattern: innodb_buffer_pool_instances
+      - notMatchRegex:
+          path: data.config
+          pattern: innodb_thread_concurrency
+
+  # m1.large — 4 CPU, 32Gi memory. Every cap is reached except the redo log,
+  # which the default 10Gi volume holds down to 512M.
+  - it: scales up on a large preset without exceeding the previous ceilings
+    release:
+      name: mariadb-test
+      namespace: tenant-test
+    set:
+      resourcesPreset: m1.large
+    asserts:
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_buffer_pool_size=16384M$
+      # min(16Gi pool, 5% of 10Gi volume) — the volume, not the pool, is the bound.
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_log_file_size=512M$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^max_connections=4096$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^key_buffer_size=128M$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^tmp_table_size=512M$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^read_rnd_buffer_size=16384K$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^table_open_cache=40714$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^thread_pool_size=4$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_read_io_threads=4$
+
+  # An explicit resources block must win over the preset, the same way it
+  # does for the MariaDB CR's own resource stanza.
+  - it: derives sizing from an explicit resources override rather than the preset
+    release:
+      name: mariadb-test
+      namespace: tenant-test
+    set:
+      resourcesPreset: t1.nano
+      resources:
+        cpu: "2"
+        memory: 4Gi
+    asserts:
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_buffer_pool_size=2048M$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_log_file_size=512M$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^max_connections=1024$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^key_buffer_size=128M$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^table_open_cache=16384$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^thread_pool_size=2$
+
+  # The redo log is bounded by the buffer pool and by the volume, and is
+  # never allowed past the 4096M the chart shipped before.
+  - it: caps the redo log at the previously shipped size on a large volume
+    release:
+      name: mariadb-test
+      namespace: tenant-test
+    set:
+      resourcesPreset: m1.large
+      size: 500Gi
+    asserts:
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_log_file_size=4096M$
+
+  # A small volume must hold the redo log down even when memory is plentiful,
+  # so first boot never preallocates a large fraction of the data volume.
+  - it: lets a small volume bound the redo log below the buffer pool
+    release:
+      name: mariadb-test
+      namespace: tenant-test
+    set:
+      resourcesPreset: m1.large
+      size: 4Gi
+    asserts:
+      # 5% of the 4Gi volume is 204M — above the 96M floor and far below the
+      # 16Gi buffer pool, so the volume fraction is the bound that lands.
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_log_file_size=204M$
+
+  # The buffer pool is the one derived value with no upper bound, so an
+  # instance with at least 128Gi of memory is sized above the 60G the chart
+  # hardcoded before. That is the intent — half of a limit the instance has,
+  # rather than a number pinned to the host the old file was written for.
+  - it: sizes the buffer pool past the old hardcoded 60G on the largest presets
+    release:
+      name: mariadb-test
+      namespace: tenant-test
+    set:
+      resourcesPreset: m1.4xlarge
+    asserts:
+      # Half of 256Gi. The old file would have left this instance on 60G.
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_buffer_pool_size=131072M$
+
+  # Settings that are not a memory allocation or a thread count are left
+  # exactly as they were — they encode durability and storage behaviour the
+  # chart cannot derive from the pod's size.
+  - it: leaves behavioural settings untouched
+    release:
+      name: mariadb-test
+      namespace: tenant-test
+    asserts:
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^sql-mode=NO_ENGINE_SUBSTITUTION$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_flush_method=O_DIRECT_NO_FSYNC$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_flush_log_at_trx_commit=2$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_io_capacity=10000$
+      - matchRegex:
+          path: data.config
+          pattern: (?m)^innodb_fast_shutdown=0$


### PR DESCRIPTION
## What this PR does

The chart shipped a my.cnf with sizing hardcoded for a large dedicated host — `innodb_buffer_pool_size=60G`, `innodb_log_file_size=4096M`, `key_buffer_size=1024M`, `max_connections=4096` — while the default preset `t1.nano` gives the pod 250m CPU and 128Mi of memory, and the default volume is 10Gi. Nothing connected the two, so the defaults asked a 128Mi container for a 60G buffer pool and made every first boot preallocate a redo log worth 40% of the volume.

That is not only a slow start. On the current default, MariaDB 10.6 is OOM-killed before it finishes checking its configuration, and on 11.8 the server refuses to start at higher limits with `Cannot map innodb_buffer_pool_size_max`. It survives in practice only because a large node's overcommit heuristics allow the mapping and a small database never touches most of it.

Sizing now derives from the instance's own limits through the same helper that fills `resources` on the CR, so both `resourcesPreset` and an explicit `resources` block work. The buffer pool takes half the memory limit, rounded down to a 128 MiB multiple because InnoDB on the 10.6 line allocates in chunks of that size and rounds requests up — a naive value would hand the pod a pool larger than its own limit. Half rather than the conventional 70-80% because that advice assumes a dedicated host where the remainder is page cache and overshoot means swapping; under a cgroup limit the same budget also has to cover per-connection buffers, temporary tables, the key cache and mysqld's own heap, and overshoot means the kernel kills the process. The redo log follows the smaller of the pool and 5% of the volume, and the remaining allocations scale from memory or CPU with floors at the server's own defaults.

`innodb_buffer_pool_instances` and `innodb_thread_concurrency` are removed rather than scaled: every shipped server version logs that they were removed and now do nothing, so this only drops a startup warning.

Settings that describe durability or disk behaviour rather than instance size — `innodb_flush_log_at_trx_commit`, `innodb_flush_method`, `innodb_io_capacity`, `innodb_fast_shutdown` — are deliberately left alone, since the chart cannot derive them from a pod's resources.

### Upgrade safety

An existing instance has a 4096M redo log and will get a smaller one. Shrinking it was verified on every shipped server version — 10.6.24, 10.11.15, 11.4.9 and 11.8.5 — after both a clean shutdown and a SIGKILL with writes still unflushed. In all cases the server replayed crash recovery first and resized the log afterwards, with data intact by checksum and `CHECK TABLE ... EXTENDED`.

The ConfigMap carries no operator watch label, so a running healthy instance keeps its current sizing until its next restart; an instance already crash-looping on the old values picks the new ones up when it restarts.

### Release note

```release-note
fix(mariadb): size my.cnf from the instance's own CPU, memory and volume instead of hardcoded values that assumed a large dedicated host. Instances on small presets previously advertised `max_connections=4096`, which they could not serve; the limit now scales with memory and starts at the server default of 151.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MariaDB server settings now scale automatically based on CPU, memory, storage, and configured resource limits.
  - Improved buffer pool, redo log, connection, cache, temporary table, and thread sizing across instance presets.
  - Large instances can use buffer pools beyond the previous fixed limit.

- **Bug Fixes**
  - Improved sizing for small-volume deployments.
  - Removed obsolete MariaDB configuration options for improved version compatibility.
  - Explicit resource settings now take precedence over preset values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->