### PR TITLE
test(etcd): stop losing the metrics probe's output to the attach race

### DIFF
--- a/hack/e2e-chainsaw/_lib/etcd-probe.sh
+++ b/hack/e2e-chainsaw/_lib/etcd-probe.sh
@@ -1,0 +1,65 @@
+# shellcheck shell=bash
+# Sourced by the chainsaw etcd Tests after `cd` to the repo root. Provides:
+#   etcd_probe_resolve — recover a throwaway probe Pod's result marker when
+#                        `kubectl run --attach` lost the container's stream
+# Sourcing has no side effects: it defines a function and nothing else. The
+# function itself assigns two `_probe_`-prefixed variables without `local`,
+# which is not POSIX and so unavailable to the `sh` Chainsaw runs these steps
+# under; the prefix is what keeps them from colliding with a caller's names.
+#
+# Why this exists. The metrics contract in
+# hack/e2e-chainsaw/etcd/chainsaw-test.yaml proves the member Pods serve
+# Prometheus metrics over plaintext http by running a one-shot curl Pod and
+# reading a `code=<status>` marker off its output. `kubectl run --attach`
+# establishes the attach connection only after the Pod reaches Running, and a
+# container that exits before that connection is up writes its stdout into the
+# void — the caller gets kubectl's own chatter ("If you don't see a command
+# prompt, try pressing enter.") and no marker. curl against a Pod IP completes
+# in milliseconds, so losing the race is routine, not exotic.
+#
+# The failure that follows is a false negative: the step reports the metrics
+# endpoint as broken on a cluster that was serving 200 throughout. It is also
+# non-deterministic in the way that reads as a flake — whether attach wins
+# depends on Pod startup timing (CNI interface setup and image pull have each
+# been observed adding seconds), so the same suite passes on the next run
+# against identical code.
+#
+# The recovery is that the container's stdout is not actually gone: kubelet
+# wrote it to the Pod's log. So a lost stream is re-read rather than believed.
+# hack/e2e-chainsaw/_lib/talos-image-cache.sh solves the same race inline for
+# the image-cache probe (root cause from the same class of bug); that inline
+# copy is what identified this call site as still carrying the race. This is
+# the extracted, unit-tested form — see hack/etcd-probe_test.bats. It is not
+# yet shared: talos-image-cache.sh still carries its own copy, and folding it
+# onto this helper would need a name that is not etcd-specific.
+#
+# Three conditions make the re-read safe rather than a way to mask real
+# failures. The marker encodes the outcome, so a `code=503` recovered from the
+# log stays a failure. An attach stream that already carried a marker is never
+# second-guessed. And the caller must delete any previous Pod of the same name
+# *and wait for it to be gone* before running the probe, then not pass `--rm`:
+# without the blocking pre-delete the re-read could find a previous
+# incarnation's marker, and `--rm` would destroy the log this recovery reads.
+#
+# Usage:
+#   out=$(etcd_probe_resolve "$attach_output" kubectl -n "$ns" logs "$pod")
+#
+# Returns the attach output when it carries a marker; otherwise the log re-read
+# when that carries one; otherwise the attach output unchanged, so whatever
+# kubectl said about the failure survives into the caller's error message. A
+# failing re-read (evicted or already-collected Pod) is tolerated rather than
+# propagated, so it cannot kill a `set -e` caller before it reports the result.
+etcd_probe_resolve() {
+  _probe_attach_out="$1"
+  shift
+  if printf '%s' "$_probe_attach_out" | grep -q 'code='; then
+    printf '%s' "$_probe_attach_out"
+    return 0
+  fi
+  _probe_log_out="$("$@" 2>/dev/null || true)"
+  if printf '%s' "$_probe_log_out" | grep -q 'code='; then
+    printf '%s' "$_probe_log_out"
+    return 0
+  fi
+  printf '%s' "$_probe_attach_out"
+}

--- a/hack/e2e-chainsaw/etcd/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/etcd/chainsaw-test.yaml
@@ -160,6 +160,8 @@ spec:
         timeout: 3m
         content: |
           set -eu
+          cd ../../..
+          . hack/e2e-chainsaw/_lib/etcd-probe.sh
           sel='app.kubernetes.io/name=etcd,app.kubernetes.io/instance=etcd,app.kubernetes.io/managed-by=etcd-operator'
           mport=$(kubectl -n "$NAMESPACE" get pods -l "$sel" \
             --field-selector=status.phase=Running \
@@ -169,10 +171,33 @@ spec:
             -o jsonpath='{.items[0].status.podIP}')
           [ -n "$mport" ] || { echo "no container port named 'metrics' on member Pod (VMPodScrape would scrape nothing)" >&2; exit 1; }
           [ -n "$pod_ip" ] || { echo "no running member Pod IP found for metrics probe" >&2; exit 1; }
+          # This delete must wait for the Pod to be gone, for two reasons:
+          # `kubectl run` below would otherwise race a still-terminating Pod of
+          # the same name, and the log re-read would have a previous
+          # incarnation's marker to find. Do not give this one --wait=false.
           kubectl -n "$NAMESPACE" delete pod etcd-metrics-probe --ignore-not-found >/dev/null 2>&1
-          probe_out=$(kubectl -n "$NAMESPACE" run etcd-metrics-probe --rm --restart=Never --attach \
+          # No --rm: it deletes the Pod the instant the container exits, taking
+          # with it the log that etcd_probe_resolve re-reads when --attach loses
+          # the stream of a container that finished before the attach connection
+          # was up. Deleted explicitly below once the result is in hand.
+          #
+          # --pod-running-timeout is set rather than left at kubectl's 1m default
+          # because curlimages/curl is not otherwise used on these nodes, so the
+          # probe pays a cold pull; a pull that outruns the budget yields no
+          # marker and fails the step exactly as a broken endpoint would.
+          attach_out=$(kubectl -n "$NAMESPACE" run etcd-metrics-probe --restart=Never --attach \
+            --pod-running-timeout=90s \
             --image=curlimages/curl:8.10.1 \
             --overrides="{\"spec\":{\"securityContext\":{\"runAsNonRoot\":true,\"runAsUser\":1000,\"seccompProfile\":{\"type\":\"RuntimeDefault\"}},\"containers\":[{\"name\":\"c\",\"image\":\"curlimages/curl:8.10.1\",\"command\":[\"sh\",\"-c\",\"curl -fsS -o /dev/null -w code=%{http_code} http://${pod_ip}:${mport}/metrics\"],\"securityContext\":{\"allowPrivilegeEscalation\":false,\"capabilities\":{\"drop\":[\"ALL\"]}}}]}}" 2>&1) || true
+          probe_out=$(etcd_probe_resolve "$attach_out" \
+            kubectl -n "$NAMESPACE" logs etcd-metrics-probe)
+          # Fire-and-forget: the result is already captured, so nothing depends
+          # on the Pod actually being gone before the check below runs. `|| true`
+          # because the step does depend on this command's exit status otherwise
+          # -- under `set -e` a transient API error here would abort with the
+          # result in hand but unreported, and with stderr already suppressed.
+          kubectl -n "$NAMESPACE" delete pod etcd-metrics-probe \
+            --ignore-not-found --wait=false >/dev/null 2>&1 || true
           echo "$probe_out" | grep -q "code=200" || { echo "metrics endpoint did not return 200 over http on the 'metrics' port; got: $probe_out" >&2; exit 1; }
         check:
           ($error == null): true

--- a/hack/etcd-probe_test.bats
+++ b/hack/etcd-probe_test.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Unit tests for the probe-output resolver in
+# hack/e2e-chainsaw/_lib/etcd-probe.sh.
+#
+# The etcd suite proves the member Pods serve Prometheus metrics over plaintext
+# http by running a throwaway curl Pod and reading back a `code=<status>` marker.
+# `kubectl run --attach` is how that marker comes back, and it loses the stream
+# of a container that exits before the attach connection is established -- curl
+# against a Pod IP finishes in milliseconds, so the loss is routine rather than
+# exotic. When it happens the
+# caller sees only kubectl's own chatter ("If you don't see a command prompt,
+# try pressing enter."), reads no marker, and reports the metrics endpoint as
+# broken -- a false negative on a healthy cluster.
+#
+# etcd_probe_resolve is the recovery: the container's stdout is still on disk in
+# the Pod's log, so a lost attach stream is re-read rather than believed. These
+# tests pin that recovery, the pass-through when attach did carry the marker,
+# and the honest surfacing of a genuine non-200 (which must NOT be masked by the
+# fallback -- a real failure has to stay a failure).
+#
+# The resolver is separated from the kubectl orchestration precisely so it can
+# be tested without a cluster; the `kubectl run`/`kubectl logs` calls around it
+# need a live cluster and are covered by the e2e run, matching how the other
+# hack/ helpers are tested.
+#
+# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
+# own line; there is no bats `run` or `$status`, and setup()/teardown() are not
+# honored. Each test runs under `set -eu -x`; assertions are direct shell tests
+# that exit non-zero on failure. Titles are delimited by ASCII double quotes and
+# only [A-Za-z0-9] survives into the generated function name, so keep them
+# distinctive in their alphanumeric run.
+#
+# Run with: hack/cozytest.sh hack/etcd-probe_test.bats
+# -----------------------------------------------------------------------------
+
+HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
+# shellcheck source=/dev/null
+. "$HACK_DIR/e2e-chainsaw/_lib/etcd-probe.sh"
+
+@test "resolver returns the attach output unchanged when it carries the marker" {
+    out="$(etcd_probe_resolve 'code=200' printf 'code=500')"
+    # The fallback must not run at all when attach already delivered a marker:
+    # re-reading the log would be a second source of truth for the same probe.
+    [ "$out" = "code=200" ]
+}
+
+@test "resolver rereads the pod log when the attach stream carried no marker" {
+    lost="If you don't see a command prompt, try pressing enter."
+    out="$(etcd_probe_resolve "$lost" printf 'code=200')"
+    # This is the regression under test: before the fallback existed the lost
+    # stream was reported verbatim as the probe result and failed the suite on a
+    # cluster whose metrics endpoint was serving 200 the whole time.
+    [ "$out" = "code=200" ]
+}
+
+@test "resolver rereads the pod log when the attach stream was entirely empty" {
+    out="$(etcd_probe_resolve '' printf 'code=200')"
+    [ "$out" = "code=200" ]
+}
+
+@test "resolver surfaces a genuine non200 from the attach stream" {
+    # A real failure must survive the resolver untouched. If this ever returns
+    # the fallback's value instead, the fallback has become a way to launder a
+    # broken metrics endpoint into a pass.
+    out="$(etcd_probe_resolve 'code=503' printf 'code=200')"
+    [ "$out" = "code=503" ]
+}
+
+@test "resolver surfaces a genuine non200 recovered from the pod log" {
+    lost="If you don't see a command prompt, try pressing enter."
+    out="$(etcd_probe_resolve "$lost" printf 'code=503')"
+    [ "$out" = "code=503" ]
+}
+
+@test "resolver keeps the lost attach output when the log reread also yields nothing" {
+    # Both sources empty means the probe genuinely produced no marker. Returning
+    # the attach text keeps whatever kubectl said about why in the failure
+    # message, instead of reporting an empty string the reader cannot act on.
+    lost="Error from server: pods etcd-metrics-probe not found"
+    out="$(etcd_probe_resolve "$lost" printf '')"
+    [ "$out" = "$lost" ]
+}
+
+@test "resolver tolerates a failing log reread without aborting the caller" {
+    # `kubectl logs` against an evicted or already-collected Pod exits non-zero.
+    # Under the suite's `set -e` that must not kill the step before it can
+    # report the probe result.
+    lost="If you don't see a command prompt, try pressing enter."
+    out="$(etcd_probe_resolve "$lost" false)"
+    [ "$out" = "$lost" ]
+}


### PR DESCRIPTION
## What this PR does

The etcd suite's metrics contract failed in CI with `metrics endpoint did not return 200 over http on the 'metrics' port; got: If you don't see a command prompt, try pressing enter.`

The probe runs a one-shot curl Pod and reads a `code=<status>` marker back off its output via `kubectl run --rm --restart=Never --attach`. `--attach` only establishes its connection once the Pod reaches Running, so a container that exits in milliseconds — which is what curl against a Pod IP does — writes its stdout into the void, and `--rm` then destroys the Pod carrying the log that still held it. The step reports the metrics endpoint as broken on a cluster that was serving it correctly throughout.

The evidence that this was output loss rather than an endpoint failure is that the captured output contained no `code=` at all. A genuine connection failure would still have printed `code=000` from `-w`, plus curl's own error text from `-fsS`, and both were being captured. Meanwhile the probe Pod's events show a clean run, all three etcd members were up without restarts, and every preceding assert in the suite passed.

The fix drops `--rm`, re-reads the Pod log when the attach stream carried no marker, and deletes the Pod explicitly afterwards. This is the same treatment `hack/e2e-chainsaw/_lib/talos-image-cache.sh` already applies to the identical race — that probe documents it inline; the etcd one was simply never given it. A `--pod-running-timeout` is set for the same reason it is there: the probe image is used nowhere else in the tree, so it pays a cold pull on every run and kubectl's one-minute default was a second way to end up with no marker.

The recovery cannot turn a real failure green. The marker encodes the outcome, so a `code=503` recovered from the log still fails the step; an attach stream that already carried a marker is never second-guessed; and the pre-run delete blocks, so a stale Pod's log cannot be read in place of this run's. Verified by running the probe's exact curl invocation against a 503 and against a dead port: the first yields `code=503`, the second `code=000` plus curl's error, and both fail. The probe still runs exactly once — this is output recovery, not a retry.

Helper extracted to `hack/e2e-chainsaw/_lib/etcd-probe.sh` with unit coverage in `hack/etcd-probe_test.bats`.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved etcd metrics probe reliability by recovering probe results when attached output is incomplete.
  * Preserved meaningful probe and Kubernetes error details, including non-success status codes.
  * Improved probe pod timing and cleanup to reduce intermittent end-to-end test failures.

* **Tests**
  * Added coverage for successful recovery, failed probes, missing output, and log retrieval errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->