### PR TITLE
test(kubernetes): size the e2e tenant apiserver to the chart default

### DIFF
--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -294,7 +294,14 @@ ${ouroboros_addon}
   controlPlane:
     apiServer:
       resources: {}
-      resourcesPreset: small
+      # Chart default (2 CPU / 2Gi), not a smaller override. The legacy "small"
+      # preset caps the tenant apiserver at 512Mi, and a two-node tenant cluster
+      # running the full addon set (cilium, coredns, metrics-server, csi,
+      # ingress-nginx, VPA) opens enough watches to exceed that: the apiserver
+      # is OOMKilled once the workers join, and every in-flight tenant
+      # HelmRelease that is waiting on a DaemonSet rollout burns its whole
+      # timeout while the control plane is restarting.
+      resourcesPreset: c1.medium
     controllerManager:
       resources: {}
       resourcesPreset: micro


### PR DESCRIPTION
## What this PR does

The `kubernetes-previous` suite failed with `timed out waiting for the condition on helmreleases/kubernetes-test-previous-version-csi`, and the reported cause looked like a dependency problem — `csi` waiting on `vsnap-crd`, `coredns` waiting on `cilium`. It was neither. The cluster snapshot taken at failure shows the tenant `kube-apiserver` containers terminated with exit code 137 within about two minutes of each other: one killed for failing its liveness probe as reclaim stalled it, the other OOMKilled outright, both against `limits.memory: 512Mi`.

The e2e fixture pinned the tenant control plane to the legacy `small` preset — 1 CPU and 512Mi — while the chart ships `c1.medium`, 2 CPU and 2Gi, as the default for this field. A two-node tenant cluster running the full addon set opens enough watches to cross 512Mi once the workers join, so the apiserver restarts, and every in-flight HelmRelease that is polling a DaemonSet rollout burns its entire ten-minute budget while the control plane is unavailable. That is why two unrelated releases, `csi` and later `ingress-nginx`, failed with the same signature while the Deployment-based releases that had installed earlier succeeded. The `DependencyNotReady` lines are aggregated first-occurrence events — `vsnap-crd` had in fact installed successfully nine minutes before cilium did.

This is a defect in the fixture rather than in the product: users on defaults get four times the memory. The default was raised deliberately in v0.40.4, "to ensure more reliable operation under higher workloads and prevent resource constraints"; the fixture was left behind on an unexplained downward override. Setting it to the chart default makes the test exercise a control plane sized the way a real one is.

No timeout is widened and no retry is added, since either would hide the cause rather than remove it. The sibling OIDC fixtures keep the smaller preset, correctly — they run a single replica with no workers, where this failure mode cannot occur. Suites are executed serially, so the additional memory applies to one tenant cluster at a time.

What this does not prove is that 2Gi is empirically sufficient; that is the value the chart itself ships, so if it still proves too small, the finding belongs to the product default rather than to this fixture.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Kubernetes test environment’s control plane resource allocation to improve reliability and reduce out-of-memory errors and timeouts.
* **Documentation**
  * Added guidance explaining the resource selection and previous failure conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->