### PR TITLE
chore(packages): drop duplicate test targets

### DIFF
--- a/packages/apps/kafka/Makefile
+++ b/packages/apps/kafka/Makefile
@@ -1,9 +1,6 @@
 include ../../../hack/package.mk
 PRESET_ENUM := ["nano","micro","small","medium","large","xlarge","2xlarge"]
 
-test:
-	helm unittest .
-
 generate:
 	cozyvalues-gen -m 'kafka' -v values.yaml -s values.schema.json -r README.md -g ../../../api/apps/v1alpha1/kafka/types.go
 	../../../hack/update-crd.sh

--- a/packages/apps/mariadb/Makefile
+++ b/packages/apps/mariadb/Makefile
@@ -3,9 +3,6 @@ MARIADB_BACKUP_TAG = $(shell awk '$$1 == "version:" {print $$2}' Chart.yaml)
 include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
 
-test:
-	helm unittest .
-
 generate:
 	cozyvalues-gen -m 'mariadb' -v values.yaml -s values.schema.json -r README.md -g ../../../api/apps/v1alpha1/mariadb/types.go
 	../../../hack/update-crd.sh

--- a/packages/extra/monitoring/Makefile
+++ b/packages/extra/monitoring/Makefile
@@ -6,8 +6,6 @@ include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
 
 .PHONY: test
-test:
-	helm unittest .
 
 generate:
 	cozyvalues-gen -v values.yaml -s values.schema.json -r README.md


### PR DESCRIPTION
## What this PR does

Three package Makefiles — `apps/mariadb`, `apps/kafka` and `extra/monitoring` — declared an identical `test` target twice, so every invocation printed:

```text
Makefile:19: warning: overriding commands for target `test'
Makefile:7: warning: ignoring old commands for target `test'
```

Make names the lines in that warning itself: it was already running the second recipe and discarding the first, so the earlier declaration was dead in each case and removing it changes nothing but the noise. All six recipes were `helm unittest .`.

Which copy is dead is not the same across the three, so this is not a mechanical edit. In `monitoring` the `.PHONY: test` line sits above the *dead* recipe rather than the live one; since `.PHONY` applies to the target name wherever it is declared, the declaration stays and only the recipe beneath it goes.

Default goals are unaffected: `hack/package.mk` sets `.DEFAULT_GOAL=help` and is included ahead of any target in these files, so `test` was never selected by first-target-wins. Confirmed with `make -p --dry-run` before and after, and each package's tests still run — 11, 35 and 9 respectively, with no warnings left.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined build workflows for MariaDB, Kafka, and Monitoring applications.
  * Removed redundant test target definitions while preserving the existing Helm unit test capability.
  * Other generation, update, and image-building workflows remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->