### PR TITLE
fix(opensearch-operator): align DNS_BASE with the platform cluster domain

### DIFF
--- a/packages/core/platform/templates/apps.yaml
+++ b/packages/core/platform/templates/apps.yaml
@@ -18,6 +18,13 @@ metadata:
 type: Opaque
 stringData:
   values.yaml: |
+    global:
+      # Emitted at the top level so Helm propagates it into subcharts via the
+      # reserved `global` key. _cluster (below) is a plain value and reaches only
+      # each package's own templates, so vendored operator subcharts that build
+      # in-cluster FQDNs from it (e.g. opensearch-operator's DNS_BASE) cannot see
+      # it. Keep in sync with _cluster.cluster-domain.
+      clusterDomain: {{ .Values.networking.clusterDomain | quote }}
     _cluster:
       root-host: {{ $rootHost | quote }}
       bundle-name: {{ .Values.bundles.system.variant | quote }}

--- a/packages/system/opensearch-operator/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+++ b/packages/system/opensearch-operator/charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
@@ -76,7 +76,7 @@ spec:
 {{- toYaml .Values.manager.livenessProbe | nindent 10 }}
         env:
         - name: DNS_BASE
-          value: {{ .Values.manager.dnsBase }}
+          value: {{ .Values.global.clusterDomain | default .Values.manager.dnsBase }}
         - name: PARALLEL_RECOVERY_ENABLED
           value: "{{ .Values.manager.parallelRecoveryEnabled }}"
         - name: PPROF_ENDPOINTS_ENABLED

--- a/packages/system/opensearch-operator/patches/leaderElection.diff
+++ b/packages/system/opensearch-operator/patches/leaderElection.diff
@@ -27,3 +27,12 @@ diff --git a/charts/opensearch-operator/templates/opensearch-operator-controller
          {{- if .Values.manager.watchNamespace }}
          - --watch-namespace={{ .Values.manager.watchNamespace }}
          {{- end }}
+@@ -67,7 +67,7 @@
+ {{- toYaml .Values.manager.livenessProbe | nindent 10 }}
+         env:
+         - name: DNS_BASE
+-          value: {{ .Values.manager.dnsBase }}
++          value: {{ .Values.global.clusterDomain | default .Values.manager.dnsBase }}
+         - name: PARALLEL_RECOVERY_ENABLED
+           value: "{{ .Values.manager.parallelRecoveryEnabled }}"
+         - name: PPROF_ENDPOINTS_ENABLED

--- a/packages/system/opensearch-operator/tests/dns_base_test.yaml
+++ b/packages/system/opensearch-operator/tests/dns_base_test.yaml
@@ -1,0 +1,52 @@
+suite: opensearch-operator DNS_BASE follows the platform cluster domain
+
+# The operator builds in-cluster service FQDNs from the DNS_BASE env var — the
+# securityadmin bootstrap job connects to `<svc>.<ns>.svc.<DNS_BASE>` and the
+# OpenSearch Dashboards Deployment points OPENSEARCH_HOSTS at the same suffix.
+# The upstream chart defaults DNS_BASE to cluster.local. Cozystack's cluster
+# domain is configurable (networking.clusterDomain, cozy.local by default), and
+# the platform emits it as `global.clusterDomain` so Helm propagates it into this
+# vendored subchart. DNS_BASE must therefore FOLLOW that value rather than a
+# hardcoded string: pinning a literal would re-break clusters that keep
+# cluster.local (e.g. Cozystack layered on an existing kubeadm/k3s/RKE2), only
+# mirrored. These cases assert the operator tracks the platform domain and falls
+# back to the upstream default when none is set — not that it equals any one
+# domain.
+templates:
+  - charts/opensearch-operator/templates/opensearch-operator-controller-manager-deployment.yaml
+release:
+  name: opensearch-operator
+  namespace: cozy-opensearch-operator
+tests:
+  - it: follows global.clusterDomain when the platform sets it
+    set:
+      global:
+        clusterDomain: example.test
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      # Guard container ordering: kube-rbac-proxy is [0], manager is [1].
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: operator-controller-manager
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: DNS_BASE
+            value: example.test
+      - notContains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: DNS_BASE
+            value: cluster.local
+  - it: falls back to the upstream default when no platform domain is set
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[1].env
+          content:
+            name: DNS_BASE
+            value: cluster.local


### PR DESCRIPTION
## Problem

The OpenSearch operator builds in-cluster service FQDNs from its `DNS_BASE` env var:

- the `securityadmin` bootstrap job connects to `<svc>.<ns>.svc.<DNS_BASE>`
- the OpenSearch Dashboards Deployment points `OPENSEARCH_HOSTS` at the same suffix

The vendored upstream chart defaults `DNS_BASE` to `cluster.local`, and the vendored subchart has no way to learn the actual cluster domain: `_cluster` is a plain value that Helm does not propagate into subcharts, and the wrapper chart's `values.yaml` is not templated.

On a `cozy.local` cluster those names never resolve:

- the `*-securityconfig-update` job loops on `Waiting to connect to the cluster` (`getaddrinfo ENOTFOUND ...svc.cluster.local`), so the `.opendistro_security` index is never created. OpenSearch nodes then fail readiness with `Not yet initialized (you may need to run securityadmin)` and the StatefulSet never reaches Ready.
- OpenSearch Dashboards crash-loop on `[ConnectionError]: getaddrinfo ENOTFOUND ...svc.cluster.local`.

## Fix

Rather than hardcode `cozy.local` (which would mirror the same failure onto clusters that keep `cluster.local`, e.g. Cozystack layered on an existing kubeadm/k3s/RKE2), make the operator **follow the platform's configurable cluster domain**:

- **Platform** emits `global.clusterDomain` (from `networking.clusterDomain`) in the `cozystack-values` Secret. Unlike `_cluster`, Helm's reserved `global` key propagates into subcharts.
- **Operator patch** (extended in `leaderElection.diff`) reads `DNS_BASE` from `.Values.global.clusterDomain`, falling back to the upstream `manager.dnsBase` default (`cluster.local`) when unset, so a bare `helm install` is unchanged.

## Testing

- `helm template` renders `DNS_BASE: cozy.local` on the default install, `cluster.local` when `global.clusterDomain=cluster.local`, and `cluster.local` with no `global` (bare install).
- The helm-unittest suite (`tests/dns_base_test.yaml`) pins that the operator *follows* the platform domain (an arbitrary `example.test` propagates) and falls back to the upstream default — not that it equals any specific string. `helm unittest .` → 2 suites / 4 tests pass.

```release-note
fix(opensearch-operator): resolve DNS_BASE from the platform cluster domain
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - OpenSearch Operator now uses the platform-configured cluster domain for in-cluster service DNS resolution.
  - Added a fallback to `cluster.local` when no custom cluster domain is configured.
  - Improves reliability for security bootstrap and OpenSearch Dashboards configuration in custom-domain environments.

- **Tests**
  - Added coverage verifying both custom cluster domains and the default fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->