### PR TITLE
fix(cert-manager): move the webhook off the kubelet's port

### DIFF
--- a/packages/system/cert-manager/tests/webhook_secure_port_test.yaml
+++ b/packages/system/cert-manager/tests/webhook_secure_port_test.yaml
@@ -1,0 +1,64 @@
+suite: cert-manager webhook secure port
+
+# Keeps the webhook off the kubelet's port. The values.yaml override this
+# guards carries the reasoning; it is not repeated here.
+#
+# The first test is the regression guard: it fails if the override is dropped
+# or if `make update` re-vendors a chart that ignores it, and it asserts the
+# listener flag together with the advertised containerPort so the two cannot
+# drift apart. The other two pin preconditions the fix depends on and already
+# hold on their own — that the port lives in the Pod's network namespace
+# rather than the node's, and that the Service reaches it by name, which is
+# what lets a port change roll out without dropping an endpoint.
+#
+# An upstream rename of the key needs no test: the vendored values.schema.json
+# sets additionalProperties: false, so the override would fail helm outright
+# rather than be silently ignored.
+
+templates:
+  - charts/cert-manager/templates/webhook-deployment.yaml
+  - charts/cert-manager/templates/webhook-service.yaml
+
+release:
+  name: cert-manager
+  namespace: cozy-cert-manager
+
+tests:
+  - it: serves the webhook on 10260, not the kubelet's 10250
+    template: charts/cert-manager/templates/webhook-deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --secure-port=10260
+      - equal:
+          path: spec.template.spec.containers[0].ports[0]
+          value:
+            name: https
+            protocol: TCP
+            containerPort: 10260
+
+  - it: keeps the webhook off the host network, so the port lives in the Pod netns
+    template: charts/cert-manager/templates/webhook-deployment.yaml
+    asserts:
+      # The template emits the key only when the value is truthy, so absence
+      # is the only shape a disabled hostNetwork can take here. isNullOrEmpty
+      # would not do: it fails on a path that does not exist.
+      - notExists:
+          path: spec.template.spec.hostNetwork
+
+  - it: resolves the Service to the webhook container by name, not by number
+    template: charts/cert-manager/templates/webhook-service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].name
+          value: https
+      - equal:
+          path: spec.ports[0].port
+          value: 443
+      - equal:
+          path: spec.ports[0].targetPort
+          value: https

--- a/packages/system/cert-manager/values.yaml
+++ b/packages/system/cert-manager/values.yaml
@@ -7,6 +7,38 @@ cert-manager:
       cpu: 50m
       memory: 128Mi
   webhook:
+    # Upstream defaults securePort to 10250, the port the kubelet serves on.
+    # That default is chosen for GKE private clusters, where apiservers may
+    # reach nodes only on 443 and 10250; it costs nothing there and is unsafe
+    # here. When a connection to the webhook Service resolves to a node IP
+    # rather than a Pod IP, it reaches the kubelet, which completes the TLS
+    # handshake with its node serving certificate, and the apiserver rejects
+    # every cert-manager admission call cluster-wide with "x509: certificate
+    # is valid for <node>, not cert-manager-webhook.cozy-cert-manager.svc".
+    # The certificate is valid — it is simply the wrong server's — so the
+    # error reads as a cert-manager fault and hides the misroute that caused
+    # it. Serving on a port nothing else answers on turns that same misroute
+    # into a connection refusal, which names the real problem. This does not
+    # prevent the misroute; it removes the collision that makes one
+    # catastrophic and misattributed.
+    #
+    # What has to hold for 10260 to be an improvement is that nothing answers
+    # on it in the node's network namespace, since the misroute lands on a
+    # node IP. Nothing does, in either cluster this chart is installed into.
+    # On management nodes the only host-network workload of the kind that
+    # might is local-ccm, which links none of the cloud-provider framework
+    # that binds 10258 and 10260 by default, and binds no TCP port at all.
+    # No cloud-controller-manager runs on a tenant node either: the kubevirt
+    # one does build on that framework, but it is a pod-networked Deployment
+    # in the management cluster, so whatever it binds stays in a Pod's
+    # namespace. Anything host-network added later to either cluster has to
+    # keep clear of the port.
+    #
+    # Under webhook.hostNetwork the webhook itself would join that namespace,
+    # where the clusterwide policy in packages/system/cilium-networkpolicy
+    # denies 10250 from the world but has no entry for 10260. Enabling
+    # hostNetwork means revisiting that policy.
+    securePort: 10260
     resources:
       limits:
         cpu: 200m


### PR DESCRIPTION
## What this PR does

The cert-manager webhook listens on port 10250 — the kubelet's port. When a connection to the webhook Service resolves to a node IP rather than the pod IP, it reaches the kubelet, which answers the TLS handshake with its own node serving certificate. The API server then rejects every cert-manager admission call in the cluster:

```text
failed calling webhook "webhook.cert-manager.io": ... x509: certificate is valid for srv3, not cert-manager-webhook.cozy-cert-manager.svc
```

The certificate is valid — it is simply the kubelet's, issued for the node name. That signature is what separates this from the cainjector failure mode, which reports `certificate signed by unknown authority`; that possibility was checked and ruled out on the run where this was observed. Here it blocked the whole platform bootstrap and pointed the operator at cert-manager rather than at the routing layer.

The value comes straight from the vendored chart, where upstream chose it deliberately for a different constraint: on GKE private clusters the API server may only reach nodes on 443 and 10250. cozystack did not override it.

Moving the webhook to 10260 is upstream's own remedy for this exact error. The cert-manager troubleshooting guide documents the identical signature — under a different cause, EKS Fargate, where each microVM runs a kubelet that already holds 10250 — and prescribes `--set webhook.securePort=10260`.

This does not fix the misroute, whose root cause is still unestablished; the run carries no dataplane state, so candidates such as a stale service map during bootstrap remain unproven. What it removes is the trap that turns a rare, transient misroute into a cluster-wide failure attributed to the wrong component. With the collision gone, the same misroute surfaces as a connection refusal.

The override lives in the package-root values file, which `make update` leaves alone, so it survives re-vendoring.

### Upgrade safety

The rendered webhook Deployment has one replica and no explicit strategy, so the defaults apply: `maxUnavailable` 0 and `maxSurge` 1. The replacement Pod must become Ready before the old one is removed. The Service targets a named port rather than a number, so during the overlap the EndpointSlice controller routes to each Pod on the port it actually serves. There is no window with zero ready endpoints, and no maintenance step is required. Had the Service pinned the port numerically, this upgrade itself would have broken cluster-wide admission.

### Not addressed here

`external-secrets-operator` runs its webhook on 10250 with the same `failurePolicy: Fail`, so it carries the identical exposure and deserves the same treatment; `metrics-server` also uses 10250 but is an APIService rather than an admission webhook. Both are left out to keep this change to one component.

Closes #3355

### Release note

```release-note
fix(cert-manager): move the admission webhook off port 10250, which the kubelet also serves. A connection misrouted to a node answered with the kubelet's certificate, failing every cert-manager admission call cluster-wide with a misleading x509 error.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured the cert-manager webhook to use secure port 10260.
  * Added coverage to verify secure port configuration, HTTPS service routing, and disabled host networking.

* **Documentation**
  * Added configuration comments explaining the secure port selection and its role in avoiding service routing conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->