### PR TITLE
fix(external-secrets): move the webhook off the kubelet's port

### DIFF
--- a/packages/system/external-secrets-operator/Makefile
+++ b/packages/system/external-secrets-operator/Makefile
@@ -3,9 +3,21 @@ export NAMESPACE=cozy-$(NAME)
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	helm repo add external-secrets https://charts.external-secrets.io
 	helm repo update external-secrets
 	helm pull external-secrets/external-secrets --untar --untardir charts
 	rm -rf charts/external-secrets/charts
+	# Upstream already ships the named targetPort as of chart 0.19.1
+	# (external-secrets/external-secrets#5108); the vendored chart predates
+	# it, so the patch carries the same one-line change until the chart is
+	# bumped past that release. --forward matters here: against a chart that
+	# already has the named form, patch(1) would silently reverse the hunk
+	# and exit 0, quietly restoring the numeric form. With it, an
+	# already-applied patch fails loudly instead — the signal to drop both
+	# the patch and this block.
+	patch --no-backup-if-mismatch --forward -p4 < patches/webhook-service-named-target-port.patch

--- a/packages/system/external-secrets-operator/charts/external-secrets/templates/webhook-service.yaml
+++ b/packages/system/external-secrets-operator/charts/external-secrets/templates/webhook-service.yaml
@@ -23,7 +23,7 @@ spec:
   {{- end }}
   ports:
   - port: 443
-    targetPort: {{ .Values.webhook.port }}
+    targetPort: webhook
     protocol: TCP
     name: webhook
   {{- if .Values.webhook.metrics.service.enabled }}

--- a/packages/system/external-secrets-operator/patches/webhook-service-named-target-port.patch
+++ b/packages/system/external-secrets-operator/patches/webhook-service-named-target-port.patch
@@ -1,0 +1,28 @@
+# Upstream renders the webhook Service's targetPort from webhook.port as a
+# number. A numeric targetPort is copied into every endpoint regardless of
+# what each Pod actually listens on, so changing webhook.port aims the
+# Service at a port the outgoing Pod does not serve until its replacement
+# passes readiness — rejecting admission for externalsecrets, secretstores
+# and clustersecretstores, and breaking CRD conversion, which routes through
+# the same Service. A named targetPort is resolved per-Pod by the
+# EndpointSlice controller, so old and new Pods are each reached on the port
+# they serve and the rollout has no gap.
+#
+# The containerPort is already named "webhook" upstream, and the metrics port
+# in this same Service already uses its name, so this only makes the webhook
+# port consistent with its neighbour. It belongs upstream; until it lands
+# there, values.yaml depends on this patch to change webhook.port safely.
+#
+diff --git a/packages/system/external-secrets-operator/charts/external-secrets/templates/webhook-service.yaml b/packages/system/external-secrets-operator/charts/external-secrets/templates/webhook-service.yaml
+index 59dbddc95..4c98cbcf0 100644
+--- a/packages/system/external-secrets-operator/charts/external-secrets/templates/webhook-service.yaml
++++ b/packages/system/external-secrets-operator/charts/external-secrets/templates/webhook-service.yaml
+@@ -23,7 +23,7 @@ spec:
+   {{- end }}
+   ports:
+   - port: 443
+-    targetPort: {{ .Values.webhook.port }}
++    targetPort: webhook
+     protocol: TCP
+     name: webhook
+   {{- if .Values.webhook.metrics.service.enabled }}

--- a/packages/system/external-secrets-operator/tests/webhook_port_test.yaml
+++ b/packages/system/external-secrets-operator/tests/webhook_port_test.yaml
@@ -1,0 +1,115 @@
+suite: external-secrets webhook port
+
+# Keeps the webhook off the kubelet's port. The values.yaml override and
+# patches/webhook-service-named-target-port.patch carry the reasoning; it is
+# not repeated here.
+#
+# Two of these are regression guards. The first pins the listener flag and
+# the advertised containerPort; the second pins the Service to the container
+# port *name*, which is what lets the port move without dropping traffic —
+# carried as a vendored patch here, and upstream's own shape since chart
+# 0.19.1 (external-secrets/external-secrets#5108), so it survives a future
+# chart bump unchanged. This chart's values.schema.json sets no
+# additionalProperties: false, so an upstream rename of webhook.port is
+# accepted and silently ignored rather than failing helm — these tests are
+# the only thing between a re-vendored chart and a silent revert to 10250.
+#
+# The rest pin preconditions that already hold and that the reasoning in
+# values.yaml depends on: that the port lives in the Pod's network namespace
+# rather than the node's, that admission fails closed, and that CRD
+# conversion routes through the same Service the port change moves.
+
+templates:
+  - charts/external-secrets/templates/webhook-deployment.yaml
+  - charts/external-secrets/templates/webhook-service.yaml
+  - charts/external-secrets/templates/validatingwebhook.yaml
+  - charts/external-secrets/templates/crds/externalsecret.yaml
+
+release:
+  name: external-secrets-operator
+  namespace: cozy-external-secrets-operator
+
+tests:
+  - it: serves the webhook on 10260, not the kubelet's 10250
+    template: charts/external-secrets/templates/webhook-deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --port=10260
+      - contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 10260
+            protocol: TCP
+            name: webhook
+
+  - it: reaches the webhook by container-port name, so the port can move without a traffic gap
+    template: charts/external-secrets/templates/webhook-service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].port
+          value: 443
+      # A name, not a number. The vendored chart renders targetPort from
+      # webhook.port, which every endpoint then shares regardless of what its
+      # Pod actually listens on; the named form makes the EndpointSlice
+      # controller resolve it per-Pod instead. Applied by the vendored patch
+      # here and shipped by upstream since chart 0.19.1. If this ever reverts
+      # to an integer, a future port change silently reintroduces the gap.
+      - equal:
+          path: spec.ports[0].targetPort
+          value: webhook
+      - equal:
+          path: spec.ports[0].name
+          value: webhook
+
+  - it: keeps the webhook off the host network, so the port lives in the Pod netns
+    template: charts/external-secrets/templates/webhook-deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.hostNetwork
+          value: false
+
+  - it: fails admission closed, which is what makes a misroute cluster-wide
+    template: charts/external-secrets/templates/validatingwebhook.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: ValidatingWebhookConfiguration
+      - equal:
+          path: metadata.name
+          value: externalsecret-validate
+      - equal:
+          path: webhooks[0].failurePolicy
+          value: Fail
+
+  - it: leaves the secretstore webhooks on the apiserver's default failurePolicy of Fail
+    template: charts/external-secrets/templates/validatingwebhook.yaml
+    documentIndex: 0
+    asserts:
+      - equal:
+          path: metadata.name
+          value: secretstore-validate
+      # These two carry no explicit failurePolicy and inherit Fail from the
+      # apiserver. Asserting absence pins that: an upstream addition of
+      # "Ignore" here would quietly widen the blast radius reasoning in
+      # values.yaml without any other test noticing.
+      - notExists:
+          path: webhooks[0].failurePolicy
+      - notExists:
+          path: webhooks[1].failurePolicy
+
+  - it: routes CRD conversion through the same Service, so the port change reaches it too
+    template: charts/external-secrets/templates/crds/externalsecret.yaml
+    asserts:
+      - isKind:
+          of: CustomResourceDefinition
+      - equal:
+          path: spec.conversion.strategy
+          value: Webhook
+      - equal:
+          path: spec.conversion.webhook.clientConfig.service.name
+          value: external-secrets-operator-webhook

--- a/packages/system/external-secrets-operator/values.yaml
+++ b/packages/system/external-secrets-operator/values.yaml
@@ -2,3 +2,61 @@ external-secrets:
   bitwarden-sdk-server:
     enabled: false  
   installCRDs: true
+  webhook:
+    # Upstream defaults this to 10250, the port the kubelet serves on. When a
+    # connection to the webhook Service resolves to a node IP rather than a
+    # Pod IP, it reaches the kubelet, which completes the TLS handshake with
+    # its node serving certificate, and the apiserver rejects the call with
+    # "x509: certificate is valid for <node>, not
+    # external-secrets-operator-webhook.cozy-external-secrets-operator.svc".
+    # The certificate is valid — it is simply the wrong server's — so the
+    # error reads as a PKI fault and hides the misroute that caused it. This
+    # does not prevent the misroute; it moves the listener to a port nothing
+    # else answers on, so the same misroute surfaces as a connection refusal
+    # that names the real problem.
+    #
+    # 10250 is not an accident upstream, and the reason is worth stating
+    # before overriding it. cert-manager's chart spells out why charts pick
+    # it: in GKE private clusters the apiserver may reach nodes only on 443
+    # and 10250, so 10250 works there without extra firewall rules. That is a
+    # property of a managed platform's node firewall, not of Kubernetes. This
+    # package is installed into the management cluster only, so the caller is
+    # always that cluster's apiserver, and on cozystack's own substrates —
+    # Talos, generic k3s, kubeadm — nothing filters it from a Pod port. The
+    # exception to check is the hosted variant (cozystackOperator.variant:
+    # hosted, bundle isp-hosted), which exists to run on managed control
+    # planes, EKS and GKE among them. Its stock preset does not render this
+    # package and the package is opt-in besides, so reaching the bad
+    # combination takes enabling both deliberately — but on a platform that
+    # restricts apiserver egress this override is wrong and should be
+    # dropped.
+    #
+    # The replacement port only helps if nothing answers on it in the node's
+    # network namespace, since that is where the misroute lands. That rules
+    # out 9443, the controller-runtime default and the number most webhooks
+    # here use: the etcd kube-rbac-proxy binds it on host-network, as
+    # packages/system/cilium-networkpolicy records, so 9443 would swap the
+    # kubelet's certificate for that proxy's and reproduce the same misleading
+    # error. Nothing in this repo binds 10260. It is
+    # CloudControllerManagerWebhookPort in k8s.io/cloud-provider, worth
+    # remembering if a host-network workload here ever links that framework.
+    # Neither cloud-controller-manager present does today: local-ccm does run
+    # host-network, but it is a bespoke binary whose flags carry no webhook or
+    # secure-port listener, and the kubevirt one is a pod-networked
+    # Deployment, so whatever it binds stays in a Pod namespace.
+    #
+    # Under webhook.hostNetwork the webhook would itself join the node
+    # namespace, where the clusterwide policy in cilium-networkpolicy denies
+    # 10250 from the world but has no entry for 10260 — enabling hostNetwork
+    # means revisiting that policy.
+    #
+    # Moving this port is only safe because patches/ points the Service at the
+    # "webhook" container-port name. Upstream renders targetPort from this
+    # value as a number, which every endpoint shares regardless of what its
+    # Pod listens on, so a port change would leave the Service aimed at a port
+    # the outgoing Pod does not serve until the replacement passes readiness —
+    # rejecting admission for externalsecrets, secretstores and
+    # clustersecretstores, and breaking CRD conversion, which routes through
+    # the same Service. A named targetPort resolves per-Pod and closes that
+    # window. See patches/webhook-service-named-target-port.patch.
+    port: 10260


### PR DESCRIPTION
## What this PR does

The external-secrets webhook listens on port 10250 — the kubelet's port — with `failurePolicy: Fail`. This is the same trap being removed from cert-manager in #3359: a connection to the webhook Service that resolves to a node IP instead of the pod IP reaches the kubelet, which completes the handshake with its own node serving certificate, and the API server rejects the call with an x509 error that blames the webhook's PKI rather than the routing layer. The port collision does not cause the misroute; it turns a rare transient one into a confidently misattributed failure.

The blast radius here is wider than admission alone: `crds.conversion.enabled` defaults to true and points every ExternalSecret CRD's conversion webhook at the same Service, so a misrouted connection also breaks CRD conversion — reads at non-storage versions, not just writes.

The webhook moves to 10260, matching #3359. The controller-runtime default 9443 was considered and rejected: the etcd kube-rbac-proxy binds it on host network, which would reproduce exactly the same wrong-certificate failure with a different certificate. Nothing in the tree binds 10260.

Unlike cert-manager, the upstream chart's Service targets the port numerically — `targetPort: {{ .Values.webhook.port }}` — and a numeric targetPort is copied into every endpoint verbatim rather than resolved per pod. With one replica, a port change would direct traffic at a port the still-running old pod does not serve while the replacement is not yet Ready, failing every admission and conversion call in the gap; surge-first rollout does not help because both pods sit behind the same number. A one-line vendored-chart patch points the Service at the `webhook` container-port name upstream already declares (the metrics port in the same Service is already named), which closes the gap: during the overlap each pod is routed on the port it actually serves. The patch is applied by `make update` with `--forward`, so an already-applied hunk fails loudly instead of being silently reversed. Upstream has already made the same change — merged as external-secrets/external-secrets#5108 and shipped since chart 0.19.1 — but the vendored chart here is 0.10.4, nine minor releases earlier, so the patch carries the fix until the chart is bumped past that point. The `--forward` guard is exactly what will flag that moment: on a bumped chart the patch fails loudly, signalling it should be dropped.

external-secrets-operator ships disabled by default and is enabled per-cluster via `bundles.enabledPackages`, so this is defensive hardening for opt-in installs rather than a response to an observed incident.

`metrics-server` is a third instance of the same port collision, left out here: it serves an APIService rather than an admission webhook, a lesser failure class deserving its own change.

### Release note

```release-note
fix(external-secrets): move the webhook off port 10250, which the kubelet also serves, and make its Service target the port by name so the move rolls out without an admission gap
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook Service routing by switching to the named `targetPort` (`webhook`) for pod traffic.
  * Configured the webhook listener to run on port **10260** to avoid prior connection/TLS certificate misrouting issues.
  * Preserved admission validation behavior and CRD conversion routing.
* **Tests**
  * Added Helm chart regression tests covering webhook port wiring, networking settings, failure policy behavior, and CRD conversion.
* **Chores**
  * Added Helm chart unit testing to the development workflow and extended the chart update process to apply the webhook routing adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
