### PR TITLE
fix(metrics-server): move the listener off the kubelet's port

### DIFF
--- a/packages/system/metrics-server/Makefile
+++ b/packages/system/metrics-server/Makefile
@@ -3,6 +3,9 @@ export NAMESPACE=cozy-monitoring
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/

--- a/packages/system/metrics-server/tests/container_port_test.yaml
+++ b/packages/system/metrics-server/tests/container_port_test.yaml
@@ -1,0 +1,84 @@
+suite: metrics-server container port
+
+# Keeps metrics-server's own listener off 10250, the port it scrapes kubelets
+# on. The values.yaml override this guards carries the reasoning; it is not
+# repeated here.
+#
+# The first test is the regression guard. The vendored chart ships no
+# values.schema.json, so an upstream rename of `containerPort` is accepted and
+# silently ignored rather than failing helm — this test is the only thing
+# between a re-vendored chart and a silent return to 10250.
+#
+# The rest pin preconditions the fix depends on and that already hold on their
+# own: that the port lives in the Pod's network namespace rather than the
+# node's, and that the Service and both probes reach it by name rather than by
+# number, which is what lets the number move without anything else having to
+# be taught to follow it. `make update` re-vendors this chart wholesale, so
+# these are the regression surface for that too.
+
+templates:
+  - charts/metrics-server/templates/deployment.yaml
+  - charts/metrics-server/templates/service.yaml
+
+release:
+  name: metrics-server
+  namespace: cozy-monitoring
+
+tests:
+  - it: serves on 4443, not 10250, the port it scrapes kubelets on
+    template: charts/metrics-server/templates/deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --secure-port=4443
+      - equal:
+          path: spec.template.spec.containers[0].ports[0]
+          value:
+            name: https
+            protocol: TCP
+            containerPort: 4443
+
+  # Also a tripwire: enabling hostNetwork here trips this test, which is the
+  # intended prompt to go and add 4443 to the clusterwide policy in
+  # packages/system/cilium-networkpolicy before the listener joins the node's
+  # namespace. See the reasoning in values.yaml.
+  - it: keeps metrics-server off the host network, so the port lives in the Pod netns
+    template: charts/metrics-server/templates/deployment.yaml
+    asserts:
+      # The template emits the key only when hostNetwork.enabled is truthy, so
+      # absence is the only shape a disabled hostNetwork can take here.
+      # isNullOrEmpty would not do: it fails on a path that does not exist.
+      - notExists:
+          path: spec.template.spec.hostNetwork
+
+  - it: reaches the container by port name, so the port can move without a traffic gap
+    template: charts/metrics-server/templates/service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.ports[0].name
+          value: https
+      - equal:
+          path: spec.ports[0].port
+          value: 443
+      # A name, not a number. A numeric targetPort is copied into every
+      # endpoint regardless of what each Pod actually listens on, which would
+      # aim the Service at a port the outgoing Pod does not serve until its
+      # replacement passes readiness. Upstream already names it here; if that
+      # ever regresses to an integer, moving the port reintroduces that gap.
+      - equal:
+          path: spec.ports[0].targetPort
+          value: https
+
+  - it: probes the container by port name, so a port change cannot strand readiness
+    template: charts/metrics-server/templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: https
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: https

--- a/packages/system/metrics-server/values.yaml
+++ b/packages/system/metrics-server/values.yaml
@@ -1,4 +1,63 @@
 metrics-server:
+  # Upstream defaults this to 10250 — the kubelet's port, and the port
+  # metrics-server itself scrapes every kubelet on.
+  #
+  # That default makes hostNetwork unusable. The chart offers
+  # hostNetwork.enabled for clusters whose apiserver cannot reach Pod IPs, but
+  # enabling it at the default puts metrics-server in the node's namespace
+  # where the kubelet already holds 10250, and the process exits with "bind:
+  # address already in use". Upstream has had this reported
+  # (kubernetes-sigs/metrics-server#1026) and kept the default anyway, on the
+  # view that hostNetwork is non-standard here and that those users can set a
+  # port themselves. This is that port, picked before the need rather than
+  # after it.
+  #
+  # It also removes a collision that would make a misrouted connection hard to
+  # read. Were a connection to the metrics-server Service to arrive at a node
+  # IP instead of a Pod IP, it would reach the kubelet, listening on the same
+  # number. Nothing here establishes that this happens — with pod-networked
+  # endpoints there is no ordinary path to it — so this is not the fix for a
+  # known routing bug. It only decides how such a misroute would present: as a
+  # connection refusal, rather than as a rejection from an unexpected daemon.
+  # That distinction is sharper here than for a webhook, because this chart's
+  # APIService sets insecureSkipTLSVerify, so the aggregation layer never
+  # checks whose certificate it received and nothing in the resulting error
+  # would name the mismatch.
+  #
+  # What the override gives up is worth stating. Upstream moved to 10250 so
+  # metrics-server would be covered by the firewall rules most clusters
+  # already have between control plane and nodes, and work without new ones. A
+  # substrate permitting only 443 and 10250 to nodes therefore needs this
+  # value reconsidered. Cozystack's own — Talos, k3s, kubeadm — do not filter
+  # it, but this package also ships into every tenant cluster and no e2e
+  # exercises the metrics API, so a wrong guess here would first surface as a
+  # user's HPA quietly not scaling, or as the dashboard's cluster-usage view
+  # going blank.
+  #
+  # 4443 is the value upstream's manifests carried through v0.6.4, before
+  # v0.7.0 shipped 10250, so it is a number already associated with this
+  # component. It sits clear of the 10248-10259 block the node components
+  # occupy, and nothing in this repo binds it.
+  #
+  # Under hostNetwork this listener joins the node's namespace, where the
+  # clusterwide policy in packages/system/cilium-networkpolicy denies 10250
+  # from the world but has no entry for 4443. That matters more than it would
+  # elsewhere, because metrics.enabled below makes the chart add
+  # --authorization-always-allow-paths=/metrics, leaving that one path
+  # unauthenticated. What it exposes is metrics-server's own scrape
+  # instrumentation, not the resource data, which stays behind the
+  # authenticated aggregated API — but enabling hostNetwork still means adding
+  # 4443 to that policy first rather than opening it on every node IP.
+  #
+  # Every reference to the port inside the chart is by name — the Service's
+  # targetPort and both probes — so the number moves without aiming any
+  # endpoint at a port its Pod does not serve. (The ServiceMonitor names the
+  # Service port rather than this one, so it is unaffected either way.)
+  # tests/container_port_test.yaml pins that and the value itself: the
+  # vendored chart ships no values.schema.json, so an upstream rename of this
+  # key would be silently ignored rather than failing helm.
+  containerPort: 4443
+
   defaultArgs:
     - --cert-dir=/tmp
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname


### PR DESCRIPTION
## What this PR does

metrics-server is the third component serving on port 10250 — the kubelet's port — after the webhooks addressed in #3359 and #3360. It ships default-enabled in the platform bundle and is also installed into every tenant Kubernetes cluster with no value overrides, so a package-root override propagates to both.

The hard defect here is different from the webhook cases. The chart has first-class `hostNetwork.enabled` support, documented upstream for clusters where the API server cannot reach pod IPs — and on the default port that mode cannot start at all: the kubelet already holds 10250, so the process dies with `bind: address already in use`. Upstream is aware (kubernetes-sigs/metrics-server#1026 carries the exact panic) and declined to change the chart default, advising hostNetwork users to set their own port. This override is that port, set ahead of need.

The misleading-certificate angle of the sibling fixes mostly does not apply: the chart defaults `apiService.insecureSkipTLSVerify` to true, so a connection misrouted to a node would fail silently rather than with a wrong-certificate error — and with endpoints resolving to pod IPs such a misroute is not established to occur here at all. The comment states that as a hypothesis, not a fact. What is factual is the consumer set: `kubectl top`, tenant HPAs, and the console's cluster-usage page all read `metrics.k8s.io`; the shipped VPA does not — it is configured with Prometheus storage.

The port is 4443 rather than the siblings' 10260, for a reason worth keeping: metrics-server is the one component of the three with supported hostNetwork, and parking it on 10260 would put a live host-network listener on exactly the port the webhook fixes rely on being silent — turning their honest connection refusals back into answered handshakes. 4443 is the value metrics-server's own manifests shipped through v0.6.4, before v0.7.0 moved them to 10250; it sits outside the 10248-10259 node-component block, and nothing in the tree binds it.

No chart patch is needed: the Service, both probes and the ServiceMonitor already reference the port by name, so the rollout-gap that required a vendored patch in #3360 does not exist here. The package also gains the standard `test:` target it was missing.

Not verified without a cluster: that the aggregated APIService stays Available through an upgrade, and that no supported substrate filters 4443 inbound on nodes — the tree configures no host firewall, but Talos and managed substrates are outside what a render can prove. There is no e2e coverage of `metrics.k8s.io` at all; a wrong guess here would surface as HPAs silently not scaling.

### Release note

```release-note
fix(metrics-server): move the listener off port 10250, which the kubelet also holds. The default made hostNetwork mode unable to start at all, and the new port keeps node-port collisions out of the metrics path.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configured the metrics server to listen on secure port 4443.
  * Updated service routing and health checks to use the named HTTPS port, improving reliability when port settings change.
  * Ensured pod networking does not rely on host networking.

* **Tests**
  * Added automated chart tests covering container ports, service routing, and liveness/readiness probes.
  * Added a test command for running the chart test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->