### PR TITLE
ci(labeler): map cert-manager, external-secrets and metrics-server scopes

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -85,6 +85,7 @@ jobs:
 
               // area/monitoring
               'monitoring':          'area/monitoring',
+              'metrics-server':      'area/monitoring',
               'vlogs':               'area/monitoring',
               'vmstack':             'area/monitoring',
               'grafana':             'area/monitoring',
@@ -104,6 +105,8 @@ jobs:
 
               // area/platform
               'platform':            'area/platform',
+              'cert-manager':        'area/platform',
+              'external-secrets':    'area/platform',
               'bundle':              'area/platform',
               'flux':                'area/platform',
               'fluxcd':              'area/platform',


### PR DESCRIPTION
## What this PR does

PRs titled with the `cert-manager`, `external-secrets` or `metrics-server` scopes landed on `area/uncategorized` because the labeler's scope map had no entry for them — all three surfaced at once in the current port-collision series (#3359, #3360, #3361). metrics-server feeds the monitoring pipeline, so it maps to `area/monitoring`; cert-manager and external-secrets are platform services, so they map to `area/platform`.

### Release note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved pull request labeling automation.
  - Pull requests involving metrics, certificate management, and external secrets are now categorized more accurately with the appropriate area labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->