### PR TITLE
fix(keycloak-configure): patch HelmRelease in release namespace on teardown

### DIFF
--- a/packages/system/keycloak-configure/templates/delete.yaml
+++ b/packages/system/keycloak-configure/templates/delete.yaml
@@ -39,7 +39,7 @@ spec:
                   done
                 done
 
-                kubectl patch hr keycloak-configure -n cozy-system --type=merge -p '{"metadata":{"finalizers":[]}}'
+                kubectl patch hr {{ .Release.Name }} -n {{ .Release.Namespace }} --type=merge -p '{"metadata":{"finalizers":[]}}'
 
 
 ---

--- a/packages/system/keycloak-configure/tests/delete_test.yaml
+++ b/packages/system/keycloak-configure/tests/delete_test.yaml
@@ -1,0 +1,58 @@
+suite: flux teardown job patches the HelmRelease in the release namespace
+
+# The pre-delete teardown Job clears the HelmRelease finalizers as its last
+# step. Its RBAC (Role + RoleBinding, resourceNames: [.Release.Name]) is created
+# in .Release.Namespace, so the kubectl patch MUST target that same namespace and
+# release name. A hardcoded namespace that differs from the install namespace
+# makes the ServiceAccount Forbidden to patch the HelmRelease, the Job retries
+# forever, and the Helm release wedges in "uninstalling".
+release:
+  name: keycloak-configure
+  namespace: cozy-keycloak
+tests:
+  - it: teardown patches the HelmRelease using the release name and namespace
+    template: templates/delete.yaml
+    documentSelector:
+      path: kind
+      value: Job
+    set:
+      _cluster:
+        root-host: example.com
+        kube-root-ca: ""
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: kubectl patch hr keycloak-configure -n cozy-keycloak
+
+  - it: teardown never targets a namespace other than the release namespace
+    template: templates/delete.yaml
+    documentSelector:
+      path: kind
+      value: Job
+    set:
+      _cluster:
+        root-host: example.com
+        kube-root-ca: ""
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: patch hr \S+ -n cozy-system
+
+  # Prove the patch is parameterized on .Release.Name / .Release.Namespace
+  # rather than matching the default install namespace by coincidence.
+  - it: teardown tracks a non-default release name and namespace
+    template: templates/delete.yaml
+    documentSelector:
+      path: kind
+      value: Job
+    release:
+      name: custom-release
+      namespace: custom-ns
+    set:
+      _cluster:
+        root-host: example.com
+        kube-root-ca: ""
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: kubectl patch hr custom-release -n custom-ns


### PR DESCRIPTION
## What this PR does

The `keycloak-configure` pre-delete teardown Job clears the Flux `HelmRelease` finalizers as its final step so the release can be uninstalled. That final `kubectl patch` targeted a hardcoded namespace that does not match where the release actually installs. The release installs into `cozy-keycloak`, and the teardown Job's own RBAC — a `Role` + `RoleBinding` granting `patch` on the `HelmRelease` by release name — is created in the release namespace, but the patch was aimed at `cozy-system`.

The result is a deadlock: the Job's `ServiceAccount` is `Forbidden` to patch the `HelmRelease` in the mismatched namespace, so the Job errors and retries forever, the `HelmRelease` sticks in `Terminating`, and the Helm release wedges in status `uninstalling`. This blocks any teardown or reinstall of the component.

The fix templates both the release name and the namespace from `{{ .Release.Name }}` / `{{ .Release.Namespace }}`, so the patch targets the namespace where the `HelmRelease` lives and where the teardown RBAC grants access. I also added a helm-unittest that pins the rendered target, guards against the hardcoded namespace regressing, and asserts the patch tracks the release name and namespace.

### Screenshots

N/A — no UI changes.

### Release note

```release-note
fix(keycloak-configure): fix the pre-delete teardown Job so uninstalling the release no longer wedges — it now patches the HelmRelease in the release namespace instead of a hardcoded one
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Helm chart deletion cleanup to patch the correct HelmRelease using the chart’s release name and namespace instead of fixed values.
  - Reduced risk of teardown targeting resources in an unintended namespace.
- **Tests**
  - Added a new delete/teardown YAML test suite to verify correct parameterization and that only the intended namespace is modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->