### PR TITLE
docs(agents): widen overview.md routing and condense activation rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,9 +22,9 @@ This file provides structured guidance for AI coding assistants and agents worki
   - Read: [`image-refs.md`](./docs/agents/image-refs.md)
   - Action: Read the entire file. Image refs live in three storage shapes and carry three classes of tag; a tool that knows only one shape skips images silently rather than failing. `hack/lib/image-refs.sh` is the enumeration shared by the promote, retag and mirror tooling — extend it there rather than teaching an individual script a new path. Note `hack/overlay-main-images.sh` is a fourth consumer that still walks the tree itself and does not source the library
 
-- **Project structure, conventions, code layout** (e.g., "where should I put X", "what's the convention for Y", "how is the project organized")
+- **Go code, Helm charts, build and test commands, project structure** (e.g., "add a field to this CRD", "fix this controller", "add a value to the postgres chart", "regenerate the values schema", "how do I build/test this", "where should I put X", "what's the convention for Y", "how is the project organized")
   - Read: [`overview.md`](./docs/agents/overview.md)
-  - Action: Read relevant sections to understand project structure and conventions
+  - Action: Read the section that matches — `Go Code` (controller-runtime patterns, kubebuilder markers), `Helm Charts` (umbrella pattern, vendored upstream charts), `Values schema generation`, `Build and Development Commands`, `Testing`, `Package Structure`
 
 - **E2E tests and E2E CI** (e.g., "write/fix an e2e test", "stabilize a flaky test", "add a bats test", "change the e2e workflow", "why did e2e fail")
   - Read: [`e2e-testing.md`](./docs/agents/e2e-testing.md)
@@ -42,13 +42,9 @@ This file provides structured guidance for AI coding assistants and agents worki
   - PR titles: a Conventional Commits header (`type(scope): description`, types from [`contributing.md`](./docs/agents/contributing.md)) auto-applies `kind/*` and `area/*` via `.github/workflows/pr-labeler.yaml`. Append `!` (or add a `BREAKING CHANGE:` footer) to apply `kind/breaking-change`
 
 **Important rules:**
-- ✅ **ONLY read the file if the task matches the documented process scope** - do not read files for tasks that don't match their purpose
-- ✅ **ALWAYS read the file FIRST** before starting the task (when applicable)
-- ✅ **Follow instructions EXACTLY** as written in the documentation
-- ✅ **Do NOT skip mandatory steps** (especially in changelog.md)
-- ✅ **Do NOT assume** you know the process - always check the documentation when the task matches
-- ❌ **Do NOT read files** for tasks that are outside their documented scope
-- 📖 **Note**: [`overview.md`](./docs/agents/overview.md) can be useful as a reference to understand project structure and conventions, even when not explicitly required by the task
+- **Match scope, then read first.** Load a process file only when the task genuinely falls in its scope, and load it before starting work — not midway through. Tasks outside a file's scope should not pull it into context.
+- **Follow it exactly.** Do not assume you already know the process, and do not skip steps (`changelog.md` especially). Where the documentation and your instinct disagree, the documentation wins.
+- **[`overview.md`](./docs/agents/overview.md) is the standing reference** for structure and conventions, useful even when no route above points at it.
 
 ## Project Overview
 


### PR DESCRIPTION
## What this PR does

`AGENTS.md` routes an agent to a documentation file based on how a request is phrased. Two things were wrong with that routing.

The `overview.md` route listed only structural triggers — "where should I put X", "what's the convention for Y", "how is the project organized". Go, Helm chart and build/test work matched none of them, so an agent asked to add a field to a CRD, fix a controller, add a value to a chart or regenerate a values schema reached no documentation at all — even though `overview.md` already covers every one of those under `Go Code`, `Helm Charts`, `Values schema generation`, `Build and Development Commands` and `Package Structure`. This widens the trigger phrases to the work agents actually get asked to do and names the sections to land in. No new documentation is added here: the content already existed, it was just unreachable from the router.

The activation rule list spent seven bullets on three rules. Bullets 1 and 6 stated the same scope constraint, once positively and once negatively; bullets 3, 4 and 5 each said "follow the documentation exactly" in different words. Condensed to three bullets, with no instruction dropped.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff rather than the title. The diff touches exactly one file, `AGENTS.md`, and no trigger in the map matches it: nothing under `packages/apps/`, `packages/extra/` or `packages/core/`, nothing under `hack/`, no platform variant, no annotation or label value, no telemetry metric, and no change to node or network requirements.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for AI coding agents working on Go code, Helm charts, build, testing, and project-structure questions.
  * Clarified documentation-loading order and reinforced following applicable instructions before beginning work.
  * Refined standing-reference guidance for project structure and conventions.
  * Improved clarity around scope-specific documentation and instruction precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->