### PR TITLE
fix(kubernetes): discover Cilium Gateway API EndpointSlices in KCCM

### DIFF
--- a/packages/apps/kubernetes/images/kubevirt-cloud-provider/patches/380.diff
+++ b/packages/apps/kubernetes/images/kubevirt-cloud-provider/patches/380.diff
@@ -1,0 +1,46 @@
+diff --git a/pkg/controller/kubevirteps/kubevirteps_controller.go b/pkg/controller/kubevirteps/kubevirteps_controller.go
+index 8af51fbe8..a53860c60 100644
+--- a/pkg/controller/kubevirteps/kubevirteps_controller.go
++++ b/pkg/controller/kubevirteps/kubevirteps_controller.go
+@@ -362,10 +362,38 @@ func (c *Controller) getTenantEPSFromInfraService(ctx context.Context, svc *v1.S
+ 			tenantServiceNamespace, err)
+ 		return nil, err
+ 	}
+-	for _, eps := range result.Items {
+-		c.tenantEPSTracker.add(&eps)
+-		tenantEPSSlices = append(tenantEPSSlices, &eps)
++	for i := range result.Items {
++		c.tenantEPSTracker.add(&result.Items[i])
++		tenantEPSSlices = append(tenantEPSSlices, &result.Items[i])
++	}
++
++	// Cilium Gateway API backs a LoadBalancer Service named "cilium-gateway-<gateway>"
++	// with an EndpointSlice that Cilium labels with "io.cilium.gateway/owning-gateway=<gateway>"
++	// (and "gateway.networking.k8s.io/gateway-name"), but NOT with the standard
++	// "kubernetes.io/service-name" label. The label lookup above therefore returns nothing,
++	// leaving the infra LoadBalancer without endpoints. When that happens, retry the lookup
++	// using the Cilium gateway label so endpoint reconciliation (and the all-VMIs fallback for
++	// endpoints without a NodeName) can proceed.
++	if len(tenantEPSSlices) == 0 {
++		const ciliumGatewaySvcPrefix = "cilium-gateway-"
++		if strings.HasPrefix(tenantServiceName, ciliumGatewaySvcPrefix) {
++			gatewayName := strings.TrimPrefix(tenantServiceName, ciliumGatewaySvcPrefix)
++			klog.Infof("No EndpointSlices found via %s for service %s; retrying via Cilium gateway label for gateway %s",
++				discovery.LabelServiceName, tenantServiceName, gatewayName)
++			gwResult, err := c.tenantClient.DiscoveryV1().EndpointSlices(tenantServiceNamespace).List(ctx,
++				metav1.ListOptions{LabelSelector: fmt.Sprintf("io.cilium.gateway/owning-gateway=%s", gatewayName)})
++			if err != nil {
++				klog.Errorf("Failed to get Cilium gateway EndpointSlices for service %s in namespace %s: %v",
++					tenantServiceName, tenantServiceNamespace, err)
++				return nil, err
++			}
++			for i := range gwResult.Items {
++				c.tenantEPSTracker.add(&gwResult.Items[i])
++				tenantEPSSlices = append(tenantEPSSlices, &gwResult.Items[i])
++			}
++		}
+ 	}
++
+ 	return tenantEPSSlices, nil
+ }
+ 


### PR DESCRIPTION
## What this PR does

The kubevirt-cloud-provider (KCCM) EndpointSlice controller (`kubevirteps`) discovers the tenant endpoints backing an infra `LoadBalancer` Service **only** via the standard `kubernetes.io/service-name` label (`getTenantEPSFromInfraService`).

Cilium Gateway API backs its `cilium-gateway-<gateway>` LoadBalancer Service with an `EndpointSlice` that Cilium labels with `io.cilium.gateway/owning-gateway=<gateway>` and `gateway.networking.k8s.io/gateway-name=<gateway>` — **but not** `kubernetes.io/service-name`. The endpoint itself is Cilium's L7 sentinel (`192.192.192.192`, no `NodeName`).

Consequently, for any Cilium `Gateway` created inside a tenant Kubernetes cluster:
- the controller finds **no** tenant EndpointSlices,
- it never populates the infra EndpointSlices, and never reaches the all-VMIs fallback (added in #379) for endpoints without a `NodeName`,
- the external MetalLB IP of the Gateway ends up with **zero backends** → no external connectivity.

This reproduces on a tenant cluster where Gateway API is enabled and a `Gateway` (class `cilium`) is created: `PROGRAMMED=True`, IP assigned, but the infra LB has no EndpointSlice and all external traffic black-holes. Switching the same workload to ingress-nginx works, because its Service has a normal selector/EndpointSlices that the controller can mirror.

### Fix

Add patch `380.diff` (applied on top of `341`/`379`): when the `kubernetes.io/service-name` lookup returns nothing for a `cilium-gateway-*` Service, retry the lookup using the Cilium `io.cilium.gateway/owning-gateway` label so reconciliation proceeds and the existing all-VMIs fallback populates the endpoints. Also fixes a latent loop-variable aliasing when collecting slices (index-based append).

Verified: patches `341`+`379`+`380` apply cleanly on `a0acf33`, the package builds, and `go test ./pkg/controller/kubevirteps/` passes. Confirmed end-to-end on a live tenant cluster (argocd Gateway): once the controller can discover the slice, the infra EndpointSlice is created pointing at all tenant VMIs on the NodePorts, and the external IP starts serving.

## Release note

```release-note
fix(kubernetes): populate EndpointSlices for Cilium Gateway API LoadBalancer services in tenant Kubernetes clusters so their external IP has backends
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LoadBalancer endpoint discovery for services backed by Cilium Gateway API.
  * Fixed endpoint tracking to ensure all discovered endpoint slices are processed reliably.
  * Added error handling when retrieving Cilium-labeled endpoint slices fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->