### PR TITLE
fix(ci): mirror and retag images whose digest is embedded in the values tag

### DIFF
--- a/hack/nightly-mirror.sh
+++ b/hack/nightly-mirror.sh
@@ -83,15 +83,21 @@ yq --version 2>&1 | grep -q mikefarah || { echo "yq (mikefarah) is required" >&2
 # SAME FILE — reintroducing the exact silent skip this rule exists to fix, in a
 # file that merely happens to sit next to an unquoted version number. Rule 1 is
 # immune because its `select(tag == "!!str")` already precedes its test().
+#
+# `registry`, `repository` and `digest` carry the same guard against a different
+# failure: they are concatenated rather than test()ed, and yq coerces int, bool,
+# null and seq on `+`, so only a !!map aborts ("!!str () cannot be added to a
+# !!map") — and that abort takes the whole file down with it. See the fuller
+# note in hack/promote-retag.sh.
 collect_refs() {
   for f in "$TREE"/*/*/values.yaml; do
     [ -f "$f" ] || continue
     yq -r '.. | select(tag == "!!str") | select(test("@sha256:[0-9a-f]{64}"))' "$f" 2>/dev/null || true
-    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("digest")) | (((.registry // "") + "/" + .repository) | sub("^/"; "")) + "@" + .digest' "$f" 2>/dev/null || true
-    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | (((.registry // "") + "/" + .repository) | sub("^/"; "")) + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
+    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("digest")) | select(.repository | tag == "!!str") | select(.digest | tag == "!!str") | select((.registry // "") | tag == "!!str") | (((.registry // "") + "/" + .repository) | sub("^/"; "")) + "@" + .digest' "$f" 2>/dev/null || true
+    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | select(.repository | tag == "!!str") | select((.registry // "") | tag == "!!str") | (((.registry // "") + "/" + .repository) | sub("^/"; "")) + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
     # $reg is a yq binding, not a shell variable — see hack/promote-retag.sh.
     # shellcheck disable=SC2016
-    yq -r '(.global.registry.address // "") as $reg | select($reg != "") | .global.images[] | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | $reg + "/" + .repository + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
+    yq -r '(.global.registry.address // "") as $reg | select($reg != "") | select($reg | tag == "!!str") | .global.images[] | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | select(.repository | tag == "!!str") | $reg + "/" + .repository + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
     yq -r '.. | select(tag == "!!map") | select(has("platformSourceUrl") and has("platformSourceRef")) | (.platformSourceUrl | sub("^oci://"; "")) + "@" + (.platformSourceRef | sub("^digest="; ""))' "$f" 2>/dev/null || true
   done
 }

--- a/hack/nightly-mirror.sh
+++ b/hack/nightly-mirror.sh
@@ -48,12 +48,22 @@ command -v yq >/dev/null     || { echo "yq (mikefarah) is required" >&2; exit 1;
 yq --version 2>&1 | grep -q mikefarah || { echo "yq (mikefarah) is required" >&2; exit 1; }
 [ "$DRY_RUN" -eq 1 ] || command -v skopeo >/dev/null || { echo "skopeo is required" >&2; exit 1; }
 
-# Collect "repo@sha256:..." refs from every package values.yaml, across the four
-# shapes the build writes (identical to hack/promote-retag.sh):
+# Collect "repo@sha256:..." refs from every package values.yaml, across the
+# shapes present in the tree today (identical to hack/promote-retag.sh — see the
+# longer note there on why this list is empirical rather than a closed set):
 #   1. single string  <repo>:<tag>@sha256:<digest>
-#   2. split map       {repository, tag, digest}
-#   3. split map       {repository, tag: <tag>@sha256:<digest>}
-#   4. OCI artifact    {platformSourceUrl: oci://<repo>, platformSourceRef: digest=...}
+#   2. split map       {[registry,] repository, tag, digest}
+#   3. split map       {[registry,] repository, tag: <tag>@sha256:<digest>}
+#   4. chart-global    global.registry.address + global.images.<n>.{repository, tag}
+#   5. OCI artifact    {platformSourceUrl: oci://<repo>, platformSourceRef: digest=...}
+#
+# Shapes 2/3's optional `registry` sibling and the whole of shape 4 cover the
+# refs whose host sits outside `repository`. Rejoining it matters twice over
+# here: a host-less ref is dropped by the SRC_REGISTRY filter below, AND the
+# closing host rewrite is a literal "$SRC_REGISTRY/" substring replace, which a
+# split-out host does not match — so such a ref would be neither mirrored nor
+# rewritten, leaving the published tree pointing at the private CI registry
+# rather than at a merely-dangling GHCR ref.
 #
 # Shape 3 is what most package Makefiles actually write: they set `.image.tag` to
 # "$(IMAGE_TAG)@$(digest)" in one yq call rather than maintaining a separate
@@ -77,8 +87,11 @@ collect_refs() {
   for f in "$TREE"/*/*/values.yaml; do
     [ -f "$f" ] || continue
     yq -r '.. | select(tag == "!!str") | select(test("@sha256:[0-9a-f]{64}"))' "$f" 2>/dev/null || true
-    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("digest")) | .repository + "@" + .digest' "$f" 2>/dev/null || true
-    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | .repository + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
+    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("digest")) | (((.registry // "") + "/" + .repository) | sub("^/"; "")) + "@" + .digest' "$f" 2>/dev/null || true
+    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | (((.registry // "") + "/" + .repository) | sub("^/"; "")) + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
+    # $reg is a yq binding, not a shell variable — see hack/promote-retag.sh.
+    # shellcheck disable=SC2016
+    yq -r '(.global.registry.address // "") as $reg | select($reg != "") | .global.images[] | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | $reg + "/" + .repository + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
     yq -r '.. | select(tag == "!!map") | select(has("platformSourceUrl") and has("platformSourceRef")) | (.platformSourceUrl | sub("^oci://"; "")) + "@" + (.platformSourceRef | sub("^digest="; ""))' "$f" 2>/dev/null || true
   done
 }

--- a/hack/nightly-mirror.sh
+++ b/hack/nightly-mirror.sh
@@ -48,16 +48,37 @@ command -v yq >/dev/null     || { echo "yq (mikefarah) is required" >&2; exit 1;
 yq --version 2>&1 | grep -q mikefarah || { echo "yq (mikefarah) is required" >&2; exit 1; }
 [ "$DRY_RUN" -eq 1 ] || command -v skopeo >/dev/null || { echo "skopeo is required" >&2; exit 1; }
 
-# Collect "repo@sha256:..." refs from every package values.yaml, across the three
+# Collect "repo@sha256:..." refs from every package values.yaml, across the four
 # shapes the build writes (identical to hack/promote-retag.sh):
 #   1. single string  <repo>:<tag>@sha256:<digest>
 #   2. split map       {repository, tag, digest}
-#   3. OCI artifact    {platformSourceUrl: oci://<repo>, platformSourceRef: digest=...}
+#   3. split map       {repository, tag: <tag>@sha256:<digest>}
+#   4. OCI artifact    {platformSourceUrl: oci://<repo>, platformSourceRef: digest=...}
+#
+# Shape 3 is what most package Makefiles actually write: they set `.image.tag` to
+# "$(IMAGE_TAG)@$(digest)" in one yq call rather than maintaining a separate
+# `digest` key. It is NOT covered by shape 2 (no `digest` key) and only partially
+# matches shape 1 — rule 1 grabs the bare tag value "<tag>@sha256:<digest>", which
+# carries no repository, so ref_repo() reduces it to "<tag>" and the SRC_REGISTRY
+# case below drops it. The image is then never copied, while the host rewrite at
+# the end of this script still rewrites its repository to DST_REGISTRY, leaving a
+# dangling reference to an image that was never pushed there. Shape 3 must be
+# matched explicitly for those images to be mirrored at all.
+#
+# The `tag == "!!str"` guard on shape 3 is load-bearing, not defensive noise:
+# yq's test() aborts the whole expression with "cannot match with !!int, can only
+# match strings" on a non-string tag, and `tag: 1.24` is ordinary YAML a
+# third-party chart may well carry unquoted. Because the invocation swallows both
+# stderr and status, that abort would silently discard every shape-3 ref in the
+# SAME FILE — reintroducing the exact silent skip this rule exists to fix, in a
+# file that merely happens to sit next to an unquoted version number. Rule 1 is
+# immune because its `select(tag == "!!str")` already precedes its test().
 collect_refs() {
   for f in "$TREE"/*/*/values.yaml; do
     [ -f "$f" ] || continue
     yq -r '.. | select(tag == "!!str") | select(test("@sha256:[0-9a-f]{64}"))' "$f" 2>/dev/null || true
     yq -r '.. | select(tag == "!!map") | select(has("repository") and has("digest")) | .repository + "@" + .digest' "$f" 2>/dev/null || true
+    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | .repository + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
     yq -r '.. | select(tag == "!!map") | select(has("platformSourceUrl") and has("platformSourceRef")) | (.platformSourceUrl | sub("^oci://"; "")) + "@" + (.platformSourceRef | sub("^digest="; ""))' "$f" 2>/dev/null || true
   done
 }

--- a/hack/nightly-mirror_test.bats
+++ b/hack/nightly-mirror_test.bats
@@ -22,7 +22,8 @@
 _make_tree() {
   D="$(printf 'a%.0s' $(seq 1 64))"   # 64-hex fake digest body
   t="$1"
-  mkdir -p "$t/system/foo" "$t/system/bar" "$t/system/split" "$t/system/third" "$t/core/installer"
+  mkdir -p "$t/system/foo" "$t/system/bar" "$t/system/split" "$t/system/third" \
+           "$t/system/splithost" "$t/system/digesthost" "$t/system/globalreg" "$t/core/installer"
   # shape 1: single string, cozystack-owned -> copied
   printf 'image: iad.ocir.io/idyksih5sir9/cozystack/foo:main@sha256:%s\n' "$D" > "$t/system/foo/values.yaml"
   # shape 2: split map, cozystack-owned -> copied
@@ -62,7 +63,46 @@ _make_tree() {
     echo '    repository: iad.ocir.io/idyksih5sir9/cozystack/numeric'
     printf '    tag: main@sha256:%s\n' "$D"
   } > "$t/system/third/values.yaml"
-  # shape 4: operator (cozystack-owned -> copied) + platformSource (cozystack-packages -> skipped)
+  # shapes 2 and 3 with the host split into a sibling `registry` key instead of
+  # living inside `repository` — the layout keycloak-operator ships. Rejoining
+  # the two is what keeps the ref recognisable: emitting the bare `repository`
+  # yields a host-less ref that the SRC_REGISTRY filter discards as third-party,
+  # the same silent drop shape 3 exists to fix. Worse here than in promote-retag,
+  # because the closing host rewrite matches the literal "$SRC_REGISTRY/" string
+  # and a split-out host does not contain it: the ref would be neither copied nor
+  # rewritten, publishing a tree that points at the private CI registry.
+  {
+    echo 'image:'
+    echo '  registry: iad.ocir.io'
+    echo '  repository: idyksih5sir9/cozystack/splithost'
+    printf '  tag: main@sha256:%s\n' "$D"
+  } > "$t/system/splithost/values.yaml"
+  {
+    echo 'image:'
+    echo '  registry: iad.ocir.io'
+    echo '  repository: idyksih5sir9/cozystack/digesthost'
+    echo '  tag: main'
+    printf '  digest: sha256:%s\n' "$D"
+  } > "$t/system/digesthost/values.yaml"
+  # shape 4: the host is a document-level key (global.registry.address) and the
+  # image map carries only a bare repository — kube-ovn's wrapper chart, whose
+  # own `make image` in cozystack/kubeovn-chart writes exactly this layout. The
+  # co-located `other` block is a chart-level image with no digest: it must not
+  # be emitted at all, proving the rule filters within global.images rather than
+  # blanket-prefixing every entry with the registry address.
+  {
+    echo 'global:'
+    echo '  registry:'
+    echo '    address: iad.ocir.io/idyksih5sir9/cozystack'
+    echo '  images:'
+    echo '    globalreg:'
+    echo '      repository: globalreg'
+    printf '      tag: v1.2.3@sha256:%s\n' "$D"
+    echo '    other:'
+    echo '      repository: other'
+    echo '      tag: v1.2.3'
+  } > "$t/system/globalreg/values.yaml"
+  # shape 5: operator (cozystack-owned -> copied) + platformSource (cozystack-packages -> skipped)
   {
     echo 'cozystackOperator:'
     printf '  image: iad.ocir.io/idyksih5sir9/cozystack/cozystack-operator:main@sha256:%s\n' "$D"
@@ -96,6 +136,15 @@ _make_tree() {
   grep -q 'docker://iad.ocir.io/idyksih5sir9/cozystack/split@sha256:.* docker://ghcr.io/cozystack/cozystack/split:0.0.0-nightly.test' "$tmp/out"
   # A shape-3 ref sharing a file with a non-string tag survives — see _make_tree.
   grep -q 'docker://ghcr.io/cozystack/cozystack/numeric:0.0.0-nightly.test' "$tmp/out"
+  # Split-out host (`registry` sibling / global.registry.address). Assert the
+  # full source ref for the same reason shape 3 does: a rule that dropped the
+  # host would plan a copy from a host-less repository, which is filtered out
+  # rather than reported, so checking only the destination proves nothing.
+  grep -q 'docker://iad.ocir.io/idyksih5sir9/cozystack/splithost@sha256:.* docker://ghcr.io/cozystack/cozystack/splithost:0.0.0-nightly.test' "$tmp/out"
+  grep -q 'docker://iad.ocir.io/idyksih5sir9/cozystack/digesthost@sha256:.* docker://ghcr.io/cozystack/cozystack/digesthost:0.0.0-nightly.test' "$tmp/out"
+  grep -q 'docker://iad.ocir.io/idyksih5sir9/cozystack/globalreg@sha256:.* docker://ghcr.io/cozystack/cozystack/globalreg:0.0.0-nightly.test' "$tmp/out"
+  # The digest-less sibling under global.images is not invented into a ref.
+  ! grep -q '/other' "$tmp/out"
   # A floating tag is moved alongside the pinned version.
   grep -q 'docker://ghcr.io/cozystack/cozystack/foo:nightly' "$tmp/out"
 

--- a/hack/nightly-mirror_test.bats
+++ b/hack/nightly-mirror_test.bats
@@ -17,12 +17,12 @@
 #
 # Run with: hack/cozytest.sh hack/nightly-mirror_test.bats
 
-# Build a synthetic baked tree exercising all three image-ref shapes plus the
+# Build a synthetic baked tree exercising all four image-ref shapes plus the
 # refs that MUST be filtered (third-party host, cozystack-packages artifact).
 _make_tree() {
   D="$(printf 'a%.0s' $(seq 1 64))"   # 64-hex fake digest body
   t="$1"
-  mkdir -p "$t/system/foo" "$t/system/bar" "$t/system/third" "$t/core/installer"
+  mkdir -p "$t/system/foo" "$t/system/bar" "$t/system/split" "$t/system/third" "$t/core/installer"
   # shape 1: single string, cozystack-owned -> copied
   printf 'image: iad.ocir.io/idyksih5sir9/cozystack/foo:main@sha256:%s\n' "$D" > "$t/system/foo/values.yaml"
   # shape 2: split map, cozystack-owned -> copied
@@ -32,9 +32,37 @@ _make_tree() {
     echo '  tag: main'
     printf '  digest: sha256:%s\n' "$D"
   } > "$t/system/bar/values.yaml"
-  # third-party single string -> skipped
-  printf 'image: docker.io/clastix/kubectl:1.0@sha256:%s\n' "$D" > "$t/system/third/values.yaml"
-  # shape 3: operator (cozystack-owned -> copied) + platformSource (cozystack-packages -> skipped)
+  # shape 3: split map with the digest embedded in `tag`, cozystack-owned -> copied.
+  # This is what most package Makefiles write (a single yq call setting .image.tag
+  # to "$(IMAGE_TAG)@$(digest)"), so it is the dominant real-world shape — linstor,
+  # kamaji, kilo, metallb and redis-operator all use it. It matches neither shape 1
+  # (rule 1 sees only the repository-less tag value, which ref_repo() reduces to the
+  # tag) nor shape 2 (no `digest` key), so until it was matched explicitly these
+  # images were silently never mirrored while the host rewrite still repointed them
+  # at the dest registry — a dangling ref that 404s at pull time.
+  {
+    echo 'image:'
+    echo '  repository: iad.ocir.io/idyksih5sir9/cozystack/split'
+    printf '  tag: main@sha256:%s\n' "$D"
+  } > "$t/system/split/values.yaml"
+  # third-party single string -> skipped, and a NUMERIC tag in the same file as a
+  # cozystack-owned shape-3 ref. `tag: 123` is ordinary YAML, but yq's test()
+  # aborts on a non-string ("cannot match with !!int"), and collect_refs swallows
+  # stderr and status — so without a type guard this abort discards the shape-3
+  # ref alongside it and `numeric` is silently never mirrored. Co-locating the two
+  # in one file is the point: the failure is per-file, not per-value.
+  {
+    printf 'image: docker.io/clastix/kubectl:1.0@sha256:%s\n' "$D"
+    echo 'vendored:'
+    echo '  image:'
+    echo '    repository: docker.io/vendor/thing'
+    echo '    tag: 123'
+    echo 'ours:'
+    echo '  image:'
+    echo '    repository: iad.ocir.io/idyksih5sir9/cozystack/numeric'
+    printf '    tag: main@sha256:%s\n' "$D"
+  } > "$t/system/third/values.yaml"
+  # shape 4: operator (cozystack-owned -> copied) + platformSource (cozystack-packages -> skipped)
   {
     echo 'cozystackOperator:'
     printf '  image: iad.ocir.io/idyksih5sir9/cozystack/cozystack-operator:main@sha256:%s\n' "$D"
@@ -58,15 +86,22 @@ _make_tree() {
     return "$rc"
   fi
 
-  # The three cozystack-owned component images are each copied to GHCR by digest.
+  # The four cozystack-owned component images are each copied to GHCR by digest.
   grep -q 'docker://iad.ocir.io/idyksih5sir9/cozystack/foo@sha256:.* docker://ghcr.io/cozystack/cozystack/foo:0.0.0-nightly.test' "$tmp/out"
   grep -q 'docker://ghcr.io/cozystack/cozystack/bar:0.0.0-nightly.test' "$tmp/out"
   grep -q 'docker://ghcr.io/cozystack/cozystack/cozystack-operator:0.0.0-nightly.test' "$tmp/out"
+  # shape 3 — the source ref must carry the REPOSITORY, not the bare tag: a rule
+  # that matched the tag alone would plan a copy from "main@sha256:..." and be
+  # dropped as non-SRC_REGISTRY, so assert the full source ref, not just the dest.
+  grep -q 'docker://iad.ocir.io/idyksih5sir9/cozystack/split@sha256:.* docker://ghcr.io/cozystack/cozystack/split:0.0.0-nightly.test' "$tmp/out"
+  # A shape-3 ref sharing a file with a non-string tag survives — see _make_tree.
+  grep -q 'docker://ghcr.io/cozystack/cozystack/numeric:0.0.0-nightly.test' "$tmp/out"
   # A floating tag is moved alongside the pinned version.
   grep -q 'docker://ghcr.io/cozystack/cozystack/foo:nightly' "$tmp/out"
 
   # Third-party images never appear in the copy plan.
   ! grep -q 'docker.io/clastix' "$tmp/out"
+  ! grep -q 'docker.io/vendor' "$tmp/out"
   # The cozystack-packages artifact is excluded — it is rebuilt downstream.
   ! grep -qE 'skopeo copy.*cozystack-packages' "$tmp/out"
 

--- a/hack/nightly-mirror_test.bats
+++ b/hack/nightly-mirror_test.bats
@@ -23,7 +23,8 @@ _make_tree() {
   D="$(printf 'a%.0s' $(seq 1 64))"   # 64-hex fake digest body
   t="$1"
   mkdir -p "$t/system/foo" "$t/system/bar" "$t/system/split" "$t/system/third" \
-           "$t/system/splithost" "$t/system/digesthost" "$t/system/globalreg" "$t/core/installer"
+           "$t/system/splithost" "$t/system/digesthost" "$t/system/globalreg" \
+           "$t/system/guarded" "$t/core/installer"
   # shape 1: single string, cozystack-owned -> copied
   printf 'image: iad.ocir.io/idyksih5sir9/cozystack/foo:main@sha256:%s\n' "$D" > "$t/system/foo/values.yaml"
   # shape 2: split map, cozystack-owned -> copied
@@ -102,6 +103,24 @@ _make_tree() {
     echo '      repository: other'
     echo '      tag: v1.2.3'
   } > "$t/system/globalreg/values.yaml"
+  # A map-typed `repository` co-located with an owned ref. This is the one
+  # non-string type that actually breaks the concat rules: yq coerces int, bool,
+  # null and seq on `+`, but a !!map raises "!!str () cannot be added to a
+  # !!map", and because collect_refs swallows stderr and status that abort would
+  # take every ref in this file with it. Same per-file blast radius as the
+  # numeric-tag case above, different trigger — so `survivor` must still be
+  # mirrored.
+  {
+    echo 'broken:'
+    echo '  image:'
+    echo '    repository:'
+    echo '      nested: oops'
+    printf '    tag: main@sha256:%s\n' "$D"
+    echo 'ours:'
+    echo '  image:'
+    echo '    repository: iad.ocir.io/idyksih5sir9/cozystack/survivor'
+    printf '    tag: main@sha256:%s\n' "$D"
+  } > "$t/system/guarded/values.yaml"
   # shape 5: operator (cozystack-owned -> copied) + platformSource (cozystack-packages -> skipped)
   {
     echo 'cozystackOperator:'
@@ -145,6 +164,8 @@ _make_tree() {
   grep -q 'docker://iad.ocir.io/idyksih5sir9/cozystack/globalreg@sha256:.* docker://ghcr.io/cozystack/cozystack/globalreg:0.0.0-nightly.test' "$tmp/out"
   # The digest-less sibling under global.images is not invented into a ref.
   ! grep -q '/other' "$tmp/out"
+  # An owned ref sharing a file with a map-typed `repository` survives.
+  grep -q 'docker://ghcr.io/cozystack/cozystack/survivor:0.0.0-nightly.test' "$tmp/out"
   # A floating tag is moved alongside the pinned version.
   grep -q 'docker://ghcr.io/cozystack/cozystack/foo:nightly' "$tmp/out"
 

--- a/hack/promote-retag.sh
+++ b/hack/promote-retag.sh
@@ -50,10 +50,29 @@ yq --version 2>&1 | grep -q mikefarah || { echo "yq (mikefarah) is required" >&2
 [ "$DRY_RUN" -eq 1 ] || command -v skopeo >/dev/null || { echo "skopeo is required" >&2; exit 1; }
 
 # Collect "repo@sha256:..." refs from every package values.yaml, across the
-# three shapes the build writes:
+# four shapes the build writes:
 #   1. single string  <repo>:<tag>@sha256:<digest>   (e.g. .cozystackAPI.image)
 #   2. split map       {repository, tag, digest}      (e.g. .cilium.image)
-#   3. OCI artifact    {platformSourceUrl: oci://<repo>, platformSourceRef: digest=sha256:<digest>}
+#   3. split map       {repository, tag: <tag>@sha256:<digest>}  (e.g. .linstorCSI.image)
+#   4. OCI artifact    {platformSourceUrl: oci://<repo>, platformSourceRef: digest=sha256:<digest>}
+#
+# Shape 3 is the dominant one: most package Makefiles set `.image.tag` to
+# "$(IMAGE_TAG)@$(digest)" in a single yq call instead of maintaining a separate
+# `digest` key. It matches neither shape 2 (no `digest` key) nor, usefully, shape
+# 1 — that rule sees only the bare tag value, which carries no repository, so
+# ref_repo() reduces "<tag>@sha256:<digest>" to "<tag>" and the ownership filter
+# drops it. Omitting this rule silently skipped eight images across six packages
+# (kamaji, kilo, linstor-csi, piraeus-server, linstor-gui, metallb-controller,
+# metallb-speaker, redis-operator): the promotion reported success while never
+# creating their :<version> tags. Unlike the nightly mirror this retags within one
+# registry, so the digests still resolve and digest-pinned installs are unaffected
+# — but the release does not carry the tags it claims to, and nothing detects it.
+#
+# The `tag == "!!str"` guard is load-bearing: yq's test() aborts the expression on
+# a non-string tag ("cannot match with !!int"), and since this invocation swallows
+# stderr and status, that abort would silently drop every shape-3 ref in the same
+# file. `tag: 1.24` unquoted in a neighbouring third-party block is enough. Rule 1
+# is immune — its `select(tag == "!!str")` already precedes its test().
 collect_refs() {
   for f in packages/*/*/values.yaml; do
     [ -f "$f" ] || continue
@@ -62,6 +81,8 @@ collect_refs() {
     # shape 2
     yq -r '.. | select(tag == "!!map") | select(has("repository") and has("digest")) | .repository + "@" + .digest' "$f" 2>/dev/null || true
     # shape 3
+    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | .repository + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
+    # shape 4
     yq -r '.. | select(tag == "!!map") | select(has("platformSourceUrl") and has("platformSourceRef")) | (.platformSourceUrl | sub("^oci://"; "")) + "@" + (.platformSourceRef | sub("^digest="; ""))' "$f" 2>/dev/null || true
   done
 }

--- a/hack/promote-retag.sh
+++ b/hack/promote-retag.sh
@@ -49,12 +49,30 @@ yq --version 2>&1 | grep -q mikefarah || { echo "yq (mikefarah) is required" >&2
 # skopeo is only needed to actually copy; a --dry-run just prints the plan.
 [ "$DRY_RUN" -eq 1 ] || command -v skopeo >/dev/null || { echo "skopeo is required" >&2; exit 1; }
 
-# Collect "repo@sha256:..." refs from every package values.yaml, across the
-# four shapes the build writes:
+# Collect "repo@sha256:..." refs from every package values.yaml. The shapes
+# below are the ones present in the tree today, found by auditing every
+# @sha256: digest under packages/*/*/values.yaml against this selector's
+# output — NOT a closed set the build is known to be limited to. Charts are
+# vendored from upstream and their values layout is theirs to change, so treat
+# this list as empirical and re-run that audit when a package is added:
 #   1. single string  <repo>:<tag>@sha256:<digest>   (e.g. .cozystackAPI.image)
-#   2. split map       {repository, tag, digest}      (e.g. .cilium.image)
-#   3. split map       {repository, tag: <tag>@sha256:<digest>}  (e.g. .linstorCSI.image)
-#   4. OCI artifact    {platformSourceUrl: oci://<repo>, platformSourceRef: digest=sha256:<digest>}
+#   2. split map       {[registry,] repository, tag, digest}      (e.g. .cilium.image)
+#   3. split map       {[registry,] repository, tag: <tag>@sha256:<digest>}
+#                      (e.g. .linstorCSI.image; .keycloak-operator.image adds registry)
+#   4. chart-global    global.registry.address + global.images.<n>.{repository, tag}
+#                      (kube-ovn's wrapper chart)
+#   5. OCI artifact    {platformSourceUrl: oci://<repo>, platformSourceRef: digest=sha256:<digest>}
+#
+# The optional `registry` sibling in shapes 2/3 and the whole of shape 4 exist
+# because the host does not always live inside `repository`. When it does not,
+# the rule must rejoin it: a host-less ref reaches the ownership filter below
+# looking third-party and is dropped, which is the same silent-skip failure
+# this selector's shape-3 rule was added to fix. keycloak-operator
+# (registry: ghcr.io + repository: cozystack/cozystack/keycloak-operator) and
+# kubeovn (global.registry.address + repository: kubeovn) are both built and
+# pushed to $REGISTRY by cozystack — kubeovn by the cozystack/kubeovn-chart
+# wrapper repo, whose own `make image` writes exactly the shape-4 layout — and
+# both went untagged for every 1.x release until these rules landed.
 #
 # Shape 3 is the dominant one: most package Makefiles set `.image.tag` to
 # "$(IMAGE_TAG)@$(digest)" in a single yq call instead of maintaining a separate
@@ -78,11 +96,21 @@ collect_refs() {
     [ -f "$f" ] || continue
     # shape 1
     yq -r '.. | select(tag == "!!str") | select(test("@sha256:[0-9a-f]{64}"))' "$f" 2>/dev/null || true
-    # shape 2
-    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("digest")) | .repository + "@" + .digest' "$f" 2>/dev/null || true
+    # shape 2. The `sub("^/"; "")` is what makes `registry` optional: absent, it
+    # alternates to "" and leaves a leading slash on the join, which is stripped
+    # back to the bare repository the rule emitted before registry was handled.
+    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("digest")) | (((.registry // "") + "/" + .repository) | sub("^/"; "")) + "@" + .digest' "$f" 2>/dev/null || true
     # shape 3
-    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | .repository + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
-    # shape 4
+    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | (((.registry // "") + "/" + .repository) | sub("^/"; "")) + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
+    # shape 4. Scoped to global.images rather than a recursive descent: the host
+    # is a document-level key, so binding it to a map found anywhere in the file
+    # would attach kube-ovn's registry to unrelated repositories. Guarding on a
+    # non-empty address keeps a chart without one from emitting "/<repo>".
+    # $reg is a yq binding, not a shell variable — the single quotes are
+    # required, so SC2016's "expressions don't expand" is inverted here.
+    # shellcheck disable=SC2016
+    yq -r '(.global.registry.address // "") as $reg | select($reg != "") | .global.images[] | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | $reg + "/" + .repository + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
+    # shape 5
     yq -r '.. | select(tag == "!!map") | select(has("platformSourceUrl") and has("platformSourceRef")) | (.platformSourceUrl | sub("^oci://"; "")) + "@" + (.platformSourceRef | sub("^digest="; ""))' "$f" 2>/dev/null || true
   done
 }
@@ -120,11 +148,20 @@ refs=""
 for raw in $(collect_refs); do
   [ -n "$raw" ] || continue
   _repo="$(ref_repo "$raw")"
-  # Retag only cozystack-owned images. This drops third-party images
-  # (docker.io/clastix/kubectl, ghcr.io/kvaps/...), bare upstream tags
-  # (kube-ovn/keycloak/kilo) and non-ref scalars (e.g. a "--migrate-image=..."
-  # arg string) — all vendored by digest but not pushed to $REGISTRY, so a
-  # skopeo copy to them would fail and (under set -e) abort the whole promotion.
+  # Retag only cozystack-owned images: those the build pushes to $REGISTRY, so
+  # a skopeo copy can succeed. Everything else is vendored by digest from a
+  # registry this job cannot push to, and a copy there would fail and (under
+  # set -e) abort the whole promotion. What this drops today:
+  #   - third-party hosts: docker.io/clastix/kubectl, ghcr.io/kvaps/...,
+  #     ghcr.io/lexfrei/{kuberture,ouroboros} (deliberately not mirrored under
+  #     ghcr.io/cozystack — see those packages' values.yaml)
+  #   - ghcr.io/cozystack/ingress-nginx-with-protobuf-exporter/*, which is a
+  #     cozystack-org repo but sits outside $REGISTRY's path
+  #   - non-ref scalars, e.g. a "--migrate-image=..." arg string
+  # Note kilo, kube-ovn and keycloak-operator are NOT in that list: all three
+  # are built and pushed to $REGISTRY, and are selected by shapes 3 and 4. An
+  # earlier version of this comment named them as unpushed third parties, which
+  # is what let their missing release tags go unnoticed.
   case "$_repo" in
     "${REGISTRY}/"*) ;;
     *) continue ;;

--- a/hack/promote-retag.sh
+++ b/hack/promote-retag.sh
@@ -91,6 +91,16 @@ yq --version 2>&1 | grep -q mikefarah || { echo "yq (mikefarah) is required" >&2
 # stderr and status, that abort would silently drop every shape-3 ref in the same
 # file. `tag: 1.24` unquoted in a neighbouring third-party block is enough. Rule 1
 # is immune — its `select(tag == "!!str")` already precedes its test().
+#
+# `registry`, `repository` and `digest` are guarded the same way, but against a
+# different failure than `tag`. They are never fed to test(); they are string-
+# concatenated, and yq coerces most scalars on `+` — an int, bool, null or seq
+# flows through and merely yields a ref the ownership filter discards. Only a
+# !!map aborts, with "!!str () cannot be added to a !!map", and that abort takes
+# the whole file's expression down with it. So the guard is narrow insurance
+# against one nested-map typo in a vendored chart silently costing every
+# co-located owned ref. Being a select() rather than a test(), it drops just the
+# offending map and lets its neighbours through.
 collect_refs() {
   for f in packages/*/*/values.yaml; do
     [ -f "$f" ] || continue
@@ -99,9 +109,9 @@ collect_refs() {
     # shape 2. The `sub("^/"; "")` is what makes `registry` optional: absent, it
     # alternates to "" and leaves a leading slash on the join, which is stripped
     # back to the bare repository the rule emitted before registry was handled.
-    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("digest")) | (((.registry // "") + "/" + .repository) | sub("^/"; "")) + "@" + .digest' "$f" 2>/dev/null || true
+    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("digest")) | select(.repository | tag == "!!str") | select(.digest | tag == "!!str") | select((.registry // "") | tag == "!!str") | (((.registry // "") + "/" + .repository) | sub("^/"; "")) + "@" + .digest' "$f" 2>/dev/null || true
     # shape 3
-    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | (((.registry // "") + "/" + .repository) | sub("^/"; "")) + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
+    yq -r '.. | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | select(.repository | tag == "!!str") | select((.registry // "") | tag == "!!str") | (((.registry // "") + "/" + .repository) | sub("^/"; "")) + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
     # shape 4. Scoped to global.images rather than a recursive descent: the host
     # is a document-level key, so binding it to a map found anywhere in the file
     # would attach kube-ovn's registry to unrelated repositories. Guarding on a
@@ -109,7 +119,7 @@ collect_refs() {
     # $reg is a yq binding, not a shell variable — the single quotes are
     # required, so SC2016's "expressions don't expand" is inverted here.
     # shellcheck disable=SC2016
-    yq -r '(.global.registry.address // "") as $reg | select($reg != "") | .global.images[] | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | $reg + "/" + .repository + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
+    yq -r '(.global.registry.address // "") as $reg | select($reg != "") | select($reg | tag == "!!str") | .global.images[] | select(tag == "!!map") | select(has("repository") and has("tag")) | select(.tag | tag == "!!str") | select(.tag | test("@sha256:[0-9a-f]{64}")) | select(.repository | tag == "!!str") | $reg + "/" + .repository + "@" + (.tag | sub(".*@"; ""))' "$f" 2>/dev/null || true
     # shape 5
     yq -r '.. | select(tag == "!!map") | select(has("platformSourceUrl") and has("platformSourceRef")) | (.platformSourceUrl | sub("^oci://"; "")) + "@" + (.platformSourceRef | sub("^digest="; ""))' "$f" 2>/dev/null || true
   done

--- a/hack/promote-retag_test.bats
+++ b/hack/promote-retag_test.bats
@@ -59,6 +59,18 @@
     grep -q "docker://ghcr.io/cozystack/cozystack/${owned}@sha256:" "$tmp/out"
   done
 
+  # Images whose host is NOT inside `repository` must be selected too. Both are
+  # built and pushed to $REGISTRY by cozystack, both carry the digest in `tag`,
+  # and both were dropped by the ownership filter for looking host-less — so
+  # neither has ever received a 1.x release tag (on GHCR keycloak-operator has
+  # only `latest`, and kubeovn's newest cozystack-versioned tag predates 1.0).
+  # keycloak-operator splits the host into a sibling `registry` key; kubeovn
+  # keeps it in the document-level global.registry.address, written by the
+  # cozystack/kubeovn-chart wrapper's own `make image`.
+  for owned in keycloak-operator kubeovn; do
+    grep -q "docker://ghcr.io/cozystack/cozystack/${owned}@sha256:" "$tmp/out"
+  done
+
   # Every docker:// ref in the copy plan is under the cozystack registry — no
   # third-party repos and no malformed arg-string refs leak through.
   bad=$(grep -oE 'docker://[^ ]+' "$tmp/out" | sed 's|docker://||' \

--- a/hack/promote-retag_test.bats
+++ b/hack/promote-retag_test.bats
@@ -48,6 +48,17 @@
   # At least one cozystack-owned image is selected.
   grep -q 'docker://ghcr.io/cozystack/cozystack/' "$tmp/out"
 
+  # Images whose digest is embedded in `tag` ({repository, tag: <t>@sha256:<d>})
+  # must be selected too. The "at least one owned ref" check above cannot catch
+  # their absence — it is satisfied by the shapes that already worked, which is
+  # why eight images across six packages were silently skipped while this suite
+  # stayed green. Naming concrete packages is deliberate: a count or a generic
+  # pattern would drift back to proving nothing. linstor-csi and piraeus-server
+  # are the two whose absence from GHCR broke the nightly e2e at image pre-pull.
+  for owned in linstor-csi piraeus-server kamaji redis-operator; do
+    grep -q "docker://ghcr.io/cozystack/cozystack/${owned}@sha256:" "$tmp/out"
+  done
+
   # Every docker:// ref in the copy plan is under the cozystack registry — no
   # third-party repos and no malformed arg-string refs leak through.
   bad=$(grep -oE 'docker://[^ ]+' "$tmp/out" | sed 's|docker://||' \


### PR DESCRIPTION
## What's broken

`collect_refs` in both `hack/nightly-mirror.sh` and `hack/promote-retag.sh` recognises three values shapes. The one most package Makefiles actually write is not among them:

```yaml
image:
  repository: <registry>/linstor-csi
  tag: main@sha256:<digest>      # digest embedded in the tag
```

Package Makefiles set `.image.tag` to `"$(IMAGE_TAG)@$(digest)"` in a single `yq` call rather than maintaining a separate `digest` key. That matches neither the `{repository, tag, digest}` rule (no `digest` key) nor, usefully, the single-string rule — that one matches the bare tag value, which carries no repository, so `ref_repo()` reduces `main@sha256:...` to the repository `main` and the ownership filter drops it.

Being dropped is silent. Both scripts then report success having simply never seen those refs.

The same emit-then-drop hits a second class, found in review: refs whose registry host does not live inside `repository` at all. `keycloak-operator` splits it into a sibling `registry` key, and `kubeovn` keeps it in the document-level `global.registry.address` with a bare `repository: kubeovn`. Both are built and pushed to `$REGISTRY` by cozystack — `kubeovn` by the `cozystack/kubeovn-chart` wrapper repo, whose own `make image` writes all three keys — and both were emitted host-less and discarded as third-party.

## Impact

**Nightly (`nightly-mirror.sh`) — this is the one that broke.** The image is never copied to GHCR, *and* the unconditional host rewrite at the end of the script still repoints its repository at the destination registry. The result is a published reference to an image that was never pushed there.

Confirmed against the `:nightly` tag on GHCR — the two packages using a recognised shape are present, and eight images across six packages using this shape are absent:

| shape | packages | `:nightly` |
|---|---|---|
| `{repository,tag,digest}` | cilium | present |
| single-string full ref | cozystack-operator | present |
| `{repository, tag:<t>@sha256}` | kamaji, kilo, linstor-csi, piraeus-server, linstor-gui, metallb-controller, metallb-speaker, redis-operator | **absent** |

This surfaced as the first full nightly run failing at install: the `e2e-image-prepuller` DaemonSet never became ready (0/3, 10-minute timeout) because `linstor-csi` and `piraeus-server` 404 on GHCR. The prepuller only templates kubeovn/linstor/cert-manager, so it exposed two of the eight; the other six would have failed later at HelmRelease install.

**Promotion (`promote-retag.sh`) — same blind spot, milder consequence.** This retags within a single registry, so the digests already exist and digest-pinned installs still resolve — there is no dangling reference and no 404. What is missing is the `:<version>` tag (and `:latest` under `MOVE_LATEST=1`) for those images, so a promoted release does not carry the tags it claims to.

The registry shows how long that has been true for the two host-split images. `keycloak-operator` carries exactly one tag, `latest`, though the package has shipped since 2024-11. `kubeovn`'s newest cozystack-versioned tag is `v1.14.11-v0.38.8`, from before the 1.0 versioning switch — while `cilium`, which uses an already-recognised shape, carries `v1.5.0` through `v1.6.0-rc.2`. Neither has received a tag from any 1.x release.

Measured against the committed tree, the dry-run selects **19 unique repositories before this change and 29 after** — the eight digest-in-tag images plus `keycloak-operator` and `kubeovn`, nothing lost.

### What the nightly does *not* recover

Four of the ten are not in the root `Makefile`'s `build` target: `kilo`, `redis-operator`, `keycloak-operator` and `kubeovn`. Their baked refs keep the committed GHCR host, so the `SRC_REGISTRY` filter still drops them and their `:nightly` tags remain absent after this PR. Installs are unaffected — those digests already resolve on GHCR. The nightly recovers the six OCIR-built images; promotion recovers all ten.

## Why this was invisible

Latent since `nightly-mirror.sh` was added — the nightly had never completed a full run, so its mirror step was never exercised end to end.

Both test suites were green throughout. `nightly-mirror_test.bats`'s fixture covered the single-string, `{repository,tag,digest}` and platformSource shapes — a layout only cilium actually uses — and omitted the dominant one. `promote-retag_test.bats` asserted "at least one cozystack-owned image is selected", which is satisfied by the shapes that already worked and cannot detect an omission.

Two comments actively pointed the wrong way, and are corrected here. The header presented its list as the shapes the build writes, which reads as exhaustive; it now says the list is empirical, names what an audit found outside it, and says to re-run that audit when a package is added. The ownership-filter comment named `kilo`, `kube-ovn` and `keycloak-operator` as third parties "not pushed to `$REGISTRY`" — all three are pushed there, and that wrong comment is part of why the missing tags went unnoticed.

Both fixtures are extended here. The promotion test names concrete packages rather than asserting a count or a generic pattern, since either would drift back to proving nothing.

## Type guards

Both digest-in-tag rules check `.tag` is a string before `test()`. Without it a non-string tag aborts the whole expression (`cannot match with !!int, can only match strings`), and since these invocations swallow stderr and status, that abort would silently discard **every** ref of this shape in the same file — reintroducing this very bug in any file that happens to carry an unquoted `tag: 1.24` next to a cozystack image. Rule 1 is immune because its `select(tag == "!!str")` already precedes its `test()`.

`registry`, `repository` and `digest` are guarded too, against a narrower failure. Those keys are concatenated rather than `test()`ed, and yq coerces int, bool, null and seq on `+` — each merely yields a ref the ownership filter discards. Only a `!!map` aborts, raising `!!str () cannot be added to a !!map`, which takes the file's whole expression with it. So that guard is insurance against a nested-map typo in a vendored chart, not against unquoted scalars. It is a `select()`, so an offending map drops only itself and its neighbours still resolve.

No non-string value of either kind exists in the tree today, so both are prevention rather than an active fix.

## Testing

- Both suites pass: `nightly-mirror_test.bats` 2/2, `promote-retag_test.bats` 4/4.
- Every new assertion was mutation-tested — removing the rule under test turns it red. Verified individually for the shape-3 registry join, the shape-2 registry join, the `global.registry.address` rule, and the `repository` type guard. Also verified that a rule matching the bare tag instead of the repository (the subtle wrong fix) fails, which is why the assertions check the full source ref rather than only the destination.
- `promote-retag.sh --dry-run` against the real committed tree: 19 → 29 unique repositories, no losses.
- An audit of every `@sha256:` digest under `packages/*/*/values.yaml` against the selector output accounts for all 35: 30 are selected, and the remaining five are third-party (`ghcr.io/lexfrei/{kuberture,ouroboros}`, `docker.io/clastix/kubectl`, `ghcr.io/kvaps/...`) or sit outside `$REGISTRY` (`ghcr.io/cozystack/ingress-nginx-with-protobuf-exporter/*`).
- `shellcheck` clean on both scripts at default severity and `-S style`.

## Ordering note for reviewers

Worth landing before the next release candidate is cut, rather than treating this as routine CI cleanup.

`promote-rc.yaml` builds the release branch from the rc's staging branch, and `pull-requests-release.yaml` runs `./hack/promote-retag.sh` from that merged tree — so the copy of the script that executes at promotion is the one frozen into the rc tag's tree, not whatever is on the default branch at promotion time. An rc cut before this merges will carry the old script and silently skip those retags when promoted.

The nightly half is also what unblocks the full-suite e2e lane, which cannot currently publish a working install closure to GHCR.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff: it touches only `hack/nightly-mirror.sh`, `hack/promote-retag.sh` and their two `.bats` suites. No `packages/`, no chart, no `values.schema.json`, no `ApplicationDefinition`, no CRD or RBAC. The `cozystack/ccp` trigger covers moving or renaming files under `hack/` and changing what a make target does; neither applies — the anchor files it gates on (`hack/package.mk`, `hack/common-envs.mk`) are untouched and no make target changes behaviour.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(ci): mirror and retag every cozystack-owned image, including those whose digest is embedded in the values `tag` and those whose registry host is stored outside `repository`. Ten images across eight packages were silently skipped: the nightly published references that 404 at install, and promoted releases did not carry the `:<version>` tags they claim.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly mirroring and retag promotion to recognize digest-pinned image references across more YAML value shapes, including digests embedded in the `tag` field and optional registry wrappers.
  * Expanded support for chart-global image definitions and safer parsing to avoid silently skipped references.
  * Strengthened selection logic to exclude third-party images from copy plans.
* **Tests**
  * Expanded dry-run coverage with additional fixture cases for split maps, `tag`-embedded digests, numeric-tag variants, and more “owned” image assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->