### PR TITLE
feat(platform): address-controller + MetalLB IAD as git-sourced optional packages

### DIFF
--- a/packages/core/platform/sources/address-controller.yaml
+++ b/packages/core/platform/sources/address-controller.yaml
@@ -1,0 +1,44 @@
+---
+# The chart is consumed straight from the upstream git repo: the PackageSource
+# references this GitRepository instead of embedding the cozystack-packages
+# OCIRepository, so nothing is vendored into this tree and a chart bump is a
+# ref change here, not a package sync.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: address-controller
+  namespace: cozy-system
+spec:
+  interval: 5m
+  url: https://github.com/lllamnyp/address-controller
+  ref:
+    branch: main
+---
+apiVersion: cozystack.io/v1alpha1
+kind: PackageSource
+metadata:
+  name: cozystack.address-controller
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: address-controller
+    namespace: cozy-system
+    path: chart
+  variants:
+  # The core, class-agnostic controller for IP addresses as a first-class
+  # resource (IPAddressClass / IPAddress / IPAddressClaim,
+  # local.sdn.cozystack.io) — the PVC/PV-binding analog. It owns claim–address
+  # binding and reclaim; actual allocation belongs to per-class drivers such
+  # as cozystack.metallb-iad.
+  - name: default
+    dependsOn:
+    - cozystack.networking
+    components:
+    - name: address-controller
+      path: address-controller
+      install:
+        namespace: cozy-address-controller
+        releaseName: address-controller
+        # The chart ships its CRDs in crds/; they are v1alpha1 and still
+        # evolving, so upgrades must be allowed to replace them.
+        upgradeCRDs: CreateReplace

--- a/packages/core/platform/sources/metallb-iad.yaml
+++ b/packages/core/platform/sources/metallb-iad.yaml
@@ -1,0 +1,47 @@
+---
+# The chart is consumed straight from the upstream git repo: the PackageSource
+# references this GitRepository instead of embedding the cozystack-packages
+# OCIRepository, so nothing is vendored into this tree and a chart bump is a
+# ref change here, not a package sync.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: metallb-iad
+  namespace: cozy-system
+spec:
+  interval: 5m
+  url: https://github.com/lllamnyp/metallb-iad
+  ref:
+    branch: main
+---
+apiVersion: cozystack.io/v1alpha1
+kind: PackageSource
+metadata:
+  name: cozystack.metallb-iad
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: metallb-iad
+    namespace: cozy-system
+    path: chart
+  variants:
+  # The MetalLB IP Allocation Driver — the per-class driver implementing the
+  # cozystack.address-controller contract for addresses announced by MetalLB.
+  # It holds reservations as placeholder Services in its own namespace
+  # (cozy-metallb-iad, which tenants must have no write access to) and needs
+  # both the core CRDs/controller and MetalLB itself in place.
+  - name: default
+    dependsOn:
+    - cozystack.address-controller
+    - cozystack.metallb
+    components:
+    - name: metallb-iad
+      path: metallb-iad
+      valuesFiles:
+      - values.yaml
+      # Points the driver at cozy-metallb (Cozystack's MetalLB namespace,
+      # not the upstream default metallb-system).
+      - values-cozystack.yaml
+      install:
+        namespace: cozy-metallb-iad
+        releaseName: metallb-iad

--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -247,5 +247,11 @@ cozystack-platform HelmRelease never becomes Ready. */}}
 {{include "cozystack.platform.package.default" (list "cozystack.bootbox" $) }}
 {{- end }}
 {{include "cozystack.platform.package.optional.default" (list "cozystack.hetzner-robotlb" $) }}
+{{- /* IP addresses as a first-class resource: the class-agnostic core plus the
+       MetalLB driver. Enable both together — the driver's PackageSource
+       dependsOn the core (and cozystack.metallb), so enabling only the driver
+       leaves it waiting forever. */}}
+{{include "cozystack.platform.package.optional.default" (list "cozystack.address-controller" $) }}
+{{include "cozystack.platform.package.optional.default" (list "cozystack.metallb-iad" $) }}
 
 {{- end }}


### PR DESCRIPTION
## What

Adds **IP addresses as a first-class resource** ([cozystack/community#35](https://github.com/cozystack/community/pull/35)) to the platform as two optional system packages:

- **`cozystack.address-controller`** — the class-agnostic core ([lllamnyp/address-controller](https://github.com/lllamnyp/address-controller)): `IPAddressClass` / `IPAddress` / `IPAddressClaim` in `local.sdn.cozystack.io`, the PVC/PV-binding analog. Owns claim–address binding, status, and reclaim; never allocates anything itself.
- **`cozystack.metallb-iad`** — the reference per-class driver ([lllamnyp/metallb-iad](https://github.com/lllamnyp/metallb-iad)) for addresses announced by MetalLB. Renders one `IPAddressPool` (`autoAssign: false`) + `L2Advertisement` per served class, holds reservations as placeholder Services in its own namespace, and attaches addresses to tenant Services via the `local.sdn.cozystack.io/ip-address-claim` annotation.

Enable with `bundles.enabledPackages: [cozystack.address-controller, cozystack.metallb-iad]` — both together; the driver's PackageSource `dependsOn` the core (its CRDs must exist first) and `cozystack.metallb`.

## PackageSource → GitRepository, nothing vendored

Unlike every existing source, these PackageSources do **not** embed the `cozystack-packages` OCIRepository. Each `sources/*.yaml` carries a Flux `GitRepository` (in `cozy-system`, pointing at the upstream repo, `ref.branch: main`) and a PackageSource whose `sourceRef` references it, with `path: chart` selecting the charts directory of that repo. The PackageSource reconciler already plumbs GitRepository sourceRefs into the ArtifactGenerator unchanged — these are just the first users of that path.

Consequences:

- No chart is vendored into `packages/system/`; the upstream repos are the single source of truth, and a version bump here is a `ref` change on the GitRepository.
- The core's CRDs ship in the chart's `crds/` directory; the component sets `upgradeCRDs: CreateReplace` since they are v1alpha1 and still evolving.
- The driver consumes a `values-cozystack.yaml` overlay (via `valuesFiles`) that points it at `cozy-metallb` instead of the upstream default `metallb-system`.

## Namespaces and tenancy

The core installs into `cozy-address-controller`. The driver installs into `cozy-metallb-iad`, and its reservation placeholders live in the release namespace by default — a namespace tenants must have no write access to, because a placeholder-labelled Service is exempt from the driver's conflict detection only inside that namespace.

## Ordering

The GitRepositories track `main` of both repos; the charts are there — [lllamnyp/address-controller#2](https://github.com/lllamnyp/address-controller/pull/2) and [lllamnyp/metallb-iad#1](https://github.com/lllamnyp/metallb-iad/pull/1) have merged, and both controllers plus the packaged charts were smoke-tested end to end on a live Cozystack cluster (claim → MetalLB-backed reservation → Service attachment → theft refusal → Retain/re-adoption → teardown).

## Validation

Rendered the platform chart with the sources in place (the `repository.yaml` `lookup` requires a cluster, so it was excluded from the offline render): all 99 PackageSources plus the two GitRepositories render; the two Package CRs appear exactly when both names are in `bundles.enabledPackages` and are absent otherwise. The driver overlay was verified to render `--metallb-namespace=cozy-metallb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
