### PR TITLE
test(mariadb): add MariaDb backup/restore e2e test

### DIFF
--- a/examples/backups/mariadb/00-bucket.yaml
+++ b/examples/backups/mariadb/00-bucket.yaml
@@ -1,6 +1,7 @@
 # Cozystack-managed S3 bucket for storing MariaDB backups. The Bucket
-# controller provisions a Secret named "<bucket>-<username>" per user; the
-# MariaDB strategy below references the "backup" user's Secret.
+# controller provisions a Secret named "bucket-<bucket>-<username>" per
+# user (the bucket app carries the "bucket-" release prefix); the MariaDB
+# strategy below references the "backup" user's Secret.
 ---
 apiVersion: apps.cozystack.io/v1alpha1
 kind: Bucket

--- a/examples/backups/mariadb/00-helpers.sh
+++ b/examples/backups/mariadb/00-helpers.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Shared helpers for the MariaDB backup/restore demo.
+# Source this file in other scripts: source "$(dirname "$0")/00-helpers.sh"
+
+export RED='\033[0;31m'
+export GREEN='\033[0;32m'
+export YELLOW='\033[1;33m'
+export BLUE='\033[0;34m'
+export MAGENTA='\033[0;35m'
+export CYAN='\033[0;36m'
+export WHITE='\033[1;37m'
+export NC='\033[0m'
+export BOLD='\033[1m'
+
+# Default settings (override via environment).
+export NAMESPACE="${NAMESPACE:-tenant-root}"
+export BUCKET_NAME="${BUCKET_NAME:-mariadb-backups}"
+# Bucket user declared in 00-bucket.yaml; the COSI flow materialises the
+# credentials Secret as "bucket-<bucket>-<user>".
+export BUCKET_USER="${BUCKET_USER:-backup}"
+export MARIADB_SRC_NAME="${MARIADB_SRC_NAME:-mariadb-src}"
+export MARIADB_TARGET_NAME="${MARIADB_TARGET_NAME:-mariadb-target}"
+# The mariadb-rd ApplicationDefinition renders the HelmRelease with
+# releaseName = "mariadb-" + appName (release.prefix in
+# packages/system/mariadb-rd/cozyrds/mariadb.yaml), so the operator-side
+# k8s.mariadb.com/MariaDB CR (and its primary Service) is mariadb-<app>.
+export MARIADB_SRC_CR="mariadb-${MARIADB_SRC_NAME}"
+export MARIADB_TARGET_CR="mariadb-${MARIADB_TARGET_NAME}"
+export STRATEGY_NAME="${STRATEGY_NAME:-mariadb-strategy-default}"
+export BACKUPCLASS_NAME="${BACKUPCLASS_NAME:-mariadb-default}"
+export BACKUPJOB_NAME="${BACKUPJOB_NAME:-mariadb-src-adhoc}"
+export RESTOREJOB_TOCOPY_NAME="${RESTOREJOB_TOCOPY_NAME:-mariadb-src-to-mariadb-target}"
+export PLAN_NAME="${PLAN_NAME:-mariadb-src-daily}"
+# App user password baked into 05-mariadb-src.yaml / 30-mariadb-target.yaml
+# (REPLACE_WITH_PASSWORD). The demo writes and reads the sentinel row as this
+# user, so both the source and the target chart specs declare it.
+export MARIADB_APP_USER="${MARIADB_APP_USER:-app}"
+export MARIADB_PASSWORD="${MARIADB_PASSWORD:-Xai7Wepo0aeThie8}"
+
+# S3 endpoint CA. cozystack's default seaweedfs serves its S3 endpoint with a
+# self-signed certificate whose CA lives in this Secret; the demo copies its
+# ca.crt into a per-app Secret the mariadb-operator Backup CR trusts via
+# storage.s3.tls.caSecretKeyRef. The name follows the seaweedfs chart's
+# fullnameOverride ("seaweedfs" -> "seaweedfs-ca-cert"); run-all.sh
+# auto-discovers the CA Certificate's actual secret when this default is
+# absent, so an upstream fullname change does not silently break the copy. On
+# a cluster whose S3 endpoint is signed by a publicly-trusted CA, set
+# S3_CA_SECRET="" to skip the copy and drop the tls block from the manifests.
+export S3_CA_SECRET="${S3_CA_SECRET:-seaweedfs-ca-cert}"
+export S3_CA_NAMESPACE="${S3_CA_NAMESPACE:-tenant-root}"
+export S3_CA_KEY="${S3_CA_KEY:-ca.crt}"
+
+log_info()    { echo -e "${BLUE}i${NC} $*" >&2; }
+log_success() { echo -e "${GREEN}OK${NC} $*" >&2; }
+log_warning() { echo -e "${YELLOW}!${NC} $*" >&2; }
+log_error()   { echo -e "${RED}x${NC} $*" >&2; }
+log_step()    { echo -e "\n${MAGENTA}${BOLD}> $*${NC}" >&2; }
+log_substep() { echo -e "${CYAN}  -> $*${NC}" >&2; }
+
+print_header() {
+    echo -e "\n${MAGENTA}${BOLD}== $1 ==${NC}\n" >&2
+}
+
+# Wait until a JSONPath value on a resource matches the desired string.
+# Optional 7th arg is a TERMINAL failure value: once the field reaches it the
+# wait returns 1 immediately instead of polling to the timeout. BackupJob and
+# RestoreJob settle on a terminal phase=Failed that never becomes Succeeded, so
+# failing fast on it keeps wall-clock (and the operator Job's log, before its
+# TTL reaper fires) in reach.
+wait_for_field() {
+    local resource_type="$1"
+    local resource_name="$2"
+    local jsonpath="$3"
+    local desired="$4"
+    local namespace="${5:-}"
+    local timeout="${6:-300}"
+    local fail_value="${7:-}"
+
+    log_substep "Waiting for $resource_type/$resource_name $jsonpath to become '$desired'..."
+    local elapsed=0
+    local ns_flag=()
+    [[ -n "$namespace" ]] && ns_flag=(-n "$namespace")
+
+    while true; do
+        local current
+        current=$(kubectl get "$resource_type" "$resource_name" "${ns_flag[@]}" -o jsonpath="$jsonpath" 2>/dev/null || true)
+        if [[ "$current" == "$desired" ]]; then
+            log_success "$resource_type/$resource_name reached '$desired'"
+            return 0
+        fi
+        if [[ -n "$fail_value" && "$current" == "$fail_value" ]]; then
+            log_error "$resource_type/$resource_name reached terminal '$current' (expected '$desired')"
+            return 1
+        fi
+        if [[ $elapsed -ge $timeout ]]; then
+            log_error "Timeout waiting for $resource_type/$resource_name (current: '$current', expected: '$desired')"
+            return 1
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+}
+
+# Wait for a HelmRelease to become Ready, with an existence backstop (the
+# apps controller creates the HR asynchronously, so a bare `kubectl wait`
+# right after `kubectl apply` races it) and a fail-fast on Stalled=True —
+# a stalled HR has exhausted its remediation retries and will never turn
+# Ready, so polling to the timeout only hides the real error.
+wait_hr_ready() {
+    local name="$1"
+    local timeout="${2:-300}"
+    local elapsed=0
+
+    log_substep "Waiting for HelmRelease/$name to become Ready..."
+    while true; do
+        if kubectl -n "$NAMESPACE" get hr "$name" >/dev/null 2>&1; then
+            local ready stalled
+            ready=$(kubectl -n "$NAMESPACE" get hr "$name" \
+                -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null || true)
+            if [[ "$ready" == "True" ]]; then
+                log_success "HelmRelease/$name is Ready"
+                return 0
+            fi
+            stalled=$(kubectl -n "$NAMESPACE" get hr "$name" \
+                -o jsonpath='{.status.conditions[?(@.type=="Stalled")].status}' 2>/dev/null || true)
+            if [[ "$stalled" == "True" ]]; then
+                log_error "HelmRelease/$name is Stalled (terminal): $(kubectl -n "$NAMESPACE" get hr "$name" \
+                    -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null)"
+                return 1
+            fi
+        fi
+        if [[ $elapsed -ge $timeout ]]; then
+            log_error "Timeout waiting for HelmRelease/$name to become Ready:"
+            kubectl -n "$NAMESPACE" get hr "$name" \
+                -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' >&2 2>/dev/null || true
+            return 1
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+}
+
+# Name of the primary pod of a k8s.mariadb.com/MariaDB CR (the writer).
+# mariadb-operator 25.10.x reports the primary identity on
+# MariaDB.status.currentPrimary rather than a pod label, so read it there.
+mariadb_primary_pod() {
+    local cr="$1"
+    kubectl -n "$NAMESPACE" get mariadbs.k8s.mariadb.com "$cr" \
+        -o jsonpath='{.status.currentPrimary}' 2>/dev/null
+}
+
+# Run a single SQL statement against a MariaDB CR's primary as the app user,
+# routing through the operator-managed primary Service (mariadb-<app>-primary).
+# Args: <cr-name> <sql>
+mysql_exec() {
+    local cr="$1" sql="$2"
+    local pod
+    pod=$(mariadb_primary_pod "$cr")
+    [[ -n "$pod" ]] || { log_error "no primary pod for MariaDB CR '$cr'"; return 1; }
+    kubectl -n "$NAMESPACE" exec "$pod" -c mariadb -- \
+        mariadb -u"$MARIADB_APP_USER" -p"$MARIADB_PASSWORD" -h "${cr}-primary" -e "$sql"
+}

--- a/examples/backups/mariadb/10-mariadb-strategy.yaml
+++ b/examples/backups/mariadb/10-mariadb-strategy.yaml
@@ -32,8 +32,8 @@ spec:
         # so deploy a per-app Secret named "<app>-mariadb-backup-creds"
         # holding AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY extracted from
         # BucketInfo (extract the access key id / secret access key from
-        # the BucketInfo JSON and project them under those two keys; a
-        # bats e2e harness lands in a follow-up PR).
+        # the BucketInfo JSON and project them under those two keys;
+        # run-all.sh in this directory does this automatically).
         accessKeyIdSecretKeyRef:
           name: "{{ .Application.metadata.name }}-mariadb-backup-creds"
           key: "AWS_ACCESS_KEY_ID"

--- a/examples/backups/mariadb/30-mariadb-target.yaml
+++ b/examples/backups/mariadb/30-mariadb-target.yaml
@@ -12,11 +12,11 @@
 # mariadb-src; replicate this whenever you want to verify a restore
 # under non-root credentials.
 #
-# Same-namespace to-copy flows are smoke-testable manually by applying
-# this manifest alongside mariadb-src. Cross-tenant restores (target in
-# tenant-test, source's seaweedfs in tenant-root) are blocked by the
-# per-tenant Cilium egress policy and stay a manual / dev-cluster flow.
-# A dedicated bats e2e harness will land in a follow-up PR.
+# Same-namespace to-copy flows are exercised by run-all.sh in this
+# directory (and by the mariadb-2-backup-roundtrip Chainsaw suite).
+# Cross-tenant restores (target in tenant-test, source's seaweedfs in
+# tenant-root) are blocked by the per-tenant Cilium egress policy and
+# stay a manual / dev-cluster flow.
 ---
 apiVersion: apps.cozystack.io/v1alpha1
 kind: MariaDB

--- a/examples/backups/mariadb/40-restorejob-to-copy.yaml
+++ b/examples/backups/mariadb/40-restorejob-to-copy.yaml
@@ -4,10 +4,10 @@
 # dump into the running target while mariadb-src stays running and
 # untouched.
 #
-# Smoke-testable manually with kubectl apply -f for the same-namespace
-# happy path. The cross-tenant variant stays manual; see
-# 30-mariadb-target.yaml for the network-policy reason. A dedicated bats
-# e2e harness will land in a follow-up PR.
+# Driven for the same-namespace happy path by run-all.sh in this
+# directory (and the mariadb-2-backup-roundtrip Chainsaw suite); also
+# applicable manually with kubectl apply -f. The cross-tenant variant
+# stays manual; see 30-mariadb-target.yaml for the network-policy reason.
 ---
 apiVersion: backups.cozystack.io/v1alpha1
 kind: RestoreJob

--- a/examples/backups/mariadb/README.md
+++ b/examples/backups/mariadb/README.md
@@ -44,6 +44,8 @@ NAMESPACE=tenant-root examples/backups/mariadb/run-all.sh
 NAMESPACE=tenant-root examples/backups/mariadb/cleanup.sh
 ```
 
+`S3_CA_NAMESPACE` defaults to `tenant-root` (where the shared seaweedfs and its CA live) independently of `NAMESPACE`. Running against a different tenant whose own seaweedfs CA lives elsewhere means overriding `S3_CA_NAMESPACE` (and `S3_CA_SECRET`) too, alongside `NAMESPACE`.
+
 `run-all.sh` writes a sentinel row into the source, waits for the `BackupJob` to reach `Succeeded`, restores to a copy with a to-copy `RestoreJob`, and asserts the sentinel round-tripped through S3 into the restored copy while the source is left untouched. Set `SKIP_RESTORE=1` to stop after a successful backup.
 
 Same-namespace flows are the supported path. Cross-tenant restores (target in `tenant-test`, source's seaweedfs in `tenant-root`) are blocked by the per-tenant Cilium egress policy and stay a manual / dev-cluster flow.

--- a/examples/backups/mariadb/README.md
+++ b/examples/backups/mariadb/README.md
@@ -27,18 +27,27 @@ MariaDB application via the `strategy.backups.cozystack.io/v1alpha1`
 | 7 | `35-restorejob-in-place.yaml` | namespaced | Destructive restore back into the source. |
 | 8 | `40-restorejob-to-copy.yaml` | namespaced | Non-destructive restore into the target. |
 
-Replace `REPLACE_WITH_*` placeholders in `10-mariadb-strategy.yaml`
-(bucket, S3 endpoint) and `05-mariadb-src.yaml` (password) before
-applying.
+The MariaDB driver delegates execution to the open-source [mariadb-operator](https://github.com/mariadb-operator/mariadb-operator) (`k8s.mariadb.com` CRDs, already shipped with Cozystack). Backups materialise as `Backup` CRs and restores as `Restore` CRs in the application's namespace; the operator handles the actual `mariadb-dump` / `mariadb-import` invocations.
 
-The MariaDB driver delegates execution to the open-source
-[mariadb-operator](https://github.com/mariadb-operator/mariadb-operator)
-(`k8s.mariadb.com` CRDs, already shipped with Cozystack). Backups
-materialise as `Backup` CRs and restores as `Restore` CRs in the
-application's namespace; the operator handles the actual `mariadb-dump`
-/ `mariadb-import` invocations.
+## Placeholders and derived Secrets
 
-Same-namespace flows are smoke-testable manually with `kubectl apply -f`.
-Cross-tenant restores are blocked by the per-tenant Cilium egress policy
-and stay a manual flow. A dedicated bats e2e harness will land in a
-follow-up PR.
+`05-mariadb-src.yaml` / `30-mariadb-target.yaml` carry `REPLACE_WITH_PASSWORD` and `10-mariadb-strategy.yaml` carries `REPLACE_WITH_COSI_BUCKET_NAME` and `REPLACE_WITH_S3_ENDPOINT` (a path-style endpoint without scheme). The strategy also references two Secrets, `<app>-mariadb-backup-creds` (the S3 credentials the mariadb-operator Backup reads) and `<app>-mariadb-backup-ca` (the CA it trusts for a self-signed endpoint), where `<app>` is the Cozystack application name. The strategy template renders those names against whichever application it drives, so the restore target needs its own pair too — a restore into `mariadb-target` looks up `mariadb-target-mariadb-backup-*`. `run-all.sh` resolves the placeholders from the provisioned `Bucket`'s `BucketInfo` Secret and materialises the pair for both the source and the target; editing by hand, you copy the coordinates from `kubectl -n <ns> get secret bucket-<bucket>-backup -o jsonpath='{.data.BucketInfo}'` and the CA from the seaweedfs CA secret in `tenant-root` (`seaweedfs-ca-cert` by default; `run-all.sh` auto-discovers it from the cert-manager Certificate if the name differs).
+
+Drop the `tls` block from `10-mariadb-strategy.yaml` (and set `S3_CA_SECRET=""` for `run-all.sh`) when the S3 endpoint is signed by a publicly-trusted CA.
+
+## Run it
+
+```sh
+# Defaults to NAMESPACE=tenant-root; override for a tenant namespace.
+NAMESPACE=tenant-root examples/backups/mariadb/run-all.sh
+# Tear everything down afterwards (idempotent).
+NAMESPACE=tenant-root examples/backups/mariadb/cleanup.sh
+```
+
+`run-all.sh` writes a sentinel row into the source, waits for the `BackupJob` to reach `Succeeded`, restores to a copy with a to-copy `RestoreJob`, and asserts the sentinel round-tripped through S3 into the restored copy while the source is left untouched. Set `SKIP_RESTORE=1` to stop after a successful backup.
+
+Same-namespace flows are the supported path. Cross-tenant restores (target in `tenant-test`, source's seaweedfs in `tenant-root`) are blocked by the per-tenant Cilium egress policy and stay a manual / dev-cluster flow.
+
+## Automated e2e
+
+The Chainsaw suite at `hack/e2e-chainsaw/mariadb/` drives this same `run-all.sh` as a second test (`mariadb-2-backup-roundtrip`), selected by Test-Impact Analysis whenever the mariadb app or the suite changes, and on every release cut. It runs in `tenant-root` against the in-cluster seaweedfs endpoint — the isolated e2e tenant cannot reach it across the Cilium egress policy, and the external ingress endpoint is an unroutable placeholder in the sandbox.

--- a/examples/backups/mariadb/cleanup.sh
+++ b/examples/backups/mariadb/cleanup.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Best-effort teardown of everything the demo creates. Idempotent;
+# missing resources are skipped silently.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/00-helpers.sh"
+
+print_header "Cleanup"
+
+log_substep "Deleting RestoreJob..."
+kubectl -n "$NAMESPACE" delete restorejob.backups.cozystack.io "$RESTOREJOB_TOCOPY_NAME" --ignore-not-found
+
+log_substep "Deleting Plan + BackupJob + derived Backup artefacts..."
+kubectl -n "$NAMESPACE" delete plan.backups.cozystack.io "$PLAN_NAME" --ignore-not-found
+kubectl -n "$NAMESPACE" delete backupjob.backups.cozystack.io "$BACKUPJOB_NAME" --ignore-not-found
+# Only the Backups of THIS demo's apps — never `--all`: on a shared cluster the
+# namespace can hold Backup artefacts of other applications and flows.
+for b in $(kubectl -n "$NAMESPACE" get backups.backups.cozystack.io \
+        -o jsonpath='{range .items[*]}{.metadata.name} {.spec.applicationRef.name}{"\n"}{end}' 2>/dev/null |
+        awk -v src="$MARIADB_SRC_NAME" -v tgt="$MARIADB_TARGET_NAME" '$2 == src || $2 == tgt {print $1}'); do
+    kubectl -n "$NAMESPACE" delete backups.backups.cozystack.io "$b" --ignore-not-found
+done
+
+# The Cozystack BackupJob/RestoreJob own their operator-side k8s.mariadb.com
+# Backup/Restore CRs only by the OwningJob labels (not OwnerReferences), so
+# deleting the Cozystack jobs does not cascade to them. Left behind, a stale
+# operator-side Backup would be reused by findMariaDBBackupForJob on the next
+# run against a bucket path that no longer exists. Prune them by owner.
+log_substep "Deleting operator-side k8s.mariadb.com Backup/Restore CRs..."
+for owner in "$BACKUPJOB_NAME" "$RESTOREJOB_TOCOPY_NAME"; do
+    kubectl -n "$NAMESPACE" delete backups.k8s.mariadb.com,restores.k8s.mariadb.com \
+        -l "backups.cozystack.io/owned-by.BackupJobName=${owner}" --ignore-not-found
+done
+
+log_substep "Deleting MariaDB apps..."
+kubectl -n "$NAMESPACE" delete mariadb.apps.cozystack.io "$MARIADB_SRC_NAME" "$MARIADB_TARGET_NAME" --ignore-not-found
+
+log_substep "Deleting per-app backup Secrets..."
+kubectl -n "$NAMESPACE" delete secret \
+    "${MARIADB_SRC_NAME}-mariadb-backup-creds" "${MARIADB_SRC_NAME}-mariadb-backup-ca" \
+    "${MARIADB_TARGET_NAME}-mariadb-backup-creds" "${MARIADB_TARGET_NAME}-mariadb-backup-ca" --ignore-not-found
+
+log_substep "Deleting Bucket..."
+kubectl -n "$NAMESPACE" delete bucket.apps.cozystack.io "$BUCKET_NAME" --ignore-not-found
+
+log_substep "Deleting BackupClass + MariaDB strategy (cluster-scoped)..."
+kubectl delete backupclass.backups.cozystack.io "$BACKUPCLASS_NAME" --ignore-not-found
+kubectl delete mariadb.strategy.backups.cozystack.io "$STRATEGY_NAME" --ignore-not-found
+
+log_success "Cleanup complete."

--- a/examples/backups/mariadb/run-all.sh
+++ b/examples/backups/mariadb/run-all.sh
@@ -1,0 +1,198 @@
+#!/bin/bash
+# Convenience runner + e2e harness for the MariaDB backup/restore demo.
+#
+# It applies the SAME numbered manifests a human reads (00-bucket.yaml ..
+# 40-restorejob-to-copy.yaml), filling the REPLACE_WITH_* placeholders from the
+# provisioned Bucket and deriving the two Secrets the manifests reference
+# (<app>-mariadb-backup-creds, <app>-mariadb-backup-ca) so the documented flow
+# and the automated test can never drift. Stops on the first failure.
+#
+# Flow: Bucket -> source MariaDB (+ a sentinel row) -> MariaDB strategy +
+# BackupClass -> ad-hoc BackupJob (wait Succeeded) -> empty target MariaDB +
+# to-copy RestoreJob (wait Succeeded) -> assert the sentinel round-tripped
+# through S3 into the restored copy while the source stays untouched.
+#
+# Why to-copy and not in-place: in-place replays the dump straight into the
+# live source MariaDB (dropping and re-creating the restored databases there),
+# so it cannot witness the restore on a separate instance. To-copy leaves the
+# source running and lands the marker row on a distinct target, a stronger
+# restore proof; the in-place dispatch is covered at the unit level by the
+# controller tests.
+#
+# Override NAMESPACE / endpoint / CA via the environment; see 00-helpers.sh.
+# hack/e2e-chainsaw/mariadb/ drives this file as mariadb-2-backup-roundtrip.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/00-helpers.sh"
+
+# Substitute the manifest placeholders. $BUCKET / $S3_HOST are resolved from the
+# Bucket below; $MARIADB_PASSWORD is the app user's password.
+subst() {
+    sed \
+        -e "s|REPLACE_WITH_COSI_BUCKET_NAME|${BUCKET}|g" \
+        -e "s|REPLACE_WITH_S3_ENDPOINT|${S3_HOST}|g" \
+        -e "s|REPLACE_WITH_PASSWORD|${MARIADB_PASSWORD}|g" \
+        "$SCRIPT_DIR/$1"
+}
+
+# The mariadb-operator provisions the demo database + app user + grant from the
+# chart as k8s.mariadb.com CRs named after the release (mariadb-<app>). The
+# grant is the last of the three to reconcile, so its readiness is the signal
+# that the app user can actually write into demo. Both "demo" and "app" are
+# already DNS-safe, so the grant CR is <cr>-demo-app.
+wait_app_grant_ready() {
+    local cr="$1" timeout="${2:-180}"
+    wait_for_field grants.k8s.mariadb.com "${cr}-demo-app" \
+        '{.status.conditions[?(@.type=="Ready")].status}' True "$NAMESPACE" "$timeout"
+}
+
+print_header "Step 00: Provision Bucket '${BUCKET_NAME}' in ${NAMESPACE}"
+kubectl -n "$NAMESPACE" apply -f "$SCRIPT_DIR/00-bucket.yaml"
+wait_hr_ready "bucket-${BUCKET_NAME}" 300
+wait_for_field bucketclaims.objectstorage.k8s.io "bucket-${BUCKET_NAME}" \
+    '{.status.bucketReady}' true "$NAMESPACE" 300
+wait_for_field bucketaccesses.objectstorage.k8s.io "bucket-${BUCKET_NAME}-${BUCKET_USER}" \
+    '{.status.accessGranted}' true "$NAMESPACE" 300
+
+log_substep "Reading bucket coordinates from BucketInfo Secret..."
+TMP=$(mktemp)
+trap 'rm -f "$TMP"' EXIT
+kubectl -n "$NAMESPACE" get secret "bucket-${BUCKET_NAME}-${BUCKET_USER}" \
+    -o jsonpath='{.data.BucketInfo}' | base64 -d > "$TMP"
+S3_ACCESS_KEY=$(jq -r '.spec.secretS3.accessKeyID' "$TMP")
+S3_SECRET_KEY=$(jq -r '.spec.secretS3.accessSecretKey' "$TMP")
+# S3_ENDPOINT can be overridden via the environment: BucketInfo advertises the
+# EXTERNAL ingress endpoint, which in-cluster Pods cannot always reach or
+# TLS-validate; the in-cluster alternative is https://seaweedfs-s3.<ns>:8333
+# (trusted via the copied CA below).
+S3_ENDPOINT="${S3_ENDPOINT:-$(jq -r '.spec.secretS3.endpoint' "$TMP")}"
+BUCKET=$(jq -r '.spec.bucketName' "$TMP")
+for v in S3_ACCESS_KEY S3_SECRET_KEY S3_ENDPOINT BUCKET; do
+    [[ -n "${!v}" && "${!v}" != "null" ]] || { log_error "BucketInfo missing required field: ${v}"; exit 1; }
+done
+# The strategy manifest takes a path-style endpoint WITHOUT scheme, so strip it.
+S3_HOST=${S3_ENDPOINT#https://}; S3_HOST=${S3_HOST#http://}
+log_success "Bucket '${BUCKET}' at endpoint '${S3_ENDPOINT}'."
+
+print_header "Step 05a: Materialise the Secrets the MariaDB strategy references"
+# Resolve the S3 endpoint CA secret. The default name tracks the seaweedfs
+# chart's fullnameOverride (seaweedfs -> seaweedfs-ca-cert), but a downstream
+# fullname change would rename it, so fall back to discovering the cert-manager
+# CA Certificate (the seaweedfs-labelled one with spec.isCA=true) and read its
+# secretName. Leave S3_CA_SECRET empty to skip the copy on a public-CA endpoint.
+if [[ -n "$S3_CA_SECRET" ]] \
+    && ! kubectl -n "$S3_CA_NAMESPACE" get secret "$S3_CA_SECRET" >/dev/null 2>&1; then
+    log_warning "S3 CA secret ${S3_CA_NAMESPACE}/${S3_CA_SECRET} not found; discovering the seaweedfs CA Certificate..."
+    # List every seaweedfs Certificate as "<isCA> <secretName>" and pick the CA
+    # one in shell — avoids kubectl jsonpath's finicky boolean-literal filter.
+    DISCOVERED_CA=$(kubectl -n "$S3_CA_NAMESPACE" get certificates.cert-manager.io \
+        -l app.kubernetes.io/name=seaweedfs \
+        -o jsonpath='{range .items[*]}{.spec.isCA}{" "}{.spec.secretName}{"\n"}{end}' 2>/dev/null \
+        | awk '$1=="true"{print $2; exit}' || true)
+    if [[ -n "$DISCOVERED_CA" ]]; then
+        log_success "Discovered seaweedfs CA secret ${S3_CA_NAMESPACE}/${DISCOVERED_CA}"
+        S3_CA_SECRET="$DISCOVERED_CA"
+    else
+        log_error "No seaweedfs CA Certificate found in ${S3_CA_NAMESPACE}; set S3_CA_SECRET explicitly (or empty for a public-CA endpoint)."
+        exit 1
+    fi
+fi
+# The strategy (10) renders <app>-mariadb-backup-creds / <app>-mariadb-backup-ca
+# against whichever application it drives. .Application is the cozystack
+# apps.cozystack.io/MariaDB object, so .Application.metadata.name is the app
+# name (mariadb-src), NOT the prefixed operator-side CR (mariadb-mariadb-src).
+# mariadb-operator reads AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY from the
+# creds Secret and trusts ca.crt from the CA Secret when talking to a
+# self-signed S3 endpoint, so a restore TARGET needs its own pair too
+# (materialised again in step 30). kubectl apply (not create) so a stale pair
+# from an earlier run is corrected.
+materialise_backup_secrets() {
+    local app="$1"
+    kubectl -n "$NAMESPACE" create secret generic "${app}-mariadb-backup-creds" \
+        --from-literal="AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY}" \
+        --from-literal="AWS_SECRET_ACCESS_KEY=${S3_SECRET_KEY}" \
+        --dry-run=client -o yaml | kubectl apply -f -
+
+    if [[ -n "$S3_CA_SECRET" ]]; then
+        log_substep "Copying S3 CA ${S3_CA_NAMESPACE}/${S3_CA_SECRET}[${S3_CA_KEY}] -> ${app}-mariadb-backup-ca..."
+        local ca_pem
+        ca_pem=$(kubectl -n "$S3_CA_NAMESPACE" get secret "$S3_CA_SECRET" \
+            -o jsonpath="{.data.${S3_CA_KEY//./\\.}}" | base64 -d)
+        [[ -n "$ca_pem" ]] || { log_error "S3 CA secret ${S3_CA_NAMESPACE}/${S3_CA_SECRET} has no ${S3_CA_KEY}"; exit 1; }
+        kubectl -n "$NAMESPACE" create secret generic "${app}-mariadb-backup-ca" \
+            --from-literal="ca.crt=${ca_pem}" \
+            --dry-run=client -o yaml | kubectl apply -f -
+    else
+        log_warning "S3_CA_SECRET empty: the strategy still references ${app}-mariadb-backup-ca."
+        log_warning "Remove the tls block from 10-mariadb-strategy.yaml by hand when the S3 endpoint uses a public CA."
+    fi
+}
+materialise_backup_secrets "$MARIADB_SRC_NAME"
+
+print_header "Step 05b: Deploy source MariaDB '${MARIADB_SRC_NAME}' and wait for it to be healthy"
+subst 05-mariadb-src.yaml | kubectl -n "$NAMESPACE" apply -f -
+wait_hr_ready "mariadb-${MARIADB_SRC_NAME}" 300
+wait_for_field mariadbs.k8s.mariadb.com "$MARIADB_SRC_CR" \
+    '{.status.conditions[?(@.type=="Ready")].status}' True "$NAMESPACE" 600
+wait_app_grant_ready "$MARIADB_SRC_CR"
+
+print_header "Step 05c: Write a sentinel row so the backup has something to prove"
+SENTINEL_TOKEN="e2e-$(date +%s)-$$"
+mysql_exec "$MARIADB_SRC_CR" "
+    CREATE TABLE IF NOT EXISTS demo.e2e_sentinel (id INT PRIMARY KEY, token VARCHAR(64));
+    REPLACE INTO demo.e2e_sentinel (id, token) VALUES (1, '${SENTINEL_TOKEN}');"
+log_success "Sentinel token: ${SENTINEL_TOKEN}"
+
+print_header "Step 10/15: Create the MariaDB strategy + BackupClass"
+subst 10-mariadb-strategy.yaml | kubectl apply -f -
+kubectl apply -f "$SCRIPT_DIR/15-backupclass.yaml"
+
+print_header "Step 25: Submit ad-hoc BackupJob '${BACKUPJOB_NAME}' and wait for Succeeded"
+kubectl -n "$NAMESPACE" apply -f "$SCRIPT_DIR/25-backupjob-adhoc.yaml"
+wait_for_field backupjobs.backups.cozystack.io "$BACKUPJOB_NAME" \
+    '{.status.phase}' Succeeded "$NAMESPACE" 600 Failed
+BACKUP_NAME=$(kubectl -n "$NAMESPACE" get backupjobs.backups.cozystack.io "$BACKUPJOB_NAME" \
+    -o jsonpath='{.status.backupRef.name}')
+[[ -n "$BACKUP_NAME" ]] || { log_error "BackupJob succeeded but reported no backupRef"; exit 1; }
+log_success "Backup artefact: ${BACKUP_NAME}"
+
+if [[ "${SKIP_RESTORE:-0}" == "1" ]]; then
+    log_warning "SKIP_RESTORE=1: stopping after a successful backup."
+    exit 0
+fi
+
+print_header "Step 30/40: Restore to a copy '${MARIADB_TARGET_NAME}' and wait for Succeeded"
+# The strategy renders <app>-mariadb-backup-creds / -ca against the TARGET
+# during a restore, so the target needs its own Secret pair (same S3 coords).
+materialise_backup_secrets "$MARIADB_TARGET_NAME"
+subst 30-mariadb-target.yaml | kubectl -n "$NAMESPACE" apply -f -
+wait_hr_ready "mariadb-${MARIADB_TARGET_NAME}" 300
+wait_for_field mariadbs.k8s.mariadb.com "$MARIADB_TARGET_CR" \
+    '{.status.conditions[?(@.type=="Ready")].status}' True "$NAMESPACE" 600
+kubectl -n "$NAMESPACE" apply -f "$SCRIPT_DIR/40-restorejob-to-copy.yaml"
+wait_for_field restorejobs.backups.cozystack.io "$RESTOREJOB_TOCOPY_NAME" \
+    '{.status.phase}' Succeeded "$NAMESPACE" 900 Failed
+# The restore replays the logical dump (schema + rows), but the app user is NOT
+# in the dump — it comes from the target chart. Wait for its grant before the
+# read below so the SELECT authenticates.
+wait_app_grant_ready "$MARIADB_TARGET_CR"
+
+print_header "Step 40 verify: the sentinel round-tripped through S3 into the copy"
+GOT=$(mysql_exec "$MARIADB_TARGET_CR" "SELECT token FROM demo.e2e_sentinel WHERE id = 1;" \
+    | awk 'NR==2{print}' | tr -d '[:space:]')
+if [[ "$GOT" != "$SENTINEL_TOKEN" ]]; then
+    log_error "sentinel mismatch: target has '${GOT}', expected '${SENTINEL_TOKEN}'"
+    exit 1
+fi
+log_success "Round-trip verified: '${MARIADB_TARGET_NAME}' restored sentinel '${GOT}' from S3."
+
+# To-copy must not mutate the source. Regressing into a source-touching restore
+# would corrupt the running instance, so assert the source still reads back.
+SRC_GOT=$(mysql_exec "$MARIADB_SRC_CR" "SELECT token FROM demo.e2e_sentinel WHERE id = 1;" \
+    | awk 'NR==2{print}' | tr -d '[:space:]')
+if [[ "$SRC_GOT" != "$SENTINEL_TOKEN" ]]; then
+    log_error "source sentinel changed after to-copy restore: source has '${SRC_GOT}', expected '${SENTINEL_TOKEN}'"
+    exit 1
+fi
+log_success "Source '${MARIADB_SRC_NAME}' left untouched by the to-copy restore."

--- a/hack/e2e-chainsaw/mariadb/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/mariadb/chainsaw-test.yaml
@@ -209,7 +209,10 @@ spec:
 # BackupJob (waits Succeeded) -> empty target MariaDB + to-copy RestoreJob
 # (waits Succeeded) and asserts the sentinel round-tripped through S3 into the
 # restored copy while the source stays untouched — the in-cluster witness that
-# a mariadb-operator backup is both taken and restorable end to end.
+# a mariadb-operator backup is both taken and restorable end to end. It follows
+# the same harness-driving shape as etcd-2-backup-roundtrip
+# (hack/e2e-chainsaw/etcd/chainsaw-test.yaml): a single run step pre-cleans any
+# leftover state, drives run-all.sh, and drains in an always-reached finally.
 #
 # Runs in tenant-root, not the default tenant-test: the S3 client here is the
 # mariadb-operator Backup/Restore Job INSIDE the tenant, and the e2e tenant is
@@ -260,6 +263,20 @@ spec:
   steps:
   - name: run
     try:
+    # Pre-clean: tenant-root is a shared, persistent namespace with fixed
+    # resource names, so a run killed before the finally below leaves stale
+    # state behind. A leftover BackupJob still carrying status.phase=Succeeded
+    # from a prior run would satisfy `wait_for_field ... Succeeded` instantly
+    # and pass without a real backup ever running. cleanup.sh is idempotent
+    # (--ignore-not-found), so this is a no-op on a clean namespace.
+    - script:
+        timeout: 8m
+        content: |
+          set -eu
+          cd ../../..
+          NAMESPACE="$NAMESPACE" examples/backups/mariadb/cleanup.sh
+        check:
+          ($error == null): true
     # The 30m budget is the whole documented flow: bucket provisioning, a
     # 2-replica source MariaDB (each replica's operator startup probe grants
     # 310s of first-boot budget — see the mariadb app suite above), the logical

--- a/hack/e2e-chainsaw/mariadb/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/mariadb/chainsaw-test.yaml
@@ -201,3 +201,90 @@ spec:
             name: mariadb-single-metrics
           status:
             replicas: 1
+---
+# Full logical-dump backup -> to-copy RestoreJob round-trip, driving the
+# validated example scripts (examples/backups/mariadb) as the harness so the
+# test and the documented flow can never drift. run-all.sh runs Bucket ->
+# source MariaDB + sentinel row -> MariaDB strategy + BackupClass -> ad-hoc
+# BackupJob (waits Succeeded) -> empty target MariaDB + to-copy RestoreJob
+# (waits Succeeded) and asserts the sentinel round-tripped through S3 into the
+# restored copy while the source stays untouched — the in-cluster witness that
+# a mariadb-operator backup is both taken and restorable end to end.
+#
+# Runs in tenant-root, not the default tenant-test: the S3 client here is the
+# mariadb-operator Backup/Restore Job INSIDE the tenant, and the e2e tenant is
+# created isolated (hack/e2e-install-cozystack.bats) — its Cilium egress
+# allowlist blocks a tenant-test Pod from reaching tenant-root's seaweedfs,
+# while a tenant-root Pod reaches it over same-tenant egress. The harness
+# targets the in-cluster endpoint (S3_ENDPOINT below) instead of the BucketInfo
+# external ingress URL, which in CI is an unroutable placeholder, and trusts
+# its self-signed cert by copying the seaweedfs CA secret (seaweedfs-ca-cert,
+# auto-discovered from the cert-manager Certificate) into the per-app CA
+# Secret. (The bucket suite's mc checks lean on the same tenant-root seaweedfs,
+# just from the test runner via port-forward.)
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: mariadb-2-backup-roundtrip
+spec:
+  namespace: tenant-root
+  skipDelete: true
+  catch:
+  - events: {}
+  - describe:
+      apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: mariadb-mariadb-src
+  - describe:
+      apiVersion: k8s.mariadb.com/v1alpha1
+      kind: MariaDB
+      name: mariadb-mariadb-src
+  - describe:
+      apiVersion: k8s.mariadb.com/v1alpha1
+      kind: Backup
+  - describe:
+      apiVersion: k8s.mariadb.com/v1alpha1
+      kind: Restore
+  - describe:
+      apiVersion: backups.cozystack.io/v1alpha1
+      kind: BackupJob
+  - describe:
+      apiVersion: backups.cozystack.io/v1alpha1
+      kind: RestoreJob
+  # The dump/import runs in mariadb-operator-created Jobs; a failed upload or
+  # TLS handshake leaves its error in those Pods' logs. Capture the source
+  # instance's Pods too (operator Jobs are short-lived and TTL-reaped).
+  - podLogs:
+      selector: app.kubernetes.io/instance=mariadb-mariadb-src
+      tail: 200
+  steps:
+  - name: run
+    try:
+    # The 30m budget is the whole documented flow: bucket provisioning, a
+    # 2-replica source MariaDB (each replica's operator startup probe grants
+    # 310s of first-boot budget — see the mariadb app suite above), the logical
+    # dump to S3, an empty 2-replica target, and the to-copy restore + verify
+    # (convention 6: justified in-line). run-all.sh fails fast on terminal
+    # BackupJob/RestoreJob phases and stalled HelmReleases rather than polling
+    # out the budget.
+    - script:
+        timeout: 30m
+        content: |
+          set -eu
+          cd ../../..
+          [ -x examples/backups/mariadb/run-all.sh ] || { echo "mariadb backup example scripts not found at examples/backups/mariadb" >&2; exit 1; }
+          NAMESPACE="$NAMESPACE" S3_ENDPOINT="https://seaweedfs-s3.tenant-root:8333" \
+            examples/backups/mariadb/run-all.sh
+        check:
+          ($error == null): true
+    finally:
+    # Removes every resource the harness created (chainsaw did not apply them,
+    # so they are not part of automatic cleanup) — including the operator-side
+    # k8s.mariadb.com Backup/Restore CRs the Cozystack jobs own only by label.
+    - description: backup-flow cleanup
+      script:
+        timeout: 8m
+        content: |
+          set -eu
+          cd ../../..
+          NAMESPACE="$NAMESPACE" examples/backups/mariadb/cleanup.sh


### PR DESCRIPTION
## What

Reworks the never-merged [`backup-mariadb-e2e`](https://github.com/cozystack/cozystack/tree/backup-mariadb-e2e) branch onto the modern Chainsaw e2e approach ([`docs/agents/e2e-testing.md`](https://github.com/cozystack/cozystack/blob/main/docs/agents/e2e-testing.md)), rebuilt on fresh `main`.

That branch bundled the whole MariaDB backup-strategy controller **plus** a `hack/e2e-apps/backup-mariadb.bats` test. The controller and the `examples/backups/mariadb/` manifests have since landed on `main` independently (`feat(platform): implement backup strategy for mariadb`), and the `hack/e2e-apps/*.bats` app suite has been replaced by `hack/e2e-chainsaw/`. So the only piece still missing was the e2e coverage — this PR delivers it the modern way.

## Changes

- **`examples/backups/mariadb/` → executable harness.** Converts the demo from static numbered YAML into the same script harness the other backup demos use (`00-helpers.sh`, `run-all.sh`, `cleanup.sh`), keeping the numbered manifests as the human-readable flow that `run-all.sh` drives — so the documented flow and the automated test can never drift. `run-all.sh` provisions a `Bucket`, derives the two per-app Secrets the strategy references from `BucketInfo` + the seaweedfs CA, deploys a source MariaDB with a sentinel row, fires an ad-hoc `BackupJob`, restores to a copy with a to-copy `RestoreJob`, and asserts the sentinel round-tripped through S3 into the copy while the source is left untouched.
- **`hack/e2e-chainsaw/mariadb/` → second Chainsaw Test** (`mariadb-2-backup-roundtrip`) that drives `run-all.sh` + `cleanup.sh`, following the merged `etcd-2-backup-roundtrip` harness-driving shape: runs in `tenant-root` (the isolated e2e tenant cannot reach `tenant-root`'s seaweedfs across the Cilium egress policy), `skipDelete` since the harness owns the resources, an idempotent pre-clean step so a run killed before `finally` cannot leave a stale `Succeeded` BackupJob that false-passes, fail-fast on terminal `BackupJob`/`RestoreJob` phases, and scoped `catch` diagnostics. Cleanup also prunes the operator-side `k8s.mariadb.com` `Backup`/`Restore` CRs the Cozystack jobs own only by label.
- **`hack/select-e2e.sh` → TIA rule for `examples/backups/<app>/`.** The harness lives outside the suite dir, so without this a harness-only diff produced an empty selection, which `pull-requests.yaml` turns into "skip the whole E2E stage" — a future bug-fix to `run-all.sh` would merge with its own round-trip test never run. The new rule maps `examples/backups/<app>/` to the `<app>` suite that drives it (dir name == suite name for every backup demo except `vmi` → `vminstance`), with three cases added to `hack/select-e2e_test.bats`.

## Conventions followed

- No retries on deterministic steps; the single `script` step carries a justified 30m budget (2 MariaDB instances × 310s first-boot startup probe + dump/restore) and fails fast rather than polling out.
- Self-contained trap-based temp-file cleanup only inside a single step; no test-level EXIT trap.
- Controller-created artifacts Chainsaw cannot reclaim are pruned explicitly by `cleanup.sh`.
- TIA verified: `examples/backups/mariadb/run-all.sh` now selects the `mariadb` suite (`hack/select-e2e.sh`), and editing `select-e2e.sh` itself escalates this PR to the full suite.

## Downstream Repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff. The change touches only e2e test material, backup examples, and CI suite-selection — no package added/renamed/removed, no `values.schema.json` / `values.yaml` / platform-values / variant / `ApplicationDefinition` / namespace / release-asset changes, and no `hack/` file moved/renamed. No downstream repository is reached.

- [x] `cozystack/website` — not affected (no package or platform/docs-source change)
- [x] `cozystack/terraform-provider-cozystack` — not affected (no app/schema/enum/default/prefix change)
- [x] `cozystack/ansible-cozystack` — not affected (no installer values / namespace / variant / node-prereq change)
- [x] `cozystack/ccp` — not affected (no `hack/` move-or-rename, no make-target behavior change)

## Notes

No `make generate` needed — the change touches only `examples/`, `hack/`, and a Chainsaw suite (the edited README is under `examples/`, not a package).

## Release note

```release-note
Add an end-to-end Chainsaw test for the MariaDB backup/restore round-trip, and convert the `examples/backups/mariadb/` demo into an executable `run-all.sh`/`cleanup.sh` harness.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end MariaDB backup and restore demonstration workflow.
  * Added automated backup round-trip validation, including data integrity checks.
  * Added reusable scripts for running the demo and cleaning up created resources.
  * Added automatic handling of backup credentials, endpoints, and trusted certificates.

* **Documentation**
  * Expanded setup, configuration, execution, cleanup, and troubleshooting guidance.
  * Documented same-namespace restore support and cross-tenant limitations.

* **Tests**
  * Added automated Chainsaw coverage for the MariaDB backup and restore workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->