### PR TITLE
fix(kubernetes): re-pin deleted centos:stream9 digest for kubevirt-csi-driver

### DIFF
--- a/packages/apps/kubernetes/images/kubevirt-csi-driver/Dockerfile
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver/Dockerfile
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
     -ldflags "-X kubevirt.io/csi-driver/pkg/service.VendorVersion=0.2.0" \
     -o kubevirt-csi-driver .
 
-FROM quay.io/centos/centos:stream9@sha256:a93e3316b14a226863327f35110909569ec554fc9e092bc307282cf00e17e3d0
+FROM quay.io/centos/centos:stream9@sha256:3714c89f1903dac5a5e1eb6c02d84189ff6d962a0c18df01feba0a5406856926
 
 RUN dnf install -y e2fsprogs xfsprogs nfs-utils && dnf clean all
 


### PR DESCRIPTION
## What this PR does

`quay.io/centos/centos:stream9` is a **rolling tag** — upstream deletes the previously-pinned digest whenever it publishes a new `stream9` build. The digest re-pinned in ce4b263ca (`sha256:a93e3316…`) has now itself been deleted upstream, so every `kubevirt-csi-driver` image build fails:

```
#3 ERROR: quay.io/centos/centos:stream9@sha256:a93e3316…: not found
ERROR: failed to solve: … failed to resolve source metadata … not found
make: *** [Makefile:43: image-kubevirt-csi-driver] Error 1
```

This breaks the **Build packages/apps/kubernetes** job on `main` and on every open PR (e.g. observed on #3383).

Re-pins to the current `stream9` manifest-list digest `sha256:3714c89f1903dac5a5e1eb6c02d84189ff6d962a0c18df01feba0a5406856926`, resolved via `docker buildx imagetools inspect quay.io/centos/centos:stream9`.

> Note: this is the second recurrence of the same class of breakage (ce4b263ca fixed the first). Because `stream9` is a rolling tag, a pinned digest will keep rotting; a follow-up could track it via renovate or pin a date-stamped/immutable tag instead. Out of scope here — this just unblocks CI.

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container build to use a refreshed CentOS Stream 9 base image.
  * No end-user-facing functionality or behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->