### PR TITLE
fix(platform): restore the isp-hosted dependency closure

### DIFF
--- a/packages/core/platform/templates/bundles/iaas.yaml
+++ b/packages/core/platform/templates/bundles/iaas.yaml
@@ -7,7 +7,7 @@
        depends on its control-plane body — rendering iaas without it leaves all 12
        Packages in DependenciesNotReady with nothing naming the cause. */ -}}
 {{- if and .Values.bundles.iaas.enabled (not .Values.bundles.system.enabled) }}
-{{- fail "bundles.iaas.enabled requires bundles.system.enabled: the iaas bundle depends on packages emitted by the system bundle (cozystack.networking, cozystack-engine, cert-manager, prometheus-operator-crds and cozystack-basics). Enable the system bundle with bundles.system.variant: isp-full or isp-full-generic." }}
+{{- fail "bundles.iaas.enabled requires bundles.system.enabled: the iaas bundle depends on packages emitted by the system bundle (cozystack.networking, cozystack.cozystack-engine, cozystack.cert-manager, cozystack.prometheus-operator-crds and cozystack.cozystack-basics). Enable the system bundle with bundles.system.variant: isp-full or isp-full-generic." }}
 {{- end }}
 {{- if and .Values.bundles.iaas.enabled (or (eq .Values.bundles.system.variant "isp-full") (eq .Values.bundles.system.variant "isp-full-generic")) }}
 {{- $kubevirtValues := dict -}}

--- a/packages/core/platform/templates/bundles/iaas.yaml
+++ b/packages/core/platform/templates/bundles/iaas.yaml
@@ -1,6 +1,14 @@
 {{- if and .Values.bundles.iaas.enabled (not (or (eq .Values.bundles.system.variant "isp-full") (eq .Values.bundles.system.variant "isp-full-generic"))) }}
 {{- fail "bundles.iaas.enabled can only be true when bundles.system.variant is 'isp-full' or 'isp-full-generic'" }}
 {{- end }}
+{{- /* Same hole as the paas/naas guards closed: bundles.system.variant keeps its
+       value when bundles.system.enabled is false, so the check above passes on a
+       configuration that skips the system bundle entirely. Every package below
+       depends on its control-plane body — rendering iaas without it leaves all 12
+       Packages in DependenciesNotReady with nothing naming the cause. */ -}}
+{{- if and .Values.bundles.iaas.enabled (not .Values.bundles.system.enabled) }}
+{{- fail "bundles.iaas.enabled requires bundles.system.enabled: the iaas bundle depends on packages emitted by the system bundle (cozystack.networking, cozystack-engine, cert-manager, prometheus-operator-crds and cozystack-basics). Enable the system bundle with bundles.system.variant: isp-full or isp-full-generic." }}
+{{- end }}
 {{- if and .Values.bundles.iaas.enabled (or (eq .Values.bundles.system.variant "isp-full") (eq .Values.bundles.system.variant "isp-full-generic")) }}
 {{- $kubevirtValues := dict -}}
 {{- if .Values.resources.cpuAllocationRatio -}}
@@ -155,7 +163,6 @@
 {{include "cozystack.platform.package.default" (list "cozystack.capi-provider-core" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.capi-provider-cp-kamaji" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.capi-provider-infra-kubevirt" $) }}
-{{include "cozystack.platform.package.default" (list "cozystack.bucket-application" $) }}
 {{include "cozystack.platform.package" (list "cozystack.kubernetes-application" "kubevirt" $) }}
 {{include "cozystack.platform.package" (list "cozystack.virtualprivatecloud-application" "kubevirt" $) }}
 {{include "cozystack.platform.package" (list "cozystack.vm-disk-application" "kubevirt" $) }}

--- a/packages/core/platform/templates/bundles/naas.yaml
+++ b/packages/core/platform/templates/bundles/naas.yaml
@@ -5,7 +5,7 @@
        imply the system bundle is actually emitted, and every package below depends
        on its control-plane body. */ -}}
 {{- if and .Values.bundles.naas.enabled (not .Values.bundles.system.enabled) }}
-{{- fail "bundles.naas.enabled requires bundles.system.enabled: the naas catalog depends on packages emitted by the system bundle (cozystack-engine, which ships the ApplicationDefinition CRD, plus cozystack.networking). To run a hosted platform where the host provides CNI, storage and virtualisation, keep bundles.system.enabled: true and set bundles.system.variant: isp-hosted (which selects a noop networking Package) with bundles.iaas.enabled: false — do not disable the system bundle." }}
+{{- fail "bundles.naas.enabled requires bundles.system.enabled: the naas catalog depends on packages emitted by the system bundle (cozystack.cozystack-engine, which ships the ApplicationDefinition CRD, plus cozystack.networking). To run a hosted platform where the host provides CNI, storage and virtualisation, keep bundles.system.enabled: true and set bundles.system.variant: isp-hosted (which selects a noop networking Package) with bundles.iaas.enabled: false — do not disable the system bundle." }}
 {{- end }}
 {{- if and .Values.bundles.naas.enabled (or (eq .Values.bundles.system.variant "isp-full") (eq .Values.bundles.system.variant "isp-full-generic") (eq .Values.bundles.system.variant "isp-hosted")) }}
 {{include "cozystack.platform.package.default" (list "cozystack.http-cache-application" $) }}

--- a/packages/core/platform/templates/bundles/naas.yaml
+++ b/packages/core/platform/templates/bundles/naas.yaml
@@ -1,6 +1,12 @@
 {{- if and .Values.bundles.naas.enabled (not (or (eq .Values.bundles.system.variant "isp-full") (eq .Values.bundles.system.variant "isp-full-generic") (eq .Values.bundles.system.variant "isp-hosted"))) }}
 {{- fail "bundles.naas.enabled can only be true when bundles.system.variant is 'isp-full', 'isp-full-generic', or 'isp-hosted'" }}
 {{- end }}
+{{- /* See the matching guard in paas.yaml: a valid bundles.system.variant does not
+       imply the system bundle is actually emitted, and every package below depends
+       on its control-plane body. */ -}}
+{{- if and .Values.bundles.naas.enabled (not .Values.bundles.system.enabled) }}
+{{- fail "bundles.naas.enabled requires bundles.system.enabled: the naas catalog depends on packages emitted by the system bundle (cozystack-engine, which ships the ApplicationDefinition CRD, plus cozystack.networking). To run a hosted platform where the host provides CNI, storage and virtualisation, keep bundles.system.enabled: true and set bundles.system.variant: isp-hosted (which selects a noop networking Package) with bundles.iaas.enabled: false — do not disable the system bundle." }}
+{{- end }}
 {{- if and .Values.bundles.naas.enabled (or (eq .Values.bundles.system.variant "isp-full") (eq .Values.bundles.system.variant "isp-full-generic") (eq .Values.bundles.system.variant "isp-hosted")) }}
 {{include "cozystack.platform.package.default" (list "cozystack.http-cache-application" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.tcp-balancer-application" $) }}

--- a/packages/core/platform/templates/bundles/paas.yaml
+++ b/packages/core/platform/templates/bundles/paas.yaml
@@ -9,7 +9,7 @@
        DependenciesNotReady forever and the cozystack-platform HelmRelease never goes
        Ready, with no error pointing at the cause. Fail the render instead. */ -}}
 {{- if and .Values.bundles.paas.enabled (not .Values.bundles.system.enabled) }}
-{{- fail "bundles.paas.enabled requires bundles.system.enabled: the paas catalog depends on packages emitted by the system bundle (cozystack-engine, which ships the ApplicationDefinition CRD, plus cozystack.networking, cert-manager, prometheus-operator-crds, postgres-operator and objectstorage-controller). To run a hosted platform where the host provides CNI, storage and virtualisation, keep bundles.system.enabled: true and set bundles.system.variant: isp-hosted (which selects a noop networking Package) with bundles.iaas.enabled: false — do not disable the system bundle." }}
+{{- fail "bundles.paas.enabled requires bundles.system.enabled: the paas catalog depends on packages emitted by the system bundle (cozystack.cozystack-engine, which ships the ApplicationDefinition CRD, plus cozystack.networking, cozystack.cert-manager, cozystack.prometheus-operator-crds, cozystack.postgres-operator and cozystack.objectstorage-controller). To run a hosted platform where the host provides CNI, storage and virtualisation, keep bundles.system.enabled: true and set bundles.system.variant: isp-hosted (which selects a noop networking Package) with bundles.iaas.enabled: false — do not disable the system bundle." }}
 {{- end }}
 {{- if and .Values.bundles.paas.enabled (or (eq .Values.bundles.system.variant "isp-full") (eq .Values.bundles.system.variant "isp-full-generic") (eq .Values.bundles.system.variant "isp-hosted")) }}
 {{include "cozystack.platform.package.default" (list "cozystack.mariadb-operator" $) }}

--- a/packages/core/platform/templates/bundles/paas.yaml
+++ b/packages/core/platform/templates/bundles/paas.yaml
@@ -1,6 +1,16 @@
 {{- if and .Values.bundles.paas.enabled (not (or (eq .Values.bundles.system.variant "isp-full") (eq .Values.bundles.system.variant "isp-full-generic") (eq .Values.bundles.system.variant "isp-hosted"))) }}
 {{- fail "bundles.paas.enabled can only be true when bundles.system.variant is 'isp-full', 'isp-full-generic', or 'isp-hosted'" }}
 {{- end }}
+{{- /* The variant check above is not sufficient: bundles.system.variant keeps its
+       value when bundles.system.enabled is false, so a preset could select a valid
+       variant and still skip the whole system bundle. Every package below depends on
+       the system bundle's control-plane body, so that combination renders an app
+       catalog whose entire dependency closure is absent — each Package then sits in
+       DependenciesNotReady forever and the cozystack-platform HelmRelease never goes
+       Ready, with no error pointing at the cause. Fail the render instead. */ -}}
+{{- if and .Values.bundles.paas.enabled (not .Values.bundles.system.enabled) }}
+{{- fail "bundles.paas.enabled requires bundles.system.enabled: the paas catalog depends on packages emitted by the system bundle (cozystack-engine, which ships the ApplicationDefinition CRD, plus cozystack.networking, cert-manager, prometheus-operator-crds, postgres-operator and objectstorage-controller). To run a hosted platform where the host provides CNI, storage and virtualisation, keep bundles.system.enabled: true and set bundles.system.variant: isp-hosted (which selects a noop networking Package) with bundles.iaas.enabled: false — do not disable the system bundle." }}
+{{- end }}
 {{- if and .Values.bundles.paas.enabled (or (eq .Values.bundles.system.variant "isp-full") (eq .Values.bundles.system.variant "isp-full-generic") (eq .Values.bundles.system.variant "isp-hosted")) }}
 {{include "cozystack.platform.package.default" (list "cozystack.mariadb-operator" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.kafka-operator" $) }}

--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -241,7 +241,7 @@ cozystack-platform HelmRelease never becomes Ready. */}}
        system-on/iaas-off configuration (i.e. isp-hosted) left
        backupstrategy-controller permanently DependenciesNotReady. Both isp-full
        presets masked that by enabling iaas. Same reasoning as the velero comment
-       below: a hard dependency of a default package must itself be emitted
+       above: a hard dependency of a default package must itself be emitted
        wherever that default package is. */ -}}
 {{include "cozystack.platform.package.default" (list "cozystack.bucket-application" $) }}
 

--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -233,6 +233,17 @@ cozystack-platform HelmRelease never becomes Ready. */}}
 {{include "cozystack.platform.package.default" (list "cozystack.etcd-operator" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.postgres-operator" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.objectstorage-controller" $) }}
+{{- /* bucket-application belongs to the system bundle, not iaas: its own
+       dependsOn closure is cozystack.networking + cozystack.objectstorage-controller
+       + cozystack.cozystack-engine, all emitted here, and nothing in it needs
+       KubeVirt or CAPI. It sat in the iaas bundle while cozystack.backupstrategy-controller
+       — a *default* package of this bundle — hard-depends on it, so every
+       system-on/iaas-off configuration (i.e. isp-hosted) left
+       backupstrategy-controller permanently DependenciesNotReady. Both isp-full
+       presets masked that by enabling iaas. Same reasoning as the velero comment
+       below: a hard dependency of a default package must itself be emitted
+       wherever that default package is. */ -}}
+{{include "cozystack.platform.package.default" (list "cozystack.bucket-application" $) }}
 
 # Optional System Packages (controlled via bundles.enabledPackages)
 {{include "cozystack.platform.package.optional.default" (list "cozystack.nfs-driver" $) }}

--- a/packages/core/platform/tests/bundles_catalog_requires_system_test.yaml
+++ b/packages/core/platform/tests/bundles_catalog_requires_system_test.yaml
@@ -1,0 +1,106 @@
+suite: paas/naas catalogs refuse to render without the system bundle
+templates:
+  - templates/bundles/paas.yaml
+  - templates/bundles/naas.yaml
+  - templates/bundles/iaas.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  # bundles.system.variant keeps its value when bundles.system.enabled is false,
+  # so the pre-existing variant guard passes on a preset that selects a valid
+  # variant and still skips the whole system bundle. That combination shipped in
+  # values-isp-hosted.yaml and produced an app catalog with no dependency
+  # closure: every Package DependenciesNotReady, the cozystack-platform
+  # HelmRelease never Ready, and nothing in the output naming the cause. Fail the
+  # render instead of letting the operator discover it hours later.
+  #
+  # Assertions are scoped with `template:` because helm-unittest otherwise checks
+  # every assertion against every template listed above, and each guard lives in
+  # only one of them.
+  - it: fails the render when paas is enabled without the system bundle
+    set:
+      bundles:
+        system:
+          enabled: false
+          variant: isp-hosted
+        paas:
+          enabled: true
+        naas:
+          enabled: false
+    asserts:
+      - failedTemplate:
+          errorPattern: "bundles\\.paas\\.enabled requires bundles\\.system\\.enabled"
+        template: templates/bundles/paas.yaml
+
+  - it: fails the render when naas is enabled without the system bundle
+    set:
+      bundles:
+        system:
+          enabled: false
+          variant: isp-hosted
+        paas:
+          enabled: false
+        naas:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "bundles\\.naas\\.enabled requires bundles\\.system\\.enabled"
+        template: templates/bundles/naas.yaml
+
+  - it: fails the render when iaas is enabled without the system bundle
+    set:
+      bundles:
+        system:
+          enabled: false
+          variant: isp-full
+        iaas:
+          enabled: true
+        paas:
+          enabled: false
+        naas:
+          enabled: false
+    asserts:
+      - failedTemplate:
+          errorPattern: "bundles\\.iaas\\.enabled requires bundles\\.system\\.enabled"
+        template: templates/bundles/iaas.yaml
+
+  # The message has to tell the operator what to do instead, otherwise the
+  # obvious reading of "requires system" is to abandon the hosted topology.
+  - it: points the operator at the isp-hosted variant rather than at disabling the bundle
+    set:
+      bundles:
+        system:
+          enabled: false
+          variant: isp-hosted
+        paas:
+          enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "bundles\\.system\\.variant: isp-hosted.*bundles\\.iaas\\.enabled: false"
+        template: templates/bundles/paas.yaml
+
+  # The guard must not fire on the supported configurations.
+  - it: renders the catalog when the system bundle is enabled on the hosted variant
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-hosted
+        paas:
+          enabled: true
+        naas:
+          enabled: true
+    asserts:
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.harbor-application
+          any: true
+        template: templates/bundles/paas.yaml
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.vpn-application
+          any: true
+        template: templates/bundles/naas.yaml

--- a/packages/core/platform/tests/bundles_isp_hosted_dependency_closure_test.yaml
+++ b/packages/core/platform/tests/bundles_isp_hosted_dependency_closure_test.yaml
@@ -1,0 +1,146 @@
+suite: isp-hosted emits the dependency closure its app catalog needs
+templates:
+  - templates/bundles/system.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  # The isp-hosted preset drops the data-plane head (the host provides CNI,
+  # storage and virtualisation) but MUST still emit the system bundle's
+  # variant-agnostic control-plane body. Shipping bundles.system.enabled: false
+  # while paas/naas stayed on rendered an app catalog whose entire dependency
+  # closure was absent: all 24 Packages sat in DependenciesNotReady forever and
+  # the cozystack-platform HelmRelease never went Ready. Each package below is a
+  # dependsOn edge of a paas/naas application PackageSource, so losing any one of
+  # them reproduces that wedge.
+  - it: emits every package the paas/naas catalog depends on
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-hosted
+        iaas:
+          enabled: false
+        paas:
+          enabled: true
+        naas:
+          enabled: true
+    asserts:
+      # Sole source of the application-definition-crd component, i.e. the
+      # ApplicationDefinition CRD every *-rd component renders against. Without
+      # it the *-rd HelmReleases fail with `no matches for kind
+      # "ApplicationDefinition" in version "cozystack.io/v1alpha1"`.
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.cozystack-engine
+          any: true
+      # The noop networking Package for this variant. 23 of the catalog's
+      # PackageSources declare dependsOn: cozystack.networking.
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.networking
+          any: true
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.cert-manager
+          any: true
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.prometheus-operator-crds
+          any: true
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.postgres-operator
+          any: true
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.objectstorage-controller
+          any: true
+
+  # bucket-application lives in the system bundle rather than iaas: its own
+  # dependsOn closure is networking + objectstorage-controller + cozystack-engine
+  # and nothing in it needs KubeVirt or CAPI, while cozystack.backupstrategy-controller
+  # — a default package of the system bundle — hard-depends on it. Keeping it in
+  # iaas left every system-on/iaas-off configuration with a permanently
+  # DependenciesNotReady backupstrategy-controller.
+  - it: emits bucket-application from the system bundle even when iaas is disabled
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-hosted
+        iaas:
+          enabled: false
+    asserts:
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.bucket-application
+          any: true
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.backupstrategy-controller
+          any: true
+
+  # The tests above drive the templates through `set:`, so they pin the template
+  # logic but would not notice values-isp-hosted.yaml itself regressing. Load the
+  # shipped preset unmodified — this is the assertion that actually fails if
+  # bundles.system.enabled goes back to false, which is how the wedge shipped.
+  - it: ships the isp-hosted preset with the system bundle enabled
+    values:
+      - ../values-isp-hosted.yaml
+    asserts:
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.cozystack-engine
+          any: true
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.networking
+          any: true
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.bucket-application
+          any: true
+
+  # The hosted variant must not drag in the data-plane it exists to exclude.
+  #
+  # `any: true` is load-bearing on a negated containsDocument. Without it the
+  # assertion negates "EVERY rendered document matches", which any multi-document
+  # render satisfies trivially — the case then passes even with cozystack.linstor
+  # emitted into the hosted branch. With `any: true` it negates "SOME document
+  # matches", which is the intended meaning.
+  - it: does not emit data-plane packages on the hosted variant
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-hosted
+        iaas:
+          enabled: false
+    asserts:
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.linstor
+          any: true
+        not: true
+      # securitygroup-controller is emitted from the common-packages helper, which
+      # only the isp-full branches call — it watches cilium.io CRDs that the noop
+      # networking variant never installs. Emitted on isp-full, absent here.
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.securitygroup-controller
+          any: true
+        not: true

--- a/packages/core/platform/values-isp-hosted.yaml
+++ b/packages/core/platform/values-isp-hosted.yaml
@@ -1,8 +1,19 @@
 migrations:
   enabled: true
 bundles:
+  # The system bundle carries two things: a variant-selected data-plane head
+  # (kubeovn/cilium/linstor on isp-full, a noop networking Package here) and a
+  # variant-agnostic control-plane body (cozystack-engine — the sole source of
+  # the ApplicationDefinition CRD — plus cert-manager, prometheus-operator-crds,
+  # postgres-operator, objectstorage-controller and the *-application catalog).
+  # "Hosted" drops the data-plane head only: the host already provides CNI,
+  # storage and virtualisation. That is expressed by variant: isp-hosted, NOT by
+  # disabling the bundle — turning it off also deletes the control-plane body,
+  # which leaves every paas/naas application Package permanently
+  # DependenciesNotReady. iaas stays off; see templates/bundles/iaas.yaml, which
+  # refuses to render on this variant.
   system:
-    enabled: false
+    enabled: true
     variant: "isp-hosted"
   iaas:
     enabled: false


### PR DESCRIPTION
## Problem

Fixes #3376. The `isp-hosted` preset shipped `bundles.system.enabled: false` while `paas` and `naas` were enabled, so it enabled an app catalog whose dependency closure it simultaneously disabled. Every emitted Package sat in `DependenciesNotReady`, the `*-rd` HelmReleases failed with `no matches for kind "ApplicationDefinition" in version "cozystack.io/v1alpha1"`, and the `cozystack-platform` HelmRelease never went Ready.

Rendering the preset at `origin/main` shows the scale: **24 emitted Packages, 24 of them blocked**, by 6 missing dependencies — two more than the issue lists (`cert-manager` and `prometheus-operator-crds` are also absent). `isp-full` renders 75 Packages with a fully satisfied closure, which is a clean control.

## Root cause

`templates/bundles/system.yaml` is gated end to end on `bundles.system.enabled`, but it carries two separable things: a variant-selected **data-plane head** (kubeovn/cilium/linstor on `isp-full`, a noop networking Package on `isp-hosted`) and a variant-agnostic **control-plane body** — `cozystack-engine`, the sole source of the `application-definition-crd` component, plus `cert-manager`, `prometheus-operator-crds`, `postgres-operator` and `objectstorage-controller`.

"Hosted" means the host already provides CNI, storage and virtualisation, so only the data-plane head should be dropped. Disabling the whole bundle also deleted the control-plane body that every variant needs.

Three things show the disable was the mistake rather than the intent: the preset still sets `variant: "isp-hosted"`; `system.yaml` contains an `isp-hosted` branch (noop networking plus default scheduler) that could never render; and `iaas.yaml` already refuses to render on this variant, encoding the same "system bundle minus iaas" contract. The preset has never worked — it was born this way in `2d022e38e` (January 2026), the refactor that replaced `bundles/paas-hosted.yaml`, whose contents confirm hosted was always meant to ship the engine, `cert-manager` and `prometheus-operator-crds`.

## Changes

1. **`values-isp-hosted.yaml`** — enable the system bundle. Hosted now emits 53 Packages with every `dependsOn` satisfied, installing 59 components against the 60 of the pre-refactor `paas-hosted` bundle, with no LINSTOR, KubeVirt, CAPI or Kamaji leakage.
2. **Move `cozystack.bucket-application`** from the iaas bundle into the system bundle. Its own `dependsOn` closure is `networking` + `objectstorage-controller` + `cozystack-engine`, none of them iaas, while `cozystack.backupstrategy-controller` — a *default* package of the system bundle — hard-depends on it. Any system-on/iaas-off configuration therefore wedged `backupstrategy-controller`; both `isp-full` presets masked this by enabling iaas. This is a second, independent bug not reported in the issue.
3. **Guards** — `paas`, `naas` and `iaas` now also require `bundles.system.enabled`. The pre-existing checks looked only at `bundles.system.variant`, which keeps its value when the bundle is disabled, so they passed on exactly this configuration. `iaas` had the identical hole (12 Packages, 6 unsatisfied deps). This turns a silent multi-hour `DependenciesNotReady` hang into a render-time failure that names the remedy.
4. **Two helm-unittest suites** — one pinning the dependency closure the catalog needs, one pinning the guards.

## Verification

- All four operator-registered variants render dependency-closed: `default` 0 Packages, `isp-hosted` 53, `isp-full` 75, `isp-full-generic` 75. The two `isp-full` variants are byte-identical before and after, so the bucket move is a no-op for them.
- Hosted is a strict subset of full with zero data-plane leakage, and its exclusions match the pre-refactor hosted bundle.
- 23 suites / 97 tests pass in `packages/core/platform`; repo-wide `hack/helm-unit-tests.sh` is green.
- Every change was **mutation-tested** — reverting each one in turn makes the suite fail, so the tests are not vacuous.
- The workaround documented in #3376 (`paas`/`naas` disabled) still renders cleanly; the new guards do not fire on it.
- Hosted runtime spot-checks: `cozystack-api` is a Deployment with only a *preferred* control-plane affinity plus blanket tolerations, and `cozystack-scheduler` uses its `default` variant (plain Deployment, no LINSTOR extender) — both schedule fine on a cluster with no control-plane nodes.

## What this does not fix

This restores the dependency closure. It is **not** by itself sufficient for a fully converged hosted install. Review surfaced further hosted-unaware defaults that the dead bundle had been masking, filed separately:

- #3387 — `apps/tenant` renders 14 `cilium.io/v2` policies with no `.Capabilities` guard, so `tenant-root` fails on a non-Cilium cluster. This is the blocker for actual hosted convergence, and it needs a deliberate decision rather than a reflexive capability guard, because those policies implement tenant network isolation.
- #3388 — `extra/monitoring` defaults `logsStorages` to the LINSTOR-only `replicated` StorageClass.
- #3389 — `bundles.disabledPackages` can still break the closure with no render-time error; the guards here cover the bundle flags only.
- #3390 — nothing in CI exercises `isp-hosted`, which is why all of the above accumulated undetected.

## Upgrade note

Existing `*-application` Package CRs carry `helm.sh/resource-policy: keep`. An operator who applied the #3376 workaround but did not also delete the retained Package CRs (as that issue instructs) will find them install once this change makes their dependencies Ready, since the reconciler re-enqueues dependents on readiness. Deleting the unwanted Packages before upgrading avoids that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fail-fast validation that requires the **System bundle** when enabling **IaaS**, **NaaS**, or **PaaS** to prevent incomplete catalogs.
  * Updated bundle composition so the **bucket application** is provided by the **System bundle**.
  * Enabled the **System bundle** by default for the `isp-hosted` variant.
* **Bug Fixes**
  * Improved error messaging to clearly indicate the required bundle/variant configuration.
* **Tests**
  * Added Helm unittest coverage for rendering-gate failures, dependency/package expectations, and hosted data-plane exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->