### PR TITLE
feat(gateway): advertise HTTP/2 via ALPN on Gateway API listeners

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
@@ -17,6 +17,12 @@ cilium:
   {{- if $.Values.addons.gatewayAPI.enabled }}
   gatewayAPI:
     enabled: true
+    # Without ALPN "h2" on the TLS listener, browsers silently downgrade every
+    # Gateway request to HTTP/1.1 (they negotiate HTTP/2 only via ALPN).
+    # Frontend hop only; backends stay HTTP/1.1 unless their Service declares
+    # appProtocol kubernetes.io/h2c (GEP-1911). Per-cluster opt-out:
+    # addons.cilium.valuesOverride.cilium.gatewayAPI.enableAlpn=false.
+    enableAlpn: true
   envoy:
     enabled: true
   {{- end }}

--- a/packages/apps/kubernetes/tests/cilium_gateway_alpn_test.yaml
+++ b/packages/apps/kubernetes/tests/cilium_gateway_alpn_test.yaml
@@ -1,0 +1,51 @@
+suite: Cilium Gateway API ALPN tests
+templates:
+  - templates/helmreleases/cilium.yaml
+values:
+  - values-ci.yaml
+tests:
+  - it: renders no gatewayAPI block when the gatewayAPI addon is disabled
+    set:
+      addons:
+        gatewayAPI:
+          enabled: false
+        cilium:
+          valuesOverride: {}
+    asserts:
+      - notExists:
+          path: spec.values.cilium.gatewayAPI
+
+  # Browsers negotiate HTTP/2 only through TLS ALPN "h2"; without enableAlpn
+  # every client of a tenant-cluster Gateway silently downgrades to HTTP/1.1.
+  - it: advertises ALPN h2 on Gateway listeners when the gatewayAPI addon is enabled
+    set:
+      addons:
+        gatewayAPI:
+          enabled: true
+        cilium:
+          valuesOverride: {}
+    asserts:
+      - equal:
+          path: spec.values.cilium.gatewayAPI.enabled
+          value: true
+      - equal:
+          path: spec.values.cilium.gatewayAPI.enableAlpn
+          value: true
+
+  - it: lets addons.cilium.valuesOverride opt a cluster out of ALPN
+    set:
+      addons:
+        gatewayAPI:
+          enabled: true
+        cilium:
+          valuesOverride:
+            cilium:
+              gatewayAPI:
+                enableAlpn: false
+    asserts:
+      - equal:
+          path: spec.values.cilium.gatewayAPI.enabled
+          value: true
+      - equal:
+          path: spec.values.cilium.gatewayAPI.enableAlpn
+          value: false

--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -16,10 +16,14 @@
 {{- $kubeovnValues := dict "kube-ovn" $kubeovnDict -}}
 {{- $_ := set $networkingComponents "kubeovn" (dict "values" $kubeovnValues) -}}
 {{- /* For Talos (isp-full): use KubePrism endpoint and disable cgroup autoMount */ -}}
+{{- /* gateway.http2 is threaded explicitly in BOTH states: inline HelmRelease
+       values override the system/cilium valuesFiles default (enableAlpn: true),
+       so an operator's http2: false actually reaches the dataplane. */ -}}
 {{- $ciliumValues := dict "cilium" (dict
   "k8sServiceHost" "localhost"
   "k8sServicePort" "7445"
-  "cgroup" (dict "autoMount" (dict "enabled" false))) -}}
+  "cgroup" (dict "autoMount" (dict "enabled" false))
+  "gatewayAPI" (dict "enableAlpn" .Values.gateway.http2)) -}}
 {{- $_ := set $networkingComponents "cilium" (dict "values" $ciliumValues) -}}
 {{- end -}}
 {{include "cozystack.platform.package" (list "cozystack.networking" "kubeovn-cilium" $ $networkingComponents) }}
@@ -82,10 +86,12 @@
 {{- $kubeovnValues := dict "kube-ovn" $kubeovnDict -}}
 {{- $_ := set $networkingComponents "kubeovn" (dict "values" $kubeovnValues) -}}
 {{- /* Cilium configuration - for generic k8s, always enable cgroup autoMount */ -}}
+{{- /* gateway.http2 threading: same rationale as the isp-full branch above. */ -}}
 {{- $ciliumValues := dict "cilium" (dict
   "k8sServiceHost" $apiHost
   "k8sServicePort" $apiPort
-  "cgroup" (dict "autoMount" (dict "enabled" true))) -}}
+  "cgroup" (dict "autoMount" (dict "enabled" true))
+  "gatewayAPI" (dict "enableAlpn" .Values.gateway.http2)) -}}
 {{- $_ := set $networkingComponents "cilium" (dict "values" $ciliumValues) -}}
 {{- end -}}
 {{- /* Use kubeovn-cilium-generic variant (no values-talos.yaml) */ -}}

--- a/packages/core/platform/tests/bundles_gateway_http2_wiring_test.yaml
+++ b/packages/core/platform/tests/bundles_gateway_http2_wiring_test.yaml
@@ -1,0 +1,94 @@
+suite: gateway.http2 bundle wiring
+templates:
+  - templates/bundles/system.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  # Browsers negotiate HTTP/2 only through TLS ALPN "h2". The knob maps to
+  # cilium.gatewayAPI.enableAlpn, which must arrive as inline component values
+  # on the cozystack.networking Package — inline HelmRelease values are the
+  # only layer that overrides the system/cilium valuesFiles default, so a
+  # value that stops rendering here silently stops reaching the dataplane.
+  - it: threads gatewayAPI.enableAlpn=true into cilium by default (isp-full)
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+    documentSelector:
+      path: metadata.name
+      value: cozystack.networking
+    asserts:
+      - equal:
+          path: spec.variant
+          value: kubeovn-cilium
+      - equal:
+          path: spec.components.cilium.values.cilium.gatewayAPI.enableAlpn
+          value: true
+
+  - it: threads gatewayAPI.enableAlpn=false when gateway.http2 is disabled (isp-full)
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+      gateway:
+        http2: false
+    documentSelector:
+      path: metadata.name
+      value: cozystack.networking
+    asserts:
+      - equal:
+          path: spec.components.cilium.values.cilium.gatewayAPI.enableAlpn
+          value: false
+
+  - it: keeps the Talos-specific cilium endpoint values alongside the ALPN flag (isp-full)
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+    documentSelector:
+      path: metadata.name
+      value: cozystack.networking
+    asserts:
+      - equal:
+          path: spec.components.cilium.values.cilium.k8sServiceHost
+          value: localhost
+      - equal:
+          path: spec.components.cilium.values.cilium.k8sServicePort
+          value: "7445"
+
+  - it: threads gatewayAPI.enableAlpn=true into cilium by default (isp-full-generic)
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full-generic
+    documentSelector:
+      path: metadata.name
+      value: cozystack.networking
+    asserts:
+      - equal:
+          path: spec.variant
+          value: kubeovn-cilium-generic
+      - equal:
+          path: spec.components.cilium.values.cilium.gatewayAPI.enableAlpn
+          value: true
+
+  - it: threads gatewayAPI.enableAlpn=false when gateway.http2 is disabled (isp-full-generic)
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full-generic
+      gateway:
+        http2: false
+    documentSelector:
+      path: metadata.name
+      value: cozystack.networking
+    asserts:
+      - equal:
+          path: spec.components.cilium.values.cilium.gatewayAPI.enableAlpn
+          value: false

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -386,6 +386,29 @@ gateway:
   # materialises the Gateway itself. This flag only controls platform-wide
   # Gateway API integration (cert-manager solver + per-service HTTPRoutes).
   enabled: false
+  # Advertise HTTP/2 on every Gateway API listener served by the bundled
+  # Cilium dataplane. Browsers negotiate HTTP/2 exclusively through TLS ALPN
+  # "h2"; with this off, Envoy advertises no ALPN protocols and every client
+  # silently falls back to HTTP/1.1 — no error anywhere, just head-of-line
+  # blocking and the per-origin connection limit that HTTP/2 removes.
+  # ingress-nginx (which the Gateway path replaces) advertised h2 out of the
+  # box, so on-by-default restores the pre-migration behaviour. ALPN offers
+  # h2 then http/1.1, so clients without HTTP/2 keep working unchanged.
+  #
+  # Frontend hop only: gateway↔backend connections stay HTTP/1.1 unless a
+  # Service opts in per GEP-1911 by declaring appProtocol
+  # kubernetes.io/h2c on its port (that backend-protocol support is switched
+  # on together with ALPN; no cozystack-shipped Service declares such a
+  # value today, so backends see no change from this flag alone).
+  #
+  # Cluster-wide: maps to Cilium's enable-gateway-api-alpn agent config, so
+  # it covers the root and every tenant Gateway at once — there is no
+  # per-Gateway granularity in the dataplane. Only effective on bundles
+  # where cozystack manages Cilium (isp-full, isp-full-generic); on
+  # isp-hosted the hosting-side CNI owns this setting. Flipping it re-rolls
+  # the cilium DaemonSet on the next platform upgrade (rollOutCiliumPods),
+  # the same disruption profile as any cilium config change.
+  http2: true
   # Namespaces that are allowed to attach HTTPRoute or TLSRoute to a tenant
   # Gateway. The publishing tenant namespace is always included implicitly.
   # Additional entries must be the exact namespace name (matched on the

--- a/packages/system/cilium/values.yaml
+++ b/packages/system/cilium/values.yaml
@@ -40,6 +40,20 @@ cilium:
         memory: 1Gi
   gatewayAPI:
     enabled: true
+    # Upstream default is false — Envoy then advertises no ALPN protocols on
+    # TLS-terminating Gateway listeners, and browsers (which negotiate HTTP/2
+    # exclusively through TLS ALPN "h2") silently fall back to HTTP/1.1 on
+    # every request. ingress-nginx, which the Gateway API path replaces,
+    # advertised h2 out of the box, so false here is a client-visible
+    # regression, not a neutral default. With true, ALPN offers h2 then
+    # http/1.1 — clients without HTTP/2 keep negotiating http/1.1 unchanged.
+    # This only affects the client↔gateway hop: gateway↔backend stays
+    # HTTP/1.1 unless a Service opts in per GEP-1911 via appProtocol
+    # kubernetes.io/h2c (enableAlpn also switches that support on; no
+    # cozystack-shipped Service declares such a value today).
+    # Platform-managed clusters can flip this through the platform chart's
+    # gateway.http2 value, which overrides this default either way.
+    enableAlpn: true
   rollOutCiliumPods: true
   operator:
     rollOutPods: true


### PR DESCRIPTION
## What this PR does

Browsers negotiate HTTP/2 exclusively through TLS ALPN: if the terminating listener does not advertise `h2`, every client silently falls back to HTTP/1.1, with no error surfaced anywhere. Cozystack's Gateway API path is served by Cilium's embedded Envoy, and Cilium ships with `enable-gateway-api-alpn=false` — so every Gateway listener advertised no ALPN protocols and all browser traffic through a Gateway ran over HTTP/1.1 (observable in browser dev tools as `http/1.1` on every request). The ingress-nginx path this replaces advertised `h2` out of the box, so the migration to Gateway API silently downgraded clients: head-of-line blocking and the ~6-connections-per-origin limit are back for anything served through a Gateway.

This PR enables ALPN (`h2`, then `http/1.1`) on Gateway API listeners, default-on, with an opt-out at each management layer:

- `packages/system/cilium/values.yaml` now defaults `gatewayAPI.enableAlpn: true`, which renders `enable-gateway-api-alpn: "true"` into the `cilium-config` ConfigMap.
- The platform chart gains `gateway.http2` (default `true`) next to the existing `gateway.enabled`/`gateway.attachedNamespaces`. The `isp-full` and `isp-full-generic` bundles thread it as inline component values into the `cozystack.networking` Package CR (`components.cilium.values.cilium.gatewayAPI.enableAlpn`); inline HelmRelease values override the package `valuesFiles`, so an explicit `gateway.http2: false` actually reaches the dataplane rather than being shadowed by the new chart default. On `isp-hosted` the hosting-side CNI owns this setting and the flag is a no-op.
- Tenant Kubernetes clusters (`packages/apps/kubernetes`) get the same fix: when the `gatewayAPI` addon is enabled, the tenant cilium HelmRelease now sets `enableAlpn: true`; individual clusters opt out via `addons.cilium.valuesOverride.cilium.gatewayAPI.enableAlpn=false`.

### Why default-on rather than opt-in

HTTP/2 for browsers was the platform's behavior before the Gateway API migration, so keeping ALPN off would preserve a regression, not a status quo. Defaulting on is safe because ALPN is a negotiation: clients that cannot speak HTTP/2 simply keep negotiating `http/1.1`, exactly as before. Operators who need the old wire behavior can set `gateway.http2: false` platform-wide.

### Frontend vs backend hop

This change affects the client↔gateway hop only. Gateway↔backend connections stay HTTP/1.1 unless a Service explicitly opts in per GEP-1911 by declaring `appProtocol: kubernetes.io/h2c` on its port. Cilium couples that backend-protocol support to the ALPN flag (`enable-gateway-api-app-protocol` flips to true together with it), but it only acts on Services that declare a recognized `appProtocol` value — and no cozystack-shipped Service does today (only plain `http`/`https` values exist in-tree, which Cilium ignores for protocol selection). So upstreams see no change from this PR alone; h2c/gRPC backends become possible to configure, not configured.

The setting is cluster-wide Cilium agent config, so it covers the root Gateway and all tenant Gateways at once — Cilium offers no per-Gateway granularity here. Flipping it re-rolls the cilium DaemonSet on upgrade (`rollOutCiliumPods: true`), the same disruption profile as any other cilium config change.

### How it was verified

- New helm-unittest suites: `packages/core/platform/tests/bundles_gateway_http2_wiring_test.yaml` asserts the Package CR carries `enableAlpn` true by default and false with `gateway.http2: false` for both cilium bundles; `packages/apps/kubernetes/tests/cilium_gateway_alpn_test.yaml` asserts the tenant HelmRelease default, the addon-off case, and the `valuesOverride` opt-out. Full suites for both charts pass (93 and 184 tests).
- `helm template` of `packages/system/cilium` confirms the value is consumed, not just rendered: default produces `enable-gateway-api-alpn: "true"` (and `enable-gateway-api-app-protocol: "true"`) in `cilium-config`; the threaded `false` produces `"false"` for both.

### Screenshots

Not a UI change.

### Downstream repositories

The website's hand-written platform values table (`content/en/docs/next/operations/configuration/platform-package.md`) needs a row for `gateway.http2` — filed as cozystack/website#625. No other downstream repository restates anything in this diff (no app `values.schema.json`, ansible-consumed platform key, or hack/ tooling changed).

- [ ] No downstream repository is affected by this change
- [x] [cozystack/website](https://github.com/cozystack/website) - follow-up: https://github.com/cozystack/website/pull/625
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
feat(gateway): Gateway API listeners now advertise HTTP/2 via TLS ALPN (h2, then http/1.1) by default, restoring the browser HTTP/2 support lost in the migration from ingress-nginx. Opt out platform-wide with gateway.http2=false, or per tenant Kubernetes cluster via addons.cilium.valuesOverride.cilium.gatewayAPI.enableAlpn=false. Backend (gateway-to-upstream) connections are unchanged and stay HTTP/1.1 unless a Service declares appProtocol kubernetes.io/h2c.
```
