### PR TITLE
fix(kubernetes): move kubevirt-csi-driver base off quay.io/centos to almalinux

### DIFF
--- a/packages/apps/kubernetes/images/kubevirt-csi-driver/Dockerfile
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver/Dockerfile
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
     -ldflags "-X kubevirt.io/csi-driver/pkg/service.VendorVersion=0.2.0" \
     -o kubevirt-csi-driver .
 
-FROM quay.io/centos/centos:stream9@sha256:3714c89f1903dac5a5e1eb6c02d84189ff6d962a0c18df01feba0a5406856926
+FROM docker.io/library/almalinux:9@sha256:d2515c769e7b73f95c4fde38c0a505336ff38f14990c0b7253b77060a049a743
 
 RUN dnf install -y e2fsprogs xfsprogs nfs-utils && dnf clean all
 


### PR DESCRIPTION
## What this PR does

`packages/apps/kubernetes/images/kubevirt-csi-driver/Dockerfile` pinned its runtime stage to `quay.io/centos/centos:stream9` by digest. Quay serves **only currently-tagged manifests** — when a rolling tag moves, the superseded digest immediately returns `MANIFEST_UNKNOWN`, with no grace period.

`stream9` rolls roughly every six days, so the pin has already died twice:

| Date | Fix | Digest pinned | Status today |
|---|---|---|---|
| Jul 15 | #3303 | `0c9db821…` → `a93e3316…` | `0c9db821` gone |
| Jul 21 | #3386 | `a93e3316…` → `3714c89f…` | `a93e3316` gone |

Each death broke `make build` on `main` and on every PR triggering a full rebuild. Because the root `build` target is serial, a failure in `packages/apps/kubernetes` (4th of 29) aborts the remaining packages and leaves the shared build cache unwritten.

Repinning cannot fix this: the freshly pinned digest is always the current live tag, so it is next in line to be retired. This is not specific to CentOS — the same probe against `quay.io/fedora/fedora:latest` and `quay.io/centos/centos:stream10` found every historical digest unfetchable.

This PR keeps the digest pin and changes the *source* to a registry that provably retains superseded manifests, making the pin durable rather than decorative. Renovate policy is unchanged — `pinDigests` stays on, and `almalinux:9` is an ordinary rolling tag on a retaining registry exactly like the `golang`, `alpine` and `debian` bases already in the grouped digest PR.

### Verification

Both bases were run locally with the Dockerfile's exact install line (`dnf install -y e2fsprogs xfsprogs nfs-utils`):

| Binary | CentOS Stream 9 | AlmaLinux 9 |
|---|---|---|
| `mkfs.ext4` | `/usr/sbin/mkfs.ext4` | `/usr/sbin/mkfs.ext4` |
| `mkfs.xfs` | `/usr/sbin/mkfs.xfs` | `/usr/sbin/mkfs.xfs` |
| `blkid` | `/usr/sbin/blkid` | `/usr/sbin/blkid` |
| `mount` | `/usr/bin/mount` | `/usr/bin/mount` |
| `umount` | `/usr/bin/umount` | `/usr/bin/umount` |
| `fsck.ext4` | `/usr/sbin/fsck.ext4` | `/usr/sbin/fsck.ext4` |
| `fsck.xfs` | `/usr/sbin/fsck.xfs` | `/usr/sbin/fsck.xfs` |
| `mount.nfs` | `/usr/sbin/mount.nfs` | `/usr/sbin/mount.nfs` |

Every path `k8s.io/mount-utils` shells out to is identical. Package versions:

| Package | CentOS Stream 9 | AlmaLinux 9 |
|---|---|---|
| `e2fsprogs` | 1.46.5-8.el9 | 1.46.5-8.el9 |
| `xfsprogs` | 6.4.0-7.el9 | 6.4.0-7.el9 |
| `nfs-utils` | 2.5.4-44.el9 | 2.5.4-42.el9_8 |
| `util-linux` | 2.37.4-26.el9 | 2.37.4-25.el9 |
| `glibc` | 2.34-274.el9 | 2.34-270.el9_8 |

Same upstream versions throughout; the el9 release-number lag is expected since AlmaLinux is downstream of RHEL 9 while CentOS Stream 9 is upstream. `e2fsprogs` and `xfsprogs` — the two that govern `mkfs`/`fsck` behaviour — are identical NVRs. `glibc` is not linked at all: the driver is built `CGO_ENABLED=0`.

The pinned digest is the OCI image index covering `amd64`, `arm64`, `ppc64le` and `s390x` — the same architecture set as the previous base.

Retention was verified empirically rather than assumed: four superseded `docker.io/library` digests taken from this repo's own git history (`golang:1.26`, `golang:1.26-alpine`, `alpine:3.24`, `alpine:3.22`) all still resolve after their tags moved.

### Scope

This addresses the immediate recurring breakage only. The broader concern in #3305 — that any retired digest blocks the entire platform build, with no advance warning and no fast path to repin — is not solved here and remains open.

### Release note

```release-note
fix(kubernetes): move the kubevirt-csi-driver runtime base from quay.io/centos/centos:stream9 to docker.io/library/almalinux:9. Quay retires superseded manifests as soon as a rolling tag moves, which broke builds twice in six days; AlmaLinux 9 provides an equivalent RHEL 9 userspace on a registry that retains them, so the digest pin remains valid over time. No functional change to the driver.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container runtime environment to use AlmaLinux 9 instead of CentOS Stream 9.
  * Kubernetes CSI driver behavior and startup configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->