### PR TITLE
fix(ci): make workflow cancellation effective

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -305,7 +305,7 @@ jobs:
     # in-build-job tests gave, without re-coupling the cheap parallel builds.
     needs: ["plan", "checks", "build", "build-talos"]
     if: |
-      always()
+      !cancelled()
       && needs.plan.outputs.code == 'true'
       && !contains(github.event.pull_request.labels.*.name, 'release')
       && needs.checks.result == 'success'
@@ -533,7 +533,7 @@ jobs:
       packages: read
       checks: write
     needs: ["finalize", "build-talos", "resolve_assets"]
-    if: ${{ always() && (needs.finalize.result == 'success' || needs.resolve_assets.result == 'success') }}
+    if: ${{ !cancelled() && (needs.finalize.result == 'success' || needs.resolve_assets.result == 'success') }}
 
     steps:
       - name: Generate GitHub App token

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -527,14 +527,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [generate-changelog, prepare-release]
     # generate-changelog is non-blocking — run as long as prepare-release succeeded.
-    # `always()` is needed so this job runs even if generate-changelog failed/skipped.
+    # `!cancelled()` lets this job run if generate-changelog failed/skipped,
+    # while still stopping it when the workflow is cancelled.
     # Not gated on release_exists: a promoted stable tag already has a draft
     # release (so prepare-release skips the rebuild), but its website docs still
     # need publishing. Gating on release_exists here skipped docs for every
     # promoted stable.
     # Stable tags only — a prerelease (ref_name contains '-') would otherwise open
     # an "update managed apps for vX.Y.Z-rc.N" website PR on every rc.
-    if: always() && needs.prepare-release.result == 'success' && !contains(github.ref_name, '-')
+    if: ${{ !cancelled() && needs.prepare-release.result == 'success' && !contains(github.ref_name, '-') }}
     permissions:
       contents: read
     steps:

--- a/docs/release.md
+++ b/docs/release.md
@@ -216,7 +216,7 @@ Known reasons this phase fails silently:
 
 ### Phase 3 — `update-website-docs`
 
-Runs with `if: always() && needs.prepare-release.result == 'success'` so it survives a failed changelog phase. Decides whether to promote `next/` → `vX.Y/` in the website repo (only for non-prerelease tags where the version directory doesn't yet exist), runs `make update-all`, then stages `content hugo.yaml data/versions` and opens a PR against `cozystack/website`.
+Runs with `if: !cancelled() && needs.prepare-release.result == 'success'` so it survives a failed or skipped changelog phase but stops when the workflow is cancelled. Decides whether to promote `next/` → `vX.Y/` in the website repo (only for non-prerelease tags where the version directory doesn't yet exist), runs `make update-all`, then stages `content hugo.yaml data/versions` and opens a PR against `cozystack/website`.
 
 If anyone changes the website Makefile to write somewhere else (e.g. `static/`, `i18n/`), the `git add` list must grow or the PR silently drops files.
 


### PR DESCRIPTION
## What this PR does

- allows superseded PR workflow runs to cancel `finalize` and `E2E Tests` instead of continuing because of job-level `always()`
- makes `update-website-docs` cancellation-responsive while preserving its behavior when changelog generation fails or is skipped
- retains step-level `always()` conditions for reports and sandbox cleanup

### Screenshots

Not applicable.

### Release note

```release-note
fix(ci): ensure superseded and manually canceled workflows stop long-running jobs
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented release and validation-related jobs from running when a workflow is cancelled.
  * Updated pull request check, end-to-end testing, and stable documentation update conditions to avoid executing after cancellation.
  * Kept existing success-gating so follow-up tasks still require prerequisite steps to complete successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->