### PR TITLE
feat(etcd-operator): bump to v0.5.3 (S3 checksum fix for non-AWS backends)

### DIFF
--- a/packages/system/etcd-operator-crds/Makefile
+++ b/packages/system/etcd-operator-crds/Makefile
@@ -14,8 +14,9 @@ CRDS = etcdclusters etcdmembers etcdsnapshots
 update:
 	rm -rf templates
 	mkdir templates
-	@for c in $(CRDS); do \
-	  curl -fsSL "https://raw.githubusercontent.com/cozystack/etcd-operator/$(ETCD_OPERATOR_REF)/charts/etcd-operator/crd-bases/etcd-operator.cozystack.io_$$c.yaml" \
-	    | awk '/^    controller-gen.kubebuilder.io\/version:/{print; print "    helm.sh/resource-policy: keep"; next} {print}' \
-	    > templates/$$c.yaml; \
+	@set -e; for c in $(CRDS); do \
+	  src=$$(mktemp); \
+	  curl -fsSL "https://raw.githubusercontent.com/cozystack/etcd-operator/$(ETCD_OPERATOR_REF)/charts/etcd-operator/crd-bases/etcd-operator.cozystack.io_$$c.yaml" -o "$$src"; \
+	  awk '/^    controller-gen.kubebuilder.io\/version:/{print; print "    helm.sh/resource-policy: keep"; next} {print}' "$$src" > templates/$$c.yaml; \
+	  rm -f "$$src"; \
 	done

--- a/packages/system/etcd-operator-crds/Makefile
+++ b/packages/system/etcd-operator-crds/Makefile
@@ -4,10 +4,18 @@ export NAMESPACE=cozy-etcd-operator
 include ../../../hack/package.mk
 
 # Pinned ref of github.com/cozystack/etcd-operator to vendor CRDs from.
-ETCD_OPERATOR_REF ?= v0.5.2
+ETCD_OPERATOR_REF ?= v0.5.3
 
+# controller-gen writes the CRDs to charts/etcd-operator/crd-bases/ upstream (there
+# is no config/crd kustomization). Vendor each verbatim and stamp
+# helm.sh/resource-policy: keep so a chart uninstall never garbage-collects the
+# CRDs and, with them, every EtcdCluster/EtcdMember/EtcdSnapshot in the cluster.
+CRDS = etcdclusters etcdmembers etcdsnapshots
 update:
 	rm -rf templates
 	mkdir templates
-	kubectl kustomize "github.com/cozystack/etcd-operator/config/crd?ref=$(ETCD_OPERATOR_REF)" | \
-	  yq -s '"templates/" + (.metadata.name | sub("\..*$$"; "")) + ".yaml"'
+	@for c in $(CRDS); do \
+	  curl -fsSL "https://raw.githubusercontent.com/cozystack/etcd-operator/$(ETCD_OPERATOR_REF)/charts/etcd-operator/crd-bases/etcd-operator.cozystack.io_$$c.yaml" \
+	    | awk '/^    controller-gen.kubebuilder.io\/version:/{print; print "    helm.sh/resource-policy: keep"; next} {print}' \
+	    > templates/$$c.yaml; \
+	done

--- a/packages/system/etcd-operator-crds/templates/etcdmembers.yaml
+++ b/packages/system/etcd-operator-crds/templates/etcdmembers.yaml
@@ -22,6 +22,9 @@ spec:
     - jsonPath: .spec.version
       name: Version
       type: string
+    - jsonPath: .status.version
+      name: Running
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Ready")].status
       name: Ready
       type: string
@@ -1359,6 +1362,17 @@ spec:
                         type: string
                     type: object
                     x-kubernetes-map-type: atomic
+                  peerAutoTLS:
+                    description: |-
+                      PeerAutoTLS is operator-managed plumbing: it carries the cluster's
+                      reserved "etcd-operator.cozystack.io/peer-auto-tls" annotation down to
+                      the member so buildPod renders etcd's --peer-auto-tls (self-signed, no
+                      shared CA) instead of mounting a peer secret. INSECURE — peer is
+                      encrypted but NOT authenticated. Set only on clusters adopted from a
+                      legacy --peer-auto-tls cluster, and never together with PeerSecretRef
+                      (an explicit peer secret supersedes the annotation). Users do not set
+                      this directly; the cluster controller derives it.
+                    type: boolean
                   peerSecretRef:
                     description: |-
                       PeerSecretRef mirrors EtcdClusterTLS.Peer.SecretRef. When nil, the
@@ -1672,6 +1686,18 @@ spec:
                 description: |-
                   Selector exposes the label-selector that matches this member's Pod
                   via /scale (consumed by the PDB controller; not user-facing).
+                type: string
+              version:
+                description: |-
+                  Version is the etcd server version this member is actually running,
+                  observed at runtime from the member's own etcd endpoint via the
+                  Maintenance Status API (StatusResponse.Version) — i.e. what etcd
+                  reports, as opposed to spec.version, which is the intended/target
+                  version the operator asks for (and pins the image tag to). Empty until
+                  the member's Pod is Ready and the operator has successfully queried it.
+                  This observed value is the source of truth for detecting version drift
+                  between intent and reality (see the VersionDrifted condition); the
+                  observation is best-effort and never gates readiness.
                 type: string
             type: object
         type: object

--- a/packages/system/etcd-operator/Chart.yaml
+++ b/packages/system/etcd-operator/Chart.yaml
@@ -3,4 +3,4 @@ name: cozy-etcd-operator
 description: Cozystack etcd-operator (etcd-operator.cozystack.io/v1alpha2) controller-manager
 type: application
 version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process
-appVersion: v0.5.2
+appVersion: v0.5.3

--- a/packages/system/etcd-operator/Makefile
+++ b/packages/system/etcd-operator/Makefile
@@ -8,7 +8,7 @@ include ../../../hack/package.mk
 # domain, VPA), so only the RBAC role is re-vendored; refresh templates/rbac.yaml
 # by hand from config/rbac/role.yaml at this ref. CRDs live in the sibling
 # etcd-operator-crds package.
-ETCD_OPERATOR_REF ?= v0.5.2
+ETCD_OPERATOR_REF ?= v0.5.3
 
 update:
 	@echo "etcd-operator is a cozystack-authored chart; refresh templates/rbac.yaml"

--- a/packages/system/etcd-operator/tests/deployment_test.yaml
+++ b/packages/system/etcd-operator/tests/deployment_test.yaml
@@ -20,12 +20,12 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/cozystack/etcd-operator:v0.5.2
+          value: ghcr.io/cozystack/etcd-operator:v0.5.3
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: OPERATOR_IMAGE
-            value: ghcr.io/cozystack/etcd-operator:v0.5.2
+            value: ghcr.io/cozystack/etcd-operator:v0.5.3
           any: true
 
   - it: "image.tag overrides the appVersion default for both the container and the agent env"


### PR DESCRIPTION
## What this PR does

Bumps the etcd-operator to **v0.5.3**, which carries the S3 request-checksum fix ([cozystack/etcd-operator#342](https://github.com/cozystack/etcd-operator/pull/342)). `git compare v0.5.2...v0.5.3` is exactly #340, #341, #342.

**Why:** scheduled etcd snapshots to non-AWS S3-compatible backends (**Ceph RGW** confirmed) fail at upload. Since early 2025 `aws-sdk-go-v2` defaults `RequestChecksumCalculation` to `WhenSupported`, which stamps a CRC32 on every upload; over HTTPS a multipart part rides it as `x-amz-content-sha256: STREAMING-UNSIGNED-PAYLOAD-TRAILER`, and RGW rejects it with `400 InvalidArgument`. v0.5.3 sets `WhenRequired` on both the S3 client and the transfer manager, so multipart uploads (>5 MiB — every real etcd snapshot) carry no checksum trailer.

**Changes:**
- `system/etcd-operator` — `appVersion` v0.5.2 → v0.5.3 (image tag follows AppVersion; `values.yaml` keeps `tag: ""`), bump `ETCD_OPERATOR_REF`, update deployment unittest expectations.
- `system/etcd-operator-crds` — re-vendor CRDs from v0.5.3. `etcdmembers` gains the additive #340 `status.version` field + **Running** printer column and picks up the `peerAutoTLS` spec field the vendored copy was already missing (all additive, backward-compatible; `etcdclusters`/`etcdsnapshots` unchanged). Fixes the stale `make update` (upstream has no `config/crd` kustomization — CRDs live in `charts/etcd-operator/crd-bases`) and makes it fail loudly on a fetch error (temp file under `set -e`, not a pipe).

**Verification:** `helm unittest` 18/18 and `helm template` green on both packages; regenerated CRDs are byte-identical to upstream `crd-bases` at v0.5.3. End-to-end on a live Ceph RGW backend (freedom-portal-stage): the v0.5.2 (client-only) agent fails a multipart snapshot upload with the 400; v0.5.3 uploads an 11 MiB multipart snapshot successfully, and the operator-driven CronJob→EtcdSnapshot path reaches `Complete`.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` file-by-file against the diff (`packages/system/etcd-operator{,-crds}/**` only — a component version bump + additive CRD re-vendor). Nothing matches: not an `apps/`/`extra/` package add/rename/remove, no `core/platform` values, no variant/bundle, no platform component add/remove, no `hack/` layout or shared-tooling change, and the provider does not type the `etcd-operator.cozystack.io` CRDs (and the change is additive/opaque regardless).

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(etcd-operator): bump to v0.5.3 — etcd snapshot uploads to non-AWS S3-compatible backends (Ceph RGW, some MinIO/R2) no longer fail with `400 InvalidArgument: x-amz-content-sha256 ...`; the snapshot agent now requests a checksum only when required, on both the S3 client and the multipart transfer manager. Also brings observed EtcdMember versions (#340) and `--watch-namespace` (#341).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime etcd version visibility to `EtcdMember` (including a “Running” status column).
  * Added `peerAutoTLS` support to `EtcdMember` for operator-managed peer TLS behavior.

* **Updates**
  * Updated the etcd-operator to version 0.5.3.
  * Refreshed bundled CRDs and ensured CRDs are preserved during Helm lifecycle operations.

* **Tests**
  * Updated deployment test expectations to use the 0.5.3 operator image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->