### PR TITLE
fix(backupstrategy-controller): give chBackupClientImage a producer

### DIFF
--- a/hack/image-pin-consistency.bats
+++ b/hack/image-pin-consistency.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# Asserts that no first-party image repository is pinned at more than one
+# digest across the committed tree.
+#
+# Promotion retags by digest: hack/promote-retag.sh copies every collected
+# <repo>@<digest> to <repo>:<stable-version>. Two different digests under one
+# repository therefore produce two copies competing for the same destination
+# tag. The first wins, the second hits the write-once guard, and the promotion
+# fails — on release day, in a workflow that runs once per release.
+#
+# This is not hypothetical. platform-migrations was pinned twice: once in
+# packages/core/platform/values.yaml (stamped by its Makefile) and once as
+# .backupStrategyController.chBackupClientImage, which had no producer at all
+# and so froze at v1.4.0-rc.2 while the other advanced to v1.5.0. v1.6.0 is the
+# first release cut through the promote path rather than a full rebuild, so it
+# would have been the first to hit it.
+#
+# The general invariant is cheaper to hold than the specific one: a duplicate
+# pin can arise from any package reusing another's image, which the tree does
+# deliberately (backupstrategy-controller reuses platform-migrations as a
+# curl+jq runner rather than shipping a second one-binary tag).
+#
+# Harness note: the CI path is hack/cozytest.sh, NOT real bats. There is no
+# `run`, `$status`, `$output`, `skip`, or setup()/teardown(); each test runs as
+# a shell function under `set -eu -x`, so a non-zero exit is the failure.
+# Paths are repo-root-relative: BATS_TEST_DIRNAME is unset and would abort the
+# whole suite under `set -u`.
+#
+# Run with: hack/cozytest.sh hack/image-pin-consistency.bats
+
+@test "no image repository is pinned at more than one digest" {
+  tmp=$(mktemp -d)
+
+  # Drive the real promotion selector rather than a reimplementation of it, so
+  # this tracks whatever set promotion actually acts on. `env -u REGISTRY`:
+  # the CI workflow exports REGISTRY=<OCIR build registry> for every job, but
+  # the committed tree vendors its digests under the script's default
+  # ghcr.io/cozystack/cozystack — inheriting the ambient value would filter for
+  # the wrong registry and match nothing.
+  rc=0
+  env -u REGISTRY hack/promote-retag.sh v9.9.9 --dry-run \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "promote-retag.sh exited $rc" >&2
+    cat "$tmp/err" >&2
+    rm -rf "$tmp"
+    return "$rc"
+  fi
+
+  # Every planned copy ends in docker://<repo>:v9.9.9. A repository appearing
+  # twice means two source digests aimed at one destination tag.
+  sed -n 's|.*docker://\(.*\):v9\.9\.9$|\1|p' "$tmp/out" | sort > "$tmp/dests"
+  dupes=$(uniq -d < "$tmp/dests")
+
+  if [ -n "$dupes" ]; then
+    echo "these repositories are pinned at more than one digest, so promotion" >&2
+    echo "would try to retag several digests to the same stable tag and fail:" >&2
+    printf '%s\n' "$dupes" >&2
+    echo >&2
+    echo "Offending pins:" >&2
+    for repo in $dupes; do
+      grep -rn --include='*.yaml' --include='*.tag' --exclude-dir=charts \
+        -- "${repo#ghcr.io/cozystack/cozystack/}" packages/ >&2 || true
+    done
+    echo >&2
+    echo "Give the duplicate key a producer that stamps the same ref (see" >&2
+    echo "packages/core/platform/Makefile), or drop the duplicate pin." >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "platform-migrations is pinned identically in both consumers" {
+  # The specific instance, pinned separately so a regression names its cause
+  # rather than only tripping the general check above. The two must match
+  # exactly, not merely resolve to the same digest: backupstrategy-controller
+  # renders its copy into a Pod spec, so a stale tag string there is what an
+  # operator reads when asking what is running.
+  a=$(yq -r '.migrations.image' packages/core/platform/values.yaml)
+  b=$(yq -r '.backupStrategyController.chBackupClientImage' \
+    packages/system/backupstrategy-controller/values.yaml)
+
+  if [ "$a" != "$b" ]; then
+    echo "platform-migrations pins have drifted:" >&2
+    echo "  packages/core/platform/values.yaml            .migrations.image" >&2
+    echo "    $a" >&2
+    echo "  backupstrategy-controller/values.yaml         .chBackupClientImage" >&2
+    echo "    $b" >&2
+    echo >&2
+    echo "packages/core/platform/Makefile stamps both; do not hand-edit either." >&2
+    return 1
+  fi
+}

--- a/packages/core/platform/Makefile
+++ b/packages/core/platform/Makefile
@@ -42,6 +42,18 @@ image-migrations:
 		--metadata-file images/migrations.json \
 		$(BUILDX_ARGS)
 	rm -rf images/migrations/etcd-operator-crds
+	# Stamp BOTH consumers of this image. backupstrategy-controller renders it
+	# into the Altinity strategy Pod as a curl+jq runner, deliberately reusing
+	# this image rather than shipping a second one-binary tag that release CI
+	# would have to re-digest every cut. That reuse only holds if the two pins
+	# move together: the second copy had no producer, so it silently froze at
+	# v1.4.0-rc.2 while this one advanced, and a promotion then tried to retag
+	# two different digests to the same stable tag — which the write-once guard
+	# in hack/promote-retag.sh turns into a failed release. hack/image-pin-
+	# consistency.bats keeps them in lockstep.
 	IMAGE="$(REGISTRY)/platform-migrations:$(IMAGE_TAG)@$$(yq -e -o json -r '.["containerimage.digest"]' images/migrations.json)" \
 		yq --inplace '.migrations.image = strenv(IMAGE)' values.yaml
+	IMAGE="$(REGISTRY)/platform-migrations:$(IMAGE_TAG)@$$(yq -e -o json -r '.["containerimage.digest"]' images/migrations.json)" \
+		yq --inplace '.backupStrategyController.chBackupClientImage = strenv(IMAGE)' \
+		../../system/backupstrategy-controller/values.yaml
 	rm -f images/migrations.json

--- a/packages/core/platform/Makefile
+++ b/packages/core/platform/Makefile
@@ -43,14 +43,18 @@ image-migrations:
 		$(BUILDX_ARGS)
 	rm -rf images/migrations/etcd-operator-crds
 	# Stamp BOTH consumers of this image. backupstrategy-controller renders it
-	# into the Altinity strategy Pod as a curl+jq runner, deliberately reusing
-	# this image rather than shipping a second one-binary tag that release CI
-	# would have to re-digest every cut. That reuse only holds if the two pins
-	# move together: the second copy had no producer, so it silently froze at
-	# v1.4.0-rc.2 while this one advanced, and a promotion then tried to retag
-	# two different digests to the same stable tag — which the write-once guard
-	# in hack/promote-retag.sh turns into a failed release. hack/image-pin-
-	# consistency.bats keeps them in lockstep.
+	# into the Altinity strategy Pod as a curl+jq runner — a WORKAROUND, not a
+	# design: that Pod needs only curl/jq/sleep/date but gets 349 MB including
+	# kubectl, helm and etcd-migrate, and this image's ENTRYPOINT is the
+	# migration runner itself. It should get a dedicated ~23 MB image owned by
+	# its own package, which would delete this cross-package stamp; see the TODO
+	# in ../../system/backupstrategy-controller/values.yaml.
+	#
+	# Until then the two pins MUST move together. The second copy had no
+	# producer, so it silently froze at v1.4.0-rc.2 while this one advanced, and
+	# a promotion then tried to retag two different digests to the same stable
+	# tag — which the write-once guard in hack/promote-retag.sh turns into a
+	# failed release. hack/image-pin-consistency.bats keeps them in lockstep.
 	IMAGE="$(REGISTRY)/platform-migrations:$(IMAGE_TAG)@$$(yq -e -o json -r '.["containerimage.digest"]' images/migrations.json)" \
 		yq --inplace '.migrations.image = strenv(IMAGE)' values.yaml
 	IMAGE="$(REGISTRY)/platform-migrations:$(IMAGE_TAG)@$$(yq -e -o json -r '.["containerimage.digest"]' images/migrations.json)" \

--- a/packages/system/backupstrategy-controller/templates/strategy-altinity-default.yaml
+++ b/packages/system/backupstrategy-controller/templates/strategy-altinity-default.yaml
@@ -23,13 +23,15 @@ spec:
       restartPolicy: Never
       containers:
         - name: ch-backup-client
-          # platform-migrations is the pre-built, digested image release
-          # CI maintains in packages/core/platform/values.yaml. It bundles
-          # curl + jq + kubectl + helm + ca-certificates on alpine, so the
-          # strategy Pod does not depend on dl-cdn.alpinelinux.org at run
-          # time — works on air-gapped clusters. The image is reused
-          # rather than a single-purpose ch-backup-client to avoid a
-          # second tag that release CI would have to re-digest each cut.
+          # WORKAROUND: this resolves to platform-migrations, which bundles
+          # curl + jq + ca-certificates on alpine — so the Pod needs no
+          # `apk add` and works air-gapped. That is the only reason it is
+          # here. It is a 349 MB migration image standing in for a curl+jq
+          # runner, and its own ENTRYPOINT is run-migrations.sh, so the
+          # `command:` override below is load-bearing: drop it and this Pod
+          # runs platform migrations with kubectl and helm on the PATH.
+          # Replace with a dedicated ch-backup-client image owned by this
+          # package; see the TODO in ../values.yaml.
           image: "{{ .Values.backupStrategyController.chBackupClientImage }}"
           imagePullPolicy: IfNotPresent
           # The clickhouse-backup HTTP API on :7171 enforces basic auth;

--- a/packages/system/backupstrategy-controller/values.yaml
+++ b/packages/system/backupstrategy-controller/values.yaml
@@ -5,10 +5,17 @@ backupStrategyController:
   # platform-migrations (already pre-built and digested by release CI in
   # packages/core/platform/values.yaml) because it bundles curl + jq +
   # ca-certificates — avoids shipping a one-binary tiny image whose tag
-  # would have to be re-digested on every release. Bumping the
-  # platform-migrations version requires updating BOTH this value and
-  # packages/core/platform/values.yaml so they remain in lockstep.
-  chBackupClientImage: "ghcr.io/cozystack/cozystack/platform-migrations:v1.4.0-rc.2@sha256:17390197a9b11d76a8dd1b24c6d1512adb7d3226b28b5bcba8551b14b1ec4be0"
+  # would have to be re-digested on every release.
+  #
+  # DO NOT hand-edit: packages/core/platform/Makefile stamps this key with
+  # the same ref it writes to .migrations.image there, so the two stay in
+  # lockstep by construction. They previously did not — this key had no
+  # producer at all and froze at v1.4.0-rc.2 while the other advanced to
+  # v1.5.0. Two digests under one repository means a promotion tries to
+  # retag both to the same stable tag, and the write-once guard in
+  # hack/promote-retag.sh fails the release. hack/image-pin-consistency.bats
+  # asserts no repository is pinned at more than one digest.
+  chBackupClientImage: "ghcr.io/cozystack/cozystack/platform-migrations:v1.5.0@sha256:8bf61f17e99eb4a3365394e3d97ac52a1d68cc84aa104894ecb09de25721dc1d"
   replicas: 2
   debug: false
   metrics:

--- a/packages/system/backupstrategy-controller/values.yaml
+++ b/packages/system/backupstrategy-controller/values.yaml
@@ -1,11 +1,31 @@
 backupStrategyController:
   image: "ghcr.io/cozystack/cozystack/backupstrategy-controller:v1.5.0@sha256:d965283f935e4b24b655bc76e37dcb3b731bec832bb5c2e3e407b0284c7526a3"
   # chBackupClientImage is the image rendered into the Altinity strategy
-  # Pod: it drives clickhouse-backup's HTTP API via curl + jq. We reuse
-  # platform-migrations (already pre-built and digested by release CI in
-  # packages/core/platform/values.yaml) because it bundles curl + jq +
-  # ca-certificates — avoids shipping a one-binary tiny image whose tag
-  # would have to be re-digested on every release.
+  # Pod: it drives clickhouse-backup's HTTP API via curl + jq.
+  #
+  # WORKAROUND — platform-migrations is the wrong image for this job and
+  # should be replaced by a dedicated one (see the TODO below). It is
+  # reused here only because it happens to bundle curl + jq, and this
+  # release could not absorb a new image. What that reuse actually costs:
+  #   - the strategy script needs exactly curl, jq, sleep and date, yet
+  #     this image is 349 MB carrying kubectl, helm, git, cozyhr and the
+  #     etcd-migrate binary into a tenant-adjacent backup Pod;
+  #   - its ENTRYPOINT is run-migrations.sh, so only the `command:`
+  #     override in strategy-altinity-default.yaml stands between this Pod
+  #     and running platform migrations with kubectl and helm on the PATH;
+  #   - it couples the backup client to migrations: bumping
+  #     ETCD_OPERATOR_VERSION or editing any migration script re-digests
+  #     this image, forcing this pin to move for reasons that have nothing
+  #     to do with backups. That coupling is what broke — see below.
+  #
+  # TODO: replace with a dedicated ch-backup-client image built by THIS
+  # package's own Makefile (alpine + curl + jq + ca-certificates measures
+  # 23 MB, 15x smaller). That also removes the cross-package stamp
+  # entirely, because the pin would then be produced by the package that
+  # owns it. The often-cited objection — "a second tag release CI must
+  # re-digest each cut" — is not the real cost: every other first-party
+  # image already pays it, automatically. The real defect was a pin with
+  # NO producer, which a package-owned image cannot reproduce.
   #
   # DO NOT hand-edit: packages/core/platform/Makefile stamps this key with
   # the same ref it writes to .migrations.image there, so the two stay in


### PR DESCRIPTION
## This is a workaround

`backupstrategy-controller` should not be running the platform **migrations** image. This PR does not fix that — it makes the existing reuse *safe* so the v1.6.0 promote can proceed, and documents in the tree exactly what is wrong and what should replace it. Treat it as a stopgap with a TODO, not as an endorsement of the design.

## What is actually wrong

The Altinity strategy Pod drives clickhouse-backup's HTTP API. Its script uses exactly four binaries — `curl`, `jq`, `sleep`, `date`. For that it currently pulls `platform-migrations`:

| | |
| --- | --- |
| Size | **349 MB** (a dedicated `alpine + curl + jq + ca-certificates` measures **23 MB**) |
| Also contains | `kubectl`, `helm`, `git`, `cozyhr`, the `etcd-migrate` binary, every migration script, vendored etcd CRDs |
| `ENTRYPOINT` | `run-migrations.sh` |

Two consequences worth naming. A tenant-adjacent backup Pod carries cluster tooling it has no use for. And because the image's own entrypoint is the migration runner, the `command:` override in the strategy template is load-bearing — drop that one line and the Pod runs platform migrations with `kubectl` and `helm` already on the PATH.

It also creates the coupling that caused the bug this PR fixes: bumping `ETCD_OPERATOR_VERSION` or editing any migration script re-digests the image, forcing the backup client's pin to move for reasons that have nothing to do with backups.

## The release blocker

`platform-migrations` was pinned at two different digests in the committed tree:

| Location | Pin | Producer |
| --- | --- | --- |
| `packages/core/platform/values.yaml` `.migrations.image` | `v1.5.0@sha256:8bf61f17…` | `packages/core/platform/Makefile` |
| `backupstrategy-controller/values.yaml` `.chBackupClientImage` | `v1.4.0-rc.2@sha256:17390197…` | **none** |

Promotion retags **by digest**: `hack/promote-retag.sh` copies every collected `<repo>@<digest>` to `<repo>:<stable-version>`. Two digests under one repository produce two copies competing for the same destination tag — the first wins, the second hits the write-once guard, and the promotion fails. A dry run against `main` emits exactly that pair:

```
▸ ghcr.io/cozystack/cozystack/platform-migrations  sha256:17390197…
  → docker://ghcr.io/cozystack/cozystack/platform-migrations:v9.9.9
▸ ghcr.io/cozystack/cozystack/platform-migrations  sha256:8bf61f17…
  → docker://ghcr.io/cozystack/cozystack/platform-migrations:v9.9.9
```

`v1.6.0` is the first release cut through promotion rather than a full rebuild. Every earlier release ran `make build`, which restamped both copies as a side effect and hid the missing producer.

## What this PR does

`packages/core/platform/Makefile` now stamps both keys with the same ref, so they move in lockstep by construction rather than by instruction, and the committed value is aligned to the digest `core/platform` already carried. Moving the runner forward two minors is safe: it is used only as a curl + jq container, and the image built at `v1.5.0` carries them (`git show v1.5.0:…/migrations/Dockerfile` → `apk add … jq ca-certificates bash curl`).

## What should replace it

A dedicated `ch-backup-client` image built by **this package's own Makefile** — measured at 23 MB, 15× smaller, with none of the cluster tooling and none of the entrypoint hazard. That also deletes the cross-package stamp this PR adds, because the pin would be produced by the package that owns it.

The objection that has kept this reuse in place — "a second tag release CI would have to re-digest each cut" — does not survive contact with the actual defect. Every other first-party image already pays that cost, automatically. What broke here was not an extra tag; it was **a pin with no producer**, which a package-owned image cannot reproduce.

I am deliberately not doing that here: it means a new image, a new build target and a new digest introduced during a release cut. It belongs in a follow-up.

## The guard

`hack/image-pin-consistency.bats` asserts the general invariant — no repository pinned at more than one digest — driven through the real promotion selector so it tracks whatever set promotion actually acts on, rather than a reimplementation that could drift from it. Plus a specific lockstep assertion so a recurrence names its cause. This check could not have been added before now: it fails on the very duplicate this PR removes.

## Testing

- `hack/image-pin-consistency.bats` — both tests pass; verified they fail when the drifted pin is restored.
- `make bats-unit-tests` green (294 tests, exit 0).
- `make -C packages/system/backupstrategy-controller test` — 11 tests, 3 suites, green.
- `helm template … --set backupStorage.bucketNameOverride=test-bucket` renders the strategy Pod with the new ref.
- The Makefile's `yq` step was simulated directly to confirm the relative path and key path resolve and that comments survive the in-place edit.
- Merged locally with #3404 onto `main` and re-run: the expanded ref collector in that PR surfaces no additional duplicate pins (314 tests, exit 0).

## Relationship to other work

Relates to #3143 — this is one instance of its unowned-pin class, the one its discussion flagged as having no producer. The four never-built packages there remain untouched.

Independent of #3404 (promote/retag/mirror storage-shape coverage); the two touch no common files and can merge in either order. Both are needed before the `v1.6.0` promote is re-cut.

## Release note

```release-note
Fixed a release-blocking duplicate pin: the ClickHouse backup client image is now stamped from the same source as the platform migrations image it reuses, so both carry one digest. Previously they could drift, which made promotion attempt to retag two digests to the same stable tag and fail. Reusing the migrations image here remains a documented workaround pending a dedicated backup-client image.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the platform migrations image digest is pinned consistently between the platform and backup strategy components.
  * Updated the backup strategy component to reference the new pinned `platform-migrations` digest.

* **Tests**
  * Added promotion/retag consistency checks to fail on conflicting source digests for the same stable tag.
  * Added drift detection to ensure `platform-migrations` image references match across consumer configuration files.

* **Documentation**
  * Expanded in-chart comments and values documentation clarifying the coupling and workaround behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->