### PR TITLE
fix(cozy-lib): converge the CA trust-anchor helper on the canonical name

### DIFF
--- a/packages/library/cozy-lib/templates/_tls.tpl
+++ b/packages/library/cozy-lib/templates/_tls.tpl
@@ -1,73 +1,41 @@
 {{/*
-=============================================================================
- TLS trust-anchor helpers
-=============================================================================
+cozy-lib.tls.caCertSecret renders the canonical CA-only trust-anchor Secret
+"<release>.tenant-ca", carrying ONLY ca.crt and never a private key.
 
-Per-app TLS in the Cozystack catalog issues a per-release, self-signed CA (via
-cert-manager or the app operator). A tenant that connects to such an endpoint
-needs the CA certificate (ca.crt) to verify the server — but nothing more. The
-objects that hold ca.crt today also hold private keys:
+Why a dedicated object: the Secrets that already hold ca.crt also hold keys —
+cert-manager's "<release>-ca" carries the CA key, the leaf "<release>-tls" the
+server key — so any RBAC that grants a tenant ca.crt through them leaks a key
+too. This helper emits ca.crt alone, labelled so the tenant reads it through the
+core.cozystack.io/tenantsecrets virtual resource the base tenant roles already
+grant (never through a raw core/v1 Secret).
 
-  - the cert-manager CA secret  <release>-ca   carries the CA private key
-    (tls.key) — full trust-chain compromise if leaked;
-  - the cert-manager leaf secret <release>-tls  carries the server private key
-    (tls.key) — server impersonation / MITM if leaked.
+Name is "<release>.tenant-ca", NOT "<release>-ca-cert": Percona Server for
+MongoDB already claims "<release>-ca-cert" with a key-bearing Secret of its own.
 
-So any RBAC path that hands a tenant ca.crt by granting read on one of those
-Secrets also hands over a private key. cozy-lib.tls.caCertSecret breaks that
-coupling: it renders a canonical trust-anchor object that carries ONLY ca.crt,
-labelled so tenants reach it through the core.cozystack.io/tenantsecrets API
-that the base tenant roles already grant — never through a Secret that contains
-tls.key.
-
-Delivery mechanism (grounded in the platform RBAC, not invented here):
-
-  - pkg/registry/core/tenantsecret/rest.go surfaces, under the virtual resource
-    core.cozystack.io/tenantsecrets, exactly the namespace Secrets labelled
-    internal.cozystack.io/tenantresource=true (TenantResourceLabelKey /
-    TenantResourceLabelValue in pkg/apis/core/v1alpha1/tenantresource_types.go).
-  - packages/system/cozystack-basics/templates/clusterroles.yaml grants
-    get/list/watch on core.cozystack.io/tenantsecrets to tenant ServiceAccounts
-    (cozy:tenant:base) and to use/admin/super-admin subjects (cozy:tenant:use:
-    base). No grant on raw core/v1 secrets is involved, so attaching the label
-    to a key-free object exposes the trust anchor without exposing any key.
-  - internal/backupcontroller/credentials_projector.go relies on the same rule
-    in reverse: it deliberately OMITS the label so its key-bearing projection
-    is NOT promoted to a TenantSecret. This helper is the positive counterpart —
-    a key-FREE object that is safe to promote.
-
-This is the chart-side shape every per-app TLS PR converges on; population of
-ca.crt stays the responsibility of whatever owns the PKI (the app operator, as
-the redis-operator fork does with its CA-only Opaque Secret, or a cert-manager
-chain resolved at the chart level). The helper itself is pure and value-driven
-so it renders deterministically and refuses, by construction and by guard, to
-carry a private key.
+This is the render-time path, for charts that hold the CA PEM as a value. Engines
+whose operator mints the CA asynchronously are served instead by the CA-extraction
+controller (internal/controller/cacert), which projects the same canonical object
+out of whatever Secret the engine produces — so a tenant learns exactly one name.
 */}}
 
 {{/*
-cozy-lib.tls.caCertSecret renders the canonical CA-only trust-anchor Secret.
-
-Invoked with a single dict argument (named parameters, not the (arg, $) list
-form, because it needs no global scope):
+Invoked with a single dict argument. A chart holding the CA PEM as a value calls
+it like this (there is no production caller yet — this is the pattern one uses):
 
   {{ include "cozy-lib.tls.caCertSecret" (dict
-       "name"      (printf "%s-ca-cert" .Release.Name)
+       "name"      (printf "%s.tenant-ca" .Release.Name)
        "namespace" .Release.Namespace
        "caCert"    $caCertPem
        "labels"    (dict "app.kubernetes.io/instance" .Release.Name)
   ) }}
 
 Parameters:
-  - name      (required) Secret name. Convention: "<release>-ca-cert".
-  - caCert    (required) the CA certificate chain in PEM. Must contain a
-              BEGIN CERTIFICATE PEM header and must NOT contain a
-              BEGIN...PRIVATE KEY PEM header; the helper fails closed on either
-              violation. Both checks are anchored to the PEM header line and are
-              case-insensitive, so they neither false-positive on certificate
-              body/comment text nor miss a lowercased hand-pasted header.
-  - namespace (optional) metadata.namespace.
-  - labels    (optional) extra labels merged onto the mandatory
-              internal.cozystack.io/tenantresource label (which always wins).
+  - name        (required) Secret name. Convention: "<release>.tenant-ca".
+  - caCert      (required) the CA chain in PEM. Must be one or more COMPLETE
+                certificate blocks and nothing else; the helper fails closed on a
+                private-key header or on any non-certificate bytes.
+  - namespace   (optional) metadata.namespace.
+  - labels      (optional) extra labels, merged onto the mandatory tenant labels.
   - annotations (optional) extra annotations.
 */}}
 {{- define "cozy-lib.tls.caCertSecret" -}}
@@ -78,23 +46,35 @@ Parameters:
 {{-   if eq $name "" -}}
 {{-     fail "cozy-lib.tls.caCertSecret: name is required" -}}
 {{-   end -}}
-{{-   $caCert := default "" .caCert -}}
+{{- /* Coerce to string first: an unquoted numeric YAML scalar (caCert: 12345)
+       parses to float64, and trim on it would die with a raw Go type error
+       instead of this helper's own fail message. (caCert: 0 reports "required",
+       not coerced — `default ""` treats 0 as empty; pinned by a test.) */ -}}
+{{-   $caCert := printf "%v" (default "" .caCert) -}}
 {{-   if eq (trim $caCert) "" -}}
 {{-     fail "cozy-lib.tls.caCertSecret: caCert is required and must be a non-empty PEM" -}}
 {{-   end -}}
-{{- /* Anchor both guards to the PEM header form, case-insensitively. A free
-       substring match would false-positive on a legitimate certificate whose
-       subject/comment text happens to contain "PRIVATE KEY", and would miss a
-       lowercase hand-pasted header. The (?i) header regex catches every key
-       variant (PKCS#8, RSA, EC, ENCRYPTED, OPENSSH, DSA) and only a real
-       BEGIN...PRIVATE KEY line, not arbitrary blob text. */ -}}
-{{-   if regexMatch "(?i)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----" $caCert -}}
+{{- /* Reject private-key material, anchored to the PEM header and case-insensitive
+       so it neither false-positives on certificate body text nor misses a
+       lowercased header. Stops at "PRIVATE KEY", not the closing dashes, so PGP's
+       "-----BEGIN PGP PRIVATE KEY BLOCK-----" is still caught. */ -}}
+{{-   if regexMatch "(?i)-----BEGIN [A-Z0-9 ]*PRIVATE KEY" $caCert -}}
 {{-     fail "cozy-lib.tls.caCertSecret: caCert must not contain private key material" -}}
 {{-   end -}}
-{{-   if not (regexMatch "(?i)-----BEGIN CERTIFICATE-----" $caCert) -}}
-{{-     fail "cozy-lib.tls.caCertSecret: caCert must contain a PEM certificate (BEGIN CERTIFICATE)" -}}
+{{- /* Require the WHOLE value (\A ... \z) to be complete certificate blocks and
+       whitespace, not merely to contain one, because ca.crt is emitted VERBATIM
+       below: preamble or trailing bytes (e.g. a raw DER/JWK key wearing no PEM
+       header) would otherwise ride into the tenant-readable anchor. This bounds
+       block SHAPE only — a Helm template has no x509 parser; the Go CA-extraction
+       controller does the full pem.Decode + x509 parse. */ -}}
+{{-   if not (regexMatch "(?i)\\A\\s*(-----BEGIN CERTIFICATE-----\\s+[A-Za-z0-9+/=][A-Za-z0-9+/=\\s]*-----END CERTIFICATE-----\\s*)+\\z" $caCert) -}}
+{{-     fail "cozy-lib.tls.caCertSecret: caCert must contain a complete PEM certificate block (BEGIN/END CERTIFICATE)" -}}
 {{-   end -}}
-{{-   $labels := merge (dict "internal.cozystack.io/tenantresource" "true") (default (dict) .labels) -}}
+{{- /* internal.cozystack.io/tenant-ca is the selector an ApplicationDefinition
+       matches and the CA-extraction controller stamps, so a helper-rendered
+       anchor must carry it to converge with a projected one. tenantresource is
+       rendered for shape but the lineage webhook recomputes it on admission. */ -}}
+{{-   $labels := merge (dict "internal.cozystack.io/tenant-ca" "true" "internal.cozystack.io/tenantresource" "true") (default (dict) .labels) -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/packages/tests/cozy-lib-tests/templates/tests/tls-cacert.yaml
+++ b/packages/tests/cozy-lib-tests/templates/tests/tls-cacert.yaml
@@ -1,5 +1,5 @@
 {{ include "cozy-lib.tls.caCertSecret" (dict
-     "name" (printf "%s-ca-cert" .Release.Name)
+     "name" (printf "%s.tenant-ca" .Release.Name)
      "namespace" .Release.Namespace
      "caCert" .Values.caCert
      "labels" (merge (dict "app.kubernetes.io/instance" .Release.Name) (default (dict) .Values.callerLabels))

--- a/packages/tests/cozy-lib-tests/tests/tls_cacert_test.yaml
+++ b/packages/tests/cozy-lib-tests/tests/tls_cacert_test.yaml
@@ -28,13 +28,19 @@ tests:
           value: v1
       - equal:
           path: metadata.name
-          value: myrelease-ca-cert
+          value: myrelease.tenant-ca
       - equal:
           path: metadata.namespace
           value: tenant-acme
       - equal:
           path: type
           value: Opaque
+      # tenant-ca is the selector an ApplicationDefinition matches and the
+      # CA-extraction controller stamps; a helper anchor must carry it to converge
+      # with a projected one on both name and label.
+      - equal:
+          path: metadata.labels["internal.cozystack.io/tenant-ca"]
+          value: "true"
       - isNotNullOrEmpty:
           path: stringData["ca.crt"]
       # The trust anchor must never carry private key material. The helper
@@ -131,7 +137,15 @@ tests:
       # slip through to a tenant-readable trust anchor.
       caCert: |
         -----BEGIN CERTIFICATE-----
-        MIIBExampleCertificateBodyOnlyNoPrivateKeyHeaderPresent0000000000
+        MIIBjTCCATOgAwIBAgIUEVKlZMojk6oxsIdEnHzgqNSB5EQwCgYIKoZIzj0EAwIw
+        GzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTAgFw0yNjA3MTYxNjM0NDZaGA8y
+        MTI2MDYyMjE2MzQ0NlowGzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTBZMBMG
+        ByqGSM49AgEGCCqGSM49AwEHA0IABHYaDAyL+v09MqV1Yp1T1AE7Y6LHqBnVF2kH
+        4mzq8ewzoqb7EF/IY/acC4G514Lsi212vky2z+yk61EIWlgzqmGjUzBRMB0GA1Ud
+        DgQWBBReFu/b3ZdMzmFjrOTD8A8bFPX6fDAfBgNVHSMEGDAWgBReFu/b3ZdMzmFj
+        rOTD8A8bFPX6fDAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIQCj
+        P8IEUi9H4YcxOyAtGt22n6WCP8dqxP4p2QfkcRl6LAIgSOIMy4oHa5IJWREYdFt9
+        L/I7Ek4FlYbzy9kZu/MXqlE=
         -----END CERTIFICATE-----
         -----BEGIN PRIVATE KEY-----
         MIIExamplePrivateKeyThatMustNeverReachTenantsViaCABundle00000000
@@ -148,27 +162,212 @@ tests:
         this is not a certificate at all
     asserts:
       - failedTemplate:
-          errorMessage: "cozy-lib.tls.caCertSecret: caCert must contain a PEM certificate (BEGIN CERTIFICATE)"
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert must contain a complete PEM certificate block (BEGIN/END CERTIFICATE)"
 
-  - it: accepts a certificate even when the literal text PRIVATE KEY appears outside a PEM header
+  # The three cases below carry a BEGIN CERTIFICATE line and no key header, so a
+  # header-only guard admitted them and rendered an anchor with nothing usable.
+  # The whole-value guard requires a COMPLETE, base64-bodied block instead.
+  - it: rejects certificate armour with no closing line
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      caCert: |
+        -----BEGIN CERTIFICATE-----
+        MIIBExampleCertificateBodyWithNoClosingLine0000000000000000000000
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert must contain a complete PEM certificate block (BEGIN/END CERTIFICATE)"
+
+  - it: rejects empty certificate armour
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      caCert: |
+        -----BEGIN CERTIFICATE-----
+        -----END CERTIFICATE-----
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert must contain a complete PEM certificate block (BEGIN/END CERTIFICATE)"
+
+  # The guard rejects a body only for characters outside the base64 alphabet — it
+  # cannot check base64 validity itself. The trailing "!" is what makes this body
+  # illegal; drop it and the body is all-base64 and would be accepted.
+  - it: rejects certificate armour whose body carries characters base64 never uses
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      caCert: |
+        -----BEGIN CERTIFICATE-----
+        this is not base64 and never could be!
+        -----END CERTIFICATE-----
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert must contain a complete PEM certificate block (BEGIN/END CERTIFICATE)"
+
+  # Documented gap: a body spelled in base64 characters passes this guard however
+  # meaningless. Only the Go controller's x509.ParseCertificate can refuse it.
+  - it: accepts armour around a base64-alphabet body it cannot decode (documented limit)
     templates:
       - templates/tests/tls-cacert-params.yaml
     set:
       useParams: true
-      name: my-ca-cert
-      namespace: tenant-acme
-      # "PRIVATE KEY" here is in a friendlyName line, not a PEM header — a free
-      # substring guard would wrongly reject this valid, key-free certificate.
+      name: my.tenant-ca
       caCert: |
-        Bag Attributes: friendlyName=acme PRIVATE KEY authority
         -----BEGIN CERTIFICATE-----
-        MIIBExampleCertificateBodyOnlyNoPrivateKeyHeaderPresent0000000000
+        this is not base64 and never could be
+        -----END CERTIFICATE-----
+    asserts:
+      - isKind:
+          of: Secret
+
+  # PGP's header puts BLOCK after "PRIVATE KEY", so a guard anchored on the closing
+  # dashes would miss it; the guard stops at "PRIVATE KEY" precisely to catch this.
+  - it: refuses a PGP private key block next to a valid certificate
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      caCert: |
+        -----BEGIN CERTIFICATE-----
+        MIIBjTCCATOgAwIBAgIUEVKlZMojk6oxsIdEnHzgqNSB5EQwCgYIKoZIzj0EAwIw
+        -----END CERTIFICATE-----
+        -----BEGIN PGP PRIVATE KEY BLOCK-----
+        lQOYBGaaaaaaExamplePgpPrivateKeyMustNeverReachTenants0000000000
+        -----END PGP PRIVATE KEY BLOCK-----
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert must not contain private key material"
+
+  # An unquoted numeric scalar in values.yaml parses to a float64, and any string
+  # operation on it dies with a raw Go template error. The guard must fail closed
+  # AND say which field the author got wrong.
+  - it: fails closed with its own message on a numeric caCert
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      caCert: 12345
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert must contain a complete PEM certificate block (BEGIN/END CERTIFICATE)"
+
+  # Coercion wart, pinned: `default ""` treats 0 as empty before printf runs, so a
+  # supplied zero reports "required". Fails closed either way — 0 is no certificate.
+  - it: reports a zero caCert as required, not as a bad certificate
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      caCert: 0
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert is required and must be a non-empty PEM"
+
+  - it: accepts a certificate chain of more than one block
+    templates:
+      - templates/tests/tls-cacert-params.yaml
+    set:
+      useParams: true
+      name: my.tenant-ca
+      # An intermediate chain is an ordinary trust anchor and must keep
+      # rendering: the tightened guard bounds the block SHAPE, not the count.
+      caCert: |
+        -----BEGIN CERTIFICATE-----
+        MIIBojCCAUegAwIBAgIUMUqqtF2pMghhaI9FEJwiX0S46MswCgYIKoZIzj0EAwIw
+        JTEjMCEGA1UEAwwaY296eS1saWItdGVzdC1pbnRlcm1lZGlhdGUwIBcNMjYwNzE2
+        MTYzNDQ2WhgPMjEyNjA2MjIxNjM0NDZaMCUxIzAhBgNVBAMMGmNvenktbGliLXRl
+        c3QtaW50ZXJtZWRpYXRlMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEePlhpS2d
+        Vaj6KcyvQfs96sNWDF+gGJDsNRXAEjPUUkBVZBdkQWVrch4f6ti7yxwrY8a9ZqJP
+        KIOB7HdvTJReeqNTMFEwHQYDVR0OBBYEFHbXOUxHp7KY7yfSQlLON+LKu68wMB8G
+        A1UdIwQYMBaAFHbXOUxHp7KY7yfSQlLON+LKu68wMA8GA1UdEwEB/wQFMAMBAf8w
+        CgYIKoZIzj0EAwIDSQAwRgIhAMgKiremKARWnyMIR4U8TXCs8nsJuYB1DjQcYYvP
+        KgyxAiEArfXXEHDpM1vBD4Nf58F98I+6RhN5yQHn7uokVrm88Cc=
+        -----END CERTIFICATE-----
+        -----BEGIN CERTIFICATE-----
+        MIIBjTCCATOgAwIBAgIUEVKlZMojk6oxsIdEnHzgqNSB5EQwCgYIKoZIzj0EAwIw
+        GzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTAgFw0yNjA3MTYxNjM0NDZaGA8y
+        MTI2MDYyMjE2MzQ0NlowGzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTBZMBMG
+        ByqGSM49AgEGCCqGSM49AwEHA0IABHYaDAyL+v09MqV1Yp1T1AE7Y6LHqBnVF2kH
+        4mzq8ewzoqb7EF/IY/acC4G514Lsi212vky2z+yk61EIWlgzqmGjUzBRMB0GA1Ud
+        DgQWBBReFu/b3ZdMzmFjrOTD8A8bFPX6fDAfBgNVHSMEGDAWgBReFu/b3ZdMzmFj
+        rOTD8A8bFPX6fDAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIQCj
+        P8IEUi9H4YcxOyAtGt22n6WCP8dqxP4p2QfkcRl6LAIgSOIMy4oHa5IJWREYdFt9
+        L/I7Ek4FlYbzy9kZu/MXqlE=
         -----END CERTIFICATE-----
     asserts:
       - isKind:
           of: Secret
       - isNotNullOrEmpty:
           path: stringData["ca.crt"]
+
+  - it: rejects a certificate wrapped in a friendlyName preamble as a structural failure
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      # "PRIVATE KEY" sits in a friendlyName preamble line, not a PEM header, so
+      # the failure is the STRUCTURAL block error — proof the key guard, anchored
+      # to the header, does not false-positive on substring text.
+      caCert: |
+        Bag Attributes: friendlyName=acme PRIVATE KEY authority
+        -----BEGIN CERTIFICATE-----
+        MIIBjTCCATOgAwIBAgIUEVKlZMojk6oxsIdEnHzgqNSB5EQwCgYIKoZIzj0EAwIw
+        GzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTAgFw0yNjA3MTYxNjM0NDZaGA8y
+        MTI2MDYyMjE2MzQ0NlowGzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTBZMBMG
+        ByqGSM49AgEGCCqGSM49AwEHA0IABHYaDAyL+v09MqV1Yp1T1AE7Y6LHqBnVF2kH
+        4mzq8ewzoqb7EF/IY/acC4G514Lsi212vky2z+yk61EIWlgzqmGjUzBRMB0GA1Ud
+        DgQWBBReFu/b3ZdMzmFjrOTD8A8bFPX6fDAfBgNVHSMEGDAWgBReFu/b3ZdMzmFj
+        rOTD8A8bFPX6fDAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIQCj
+        P8IEUi9H4YcxOyAtGt22n6WCP8dqxP4p2QfkcRl6LAIgSOIMy4oHa5IJWREYdFt9
+        L/I7Ek4FlYbzy9kZu/MXqlE=
+        -----END CERTIFICATE-----
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert must contain a complete PEM certificate block (BEGIN/END CERTIFICATE)"
+
+  # The whole-value anchor rejects a valid block carrying bytes before or after it,
+  # since the value is emitted verbatim. The controller strips such bytes by
+  # re-encoding; a Helm template can only refuse them.
+  - it: rejects a certificate preceded by a human-readable preamble
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      # What `openssl x509 -text` prints ahead of the PEM block.
+      caCert: |
+        Certificate:
+            Data:
+                Version: 3 (0x2)
+        -----BEGIN CERTIFICATE-----
+        MIIBjTCCATOgAwIBAgIUEVKlZMojk6oxsIdEnHzgqNSB5EQwCgYIKoZIzj0EAwIw
+        GzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTAgFw0yNjA3MTYxNjM0NDZaGA8y
+        MTI2MDYyMjE2MzQ0NlowGzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTBZMBMG
+        ByqGSM49AgEGCCqGSM49AwEHA0IABHYaDAyL+v09MqV1Yp1T1AE7Y6LHqBnVF2kH
+        4mzq8ewzoqb7EF/IY/acC4G514Lsi212vky2z+yk61EIWlgzqmGjUzBRMB0GA1Ud
+        DgQWBBReFu/b3ZdMzmFjrOTD8A8bFPX6fDAfBgNVHSMEGDAWgBReFu/b3ZdMzmFj
+        rOTD8A8bFPX6fDAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIQCj
+        P8IEUi9H4YcxOyAtGt22n6WCP8dqxP4p2QfkcRl6LAIgSOIMy4oHa5IJWREYdFt9
+        L/I7Ek4FlYbzy9kZu/MXqlE=
+        -----END CERTIFICATE-----
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert must contain a complete PEM certificate block (BEGIN/END CERTIFICATE)"
+
+  - it: rejects a certificate trailed by arbitrary bytes
+    templates:
+      - templates/tests/tls-cacert.yaml
+    set:
+      caCert: |
+        -----BEGIN CERTIFICATE-----
+        MIIBjTCCATOgAwIBAgIUEVKlZMojk6oxsIdEnHzgqNSB5EQwCgYIKoZIzj0EAwIw
+        GzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTAgFw0yNjA3MTYxNjM0NDZaGA8y
+        MTI2MDYyMjE2MzQ0NlowGzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTBZMBMG
+        ByqGSM49AgEGCCqGSM49AwEHA0IABHYaDAyL+v09MqV1Yp1T1AE7Y6LHqBnVF2kH
+        4mzq8ewzoqb7EF/IY/acC4G514Lsi212vky2z+yk61EIWlgzqmGjUzBRMB0GA1Ud
+        DgQWBBReFu/b3ZdMzmFjrOTD8A8bFPX6fDAfBgNVHSMEGDAWgBReFu/b3ZdMzmFj
+        rOTD8A8bFPX6fDAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIQCj
+        P8IEUi9H4YcxOyAtGt22n6WCP8dqxP4p2QfkcRl6LAIgSOIMy4oHa5IJWREYdFt9
+        L/I7Ek4FlYbzy9kZu/MXqlE=
+        -----END CERTIFICATE-----
+        and then some trailing bytes
+    asserts:
+      - failedTemplate:
+          errorMessage: "cozy-lib.tls.caCertSecret: caCert must contain a complete PEM certificate block (BEGIN/END CERTIFICATE)"
 
   - it: fails closed when name is empty
     templates:
@@ -179,7 +378,15 @@ tests:
       namespace: tenant-acme
       caCert: |
         -----BEGIN CERTIFICATE-----
-        MIIBExampleCertificateBodyOnlyNoPrivateKeyHeaderPresent0000000000
+        MIIBjTCCATOgAwIBAgIUEVKlZMojk6oxsIdEnHzgqNSB5EQwCgYIKoZIzj0EAwIw
+        GzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTAgFw0yNjA3MTYxNjM0NDZaGA8y
+        MTI2MDYyMjE2MzQ0NlowGzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTBZMBMG
+        ByqGSM49AgEGCCqGSM49AwEHA0IABHYaDAyL+v09MqV1Yp1T1AE7Y6LHqBnVF2kH
+        4mzq8ewzoqb7EF/IY/acC4G514Lsi212vky2z+yk61EIWlgzqmGjUzBRMB0GA1Ud
+        DgQWBBReFu/b3ZdMzmFjrOTD8A8bFPX6fDAfBgNVHSMEGDAWgBReFu/b3ZdMzmFj
+        rOTD8A8bFPX6fDAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIQCj
+        P8IEUi9H4YcxOyAtGt22n6WCP8dqxP4p2QfkcRl6LAIgSOIMy4oHa5IJWREYdFt9
+        L/I7Ek4FlYbzy9kZu/MXqlE=
         -----END CERTIFICATE-----
     asserts:
       - failedTemplate:
@@ -190,15 +397,23 @@ tests:
       - templates/tests/tls-cacert-params.yaml
     set:
       useParams: true
-      name: my-ca-cert
+      name: my.tenant-ca
       caCert: |
         -----BEGIN CERTIFICATE-----
-        MIIBExampleCertificateBodyOnlyNoPrivateKeyHeaderPresent0000000000
+        MIIBjTCCATOgAwIBAgIUEVKlZMojk6oxsIdEnHzgqNSB5EQwCgYIKoZIzj0EAwIw
+        GzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTAgFw0yNjA3MTYxNjM0NDZaGA8y
+        MTI2MDYyMjE2MzQ0NlowGzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTBZMBMG
+        ByqGSM49AgEGCCqGSM49AwEHA0IABHYaDAyL+v09MqV1Yp1T1AE7Y6LHqBnVF2kH
+        4mzq8ewzoqb7EF/IY/acC4G514Lsi212vky2z+yk61EIWlgzqmGjUzBRMB0GA1Ud
+        DgQWBBReFu/b3ZdMzmFjrOTD8A8bFPX6fDAfBgNVHSMEGDAWgBReFu/b3ZdMzmFj
+        rOTD8A8bFPX6fDAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIQCj
+        P8IEUi9H4YcxOyAtGt22n6WCP8dqxP4p2QfkcRl6LAIgSOIMy4oHa5IJWREYdFt9
+        L/I7Ek4FlYbzy9kZu/MXqlE=
         -----END CERTIFICATE-----
     asserts:
       - equal:
           path: metadata.name
-          value: my-ca-cert
+          value: my.tenant-ca
       - notExists:
           path: metadata.namespace
 

--- a/packages/tests/cozy-lib-tests/tests/tls_cacert_values.yaml
+++ b/packages/tests/cozy-lib-tests/tests/tls_cacert_values.yaml
@@ -1,4 +1,16 @@
+# A REAL, self-signed CA certificate (EC P-256, long-dated), not a
+# certificate-shaped string. The regex guard cannot parse x509, so a fake body
+# would pass identically — keeping this real is what makes the suite assert
+# against something a verifier would actually accept.
 caCert: |
   -----BEGIN CERTIFICATE-----
-  MIIBExampleCACertificateOnlyNoPrivateKeyMaterialPresentHere00000000
+  MIIBjTCCATOgAwIBAgIUEVKlZMojk6oxsIdEnHzgqNSB5EQwCgYIKoZIzj0EAwIw
+  GzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTAgFw0yNjA3MTYxNjM0NDZaGA8y
+  MTI2MDYyMjE2MzQ0NlowGzEZMBcGA1UEAwwQY296eS1saWItdGVzdC1jYTBZMBMG
+  ByqGSM49AgEGCCqGSM49AwEHA0IABHYaDAyL+v09MqV1Yp1T1AE7Y6LHqBnVF2kH
+  4mzq8ewzoqb7EF/IY/acC4G514Lsi212vky2z+yk61EIWlgzqmGjUzBRMB0GA1Ud
+  DgQWBBReFu/b3ZdMzmFjrOTD8A8bFPX6fDAfBgNVHSMEGDAWgBReFu/b3ZdMzmFj
+  rOTD8A8bFPX6fDAPBgNVHRMBAf8EBTADAQH/MAoGCCqGSM49BAMCA0gAMEUCIQCj
+  P8IEUi9H4YcxOyAtGt22n6WCP8dqxP4p2QfkcRl6LAIgSOIMy4oHa5IJWREYdFt9
+  L/I7Ek4FlYbzy9kZu/MXqlE=
   -----END CERTIFICATE-----


### PR DESCRIPTION
## What this PR does

Ships `cozy-lib.tls.caCertSecret`, a render-time helper that emits a key-free trust-anchor Secret carrying only `ca.crt`. It converges the object name on `<release>.tenant-ca`, requires the whole value to be certificate blocks so a stray private-key header or trailing bytes are rejected, and coerces numeric scalars before the guard runs so a numeric value cannot slip past.

No chart calls it yet. It is the render-time producer half of the trust-anchor contract; the controller half is #3407, now merged. The doc-comment on the helper shows the one-line call a chart uses, and says outright there is no caller yet, so nobody reads it as wired when it is not.

Split out from #3299. Comments trimmed on review.

```release-note
fix(cozy-lib): the CA trust-anchor helper emits the canonical `<release>.tenant-ca` name and rejects non-certificate input.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated generated TLS CA Secret naming to use the `<release>.tenant-ca` convention.
  - Added/ensured a tenant CA label is set alongside the existing tenant resource label.
  - Continued support for custom labels (caller labels still applied).

- **Bug Fixes**
  - Strengthened CA certificate PEM validation to be fail-closed: requires non-empty, complete `BEGIN/END CERTIFICATE` blocks only.
  - Rejects private-key material and other malformed or improperly structured PEM input, including unexpected extra content.

- **Tests**
  - Updated TLS CA certificate fixtures and assertions to cover additional negative cases and refined error expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->