### PR TITLE
fix(cozystack-basics): gate the hostname VAP policies on the VAP API

### DIFF
--- a/packages/system/cozystack-basics/templates/gateway-hostname-policy.yaml
+++ b/packages/system/cozystack-basics/templates/gateway-hostname-policy.yaml
@@ -1,3 +1,5 @@
+{{- /* Render only where the ValidatingAdmissionPolicy API is served (GA since Kubernetes 1.30; the management cluster requires 1.33+). Same guard as packages/core/platform/templates/deletion-protection.yaml. */}}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy" }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -154,3 +156,4 @@ metadata:
 spec:
   policyName: cozystack-namespace-host-label-policy
   validationActions: [Deny]
+{{- end }}

--- a/packages/system/cozystack-basics/templates/ingress-hostname-policy.yaml
+++ b/packages/system/cozystack-basics/templates/ingress-hostname-policy.yaml
@@ -57,7 +57,8 @@
   labelling yet — in which case the caller should retry.
 */}}
 {{- $rootHost := index .Values._cluster "root-host" }}
-{{- if $rootHost }}
+{{- /* Also gate on the ValidatingAdmissionPolicy API (GA since Kubernetes 1.30; the management cluster requires 1.33+), so a cluster without it does not get an unrenderable resource. Same guard as packages/core/platform/templates/deletion-protection.yaml. */}}
+{{- if and $rootHost (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy") }}
 {{- $A := `namespaceObject.metadata.labels["namespace.cozystack.io/host"]` }}
 {{- $celValidator := printf `(namespaceObject == null || !has(namespaceObject.metadata.labels) || !("namespace.cozystack.io/host" in namespaceObject.metadata.labels)) ? false : (!has(object.spec.defaultBackend) && (!has(object.spec.rules) || object.spec.rules.all(r, has(r.host) && r.host != "" && (r.host == %s || r.host.endsWith("." + %s) || (!r.host.startsWith("*.") && !(r.host == %q || r.host.endsWith(%q)))))) && (!has(object.spec.tls) || object.spec.tls.all(t, !has(t.hosts) || t.hosts.all(h, h != "" && (h == %s || h.endsWith("." + %s) || (!h.startsWith("*.") && !(h == %q || h.endsWith(%q))))))))` $A $A $rootHost (printf ".%s" $rootHost) $A $A $rootHost (printf ".%s" $rootHost) -}}
 ---

--- a/packages/system/cozystack-basics/templates/route-hostname-policy.yaml
+++ b/packages/system/cozystack-basics/templates/route-hostname-policy.yaml
@@ -36,6 +36,8 @@
   finished labelling yet — in which case the caller should retry.
 */}}
 {{- $celValidator := `(namespaceObject == null || !has(namespaceObject.metadata.labels) || !("namespace.cozystack.io/host" in namespaceObject.metadata.labels)) ? false : (!has(object.spec.hostnames) || object.spec.hostnames.all(h, h == namespaceObject.metadata.labels["namespace.cozystack.io/host"] || h.endsWith("." + namespaceObject.metadata.labels["namespace.cozystack.io/host"])))` -}}
+{{- /* Render only where the ValidatingAdmissionPolicy API is served (GA since Kubernetes 1.30; the management cluster requires 1.33+). Same guard as packages/core/platform/templates/deletion-protection.yaml. */}}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy" }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
@@ -104,3 +106,4 @@ metadata:
 spec:
   policyName: cozystack-route-hostname-policy-tls
   validationActions: [Deny]
+{{- end }}

--- a/packages/system/cozystack-basics/tests/gateway-hostname-policy_test.yaml
+++ b/packages/system/cozystack-basics/tests/gateway-hostname-policy_test.yaml
@@ -19,6 +19,13 @@ release:
 # Both gates are dropped; inheritance now flows via the label
 # selector on Gateway.spec.listeners[].allowedRoutes.
 
+# The template now gates on the ValidatingAdmissionPolicy API (GA since
+# Kubernetes 1.30); helm-unittest's default capability set omits it, so every
+# rendering test declares it, exactly as the platform deletion-protection suite.
+capabilities:
+  apiVersions:
+    - admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy
+
 tests:
   - it: renders 3 VAPs + 3 Bindings (6 documents total)
     asserts:

--- a/packages/system/cozystack-basics/tests/hostname-policies-capability-gate_test.yaml
+++ b/packages/system/cozystack-basics/tests/hostname-policies-capability-gate_test.yaml
@@ -1,0 +1,30 @@
+suite: cozystack-basics hostname VAP policies are gated on the ValidatingAdmissionPolicy API
+templates:
+  - templates/route-hostname-policy.yaml
+  - templates/gateway-hostname-policy.yaml
+  - templates/ingress-hostname-policy.yaml
+release:
+  name: cozystack-basics
+  namespace: cozy-system
+# root-host is set so the ingress policy's own value gate passes; with it set,
+# the only reason any of these three templates render nothing is the missing
+# ValidatingAdmissionPolicy API declared below. helm-unittest's per-test
+# capabilities merge rather than replace the suite's, so the absent case is a
+# separate suite pinned at suite level (mirrors the platform notes gate suite).
+set:
+  _cluster:
+    root-host: example.org
+capabilities:
+  apiVersions: []
+tests:
+  - it: none of the hostname VAP policies render when the API is unavailable
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/route-hostname-policy.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/gateway-hostname-policy.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/ingress-hostname-policy.yaml

--- a/packages/system/cozystack-basics/tests/ingress-hostname-policy_test.yaml
+++ b/packages/system/cozystack-basics/tests/ingress-hostname-policy_test.yaml
@@ -13,6 +13,13 @@ set:
   _cluster:
     root-host: example.org
 
+# The template now also gates on the ValidatingAdmissionPolicy API (GA since
+# Kubernetes 1.30); helm-unittest's default capability set omits it, so every
+# rendering test declares it, exactly as the platform deletion-protection suite.
+capabilities:
+  apiVersions:
+    - admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy
+
 tests:
   - it: renders ValidatingAdmissionPolicy + Binding for legacy Ingress
     # Legacy Ingress (networking.k8s.io/v1) is the default ingress path

--- a/packages/system/cozystack-basics/tests/route-hostname-policy_test.yaml
+++ b/packages/system/cozystack-basics/tests/route-hostname-policy_test.yaml
@@ -6,6 +6,13 @@ release:
   name: cozystack-basics
   namespace: cozy-system
 
+# The template now gates on the ValidatingAdmissionPolicy API (GA since
+# Kubernetes 1.30); helm-unittest's default capability set omits it, so every
+# rendering test declares it, exactly as the platform deletion-protection suite.
+capabilities:
+  apiVersions:
+    - admissionregistration.k8s.io/v1/ValidatingAdmissionPolicy
+
 tests:
   - it: renders ValidatingAdmissionPolicy + Binding for HTTPRoute and TLSRoute (Layer 7)
     # Layer 7 (route-hostname VAP) is the only VAP rendered by THIS


### PR DESCRIPTION
## What this PR does

Wraps the route, gateway, and ingress hostname `ValidatingAdmissionPolicy` templates in a `.Capabilities.APIVersions.Has` gate so they render only where the VAP API is available. Without it, an operator-generated HelmRelease with drift detection off renders the policies out at first install on a cluster missing the API and never adds them back. Each template gains a sibling test asserting it renders zero documents when the API is absent. Install-robustness fix, split out from #3299.

```release-note
fix(cozystack-basics): hostname ValidatingAdmissionPolicies render only where the VAP API is available, so a first install on a cluster without it no longer drops them permanently.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hostname validation policies now render only when the Kubernetes admission policy API is available, preventing unsupported policy resources on older clusters.
* **Tests**
  * Added/updated unit tests to explicitly simulate both missing and present admission policy API capabilities, ensuring templates render (or not) as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->