### PR TITLE
feat(api)!: require the application release prefix to be dot-free

### DIFF
--- a/api/v1alpha1/applicationdefinitions_types.go
+++ b/api/v1alpha1/applicationdefinitions_types.go
@@ -79,7 +79,12 @@ type ApplicationDefinitionRelease struct {
 	ChartRef *helmv2.CrossNamespaceSourceReference `json:"chartRef"`
 	// Labels for the release
 	Labels map[string]string `json:"labels,omitempty"`
-	// Prefix for the release name
+	// Prefix for the release name. Release names are "<prefix><app name>" and the
+	// tenant CA trust anchor is projected to "<release>.tenant-ca", where the dot
+	// is a separator no release name may contain — so the prefix must be dot-free.
+	// It is restricted to lowercase DNS-1123 characters, which excludes the dot by
+	// construction.
+	// +kubebuilder:validation:Pattern=`^[a-z0-9-]*$`
 	Prefix string `json:"prefix"`
 
 	// WaitStrategy maps to HelmReleaseSpec.WaitStrategy.Name — a deliberate

--- a/packages/system/application-definition-crd/definition/cozystack.io_applicationdefinitions.yaml
+++ b/packages/system/application-definition-crd/definition/cozystack.io_applicationdefinitions.yaml
@@ -361,7 +361,13 @@ spec:
                     description: Labels for the release
                     type: object
                   prefix:
-                    description: Prefix for the release name
+                    description: |-
+                      Prefix for the release name. Release names are "<prefix><app name>" and the
+                      tenant CA trust anchor is projected to "<release>.tenant-ca", where the dot
+                      is a separator no release name may contain — so the prefix must be dot-free.
+                      It is restricted to lowercase DNS-1123 characters, which excludes the dot by
+                      construction.
+                    pattern: ^[a-z0-9-]*$
                     type: string
                   waitStrategy:
                     description: |-


### PR DESCRIPTION
## What this PR does

Constrains `ApplicationDefinition.spec.application.release.prefix` to `^[a-z0-9-]*$`, which excludes the dot. Release names are `<prefix><app>`, and the tenant CA trust anchor is projected to `<release>.tenant-ca`; the dot is the separator that keeps that name unreachable by any engine, so a prefix carrying a dot would break the guarantee. Every in-tree prefix already conforms. Split out from #3299.

```release-note
feat(api)!: `ApplicationDefinition.spec.application.release.prefix` must match `^[a-z0-9-]*$` (dot-free). A definition with a prefix containing a dot or any other character is rejected at admission; correct it before applying this CRD.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for release prefixes to allow only lowercase letters, numbers, and hyphens.
  * Updated guidance explaining how prefixes affect generated release names and tenant CA trust anchors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->