### PR TITLE
chore: ignore root-level Go binaries built from cmd/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,26 @@ _repos
 .idea
 .vscode
 
+# Go binaries built straight into the repository root.
+#
+# `go build ./cmd/<name>` (without -o) drops the executable in the working
+# directory under the package name, so every package under cmd/ has a
+# root-level binary waiting to happen — each ~80 MB, and nothing else here
+# matched them, leaving `git add .` one keystroke from committing one.
+/api-gate
+/backup-controller
+/backupstrategy-controller
+/check-readiness
+/cozypkg
+/cozystack-api
+/cozystack-controller
+/cozystack-operator
+/flux-plunger
+/flux-shard-operator
+/kubeovn-plunger
+/lineage-controller-webhook
+/securitygroup-controller
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml


### PR DESCRIPTION
## What this PR does

Adds the root-level binary names that `go build ./cmd/<name>` (without `-o`) drops in the repository root to `.gitignore`, so `git add .` cannot accidentally commit an ~80 MB executable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository settings to exclude generated Go executables from version control.
  * Added explanatory comments for the ignored build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->