### PR TITLE
fix(backups): request S3 checksum only when required for barman-cloud (non-AWS S3 / Ceph RGW)

### DIFF
--- a/internal/backupcontroller/cnpgstrategy_controller.go
+++ b/internal/backupcontroller/cnpgstrategy_controller.go
@@ -436,8 +436,9 @@ func (r *BackupJobReconciler) applyClusterPluginBackup(ctx context.Context, name
 		Controller: &controller,
 	}}
 	objStore.Spec = cnpgtypes.ObjectStoreSpec{
-		Configuration:   *buildBarmanObjectStore(t.BarmanObjectStore, ""),
-		RetentionPolicy: t.BarmanObjectStore.RetentionPolicy,
+		Configuration:                *buildBarmanObjectStore(t.BarmanObjectStore, ""),
+		RetentionPolicy:              t.BarmanObjectStore.RetentionPolicy,
+		InstanceSidecarConfiguration: barmanSidecarConfiguration(),
 	}
 	if err := r.Patch(ctx, objStore, client.Apply, client.FieldOwner(cnpgFieldManager), client.ForceOwnership); err != nil {
 		return "", fmt.Errorf("apply ObjectStore %s/%s: %w", namespace, objStoreName, err)
@@ -1388,6 +1389,24 @@ func buildBarmanPlugin(objectStoreName, serverName string) cnpgtypes.PluginConfi
 		Name:          cnpgtypes.PluginName,
 		IsWALArchiver: &isWALArchiver,
 		Parameters:    params,
+	}
+}
+
+// barmanSidecarConfiguration pins the barman-cloud sidecar's boto3 request
+// checksum policy to "when_required". Since botocore ~1.36 the default
+// (when_supported) attaches a flexible checksum to every PutObject, which
+// non-AWS S3-compatible backends (Ceph RGW, and the platform's own default
+// SeaweedFS system bucket) reject with "x-amz-content-sha256 must be
+// UNSIGNED-PAYLOAD, ...". Compute a checksum only when required; AWS S3
+// accepts that too, so it is a safe default everywhere. This mirrors the same
+// env set on the chart-rendered ObjectStores (packages/{apps/postgres,
+// system/keycloak}/templates/db.yaml) and the etcd-operator fix (#342).
+func barmanSidecarConfiguration() *cnpgtypes.InstanceSidecarConfiguration {
+	return &cnpgtypes.InstanceSidecarConfiguration{
+		Env: []cnpgtypes.EnvVar{{
+			Name:  "AWS_REQUEST_CHECKSUM_CALCULATION",
+			Value: "when_required",
+		}},
 	}
 }
 

--- a/internal/backupcontroller/cnpgstrategy_controller_test.go
+++ b/internal/backupcontroller/cnpgstrategy_controller_test.go
@@ -1464,6 +1464,17 @@ func TestApplyClusterPluginBackup_PatchesExistingCluster(t *testing.T) {
 	if store.Spec.RetentionPolicy != "30d" {
 		t.Errorf("ObjectStore retentionPolicy: got %q", store.Spec.RetentionPolicy)
 	}
+	// The ObjectStore must pin the barman-cloud sidecar's S3 request-checksum
+	// policy to when_required, or uploads to non-AWS S3 gateways (Ceph RGW, the
+	// platform's own SeaweedFS system bucket) fail with an x-amz-content-sha256
+	// InvalidArgument. The chart does not render this ObjectStore in the
+	// platform-managed useSystemBucket=true flow, so this Go path is the only
+	// place that sets it there.
+	sc := store.Spec.InstanceSidecarConfiguration
+	if sc == nil || len(sc.Env) != 1 ||
+		sc.Env[0].Name != "AWS_REQUEST_CHECKSUM_CALCULATION" || sc.Env[0].Value != "when_required" {
+		t.Errorf("ObjectStore instanceSidecarConfiguration.env: got %+v, want [AWS_REQUEST_CHECKSUM_CALCULATION=when_required]", sc)
+	}
 	// The ObjectStore must be owner-referenced to the Cluster so Kubernetes GC
 	// removes it when the Cluster is deleted (no orphan in the platform flow,
 	// where the chart does not render this ObjectStore).

--- a/internal/backupcontroller/cnpgtypes/types.go
+++ b/internal/backupcontroller/cnpgtypes/types.go
@@ -208,6 +208,23 @@ type ObjectStoreSpec struct {
 	// RetentionPolicy is a barman retention expression validated by the plugin
 	// CRD against ^[1-9][0-9]*[dwm]$ (e.g. "30d").
 	RetentionPolicy string `json:"retentionPolicy,omitempty"`
+	// InstanceSidecarConfiguration passes settings to the barman-cloud sidecar
+	// that the plugin injects into the CNPG pods. Only the fields we set are
+	// modelled (see the upstream ObjectStore CRD for the full type).
+	InstanceSidecarConfiguration *InstanceSidecarConfiguration `json:"instanceSidecarConfiguration,omitempty"`
+}
+
+// InstanceSidecarConfiguration is a minimal mirror of the barman-cloud
+// ObjectStore's spec.instanceSidecarConfiguration (only spec.env).
+type InstanceSidecarConfiguration struct {
+	Env []EnvVar `json:"env,omitempty"`
+}
+
+// EnvVar is a minimal corev1.EnvVar (name/value only) — enough to pass a
+// literal environment variable to the barman-cloud sidecar.
+type EnvVar struct {
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
 }
 
 type BackupStatus struct {

--- a/internal/backupcontroller/cnpgtypes/zz_generated.deepcopy.go
+++ b/internal/backupcontroller/cnpgtypes/zz_generated.deepcopy.go
@@ -239,6 +239,27 @@ func (in *ObjectStoreList) DeepCopyObject() runtime.Object {
 func (in *ObjectStoreSpec) DeepCopyInto(out *ObjectStoreSpec) {
 	*out = *in
 	in.Configuration.DeepCopyInto(&out.Configuration)
+	if in.InstanceSidecarConfiguration != nil {
+		out.InstanceSidecarConfiguration = new(InstanceSidecarConfiguration)
+		in.InstanceSidecarConfiguration.DeepCopyInto(out.InstanceSidecarConfiguration)
+	}
+}
+
+func (in *InstanceSidecarConfiguration) DeepCopyInto(out *InstanceSidecarConfiguration) {
+	*out = *in
+	if in.Env != nil {
+		out.Env = make([]EnvVar, len(in.Env))
+		copy(out.Env, in.Env)
+	}
+}
+
+func (in *InstanceSidecarConfiguration) DeepCopy() *InstanceSidecarConfiguration {
+	if in == nil {
+		return nil
+	}
+	out := new(InstanceSidecarConfiguration)
+	in.DeepCopyInto(out)
+	return out
 }
 
 func (in *Backup) DeepCopy() *Backup {

--- a/packages/apps/postgres/templates/db.yaml
+++ b/packages/apps/postgres/templates/db.yaml
@@ -262,6 +262,15 @@ spec:
   {{- if .Values.backup.retentionPolicy }}
   retentionPolicy: {{ .Values.backup.retentionPolicy | quote }}
   {{- end }}
+  # Ceph RGW and other non-AWS S3-compatible backends reject botocore's default
+  # flexible request checksum (the x-amz-content-sha256 that barman-cloud's
+  # boto3 sends on every upload) with "InvalidArgument: x-amz-content-sha256
+  # must be UNSIGNED-PAYLOAD, ...". Compute a checksum only when the operation
+  # requires one; AWS S3 accepts this too, so it is a safe default everywhere.
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
   configuration:
     destinationPath: {{ $destinationPath }}
     endpointURL: {{ $endpointURL }}
@@ -288,6 +297,11 @@ kind: ObjectStore
 metadata:
   name: {{ .Release.Name }}-recovery
 spec:
+  # Same non-AWS S3 request-checksum workaround as the backup ObjectStore above.
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
   configuration:
     destinationPath: {{ $destinationPath }}
     endpointURL: {{ $endpointURL }}

--- a/packages/apps/postgres/templates/db.yaml
+++ b/packages/apps/postgres/templates/db.yaml
@@ -262,15 +262,9 @@ spec:
   {{- if .Values.backup.retentionPolicy }}
   retentionPolicy: {{ .Values.backup.retentionPolicy | quote }}
   {{- end }}
-  # Ceph RGW and other non-AWS S3-compatible backends reject botocore's default
-  # flexible request checksum (the x-amz-content-sha256 that barman-cloud's
-  # boto3 sends on every upload) with "InvalidArgument: x-amz-content-sha256
-  # must be UNSIGNED-PAYLOAD, ...". Compute a checksum only when the operation
-  # requires one; AWS S3 accepts this too, so it is a safe default everywhere.
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
+  # Pin the barman-cloud sidecar's S3 request checksum to when_required
+  # (rationale in cozy-lib.barman.checksumSidecarConfiguration).
+  {{- include "cozy-lib.barman.checksumSidecarConfiguration" . | nindent 2 }}
   configuration:
     destinationPath: {{ $destinationPath }}
     endpointURL: {{ $endpointURL }}
@@ -297,11 +291,8 @@ kind: ObjectStore
 metadata:
   name: {{ .Release.Name }}-recovery
 spec:
-  # Same non-AWS S3 request-checksum workaround as the backup ObjectStore above.
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
+  # Same S3 request-checksum pin as the backup ObjectStore above.
+  {{- include "cozy-lib.barman.checksumSidecarConfiguration" . | nindent 2 }}
   configuration:
     destinationPath: {{ $destinationPath }}
     endpointURL: {{ $endpointURL }}

--- a/packages/apps/postgres/tests/backup_storage_test.yaml
+++ b/packages/apps/postgres/tests/backup_storage_test.yaml
@@ -97,6 +97,22 @@ tests:
         documentSelector:
           path: kind
           value: ObjectStore
+      # The barman-cloud sidecar's S3 request checksum is pinned to when_required
+      # (non-AWS S3 gateways reject the botocore default flexible checksum).
+      - equal:
+          path: spec.instanceSidecarConfiguration.env[0].name
+          value: AWS_REQUEST_CHECKSUM_CALCULATION
+        template: templates/db.yaml
+        documentSelector:
+          path: kind
+          value: ObjectStore
+      - equal:
+          path: spec.instanceSidecarConfiguration.env[0].value
+          value: when_required
+        template: templates/db.yaml
+        documentSelector:
+          path: kind
+          value: ObjectStore
       - hasDocuments:
           count: 1
         template: templates/backup-secret.yaml
@@ -200,6 +216,21 @@ tests:
           value: pg-test-recovery
       - notExists:
           path: spec.configuration.serverName
+        template: templates/db.yaml
+        documentSelector:
+          path: metadata.name
+          value: pg-test-recovery
+      # The non-AWS S3 request-checksum pin is applied to the recovery ObjectStore too.
+      - equal:
+          path: spec.instanceSidecarConfiguration.env[0].name
+          value: AWS_REQUEST_CHECKSUM_CALCULATION
+        template: templates/db.yaml
+        documentSelector:
+          path: metadata.name
+          value: pg-test-recovery
+      - equal:
+          path: spec.instanceSidecarConfiguration.env[0].value
+          value: when_required
         template: templates/db.yaml
         documentSelector:
           path: metadata.name

--- a/packages/library/cozy-lib/templates/_barman.tpl
+++ b/packages/library/cozy-lib/templates/_barman.tpl
@@ -1,0 +1,24 @@
+{{- /*
+cozy-lib.barman.checksumSidecarConfiguration renders a barman-cloud ObjectStore
+`spec.instanceSidecarConfiguration` that pins the sidecar's boto3 request-checksum
+policy to when_required.
+
+Since botocore ~1.36 (early 2025) the default RequestChecksumCalculation is
+when_supported, which attaches a flexible checksum (the x-amz-content-sha256
+header) to every PutObject. Non-AWS S3-compatible backends (Ceph RADOS Gateway,
+the platform's own SeaweedFS system bucket, some MinIO/Cloudflare R2 builds)
+reject it with "InvalidArgument: x-amz-content-sha256 must be UNSIGNED-PAYLOAD,
+...", so every backup/WAL-archive upload fails against them. when_required
+computes a checksum only when the operation mandates one; AWS S3 accepts that on
+a plain PutObject too, so it is a safe default everywhere.
+
+Emit under an ObjectStore `spec:` with `{{- include "cozy-lib.barman.checksumSidecarConfiguration" . | nindent 2 }}`.
+The Go-driven platform (useSystemBucket=true) ObjectStore sets the same env in
+internal/backupcontroller/cnpgstrategy_controller.go (barmanSidecarConfiguration).
+*/ -}}
+{{- define "cozy-lib.barman.checksumSidecarConfiguration" -}}
+instanceSidecarConfiguration:
+  env:
+    - name: AWS_REQUEST_CHECKSUM_CALCULATION
+      value: when_required
+{{- end -}}

--- a/packages/system/keycloak/templates/db.yaml
+++ b/packages/system/keycloak/templates/db.yaml
@@ -51,6 +51,15 @@ spec:
   {{- if .Values.backup.retentionPolicy }}
   retentionPolicy: {{ .Values.backup.retentionPolicy | quote }}
   {{- end }}
+  # Ceph RGW and other non-AWS S3-compatible backends reject botocore's default
+  # flexible request checksum (the x-amz-content-sha256 that barman-cloud's
+  # boto3 sends on every upload) with "InvalidArgument: x-amz-content-sha256
+  # must be UNSIGNED-PAYLOAD, ...". Compute a checksum only when the operation
+  # requires one; AWS S3 accepts this too, so it is a safe default everywhere.
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
   configuration:
     destinationPath: {{ .Values.backup.destinationPath | quote }}
     {{- with .Values.backup.endpointURL }}

--- a/packages/system/keycloak/templates/db.yaml
+++ b/packages/system/keycloak/templates/db.yaml
@@ -51,15 +51,9 @@ spec:
   {{- if .Values.backup.retentionPolicy }}
   retentionPolicy: {{ .Values.backup.retentionPolicy | quote }}
   {{- end }}
-  # Ceph RGW and other non-AWS S3-compatible backends reject botocore's default
-  # flexible request checksum (the x-amz-content-sha256 that barman-cloud's
-  # boto3 sends on every upload) with "InvalidArgument: x-amz-content-sha256
-  # must be UNSIGNED-PAYLOAD, ...". Compute a checksum only when the operation
-  # requires one; AWS S3 accepts this too, so it is a safe default everywhere.
-  instanceSidecarConfiguration:
-    env:
-      - name: AWS_REQUEST_CHECKSUM_CALCULATION
-        value: when_required
+  # Pin the barman-cloud sidecar's S3 request checksum to when_required
+  # (rationale in cozy-lib.barman.checksumSidecarConfiguration).
+  {{- include "cozy-lib.barman.checksumSidecarConfiguration" . | nindent 2 }}
   configuration:
     destinationPath: {{ .Values.backup.destinationPath | quote }}
     {{- with .Values.backup.endpointURL }}

--- a/packages/system/keycloak/tests/db_backup_test.yaml
+++ b/packages/system/keycloak/tests/db_backup_test.yaml
@@ -1,0 +1,40 @@
+suite: keycloak DB backup ObjectStore (barman-cloud plugin)
+templates:
+  - templates/db.yaml
+release:
+  name: keycloak
+  namespace: cozy-keycloak
+tests:
+  - it: "backup enabled: renders a barman-cloud ObjectStore that pins the sidecar S3 request checksum to when_required"
+    set:
+      _cluster:
+        root-host: example.org
+        cluster-domain: cozy.local
+      backup:
+        enabled: true
+        destinationPath: s3://aenix/keycloak-db/
+        endpointURL: https://s3.frcloud.kz
+        existingSecretName: keycloak-db-backup-s3-creds
+    asserts:
+      # A barman-cloud ObjectStore is rendered for the Keycloak DB.
+      - equal:
+          path: metadata.name
+          value: keycloak-db
+        documentSelector:
+          path: kind
+          value: ObjectStore
+      # Non-AWS S3 gateways (Ceph RGW, the platform's SeaweedFS system bucket)
+      # reject botocore's default flexible checksum; the sidecar must request
+      # one only when required.
+      - equal:
+          path: spec.instanceSidecarConfiguration.env[0].name
+          value: AWS_REQUEST_CHECKSUM_CALCULATION
+        documentSelector:
+          path: kind
+          value: ObjectStore
+      - equal:
+          path: spec.instanceSidecarConfiguration.env[0].value
+          value: when_required
+        documentSelector:
+          path: kind
+          value: ObjectStore


### PR DESCRIPTION
## What this PR does

Fixes CNPG **barman-cloud plugin** backups to non-AWS, S3-compatible object
stores (Ceph RADOS Gateway, and some MinIO / Cloudflare R2 builds).

The plugin's sidecar uploads via **boto3**. Since botocore ~1.36 (early 2025)
the default `RequestChecksumCalculation` is `when_supported`, so a flexible
checksum (CRC32) plus the corresponding `x-amz-content-sha256` handling is
attached to every `PutObject`. AWS S3 accepts it, but several S3-compatible
backends reject the request:

```
InvalidArgument: x-amz-content-sha256 must be UNSIGNED-PAYLOAD,
STREAMING-AWS4-HMAC-SHA256-PAYLOAD or a valid sha256 value.
```

so every backup / WAL-archive upload fails against them and the
`ScheduledBackup` never stores anything.

This sets `spec.instanceSidecarConfiguration.env` on the rendered
`ObjectStore`s to carry `AWS_REQUEST_CHECKSUM_CALCULATION=when_required`
(botocore reads this env var from the sidecar's environment). `when_required`
computes a checksum only for operations that mandate one; a plain `PutObject`
then carries none, which both AWS S3 and the affected backends accept — a safe
default everywhere. No API/CRD change, no new value, no new dependency.

Applied to every barman-cloud `ObjectStore` Cozystack creates:
- **chart-rendered** — `packages/system/keycloak/templates/db.yaml` (Keycloak
  system DB) and `packages/apps/postgres/templates/db.yaml` (postgres app —
  backup **and** bootstrap-recovery `ObjectStore`s), via a shared `cozy-lib`
  helper (`cozy-lib.barman.checksumSidecarConfiguration`);
- **Go-constructed** — the platform-managed `useSystemBucket=true` `ObjectStore`
  SSA-applied by `internal/backupcontroller/cnpgstrategy_controller.go`
  (`barmanSidecarConfiguration`), whose default system bucket is SeaweedFS.

Regression coverage: a Go unit test on the SSA-applied `ObjectStore`, plus
helm-unittest assertions on `spec.instanceSidecarConfiguration.env` for all
three rendered `ObjectStore`s (mutation-checked — reverting the change fails
them).

Mirrors the same fix already applied to the etcd path in
`cozystack/etcd-operator#342` (released in `v0.5.3`) for the same Ceph RGW
backend.

**Verification:** reproduced end-to-end against a real Ceph RGW endpoint. With
default botocore, `PutObject` fails with the `InvalidArgument` above; with
`AWS_REQUEST_CHECKSUM_CALCULATION=when_required` in the environment it succeeds.
Deployed the plugin + a throwaway CNPG cluster whose `ObjectStore` carried this
env: continuous WAL archiving reported `ContinuousArchiving=True` and an
on-demand `Backup` completed, with the base backup and WAL segments present in
the bucket. `helm template` renders the env on all three `ObjectStore`s; the
`packages/apps/postgres` unit-test suite still passes.

### Screenshots

N/A — no UI changes.

### Downstream repositories

<!-- Walked the trigger map in docs/agents/contributing.md against the diff,
file by file. The diff touches only two Helm templates (ObjectStore renders);
it adds no package, no values.yaml / values.schema.json field, no API/CRD
change, no variant/component/asset change, no ApplicationDefinition change, and
no developer-tooling change. None of the trigger-map entries match. -->

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(backups): CNPG barman-cloud backups now work against non-AWS S3-compatible object stores (Ceph RADOS Gateway, some MinIO/Cloudflare R2). The backup sidecar requests an S3 request checksum only when required, avoiding the "x-amz-content-sha256 must be UNSIGNED-PAYLOAD, ..." error that previously broke every backup and WAL-archive upload to those backends. No change for AWS S3.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with S3-compatible, non-AWS storage backends for PostgreSQL and Keycloak backups and recovery.
  * Pin the barman-cloud sidecar to compute AWS request checksums only when required (`AWS_REQUEST_CHECKSUM_CALCULATION=when_required`) to prevent failures with strict S3 gateways.
* **Tests**
  * Updated/added assertions in controller and Helm/YAML suites to verify the checksum pin is applied to generated and recovery ObjectStores (Postgres and Keycloak).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->