### PR TITLE
fix(e2e): improve failure diagnostics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     - id: run-make-generate-root
       name: Run 'make generate' at repo root
       entry: |
-        flock -x .git/pre-commit.lock sh -c '
+        sh -c 'exec flock -x "$(git rev-parse --git-common-dir)/pre-commit.lock" "$@"' -- sh -c '
           echo "Running make generate at repo root"
           make generate || exit $?
           git diff --color=always | cat
@@ -15,7 +15,7 @@ repos:
     - id: run-make-generate
       name: Run 'make generate' in all app directories
       entry: |
-        flock -x .git/pre-commit.lock sh -c '
+        sh -c 'exec flock -x "$(git rev-parse --git-common-dir)/pre-commit.lock" "$@"' -- sh -c '
           for dir in ./packages/apps/*/ ./packages/extra/*/; do
             if [ -d "$dir" ]; then
               echo "Running make generate in $dir"

--- a/hack/capture-dataplane.bats
+++ b/hack/capture-dataplane.bats
@@ -10,6 +10,7 @@
 #   - lb_first_ready_endpoint -- pick the first addressed, non-NotReady endpoint;
 #   - lb_announcer_node       -- the speaker node of the most recent announce;
 #   - lb_capture_decision     -- capture only when every probe failed.
+#   - pod_filter_affected     -- retain scheduled NotReady pods even without IPs.
 #
 # The kubectl exec / tcpdump capture itself is not unit-testable (it needs a
 # live cluster); these tests pin the derivations that decide WHICH node to
@@ -40,6 +41,47 @@ SCRIPT="$HACK_DIR/e2e-capture-dataplane.sh"
 E2E_CAPTURE_DATAPLANE_LIB=1
 # shellcheck source=/dev/null
 . "$SCRIPT"
+
+@test "pod_filter_affected keeps a scheduled NotReady pod without a podIP" {
+  rows="$(printf '%s\n' \
+    'tenant|no-ip||node-a|False|Pending' \
+    'tenant|with-ip|192.0.2.80|node-b|False|Running')"
+
+  out="$(printf '%s\n' "$rows" | pod_filter_affected)"
+
+  [ "$(printf '%s\n' "$out" | rg -c .)" -eq 2 ]
+  printf '%s\n' "$out" | rg -q '^tenant\|no-ip\|\|node-a\|False\|Pending$'
+}
+
+@test "pod_filter_affected drops Ready unscheduled and terminal pods" {
+  rows="$(printf '%s\n' \
+    'tenant|ready|192.0.2.81|node-a|True|Running' \
+    'tenant|unscheduled|||False|Pending' \
+    'tenant|succeeded|192.0.2.82|node-b|False|Succeeded' \
+    'tenant|failed|192.0.2.83|node-b|False|Failed')"
+
+  [ -z "$(printf '%s\n' "$rows" | pod_filter_affected)" ]
+}
+
+@test "runtime checks LoadBalancers when there are no affected pods" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  calls="$tmp/kubectl.calls"
+  mkdir -p "$tmp/bin"
+  cat > "$tmp/bin/kubectl" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$MOCK_KUBECTL_CALLS"
+exit 0
+EOF
+  chmod +x "$tmp/bin/kubectl"
+
+  MOCK_KUBECTL_CALLS="$calls" PATH="$tmp/bin:$PATH" \
+    "$SCRIPT" "$tmp/out" > "$tmp/stdout" 2>&1
+
+  rg -q '^get svc -A ' "$calls"
+  rg -q 'checking LoadBalancers independently' "$tmp/stdout"
+  rg -q 'no Service type=LoadBalancer' "$tmp/stdout"
+}
 
 @test "lb_filter_services keeps only LoadBalancer rows that have an ingress IP" {
   rows="$(printf '%s\n' \

--- a/hack/capture-dataplane.bats
+++ b/hack/capture-dataplane.bats
@@ -49,8 +49,8 @@ E2E_CAPTURE_DATAPLANE_LIB=1
 
   out="$(printf '%s\n' "$rows" | pod_filter_affected)"
 
-  [ "$(printf '%s\n' "$out" | rg -c .)" -eq 2 ]
-  printf '%s\n' "$out" | rg -q '^tenant\|no-ip\|\|node-a\|False\|Pending$'
+  [ "$(printf '%s\n' "$out" | awk 'END { print NR }')" -eq 2 ]
+  printf '%s\n' "$out" | awk '$0 == "tenant|no-ip||node-a|False|Pending" { found = 1 } END { exit !found }'
 }
 
 @test "pod_filter_affected drops Ready unscheduled and terminal pods" {
@@ -78,9 +78,9 @@ EOF
   MOCK_KUBECTL_CALLS="$calls" PATH="$tmp/bin:$PATH" \
     "$SCRIPT" "$tmp/out" > "$tmp/stdout" 2>&1
 
-  rg -q '^get svc -A ' "$calls"
-  rg -q 'checking LoadBalancers independently' "$tmp/stdout"
-  rg -q 'no Service type=LoadBalancer' "$tmp/stdout"
+  awk '$0 ~ /^get svc -A / { found = 1 } END { exit !found }' "$calls"
+  awk 'index($0, "checking LoadBalancers independently") { found = 1 } END { exit !found }' "$tmp/stdout"
+  awk 'index($0, "no Service type=LoadBalancer") { found = 1 } END { exit !found }' "$tmp/stdout"
 }
 
 @test "lb_filter_services keeps only LoadBalancer rows that have an ingress IP" {

--- a/hack/cozyreport-talos.bats
+++ b/hack/cozyreport-talos.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+# Regression coverage for host-node Talos diagnostics in hack/cozyreport.sh.
+# The full report needs a cluster; this test sources only the focused helper and
+# replaces talosctl with a shell function that records the exact argument vector.
+
+HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
+SCRIPT="$HACK_DIR/cozyreport.sh"
+
+COZYREPORT_LIB=1
+# shellcheck source=/dev/null
+. "$SCRIPT"
+
+# cozytest.sh's parser ends an @test block at the first bare `}`, so keep the
+# talosctl mock at top level rather than nesting a function inside the test.
+talosctl() {
+  printf '%s\n' "$*" >> "$calls"
+}
+
+@test "Talos host diagnostics pass an endpoint and use valid dmesg flags" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  calls="$tmp/talosctl.calls"
+
+  cozyreport_collect_talos_node /workspace/talosconfig 192.0.2.11 "$tmp"
+
+  [ "$(sed -n '1p' "$calls")" = "--talosconfig /workspace/talosconfig -e 192.0.2.11 -n 192.0.2.11 dmesg" ]
+  [ "$(sed -n '2p' "$calls")" = "--talosconfig /workspace/talosconfig -e 192.0.2.11 -n 192.0.2.11 logs kubelet --tail=500" ]
+  [ "$(sed -n '3p' "$calls")" = "--talosconfig /workspace/talosconfig -e 192.0.2.11 -n 192.0.2.11 logs containerd --tail=500" ]
+  if sed -n '1p' "$calls" | rg -q -- '--tail'; then
+    echo "dmesg must not receive the boolean --tail flag" >&2
+    false
+  fi
+}

--- a/hack/cozyreport-talos.bats
+++ b/hack/cozyreport-talos.bats
@@ -26,8 +26,8 @@ talosctl() {
   [ "$(sed -n '1p' "$calls")" = "--talosconfig /workspace/talosconfig -e 192.0.2.11 -n 192.0.2.11 dmesg" ]
   [ "$(sed -n '2p' "$calls")" = "--talosconfig /workspace/talosconfig -e 192.0.2.11 -n 192.0.2.11 logs kubelet --tail=500" ]
   [ "$(sed -n '3p' "$calls")" = "--talosconfig /workspace/talosconfig -e 192.0.2.11 -n 192.0.2.11 logs containerd --tail=500" ]
-  if sed -n '1p' "$calls" | rg -q -- '--tail'; then
+  case "$(sed -n '1p' "$calls")" in *--tail*)
     echo "dmesg must not receive the boolean --tail flag" >&2
     false
-  fi
+  esac
 }

--- a/hack/cozyreport.sh
+++ b/hack/cozyreport.sh
@@ -1,4 +1,31 @@
 #!/bin/sh
+
+# cozyreport_collect_talos_node <talosconfig> <node> <output-dir>
+#
+# The e2e talosconfig intentionally carries no endpoints, so both -e and -n are
+# required. Each node's InternalIP is itself a Talos API endpoint. `dmesg
+# --tail` is a boolean follow-mode flag (unlike `logs --tail`, which is an
+# integer), so request the complete kernel ring buffer and retain bounded tails
+# only for kubelet/containerd service logs.
+cozyreport_collect_talos_node() {
+  _crt_config=$1
+  _crt_node=$2
+  _crt_dir=$3
+
+  talosctl --talosconfig "$_crt_config" -e "$_crt_node" -n "$_crt_node" \
+    dmesg > "$_crt_dir/talos-$_crt_node-dmesg.txt" 2>&1 || true
+  talosctl --talosconfig "$_crt_config" -e "$_crt_node" -n "$_crt_node" \
+    logs kubelet --tail=500 > "$_crt_dir/talos-$_crt_node-kubelet.log" 2>&1 || true
+  talosctl --talosconfig "$_crt_config" -e "$_crt_node" -n "$_crt_node" \
+    logs containerd --tail=500 > "$_crt_dir/talos-$_crt_node-containerd.log" 2>&1 || true
+}
+
+# Let the focused BATS test source the command builder without running the full
+# cluster report. Production callers never set this variable.
+if [ -n "${COZYREPORT_LIB:-}" ]; then
+  return 0 2>/dev/null
+fi
+
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPORT_DATE=$(date +%Y-%m-%d_%H-%M-%S)
 REPORT_NAME=${1:-cozyreport-$REPORT_DATE}
@@ -342,9 +369,7 @@ if [ -f /workspace/talosconfig ]; then
   NODES=$(kubectl get nodes -o jsonpath='{range .items[*]}{.status.addresses[?(@.type=="InternalIP")].address}{"\n"}{end}' 2>/dev/null)
   for node in ${NODES:-192.168.123.11 192.168.123.12 192.168.123.13}; do
     [ -z "$node" ] && continue
-    talosctl --talosconfig /workspace/talosconfig -n "$node" dmesg --tail=200 > "$DIR/talos-$node-dmesg.txt" 2>&1 || true
-    talosctl --talosconfig /workspace/talosconfig -n "$node" logs kubelet --tail=500 > "$DIR/talos-$node-kubelet.log" 2>&1 || true
-    talosctl --talosconfig /workspace/talosconfig -n "$node" logs containerd --tail=500 > "$DIR/talos-$node-containerd.log" 2>&1 || true
+    cozyreport_collect_talos_node /workspace/talosconfig "$node" "$DIR"
   done
 fi
 

--- a/hack/e2e-capture-dataplane.sh
+++ b/hack/e2e-capture-dataplane.sh
@@ -18,7 +18,8 @@
 # root-caused after the fact. This collects exactly that state from the pod's
 # node so the next recurrence is dispositive.
 #
-# What it captures, per affected pod (NotReady, scheduled, has a podIP):
+# What it captures, per affected pod (NotReady and scheduled; podIP may still
+# be empty while CNI endpoint allocation is the thing that is stuck):
 #   - cilium-agent on the node:  cilium-dbg endpoint list; bpf ct entries for
 #     the podIP; a short bounded `cilium-dbg monitor --type drop`; hubble
 #     dropped-verdict observations (if the hubble CLI is present in the agent).
@@ -200,6 +201,16 @@ lb_budget_ok() {
   if [ "$1" -lt "$2" ]; then echo yes; else echo no; fi
 }
 
+# pod_filter_affected: stdin =
+# `namespace|name|podIP|nodeName|ready|phase` rows. Keep scheduled, non-terminal
+# pods whose Ready condition is not True. podIP is deliberately NOT a gate: the
+# cilium endpointManager leak this collector diagnoses can strand a pod before
+# an IP is assigned, and the node-global Cilium/OVN state plus pod events remain
+# useful in that state. IP-specific commands are gated later at their call sites.
+pod_filter_affected() {
+  awk -F'|' '$4 != "" && $5 != "True" && $6 != "Succeeded" && $6 != "Failed"'
+}
+
 # Sourcing guard: hack/capture-dataplane.bats sets E2E_CAPTURE_DATAPLANE_LIB and
 # sources this file purely to reach the helpers above; return before touching $1
 # or running any capture so the unit test never needs a cluster. The script's
@@ -240,40 +251,20 @@ mkdir -p "$OUT" 2>/dev/null || exit 0
 
 log() { echo "[capture-dataplane] $*"; }
 
-# Affected = scheduled (has nodeName), has a podIP (so an endpoint exists to
-# inspect), Ready!=True, and not already terminal. That is the superset of the
-# "readiness/startup probe failing with connection refused" symptom -- a pod
-# that is Running with an IP but whose Ready condition is False is exactly the
-# transient's signature. Succeeded/Failed pods (completed Jobs, hook pods) are
-# Ready!=True too but are not the symptom, so they are excluded to keep the
-# MAX_PODS budget on Running/Pending pods that are actually wedged.
+# Affected = scheduled (has nodeName), Ready!=True, and not already terminal.
+# A podIP is intentionally optional: a CNI endpoint leak can strand the pod
+# before allocation. Running pods with an IP cover the host->pod probe failure;
+# Pending pods without one cover the endpoint-allocation failure. Succeeded/
+# Failed pods (completed Jobs, hook pods) are Ready!=True too but are not either
+# symptom, so they are excluded to keep the MAX_PODS budget on actual wedges.
 # jsonpath keeps this dependency-free (no jq / go-template reassignment).
 affected=$(kubectl get pods -A \
   -o jsonpath='{range .items[*]}{.metadata.namespace}{"|"}{.metadata.name}{"|"}{.status.podIP}{"|"}{.spec.nodeName}{"|"}{.status.conditions[?(@.type=="Ready")].status}{"|"}{.status.phase}{"\n"}{end}' \
-  2>/dev/null | awk -F'|' '$3!="" && $4!="" && $5!="True" && $6!="Succeeded" && $6!="Failed"')
+  2>/dev/null | pod_filter_affected)
 
-if [ -z "$affected" ]; then
-  log "no NotReady pods with a podIP+node -- nothing to capture"
-  exit 0
-fi
-
-ncount=$(printf '%s\n' "$affected" | wc -l | tr -d ' ')
-log "capturing host->pod data-plane for up to $MAX_PODS of $ncount affected pod(s) -> $OUT"
-
-# OVN southbound logical-flow dump is cluster-global, so capture it once rather
-# than per pod. ovn-central is a Deployment (not per-node); any replica answers.
-# --no-leader-only lets a read land on a raft follower instead of erroring.
-central=$(kubectl get pod -n "$KUBEOVN_NS" -l app=ovn-central \
-  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
-if [ -n "$central" ]; then
-  {
-    echo "=== ovn-sbctl lflow-list (cluster-global, pod=$central) ==="
-    timeout 30 kubectl exec -n "$KUBEOVN_NS" "$central" -c ovn-central -- \
-      ovn-sbctl --no-leader-only lflow-list 2>&1 || true
-  } > "$OUT/ovn-lflows.txt" 2>&1 || true
-else
-  log "no ovn-central pod in $KUBEOVN_NS -- skipping OVN logical-flow dump"
-fi
+# Set even when the pod path is empty; the per-pod capture references it, while
+# the independent LoadBalancer path below does not.
+central=""
 
 # pod_on_node <ns> <label> <node> -> first matching pod name (empty if none).
 pod_on_node() {
@@ -383,10 +374,32 @@ capture_node() {
   } >> "$nf" 2>&1 || true
 }
 
-i=0
-printf '%s\n' "$affected" | {
+if [ -z "$affected" ]; then
+  log "no scheduled NotReady pods -- skipping host->pod capture; checking LoadBalancers independently"
+else
+  ncount=$(printf '%s\n' "$affected" | wc -l | tr -d ' ')
+  log "capturing host->pod data-plane for up to $MAX_PODS of $ncount affected pod(s) -> $OUT"
+
+  # OVN southbound logical-flow dump is cluster-global, so capture it once
+  # rather than per pod. ovn-central is a Deployment (not per-node); any replica
+  # answers. --no-leader-only lets a read land on a raft follower instead of
+  # erroring.
+  central=$(kubectl get pod -n "$KUBEOVN_NS" -l app=ovn-central \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null)
+  if [ -n "$central" ]; then
+    {
+      echo "=== ovn-sbctl lflow-list (cluster-global, pod=$central) ==="
+      timeout 30 kubectl exec -n "$KUBEOVN_NS" "$central" -c ovn-central -- \
+        ovn-sbctl --no-leader-only lflow-list 2>&1 || true
+    } > "$OUT/ovn-lflows.txt" 2>&1 || true
+  else
+    log "no ovn-central pod in $KUBEOVN_NS -- skipping OVN logical-flow dump"
+  fi
+
+  i=0
+  printf '%s\n' "$affected" | {
   while IFS='|' read -r ns pod podip node _ready _phase; do
-    [ -n "$ns" ] && [ -n "$pod" ] && [ -n "$podip" ] && [ -n "$node" ] || continue
+    [ -n "$ns" ] && [ -n "$pod" ] && [ -n "$node" ] || continue
     i=$((i + 1))
     if [ "$i" -gt "$MAX_PODS" ]; then
       log "reached MAX_PODS=$MAX_PODS cap; $((ncount - MAX_PODS)) more affected pod(s) NOT captured"
@@ -403,7 +416,7 @@ printf '%s\n' "$affected" | {
     ovs=$(pod_on_node "$KUBEOVN_NS" app=ovs "$node")
     {
       echo "################################################################"
-      echo "# POD $ns/$pod  podIP=$podip  node=$node  (Ready=$_ready)"
+      echo "# POD $ns/$pod  podIP=${podip:-<none>}  node=$node  (Ready=$_ready)"
       echo "# node-global captures are in node-$node.txt"
       echo "################################################################"
 
@@ -414,7 +427,13 @@ printf '%s\n' "$affected" | {
       kubectl get events -n "$ns" --field-selector "involvedObject.name=$pod" \
         -o jsonpath='{range .items[*]}{.lastTimestamp}{" "}{.reason}{": "}{.message}{"\n"}{end}' 2>&1 || true
 
-      if [ -n "$agent" ]; then
+      if [ -z "$podip" ]; then
+        echo
+        echo "=== pod has no podIP; IP-specific route/conntrack capture skipped ==="
+        echo "Node-global Cilium/OVN state and pod allocation events remain captured."
+      fi
+
+      if [ -n "$podip" ] && [ -n "$agent" ]; then
         echo
         echo "=== cilium-dbg bpf ct list global | grep $podip (node=$node agent=$agent) ==="
         timeout 25 kubectl exec -n "$CILIUM_NS" "$agent" -c cilium-agent -- \
@@ -422,7 +441,7 @@ printf '%s\n' "$affected" | {
       fi
 
       cni=$(pod_on_node "$KUBEOVN_NS" app=kube-ovn-cni "$node")
-      if [ -n "$cni" ]; then
+      if [ -n "$podip" ] && [ -n "$cni" ]; then
         echo
         echo "=== host netns: ip route get $podip (via kube-ovn cni-server) ==="
         timeout 15 kubectl exec -n "$KUBEOVN_NS" "$cni" -c cni-server -- \
@@ -471,7 +490,8 @@ printf '%s\n' "$affected" | {
     } > "$pf" 2>&1 || true
   done
   log "host->pod data-plane capture complete"
-}
+  }
+fi
 
 # ============================================================================ #
 # LoadBalancer-datapath capture (see the header block for the full rationale).  #

--- a/hack/e2e-chainsaw/bucket/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/bucket/chainsaw-test.yaml
@@ -23,6 +23,7 @@ spec:
   - get:
       apiVersion: objectstorage.k8s.io/v1alpha1
       kind: Bucket
+      format: yaml
   - script:
       content: kubectl -n cozy-objectstorage-controller get pods
   steps:

--- a/hack/e2e-chainsaw/harbor/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/harbor/chainsaw-test.yaml
@@ -31,6 +31,7 @@ spec:
   - get:
       apiVersion: objectstorage.k8s.io/v1alpha1
       kind: Bucket
+      format: yaml
   - script:
       content: kubectl -n cozy-objectstorage-controller get pods
   - podLogs:


### PR DESCRIPTION
## What this PR does

Improves E2E failure diagnostics tracked in #3368:

- preserves scheduled, non-terminal NotReady pods before a pod IP is assigned
- always captures load-balancer state while gating IP-dependent diagnostics
- collects Talos dmesg, kubelet, and containerd logs per host node using explicit endpoint and node arguments
- renders COSI Bucket catch output as YAML
- makes pre-commit generation locking work from linked worktrees
- adds regression coverage for dataplane and Talos collection

Tenant-worker Talos logs remain outside this PR because the runner does not currently have a tenant talosconfig.

Part of #3368.

## Testing

- `hack/cozytest.sh hack/capture-dataplane.bats`
- `hack/cozytest.sh hack/cozyreport-talos.bats`
- `sh -n hack/e2e-capture-dataplane.sh`
- `sh -n hack/cozyreport.sh`
- `chainsaw test --no-cluster --config hack/e2e-chainsaw/.chainsaw.yaml --include-test-regex '^$' hack/e2e-chainsaw/bucket hack/e2e-chainsaw/harbor`
- `pre-commit run --all-files`

### Screenshots

Not applicable.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(e2e): improve diagnostic capture for dataplane, Talos, and COSI failures
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dataplane diagnostics for scheduled pods that are NotReady, including cases without an assigned IP.
  - LoadBalancer checks now proceed even when no affected pods are found.
  - Standardized Talos node diagnostics collection for consistent kernel, kubelet, and containerd logs.
  - Improved reliability of generation hooks by using a git-common lockfile path for concurrent runs.

- **Tests**
  - Added/expanded Bats coverage for dataplane pod filtering and Talos diagnostics argument correctness.
  - Improved end-to-end bucket test retrieval/formatting for clearer failure output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->