### PR TITLE
docs(agents): document the OCIR/GHCR registry split

### DIFF
--- a/docs/agents/overview.md
+++ b/docs/agents/overview.md
@@ -90,9 +90,27 @@ make generate       # Regenerate values.schema.json + README.md from values.yaml
 
 Build environment variables:
 
-- `REGISTRY` — Docker registry (default `ghcr.io/cozystack/cozystack`).
+- `REGISTRY` — target registry for the build (default `ghcr.io/cozystack/cozystack`). CI overrides it per workflow — see [Registries](#registries).
 - `PUSH=1` / `LOAD=0` — control buildx push/load behaviour.
 - `LOAD=1 PUSH=0` — load images locally instead of pushing.
+
+### Registries
+
+Cozystack publishes to two registries with different trust levels. They are **not** interchangeable, and the `REGISTRY` default above applies only to a local build.
+
+| | `iad.ocir.io/idyksih5sir9/cozystack` (OCIR) | `ghcr.io/cozystack/cozystack` (GHCR) |
+| --- | --- | --- |
+| Role | CI build registry | Public release registry |
+| Holds | PR images (`pr-<N>-<sha>`), `main` builds, the shared buildx cache | releases, release candidates, nightlies |
+| Written by | [`pull-requests.yaml`](../../.github/workflows/pull-requests.yaml), [`build-main.yaml`](../../.github/workflows/build-main.yaml) | [`tags.yaml`](../../.github/workflows/tags.yaml), [`nightly.yaml`](../../.github/workflows/nightly.yaml), [`pull-requests-release.yaml`](../../.github/workflows/pull-requests-release.yaml) |
+| Read by | e2e, and developers installing a PR build | end users |
+| Auth to push | `OCIR_USER` / `OCIR_TOKEN` repo secrets | `GITHUB_TOKEN` + `permissions: packages: write` |
+
+Both allow anonymous pull, so nothing that only reads images needs credentials — the e2e job has no registry login at all.
+
+Images move OCIR → GHCR **by digest only**: [`nightly.yaml`](../../.github/workflows/nightly.yaml) mirrors the latest `main` build, and promotion retags an rc that already passed e2e ([`hack/promote-retag.sh`](../../hack/promote-retag.sh)). Nothing is rebuilt on the way to GHCR, so a released image is bit-for-bit the image that was tested. [`retention.yaml`](../../.github/workflows/retention.yaml) prunes old nightly versions on the GHCR side.
+
+The practical rule: **treat GHCR as user-facing and OCIR as scratch.** A wrong or overwritten tag in OCIR costs a rebuild; in GHCR it reaches whoever installs next. See [`release.md`](../release.md) for the full release and nightly flow.
 
 ### Values schema generation
 


### PR DESCRIPTION
## What this PR does

Cozystack publishes to two registries with very different trust levels: OCIR is the ephemeral CI build registry holding PR images, `main` builds and the shared buildx cache, and GHCR is the public release registry users install from. Nothing in `docs/agents/` said so. The distinction was only derivable from four scattered places — one sentence in the nightly section of `docs/release.md`, plus comments inside `nightly.yaml`, `tags.yaml` and `pull-requests-release.yaml`.

Meanwhile `overview.md`, the file that exists to explain conventions, described only ``REGISTRY`` — Docker registry (default `ghcr.io/cozystack/cozystack`). That is the local build default, but read in a CI context it suggests GHCR is the registry for everything, which is the opposite of how the pipeline is wired. `image-refs.md` compounds it: it refers to "the private build registry" and "the public registry" throughout without ever naming either.

This adds a `### Registries` section to `overview.md` covering the role of each registry, who writes to it and who reads from it, the credentials each push path uses, and the digest-only OCIR → GHCR promotion. It also rescopes the `REGISTRY` bullet so it reads as a build default rather than a project-wide one.

Documentation only — no behaviour change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

Walked the trigger map in `contributing.md` against the diff. The change touches one file under `docs/agents/` and restates no contract any downstream repository mirrors — it adds no package, touches no schema, no variant, no namespace, no `hack/` path and no release-prep behaviour. The `ccp` entry closest to this change is release-prep behaviour in `tags.yaml`, which is untouched.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified build environment variables, including registry defaults and CI overrides.
  * Documented build controls for pushing and loading images.
  * Added guidance on registry roles, authentication, image retention, anonymous pulls, and image promotion.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->