### PR TITLE
fix(kubernetes): raise kubevirt-csi API client rate limits

### DIFF
--- a/packages/apps/kubernetes/images/kubevirt-csi-driver/main.go
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver/main.go
@@ -37,6 +37,17 @@ var (
 
 	runNodeService       = flag.Bool("run-node-service", true, "Specifies rather or not to run the node service, the default is true")
 	runControllerService = flag.Bool("run-controller-service", true, "Specifies rather or not to run the controller service, the default is true")
+
+	kubeAPIQPS   = flag.Float64("kube-api-qps", defaultKubeAPIQPS, "QPS limit for the infra- and tenant-cluster Kubernetes API clients. client-go defaults to 5, which starves the once-per-second infra PVC-bound poll in the NFS ControllerPublishVolume path under a burst of concurrent attaches.")
+	kubeAPIBurst = flag.Int("kube-api-burst", defaultKubeAPIBurst, "Burst limit for the infra- and tenant-cluster Kubernetes API clients (client-go default is 10).")
+)
+
+// Chosen well above the client-go defaults (5 QPS / 10 burst) so a scale-out
+// burst of PVC attaches does not starve the bound poll, while staying well
+// within the infra API server's capacity.
+const (
+	defaultKubeAPIQPS   = 100
+	defaultKubeAPIBurst = 200
 )
 
 func init() {
@@ -65,6 +76,9 @@ func handle() {
 	if volumePrefix == nil || *volumePrefix == "" {
 		klog.Fatal("volume-prefix must be set")
 	}
+	if err := validateRateLimitFlags(*kubeAPIQPS, *kubeAPIBurst); err != nil {
+		klog.Fatal(err)
+	}
 
 	inClusterConfig, err := rest.InClusterConfig()
 	if err != nil {
@@ -88,6 +102,9 @@ func handle() {
 	} else {
 		infraRestConfig = inClusterConfig
 	}
+
+	applyKubeAPIRateLimits(tenantRestConfig, *kubeAPIQPS, *kubeAPIBurst)
+	applyKubeAPIRateLimits(infraRestConfig, *kubeAPIQPS, *kubeAPIBurst)
 
 	tenantClientSet, err := kubernetes.NewForConfig(tenantRestConfig)
 	if err != nil {
@@ -182,6 +199,32 @@ func handle() {
 	s := service.NewNonBlockingGRPCServer()
 	s.Start(*endpoint, upstreamDriver.IdentityService, cs, ns)
 	s.Wait()
+}
+
+// validateRateLimitFlags rejects non-positive limits. client-go treats QPS == 0
+// as "use the 5 QPS default" and QPS < 0 as "no rate limiting at all", so an
+// operator passing 0 expecting "unlimited" would silently get the starving
+// default this fix exists to avoid; refuse both rather than surprise them.
+func validateRateLimitFlags(qps float64, burst int) error {
+	if qps <= 0 {
+		return fmt.Errorf("kube-api-qps must be positive, got %v", qps)
+	}
+	if burst <= 0 {
+		return fmt.Errorf("kube-api-burst must be positive, got %d", burst)
+	}
+	return nil
+}
+
+// applyKubeAPIRateLimits raises a rest.Config's client-side rate limiter above
+// the client-go default of 5 QPS / 10 burst. The NFS-volume ControllerPublishVolume
+// path polls the infra PersistentVolumeClaim once per second for up to two minutes;
+// when a tenant scales out and several volumes attach at once, the default limiter
+// starves and the poll fails with "client rate limiter Wait returned an error:
+// context deadline exceeded", which the tenant kubelet surfaces as
+// FailedAttachVolume.
+func applyKubeAPIRateLimits(cfg *rest.Config, qps float64, burst int) {
+	cfg.QPS = float32(qps)
+	cfg.Burst = burst
 }
 
 func configureStorageClassEnforcement(infraStorageClassEnforcement string) util.StorageClassEnforcement {

--- a/packages/apps/kubernetes/images/kubevirt-csi-driver/main_test.go
+++ b/packages/apps/kubernetes/images/kubevirt-csi-driver/main_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+// client-go applies these limits to a rest.Config that leaves QPS/Burst unset.
+// They are what the driver ran with before this fix.
+const (
+	clientGoDefaultQPS   float32 = 5
+	clientGoDefaultBurst int     = 10
+)
+
+// applyKubeAPIRateLimits must raise the client both above the client-go default,
+// otherwise the ControllerPublishVolume PVC-bound poll keeps starving under a
+// burst of concurrent attaches.
+func TestApplyKubeAPIRateLimitsRaisesAboveClientGoDefault(t *testing.T) {
+	cfg := &rest.Config{}
+	applyKubeAPIRateLimits(cfg, defaultKubeAPIQPS, defaultKubeAPIBurst)
+
+	if cfg.QPS <= clientGoDefaultQPS {
+		t.Errorf("QPS = %v, want > %v (client-go default)", cfg.QPS, clientGoDefaultQPS)
+	}
+	if cfg.Burst <= clientGoDefaultBurst {
+		t.Errorf("Burst = %d, want > %d (client-go default)", cfg.Burst, clientGoDefaultBurst)
+	}
+}
+
+// A non-default qps/burst must actually reach the config, so --kube-api-qps and
+// --kube-api-burst are real tuning knobs and not just decoration over the constants.
+func TestApplyKubeAPIRateLimitsPropagatesValues(t *testing.T) {
+	cfg := &rest.Config{}
+	applyKubeAPIRateLimits(cfg, 42, 84)
+
+	if cfg.QPS != 42 {
+		t.Errorf("QPS = %v, want 42", cfg.QPS)
+	}
+	if cfg.Burst != 84 {
+		t.Errorf("Burst = %d, want 84", cfg.Burst)
+	}
+}
+
+// The default flag values must pass validation, and a non-positive value — which
+// client-go would silently turn into the starving default (0) or unlimited
+// (<0) — must be rejected.
+func TestValidateRateLimitFlags(t *testing.T) {
+	if err := validateRateLimitFlags(defaultKubeAPIQPS, defaultKubeAPIBurst); err != nil {
+		t.Errorf("defaults must be valid, got %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		qps   float64
+		burst int
+	}{
+		{"zero qps falls back to the starving default", 0, defaultKubeAPIBurst},
+		{"negative qps disables rate limiting", -1, defaultKubeAPIBurst},
+		{"zero burst", defaultKubeAPIQPS, 0},
+		{"negative burst", defaultKubeAPIQPS, -5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validateRateLimitFlags(tc.qps, tc.burst); err == nil {
+				t.Errorf("validateRateLimitFlags(%v, %d) = nil, want error", tc.qps, tc.burst)
+			}
+		})
+	}
+}
+
+// Behavioural regression for the FailedAttachVolume flake. The NFS-volume
+// ControllerPublishVolume path polls the infra PVC once per second for up to two
+// minutes; when several volumes attach at once the default 5 QPS / 10 burst limiter starves and Wait returns
+// "context deadline exceeded" — the exact error the tenant kubelet reports as
+// FailedAttachVolume. The limits applyKubeAPIRateLimits sets must admit that burst.
+func TestRateLimitedConfigAdmitsBurstThatDefaultStarves(t *testing.T) {
+	// A burst larger than any refill the deadline can supply: 5 QPS over 500ms
+	// tops up ~2.5 tokens on top of a 10-token bucket, so the default limiter
+	// cannot admit 200 waiters before the deadline, while a bucket sized for the
+	// burst admits them immediately. Both outcomes are deterministic.
+	const burst = 200
+	const deadline = 500 * time.Millisecond
+
+	drain := func(qps float32, b int) error {
+		lim := flowcontrol.NewTokenBucketRateLimiter(qps, b)
+		ctx, cancel := context.WithTimeout(context.Background(), deadline)
+		defer cancel()
+		for range burst {
+			if err := lim.Wait(ctx); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if err := drain(clientGoDefaultQPS, clientGoDefaultBurst); err == nil {
+		t.Fatal("default 5 QPS / 10 burst limiter admitted the burst; the test can no longer prove the fix")
+	}
+
+	cfg := &rest.Config{}
+	applyKubeAPIRateLimits(cfg, defaultKubeAPIQPS, defaultKubeAPIBurst)
+	if err := drain(cfg.QPS, cfg.Burst); err != nil {
+		t.Errorf("configured limiter (%v QPS / %d burst) still starved on the attach burst: %v", cfg.QPS, cfg.Burst, err)
+	}
+}


### PR DESCRIPTION
## What this PR does

The kubevirt-csi-driver builds its infra and tenant cluster clients from a `rest.Config` with QPS/Burst left unset, so client-go uses its default 5 QPS / 10 burst. The wrapper's NFS `ControllerPublishVolume` polls the infra PVC once per second for up to two minutes. When a tenant scales out and several volumes attach at once, that shared token bucket starves and the poll returns `client rate limiter Wait returned an error: context deadline exceeded`, which the tenant kubelet reports as `FailedAttachVolume`. It looks like an intermittent E2E failure attaching a tenant volume, with nothing wrong in the storage backend.

This sets QPS/Burst to 100/200 on both configs, before any client is built. The new flags `--kube-api-qps` and `--kube-api-burst` make the limits tunable. The compiled-in defaults are the real fix: the deployment passes no client flags, so both configs resolve to the in-cluster config and pick up the new defaults. Non-positive values are rejected, since client-go would read `0` as the starving default and a negative value as no rate limiting.

Includes a regression test: a burst of 200 waiters times out against the default 5 QPS / 10 burst limiter and passes against the configured one.

### Screenshots

None. No UI changes.

### Downstream repositories

The diff touches only the driver's Go source in `packages/apps/kubernetes/images/kubevirt-csi-driver/`. No package was added, renamed or removed, and no `values.schema.json`, chart values, `ApplicationDefinition`, node prerequisite, metric or label changed. Nothing in the downstream trigger map is reached.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(kubernetes): raise the kubevirt-csi-driver API client rate limits (QPS/Burst, tunable via --kube-api-qps and --kube-api-burst) above the client-go defaults so a burst of concurrent volume attaches no longer times out as FailedAttachVolume.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Kubernetes API request rate limits for improved handling of high-volume operations.
  * Added validation to prevent invalid or non-positive rate-limit settings.

* **Bug Fixes**
  * Improved reliability during bursts of concurrent volume attachment requests by reducing request throttling and timeout risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->