### PR TITLE
test(e2e): make kuberture split-horizon probes survive Cilium ingress-IP race

### DIFF
--- a/hack/e2e-chainsaw/kuberture/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kuberture/chainsaw-test.yaml
@@ -4,7 +4,7 @@
 # annotation-shape checks and the split-horizon log assertions stay scripts.
 #
 # Everything is applied by chainsaw (the cluster-scoped Package, the cluster
-# RBAC, the probe Pods), so cleanup is automatic — no inlined teardown.
+# RBAC, the probe Jobs), so cleanup is automatic — no inlined teardown.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: Test
 metadata:
@@ -21,6 +21,12 @@ spec:
   - podLogs:
       namespace: cozy-kuberture
       selector: app.kubernetes.io/name=kuberture
+      tail: 100
+  # The split-horizon probe pods don't carry the kuberture addon label, so the
+  # selector above misses them; capture their stdout on failure too.
+  - podLogs:
+      namespace: cozy-kuberture
+      selector: app.kubernetes.io/name=kuberture-e2e-edns-probe
       tail: 100
   steps:
   - name: create-package
@@ -129,34 +135,44 @@ spec:
     try:
     - apply:
         file: probes.yaml
-    - script:
+    # Assert each single-shot probe Job reaches Complete rather than polling a
+    # fixed Pod name. The Job re-creates its pod on a fresh IP if the Cilium
+    # reserved:ingress race wedges one and the leak-healer deletes it, so the
+    # proof survives that infra flake instead of failing on a vanished Pod.
+    - assert:
         timeout: 4m
+        resource:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: kuberture-e2e-edns-public
+            namespace: cozy-kuberture
+          status:
+            (conditions[?type == 'Complete']):
+            - status: "True"
+    - assert:
+        timeout: 4m
+        resource:
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: kuberture-e2e-edns-internal
+            namespace: cozy-kuberture
+          status:
+            (conditions[?type == 'Complete']):
+            - status: "True"
+    - script:
+        timeout: 1m
         content: |
           set -eu
-          for probe in public internal; do
-            deadline=$(( $(date +%s) + 180 ))
-            until kubectl -n cozy-kuberture get pod "kuberture-e2e-edns-${probe}" \
-                -o jsonpath='{.status.phase}' 2>/dev/null | grep -Eq '^(Succeeded|Failed)$'; do
-              [ "$(date +%s)" -ge "$deadline" ] && break
-              sleep 3
-            done
-            # Guard the capture: if the loop timed out before the Pod existed,
-            # an unguarded read fails under `set -e` and skips the dump below.
-            if ! phase=$(kubectl -n cozy-kuberture get pod "kuberture-e2e-edns-${probe}" -o jsonpath='{.status.phase}' 2>/dev/null); then
-              phase="Missing"
-            fi
-            if [ "$phase" != "Succeeded" ]; then
-              echo "==== probe ${probe} failed: phase=${phase} ===="
-              kubectl -n cozy-kuberture describe pod "kuberture-e2e-edns-${probe}" || true
-              kubectl -n cozy-kuberture logs "pod/kuberture-e2e-edns-${probe}" || true
-              exit 1
-            fi
-          done
-
           pub_host=kuberture-e2e-public.cozystack.test
           int_host=kuberture-e2e-internal.cozystack.test
-          pub_logs=$(kubectl -n cozy-kuberture logs pod/kuberture-e2e-edns-public)
-          int_logs=$(kubectl -n cozy-kuberture logs pod/kuberture-e2e-edns-internal)
+
+          # Read each Job's succeeded pod by its job-name label. The healer may
+          # have deleted earlier wedged pods, but the Complete condition asserted
+          # above guarantees one succeeded pod remains to carry the logs.
+          pub_logs=$(kubectl -n cozy-kuberture logs --tail=-1 --max-log-requests=8 -l batch.kubernetes.io/job-name=kuberture-e2e-edns-public)
+          int_logs=$(kubectl -n cozy-kuberture logs --tail=-1 --max-log-requests=8 -l batch.kubernetes.io/job-name=kuberture-e2e-edns-internal)
 
           # The default-prefix probe sees only the public hostname; the internal-
           # prefix probe sees only the internal hostname.

--- a/hack/e2e-chainsaw/kuberture/probes.yaml
+++ b/hack/e2e-chainsaw/kuberture/probes.yaml
@@ -1,7 +1,14 @@
-# external-dns probe SA/RBAC + two single-shot probe Pods, each with a distinct
+# external-dns probe SA/RBAC + two single-shot probe Jobs, each with a distinct
 # --annotation-prefix (the upstream Split Horizon DNS pattern). external-dns
 # 0.20 initialises its informer cache cluster-wide before applying --namespace,
 # so the probe needs a ClusterRole, not a namespaced Role.
+#
+# The probes are Jobs, not bare Pods, on purpose. When the Cilium host-scope
+# IPAM + Gateway API restore-window race hands a probe the per-node
+# reserved:ingress IP (cilium/cilium#46799), the sandbox is rejected with
+# "IP already in use" and the e2e leak-healer deletes the wedged pod, expecting
+# a controller to reschedule it onto a free IP. A bare Pod has no controller, so
+# that delete was terminal and the probe never returned; the Job re-creates it.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -33,50 +40,62 @@ roleRef:
   kind: ClusterRole
   name: kuberture-e2e-edns-probe
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: kuberture-e2e-edns-public
   namespace: cozy-kuberture
 spec:
-  serviceAccountName: kuberture-e2e-edns-probe
-  restartPolicy: Never
-  containers:
-    - name: edns
-      image: registry.k8s.io/external-dns/external-dns:v0.20.0
-      args:
-        - --source=service
-        - --namespace=cozy-kuberture
-        - --provider=inmemory
-        - --inmemory-zone=cozystack.test
-        - --registry=noop
-        - --once
-        - --interval=10s
-        - --annotation-prefix=external-dns.alpha.kubernetes.io/
-        - --domain-filter=cozystack.test
-        - --log-level=info
-        - --log-format=text
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kuberture-e2e-edns-probe
+    spec:
+      serviceAccountName: kuberture-e2e-edns-probe
+      restartPolicy: Never
+      containers:
+        - name: edns
+          image: registry.k8s.io/external-dns/external-dns:v0.20.0
+          args:
+            - --source=service
+            - --namespace=cozy-kuberture
+            - --provider=inmemory
+            - --inmemory-zone=cozystack.test
+            - --registry=noop
+            - --once
+            - --interval=10s
+            - --annotation-prefix=external-dns.alpha.kubernetes.io/
+            - --domain-filter=cozystack.test
+            - --log-level=info
+            - --log-format=text
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: kuberture-e2e-edns-internal
   namespace: cozy-kuberture
 spec:
-  serviceAccountName: kuberture-e2e-edns-probe
-  restartPolicy: Never
-  containers:
-    - name: edns
-      image: registry.k8s.io/external-dns/external-dns:v0.20.0
-      args:
-        - --source=service
-        - --namespace=cozy-kuberture
-        - --provider=inmemory
-        - --inmemory-zone=cozystack.test
-        - --registry=noop
-        - --once
-        - --interval=10s
-        - --annotation-prefix=kuberture-e2e-internal-dns.io/
-        - --domain-filter=cozystack.test
-        - --log-level=info
-        - --log-format=text
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kuberture-e2e-edns-probe
+    spec:
+      serviceAccountName: kuberture-e2e-edns-probe
+      restartPolicy: Never
+      containers:
+        - name: edns
+          image: registry.k8s.io/external-dns/external-dns:v0.20.0
+          args:
+            - --source=service
+            - --namespace=cozy-kuberture
+            - --provider=inmemory
+            - --inmemory-zone=cozystack.test
+            - --registry=noop
+            - --once
+            - --interval=10s
+            - --annotation-prefix=kuberture-e2e-internal-dns.io/
+            - --domain-filter=cozystack.test
+            - --log-level=info
+            - --log-format=text


### PR DESCRIPTION
## What this PR does

The split-horizon-routing-proof step ran two external-dns probes as bare Pods and polled them by fixed name. When the Cilium host-scope IPAM plus Gateway API restore race (cilium/cilium#46799) hands a probe the per-node reserved:ingress IP, the sandbox is rejected with "IP already in use" and the e2e leak-healer deletes the wedged pod, expecting a controller to reschedule it onto a free IP. A bare Pod has no controller, so that delete was terminal: the probe vanished and the step failed on a NotFound pod. It surfaces as an intermittent kuberture E2E failure with a `FailedCreatePodSandBox` event on a probe pod.

This runs the probes as Jobs. The Job re-creates its pod on a fresh IP after the healer deletes it, so the proof survives the race. Each Job is asserted to reach Complete instead of polling a fixed pod name, and its logs are read by the job-name label. The failure path also gains a catch podLogs selector for the probe pods, so their stdout is captured when a probe fails for a different reason.

### Screenshots

None. No UI changes.

### Downstream repositories

The diff touches only the kuberture E2E suite under `hack/e2e-chainsaw/kuberture/`. No package, values schema, chart, CRD or platform manifest changed. Nothing in the downstream trigger map is reached.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test reliability by hardening the split-horizon routing proof against probe workload churn.
  * Strengthened route isolation validation between public and internal probes.
  * Enhanced failure diagnostics by capturing logs from the completed probe Jobs.
* **Testing**
  * Updated DNS EDNS probes to run as Kubernetes Jobs (instead of bare Pods) to support retries and rescheduling.
  * Added explicit assertions that both public and internal probe Jobs reach **Complete** before running hostname/route isolation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->