### PR TITLE
ci(go-build): add go build ./... gate for every Go module

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -1,0 +1,55 @@
+name: Go Build Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '**/go.mod'
+      - '**/go.sum'
+      - '.github/workflows/go-build.yml'
+
+concurrency:
+  group: go-build-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# Top-level token defaults to read-only; jobs request the minimum extra scopes.
+permissions:
+  contents: read
+
+jobs:
+  # Compile every Go module in the repo. `make build` only builds the Docker
+  # images and cmd/cozypkg, so a broken submodule stays green until something
+  # imports it. `go build ./...` per module is the missing compile gate
+  # (go test ./... is deliberately not run here — the root module's generated
+  # code round-trip suites depend on tool versions outside this repo's control;
+  # they run from their generator workflows instead).
+  go-build:
+    name: go build (${{ matrix.module }})
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        module:
+          - '.'
+          - api/apps/v1alpha1
+          - packages/apps/kubernetes/images/kubevirt-csi-driver
+          - packages/system/dashboard/images/token-proxy
+          - packages/system/kubeovn-webhook/images/kubeovn-webhook
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: ${{ matrix.module }}/go.mod
+          cache-dependency-path: ${{ matrix.module }}/go.sum
+
+      - name: go build ./...
+        working-directory: ${{ matrix.module }}
+        run: go build ./...


### PR DESCRIPTION
## What this PR does

Adds the missing `go build ./...` gate to PR CI. `make build` only compiles the Docker images and `cmd/cozypkg`, so a Go module that stops compiling stays green until something imports it. This is the last of the three Go gates tracked in #2499; the codegen-drift gate (`.github/workflows/codegen-drift.yml`) and the go-unit-tests gate (`make unit-tests`) already landed.

The new `go-build` workflow compiles the root module and each submodule (`api/apps/v1alpha1`, `packages/apps/kubernetes/images/kubevirt-csi-driver`, `packages/system/dashboard/images/token-proxy`, `packages/system/kubeovn-webhook/images/kubeovn-webhook`) as an independent matrix. It mirrors the codegen-drift gate: GitHub-hosted, SHA-pinned actions, and decoupled from the heavy E2E pipeline so contributors get fast compile feedback.

`go test ./...` is intentionally not added here: the root module's generated-code round-trip suites depend on generator tool versions outside this repo's control (kubebuilder, openapi-gen), which is why `make go-unit-tests` stays scoped to `./pkg/...`. Compilation has no such dependency, so `go build ./...` is safe to run broadly. All five modules were confirmed to build against the current `main`.

### Note for maintainers

Like the sibling `codegen-drift` gate, this workflow is path-filtered, so it does not run on PRs that touch no Go file. If the per-module matrix contexts are later marked as required in branch protection, a docs-only PR would leave those contexts pending forever and block merge. If they must be required, gate them behind an always-running summary job (the pattern `pull-requests.yaml` uses) rather than marking the path-filtered contexts required directly.

### Downstream repositories

Walked the trigger map against the diff. The only changed path is a new `.github/workflows/go-build.yml`; no downstream repository triggers on it.

- [x] No downstream repository is affected by this change

### Release note

```release-note
ci(go-build): add a go build ./... compile gate for every Go module in PR CI
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated Go build checks for pull requests that modify Go source or module files.
  * Verifies each configured Go module compiles successfully using its declared Go version.
  * Cancels outdated checks when newer changes are submitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->