### PR TITLE
chore(ci): namespace the backport labels under kind/

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
   - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
 - If it's a work in progress, consider creating this PR as a draft.
 - Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
-- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
+- Add the label `kind/backport` if it's a bugfix that needs to be backported to a previous version.
 -->
 
 ## What this PR does

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -78,6 +78,18 @@
   color: 'e11d21'
   description: Indicates the change introduces a breaking API or behaviour change
 
+# kind/backport-previous has no upstream Kubernetes equivalent (k8s has no
+# two-release-line model); it stays under kind/ per the file convention.
+- name: kind/backport
+  color: 'fbca04'
+  description: Categorizes issue or PR as requiring a backport to the current release line
+  aliases: ['backport']
+
+- name: kind/backport-previous
+  color: 'fbd876'
+  description: Categorizes issue or PR as requiring a backport to the previous release line
+  aliases: ['backport-previous']
+
 # ──────────────────────────────────────────────
 # priority/ — urgency
 # ──────────────────────────────────────────────
@@ -277,14 +289,6 @@
 - name: upstream-issue
   color: 'aaaaaa'
   description: Requires resolving an issue in an upstream project
-
-- name: backport
-  color: 'fbca04'
-  description: Should change be backported on previous release
-
-- name: backport-previous
-  color: 'fbd876'
-  description: Backport target — previous release line
 
 - name: release
   color: 'aaaaaa'

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -19,9 +19,9 @@ jobs:
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
       (
-        contains(github.event.pull_request.labels.*.name, 'backport') ||
-        contains(github.event.pull_request.labels.*.name, 'backport-previous') ||
-        (github.event.action == 'labeled' && (github.event.label.name == 'backport' || github.event.label.name == 'backport-previous'))
+        contains(github.event.pull_request.labels.*.name, 'kind/backport') ||
+        contains(github.event.pull_request.labels.*.name, 'kind/backport-previous') ||
+        (github.event.action == 'labeled' && (github.event.label.name == 'kind/backport' || github.event.label.name == 'kind/backport-previous'))
       )
     # GitHub API calls only — no docker, no repo toolchain: GitHub-hosted.
     runs-on: ubuntu-latest
@@ -40,8 +40,8 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const labels = pr.labels.map(l => l.name);
-            const isBackport = labels.includes('backport');
-            const isBackportPrevious = labels.includes('backport-previous');
+            const isBackport = labels.includes('kind/backport');
+            const isBackportPrevious = labels.includes('kind/backport-previous');
             
             core.setOutput('backport', isBackport ? 'true' : 'false');
             core.setOutput('backport_previous', isBackportPrevious ? 'true' : 'false');

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -39,7 +39,7 @@ jobs:
             triage/accepted,kind/regression
           exempt-pr-labels: >-
             lifecycle/frozen,do-not-merge/hold,
-            backport,backport-previous
+            kind/backport,kind/backport-previous
           days-before-stale: 60
           days-before-close: 14
           operations-per-run: 100

--- a/docs/agents/contributing.md
+++ b/docs/agents/contributing.md
@@ -105,7 +105,7 @@ git commit --signoff -m "docs(contributing): add installation guide"
 
 **Special handling:**
 
-- `[Backport release-1.x]` prefix is stripped before parsing; `area/release` and `backport` labels are added.
+- `[Backport release-1.x]` prefix is stripped before parsing; the `area/release` label is added.
 - Composite scope (`feat(platform, system, apps): ...`) — each comma-separated part is mapped independently.
 - `!` after type or `BREAKING CHANGE:` footer in the body → `kind/breaking-change`.
 - Unmapped scope or non-conventional title → `area/uncategorized` (signals the PR needs manual area selection).

--- a/docs/release.md
+++ b/docs/release.md
@@ -282,8 +282,8 @@ The matching Talos node image is `ghcr.io/cozystack/cozystack/cozystack-nocloud:
 
 | Label | Target branch |
 |-------|---------------|
-| `backport` | `release-X.Y` (current latest minor) |
-| `backport-previous` | `release-X.(Y-1)` |
+| `kind/backport` | `release-X.Y` (current latest minor) |
+| `kind/backport-previous` | `release-X.(Y-1)` |
 
 Resolution is dynamic via `getLatestRelease` at run time — no need to hardcode branch names.
 
@@ -309,7 +309,7 @@ git push origin release-X.Y  # or push to a new branch and open a PR
 To find the bot's failed comments across a batch of PRs:
 
 ```bash
-for n in $(gh pr list --search "label:backport label:backport-previous merged:>=2026-01-01" --json number --jq '.[].number'); do
+for n in $(gh pr list --search "label:kind/backport label:kind/backport-previous merged:>=2026-01-01" --json number --jq '.[].number'); do
   echo "=== #$n ==="
   gh pr view $n --json comments --jq '.comments[] | select(.author.login == "github-actions" or (.author.login | contains("backport"))) | .body' | head -20
 done
@@ -321,8 +321,8 @@ A patch release includes bugfixes for code that shipped in the corresponding min
 
 ```bash
 # 1. Inventory PRs already labeled for backport (merged but not yet on release-X.Y)
-gh pr list --search "is:merged label:backport" --limit 100
-gh pr list --search "is:merged label:backport-previous" --limit 100
+gh pr list --search "is:merged label:kind/backport" --limit 100
+gh pr list --search "is:merged label:kind/backport-previous" --limit 100
 
 # 2. List commits on main since the release branch diverged that are NOT yet on release-X.Y
 git merge-base origin/main origin/release-X.Y


### PR DESCRIPTION
## What this PR does

Aligns the backport labels with the namespaced label convention the `.github/labels.yml` header declares (the Kubernetes scheme: `kind/`, `area/`, `priority/`, ...). `backport` and `backport-previous` were the only labels left top-level, violating that header.

Renames them to `kind/backport` and `kind/backport-previous`, moves them into the `kind/` section, and carries the old names as `aliases:` so `EndBug/label-sync` renames them in place without dropping history on already-tagged issues and PRs. Upstream Kubernetes uses `kind/backport` for the same meaning; `kind/backport-previous` has no upstream equivalent (k8s has no two-release-line model) but stays under `kind/` per the file convention.

Updates the label literals in `.github/workflows/backport.yaml` in lockstep: the `prepare` job's `if:` filter and the label-detection script. This is the only workflow that consumes these labels. `pr-labeler.yaml`'s `backport` entry is a Conventional-Commit scope-to-area mapping (`fix(backport): ...` → `area/release`), not a label reference, so it is left unchanged.

The top-level `release` label was raised in #2585 as an open question. It is a functional trigger keyed by literal name across several workflows (`pull-requests.yaml`, `pull-requests-release.yaml`, the backport gating), so renaming it is a wider cross-workflow change out of scope for this label-convention alignment. Left as-is intentionally.

The `labels.yml` schema validator (description length, hex color, unique names, alias/name collisions) was run locally against the result and passes.

Closes #2585.

### Downstream repositories

Walked the trigger map against the diff. Changed paths are `.github/labels.yml` and `.github/workflows/backport.yaml`; no downstream repository triggers on either.

- [x] No downstream repository is affected by this change

### Release note

```release-note
chore(ci): rename the backport / backport-previous labels to kind/backport and kind/backport-previous (old names preserved as aliases; no action needed for existing labeled PRs)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Workflow Improvements**
  - Standardized backport labels under the `kind/` category.
  - Backport automation now recognizes the updated labels.
  - Backport pull requests are exempt from stale cleanup.

- **Documentation**
  - Updated contribution and release instructions to reflect the new backport labels.
  - Revised pull request template guidance for bugfix backports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->