### PR TITLE
fix(ci): keep full-suite E2E escalation immune to unrelated suite edits

### DIFF
--- a/hack/select-e2e.sh
+++ b/hack/select-e2e.sh
@@ -150,29 +150,51 @@ while :; do
   all_sources="$all_sources $new"
 done
 
-# Filter to *-application sources, then map to Chainsaw suite names.
-final=""
+# Filter to *-application sources, then map to Chainsaw suite names. Kept
+# separate from the directly-selected per-suite edits below so the
+# no-app-descendants safety net can key off the source-derived selection alone.
+sources_final=""
 for s in $all_sources; do
   app=${s#cozystack.}
   case "$app" in
-    *-application) final="$final $(src_to_suites "$app")" ;;
-    external-dns) final="$final external-dns" ;;
+    *-application) sources_final="$sources_final $(src_to_suites "$app")" ;;
+    external-dns) sources_final="$sources_final external-dns" ;;
   esac
 done
 
-# Add directly-selected suites from per-suite edits.
-final="$final $selected_apps"
-
-# Deduplicate; intersect with available Chainsaw suites.
-final_apps=$(echo "$final" | tr ' ' '\n' | sort -u | grep -v '^$' | while read -r app; do
+# Suites contributed by the PackageSource graph alone, intersected with the
+# available Chainsaw suites.
+sources_apps=$(echo "$sources_final" | tr ' ' '\n' | sort -u | grep -v '^$' | while read -r app; do
   if echo "$all_apps" | grep -Fxq "$app"; then
     echo "$app"
   fi
 done | paste -sd ' ' -)
 
-# Safety net: a system source with no *-application descendants would otherwise
-# silently skip E2E. Fall back to full suite so a path inside the graph is
-# never silently dropped.
+# Safety net: a selected packages/* component that resolves into the graph but
+# has no *-application descendant would otherwise silently skip E2E. The signal
+# is the source-derived selection being empty, and it must be read ONLY from the
+# graph — never from the combined result. A PR that also edits one unrelated
+# suite's tests contributes that suite via $selected_apps, and keying the
+# escalation off the combined result let that lone suite mask it (the same
+# system-package change selected the full suite alone but exactly one suite
+# alongside a suite edit). Fall back to the full suite so a graph path is never
+# silently dropped.
+if [ -n "$selected_sources" ] && [ -z "$sources_apps" ]; then
+  echo "$all_apps" | paste -sd ' ' -
+  exit 0
+fi
+
+# Combine the graph-derived suites with the directly-selected per-suite edits,
+# deduplicate, and intersect with the available Chainsaw suites.
+final_apps=$(printf '%s %s' "$sources_apps" "$selected_apps" | tr ' ' '\n' | sort -u | grep -v '^$' | while read -r app; do
+  if echo "$all_apps" | grep -Fxq "$app"; then
+    echo "$app"
+  fi
+done | paste -sd ' ' -)
+
+# Original catch-all: something was selected (trigger_any) yet nothing runnable
+# resolved — e.g. a per-suite edit on a directory that has no chainsaw-test.yaml
+# yet. Escalate rather than silently skip.
 if [ -z "$final_apps" ]; then
   echo "$all_apps" | paste -sd ' ' -
   exit 0

--- a/hack/select-e2e.sh
+++ b/hack/select-e2e.sh
@@ -173,7 +173,7 @@ done | paste -sd ' ' -)
 # Safety net: a selected packages/* component that resolves into the graph but
 # has no *-application descendant would otherwise silently skip E2E. The signal
 # is the source-derived selection being empty, and it must be read ONLY from the
-# graph — never from the combined result. A PR that also edits one unrelated
+# graph, never from the combined result. A PR that also edits one unrelated
 # suite's tests contributes that suite via $selected_apps, and keying the
 # escalation off the combined result let that lone suite mask it (the same
 # system-package change selected the full suite alone but exactly one suite
@@ -193,7 +193,7 @@ final_apps=$(printf '%s %s' "$sources_apps" "$selected_apps" | tr ' ' '\n' | sor
 done | paste -sd ' ' -)
 
 # Original catch-all: something was selected (trigger_any) yet nothing runnable
-# resolved — e.g. a per-suite edit on a directory that has no chainsaw-test.yaml
+# resolved, e.g. a per-suite edit on a directory that has no chainsaw-test.yaml
 # yet. Escalate rather than silently skip.
 if [ -z "$final_apps" ]; then
   echo "$all_apps" | paste -sd ' ' -

--- a/hack/select-e2e_test.bats
+++ b/hack/select-e2e_test.bats
@@ -170,3 +170,30 @@
     output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources") || true
     [ -z "$output" ]
 }
+
+@test "no-app-descendant package change still escalates alongside a per-suite edit" {
+    # A system package whose PackageSource graph resolves to no runnable
+    # *-application suite (monitoring-application ships no Chainsaw suite)
+    # escalates to the full suite on its own via the safety net. Editing one
+    # unrelated suite's tests in the same PR must NOT defeat that escalation:
+    # keying the safety net off the combined selection let the lone edited suite
+    # mask it, so the same change selected the full suite alone but exactly one
+    # suite alongside a suite edit (#3330).
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cp -r packages/core/platform/sources "$tmp/sources"
+
+    # Baseline: the package alone triggers the full suite. This also anchors the
+    # test: if the graph ever grows an app descendant for this package, this
+    # assertion fails loudly instead of the regression check passing vacuously.
+    echo "packages/system/monitoring/values.yaml" > "$tmp/alone"
+    alone=$(hack/select-e2e.sh "$tmp/alone" "$tmp/sources")
+    [ "$(echo "$alone" | wc -w)" -gt 5 ]
+
+    # Regression: the same change plus an unrelated per-suite edit must still run
+    # the full suite, not collapse to just the edited suite.
+    echo "packages/system/monitoring/values.yaml" > "$tmp/both"
+    echo "hack/e2e-chainsaw/redis/chainsaw-test.yaml" >> "$tmp/both"
+    both=$(hack/select-e2e.sh "$tmp/both" "$tmp/sources")
+    [ "$(echo "$both" | wc -w)" -gt 5 ]
+}


### PR DESCRIPTION
## What this PR does

Fixes a correctness bug in the diff-driven E2E test selector `hack/select-e2e.sh`. When a changed `packages/*` component resolves into the PackageSource graph but has no `*-application` descendant, the selector is supposed to escalate to the full Chainsaw suite via its safety net rather than silently skip E2E. That safety net keyed off the *combined* selection being empty, so if the same PR also edited one unrelated suite's tests, that suite was contributed through `selected_apps`, `final_apps` became non-empty, and the escalation was silently swallowed: the same system-package change selected the full suite alone but exactly one suite alongside a suite edit.

The fix decides the escalation from the source-derived selection alone (`sources_apps`), independent of directly-selected per-suite edits, and then unions the per-suite edits afterward. The original empty-`final_apps` catch-all is kept for the separate case of a per-suite edit on a directory that has no `chainsaw-test.yaml` yet.

Adds a regression test covering a no-app-descendant package change combined with an unrelated per-suite edit (RED before the fix, GREEN after). The full `select-e2e_test.bats` suite passes and `shellcheck` is clean on the changed code.

### Downstream repositories

Walked the trigger map against the diff. Changed paths are `hack/select-e2e.sh` and `hack/select-e2e_test.bats`; the only `hack/`-related downstream trigger (cozystack/ccp) is about moving or renaming files under `hack/` or changing make-target behaviour, and this PR does neither.

- [x] No downstream repository is affected by this change

### Release note

```release-note
fix(ci): a PR that edits one E2E suite's tests no longer suppresses full-suite escalation for an unrelated system-package change
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test selection when system package changes have no directly runnable application tests.
  * Ensured these changes trigger the full test suite, even when unrelated suite-specific edits are included.

* **Tests**
  * Added coverage verifying correct escalation to the full end-to-end suite in mixed-change scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->