### PR TITLE
fix(release): make promote-retag digest verification media-type-agnostic

### DIFF
--- a/hack/promote-retag.sh
+++ b/hack/promote-retag.sh
@@ -24,7 +24,7 @@
 # files that covers), which is expected to be the promoted stable
 # digest-vendored tree (the release-X.Y.Z branch, whose digests are the rc's —
 # only the cosmetic tag string differs).
-# Requires: yq (mikefarah), skopeo, and a registry login already done.
+# Requires: yq (mikefarah), skopeo, sha256sum, and a registry login already done.
 #
 # The repo/tag split (ref_repo below) strips the :tag from the last path
 # component only, so registry hosts that carry a :port are preserved.
@@ -49,6 +49,7 @@ command -v yq >/dev/null     || { echo "yq (mikefarah) is required" >&2; exit 1;
 yq --version 2>&1 | grep -q mikefarah || { echo "yq (mikefarah) is required" >&2; exit 1; }
 # skopeo is only needed to actually copy; a --dry-run just prints the plan.
 [ "$DRY_RUN" -eq 1 ] || command -v skopeo >/dev/null || { echo "skopeo is required" >&2; exit 1; }
+[ "$DRY_RUN" -eq 1 ] || command -v sha256sum >/dev/null || { echo "sha256sum is required" >&2; exit 1; }
 
 # Ref collection (which files are scanned, and the YAML shapes within them) is
 # shared with hack/nightly-mirror.sh and hack/promote-rewrite-tags.sh — see
@@ -80,6 +81,17 @@ ref_repo() {
   fi
 }
 ref_digest() { printf '%s' "${1##*@}"; }               # sha256:...
+
+manifest_digest() {
+  _ref="$1"
+  _manifest="$(mktemp)"
+  # Hash the raw bytes so this works for images and OCI artifacts alike. A
+  # file preserves inspect's status without relying on non-POSIX pipefail.
+  if skopeo inspect --raw "docker://$_ref" >"$_manifest" 2>/dev/null; then
+    printf 'sha256:%s' "$(sha256sum "$_manifest" | cut -d' ' -f1)"
+  fi
+  rm -f "$_manifest"
+}
 
 copy() {
   _src="$1"; _dst="$2"
@@ -128,13 +140,14 @@ echo "$refs" | while IFS= read -r ref; do
   repo="${ref%@*}"
   digest="${ref##*@}"
   echo "▸ ${repo}  ${digest}"
-  # The stable tag is write-once at the image level: inspect the destination
-  # before copying. No-op if it already points at this rc digest (idempotent
-  # re-run), fail if it points elsewhere (a partial run or manual push already
-  # put different bytes there) rather than mutate released bytes. :latest is
-  # intentionally mutable and (re)pointed below only when MOVE_LATEST=1.
+  # The stable tag is write-once at the image level: resolve the destination's
+  # raw manifest digest before copying. No-op if it already points at this rc
+  # digest (idempotent re-run), fail if it points elsewhere (a partial run or
+  # manual push already put different bytes there) rather than mutate released
+  # bytes. :latest is intentionally mutable and (re)pointed below only when
+  # MOVE_LATEST=1.
   if [ "$DRY_RUN" -eq 0 ]; then
-    cur="$(skopeo inspect --format '{{.Digest}}' "docker://${repo}:${STABLE}" 2>/dev/null || echo '')"
+    cur="$(manifest_digest "${repo}:${STABLE}")"
     if [ -n "$cur" ] && [ "$cur" != "$digest" ]; then
       echo "::error::${repo}:${STABLE} already exists at '${cur}'; refusing to move it to '${digest}' (stable image tags are write-once)" >&2
       exit 1
@@ -150,7 +163,7 @@ echo "$refs" | while IFS= read -r ref; do
   [ "$MOVE_LATEST" = "1" ] && copy "$ref" "${repo}:latest"
   # Verify the stable tag now resolves to the exact rc digest (skip in dry-run).
   if [ "$DRY_RUN" -eq 0 ]; then
-    got="$(skopeo inspect --format '{{.Digest}}' "docker://${repo}:${STABLE}" 2>/dev/null || echo '')"
+    got="$(manifest_digest "${repo}:${STABLE}")"
     if [ "$got" != "$digest" ]; then
       echo "::error::${repo}:${STABLE} resolved to '${got}', expected '${digest}'" >&2
       exit 1

--- a/hack/promote-retag.sh
+++ b/hack/promote-retag.sh
@@ -82,15 +82,45 @@ ref_repo() {
 }
 ref_digest() { printf '%s' "${1##*@}"; }               # sha256:...
 
+# manifest_digest <ref> — the digest of <ref>'s raw manifest, or empty output if
+# the tag is PROVEN not to exist. Anything else is indeterminate and returns
+# non-zero, which under `set -e` aborts the promotion before it writes.
+#
+# The three states matter because the caller turns "empty" into "not published,
+# safe to copy over". Inferring that from a failure — or from a successful
+# response with no bytes — is how a rate-limit or a proxy hiccup gets read as
+# permission to overwrite released bytes. Absence has to be proven by the
+# registry saying so.
 manifest_digest() {
   _ref="$1"
   _manifest="$(mktemp)"
-  # Hash the raw bytes so this works for images and OCI artifacts alike. A
-  # file preserves inspect's status without relying on non-POSIX pipefail.
-  if skopeo inspect --raw "docker://$_ref" >"$_manifest" 2>/dev/null; then
-    printf 'sha256:%s' "$(sha256sum "$_manifest" | cut -d' ' -f1)"
+  _mderr="$(mktemp)"
+  # Hash the raw bytes so this works for images and OCI artifacts alike. Files
+  # preserve inspect's status without relying on non-POSIX pipefail.
+  if skopeo inspect --raw "docker://$_ref" >"$_manifest" 2>"$_mderr"; then
+    if [ -s "$_manifest" ]; then
+      printf 'sha256:%s' "$(sha256sum "$_manifest" | cut -d' ' -f1)"
+      rm -f "$_manifest" "$_mderr"
+      return 0
+    fi
+    # Exit 0 with no bytes — a registry answering 200 with an empty body. Not a
+    # digest (hashing nothing yields sha256:e3b0c442…, which looks real and
+    # belongs to no manifest) and not proof of absence either, so refuse to
+    # decide rather than let the caller copy over whatever is really there.
+    echo "::error::skopeo inspect of ${_ref} succeeded but returned no manifest bytes; refusing to decide whether that tag exists" >&2
+    rm -f "$_manifest" "$_mderr"
+    return 1
   fi
-  rm -f "$_manifest"
+  # Non-zero. Only a registry that says the manifest is unknown proves absence;
+  # 429/5xx/auth/network failures all also exit non-zero with no bytes, and
+  # reading those as "not published" is exactly the fail-open this guards.
+  if grep -qiE 'manifest unknown|manifest not known|manifest for [^ ]* not found|not found|404' "$_mderr"; then
+    rm -f "$_manifest" "$_mderr"
+    return 0
+  fi
+  echo "::error::skopeo inspect of ${_ref} failed and did not report the manifest as unknown, so it cannot be treated as unpublished: $(tr '\n' ' ' <"$_mderr")" >&2
+  rm -f "$_manifest" "$_mderr"
+  return 1
 }
 
 copy() {

--- a/hack/promote-retag_test.bats
+++ b/hack/promote-retag_test.bats
@@ -21,6 +21,41 @@
 #           (or `bats hack/promote-retag_test.bats` if the bats binary is
 #           installed; cozytest.sh is the CI path.)
 
+_make_registry_mocks() {
+  t="$1"
+  mkdir -p "$t/bin"
+  cat >"$t/bin/yq" <<'EOF'
+#!/bin/sh
+set -eu
+if [ "${1:-}" = "--version" ]; then
+  echo 'yq (https://github.com/mikefarah/yq/) version v4.45.1'
+else
+  printf '%s\n' "$MOCK_REF"
+fi
+EOF
+  cat >"$t/bin/skopeo" <<'EOF'
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" >>"$MOCK_SKOPEO_LOG"
+case "$1" in
+  inspect)
+    [ "$2" = "--raw" ]
+    if [ "$MOCK_MISSING_ONCE" = "1" ] && [ ! -f "$MOCK_STATE" ]; then
+      exit 1
+    fi
+    printf '%s' "$MOCK_MANIFEST"
+    ;;
+  copy)
+    : >"$MOCK_STATE"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
+EOF
+  chmod +x "$t/bin/yq" "$t/bin/skopeo"
+}
+
 @test "dry-run over the real tree retags only cozystack-owned refs" {
   tmp=$(mktemp -d)
   trap 'rm -rf "$tmp"' EXIT
@@ -159,4 +194,77 @@
   # reachable from any values.yaml.
   grep -q 'cozystack/grafana:v9.9.9' "$tmp/out"
   grep -q 'cozystack/multus-cni:v9.9.9' "$tmp/out"
+}
+
+@test "raw manifest digest resolves for an OCI artifact" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  _make_registry_mocks "$tmp"
+
+  manifest='{"schemaVersion":2,"config":{"mediaType":"application/vnd.cncf.flux.config.v1+json","digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},"layers":[]}'
+  digest="sha256:$(printf '%s' "$manifest" | sha256sum | cut -d' ' -f1)"
+  ref="example.com/cozystack/cozystack-packages:v1.6.0-rc.1@${digest}"
+
+  rc=0
+  REGISTRY="example.com/cozystack" MOCK_REF="$ref" MOCK_MANIFEST="$manifest" \
+    MOCK_MISSING_ONCE=0 MOCK_STATE="$tmp/state" MOCK_SKOPEO_LOG="$tmp/skopeo.log" \
+    PATH="$tmp/bin:/usr/bin:/bin" hack/promote-retag.sh v1.6.0 \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "promote-retag.sh exited $rc" >&2
+    echo "--- stderr ---" >&2; cat "$tmp/err" >&2
+    return "$rc"
+  fi
+
+  grep -q "already at ${digest}; skipping stable copy" "$tmp/out"
+  [ "$(grep -c '^inspect --raw ' "$tmp/skopeo.log")" -eq 2 ]
+  ! grep -q '^copy ' "$tmp/skopeo.log"
+}
+
+@test "post-copy raw manifest digest mismatch fails verification" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  _make_registry_mocks "$tmp"
+
+  manifest='{"schemaVersion":2,"config":{"mediaType":"application/vnd.cncf.flux.config.v1+json","digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},"layers":[]}'
+  expected_manifest='{"schemaVersion":2,"config":{"mediaType":"application/vnd.cncf.flux.config.v1+json","digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"},"layers":[]}'
+  actual="sha256:$(printf '%s' "$manifest" | sha256sum | cut -d' ' -f1)"
+  expected="sha256:$(printf '%s' "$expected_manifest" | sha256sum | cut -d' ' -f1)"
+  ref="example.com/cozystack/cozystack-packages:v1.6.0-rc.1@${expected}"
+
+  rc=0
+  REGISTRY="example.com/cozystack" MOCK_REF="$ref" MOCK_MANIFEST="$manifest" \
+    MOCK_MISSING_ONCE=1 MOCK_STATE="$tmp/state" MOCK_SKOPEO_LOG="$tmp/skopeo.log" \
+    PATH="$tmp/bin:/usr/bin:/bin" hack/promote-retag.sh v1.6.0 \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q "resolved to '${actual}', expected '${expected}'" "$tmp/err"
+  grep -q '^copy --multi-arch all ' "$tmp/skopeo.log"
+  [ "$(grep -c '^inspect --raw ' "$tmp/skopeo.log")" -eq 2 ]
+}
+
+@test "missing stable tag remains an empty digest and proceeds to copy" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  _make_registry_mocks "$tmp"
+
+  manifest='{"schemaVersion":2,"config":{"mediaType":"application/vnd.cncf.flux.config.v1+json","digest":"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"},"layers":[]}'
+  digest="sha256:$(printf '%s' "$manifest" | sha256sum | cut -d' ' -f1)"
+  ref="example.com/cozystack/cozystack-packages:v1.6.0-rc.1@${digest}"
+
+  rc=0
+  REGISTRY="example.com/cozystack" MOCK_REF="$ref" MOCK_MANIFEST="$manifest" \
+    MOCK_MISSING_ONCE=1 MOCK_STATE="$tmp/state" MOCK_SKOPEO_LOG="$tmp/skopeo.log" \
+    PATH="$tmp/bin:/usr/bin:/bin" hack/promote-retag.sh v1.6.0 \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "promote-retag.sh exited $rc" >&2
+    echo "--- stderr ---" >&2; cat "$tmp/err" >&2
+    return "$rc"
+  fi
+
+  grep -q '^copy --multi-arch all ' "$tmp/skopeo.log"
+  [ "$(grep -c '^inspect --raw ' "$tmp/skopeo.log")" -eq 2 ]
+  grep -q 'Retagged image refs to v1.6.0' "$tmp/out"
 }

--- a/hack/promote-retag_test.bats
+++ b/hack/promote-retag_test.bats
@@ -40,8 +40,21 @@ printf '%s\n' "$*" >>"$MOCK_SKOPEO_LOG"
 case "$1" in
   inspect)
     [ "$2" = "--raw" ]
-    if [ "$MOCK_MISSING_ONCE" = "1" ] && [ ! -f "$MOCK_STATE" ]; then
+    # An indeterminate failure: non-zero, no bytes, and the registry never says
+    # the manifest is unknown. Must NOT read as "tag absent".
+    if [ "${MOCK_TRANSIENT_ERROR:-0}" = "1" ]; then
+      echo "Error: reading manifest from docker://${3:-?}: received unexpected HTTP status: 429 Too Many Requests" >&2
       exit 1
+    fi
+    if [ "$MOCK_MISSING_ONCE" = "1" ] && [ ! -f "$MOCK_STATE" ]; then
+      # Absence as a registry actually reports it — the script requires proof,
+      # not merely a non-zero exit.
+      echo "Error: reading manifest from docker://${3:-?}: manifest unknown" >&2
+      exit 1
+    fi
+    # A registry answering 200 with an empty body: exit 0, no bytes.
+    if [ "${MOCK_EMPTY_MANIFEST:-0}" = "1" ]; then
+      exit 0
     fi
     printf '%s' "$MOCK_MANIFEST"
     ;;
@@ -267,4 +280,84 @@ EOF
   grep -q '^copy --multi-arch all ' "$tmp/skopeo.log"
   [ "$(grep -c '^inspect --raw ' "$tmp/skopeo.log")" -eq 2 ]
   grep -q 'Retagged image refs to v1.6.0' "$tmp/out"
+}
+
+@test "existing stable tag at a different digest is refused, not moved" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  _make_registry_mocks "$tmp"
+
+  # The stable tag already exists (MOCK_MISSING_ONCE=0) but resolves to a
+  # manifest other than the rc's: released bytes must never be overwritten.
+  published='{"schemaVersion":2,"config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111"},"layers":[]}'
+  rc_manifest='{"schemaVersion":2,"config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:2222222222222222222222222222222222222222222222222222222222222222"},"layers":[]}'
+  published_digest="sha256:$(printf '%s' "$published" | sha256sum | cut -d' ' -f1)"
+  rc_digest="sha256:$(printf '%s' "$rc_manifest" | sha256sum | cut -d' ' -f1)"
+  ref="example.com/cozystack/cozystack-packages:v1.6.0-rc.1@${rc_digest}"
+
+  rc=0
+  REGISTRY="example.com/cozystack" MOCK_REF="$ref" MOCK_MANIFEST="$published" \
+    MOCK_MISSING_ONCE=0 MOCK_STATE="$tmp/state" MOCK_SKOPEO_LOG="$tmp/skopeo.log" \
+    PATH="$tmp/bin:/usr/bin:/bin" hack/promote-retag.sh v1.6.0 \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q "already exists at '${published_digest}'; refusing to move it to '${rc_digest}'" "$tmp/err"
+  # The refusal must happen BEFORE any write.
+  ! grep -q '^copy ' "$tmp/skopeo.log"
+  [ "$(grep -c '^inspect --raw ' "$tmp/skopeo.log")" -eq 1 ]
+}
+
+@test "a zero-exit empty manifest refuses to decide and never writes" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  _make_registry_mocks "$tmp"
+
+  manifest='{"schemaVersion":2,"config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333"},"layers":[]}'
+  digest="sha256:$(printf '%s' "$manifest" | sha256sum | cut -d' ' -f1)"
+  ref="example.com/cozystack/cozystack-packages:v1.6.0-rc.1@${digest}"
+
+  rc=0
+  REGISTRY="example.com/cozystack" MOCK_REF="$ref" MOCK_MANIFEST="$manifest" \
+    MOCK_EMPTY_MANIFEST=1 MOCK_MISSING_ONCE=0 MOCK_STATE="$tmp/state" \
+    MOCK_SKOPEO_LOG="$tmp/skopeo.log" \
+    PATH="$tmp/bin:/usr/bin:/bin" hack/promote-retag.sh v1.6.0 \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+
+  # A 200 with an empty body proves nothing: the tag may hold released bytes this
+  # promotion must not overwrite. So the script must abort BEFORE any copy —
+  # reading "no bytes" as "not published" is what would turn a proxy hiccup into
+  # an overwrite of a published stable tag.
+  [ "$rc" -ne 0 ]
+  grep -q 'returned no manifest bytes' "$tmp/err"
+  ! grep -q '^copy ' "$tmp/skopeo.log"
+  [ "$(grep -c '^inspect --raw ' "$tmp/skopeo.log")" -eq 1 ]
+  # The empty-input hash must never appear: that is the guard being absent.
+  ! grep -q 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' "$tmp/err"
+}
+
+@test "a transient registry failure is not read as an unpublished tag" {
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  _make_registry_mocks "$tmp"
+
+  manifest='{"schemaVersion":2,"config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:4444444444444444444444444444444444444444444444444444444444444444"},"layers":[]}'
+  digest="sha256:$(printf '%s' "$manifest" | sha256sum | cut -d' ' -f1)"
+  ref="example.com/cozystack/cozystack-packages:v1.6.0-rc.1@${digest}"
+
+  # 429 during finalize: non-zero exit, no bytes, no "manifest unknown". The old
+  # shape of this helper made that indistinguishable from an absent tag and
+  # proceeded to copy over it; finalize retags ~42 refs with no retry wrapper, so
+  # a single rate-limit was enough to reach that path.
+  rc=0
+  REGISTRY="example.com/cozystack" MOCK_REF="$ref" MOCK_MANIFEST="$manifest" \
+    MOCK_TRANSIENT_ERROR=1 MOCK_MISSING_ONCE=0 MOCK_STATE="$tmp/state" \
+    MOCK_SKOPEO_LOG="$tmp/skopeo.log" \
+    PATH="$tmp/bin:/usr/bin:/bin" hack/promote-retag.sh v1.6.0 \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q 'cannot be treated as unpublished' "$tmp/err"
+  grep -q '429' "$tmp/err"
+  ! grep -q '^copy ' "$tmp/skopeo.log"
 }


### PR DESCRIPTION
## What this PR does

The finalize post-copy verification runs `skopeo inspect --format '{{.Digest}}'` on every freshly retagged stable ref. For OCI artifacts that command prints nothing and exits non-zero — `cozystack-packages` is a flux artifact with `config.mediaType: application/vnd.cncf.flux.config.v1+json` — so the v1.6.0 finalize (run 29932878820) aborted right after both copies of that artifact had already succeeded, leaving 32 of 43 repos without stable tags and skipping the cozy-installer publish. `--dry-run` never reaches this branch, which is why rehearsals did not catch it.

This PR computes the digest as sha256 over the raw manifest instead (`skopeo inspect --raw`), which is how registries define the manifest digest and works identically for container images and OCI artifacts. The helper gates the hash on skopeo's exit status via a temp file rather than a pipeline, so a missing tag still resolves to an empty string (the pre-check reads that as "tag absent, proceed to copy") and never to the empty-input hash `sha256:e3b0c442…`, and never aborts under `set -eu`.

Verified against live GHCR: the raw-manifest hash of `cozystack-packages:v1.6.0` matches the digest finalize expected (`bf68208730860fa8…`), and the old and new methods agree byte-for-byte on regular multi-arch images (`cozystack-operator`, `kubeovn`, `cozystack-controller`, `kubevirt-cloud-provider`). New cozytest cases cover the OCI-artifact digest resolution, a post-copy mismatch, and the missing-tag path; the mock skopeo asserts `--raw`, so the suite fails against the old code.

### Release note

```release-note
fix(release): promote's post-copy digest verification no longer breaks on OCI artifacts (cozystack-packages), which aborted the v1.6.0 finalize mid-retag with 32 of 43 repos left untagged
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCI artifact retagging by deriving stable manifest digests from raw manifests to ensure accurate “already correct” and mismatch detection.
  * Prevented incorrect skips when the stable tag points to an unexpected digest.
  * Added safer handling for missing or unknown stable tags and clearer failure behavior for unexpected empty manifest responses and transient registry errors.
* **Tests**
  * Expanded promotion/retag test coverage for digest-based resolution, post-copy verification mismatches, missing-tag behavior, and transient registry failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->