### PR TITLE
chore(release): don't activate kubernetes-nodes on the release-1.6 line

### DIFF
--- a/packages/core/platform/templates/bundles/iaas.yaml
+++ b/packages/core/platform/templates/bundles/iaas.yaml
@@ -157,7 +157,6 @@
 {{include "cozystack.platform.package.default" (list "cozystack.capi-provider-infra-kubevirt" $) }}
 {{include "cozystack.platform.package.default" (list "cozystack.bucket-application" $) }}
 {{include "cozystack.platform.package" (list "cozystack.kubernetes-application" "kubevirt" $) }}
-{{include "cozystack.platform.package" (list "cozystack.kubernetes-nodes-application" "kubevirt" $) }}
 {{include "cozystack.platform.package" (list "cozystack.virtualprivatecloud-application" "kubevirt" $) }}
 {{include "cozystack.platform.package" (list "cozystack.vm-disk-application" "kubevirt" $) }}
 {{include "cozystack.platform.package" (list "cozystack.vm-instance-application" "kubevirt" $) }}


### PR DESCRIPTION
## What this changes

`kubernetes-nodes` is not ready to launch on the 1.6 line yet, so this removes its single include from the `iaas` platform bundle (`packages/core/platform/templates/bundles/iaas.yaml`). The platform stops activating the package while it still ships in the release; the line comes back when the feature is ready.

## Scope

One line removed, nothing else. The `kubernetes-nodes` app package, its API types (`api/apps/v1alpha1/kubernetesnodes`), and the `kubernetes-nodes-rd` system package are all kept intact — this deactivates the feature, it does not delete it.

```release-note
NONE
```
