### PR TITLE
feat(tenant): allow egress to vlinsert in parent tenants

### DIFF
--- a/packages/apps/tenant/templates/networkpolicy.yaml
+++ b/packages/apps/tenant/templates/networkpolicy.yaml
@@ -52,7 +52,20 @@ spec:
     {{- end }}
     {{- end }}
     {{- end }}
-  {{- end }}    
+  {{- end }}
+  {{- if ne (include "tenant.name" .) "tenant-root" }}
+  - toEndpoints:
+    {{- if hasPrefix "tenant-" .Release.Namespace }}
+    {{- $parts := splitList "-" .Release.Namespace }}
+    {{- range $i, $v := $parts }}
+    {{- if ne $i 0 }}
+    - matchLabels:
+        "k8s:app.kubernetes.io/name": "vlinsert"
+        "k8s:io.kubernetes.pod.namespace": {{ join "-" (slice $parts 0 (add $i 1)) }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
   {{- if ne (include "tenant.name" .) "tenant-root" }}
   - toEndpoints:
     {{- if hasPrefix "tenant-" .Release.Namespace }}

--- a/packages/apps/tenant/tests/networkpolicy_egress_test.yaml
+++ b/packages/apps/tenant/tests/networkpolicy_egress_test.yaml
@@ -1,0 +1,77 @@
+suite: tenant egress to ancestor observability ingest
+# The <tenant>-egress CiliumClusterwideNetworkPolicy (networkpolicy.yaml)
+# opens child-tenant egress to a fixed set of ancestor-namespace services:
+# vminsert (VictoriaMetrics ingest), vlinsert (VictoriaLogs ingest), etcd,
+# and ingress controllers. A child tenant running monitoring-agents relies
+# on these allowances to ship metrics and container logs up to a parent
+# tenant's observability stack with no hand-edited CCNP.
+#
+# vlinsert is a security boundary: it is an allow rule on a clusterwide
+# policy, so a silent template regression would quietly cut a child
+# tenant's log delivery (observed as fluent-bit "no upstream connections
+# available", with the drop invisible downstream because the packet never
+# leaves the source node). Pin it here alongside vminsert so neither block
+# can disappear or drift its selector unnoticed.
+#
+# The ancestor namespace is derived from the release namespace by a pure
+# splitList/join walk (no cluster lookup), so helm-unittest renders it
+# offline. Depth-2 child tenant-htdev in namespace tenant-ktj resolves its
+# single ancestor to tenant-ktj.
+templates:
+  - templates/networkpolicy.yaml
+set:
+  _cluster:
+    root-host: example.com
+tests:
+  - it: child tenant egress allows vlinsert and vminsert in the parent namespace
+    release:
+      name: tenant-htdev
+      namespace: tenant-ktj
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: tenant-ktj-htdev-egress
+        contains:
+          path: spec.egress
+          content:
+            toEndpoints:
+              - matchLabels:
+                  "k8s:app.kubernetes.io/name": "vlinsert"
+                  "k8s:io.kubernetes.pod.namespace": tenant-ktj
+      - documentSelector:
+          path: metadata.name
+          value: tenant-ktj-htdev-egress
+        contains:
+          path: spec.egress
+          content:
+            toEndpoints:
+              - matchLabels:
+                  "k8s:app.kubernetes.io/name": "vminsert"
+                  "k8s:io.kubernetes.pod.namespace": tenant-ktj
+
+  - it: root tenant egress emits no ancestor ingest blocks
+    # The `ne (include "tenant.name" .) "tenant-root"` guard must suppress
+    # every ancestor-egress block for the root tenant, which has no ancestor
+    # to reach. Its egress list carries only the self-namespace allow, so a
+    # broken guard (which would emit vlinsert scoped to tenant-root) is
+    # caught both by the explicit notContains and by the exact length pin.
+    release:
+      name: tenant-root
+      namespace: tenant-root
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: tenant-root-egress
+        notContains:
+          path: spec.egress
+          content:
+            toEndpoints:
+              - matchLabels:
+                  "k8s:app.kubernetes.io/name": "vlinsert"
+                  "k8s:io.kubernetes.pod.namespace": tenant-root
+      - documentSelector:
+          path: metadata.name
+          value: tenant-root-egress
+        lengthEqual:
+          path: spec.egress
+          count: 1


### PR DESCRIPTION
## Summary

Tenant egress `CiliumClusterwideNetworkPolicy` already permits child tenants to reach `vminsert` (VictoriaMetrics ingest) and `etcd` and ingress controllers in any ancestor namespace. `vlinsert` (VictoriaLogs ingest) was missing — so a child tenant that runs its own `monitoring-agents` cannot forward container logs to a parent tenant's VictoriaLogs.

Mirrors the existing `vminsert` block.

## Problem statement

In a chain `tenant-root → tenant-a → tenant-a-b`, the `tenant-a-b` tenant's fluent-bit (deployed via `monitoring-agents`) tries to POST to `vlinsert-generic.tenant-a.svc:9481` (parent's VictoriaLogs). The current `tenant-a-b-egress` CCNP only allows egress to ancestor namespaces for `vminsert` / `etcd` / `ingress`-labelled endpoints. Connections to `vlinsert` are dropped at L4 by Cilium.

Observable as `no upstream connections available` errors in fluent-bit, with no visible drops anywhere downstream — the dropped packets never leave the source node.

## Change

Add a third `toEndpoints` block matching `app.kubernetes.io/name: vlinsert` in any ancestor namespace, identical in structure to the existing `vminsert` block.

## Test plan

- [x] `helm template packages/apps/tenant` for a child tenant — verify the new block appears.
- [ ] Real-world: deploy a `kubernetes` app inside a tenant with `addons.monitoringAgents.enabled: true`; verify fluent-bit logs reach the parent tenant's VictoriaLogs without manual CCNP additions.

## Notes

The same `splitList "-"` pattern is used as in the surrounding blocks, which assumes the parent name encodes the full hierarchy via dashes — that ancestor-walk bug is tracked separately in #2810 / #2171 and is intentionally not touched here to keep this PR minimal.

## Release note

```release-note
feat(tenant): allow child tenants running monitoring-agents to forward container logs to a parent tenant's VictoriaLogs (vlinsert) without manual CiliumClusterwideNetworkPolicy edits
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tenant network policy egress rules to correctly match tenant-scoped insert pods in ancestor-tenant scenarios.
  * Improved targeting of insert pods for non-root tenant environments to keep expected connectivity behavior consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->