### PR TITLE
feat(workloadmonitor): bucket metrics endpoint override

### DIFF
--- a/cmd/cozystack-controller/main.go
+++ b/cmd/cozystack-controller/main.go
@@ -87,6 +87,7 @@ func main() {
 	var telemetryEndpoint string
 	var telemetryInterval string
 	var quotaBufferPercent int64
+	var seaweedfsMetricsEndpoint string
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -106,6 +107,10 @@ func main() {
 		"Interval between telemetry data collection (e.g. 15m, 1h)")
 	flag.Int64Var(&quotaBufferPercent, "tenant-quota-buffer-percent", 0,
 		"Temporary buffer (e.g. 130 = +30%) added to every hierarchical tenant quota pool so workloads already over a freshly-introduced quota keep running during rollout. 0 disables it.")
+	flag.StringVar(&seaweedfsMetricsEndpoint, "seaweedfs-metrics-endpoint", "",
+		"Base URL of a Prometheus-compatible query API to fetch SeaweedFS bucket size metrics from, e.g. https://vm.example.com/path/to/prometheus (/api/v1/query is appended). "+
+			"Overrides discovery via the namespace.cozystack.io/monitoring label; use when SeaweedFS and the monitoring stack that scrapes it run in a separate cluster. "+
+			"Basic auth may be embedded as userinfo (https://user:pass@host/...). Empty keeps label-based discovery.")
 	opts := zap.Options{
 		Development: false,
 	}
@@ -117,6 +122,16 @@ func main() {
 	if err != nil {
 		setupLog.Error(err, "invalid telemetry interval")
 		os.Exit(1)
+	}
+
+	// Validate and normalize the SeaweedFS metrics endpoint override; the sizes
+	// it serves feed billing, so a malformed URL must fail startup, not queries.
+	if seaweedfsMetricsEndpoint != "" {
+		seaweedfsMetricsEndpoint, err = controller.ParseMetricsEndpointURL(seaweedfsMetricsEndpoint)
+		if err != nil {
+			setupLog.Error(err, "invalid --seaweedfs-metrics-endpoint")
+			os.Exit(1)
+		}
 	}
 
 	// Configure telemetry
@@ -218,8 +233,10 @@ func main() {
 	}
 
 	if err = (&controller.WorkloadMonitorReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:                   mgr.GetClient(),
+		Scheme:                   mgr.GetScheme(),
+		Recorder:                 mgr.GetEventRecorderFor("workloadmonitor-controller"),
+		SeaweedfsMetricsEndpoint: seaweedfsMetricsEndpoint,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "WorkloadMonitor")
 		os.Exit(1)

--- a/internal/controller/workloadmonitor_controller.go
+++ b/internal/controller/workloadmonitor_controller.go
@@ -15,6 +15,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -45,6 +46,9 @@ const (
 	vmSelectService = "vmselect-shortterm"
 	vmSelectPort    = "8481"
 	vmSelectPath    = "/select/0/prometheus"
+	// Resource keys reported on bucket Workloads.
+	resourceS3StorageBytes         = "s3-storage-bytes"
+	resourceS3PhysicalStorageBytes = "s3-physical-storage-bytes"
 )
 
 // prometheusHTTPClient is a dedicated HTTP client for Prometheus queries,
@@ -54,7 +58,14 @@ var prometheusHTTPClient = &http.Client{Timeout: 10 * time.Second}
 // WorkloadMonitorReconciler reconciles a WorkloadMonitor object
 type WorkloadMonitorReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+	// SeaweedfsMetricsEndpoint, when non-empty, is the base URL of the
+	// Prometheus-compatible query API to fetch SeaweedFS bucket size metrics
+	// from, instead of discovering the monitoring stack via the
+	// namespace.cozystack.io/monitoring label. Used when SeaweedFS and the
+	// stack that scrapes it run outside this cluster.
+	SeaweedfsMetricsEndpoint string
 }
 
 // +kubebuilder:rbac:groups=cozystack.io,resources=workloadmonitors,verbs=get;list;watch;create;update;patch;delete
@@ -64,6 +75,7 @@ type WorkloadMonitorReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=objectstorage.k8s.io,resources=bucketclaims,verbs=get;list;watch
 
 // isBucketClaimReady checks if the BucketClaim has been provisioned.
@@ -135,21 +147,49 @@ func updateOwnerReferences(obj metav1.Object, monitor client.Object) {
 	obj.SetOwnerReferences(owners)
 }
 
+// ParseMetricsEndpointURL validates an administrator-supplied metrics endpoint
+// URL and normalizes it to a base without a trailing slash, so that appending
+// /api/v1/query never doubles or drops a slash. Userinfo is allowed: net/http
+// turns it into basic auth on every request.
+func ParseMetricsEndpointURL(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return "", fmt.Errorf("scheme must be http or https, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("URL must be absolute with a host")
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("URL must not carry a query string or fragment")
+	}
+	return strings.TrimRight(u.String(), "/"), nil
+}
+
 // resolvePrometheusURL returns the Prometheus-compatible API base URL for the given namespace.
-// It reads the namespace.cozystack.io/monitoring label to find the monitoring namespace,
-// then constructs the vmselect URL. Returns empty string if monitoring is not configured.
-func (r *WorkloadMonitorReconciler) resolvePrometheusURL(ctx context.Context, namespace string) string {
-	logger := log.FromContext(ctx)
+// The SeaweedfsMetricsEndpoint override, when configured, takes precedence; otherwise the
+// namespace.cozystack.io/monitoring label names the monitoring namespace and the well-known
+// vmselect URL inside it is constructed. Returns empty string if monitoring is not configured.
+func (r *WorkloadMonitorReconciler) resolvePrometheusURL(ctx context.Context, namespace string) (string, error) {
+	if r.SeaweedfsMetricsEndpoint != "" {
+		return r.SeaweedfsMetricsEndpoint, nil
+	}
 	ns := &corev1.Namespace{}
 	if err := r.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
-		logger.V(1).Info("Failed to read namespace for monitoring resolution", "namespace", namespace, "error", err)
-		return ""
+		// The namespace is the monitor's own, so NotFound only happens while
+		// it is being deleted; there is no monitoring to resolve then.
+		if apierrors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("reading namespace %s: %w", namespace, err)
 	}
 	monitoringNS := ns.Labels[namespaceMonitoringLabel]
 	if monitoringNS == "" {
-		return ""
+		return "", nil
 	}
-	return fmt.Sprintf("http://%s.%s.svc:%s%s", vmSelectService, monitoringNS, vmSelectPort, vmSelectPath)
+	return fmt.Sprintf("http://%s.%s.svc:%s%s", vmSelectService, monitoringNS, vmSelectPort, vmSelectPath), nil
 }
 
 // bucketMetrics holds size metrics for a single bucket, keyed by metric name.
@@ -164,18 +204,21 @@ type bucketMetrics struct {
 // bucket names in a single Prometheus query and returns them keyed by bucket
 // name. The query is scoped to only the requested buckets to avoid fetching
 // metrics for buckets belonging to other WorkloadMonitors.
-func (r *WorkloadMonitorReconciler) queryAllBucketMetrics(ctx context.Context, prometheusBaseURL string, bucketNames []string) map[string]*bucketMetrics {
+//
+// Any failure to obtain a well-formed answer is returned as an error, never as
+// an empty result: the sizes feed billing, and the caller must be able to tell
+// "the endpoint said the bucket is empty" apart from "the endpoint could not
+// be queried".
+func (r *WorkloadMonitorReconciler) queryAllBucketMetrics(ctx context.Context, prometheusBaseURL string, bucketNames []string) (map[string]*bucketMetrics, error) {
 	result := make(map[string]*bucketMetrics)
 	if prometheusBaseURL == "" || len(bucketNames) == 0 {
-		return result
+		return result, nil
 	}
-	logger := log.FromContext(ctx)
 
 	query := fmt.Sprintf(`{__name__=~"SeaweedFS_s3_bucket_(size|physical_size)_bytes",bucket=~"%s"}`, strings.Join(bucketNames, "|"))
 	u, err := url.Parse(strings.TrimRight(prometheusBaseURL, "/") + "/api/v1/query")
 	if err != nil {
-		logger.Error(err, "Failed to parse Prometheus URL")
-		return result
+		return nil, fmt.Errorf("parsing Prometheus URL: %w", err)
 	}
 	u.RawQuery = url.Values{"query": {query}}.Encode()
 
@@ -184,26 +227,22 @@ func (r *WorkloadMonitorReconciler) queryAllBucketMetrics(ctx context.Context, p
 
 	req, err := http.NewRequestWithContext(httpCtx, http.MethodGet, u.String(), nil)
 	if err != nil {
-		logger.Error(err, "Failed to create Prometheus request")
-		return result
+		return nil, fmt.Errorf("creating Prometheus request: %w", err)
 	}
 
 	resp, err := prometheusHTTPClient.Do(req)
 	if err != nil {
-		logger.V(1).Info("Failed to query Prometheus for bucket metrics", "error", err)
-		return result
+		return nil, fmt.Errorf("querying Prometheus: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		logger.V(1).Info("Prometheus returned non-OK status for bucket metrics", "status", resp.StatusCode)
-		return result
+		return nil, fmt.Errorf("Prometheus returned status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
 	if err != nil {
-		logger.Error(err, "Failed to read Prometheus response")
-		return result
+		return nil, fmt.Errorf("reading Prometheus response: %w", err)
 	}
 
 	var promResp struct {
@@ -216,11 +255,10 @@ func (r *WorkloadMonitorReconciler) queryAllBucketMetrics(ctx context.Context, p
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(body, &promResp); err != nil {
-		logger.Error(err, "Failed to parse Prometheus response")
-		return result
+		return nil, fmt.Errorf("parsing Prometheus response: %w", err)
 	}
 	if promResp.Status != "success" {
-		return result
+		return nil, fmt.Errorf("Prometheus query finished with status %q", promResp.Status)
 	}
 
 	for _, r := range promResp.Data.Result {
@@ -255,7 +293,7 @@ func (r *WorkloadMonitorReconciler) queryAllBucketMetrics(ctx context.Context, p
 		}
 	}
 
-	return result
+	return result, nil
 }
 
 // reconcileBucketClaimForMonitor creates or updates a Workload object for the given BucketClaim and WorkloadMonitor.
@@ -274,20 +312,6 @@ func (r *WorkloadMonitorReconciler) reconcileBucketClaimForMonitor(
 		},
 	}
 
-	resources := make(map[string]resource.Quantity)
-
-	// Look up pre-fetched bucket metrics by the SeaweedFS bucket name.
-	// bc.Status.BucketName is the COSI Bucket name, which the COSI driver
-	// uses directly as the SeaweedFS bucket name.
-	if bm, ok := allMetrics[bc.Status.BucketName]; ok {
-		if bm.HasLogical {
-			resources["s3-storage-bytes"] = *resource.NewQuantity(bm.LogicalSize, resource.BinarySI)
-		}
-		if bm.HasPhysical {
-			resources["s3-physical-storage-bytes"] = *resource.NewQuantity(bm.PhysicalSize, resource.BinarySI)
-		}
-	}
-
 	monitorLabels := r.getMonitorLabels(monitor)
 	_, err := ctrl.CreateOrUpdate(ctx, r.Client, workload, func() error {
 		updateOwnerReferences(workload.GetObjectMeta(), &bc)
@@ -303,6 +327,29 @@ func (r *WorkloadMonitorReconciler) reconcileBucketClaimForMonitor(
 			workload.Labels[k] = v
 		}
 		workload.Labels[workloadMonitorLabel] = monitor.Name
+
+		// Start from the sizes already recorded on the Workload: when the
+		// metrics endpoint is unreachable or reports nothing for this bucket,
+		// the last known good values must survive rather than collapse to
+		// "no size", which billing would read as an empty bucket.
+		resources := make(map[string]resource.Quantity)
+		for _, key := range []string{resourceS3StorageBytes, resourceS3PhysicalStorageBytes} {
+			if q, ok := workload.Status.Resources[key]; ok {
+				resources[key] = q
+			}
+		}
+
+		// Look up pre-fetched bucket metrics by the SeaweedFS bucket name.
+		// bc.Status.BucketName is the COSI Bucket name, which the COSI driver
+		// uses directly as the SeaweedFS bucket name.
+		if bm, ok := allMetrics[bc.Status.BucketName]; ok {
+			if bm.HasLogical {
+				resources[resourceS3StorageBytes] = *resource.NewQuantity(bm.LogicalSize, resource.BinarySI)
+			}
+			if bm.HasPhysical {
+				resources[resourceS3PhysicalStorageBytes] = *resource.NewQuantity(bm.PhysicalSize, resource.BinarySI)
+			}
+		}
 
 		workload.Status.Kind = monitor.Spec.Kind
 		workload.Status.Type = monitor.Spec.Type
@@ -628,15 +675,31 @@ func (r *WorkloadMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
+	var bucketMetricsErr error
 	if len(bucketClaimList.Items) > 0 {
-		bucketPromURL := r.resolvePrometheusURL(ctx, monitor.Namespace)
 		var bucketNames []string
 		for _, bc := range bucketClaimList.Items {
 			if bc.Status.BucketName != "" {
 				bucketNames = append(bucketNames, bc.Status.BucketName)
 			}
 		}
-		allBucketMetrics := r.queryAllBucketMetrics(ctx, bucketPromURL, bucketNames)
+		var allBucketMetrics map[string]*bucketMetrics
+		bucketPromURL, err := r.resolvePrometheusURL(ctx, monitor.Namespace)
+		if err == nil {
+			allBucketMetrics, err = r.queryAllBucketMetrics(ctx, bucketPromURL, bucketNames)
+		}
+		if err != nil {
+			// Never let a metrics failure degrade into "bucket size = 0":
+			// the Workloads below are still reconciled, but they keep their
+			// last known sizes, and the failure is surfaced via an event,
+			// the log, and the returned error.
+			bucketMetricsErr = fmt.Errorf("fetching bucket size metrics: %w", err)
+			logger.Error(bucketMetricsErr, "Retaining last known bucket sizes", "monitor", monitor.Name)
+			if r.Recorder != nil {
+				r.Recorder.Eventf(monitor, corev1.EventTypeWarning, "BucketMetricsUnavailable",
+					"Failed to fetch bucket size metrics, retaining last known values: %v", err)
+			}
+		}
 		for _, bc := range bucketClaimList.Items {
 			if err := r.reconcileBucketClaimForMonitor(ctx, monitor, bc, allBucketMetrics); err != nil {
 				logger.Error(err, "Failed to reconcile Workload for BucketClaim", "BucketClaim", bc.Name)
@@ -670,6 +733,13 @@ func (r *WorkloadMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	if err != nil {
 		logger.Error(err, "unable to update WorkloadMonitor status after retries")
 		return ctrl.Result{}, err
+	}
+
+	// Returning the metrics error makes the failure count in controller-runtime's
+	// reconcile error metrics and retries with backoff instead of quietly waiting
+	// for the next periodic requeue.
+	if bucketMetricsErr != nil {
+		return ctrl.Result{}, bucketMetricsErr
 	}
 
 	// Requeue periodically if there are BucketClaims to keep sizes up to date.

--- a/internal/controller/workloadmonitor_controller_test.go
+++ b/internal/controller/workloadmonitor_controller_test.go
@@ -10,6 +10,7 @@ import (
 
 	cozyv1alpha1 "github.com/cozystack/cozystack/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -660,7 +661,10 @@ func TestQueryAllBucketMetrics(t *testing.T) {
 	defer srv.Close()
 
 	reconciler := &WorkloadMonitorReconciler{}
-	metrics := reconciler.queryAllBucketMetrics(context.TODO(), srv.URL, []string{"bucket-aaa", "bucket-bbb"})
+	metrics, err := reconciler.queryAllBucketMetrics(context.TODO(), srv.URL, []string{"bucket-aaa", "bucket-bbb"})
+	if err != nil {
+		t.Fatalf("queryAllBucketMetrics returned error: %v", err)
+	}
 
 	bm, ok := metrics["bucket-aaa"]
 	if !ok {
@@ -692,7 +696,10 @@ func TestQueryAllBucketMetricsEmpty(t *testing.T) {
 	defer srv.Close()
 
 	reconciler := &WorkloadMonitorReconciler{}
-	metrics := reconciler.queryAllBucketMetrics(context.TODO(), srv.URL, []string{"bucket-aaa", "bucket-bbb"})
+	metrics, err := reconciler.queryAllBucketMetrics(context.TODO(), srv.URL, []string{"bucket-aaa", "bucket-bbb"})
+	if err != nil {
+		t.Fatalf("queryAllBucketMetrics returned error: %v", err)
+	}
 	if len(metrics) != 0 {
 		t.Errorf("expected empty metrics, got %d", len(metrics))
 	}
@@ -705,21 +712,84 @@ func TestQueryAllBucketMetricsServerError(t *testing.T) {
 	defer srv.Close()
 
 	reconciler := &WorkloadMonitorReconciler{}
-	metrics := reconciler.queryAllBucketMetrics(context.TODO(), srv.URL, []string{"bucket-aaa", "bucket-bbb"})
-	if len(metrics) != 0 {
-		t.Errorf("expected empty metrics on error, got %d", len(metrics))
+	_, err := reconciler.queryAllBucketMetrics(context.TODO(), srv.URL, []string{"bucket-aaa", "bucket-bbb"})
+	if err == nil {
+		t.Error("expected error on server failure, got nil")
 	}
 }
 
 func TestQueryAllBucketMetricsNoURL(t *testing.T) {
 	reconciler := &WorkloadMonitorReconciler{}
-	metrics := reconciler.queryAllBucketMetrics(context.TODO(), "", nil)
+	metrics, err := reconciler.queryAllBucketMetrics(context.TODO(), "", nil)
+	if err != nil {
+		t.Fatalf("queryAllBucketMetrics returned error: %v", err)
+	}
 	if len(metrics) != 0 {
 		t.Errorf("expected empty metrics when URL is empty, got %d", len(metrics))
 	}
 }
 
-func TestResolvePrometheusURL(t *testing.T) {
+func TestQueryAllBucketMetricsPathPrefixAndUserinfo(t *testing.T) {
+	var gotPath, gotUser, gotPass string
+	var gotOK bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotUser, gotPass, gotOK = r.BasicAuth()
+		fmt.Fprint(w, `{"status":"success","data":{"resultType":"vector","result":[]}}`)
+	}))
+	defer srv.Close()
+
+	reconciler := &WorkloadMonitorReconciler{}
+	// Trailing slash on the base URL must not produce a double slash before
+	// /api/v1/query, and userinfo must arrive as basic auth.
+	baseURL := strings.Replace(srv.URL, "http://", "http://billing:hunter2@", 1) + "/path/to/prometheus/"
+	if _, err := reconciler.queryAllBucketMetrics(context.TODO(), baseURL, []string{"bucket-aaa"}); err != nil {
+		t.Fatalf("queryAllBucketMetrics returned error: %v", err)
+	}
+
+	if gotPath != "/path/to/prometheus/api/v1/query" {
+		t.Errorf("expected path prefix preserved, got %q", gotPath)
+	}
+	if !gotOK || gotUser != "billing" || gotPass != "hunter2" {
+		t.Errorf("expected basic auth billing/hunter2 from userinfo, got %q/%q ok=%v", gotUser, gotPass, gotOK)
+	}
+}
+
+func TestParseMetricsEndpointURL(t *testing.T) {
+	valid := map[string]string{
+		"https://vm.example.com":                       "https://vm.example.com",
+		"https://vm.example.com/":                      "https://vm.example.com",
+		"https://vm.example.com:8427/vm/prometheus":    "https://vm.example.com:8427/vm/prometheus",
+		"https://user:pass@vm.example.com/prometheus":  "https://user:pass@vm.example.com/prometheus",
+		"http://vm.example.com/select/0/prometheus///": "http://vm.example.com/select/0/prometheus",
+	}
+	for raw, want := range valid {
+		got, err := ParseMetricsEndpointURL(raw)
+		if err != nil {
+			t.Errorf("ParseMetricsEndpointURL(%q) returned error: %v", raw, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("ParseMetricsEndpointURL(%q) = %q, want %q", raw, got, want)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"vm.example.com/prometheus",
+		"ftp://vm.example.com",
+		"https://",
+		"https://vm.example.com/prometheus?query=up",
+		"https://vm.example.com/prometheus#frag",
+	}
+	for _, raw := range invalid {
+		if got, err := ParseMetricsEndpointURL(raw); err == nil {
+			t.Errorf("ParseMetricsEndpointURL(%q) = %q, want error", raw, got)
+		}
+	}
+}
+
+func TestResolvePrometheusURLFromLabel(t *testing.T) {
 	s := newTestScheme()
 
 	ns := &corev1.Namespace{
@@ -737,7 +807,10 @@ func TestResolvePrometheusURL(t *testing.T) {
 		Build()
 
 	reconciler := &WorkloadMonitorReconciler{Client: fakeClient, Scheme: s}
-	url := reconciler.resolvePrometheusURL(context.TODO(), "tenant-demo")
+	url, err := reconciler.resolvePrometheusURL(context.TODO(), "tenant-demo")
+	if err != nil {
+		t.Fatalf("resolvePrometheusURL returned error: %v", err)
+	}
 
 	expected := "http://vmselect-shortterm.tenant-root.svc:8481/select/0/prometheus"
 	if url != expected {
@@ -760,10 +833,45 @@ func TestResolvePrometheusURLNoLabel(t *testing.T) {
 		Build()
 
 	reconciler := &WorkloadMonitorReconciler{Client: fakeClient, Scheme: s}
-	url := reconciler.resolvePrometheusURL(context.TODO(), "tenant-demo")
+	url, err := reconciler.resolvePrometheusURL(context.TODO(), "tenant-demo")
+	if err != nil {
+		t.Fatalf("resolvePrometheusURL returned error: %v", err)
+	}
 
 	if url != "" {
 		t.Errorf("expected empty URL when no monitoring label, got %q", url)
+	}
+}
+
+func TestResolvePrometheusURLEndpointOverrideWinsOverLabel(t *testing.T) {
+	s := newTestScheme()
+
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tenant-demo",
+			Labels: map[string]string{
+				"namespace.cozystack.io/monitoring": "tenant-root",
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(ns).
+		Build()
+
+	reconciler := &WorkloadMonitorReconciler{
+		Client:                   fakeClient,
+		Scheme:                   s,
+		SeaweedfsMetricsEndpoint: "https://vm.example.com/path/to/prometheus",
+	}
+	url, err := reconciler.resolvePrometheusURL(context.TODO(), "tenant-demo")
+	if err != nil {
+		t.Fatalf("resolvePrometheusURL returned error: %v", err)
+	}
+
+	if url != "https://vm.example.com/path/to/prometheus" {
+		t.Errorf("expected the endpoint override to win over label discovery, got %q", url)
 	}
 }
 
@@ -844,5 +952,217 @@ func TestReconcileBucketClaimRequeuesWhenBucketsExist(t *testing.T) {
 	}
 	if len(workload.Status.Resources) != 0 {
 		t.Errorf("expected empty resources without monitoring, got %v", workload.Status.Resources)
+	}
+}
+
+// newBucketFixture returns a plain namespace, a bucket WorkloadMonitor, and a
+// ready BucketClaim named my-bucket whose SeaweedFS bucket is cosi-abc123.
+func newBucketFixture() (*corev1.Namespace, *cozyv1alpha1.WorkloadMonitor, *cosiv1alpha1.BucketClaim) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "tenant-demo",
+		},
+	}
+	monitor := &cozyv1alpha1.WorkloadMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-bucket",
+			Namespace: "tenant-demo",
+		},
+		Spec: cozyv1alpha1.WorkloadMonitorSpec{
+			Kind: "bucket",
+			Type: "s3",
+			Selector: map[string]string{
+				"app.kubernetes.io/instance": "my-bucket",
+			},
+		},
+	}
+	bc := &cosiv1alpha1.BucketClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-bucket",
+			Namespace: "tenant-demo",
+			Labels: map[string]string{
+				"app.kubernetes.io/instance": "my-bucket",
+			},
+		},
+		Spec: cosiv1alpha1.BucketClaimSpec{
+			BucketClassName: "seaweedfs",
+			Protocols:       []cosiv1alpha1.Protocol{cosiv1alpha1.ProtocolS3},
+		},
+		Status: cosiv1alpha1.BucketClaimStatus{
+			BucketReady: true,
+			BucketName:  "cosi-abc123",
+		},
+	}
+	return ns, monitor, bc
+}
+
+func TestReconcileBucketMetricsFromEndpointOverride(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/vm/select/0/prometheus/api/v1/query" {
+			t.Errorf("unexpected query path %q", r.URL.Path)
+		}
+		fmt.Fprint(w, `{"status":"success","data":{"resultType":"vector","result":[
+			{"metric":{"__name__":"SeaweedFS_s3_bucket_size_bytes","bucket":"cosi-abc123"},"value":[1713000000,"4096"]}
+		]}}`)
+	}))
+	defer srv.Close()
+
+	s := newTestScheme()
+	ns, monitor, bc := newBucketFixture()
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(ns, monitor, bc).
+		WithStatusSubresource(monitor).
+		Build()
+
+	reconciler := &WorkloadMonitorReconciler{
+		Client:                   fakeClient,
+		Scheme:                   s,
+		SeaweedfsMetricsEndpoint: srv.URL + "/vm/select/0/prometheus",
+	}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{
+		Name:      "my-bucket",
+		Namespace: "tenant-demo",
+	}}
+	if _, err := reconciler.Reconcile(context.TODO(), req); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	workload := &cozyv1alpha1.Workload{}
+	if err := fakeClient.Get(context.TODO(), types.NamespacedName{
+		Name:      "bucket-my-bucket",
+		Namespace: "tenant-demo",
+	}, workload); err != nil {
+		t.Fatalf("Failed to get Workload: %v", err)
+	}
+
+	q, ok := workload.Status.Resources["s3-storage-bytes"]
+	if !ok {
+		t.Fatal("expected s3-storage-bytes from the overridden endpoint")
+	}
+	if q.Value() != 4096 {
+		t.Errorf("expected s3-storage-bytes=4096, got %d", q.Value())
+	}
+}
+
+func TestReconcileRetainsLastKnownSizesOnQueryFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	s := newTestScheme()
+	ns, monitor, bc := newBucketFixture()
+
+	// A Workload from a previous successful reconcile already carries sizes.
+	workload := &cozyv1alpha1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bucket-my-bucket",
+			Namespace: "tenant-demo",
+		},
+		Status: cozyv1alpha1.WorkloadStatus{
+			Kind: "bucket",
+			Type: "s3",
+			Resources: map[string]resource.Quantity{
+				"s3-storage-bytes":          *resource.NewQuantity(4096, resource.BinarySI),
+				"s3-physical-storage-bytes": *resource.NewQuantity(8192, resource.BinarySI),
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(ns, monitor, bc, workload).
+		WithStatusSubresource(monitor).
+		Build()
+
+	reconciler := &WorkloadMonitorReconciler{
+		Client:                   fakeClient,
+		Scheme:                   s,
+		SeaweedfsMetricsEndpoint: srv.URL,
+	}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{
+		Name:      "my-bucket",
+		Namespace: "tenant-demo",
+	}}
+
+	// The failure must be loud: the reconcile returns an error instead of
+	// pretending the buckets are empty.
+	if _, err := reconciler.Reconcile(context.TODO(), req); err == nil {
+		t.Error("expected Reconcile to return an error when the metrics endpoint fails")
+	}
+
+	updated := &cozyv1alpha1.Workload{}
+	if err := fakeClient.Get(context.TODO(), types.NamespacedName{
+		Name:      "bucket-my-bucket",
+		Namespace: "tenant-demo",
+	}, updated); err != nil {
+		t.Fatalf("Failed to get Workload: %v", err)
+	}
+
+	q, ok := updated.Status.Resources["s3-storage-bytes"]
+	if !ok || q.Value() != 4096 {
+		t.Errorf("expected last known s3-storage-bytes=4096 retained, got %v (present=%v)", q.Value(), ok)
+	}
+	qp, ok := updated.Status.Resources["s3-physical-storage-bytes"]
+	if !ok || qp.Value() != 8192 {
+		t.Errorf("expected last known s3-physical-storage-bytes=8192 retained, got %v (present=%v)", qp.Value(), ok)
+	}
+}
+
+func TestReconcileRetainsLastKnownSizesWhenBucketMissingFromResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"status":"success","data":{"resultType":"vector","result":[]}}`)
+	}))
+	defer srv.Close()
+
+	s := newTestScheme()
+	ns, monitor, bc := newBucketFixture()
+
+	workload := &cozyv1alpha1.Workload{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bucket-my-bucket",
+			Namespace: "tenant-demo",
+		},
+		Status: cozyv1alpha1.WorkloadStatus{
+			Kind: "bucket",
+			Type: "s3",
+			Resources: map[string]resource.Quantity{
+				"s3-storage-bytes": *resource.NewQuantity(4096, resource.BinarySI),
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(ns, monitor, bc, workload).
+		WithStatusSubresource(monitor).
+		Build()
+
+	reconciler := &WorkloadMonitorReconciler{
+		Client:                   fakeClient,
+		Scheme:                   s,
+		SeaweedfsMetricsEndpoint: srv.URL,
+	}
+	req := reconcile.Request{NamespacedName: types.NamespacedName{
+		Name:      "my-bucket",
+		Namespace: "tenant-demo",
+	}}
+	if _, err := reconciler.Reconcile(context.TODO(), req); err != nil {
+		t.Fatalf("Reconcile returned error: %v", err)
+	}
+
+	updated := &cozyv1alpha1.Workload{}
+	if err := fakeClient.Get(context.TODO(), types.NamespacedName{
+		Name:      "bucket-my-bucket",
+		Namespace: "tenant-demo",
+	}, updated); err != nil {
+		t.Fatalf("Failed to get Workload: %v", err)
+	}
+
+	q, ok := updated.Status.Resources["s3-storage-bytes"]
+	if !ok || q.Value() != 4096 {
+		t.Errorf("expected last known s3-storage-bytes=4096 retained when series is absent, got %v (present=%v)", q.Value(), ok)
 	}
 }

--- a/packages/system/cozystack-controller/templates/deployment.yaml
+++ b/packages/system/cozystack-controller/templates/deployment.yaml
@@ -27,3 +27,6 @@ spec:
         {{- if .Values.cozystackController.disableTelemetry }}
         - --disable-telemetry
         {{- end }}
+        {{- with .Values.cozystackController.seaweedfsMetricsEndpoint }}
+        - --seaweedfs-metrics-endpoint={{ . }}
+        {{- end }}

--- a/packages/system/cozystack-controller/values.yaml
+++ b/packages/system/cozystack-controller/values.yaml
@@ -2,3 +2,8 @@ cozystackController:
   image: ghcr.io/cozystack/cozystack/cozystack-controller:v1.6.0@sha256:b01f6fe6e8fe6426b112fbda2b4abac946b4e45cd118137c9001c9e6ee784b3d
   debug: false
   disableTelemetry: false
+  # Base URL of a Prometheus-compatible query API to fetch SeaweedFS bucket
+  # size metrics from, for deployments where SeaweedFS and the monitoring
+  # stack that scrapes it run in a separate cluster. Empty keeps discovery
+  # via the namespace.cozystack.io/monitoring label.
+  seaweedfsMetricsEndpoint: ""


### PR DESCRIPTION
## What this PR does

The cozystack-controller meters S3 bucket sizes for billing by querying SeaweedFS `SeaweedFS_s3_bucket_(size|physical_size)_bytes` metrics from a VictoriaMetrics vmselect it locates via the `namespace.cozystack.io/monitoring` label on the tenant namespace. That discovery hardcodes the assumption that the monitoring stack scraping SeaweedFS runs in the same cluster. Some deployments host SeaweedFS — API and metrics both — in a separate cluster, so bucket sizes must be fetched from a remote Prometheus-compatible endpoint that discovery can never produce.

### Configuration surface

A single controller flag, `--seaweedfs-metrics-endpoint`, exposed as a chart value:

```yaml
cozystackController:
  seaweedfsMetricsEndpoint: "https://vm.example.com/path/to/prometheus"
```

The value is an arbitrary base URL of a Prometheus-compatible query API — scheme, host, optional port, and an optional path prefix — and the controller appends `/api/v1/query` to it, normalizing slashes so a trailing slash or a path prefix never produces a doubled or dropped slash. Basic auth can be embedded as URL userinfo (`https://user:pass@vm.example.com/...`); net/http turns it into an `Authorization` header on every request. TLS uses the system trust roots; a custom CA or bearer-token support would be a follow-up flag if a deployment needs it. The flag is validated and normalized at startup (absolute URL, http/https, no query string or fragment), so a malformed value fails the rollout instead of failing queries at runtime.

Cluster-wide scope is deliberate: where SeaweedFS and its metrics live is a property of the deployment, not of any tenant, and tenant monitoring stacks keep working and keep being discovered via the `namespace.cozystack.io/monitoring` label for everything else — the flag only redirects the bucket-size queries. Being a deployment argument, it is settable exclusively by platform administrators, so no new writable surface is exposed to tenants. Rejected alternatives: a WorkloadMonitor spec field (bucket monitors are rendered by the tenant-facing bucket chart, so the field would have to travel through tenant-writable values — an SSRF primitive — and it would be near-permanent CRD surface for a deployment-level fact) and per-namespace annotations (per-tenant granularity that nothing needs, plus a second admin-facing configuration mechanism to document and validate).

### Backwards compatibility

Strictly opt-in: with the flag unset — the default — resolution walks the exact same label-discovery path and produces the same vmselect URL. No existing deployment changes behaviour.

### Billing safety: failures no longer collapse to zero

This also fixes a latent billing bug in the existing path: any metrics query failure (endpoint down, non-200, malformed response) produced an empty result map, and the reconciler overwrote `Workload.status.resources` with it — silently wiping the recorded bucket sizes, which billing reads as an empty bucket. Now:

- `queryAllBucketMetrics` returns errors instead of swallowing them into an empty map, so "the bucket is empty" and "the endpoint could not be queried" are distinguishable.
- On failure — and per bucket, when a query succeeds but reports no series for a bucket that previously had a size — the reconciler retains the last known `s3-storage-bytes` and `s3-physical-storage-bytes` values instead of dropping them.
- The failure is surfaced three ways: a `BucketMetricsUnavailable` warning event on the WorkloadMonitor, an error-level log line, and an error returned from `Reconcile`, which lands in controller-runtime's reconcile error metrics for alerting.

Unit tests cover URL validation and path joining, flag-over-discovery precedence, userinfo-based basic auth, and both retention scenarios (query failure and missing series).

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff (controller Go code plus the cozystack-controller chart value and arg plumbing): none of the listed triggers match — no package added or renamed, no CRD, `ApplicationDefinition`, or platform values change, no `hack/` or layout change.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
feat(workloadmonitor): a new --seaweedfs-metrics-endpoint controller flag (chart value cozystackController.seaweedfsMetricsEndpoint) points bucket size metering at an explicit Prometheus-compatible endpoint for deployments where SeaweedFS and its metrics live in a separate cluster; metrics query failures now retain the last known bucket sizes and surface an event and error instead of silently zeroing billing data
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional SeaweedFS metrics endpoint configuration.
  * Metrics endpoint URLs are validated and normalized before use.
  * Added support for endpoint overrides when discovering bucket metrics.
* **Bug Fixes**
  * Preserved previously recorded bucket sizes when metrics are unavailable or incomplete.
  * Metrics failures now trigger retries and visible warning events without blocking other reconciliation.
  * Improved handling of invalid or unsuccessful metrics responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->