### PR TITLE
fix(dashboard): stop requesting offline_access so logout can revoke sessions

### DIFF
--- a/packages/system/dashboard/templates/gatekeeper.yaml
+++ b/packages/system/dashboard/templates/gatekeeper.yaml
@@ -77,7 +77,14 @@ spec:
             - --cookie-secure=true
             - --cookie-secret=$(OAUTH2_PROXY_COOKIE_SECRET)
             - --skip-provider-button
-            - --scope=openid email profile offline_access
+            # No offline_access: that scope makes Keycloak issue an *offline*
+            # refresh token, which is decoupled from the SSO session and is NOT
+            # revoked by logout (end_session). Since oauth2-proxy keeps the
+            # refresh token in the kc-access cookie and silently refreshes it,
+            # a copied cookie would stay valid for the whole offline-session
+            # lifetime (~30d) even after the user logs out. An online refresh
+            # token is bound to the SSO session and is revoked on logout.
+            - --scope=openid email profile
             {{- if eq $oidcInsecureSkipVerify "true" }}
             - --ssl-insecure-skip-verify=true
             {{- end }}

--- a/packages/system/dashboard/templates/keycloakclient.yaml
+++ b/packages/system/dashboard/templates/keycloakclient.yaml
@@ -69,8 +69,11 @@ spec:
   defaultClientScopes:
     - groups
     - kubernetes-client
-  optionalClientScopes:
-    - offline_access
+  # offline_access is intentionally not offered: an offline refresh token
+  # survives logout (see the proxy Deployment's --scope). NB the
+  # keycloak-operator only adds client scopes, so dropping this does not strip
+  # the realm-default offline_access from an already-created client; the proxy
+  # --scope change is what prevents issuance.
   attributes:
     post.logout.redirect.uris: "+"
     client.session.idle.timeout: "86400"

--- a/packages/system/linstor-gui/templates/gatekeeper.yaml
+++ b/packages/system/linstor-gui/templates/gatekeeper.yaml
@@ -89,7 +89,14 @@ spec:
             - --cookie-secure=true
             - --cookie-secret=$(OAUTH2_PROXY_COOKIE_SECRET)
             - --skip-provider-button
-            - --scope=openid email profile groups offline_access
+            # No offline_access: that scope makes Keycloak issue an *offline*
+            # refresh token, which is decoupled from the SSO session and is NOT
+            # revoked by logout (end_session). Since oauth2-proxy keeps the
+            # refresh token in the kc-access cookie and silently refreshes it,
+            # a copied cookie would stay valid for the whole offline-session
+            # lifetime (~30d) even after the user logs out. An online refresh
+            # token is bound to the SSO session and is revoked on logout.
+            - --scope=openid email profile groups
             - --allowed-group=cozystack-cluster-admin
             {{- if eq $oidcInsecureSkipVerify "true" }}
             - --ssl-insecure-skip-verify=true

--- a/packages/system/linstor-gui/templates/keycloakclient.yaml
+++ b/packages/system/linstor-gui/templates/keycloakclient.yaml
@@ -63,8 +63,11 @@ spec:
   webUrl: "https://linstor-gui.{{ $host }}"
   defaultClientScopes:
     - groups
-  optionalClientScopes:
-    - offline_access
+  # offline_access is intentionally not offered: an offline refresh token
+  # survives logout (see the proxy Deployment's --scope). NB the
+  # keycloak-operator only adds client scopes, so dropping this does not strip
+  # the realm-default offline_access from an already-created client; the proxy
+  # --scope change is what prevents issuance.
   attributes:
     post.logout.redirect.uris: "+"
   redirectUris:

--- a/packages/system/linstor-gui/tests/ingress_auth_test.yaml
+++ b/packages/system/linstor-gui/tests/ingress_auth_test.yaml
@@ -127,7 +127,7 @@ tests:
           content: --oidc-issuer-url=https://keycloak.dev10.example.org/realms/cozy
       - contains:
           path: spec.template.spec.containers[0].args
-          content: --scope=openid email profile groups offline_access
+          content: --scope=openid email profile groups
       - contains:
           path: spec.template.spec.containers[0].args
           content: --allowed-group=cozystack-cluster-admin


### PR DESCRIPTION
## What this PR does

The dashboard and linstor-gui auth-proxies (oauth2-proxy) requested the
`offline_access` scope, so Keycloak issued an **offline** refresh token.
oauth2-proxy has no server-side session store: it keeps the refresh token in
the `kc-access` cookie and silently refreshes it (`--cookie-refresh`). An
offline token is decoupled from the SSO session by design, so logout
(`end_session`) does not revoke it. As a result a copied `kc-access` cookie
stayed usable for the whole offline-session lifetime (Keycloak default ~30
days) even after the user logged out — logout did not invalidate it.

This drops `offline_access` from the proxy `--scope` in both packages, so
Keycloak issues an **online** refresh token bound to the SSO session, which
logout revokes. The `offline_access` optional client scope is also removed for
cleanliness (with a note on why).

Scope of the fix:

- `packages/system/dashboard` — proxy `--scope` + optional client scope
- `packages/system/linstor-gui` — proxy `--scope` + optional client scope + ingress auth unittest

The public `kubernetes` OIDC clients (kubectl `oidc-login`) are intentionally
left untouched: `offline_access` is legitimate there and those clients do not
sit behind oauth2-proxy.

Notes:

- The keycloak-operator only *adds* client scopes, so removing the optional
  scope does not strip the realm-default `offline_access` from an
  already-created client. The proxy `--scope` change is what actually prevents
  issuance.
- This prevents *new* offline tokens. Offline sessions already issued to
  existing users remain valid until the realm's offline-session idle timeout
  (~30d) or explicit revocation via the Keycloak Admin REST API / Account
  Console.
- After this change dashboard session lifetime is governed by the online SSO
  session (`client.session.idle.timeout` / `client.session.max.lifespan`).

### Screenshots

Not applicable — no UI change (auth-proxy OIDC scope only).

### Downstream repositories

Walked the trigger map against the diff: the change touches only helm templates
and a unittest under `packages/system/dashboard` and `packages/system/linstor-gui`.
No downstream repository restates the auth-proxy OIDC scope.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(dashboard): stop requesting the offline_access scope in the dashboard and linstor-gui auth-proxies so that logout revokes the session; a copied kc-access cookie is no longer refreshable after logout. Offline sessions already issued to existing users must be revoked manually via Keycloak.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Removed requests for offline access and persistent refresh tokens from OIDC authentication.
  * Sessions now rely on standard scopes, helping ensure logout invalidates authentication as expected.

* **Tests**
  * Updated authentication checks to verify the revised OIDC scope configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->