### PR TITLE
fix(e2e): disable guest fsync on ephemeral CI VM disks

### DIFF
--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -388,7 +388,7 @@ EOF
   # endpoints (both Kamaji control-plane pods), so a single apiserver pod restart
   # is routed around transparently. `kubectl port-forward` instead pins to one
   # pod and dies when that pod blips: a lone kube-apiserver restart was observed
-  # leaving localhost refusing connections for the entire 12m node-Ready wait
+  # leaving localhost refusing connections for the entire 18m node-Ready wait
   # while the cluster was in fact healthy (CAPI NodeHealthy=True on both nodes),
   # failing the test on a dead tunnel. The LB endpoint is also stable until
   # teardown, so the failure snapshot can still reach the tenant. Test-scoped and
@@ -441,14 +441,30 @@ EOF
   # two budgets starve each other under load: a slow KubeVirt VM boot consumes
   # the join budget, then the tenant cluster's cilium CNI needs several more
   # minutes to make the freshly-joined nodes Ready — overflowing the fixed 3m
-  # Ready window even though the CNI converges fine. One 12m deadline that polls
+  # Ready window even though the CNI converges fine. One deadline that polls
   # for ">=2 nodes Ready" is robust to wherever the time goes.
-  if ! timeout 12m bash -c '
+  #
+  # 18m, not the earlier 12m: this single budget has to absorb the *entire*
+  # worker bring-up, and the `machinedeployment .status.replicas=2` gate above
+  # clears while the KubeVirt VMs are still only Machine objects — the clock
+  # here starts ~2m before the guest VMIs even exist. Under host storage
+  # pressure that margin evaporates: in run 30260770694 a transient
+  # `drbd.linbit.com/lost-quorum` taint delayed the worker DataVolume imports,
+  # the worker VMIs were created ~2m into this wait, and the guests then had
+  # only ~10m to import Talos, boot, register a kubelet and let cilium turn the
+  # nodes Ready. They did not make it: both kubernetes-latest and
+  # kubernetes-previous failed here at exactly 12m with zero Nodes registered
+  # and the tenant cilium HR still mid-install. A less-loaded fleet run passed
+  # the same suites unchanged, so this is load-induced slowness, not a stuck
+  # bring-up; 18m restores margin and still sits well inside the 40m step
+  # timeout (the downstream LB/NFS/ouroboros checks add ~10-15m on the happy
+  # path).
+  if ! timeout 18m bash -c '
     until [ "$(kubectl --kubeconfig tenantkubeconfig-'"${test_name}"' get nodes --no-headers 2>/dev/null | grep -cw Ready)" -ge 2 ]; do
       sleep 5
     done
   '; then
-    # Node-join failed: fewer than 2 tenant nodes became Ready inside the 12m
+    # Node-join failed: fewer than 2 tenant nodes became Ready inside the 18m
     # deadline. Dump scoped diagnostics that split the failure sub-modes, then
     # fail fast — no point running LB/NFS tests without Ready nodes.
     #
@@ -460,7 +476,7 @@ EOF
     # (2b) is the failure mode a follow-up fix has to target, and it cannot be
     # designed without this artifact. Every capture is guarded with `|| true`
     # so a capture failure never masks the real `exit 1`.
-    echo "=== node-join failed: fewer than 2 tenant nodes Ready within 12m — diagnostics follow ==="
+    echo "=== node-join failed: fewer than 2 tenant nodes Ready within 18m — diagnostics follow ==="
     kubectl --kubeconfig "tenantkubeconfig-${test_name}" describe nodes || true
     kubectl -n tenant-test get hr || true
 

--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -100,9 +100,9 @@ EOF
     qemu-system-x86_64 -machine type=pc,accel=kvm -cpu host -smp 8 -m 24576 \
       -device virtio-net,netdev=net0,mac=52:54:00:12:34:5${i} \
       -netdev tap,id=net0,ifname=cozy-srv${i},script=no,downscript=no \
-      -drive file=srv${i}/system.img,if=virtio,format=raw \
-      -drive file=srv${i}/seed.img,if=virtio,format=raw \
-      -drive file=srv${i}/data.img,if=virtio,format=raw \
+      -drive file=srv${i}/system.img,if=virtio,format=raw,cache=unsafe \
+      -drive file=srv${i}/seed.img,if=virtio,format=raw,cache=unsafe \
+      -drive file=srv${i}/data.img,if=virtio,format=raw,cache=unsafe \
       -display none -daemonize -pidfile srv${i}/qemu.pid
   done
 


### PR DESCRIPTION
## What this PR does

The e2e QEMU guests are launched in `hack/e2e-prepare-cluster.bats` with three `-drive … if=virtio,format=raw` lines that carry no `cache=` option, so QEMU falls back to its `cache=writeback` default, which honors every guest fsync against the host-backed raw disk files.

The management-cluster Talos etcd — which holds every operator's leader-election lease — fsyncs on each Raft commit. During the VM-heavy suites, containerd is simultaneously unpacking dozens of images and CDI is importing multi-GB VM disks onto the same host-backed raw files. The resulting fsync storm serializes etcd's writes into multi-second stalls, so the management apiserver returns `context deadline exceeded` on lease PUTs, and several operators (capk, etcd-operator, fdb-operator, cilium-operator, kamaji) lose leadership at the same moment. Whichever chainsaw suite is mid-flight then fails — a different one each run (vmcluster, kubernetes-latest, vmdisk), which is the fingerprint of shared-resource contention rather than a bug in any single suite.

This adds `cache=unsafe` to each guest drive. That makes guest flushes no-ops against the host page cache, which removes the fsync-gated etcd stalls at the root of the flakiness. It is safe here precisely because these CI VMs are ephemeral and destroyed at the end of every run — a crash before writeback loses only throwaway state — and it must never be used for real data. The change is minimal and uniform across all three guest drives; no non-guest drive is touched (there are none in this file).

Runner sizing alone (#3251) did not resolve this, because more CPU and memory do not change the I/O path: the guest fsyncs still propagate through `cache=writeback` to the host, and etcd still stalls behind the same fsync storm. This addresses the I/O path directly.

`git log -S 'cache='` on this file is empty, so a cache mode has never previously been set here.

### Screenshots

Not applicable — no UI changes.

### Downstream repositories

I walked the trigger map in `docs/agents/contributing.md` against the actual diff. The only entries that reference `hack/e2e-prepare-cluster.bats` (ansible-cozystack and ccp) are scoped to node prerequisites — kernel modules, containerd settings, the LVM `global_filter`, and the cluster domain. This change touches none of those: it adds a QEMU host-side hypervisor flag (`cache=unsafe`) to the CI VM `-drive` options, which is invisible to the guest OS and to any real node. No downstream repository is affected.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(e2e): boot e2e QEMU guests with cache=unsafe so ephemeral CI VM fsyncs no longer stall the management-cluster etcd, removing the cross-operator leader-election flakiness that failed a different chainsaw suite each run
```

---

This PR was prepared with the assistance of an AI agent (Claude). A human maintainer reviewed the diff and the reasoning before submission and remains responsible for the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end virtual machine startup testing to use optimized QEMU disk caching settings for improved reliability and performance.
  * Improved end-to-end Kubernetes cluster readiness checks under load by extending the deadline for reaching “at least 2 nodes Ready,” and aligned related messaging and failure diagnostics accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->