### PR TITLE
fix(ci, kubernetes): build container disks concurrently to unblock Build

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -33,12 +33,17 @@ jobs:
     # buildkit; concurrent build jobs serialize on buildkit's single-writer bbolt
     # cache lock + exporter mutex and stall to the 30-min timeout (proven via a
     # live SIGUSR1 goroutine dump). One VM per job => one buildkit per job => that
-    # contention is severed by construction. `make build` is serial (one image at
-    # a time), so a small shape suffices -- 4cpu/16gb, not the 24cpu the e2e job
-    # uses -- and it leans on the warm mode=max cache (#2938) to stay under the
-    # 30-min wall. The `debug` label still routes to self-hosted for the
-    # breakpoint path. Phase 0.5 of #2937.
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-4cpu-16gb-x86-64' }}
+    # contention is severed by construction. Phase 0.5 of #2937.
+    #
+    # 24cpu/96gb rather than the 4cpu/16gb this used to run on: `make build` is
+    # still serial across images, but this branch is the only one that still
+    # builds ubuntu-container-disk, and it does so once per Kubernetes minor with
+    # no shared build cache to warm it (main dropped the image in 39cdc8866, six
+    # days before release-1.5 was cut, so nothing writes its :*-buildcache refs).
+    # Those six builds now run concurrently, and each drives its own libguestfs
+    # appliance -- ~9gb of RAM and a core apiece, which the small shape cannot
+    # give. The `debug` label still routes to self-hosted for the breakpoint path.
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-24cpu-96gb-x86-64' }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/packages/apps/kubernetes/Makefile
+++ b/packages/apps/kubernetes/Makefile
@@ -20,19 +20,30 @@ update:
 
 image: image-ubuntu-container-disk image-kubevirt-cloud-provider image-kubevirt-csi-driver image-cluster-autoscaler
 
+# One container disk per Kubernetes minor. Each build spends ~4-5min inside a
+# libguestfs appliance installing that minor's kubelet/kubeadm into its own copy
+# of the cloud image, and the versions share no per-version work, so build them
+# concurrently: the serial loop this replaced spent ~28min of the Build job's
+# 30min budget on this target alone. The sub-make carries its own -j so the root
+# `make build` stays serial, and buildkit dedups the shared guestfish and
+# cloud-image stages across the concurrent solves. --output-sync=target groups
+# each version's log under its target name -- six interleaved buildx progress
+# streams are unreadable otherwise.
 image-ubuntu-container-disk:
-	$(foreach ver,$(KUBERNETES_VERSIONS), \
-		docker buildx build images/ubuntu-container-disk \
-			--build-arg KUBERNETES_VERSION=$(ver) \
-			--tag $(REGISTRY)/ubuntu-container-disk:$(ver)-$(IMAGE_TAG) \
-			$(if $(filter 1,$(PUBLISH_VERSIONED)),--tag $(REGISTRY)/ubuntu-container-disk:$(ver)) \
-			$(call cache-args,ubuntu-container-disk,$(ver)-buildcache) \
-			--metadata-file images/ubuntu-container-disk-$(ver).json \
-			$(BUILDX_ARGS) && \
-		echo "$(REGISTRY)/ubuntu-container-disk:$(ver)-$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/ubuntu-container-disk-$(ver).json -o json -r)" \
-			> images/ubuntu-container-disk-$(ver).tag && \
-		rm -f images/ubuntu-container-disk-$(ver).json; \
-	)
+	$(MAKE) -j$(words $(KUBERNETES_VERSIONS)) --output-sync=target \
+		$(addprefix image-ubuntu-container-disk-,$(KUBERNETES_VERSIONS))
+
+image-ubuntu-container-disk-%:
+	docker buildx build images/ubuntu-container-disk \
+		--build-arg KUBERNETES_VERSION=$* \
+		--tag $(REGISTRY)/ubuntu-container-disk:$*-$(IMAGE_TAG) \
+		$(if $(filter 1,$(PUBLISH_VERSIONED)),--tag $(REGISTRY)/ubuntu-container-disk:$*) \
+		$(call cache-args,ubuntu-container-disk,$*-buildcache) \
+		--metadata-file images/ubuntu-container-disk-$*.json \
+		$(BUILDX_ARGS)
+	echo "$(REGISTRY)/ubuntu-container-disk:$*-$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/ubuntu-container-disk-$*.json -o json -r)" \
+		> images/ubuntu-container-disk-$*.tag
+	rm -f images/ubuntu-container-disk-$*.json
 
 image-kubevirt-cloud-provider:
 	docker buildx build images/kubevirt-cloud-provider \


### PR DESCRIPTION
## What this PR does

Every `release-1.5` PR Build job dies at the 30-minute timeout, and all of it is spent in one target. `image-ubuntu-container-disk` builds one disk per Kubernetes minor — six of them — and each spends ~4-5min inside a libguestfs appliance installing that minor's kubelet/kubeadm into its own copy of the cloud image. Serially that is ~28min of the 30min budget, measured on [the Build job of #3326](https://github.com/cozystack/cozystack/actions/runs/29519466991/job/87694084942):

| version | wall clock |
| --- | --- |
| v1.35 | 6:00 |
| v1.34 | 4:21 |
| v1.33 | 4:27 |
| v1.32 | 4:39 |
| v1.31 | 4:42 |
| v1.30 | cancelled at the timeout |

None of it is cached, and a cache warmer would not fix it on its own. Only `build-main.yaml` sets `WRITE_CACHE=1`, and `main` dropped this image from `make image` in 39cdc8866 six days before `release-1.5` was cut, so the `:*-buildcache` refs the build reads have never been written — the CI log shows all six importers failing with `not found`. `release-1.5` is now the only branch that builds this image at all, so its build has been cold since the branch was created.

The six builds share no per-version work, so this runs them concurrently instead. A sub-make carries its own `-j`, which keeps the root `make build` serial, and buildkit dedups the shared guestfish and cloud-image stages across the concurrent solves. `--output-sync=target` groups each version's log under its target name; six interleaved buildx progress streams carry no per-solve identifier and are unreadable otherwise.

Build also moves off the `4cpu/16gb` shape, because six concurrent libguestfs appliances want roughly 9gb of RAM and a core apiece. The comment justifying the small shape assumed a warm mode=max cache, which does not hold for this image on this branch. `timeout-minutes` deliberately stays at 30 — fitting inside it is the point of the change.

This also stops swallowing failures. The loop separated versions with `;`, so make saw only the last version's exit status: a failed build for any other version left its committed `.tag` file stale and the job green. Under the sub-make, a failure in any version fails the target.

### Verification

- The per-version `buildx` / `echo` / `rm` command set is byte-identical to the loop it replaces, checked across defaults, `PUBLISH_VERSIONED=1`, and `IMAGE_TAG` + `PUBLISH_FLOATING=1` + `WRITE_CACHE=1` together — so the versioned tag, the floating tag and `--cache-to` all still expand correctly.
- `make -n image` still emits exactly 9 `buildx` invocations (6 disks plus cloud-provider, csi-driver, cluster-autoscaler); the new pattern rule shadows none of them.
- `.tag` and `.json` filenames are unchanged, so the `Files.Get` lookups in `templates/cluster.yaml` still resolve.
- Failure propagation was reproduced on a reduced Makefile: the `;`-separated loop returns exit 0 with a failing non-final version, the sub-make returns exit 2.

Wall clock is the one thing only CI can confirm. The slowest single build carries the one-time guestfish and cloud-image work that the others reuse, so the target should land near that ~6min rather than 28.

Once this is green it unblocks the other stuck `release-1.5` backports on retest: #3402, #3370, #3366, #3364, #3356, #3326, #3321, #3202.

### Release note

```release-note
fix(ci): build the per-Kubernetes-minor `ubuntu-container-disk` images concurrently so the release-1.5 Build job no longer exceeds its 30-minute timeout, and fail the build when any single version fails instead of only the last one.
```
