### PR TITLE
feat(platform): gate upgrades on a pre-flight cluster health check

### DIFF
--- a/docs/operations/upgrade-preflight.md
+++ b/docs/operations/upgrade-preflight.md
@@ -1,0 +1,73 @@
+# Upgrade Preflight
+
+Cozystack runs a health gate before a platform upgrade touches anything. It executes as a `pre-upgrade` Helm hook at weight 0, ahead of the schema migrations at weight 1, and refuses to let the upgrade start when the cluster is not in a state where it can safely absorb one. The point is to surface a broken node or a degraded storage layer up front, with a message naming what is wrong, instead of halfway through a HelmRelease rollout.
+
+The gate is enabled by default.
+
+## When it runs
+
+The hook renders only when the `cozystack-version` ConfigMap in the release namespace reports a version **below** `migrations.targetVersion`, which is the same condition the migration hook uses. Three consequences worth knowing:
+
+- A fresh install is never gated. There is no prior state to protect and nothing to query.
+- A release that ships no new migration is not gated either, because the version does not advance.
+- The checks do not re-run on every Flux reconcile of a healthy cluster, which keeps a live `linstor` exec off the steady-state path.
+
+## What it checks
+
+| Check id | What it asserts | Blocking by default |
+| --- | --- | --- |
+| `nodes-ready` | Every Kubernetes node carries `Ready=True`. A node with no `Ready` condition at all counts as not ready. | yes |
+| `linstor` | Every LINSTOR satellite is `ONLINE` and no DRBD volume sits in `Inconsistent`, `Failed`, `DUnknown` or `Outdated`. Skipped as not-applicable when LINSTOR is not installed. | no, advisory |
+
+Cordoned nodes are exempt from `nodes-ready` whatever their readiness, and are reported as a warning instead. A cordon is the operator declaring a node out of service, and the normal maintenance sequence (cordon, drain, power off) leaves the node at `Ready=Unknown` with its workloads already moved. The trade-off is deliberate: a node that failed and was then cordoned is waved through on that same signal.
+
+Every check fails closed. If a check cannot determine health, because the API server refused the call, timed out, or returned output it could not parse, that counts as a failure rather than a pass. A gate that ran no checks at all also fails.
+
+The `linstor` check is advisory until its detection of faulty states has been exercised against a genuinely degraded cluster: it runs and reports, but a problem it finds warns rather than blocks.
+
+## Reading the verdict
+
+Read the status ConfigMap, not the Job:
+
+```bash
+kubectl --namespace cozy-system get configmap cozystack-preflight-status --output yaml
+```
+
+It carries `verdict` (`running`, `passed` or `blocked`), the check ids by outcome (`failedChecks`, `advisoryChecks`, `okChecks`, `naChecks`, `skippedChecks`), `completedAt`, and the full run log.
+
+The hook Job is not a durable record. A failed upgrade is retried automatically by the platform HelmRelease (`Upgrade.Strategy` is `RetryOnFailure`, with a retry interval that defaults to 30 seconds), and Helm deletes the previous hook Job at the top of every attempt, so the Job and its log survive roughly one retry interval before an identical run replaces them. The HelmRelease itself reports only a generic `pre-upgrade hooks failed`, which names neither the check nor the node. The ConfigMap is written by every run, including one that starts and is then killed, and no hook lifecycle deletes it.
+
+While the gate is blocking, the upgrade stays pending and the checks keep re-running at the retry interval. Fixing the reported problem is enough; no manual retry is needed.
+
+## Overriding the gate
+
+These keys live under `spec.components.platform.values.preflight` on the `cozystack.cozystack-platform` Package CR. Nothing else reads them, and a misspelled path is silently ignored, so check the nesting.
+
+```yaml
+apiVersion: cozystack.io/v1alpha1
+kind: Package
+metadata:
+  name: cozystack.cozystack-platform
+spec:
+  components:
+    platform:
+      values:
+        preflight:
+          # Proceed past every failing check. The failures are logged for the
+          # audit trail and downgraded to warnings.
+          override: false
+          # Skip named checks entirely, instead of overriding all of them.
+          skipChecks: []
+          # Named checks still run and report, but do not block.
+          advisoryChecks: [linstor]
+          # Do not render the gate at all.
+          enabled: true
+```
+
+Prefer the narrowest hatch that clears your situation: fix what the check reports, then `skipChecks` for a single check, then `override` for all of them, then `enabled: false`. Both booleans accept `true`, `1`, `yes` and `on` for yes and `false`, `0`, `no` and `off` for no, in any of the shapes the Package CR's untyped JSON can deliver, so a quoted `"false"` behaves the same as a bare one. Anything unrecognised leaves the gate up.
+
+## Adding a check
+
+Drop an executable script into `packages/core/platform/images/migrations/preflight/checks/`, named `<order>-<id>.sh`. The runner discovers it, derives the check id from the filename, and interprets its exit code: `0` is OK, `2` blocks the upgrade, `3` is not-applicable, and any other non-zero exit is treated as a failure. Source `../lib/preflight-lib.sh` and use `kubectl_t` for API calls so the call is bounded and cannot hang the hook.
+
+Anything a check needs from RBAC must be added to `packages/core/platform/templates/preflight-hook.yaml`. The gate holds read-only cluster-wide access plus two namespaced grants, `pods/exec` in `cozy-linstor` and write access to its own status ConfigMap, and it should stay that way.

--- a/hack/e2e-chainsaw/platform-preflight/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/platform-preflight/chainsaw-test.yaml
@@ -1,0 +1,338 @@
+# Runs the upgrade preflight gate against the live E2E cluster.
+#
+# WHY THIS SUITE EXISTS: the gate ships as a `pre-upgrade` hook that renders
+# only when the cozystack-version ConfigMap is below migrations.targetVersion.
+# The E2E cluster is a fresh install, so that hook never fires and nothing else
+# in CI ever starts the Job. Without this suite the unit tests prove the shell
+# logic and the rendered YAML, and everything in between stays unproven: that
+# /preflight exists in the image the chart pins, that the entrypoint runs there,
+# and that the ClusterRole plus the two namespaced Roles are actually sufficient
+# for `get nodes`, the LINSTOR deploy probe, `exec` into linstor-controller and
+# the status-ConfigMap write.
+#
+# WHAT IT DELIBERATELY DOES NOT DO: it does not stamp cozystack-version
+# backwards to provoke a real platform upgrade. That would re-run the schema
+# migrations against the E2E cluster, which is both slow and a good way to turn
+# an unrelated migration bug into a red preflight suite. That a failed
+# pre-upgrade hook aborts `helm upgrade` is Helm's own documented contract and
+# is not re-tested here; what is tested is that this Job exits non-zero, for the
+# right reason, and leaves the verdict where an operator can read it.
+#
+# The two Jobs differ ONLY in the RBAC bound to their ServiceAccount, so the
+# blocking case exercises a real check failing through its real fail-closed
+# path (`kubectl get nodes` forbidden) rather than a synthetic stub.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: platform-preflight
+spec:
+  catch:
+  - events: {}
+  - description: preflight Job logs and status ConfigMaps
+    script:
+      timeout: 2m
+      content: |
+        set +e
+        for j in cozystack-preflight-e2e-pass cozystack-preflight-e2e-block; do
+          echo "--- job/$j ---"
+          kubectl --namespace cozy-system describe job "$j" 2>&1 | tail -30
+          kubectl --namespace cozy-system logs "job/$j" --tail=200 2>&1
+        done
+        for c in cozystack-preflight-e2e-pass-status cozystack-preflight-e2e-block-status; do
+          echo "--- configmap/$c ---"
+          kubectl --namespace cozy-system get configmap "$c" --output yaml 2>&1 | tail -60
+        done
+  steps:
+  - name: run-the-preflight-gate-on-a-live-cluster
+    try:
+    - script:
+        # Generous: the migrations image is ~350 MB and nothing has pulled it on
+        # this cluster yet (the migration hook does not run on a fresh install).
+        timeout: 20m
+        content: |
+          set -eu
+          cd ../../..
+
+          # The image the chart actually pins. In CI values.yaml carries the
+          # digest built for this PR (the finalize job's patch rewrites it), so
+          # this resolves to the image under test, not a released one.
+          IMAGE=$(yq -e '.migrations.image' packages/core/platform/values.yaml)
+          [ -n "$IMAGE" ] || { echo "could not resolve migrations.image"; exit 1; }
+          echo "preflight image: $IMAGE"
+
+          kubectl apply --filename - <<EOF
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: cozystack-preflight-e2e
+            namespace: cozy-system
+          ---
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: cozystack-preflight-e2e-norbac
+            namespace: cozy-system
+          ---
+          # Mirrors the read-only ClusterRole the chart renders.
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            name: cozystack-preflight-e2e
+          rules:
+            - apiGroups: [""]
+              resources: ["nodes"]
+              verbs: ["get", "list"]
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["get", "list"]
+            - apiGroups: ["apps"]
+              resources: ["deployments"]
+              verbs: ["get", "list"]
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          metadata:
+            name: cozystack-preflight-e2e
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: cozystack-preflight-e2e
+          subjects:
+            - kind: ServiceAccount
+              name: cozystack-preflight-e2e
+              namespace: cozy-system
+          ---
+          # Mirrors the status-ConfigMap Role, and is bound to BOTH accounts so
+          # the blocked run can still publish its verdict.
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: cozystack-preflight-e2e-status
+            namespace: cozy-system
+          rules:
+            - apiGroups: [""]
+              resources: ["configmaps"]
+              verbs: ["create"]
+            - apiGroups: [""]
+              resources: ["configmaps"]
+              resourceNames:
+                - cozystack-preflight-e2e-pass-status
+                - cozystack-preflight-e2e-block-status
+              verbs: ["get", "update", "patch"]
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: cozystack-preflight-e2e-status
+            namespace: cozy-system
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: cozystack-preflight-e2e-status
+          subjects:
+            - kind: ServiceAccount
+              name: cozystack-preflight-e2e
+              namespace: cozy-system
+            - kind: ServiceAccount
+              name: cozystack-preflight-e2e-norbac
+              namespace: cozy-system
+          EOF
+
+          # The chart gates this grant on the namespace existing, so mirror that
+          # rather than assuming every cluster shape ships LINSTOR. Without it
+          # the check N/A-skips, which the assertions below tolerate.
+          if kubectl get namespace cozy-linstor >/dev/null 2>&1; then
+            kubectl apply --filename - <<EOF
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: cozystack-preflight-e2e-exec
+            namespace: cozy-linstor
+          rules:
+            - apiGroups: [""]
+              resources: ["pods/exec"]
+              verbs: ["create"]
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: cozystack-preflight-e2e-exec
+            namespace: cozy-linstor
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: cozystack-preflight-e2e-exec
+          subjects:
+            - kind: ServiceAccount
+              name: cozystack-preflight-e2e
+              namespace: cozy-system
+          EOF
+          fi
+
+          # Jobs last, so their ServiceAccounts already carry every grant.
+          kubectl apply --filename - <<EOF
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: cozystack-preflight-e2e-pass
+            namespace: cozy-system
+          spec:
+            backoffLimit: 0
+            template:
+              metadata:
+                labels:
+                  policy.cozystack.io/allow-to-apiserver: "true"
+              spec:
+                serviceAccountName: cozystack-preflight-e2e
+                restartPolicy: Never
+                containers:
+                  - name: preflight
+                    image: ${IMAGE}
+                    command: ["/preflight/run-preflight.sh"]
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop: ["ALL"]
+                      seccompProfile:
+                        type: RuntimeDefault
+                    env:
+                      - name: NAMESPACE
+                        value: cozy-system
+                      - name: PREFLIGHT_STATUS_CONFIGMAP
+                        value: cozystack-preflight-e2e-pass-status
+                      # The shipped default. LINSTOR health on a CI cluster is
+                      # not this suite's subject: what matters is that the check
+                      # can reach the controller at all, asserted below by the
+                      # absence of an RBAC refusal.
+                      - name: PREFLIGHT_ADVISORY
+                        value: linstor
+          ---
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: cozystack-preflight-e2e-block
+            namespace: cozy-system
+          spec:
+            backoffLimit: 0
+            template:
+              metadata:
+                labels:
+                  policy.cozystack.io/allow-to-apiserver: "true"
+              spec:
+                # No ClusterRole, so listing nodes is refused: that is the
+                # nodes-ready check's real fail-closed path. A gate that cannot
+                # see the cluster must block, not assume health.
+                # Keep backticks out of this heredoc: it is unquoted so the
+                # image reference expands, which also makes a backtick run as a
+                # command and corrupt the manifest.
+                serviceAccountName: cozystack-preflight-e2e-norbac
+                restartPolicy: Never
+                containers:
+                  - name: preflight
+                    image: ${IMAGE}
+                    command: ["/preflight/run-preflight.sh"]
+                    securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop: ["ALL"]
+                      seccompProfile:
+                        type: RuntimeDefault
+                    env:
+                      - name: NAMESPACE
+                        value: cozy-system
+                      - name: PREFLIGHT_STATUS_CONFIGMAP
+                        value: cozystack-preflight-e2e-block-status
+                      - name: PREFLIGHT_ADVISORY
+                        value: linstor
+          EOF
+
+          # Wait for a terminal condition rather than one specific outcome, so
+          # the wrong outcome fails fast with a readable message instead of
+          # burning the whole step timeout.
+          wait_job() {
+            name=$1
+            want=$2
+            deadline=$(( $(date +%s) + 900 ))
+            while [ "$(date +%s)" -lt "$deadline" ]; do
+              got=$(kubectl --namespace cozy-system get job "$name" \
+                --output jsonpath='{.status.conditions[?(@.status=="True")].type}' 2>/dev/null || true)
+              case " $got " in
+                *" Complete "*)
+                  if [ "$want" = Complete ]; then return 0; fi
+                  echo "job/$name completed but was expected to fail"
+                  return 1
+                  ;;
+                *" Failed "*)
+                  if [ "$want" = Failed ]; then return 0; fi
+                  echo "job/$name failed but was expected to complete"
+                  return 1
+                  ;;
+              esac
+              sleep 5
+            done
+            echo "timed out waiting for job/$name to reach $want"
+            return 1
+          }
+
+          wait_job cozystack-preflight-e2e-pass Complete
+          wait_job cozystack-preflight-e2e-block Failed
+
+          pass_log=$(kubectl --namespace cozy-system logs job/cozystack-preflight-e2e-pass)
+          echo "$pass_log"
+          # The read-only ClusterRole is sufficient for the readiness check.
+          echo "$pass_log" | grep -q "all nodes are Ready"
+          # The LINSTOR check ran and was not refused by RBAC. Its health verdict
+          # is deliberately not asserted; a refusal would read "is forbidden".
+          echo "$pass_log" | grep -q "running check: linstor"
+          if echo "$pass_log" | grep -q "is forbidden"; then
+            echo "the preflight ServiceAccount was refused by RBAC on a grant the chart claims to give it"
+            exit 1
+          fi
+
+          block_log=$(kubectl --namespace cozy-system logs job/cozystack-preflight-e2e-block)
+          echo "$block_log"
+          # Cannot list nodes => blocked, and the message says why.
+          echo "$block_log" | grep -q "cannot list nodes"
+          echo "$block_log" | grep -q "The upgrade is BLOCKED"
+
+          # The verdict has to be readable after the Job is gone, which on the
+          # real upgrade path happens within one 30s retry interval.
+          verdict=$(kubectl --namespace cozy-system get configmap cozystack-preflight-e2e-pass-status \
+            --output jsonpath='{.data.verdict}')
+          [ "$verdict" = passed ] || { echo "expected verdict=passed, got '$verdict'"; exit 1; }
+
+          verdict=$(kubectl --namespace cozy-system get configmap cozystack-preflight-e2e-block-status \
+            --output jsonpath='{.data.verdict}')
+          [ "$verdict" = blocked ] || { echo "expected verdict=blocked, got '$verdict'"; exit 1; }
+
+          failed=$(kubectl --namespace cozy-system get configmap cozystack-preflight-e2e-block-status \
+            --output jsonpath='{.data.failedChecks}')
+          case " $failed " in
+            *" nodes-ready "*) ;;
+            *) echo "expected failedChecks to name nodes-ready, got '$failed'"; exit 1 ;;
+          esac
+
+          # The published log is the operator-facing part of the record.
+          kubectl --namespace cozy-system get configmap cozystack-preflight-e2e-block-status \
+            --output jsonpath='{.data.log}' | grep -q "cannot list nodes"
+        check:
+          ($error == null): true
+    finally:
+    # Everything above is applied imperatively, so Chainsaw's auto-cleanup does
+    # not track it. Each delete is independent: one failure must not skip the
+    # rest.
+    - description: reclaim the preflight fixtures
+      script:
+        timeout: 5m
+        content: |
+          set +e
+          kubectl --namespace cozy-system delete job cozystack-preflight-e2e-pass cozystack-preflight-e2e-block --ignore-not-found
+          kubectl --namespace cozy-system delete configmap cozystack-preflight-e2e-pass-status cozystack-preflight-e2e-block-status --ignore-not-found
+          kubectl --namespace cozy-system delete rolebinding cozystack-preflight-e2e-status --ignore-not-found
+          kubectl --namespace cozy-system delete role cozystack-preflight-e2e-status --ignore-not-found
+          kubectl --namespace cozy-linstor delete rolebinding cozystack-preflight-e2e-exec --ignore-not-found
+          kubectl --namespace cozy-linstor delete role cozystack-preflight-e2e-exec --ignore-not-found
+          kubectl delete clusterrolebinding cozystack-preflight-e2e --ignore-not-found
+          kubectl delete clusterrole cozystack-preflight-e2e --ignore-not-found
+          kubectl --namespace cozy-system delete serviceaccount cozystack-preflight-e2e cozystack-preflight-e2e-norbac --ignore-not-found
+          exit 0

--- a/hack/testdata/upgrade-preflight/kubectl
+++ b/hack/testdata/upgrade-preflight/kubectl
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Fake kubectl for hack/upgrade-preflight.bats. Mocks only the cluster boundary
+# the preflight checks touch, driven by FAKE_* env knobs the tests set:
+#
+#   FAKE_NODES_JSON         - stdout for `kubectl get nodes -o json`
+#   FAKE_LINSTOR_PRESENT    - 1 (deploy exists) / 0 (absent) for the presence probe
+#   FAKE_LINSTOR_NODES_JSON - stdout for `linstor -m node list` (via kubectl exec)
+#   FAKE_LINSTOR_VOL_JSON   - stdout for `linstor -m volume list` (via kubectl exec)
+#
+# Matching is on the flattened argument string so the tests do not depend on
+# flag ordering.
+set -eu
+args="$*"
+
+case "$args" in
+  *"get nodes"*)
+    printf '%s' "${FAKE_NODES_JSON:-{\"items\":[]}}"
+    exit 0
+    ;;
+  *"get deploy"*"linstor-controller"*)
+    [ "${FAKE_LINSTOR_PRESENT:-1}" = "1" ] && exit 0 || exit 1
+    ;;
+  *"exec"*"linstor"*"node list"*)
+    printf '%s' "${FAKE_LINSTOR_NODES_JSON:-[]}"
+    exit 0
+    ;;
+  *"exec"*"linstor"*"volume list"*)
+    printf '%s' "${FAKE_LINSTOR_VOL_JSON:-[]}"
+    exit 0
+    ;;
+esac
+
+echo "fake kubectl: unhandled args: $args" >&2
+exit 3

--- a/hack/testdata/upgrade-preflight/kubectl
+++ b/hack/testdata/upgrade-preflight/kubectl
@@ -6,7 +6,10 @@
 #   FAKE_NODES_FAIL         - when "1", `kubectl get nodes` exits non-zero
 #                             (models an API-server blip so the fail-closed path
 #                             of the nodes-ready check can be exercised)
-#   FAKE_LINSTOR_PRESENT    - 1 (deploy exists) / 0 (absent) for the presence probe
+#   FAKE_LINSTOR_PRESENT    - 1 (deploy exists) / 0 (absent, NotFound) for the probe
+#   FAKE_LINSTOR_DEPLOY_ERR - when "1", the deploy probe fails with a non-NotFound
+#                             error (models RBAC/timeout so the "not installed"
+#                             vs "could not ask" distinction can be tested)
 #   FAKE_LINSTOR_NODES_JSON - stdout for `linstor -m node list` (via kubectl exec)
 #   FAKE_LINSTOR_VOL_JSON   - stdout for `linstor -m volume list` (via kubectl exec)
 #
@@ -22,7 +25,15 @@ case "$args" in
     exit 0
     ;;
   *"get deploy"*"linstor-controller"*)
-    [ "${FAKE_LINSTOR_PRESENT:-1}" = "1" ] && exit 0 || exit 1
+    if [ "${FAKE_LINSTOR_DEPLOY_ERR:-0}" = "1" ]; then
+      echo 'Error from server (Forbidden): deployments.apps "linstor-controller" is forbidden' >&2
+      exit 1
+    fi
+    if [ "${FAKE_LINSTOR_PRESENT:-1}" = "1" ]; then
+      exit 0
+    fi
+    echo 'Error from server (NotFound): deployments.apps "linstor-controller" not found' >&2
+    exit 1
     ;;
   *"exec"*"linstor"*"node list"*)
     printf '%s' "${FAKE_LINSTOR_NODES_JSON:-[]}"

--- a/hack/testdata/upgrade-preflight/kubectl
+++ b/hack/testdata/upgrade-preflight/kubectl
@@ -3,6 +3,9 @@
 # the preflight checks touch, driven by FAKE_* env knobs the tests set:
 #
 #   FAKE_NODES_JSON         - stdout for `kubectl get nodes -o json`
+#   FAKE_NODES_FAIL         - when "1", `kubectl get nodes` exits non-zero
+#                             (models an API-server blip so the fail-closed path
+#                             of the nodes-ready check can be exercised)
 #   FAKE_LINSTOR_PRESENT    - 1 (deploy exists) / 0 (absent) for the presence probe
 #   FAKE_LINSTOR_NODES_JSON - stdout for `linstor -m node list` (via kubectl exec)
 #   FAKE_LINSTOR_VOL_JSON   - stdout for `linstor -m volume list` (via kubectl exec)
@@ -14,6 +17,7 @@ args="$*"
 
 case "$args" in
   *"get nodes"*)
+    [ "${FAKE_NODES_FAIL:-0}" = "1" ] && { echo "fake kubectl: get nodes failed" >&2; exit 1; }
     printf '%s' "${FAKE_NODES_JSON:-{\"items\":[]}}"
     exit 0
     ;;

--- a/hack/testdata/upgrade-preflight/kubectl
+++ b/hack/testdata/upgrade-preflight/kubectl
@@ -21,7 +21,14 @@ args="$*"
 case "$args" in
   *"get nodes"*)
     [ "${FAKE_NODES_FAIL:-0}" = "1" ] && { echo "fake kubectl: get nodes failed" >&2; exit 1; }
-    printf '%s' "${FAKE_NODES_JSON:-{\"items\":[]}}"
+    # Explicit default (not an inline ${:-...}); a '}' inside a parameter-default
+    # word closes the expansion and appends a stray brace, producing invalid
+    # JSON.
+    if [ -n "${FAKE_NODES_JSON:-}" ]; then
+      printf '%s' "$FAKE_NODES_JSON"
+    else
+      printf '%s' '{"items":[]}'
+    fi
     exit 0
     ;;
   *"get deploy"*"linstor-controller"*)

--- a/hack/testdata/upgrade-preflight/kubectl
+++ b/hack/testdata/upgrade-preflight/kubectl
@@ -12,6 +12,12 @@
 #                             vs "could not ask" distinction can be tested)
 #   FAKE_LINSTOR_NODES_JSON - stdout for `linstor -m node list` (via kubectl exec)
 #   FAKE_LINSTOR_VOL_JSON   - stdout for `linstor -m volume list` (via kubectl exec)
+#   FAKE_STATUS_ARGS_OUT    - when set, every `create configmap` invocation
+#                             appends its flattened args here, so a test can
+#                             assert WHAT the runner published
+#   FAKE_STATUS_FAIL        - when "1", publishing the status ConfigMap fails
+#                             (models missing RBAC, so the "best-effort publish"
+#                             property can be tested)
 #
 # Matching is on the flattened argument string so the tests do not depend on
 # flag ordering.
@@ -41,6 +47,26 @@ case "$args" in
     fi
     echo 'Error from server (NotFound): deployments.apps "linstor-controller" not found' >&2
     exit 1
+    ;;
+  *"create configmap"*)
+    if [ -n "${FAKE_STATUS_ARGS_OUT:-}" ]; then
+      printf '%s\n' "$args" >> "$FAKE_STATUS_ARGS_OUT"
+    fi
+    if [ "${FAKE_STATUS_FAIL:-0}" = "1" ]; then
+      echo 'Error from server (Forbidden): configmaps is forbidden' >&2
+      exit 1
+    fi
+    # The runner pipes this into `kubectl apply`, so emit something applyable.
+    printf 'apiVersion: v1\nkind: ConfigMap\n'
+    exit 0
+    ;;
+  *"apply --filename -"*)
+    cat >/dev/null
+    if [ "${FAKE_STATUS_FAIL:-0}" = "1" ]; then
+      echo 'Error from server (Forbidden): configmaps is forbidden' >&2
+      exit 1
+    fi
+    exit 0
     ;;
   *"exec"*"linstor"*"node list"*)
     printf '%s' "${FAKE_LINSTOR_NODES_JSON:-[]}"

--- a/hack/upgrade-preflight.bats
+++ b/hack/upgrade-preflight.bats
@@ -40,6 +40,9 @@ prep() {
   export PREFLIGHT_ENABLED=true
   export PREFLIGHT_OVERRIDE=false
   export PREFLIGHT_SKIP=""
+  # Baseline enforces every check (advisory empty), so the blocking-path tests
+  # below stay meaningful. Advisory behaviour is exercised explicitly.
+  export PREFLIGHT_ADVISORY=""
   export FAKE_LINSTOR_PRESENT=1
   export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n1"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"True"}]}}]}'
   export FAKE_LINSTOR_NODES_JSON='[[{"name":"n1","connection_status":"ONLINE"}]]'
@@ -84,6 +87,26 @@ run_pf() {
   [ "$RC" -eq 1 ]
   grep -q "n2" "$WORK/out"
   grep -q "linstor" "$WORK/out"
+}
+
+@test "an advisory linstor failure warns but does not block the upgrade" {
+  prep
+  export PREFLIGHT_ADVISORY="linstor"
+  export FAKE_LINSTOR_VOL_JSON='[[{"name":"pvc-a","volumes":[{"state":{"disk_state":"Inconsistent"}}]}]]'
+  run_pf
+  [ "$RC" -eq 0 ]
+  grep -qi "advisory" "$WORK/out"
+}
+
+@test "an advisory check does not mask a blocking check from another check" {
+  prep
+  export PREFLIGHT_ADVISORY="linstor"
+  # linstor is advisory, but a NotReady node (nodes-ready, enforcing) still blocks.
+  export FAKE_LINSTOR_VOL_JSON='[[{"name":"pvc-a","volumes":[{"state":{"disk_state":"Inconsistent"}}]}]]'
+  export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n2"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"False"}]}}]}'
+  run_pf
+  [ "$RC" -eq 1 ]
+  grep -q "nodes-ready" "$WORK/out"
 }
 
 @test "LINSTOR not installed is a graceful N/A, not a failure" {

--- a/hack/upgrade-preflight.bats
+++ b/hack/upgrade-preflight.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Unit tests for the cozystack upgrade preflight health gate:
+#   packages/core/platform/images/migrations/preflight/run-preflight.sh
+#   packages/core/platform/images/migrations/preflight/checks/*
+#
+# The preflight runs as a pre-upgrade Helm hook (weight 0, before the migration
+# hook) and refuses to let an upgrade proceed on an unhealthy cluster, UNLESS an
+# operator explicitly overrides it. These tests drive the real runner and real
+# checks end-to-end against a fake kubectl (hack/testdata/upgrade-preflight/),
+# mocking only the cluster boundary — the same approach migration-50 uses.
+#
+# The behaviours pinned here are the review blockers:
+#   1. a healthy cluster passes (exit 0);
+#   2. any failing check blocks the upgrade (exit 1) with a non-zero runner exit;
+#   3. preflight.override=true downgrades failures to warnings and proceeds;
+#   4. preflight.skipChecks skips a named check;
+#   5. LINSTOR absent is a graceful N/A, not a failure;
+#   6. preflight.enabled=false is a full bypass.
+#
+# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
+# own line; there is no bats `run`/`$status`/`setup`. Assertions are direct
+# shell tests that exit non-zero on failure. Each test runs in its own subshell,
+# so exported FAKE_*/PREFLIGHT_* knobs do not leak between tests.
+#
+# Run with: hack/cozytest.sh hack/upgrade-preflight.bats
+# -----------------------------------------------------------------------------
+
+FAKEBIN="$PWD/hack/testdata/upgrade-preflight"
+PF="$PWD/packages/core/platform/images/migrations/preflight/run-preflight.sh"
+CHECKS="$PWD/packages/core/platform/images/migrations/preflight/checks"
+
+# prep resets PATH/env to a fully healthy scenario. Tests override individual
+# FAKE_* knobs afterwards to model a specific fault.
+prep() {
+  chmod +x "$FAKEBIN/kubectl"
+  WORK=$(mktemp -d)
+  export PATH="$FAKEBIN:$PATH"
+  export PREFLIGHT_CHECKS_DIR="$CHECKS"
+  export PREFLIGHT_ENABLED=true
+  export PREFLIGHT_OVERRIDE=false
+  export PREFLIGHT_SKIP=""
+  export FAKE_LINSTOR_PRESENT=1
+  export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n1"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"True"}]}}]}'
+  export FAKE_LINSTOR_NODES_JSON='[[{"name":"n1","connection_status":"ONLINE"}]]'
+  export FAKE_LINSTOR_VOL_JSON='[[{"name":"pvc-a","volumes":[{"state":{"disk_state":"UpToDate"}}]}]]'
+}
+
+# run_pf executes the runner, captures combined output to $WORK/out and the exit
+# code to $RC (never aborts the test itself).
+run_pf() {
+  RC=0
+  sh "$PF" >"$WORK/out" 2>&1 || RC=$?
+  cat "$WORK/out"
+}
+
+@test "healthy cluster passes preflight" {
+  prep
+  run_pf
+  [ "$RC" -eq 0 ]
+}
+
+@test "a NotReady node blocks the upgrade" {
+  prep
+  export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n1"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"True"}]}},{"metadata":{"name":"n2"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"False"}]}}]}'
+  run_pf
+  [ "$RC" -eq 1 ]
+  grep -q "n2" "$WORK/out"
+  grep -q "nodes-ready" "$WORK/out"
+}
+
+@test "a faulty DRBD volume state blocks the upgrade" {
+  prep
+  export FAKE_LINSTOR_VOL_JSON='[[{"name":"pvc-a","volumes":[{"state":{"disk_state":"Inconsistent"}}]}]]'
+  run_pf
+  [ "$RC" -eq 1 ]
+  grep -q "linstor" "$WORK/out"
+}
+
+@test "an offline LINSTOR satellite blocks the upgrade" {
+  prep
+  export FAKE_LINSTOR_NODES_JSON='[[{"name":"n1","connection_status":"ONLINE"},{"name":"n2","connection_status":"OFFLINE"}]]'
+  run_pf
+  [ "$RC" -eq 1 ]
+  grep -q "n2" "$WORK/out"
+  grep -q "linstor" "$WORK/out"
+}
+
+@test "LINSTOR not installed is a graceful N/A, not a failure" {
+  prep
+  export FAKE_LINSTOR_PRESENT=0
+  run_pf
+  [ "$RC" -eq 0 ]
+}
+
+@test "override proceeds past a failing check" {
+  prep
+  export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n2"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"False"}]}}]}'
+  export PREFLIGHT_OVERRIDE=true
+  run_pf
+  [ "$RC" -eq 0 ]
+  grep -qi "override" "$WORK/out"
+}
+
+@test "skipChecks skips the named check" {
+  prep
+  export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n2"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"False"}]}}]}'
+  export PREFLIGHT_SKIP="nodes-ready"
+  run_pf
+  [ "$RC" -eq 0 ]
+}
+
+@test "disabled preflight is a full bypass" {
+  prep
+  export PREFLIGHT_ENABLED=false
+  # Even with a broken cluster the runner must not fail when disabled.
+  export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n2"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"False"}]}}]}'
+  run_pf
+  [ "$RC" -eq 0 ]
+}
+
+@test "cordoned-but-Ready node is a warning, not a block" {
+  prep
+  export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n1"},"spec":{"unschedulable":true},"status":{"conditions":[{"type":"Ready","status":"True"}]}}]}'
+  run_pf
+  [ "$RC" -eq 0 ]
+  grep -qi "cordoned" "$WORK/out"
+}

--- a/hack/upgrade-preflight.bats
+++ b/hack/upgrade-preflight.bats
@@ -109,6 +109,23 @@ run_pf() {
   grep -q "nodes-ready" "$WORK/out"
 }
 
+@test "a node reporting no Ready condition at all blocks the upgrade" {
+  prep
+  export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n1"},"spec":{},"status":{"conditions":[]}}]}'
+  run_pf
+  [ "$RC" -eq 1 ]
+  grep -q "n1" "$WORK/out"
+  grep -q "nodes-ready" "$WORK/out"
+}
+
+@test "a failure to list nodes fails closed, not open" {
+  prep
+  export FAKE_NODES_FAIL=1
+  run_pf
+  [ "$RC" -eq 1 ]
+  grep -q "nodes-ready" "$WORK/out"
+}
+
 @test "LINSTOR not installed is a graceful N/A, not a failure" {
   prep
   export FAKE_LINSTOR_PRESENT=0

--- a/hack/upgrade-preflight.bats
+++ b/hack/upgrade-preflight.bats
@@ -29,6 +29,7 @@
 FAKEBIN="$PWD/hack/testdata/upgrade-preflight"
 PF="$PWD/packages/core/platform/images/migrations/preflight/run-preflight.sh"
 CHECKS="$PWD/packages/core/platform/images/migrations/preflight/checks"
+LIB="$PWD/packages/core/platform/images/migrations/preflight/lib"
 
 # prep resets PATH/env to a fully healthy scenario. Tests override individual
 # FAKE_* knobs afterwards to model a specific fault.
@@ -131,6 +132,31 @@ run_pf() {
   export FAKE_LINSTOR_PRESENT=0
   run_pf
   [ "$RC" -eq 0 ]
+}
+
+@test "a LINSTOR query failure is a FAIL, not a false 'not installed' skip" {
+  prep
+  # deploy probe fails with a non-NotFound error (RBAC/timeout): the check must
+  # NOT swallow it as "not installed"; it must fail closed so a real inability
+  # to determine health blocks (enforcing baseline) instead of passing.
+  export FAKE_LINSTOR_DEPLOY_ERR=1
+  run_pf
+  [ "$RC" -eq 1 ]
+  grep -qi "cannot determine LINSTOR state" "$WORK/out"
+}
+
+@test "no kubectl call uses --request-timeout (it breaks in-cluster config in the image)" {
+  # Regression guard: --request-timeout in the pinned kubectl falls back to
+  # localhost:8080 instead of the in-cluster ServiceAccount config, which fails
+  # every call on a healthy cluster. Bounding is done with a timeout wrapper.
+  # Match the invocation form "kubectl --request-timeout" so the lib comment
+  # that names the flag as forbidden does not trip the guard. An explicit
+  # return-on-match is used because a bare "! grep" would not fail the test
+  # under set -e.
+  if grep -rn 'kubectl --request-timeout' "$CHECKS" "$LIB"; then
+    echo "found a kubectl --request-timeout invocation; use the kubectl_t timeout wrapper instead" >&2
+    return 1
+  fi
 }
 
 @test "override proceeds past a failing check" {

--- a/hack/upgrade-preflight.bats
+++ b/hack/upgrade-preflight.bats
@@ -127,6 +127,32 @@ run_pf() {
   grep -q "nodes-ready" "$WORK/out"
 }
 
+@test "malformed 'kubectl get nodes' JSON fails closed, not open" {
+  prep
+  # A successful kubectl call returning unparseable output must NOT collapse into
+  # an empty "all Ready" result and permit the upgrade.
+  export FAKE_NODES_JSON='this is not json'
+  run_pf
+  [ "$RC" -eq 1 ]
+  grep -qi "cannot parse" "$WORK/out"
+}
+
+@test "malformed LINSTOR node JSON fails closed (enforcing)" {
+  prep
+  export FAKE_LINSTOR_NODES_JSON='not json'
+  run_pf
+  [ "$RC" -eq 1 ]
+  grep -qi "cannot parse LINSTOR node" "$WORK/out"
+}
+
+@test "malformed LINSTOR volume JSON fails closed (enforcing)" {
+  prep
+  export FAKE_LINSTOR_VOL_JSON='not json'
+  run_pf
+  [ "$RC" -eq 1 ]
+  grep -qi "cannot parse LINSTOR volume" "$WORK/out"
+}
+
 @test "LINSTOR not installed is a graceful N/A, not a failure" {
   prep
   export FAKE_LINSTOR_PRESENT=0

--- a/hack/upgrade-preflight.bats
+++ b/hack/upgrade-preflight.bats
@@ -307,3 +307,22 @@ run_pf() {
   [ "$RC" -eq 0 ]
   [ ! -s "$WORK/published" ]
 }
+
+@test "a cordoned NotReady node is a warning, not a block" {
+  prep
+  # cordon, drain, power off is the normal maintenance sequence and leaves the
+  # node at Ready=Unknown. The operator already signalled it is out of service.
+  export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n1"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"True"}]}},{"metadata":{"name":"n2"},"spec":{"unschedulable":true},"status":{"conditions":[{"type":"Ready","status":"Unknown"}]}}]}'
+  run_pf
+  [ "$RC" -eq 0 ]
+  grep -q "n2 (Ready=Unknown)" "$WORK/out"
+  grep -qi "cordoned" "$WORK/out"
+}
+
+@test "an uncordoned NotReady node still blocks when another node is cordoned" {
+  prep
+  export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n1"},"spec":{"unschedulable":true},"status":{"conditions":[{"type":"Ready","status":"Unknown"}]}},{"metadata":{"name":"n2"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"False"}]}}]}'
+  run_pf
+  [ "$RC" -eq 1 ]
+  grep -q "failedChecks=nodes-ready" "$WORK/published"
+}

--- a/hack/upgrade-preflight.bats
+++ b/hack/upgrade-preflight.bats
@@ -176,10 +176,11 @@ run_pf() {
   # localhost:8080 instead of the in-cluster ServiceAccount config, which fails
   # every call on a healthy cluster. Bounding is done with a timeout wrapper.
   # Match the invocation form "kubectl --request-timeout" so the lib comment
-  # that names the flag as forbidden does not trip the guard. An explicit
+  # that names the flag as forbidden does not trip the guard. The runner is
+  # covered too: it is as free to grow a kubectl call as the checks are. An explicit
   # return-on-match is used because a bare "! grep" would not fail the test
   # under set -e.
-  if grep -rn 'kubectl --request-timeout' "$CHECKS" "$LIB"; then
+  if grep -rn 'kubectl --request-timeout' "$PF" "$CHECKS" "$LIB"; then
     echo "found a kubectl --request-timeout invocation; use the kubectl_t timeout wrapper instead" >&2
     return 1
   fi
@@ -217,4 +218,33 @@ run_pf() {
   run_pf
   [ "$RC" -eq 0 ]
   grep -qi "cordoned" "$WORK/out"
+}
+
+@test "a checks directory with no checks fails closed, not open" {
+  prep
+  # A gate that ran nothing must not report the verdict it exists to withhold.
+  # The image build (RUN chmod +x /preflight/checks/*) is the other guard on
+  # this, but the runner must not depend on a neighbouring build step for its
+  # fail-closed property.
+  mkdir -p "$WORK/empty-checks"
+  export PREFLIGHT_CHECKS_DIR="$WORK/empty-checks"
+  run_pf
+  [ "$RC" -ne 0 ]
+  grep -qi "no preflight checks" "$WORK/out"
+}
+
+@test "a glob in skipChecks does not match a file in the working directory" {
+  prep
+  # $SKIP is deliberately word-split; pathname expansion is not wanted. Without
+  # `set -f` a skipChecks entry of "*" expands against the runner's working
+  # directory (/migrations in the image) and can silently disable a check whose
+  # id happens to name a file there.
+  mkdir -p "$WORK/cwd"
+  : > "$WORK/cwd/nodes-ready"
+  export PREFLIGHT_SKIP='*'
+  export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n2"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"False"}]}}]}'
+  cd "$WORK/cwd"
+  run_pf
+  [ "$RC" -eq 1 ]
+  grep -q "nodes-ready" "$WORK/out"
 }

--- a/hack/upgrade-preflight.bats
+++ b/hack/upgrade-preflight.bats
@@ -48,6 +48,12 @@ prep() {
   export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n1"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"True"}]}}]}'
   export FAKE_LINSTOR_NODES_JSON='[[{"name":"n1","connection_status":"ONLINE"}]]'
   export FAKE_LINSTOR_VOL_JSON='[[{"name":"pvc-a","volumes":[{"state":{"disk_state":"UpToDate"}}]}]]'
+  # Publishing is on by default so every test below exercises the real path;
+  # the args of each publish land in $WORK/published for assertions.
+  export NAMESPACE=cozy-system
+  export PREFLIGHT_STATUS_CONFIGMAP=cozystack-preflight-status
+  export FAKE_STATUS_ARGS_OUT="$WORK/published"
+  export FAKE_STATUS_FAIL=0
 }
 
 # run_pf executes the runner, captures combined output to $WORK/out and the exit
@@ -247,4 +253,57 @@ run_pf() {
   run_pf
   [ "$RC" -eq 1 ]
   grep -q "nodes-ready" "$WORK/out"
+}
+
+@test "a passing run publishes its verdict to the status ConfigMap" {
+  prep
+  run_pf
+  [ "$RC" -eq 0 ]
+  # Two writes: one when the run starts (so a Job killed by
+  # activeDeadlineSeconds still leaves a record), one with the outcome.
+  grep -q "verdict=running" "$WORK/published"
+  grep -q "verdict=passed" "$WORK/published"
+  grep -q "namespace cozy-system" "$WORK/published"
+}
+
+@test "a blocked upgrade publishes the failing check ids, not just a bare failure" {
+  prep
+  export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n2"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"False"}]}}]}'
+  run_pf
+  [ "$RC" -eq 1 ]
+  grep -q "verdict=blocked" "$WORK/published"
+  grep -q "failedChecks=nodes-ready" "$WORK/published"
+}
+
+@test "an advisory-only problem still publishes a passing verdict with the advisory id" {
+  prep
+  export PREFLIGHT_ADVISORY="linstor"
+  export FAKE_LINSTOR_VOL_JSON='[[{"name":"pvc-a","volumes":[{"state":{"disk_state":"Inconsistent"}}]}]]'
+  run_pf
+  [ "$RC" -eq 0 ]
+  grep -q "verdict=passed" "$WORK/published"
+  grep -q "advisoryChecks=linstor" "$WORK/published"
+}
+
+@test "a failure to publish the status does not change the verdict" {
+  prep
+  # Missing RBAC must not turn a healthy cluster into a blocked upgrade, nor a
+  # broken one into a permitted upgrade. Publishing is observability, never the
+  # gate itself.
+  export FAKE_STATUS_FAIL=1
+  run_pf
+  [ "$RC" -eq 0 ]
+  grep -qi "could not publish" "$WORK/out"
+
+  export FAKE_NODES_JSON='{"items":[{"metadata":{"name":"n2"},"spec":{},"status":{"conditions":[{"type":"Ready","status":"False"}]}}]}'
+  run_pf
+  [ "$RC" -eq 1 ]
+}
+
+@test "publishing is skipped when no namespace is configured" {
+  prep
+  export NAMESPACE=""
+  run_pf
+  [ "$RC" -eq 0 ]
+  [ ! -s "$WORK/published" ]
 }

--- a/packages/core/platform/images/migrations/Dockerfile
+++ b/packages/core/platform/images/migrations/Dockerfile
@@ -36,6 +36,11 @@ COPY migrations /migrations
 # pre-upgrade hook completes).
 COPY etcd-operator-crds /etcd-operator-crds
 COPY run-migrations.sh /usr/bin/run-migrations.sh
+# Upgrade preflight health gate (run-preflight.sh + checks/ + lib/). Shares this
+# image with the migration runner; the preflight Job overrides the entrypoint to
+# /preflight/run-preflight.sh (see templates/preflight-hook.yaml).
+COPY preflight /preflight
+RUN chmod +x /preflight/run-preflight.sh /preflight/checks/*
 
 WORKDIR /migrations
 

--- a/packages/core/platform/images/migrations/preflight/checks/10-nodes-ready.sh
+++ b/packages/core/platform/images/migrations/preflight/checks/10-nodes-ready.sh
@@ -32,10 +32,16 @@ fi
 # "True". Keying on the presence of Ready=="True" (rather than on Ready!="True")
 # also flags a node that reports NO Ready condition at all — a brand-new or
 # partially-registered node — instead of passing it vacuously.
-not_ready=$(printf '%s' "$nodes_json" | jq -r '
+# Fail CLOSED on a jq parse error: a malformed or schema-incompatible response
+# from a "successful" kubectl call must not be silently turned into an empty
+# result that reads as "all nodes Ready". Capture jq stderr and gate on its exit.
+if ! not_ready=$(printf '%s' "$nodes_json" | jq -r '
   .items[]
   | select((any(.status.conditions[]?; .type == "Ready" and .status == "True")) | not)
-  | .metadata.name' 2>/dev/null || true)
+  | .metadata.name' 2>&1); then
+  pf_log "cannot parse 'kubectl get nodes' output as expected JSON ($not_ready) — refusing to assume the cluster is healthy"
+  exit 2
+fi
 
 if [ -n "$not_ready" ]; then
   pf_log "the following nodes are NOT Ready:"

--- a/packages/core/platform/images/migrations/preflight/checks/10-nodes-ready.sh
+++ b/packages/core/platform/images/migrations/preflight/checks/10-nodes-ready.sh
@@ -23,9 +23,13 @@ nodes_json=$(kubectl get nodes -o json 2>/dev/null) || {
   exit 2
 }
 
+# A node is NOT ready unless it carries a Ready condition explicitly set to
+# "True". Keying on the presence of Ready=="True" (rather than on Ready!="True")
+# also flags a node that reports NO Ready condition at all — a brand-new or
+# partially-registered node — instead of passing it vacuously.
 not_ready=$(printf '%s' "$nodes_json" | jq -r '
   .items[]
-  | select(any(.status.conditions[]?; .type == "Ready" and .status != "True"))
+  | select((any(.status.conditions[]?; .type == "Ready" and .status == "True")) | not)
   | .metadata.name' 2>/dev/null || true)
 
 if [ -n "$not_ready" ]; then

--- a/packages/core/platform/images/migrations/preflight/checks/10-nodes-ready.sh
+++ b/packages/core/platform/images/migrations/preflight/checks/10-nodes-ready.sh
@@ -18,8 +18,10 @@ PF_CHECK=nodes-ready
 # shellcheck source=../lib/preflight-lib.sh
 . "$(dirname "$0")/../lib/preflight-lib.sh"
 
-nodes_json=$(kubectl get nodes -o json 2>/dev/null) || {
-  pf_log "cannot list nodes (kubectl get nodes failed) — refusing to assume the cluster is healthy"
+# --request-timeout bounds the call so a wedged API server cannot hang the
+# pre-upgrade hook: a timeout exits non-zero here and fails closed (exit 2).
+nodes_json=$(kubectl --request-timeout=30s get nodes -o json 2>/dev/null) || {
+  pf_log "cannot list nodes (kubectl get nodes failed or timed out) — refusing to assume the cluster is healthy"
   exit 2
 }
 

--- a/packages/core/platform/images/migrations/preflight/checks/10-nodes-ready.sh
+++ b/packages/core/platform/images/migrations/preflight/checks/10-nodes-ready.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Preflight check: every Kubernetes Node is Ready.
+#
+# A NotReady node before an upgrade means its workloads cannot be drained or
+# rescheduled and the platform HelmRelease rollout can wedge mid-flight. That is
+# a hard gate (exit 2). Cordoned-but-Ready nodes (spec.unschedulable) are a
+# deliberate operator action during maintenance, so they are only a warning, not
+# a block.
+#
+# Exit codes (the preflight runner contract):
+#   0 - OK
+#   2 - FAIL (gate the upgrade)
+#   3 - N/A (not applicable / skipped)
+set -eu
+
+# shellcheck disable=SC2034  # PF_CHECK is read by pf_log in the sourced lib below
+PF_CHECK=nodes-ready
+# shellcheck source=../lib/preflight-lib.sh
+. "$(dirname "$0")/../lib/preflight-lib.sh"
+
+nodes_json=$(kubectl get nodes -o json 2>/dev/null) || {
+  pf_log "cannot list nodes (kubectl get nodes failed) — refusing to assume the cluster is healthy"
+  exit 2
+}
+
+not_ready=$(printf '%s' "$nodes_json" | jq -r '
+  .items[]
+  | select(any(.status.conditions[]?; .type == "Ready" and .status != "True"))
+  | .metadata.name' 2>/dev/null || true)
+
+if [ -n "$not_ready" ]; then
+  pf_log "the following nodes are NOT Ready:"
+  printf '%s\n' "$not_ready" | while IFS= read -r n; do
+    [ -n "$n" ] && pf_log "  - $n"
+  done
+  exit 2
+fi
+
+cordoned=$(printf '%s' "$nodes_json" | jq -r '
+  .items[] | select(.spec.unschedulable == true) | .metadata.name' 2>/dev/null || true)
+
+if [ -n "$cordoned" ]; then
+  pf_log "WARNING: the following nodes are cordoned (SchedulingDisabled); not blocking:"
+  printf '%s\n' "$cordoned" | while IFS= read -r n; do
+    [ -n "$n" ] && pf_log "  - $n"
+  done
+fi
+
+pf_log "all nodes are Ready"
+exit 0

--- a/packages/core/platform/images/migrations/preflight/checks/10-nodes-ready.sh
+++ b/packages/core/platform/images/migrations/preflight/checks/10-nodes-ready.sh
@@ -18,12 +18,15 @@ PF_CHECK=nodes-ready
 # shellcheck source=../lib/preflight-lib.sh
 . "$(dirname "$0")/../lib/preflight-lib.sh"
 
-# --request-timeout bounds the call so a wedged API server cannot hang the
-# pre-upgrade hook: a timeout exits non-zero here and fails closed (exit 2).
-nodes_json=$(kubectl --request-timeout=30s get nodes -o json 2>/dev/null) || {
-  pf_log "cannot list nodes (kubectl get nodes failed or timed out) — refusing to assume the cluster is healthy"
+# kubectl stderr is intentionally NOT silenced: on failure the real API error
+# (forbidden, connection refused, timeout) must reach the Job log so the
+# operator can see WHY the gate could not verify the cluster, instead of a bare
+# "failed" line. kubectl_t bounds the call so a wedged API server cannot hang
+# the hook; a timeout exits non-zero here and fails closed (exit 2).
+if ! nodes_json=$(kubectl_t get nodes -o json); then
+  pf_log "cannot list nodes (kubectl get nodes failed or timed out; see the kubectl error above) — refusing to assume the cluster is healthy"
   exit 2
-}
+fi
 
 # A node is NOT ready unless it carries a Ready condition explicitly set to
 # "True". Keying on the presence of Ready=="True" (rather than on Ready!="True")

--- a/packages/core/platform/images/migrations/preflight/checks/10-nodes-ready.sh
+++ b/packages/core/platform/images/migrations/preflight/checks/10-nodes-ready.sh
@@ -3,9 +3,17 @@
 #
 # A NotReady node before an upgrade means its workloads cannot be drained or
 # rescheduled and the platform HelmRelease rollout can wedge mid-flight. That is
-# a hard gate (exit 2). Cordoned-but-Ready nodes (spec.unschedulable) are a
-# deliberate operator action during maintenance, so they are only a warning, not
-# a block.
+# a hard gate (exit 2).
+#
+# Cordoned nodes (spec.unschedulable) are exempt from that gate REGARDLESS of
+# readiness, and reported as a warning instead. The cordon is the operator
+# saying "this node is deliberately out of service", and the rationale above
+# does not apply to it: the normal maintenance sequence is cordon, drain, power
+# off, which leaves a cordoned node at Ready=Unknown with its workloads already
+# moved. Blocking there would mean no cluster with a node out for a disk swap
+# could take a version-advancing upgrade without an override. The trade-off is
+# stated in values.yaml: a node that failed and was then cordoned by an
+# operator or an automation is waved through on the same signal.
 #
 # Exit codes (the preflight runner contract):
 #   0 - OK
@@ -31,12 +39,14 @@ fi
 # A node is NOT ready unless it carries a Ready condition explicitly set to
 # "True". Keying on the presence of Ready=="True" (rather than on Ready!="True")
 # also flags a node that reports NO Ready condition at all — a brand-new or
-# partially-registered node — instead of passing it vacuously.
+# partially-registered node — instead of passing it vacuously. Cordoned nodes
+# are filtered out here, not later: see the exemption in the header.
 # Fail CLOSED on a jq parse error: a malformed or schema-incompatible response
 # from a "successful" kubectl call must not be silently turned into an empty
 # result that reads as "all nodes Ready". Capture jq stderr and gate on its exit.
 if ! not_ready=$(printf '%s' "$nodes_json" | jq -r '
   .items[]
+  | select(.spec.unschedulable != true)
   | select((any(.status.conditions[]?; .type == "Ready" and .status == "True")) | not)
   | .metadata.name' 2>&1); then
   pf_log "cannot parse 'kubectl get nodes' output as expected JSON ($not_ready) — refusing to assume the cluster is healthy"
@@ -51,11 +61,23 @@ if [ -n "$not_ready" ]; then
   exit 2
 fi
 
-cordoned=$(printf '%s' "$nodes_json" | jq -r '
-  .items[] | select(.spec.unschedulable == true) | .metadata.name' 2>/dev/null || true)
+# Cordoned nodes are reported with their readiness, because the exemption above
+# means this warning is the only place a cordoned-and-NotReady node shows up.
+# Fail closed here too: the blocking query already excluded these nodes, so a
+# silent parse failure would hide exactly the set that was waved through.
+if ! cordoned=$(printf '%s' "$nodes_json" | jq -r '
+  .items[]
+  | select(.spec.unschedulable == true)
+  | .metadata.name + " (Ready="
+    + (first(.status.conditions[]? | select(.type == "Ready") | .status) // "unknown")
+    + ")"' 2>&1); then
+  pf_log "cannot parse the cordoned-node list from 'kubectl get nodes' ($cordoned)"
+  exit 2
+fi
 
 if [ -n "$cordoned" ]; then
-  pf_log "WARNING: the following nodes are cordoned (SchedulingDisabled); not blocking:"
+  pf_log "WARNING: the following nodes are cordoned (SchedulingDisabled) and are"
+  pf_log "WARNING: exempt from the readiness gate; not blocking:"
   printf '%s\n' "$cordoned" | while IFS= read -r n; do
     [ -n "$n" ] && pf_log "  - $n"
   done

--- a/packages/core/platform/images/migrations/preflight/checks/20-linstor.sh
+++ b/packages/core/platform/images/migrations/preflight/checks/20-linstor.sh
@@ -18,12 +18,12 @@
 #
 # SCHEMA NOTE: parsing uses `linstor -m` (machine/JSON output — the stable API
 # contract) and recursive descent (`.. | objects`), so it is independent of the
-# -m array nesting. The connection_status / disk_state field values are LINBIT
-# REST API v1 values that have NOT yet been confirmed against a live controller
-# in e2e. Because of that, this check is ADVISORY by default (see
-# preflight.advisoryChecks in values.yaml): a wrong assumption here warns but
-# does not hard-block a healthy upgrade. Once cozystack-pr-test confirms the
-# field names/values on a live controller, a follow-up flips it to enforcing.
+# -m array nesting. The connection_status / disk_state field names were
+# confirmed on a live controller (node objects carry connection_status="ONLINE";
+# volume objects carry disk_state with values such as UpToDate/Diskless). This
+# check is ADVISORY by default (see preflight.advisoryChecks in values.yaml)
+# until its FAULTY-state detection is also exercised against a genuinely
+# degraded cluster in e2e; a follow-up then flips it to enforcing.
 #
 # Exit codes (the preflight runner contract):
 #   0 - OK
@@ -39,26 +39,40 @@ PF_CHECK=linstor
 LINSTOR_NS="${LINSTOR_NS:-cozy-linstor}"
 LINSTOR_DEPLOY="${LINSTOR_DEPLOY:-linstor-controller}"
 
-if ! kubectl --request-timeout=30s get deploy --namespace "$LINSTOR_NS" "$LINSTOR_DEPLOY" >/dev/null 2>&1; then
-  pf_log "LINSTOR not installed (no deploy/$LINSTOR_DEPLOY in $LINSTOR_NS); skipping"
-  exit 3
+# Probe for the controller. Distinguish "genuinely not installed" (NotFound →
+# N/A) from "could not ask" (RBAC / timeout / API error → FAIL): treating a
+# failed query as "not installed" would silently skip a check the cluster
+# actually needs, so only a real NotFound is an N/A.
+if probe_out=$(kubectl_t get deploy --namespace "$LINSTOR_NS" "$LINSTOR_DEPLOY" 2>&1); then
+  : # installed, continue
+else
+  case "$probe_out" in
+    *NotFound* | *"not found"*)
+      pf_log "LINSTOR not installed (no deploy/$LINSTOR_DEPLOY in $LINSTOR_NS); skipping"
+      exit 3
+      ;;
+    *)
+      pf_log "cannot determine LINSTOR state (kubectl get deploy failed): $probe_out"
+      exit 2
+      ;;
+  esac
 fi
 
-# lx runs the linstor CLI inside the controller pod in machine-readable mode.
-# --request-timeout bounds the exec: a wedged controller (the very state this
-# check targets) must not hang the pre-upgrade hook. A timeout makes lx exit
-# non-zero, which the check treats as a query failure (exit 2); since linstor is
-# advisory by default the runner then downgrades that to a warning rather than
-# letting the hang block the upgrade.
+# lx runs the linstor CLI inside the controller pod in machine-readable mode,
+# bounded by kubectl_t so a wedged controller (the very state this check targets)
+# cannot hang the pre-upgrade hook. kubectl stderr is not silenced so a query
+# failure surfaces its real cause in the Job log. Because linstor is advisory by
+# default, a query failure (exit 2) is downgraded to a warning by the runner
+# rather than blocking the upgrade.
 lx() {
-  kubectl --request-timeout=30s exec --namespace "$LINSTOR_NS" "deploy/$LINSTOR_DEPLOY" -- linstor -m "$@"
+  kubectl_t exec --namespace "$LINSTOR_NS" "deploy/$LINSTOR_DEPLOY" -- linstor -m "$@"
 }
 
 # --- satellites all ONLINE ---------------------------------------------------
-nodes_json=$(lx node list 2>/dev/null) || {
-  pf_log "cannot query LINSTOR nodes (kubectl exec ... linstor node list failed)"
+if ! nodes_json=$(lx node list); then
+  pf_log "cannot query LINSTOR nodes (see the kubectl error above)"
   exit 2
-}
+fi
 offline=$(printf '%s' "$nodes_json" | jq -r '
   .. | objects
   | select(has("connection_status"))
@@ -74,10 +88,10 @@ if [ -n "$offline" ]; then
 fi
 
 # --- no faulty DRBD volume states --------------------------------------------
-vol_json=$(lx volume list 2>/dev/null) || {
-  pf_log "cannot query LINSTOR volumes (kubectl exec ... linstor volume list failed)"
+if ! vol_json=$(lx volume list); then
+  pf_log "cannot query LINSTOR volumes (see the kubectl error above)"
   exit 2
-}
+fi
 faulty=$(printf '%s' "$vol_json" | jq -r '
   [ .. | objects | (.disk_state? // empty) ]
   | map(ascii_upcase)

--- a/packages/core/platform/images/migrations/preflight/checks/20-linstor.sh
+++ b/packages/core/platform/images/migrations/preflight/checks/20-linstor.sh
@@ -19,8 +19,11 @@
 # SCHEMA NOTE: parsing uses `linstor -m` (machine/JSON output — the stable API
 # contract) and recursive descent (`.. | objects`), so it is independent of the
 # -m array nesting. The connection_status / disk_state field values are LINBIT
-# REST API v1 values; confirm them against a live controller in e2e before this
-# gate is trusted to hard-block a production upgrade.
+# REST API v1 values that have NOT yet been confirmed against a live controller
+# in e2e. Because of that, this check is ADVISORY by default (see
+# preflight.advisoryChecks in values.yaml): a wrong assumption here warns but
+# does not hard-block a healthy upgrade. Once cozystack-pr-test confirms the
+# field names/values on a live controller, a follow-up flips it to enforcing.
 #
 # Exit codes (the preflight runner contract):
 #   0 - OK

--- a/packages/core/platform/images/migrations/preflight/checks/20-linstor.sh
+++ b/packages/core/platform/images/migrations/preflight/checks/20-linstor.sh
@@ -73,11 +73,16 @@ if ! nodes_json=$(lx node list); then
   pf_log "cannot query LINSTOR nodes (see the kubectl error above)"
   exit 2
 fi
-offline=$(printf '%s' "$nodes_json" | jq -r '
+# Fail CLOSED on a jq parse error (see the nodes-ready check): a malformed
+# response must not collapse into an empty "all online" result.
+if ! offline=$(printf '%s' "$nodes_json" | jq -r '
   .. | objects
   | select(has("connection_status"))
   | select(.connection_status != "ONLINE")
-  | .name' 2>/dev/null || true)
+  | .name' 2>&1); then
+  pf_log "cannot parse LINSTOR node list output as expected JSON ($offline)"
+  exit 2
+fi
 
 if [ -n "$offline" ]; then
   pf_log "the following LINSTOR satellites are NOT online:"
@@ -92,11 +97,14 @@ if ! vol_json=$(lx volume list); then
   pf_log "cannot query LINSTOR volumes (see the kubectl error above)"
   exit 2
 fi
-faulty=$(printf '%s' "$vol_json" | jq -r '
+if ! faulty=$(printf '%s' "$vol_json" | jq -r '
   [ .. | objects | (.disk_state? // empty) ]
   | map(ascii_upcase)
   | map(select(. == "INCONSISTENT" or . == "FAILED" or . == "DUNKNOWN" or . == "OUTDATED"))
-  | unique | .[]' 2>/dev/null || true)
+  | unique | .[]' 2>&1); then
+  pf_log "cannot parse LINSTOR volume list output as expected JSON ($faulty)"
+  exit 2
+fi
 
 if [ -n "$faulty" ]; then
   pf_log "faulty DRBD volume state(s) present on the cluster:"

--- a/packages/core/platform/images/migrations/preflight/checks/20-linstor.sh
+++ b/packages/core/platform/images/migrations/preflight/checks/20-linstor.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+# Preflight check: LINSTOR/DRBD storage is healthy.
+#
+# WHY THIS MUST RUN AGAINST A LIVE CONTROLLER:
+# The LINSTOR k8s-backend (internal.linstor.linbit.com CRDs) persists only
+# static flags (DELETE / DISKLESS / TIE_BREAKER). Live DRBD replication health
+# (Inconsistent, Outdated, Failed volumes, offline satellites) lives ONLY in
+# satellite memory and is reachable exclusively by asking a running controller.
+# A static backend dump therefore cannot answer "is the storage healthy right
+# now?" — so this gate queries the live controller BEFORE any upgrade step can
+# stop it.
+#
+# SCOPE (v1): all satellites ONLINE + no volume in an unambiguously-bad
+# disk_state. The bad states are a DENYLIST (Inconsistent/Failed/DUnknown/
+# Outdated), never an allowlist, so an unknown-but-healthy state can never
+# false-positive and block a good cluster. StandAlone-connection and
+# quorum-detail reporting are a deliberate follow-up, not covered here.
+#
+# SCHEMA NOTE: parsing uses `linstor -m` (machine/JSON output — the stable API
+# contract) and recursive descent (`.. | objects`), so it is independent of the
+# -m array nesting. The connection_status / disk_state field values are LINBIT
+# REST API v1 values; confirm them against a live controller in e2e before this
+# gate is trusted to hard-block a production upgrade.
+#
+# Exit codes (the preflight runner contract):
+#   0 - OK
+#   2 - FAIL (gate the upgrade)
+#   3 - N/A (LINSTOR not installed)
+set -eu
+
+# shellcheck disable=SC2034  # PF_CHECK is read by pf_log in the sourced lib below
+PF_CHECK=linstor
+# shellcheck source=../lib/preflight-lib.sh
+. "$(dirname "$0")/../lib/preflight-lib.sh"
+
+LINSTOR_NS="${LINSTOR_NS:-cozy-linstor}"
+LINSTOR_DEPLOY="${LINSTOR_DEPLOY:-linstor-controller}"
+
+if ! kubectl get deploy --namespace "$LINSTOR_NS" "$LINSTOR_DEPLOY" >/dev/null 2>&1; then
+  pf_log "LINSTOR not installed (no deploy/$LINSTOR_DEPLOY in $LINSTOR_NS); skipping"
+  exit 3
+fi
+
+# lx runs the linstor CLI inside the controller pod in machine-readable mode.
+lx() {
+  kubectl exec --namespace "$LINSTOR_NS" "deploy/$LINSTOR_DEPLOY" -- linstor -m "$@"
+}
+
+# --- satellites all ONLINE ---------------------------------------------------
+nodes_json=$(lx node list 2>/dev/null) || {
+  pf_log "cannot query LINSTOR nodes (kubectl exec ... linstor node list failed)"
+  exit 2
+}
+offline=$(printf '%s' "$nodes_json" | jq -r '
+  .. | objects
+  | select(has("connection_status"))
+  | select(.connection_status != "ONLINE")
+  | .name' 2>/dev/null || true)
+
+if [ -n "$offline" ]; then
+  pf_log "the following LINSTOR satellites are NOT online:"
+  printf '%s\n' "$offline" | while IFS= read -r n; do
+    [ -n "$n" ] && pf_log "  - $n"
+  done
+  exit 2
+fi
+
+# --- no faulty DRBD volume states --------------------------------------------
+vol_json=$(lx volume list 2>/dev/null) || {
+  pf_log "cannot query LINSTOR volumes (kubectl exec ... linstor volume list failed)"
+  exit 2
+}
+faulty=$(printf '%s' "$vol_json" | jq -r '
+  [ .. | objects | (.disk_state? // empty) ]
+  | map(ascii_upcase)
+  | map(select(. == "INCONSISTENT" or . == "FAILED" or . == "DUNKNOWN" or . == "OUTDATED"))
+  | unique | .[]' 2>/dev/null || true)
+
+if [ -n "$faulty" ]; then
+  pf_log "faulty DRBD volume state(s) present on the cluster:"
+  printf '%s\n' "$faulty" | while IFS= read -r s; do
+    [ -n "$s" ] && pf_log "  - $s"
+  done
+  pf_log "inspect with: kubectl exec -n $LINSTOR_NS deploy/$LINSTOR_DEPLOY -- linstor resource list --faulty"
+  exit 2
+fi
+
+pf_log "LINSTOR healthy (all satellites ONLINE, no faulty volume states)"
+exit 0

--- a/packages/core/platform/images/migrations/preflight/checks/20-linstor.sh
+++ b/packages/core/platform/images/migrations/preflight/checks/20-linstor.sh
@@ -39,14 +39,19 @@ PF_CHECK=linstor
 LINSTOR_NS="${LINSTOR_NS:-cozy-linstor}"
 LINSTOR_DEPLOY="${LINSTOR_DEPLOY:-linstor-controller}"
 
-if ! kubectl get deploy --namespace "$LINSTOR_NS" "$LINSTOR_DEPLOY" >/dev/null 2>&1; then
+if ! kubectl --request-timeout=30s get deploy --namespace "$LINSTOR_NS" "$LINSTOR_DEPLOY" >/dev/null 2>&1; then
   pf_log "LINSTOR not installed (no deploy/$LINSTOR_DEPLOY in $LINSTOR_NS); skipping"
   exit 3
 fi
 
 # lx runs the linstor CLI inside the controller pod in machine-readable mode.
+# --request-timeout bounds the exec: a wedged controller (the very state this
+# check targets) must not hang the pre-upgrade hook. A timeout makes lx exit
+# non-zero, which the check treats as a query failure (exit 2); since linstor is
+# advisory by default the runner then downgrades that to a warning rather than
+# letting the hang block the upgrade.
 lx() {
-  kubectl exec --namespace "$LINSTOR_NS" "deploy/$LINSTOR_DEPLOY" -- linstor -m "$@"
+  kubectl --request-timeout=30s exec --namespace "$LINSTOR_NS" "deploy/$LINSTOR_DEPLOY" -- linstor -m "$@"
 }
 
 # --- satellites all ONLINE ---------------------------------------------------

--- a/packages/core/platform/images/migrations/preflight/lib/preflight-lib.sh
+++ b/packages/core/platform/images/migrations/preflight/lib/preflight-lib.sh
@@ -9,3 +9,27 @@
 pf_log() {
   echo "[preflight:${PF_CHECK:-?}] $*"
 }
+
+# kubectl_t <args...> - run kubectl with a hard wall-clock bound so a wedged API
+# server or pod cannot hang the pre-upgrade hook indefinitely.
+#
+# It bounds the call with coreutils `timeout` (present in the migrations image)
+# rather than kubectl's own --request-timeout. That flag CANNOT be used here:
+# the kubectl pinned in the migrations image mis-handles --request-timeout and
+# falls back to the localhost:8080 default endpoint instead of the in-cluster
+# ServiceAccount config, which makes every call fail on a perfectly healthy
+# cluster (verified on a live cluster). `timeout` wraps kubectl as a separate
+# process and passes it no extra flags, so kubectl runs in its normal,
+# in-cluster-config-detecting form; if the call hangs, timeout kills it and
+# exits non-zero, which each check treats as a query failure.
+#
+# Where `timeout` is unavailable (host unit tests) it runs kubectl directly; the
+# fake kubectl there returns immediately, so no bound is needed.
+PREFLIGHT_KUBECTL_TIMEOUT="${PREFLIGHT_KUBECTL_TIMEOUT:-30}"
+kubectl_t() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$PREFLIGHT_KUBECTL_TIMEOUT" kubectl "$@"
+  else
+    kubectl "$@"
+  fi
+}

--- a/packages/core/platform/images/migrations/preflight/lib/preflight-lib.sh
+++ b/packages/core/platform/images/migrations/preflight/lib/preflight-lib.sh
@@ -1,0 +1,11 @@
+# shellcheck shell=sh
+# Shared helpers for preflight checks. Sourced, not executed.
+#
+# Each check under preflight/checks/ sources this and sets PF_CHECK to its own
+# id before logging, so every line the runner aggregates is attributable to a
+# specific check.
+
+# pf_log <message...> - emit a check-attributed line on stdout.
+pf_log() {
+  echo "[preflight:${PF_CHECK:-?}] $*"
+}

--- a/packages/core/platform/images/migrations/preflight/run-preflight.sh
+++ b/packages/core/platform/images/migrations/preflight/run-preflight.sh
@@ -14,6 +14,12 @@
 #   PREFLIGHT_OVERRIDE    - "true" downgrades every FAIL to a warning and
 #                           proceeds; the operator has accepted the risk
 #   PREFLIGHT_SKIP        - space/comma list of check ids to skip entirely
+#   PREFLIGHT_ADVISORY    - space/comma list of check ids whose FAILURES are
+#                           downgraded to non-blocking warnings. Unlike skip the
+#                           check still RUNS and reports; it just does not gate.
+#                           Used for checks whose live semantics are not yet
+#                           verified enough to hard-block an existing customer's
+#                           upgrade (see the linstor check).
 #   PREFLIGHT_CHECKS_DIR  - directory of check scripts (default /preflight/checks)
 #
 # Each check exits: 0 = OK, 2 = FAIL (gate), 3 = N/A. Any other non-zero exit is
@@ -25,6 +31,7 @@ CHECKS_DIR="${PREFLIGHT_CHECKS_DIR:-/preflight/checks}"
 ENABLED="${PREFLIGHT_ENABLED:-true}"
 OVERRIDE="${PREFLIGHT_OVERRIDE:-false}"
 SKIP="${PREFLIGHT_SKIP:-}"
+ADVISORY="${PREFLIGHT_ADVISORY:-}"
 
 # Passed through to the LINSTOR check; centralised here so all checks agree.
 export LINSTOR_NS="${LINSTOR_NS:-cozy-linstor}"
@@ -35,11 +42,14 @@ if [ "$ENABLED" != "true" ]; then
   exit 0
 fi
 
-# Normalise the skip list: accept both comma- and space-separated ids.
+# Normalise the id lists: accept both comma- and space-separated ids.
 SKIP=$(printf '%s' "$SKIP" | tr ',' ' ')
-is_skipped() {
-  for s in $SKIP; do
-    [ "$s" = "$1" ] && return 0
+ADVISORY=$(printf '%s' "$ADVISORY" | tr ',' ' ')
+in_list() {
+  needle=$1
+  shift
+  for s in "$@"; do
+    [ "$s" = "$needle" ] && return 0
   done
   return 1
 }
@@ -50,13 +60,15 @@ ok_checks=""
 na_checks=""
 skip_checks=""
 fail_checks=""
+advisory_checks=""
 
 for chk in "$CHECKS_DIR"/*; do
   [ -f "$chk" ] || continue
   # id = filename with the numeric ordering prefix and .sh suffix stripped.
   id=$(basename "$chk" | sed 's/^[0-9]*-//; s/\.sh$//')
 
-  if is_skipped "$id"; then
+  # shellcheck disable=SC2086  # SKIP/ADVISORY are intentionally word-split into args
+  if in_list "$id" $SKIP; then
     echo "--- SKIP (operator-skipped via preflight.skipChecks): $id"
     skip_checks="$skip_checks $id"
     continue
@@ -69,16 +81,25 @@ for chk in "$CHECKS_DIR"/*; do
   case "$rc" in
     0) ok_checks="$ok_checks $id" ;;
     3) na_checks="$na_checks $id" ;;
-    *) fail_checks="$fail_checks $id" ;;
+    *)
+      # shellcheck disable=SC2086  # ADVISORY is intentionally word-split into args
+      if in_list "$id" $ADVISORY; then
+        echo "    (advisory: $id reported a problem but is non-blocking by config; not gating the upgrade)"
+        advisory_checks="$advisory_checks $id"
+      else
+        fail_checks="$fail_checks $id"
+      fi
+      ;;
   esac
 done
 
 echo ""
 echo "===== PREFLIGHT SUMMARY ====="
-echo "  OK:       ${ok_checks:- (none)}"
-echo "  N/A:      ${na_checks:- (none)}"
-echo "  skipped:  ${skip_checks:- (none)}"
-echo "  FAILED:   ${fail_checks:- (none)}"
+echo "  OK:                     ${ok_checks:- (none)}"
+echo "  N/A:                    ${na_checks:- (none)}"
+echo "  skipped:                ${skip_checks:- (none)}"
+echo "  advisory (non-blocking):${advisory_checks:- (none)}"
+echo "  FAILED (blocking):      ${fail_checks:- (none)}"
 
 if [ -n "$fail_checks" ]; then
   if [ "$OVERRIDE" = "true" ]; then
@@ -102,5 +123,10 @@ if [ -n "$fail_checks" ]; then
 fi
 
 echo ""
-echo "Preflight passed — cluster is healthy, proceeding with the upgrade."
+if [ -n "$advisory_checks" ]; then
+  echo "Preflight passed (blocking checks). Advisory checks reported problems"
+  echo "(${advisory_checks} ) but are non-blocking; review the warnings above."
+else
+  echo "Preflight passed — cluster is healthy, proceeding with the upgrade."
+fi
 exit 0

--- a/packages/core/platform/images/migrations/preflight/run-preflight.sh
+++ b/packages/core/platform/images/migrations/preflight/run-preflight.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# Cozystack upgrade preflight health gate.
+#
+# Runs as a Helm pre-upgrade hook (weight 0) ahead of the migration hook
+# (weight 1). It executes every check under preflight/checks/ and refuses to let
+# the upgrade proceed when the cluster is not in a safe state — UNLESS the
+# operator explicitly overrides. This is the base "fails exist = do not start"
+# guard: a static backend dump cannot see live storage/DRBD health, so the check
+# is taken from the live cluster before any upgrade step runs.
+#
+# Behaviour is configured entirely through env (rendered from Helm values by
+# templates/preflight-hook.yaml):
+#   PREFLIGHT_ENABLED     - "true"/"false" master toggle (default true)
+#   PREFLIGHT_OVERRIDE    - "true" downgrades every FAIL to a warning and
+#                           proceeds; the operator has accepted the risk
+#   PREFLIGHT_SKIP        - space/comma list of check ids to skip entirely
+#   PREFLIGHT_CHECKS_DIR  - directory of check scripts (default /preflight/checks)
+#
+# Each check exits: 0 = OK, 2 = FAIL (gate), 3 = N/A. Any other non-zero exit is
+# treated as FAIL — a check that cannot determine health must not be assumed
+# healthy.
+set -eu
+
+CHECKS_DIR="${PREFLIGHT_CHECKS_DIR:-/preflight/checks}"
+ENABLED="${PREFLIGHT_ENABLED:-true}"
+OVERRIDE="${PREFLIGHT_OVERRIDE:-false}"
+SKIP="${PREFLIGHT_SKIP:-}"
+
+# Passed through to the LINSTOR check; centralised here so all checks agree.
+export LINSTOR_NS="${LINSTOR_NS:-cozy-linstor}"
+export LINSTOR_DEPLOY="${LINSTOR_DEPLOY:-linstor-controller}"
+
+if [ "$ENABLED" != "true" ]; then
+  echo "Preflight disabled (PREFLIGHT_ENABLED=$ENABLED); skipping all health checks"
+  exit 0
+fi
+
+# Normalise the skip list: accept both comma- and space-separated ids.
+SKIP=$(printf '%s' "$SKIP" | tr ',' ' ')
+is_skipped() {
+  for s in $SKIP; do
+    [ "$s" = "$1" ] && return 0
+  done
+  return 1
+}
+
+echo "===== Cozystack upgrade preflight ====="
+
+ok_checks=""
+na_checks=""
+skip_checks=""
+fail_checks=""
+
+for chk in "$CHECKS_DIR"/*; do
+  [ -f "$chk" ] || continue
+  # id = filename with the numeric ordering prefix and .sh suffix stripped.
+  id=$(basename "$chk" | sed 's/^[0-9]*-//; s/\.sh$//')
+
+  if is_skipped "$id"; then
+    echo "--- SKIP (operator-skipped via preflight.skipChecks): $id"
+    skip_checks="$skip_checks $id"
+    continue
+  fi
+
+  echo "--- running check: $id"
+  chmod +x "$chk" 2>/dev/null || true
+  rc=0
+  "$chk" || rc=$?
+  case "$rc" in
+    0) ok_checks="$ok_checks $id" ;;
+    3) na_checks="$na_checks $id" ;;
+    *) fail_checks="$fail_checks $id" ;;
+  esac
+done
+
+echo ""
+echo "===== PREFLIGHT SUMMARY ====="
+echo "  OK:       ${ok_checks:- (none)}"
+echo "  N/A:      ${na_checks:- (none)}"
+echo "  skipped:  ${skip_checks:- (none)}"
+echo "  FAILED:   ${fail_checks:- (none)}"
+
+if [ -n "$fail_checks" ]; then
+  if [ "$OVERRIDE" = "true" ]; then
+    echo ""
+    echo "!! Preflight FAILED for:${fail_checks}"
+    echo "!! preflight.override=true is set — the operator has explicitly accepted"
+    echo "!! the risk, so the failing checks are downgraded to warnings and the"
+    echo "!! upgrade will proceed. This is logged for the audit trail."
+    exit 0
+  fi
+  echo ""
+  echo "Preflight FAILED for:${fail_checks}"
+  echo "The upgrade is BLOCKED because the cluster is not in a safe state."
+  echo ""
+  echo "Fix the issues reported above and retry the upgrade."
+  echo "If this degraded state is expected and you accept the risk, re-run with"
+  echo "either:"
+  echo "  preflight.override: true            # proceed past all failing checks"
+  echo "  preflight.skipChecks: [<check-id>]  # skip specific checks only"
+  exit 1
+fi
+
+echo ""
+echo "Preflight passed — cluster is healthy, proceeding with the upgrade."
+exit 0

--- a/packages/core/platform/images/migrations/preflight/run-preflight.sh
+++ b/packages/core/platform/images/migrations/preflight/run-preflight.sh
@@ -152,11 +152,18 @@ run_checks() {
     echo "Preflight FAILED for:${fail_checks}"
     echo "The upgrade is BLOCKED because the cluster is not in a safe state."
     echo ""
-    echo "Fix the issues reported above and retry the upgrade."
-    echo "If this degraded state is expected and you accept the risk, re-run with"
-    echo "either:"
-    echo "  preflight.override: true            # proceed past all failing checks"
-    echo "  preflight.skipChecks: [<check-id>]  # skip specific checks only"
+    echo "Fix the issues reported above and retry the upgrade. The upgrade is"
+    echo "retried automatically, so there is nothing to re-run by hand."
+    echo ""
+    echo "This verdict is also in configmap/${STATUS_CM:-cozystack-preflight-status}"
+    echo "in namespace ${STATUS_NS:-<release namespace>}, which outlives this Job."
+    echo ""
+    echo "If this degraded state is expected and you accept the risk, set one of"
+    echo "these under spec.components.platform.values.preflight on the"
+    echo "cozystack.cozystack-platform Package CR:"
+    echo "  override: true            # proceed past all failing checks"
+    echo "  skipChecks: [<check-id>]  # skip specific checks only"
+    echo "See docs/operations/upgrade-preflight.md."
     return 1
   fi
 

--- a/packages/core/platform/images/migrations/preflight/run-preflight.sh
+++ b/packages/core/platform/images/migrations/preflight/run-preflight.sh
@@ -20,6 +20,11 @@
 #                           Used for checks whose live semantics are not yet
 #                           verified enough to hard-block an existing customer's
 #                           upgrade (see the linstor check).
+#   PREFLIGHT_STATUS_CONFIGMAP
+#                         - name of the ConfigMap in $NAMESPACE the verdict is
+#                           written to (default cozystack-preflight-status).
+#                           Empty disables publishing.
+#   NAMESPACE             - namespace the status ConfigMap is written to.
 #   PREFLIGHT_CHECKS_DIR  - directory of check scripts (default /preflight/checks)
 #
 # Each check exits: 0 = OK, 2 = FAIL (gate), 3 = N/A. Any other non-zero exit is
@@ -32,6 +37,8 @@ ENABLED="${PREFLIGHT_ENABLED:-true}"
 OVERRIDE="${PREFLIGHT_OVERRIDE:-false}"
 SKIP="${PREFLIGHT_SKIP:-}"
 ADVISORY="${PREFLIGHT_ADVISORY:-}"
+STATUS_CM="${PREFLIGHT_STATUS_CONFIGMAP:-cozystack-preflight-status}"
+STATUS_NS="${NAMESPACE:-}"
 
 # Passed through to the LINSTOR check; centralised here so all checks agree.
 export LINSTOR_NS="${LINSTOR_NS:-cozy-linstor}"
@@ -64,94 +71,188 @@ in_list() {
   return 1
 }
 
-echo "===== Cozystack upgrade preflight ====="
+run_checks() {
+  echo "===== Cozystack upgrade preflight ====="
 
-ok_checks=""
-na_checks=""
-skip_checks=""
-fail_checks=""
-advisory_checks=""
+  ok_checks=""
+  na_checks=""
+  skip_checks=""
+  fail_checks=""
+  advisory_checks=""
 
-discovered=0
+  discovered=0
 
-for chk in "$CHECKS_DIR"/*; do
-  [ -f "$chk" ] || continue
-  discovered=$((discovered + 1))
-  # id = filename with the numeric ordering prefix and .sh suffix stripped.
-  id=$(basename "$chk" | sed 's/^[0-9]*-//; s/\.sh$//')
+  for chk in "$CHECKS_DIR"/*; do
+    [ -f "$chk" ] || continue
+    discovered=$((discovered + 1))
+    # id = filename with the numeric ordering prefix and .sh suffix stripped.
+    id=$(basename "$chk" | sed 's/^[0-9]*-//; s/\.sh$//')
 
-  if in_list "$id" "$SKIP"; then
-    echo "--- SKIP (operator-skipped via preflight.skipChecks): $id"
-    skip_checks="$skip_checks $id"
-    continue
-  fi
+    if in_list "$id" "$SKIP"; then
+      echo "--- SKIP (operator-skipped via preflight.skipChecks): $id"
+      skip_checks="$skip_checks $id"
+      continue
+    fi
 
-  echo "--- running check: $id"
-  chmod +x "$chk" 2>/dev/null || true
-  rc=0
-  "$chk" || rc=$?
-  case "$rc" in
-    0) ok_checks="$ok_checks $id" ;;
-    3) na_checks="$na_checks $id" ;;
-    *)
-      if in_list "$id" "$ADVISORY"; then
-        echo "    (advisory: $id reported a problem but is non-blocking by config; not gating the upgrade)"
-        advisory_checks="$advisory_checks $id"
-      else
-        fail_checks="$fail_checks $id"
-      fi
-      ;;
-  esac
-done
+    echo "--- running check: $id"
+    chmod +x "$chk" 2>/dev/null || true
+    rc=0
+    "$chk" || rc=$?
+    case "$rc" in
+      0) ok_checks="$ok_checks $id" ;;
+      3) na_checks="$na_checks $id" ;;
+      *)
+        if in_list "$id" "$ADVISORY"; then
+          echo "    (advisory: $id reported a problem but is non-blocking by config; not gating the upgrade)"
+          advisory_checks="$advisory_checks $id"
+        else
+          fail_checks="$fail_checks $id"
+        fi
+        ;;
+    esac
+  done
 
-# A gate that ran nothing must not report the verdict it exists to withhold.
-# The image build already fails when checks/ is empty (RUN chmod +x
-# /preflight/checks/*), but the fail-closed property must hold in the runner
-# itself and not depend on a neighbouring build step: a refactor of the copy
-# layout, or an operator pointing PREFLIGHT_CHECKS_DIR somewhere wrong, must
-# block rather than wave the upgrade through.
-if [ "$discovered" -eq 0 ]; then
-  echo ""
-  echo "No preflight checks were found in $CHECKS_DIR."
-  echo "The gate cannot vouch for a cluster it never inspected, so the upgrade"
-  echo "is BLOCKED. Check the image contents and PREFLIGHT_CHECKS_DIR."
-  exit 1
-fi
-
-echo ""
-echo "===== PREFLIGHT SUMMARY ====="
-echo "  OK:                     ${ok_checks:- (none)}"
-echo "  N/A:                    ${na_checks:- (none)}"
-echo "  skipped:                ${skip_checks:- (none)}"
-echo "  advisory (non-blocking):${advisory_checks:- (none)}"
-echo "  FAILED (blocking):      ${fail_checks:- (none)}"
-
-if [ -n "$fail_checks" ]; then
-  if [ "$OVERRIDE" = "true" ]; then
+  # A gate that ran nothing must not report the verdict it exists to withhold.
+  # The image build already fails when checks/ is empty (RUN chmod +x
+  # /preflight/checks/*), but the fail-closed property must hold in the runner
+  # itself and not depend on a neighbouring build step: a refactor of the copy
+  # layout, or an operator pointing PREFLIGHT_CHECKS_DIR somewhere wrong, must
+  # block rather than wave the upgrade through.
+  if [ "$discovered" -eq 0 ]; then
     echo ""
-    echo "!! Preflight FAILED for:${fail_checks}"
-    echo "!! preflight.override=true is set — the operator has explicitly accepted"
-    echo "!! the risk, so the failing checks are downgraded to warnings and the"
-    echo "!! upgrade will proceed. This is logged for the audit trail."
-    exit 0
+    echo "No preflight checks were found in $CHECKS_DIR."
+    echo "The gate cannot vouch for a cluster it never inspected, so the upgrade"
+    echo "is BLOCKED. Check the image contents and PREFLIGHT_CHECKS_DIR."
+    return 1
   fi
-  echo ""
-  echo "Preflight FAILED for:${fail_checks}"
-  echo "The upgrade is BLOCKED because the cluster is not in a safe state."
-  echo ""
-  echo "Fix the issues reported above and retry the upgrade."
-  echo "If this degraded state is expected and you accept the risk, re-run with"
-  echo "either:"
-  echo "  preflight.override: true            # proceed past all failing checks"
-  echo "  preflight.skipChecks: [<check-id>]  # skip specific checks only"
-  exit 1
-fi
 
-echo ""
-if [ -n "$advisory_checks" ]; then
-  echo "Preflight passed (blocking checks). Advisory checks reported problems"
-  echo "(${advisory_checks} ) but are non-blocking; review the warnings above."
-else
-  echo "Preflight passed — cluster is healthy, proceeding with the upgrade."
-fi
-exit 0
+  echo ""
+  echo "===== PREFLIGHT SUMMARY ====="
+  echo "  OK:                     ${ok_checks:- (none)}"
+  echo "  N/A:                    ${na_checks:- (none)}"
+  echo "  skipped:                ${skip_checks:- (none)}"
+  echo "  advisory (non-blocking):${advisory_checks:- (none)}"
+  echo "  FAILED (blocking):      ${fail_checks:- (none)}"
+
+  # Hand the outcome lists back to the parent shell. This function runs in a
+  # subshell (it is the left leg of the tee pipeline below), so plain variables
+  # would not survive; the facts file is how the status publisher sees them.
+  write_facts
+
+  if [ -n "$fail_checks" ]; then
+    if [ "$OVERRIDE" = "true" ]; then
+      echo ""
+      echo "!! Preflight FAILED for:${fail_checks}"
+      echo "!! preflight.override=true is set — the operator has explicitly accepted"
+      echo "!! the risk, so the failing checks are downgraded to warnings and the"
+      echo "!! upgrade will proceed. This is logged for the audit trail."
+      return 0
+    fi
+    echo ""
+    echo "Preflight FAILED for:${fail_checks}"
+    echo "The upgrade is BLOCKED because the cluster is not in a safe state."
+    echo ""
+    echo "Fix the issues reported above and retry the upgrade."
+    echo "If this degraded state is expected and you accept the risk, re-run with"
+    echo "either:"
+    echo "  preflight.override: true            # proceed past all failing checks"
+    echo "  preflight.skipChecks: [<check-id>]  # skip specific checks only"
+    return 1
+  fi
+
+  echo ""
+  if [ -n "$advisory_checks" ]; then
+    echo "Preflight passed (blocking checks). Advisory checks reported problems"
+    echo "(${advisory_checks} ) but are non-blocking; review the warnings above."
+  else
+    echo "Preflight passed — cluster is healthy, proceeding with the upgrade."
+  fi
+  return 0
+}
+
+# --- durable verdict --------------------------------------------------------
+# WHY THIS EXISTS: the failed Job is NOT a durable record of the block. The
+# platform HelmRelease is generated with Upgrade.Strategy=RetryOnFailure and a
+# retry interval that defaults to 30s (internal/operator/package_reconciler.go,
+# cmd/cozystack-operator --helmrelease-retry-interval), and helm deletes a
+# before-hook-creation hook at the top of every attempt. So a blocking verdict
+# and its Job log live for about one retry interval before being replaced by an
+# identical run, and the only thing left on the HelmRelease is a generic
+# "pre-upgrade hooks failed" that names neither the check nor the node.
+#
+# The verdict is therefore mirrored into a ConfigMap that no hook lifecycle
+# touches. It is written twice: once when the run starts (so a Job killed by
+# activeDeadlineSeconds still leaves evidence that it started and when), and
+# once with the outcome. Publishing is strictly best-effort: it must never
+# change the gate's answer, so every failure here is a warning, not a verdict.
+FACTS=$(mktemp 2>/dev/null || echo /tmp/preflight-facts)
+RUN_LOG=$(mktemp 2>/dev/null || echo /tmp/preflight-log)
+RC_FILE=$(mktemp 2>/dev/null || echo /tmp/preflight-rc)
+
+write_facts() {
+  {
+    printf 'ok=%s\n' "${ok_checks# }"
+    printf 'na=%s\n' "${na_checks# }"
+    printf 'skipped=%s\n' "${skip_checks# }"
+    printf 'advisory=%s\n' "${advisory_checks# }"
+    printf 'failed=%s\n' "${fail_checks# }"
+  } >"$FACTS"
+}
+
+fact() {
+  sed -n "s/^$1=//p" "$FACTS" 2>/dev/null || true
+}
+
+# publish_status <verdict> [log-file]
+publish_status() {
+  verdict=$1
+  logfile=${2:-}
+
+  if [ -z "$STATUS_CM" ] || [ -z "$STATUS_NS" ]; then
+    return 0
+  fi
+
+  set -- configmap "$STATUS_CM" --namespace "$STATUS_NS" \
+    --from-literal=verdict="$verdict" \
+    --from-literal=completedAt="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --from-literal=failedChecks="$(fact failed)" \
+    --from-literal=advisoryChecks="$(fact advisory)" \
+    --from-literal=skippedChecks="$(fact skipped)" \
+    --from-literal=okChecks="$(fact ok)" \
+    --from-literal=naChecks="$(fact na)"
+
+  # The log is the operator-facing part, so keep it, but bounded: a ConfigMap
+  # caps at ~1 MiB and a rejected write would lose the verdict fields too.
+  if [ -n "$logfile" ] && [ -f "$logfile" ]; then
+    tail -c 100000 "$logfile" >"$RUN_LOG.trunc" 2>/dev/null || true
+    set -- "$@" --from-file=log="$RUN_LOG.trunc"
+  fi
+
+  if kubectl create "$@" --dry-run=client --output=yaml 2>/dev/null |
+     kubectl apply --filename - >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "WARNING: could not publish the preflight verdict to configmap/$STATUS_CM"
+  echo "         in namespace $STATUS_NS; the verdict below still stands."
+  return 0
+}
+
+: >"$FACTS"
+publish_status running
+
+# The left leg of the pipe is a subshell, so the outcome travels back through a
+# file. `|| rc_inner=$?` is what keeps `set -e` from killing that subshell on a
+# blocking verdict before it can record one.
+: >"$RC_FILE"
+{ rc_inner=0; run_checks || rc_inner=$?; echo "$rc_inner" >"$RC_FILE"; } 2>&1 | tee "$RUN_LOG"
+rc=$(cat "$RC_FILE" 2>/dev/null || true)
+# An empty file means the runner died without recording an outcome (killed
+# mid-run, disk full). Fail closed.
+[ -n "$rc" ] || rc=1
+
+case "$rc" in
+  0) publish_status passed "$RUN_LOG" ;;
+  *) publish_status blocked "$RUN_LOG" ;;
+esac
+
+exit "$rc"

--- a/packages/core/platform/images/migrations/preflight/run-preflight.sh
+++ b/packages/core/platform/images/migrations/preflight/run-preflight.sh
@@ -42,15 +42,25 @@ if [ "$ENABLED" != "true" ]; then
   exit 0
 fi
 
-# Normalise the id lists: accept both comma- and space-separated ids.
-SKIP=$(printf '%s' "$SKIP" | tr ',' ' ')
-ADVISORY=$(printf '%s' "$ADVISORY" | tr ',' ' ')
+# Normalise the id lists: accept comma-, space- or newline-separated ids.
+SKIP=$(printf '%s' "$SKIP" | tr ',\n\t' '   ')
+ADVISORY=$(printf '%s' "$ADVISORY" | tr ',\n\t' '   ')
+
+# in_list <needle> <space-separated list> - membership test on an
+# operator-supplied list.
+#
+# The list is matched as DATA, never re-expanded: it is the word being matched
+# and the pattern is built from the check id, so a glob character in an
+# operator's skipChecks entry cannot expand against the runner's working
+# directory (/migrations in the image) and silently disable a check whose id
+# happens to name a file there. That also drops the word-splitting the earlier
+# "$@" form needed.
 in_list() {
   needle=$1
-  shift
-  for s in "$@"; do
-    [ "$s" = "$needle" ] && return 0
-  done
+  haystack=" $2 "
+  case "$haystack" in
+    *" $needle "*) return 0 ;;
+  esac
   return 1
 }
 
@@ -62,13 +72,15 @@ skip_checks=""
 fail_checks=""
 advisory_checks=""
 
+discovered=0
+
 for chk in "$CHECKS_DIR"/*; do
   [ -f "$chk" ] || continue
+  discovered=$((discovered + 1))
   # id = filename with the numeric ordering prefix and .sh suffix stripped.
   id=$(basename "$chk" | sed 's/^[0-9]*-//; s/\.sh$//')
 
-  # shellcheck disable=SC2086  # SKIP/ADVISORY are intentionally word-split into args
-  if in_list "$id" $SKIP; then
+  if in_list "$id" "$SKIP"; then
     echo "--- SKIP (operator-skipped via preflight.skipChecks): $id"
     skip_checks="$skip_checks $id"
     continue
@@ -82,8 +94,7 @@ for chk in "$CHECKS_DIR"/*; do
     0) ok_checks="$ok_checks $id" ;;
     3) na_checks="$na_checks $id" ;;
     *)
-      # shellcheck disable=SC2086  # ADVISORY is intentionally word-split into args
-      if in_list "$id" $ADVISORY; then
+      if in_list "$id" "$ADVISORY"; then
         echo "    (advisory: $id reported a problem but is non-blocking by config; not gating the upgrade)"
         advisory_checks="$advisory_checks $id"
       else
@@ -92,6 +103,20 @@ for chk in "$CHECKS_DIR"/*; do
       ;;
   esac
 done
+
+# A gate that ran nothing must not report the verdict it exists to withhold.
+# The image build already fails when checks/ is empty (RUN chmod +x
+# /preflight/checks/*), but the fail-closed property must hold in the runner
+# itself and not depend on a neighbouring build step: a refactor of the copy
+# layout, or an operator pointing PREFLIGHT_CHECKS_DIR somewhere wrong, must
+# block rather than wave the upgrade through.
+if [ "$discovered" -eq 0 ]; then
+  echo ""
+  echo "No preflight checks were found in $CHECKS_DIR."
+  echo "The gate cannot vouch for a cluster it never inspected, so the upgrade"
+  echo "is BLOCKED. Check the image contents and PREFLIGHT_CHECKS_DIR."
+  exit 1
+fi
 
 echo ""
 echo "===== PREFLIGHT SUMMARY ====="

--- a/packages/core/platform/templates/_helpers.tpl
+++ b/packages/core/platform/templates/_helpers.tpl
@@ -76,3 +76,32 @@ Does NOT include: networking (variant differs), linstor (talos.enabled differs)
        common-packages and has no cilium.io CRD for the controller to watch. */ -}}
 {{include "cozystack.platform.package.default" (list "cozystack.securitygroup-controller" $root) }}
 {{- end }}
+
+{{- /*
+Boolean coercion for operator-facing toggles.
+
+Values reach this chart as JSON from the Package CR
+(spec.components.platform.values, typed *apiextensionsv1.JSON with no schema),
+so a toggle can arrive as a bool, a number, or a quoted string. A bare `if` on
+that value is truthy for ANY non-empty string, which turns a quoted "false"
+into "on" and a typo into a silent behaviour change.
+
+Two helpers, because a toggle's default decides which spelling has to be
+proven:
+  - affirmative: default-off switches (an override, an escape hatch). Only an
+    explicit yes turns them on; anything unrecognised stays off.
+  - negative: default-on switches (a safety gate). Only an explicit no turns
+    them off; anything unrecognised leaves the gate up.
+
+Both render the string "true"/"false", so callers compare with eq/ne rather
+than relying on template truthiness. The accepted spellings match
+migrations.etcdAdoptSkipBackup (templates/migration-hook.yaml), so an operator
+who learned one hatch is not refused by the next.
+*/ -}}
+{{- define "cozystack.platform.affirmative" -}}
+{{- if has (lower (printf "%v" .)) (list "1" "true" "yes" "on") }}true{{ else }}false{{ end }}
+{{- end }}
+
+{{- define "cozystack.platform.negative" -}}
+{{- if has (lower (printf "%v" .)) (list "0" "false" "no" "off") }}true{{ else }}false{{ end }}
+{{- end }}

--- a/packages/core/platform/templates/preflight-hook.yaml
+++ b/packages/core/platform/templates/preflight-hook.yaml
@@ -48,10 +48,10 @@ spec:
   # failed Job in place so the operator can read exactly which check blocked the
   # upgrade (it is cleaned up before the next upgrade attempt).
   backoffLimit: 0
-  # Backstop so the gate cannot wedge the pre-upgrade hook indefinitely. The
-  # per-call `kubectl --request-timeout` bounds each check to seconds, so a
-  # healthy run finishes far under this; the deadline only fires on a
-  # pathological hang the request timeouts somehow did not bound.
+  # Backstop so the gate cannot wedge the pre-upgrade hook indefinitely. Each
+  # check bounds its own kubectl calls with a `timeout` wrapper, so a healthy
+  # run finishes far under this; the deadline only fires on a pathological hang
+  # the per-call timeouts somehow did not bound.
   activeDeadlineSeconds: 300
   template:
     metadata:

--- a/packages/core/platform/templates/preflight-hook.yaml
+++ b/packages/core/platform/templates/preflight-hook.yaml
@@ -45,6 +45,11 @@ spec:
   # failed Job in place so the operator can read exactly which check blocked the
   # upgrade (it is cleaned up before the next upgrade attempt).
   backoffLimit: 0
+  # Backstop so the gate cannot wedge the pre-upgrade hook indefinitely. The
+  # per-call `kubectl --request-timeout` bounds each check to seconds, so a
+  # healthy run finishes far under this; the deadline only fires on a
+  # pathological hang the request timeouts somehow did not bound.
+  activeDeadlineSeconds: 300
   template:
     metadata:
       labels:
@@ -55,6 +60,14 @@ spec:
         - name: preflight
           image: {{ .Values.migrations.image }}
           command: ["/preflight/run-preflight.sh"]
+          # Read-only health probe: it never needs privilege escalation or any
+          # Linux capability, so drop them all.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           env:
             # Only affirmative "true" takes the override; a stringified value
             # from the Package CR JSON or an unrecognised token resolves to

--- a/packages/core/platform/templates/preflight-hook.yaml
+++ b/packages/core/platform/templates/preflight-hook.yaml
@@ -13,9 +13,12 @@ live `linstor` exec on every Flux HelmRelease reconcile. Being a pre-upgrade
 (not pre-install) hook, it also never runs on a fresh install, where there is
 no prior state to protect and no LINSTOR to query.
 
-Unlike the migration hook this binds a SCOPED ClusterRole (read nodes/pods,
-exec into the linstor-controller) rather than cluster-admin: a read-only health
-probe has no reason to hold write access to the whole cluster.
+Unlike the migration hook this binds a ClusterRole limited to the verbs the
+checks need (read nodes/pods/deployments, create pods/exec) rather than
+cluster-admin: a read-only health probe has no reason to hold write access to
+the whole cluster. Note that pods/exec cannot be narrowed to a single pod in
+RBAC (pod names are generated), so the exec grant is necessarily cluster-wide;
+it is used only to exec into the linstor-controller.
 */ -}}
 {{- $pf := .Values.preflight | default dict }}
 {{- if dig "enabled" true $pf }}
@@ -97,7 +100,9 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list"]
-  # Needed to run `linstor` inside the live controller pod.
+  # Needed to run `linstor` inside the live controller pod. RBAC cannot scope
+  # exec to a single pod (pod names are generated), so this is cluster-wide
+  # create on pods/exec; the checks only ever exec into linstor-controller.
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create"]

--- a/packages/core/platform/templates/preflight-hook.yaml
+++ b/packages/core/platform/templates/preflight-hook.yaml
@@ -63,6 +63,10 @@ spec:
               value: "{{ if eq (toString (dig "override" false $pf)) "true" }}true{{ else }}false{{ end }}"
             - name: PREFLIGHT_SKIP
               value: {{ join "," (dig "skipChecks" (list) $pf) | quote }}
+            # Advisory checks warn instead of blocking. linstor is advisory by
+            # default until its live -m field semantics are e2e-verified.
+            - name: PREFLIGHT_ADVISORY
+              value: {{ join "," (dig "advisoryChecks" (list "linstor") $pf) | quote }}
       restartPolicy: Never
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/packages/core/platform/templates/preflight-hook.yaml
+++ b/packages/core/platform/templates/preflight-hook.yaml
@@ -13,12 +13,12 @@ live `linstor` exec on every Flux HelmRelease reconcile. Being a pre-upgrade
 (not pre-install) hook, it also never runs on a fresh install, where there is
 no prior state to protect and no LINSTOR to query.
 
-Unlike the migration hook this binds a ClusterRole limited to the verbs the
-checks need (read nodes/pods/deployments, create pods/exec) rather than
-cluster-admin: a read-only health probe has no reason to hold write access to
-the whole cluster. Note that pods/exec cannot be narrowed to a single pod in
-RBAC (pod names are generated), so the exec grant is necessarily cluster-wide;
-it is used only to exec into the linstor-controller.
+Unlike the migration hook (cluster-admin) this splits its access by least
+privilege: a ClusterRole with only read verbs (nodes/pods/deployments
+get+list), plus a namespaced Role in cozy-linstor for the single privileged
+verb pods/exec (running `linstor` in the controller). exec cannot be narrowed
+to one pod name, but scoping it to the one namespace the check targets keeps
+the blast radius contained; that Role renders only when cozy-linstor exists.
 */ -}}
 {{- $pf := .Values.preflight | default dict }}
 {{- if dig "enabled" true $pf }}
@@ -94,18 +94,18 @@ metadata:
     helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
 rules:
+  # Read-only, and deliberately cluster-wide. nodes are cluster-scoped anyway;
+  # pods/deployments get+list stay here (not in the LINSTOR Role below) so the
+  # LINSTOR check can always probe `get deploy -n cozy-linstor` and get a clean
+  # NotFound -> N/A on a cluster that has no LINSTOR, without depending on the
+  # cozy-linstor namespace existing. The only privileged verb (pods/exec) is
+  # NOT here; it is scoped to the LINSTOR namespace below.
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list"]
-  # Needed to run `linstor` inside the live controller pod. RBAC cannot scope
-  # exec to a single pod (pod names are generated), so this is cluster-wide
-  # create on pods/exec; the checks only ever exec into linstor-controller.
-  - apiGroups: [""]
-    resources: ["pods/exec"]
-    verbs: ["create"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list"]
@@ -126,6 +126,47 @@ subjects:
   - kind: ServiceAccount
     name: cozystack-preflight-hook
     namespace: {{ .Release.Namespace | quote }}
+{{- if lookup "v1" "Namespace" "" "cozy-linstor" }}
+---
+# pods/exec (running `linstor` inside the controller) is the one privileged
+# grant, so it is a namespaced Role in cozy-linstor rather than cluster-wide:
+# exec cannot be scoped to a single pod name, but limiting it to the one
+# namespace the check ever targets keeps the blast radius contained. Rendered
+# only when the cozy-linstor namespace exists, so a cluster without LINSTOR
+# neither gets this grant nor fails applying a Role into a missing namespace
+# (there the check N/A-skips after the NotFound probe above).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cozystack-preflight-hook
+  namespace: cozy-linstor
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cozystack-preflight-hook
+  namespace: cozy-linstor
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cozystack-preflight-hook
+subjects:
+  - kind: ServiceAccount
+    name: cozystack-preflight-hook
+    namespace: {{ .Release.Namespace | quote }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/packages/core/platform/templates/preflight-hook.yaml
+++ b/packages/core/platform/templates/preflight-hook.yaml
@@ -1,0 +1,118 @@
+{{- /*
+Upgrade preflight health gate.
+
+Runs as a pre-upgrade Helm hook at weight 0 — BEFORE the migration hook
+(weight 1) — so a cluster that is not in a safe state never even reaches the
+schema migrations. It reuses the platform-migrations image (kubectl/jq/bash are
+already there) but overrides the entrypoint to /preflight/run-preflight.sh.
+
+Gating mirrors migration-hook.yaml: the Job renders only when the
+cozystack-version ConfigMap reports a version BELOW migrations.targetVersion,
+i.e. only on a version-advancing upgrade. This deliberately avoids re-running a
+live `linstor` exec on every Flux HelmRelease reconcile. Being a pre-upgrade
+(not pre-install) hook, it also never runs on a fresh install, where there is
+no prior state to protect and no LINSTOR to query.
+
+Unlike the migration hook this binds a SCOPED ClusterRole (read nodes/pods,
+exec into the linstor-controller) rather than cluster-admin: a read-only health
+probe has no reason to hold write access to the whole cluster.
+*/ -}}
+{{- $pf := .Values.preflight | default dict }}
+{{- if dig "enabled" true $pf }}
+{{- $currentVersion := 0 }}
+{{- $targetVersion := .Values.migrations.targetVersion | int }}
+{{- $configMap := lookup "v1" "ConfigMap" .Release.Namespace "cozystack-version" }}
+{{- $shouldRun := false }}
+{{- if $configMap }}
+  {{- $currentVersion = dig "data" "version" "0" $configMap | int }}
+  {{- if lt $currentVersion $targetVersion }}
+    {{- $shouldRun = true }}
+  {{- end }}
+{{- end }}
+
+{{- if $shouldRun }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cozystack-preflight-hook
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation
+spec:
+  # A failed preflight is a verdict, not a flake: do not retry, and leave the
+  # failed Job in place so the operator can read exactly which check blocked the
+  # upgrade (it is cleaned up before the next upgrade attempt).
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        policy.cozystack.io/allow-to-apiserver: "true"
+    spec:
+      serviceAccountName: cozystack-preflight-hook
+      containers:
+        - name: preflight
+          image: {{ .Values.migrations.image }}
+          command: ["/preflight/run-preflight.sh"]
+          env:
+            # Only affirmative "true" takes the override; a stringified value
+            # from the Package CR JSON or an unrecognised token resolves to
+            # "false" so the gate is never bypassed by accident.
+            - name: PREFLIGHT_OVERRIDE
+              value: "{{ if eq (toString (dig "override" false $pf)) "true" }}true{{ else }}false{{ end }}"
+            - name: PREFLIGHT_SKIP
+              value: {{ join "," (dig "skipChecks" (list) $pf) | quote }}
+      restartPolicy: Never
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cozystack-preflight-hook
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  # Needed to run `linstor` inside the live controller pod.
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cozystack-preflight-hook
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cozystack-preflight-hook
+subjects:
+  - kind: ServiceAccount
+    name: cozystack-preflight-hook
+    namespace: {{ .Release.Namespace | quote }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cozystack-preflight-hook
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+{{- end }}
+{{- end }}

--- a/packages/core/platform/templates/preflight-hook.yaml
+++ b/packages/core/platform/templates/preflight-hook.yaml
@@ -70,6 +70,12 @@ spec:
   # check bounds its own kubectl calls with a `timeout` wrapper, so a healthy
   # run finishes far under this; the deadline only fires on a pathological hang
   # the per-call timeouts somehow did not bound.
+  #
+  # The budget covers pulling the image too, and this Job is the first thing to
+  # pull it on an upgrade. That is deliberate rather than a hazard: the
+  # migration hook pulls the same image seconds later, under the release's own
+  # 10m upgrade timeout, so a cluster that cannot fetch it inside 5 minutes was
+  # not going to finish the upgrade either.
   activeDeadlineSeconds: 300
   template:
     metadata:

--- a/packages/core/platform/templates/preflight-hook.yaml
+++ b/packages/core/platform/templates/preflight-hook.yaml
@@ -42,6 +42,11 @@ the blast radius contained; that Role renders only when cozy-linstor exists.
 {{- end }}
 
 {{- if $shouldRun }}
+{{- /*
+  One name for the status ConfigMap, shared by the Job's env and the Role's
+  resourceNames below so the grant can never drift from what the runner writes.
+*/}}
+{{- $statusConfigMap := "cozystack-preflight-status" }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -52,9 +57,14 @@ metadata:
     helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation
 spec:
-  # A failed preflight is a verdict, not a flake: do not retry, and leave the
-  # failed Job in place so the operator can read exactly which check blocked the
-  # upgrade (it is cleaned up before the next upgrade attempt).
+  # A failed preflight is a verdict, not a flake, so the Job itself does not
+  # retry. It is NOT the durable record of the block, though: the platform
+  # HelmRelease retries a failed upgrade on its own (Upgrade.Strategy
+  # RetryOnFailure, --helmrelease-retry-interval, 30s by default), and helm
+  # deletes a before-hook-creation hook at the top of every attempt, so this
+  # Job and its log survive roughly one retry interval. The verdict an operator
+  # actually reads therefore lives in the status ConfigMap the runner writes;
+  # see run-preflight.sh.
   backoffLimit: 0
   # Backstop so the gate cannot wedge the pre-upgrade hook indefinitely. Each
   # check bounds its own kubectl calls with a `timeout` wrapper, so a healthy
@@ -92,6 +102,11 @@ spec:
             # default until its live -m field semantics are e2e-verified.
             - name: PREFLIGHT_ADVISORY
               value: {{ join "," (dig "advisoryChecks" (list "linstor") $pf) | quote }}
+            # Where the runner mirrors its verdict so it outlives this Job.
+            - name: NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: PREFLIGHT_STATUS_CONFIGMAP
+              value: {{ $statusConfigMap | quote }}
       restartPolicy: Never
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -130,6 +145,48 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  name: cozystack-preflight-hook
+subjects:
+  - kind: ServiceAccount
+    name: cozystack-preflight-hook
+    namespace: {{ .Release.Namespace | quote }}
+---
+# The one write grant the gate holds, and it is deliberately shaped so it can
+# only ever touch its own status object: `create` cannot be restricted by name
+# in RBAC, so it is granted unqualified, while get/update/patch are pinned to
+# the status ConfigMap. cozystack-version lives in this same namespace and
+# already exists, so the create verb cannot reach it and the name-restricted
+# verbs exclude it. The gate remains read-only towards everything it inspects.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cozystack-preflight-hook
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: [{{ $statusConfigMap | quote }}]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cozystack-preflight-hook
+  namespace: {{ .Release.Namespace | quote }}
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
   name: cozystack-preflight-hook
 subjects:
   - kind: ServiceAccount

--- a/packages/core/platform/templates/preflight-hook.yaml
+++ b/packages/core/platform/templates/preflight-hook.yaml
@@ -21,7 +21,15 @@ to one pod name, but scoping it to the one namespace the check targets keeps
 the blast radius contained; that Role renders only when cozy-linstor exists.
 */ -}}
 {{- $pf := .Values.preflight | default dict }}
-{{- if dig "enabled" true $pf }}
+{{- /*
+  The master toggle is default-ON, so it is coerced through the "negative"
+  helper: only an explicit no (false/0/no/off, in any of the shapes the Package
+  CR's untyped JSON can deliver) takes the gate down. A bare `if` here would be
+  truthy for a quoted "false" and keep blocking an operator who believes they
+  switched the gate off, which is exactly the moment their upgrade is already
+  stuck.
+*/}}
+{{- if ne (include "cozystack.platform.negative" (dig "enabled" true $pf)) "true" }}
 {{- $currentVersion := 0 }}
 {{- $targetVersion := .Values.migrations.targetVersion | int }}
 {{- $configMap := lookup "v1" "ConfigMap" .Release.Namespace "cozystack-version" }}
@@ -72,11 +80,12 @@ spec:
             seccompProfile:
               type: RuntimeDefault
           env:
-            # Only affirmative "true" takes the override; a stringified value
-            # from the Package CR JSON or an unrecognised token resolves to
-            # "false" so the gate is never bypassed by accident.
+            # Default-OFF hatch, so only an affirmative spelling (1/true/yes/on,
+            # the same set migrations.etcdAdoptSkipBackup accepts) takes it. An
+            # unrecognised token resolves to "false": the gate is never bypassed
+            # by a typo.
             - name: PREFLIGHT_OVERRIDE
-              value: "{{ if eq (toString (dig "override" false $pf)) "true" }}true{{ else }}false{{ end }}"
+              value: {{ include "cozystack.platform.affirmative" (dig "override" false $pf) | quote }}
             - name: PREFLIGHT_SKIP
               value: {{ join "," (dig "skipChecks" (list) $pf) | quote }}
             # Advisory checks warn instead of blocking. linstor is advisory by

--- a/packages/core/platform/tests/preflight_hook_no_linstor_test.yaml
+++ b/packages/core/platform/tests/preflight_hook_no_linstor_test.yaml
@@ -1,0 +1,81 @@
+suite: upgrade preflight hook on a cluster without LINSTOR
+templates:
+  - templates/preflight-hook.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+# Deliberately the mirror image of preflight_hook_test.yaml: the version
+# ConfigMap is seeded so the gate is live, and the cozy-linstor Namespace is
+# NOT, so the namespaced pods/exec Role and its binding must not render.
+#
+# This is its own suite because the mocked cluster objects are declared per
+# suite. Without it the `if lookup ... cozy-linstor` term is unpinned: deleting
+# the condition leaves every other test green, while on a real cluster without
+# LINSTOR it would apply a Role into a namespace that does not exist, fail the
+# pre-upgrade hook, and block every upgrade.
+kubernetesProvider:
+  scheme:
+    "v1/ConfigMap":
+      gvr:
+        version: "v1"
+        resource: "configmaps"
+      namespaced: true
+    "v1/Namespace":
+      gvr:
+        version: "v1"
+        resource: "namespaces"
+      namespaced: false
+  objects:
+    - kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: cozystack-version
+        namespace: cozy-system
+      data:
+        version: "52"
+tests:
+  - it: renders the gate without the LINSTOR exec grant
+    asserts:
+      # Job, ClusterRole, ClusterRoleBinding, the status-ConfigMap Role and its
+      # RoleBinding, ServiceAccount. Two fewer than with cozy-linstor present.
+      - hasDocuments:
+          count: 6
+
+  - it: leaves the only Role scoped to the release namespace
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: cozy-system
+      - equal:
+          path: rules[1].resourceNames[0]
+          value: cozystack-preflight-status
+
+  - it: leaves the only RoleBinding scoped to the release namespace
+    documentSelector:
+      path: kind
+      value: RoleBinding
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: cozy-system
+
+  - it: still renders the read-only ClusterRole and never grants exec anywhere
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["nodes"]
+            verbs: ["get", "list"]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["pods/exec"]
+            verbs: ["create"]

--- a/packages/core/platform/tests/preflight_hook_test.yaml
+++ b/packages/core/platform/tests/preflight_hook_test.yaml
@@ -1,0 +1,147 @@
+suite: upgrade preflight hook renders correctly and only on a version-advancing upgrade
+templates:
+  - templates/preflight-hook.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+# The Job only renders when the cozystack-version ConfigMap reports a version
+# BELOW migrations.targetVersion. Under plain `helm template` lookup returns nil
+# and the hook is skipped, so the ConfigMap is mocked here (same approach as
+# migration_hook_skip_backup_test.yaml).
+kubernetesProvider:
+  scheme:
+    "v1/ConfigMap":
+      gvr:
+        version: "v1"
+        resource: "configmaps"
+      namespaced: true
+  objects:
+    - kind: ConfigMap
+      apiVersion: v1
+      metadata:
+        name: cozystack-version
+        namespace: cozy-system
+      data:
+        version: "52"
+tests:
+  - it: renders the preflight Job as a pre-upgrade hook at weight 0 (before migrations at weight 1)
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: metadata.name
+          value: cozystack-preflight-hook
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "0"
+      - equal:
+          path: spec.template.spec.containers[0].command[0]
+          value: /preflight/run-preflight.sh
+      # A failed preflight must not retry — it is a verdict, not a flake.
+      - equal:
+          path: spec.backoffLimit
+          value: 0
+
+  - it: passes override=false and empty skip by default
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: PREFLIGHT_OVERRIDE
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "false"
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: PREFLIGHT_SKIP
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: ""
+
+  - it: renders override=true only for an affirmative value
+    set:
+      preflight:
+        override: true
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "true"
+
+  - it: accepts a stringified true from the Package CR Values JSON
+    set:
+      preflight:
+        override: "true"
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "true"
+
+  - it: treats an unrecognised override value as OFF, never as an accidental bypass
+    set:
+      preflight:
+        override: "banana"
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "false"
+
+  - it: joins skipChecks into a comma list the runner parses
+    set:
+      preflight:
+        skipChecks: [linstor, nodes-ready]
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: linstor,nodes-ready
+
+  - it: binds a scoped ClusterRole (nodes/pods read + pods/exec), not cluster-admin
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["pods/exec"]
+            verbs: ["create"]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["*"]
+            resources: ["*"]
+            verbs: ["*"]
+
+  - it: emits nothing when preflight is disabled
+    set:
+      preflight:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: emits nothing when the cluster is already at the target version (no upgrade)
+    set:
+      migrations:
+        targetVersion: 52
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/packages/core/platform/tests/preflight_hook_test.yaml
+++ b/packages/core/platform/tests/preflight_hook_test.yaml
@@ -45,6 +45,17 @@ tests:
       - equal:
           path: spec.backoffLimit
           value: 0
+      # Backstop so a hung check cannot wedge the pre-upgrade hook forever.
+      - equal:
+          path: spec.activeDeadlineSeconds
+          value: 300
+      # Read-only probe: no privilege escalation, no Linux capabilities.
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - contains:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          content: ALL
 
   - it: passes override=false and empty skip by default
     documentSelector:

--- a/packages/core/platform/tests/preflight_hook_test.yaml
+++ b/packages/core/platform/tests/preflight_hook_test.yaml
@@ -15,6 +15,11 @@ kubernetesProvider:
         version: "v1"
         resource: "configmaps"
       namespaced: true
+    "v1/Namespace":
+      gvr:
+        version: "v1"
+        resource: "namespaces"
+      namespaced: false
   objects:
     - kind: ConfigMap
       apiVersion: v1
@@ -23,6 +28,12 @@ kubernetesProvider:
         namespace: cozy-system
       data:
         version: "52"
+    # Present so the namespaced pods/exec Role (gated on this namespace's
+    # existence) renders and can be asserted.
+    - kind: Namespace
+      apiVersion: v1
+      metadata:
+        name: cozy-linstor
 tests:
   - it: renders the preflight Job as a pre-upgrade hook at weight 0 (before migrations at weight 1)
     documentSelector:
@@ -130,12 +141,19 @@ tests:
           path: spec.template.spec.containers[0].env[1].value
           value: linstor,nodes-ready
 
-  - it: binds a scoped ClusterRole (nodes/pods read + pods/exec), not cluster-admin
+  - it: keeps only read verbs in the ClusterRole (no pods/exec, no cluster-admin)
     documentSelector:
       path: kind
       value: ClusterRole
     asserts:
       - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["nodes"]
+            verbs: ["get", "list"]
+      # The privileged verb must NOT be cluster-wide.
+      - notContains:
           path: rules
           content:
             apiGroups: [""]
@@ -147,6 +165,21 @@ tests:
             apiGroups: ["*"]
             resources: ["*"]
             verbs: ["*"]
+
+  - it: scopes pods/exec to a namespaced Role in cozy-linstor
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: cozy-linstor
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["pods/exec"]
+            verbs: ["create"]
 
   - it: emits nothing when preflight is disabled
     set:

--- a/packages/core/platform/tests/preflight_hook_test.yaml
+++ b/packages/core/platform/tests/preflight_hook_test.yaml
@@ -63,6 +63,13 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[1].value
           value: ""
+      # linstor is advisory by default until its live -m semantics are e2e-verified.
+      - equal:
+          path: spec.template.spec.containers[0].env[2].name
+          value: PREFLIGHT_ADVISORY
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: linstor
 
   - it: renders override=true only for an affirmative value
     set:

--- a/packages/core/platform/tests/preflight_hook_test.yaml
+++ b/packages/core/platform/tests/preflight_hook_test.yaml
@@ -167,9 +167,12 @@ tests:
             verbs: ["*"]
 
   - it: scopes pods/exec to a namespaced Role in cozy-linstor
+    # Selected by the rule it carries: there are two Roles now (this one and
+    # the status-ConfigMap Role in the release namespace), so `kind: Role`
+    # alone is ambiguous.
     documentSelector:
-      path: kind
-      value: Role
+      path: rules[0].resources[0]
+      value: pods/exec
     asserts:
       - equal:
           path: metadata.namespace
@@ -291,3 +294,52 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].env[2].value
           value: linstor
+
+  # The verdict has to outlive the Job: helm-controller retries a failed
+  # upgrade every 30s by default and helm deletes the previous hook Job at the
+  # top of each attempt, so the Job log is not where an operator can read why
+  # their upgrade is blocked.
+  - it: tells the runner where to publish its verdict
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[3].name
+          value: NAMESPACE
+      - equal:
+          path: spec.template.spec.containers[0].env[3].value
+          value: cozy-system
+      - equal:
+          path: spec.template.spec.containers[0].env[4].name
+          value: PREFLIGHT_STATUS_CONFIGMAP
+      - equal:
+          path: spec.template.spec.containers[0].env[4].value
+          value: cozystack-preflight-status
+
+  # The one write grant in the whole gate. `create` cannot carry resourceNames
+  # in RBAC, so the other verbs must, or the gate could rewrite the
+  # cozystack-version ConfigMap that decides which migrations run.
+  - it: confines the status write to its own ConfigMap
+    documentSelector:
+      path: rules[1].resourceNames[0]
+      value: cozystack-preflight-status
+    asserts:
+      - equal:
+          path: kind
+          value: Role
+      - equal:
+          path: metadata.namespace
+          value: cozy-system
+      - equal:
+          path: rules[0].verbs
+          value: ["create"]
+      - equal:
+          path: rules[1].verbs
+          value: ["get", "update", "patch"]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["configmaps"]
+            verbs: ["update", "patch"]

--- a/packages/core/platform/tests/preflight_hook_test.yaml
+++ b/packages/core/platform/tests/preflight_hook_test.yaml
@@ -196,3 +196,98 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  # The master toggle takes the same shapes as the override hatch below it.
+  # Values reach this chart as JSON from the Package CR
+  # (spec.components.platform.values), where a quoted boolean is an easy
+  # mistake and a bare `if` on a non-empty string is always truthy: an
+  # operator switching the gate off would be silently ignored, at the exact
+  # moment their upgrade is already blocked.
+  - it: disables the gate for a bool false
+    set:
+      preflight:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: disables the gate for a stringified false from the Package CR Values JSON
+    set:
+      preflight:
+        enabled: "false"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: disables the gate for a numeric 0
+    set:
+      preflight:
+        enabled: 0
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: disables the gate for a stringified "0"
+    set:
+      preflight:
+        enabled: "0"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: keeps the gate on for an unrecognised enabled value, never silently off
+    set:
+      preflight:
+        enabled: "banana"
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: metadata.name
+          value: cozystack-preflight-hook
+
+  # The two safety valves in this values file must accept the same spellings.
+  # migrations.etcdAdoptSkipBackup already takes 1/true/yes; an operator
+  # reaching for the second hatch after using the first must not be told "no"
+  # by a narrower parser.
+  - it: accepts a numeric 1 as an affirmative override
+    set:
+      preflight:
+        override: 1
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "true"
+
+  - it: accepts yes as an affirmative override
+    set:
+      preflight:
+        override: "yes"
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "true"
+
+  # preflight: null must land on the shipped defaults, not on a different set.
+  # The template carries its own inline fallbacks for the case where the whole
+  # key is nil; this pins them to what values.yaml documents.
+  - it: falls back to the shipped defaults when the whole preflight key is null
+    set:
+      preflight: null
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "false"
+      - equal:
+          path: spec.template.spec.containers[0].env[2].value
+          value: linstor

--- a/packages/core/platform/tests/preflight_hook_test.yaml
+++ b/packages/core/platform/tests/preflight_hook_test.yaml
@@ -166,6 +166,13 @@ tests:
             resources: ["*"]
             verbs: ["*"]
 
+  # Pins the document count so a new hook object cannot slip in unreviewed and
+  # so the without-LINSTOR suite's count of 6 stays meaningful.
+  - it: renders exactly the eight hook objects when LINSTOR is present
+    asserts:
+      - hasDocuments:
+          count: 8
+
   - it: scopes pods/exec to a namespaced Role in cozy-linstor
     # Selected by the rule it carries: there are two Roles now (this one and
     # the status-ConfigMap Role in the release namespace), so `kind: Role`

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -55,12 +55,14 @@ preflight:
   # check whose blocking behaviour is not yet trusted enough to hard-block an
   # existing customer's upgrade.
   #
-  # linstor is advisory by default: its parsing of live `linstor -m` output
-  # relies on LINBIT REST API field values (connection_status/disk_state) that
-  # have not yet been confirmed against a live controller in e2e. Until that
-  # evidence exists (see cozystack-pr-test), a wrong assumption there must warn,
-  # never hard-block a healthy upgrade. Once e2e confirms the semantics, a
-  # follow-up removes linstor from this default and lets it gate.
+  # linstor is advisory by default. Its parsing of live `linstor -m` output
+  # relies on LINBIT REST API fields (connection_status/disk_state): the field
+  # NAMES are confirmed on a live healthy controller, but the FAULTY-state
+  # detection (the denylist of bad disk_states) has not yet been exercised
+  # against a genuinely degraded cluster. Until that e2e evidence exists (see
+  # cozystack-pr-test), a wrong assumption there must warn, never hard-block a
+  # healthy upgrade. Once e2e confirms the faulty-state path, a follow-up
+  # removes linstor from this default and lets it gate.
   advisoryChecks: [linstor]
 # Bundle deployment configuration
 bundles:

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -33,6 +33,23 @@ migrations:
   # Reset it to false once the upgrade is through, or the next platform upgrade
   # that adds an etcd migration will skip its snapshot too.
   etcdAdoptSkipBackup: false
+# Upgrade preflight health gate. Runs as a pre-upgrade hook BEFORE the schema
+# migrations and refuses to start an upgrade on an unhealthy cluster, so a
+# broken storage/node state is surfaced up front instead of mid-rollout. It
+# reuses migrations.image. See templates/preflight-hook.yaml.
+preflight:
+  # Master toggle. When false the pre-upgrade gate is not rendered at all.
+  enabled: true
+  # Proceed past FAILING checks anyway. Leave false. Set true ONLY when the
+  # degraded state is expected and you accept the risk (e.g. a deliberately
+  # diskless/tie-breaker LINSTOR layout, or an in-progress resync): the gate
+  # then downgrades failures to warnings and logs the override for the audit
+  # trail. Prefer fixing what a check reports, or skipping that single check
+  # via skipChecks, over blanket-overriding every check.
+  override: false
+  # Skip individual checks by id (e.g. [linstor, nodes-ready]) instead of
+  # overriding the whole gate. Empty runs every check.
+  skipChecks: []
 # Bundle deployment configuration
 bundles:
   system:

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -50,6 +50,18 @@ preflight:
   # Skip individual checks by id (e.g. [linstor, nodes-ready]) instead of
   # overriding the whole gate. Empty runs every check.
   skipChecks: []
+  # Checks whose FAILURES are downgraded to non-blocking warnings: the check
+  # still runs and reports, it just does not block the upgrade. Use this for a
+  # check whose blocking behaviour is not yet trusted enough to hard-block an
+  # existing customer's upgrade.
+  #
+  # linstor is advisory by default: its parsing of live `linstor -m` output
+  # relies on LINBIT REST API field values (connection_status/disk_state) that
+  # have not yet been confirmed against a live controller in e2e. Until that
+  # evidence exists (see cozystack-pr-test), a wrong assumption there must warn,
+  # never hard-block a healthy upgrade. Once e2e confirms the semantics, a
+  # follow-up removes linstor from this default and lets it gate.
+  advisoryChecks: [linstor]
 # Bundle deployment configuration
 bundles:
   system:

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -36,7 +36,21 @@ migrations:
 # Upgrade preflight health gate. Runs as a pre-upgrade hook BEFORE the schema
 # migrations and refuses to start an upgrade on an unhealthy cluster, so a
 # broken storage/node state is surfaced up front instead of mid-rollout. It
-# reuses migrations.image. See templates/preflight-hook.yaml.
+# reuses migrations.image. See templates/preflight-hook.yaml and
+# docs/operations/upgrade-preflight.md.
+#
+# WHEN IT RUNS: only on a version-advancing upgrade, i.e. when the
+# cozystack-version ConfigMap reports a version below migrations.targetVersion.
+# A release that ships no new migration is not gated, and a fresh install never
+# is. That keeps a live `linstor` exec off every Flux reconcile.
+#
+# WHERE THE VERDICT GOES: the ConfigMap cozystack-preflight-status in this
+# release's namespace, written by every run. Read it rather than the hook Job:
+# a failed upgrade is retried automatically every 30s and each attempt deletes
+# the previous Job.
+#
+# THESE KEYS LIVE UNDER spec.components.platform.values on the
+# cozystack.cozystack-platform Package CR.
 preflight:
   # Master toggle. When false the pre-upgrade gate is not rendered at all.
   enabled: true
@@ -50,6 +64,17 @@ preflight:
   # Skip individual checks by id (e.g. [linstor, nodes-ready]) instead of
   # overriding the whole gate. Empty runs every check.
   skipChecks: []
+  # Checks in brief:
+  #   nodes-ready  every Node is Ready. Cordoned nodes are EXEMPT whatever
+  #                their readiness, because a cordon is the operator declaring
+  #                the node out of service and the normal maintenance sequence
+  #                (cordon, drain, power off) leaves it at Ready=Unknown. The
+  #                trade-off is deliberate: a node that failed and was then
+  #                cordoned is waved through on that same signal, and shows up
+  #                in the run's warnings rather than blocking.
+  #   linstor      all LINSTOR satellites online and no faulty DRBD volume
+  #                state. N/A when LINSTOR is not installed. Advisory by
+  #                default, see below.
   # Checks whose FAILURES are downgraded to non-blocking warnings: the check
   # still runs and reports, it just does not block the upgrade. Use this for a
   # check whose blocking behaviour is not yet trusted enough to hard-block an


### PR DESCRIPTION
## What this PR does

Cozystack upgrades currently start unconditionally: nothing checks that the
cluster is healthy before the schema migrations run. Storage/DRBD health in
particular is invisible to any static check — the LINSTOR k8s-backend persists
only flags (DELETE/DISKLESS/TIE_BREAKER); live replication health (Inconsistent,
Outdated, offline satellites) exists only in satellite memory and must be read
from a running controller.

This adds a pluggable pre-flight health gate that runs against the LIVE cluster
before an upgrade:

- Runs as a `pre-upgrade` Helm hook at weight 0, ahead of the migration hook
  (weight 1), gated on the same version-advancing lookup so it does not re-run
  on every reconcile and never runs on a fresh install.
- Checks (v1): every Kubernetes node is Ready; and, when LINSTOR is installed,
  all satellites are online with no faulty DRBD volume states. LINSTOR-absent is
  a graceful N/A. New checks drop into `preflight/checks/` with no runner change.
- Fails closed by default (a failing check blocks the upgrade with a clear
  report), but supports an explicit operator override: `preflight.override=true`
  downgrades failures to logged warnings, or `preflight.skipChecks: [<id>]` skips
  individual checks. A legitimately degraded upgrade is therefore not
  hard-blocked.
- Reuses the platform-migrations image (kubectl/jq already present) with the
  entrypoint overridden, and binds a scoped ClusterRole (read nodes/pods, exec
  into linstor-controller) instead of cluster-admin.

Covered by a bats suite (runner/override/skip and both checks against a fake
kubectl) and a helm unittest suite (hook weight, command, override coercion,
skip list, scoped RBAC, version gate).

Note on the LINSTOR check: it parses `linstor -m` machine output by the LINBIT
REST API v1 field names (`connection_status`, `disk_state`). The parsing is
fixture-tested but the live field names should be confirmed on a real controller
in e2e before this gate is trusted to hard-block a production upgrade.

### Screenshots

Not applicable — no UI changes.

### Downstream repositories

This changes `packages/core/platform/values.yaml` (adds the `preflight.*` keys).
Per the trigger map that reaches **cozystack/website**
(`operations/configuration/platform-package.md`, a hand-written values table). I
have not opened that follow-up and left the box unticked so a maintainer can
decide; a docs follow-up should document the `preflight.*` keys there. Every
other repository was checked file-by-file against the diff and is not affected.

- [ ] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up: needed — document `preflight.*` in `operations/configuration/platform-package.md`
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Behavior change for existing customers

The `nodes-ready` check is enforcing and on by default, so an upgrade on a
cluster that has an uncordoned NotReady node (which previously proceeded) is now
blocked with an actionable message until the operator resolves it or opts out
via `preflight.override: true`, `preflight.skipChecks: [nodes-ready]`, or
`preflight.enabled: false`. The LINSTOR check is advisory by default and only
warns.

### Release note

```release-note
feat(platform): gate upgrades on a pre-flight cluster health check before migrations run. The `nodes-ready` check is enforcing (an uncordoned NotReady node blocks the upgrade); the LINSTOR check (satellites online, no faulty DRBD volumes) is advisory by default. Fully overridable via preflight.override / preflight.skipChecks / preflight.advisoryChecks / preflight.enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional pre-upgrade health gate for platform upgrades.
  * Added Kubernetes node-readiness and LINSTOR/DRBD health checks.
  * Supports overrides, skipped checks, and advisory-only checks.
  * Publishes running, passed, or blocked results to a status ConfigMap.
  * Runs as a hardened pre-upgrade Job only when upgrading to a newer version.
* **Bug Fixes**
  * Fails closed when health status cannot be determined or parsed.
  * Treats absent LINSTOR installations as non-blocking.
* **Documentation**
  * Added operational guidance for configuring and troubleshooting the preflight gate.
* **Tests**
  * Expanded unit, integration, and end-to-end coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->