### PR TITLE
fix(external-dns): add startupProbe to survive slow first start under load

### DIFF
--- a/packages/system/external-dns/Makefile
+++ b/packages/system/external-dns/Makefile
@@ -3,8 +3,21 @@ export NAMESPACE=cozy-$(NAME)
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	helm repo add external-dns https://kubernetes-sigs.github.io/external-dns/
 	helm repo update external-dns
-	helm pull external-dns/external-dns --untar --untardir charts
+	# Pin the vendored chart version. `helm pull` without --version grabs
+	# whatever is latest on the repo, which can shift the deployment.yaml
+	# layout and silently break patches/deployment-startup-probe.diff. Bumping
+	# this pin is a deliberate step that must regenerate the patch against the
+	# new upstream and re-run `make test`.
+	helm pull external-dns/external-dns --untar --untardir charts --version 1.20.0
+	# cozystack: re-apply local mods carried as patches/*.diff so an upstream
+	# chart bump does not silently revert them. The diff is byte-consistent with
+	# the vendored tree and applied against the freshly-pulled upstream.
+	# See cozystack/cozystack#3459 for the startup-probe fix rationale.
+	patch --no-backup-if-mismatch -p1 < patches/deployment-startup-probe.diff

--- a/packages/system/external-dns/charts/external-dns/templates/deployment.yaml
+++ b/packages/system/external-dns/charts/external-dns/templates/deployment.yaml
@@ -157,18 +157,20 @@ spec:
             - name: http
               protocol: TCP
               containerPort: 7979
+          {{- /*
+          cozystack (patches/deployment-startup-probe.diff): the upstream
+          external-dns chart templates only liveness/readiness and renders no
+          startupProbe, so a slow first start has no grace period distinct
+          from liveness. Under E2E-sandbox load the informer source-cache sync
+          outlasts the liveness budget (initialDelaySeconds 10 + periodSeconds
+          10 * failureThreshold 2 = ~30s), kubelet SIGKILLs a healthy-but-slow
+          container before it binds /healthz on :7979, and the restart loop
+          cascades into the wrapping HelmRelease timing out. A values-driven
+          startupProbe gates liveness on the slow-start window instead. Rendered
+          with `with` so an unset value is a no-op (upstream-compatible).
+          See cozystack/cozystack#3459.
+          */}}
           {{- with .Values.startupProbe }}
-          # cozystack (patches/deployment-startup-probe.diff): the upstream
-          # external-dns chart templates only liveness/readiness and renders no
-          # startupProbe, so a slow first start has no grace period distinct
-          # from liveness. Under E2E-sandbox load the informer source-cache sync
-          # outlasts the liveness budget (initialDelaySeconds 10 + periodSeconds
-          # 10 * failureThreshold 2 = ~30s), kubelet SIGKILLs a healthy-but-slow
-          # container before it binds /healthz on :7979, and the restart loop
-          # cascades into the wrapping HelmRelease timing out. A values-driven
-          # startupProbe gates liveness on the slow-start window instead. Rendered
-          # with `with` so an unset value is a no-op (upstream-compatible).
-          # See cozystack/cozystack#3459.
           startupProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/packages/system/external-dns/charts/external-dns/templates/deployment.yaml
+++ b/packages/system/external-dns/charts/external-dns/templates/deployment.yaml
@@ -157,6 +157,21 @@ spec:
             - name: http
               protocol: TCP
               containerPort: 7979
+          {{- with .Values.startupProbe }}
+          # cozystack (patches/deployment-startup-probe.diff): the upstream
+          # external-dns chart templates only liveness/readiness and renders no
+          # startupProbe, so a slow first start has no grace period distinct
+          # from liveness. Under E2E-sandbox load the informer source-cache sync
+          # outlasts the liveness budget (initialDelaySeconds 10 + periodSeconds
+          # 10 * failureThreshold 2 = ~30s), kubelet SIGKILLs a healthy-but-slow
+          # container before it binds /healthz on :7979, and the restart loop
+          # cascades into the wrapping HelmRelease timing out. A values-driven
+          # startupProbe gates liveness on the slow-start window instead. Rendered
+          # with `with` so an unset value is a no-op (upstream-compatible).
+          # See cozystack/cozystack#3459.
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:

--- a/packages/system/external-dns/patches/deployment-startup-probe.diff
+++ b/packages/system/external-dns/patches/deployment-startup-probe.diff
@@ -1,0 +1,26 @@
+diff --git a/charts/external-dns/templates/deployment.yaml b/charts/external-dns/templates/deployment.yaml
+index b213f754f..96943b492 100644
+--- a/charts/external-dns/templates/deployment.yaml
++++ b/charts/external-dns/templates/deployment.yaml
+@@ -157,6 +157,21 @@ spec:
+             - name: http
+               protocol: TCP
+               containerPort: 7979
++          {{- with .Values.startupProbe }}
++          # cozystack (patches/deployment-startup-probe.diff): the upstream
++          # external-dns chart templates only liveness/readiness and renders no
++          # startupProbe, so a slow first start has no grace period distinct
++          # from liveness. Under E2E-sandbox load the informer source-cache sync
++          # outlasts the liveness budget (initialDelaySeconds 10 + periodSeconds
++          # 10 * failureThreshold 2 = ~30s), kubelet SIGKILLs a healthy-but-slow
++          # container before it binds /healthz on :7979, and the restart loop
++          # cascades into the wrapping HelmRelease timing out. A values-driven
++          # startupProbe gates liveness on the slow-start window instead. Rendered
++          # with `with` so an unset value is a no-op (upstream-compatible).
++          # See cozystack/cozystack#3459.
++          startupProbe:
++            {{- toYaml . | nindent 12 }}
++          {{- end }}
+           livenessProbe:
+             {{- toYaml .Values.livenessProbe | nindent 12 }}
+           readinessProbe:

--- a/packages/system/external-dns/patches/deployment-startup-probe.diff
+++ b/packages/system/external-dns/patches/deployment-startup-probe.diff
@@ -1,23 +1,25 @@
 diff --git a/charts/external-dns/templates/deployment.yaml b/charts/external-dns/templates/deployment.yaml
-index b213f754f..96943b492 100644
+index b213f75..b665456 100644
 --- a/charts/external-dns/templates/deployment.yaml
 +++ b/charts/external-dns/templates/deployment.yaml
-@@ -157,6 +157,21 @@ spec:
+@@ -157,6 +157,23 @@ spec:
              - name: http
                protocol: TCP
                containerPort: 7979
++          {{- /*
++          cozystack (patches/deployment-startup-probe.diff): the upstream
++          external-dns chart templates only liveness/readiness and renders no
++          startupProbe, so a slow first start has no grace period distinct
++          from liveness. Under E2E-sandbox load the informer source-cache sync
++          outlasts the liveness budget (initialDelaySeconds 10 + periodSeconds
++          10 * failureThreshold 2 = ~30s), kubelet SIGKILLs a healthy-but-slow
++          container before it binds /healthz on :7979, and the restart loop
++          cascades into the wrapping HelmRelease timing out. A values-driven
++          startupProbe gates liveness on the slow-start window instead. Rendered
++          with `with` so an unset value is a no-op (upstream-compatible).
++          See cozystack/cozystack#3459.
++          */}}
 +          {{- with .Values.startupProbe }}
-+          # cozystack (patches/deployment-startup-probe.diff): the upstream
-+          # external-dns chart templates only liveness/readiness and renders no
-+          # startupProbe, so a slow first start has no grace period distinct
-+          # from liveness. Under E2E-sandbox load the informer source-cache sync
-+          # outlasts the liveness budget (initialDelaySeconds 10 + periodSeconds
-+          # 10 * failureThreshold 2 = ~30s), kubelet SIGKILLs a healthy-but-slow
-+          # container before it binds /healthz on :7979, and the restart loop
-+          # cascades into the wrapping HelmRelease timing out. A values-driven
-+          # startupProbe gates liveness on the slow-start window instead. Rendered
-+          # with `with` so an unset value is a no-op (upstream-compatible).
-+          # See cozystack/cozystack#3459.
 +          startupProbe:
 +            {{- toYaml . | nindent 12 }}
 +          {{- end }}

--- a/packages/system/external-dns/tests/deployment_startup_probe_test.yaml
+++ b/packages/system/external-dns/tests/deployment_startup_probe_test.yaml
@@ -1,0 +1,56 @@
+suite: cozy-external-dns startup-probe cozystack patch
+release:
+  name: external-dns
+  namespace: cozy-external-dns
+tests:
+  # cozystack carries `patches/deployment-startup-probe.diff` on the vendored
+  # external-dns v1.20.0 subchart because the upstream deployment.yaml templates
+  # only liveness/readiness and renders no startupProbe, so a slow first start
+  # (informer source-cache sync under E2E-sandbox load) is SIGKILLed by liveness
+  # into a restart loop that cascades into the wrapping HelmRelease timing out
+  # (see cozystack/cozystack#3459). If a future `make update` bump re-pulls
+  # upstream and the local patch drops off, or an upstream refactor renames or
+  # replaces this Deployment, these asserts catch it before the flake returns.
+  - it: external-dns Deployment carries a startupProbe covering the slow-start window
+    template: charts/external-dns/templates/deployment.yaml
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].startupProbe
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.port
+          value: http
+      # Budget = periodSeconds * failureThreshold. Pinning both exact values
+      # locks the total (5 * 45 = 225s) as a regression sentinel: a chart bump
+      # that silently zeroed one of them would still fall out here. Bumping the
+      # budget deliberately requires a matching test update; the comment on the
+      # package values.yaml covers why it must stay inside the operator's 10m
+      # HelmRelease install timeout.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 45
+
+  # Liveness / readiness must survive the patch unchanged on the same /healthz
+  # endpoint. startupProbe covers the slow-start window; once it passes the
+  # kubelet gates on the normal probes at their default cadence. If an upstream
+  # refactor renamed the port or path, this catches the drift.
+  - it: external-dns Deployment leaves upstream liveness and readiness intact on /healthz
+    template: charts/external-dns/templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: http

--- a/packages/system/external-dns/values.yaml
+++ b/packages/system/external-dns/values.yaml
@@ -29,3 +29,18 @@ external-dns:
     requests:
       cpu: 10m
       memory: 64Mi
+
+  # -- Startup probe for the `external-dns` container. Gives a slow first start
+  # (informer source-cache sync under CI-cluster load) a grace period before the
+  # liveness probe begins evaluating, so a healthy-but-slow start is not SIGKILLed
+  # into a restart loop. Budget = periodSeconds * failureThreshold = 5 * 45 = 225s;
+  # comfortably clears the single-digit-second healthy bind time while staying well
+  # inside the operator's default 10m HelmRelease install timeout. Requires the
+  # cozystack `patches/deployment-startup-probe.diff` template patch to render.
+  # See cozystack/cozystack#3459.
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    periodSeconds: 5
+    failureThreshold: 45


### PR DESCRIPTION
## What this PR does

Fixes the `external-dns/external-dns-inmemory` Chainsaw E2E flake (#3459).

The `external-dns` container binds its `/healthz` server on `:7979` only after the informer source-cache sync completes. The upstream chart templates no `startupProbe`, so a slow first start has no grace period distinct from the tight `livenessProbe` (initialDelaySeconds 10 + periodSeconds 10 × failureThreshold 2 ≈ 30s). Under CI-cluster load the sync outlasts that budget, kubelet SIGKILLs a healthy-but-slow container (exitCode 137), and the restart loop cascades: Deployment never Ready → HR `cozy-external-dns` InstallFailed → HR `external-dns` InstallFailed → Chainsaw case FAIL.

This is not a regression of any feature PR: in the same run `kubernetes-previous` and `kubernetes-latest` pass; the external-dns chart is orthogonal.

Fix: render a values-driven `startupProbe` on `/healthz:7979` so `livenessProbe` only begins evaluating after the slow-start window. Budget = periodSeconds 5 × failureThreshold 45 = 225s, comfortably clearing the single-digit-second healthy bind time while staying well inside the operator's default 10m HelmRelease install timeout. Same class of fix as #3204 (snapshot-controller), applied to a different component.

The template stanza is rendered with `{{- with .Values.startupProbe }}`, so an unset value is a no-op (upstream-compatible). Because the chart is vendored via `helm pull`, the template change is carried as `patches/deployment-startup-probe.diff` and re-applied by `make update`; the `--version 1.20.0` pin guards the patch against an upstream layout shift. A helm-unittest locks the patch in and pins the budget as a regression sentinel.

### Downstream repositories

Walked the trigger map file-by-file against the diff. This is internal probe tuning on a vendored system chart: no API/CRD change, no user-facing values schema, no docs surface.

- [x] No downstream repository is affected by this change

### Release note

```release-note
fix(external-dns): add a startupProbe so external-dns tolerates a slow first start (informer cache sync) under cluster load instead of being killed by the liveness probe into a restart loop
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional startup health check for ExternalDNS to support slower initial startup.
  * Configured the check to monitor the existing health endpoint before liveness checks begin.

* **Bug Fixes**
  * Prevented ExternalDNS from being restarted prematurely while it is still becoming ready.

* **Tests**
  * Added Helm tests covering startup, liveness, and readiness probe configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->