### PR TITLE
docs(governance): document the Reviewer role and align the maintainer roster

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -29,8 +29,8 @@ this table names the people and is kept in step with it.
 | Reviewer | GitHub Username | Company | Area |
 | -------- | --------------- | ------- | ---- |
 | Kirill Ilin | [@sircthulhu](https://github.com/sircthulhu) | Ænix | Controllers, Keycloak, system operators |
-| Andrey Kolkov | [@androndo](https://github.com/androndo) | Independent | Backups |
-| — | [@scooby87](https://github.com/scooby87) | — | Virtualization (KubeVirt, vm-instance, vm-disk) |
+| Andrey Kolkov | [@androndo](https://github.com/androndo) | Ænix | Backups |
+| Aleksei Artamonov | [@scooby87](https://github.com/scooby87) | Ænix | Virtualization (KubeVirt, vm-instance, vm-disk) |
 
 ## Emeritus Maintainers
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,11 +5,9 @@
 | Maintainer | GitHub Username | Company |          Responsibility           |
 | ---------- | --------------- | ------- | --------------------------------- |
 | Andrei Kvapil | [@kvaps](https://github.com/kvaps) | Ænix | Core Maintainer |
-| George Gaál | [@gecube](https://github.com/gecube) | Independent | DevOps Practices in Platform, Developers Advocate |
 | Kingdon Barrett | [@kingdonb](https://github.com/kingdonb) | Urmanac | FluxCD and flux-operator |
 | Timofei Larkin | [@lllamnyp](https://github.com/lllamnyp) | Ænix | Core Maintainer |
 | Timur Tukaev | [@tym83](https://github.com/tym83) | Ænix | Cozystack Website, Marketing, Community Management |
-| Nikita Bykov | [@nbykov0](https://github.com/nbykov0) | Independent | Maintainer of ARM and stuff |
 | Matthieu Robin | [@matthieu-robin](https://github.com/matthieu-robin) | Hidora | Managed Applications, Platform Quality & Benchmarking |
 | Mattia Eleuteri | [@mattia-eleuteri](https://github.com/mattia-eleuteri) | Hidora | CSI, Storage, Networking & Security |
 | Aleksei Sviridkin | [@lexfrei](https://github.com/lexfrei) | Ænix | Release engineering, CI, Talos tooling, security pipeline |
@@ -41,4 +39,6 @@ We thank the following former maintainers for their contributions to Cozystack.
 | Maintainer | GitHub Username |
 | ---------- | --------------- |
 | Artem Bortnikov | [@aobort](https://github.com/aobort) |
+| George Gaál | [@gecube](https://github.com/gecube) |
 | Kirill Klinchenkov | [@klinch0](https://github.com/klinch0) |
+| Nikita Bykov | [@nbykov0](https://github.com/nbykov0) |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,27 @@
 | Nikita Bykov | [@nbykov0](https://github.com/nbykov0) | Independent | Maintainer of ARM and stuff |
 | Matthieu Robin | [@matthieu-robin](https://github.com/matthieu-robin) | Hidora | Managed Applications, Platform Quality & Benchmarking |
 | Mattia Eleuteri | [@mattia-eleuteri](https://github.com/mattia-eleuteri) | Hidora | CSI, Storage, Networking & Security |
+| Aleksei Sviridkin | [@lexfrei](https://github.com/lexfrei) | Ænix | Release engineering, CI, Talos tooling, security pipeline |
+| Daniil Miasnikov | [@myasnikovdaniil](https://github.com/myasnikovdaniil) | Ænix | Platform, API, CI/CD, project infrastructure |
+| Ivan Okhotnikov | [@IvanHunters](https://github.com/IvanHunters) | Ænix | Monitoring, Dashboard, cozystack-api |
+
+## Reviewers
+
+Reviewers own a specific area of the codebase rather than the project as a
+whole: they review and approve changes to that area, and carry write access for
+it, without the project-wide responsibilities of a maintainer. The role, and the
+process for entering it, is defined in
+[CONTRIBUTOR_LADDER.md](https://github.com/cozystack/cozystack/blob/main/CONTRIBUTOR_LADDER.md).
+
+The authoritative mapping from an area to the people who own it is
+[`.github/CODEOWNERS`](https://github.com/cozystack/cozystack/blob/main/.github/CODEOWNERS);
+this table names the people and is kept in step with it.
+
+| Reviewer | GitHub Username | Company | Area |
+| -------- | --------------- | ------- | ---- |
+| Kirill Ilin | [@sircthulhu](https://github.com/sircthulhu) | Ænix | Controllers, Keycloak, system operators |
+| Andrey Kolkov | [@androndo](https://github.com/androndo) | Independent | Backups |
+| — | [@scooby87](https://github.com/scooby87) | — | Virtualization (KubeVirt, vm-instance, vm-disk) |
 
 ## Emeritus Maintainers
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,7 +29,7 @@ Please do **not** report security vulnerabilities through public GitHub issues, 
 Please report vulnerabilities privately through one of the following channels, in order of preference:
 
 1. **GitHub Private Vulnerability Reporting** — the preferred channel. Open the repository's **Security** tab, then **Advisories** → **Report a vulnerability** (<https://github.com/cozystack/cozystack/security/advisories/new>). This creates a confidential advisory visible only to you and the maintainers, and is the CNCF-recommended path for coordinated disclosure.
-2. **Contact a maintainer** listed in [`MAINTAINERS.md`](MAINTAINERS.md) through an existing private channel you already have.
+2. **Contact a maintainer** listed in [`MAINTAINERS.md`](MAINTAINERS.md) through an existing private channel you already have. Reports are triaged by the maintainers responsible for security response — [@kvaps](https://github.com/kvaps), [@lexfrei](https://github.com/lexfrei), [@tym83](https://github.com/tym83), [@matthieu-robin](https://github.com/matthieu-robin) and [@mattia-eleuteri](https://github.com/mattia-eleuteri) — but any maintainer can receive a report and route it.
 3. If you have neither, use a public community channel only to request a private contact path, without disclosing any vulnerability details.
 
 Please do not include exploit details, credentials, tokens, private keys, customer data, or other sensitive material in any public message.


### PR DESCRIPTION
## What this PR does

Makes the documented roster match who actually holds write access, which CNCF Incubation checks directly through the API ("Code and Doc ownership in GitHub matches documented governance roles", Required).

The two lists currently describe different projects. Ten people hold write or admin on this repository without appearing in `MAINTAINERS.md`; three people listed there — `@kingdonb`, `@matthieu-robin`, `@mattia-eleuteri` — hold only read, one of them while carrying "CSI, Storage, Networking & Security" as a documented responsibility. There is no in-between state a reviewer will accept: someone with write is either a maintainer or a reviewer, and should be findable as one.

**Maintainers, +3.** `@lexfrei`, `@myasnikovdaniil` and `@IvanHunters` work across the whole tree rather than in one area, and already review other people's changes at maintainer volume.

**Reviewers, new table.** `@sircthulhu`, `@androndo` and `@scooby87` own a specific area with write access, without the project-wide responsibilities of a maintainer. The role is not invented here, and it is not new in practice either: `CONTRIBUTOR_LADDER.md` defines a Reviewer as someone named in the owners file for one or more directories, and `.github/CODEOWNERS` has named people since August 2024 — these three among them since February and April. What was missing is that `MAINTAINERS.md` never said so, which is why the roster and the access rights read as unrelated. The authoritative area-to-owner mapping stays in `.github/CODEOWNERS`; this table only names the people.

**Emeritus, +2.** `@gecube` and `@nbykov0` move to the emeritus section. Neither is carrying the responsibilities the ladder attaches to the role — reviewing at least 40 pull requests a year and taking part in the project's technical direction — and the section exists to record exactly that, as a note on past contribution rather than a withdrawal of it.

**Security contacts.** `SECURITY.md` already routes reports correctly; this names the maintainers who triage them, so the Required "contact information" item points at people.

### What this PR does not do, and depends on

- `.github/CODEOWNERS` on `main` is still a single wildcard line naming seven people, five of whom are not in `MAINTAINERS.md`. Aligning it is #3228, which already scopes ownership by area and has been in draft since 7 July. **This PR should land with or after it** — until then the Reviewers table points at a file that does not yet reflect it. The area additions still missing from #3228 (`@kingdonb` on `packages/system/fluxcd*`, GPU/HAMi, `metrics-server`/`seaweedfs`) are prepared and not pushed, because that branch is not mine to force.
- Permission changes themselves are not in any PR: raising `@kingdonb`, `@matthieu-robin` and `@mattia-eleuteri` to write, and dropping write from the four contributors who are neither maintainers nor reviewers, is done by hand in the org.
- Two cells need confirmation from the people involved: `@scooby87` publishes no name or company, and `@androndo`'s "Independent" is inferred rather than stated. Both are placeholders, not claims.

### Screenshots

N/A — documentation change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

Walked the trigger map against the diff: no row matches. The change touches no package, no schema, no `ApplicationDefinition`, no platform variant, no release asset and no node prerequisite. The website carries no page mirroring `MAINTAINERS.md` — only blog posts that mention maintainers in passing, which are historical and not regenerated.

The CNCF `.project` metadata does mirror this file, and is being updated in a companion PR in [cozystack/.project](https://github.com/cozystack/.project): `project_lead` there still points at an emeritus maintainer, and the roster needs the same three additions plus the reviewers team. That repository is not on this checklist because it is CNCF automation metadata rather than a downstream consumer of the platform.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded maintainer and reviewer listings, including area ownership guidance.
  * Clarified vulnerability reporting instructions with specific private contact options and security triage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

