### PR TITLE
docs(monitoring): correct the release name the OIDC comment, guide and test fixture encode

### DIFF
--- a/docs/oidc-grafana.md
+++ b/docs/oidc-grafana.md
@@ -1,7 +1,7 @@
 # OIDC for the Grafana instance (Phase 1)
 
 Cozystack ships one Grafana codebase deployed twice: as
-`monitoring-system` in the platform's `cozy-monitoring` namespace and as
+`monitoring-system` in the platform's `tenant-root` namespace and as
 `monitoring` in every tenant namespace. Both instances opt in to OIDC
 authentication through the same flat selector on the `Monitoring` CR.
 This document covers the operator-facing surface: what the modes mean,

--- a/docs/oidc-grafana.md
+++ b/docs/oidc-grafana.md
@@ -1,11 +1,6 @@
 # OIDC for the Grafana instance (Phase 1)
 
-Cozystack ships one Grafana codebase deployed twice: as
-`monitoring-system` in the platform's `cozy-monitoring` namespace and as
-`monitoring` in every tenant namespace. Both instances opt in to OIDC
-authentication through the same flat selector on the `Monitoring` CR.
-This document covers the operator-facing surface: what the modes mean,
-what the chart provisions, and how a user signs in.
+Cozystack ships one Grafana codebase deployed twice, both released as `monitoring-system` and differing only by namespace: the platform instance runs in `tenant-root` and a per-tenant instance runs in every tenant namespace. Both instances opt in to OIDC authentication through the same flat selector on the `Monitoring` CR. This document covers the operator-facing surface: what the modes mean, what the chart provisions, and how a user signs in.
 
 The architectural rationale lives in
 [cozystack/community#24](https://github.com/cozystack/community/pull/24)

--- a/docs/oidc-grafana.md
+++ b/docs/oidc-grafana.md
@@ -1,11 +1,6 @@
 # OIDC for the Grafana instance (Phase 1)
 
-Cozystack ships one Grafana codebase deployed twice: as
-`monitoring-system` in the platform's `tenant-root` namespace and as
-`monitoring` in every tenant namespace. Both instances opt in to OIDC
-authentication through the same flat selector on the `Monitoring` CR.
-This document covers the operator-facing surface: what the modes mean,
-what the chart provisions, and how a user signs in.
+Cozystack ships one Grafana codebase deployed twice, both released as `monitoring-system` and differing only by namespace: the platform instance runs in `tenant-root` and a per-tenant instance runs in every tenant namespace. Both instances opt in to OIDC authentication through the same flat selector on the `Monitoring` CR. This document covers the operator-facing surface: what the modes mean, what the chart provisions, and how a user signs in.
 
 The architectural rationale lives in
 [cozystack/community#24](https://github.com/cozystack/community/pull/24)

--- a/packages/system/monitoring/templates/_helpers.tpl
+++ b/packages/system/monitoring/templates/_helpers.tpl
@@ -4,8 +4,8 @@
   Naming — the identity unit is the Monitoring release, so the clientId
   and the audience scope are `<namespace>-<release>` prefixed. That
   gives:
-    tenant-foo/monitoring        (per-tenant Grafana in tenant-foo ns)
-    cozy-monitoring/monitoring-system  (platform Grafana in cozy-monitoring ns)
+    tenant-foo/monitoring-system   (per-tenant Grafana in tenant-foo ns)
+    tenant-root/monitoring-system  (platform Grafana in the tenant-root ns)
   A token minted for one instance is rejected by the other's Grafana
   because the per-cluster audience scope binds `id_token.aud` to the
   clientId — same isolation primitive as the tenant kube-apiserver PR

--- a/packages/system/monitoring/tests/oidc_test.yaml
+++ b/packages/system/monitoring/tests/oidc_test.yaml
@@ -6,7 +6,7 @@ templates:
   - templates/grafana/grafana.yaml
 
 release:
-  name: monitoring
+  name: monitoring-system
   namespace: tenant-root
 
 # Baseline `_cluster` / `_namespace` values wired by cozystack-basics
@@ -146,7 +146,7 @@ tests:
         documentIndex: 1
       - equal:
           path: spec.secret
-          value: "$monitoring-oidc-client:client-secret"
+          value: "$monitoring-system-oidc-client:client-secret"
         documentIndex: 1
       - equal:
           path: spec.redirectUris[0]
@@ -154,7 +154,7 @@ tests:
         documentIndex: 1
       - contains:
           path: spec.defaultClientScopes
-          content: tenant-root-monitoring-audience
+          content: tenant-root-monitoring-system-audience
         documentIndex: 1
       # `groups` scope is the platform-managed realm-default that emits
       # the caller's Keycloak groups into the token; must be listed
@@ -174,11 +174,11 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: tenant-root-monitoring-audience
+          value: tenant-root-monitoring-system-audience
         documentIndex: 0
       - equal:
           path: spec.protocolMappers[0].config["included.client.audience"]
-          value: tenant-root-monitoring
+          value: tenant-root-monitoring-system
         documentIndex: 0
 
   - it: mode=System persists a random client-secret at install
@@ -194,7 +194,7 @@ tests:
           value: Secret
       - equal:
           path: metadata.name
-          value: monitoring-oidc-client
+          value: monitoring-system-oidc-client
       # 32 random alphanumeric chars base64-encoded → 44 chars (43 + '=' padding).
       - matchRegex:
           path: data["client-secret"]
@@ -214,7 +214,7 @@ tests:
           value: "true"
       - equal:
           path: spec.config["auth.generic_oauth"].client_id
-          value: tenant-root-monitoring
+          value: tenant-root-monitoring-system
       - equal:
           path: spec.config["auth.generic_oauth"].client_secret
           value: "${GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET}"
@@ -223,7 +223,7 @@ tests:
           value: "https://keycloak.example.org/realms/cozy/protocol/openid-connect/auth"
       - equal:
           path: spec.config["auth.generic_oauth"].scopes
-          value: "openid email profile groups tenant-root-monitoring-audience"
+          value: "openid email profile groups tenant-root-monitoring-system-audience"
       # Tenant-membership gate — unconditionally emitted in System mode
       # (chart-owned, not tied to spec.oidc.users). Rejects logins whose
       # token does not carry at least one of the release's tenant-scoped
@@ -299,7 +299,7 @@ tests:
           value: "groups"
       - equal:
           path: spec.config["auth.generic_oauth"].scopes
-          value: "openid email profile groups tenant-root-monitoring-audience"
+          value: "openid email profile groups tenant-root-monitoring-system-audience"
 
   - it: mode=System allowed_groups uses the release namespace as tenant prefix (nested tenant)
     # Regression guard against a helper regression that would compute
@@ -310,7 +310,7 @@ tests:
     # every user of the release on a nested tenant.
     template: templates/grafana/grafana.yaml
     release:
-      name: monitoring
+      name: monitoring-system
       namespace: tenant-foo-bar
     set:
       _cluster:
@@ -349,7 +349,7 @@ tests:
             name: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: monitoring-oidc-client
+                name: monitoring-system-oidc-client
                 key: client-secret
 
   - it: mode=System keeps disable_login_form false so admin creds stay a break-glass path
@@ -380,7 +380,7 @@ tests:
           value: Job
       - equal:
           path: metadata.name
-          value: monitoring-oidc-users
+          value: monitoring-system-oidc-users
       - equal:
           path: metadata.annotations["helm.sh/hook"]
           value: post-install,post-upgrade

--- a/packages/system/monitoring/tests/oidc_test.yaml
+++ b/packages/system/monitoring/tests/oidc_test.yaml
@@ -6,7 +6,7 @@ templates:
   - templates/grafana/grafana.yaml
 
 release:
-  name: monitoring
+  name: monitoring-system
   namespace: tenant-root
 
 # Baseline `_cluster` / `_namespace` values wired by cozystack-basics
@@ -159,7 +159,7 @@ tests:
         documentIndex: 1
       - equal:
           path: spec.secret
-          value: "$monitoring-oidc-client:client-secret"
+          value: "$monitoring-system-oidc-client:client-secret"
         documentIndex: 1
       - equal:
           path: spec.redirectUris[0]
@@ -167,7 +167,7 @@ tests:
         documentIndex: 1
       - contains:
           path: spec.defaultClientScopes
-          content: tenant-root-monitoring-audience
+          content: tenant-root-monitoring-system-audience
         documentIndex: 1
       # `groups` scope is the platform-managed realm-default that emits
       # the caller's Keycloak groups into the token; must be listed
@@ -187,11 +187,11 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: tenant-root-monitoring-audience
+          value: tenant-root-monitoring-system-audience
         documentIndex: 0
       - equal:
           path: spec.protocolMappers[0].config["included.client.audience"]
-          value: tenant-root-monitoring
+          value: tenant-root-monitoring-system
         documentIndex: 0
 
   - it: mode=System persists a random client-secret at install
@@ -207,7 +207,7 @@ tests:
           value: Secret
       - equal:
           path: metadata.name
-          value: monitoring-oidc-client
+          value: monitoring-system-oidc-client
       # 32 random alphanumeric chars base64-encoded → 44 chars (43 + '=' padding).
       - matchRegex:
           path: data["client-secret"]
@@ -227,7 +227,7 @@ tests:
           value: "true"
       - equal:
           path: spec.config["auth.generic_oauth"].client_id
-          value: tenant-root-monitoring
+          value: tenant-root-monitoring-system
       - equal:
           path: spec.config["auth.generic_oauth"].client_secret
           value: "${GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET}"
@@ -236,7 +236,7 @@ tests:
           value: "https://keycloak.example.org/realms/cozy/protocol/openid-connect/auth"
       - equal:
           path: spec.config["auth.generic_oauth"].scopes
-          value: "openid email profile groups tenant-root-monitoring-audience"
+          value: "openid email profile groups tenant-root-monitoring-system-audience"
       # Tenant-membership gate — unconditionally emitted in System mode
       # (chart-owned, not tied to spec.oidc.users). Rejects logins whose
       # token does not carry at least one of the release's tenant-scoped
@@ -312,7 +312,7 @@ tests:
           value: "groups"
       - equal:
           path: spec.config["auth.generic_oauth"].scopes
-          value: "openid email profile groups tenant-root-monitoring-audience"
+          value: "openid email profile groups tenant-root-monitoring-system-audience"
 
   - it: mode=System allowed_groups uses the release namespace as tenant prefix (nested tenant)
     # Regression guard against a helper regression that would compute
@@ -323,7 +323,7 @@ tests:
     # every user of the release on a nested tenant.
     template: templates/grafana/grafana.yaml
     release:
-      name: monitoring
+      name: monitoring-system
       namespace: tenant-foo-bar
     set:
       _cluster:
@@ -362,7 +362,7 @@ tests:
             name: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
             valueFrom:
               secretKeyRef:
-                name: monitoring-oidc-client
+                name: monitoring-system-oidc-client
                 key: client-secret
 
   - it: mode=System keeps disable_login_form false so admin creds stay a break-glass path
@@ -393,7 +393,7 @@ tests:
           value: Job
       - equal:
           path: metadata.name
-          value: monitoring-oidc-users
+          value: monitoring-system-oidc-users
       - equal:
           path: metadata.annotations["helm.sh/hook"]
           value: post-install,post-upgrade


### PR DESCRIPTION
## What this PR does

The Grafana OIDC `clientId`, audience-scope name, client-secret name and users-Job name are all derived from the Monitoring release name. In a running cluster that release is always `monitoring-system`: the tenant chart's outer HelmRelease `monitoring` points at `extra/monitoring`, whose `templates/helmrelease.yaml` creates the inner HelmRelease `{{ .Release.Name }}-system` that carries `system/monitoring` and renders OIDC. There is no release named `monitoring` that renders OIDC.

Three places encoded a release named `monitoring` (i.e. `<ns>-monitoring`, where a cluster renders `<ns>-monitoring-system`), per #3338:

- `packages/system/monitoring/templates/_helpers.tpl` header comment — both example lines were wrong. The per-tenant release is `monitoring-system`, and the platform Grafana lives in the `tenant-root` namespace, not `cozy-monitoring`. (`cozy-monitoring` only hosts the ExternalName services that redirect to the platform stack the root tenant hosts in `tenant-root` — see `packages/system/cozystack-basics/templates/monitoring-external-services.yaml`.)
- `docs/oidc-grafana.md` — placed the platform release in `cozy-monitoring`; it lives in `tenant-root`. The release name `monitoring-system` there was already correct, so only the namespace is changed.
- `packages/system/monitoring/tests/oidc_test.yaml` — the suite pinned `release.name: monitoring`, so its clientId / audience-scope / client-secret / users-Job assertions pinned names no cluster renders. Both fixtures are set to `monitoring-system` and the derived expected values updated to what a cluster actually renders.

Nothing changes at runtime — the templates are self-consistent whatever the release is called; this only aligns the descriptions and the test fixture with reality.

Out of scope here (from the issue, left for a maintainer decision):
- Confirming/removing the apparently-dead `cozystack.monitoring` PackageSource in `packages/core/platform/sources/monitoring.yaml` (issue item 3) — removing a source is a call I can't safely make.
- Re-checking Detail B of #3259 against the corrected topology (issue item 4).

Verification: `helm unittest -f 'tests/oidc_test.yaml' packages/system/monitoring` — 37/37 pass. Baseline was 37/37; after setting the fixtures I updated only the assertions helm-unittest reported as newly diverging, then re-ran to green.

Disclosure: prepared with AI assistance; I reviewed the change and verified the release-name topology against the source files cited above.

### Screenshots

N/A — no UI changes.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff, file by file. The three changed paths are a `system/monitoring` chart `_helpers.tpl` comment, the repo-internal `docs/oidc-grafana.md`, and a chart test fixture. None match a listed trigger: no change under `packages/apps/` or `packages/extra/`, no `packages/core/platform/values.yaml`, and no variant/bundle/component/release-asset/Talos/tooling change. So no downstream repository is mechanically affected. (The website's own OIDC page referenced in cozystack/website#597 is a separate artifact the reporter is already engaged with, outside this repo's trigger map.)

- [x] No downstream repository is affected by this change

### Release note

```release-note
docs(monitoring): correct the release name (`monitoring-system`) and platform namespace (`tenant-root`) encoded in the Grafana OIDC helper comment, the OIDC guide, and the chart test fixture.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated Grafana OIDC audience and scope naming to use `monitoring-system` for platform and per-tenant instances.
  - Renamed related authentication and credential resource identifiers to match the new Grafana naming.

- **Documentation**
  - Clarified that the platform Grafana instance runs in `tenant-root`, while per-tenant instances run in each tenant namespace.

- **Tests**
  - Updated OIDC test expectations to reflect the new naming across rendered resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->