### PR TITLE
ci: warm the build cache on release-1.5 pushes

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -1,9 +1,23 @@
-name: Build cache (main)
+name: Build cache (release-1.5)
 
-# Warms the shared mode=max build cache so PR builds start hot.
+# Warms the mode=max build cache for THIS branch so its PR builds start hot.
+#
+# On main this workflow fires on main pushes; on a release branch it has to fire
+# on that branch's own pushes, because the cache main writes is main's content.
+# Nothing had been warming release-1.5: main dropped ubuntu-container-disk from
+# `make image` in 39cdc8866, six days before this branch was cut, so its six
+# :*-buildcache refs were never written at all, and every other ref carries
+# main's sources rather than this branch's. The result was a PR Build that ran
+# cold end to end and timed out -- ~28min of it in ubuntu-container-disk alone
+# before #3457 parallelised that target, and ~38min across all 28 packages after.
+#
+# The cache is written to its OWN namespace (CACHE_REGISTRY below), not the
+# shared one. Writing the shared refs from here would replace main's layers with
+# this branch's, so main's next PR build would miss on everything and blow its
+# own 30-min timeout until the next main push re-warmed it.
 #
 # PR builds (pull-requests.yaml) read the cache but never write it
-# (WRITE_CACHE unset -> 0). Only this serialized main build writes
+# (WRITE_CACHE unset -> 0). Only this serialized branch build writes
 # CACHE_REGISTRY/<img>:buildcache, so concurrent PR builds never race on the
 # cache manifest -- the 409 collisions PR #2711 fixed for image tags would
 # otherwise reappear on the cache ref. Cache is mode=max so all multistage
@@ -19,23 +33,32 @@ name: Build cache (main)
 env:
   # Same per-CI registry as pull-requests.yaml; the cache is co-located here.
   REGISTRY: iad.ocir.io/idyksih5sir9/cozystack
+  # Branch-scoped cache namespace, kept in sync with the Build job in
+  # pull-requests.yaml. Both must point at the same place or PR builds read a
+  # cache nobody writes.
+  CACHE_REGISTRY: iad.ocir.io/idyksih5sir9/cozystack-cache-release-1.5
 
 on:
   push:
-    branches: [main]
+    branches: [release-1.5]
     paths-ignore:
       - 'docs/**'
 
-# Only the newest main commit's cache matters; cancel older in-flight warmers.
+# Only the newest commit's cache matters; cancel older in-flight warmers.
 concurrency:
-  group: build-main-cache
+  group: build-release-1.5-cache
   cancel-in-progress: true
 
 jobs:
   warm-cache:
     name: Warm build cache
-    runs-on: [self-hosted]
-    timeout-minutes: 90
+    # Was [self-hosted], which is the decommissioned cozy-runner-1 (#2937) -- this
+    # workflow could not have run on this branch even once. Same ephemeral shape
+    # the main warmer moved to; a cold serial `make build` here is CPU-bound.
+    runs-on: oracle-vm-24cpu-96gb-x86-64
+    # The first run is fully cold and builds six ubuntu-container-disk images on
+    # top of the other 28 packages; later runs mostly re-export a warm cache.
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: write
@@ -92,7 +115,7 @@ jobs:
           BUILDER: ${{ steps.buildx.outputs.name }}
           # WRITE_CACHE=1 turns on --cache-to (mode=max) for every image.
           WRITE_CACHE: '1'
-          # Publish a floating :main handle; do not move :latest (releases do).
-          IMAGE_TAG: main
+          # Floating handle for this branch; do not move :latest (releases do).
+          IMAGE_TAG: release-1.5
           PUBLISH_VERSIONED: '0'
           PUBLISH_FLOATING: '0'

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -33,12 +33,17 @@ jobs:
     # buildkit; concurrent build jobs serialize on buildkit's single-writer bbolt
     # cache lock + exporter mutex and stall to the 30-min timeout (proven via a
     # live SIGUSR1 goroutine dump). One VM per job => one buildkit per job => that
-    # contention is severed by construction. `make build` is serial (one image at
-    # a time), so a small shape suffices -- 4cpu/16gb, not the 24cpu the e2e job
-    # uses -- and it leans on the warm mode=max cache (#2938) to stay under the
-    # 30-min wall. The `debug` label still routes to self-hosted for the
-    # breakpoint path. Phase 0.5 of #2937.
-    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-4cpu-16gb-x86-64' }}
+    # contention is severed by construction. Phase 0.5 of #2937.
+    #
+    # 24cpu/96gb rather than the 4cpu/16gb this used to run on: `make build` is
+    # still serial across images, but this branch is the only one that still
+    # builds ubuntu-container-disk, and it does so once per Kubernetes minor with
+    # no shared build cache to warm it (main dropped the image in 39cdc8866, six
+    # days before release-1.5 was cut, so nothing writes its :*-buildcache refs).
+    # Those six builds now run concurrently, and each drives its own libguestfs
+    # appliance -- ~9gb of RAM and a core apiece, which the small shape cannot
+    # give. The `debug` label still routes to self-hosted for the breakpoint path.
+    runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-24cpu-96gb-x86-64' }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -3,6 +3,11 @@ name: Pull Request
 env:
   # TODO: unhardcode this
   REGISTRY: iad.ocir.io/idyksih5sir9/cozystack
+  # Read the cache build-main.yaml writes for THIS branch, not the shared refs
+  # main writes -- those carry main's sources and mostly miss here. Must stay in
+  # sync with CACHE_REGISTRY in build-main.yaml. Builds only read it
+  # (WRITE_CACHE defaults to 0), so a miss is a cold build, never an error.
+  CACHE_REGISTRY: iad.ocir.io/idyksih5sir9/cozystack-cache-release-1.5
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -44,7 +49,13 @@ jobs:
     # appliance -- ~9gb of RAM and a core apiece, which the small shape cannot
     # give. The `debug` label still routes to self-hosted for the breakpoint path.
     runs-on: ${{ contains(github.event.pull_request.labels.*.name, 'debug') && 'self-hosted' || 'oracle-vm-24cpu-96gb-x86-64' }}
-    timeout-minutes: 30
+    # A warm cache puts this job around 15min. 30 was not enough for a cold one:
+    # the branch-scoped cache starts empty, and anything that invalidates it
+    # (a Dockerfile edit, a go.mod bump) drops a later build back to ~45min --
+    # six container disks plus 28 packages built from scratch. Sized for that
+    # case rather than for the warm one, so a cold build reports its real
+    # failure instead of a timeout that says nothing about why.
+    timeout-minutes: 75
     permissions:
       contents: read
       packages: write

--- a/packages/apps/kubernetes/Makefile
+++ b/packages/apps/kubernetes/Makefile
@@ -20,19 +20,30 @@ update:
 
 image: image-ubuntu-container-disk image-kubevirt-cloud-provider image-kubevirt-csi-driver image-cluster-autoscaler
 
+# One container disk per Kubernetes minor. Each build spends ~4-5min inside a
+# libguestfs appliance installing that minor's kubelet/kubeadm into its own copy
+# of the cloud image, and the versions share no per-version work, so build them
+# concurrently: the serial loop this replaced spent ~28min of the Build job's
+# 30min budget on this target alone. The sub-make carries its own -j so the root
+# `make build` stays serial, and buildkit dedups the shared guestfish and
+# cloud-image stages across the concurrent solves. --output-sync=target groups
+# each version's log under its target name -- six interleaved buildx progress
+# streams are unreadable otherwise.
 image-ubuntu-container-disk:
-	$(foreach ver,$(KUBERNETES_VERSIONS), \
-		docker buildx build images/ubuntu-container-disk \
-			--build-arg KUBERNETES_VERSION=$(ver) \
-			--tag $(REGISTRY)/ubuntu-container-disk:$(ver)-$(IMAGE_TAG) \
-			$(if $(filter 1,$(PUBLISH_VERSIONED)),--tag $(REGISTRY)/ubuntu-container-disk:$(ver)) \
-			$(call cache-args,ubuntu-container-disk,$(ver)-buildcache) \
-			--metadata-file images/ubuntu-container-disk-$(ver).json \
-			$(BUILDX_ARGS) && \
-		echo "$(REGISTRY)/ubuntu-container-disk:$(ver)-$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/ubuntu-container-disk-$(ver).json -o json -r)" \
-			> images/ubuntu-container-disk-$(ver).tag && \
-		rm -f images/ubuntu-container-disk-$(ver).json; \
-	)
+	$(MAKE) -j$(words $(KUBERNETES_VERSIONS)) --output-sync=target \
+		$(addprefix image-ubuntu-container-disk-,$(KUBERNETES_VERSIONS))
+
+image-ubuntu-container-disk-%:
+	docker buildx build images/ubuntu-container-disk \
+		--build-arg KUBERNETES_VERSION=$* \
+		--tag $(REGISTRY)/ubuntu-container-disk:$*-$(IMAGE_TAG) \
+		$(if $(filter 1,$(PUBLISH_VERSIONED)),--tag $(REGISTRY)/ubuntu-container-disk:$*) \
+		$(call cache-args,ubuntu-container-disk,$*-buildcache) \
+		--metadata-file images/ubuntu-container-disk-$*.json \
+		$(BUILDX_ARGS)
+	echo "$(REGISTRY)/ubuntu-container-disk:$*-$(IMAGE_TAG)@$$(yq e '."containerimage.digest"' images/ubuntu-container-disk-$*.json -o json -r)" \
+		> images/ubuntu-container-disk-$*.tag
+	rm -f images/ubuntu-container-disk-$*.json
 
 image-kubevirt-cloud-provider:
 	docker buildx build images/kubevirt-cloud-provider \


### PR DESCRIPTION
## What this PR does

Nothing has ever warmed `release-1.5`'s build cache, so every PR build on this branch runs cold end to end and exceeds its 30-minute timeout.

This branch's copy of `build-main.yaml` is dead code. It triggers on `push: branches: [main]`, which never happens here, and it targets `[self-hosted]` — the decommissioned cozy-runner-1 (#2937) — so it could not have run even if it fired. This PR points it at this branch instead.

Both halves of the cold build trace back to 39cdc8866 (`feat(kubernetes): bootstrap tenant workers with Talos via CABPT`) landing on `main` on 2026-06-16, six days before `release-1.5` was cut on 2026-06-22:

- That commit dropped `ubuntu-container-disk` from `make image`, so `main` stopped writing its six `:<minor>-buildcache` refs. `release-1.5` is now the only branch that still builds the image, and the CI log shows all six importers failing with `not found`. Serially that was ~28min of the 30min budget; #3457 parallelises the target down to ~10min.
- Every other cache ref carries `main`'s sources, which have diverged from this branch, so most of the remaining 28 packages miss too. Measured on the #3457 run: ~38min across the full build, and no single hot spot left to attack — `apps/kubernetes` at 15m07s and `system/linstor` at 5m39s, everything else 20-60s each.

### Changes

| | before | after |
| --- | --- | --- |
| trigger | `push: [main]` | `push: [release-1.5]` |
| runner | `[self-hosted]` (decommissioned) | `oracle-vm-24cpu-96gb-x86-64` |
| cache namespace | shared `cozystack/` | `cozystack-cache-release-1.5/` |
| `IMAGE_TAG` | `main` | `release-1.5` |
| warmer timeout | 90 | 120 |

`pull-requests.yaml` gets the same `CACHE_REGISTRY` so PR builds read what the warmer writes, and its Build timeout goes to 75 minutes.

The cache namespace is branch-scoped on purpose. Writing the shared refs from here would replace `main`'s layers with this branch's, so `main`'s next PR build would miss on everything and blow its own 30-minute timeout until the next `main` push re-warmed it. `CACHE_REGISTRY` already exists as a knob in `hack/common-envs.mk`, so this is one env var per job rather than new machinery. Image tags are unaffected — they still resolve to `cozystack/<image>`, only cache refs move.

The timeout raise is not optional. The new namespace starts empty, so this PR and the next one still build cold at ~45min, and anything that later invalidates the cache broadly — a Dockerfile edit, a `go.mod` bump — costs the same again. 30 minutes only ever fit a warm build, and when it did not fit, the job reported a timeout rather than whatever actually went wrong.

### Verification

- Both workflows are asserted to agree on the cache namespace, rather than eyeballed.
- Confirmed the env split renders as intended: `--tag iad.ocir.io/…/cozystack/ubuntu-container-disk:v1.35-release-1.5` alongside `--cache-from`/`--cache-to` on `…/cozystack-cache-release-1.5/ubuntu-container-disk:v1.35-buildcache`.
- `WRITE_CACHE` stays unset in PR builds, so they remain read-only against the cache and never race on a manifest.

### Notes for the reviewer

- **Stacked on #3457.** Both PRs edit adjacent lines of `pull-requests.yaml`, so keeping them independent guaranteed a conflict. GitHub retargets this to `release-1.5` automatically once #3457 merges.
- **The filename stays `build-main.yaml`** even though it no longer warms `main`. Renaming it would make any later backport touching `main`'s copy arrive as a whole new file rather than a modification, which is the failure mode the backport bot already hits on this branch.
- **One assumption I could not test locally:** the registry credentials need repo-create permission for the new `cozystack-cache-release-1.5/*` path. It is the same tenancy namespace that already auto-creates repos as packages get added, so it should hold — but if it does not, `--cache-to` fails the warmer, and the fallback is a cache-tag suffix in `hack/common-envs.mk` instead of a separate namespace.
- **Sequencing:** the merge commit is itself a push to `release-1.5`, so the warmer fires on merge and takes ~50-60min cold. PR builds after that should be ~15min. The warmer cannot be triggered manually — `workflow_dispatch` is only available for workflows present on the default branch, and this one exists only here.
- **Out of scope, but adjacent:** `tags.yaml`, `release-e2e.yaml` and `pull-requests-release.yaml` on this branch all still say `runs-on: [self-hosted]`, so the release and release-e2e lanes are broken the same way this warmer was.

### Release note

```release-note
NONE
```
