### PR TITLE
fix(reloader): add startupProbe to survive slow first start under load

### DIFF
--- a/packages/system/reloader/Makefile
+++ b/packages/system/reloader/Makefile
@@ -1,10 +1,39 @@
 export NAME=reloader
 export NAMESPACE=cozy-$(NAME)
+export REPO_NAME=stakater
+export REPO_URL=https://stakater.github.io/stakater-charts
+export CHART_NAME=reloader
+# Pin the vendored chart exactly. An unpinned pull takes whatever is latest,
+# which drags a Reloader upgrade into whatever change happens to run `update`
+# next and can move the deployment.yaml layout out from under
+# patches/deployment-startup-probe.diff. Raising this is a deliberate step:
+# regenerate the patch against the new upstream and re-run `make test`.
+#
+# Read this as "the version that is vendored", not "the current version":
+# upstream is at 2.2.14 / app v1.4.19 while this is 2.0.0 / app v1.3.0. The pin
+# is what makes the vendored tree reproducible, and it does not itself schedule
+# the catch-up bump, which is its own change.
+export CHART_VERSION=2.0.0
 
 include ../../../hack/package.mk
 
-update:
-	rm -rf charts
-	helm repo add stakater https://stakater.github.io/stakater-charts
-	helm repo update
-	helm pull stakater/reloader --untar --untardir charts
+test:
+	helm unittest .
+	# CHART_VERSION names the version that is vendored, and nothing else
+	# enforces that: bumping the pin without re-running `make update` leaves the
+	# committed tree on the old chart and the claim quietly false.
+	@actual_version=$$(awk '/^version:/ {print $$2}' charts/reloader/Chart.yaml | tr -d '"'); \
+	if [ "$$actual_version" != "$(CHART_VERSION)" ]; then \
+	  echo "ERROR: vendored charts/reloader/Chart.yaml version=$$actual_version but Makefile CHART_VERSION=$(CHART_VERSION). Re-run 'make update'."; \
+	  exit 1; \
+	fi
+
+update: clean reloader-update
+	# Re-apply local modifications carried as patches/*.diff. clean runs first,
+	# so this target always patches a freshly pulled tree; --forward guards the
+	# re-run by hand over a tree that already carries the change, where patch(1)
+	# defaults diverge by implementation: GNU 2.7.6 refuses and exits 1, Apple
+	# 2.0-12u11 takes its "Assume -R? [y]" default and strips the hunk back out
+	# with exit 0, and GNU under --batch does the same. --forward refuses in all
+	# three, leaving a .rej and a non-zero exit.
+	patch --forward --no-backup-if-mismatch -p1 < patches/deployment-startup-probe.diff

--- a/packages/system/reloader/charts/reloader/templates/deployment.yaml
+++ b/packages/system/reloader/charts/reloader/templates/deployment.yaml
@@ -161,6 +161,17 @@ spec:
         ports:
         - name: http
           containerPort: 9090
+        {{- /*
+        cozystack (patches/deployment-startup-probe.diff): the upstream chart
+        renders no startupProbe, which leaves a slow first start no grace period
+        of its own. Why that matters and how the budget was chosen is documented
+        next to the knob, in the package values.yaml. Rendered with `with`, so an
+        unset value emits nothing and the template stays upstream-compatible.
+        */}}
+        {{- with .Values.reloader.deployment.startupProbe }}
+        startupProbe:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /live

--- a/packages/system/reloader/patches/deployment-startup-probe.diff
+++ b/packages/system/reloader/patches/deployment-startup-probe.diff
@@ -1,0 +1,36 @@
+# The upstream chart renders liveness and readiness from values but no
+# startupProbe at all, so a slow first start has no grace period of its own and
+# is killed by liveness inside ~60s. Reloader binds its :9090 listener as the
+# last statement of startReloader, after a package-level
+# `IsOpenshift = isOpenshift()` in pkg/kube issues a GET
+# /apis/project.openshift.io on a context with no deadline, before main() is
+# entered, so the probes are refused for as long as that takes. The budget and
+# the reasoning behind the numbers live in the package values.yaml.
+#
+# Chart source: https://github.com/stakater/stakater-charts (reloader)
+# This belongs upstream: the chart already renders the other two probes from
+# values, so a startupProbe block is the same shape of change. Not reported
+# upstream yet. Still absent as of chart 2.2.14 / app v1.4.19, where
+# isOpenshift() is also still eager, so the patch is needed on current upstream
+# and not only on the pinned 2.0.0. Drop this hunk once upstream renders one.
+diff --git a/charts/reloader/templates/deployment.yaml b/charts/reloader/templates/deployment.yaml
+--- a/charts/reloader/templates/deployment.yaml
++++ b/charts/reloader/templates/deployment.yaml
+@@ -161,6 +161,17 @@
+         ports:
+         - name: http
+           containerPort: 9090
++        {{- /*
++        cozystack (patches/deployment-startup-probe.diff): the upstream chart
++        renders no startupProbe, which leaves a slow first start no grace period
++        of its own. Why that matters and how the budget was chosen is documented
++        next to the knob, in the package values.yaml. Rendered with `with`, so an
++        unset value emits nothing and the template stays upstream-compatible.
++        */}}
++        {{- with .Values.reloader.deployment.startupProbe }}
++        startupProbe:
++          {{- toYaml . | nindent 10 }}
++        {{- end }}
+         livenessProbe:
+           httpGet:
+             path: /live

--- a/packages/system/reloader/tests/deployment_startup_probe_test.yaml
+++ b/packages/system/reloader/tests/deployment_startup_probe_test.yaml
@@ -1,0 +1,96 @@
+suite: cozy-reloader startup probe
+release:
+  name: reloader
+  namespace: cozy-reloader
+tests:
+  # The vendored Reloader chart renders no startupProbe. Reloader binds its
+  # :9090 listener as the last statement of startReloader, after a package-level
+  # GET /apis/project.openshift.io that carries no deadline, so a slow first
+  # start answers every probe with a connection refused and gets killed inside
+  # the ~60s liveness budget, restarting into a loop that never finishes the
+  # prologue. patches/deployment-startup-probe.diff adds the probe that gates
+  # liveness on that window. If a chart refresh drops the patch, or an upstream
+  # refactor renames the port or the endpoint, these asserts fail before the
+  # restart loop can come back.
+  - it: renders a startup probe covering the slow-start window
+    template: charts/reloader/templates/deployment.yaml
+    asserts:
+      - exists:
+          path: spec.template.spec.containers[0].startupProbe
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /live
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.port
+          value: http
+      # Budget = periodSeconds * failureThreshold. Both values are pinned so a
+      # refresh that zeroed either one still falls out here; changing the budget
+      # on purpose means changing this test with it.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 45
+      # Pinned because the kubelet default is 1s, and at this container's 100m
+      # CPU limit a throttled process can hold the socket open while still
+      # needing longer than a second to answer. Dropping this key would burn all
+      # 45 attempts on timeouts and kill the container anyway.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.timeoutSeconds
+          value: 5
+
+  # The template renders the stanza under `with`, so an unset value has to emit
+  # nothing at all: the patch stays upstream-compatible only as long as that
+  # holds. A refactor to `if` plus `toYaml` without the guard would emit
+  # `startupProbe: null` and the happy-path case above would not notice.
+  - it: emits no startup probe when the value is unset
+    template: charts/reloader/templates/deployment.yaml
+    set:
+      reloader.reloader.deployment.startupProbe: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+      # Unsetting the startup probe must not disturb what upstream renders.
+      - exists:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  # The startup probe covers the pre-bind window and nothing else: once it
+  # succeeds the kubelet falls back on the upstream probes at their own cadence,
+  # so those have to survive the patch untouched.
+  #
+  # The liveness numbers are pinned, not just its endpoint, because they are the
+  # premise the startup probe is sized against: initialDelaySeconds 10 +
+  # periodSeconds 10 * failureThreshold 5 is the ~60s budget that the package
+  # values.yaml quotes as the window a slow start overruns. An upstream refresh
+  # that moved failureThreshold to 2 would tighten that window, and one that
+  # moved it to 30 would make this patch redundant; either way the documented
+  # arithmetic would silently stop describing the chart. Pin them so the
+  # rationale cannot rot without a red test.
+  - it: leaves the upstream liveness and readiness probes intact
+    template: charts/reloader/templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /live
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /metrics
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: http

--- a/packages/system/reloader/values.yaml
+++ b/packages/system/reloader/values.yaml
@@ -9,3 +9,54 @@ reloader:
         requests:
           cpu: 10m
           memory: 128Mi
+
+      # -- Startup probe for the `reloader` container. This is the canonical
+      # explanation for the cozystack `patches/deployment-startup-probe.diff`
+      # template patch, which is what makes the key render at all; the template
+      # itself only points back here.
+      #
+      # Reloader binds its :9090 listener as the last statement of
+      # `startReloader`, so /live and /metrics answer connection refused until
+      # everything before it has finished. The blocking part of that prologue is
+      # not the informer construction, which is lazy: it is the package-level
+      # `IsOpenshift = isOpenshift()` in pkg/kube, which issues a
+      # GET /apis/project.openshift.io against the API server, with a
+      # context.TODO() that carries no deadline of its own, before main() is
+      # even entered. Its latency is the API server's, and the container runs at
+      # a 100m CPU limit while it waits.
+      #
+      # Without a startup probe the only grace period is the liveness budget:
+      # initialDelaySeconds 10 + periodSeconds 10 * failureThreshold 5, about
+      # 60s. A first start that needs longer is killed mid-prologue, and the
+      # restart does not resume it, it runs it again from the beginning, so the
+      # loop sustains itself.
+      #
+      # Budget here = periodSeconds * failureThreshold = 5 * 45, about 225s.
+      # Several times the window that was not enough, still well inside the
+      # install timeout that applies (not Flux's own default: cozystack-operator
+      # stamps every generated HelmRelease with --helmrelease-install-timeout,
+      # 10m by default), and short enough that a container which is genuinely
+      # dead surfaces within a few minutes rather than hiding behind the probe.
+      #
+      # Why a startup probe rather than the liveness knobs the chart already
+      # exposes, neither of which would need a patch:
+      # - livenessProbe.failureThreshold buys the grace permanently, loosening
+      #   steady-state hang detection for the life of the container.
+      # - livenessProbe.initialDelaySeconds is start-up-only and would genuinely
+      #   do, but it is a fixed blind window on every start; a startup probe
+      #   returns liveness to its tight budget the moment the listener binds.
+      # Adaptive against fixed is the trade. It is narrower than it sounds while
+      # reloader.enableHA is unset, since /live is then a constant 200 and
+      # liveness can only catch the listener dying outright.
+      #
+      # timeoutSeconds matches the 5s the chart gives liveness and readiness,
+      # rather than the kubelet default of 1s, because at a 100m CPU limit the
+      # listener can be up while a throttled process still needs more than a
+      # second to answer.
+      startupProbe:
+        httpGet:
+          path: /live
+          port: http
+        periodSeconds: 5
+        failureThreshold: 45
+        timeoutSeconds: 5


### PR DESCRIPTION
## What this PR does

Adds a startup probe to the reloader deployment, rendered from package values through a patch on the vendored chart.

Reloader went into CrashLoopBackOff on a loaded install. Events show `Liveness probe failed: ... connect: connection refused`, repeating on the liveness cadence until the kubelet gave up.

A refusal rather than a timeout closes two questions at once. It is an RST from the target netns, so the packet arrived and the pod network is fine. It also rules out the mode in [stakater/Reloader#252](https://github.com/stakater/Reloader/issues/252), where the listener is already up and `/metrics` just answers slowly; that one produces probe timeouts. Nothing was listening on `:9090` yet.

`http.ListenAndServe` is the last statement of `startReloader`, so the whole prologue runs before the socket opens. The slow part is not the informers, those are lazy and do their List in a goroutine. It is `IsOpenshift = isOpenshift()` in `pkg/kube`: a package-level var, so it runs at init before `main()`, and it does a `GET /apis/project.openshift.io` on a `context.TODO()` carrying no deadline. The latency is the API server's, and the container waits it out under a 100m CPU limit.

Without a startup probe the only grace period is the liveness budget itself, `initialDelaySeconds 10 + periodSeconds 10 * failureThreshold 5`. A start that overruns it gets killed mid-prologue, and the restart re-runs the prologue from the top against an API server that is no less busy, so the loop feeds itself.

This reaches past reloader. `packages/core/platform/sources/linstor.yaml` lists `cozystack.reloader` in the LINSTOR stack's `dependsOn`, and `dependsOn` fans out to every component of that stack, so a reloader stuck in this loop blocks that whole install.

The probe is `/live` at `periodSeconds 5` and `failureThreshold 45`, about 225s, well inside the 10m install timeout that cozystack-operator stamps on generated HelmReleases. Liveness is suspended while it runs and gets its tight budget back as soon as the listener binds. `timeoutSeconds` is 5 to match the other two probes instead of the kubelet default of 1s, since a throttled process at 100m can hold the socket open and still need more than a second to answer.

Both liveness knobs the chart already exposes would work without any patch. Widening `failureThreshold` buys the grace permanently and loosens hang detection for the life of the container. `initialDelaySeconds` is start-up-only and would genuinely do, but it is a fixed blind window on every start, including one that binds in three seconds, and nothing restarts a container that wedges inside it. Adaptive against fixed is the trade. The win is smaller than it sounds while `reloader.enableHA` is unset, since `/live` is a constant 200 then and liveness only catches the listener dying outright.

A chart bump does not fix this. 2.2.14 still renders no `startupProbe` anywhere, and v1.4.19 added a second eager package-level call next to `IsOpenshift`, so the prologue got longer instead of shorter. `packages/system/velero` already carries a startupProbe patch on its vendored chart for the same reason.

`make update` now drives the shared `%-update` rule with an exact `CHART_VERSION`. It has to be exact. With a stale local repo cache `helm pull --version 2.0.0` fails with version-not-found, while `--version "^2.0.0"` quietly resolves to 2.2.14, whose `deployment.yaml` has the ports block at line 179 instead of 161, so the hunk would fuzz or land somewhere unintended.

The patch runs with `--forward` because `patch(1)` defaults diverge between implementations over a tree that already carries the change. GNU 2.7.6 refuses and exits 1. Apple 2.0-12u11 takes its `Assume -R? [y]` default, strips the hunk back out and exits 0. GNU under `--batch` does the same, which is the trap, since `--batch` is what you reach for to make a script non-interactive. `--forward` refuses in all three and leaves a `.rej`.

Two things keep the probe from disappearing quietly, and they fire at different times. `--forward` catches it at the moment someone re-runs the patch by hand. The test only catches it at the next run of the suite, late enough for a commit to travel in between.

`make test` also checks that the vendored `Chart.yaml` still records the pinned version, so bumping `CHART_VERSION` without re-running `make update` fails instead of leaving the pin and the tree disagreeing. Checked by doing the violation and watching it go red.

### Screenshots

Not applicable, no UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff. All five files sit inside one `packages/system` package. No package is added, renamed or removed, nothing under `hack/` is touched, and no CRD, namespace, `packages/core` values key, version enum or release asset changes.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(reloader): add a startup probe so a slow first start is not killed by the liveness probe and left in CrashLoopBackOff, which also unblocks the LINSTOR stack that depends on reloader
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable startup health probe for the Reloader service.
  * The probe allows additional time for the service to start before health checks begin.
  * Documented the probe’s timing and behavior in the chart configuration.

* **Bug Fixes**
  * Preserved existing liveness and readiness probe behavior.

* **Tests**
  * Added coverage for enabled, disabled, and unaffected health probes.
  * Added validation to ensure the chart version matches the pinned release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->