### PR TITLE
fix(ci): overlay images from the PR base branch, and publish per-line artifacts

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,116 @@
+name: Build release line
+
+# Publishes the per-line equivalent of what build-main.yaml publishes for main:
+# every image tagged with the line's branch name, and the whole packages tree as
+# the `cozystack-packages:<branch>` OCI artifact with each image reference
+# digest-pinned to the images this run just pushed (`make build` ->
+# packages/core/installer image-packages does the `flux push artifact`).
+#
+# Why it exists: pull-requests.yaml overlays image refs for every package a PR
+# did NOT rebuild, so that e2e and the installer do not test last-release images
+# for everything outside the PR's build matrix. That overlay had only
+# `cozystack-packages:main` to read, which meant a release-line PR was handed
+# MAIN's binaries to run against its own line's charts — a cross-generation mix
+# that failed deterministically (see #3437: main's cozystack-controller served an
+# aggregated OpenAPI release-1.6's charts could not validate against). With this
+# artifact published per line, the overlay reads the PR's own base branch and the
+# generations match.
+#
+# Cost: one full `make build` per push to a maintained line, i.e. per merged
+# backport. That is the price of release-line PRs testing their line's tip rather
+# than its last release.
+
+env:
+  # Same per-CI registry as pull-requests.yaml and build-main.yaml.
+  REGISTRY: iad.ocir.io/idyksih5sir9/cozystack
+
+on:
+  push:
+    # Maintained LINE branches only: `release-<major>.<minor>`. The `+` quantifies
+    # the preceding character class, and `.` is literal, so this matches
+    # release-1.6 but NOT the per-release staging branches promote-rc.yaml creates
+    # (release-1.6.1) nor rc staging branches (release-1.6.0-rc.4) — building
+    # those would be pure waste, since their images are built by tags.yaml.
+    branches: ['release-[0-9]+.[0-9]+']
+    paths-ignore:
+      - 'docs/**'
+
+# Per line: a newer push to the same line supersedes an in-flight build, but
+# different lines build independently.
+concurrency:
+  group: build-release-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-line:
+    name: Build ${{ github.ref_name }} images and packages artifact
+    runs-on: oracle-vm-24cpu-96gb-x86-64
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          # This workflow holds packages:write and an OCIR push token; it never
+          # pushes git, so don't leave the checkout's GITHUB_TOKEN in .git/config
+          # where a later build step could read it.
+          persist-credentials: false
+
+      # Ephemeral runners lack the flux CLI the installer's image-packages step
+      # shells out to; install if absent (idempotent).
+      - name: Set up build toolchain
+        run: |
+          command -v flux >/dev/null \
+            || curl -fsSL https://fluxcd.io/install.sh | sudo bash
+
+      - name: Set up Docker config
+        run: |
+          if [ -d ~/.docker ]; then
+            cp -r ~/.docker "${{ runner.temp }}/.docker"
+          fi
+
+      - name: Login to OCIR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.OCIR_USER }}
+          password: ${{ secrets.OCIR_TOKEN }}
+          registry: iad.ocir.io
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
+
+      # Same isolated buildkit as build-main.yaml, so a line build never contends
+      # with PR builds on the shared embedded builder.
+      - name: Set up Buildx (docker-container driver)
+        id: buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          driver: docker-container
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
+
+      - name: Build line images and publish the packages artifact
+        run: make build
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
+          BUILDER: ${{ steps.buildx.outputs.name }}
+          # READ the shared mode=max cache, never write it. CACHE_REGISTRY/<img>:
+          # buildcache is a single ref per image and build-main.yaml is
+          # deliberately its only writer, serialized, precisely so concurrent
+          # builds cannot race on the cache manifest (the 409 collision class
+          # #2711 fixed for image tags). A line build can overlap a main build, so
+          # writing here would reintroduce exactly that race.
+          WRITE_CACHE: '0'
+          # Floating per-line handle: images and the packages artifact both land
+          # under the branch name (e.g. :release-1.6). Versioned and :latest tags
+          # belong to releases (tags.yaml / finalize), never to this workflow.
+          IMAGE_TAG: ${{ github.ref_name }}
+          PUBLISH_VERSIONED: '0'
+          PUBLISH_FLOATING: '0'

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -378,36 +378,49 @@ jobs:
       # (build-main not yet green) is a no-op: packages keep their committed
       # refs (prior behaviour). See hack/overlay-main-images.sh.
       #
-      # ONLY for PRs based on main. On a release-line PR the committed refs are
-      # not stale — they are that line's released digests, which is exactly what
-      # its charts are written against. Overlaying main's images there deploys
-      # main's binaries onto a release branch's charts, and the mismatch grows
-      # with every commit main gains: #3437 (a one-line change on release-1.6)
-      # failed install deterministically because main's cozystack-controller
-      # served an aggregated OpenAPI its charts could not validate against
-      # (`unknown model in reference: …v1alpha1.OptionSpec`), which reads as a
-      # broken PR while nothing in the PR is broken. Retargeting the overlay at a
-      # per-line artifact is not possible today: build-main.yaml publishes only
-      # cozystack-packages:main, with no release-* equivalent.
-      - name: Pull current-main packages tree
-        if: github.base_ref == 'main'
+      # Read the artifact for the PR's OWN base branch, not always main. Overlaying
+      # main's images onto a release-line PR mixes generations: main's binaries
+      # against that line's charts. #3437 (a one-line change on release-1.6) failed
+      # install deterministically that way, because main's cozystack-controller
+      # served an aggregated OpenAPI release-1.6's charts could not validate
+      # against (`unknown model in reference: …v1alpha1.OptionSpec`) — a broken
+      # lane reading as a broken PR. build-release.yaml publishes
+      # cozystack-packages:<line> for every maintained release-<major>.<minor>
+      # branch, so each base branch has its own artifact to read.
+      #
+      # A missing artifact stays a no-op (packages keep their committed refs), which
+      # also covers a line whose first build-release run has not landed yet.
+      - name: Pull base-branch packages tree
         run: |
           rm -rf _out/mainpkgs
           mkdir -p _out/mainpkgs
-          flux pull artifact "oci://${REGISTRY}/cozystack-packages:main" \
-            --output _out/mainpkgs \
-            || { echo "cozystack-packages:main pull failed — keeping committed refs"; rm -rf _out/mainpkgs; }
+          if ! flux pull artifact "oci://${REGISTRY}/cozystack-packages:${BASE_REF}" \
+                 --output _out/mainpkgs; then
+            rm -rf _out/mainpkgs
+            # Degrading to committed refs is safe, but SAY so: on a release line a
+            # missing artifact means build-release.yaml has not published this line
+            # yet (first build pending, or its branch filter does not match this
+            # branch), and the PR is then testing the line's last release instead of
+            # its tip. Silent would look identical to a working overlay.
+            if [ "${BASE_REF}" = "main" ]; then
+              echo "cozystack-packages:${BASE_REF} pull failed — keeping committed refs"
+            else
+              echo "::warning title=No packages artifact for ${BASE_REF}::Keeping committed refs, so unbuilt packages use this line's last release rather than its tip. Check that build-release.yaml has run for ${BASE_REF}."
+            fi
+          fi
         env:
           DOCKER_CONFIG: ${{ runner.temp }}/.docker
-      - name: Overlay current-main refs for unbuilt packages
+          # Env-passed, not interpolated into the script: base_ref is repo-controlled
+          # here (a branch name in this repo), but the workflow-injection hygiene
+          # applies uniformly.
+          BASE_REF: ${{ github.base_ref }}
+      - name: Overlay base-branch refs for unbuilt packages
         # Best-effort: this only improves WHICH images e2e and the installer use,
         # so an unexpected failure must degrade to the committed refs (prior
         # behaviour), never block the PR. overlay-main-images.sh already handles
-        # the expected paths (missing artifact, drift, absent unit) internally.
-        # Guarded on the base branch for the same reason as the pull above; the
-        # script would treat the absent artifact as a no-op anyway, but a
-        # release-line PR should not depend on that to avoid main's images.
-        if: github.base_ref == 'main'
+        # the expected paths (missing artifact, drift, absent unit) internally —
+        # including the empty directory the step above leaves when a line has no
+        # artifact yet.
         run: |
           hack/overlay-main-images.sh _out/mainpkgs "$BUILD_MATRIX" "$PR_TOUCHED" \
             || echo "::warning::overlay-main-images failed; unbuilt packages keep committed refs"

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -377,7 +377,20 @@ jobs:
       # pr.patch e2e applies — already reflect the overlay. A missing artifact
       # (build-main not yet green) is a no-op: packages keep their committed
       # refs (prior behaviour). See hack/overlay-main-images.sh.
+      #
+      # ONLY for PRs based on main. On a release-line PR the committed refs are
+      # not stale — they are that line's released digests, which is exactly what
+      # its charts are written against. Overlaying main's images there deploys
+      # main's binaries onto a release branch's charts, and the mismatch grows
+      # with every commit main gains: #3437 (a one-line change on release-1.6)
+      # failed install deterministically because main's cozystack-controller
+      # served an aggregated OpenAPI its charts could not validate against
+      # (`unknown model in reference: …v1alpha1.OptionSpec`), which reads as a
+      # broken PR while nothing in the PR is broken. Retargeting the overlay at a
+      # per-line artifact is not possible today: build-main.yaml publishes only
+      # cozystack-packages:main, with no release-* equivalent.
       - name: Pull current-main packages tree
+        if: github.base_ref == 'main'
         run: |
           rm -rf _out/mainpkgs
           mkdir -p _out/mainpkgs
@@ -391,6 +404,10 @@ jobs:
         # so an unexpected failure must degrade to the committed refs (prior
         # behaviour), never block the PR. overlay-main-images.sh already handles
         # the expected paths (missing artifact, drift, absent unit) internally.
+        # Guarded on the base branch for the same reason as the pull above; the
+        # script would treat the absent artifact as a no-op anyway, but a
+        # release-line PR should not depend on that to avoid main's images.
+        if: github.base_ref == 'main'
         run: |
           hack/overlay-main-images.sh _out/mainpkgs "$BUILD_MATRIX" "$PR_TOUCHED" \
             || echo "::warning::overlay-main-images failed; unbuilt packages keep committed refs"

--- a/hack/overlay-main-images_test.bats
+++ b/hack/overlay-main-images_test.bats
@@ -149,30 +149,70 @@
 }
 
 # ── workflow wiring ─────────────────────────────────────────────────────────
-# The script is only half the mechanism; WHEN the workflow invokes it decides
-# which branch's images a PR gets. Both steps must be gated on the base branch,
-# so a release-line PR keeps that line's committed digests instead of running
-# main's binaries against its charts.
+# The script is only half the mechanism; WHICH artifact the workflow hands it
+# decides which generation of images a PR gets. A release-line PR must read its
+# own line's artifact — reading main's puts main's binaries against that line's
+# charts, which failed install deterministically (#3437).
 
-@test "the overlay steps are gated on a main base branch" {
+@test "the overlay reads the artifact for the PR's own base branch" {
   root=$(pwd)
   wf="$root/.github/workflows/pull-requests.yaml"
   [ -f "$wf" ]
 
-  # Executable lines only: a commented-out guard must not satisfy this.
+  # Executable lines only: a comment mentioning the tag must not satisfy this.
   code="$(grep -v '^[[:space:]]*#' "$wf")"
 
-  # Each overlay step name must be followed by the base-branch guard before the
-  # step's `run:` — assert per step, so adding a third unguarded step is caught.
-  for step in "Pull current-main packages tree" "Overlay current-main refs for unbuilt packages"; do
-    block="$(printf '%s\n' "$code" | awk -v s="      - name: $step" '
-      $0 == s { inside = 1; next }
-      /^      - name: / { inside = 0 }
-      inside')"
-    [ -n "$block" ] || { echo "step not found in $wf: $step" >&2; exit 1; }
-    printf '%s\n' "$block" | grep -qF "if: github.base_ref == 'main'" || {
-      echo "step '$step' is not gated on the base branch; a release-line PR would" >&2
-      echo "get main's images overlaid onto that line's charts." >&2
-      exit 1; }
-  done
+  block="$(printf '%s\n' "$code" | awk '
+    $0 == "      - name: Pull base-branch packages tree" { inside = 1; next }
+    /^      - name: / { inside = 0 }
+    inside')"
+  [ -n "$block" ] || { echo "the base-branch packages pull step is missing from $wf" >&2; exit 1; }
+
+  # The artifact tag must come from the base branch, passed via env.
+  printf '%s\n' "$block" | grep -qF 'cozystack-packages:${BASE_REF}' || {
+    echo "the packages artifact tag is not the PR's base branch. Reading a fixed" >&2
+    echo "tag (e.g. :main) hands a release-line PR another generation's images." >&2
+    exit 1; }
+  printf '%s\n' "$block" | grep -qF 'BASE_REF: ${{ github.base_ref }}' || {
+    echo "BASE_REF is not wired to github.base_ref in the pull step's env." >&2; exit 1; }
+
+  # A hardcoded :main anywhere in the two overlay steps defeats the point.
+  overlay="$(printf '%s\n' "$code" | awk '
+    $0 == "      - name: Overlay base-branch refs for unbuilt packages" { inside = 1; next }
+    /^      - name: / { inside = 0 }
+    inside')"
+  [ -n "$overlay" ] || { echo "the overlay step is missing from $wf" >&2; exit 1; }
+  printf '%s\n%s\n' "$block" "$overlay" | grep -qF 'cozystack-packages:main' && {
+    echo "an overlay step still pins cozystack-packages:main" >&2; exit 1; }
+  return 0
+}
+
+@test "every maintained release line publishes its own packages artifact" {
+  root=$(pwd)
+  wf="$root/.github/workflows/build-release.yaml"
+  [ -f "$wf" ] || {
+    echo "build-release.yaml is missing: without a per-line artifact the overlay" >&2
+    echo "above degrades to a no-op on release branches, so their PRs test the" >&2
+    echo "line's last release rather than its tip." >&2
+    exit 1; }
+
+  code="$(grep -v '^[[:space:]]*#' "$wf")"
+
+  # Line branches only. The per-release and rc staging branches promote-rc.yaml
+  # and tags.yaml create (release-1.6.1, release-1.6.0-rc.4) must NOT trigger a
+  # full rebuild — their images come from the tag build.
+  printf '%s\n' "$code" | grep -qF "branches: ['release-[0-9]+.[0-9]+']" || {
+    echo "build-release.yaml does not restrict its trigger to release-<major>.<minor>" >&2; exit 1; }
+
+  # The artifact and image tag must be the branch, or the overlay cannot find it.
+  printf '%s\n' "$code" | grep -qF 'IMAGE_TAG: ${{ github.ref_name }}' || {
+    echo "build-release.yaml does not tag images/artifact with the branch name" >&2; exit 1; }
+
+  # It must not write the shared mode=max cache: that ref has exactly one
+  # serialized writer (build-main.yaml) so concurrent builds cannot race on the
+  # cache manifest. A line build can overlap a main build.
+  printf '%s\n' "$code" | grep -qF "WRITE_CACHE: '0'" || {
+    echo "build-release.yaml must set WRITE_CACHE: '0' — writing the shared" >&2
+    echo ":buildcache ref races build-main.yaml on the cache manifest." >&2
+    exit 1; }
 }

--- a/hack/overlay-main-images_test.bats
+++ b/hack/overlay-main-images_test.bats
@@ -147,3 +147,32 @@
   grep -q 'present:main@sha256:bbbb' packages/apps/present/images/present.tag
   [ ! -e packages/apps/ghost/images/ghost.tag ]
 }
+
+# ── workflow wiring ─────────────────────────────────────────────────────────
+# The script is only half the mechanism; WHEN the workflow invokes it decides
+# which branch's images a PR gets. Both steps must be gated on the base branch,
+# so a release-line PR keeps that line's committed digests instead of running
+# main's binaries against its charts.
+
+@test "the overlay steps are gated on a main base branch" {
+  root=$(pwd)
+  wf="$root/.github/workflows/pull-requests.yaml"
+  [ -f "$wf" ]
+
+  # Executable lines only: a commented-out guard must not satisfy this.
+  code="$(grep -v '^[[:space:]]*#' "$wf")"
+
+  # Each overlay step name must be followed by the base-branch guard before the
+  # step's `run:` — assert per step, so adding a third unguarded step is caught.
+  for step in "Pull current-main packages tree" "Overlay current-main refs for unbuilt packages"; do
+    block="$(printf '%s\n' "$code" | awk -v s="      - name: $step" '
+      $0 == s { inside = 1; next }
+      /^      - name: / { inside = 0 }
+      inside')"
+    [ -n "$block" ] || { echo "step not found in $wf: $step" >&2; exit 1; }
+    printf '%s\n' "$block" | grep -qF "if: github.base_ref == 'main'" || {
+      echo "step '$step' is not gated on the base branch; a release-line PR would" >&2
+      echo "get main's images overlaid onto that line's charts." >&2
+      exit 1; }
+  done
+}


### PR DESCRIPTION
## What this PR does

The PR finalize job overlays image refs for every package a PR did not rebuild, so e2e and the installer do not test last-release images for everything outside the PR's build matrix. It could only ever read `cozystack-packages:main`, which meant a **release-line PR was handed main's binaries to run against its own line's charts**.

cozystack/cozystack#3437 is the demonstration: a one-line change on `release-1.6` deactivating an app failed install deterministically, twice, with

```
helmrelease/backupstrategy-controller: Helm install failed …
error validating data: SchemaError(github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.Option.spec):
unknown model in reference: "github.com~1cozystack~1cozystack~1pkg~1apis~1core~1v1alpha1.OptionSpec"
```

main's `cozystack-controller` served an aggregated OpenAPI that `release-1.6`'s charts could not validate against. Nothing in that PR was broken; the lane was. Both branches carry `option_types.go` and key `OptionSpec` identically in the committed generated OpenAPI, so this is a generation mismatch at runtime, not a codegen drift.

This PR fixes it by giving every base branch its own artifact to overlay from, rather than by turning the overlay off.

### The change

1. **`pull-requests.yaml`** reads `cozystack-packages:${BASE_REF}` (`github.base_ref`) instead of a hardcoded `:main`.
2. **`build-release.yaml`** (new) publishes that artifact for maintained `release-<major>.<minor>` branches exactly as `build-main.yaml` does for main: every image tagged with the branch, and the whole packages tree pushed with each reference digest-pinned to what the run just built.

An earlier revision of this branch simply skipped the overlay for non-main bases. That fixed the wrong-images problem but left release-line PRs testing their line's *last release*: for any package the PR did not rebuild, the committed ref is the released digest, so a component changed by an earlier backport was still exercised as its pre-backport binary until the next rc. Per-line artifacts remove that gap too, which is why the guard was replaced rather than kept.

### Three deliberate choices

**The trigger matches line branches only** (`release-[0-9]+.[0-9]+`). The per-release and rc staging branches `promote-rc.yaml` and `tags.yaml` create — `release-1.6.1`, `release-1.6.0-rc.4` — must not trigger a full rebuild; their images come from the tag build and rebuilding them is waste.

**`WRITE_CACHE` stays `0`.** `CACHE_REGISTRY/<img>:buildcache` is a single ref per image and `build-main.yaml` is deliberately its only, serialized writer so concurrent builds cannot race on the cache manifest — the 409 class #2711 fixed for image tags. A line build can overlap a main build, so writing here would reintroduce that race. Line builds read the cache.

**A missing artifact still degrades to committed refs, but says so.** On a release line it emits a `::warning::` naming the branch. Silent degradation is indistinguishable from a working overlay, which is how a mis-specified branch filter could hide for a whole release cycle.

### Cost

One `make build` per push to a maintained line — in practice per merged backport. That is the price of release-line PRs testing their line's tip instead of its last release.

### Verification

`hack/overlay-main-images_test.bats` pins the artifact tag to the base branch, rejects a hardcoded `:main` in either overlay step, and pins `build-release.yaml`'s branch filter, image tag and `WRITE_CACHE: '0'`. Mutation-checked: restoring `:main`, setting `WRITE_CACHE: '1'`, and broadening the filter to `release-*` each fail a test. 13/13 green; `actionlint` and `zizmor` clean.

Worth an explicit ack in review: the branch-filter pattern is the one thing no local test can prove, since only GitHub evaluates it. If it does not match, `build-release` never runs and the new `::warning::` is what surfaces it on the next release-line PR.

### Backport

`release-1.6` needs this too — for `pull_request` events GitHub builds the workflow from the merge ref, so a release-line PR only stops receiving main's images once the change is on its base branch. cozystack/cozystack#3472 carried the interim guard and is closed in favour of backporting this instead.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Build release line” workflow that builds and publishes images and the packages artifact for maintained `release-<major>.<minor>` branches.

* **Bug Fixes**
  * Updated PR workflow finalization to use base-branch–specific package overlays, avoiding incorrect main-branch image references when targeting release branches.
  * Improved fallback behavior when the base-branch packages artifact is unavailable.

* **Tests**
  * Added workflow wiring tests to verify base-branch artifact usage and that each maintained release line publishes its own packages artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->