### PR TITLE
fix(ci): only overlay current-main images on main-based PRs

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -377,7 +377,20 @@ jobs:
       # pr.patch e2e applies — already reflect the overlay. A missing artifact
       # (build-main not yet green) is a no-op: packages keep their committed
       # refs (prior behaviour). See hack/overlay-main-images.sh.
+      #
+      # ONLY for PRs based on main. On a release-line PR the committed refs are
+      # not stale — they are that line's released digests, which is exactly what
+      # its charts are written against. Overlaying main's images there deploys
+      # main's binaries onto a release branch's charts, and the mismatch grows
+      # with every commit main gains: #3437 (a one-line change on release-1.6)
+      # failed install deterministically because main's cozystack-controller
+      # served an aggregated OpenAPI its charts could not validate against
+      # (`unknown model in reference: …v1alpha1.OptionSpec`), which reads as a
+      # broken PR while nothing in the PR is broken. Retargeting the overlay at a
+      # per-line artifact is not possible today: build-main.yaml publishes only
+      # cozystack-packages:main, with no release-* equivalent.
       - name: Pull current-main packages tree
+        if: github.base_ref == 'main'
         run: |
           rm -rf _out/mainpkgs
           mkdir -p _out/mainpkgs
@@ -391,6 +404,10 @@ jobs:
         # so an unexpected failure must degrade to the committed refs (prior
         # behaviour), never block the PR. overlay-main-images.sh already handles
         # the expected paths (missing artifact, drift, absent unit) internally.
+        # Guarded on the base branch for the same reason as the pull above; the
+        # script would treat the absent artifact as a no-op anyway, but a
+        # release-line PR should not depend on that to avoid main's images.
+        if: github.base_ref == 'main'
         run: |
           hack/overlay-main-images.sh _out/mainpkgs "$BUILD_MATRIX" "$PR_TOUCHED" \
             || echo "::warning::overlay-main-images failed; unbuilt packages keep committed refs"

--- a/hack/overlay-main-images_test.bats
+++ b/hack/overlay-main-images_test.bats
@@ -147,3 +147,32 @@
   grep -q 'present:main@sha256:bbbb' packages/apps/present/images/present.tag
   [ ! -e packages/apps/ghost/images/ghost.tag ]
 }
+
+# ── workflow wiring ─────────────────────────────────────────────────────────
+# The script is only half the mechanism; WHEN the workflow invokes it decides
+# which branch's images a PR gets. Both steps must be gated on the base branch,
+# so a release-line PR keeps that line's committed digests instead of running
+# main's binaries against its charts.
+
+@test "the overlay steps are gated on a main base branch" {
+  root=$(pwd)
+  wf="$root/.github/workflows/pull-requests.yaml"
+  [ -f "$wf" ]
+
+  # Executable lines only: a commented-out guard must not satisfy this.
+  code="$(grep -v '^[[:space:]]*#' "$wf")"
+
+  # Each overlay step name must be followed by the base-branch guard before the
+  # step's `run:` — assert per step, so adding a third unguarded step is caught.
+  for step in "Pull current-main packages tree" "Overlay current-main refs for unbuilt packages"; do
+    block="$(printf '%s\n' "$code" | awk -v s="      - name: $step" '
+      $0 == s { inside = 1; next }
+      /^      - name: / { inside = 0 }
+      inside')"
+    [ -n "$block" ] || { echo "step not found in $wf: $step" >&2; exit 1; }
+    printf '%s\n' "$block" | grep -qF "if: github.base_ref == 'main'" || {
+      echo "step '$step' is not gated on the base branch; a release-line PR would" >&2
+      echo "get main's images overlaid onto that line's charts." >&2
+      exit 1; }
+  done
+}


### PR DESCRIPTION
## What this PR does

Backport of cozystack/cozystack#3471 to `release-1.6` (clean cherry-pick, `-x` reference in the commit).

The overlay must be fixed **on this branch** to have any effect here: for `pull_request` events GitHub builds the workflow from the merge ref, so a release-line PR only stops receiving main's images once the guard is on the base branch. Landing #3471 on `main` alone does nothing for the 1.6 line.

### Why it matters here specifically

The finalize job pulls `cozystack-packages:main` and repoints every package a PR did not rebuild at current-main images. On this branch that deploys main's binaries onto `release-1.6`'s charts, and the mismatch grows with every commit main gains.

cozystack/cozystack#3437 — a one-line change deactivating an app in a bundle — failed install deterministically, twice:

```
helmrelease/backupstrategy-controller: Helm install failed …
error validating data: SchemaError(github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.Option.spec):
unknown model in reference: "github.com~1cozystack~1cozystack~1pkg~1apis~1core~1v1alpha1.OptionSpec"
```

`cozystack-controller:main` served an aggregated OpenAPI this branch's charts could not validate against. Every 1.6 backport is exposed to the same thing, and the symptom reads as a broken PR rather than a broken lane.

After this merges, re-running #3437's E2E picks the guard up with no rebase.

### Verification

`hack/overlay-main-images_test.bats` pins the wiring per step, mutation-checked by removing one guard. 12/12 green on this branch, `actionlint` clean.

### Release note

```release-note
NONE
```
