### PR TITLE
ci: install flux in the release-1.5 cache warmer

### DIFF
--- a/.github/workflows/build-main.yaml
+++ b/.github/workflows/build-main.yaml
@@ -74,6 +74,16 @@ jobs:
           # .git/config where a later build step could read it.
           persist-credentials: false
 
+      # `make build` ends at packages/core/installer, whose image-packages target
+      # shells out to `flux push artifact`. The self-hosted runner this workflow
+      # used to target had flux baked in; the ephemeral shape does not, so without
+      # this the warmer builds all 28 packages and then fails on the last one.
+      # pull-requests.yaml installs it for the same reason. Idempotent.
+      - name: Set up build toolchain
+        run: |
+          command -v flux >/dev/null \
+            || curl -fsSL https://fluxcd.io/install.sh | sudo bash
+
       - name: Set up Docker config
         run: |
           if [ -d ~/.docker ]; then


### PR DESCRIPTION
## What this PR does

Adds the flux CLI to the release-1.5 cache warmer, which #3469 moved onto the ephemeral runner shape without carrying over the toolchain step that main's warmer and this branch's `pull-requests.yaml` both have.

`make build` finishes at `packages/core/installer`, whose `image-packages` target shells out to `flux push artifact`. The self-hosted runner the warmer used to target had flux baked in; the ephemeral shape does not.

Confirmed on the first warmer run after #3469 merged ([run 30430753152](https://github.com/cozystack/cozystack/actions/runs/30430753152)): it failed at 49 minutes with `/bin/sh: 1: flux: not found` on `Makefile:35`, the last of 28 packages.

The cache itself came out warm, because every package exports its cache as it builds and installer is last:

| | |
| --- | --- |
| cache export operations | 87 |
| cache manifests written | 70 |
| repos created under `CACHE_REGISTRY` | 34 |
| `ubuntu-container-disk` refs (`v1.30`–`v1.35`, `mode=max`) | all 6 |
| real auth or export failures | 0 |

So the only loss was the `cozystack-packages:release-1.5` artifact push, and nothing downstream depends on it — PR builds build the installer themselves with flux present. This also settles the open question from #3469: the registry credentials can create repositories under the new `cozystack-cache-release-1.5/*` namespace, so no fallback to a cache-tag suffix is needed.

Fixing it still matters. A permanently red warmer means a genuine breakage is indistinguishable from this known-broken tail, and nothing else reports on that workflow.

The alternative would be teaching the warmer to run the 28 image builds without the artifact push, but no such target exists and it would diverge from main's warmer for no gain. Installing the CLI keeps the two warmers identical in shape, and matches main publishing `cozystack-packages:main` from its own warmer.

### Release note

```release-note
NONE
```
