### PR TITLE
test(hack): run the unit bats suite under bats(1)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -56,6 +56,14 @@ jobs:
           curl -sSL https://github.com/cozystack/cozyvalues-gen/releases/download/v1.6.0/cozyvalues-gen-linux-amd64.tar.gz | tar -xzvf- -C /usr/local/bin/ cozyvalues-gen
 
       - name: Run pre-commit hooks
+        # bats-unit-tests is a local-developer gate, skipped here. This job
+        # lints changed YAML/Markdown, and the hook's path filter covers
+        # .github/workflows/, so a workflow edit would otherwise drag the whole
+        # 328-test shell suite into a lint lane -- on a runner with no bats,
+        # and duplicating the `checks` job in pull-requests.yaml that already
+        # runs `make unit-tests`.
+        env:
+          SKIP: bats-unit-tests
         run: |
           git fetch origin main || git fetch origin master
           base_commit=$(git rev-parse --verify origin/main || git rev-parse --verify origin/master || echo "")

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -107,11 +107,32 @@ jobs:
       # Ephemeral runners don't carry the helm-unittest plugin the persistent
       # self-hosted runner accreted. Install if absent (idempotent).
       - name: Set up test toolchain
+        env:
+          BATS_VERSION: v1.13.0
         run: |
+          set -euo pipefail
           helm plugin list 2>/dev/null | grep -q unittest \
             || helm plugin install https://github.com/helm-unittest/helm-unittest
+          # The hack/*.bats unit suite moved from hack/cozytest.sh (pure bash,
+          # no dependency) to bats(1) in #3453, so the runner image now needs
+          # bats. Installed from a pinned tag rather than the distro package,
+          # whose version varies by base image. GNU parallel is optional --
+          # the Makefile falls back to a serial run when it is absent.
+          if ! command -v bats >/dev/null 2>&1; then
+            git clone --depth 1 --branch "$BATS_VERSION" \
+              https://github.com/bats-core/bats-core.git /tmp/bats-core
+            sudo /tmp/bats-core/install.sh /usr/local
+          fi
+          bats --version
       - name: Run unit tests
         run: make unit-tests
+      - name: Upload unit test report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: bats-unit-report
+          path: _out/test-reports/
+          if-no-files-found: ignore
       - name: Run controller Go tests
         run: make test-controllers
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,22 @@ repos:
         '
       language: system
       files: ^.*$
+    # The hack/*.bats unit suite, hermetic and parallel-safe, runs in ~26s on
+    # 8 cores under bats -j (#3453) -- cheap enough to gate a commit, and
+    # faster than the two hooks above. Requires bats-core on PATH; the make
+    # target says so explicitly when it is missing.
+    #
+    # The path filter is the union of what the suite reads, not just the
+    # scripts under test: several tests assert cross-tree consistency
+    # (image-pin-consistency over packages/, downstream-trigger-map over
+    # workflows, md-no-hardwrap over .claude/hooks/), so narrowing this to
+    # hack/ would let exactly the regressions they exist to catch through.
+    - id: bats-unit-tests
+      name: Run hack/*.bats unit tests
+      entry: make bats-unit-tests
+      language: system
+      files: ^(hack/|Makefile$|\.github/workflows/|packages/|\.claude/hooks/)
+      pass_filenames: false
 # Lints changed GitHub Actions workflows for unpinned actions and excessive token
 # permissions (audit scope is set in .github/zizmor.yml). Runs offline so it needs
 # no GitHub token locally. The same gate runs tree-wide in .github/workflows/zizmor.yml.

--- a/Makefile
+++ b/Makefile
@@ -150,9 +150,16 @@ test-controllers:
 test-check-readiness:
 	go test ./test/check-readiness/ -count=1
 
-# Discover every hack/*.bats file that is NOT an e2e test and run it
-# through cozytest.sh. Drop a new *.bats file in hack/ and it is picked
-# up automatically on the next `make unit-tests` run.
+# Discover every hack/*.bats file that is NOT an e2e test and run it under
+# bats(1). Drop a new *.bats file in hack/ and it is picked up automatically
+# on the next `make unit-tests` run.
+#
+# These are hermetic unit tests of hack/*.sh, and they run under real bats
+# rather than hack/cozytest.sh (#3453). The live-cluster suite
+# (hack/e2e-*.bats) stays on cozytest, whose streaming trace and snapshot
+# behaviour earn their place over a 15-minute test; bats buffers a test's
+# output until it completes. Filtering by the e2e- prefix is what keeps the
+# two runners apart.
 #
 # Caveat: $(wildcard ...) returns space-separated names, so a filename
 # containing a literal space would split into multiple tokens here. All
@@ -161,15 +168,25 @@ test-check-readiness:
 # (e.g. to use `find ... -print0 | xargs -0`).
 BATS_UNIT_FILES := $(filter-out hack/e2e-%.bats,$(wildcard hack/*.bats))
 
+# `bats -j` needs GNU parallel and exits non-zero rather than degrading when
+# it is missing, so resolve the job count to 1 unless parallel is present.
+BATS_JOBS ?= $(shell command -v parallel >/dev/null 2>&1 && nproc 2>/dev/null || echo 1)
+
+# JUnit XML so CI annotates the failing test instead of requiring a log read.
+# _out is gitignored.
+BATS_REPORT_DIR ?= _out/test-reports
+
 bats-unit-tests:
 	@if [ -z "$(BATS_UNIT_FILES)" ]; then \
 		echo "ERROR: no hack/*.bats unit test files found"; \
 		exit 1; \
 	fi
-	@for f in $(BATS_UNIT_FILES); do \
-		echo "--- running $$f ---"; \
-		hack/cozytest.sh "$$f" || exit 1; \
-	done
+	@command -v bats >/dev/null 2>&1 || { \
+		echo "ERROR: bats not found. Install bats-core >= 1.5 — https://bats-core.readthedocs.io"; \
+		exit 1; \
+	}
+	@mkdir -p $(BATS_REPORT_DIR)
+	bats -j $(BATS_JOBS) --report-formatter junit -o $(BATS_REPORT_DIR) $(BATS_UNIT_FILES)
 
 # Operator-facing host preflight check. Warns about a standalone
 # containerd.service or docker.service running alongside the embedded


### PR DESCRIPTION
Part 1 of a stack implementing #3453. Stacked PR — review this one first; the layer above depends on it.

## What

Moves the 32 hermetic `hack/*.bats` unit tests off `hack/cozytest.sh` and onto `bats(1)`. The 3 live-cluster files (`hack/e2e-*.bats`) stay on cozytest, whose streaming trace and per-failure snapshots earn their place over a 15-minute test; bats buffers a test's output until it completes. The `hack/e2e-%.bats` filter already in `BATS_UNIT_FILES` is what keeps the two runners apart, so nothing new is needed to separate them.

## Why

`cozytest.sh` reads a hand-rolled subset of the BATS grammar while every test file carries a `#!/usr/bin/env bats` shebang, so the format advertises semantics the runner does not implement — and the divergences fail silently. Its awk transform emits `return 0` before every bare column-0 `}`, which voids the exit code of any helper defined at file scope: a helper wrapping the subject under test reports success while the subject exits non-zero, and every assertion built on it passes vacuously. The same rewrite corrupts heredoc fixtures, and title sanitization silently collapses two tests whose names differ only in punctuation.

Switching runners deletes that whole class for 32 files at once, and buys `--filter-status failed`, JUnit output, and `-j`.

## Verification

| Check | Result |
|---|---|
| `make bats-unit-tests` | **328 tests, 0 failures, 26.5s** (`bats -j 8`) |
| Source edits needed to pass | **none** — the files were written to the intersection of both runners |
| zizmor `--offline` on the changed workflow | clean |
| pre-commit hook | passes |

## Two consequences worth flagging

**bats is a new dependency.** cozytest is pure bash+awk, so no runner image or contributor machine has ever needed anything else. CI installs it from a pinned tag rather than the distro package, whose version varies by base image, and the make target says so plainly when it is absent. GNU parallel stays optional — `BATS_JOBS` resolves to 1 without it, since `bats -j` exits non-zero rather than degrading.

**The tested shell changes.** cozytest is `#!/bin/sh`, which is dash on the CI runner, and bats runs bash. Seven POSIX scripts that tests *source* rather than execute — `seaweedfs-naming-audit.sh`, `promote-rewrite-tags.sh`, `lib/image-refs.sh`, the three `e2e-capture` scripts and `cozystack-version.sh` — therefore lose a runtime dash check they had by accident; `seaweedfs-naming-audit.sh:50` documents relying on it explicitly. Four `shell=bash` files under `e2e-chainsaw/_lib` gain correct fidelity for the same reason. The static replacement is the shellcheck gate in item 5 of #3453, which does not exist yet, so that item is now a real follow-up dependency rather than optional polish.

## Not in this PR

`set -u` is not restored here. bats enforces `-e` but not `-u`, and there is no runner-level way to inject it, so it needs a per-file load — that is the layer above.

Refs: #3453
