### PR TITLE
test(hack): restore set -u and refresh the cozytest-era headers

### DIFF
--- a/hack/admin-kubeconfig-invariant.bats
+++ b/hack/admin-kubeconfig-invariant.bats
@@ -18,6 +18,8 @@
 # project's CI runners and on the maintainer workstation.
 # -----------------------------------------------------------------------------
 
+load test_helper
+
 @test "every Deployment mounting admin-kubeconfig has optional:true and wait-for-kubeconfig init" {
   values_file="packages/apps/kubernetes/tests/values-ci.yaml"
   [ -f "$values_file" ]

--- a/hack/build-matrix_test.bats
+++ b/hack/build-matrix_test.bats
@@ -1,10 +1,13 @@
 #!/usr/bin/env bats
 # Unit tests for hack/build-matrix.sh — the CI build-matrix selector.
 #
-# Run via hack/cozytest.sh from the repo root (make bats-unit-tests); the
-# relative `hack/build-matrix.sh` calls below resolve against that cwd. A bats
-# setup() hook would be dead here — cozytest never invokes it — so the
-# repo-root cwd is supplied by the runner rather than a setup() cd.
+# Run via bats from the repo root (make bats-unit-tests); the relative
+# `hack/build-matrix.sh` calls below resolve against that cwd, which the
+# runner supplies rather than a setup() cd. Note that setup() hooks DO run
+# under bats — hack/test_helper.bash defines the shared one — so a setup()
+# added here must call strict_setup() to keep `set -u`.
+
+load test_helper
 
 @test "no argument emits the full matrix" {
   out=$(hack/build-matrix.sh)
@@ -16,7 +19,7 @@
 
 @test "talos and installer are excluded from the parallel matrix" {
   out=$(hack/build-matrix.sh)
-  # `! cmd` would be vacuous: cozytest.sh runs each @test under `set -e`, which
+  # `! cmd` would be vacuous: each @test runs under `set -e`, which
   # is suppressed for a `!`-negated pipeline, so a regression that wrongly
   # included these paths would not fail the test. Assert via `if cmd; then ...`.
   if echo "$out" | grep -q '"packages/core/talos"'; then echo "FAIL: packages/core/talos must be excluded from the parallel matrix"; false; fi

--- a/hack/capture-dataplane.bats
+++ b/hack/capture-dataplane.bats
@@ -23,15 +23,10 @@
 # asserts with `[ ... ]`, matching this repo's plain-shell bats convention (no
 # `run` helper). Mock IPs use the RFC 5737 / RFC 3849 documentation ranges.
 #
-# Title syntax constraints (inherited from cozytest.sh's awk parser):
-#   - Titles delimited by ASCII double quotes; embedded quotes truncate.
-#   - Only [A-Za-z0-9] from the title survives into the function name, so keep
-#     titles distinctive in their alphanumeric run.
-#
-# Run with: hack/cozytest.sh hack/capture-dataplane.bats
-#           (or `bats hack/capture-dataplane.bats` if the bats binary is
-#           installed; cozytest.sh is the CI path.)
+# Run with: bats hack/capture-dataplane.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
 SCRIPT="$HACK_DIR/e2e-capture-dataplane.sh"
@@ -95,7 +90,7 @@ EOF
   [ "$(printf '%s\n' "$out" | grep -c .)" -eq 2 ]
   printf '%s\n' "$out" | grep -q '^tenant|app|LoadBalancer|192.0.2.50|'
   printf '%s\n' "$out" | grep -q '^tenant|db|LoadBalancer|192.0.2.51|'
-  # `! cmd` is vacuous under cozytest's `set -e` (errexit is suppressed for a
+  # `! cmd` is vacuous under `set -e` (errexit is suppressed for a
   # `!`-negated pipeline), so a filter regression that let these rows through
   # would not fail the test. Assert the absence via `if cmd; then ...; false`.
   if printf '%s\n' "$out" | grep -q 'kube-dns'; then echo "FAIL: lb_filter_services must drop the kube-dns row"; false; fi

--- a/hack/capture-previous-logs.bats
+++ b/hack/capture-previous-logs.bats
@@ -23,15 +23,10 @@
 # asserts with `[ ... ]`, matching this repo's plain-shell bats convention (no
 # `run` helper).
 #
-# Title syntax constraints (inherited from cozytest.sh's awk parser):
-#   - Titles delimited by ASCII double quotes; embedded quotes truncate.
-#   - Only [A-Za-z0-9] from the title survives into the function name, so keep
-#     titles distinctive in their alphanumeric run.
-#
-# Run with: hack/cozytest.sh hack/capture-previous-logs.bats
-#           (or `bats hack/capture-previous-logs.bats` if the bats binary is
-#           installed; cozytest.sh is the CI path.)
+# Run with: bats hack/capture-previous-logs.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
 SCRIPT="$HACK_DIR/e2e-capture-previous-logs.sh"
@@ -54,7 +49,7 @@ E2E_CAPTURE_PREVLOGS_LIB=1
   [ "$(printf '%s\n' "$out" | grep -c .)" -eq 2 ]
   printf '%s\n' "$out" | grep -q '^tenant-test|mariadb-test-0|mariadb|container|3$'
   printf '%s\n' "$out" | grep -q '^tenant-test|mariadb-test-0|init-datadir|init|2$'
-  # `! cmd` is vacuous under cozytest's `set -e` (errexit is suppressed for a
+  # `! cmd` is vacuous under `set -e` (errexit is suppressed for a
   # `!`-negated pipeline), so a filter regression that let these rows through
   # would not fail the test. Assert the absence via `if cmd; then ...; false`.
   if printf '%s\n' "$out" | grep -q 'mariadb-test-1'; then echo "FAIL: must drop the zero-restart replica"; false; fi

--- a/hack/check-applicationdefinition-crd-ordering.bats
+++ b/hack/check-applicationdefinition-crd-ordering.bats
@@ -16,6 +16,8 @@
 # Requires: yq (mikefarah v4+), jq. Both are available on the project's CI
 # runners and on the maintainer workstation.
 
+load test_helper
+
 REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
 SOURCES_DIR="$REPO_ROOT/packages/core/platform/sources"
 

--- a/hack/check-gpu-operator-variants.bats
+++ b/hack/check-gpu-operator-variants.bats
@@ -38,9 +38,11 @@
 # directly here — the prefix is meaningful only when the parent wrapper
 # chart is in play.
 #
-# Compatible with both `bats` directly and the in-repo cozytest.sh runner.
-# cozytest.sh runs each @test in a fresh subshell with `set -u` and does
-# not honor bats setup()/teardown(), so we provision TMP inline per test.
+# Runs under bats(1), which gives each @test its own subshell;
+# hack/test_helper.bash restores the `set -u` cozytest.sh applied before
+# #3453. TMP is provisioned inline per test rather than in a setup() hook.
+
+load test_helper
 
 REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
 CHART="$REPO_ROOT/packages/system/gpu-operator/charts/gpu-operator"

--- a/hack/check-gpu-recording-rules.bats
+++ b/hack/check-gpu-recording-rules.bats
@@ -28,13 +28,10 @@
 # enforced: some rules exist for ad-hoc PromQL or upcoming dashboards. Treat
 # unused rules as an editorial concern, not a regression.
 #
-# Title syntax constraints from cozytest.sh's awk parser:
-#   - Titles delimited by ASCII double quotes; embedded quotes truncate.
-#   - Only [A-Za-z0-9] from the title survives into the function name; titles
-#     differing only in punctuation collapse to the same function.
-#
-# Run with: hack/cozytest.sh hack/check-gpu-recording-rules.bats
+# Run with: bats hack/check-gpu-recording-rules.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
 RULES_FILE="$REPO_ROOT/packages/system/monitoring-agents/alerts/gpu-recording.rules.yaml"

--- a/hack/check-host-runtime.bats
+++ b/hack/check-host-runtime.bats
@@ -14,25 +14,17 @@
 #
 # Each test installs a `trap 'rm -rf "$STUB_DIR"' EXIT` immediately after
 # creating the stub dir so cleanup runs even when an assertion fails mid-test
-# under `set -e`. cozytest.sh runs each @test in its own subshell, so traps
-# scope per test and do not leak across tests.
+# under `set -e`. bats runs each @test in its own subshell, so traps scope per
+# test and do not leak across tests.
 #
-# Tests are otherwise self-contained — no shared setup/teardown helpers,
-# because cozytest.sh's awk parser only recognizes @test blocks and treats a
-# bare `}` on its own line as the end of a test function.
+# Tests are otherwise self-contained: each provisions its own stub dir rather
+# than sharing a setup()/teardown() pair. hack/test_helper.bash supplies the
+# only shared setup(), restoring the `set -u` cozytest.sh applied before #3453.
 #
-# Title syntax constraints (inherited from cozytest.sh's awk parser):
-#   - Titles must be delimited by ASCII double quotes; embedded literal
-#     double quotes are NOT escaped and will silently truncate the title.
-#   - Only alphanumeric characters from the title survive into the shell
-#     function name (everything else becomes '_'), so titles that differ
-#     only in punctuation collapse to the same function name. Keep titles
-#     distinctive in their alphanumeric run.
-#
-# Run with: hack/cozytest.sh hack/check-host-runtime.bats
-#           (or `bats hack/check-host-runtime.bats` if the bats binary is
-#           installed; cozytest.sh is the CI path.)
+# Run with: bats hack/check-host-runtime.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 @test "clean host with no runtime services exits silently" {
   STUB_DIR=$(mktemp -d)

--- a/hack/check-kafka-rd-schema.bats
+++ b/hack/check-kafka-rd-schema.bats
@@ -6,6 +6,8 @@
 # absent (omitempty *bool) rather than an explicit null, and the template
 # detects that via `kindIs "invalid"`.
 
+load test_helper
+
 REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
 COZYRDS="$REPO_ROOT/packages/system/kafka-rd/cozyrds/kafka.yaml"
 

--- a/hack/check-kafka-rd-secrets.bats
+++ b/hack/check-kafka-rd-secrets.bats
@@ -2,6 +2,8 @@
 # Unit test: kafka-rd cozyrds must reference the Strimzi-generated
 # clients-ca-cert secret (not the bare clients-ca name, which does not exist).
 
+load test_helper
+
 REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
 COZYRDS="$REPO_ROOT/packages/system/kafka-rd/cozyrds/kafka.yaml"
 

--- a/hack/cilium-leak-healer_test.bats
+++ b/hack/cilium-leak-healer_test.bats
@@ -18,11 +18,14 @@
 # CILIUM_LEAK_HEALER_LIB set, which its sourcing guard honours by defining the
 # helpers and returning before the heal loop -- so no cluster is required and
 # the loop never executes. Assertions use plain `[ ... ]` / if-then-false, not a
-# `run` helper (cozytest.sh has no `run`). Mock IPs use the RFC 5737
+# `run` helper (available under bats, simply unused here). Mock IPs use the
+# RFC 5737
 # documentation range (TEST-NET-1, 192.0.2.0/24).
 #
-# Run with: hack/cozytest.sh hack/cilium-leak-healer_test.bats
+# Run with: bats hack/cilium-leak-healer_test.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
 SCRIPT="$HACK_DIR/e2e-cilium-endpoint-leak-healer.sh"

--- a/hack/cozyreport-talos.bats
+++ b/hack/cozyreport-talos.bats
@@ -3,6 +3,8 @@
 # The full report needs a cluster; this test sources only the focused helper and
 # replaces talosctl with a shell function that records the exact argument vector.
 
+load test_helper
+
 HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
 SCRIPT="$HACK_DIR/cozyreport.sh"
 
@@ -10,8 +12,9 @@ COZYREPORT_LIB=1
 # shellcheck source=/dev/null
 . "$SCRIPT"
 
-# cozytest.sh's parser ends an @test block at the first bare `}`, so keep the
-# talosctl mock at top level rather than nesting a function inside the test.
+# The talosctl mock stays at top level rather than nested inside a test. That
+# was forced by cozytest.sh's parser, which ended an @test block at the first
+# bare `}`; bats does not, but a shared top-level mock is clearer anyway.
 talosctl() {
   printf '%s\n' "$*" >> "$calls"
 }

--- a/hack/cozystack-version-stamp.bats
+++ b/hack/cozystack-version-stamp.bats
@@ -11,13 +11,16 @@
 # same manager would strip the label, so the manifest is centralized here and
 # every migration sources it instead of copy-pasting a heredoc.
 #
-# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
-# own line; there is no bats `run` or `$status`. Assertions are expressed as
-# direct shell tests that exit non-zero on failure. Each test runs in its own
+# Runs under bats(1). `run` and `$status` are available but unused here:
+# assertions are expressed as direct shell tests that exit non-zero on
+# failure. bats supplies `set -e`, and hack/test_helper.bash restores the
+# `set -u` that cozytest.sh applied before #3453. Each test runs in its own
 # subshell, so NAMESPACE set/unset in one test does not leak into another.
 #
-# Run with: hack/cozytest.sh hack/cozystack-version-stamp.bats
+# Run with: bats hack/cozystack-version-stamp.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 @test "renders parseable YAML for a version" {
     . packages/core/platform/images/migrations/migrations/lib/cozystack-version.sh

--- a/hack/downstream-trigger-map.bats
+++ b/hack/downstream-trigger-map.bats
@@ -39,6 +39,8 @@
 # from its own guard; the plan step in .github/workflows/pull-requests.yaml carves
 # out docs/agents/contributing.md so that editing the map alone still runs these.
 
+load test_helper
+
 REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
 MAP_FILE="$REPO_ROOT/docs/agents/contributing.md"
 TEMPLATE_FILE="$REPO_ROOT/.github/PULL_REQUEST_TEMPLATE.md"

--- a/hack/etcd-probe_test.bats
+++ b/hack/etcd-probe_test.bats
@@ -24,15 +24,15 @@
 # need a live cluster and are covered by the e2e run, matching how the other
 # hack/ helpers are tested.
 #
-# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
-# own line; there is no bats `run` or `$status`, and setup()/teardown() are not
-# honored. Each test runs under `set -eu -x`; assertions are direct shell tests
-# that exit non-zero on failure. Titles are delimited by ASCII double quotes and
-# only [A-Za-z0-9] survives into the generated function name, so keep them
-# distinctive in their alphanumeric run.
+# Runs under bats(1). `run` and `$status` are available but unused here;
+# assertions are direct shell tests that exit non-zero on failure. bats
+# supplies `set -e`, and hack/test_helper.bash restores the `set -u` that
+# cozytest.sh applied before #3453.
 #
-# Run with: hack/cozytest.sh hack/etcd-probe_test.bats
+# Run with: bats hack/etcd-probe_test.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
 # shellcheck source=/dev/null

--- a/hack/image-pin-consistency.bats
+++ b/hack/image-pin-consistency.bats
@@ -20,13 +20,15 @@
 # deliberately (backupstrategy-controller reuses platform-migrations as a
 # curl+jq runner rather than shipping a second one-binary tag).
 #
-# Harness note: the CI path is hack/cozytest.sh, NOT real bats. There is no
-# `run`, `$status`, `$output`, `skip`, or setup()/teardown(); each test runs as
-# a shell function under `set -eu -x`, so a non-zero exit is the failure.
-# Paths are repo-root-relative: BATS_TEST_DIRNAME is unset and would abort the
-# whole suite under `set -u`.
+# Harness note: the CI path is bats(1) since #3453, so `run`, `$status`,
+# `$output`, `skip` and setup()/teardown() are all available — this file
+# simply does not use them, and a non-zero exit is the failure. bats supplies
+# `set -e`; hack/test_helper.bash restores `set -u`. Paths stay
+# repo-root-relative, which worked under both runners.
 #
-# Run with: hack/cozytest.sh hack/image-pin-consistency.bats
+# Run with: bats hack/image-pin-consistency.bats
+
+load test_helper
 
 @test "no image repository is pinned at more than one digest" {
   tmp=$(mktemp -d)

--- a/hack/kubernetes-md0-migration.bats
+++ b/hack/kubernetes-md0-migration.bats
@@ -20,17 +20,20 @@
 # "The stamp ran" is detected by the version stamp's `kubectl apply` appearing
 # in the fake's call log — equivalently, CURRENT_VERSION was/was not advanced.
 #
-# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
-# own line (column 0); there is no bats `run`/`$status`/`setup`/`teardown`.
-# Assertions are direct shell tests that exit non-zero on failure, and the
-# fake-kubectl heredocs deliberately keep every `}` off column 0 so the parser
-# does not mistake one for the end of a test. Each @test runs in its own
-# subshell, and cleanup is inline (no EXIT/RETURN trap — see
+# Runs under bats(1). `run` and `$status` are available but unused here:
+# assertions are direct shell tests that exit non-zero on failure. bats
+# supplies `set -e`, and hack/test_helper.bash restores the `set -u` that
+# cozytest.sh applied before #3453. The fake-kubectl heredocs keep every `}`
+# off column 0 — a cozytest parser constraint that no longer binds, since bats
+# does not rewrite the file, but harmless to leave in place. Each @test runs in
+# its own subshell, and cleanup is inline (no EXIT/RETURN trap — see
 # docs/agents/e2e-testing.md §3).
 #
-# Run with: hack/cozytest.sh hack/kubernetes-md0-migration.bats
+# Run with: bats hack/kubernetes-md0-migration.bats
 #           (or `bats hack/kubernetes-md0-migration.bats`)
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
 REPO_ROOT="$(cd "$HACK_DIR/.." && pwd)"
@@ -43,7 +46,8 @@ MIGRATION="$REPO_ROOT/packages/core/platform/images/migrations/migrations/47"
 #     an object whose nodeGroups lacks md0 (so the migration tries to patch);
 #   - `patch` fails when MOCK_FAIL=patch, else succeeds;
 #   - `apply` (the version stamp) is a no-op that drains stdin.
-# No line below is a bare column-0 `}`, so cozytest.sh's parser leaves it intact.
+# No line below is a bare column-0 `}` — a cozytest.sh parser constraint that
+# bats does not impose, kept only so the heredoc stays diff-stable.
 write_fake_kubectl() {
   cat > "$1/kubectl" <<'KEOF'
 #!/bin/sh

--- a/hack/md-no-hardwrap.bats
+++ b/hack/md-no-hardwrap.bats
@@ -26,6 +26,8 @@
 # The hook speaks the agent hook protocol: a JSON payload on stdin, exit 0 to
 # allow, exit 2 to block with an explanation on stderr.
 
+load test_helper
+
 REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
 HOOK="$REPO_ROOT/.claude/hooks/md-no-hardwrap.py"
 
@@ -429,9 +431,11 @@ wrapped across two lines."')"
   # `gh api --input -` takes JSON, not markdown. Its braces and quoted keys
   # are not a hardwrapped paragraph.
   #
-  # The JSON is indented so that no line of it starts with `}`: cozytest.sh
-  # converts each @test into a shell function with awk, and a bare `}` in the
-  # first column ends that function early, silently truncating the test.
+  # The JSON is indented so that no line of it starts with `}`. That was
+  # forced by cozytest.sh, which converted each @test into a shell function
+  # with awk and ended it at a bare column-0 `}`, silently truncating the
+  # test. bats does not rewrite the file, so the indentation is now only a
+  # readability choice.
   payload="$(bash_payload 'gh api --method POST /repos/o/r/pulls/1/reviews --input - <<EOF
   {
     "event": "COMMENT",

--- a/hack/migration-50-etcd-adopt.bats
+++ b/hack/migration-50-etcd-adopt.bats
@@ -18,12 +18,15 @@
 #   3. the operator is scaled to 0 BEFORE etcd-migrate --apply and back to 1
 #      AFTER, with --apply always carrying the S3 backup destination.
 #
-# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
-# own line; there is no bats `run`/`$status`/`setup`. Assertions are direct
-# shell tests that exit non-zero on failure.
+# Runs under bats(1). `run` and `$status` are available but unused here:
+# assertions are direct shell tests that exit non-zero on failure. bats
+# supplies `set -e`, and hack/test_helper.bash restores the `set -u` that
+# cozytest.sh applied before #3453.
 #
-# Run with: hack/cozytest.sh hack/migration-50-etcd-adopt.bats
+# Run with: bats hack/migration-50-etcd-adopt.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 FAKEBIN="$PWD/hack/testdata/migration-50"
 MIG="$PWD/packages/core/platform/images/migrations/migrations/50"

--- a/hack/migration-seaweedfs-db-adopt.bats
+++ b/hack/migration-seaweedfs-db-adopt.bats
@@ -55,12 +55,15 @@
 # the script does any work, while on a developer box /bin/sh is often bash, which
 # runs green and proves nothing about ash.
 #
-# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
-# own line; there is no bats `run`/`$status`/`setup`. Assertions are direct
-# shell tests that exit non-zero on failure.
+# Runs under bats(1). `run` and `$status` are available but unused here:
+# assertions are direct shell tests that exit non-zero on failure. bats
+# supplies `set -e`, and hack/test_helper.bash restores the `set -u` that
+# cozytest.sh applied before #3453.
 #
-# Run with: hack/cozytest.sh hack/migration-seaweedfs-db-adopt.bats
+# Run with: bats hack/migration-seaweedfs-db-adopt.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 FAKEBIN="$PWD/hack/testdata/migration-seaweedfs-db"
 MIG_DIR="$PWD/packages/core/platform/images/migrations/migrations"
@@ -79,10 +82,13 @@ ALPINE=$(sed -n 's/^FROM \(alpine:[^ ]*\).*$/\1/p' \
 # assertions read back on the host. --network none because nothing here may
 # reach a real cluster; --user keeps $WORK removable by the test afterwards.
 #
-# The explicit `return` is load-bearing: cozytest.sh's awk generator rewrites
-# every bare `}` in column 0 into `return 0` + `}`, so a helper that falls off
-# its own end returns 0 no matter what it ran, and every fail-closed assertion
-# below would pass vacuously. Capture the status and return it by hand.
+# The explicit `return` is no longer load-bearing: it worked around
+# cozytest.sh's awk generator, which rewrote every bare `}` in column 0 into
+# `return 0` + `}`, so a helper falling off its own end returned 0 whatever it
+# ran and every fail-closed assertion below passed vacuously. bats does not
+# rewrite function bodies, so this is now belt-and-braces. Kept because
+# returning the status explicitly is clearer than relying on the fall-through
+# either way.
 run_migration() {
   _run_migration_rc=0
   docker run --rm --network none \

--- a/hack/monitoring-pvc-backfill-migration.bats
+++ b/hack/monitoring-pvc-backfill-migration.bats
@@ -23,14 +23,17 @@
 #   - stamps the version (kubectl apply) on a clean run;
 #   - is a safe no-op that still stamps when the CRDs are absent.
 #
-# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
-# own line (column 0); assertions are direct shell tests, and the fake-kubectl
-# heredoc keeps every `}` off column 0. Each @test cleans up inline (no
+# Runs under bats(1); assertions are direct shell tests that exit non-zero on
+# failure. bats supplies `set -e`, and hack/test_helper.bash restores the
+# `set -u` that cozytest.sh applied before #3453. The fake-kubectl heredoc
+# keeps every `}` off column 0 — a cozytest parser constraint that no longer
+# binds, but harmless to leave in place. Each @test cleans up inline (no
 # EXIT/RETURN trap — see docs/agents/e2e-testing.md §3).
 #
-# Run with: hack/cozytest.sh hack/monitoring-pvc-backfill-migration.bats
-#           (or `bats hack/monitoring-pvc-backfill-migration.bats`)
+# Run with: bats hack/monitoring-pvc-backfill-migration.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
 REPO_ROOT="$(cd "$HACK_DIR/.." && pwd)"
@@ -40,7 +43,8 @@ MIGRATION="$REPO_ROOT/packages/core/platform/images/migrations/migrations/51"
 # Emits a fake `kubectl` that logs every call to $KLOG and, when $MOCK_ABSENT=1,
 # reports the VM/VL CRDs as absent. Ordering matters: the CR appname read is
 # matched by *managedMetadata* before the generic *vmclusters*/*vlclusters* list.
-# No line below is a bare column-0 `}`, so cozytest.sh's parser leaves it intact.
+# No line below is a bare column-0 `}` — a cozytest.sh parser constraint that
+# bats does not impose, kept only so the heredoc stays diff-stable.
 write_fake_kubectl() {
   cat > "$1/kubectl" <<'KEOF'
 #!/bin/sh

--- a/hack/nightly-mirror_test.bats
+++ b/hack/nightly-mirror_test.bats
@@ -8,17 +8,19 @@
 # tree), and every copy targets the destination registry with the source digest
 # preserved.
 #
-# Harness note: the CI path is hack/cozytest.sh, NOT real bats — see the same
-# note in hack/promote-retag_test.bats. No `run`, `$status`, `$output`, `skip`,
-# or setup()/teardown(); each @test is a shell function under `set -eu -x`, so a
-# non-zero exit aborts the test (that is the exit-0 assertion). A test that
-# expects a non-zero exit must capture it with `|| rc=$?`. mikefarah yq is
-# assumed present (provided by the test toolchain).
+# Harness note: the CI path is bats(1) since #3453 — see the same note in
+# hack/promote-retag_test.bats. `run`, `$status`, `$output`, `skip` and
+# setup()/teardown() are available but unused here; a non-zero exit aborts the
+# test (that is the exit-0 assertion). A test that expects a non-zero exit must
+# capture it with `|| rc=$?`. mikefarah yq is assumed present (provided by the
+# test toolchain).
 #
-# Run with: hack/cozytest.sh hack/nightly-mirror_test.bats
+# Run with: bats hack/nightly-mirror_test.bats
 
 # Build a synthetic baked tree exercising all four image-ref shapes plus the
 # refs that MUST be filtered (third-party host, cozystack-packages artifact).
+
+load test_helper
 _make_tree() {
   D="$(printf 'a%.0s' $(seq 1 64))"   # 64-hex fake digest body
   t="$1"

--- a/hack/overlay-main-images_test.bats
+++ b/hack/overlay-main-images_test.bats
@@ -4,12 +4,14 @@
 # cozystack-packages:main artifact.
 #
 # Run from the repo root:  bats hack/overlay-main-images_test.bats
-# (CI runs it via hack/cozytest.sh through `make unit-tests`.)
+# (CI runs it via bats through `make unit-tests`.)
 #
 # Each test builds a throwaway tree: a `packages/` tree on release (ghcr/v1.5.0)
 # refs, and a `main/` dir standing in for the extracted cozystack-packages:main
 # artifact (root = contents of packages/) on current-main (OCIR/:main) refs.
 # $root is the real repo, captured before cd.
+
+load test_helper
 
 @test "overlays an unbuilt unit (.tag) to current-main and reports it" {
   root=$(pwd)

--- a/hack/promote-retag_test.bats
+++ b/hack/promote-retag_test.bats
@@ -8,18 +8,17 @@
 # cannot push to aborted the whole promotion. The selector must emit only
 # cozystack-owned ($REGISTRY/...) refs.
 #
-# Harness note: the CI path is hack/cozytest.sh, NOT real bats. cozytest.sh's
-# awk parser recognizes only @test blocks and a bare `}` on its own line; there
-# is no `run`, `$status`, `$output`, `skip`, or setup()/teardown(). Each test
-# runs as a shell function under `set -eu -x`, so a non-zero exit aborts the
-# test (that is the exit-0 assertion) and other expectations are direct shell
-# tests. A test that expects a non-zero exit must capture it with `|| rc=$?`
-# so the harness's `set -e` does not abort first. mikefarah yq is assumed
-# present (provided by the test toolchain, like the other yq-using bats here).
+# Harness note: the CI path is bats(1) since #3453, so `run`, `$status`,
+# `$output`, `skip` and setup()/teardown() are all available — this file simply
+# does not use them. A non-zero exit aborts the test (that is the exit-0
+# assertion) and other expectations are direct shell tests. A test that expects
+# a non-zero exit must capture it with `|| rc=$?` so `set -e` does not abort
+# first. mikefarah yq is assumed present (provided by the test toolchain, like
+# the other yq-using bats here).
 #
-# Run with: hack/cozytest.sh hack/promote-retag_test.bats
-#           (or `bats hack/promote-retag_test.bats` if the bats binary is
-#           installed; cozytest.sh is the CI path.)
+# Run with: bats hack/promote-retag_test.bats
+
+load test_helper
 
 @test "dry-run over the real tree retags only cozystack-owned refs" {
   tmp=$(mktemp -d)

--- a/hack/promote-rewrite-tags_test.bats
+++ b/hack/promote-rewrite-tags_test.bats
@@ -17,16 +17,16 @@
 # registry prefix finds files it has never heard of, which is the whole failure
 # mode. Stamp wider than the rewrite, then assert the rewrite cleaned all of it.
 #
-# Harness note: the CI path is hack/cozytest.sh, NOT real bats. cozytest.sh's
-# awk parser recognizes only @test blocks and a bare `}` on its own line; there
-# is no `run`, `$status`, `$output`, `skip`, or setup()/teardown(). Each test
-# runs as a shell function under `set -eu -x`, so a non-zero exit aborts the
-# test (that is the exit-0 assertion). A test that expects a non-zero exit must
-# capture it with `|| rc=$?` so the harness's `set -e` does not abort first.
-# Paths are repo-root-relative: BATS_TEST_DIRNAME is unset here and would abort
-# the whole suite under `set -u`.
+# Harness note: the CI path is bats(1) since #3453, so `run`, `$status`,
+# `$output`, `skip` and setup()/teardown() are all available — this file simply
+# does not use them. A non-zero exit aborts the test (that is the exit-0
+# assertion). A test that expects a non-zero exit must capture it with
+# `|| rc=$?` so `set -e` does not abort first. Paths stay repo-root-relative,
+# which worked under both runners.
 #
-# Run with: hack/cozytest.sh hack/promote-rewrite-tags_test.bats
+# Run with: bats hack/promote-rewrite-tags_test.bats
+
+load test_helper
 
 @test "rewrite leaves no rc reference anywhere in the tree" {
   tmp=$(mktemp -d)

--- a/hack/remediation-guard.bats
+++ b/hack/remediation-guard.bats
@@ -12,12 +12,15 @@
 # are useless there because flux's ClearFailures zeroes them on successful
 # reconciliation; .status.history retains the snapshot trail.
 #
-# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on
-# its own line; there is no bats `run` or `$status`. Assertions are
-# expressed as direct shell tests that exit non-zero on failure.
+# Runs under bats(1). `run` and `$status` are available but unused here:
+# assertions are expressed as direct shell tests that exit non-zero on
+# failure. bats supplies `set -e`, and hack/test_helper.bash restores the
+# `set -u` that cozytest.sh applied before #3453.
 #
-# Run with: hack/cozytest.sh hack/remediation-guard.bats
+# Run with: bats hack/remediation-guard.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 @test "empty history returns not-detected" {
     . hack/e2e-chainsaw/_lib/remediation-guard.sh

--- a/hack/run-kubernetes-drain_test.bats
+++ b/hack/run-kubernetes-drain_test.bats
@@ -9,12 +9,15 @@
 # is never misread as "the tenant has drained". The function returns 0 (drained)
 # only when every capture is empty/whitespace, non-zero otherwise.
 #
-# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
-# own line; there is no bats `run` or `$status`. Assertions are expressed as
-# direct shell tests that exit non-zero on failure.
+# Runs under bats(1). `run` and `$status` are available but unused here:
+# assertions are expressed as direct shell tests that exit non-zero on
+# failure. bats supplies `set -e`, and hack/test_helper.bash restores the
+# `set -u` that cozytest.sh applied before #3453.
 #
-# Run with: hack/cozytest.sh hack/run-kubernetes-drain_test.bats
+# Run with: bats hack/run-kubernetes-drain_test.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 @test "all-empty captures report drained" {
     . hack/e2e-chainsaw/_lib/run-kubernetes.sh

--- a/hack/seaweedfs-guard-parity.bats
+++ b/hack/seaweedfs-guard-parity.bats
@@ -25,8 +25,10 @@
 # release; extra/ is <name> and derives the child), and that is the ONLY sanctioned
 # difference. Both are asserted separately below.
 #
-# Run with: hack/cozytest.sh hack/seaweedfs-guard-parity.bats
+# Run with: bats hack/seaweedfs-guard-parity.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 SYS="$PWD/packages/system/seaweedfs/templates/naming-guard.yaml"
 EXTRA="$PWD/packages/extra/seaweedfs/templates/seaweedfs.yaml"

--- a/hack/seaweedfs-naming-audit.bats
+++ b/hack/seaweedfs-naming-audit.bats
@@ -20,11 +20,19 @@
 # Moving the classifier into a file with tests is the point. These drive it
 # against a fake kubectl, mocking only the cluster boundary.
 #
-# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its own
-# line; there is no bats `run`/`$status`/`setup`.
+# Runs under bats(1). `run` and `$status` are available but unused here.
+# hack/test_helper.bash restores the `set -u` that cozytest.sh applied before
+# #3453.
 #
-# Run with: hack/cozytest.sh hack/seaweedfs-naming-audit.bats
+# Note that the script under test is POSIX sh and is EXECUTED by /bin/sh at
+# run time, but SOURCED into bats' bash here. A bash-only construct added to
+# it would pass this suite and fail in production; shellcheck's `shell=sh`
+# directive in the script is what guards that now.
+#
+# Run with: bats hack/seaweedfs-naming-audit.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 SEAWEEDFS_AUDIT_LIB=1
 export SEAWEEDFS_AUDIT_LIB

--- a/hack/select-e2e_test.bats
+++ b/hack/select-e2e_test.bats
@@ -2,14 +2,16 @@
 # -----------------------------------------------------------------------------
 # Unit tests for hack/select-e2e.sh
 #
-# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
-# own line; there is no bats `run` or `$status`. Each test runs as a shell
-# function under `set -eu -x`, so assertions are direct shell tests that exit
-# non-zero on failure. setup()/teardown() are not honored — each test creates
-# and cleans its own scratch dir.
+# Runs under bats(1). Assertions are direct shell tests that exit non-zero on
+# failure; `run` and `$status` are available but unused here. bats supplies
+# `set -e`, and hack/test_helper.bash restores the `set -u` that cozytest.sh
+# applied before #3453. Each test creates and cleans its own scratch dir
+# rather than sharing a setup()/teardown() pair.
 #
-# Run with: hack/cozytest.sh hack/select-e2e_test.bats
+# Run with: bats hack/select-e2e_test.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 @test "single app diff selects only that suite" {
     tmp=$(mktemp -d)

--- a/hack/select-install_test.bats
+++ b/hack/select-install_test.bats
@@ -2,19 +2,20 @@
 # -----------------------------------------------------------------------------
 # Unit tests for hack/select-install.sh
 #
-# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
-# own line; there is no bats `run` or `$status`. Each test runs as a shell
-# function under `set -eu -x`, so assertions are direct shell tests that exit
-# non-zero on failure. setup()/teardown() are not honored; per-test `trap ...
-# EXIT` cleanup IS honored. To assert a NON-zero exit, invert with `if` so
-# `set -e` doesn't abort the test.
+# Runs under bats(1). Assertions are direct shell tests that exit non-zero on
+# failure; `run` and `$status` are available but unused here. bats supplies
+# `set -e`, and hack/test_helper.bash restores the `set -u` that cozytest.sh
+# applied before #3453. Per-test `trap ... EXIT` cleanup is honored. To assert
+# a NON-zero exit, invert with `if` so `set -e` doesn't abort the test.
 #
 # Tests that only READ the production sources call the script directly (it
 # defaults sources-dir to packages/core/platform/sources); only the tests that
 # build a synthetic graph or suite tree use a scratch dir.
 #
-# Run with: hack/cozytest.sh hack/select-install_test.bats
+# Run with: bats hack/select-install_test.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 @test "single app selects its forward dependency closure" {
     output=$(hack/select-install.sh "postgres")

--- a/hack/talos-image-cache_test.bats
+++ b/hack/talos-image-cache_test.bats
@@ -28,14 +28,16 @@
 # Root cause + fix are from cozystack/cozystack#3254 (@lexfrei); this is the port
 # to the Chainsaw layout (hack/e2e-chainsaw/_lib/).
 #
-# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
-# own line; there is no bats `run` or `$status`, and setup()/teardown() are not
-# honored. Each test runs under `set -eu -x`; assertions are direct shell tests
-# that exit non-zero on failure. mikefarah yq prints `---` between matched
+# Runs under bats(1). `run` and `$status` are available but unused here;
+# assertions are direct shell tests that exit non-zero on failure. bats
+# supplies `set -e`, and hack/test_helper.bash restores the `set -u` that
+# cozytest.sh applied before #3453. mikefarah yq prints `---` between matched
 # documents, so document streams are compared with those separators stripped.
 #
-# Run with: hack/cozytest.sh hack/talos-image-cache_test.bats
+# Run with: bats hack/talos-image-cache_test.bats
 # -----------------------------------------------------------------------------
+
+load test_helper
 
 @test "manifest documents partition into pre-Cilium apply plus the Cilium policy" {
     manifest=hack/e2e-talos-image-cache.yaml

--- a/hack/test_helper.bash
+++ b/hack/test_helper.bash
@@ -1,0 +1,25 @@
+# Shared setup for the hack/*.bats unit suite.
+#
+# Bats enforces `set -e` on a test body but does not enable `set -u`, while
+# hack/cozytest.sh -- the runner this suite used before #3453 -- ran every
+# body under `set -eu -x`. Without this file a test that reads an unset
+# variable silently sees an empty string and passes, which is the one
+# strictness property the move to bats would otherwise drop.
+#
+# `set -u` here is deliberately scoped to the test body. It is a shell
+# option, not an exported one, so it does not reach the hack/*.sh scripts
+# the tests exercise as subprocesses. Exporting it instead (SHELLOPTS=nounset
+# in the environment) does propagate, changes the behaviour of the scripts
+# under test rather than the tests themselves, and was measured to break the
+# suite -- so it is not an alternative to loading this file.
+#
+# A test file that needs its own fixture setup must call `strict_setup`
+# from its `setup()` rather than relying on the definition below, since a
+# later `setup()` in the file silently replaces this one.
+strict_setup() {
+  set -u
+}
+
+setup() {
+  strict_setup
+}


### PR DESCRIPTION
Part 2 of a stack implementing #3453. Stacked on top of the runner switch — **review that one first**; this diff only makes sense against it.

## What

Restores the `set -u` that `hack/cozytest.sh` applied to every test body, and rewrites the 27 file headers that documented the cozytest contract in prose.

## Why `set -u` needs a per-file load

bats enforces `set -e` but not `set -u`, so without this a test that reads an unset variable silently sees an empty string and passes — the one strictness property the move to bats would otherwise drop. There is no runner-level way to inject it. Two mechanisms were measured and rejected:

| Mechanism | Result |
|---|---|
| `setup()` in `--setup-suite-file` | Does not reach test files at all — the unset-variable canary still passes |
| `SHELLOPTS=nounset` in the environment | Does reach them, but is **exported**, so it also applies to the `hack/*.sh` scripts under test — changing the behaviour of the code being tested rather than the tests, and dropping 2 tests outright |
| `set -u` inside `setup()` (chosen) | Shell option, not exported, so it stays scoped to the test body |

`hack/test_helper.bash` defines the shared `setup()`; all 32 unit files load it.

## Verification

The restoration is mutation-checked, not assumed. A canary test reading an unset variable aborts with `unbound variable` with the load in place, and passes vacuously without it:

```
not ok 329 CANARY unset variable must abort the test
# hack/zz-canary-tmp.bats: line 8: DELIBERATELY_UNSET_CANARY: unbound variable
```

The suite is **328/328 green** either way, so nothing in the tree was relying on the laxer behaviour. `make bats-unit-tests` and the pre-commit hook both pass.

## The headers

27 of the 32 files stated things that are now false: "there is no bats `run` or `$status`", "setup()/teardown() are not honored", "Run with: hack/cozytest.sh ...", title-sanitization rules inherited from the awk parser, and instructions to keep `}` off column 0 so the parser would not truncate a test. A false comment about the harness is worse than no comment — the next author reads "setup() is not honored" and hand-rolls per-test cleanup the runner would have done for them.

Where a constraint merely stopped binding rather than reversing, the comment says so instead of vanishing: the column-0 heredoc indentation and the manual status capture in `migration-seaweedfs-db-adopt.bats` are both kept and marked belt-and-braces. Claims that survived the move are left alone — `! cmd` really is still vacuous under `set -e`, because bash suppresses errexit for a negated command exactly as dash did.

`hack/seaweedfs-naming-audit.bats` gains a note that its subject is POSIX sh executed by `/bin/sh` but sourced into bats' bash, so shellcheck's `shell=sh` directive is now the only thing guarding that gap.

Refs: #3453
