### PR TITLE
chore(codeowners): don't gate per-app generated files on architect review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -107,6 +107,18 @@
 /pkg/registry/                               @kvaps @lllamnyp
 /pkg/generated/                              @kvaps @lllamnyp
 
+# --- Per-app generated mirrors of values.schema.json: no owner ---
+# These files are entirely produced by `make generate` (cozyvalues-gen and
+# hack/update-crd.sh) from each app's own values.yaml, which is already
+# reviewed under its /packages/apps/ or /packages/extra/ entry above.
+# Correctness is enforced by the pre-commit `run-make-generate` /
+# `run-make-generate-root` CI hooks (regenerate, then fail on any diff), not
+# by human review, so no owner is listed here — that intentionally waives
+# the /api/ codeowner requirement above for just these generated paths.
+/api/apps/v1alpha1/*/types.go
+/api/apps/v1alpha1/*/zz_generated.deepcopy.go
+/packages/system/*/cozyrds/
+
 # --- Docs ---
 /docs/                                       @lexfrei @myasnikovdaniil
 

--- a/api/.gitattributes
+++ b/api/.gitattributes
@@ -1,1 +1,2 @@
-zz_generated_deepcopy.go linguist-generated
+zz_generated.deepcopy.go linguist-generated
+apps/v1alpha1/*/types.go linguist-generated

--- a/packages/system/.gitattributes
+++ b/packages/system/.gitattributes
@@ -1,0 +1,1 @@
+*/cozyrds/*.yaml linguist-generated


### PR DESCRIPTION
## What this PR does

`.github/CODEOWNERS` scopes `/api/` to the architects (`@kvaps @lllamnyp`), meant for hand-authored API surface: the aggregated apiserver, the registry, the core API types. But `api/apps/v1alpha1/<name>/types.go` and `api/apps/v1alpha1/<name>/zz_generated.deepcopy.go` are entirely produced by `make generate` from each app's own `values.yaml`/`values.schema.json` — 23 of the 32 packages under `packages/apps/` and `packages/extra/` wire this into their `generate` target. Since CODEOWNERS applies the last matching pattern and nothing more specific overrode `/api/` for these paths, any PR that edits an app's `values.yaml` documentation and reruns `make generate` (mandatory per the contributing guide) ends up requiring an architect review, no matter which area actually changed — even though the app's own reviewers already cover the source file that produced the diff. `packages/system/<name>-rd/cozyrds/<name>.yaml` has the same problem in a milder form: it isn't scoped by CODEOWNERS at all, so it falls through to the generic `/packages/` owners instead of the app's own team, again just because it's a generated mirror.

This adds a CODEOWNERS entry with no owner for these three generated paths, so touching them alone does not pull in any codeowner requirement beyond what the source `values.yaml` already needs. This is intentional and safe: both are verified by the existing pre-commit CI (`run-make-generate` / `run-make-generate-root`), which reruns the generator and fails the check if the committed output does not match — a stronger, mechanical guarantee against drift or hand-tampering than a human skim of a generated diff would be.

While in there: `api/.gitattributes` had a stale `linguist-generated` pattern (`zz_generated_deepcopy.go`) that has never matched any real file in this repo — the actual generated files are named `zz_generated.deepcopy.go` (dot, not underscore, matching the standard controller-gen output). Fixed the pattern and added the same treatment for the per-app `types.go` files and for `packages/system/*/cozyrds/*.yaml`, so all of them collapse in the PR diff view instead of just some.

### Screenshots

Not applicable — no UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change

This only touches `.github/CODEOWNERS` and `.gitattributes` files; it changes neither the `values.schema.json` contract, generated CRDs, version enums, nor anything else in the trigger map in `docs/agents/contributing.md`.

### Release note

```release-note
chore(codeowners): per-app generated API type mirrors and cozyrds manifests no longer require architect review on their own — only the source values.yaml they're generated from does, with the existing make-generate CI check guarding against drift.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository metadata to better identify generated API and application artifacts.
  * Added ownership exceptions for generated files and application-specific configuration directories.
  * Marked generated CozyRDS configuration files for improved repository classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->