### PR TITLE
docs(community): add a Role nomination issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -8,7 +8,7 @@ contact_links:
     about: Changes that affect multiple components or APIs, or that need a decision before any code is written (a new subsystem, an API change with tradeoffs). Open a design-proposal PR in the community repo.
   - name: 🏛️ Governance, process, or community
     url: https://github.com/cozystack/community/issues/new
-    about: Maintainership, decision-making, meetings, working groups, community resources — these live in the community repo.
+    about: Decision-making, meetings, working groups, community resources — these live in the community repo. Exception, kept here because MAINTAINERS.md, CODEOWNERS and the ladder all live in this repo: nominating someone to Reviewer or Maintainer, for which use the Role nomination template above.
   - name: 💬 Chat (Telegram / CNCF Slack)
     url: https://t.me/cozystack
     about: Real-time discussion with the Cozystack community.

--- a/.github/ISSUE_TEMPLATE/role_nomination.md
+++ b/.github/ISSUE_TEMPLATE/role_nomination.md
@@ -1,0 +1,53 @@
+---
+name: Role nomination (Reviewer or Maintainer)
+about: Propose promoting a contributor to Reviewer or Maintainer
+title: 'Proposal: Promote @<github-handle> to <Reviewer|Maintainer>'
+labels: 'community'
+assignees: ''
+---
+
+<!--
+Read CONTRIBUTOR_LADDER.md before filing: it defines both roles, their requirements and the privileges that come with them.
+
+Anyone may open a nomination, including a self-nomination. Only maintainers vote.
+
+This issue collects the discussion and the votes. The formal step is a separate pull request — CODEOWNERS for a Reviewer, MAINTAINERS.md for a Maintainer — opened after the vote passes.
+-->
+
+## Nominee
+
+- **Name:**
+- **GitHub:** @
+- **Affiliation:**
+- **Proposed role:** Reviewer / Maintainer
+- **Area** (Reviewer only — the directories or component this covers):
+
+## Why
+
+<!-- What has this person actually done, and why does the project benefit from giving them this role? Cover both the work and the judgement: reviews given, issues triaged, questions answered, releases tested, discussions moved forward. Contributions that are not code count. -->
+
+## Representative contributions
+
+<!-- Link pull requests, reviews, issues or discussions. A handful of representative examples is more useful than an exhaustive list. Say which areas of the project they touch. -->
+
+## Requirements
+
+<!-- Tick what the nominee meets per CONTRIBUTOR_LADDER.md. If something is not met, say so and explain why the nomination still stands — an honest gap is fine, an unticked box that nobody mentions is not. -->
+
+- [ ] Contributing for the period the ladder requires
+- [ ] Sustained contribution record (PRs, reviews, issues, or an equivalent)
+- [ ] Two sponsors, at least one from a different employer
+- [ ] Demonstrated depth in the area they would own
+- [ ] Supportive of new and occasional contributors
+
+## Voting
+
+Voting is open to current maintainers, listed in [MAINTAINERS.md](https://github.com/cozystack/cozystack/blob/main/MAINTAINERS.md). Vote in a comment with `+1` (approve), `0` (abstain) or `-1` (do not approve). A `-1` should come with a short reason, so the concern can be addressed.
+
+The vote closes after **5 calendar days**, or once a majority of current maintainers have voted — whichever comes first. Passing requires a majority of current maintainers, per GOVERNANCE.md.
+
+## Next steps if it passes
+
+1. The nominee confirms in a comment that they accept the responsibilities of the role.
+2. Open the pull request — add them to `.github/CODEOWNERS` for a Reviewer, or to `MAINTAINERS.md` for a Maintainer. Nominations are recorded through a PR, not a direct push to `main`.
+3. Grant the GitHub permissions the role requires, and link the merged PR here before closing this issue.


### PR DESCRIPTION
## What this PR does

Adds a `Role nomination` issue template covering both the Reviewer and Maintainer rungs, and notes the exception in the `config.yml` routing.

Both Hidora maintainers were promoted through a well-run public vote in #2343 and #2344: a written rationale, representative contributions, a 5-day window, `+1`/`0`/`-1` from the maintainer roster, the nominee confirming acceptance, and explicit next steps. That shape was never written down afterwards, so the next nomination would have to reinvent it — and the Reviewer rung documented in July has no filed nomination at all, its three entries having been added by direct commit rather than through the PR the ladder describes.

The template is that issue turned into a form. It asks for the area a Reviewer would own, lists what `CONTRIBUTOR_LADDER.md` requires, and asks explicitly for an honest note when a requirement is not met rather than a quietly unticked box. It also records that the promotion itself lands through a pull request against `CODEOWNERS` or `MAINTAINERS.md`.

The `config.yml` contact link routes governance to the community repo. Nominations stay here, because `MAINTAINERS.md`, `CODEOWNERS` and `CONTRIBUTOR_LADDER.md` all live in this repository and this is where both prior votes happened. The link text now says so instead of sending a nominator to the wrong repo.

Nothing in the voting rules is invented here: the 5-day window and the majority threshold are what #2343 used and what `GOVERNANCE.md` already states.

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
docs(community): add a Role nomination issue template for the Reviewer and Maintainer rungs
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a role nomination issue template for proposing Reviewers and Maintainers.
  * Documented eligibility criteria, required nomination details, approval rules, timelines, and follow-up steps.
  * Updated the Governance contact guidance to direct role nominations to the new template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->