### PR TITLE
fix(postgres-operator): align CNPG operator and CRDs to 1.28.2 for PVC resize-deadlock fix

### DIFF
--- a/packages/system/postgres-operator/Makefile
+++ b/packages/system/postgres-operator/Makefile
@@ -12,5 +12,6 @@ update:
 	helm repo update cnpg
 	helm pull cnpg/cloudnative-pg --untar --untardir charts --version 0.27.1
 	rm -rf charts/cloudnative-pg/charts
+	patch --no-backup-if-mismatch -p4 < patches/cloudnative-pg-1.28.2.patch
 	helm pull cnpg/plugin-barman-cloud --untar --untardir charts --version 0.7.0
 	rm -rf charts/plugin-barman-cloud/charts

--- a/packages/system/postgres-operator/charts/cloudnative-pg/Chart.yaml
+++ b/packages/system/postgres-operator/charts/cloudnative-pg/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.28.1
+appVersion: 1.28.2
 dependencies:
 - alias: monitoring
   condition: monitoring.grafanaDashboard.create

--- a/packages/system/postgres-operator/charts/cloudnative-pg/templates/crds/crds.yaml
+++ b/packages/system/postgres-operator/charts/cloudnative-pg/templates/crds/crds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: backups.postgresql.cnpg.io
 spec:
@@ -466,7 +466,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusterimagecatalogs.postgresql.cnpg.io
 spec:
@@ -515,6 +515,112 @@ spec:
                 items:
                   description: CatalogImage defines the image and major version
                   properties:
+                    extensions:
+                      description: The configuration of the extensions to be added
+                      items:
+                        description: |-
+                          ExtensionConfiguration is the configuration used to add
+                          PostgreSQL extensions to the Cluster.
+                        properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
+                          dynamic_library_path:
+                            description: |-
+                              The list of directories inside the image which should be added to dynamic_library_path.
+                              If not defined, defaults to "/lib".
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          extension_control_path:
+                            description: |-
+                              The list of directories inside the image which should be added to extension_control_path.
+                              If not defined, defaults to "/share".
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: The image containing the extension.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          ld_library_path:
+                            description: The list of directories inside the image
+                              which should be added to ld_library_path.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: The name of the extension, required
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
                     image:
                       description: The image reference
                       type: string
@@ -548,7 +654,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: clusters.postgresql.cnpg.io
 spec:
@@ -4913,6 +5019,13 @@ spec:
                         ExtensionConfiguration is the configuration used to add
                         PostgreSQL extensions to the Cluster.
                       properties:
+                        bin_path:
+                          description: |-
+                            A list of directories within the image to be appended to the
+                            PostgreSQL process's `PATH` environment variable.
+                          items:
+                            type: string
+                          type: array
                         dynamic_library_path:
                           description: |-
                             The list of directories inside the image which should be added to dynamic_library_path.
@@ -4920,6 +5033,45 @@ spec:
                           items:
                             type: string
                           type: array
+                        env:
+                          description: |-
+                            Env is a list of custom environment variables to be set in the
+                            PostgreSQL process for this extension. It is the responsibility of the
+                            cluster administrator to ensure the variables are correct for the
+                            specific extension. Note that changes to these variables require
+                            a manual cluster restart to take effect.
+                          items:
+                            description: |-
+                              ExtensionEnvVar defines an environment variable for a specific extension
+                              image volume.
+                            properties:
+                              name:
+                                description: |-
+                                  Name of the environment variable to be injected into the
+                                  PostgreSQL process.
+                                minLength: 1
+                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                type: string
+                              value:
+                                description: |-
+                                  Value of the environment variable. CloudNativePG performs a direct
+                                  replacement of this value, with support for placeholder expansion.
+                                  The ${`image_root`} placeholder resolves to the absolute mount path
+                                  of the extension's volume (e.g., `/extensions/my-extension`). This
+                                  is particularly useful for allowing applications or libraries to
+                                  locate specific directories within the mounted image.
+                                  Unrecognized placeholders are rejected. To include a literal ${...}
+                                  in the value, escape it as $${...}.
+                                minLength: 1
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
                         extension_control_path:
                           description: |-
                             The list of directories inside the image which should be added to extension_control_path.
@@ -4928,7 +5080,7 @@ spec:
                             type: string
                           type: array
                         image:
-                          description: The image containing the extension, required
+                          description: The image containing the extension.
                           properties:
                             pullPolicy:
                               description: |-
@@ -4948,9 +5100,6 @@ spec:
                                 container images in workload controllers like Deployments and StatefulSets.
                               type: string
                           type: object
-                          x-kubernetes-validations:
-                          - message: An image reference is required
-                            rule: has(self.reference)
                         ld_library_path:
                           description: The list of directories inside the image which
                             should be added to ld_library_path.
@@ -4963,7 +5112,6 @@ spec:
                           pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
                           type: string
                       required:
-                      - image
                       - name
                       type: object
                     type: array
@@ -7787,7 +7935,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: databases.postgresql.cnpg.io
 spec:
@@ -8382,7 +8530,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: failoverquorums.postgresql.cnpg.io
 spec:
@@ -8460,7 +8608,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: imagecatalogs.postgresql.cnpg.io
 spec:
@@ -8508,6 +8656,112 @@ spec:
                 items:
                   description: CatalogImage defines the image and major version
                   properties:
+                    extensions:
+                      description: The configuration of the extensions to be added
+                      items:
+                        description: |-
+                          ExtensionConfiguration is the configuration used to add
+                          PostgreSQL extensions to the Cluster.
+                        properties:
+                          bin_path:
+                            description: |-
+                              A list of directories within the image to be appended to the
+                              PostgreSQL process's `PATH` environment variable.
+                            items:
+                              type: string
+                            type: array
+                          dynamic_library_path:
+                            description: |-
+                              The list of directories inside the image which should be added to dynamic_library_path.
+                              If not defined, defaults to "/lib".
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: |-
+                              Env is a list of custom environment variables to be set in the
+                              PostgreSQL process for this extension. It is the responsibility of the
+                              cluster administrator to ensure the variables are correct for the
+                              specific extension. Note that changes to these variables require
+                              a manual cluster restart to take effect.
+                            items:
+                              description: |-
+                                ExtensionEnvVar defines an environment variable for a specific extension
+                                image volume.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name of the environment variable to be injected into the
+                                    PostgreSQL process.
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
+                                  type: string
+                                value:
+                                  description: |-
+                                    Value of the environment variable. CloudNativePG performs a direct
+                                    replacement of this value, with support for placeholder expansion.
+                                    The ${`image_root`} placeholder resolves to the absolute mount path
+                                    of the extension's volume (e.g., `/extensions/my-extension`). This
+                                    is particularly useful for allowing applications or libraries to
+                                    locate specific directories within the mounted image.
+                                    Unrecognized placeholders are rejected. To include a literal ${...}
+                                    in the value, escape it as $${...}.
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          extension_control_path:
+                            description: |-
+                              The list of directories inside the image which should be added to extension_control_path.
+                              If not defined, defaults to "/share".
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: The image containing the extension.
+                            properties:
+                              pullPolicy:
+                                description: |-
+                                  Policy for pulling OCI objects. Possible values are:
+                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                type: string
+                              reference:
+                                description: |-
+                                  Required: Image or artifact reference to be used.
+                                  Behaves in the same way as pod.spec.containers[*].image.
+                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                            type: object
+                          ld_library_path:
+                            description: The list of directories inside the image
+                              which should be added to ld_library_path.
+                            items:
+                              type: string
+                            type: array
+                          name:
+                            description: The name of the extension, required
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
                     image:
                       description: The image reference
                       type: string
@@ -8541,7 +8795,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: poolers.postgresql.cnpg.io
 spec:
@@ -17910,7 +18164,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: publications.postgresql.cnpg.io
 spec:
@@ -18106,7 +18360,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: scheduledbackups.postgresql.cnpg.io
 spec:
@@ -18298,7 +18552,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.0
+    controller-gen.kubebuilder.io/version: v0.20.1
     helm.sh/resource-policy: keep
   name: subscriptions.postgresql.cnpg.io
 spec:

--- a/packages/system/postgres-operator/patches/cloudnative-pg-1.28.2.patch
+++ b/packages/system/postgres-operator/patches/cloudnative-pg-1.28.2.patch
@@ -1,0 +1,414 @@
+--- a/packages/system/postgres-operator/charts/cloudnative-pg/Chart.yaml
++++ b/packages/system/postgres-operator/charts/cloudnative-pg/Chart.yaml
+@@ -1,5 +1,5 @@
+ apiVersion: v2
+-appVersion: 1.28.1
++appVersion: 1.28.2
+ dependencies:
+ - alias: monitoring
+   condition: monitoring.grafanaDashboard.create
+--- a/packages/system/postgres-operator/charts/cloudnative-pg/templates/crds/crds.yaml
++++ b/packages/system/postgres-operator/charts/cloudnative-pg/templates/crds/crds.yaml
+@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+   annotations:
+-    controller-gen.kubebuilder.io/version: v0.20.0
++    controller-gen.kubebuilder.io/version: v0.20.1
+     helm.sh/resource-policy: keep
+   name: backups.postgresql.cnpg.io
+ spec:
+@@ -466,7 +466,7 @@ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+   annotations:
+-    controller-gen.kubebuilder.io/version: v0.20.0
++    controller-gen.kubebuilder.io/version: v0.20.1
+     helm.sh/resource-policy: keep
+   name: clusterimagecatalogs.postgresql.cnpg.io
+ spec:
+@@ -515,6 +515,112 @@ spec:
+                 items:
+                   description: CatalogImage defines the image and major version
+                   properties:
++                    extensions:
++                      description: The configuration of the extensions to be added
++                      items:
++                        description: |-
++                          ExtensionConfiguration is the configuration used to add
++                          PostgreSQL extensions to the Cluster.
++                        properties:
++                          bin_path:
++                            description: |-
++                              A list of directories within the image to be appended to the
++                              PostgreSQL process's `PATH` environment variable.
++                            items:
++                              type: string
++                            type: array
++                          dynamic_library_path:
++                            description: |-
++                              The list of directories inside the image which should be added to dynamic_library_path.
++                              If not defined, defaults to "/lib".
++                            items:
++                              type: string
++                            type: array
++                          env:
++                            description: |-
++                              Env is a list of custom environment variables to be set in the
++                              PostgreSQL process for this extension. It is the responsibility of the
++                              cluster administrator to ensure the variables are correct for the
++                              specific extension. Note that changes to these variables require
++                              a manual cluster restart to take effect.
++                            items:
++                              description: |-
++                                ExtensionEnvVar defines an environment variable for a specific extension
++                                image volume.
++                              properties:
++                                name:
++                                  description: |-
++                                    Name of the environment variable to be injected into the
++                                    PostgreSQL process.
++                                  minLength: 1
++                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
++                                  type: string
++                                value:
++                                  description: |-
++                                    Value of the environment variable. CloudNativePG performs a direct
++                                    replacement of this value, with support for placeholder expansion.
++                                    The ${`image_root`} placeholder resolves to the absolute mount path
++                                    of the extension's volume (e.g., `/extensions/my-extension`). This
++                                    is particularly useful for allowing applications or libraries to
++                                    locate specific directories within the mounted image.
++                                    Unrecognized placeholders are rejected. To include a literal ${...}
++                                    in the value, escape it as $${...}.
++                                  minLength: 1
++                                  type: string
++                              required:
++                              - name
++                              - value
++                              type: object
++                            type: array
++                            x-kubernetes-list-map-keys:
++                            - name
++                            x-kubernetes-list-type: map
++                          extension_control_path:
++                            description: |-
++                              The list of directories inside the image which should be added to extension_control_path.
++                              If not defined, defaults to "/share".
++                            items:
++                              type: string
++                            type: array
++                          image:
++                            description: The image containing the extension.
++                            properties:
++                              pullPolicy:
++                                description: |-
++                                  Policy for pulling OCI objects. Possible values are:
++                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
++                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
++                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
++                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
++                                type: string
++                              reference:
++                                description: |-
++                                  Required: Image or artifact reference to be used.
++                                  Behaves in the same way as pod.spec.containers[*].image.
++                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
++                                  More info: https://kubernetes.io/docs/concepts/containers/images
++                                  This field is optional to allow higher level config management to default or override
++                                  container images in workload controllers like Deployments and StatefulSets.
++                                type: string
++                            type: object
++                          ld_library_path:
++                            description: The list of directories inside the image
++                              which should be added to ld_library_path.
++                            items:
++                              type: string
++                            type: array
++                          name:
++                            description: The name of the extension, required
++                            minLength: 1
++                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
++                            type: string
++                        required:
++                        - name
++                        type: object
++                      type: array
++                      x-kubernetes-list-map-keys:
++                      - name
++                      x-kubernetes-list-type: map
+                     image:
+                       description: The image reference
+                       type: string
+@@ -548,7 +654,7 @@ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+   annotations:
+-    controller-gen.kubebuilder.io/version: v0.20.0
++    controller-gen.kubebuilder.io/version: v0.20.1
+     helm.sh/resource-policy: keep
+   name: clusters.postgresql.cnpg.io
+ spec:
+@@ -4913,6 +5019,13 @@ spec:
+                         ExtensionConfiguration is the configuration used to add
+                         PostgreSQL extensions to the Cluster.
+                       properties:
++                        bin_path:
++                          description: |-
++                            A list of directories within the image to be appended to the
++                            PostgreSQL process's `PATH` environment variable.
++                          items:
++                            type: string
++                          type: array
+                         dynamic_library_path:
+                           description: |-
+                             The list of directories inside the image which should be added to dynamic_library_path.
+@@ -4920,6 +5033,45 @@ spec:
+                           items:
+                             type: string
+                           type: array
++                        env:
++                          description: |-
++                            Env is a list of custom environment variables to be set in the
++                            PostgreSQL process for this extension. It is the responsibility of the
++                            cluster administrator to ensure the variables are correct for the
++                            specific extension. Note that changes to these variables require
++                            a manual cluster restart to take effect.
++                          items:
++                            description: |-
++                              ExtensionEnvVar defines an environment variable for a specific extension
++                              image volume.
++                            properties:
++                              name:
++                                description: |-
++                                  Name of the environment variable to be injected into the
++                                  PostgreSQL process.
++                                minLength: 1
++                                pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
++                                type: string
++                              value:
++                                description: |-
++                                  Value of the environment variable. CloudNativePG performs a direct
++                                  replacement of this value, with support for placeholder expansion.
++                                  The ${`image_root`} placeholder resolves to the absolute mount path
++                                  of the extension's volume (e.g., `/extensions/my-extension`). This
++                                  is particularly useful for allowing applications or libraries to
++                                  locate specific directories within the mounted image.
++                                  Unrecognized placeholders are rejected. To include a literal ${...}
++                                  in the value, escape it as $${...}.
++                                minLength: 1
++                                type: string
++                            required:
++                            - name
++                            - value
++                            type: object
++                          type: array
++                          x-kubernetes-list-map-keys:
++                          - name
++                          x-kubernetes-list-type: map
+                         extension_control_path:
+                           description: |-
+                             The list of directories inside the image which should be added to extension_control_path.
+@@ -4928,7 +5080,7 @@ spec:
+                             type: string
+                           type: array
+                         image:
+-                          description: The image containing the extension, required
++                          description: The image containing the extension.
+                           properties:
+                             pullPolicy:
+                               description: |-
+@@ -4948,9 +5100,6 @@ spec:
+                                 container images in workload controllers like Deployments and StatefulSets.
+                               type: string
+                           type: object
+-                          x-kubernetes-validations:
+-                          - message: An image reference is required
+-                            rule: has(self.reference)
+                         ld_library_path:
+                           description: The list of directories inside the image which
+                             should be added to ld_library_path.
+@@ -4963,7 +5112,6 @@ spec:
+                           pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
+                           type: string
+                       required:
+-                      - image
+                       - name
+                       type: object
+                     type: array
+@@ -7787,7 +7935,7 @@ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+   annotations:
+-    controller-gen.kubebuilder.io/version: v0.20.0
++    controller-gen.kubebuilder.io/version: v0.20.1
+     helm.sh/resource-policy: keep
+   name: databases.postgresql.cnpg.io
+ spec:
+@@ -8382,7 +8530,7 @@ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+   annotations:
+-    controller-gen.kubebuilder.io/version: v0.20.0
++    controller-gen.kubebuilder.io/version: v0.20.1
+     helm.sh/resource-policy: keep
+   name: failoverquorums.postgresql.cnpg.io
+ spec:
+@@ -8460,7 +8608,7 @@ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+   annotations:
+-    controller-gen.kubebuilder.io/version: v0.20.0
++    controller-gen.kubebuilder.io/version: v0.20.1
+     helm.sh/resource-policy: keep
+   name: imagecatalogs.postgresql.cnpg.io
+ spec:
+@@ -8508,6 +8656,112 @@ spec:
+                 items:
+                   description: CatalogImage defines the image and major version
+                   properties:
++                    extensions:
++                      description: The configuration of the extensions to be added
++                      items:
++                        description: |-
++                          ExtensionConfiguration is the configuration used to add
++                          PostgreSQL extensions to the Cluster.
++                        properties:
++                          bin_path:
++                            description: |-
++                              A list of directories within the image to be appended to the
++                              PostgreSQL process's `PATH` environment variable.
++                            items:
++                              type: string
++                            type: array
++                          dynamic_library_path:
++                            description: |-
++                              The list of directories inside the image which should be added to dynamic_library_path.
++                              If not defined, defaults to "/lib".
++                            items:
++                              type: string
++                            type: array
++                          env:
++                            description: |-
++                              Env is a list of custom environment variables to be set in the
++                              PostgreSQL process for this extension. It is the responsibility of the
++                              cluster administrator to ensure the variables are correct for the
++                              specific extension. Note that changes to these variables require
++                              a manual cluster restart to take effect.
++                            items:
++                              description: |-
++                                ExtensionEnvVar defines an environment variable for a specific extension
++                                image volume.
++                              properties:
++                                name:
++                                  description: |-
++                                    Name of the environment variable to be injected into the
++                                    PostgreSQL process.
++                                  minLength: 1
++                                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]*$
++                                  type: string
++                                value:
++                                  description: |-
++                                    Value of the environment variable. CloudNativePG performs a direct
++                                    replacement of this value, with support for placeholder expansion.
++                                    The ${`image_root`} placeholder resolves to the absolute mount path
++                                    of the extension's volume (e.g., `/extensions/my-extension`). This
++                                    is particularly useful for allowing applications or libraries to
++                                    locate specific directories within the mounted image.
++                                    Unrecognized placeholders are rejected. To include a literal ${...}
++                                    in the value, escape it as $${...}.
++                                  minLength: 1
++                                  type: string
++                              required:
++                              - name
++                              - value
++                              type: object
++                            type: array
++                            x-kubernetes-list-map-keys:
++                            - name
++                            x-kubernetes-list-type: map
++                          extension_control_path:
++                            description: |-
++                              The list of directories inside the image which should be added to extension_control_path.
++                              If not defined, defaults to "/share".
++                            items:
++                              type: string
++                            type: array
++                          image:
++                            description: The image containing the extension.
++                            properties:
++                              pullPolicy:
++                                description: |-
++                                  Policy for pulling OCI objects. Possible values are:
++                                  Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
++                                  Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
++                                  IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
++                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
++                                type: string
++                              reference:
++                                description: |-
++                                  Required: Image or artifact reference to be used.
++                                  Behaves in the same way as pod.spec.containers[*].image.
++                                  Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
++                                  More info: https://kubernetes.io/docs/concepts/containers/images
++                                  This field is optional to allow higher level config management to default or override
++                                  container images in workload controllers like Deployments and StatefulSets.
++                                type: string
++                            type: object
++                          ld_library_path:
++                            description: The list of directories inside the image
++                              which should be added to ld_library_path.
++                            items:
++                              type: string
++                            type: array
++                          name:
++                            description: The name of the extension, required
++                            minLength: 1
++                            pattern: ^[a-z0-9]([-a-z0-9_]*[a-z0-9])?$
++                            type: string
++                        required:
++                        - name
++                        type: object
++                      type: array
++                      x-kubernetes-list-map-keys:
++                      - name
++                      x-kubernetes-list-type: map
+                     image:
+                       description: The image reference
+                       type: string
+@@ -8541,7 +8795,7 @@ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+   annotations:
+-    controller-gen.kubebuilder.io/version: v0.20.0
++    controller-gen.kubebuilder.io/version: v0.20.1
+     helm.sh/resource-policy: keep
+   name: poolers.postgresql.cnpg.io
+ spec:
+@@ -17910,7 +18164,7 @@ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+   annotations:
+-    controller-gen.kubebuilder.io/version: v0.20.0
++    controller-gen.kubebuilder.io/version: v0.20.1
+     helm.sh/resource-policy: keep
+   name: publications.postgresql.cnpg.io
+ spec:
+@@ -18106,7 +18360,7 @@ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+   annotations:
+-    controller-gen.kubebuilder.io/version: v0.20.0
++    controller-gen.kubebuilder.io/version: v0.20.1
+     helm.sh/resource-policy: keep
+   name: scheduledbackups.postgresql.cnpg.io
+ spec:
+@@ -18298,7 +18552,7 @@ apiVersion: apiextensions.k8s.io/v1
+ kind: CustomResourceDefinition
+ metadata:
+   annotations:
+-    controller-gen.kubebuilder.io/version: v0.20.0
++    controller-gen.kubebuilder.io/version: v0.20.1
+     helm.sh/resource-policy: keep
+   name: subscriptions.postgresql.cnpg.io
+ spec:

--- a/packages/system/postgres-operator/tests/cnpg-version_test.yaml
+++ b/packages/system/postgres-operator/tests/cnpg-version_test.yaml
@@ -1,0 +1,38 @@
+suite: CNPG operator and CRDs stay aligned
+
+templates:
+  - charts/cloudnative-pg/templates/deployment.yaml
+  - charts/cloudnative-pg/templates/rbac.yaml
+  - charts/cloudnative-pg/templates/config.yaml
+  - charts/cloudnative-pg/templates/monitoring-configmap.yaml
+  - charts/cloudnative-pg/templates/crds/crds.yaml
+
+release:
+  name: postgres-operator
+  namespace: cozy-postgres-operator
+
+tests:
+  - it: runs the CNPG 1.28.2 operator image
+    template: charts/cloudnative-pg/templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.2
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: ghcr.io/cloudnative-pg/cloudnative-pg:1.28.2
+      - equal:
+          path: metadata.labels["app.kubernetes.io/version"]
+          value: 1.28.2
+
+  - it: ships the CNPG 1.28.2 CRDs patched in lockstep with the operator
+    template: charts/cloudnative-pg/templates/crds/crds.yaml
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations["controller-gen.kubebuilder.io/version"]
+          value: v0.20.1
+      - documentIndex: 0
+        equal:
+          path: spec.versions[0].schema.openAPIV3Schema.properties.status.properties.instanceID.properties.sessionID.type
+          value: string

--- a/packages/system/postgres-operator/values.yaml
+++ b/packages/system/postgres-operator/values.yaml
@@ -1,13 +1,17 @@
 cloudnative-pg:
   crds:
     create: true
-  # Image tag intentionally left to the chart's appVersion (1.28.1). Do NOT pin
-  # image.tag to a version the vendored chart's CRDs don't match: an operator
-  # newer than its CRDs writes status fields the CRD prunes (e.g.
-  # status.instanceID.sessionID, added in CNPG 1.27.3), which makes the operator
-  # believe the instance manager restarted and fail EVERY backup cluster-wide
-  # ("instance manager was restarted during backup"). Bump the chart version in
-  # the Makefile to move the operator + CRDs together.
+  # The vendored chart is 0.27.1 (appVersion 1.28.1). patches/cloudnative-pg-1.28.2.patch,
+  # applied by `make update`, raises the operator image AND its CRDs together to 1.28.2 for the
+  # PVC resize-deadlock fix (cloudnative-pg#9980 / #9981), which ships in the 1.28.2 operator
+  # binary. Upstream publishes a chart only per minor .0/.1, so there is no 1.28.2 chart to bump
+  # to on the 1.28 line without jumping a minor - hence the patch keeps operator and CRDs aligned.
+  #
+  # Do NOT pin image.tag here: the tag follows the chart's appVersion, so operator and CRDs stay
+  # in lockstep. Pinning image.tag to a version the CRDs do not match makes the operator write
+  # status fields the CRD prunes (e.g. status.instanceID.sessionID, added in CNPG 1.27.3),
+  # failing every backup cluster-wide. To move the operator + CRDs, edit the patch (or bump the
+  # chart version in the Makefile).
 
 # CloudNativePG Barman Cloud Plugin (github.com/cloudnative-pg/plugin-barman-cloud).
 # Native spec.backup.barmanObjectStore is deprecated in CNPG 1.27 and removed in 1.29,


### PR DESCRIPTION
## What this PR does

Raises the CloudNativePG operator image **and its CRDs together** to 1.28.2, which carries the PVC resize-deadlock fix (cloudnative-pg#9980 / cloudnative-pg#9981). Symptom: after a simultaneous `resources` + `size` change on a single-instance Postgres, the operator deletes the sole primary Pod, classifies the PVC as `resizing`, and never recreates the Pod — the cluster wedges with zero instances and the disk FS resize never completes.

Upstream publishes a CloudNativePG chart only per minor (`.0`/`.1`), so there is no 1.28.2 chart on the 1.28 line. Following the pattern of #3526 / #3528, `patches/cloudnative-pg-1.28.2.patch` (applied by `make update`) raises the vendored chart's `appVersion` and CRDs from 1.28.1 to 1.28.2 in lockstep. The operator image follows `appVersion`, so there is no `image.tag` pin (keeping operator and CRDs aligned and avoiding #3479).

Verified #3479-safe: there are no CRD `status` field changes between 1.28.1 and 1.28.2 — only the `extensions` spec grows. Backportable to release-1.6 as-is (same 0.27.1 base chart).

### Release note

```release-note
fix(postgres-operator): align CloudNativePG operator and CRDs to 1.28.2, fixing the PVC resize-deadlock that wedged single-instance PostgreSQL clusters after a simultaneous resources+size change
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for PostgreSQL extension configuration in catalog and cluster schemas.
  - Made extension image settings optional where appropriate.

- **Bug Fixes**
  - Updated CloudNativePG to version 1.28.2, including the PVC resize deadlock fix.
  - Kept the operator image and CRDs aligned at the same version.

- **Documentation**
  - Clarified versioning and chart update guidance.

- **Tests**
  - Added checks confirming operator image and CRD version alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->