### PR TITLE
[Backport release-1.6] fix(ci): overlay images from the PR base branch, and publish per-line artifacts

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -1,0 +1,116 @@
+name: Build release line
+
+# Publishes the per-line equivalent of what build-main.yaml publishes for main:
+# every image tagged with the line's branch name, and the whole packages tree as
+# the `cozystack-packages:<branch>` OCI artifact with each image reference
+# digest-pinned to the images this run just pushed (`make build` ->
+# packages/core/installer image-packages does the `flux push artifact`).
+#
+# Why it exists: pull-requests.yaml overlays image refs for every package a PR
+# did NOT rebuild, so that e2e and the installer do not test last-release images
+# for everything outside the PR's build matrix. That overlay had only
+# `cozystack-packages:main` to read, which meant a release-line PR was handed
+# MAIN's binaries to run against its own line's charts — a cross-generation mix
+# that failed deterministically (see #3437: main's cozystack-controller served an
+# aggregated OpenAPI release-1.6's charts could not validate against). With this
+# artifact published per line, the overlay reads the PR's own base branch and the
+# generations match.
+#
+# Cost: one full `make build` per push to a maintained line, i.e. per merged
+# backport. That is the price of release-line PRs testing their line's tip rather
+# than its last release.
+
+env:
+  # Same per-CI registry as pull-requests.yaml and build-main.yaml.
+  REGISTRY: iad.ocir.io/idyksih5sir9/cozystack
+
+on:
+  push:
+    # Maintained LINE branches only: `release-<major>.<minor>`. The `+` quantifies
+    # the preceding character class, and `.` is literal, so this matches
+    # release-1.6 but NOT the per-release staging branches promote-rc.yaml creates
+    # (release-1.6.1) nor rc staging branches (release-1.6.0-rc.4) — building
+    # those would be pure waste, since their images are built by tags.yaml.
+    branches: ['release-[0-9]+.[0-9]+']
+    paths-ignore:
+      - 'docs/**'
+
+# Per line: a newer push to the same line supersedes an in-flight build, but
+# different lines build independently.
+concurrency:
+  group: build-release-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-line:
+    name: Build ${{ github.ref_name }} images and packages artifact
+    runs-on: oracle-vm-24cpu-96gb-x86-64
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          # This workflow holds packages:write and an OCIR push token; it never
+          # pushes git, so don't leave the checkout's GITHUB_TOKEN in .git/config
+          # where a later build step could read it.
+          persist-credentials: false
+
+      # Ephemeral runners lack the flux CLI the installer's image-packages step
+      # shells out to; install if absent (idempotent).
+      - name: Set up build toolchain
+        run: |
+          command -v flux >/dev/null \
+            || curl -fsSL https://fluxcd.io/install.sh | sudo bash
+
+      - name: Set up Docker config
+        run: |
+          if [ -d ~/.docker ]; then
+            cp -r ~/.docker "${{ runner.temp }}/.docker"
+          fi
+
+      - name: Login to OCIR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.OCIR_USER }}
+          password: ${{ secrets.OCIR_TOKEN }}
+          registry: iad.ocir.io
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
+
+      # Same isolated buildkit as build-main.yaml, so a line build never contends
+      # with PR builds on the shared embedded builder.
+      - name: Set up Buildx (docker-container driver)
+        id: buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        with:
+          driver: docker-container
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
+
+      - name: Build line images and publish the packages artifact
+        run: make build
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
+          BUILDER: ${{ steps.buildx.outputs.name }}
+          # READ the shared mode=max cache, never write it. CACHE_REGISTRY/<img>:
+          # buildcache is a single ref per image and build-main.yaml is
+          # deliberately its only writer, serialized, precisely so concurrent
+          # builds cannot race on the cache manifest (the 409 collision class
+          # #2711 fixed for image tags). A line build can overlap a main build, so
+          # writing here would reintroduce exactly that race.
+          WRITE_CACHE: '0'
+          # Floating per-line handle: images and the packages artifact both land
+          # under the branch name (e.g. :release-1.6). Versioned and :latest tags
+          # belong to releases (tags.yaml / finalize), never to this workflow.
+          IMAGE_TAG: ${{ github.ref_name }}
+          PUBLISH_VERSIONED: '0'
+          PUBLISH_FLOATING: '0'

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -378,36 +378,49 @@ jobs:
       # (build-main not yet green) is a no-op: packages keep their committed
       # refs (prior behaviour). See hack/overlay-main-images.sh.
       #
-      # ONLY for PRs based on main. On a release-line PR the committed refs are
-      # not stale — they are that line's released digests, which is exactly what
-      # its charts are written against. Overlaying main's images there deploys
-      # main's binaries onto a release branch's charts, and the mismatch grows
-      # with every commit main gains: #3437 (a one-line change on release-1.6)
-      # failed install deterministically because main's cozystack-controller
-      # served an aggregated OpenAPI its charts could not validate against
-      # (`unknown model in reference: …v1alpha1.OptionSpec`), which reads as a
-      # broken PR while nothing in the PR is broken. Retargeting the overlay at a
-      # per-line artifact is not possible today: build-main.yaml publishes only
-      # cozystack-packages:main, with no release-* equivalent.
-      - name: Pull current-main packages tree
-        if: github.base_ref == 'main'
+      # Read the artifact for the PR's OWN base branch, not always main. Overlaying
+      # main's images onto a release-line PR mixes generations: main's binaries
+      # against that line's charts. #3437 (a one-line change on release-1.6) failed
+      # install deterministically that way, because main's cozystack-controller
+      # served an aggregated OpenAPI release-1.6's charts could not validate
+      # against (`unknown model in reference: …v1alpha1.OptionSpec`) — a broken
+      # lane reading as a broken PR. build-release.yaml publishes
+      # cozystack-packages:<line> for every maintained release-<major>.<minor>
+      # branch, so each base branch has its own artifact to read.
+      #
+      # A missing artifact stays a no-op (packages keep their committed refs), which
+      # also covers a line whose first build-release run has not landed yet.
+      - name: Pull base-branch packages tree
         run: |
           rm -rf _out/mainpkgs
           mkdir -p _out/mainpkgs
-          flux pull artifact "oci://${REGISTRY}/cozystack-packages:main" \
-            --output _out/mainpkgs \
-            || { echo "cozystack-packages:main pull failed — keeping committed refs"; rm -rf _out/mainpkgs; }
+          if ! flux pull artifact "oci://${REGISTRY}/cozystack-packages:${BASE_REF}" \
+                 --output _out/mainpkgs; then
+            rm -rf _out/mainpkgs
+            # Degrading to committed refs is safe, but SAY so: on a release line a
+            # missing artifact means build-release.yaml has not published this line
+            # yet (first build pending, or its branch filter does not match this
+            # branch), and the PR is then testing the line's last release instead of
+            # its tip. Silent would look identical to a working overlay.
+            if [ "${BASE_REF}" = "main" ]; then
+              echo "cozystack-packages:${BASE_REF} pull failed — keeping committed refs"
+            else
+              echo "::warning title=No packages artifact for ${BASE_REF}::Keeping committed refs, so unbuilt packages use this line's last release rather than its tip. Check that build-release.yaml has run for ${BASE_REF}."
+            fi
+          fi
         env:
           DOCKER_CONFIG: ${{ runner.temp }}/.docker
-      - name: Overlay current-main refs for unbuilt packages
+          # Env-passed, not interpolated into the script: base_ref is repo-controlled
+          # here (a branch name in this repo), but the workflow-injection hygiene
+          # applies uniformly.
+          BASE_REF: ${{ github.base_ref }}
+      - name: Overlay base-branch refs for unbuilt packages
         # Best-effort: this only improves WHICH images e2e and the installer use,
         # so an unexpected failure must degrade to the committed refs (prior
         # behaviour), never block the PR. overlay-main-images.sh already handles
-        # the expected paths (missing artifact, drift, absent unit) internally.
-        # Guarded on the base branch for the same reason as the pull above; the
-        # script would treat the absent artifact as a no-op anyway, but a
-        # release-line PR should not depend on that to avoid main's images.
-        if: github.base_ref == 'main'
+        # the expected paths (missing artifact, drift, absent unit) internally —
+        # including the empty directory the step above leaves when a line has no
+        # artifact yet.
         run: |
           hack/overlay-main-images.sh _out/mainpkgs "$BUILD_MATRIX" "$PR_TOUCHED" \
             || echo "::warning::overlay-main-images failed; unbuilt packages keep committed refs"

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -377,7 +377,20 @@ jobs:
       # pr.patch e2e applies — already reflect the overlay. A missing artifact
       # (build-main not yet green) is a no-op: packages keep their committed
       # refs (prior behaviour). See hack/overlay-main-images.sh.
+      #
+      # ONLY for PRs based on main. On a release-line PR the committed refs are
+      # not stale — they are that line's released digests, which is exactly what
+      # its charts are written against. Overlaying main's images there deploys
+      # main's binaries onto a release branch's charts, and the mismatch grows
+      # with every commit main gains: #3437 (a one-line change on release-1.6)
+      # failed install deterministically because main's cozystack-controller
+      # served an aggregated OpenAPI its charts could not validate against
+      # (`unknown model in reference: …v1alpha1.OptionSpec`), which reads as a
+      # broken PR while nothing in the PR is broken. Retargeting the overlay at a
+      # per-line artifact is not possible today: build-main.yaml publishes only
+      # cozystack-packages:main, with no release-* equivalent.
       - name: Pull current-main packages tree
+        if: github.base_ref == 'main'
         run: |
           rm -rf _out/mainpkgs
           mkdir -p _out/mainpkgs
@@ -391,6 +404,10 @@ jobs:
         # so an unexpected failure must degrade to the committed refs (prior
         # behaviour), never block the PR. overlay-main-images.sh already handles
         # the expected paths (missing artifact, drift, absent unit) internally.
+        # Guarded on the base branch for the same reason as the pull above; the
+        # script would treat the absent artifact as a no-op anyway, but a
+        # release-line PR should not depend on that to avoid main's images.
+        if: github.base_ref == 'main'
         run: |
           hack/overlay-main-images.sh _out/mainpkgs "$BUILD_MATRIX" "$PR_TOUCHED" \
             || echo "::warning::overlay-main-images failed; unbuilt packages keep committed refs"

--- a/hack/overlay-main-images_test.bats
+++ b/hack/overlay-main-images_test.bats
@@ -149,30 +149,70 @@
 }
 
 # ── workflow wiring ─────────────────────────────────────────────────────────
-# The script is only half the mechanism; WHEN the workflow invokes it decides
-# which branch's images a PR gets. Both steps must be gated on the base branch,
-# so a release-line PR keeps that line's committed digests instead of running
-# main's binaries against its charts.
+# The script is only half the mechanism; WHICH artifact the workflow hands it
+# decides which generation of images a PR gets. A release-line PR must read its
+# own line's artifact — reading main's puts main's binaries against that line's
+# charts, which failed install deterministically (#3437).
 
-@test "the overlay steps are gated on a main base branch" {
+@test "the overlay reads the artifact for the PR's own base branch" {
   root=$(pwd)
   wf="$root/.github/workflows/pull-requests.yaml"
   [ -f "$wf" ]
 
-  # Executable lines only: a commented-out guard must not satisfy this.
+  # Executable lines only: a comment mentioning the tag must not satisfy this.
   code="$(grep -v '^[[:space:]]*#' "$wf")"
 
-  # Each overlay step name must be followed by the base-branch guard before the
-  # step's `run:` — assert per step, so adding a third unguarded step is caught.
-  for step in "Pull current-main packages tree" "Overlay current-main refs for unbuilt packages"; do
-    block="$(printf '%s\n' "$code" | awk -v s="      - name: $step" '
-      $0 == s { inside = 1; next }
-      /^      - name: / { inside = 0 }
-      inside')"
-    [ -n "$block" ] || { echo "step not found in $wf: $step" >&2; exit 1; }
-    printf '%s\n' "$block" | grep -qF "if: github.base_ref == 'main'" || {
-      echo "step '$step' is not gated on the base branch; a release-line PR would" >&2
-      echo "get main's images overlaid onto that line's charts." >&2
-      exit 1; }
-  done
+  block="$(printf '%s\n' "$code" | awk '
+    $0 == "      - name: Pull base-branch packages tree" { inside = 1; next }
+    /^      - name: / { inside = 0 }
+    inside')"
+  [ -n "$block" ] || { echo "the base-branch packages pull step is missing from $wf" >&2; exit 1; }
+
+  # The artifact tag must come from the base branch, passed via env.
+  printf '%s\n' "$block" | grep -qF 'cozystack-packages:${BASE_REF}' || {
+    echo "the packages artifact tag is not the PR's base branch. Reading a fixed" >&2
+    echo "tag (e.g. :main) hands a release-line PR another generation's images." >&2
+    exit 1; }
+  printf '%s\n' "$block" | grep -qF 'BASE_REF: ${{ github.base_ref }}' || {
+    echo "BASE_REF is not wired to github.base_ref in the pull step's env." >&2; exit 1; }
+
+  # A hardcoded :main anywhere in the two overlay steps defeats the point.
+  overlay="$(printf '%s\n' "$code" | awk '
+    $0 == "      - name: Overlay base-branch refs for unbuilt packages" { inside = 1; next }
+    /^      - name: / { inside = 0 }
+    inside')"
+  [ -n "$overlay" ] || { echo "the overlay step is missing from $wf" >&2; exit 1; }
+  printf '%s\n%s\n' "$block" "$overlay" | grep -qF 'cozystack-packages:main' && {
+    echo "an overlay step still pins cozystack-packages:main" >&2; exit 1; }
+  return 0
+}
+
+@test "every maintained release line publishes its own packages artifact" {
+  root=$(pwd)
+  wf="$root/.github/workflows/build-release.yaml"
+  [ -f "$wf" ] || {
+    echo "build-release.yaml is missing: without a per-line artifact the overlay" >&2
+    echo "above degrades to a no-op on release branches, so their PRs test the" >&2
+    echo "line's last release rather than its tip." >&2
+    exit 1; }
+
+  code="$(grep -v '^[[:space:]]*#' "$wf")"
+
+  # Line branches only. The per-release and rc staging branches promote-rc.yaml
+  # and tags.yaml create (release-1.6.1, release-1.6.0-rc.4) must NOT trigger a
+  # full rebuild — their images come from the tag build.
+  printf '%s\n' "$code" | grep -qF "branches: ['release-[0-9]+.[0-9]+']" || {
+    echo "build-release.yaml does not restrict its trigger to release-<major>.<minor>" >&2; exit 1; }
+
+  # The artifact and image tag must be the branch, or the overlay cannot find it.
+  printf '%s\n' "$code" | grep -qF 'IMAGE_TAG: ${{ github.ref_name }}' || {
+    echo "build-release.yaml does not tag images/artifact with the branch name" >&2; exit 1; }
+
+  # It must not write the shared mode=max cache: that ref has exactly one
+  # serialized writer (build-main.yaml) so concurrent builds cannot race on the
+  # cache manifest. A line build can overlap a main build.
+  printf '%s\n' "$code" | grep -qF "WRITE_CACHE: '0'" || {
+    echo "build-release.yaml must set WRITE_CACHE: '0' — writing the shared" >&2
+    echo ":buildcache ref races build-main.yaml on the cache manifest." >&2
+    exit 1; }
 }

--- a/hack/overlay-main-images_test.bats
+++ b/hack/overlay-main-images_test.bats
@@ -147,3 +147,32 @@
   grep -q 'present:main@sha256:bbbb' packages/apps/present/images/present.tag
   [ ! -e packages/apps/ghost/images/ghost.tag ]
 }
+
+# ── workflow wiring ─────────────────────────────────────────────────────────
+# The script is only half the mechanism; WHEN the workflow invokes it decides
+# which branch's images a PR gets. Both steps must be gated on the base branch,
+# so a release-line PR keeps that line's committed digests instead of running
+# main's binaries against its charts.
+
+@test "the overlay steps are gated on a main base branch" {
+  root=$(pwd)
+  wf="$root/.github/workflows/pull-requests.yaml"
+  [ -f "$wf" ]
+
+  # Executable lines only: a commented-out guard must not satisfy this.
+  code="$(grep -v '^[[:space:]]*#' "$wf")"
+
+  # Each overlay step name must be followed by the base-branch guard before the
+  # step's `run:` — assert per step, so adding a third unguarded step is caught.
+  for step in "Pull current-main packages tree" "Overlay current-main refs for unbuilt packages"; do
+    block="$(printf '%s\n' "$code" | awk -v s="      - name: $step" '
+      $0 == s { inside = 1; next }
+      /^      - name: / { inside = 0 }
+      inside')"
+    [ -n "$block" ] || { echo "step not found in $wf: $step" >&2; exit 1; }
+    printf '%s\n' "$block" | grep -qF "if: github.base_ref == 'main'" || {
+      echo "step '$step' is not gated on the base branch; a release-line PR would" >&2
+      echo "get main's images overlaid onto that line's charts." >&2
+      exit 1; }
+  done
+}


### PR DESCRIPTION
## What this PR does

Hand backport of #3471 to `release-1.6`. Two clean cherry-picks, each carrying its `-x` reference; the resulting tree is byte-identical to #3471's merged state for all three files.

The overlay must be fixed **on this branch** to have any effect here. For `pull_request` events GitHub builds the workflow from the merge ref, and for `push` events it reads the workflow from the pushed ref — so neither half of #3471 reaches this line while it lives only on `main`. Concretely, `build-release.yaml` on `main` never fires for a push to `release-1.6`, and a `release-1.6` PR keeps using this branch's copy of `pull-requests.yaml`.

## Why the bot could not do this

The automatic backport reported success on every job and opened nothing (run 30817682877). It is not a conflict — #3471 carries an empty commit, `007d0b1a` (`chore(ci): re-trigger CI after a label event produced a no-op run`, zero files). `korthout/backport-action` cherry-picks commit-by-commit without `--allow-empty`, so that commit fails with `The previous cherry-pick is now empty`; the `draft_commit_conflicts` fallback then runs `git commit --all -m BACKPORT-CONFLICT`, which also has nothing to commit, and the action aborts:

```
git cherry-pick -x 007d0b1a22ec1aadca95960645d8232a5b202fcb
The previous cherry-pick is now empty, possibly due to conflict resolution.
git commit --all -m BACKPORT-CONFLICT
The previous cherry-pick is now empty, possibly due to conflict resolution.
git cherry-pick --abort
Backport failed for `release-1.6`, because it was unable to cherry-pick the commit(s).
```

This is a general gap, not specific to this PR: any labelled PR containing an empty commit backports to nothing, and the failure surfaces as three green jobs. Worth a follow-up on the workflow — skipping empty commits, or having the action's failure fail the job — but that is out of scope here.

## What this unblocks

#3437 fails install deterministically on this line today, because the unguarded overlay hands it main's `cozystack-controller` to run against `release-1.6`'s charts. The binary indexes `internal.cozystack.io/v1alpha1 TenantProjection` at startup, this branch ships no such CRD, so it fatals and every release that depends on it stalls. With this merged, the overlay reads `cozystack-packages:release-1.6` instead.

That works even before the first `build-release.yaml` run publishes the artifact: a missing artifact degrades to the committed refs, which on this branch are the v1.6.0 digests its charts are written against. The degraded path is also no longer silent — it emits a warning naming the branch.

#3437 will need a new head commit rather than a re-run, since the finalize job is reused on re-run and its existing `pr.patch` already has main's refs baked in.

## Note on cost

Merging this is itself a push to `release-1.6`, so `build-release.yaml` fires on it and runs a full `make build` (up to 2h on a 24-cpu runner) to publish the line's images and `cozystack-packages:release-1.6`. That recurs per push to this line; `concurrency` with `cancel-in-progress` collapses bursts, and `paths-ignore` only exempts `docs/**`.

## Verification

`hack/overlay-main-images_test.bats` 13/13 green on this branch, including the two wiring tests the backport brings (`the overlay reads the artifact for the PR's own base branch`, `every maintained release line publishes its own packages artifact`). `actionlint` clean on both workflows, and both parse as YAML. `hack/common-envs.mk` is byte-identical between `main` and `release-1.6`, so `IMAGE_TAG`, `WRITE_CACHE`, `PUBLISH_VERSIONED` and `PUBLISH_FLOATING` behave here exactly as they do on main.

### Release note

```release-note
NONE
```
