### PR TITLE
fix(cozy-lib): round the sanitized CPU request up to a whole milli-CPU

### DIFF
--- a/packages/extra/etcd/tests/vpa_test.yaml
+++ b/packages/extra/etcd/tests/vpa_test.yaml
@@ -1,0 +1,39 @@
+suite: etcd VerticalPodAutoscaler bounds
+
+release:
+  name: etcd
+  namespace: tenant-root
+
+templates:
+  - templates/vpa.yaml
+
+tests:
+  - it: brackets the sanitized request with a floor and a ceiling
+    set:
+      _cluster: {}
+    asserts:
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].minAllowed.cpu
+          value: "0.025"
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].maxAllowed.cpu
+          value: "0.5"
+
+  # Regression guard for #3517. minAllowed/maxAllowed are bounds on the
+  # *request* the VPA sets, so they go through cozy-lib.resources.sanitize and
+  # are divided by cpuAllocationRatio like every other request in the chart.
+  # 250m / 4 = 62.5m, which the VPA admission webhook rejects outright
+  # ("MinAllowed: CPU [62500u] must be a whole number of milli CPUs"), leaving
+  # the HelmRelease looping UpgradeFailed -> RollbackFailed forever. The helper
+  # now rounds up to a whole milli-CPU, so any ratio renders a valid quantity.
+  - it: renders whole milli-CPU bounds on a ratio that does not divide 250m
+    set:
+      _cluster:
+        cpu-allocation-ratio: 4
+    asserts:
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].minAllowed.cpu
+          value: 63m
+      - equal:
+          path: spec.resourcePolicy.containerPolicies[0].maxAllowed.cpu
+          value: "1.25"

--- a/packages/extra/etcd/tests/vpa_test.yaml
+++ b/packages/extra/etcd/tests/vpa_test.yaml
@@ -23,7 +23,7 @@ tests:
   # *request* the VPA sets, so they go through cozy-lib.resources.sanitize and
   # are divided by cpuAllocationRatio like every other request in the chart.
   # 250m / 4 = 62.5m, which the VPA admission webhook rejects outright
-  # ("MinAllowed: CPU [62500u] must be a whole number of milli CPUs"), leaving
+  # ("minAllowed: CPU [62500u] must be a whole number of milli CPUs"), leaving
   # the HelmRelease looping UpgradeFailed -> RollbackFailed forever. The helper
   # now rounds up to a whole milli-CPU, so any ratio renders a valid quantity.
   - it: renders whole milli-CPU bounds on a ratio that does not divide 250m

--- a/packages/library/cozy-lib/templates/_resources.tpl
+++ b/packages/library/cozy-lib/templates/_resources.tpl
@@ -110,10 +110,19 @@
         The %.6f round-trip strips binary-float noise (0.25/10*1000 can come
         out as 25.000000000000004) so an exactly divisible value keeps its
         current rendering instead of being bumped to the next milli-CPU.
+        That tolerance has a floor: a request below 0.0000005m normalizes to
+        zero, which would look exactly divisible and render as the raw float
+        (1m / 10000000 came out as "1e-10", not a valid quantity). Any
+        positive request that rounds to zero milli-CPU is therefore clamped to
+        1m, the smallest quantity that is both valid and non-zero. Reaching it
+        takes a ratio above two million, so this guards the arbitrary-ratio
+        contract rather than any realistic configuration.
 */}}
 {{-       $cpuRequestMilli := mulf $cpuRequestF64 1000.0 | printf "%.6f" | float64 }}
 {{-       $cpuRequestMilliCeil := ceil $cpuRequestMilli }}
-{{-       if eq $cpuRequestMilli $cpuRequestMilliCeil }}
+{{-       if and (gt $cpuRequestF64 0.0) (eq $cpuRequestMilliCeil 0.0) }}
+{{-         $_ := set $output.requests $k "1m" }}
+{{-       else if eq $cpuRequestMilli $cpuRequestMilliCeil }}
 {{-         $_ := set $output.requests $k ($cpuRequestF64 | toString) }}
 {{-       else }}
 {{-         $_ := set $output.requests $k (printf "%dm" (int64 $cpuRequestMilliCeil)) }}

--- a/packages/library/cozy-lib/templates/_resources.tpl
+++ b/packages/library/cozy-lib/templates/_resources.tpl
@@ -59,7 +59,9 @@
   A sanitized resource map is a dict with resource-name to resource-quantity.
   All resources are returned with equal **requests** and **limits**, except for
   **cpu**, whose *request* is reduced by the CPU-allocation ratio obtained from
-  `cozy-lib.resources.cpuAllocationRatio`.
+  `cozy-lib.resources.cpuAllocationRatio` and then rounded **up** to a whole
+  number of milli-CPUs (a CPU quantity finer than 1m is invalid for the VPA
+  admission webhook and meaningless for the scheduler).
 
   The template now expects **one flat map** as input (no nested `requests:` /
   `limits:` sections).  Each value in that map is taken as the *limit* for the
@@ -97,7 +99,25 @@
 {{-     if eq $k "cpu" }}
 {{-       $vcpuRequestF64 := (include "cozy-lib.resources.toFloat" $v) | float64 }}
 {{-       $cpuRequestF64 := divf $vcpuRequestF64 $cpuAllocationRatio }}
-{{-       $_ := set $output.requests $k ($cpuRequestF64 | toString) }}
+{{- /*
+        A CPU quantity must be a whole number of milli-CPUs: the VPA admission
+        webhook rejects anything finer ("MinAllowed: CPU [62500u] must be a
+        whole number of milli CPUs"), and a sub-milli request is meaningless
+        anyway. A ratio that does not divide the value evenly produces one:
+        250m / 4 = 62.5m. Round the request up to the next whole milli-CPU so
+        every allocation ratio renders a valid quantity, never below the
+        intended fraction of the limit.
+        The %.6f round-trip strips binary-float noise (0.25/10*1000 can come
+        out as 25.000000000000004) so an exactly divisible value keeps its
+        current rendering instead of being bumped to the next milli-CPU.
+*/}}
+{{-       $cpuRequestMilli := mulf $cpuRequestF64 1000.0 | printf "%.6f" | float64 }}
+{{-       $cpuRequestMilliCeil := ceil $cpuRequestMilli }}
+{{-       if eq $cpuRequestMilli $cpuRequestMilliCeil }}
+{{-         $_ := set $output.requests $k ($cpuRequestF64 | toString) }}
+{{-       else }}
+{{-         $_ := set $output.requests $k (printf "%dm" (int64 $cpuRequestMilliCeil)) }}
+{{-       end }}
 {{-       $_ := set $output.limits $k ($v | toString) }}
 {{-     else if eq $k "memory" }}
 {{-       $vMemoryRequestF64 := (include "cozy-lib.resources.toFloat" $v) | float64 }}

--- a/packages/library/cozy-lib/templates/_resources.tpl
+++ b/packages/library/cozy-lib/templates/_resources.tpl
@@ -64,7 +64,9 @@
   A sanitized resource map is a dict with resource-name to resource-quantity.
   All resources are returned with equal **requests** and **limits**, except for
   **cpu**, whose *request* is reduced by the CPU-allocation ratio obtained from
-  `cozy-lib.resources.cpuAllocationRatio`.
+  `cozy-lib.resources.cpuAllocationRatio` and then rounded **up** to a whole
+  number of milli-CPUs (a CPU quantity finer than 1m is invalid for the VPA
+  admission webhook and meaningless for the scheduler).
 
   The template now expects **one flat map** as input (no nested `requests:` /
   `limits:` sections).  Each value in that map is taken as the *limit* for the
@@ -102,7 +104,25 @@
 {{-     if eq $k "cpu" }}
 {{-       $vcpuRequestF64 := (include "cozy-lib.resources.toFloat" $v) | float64 }}
 {{-       $cpuRequestF64 := divf $vcpuRequestF64 $cpuAllocationRatio }}
-{{-       $_ := set $output.requests $k ($cpuRequestF64 | toString) }}
+{{- /*
+        A CPU quantity must be a whole number of milli-CPUs: the VPA admission
+        webhook rejects anything finer ("MinAllowed: CPU [62500u] must be a
+        whole number of milli CPUs"), and a sub-milli request is meaningless
+        anyway. A ratio that does not divide the value evenly produces one:
+        250m / 4 = 62.5m. Round the request up to the next whole milli-CPU so
+        every allocation ratio renders a valid quantity, never below the
+        intended fraction of the limit.
+        The %.6f round-trip strips binary-float noise (0.25/10*1000 can come
+        out as 25.000000000000004) so an exactly divisible value keeps its
+        current rendering instead of being bumped to the next milli-CPU.
+*/}}
+{{-       $cpuRequestMilli := mulf $cpuRequestF64 1000.0 | printf "%.6f" | float64 }}
+{{-       $cpuRequestMilliCeil := ceil $cpuRequestMilli }}
+{{-       if eq $cpuRequestMilli $cpuRequestMilliCeil }}
+{{-         $_ := set $output.requests $k ($cpuRequestF64 | toString) }}
+{{-       else }}
+{{-         $_ := set $output.requests $k (printf "%dm" (int64 $cpuRequestMilliCeil)) }}
+{{-       end }}
 {{-       $_ := set $output.limits $k ($v | toString) }}
 {{-     else if eq $k "memory" }}
 {{-       $vMemoryRequestF64 := (include "cozy-lib.resources.toFloat" $v) | float64 }}

--- a/packages/library/cozy-lib/templates/_resources.tpl
+++ b/packages/library/cozy-lib/templates/_resources.tpl
@@ -106,17 +106,21 @@
 {{-       $cpuRequestF64 := divf $vcpuRequestF64 $cpuAllocationRatio }}
 {{- /*
         A CPU quantity must be a whole number of milli-CPUs: the VPA admission
-        webhook rejects anything finer ("MinAllowed: CPU [62500u] must be a
+        webhook rejects anything finer ("minAllowed: CPU [62500u] must be a
         whole number of milli CPUs"), and a sub-milli request is meaningless
         anyway. A ratio that does not divide the value evenly produces one:
         250m / 4 = 62.5m. Round the request up to the next whole milli-CPU so
         every allocation ratio renders a valid quantity, never below the
-        intended fraction of the limit.
-        The %.6f round-trip strips binary-float noise (0.25/10*1000 can come
-        out as 25.000000000000004) so an exactly divisible value keeps its
-        current rendering instead of being bumped to the next milli-CPU.
+        intended fraction of the limit. A request whose shortest decimal form
+        is already whole-milli keeps that form, so the default ratio of 10
+        renders exactly as it did before.
+        The comparison needs no tolerance: sprig's divf/mulf run on
+        shopspring/decimal rather than float64, so 250m / 10 * 1000 is exactly
+        25 and not 25.000000000000004. A tolerance would in fact reintroduce
+        the bug it looks like it prevents, by accepting a value such as
+        100.0000004m as whole-milli and rendering it verbatim.
 */}}
-{{-       $cpuRequestMilli := mulf $cpuRequestF64 1000.0 | printf "%.6f" | float64 }}
+{{-       $cpuRequestMilli := mulf $cpuRequestF64 1000.0 | float64 }}
 {{-       $cpuRequestMilliCeil := ceil $cpuRequestMilli }}
 {{-       if eq $cpuRequestMilli $cpuRequestMilliCeil }}
 {{-         $_ := set $output.requests $k ($cpuRequestF64 | toString) }}

--- a/packages/tests/cozy-lib-tests/templates/tests/resources.yaml
+++ b/packages/tests/cozy-lib-tests/templates/tests/resources.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Release.Name }}-resources
+spec:
+  containers:
+  - name: main
+    image: busybox
+    {{- with .Values.resources }}
+    resources: {{- include "cozy-lib.resources.sanitize" (list . $) | nindent 6 }}
+    {{- end }}

--- a/packages/tests/cozy-lib-tests/tests/resources_test.yaml
+++ b/packages/tests/cozy-lib-tests/tests/resources_test.yaml
@@ -42,6 +42,36 @@ tests:
           path: spec.containers[0].resources.requests.cpu
           value: 334m
 
+  # Boundary of the %.6f tolerance: below 0.0000005m the normalized value is
+  # zero, which looks exactly divisible and rendered the raw float ("1e-10"),
+  # not a valid quantity. Clamp to the smallest valid non-zero request instead.
+  - it: clamps a positive request that rounds to zero milli-CPU to 1m
+    set:
+      _cluster:
+        cpu-allocation-ratio: 10000000
+      resources:
+        cpu: 1m
+        memory: 256Mi
+    asserts:
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: 1m
+      - equal:
+          path: spec.containers[0].resources.limits.cpu
+          value: 1m
+
+  - it: leaves a genuinely zero CPU request at zero
+    set:
+      _cluster:
+        cpu-allocation-ratio: 4
+      resources:
+        cpu: 0
+        memory: 256Mi
+    asserts:
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: "0"
+
   - it: keeps the rendering unchanged on the default ratio
     set:
       resources:

--- a/packages/tests/cozy-lib-tests/tests/resources_test.yaml
+++ b/packages/tests/cozy-lib-tests/tests/resources_test.yaml
@@ -1,0 +1,112 @@
+# ./tests/resources_test.yaml
+suite: resources sanitize helper
+
+templates:
+  - templates/tests/resources.yaml
+
+release:
+  name: myrelease
+  namespace: default
+
+tests:
+  # Regression guard for the VPA admission webhook, which rejects a CPU
+  # quantity finer than 1m ("MinAllowed: CPU [62500u] must be a whole number
+  # of milli CPUs"). Before the fix, 250m / 4 rendered as "0.0625" and any
+  # chart feeding a sanitized CPU request to a VerticalPodAutoscaler was stuck
+  # in an UpgradeFailed/RollbackFailed loop on such a ratio.
+  - it: rounds the CPU request up to a whole milli-CPU on an indivisible ratio
+    set:
+      _cluster:
+        cpu-allocation-ratio: 4
+      resources:
+        cpu: 250m
+        memory: 256Mi
+    asserts:
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: 63m
+      - equal:
+          path: spec.containers[0].resources.limits.cpu
+          value: 250m
+
+  - it: rounds up rather than down so the request never drops below the fraction
+    set:
+      _cluster:
+        cpu-allocation-ratio: 3
+      resources:
+        cpu: 1000m
+        memory: 256Mi
+    asserts:
+      # 1000m / 3 = 333.33...m
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: 334m
+
+  - it: keeps the rendering unchanged on the default ratio
+    set:
+      resources:
+        cpu: 250m
+        memory: 256Mi
+    asserts:
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: "0.025"
+      - equal:
+          path: spec.containers[0].resources.limits.cpu
+          value: 250m
+
+  - it: keeps the rendering unchanged when a non-default ratio divides evenly
+    set:
+      _cluster:
+        cpu-allocation-ratio: 4
+      resources:
+        cpu: 1000m
+        memory: 256Mi
+    asserts:
+      # 1000m / 4 = 250m exactly, so no rounding and no re-formatting
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: "0.25"
+
+  # 700m / 1 is 699.9999999999999m in binary floating point. Without the
+  # %.6f round-trip in the helper, ceil() would bump it to 700m and change the
+  # rendered value of an exactly divisible request.
+  - it: does not let binary-float noise bump an exact value to the next milli
+    set:
+      _cluster:
+        cpu-allocation-ratio: 1
+      resources:
+        cpu: 700m
+        memory: 256Mi
+    asserts:
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: "0.7"
+
+  - it: never renders a sub-milli CPU request
+    set:
+      _cluster:
+        cpu-allocation-ratio: 10
+      resources:
+        cpu: 1m
+        memory: 256Mi
+    asserts:
+      # 1m / 10 = 0.1m, which is not a representable CPU quantity
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: 1m
+
+  - it: leaves memory requests untouched
+    set:
+      _cluster:
+        cpu-allocation-ratio: 4
+      resources:
+        cpu: 250m
+        memory: 256Mi
+    asserts:
+      - equal:
+          path: spec.containers[0].resources.requests.memory
+          value: "268435456"
+      - equal:
+          path: spec.containers[0].resources.limits.memory
+          value: 256Mi

--- a/packages/tests/cozy-lib-tests/tests/resources_test.yaml
+++ b/packages/tests/cozy-lib-tests/tests/resources_test.yaml
@@ -10,7 +10,7 @@ release:
 
 tests:
   # Regression guard for the VPA admission webhook, which rejects a CPU
-  # quantity finer than 1m ("MinAllowed: CPU [62500u] must be a whole number
+  # quantity finer than 1m ("minAllowed: CPU [62500u] must be a whole number
   # of milli CPUs"). Before the fix, 250m / 4 rendered as "0.0625" and any
   # chart feeding a sanitized CPU request to a VerticalPodAutoscaler was stuck
   # in an UpgradeFailed/RollbackFailed loop on such a ratio.
@@ -42,6 +42,37 @@ tests:
           path: spec.containers[0].resources.requests.cpu
           value: 334m
 
+  # Extreme end of the arbitrary-ratio contract: 1m / 10000000 is 0.0000001m,
+  # which the exact-value branch would render as the raw float "1e-10", not a
+  # valid quantity. ceil() carries any positive sub-milli request to 1m, the
+  # smallest request that is both valid and non-zero.
+  - it: renders a positive request below 1m as 1m at an extreme ratio
+    set:
+      _cluster:
+        cpu-allocation-ratio: 10000000
+      resources:
+        cpu: 1m
+        memory: 256Mi
+    asserts:
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: 1m
+      - equal:
+          path: spec.containers[0].resources.limits.cpu
+          value: 1m
+
+  - it: leaves a genuinely zero CPU request at zero
+    set:
+      _cluster:
+        cpu-allocation-ratio: 4
+      resources:
+        cpu: 0
+        memory: 256Mi
+    asserts:
+      - equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: "0"
+
   - it: keeps the rendering unchanged on the default ratio
     set:
       resources:
@@ -68,20 +99,21 @@ tests:
           path: spec.containers[0].resources.requests.cpu
           value: "0.25"
 
-  # 700m / 1 is 699.9999999999999m in binary floating point. Without the
-  # %.6f round-trip in the helper, ceil() would bump it to 700m and change the
-  # rendered value of an exactly divisible request.
-  - it: does not let binary-float noise bump an exact value to the next milli
+  # The helper must not smooth the value before deciding whether it is already
+  # whole-milli. A tolerance of 1e-6 milli-CPU (the %.6f round-trip this fix
+  # originally carried) reads 100.0000004m as exact and renders it verbatim as
+  # "0.1000000004", the very quantity the webhook rejects.
+  - it: rounds up a value that is whole-milli only to within a tolerance
     set:
       _cluster:
         cpu-allocation-ratio: 1
       resources:
-        cpu: 700m
+        cpu: 100.0000004m
         memory: 256Mi
     asserts:
       - equal:
           path: spec.containers[0].resources.requests.cpu
-          value: "0.7"
+          value: 101m
 
   - it: never renders a sub-milli CPU request
     set:


### PR DESCRIPTION
## What this PR does

Fixes #3517.

`cozy-lib.resources.sanitize` divides the CPU limit by `cpuAllocationRatio` and rendered the quotient as a bare float. When the ratio does not divide the value evenly the result is finer than a milli-CPU, and the VPA admission webhook rejects the object outright:

```
admission webhook "vpa.k8s.io" denied the request:
minAllowed: CPU [62500u] must be a whole number of milli CPUs
```

`packages/extra/etcd/templates/vpa.yaml` routes its VPA `minAllowed`/`maxAllowed` through the helper, so with `cpuAllocationRatio: 4` its floor renders as `250m / 4 = 62.5m` and the `etcd` HelmRelease loops `UpgradeFailed` → `RollbackFailed` forever: the rollback target renders the same invalid value. Since v1.6.0 HelmReleases wait on each other, so that one stuck app also blocks `tenant-root` → `cozystack-basics` → `kubevirt-cdi-operator`, and without CDI the Talos worker rollover cannot import the worker OS image. Only the divisors of 250 worked as ratios, which is an artefact of one chart's hardcoded `250m` floor rather than a real constraint on the operator.

- `packages/library/cozy-lib/templates/_resources.tpl`: round the sanitized CPU request **up** to the next whole milli-CPU. Up, never down, so the request stays at or above the intended fraction of the limit. And only when rounding is actually needed: an exactly divisible value keeps its current float rendering, so nothing changes on the default ratio.
- The whole-milli test is exact, with no tolerance around it. sprig's `divf`/`mulf` run on `shopspring/decimal` rather than float64, so `mulf (divf 0.25 10.0) 1000.0` renders exactly `25` in Helm and there is no binary-float noise on this codepath to smooth over. A tolerance would in fact reintroduce the bug: a value that is whole-milli only to within `5e-7` would read as exact and render verbatim, so `cpu: 100.0000004m` at ratio 1 would render `0.1000000004`, rejected for the same reason `62.5m` is. There is a test for that case.
- `packages/tests/cozy-lib-tests/`: new `resources` template plus a `resources_test.yaml` suite covering the indivisible ratio, the round-up direction, the two unchanged-rendering cases, a whole-milli-only-within-a-tolerance value, sub-milli input at an ordinary and at an extreme ratio, a genuinely zero request, and that memory is untouched.
- `packages/extra/etcd/tests/vpa_test.yaml`: regression guard asserting the chart's rendered VPA `minAllowed.cpu` is a whole milli-CPU (`63m`) with `cpu-allocation-ratio: 4`, and that the default ratio still renders `0.025` / `0.5`.

### Why in `sanitize` and not in the etcd chart

The issue also suggests taking `minAllowed`/`maxAllowed` out of `sanitize` in the etcd chart, on the grounds that VPA policy bounds are not workload requests. I looked at that first and it is the wrong fix here:

- `minAllowed`/`maxAllowed` bound the **request** the VPA writes, and in Cozystack every request is `limit / cpuAllocationRatio` — `packages/extra/etcd/templates/etcd-cluster.yaml` sanitizes `.Values.resources` the same way. On the default ratio the etcd request is `1000m / 10 = 100m`, bracketed by `minAllowed 25m` and `maxAllowed 500m`. Dropping `sanitize` would make the floor a literal `250m`, i.e. **10x** the intended request floor, and let the ceiling reach `5000m`. It would also change rendered output on the default ratio, for every existing cluster.
- It fixes one chart. The same helper feeds every app's requests, and at `cpuAllocationRatio: 4` seven other charts (`http-cache`, `mariadb`, `nats`, `rabbitmq`, `redis`, `tcp-balancer`, `valkey` — all from the `250m` nano presets) also render `cpu: "0.0625"`. Those go into pod requests rather than a VPA object so they are not rejected, but they are still not quantities we should be emitting.
- No other chart routes `minAllowed` through `sanitize`, so there is no consistency argument either way: the other VPA templates (`etcd-operator`, `monitoring`, `monitoring-agents`, `vpa-for-vpa`) use hand-picked literals in system charts where no allocation ratio applies.

### How it was validated

- `hack/helm-unit-tests.sh`, full run: 81 packages green, before and after. The only difference between the two runs is the two new suites appearing as `PASS`; no existing suite changed status.
- Both new suites were confirmed to **fail** against `main`'s helper (5 tests in `resources_test.yaml`, 1 in the etcd `vpa_test.yaml`), so they guard the regression rather than merely describing the new behaviour.
- Breadth of the bug: over the 905000 combinations of a whole-milli limit `1m`..`1000m` against an integer ratio `1`..`905`, `main` renders a quantity finer than 1m for **898026** of them (99.2%) and this branch for **none**.
- Rendered-output check on the default ratio: `helm template` over all 164 chart directories under `packages/{apps,extra,system,core}`, before and after, byte-diffed. 129 render standalone; all 129 are identical apart from 8 whose diff is only their per-render random secrets and self-signed certs (no `cpu` line differs in any of them).
- Same sweep with `--set _cluster.cpu-allocation-ratio=4`: `main` emits 11 sub-milli `cpu: "0.0625"` requests across 7 charts, this branch emits **0**.
- The quoted webhook error was checked against the VPA we actually ship (1.5.1): `pkg/admission-controller/resource/vpa/handler.go` wraps the quantity error as lowercase `minAllowed:`/`maxAllowed:`, and `62.5m` canonicalises to `62500u`.
- Not verified: nothing from this branch was applied to a live cluster, so the end of the chain (the webhook accepting the object, the etcd HelmRelease converging, CDI unblocking) is inferred from the rendered manifests and the webhook's own error message, not observed.

### Screenshots

Not applicable, no UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff. The diff is one Helm library template plus test files: no package added, renamed or removed; no `values.yaml`, `values.schema.json`, version enum or default changed; no `ApplicationDefinition`, CRD, namespace, `hack/` file, package layout or release asset touched. The terraform provider restates app defaults, but no default moves here — the rendered value only changes for a non-default `cpuAllocationRatio`, which the provider does not model.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(cozy-lib): round the sanitized CPU request up to a whole milli-CPU. A `cpuAllocationRatio` that does not divide a chart's CPU value evenly (for example `4` against the `250m` VPA floor of the etcd chart) produced a quantity finer than 1m, which the VPA admission webhook rejects, leaving the etcd HelmRelease looping UpgradeFailed/RollbackFailed and — since v1.6.0, where HelmReleases wait on each other — blocking tenant-root, cozystack-basics and CDI behind it. Any allocation ratio now renders a valid quantity; rendering is unchanged whenever the ratio divides evenly, including on the default ratio of 10.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - CPU resource requests are now sanitized to avoid floating-point precision issues.
  - Fractional milli-CPU requests are rounded up to the nearest whole milli-CPU, with positive sub-milli requests clamped to `1m`.
  - Exact and zero CPU values remain unchanged.
  - CPU limits and memory requests continue to be preserved without modification.

- **Documentation**
  - Updated resource guidance to describe CPU request rounding behavior.

- **Tests**
  - Added coverage for allocation ratios, default bounds, rounding, precision, and resource preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
