### PR TITLE
fix(backupstrategy-controller): repair lookup-gated backup objects

### DIFF
--- a/cmd/backupstrategy-controller/main.go
+++ b/cmd/backupstrategy-controller/main.go
@@ -27,6 +27,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -199,6 +200,29 @@ func main() {
 	if systemNamespaces := os.Getenv("BACKUP_STORAGE_SYSTEM_NAMESPACES"); systemNamespaces != "" {
 		if err := mgr.Add(backupcontroller.NewSystemCredentialsProjector(mgr.GetClient(), credentialsConfig, systemNamespaces, 0)); err != nil {
 			setupLog.Error(err, "unable to add SystemCredentialsProjector runnable")
+			os.Exit(1)
+		}
+	}
+
+	// The default Strategy CRs and the Velero BSL are Helm-templated behind
+	// a lookup of the BucketClaim the same chart creates, so a fresh install
+	// renders them empty — permanently, because helm-controller does not
+	// re-render an unchanged, successful release. The gate detects that and
+	// forces the one real Helm upgrade that materialises them. Disabled when
+	// the HelmRelease coordinates are not plumbed (e.g. a chart-less local run).
+	if hrName := os.Getenv("BACKUP_DEFAULT_OBJECTS_HELMRELEASE_NAME"); hrName != "" {
+		gate := &backupcontroller.DefaultObjectsGate{
+			Client:          mgr.GetClient(),
+			Config:          credentialsConfig,
+			BackupClassName: os.Getenv("BACKUP_DEFAULT_OBJECTS_BACKUPCLASS"),
+			HelmRelease: types.NamespacedName{
+				Namespace: os.Getenv("BACKUP_DEFAULT_OBJECTS_HELMRELEASE_NAMESPACE"),
+				Name:      hrName,
+			},
+			VeleroNamespace: os.Getenv("BACKUP_DEFAULT_OBJECTS_VELERO_NAMESPACE"),
+		}
+		if err := gate.SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to add DefaultObjectsGate runnable")
 			os.Exit(1)
 		}
 	}

--- a/cmd/backupstrategy-controller/main.go
+++ b/cmd/backupstrategy-controller/main.go
@@ -220,6 +220,16 @@ func main() {
 				Name:      hrName,
 			},
 			VeleroNamespace: os.Getenv("BACKUP_DEFAULT_OBJECTS_VELERO_NAMESPACE"),
+			// The platform bucket's <bucket>-system release renders the
+			// credentials Secret the projector reads, behind the same kind
+			// of install-time lookup — and while that Secret is missing
+			// nothing downstream can resolve. Empty when the bucket is not
+			// provisioned by Cozystack (external S3), where the Secret is
+			// admin-managed and no release renders it.
+			CredentialsHelmRelease: types.NamespacedName{
+				Namespace: os.Getenv("BACKUP_CREDENTIALS_HELMRELEASE_NAMESPACE"),
+				Name:      os.Getenv("BACKUP_CREDENTIALS_HELMRELEASE_NAME"),
+			},
 		}
 		if err := gate.SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to add DefaultObjectsGate runnable")

--- a/docs/operations/backup-classes.md
+++ b/docs/operations/backup-classes.md
@@ -93,9 +93,46 @@ On a fresh-cluster install, the Velero `BackupStorageLocation` `cozy-default` is
 
 ### Cozy-default Bucket bootstrap
 
-`cozy-default` ships an `apps.cozystack.io/Bucket cozy-backups` CR in `tenant-root`, which the bucket-application chart turns into a `BucketClaim`; the COSI driver then assigns the real S3 bucket name and writes it to the BucketClaim's `.status.bucketName`. The strategy templates and the Velero BSL all read that real bucket name (Helm `lookup` against the BucketClaim). On a fresh install the BucketClaim takes a short reconcile cycle to populate its status — until it does, the strategy templates render empty and only the `Bucket` CR + `BackupClass` are present in the cluster. The HelmRelease re-reconciles on its interval (5 minutes by default — set by the cozystack operator's `helmrelease-interval` flag, not a Flux default), at which point the populated BucketClaim status causes the missing strategy templates to materialise.
+`cozy-default` ships an `apps.cozystack.io/Bucket cozy-backups` CR in `tenant-root`, which the bucket-application chart turns into a `BucketClaim`; the COSI driver then assigns the real S3 bucket name (`bucket-<claim-UID>`, so it cannot be computed in advance) and writes it to the BucketClaim's `.status.bucketName`. The strategy templates and the Velero BSL all read that real bucket name (Helm `lookup` against the BucketClaim). On a fresh install the BucketClaim takes a reconcile cycle to populate its status — until it does, the strategy templates render empty and only the `Bucket` CR + `BackupClass` are present in the cluster.
 
-If you need the BackupClass functional immediately (e.g. an e2e), trigger a Flux reconcile (`flux reconcile helmrelease backupstrategy-controller -n cozy-backup-controller`) once you see `kubectl get bucketclaim -n tenant-root bucket-cozy-backups -o jsonpath='{.status.bucketName}'` non-empty.
+**That skip does not repair itself on a reconcile.** helm-controller re-renders a release only when its chart or values change; the interval reconcile is a no-op for a healthy release, and drift detection is off on operator-generated HelmReleases. A cluster that lost the race at install time therefore keeps `BackupClass cozy-default` with **no** `Strategy` CRs and **no** Velero BSL indefinitely — which also fail-closes the pre-adoption snapshot in the v1.6.0 etcd migration.
+
+Convergence is driven instead by the controller's default-objects gate (`backupStorage.reconcileDefaultObjects`, on by default). Once the bucket name is resolvable it checks that every object `cozy-default` routes to exists, and stamps `reconcile.fluxcd.io/forceAt` + `requestedAt` on the `backupstrategy-controller` HelmRelease to force the real Helm upgrade that re-runs the lookups. Expect the objects within one minute of the bucket becoming ready. Watch it with:
+
+```bash
+kubectl -n cozy-backup-controller logs deploy/backupstrategy-controller | grep default-objects-gate
+```
+
+#### Manual recovery on an affected cluster
+
+Only needed on a cluster running a version without the gate (or with `reconcileDefaultObjects: false`). A plain `flux reconcile helmrelease` does **nothing** here — it does not re-render. You need a forced upgrade, and **both** annotations: `forceAt` is what makes helm-controller run a real Helm upgrade, and it is only honoured together with `requestedAt`.
+
+First confirm the bucket name is actually resolvable — forcing before that just re-runs the same empty lookup:
+
+```bash
+kubectl -n tenant-root get bucketclaim bucket-cozy-backups -o jsonpath='{.status.bucketName}'
+```
+
+Then force the two releases, **in this order**:
+
+```bash
+# 1. The credentials Secret. It is rendered by the -system release, not by
+#    bucket-cozy-backups — easy to miss, and the projector (hence every
+#    strategy and Velero) has no source without it.
+ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+kubectl -n tenant-root annotate helmrelease bucket-cozy-backups-system \
+  reconcile.fluxcd.io/forceAt="$ts" reconcile.fluxcd.io/requestedAt="$ts" --overwrite
+kubectl -n tenant-root get secret bucket-cozy-backups-system-credentials
+
+# 2. The Strategy CRs and the Velero BSL.
+ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+kubectl -n cozy-backup-controller annotate helmrelease backupstrategy-controller \
+  reconcile.fluxcd.io/forceAt="$ts" reconcile.fluxcd.io/requestedAt="$ts" --overwrite
+kubectl get $(kubectl get crd -o name | grep strategy.backups.cozystack.io) 2>/dev/null
+kubectl -n cozy-velero get backupstoragelocation cozy-default
+```
+
+The race is nested: step 2's `lookup` resolves from the BucketClaim status, but the projector — and the v1.6.0 etcd migration — read the Secret from step 1, so a cluster missing both needs both.
 
 ### Observability
 
@@ -105,6 +142,11 @@ The credentials projector emits two Prometheus counters labelled by `namespace` 
 - `cozystack_backup_credentials_projection_failures_total`
 
 Alert on `rate(cozystack_backup_credentials_projection_failures_total[5m]) > 0` or `absent_over_time(cozystack_backup_credentials_projection_successes_total[10m])` to catch a stale BSL credential or a malformed source Secret without log scraping.
+
+The default-objects gate emits two more:
+
+- `cozystack_backup_default_objects_missing{backupclass="cozy-default"}` — how many objects `cozy-default` routes to are absent. **This is the alert that would have caught the missing Strategy CRs**: it is non-zero whatever the HelmRelease's `Ready` condition says. Alert on `min_over_time(cozystack_backup_default_objects_missing[15m]) > 0`.
+- `cozystack_backup_default_objects_force_reconciles_total` — forced Helm upgrades issued. A counter that keeps climbing means the forced render is not producing the objects (a missing CRD, for instance), which is a different problem from the install-time race.
 
 ## Admin overrides for `cozy-default`
 

--- a/docs/operations/backup-classes.md
+++ b/docs/operations/backup-classes.md
@@ -97,7 +97,13 @@ On a fresh-cluster install, the Velero `BackupStorageLocation` `cozy-default` is
 
 **That skip does not repair itself on a reconcile.** helm-controller re-renders a release only when its chart or values change; the interval reconcile is a no-op for a healthy release, and drift detection is off on operator-generated HelmReleases. A cluster that lost the race at install time therefore keeps `BackupClass cozy-default` with **no** `Strategy` CRs and **no** Velero BSL indefinitely — which also fail-closes the pre-adoption snapshot in the v1.6.0 etcd migration.
 
-Convergence is driven instead by the controller's default-objects gate (`backupStorage.reconcileDefaultObjects`, on by default). Once the bucket name is resolvable it checks that every object `cozy-default` routes to exists, and stamps `reconcile.fluxcd.io/forceAt` + `requestedAt` on the `backupstrategy-controller` HelmRelease to force the real Helm upgrade that re-runs the lookups. Expect the objects within one minute of the bucket becoming ready. Watch it with:
+The same trap sits one release earlier, on the Secret everything else depends on. `bucket-cozy-backups-system-credentials` is rendered by the `bucket-cozy-backups-system` release behind a `lookup` of the COSI Secret, and is skipped just as permanently when that lookup is empty. Without it the credentials projector has no source at all, so no strategy, no Velero and no v1.6.0 etcd migration can resolve — and the gate cannot even determine the bucket name, which it reads from that Secret.
+
+Convergence is driven instead by the controller's default-objects gate (`backupStorage.reconcileDefaultObjects`, on by default), which repairs both, in order. While the credentials Secret is absent or carries no bucket name, the gate stamps `reconcile.fluxcd.io/forceAt` + `requestedAt` on the **bucket's** `bucket-<name>-system` HelmRelease. Once the bucket name resolves it checks that every object `cozy-default` routes to exists and stamps the same pair on the **`backupstrategy-controller`** HelmRelease, forcing the real Helm upgrade that re-runs the lookups. The two are throttled independently (one force per 5 minutes each), so the second is not delayed by the first. Expect the objects within a minute or two of the bucket becoming ready.
+
+The gate does not force a suspended HelmRelease — helm-controller ignores both annotations while `spec.suspend` is true, so it logs the skip and leaves the force counter alone. A release left suspended (`cozyhr suspend`) is therefore never repaired until it is resumed.
+
+Watch it with:
 
 ```bash
 kubectl -n cozy-backup-controller logs deploy/backupstrategy-controller | grep default-objects-gate
@@ -143,10 +149,11 @@ The credentials projector emits two Prometheus counters labelled by `namespace` 
 
 Alert on `rate(cozystack_backup_credentials_projection_failures_total[5m]) > 0` or `absent_over_time(cozystack_backup_credentials_projection_successes_total[10m])` to catch a stale BSL credential or a malformed source Secret without log scraping.
 
-The default-objects gate emits two more:
+The default-objects gate emits three more:
 
-- `cozystack_backup_default_objects_missing{backupclass="cozy-default"}` — how many objects `cozy-default` routes to are absent. **This is the alert that would have caught the missing Strategy CRs**: it is non-zero whatever the HelmRelease's `Ready` condition says. Alert on `min_over_time(cozystack_backup_default_objects_missing[15m]) > 0`.
-- `cozystack_backup_default_objects_force_reconciles_total` — forced Helm upgrades issued. A counter that keeps climbing means the forced render is not producing the objects (a missing CRD, for instance), which is a different problem from the install-time race.
+- `cozystack_backup_default_objects_missing{backupclass="cozy-default"}` — how many of the objects the platform default backups depend on are absent: the credentials Secret, the Strategy CRs `cozy-default` routes to, and the Velero BSL. **This is the alert that would have caught the missing Strategy CRs**: it is non-zero whatever the HelmRelease's `Ready` condition says. Alert on `min_over_time(cozystack_backup_default_objects_missing[15m]) > 0`.
+- `cozystack_backup_default_objects_check_errors_total{backupclass="cozy-default"}` — checks that could not reach a conclusion (an API error reading the source Secret, the BackupClass, or one of the routed objects). The gauge above is deliberately **not** written on those ticks, so that it does not flap on a transient API error — which means that while this counter climbs, the gauge is stale and a `0` on it proves nothing. Pair the two: `min_over_time(cozystack_backup_default_objects_missing[15m]) > 0 or rate(cozystack_backup_default_objects_check_errors_total[15m]) > 0`.
+- `cozystack_backup_default_objects_force_reconciles_total{namespace,name}` — forced Helm upgrades issued, labelled by the release forced (this chart's own, or the bucket's `-system` release). A counter that keeps climbing means the forced render is not producing the objects (a missing CRD, for instance), which is a different problem from the install-time race. A suspended release is skipped before the patch and is **not** counted here, so a paused release cannot masquerade as a render that keeps failing — look for the `skipped forcing a suspended HelmRelease` log line instead.
 
 ## Admin overrides for `cozy-default`
 

--- a/internal/backupcontroller/default_objects_gate.go
+++ b/internal/backupcontroller/default_objects_gate.go
@@ -2,6 +2,7 @@ package backupcontroller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -13,6 +14,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
@@ -27,15 +29,21 @@ import (
 	backupsv1alpha1 "github.com/cozystack/cozystack/api/backups/v1alpha1"
 )
 
-// defaultObjectsMissing reports how many of the objects the platform
-// BackupClass depends on are absent from the cluster. It is the signal an
-// operator alerts on: a non-zero value that does not return to zero means
-// the platform default backups are not usable, whatever the HelmRelease's
-// Ready condition says.
+// defaultObjectsMissing reports how many of the objects the platform default
+// backups depend on are absent from the cluster: the bucket credentials
+// Secret the projector reads, the Strategy CRs the BackupClass routes to,
+// and the Velero BSL. It is the signal an operator alerts on: a non-zero
+// value that does not return to zero means the platform default backups are
+// not usable, whatever the HelmRelease's Ready condition says.
+//
+// It is only written when a check reached a conclusion. An API error mid-check
+// leaves the previous value in place rather than flapping the alert, so the
+// gauge alone cannot distinguish "healthy" from "not evaluated" — that is what
+// defaultObjectsCheckErrors is for, and the runbook pairs the two.
 var defaultObjectsMissing = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "cozystack_backup_default_objects_missing",
-		Help: "Number of objects referenced by the platform BackupClass that do not exist in the cluster.",
+		Help: "Number of objects the platform default backups depend on (bucket credentials Secret, BackupClass strategy CRs, Velero BSL) that do not exist in the cluster.",
 	},
 	[]string{"backupclass"},
 )
@@ -44,6 +52,8 @@ var defaultObjectsMissing = prometheus.NewGaugeVec(
 // issued to materialise those objects. A counter that keeps climbing means
 // the forced render is not producing the objects (e.g. a CRD is missing),
 // which is a different failure than the install-time race this gate closes.
+// A suspended release is NOT counted here: it is skipped before the patch,
+// so a paused release cannot masquerade as a render that keeps failing.
 var defaultObjectsForceReconciles = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Name: "cozystack_backup_default_objects_force_reconciles_total",
@@ -52,8 +62,21 @@ var defaultObjectsForceReconciles = prometheus.NewCounterVec(
 	[]string{"namespace", "name"},
 )
 
+// defaultObjectsCheckErrors counts the checks that could not reach a
+// conclusion (API error reading the source Secret, the BackupClass, or one
+// of the routed objects). While this climbs, defaultObjectsMissing is stale:
+// alerting on the gauge alone would silently keep reporting the last known
+// state, including a 0 that is no longer true.
+var defaultObjectsCheckErrors = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "cozystack_backup_default_objects_check_errors_total",
+		Help: "Number of default backup object checks that failed before reaching a conclusion, leaving cozystack_backup_default_objects_missing stale.",
+	},
+	[]string{"backupclass"},
+)
+
 func init() {
-	metrics.Registry.MustRegister(defaultObjectsMissing, defaultObjectsForceReconciles)
+	metrics.Registry.MustRegister(defaultObjectsMissing, defaultObjectsForceReconciles, defaultObjectsCheckErrors)
 }
 
 const (
@@ -122,6 +145,18 @@ type DefaultObjectsGate struct {
 	// HelmRelease is the release that renders those objects and is forced
 	// when they are missing. Empty name disables the gate.
 	HelmRelease types.NamespacedName
+	// CredentialsHelmRelease is the platform bucket's <bucket>-system
+	// release, which renders the user-credentials Secret named by
+	// Config.SourceSecretName behind a `lookup` of the COSI Secret — the
+	// same permanent-skip trap as the Strategy CRs, one release earlier.
+	// Forcing it is what unblocks everything downstream, since the gate
+	// itself cannot resolve the bucket name without that Secret.
+	//
+	// Empty when the platform bucket is not provisioned by Cozystack
+	// (backupStorage.provisionBucket=false, external S3): the Secret is
+	// then admin-managed and no release renders it, so there is nothing
+	// to force.
+	CredentialsHelmRelease types.NamespacedName
 	// VeleroNamespace is where the cozy-default BackupStorageLocation
 	// lives. Empty skips the BSL check (velero.bslEnabled=false).
 	VeleroNamespace string
@@ -134,9 +169,21 @@ type DefaultObjectsGate struct {
 	MinForceInterval time.Duration
 
 	// now is a test seam for the throttle clock.
-	now       func() time.Time
-	lastForce time.Time
+	now func() time.Time
+	// lastForce and lastCredentialsForce throttle the two releases
+	// independently: the credentials release is forced during the window in
+	// which the objects release cannot even be evaluated, so sharing one
+	// timestamp would make the first force delay the second by
+	// MinForceInterval for no reason.
+	lastForce            time.Time
+	lastCredentialsForce time.Time
 }
+
+// errHelmReleaseSuspended reports that the target release has
+// spec.suspend: true. helm-controller ignores reconcile.fluxcd.io/forceAt on
+// a suspended release, so patching it would be a no-op repeated every
+// MinForceInterval for as long as the suspension lasts.
+var errHelmReleaseSuspended = errors.New("HelmRelease is suspended")
 
 var (
 	_ manager.Runnable               = (*DefaultObjectsGate)(nil)
@@ -185,6 +232,9 @@ func (g *DefaultObjectsGate) Start(ctx context.Context) error {
 	if g.now == nil {
 		g.now = time.Now
 	}
+	// force() logs the suspended-release skip from deep in the call stack;
+	// without this it would land on a bare logger with no name.
+	ctx = log.IntoContext(ctx, logger)
 
 	tick := time.NewTicker(g.Period)
 	defer tick.Stop()
@@ -232,15 +282,30 @@ func (g *DefaultObjectsGate) checkAndLog(ctx context.Context, logger logr.Logger
 		// metric, and this runs every minute for the life of the cluster.
 		logger.Info("default backup objects check failed", "error", err.Error())
 	case len(missing) > 0 && forced:
+		// The release named here is whichever one renders what is missing:
+		// the credentials Secret comes from the bucket's <bucket>-system
+		// release, everything else from this chart's own.
 		logger.Info("forced a Helm upgrade to create missing default backup objects",
-			"helmRelease", g.HelmRelease.String(), "missing", missing)
+			"helmRelease", g.forcedReleaseFor(missing).String(), "missing", missing)
 	case len(missing) > 0:
-		logger.Info("default backup objects still missing, force throttled",
-			"helmRelease", g.HelmRelease.String(), "missing", missing,
+		logger.Info("default backup objects still missing, no force issued on this tick",
+			"helmRelease", g.forcedReleaseFor(missing).String(), "missing", missing,
 			"minForceInterval", g.MinForceInterval.String())
 	default:
 		logger.V(1).Info("all default backup objects present")
 	}
+}
+
+// forcedReleaseFor reports which release renders the given missing set, for
+// logging only. reconcileCredentials returns the credentials Secret as the
+// sole missing object, and it is never mixed with the routed objects —
+// resolving the bucket name is a precondition for checking those at all.
+func (g *DefaultObjectsGate) forcedReleaseFor(missing []string) types.NamespacedName {
+	credsKey := fmt.Sprintf("Secret/%s", g.Config.SourceSecretName)
+	if len(missing) == 1 && missing[0] == credsKey && g.CredentialsHelmRelease.Name != "" {
+		return g.CredentialsHelmRelease
+	}
+	return g.HelmRelease
 }
 
 // Check resolves the platform bucket name, verifies that every object the
@@ -248,40 +313,47 @@ func (g *DefaultObjectsGate) checkAndLog(ctx context.Context, logger logr.Logger
 // missing. It returns the missing objects (formatted for logs) and whether
 // a forced upgrade was issued on this call.
 //
-// It is a no-op while the bucket name is unresolvable: forcing then would
-// re-render the same empty lookup. That covers both an absent source Secret
-// and one whose bucket name is still empty, which are the same bootstrap state
-// seen a moment apart. The bucket name is read from the projector's source
-// Secret rather than from the BucketClaim, so the gate needs no objectstorage
-// RBAC and works for the external-S3 path too.
+// While the source Secret is absent or carries no bucket name, the gate
+// cannot evaluate the routed objects — their templates gate on the same
+// unresolved bucket — so it instead forces the release that renders that
+// Secret (see reconcileCredentials). The bucket name is read from the
+// projector's source Secret rather than from the BucketClaim, so the gate
+// needs no objectstorage RBAC and works for the external-S3 path too.
 func (g *DefaultObjectsGate) Check(ctx context.Context) ([]string, bool, error) {
 	src := &corev1.Secret{}
 	if err := g.Client.Get(ctx, types.NamespacedName{Namespace: g.Config.SourceNamespace, Name: g.Config.SourceSecretName}, src); err != nil {
 		if apierrors.IsNotFound(err) {
-			// The projector has not created the Secret yet. Same no-op as an
-			// unresolved bucket name: without it, every tick of the whole
-			// bootstrap window logs a check failure for an expected state.
-			return nil, false, nil
+			// The Secret the projector reads does not exist. On a fresh
+			// install that is the bootstrap window; months later it is the
+			// permanent skip this gate exists to repair, and the two are
+			// indistinguishable from here — so treat both the same way and
+			// let the throttle bound the cost.
+			return g.reconcileCredentials(ctx)
 		}
+		defaultObjectsCheckErrors.WithLabelValues(g.BackupClassName).Inc()
 		return nil, false, fmt.Errorf("get source credentials Secret %s/%s: %w", g.Config.SourceNamespace, g.Config.SourceSecretName, err)
 	}
 	creds, err := parseSourceSecret(src)
 	if err != nil {
+		defaultObjectsCheckErrors.WithLabelValues(g.BackupClassName).Inc()
 		return nil, false, err
 	}
 	if creds.bucket == "" {
-		// The bucket is not provisioned yet (or an admin-managed Secret
-		// omits the name). Nothing a re-render could resolve.
-		return nil, false, nil
+		// The Secret exists but carries no bucket name: a partially rendered
+		// or hand-written Secret. Same treatment — a re-render of the
+		// producing release is the only thing that can complete it.
+		return g.reconcileCredentials(ctx)
 	}
 
 	backupClass := &backupsv1alpha1.BackupClass{}
 	if err := g.Client.Get(ctx, client.ObjectKey{Name: g.BackupClassName}, backupClass); err != nil {
+		defaultObjectsCheckErrors.WithLabelValues(g.BackupClassName).Inc()
 		return nil, false, fmt.Errorf("get BackupClass %s: %w", g.BackupClassName, err)
 	}
 
 	missing, err := g.missingObjects(ctx, backupClass)
 	if err != nil {
+		defaultObjectsCheckErrors.WithLabelValues(g.BackupClassName).Inc()
 		return nil, false, err
 	}
 	defaultObjectsMissing.WithLabelValues(g.BackupClassName).Set(float64(len(missing)))
@@ -289,22 +361,73 @@ func (g *DefaultObjectsGate) Check(ctx context.Context) ([]string, bool, error) 
 		return nil, false, nil
 	}
 
-	now := g.now()
-	if !g.lastForce.IsZero() && now.Sub(g.lastForce) < g.MinForceInterval {
+	return g.force(ctx, g.HelmRelease, &g.lastForce, missing)
+}
+
+// reconcileCredentials handles the one object the gate cannot check the same
+// way as the others: the bucket user-credentials Secret it reads to resolve
+// the bucket name in the first place.
+//
+// That Secret is rendered by the platform bucket's <bucket>-system release
+// behind a `lookup` of the COSI Secret, so it is subject to the identical
+// permanent-skip trap — and when it is missing, nothing downstream can
+// resolve: the projector has no source, every Strategy CR and the Velero BSL
+// stay gated off, and migration 50 cannot find its snapshot target.
+//
+// The chart cannot repair this itself. Making the render `fail` instead of
+// skip would abort the whole <bucket>-system release — the other users'
+// Secrets and the bucket UI Deployment/Service/Ingress with it — and one
+// user whose BucketAccess never provisions would park the release in Failed,
+// blocking every later upgrade of that bucket with no per-bucket way out. So
+// the repair belongs here, where it is per-object and costs a throttled
+// annotation patch: exactly the mechanism the gate already applies to the
+// Strategy CRs, one release earlier in the chain.
+//
+// Forcing that release cannot deadlock its own precondition: the BucketClaim
+// and the BucketAccess whose COSI Secret the lookup reads are rendered
+// unconditionally by the PARENT release (packages/apps/bucket/templates/
+// bucketclaim.yaml), not by the one being forced.
+func (g *DefaultObjectsGate) reconcileCredentials(ctx context.Context) ([]string, bool, error) {
+	missing := []string{fmt.Sprintf("Secret/%s", g.Config.SourceSecretName)}
+	defaultObjectsMissing.WithLabelValues(g.BackupClassName).Set(float64(len(missing)))
+	if g.CredentialsHelmRelease.Name == "" || g.CredentialsHelmRelease.Namespace == "" {
+		// External S3: the Secret is admin-managed and no release renders
+		// it. Report it missing, force nothing.
 		return missing, false, nil
 	}
-	if err := g.forceHelmRelease(ctx, now); err != nil {
-		if apierrors.IsNotFound(err) {
+	return g.force(ctx, g.CredentialsHelmRelease, &g.lastCredentialsForce, missing)
+}
+
+// force issues at most one throttled forced Helm upgrade of target and
+// reports whether it went through. last is the caller's throttle timestamp,
+// advanced on every outcome that must not be retried immediately.
+func (g *DefaultObjectsGate) force(ctx context.Context, target types.NamespacedName, last *time.Time, missing []string) ([]string, bool, error) {
+	now := g.now()
+	if !last.IsZero() && now.Sub(*last) < g.MinForceInterval {
+		return missing, false, nil
+	}
+	if err := g.forceHelmRelease(ctx, target, now); err != nil {
+		switch {
+		case apierrors.IsNotFound(err):
 			// Not a Flux-managed install (a plain `helm install` for local
 			// development). There is nothing to force; stay quiet rather
 			// than logging an error every tick.
-			g.lastForce = now
+			*last = now
+			return missing, false, nil
+		case errors.Is(err, errHelmReleaseSuspended):
+			// Deliberate operator state (cozyhr suspend, maintenance). The
+			// annotations would be ignored, so skip the patch entirely and
+			// leave the force counter alone — a climbing counter must keep
+			// meaning "the forced render is not producing the objects".
+			log.FromContext(ctx).Info("skipped forcing a suspended HelmRelease; missing default backup objects will not be repaired until it is resumed",
+				"helmRelease", target.String(), "missing", missing)
+			*last = now
 			return missing, false, nil
 		}
-		return missing, false, fmt.Errorf("force HelmRelease %s: %w", g.HelmRelease.String(), err)
+		return missing, false, fmt.Errorf("force HelmRelease %s: %w", target.String(), err)
 	}
-	g.lastForce = now
-	defaultObjectsForceReconciles.WithLabelValues(g.HelmRelease.Namespace, g.HelmRelease.Name).Inc()
+	*last = now
+	defaultObjectsForceReconciles.WithLabelValues(target.Namespace, target.Name).Inc()
 	return missing, true, nil
 }
 
@@ -398,13 +521,32 @@ func (g *DefaultObjectsGate) missingObjects(ctx context.Context, backupClass *ba
 // helm-controller to reconcile, which is a no-op for a release whose chart
 // and values are unchanged — it is forceAt that makes it run a real Helm
 // upgrade, and forceAt is only honoured together with requestedAt.
-func (g *DefaultObjectsGate) forceHelmRelease(ctx context.Context, now time.Time) error {
+//
+// A point Get precedes the patch so a suspended release is skipped rather
+// than re-stamped forever: helm-controller ignores both annotations while
+// spec.suspend is true, and `cozyhr suspend` sets exactly that. Without the
+// check the gate would patch every MinForceInterval for the whole suspension
+// and inflate the force counter, which the runbook reads as a render that
+// keeps failing — the wrong diagnosis. The Get needs no RBAC beyond the
+// `get` on helmreleases the chart already grants.
+func (g *DefaultObjectsGate) forceHelmRelease(ctx context.Context, target types.NamespacedName, now time.Time) error {
+	hr, err := g.Resource(helmReleaseGVR).Namespace(target.Namespace).Get(ctx, target.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	// A malformed spec.suspend (wrong type) is reported by NestedBool as an
+	// error; treat it as not suspended and let the patch proceed, rather
+	// than silently disabling the repair on a field we could not parse.
+	if suspended, found, err := unstructured.NestedBool(hr.Object, "spec", "suspend"); err == nil && found && suspended {
+		return errHelmReleaseSuspended
+	}
+
 	stamp := now.UTC().Format(time.RFC3339Nano)
 	patch := fmt.Sprintf(
 		`{"metadata":{"annotations":{"reconcile.fluxcd.io/forceAt":%q,"reconcile.fluxcd.io/requestedAt":%q}}}`,
 		stamp, stamp,
 	)
-	_, err := g.Resource(helmReleaseGVR).Namespace(g.HelmRelease.Namespace).
-		Patch(ctx, g.HelmRelease.Name, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
+	_, err = g.Resource(helmReleaseGVR).Namespace(target.Namespace).
+		Patch(ctx, target.Name, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
 	return err
 }

--- a/internal/backupcontroller/default_objects_gate.go
+++ b/internal/backupcontroller/default_objects_gate.go
@@ -329,6 +329,15 @@ func (g *DefaultObjectsGate) missingObjects(ctx context.Context, backupClass *ba
 		if strategy.StrategyRef.APIGroup != nil && *strategy.StrategyRef.APIGroup != "" {
 			group = *strategy.StrategyRef.APIGroup
 		}
+		// When the Velero BSL is disabled (velero.bslEnabled=false, surfaced
+		// here as an empty VeleroNamespace) the chart gates the Velero
+		// Strategy CRs off the SAME flag, so they are never rendered. The
+		// BackupClass still routes to them unconditionally, so counting them
+		// as missing would force a Helm upgrade every MinForceInterval
+		// forever against a render that can never produce them.
+		if g.VeleroNamespace == "" && group == strategyAPIGroup && kind == "Velero" {
+			continue
+		}
 		key := fmt.Sprintf("%s/%s", kind, name)
 		if _, dup := seen[key]; dup {
 			continue

--- a/internal/backupcontroller/default_objects_gate.go
+++ b/internal/backupcontroller/default_objects_gate.go
@@ -199,8 +199,32 @@ func (g *DefaultObjectsGate) Start(ctx context.Context) error {
 	}
 }
 
+// checkTimeout bounds a single check. It stays below Period so a slow check
+// cannot overlap the next tick, and is capped so a long Period does not mean a
+// correspondingly long stall.
+func (g *DefaultObjectsGate) checkTimeout() time.Duration {
+	const maxTimeout = 30 * time.Second
+	if g.Period <= 0 {
+		return maxTimeout
+	}
+	if half := g.Period / 2; half < maxTimeout {
+		return half
+	}
+	return maxTimeout
+}
+
 func (g *DefaultObjectsGate) checkAndLog(ctx context.Context, logger logr.Logger) {
-	missing, forced, err := g.Check(ctx)
+	// Bound every tick. Check makes several sequential API calls (Secret get,
+	// BackupClass get, one Get per routed strategy, HelmRelease patch) and the
+	// manager context is only cancelled at shutdown, so an API server that
+	// stalls on any one of them would block here indefinitely. The loop that
+	// drives this is sequential, so that single stuck call would stop all
+	// later checks for the life of the pod: the recovery this gate exists to
+	// provide would go silent, with a stale gauge and no further log line, and
+	// only a restart would bring it back.
+	checkCtx, cancel := context.WithTimeout(ctx, g.checkTimeout())
+	defer cancel()
+	missing, forced, err := g.Check(checkCtx)
 	switch {
 	case err != nil:
 		// Info, not Error: every branch here is either transient (the
@@ -225,12 +249,20 @@ func (g *DefaultObjectsGate) checkAndLog(ctx context.Context, logger logr.Logger
 // a forced upgrade was issued on this call.
 //
 // It is a no-op while the bucket name is unresolvable: forcing then would
-// re-render the same empty lookup. The bucket name is read from the
-// projector's source Secret rather than from the BucketClaim, so the gate
-// needs no objectstorage RBAC and works for the external-S3 path too.
+// re-render the same empty lookup. That covers both an absent source Secret
+// and one whose bucket name is still empty, which are the same bootstrap state
+// seen a moment apart. The bucket name is read from the projector's source
+// Secret rather than from the BucketClaim, so the gate needs no objectstorage
+// RBAC and works for the external-S3 path too.
 func (g *DefaultObjectsGate) Check(ctx context.Context) ([]string, bool, error) {
 	src := &corev1.Secret{}
 	if err := g.Client.Get(ctx, types.NamespacedName{Namespace: g.Config.SourceNamespace, Name: g.Config.SourceSecretName}, src); err != nil {
+		if apierrors.IsNotFound(err) {
+			// The projector has not created the Secret yet. Same no-op as an
+			// unresolved bucket name: without it, every tick of the whole
+			// bootstrap window logs a check failure for an expected state.
+			return nil, false, nil
+		}
 		return nil, false, fmt.Errorf("get source credentials Secret %s/%s: %w", g.Config.SourceNamespace, g.Config.SourceSecretName, err)
 	}
 	creds, err := parseSourceSecret(src)

--- a/internal/backupcontroller/default_objects_gate.go
+++ b/internal/backupcontroller/default_objects_gate.go
@@ -364,15 +364,28 @@ func (g *DefaultObjectsGate) missingObjects(ctx context.Context, backupClass *ba
 	}
 
 	if g.VeleroNamespace != "" {
-		_, err := g.Resource(backupStorageLocationGVR).Namespace(g.VeleroNamespace).Get(ctx, defaultBackupStorageLocationName, metav1.GetOptions{})
+		// Resolve through the RESTMapper, like the strategy loop above, so a
+		// genuinely absent Velero API is a NoMatch we skip rather than a
+		// NotFound we count. The dynamic client's Get bypasses the mapper and
+		// returns a plain 404 for an unserved group, which IsNotFound would
+		// catch first, making the "CRDs absent" branch dead code and looping
+		// the gate forever if Velero were removed while bslEnabled=true.
+		mapping, err := g.RESTMapping(schema.GroupKind{Group: backupStorageLocationGVR.Group, Kind: "BackupStorageLocation"})
 		switch {
 		case err == nil:
-		case apierrors.IsNotFound(err):
-			missing = append(missing, fmt.Sprintf("BackupStorageLocation/%s", defaultBackupStorageLocationName))
+			_, getErr := g.Resource(mapping.Resource).Namespace(g.VeleroNamespace).Get(ctx, defaultBackupStorageLocationName, metav1.GetOptions{})
+			switch {
+			case getErr == nil:
+			case apierrors.IsNotFound(getErr):
+				missing = append(missing, fmt.Sprintf("BackupStorageLocation/%s", defaultBackupStorageLocationName))
+			default:
+				return nil, fmt.Errorf("get BackupStorageLocation %s: %w", defaultBackupStorageLocationName, getErr)
+			}
 		case meta.IsNoMatchError(err):
-			// Velero CRDs absent: nothing to materialise.
+			// Velero API not served (e.g. Velero uninstalled after bootstrap):
+			// no Helm re-render can create the BSL, so it is not "missing".
 		default:
-			return nil, fmt.Errorf("get BackupStorageLocation %s: %w", defaultBackupStorageLocationName, err)
+			return nil, fmt.Errorf("map BackupStorageLocation: %w", err)
 		}
 	}
 

--- a/internal/backupcontroller/default_objects_gate.go
+++ b/internal/backupcontroller/default_objects_gate.go
@@ -1,0 +1,356 @@
+package backupcontroller
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	backupsv1alpha1 "github.com/cozystack/cozystack/api/backups/v1alpha1"
+)
+
+// defaultObjectsMissing reports how many of the objects the platform
+// BackupClass depends on are absent from the cluster. It is the signal an
+// operator alerts on: a non-zero value that does not return to zero means
+// the platform default backups are not usable, whatever the HelmRelease's
+// Ready condition says.
+var defaultObjectsMissing = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "cozystack_backup_default_objects_missing",
+		Help: "Number of objects referenced by the platform BackupClass that do not exist in the cluster.",
+	},
+	[]string{"backupclass"},
+)
+
+// defaultObjectsForceReconciles counts the forced Helm upgrades the gate
+// issued to materialise those objects. A counter that keeps climbing means
+// the forced render is not producing the objects (e.g. a CRD is missing),
+// which is a different failure than the install-time race this gate closes.
+var defaultObjectsForceReconciles = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "cozystack_backup_default_objects_force_reconciles_total",
+		Help: "Number of forced HelmRelease reconciles issued to create missing platform backup objects.",
+	},
+	[]string{"namespace", "name"},
+)
+
+func init() {
+	metrics.Registry.MustRegister(defaultObjectsMissing, defaultObjectsForceReconciles)
+}
+
+const (
+	// strategyAPIGroup is the API group of the strategy.backups.cozystack.io
+	// CRs a BackupClass routes to. BackupClassStrategy.StrategyRef is a
+	// TypedLocalObjectReference and carries no version, so the group+kind
+	// are mapped to a resource through the RESTMapper.
+	strategyAPIGroup = "strategy.backups.cozystack.io"
+
+	// defaultBackupStorageLocationName is the Velero BSL the cozy-default
+	// Velero strategies reference via storageLocation. It is rendered by the
+	// same lookup-gated template as the Strategy CRs, so it belongs to the
+	// same existence check.
+	defaultBackupStorageLocationName = "cozy-default"
+)
+
+var backupStorageLocationGVR = schema.GroupVersionResource{
+	Group:    "velero.io",
+	Version:  "v1",
+	Resource: "backupstoragelocations",
+}
+
+// DefaultObjectsGate closes a race the chart's templates cannot close by
+// themselves.
+//
+// The default Strategy CRs and the Velero BackupStorageLocation are
+// Helm-templated behind a `lookup` of the BucketClaim the SAME chart
+// creates, because the S3 bucket name is assigned by the COSI driver
+// (`bucket-<claim-UID>`) and is therefore unknowable at render time. On a
+// fresh install the lookup is empty and those templates render nothing.
+// helm-controller does not re-render a release that succeeded and whose
+// chart and values did not change (drift detection is off on
+// operator-generated HelmReleases), so the skip is PERMANENT: the objects
+// are never created, and the only recovery is a forced Helm upgrade
+// (reconcile.fluxcd.io/forceAt + requestedAt — a plain reconcile request
+// does not re-render).
+//
+// This runnable performs that recovery automatically. Once the bucket name
+// is resolvable — read from the same platform credentials Secret the
+// projector already consumes, so no new dependency and no `lookup` — it
+// checks that every object the platform BackupClass routes to actually
+// exists, and forces one Helm upgrade when any is missing. A forced
+// upgrade re-runs the lookups, so the gated templates materialise.
+//
+// It deliberately does not create the objects itself: their bodies are
+// values-driven (endpoint, region, forcePathStyle, the Altinity strategy's
+// whole PodTemplateSpec) and Helm remains their single owner. The gate only
+// makes sure the render that produces them actually happens.
+type DefaultObjectsGate struct {
+	// Client reads the BackupClass (cached) and the source credentials
+	// Secret (uncached — the manager disables the Secret cache).
+	Client client.Client
+	// Interface is a dynamic client used for the per-object existence
+	// checks and the HelmRelease annotation patch. Going through the
+	// dynamic client keeps these reads off the controller-runtime cache,
+	// so they need only `get` RBAC and start no cluster-wide informers.
+	dynamic.Interface
+	meta.RESTMapper
+
+	// Config supplies the source credentials Secret coordinates. Reused
+	// verbatim from the credentials projector.
+	Config BackupCredentialsConfig
+	// BackupClassName is the platform BackupClass whose strategyRefs
+	// enumerate the objects that must exist. Empty disables the gate.
+	BackupClassName string
+	// HelmRelease is the release that renders those objects and is forced
+	// when they are missing. Empty name disables the gate.
+	HelmRelease types.NamespacedName
+	// VeleroNamespace is where the cozy-default BackupStorageLocation
+	// lives. Empty skips the BSL check (velero.bslEnabled=false).
+	VeleroNamespace string
+
+	// Period is the check interval. Defaults to 1 minute.
+	Period time.Duration
+	// MinForceInterval throttles forced upgrades so a condition the forced
+	// render cannot fix (missing CRD, wrong bucket) does not turn into a
+	// hot loop against helm-controller. Defaults to 5 minutes.
+	MinForceInterval time.Duration
+
+	// now is a test seam for the throttle clock.
+	now       func() time.Time
+	lastForce time.Time
+}
+
+var (
+	_ manager.Runnable               = (*DefaultObjectsGate)(nil)
+	_ manager.LeaderElectionRunnable = (*DefaultObjectsGate)(nil)
+)
+
+// NeedLeaderElection keeps a single replica forcing the release. Two
+// replicas racing the same annotation patch would double the Helm upgrades
+// for no benefit.
+func (g *DefaultObjectsGate) NeedLeaderElection() bool { return true }
+
+// SetupWithManager wires the dynamic client and the RESTMapper from the
+// manager's rest.Config, mirroring RestoreJobReconciler, and registers the
+// gate as a manager Runnable.
+func (g *DefaultObjectsGate) SetupWithManager(mgr ctrl.Manager) error {
+	cfg := mgr.GetConfig()
+	var err error
+	if g.Interface, err = dynamic.NewForConfig(cfg); err != nil {
+		return err
+	}
+	var h *http.Client
+	if h, err = rest.HTTPClientFor(cfg); err != nil {
+		return err
+	}
+	if g.RESTMapper, err = apiutil.NewDynamicRESTMapper(cfg, h); err != nil {
+		return err
+	}
+	return mgr.Add(g)
+}
+
+func (g *DefaultObjectsGate) Start(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName("default-objects-gate")
+	if g.BackupClassName == "" || g.HelmRelease.Name == "" || g.HelmRelease.Namespace == "" || !g.Config.IsEnabled() {
+		logger.V(1).Info("default backup objects gate disabled",
+			"backupClass", g.BackupClassName,
+			"helmRelease", g.HelmRelease.String(),
+			"credentialsConfigured", g.Config.IsEnabled())
+		return nil
+	}
+	if g.Period == 0 {
+		g.Period = time.Minute
+	}
+	if g.MinForceInterval == 0 {
+		g.MinForceInterval = 5 * time.Minute
+	}
+	if g.now == nil {
+		g.now = time.Now
+	}
+
+	tick := time.NewTicker(g.Period)
+	defer tick.Stop()
+	g.checkAndLog(ctx, logger)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-tick.C:
+			g.checkAndLog(ctx, logger)
+		}
+	}
+}
+
+func (g *DefaultObjectsGate) checkAndLog(ctx context.Context, logger logr.Logger) {
+	missing, forced, err := g.Check(ctx)
+	switch {
+	case err != nil:
+		// Info, not Error: every branch here is either transient (the
+		// bucket is still being provisioned) or already exposed as a
+		// metric, and this runs every minute for the life of the cluster.
+		logger.Info("default backup objects check failed", "error", err.Error())
+	case len(missing) > 0 && forced:
+		logger.Info("forced a Helm upgrade to create missing default backup objects",
+			"helmRelease", g.HelmRelease.String(), "missing", missing)
+	case len(missing) > 0:
+		logger.Info("default backup objects still missing, force throttled",
+			"helmRelease", g.HelmRelease.String(), "missing", missing,
+			"minForceInterval", g.MinForceInterval.String())
+	default:
+		logger.V(1).Info("all default backup objects present")
+	}
+}
+
+// Check resolves the platform bucket name, verifies that every object the
+// BackupClass routes to exists, and forces one Helm upgrade when any is
+// missing. It returns the missing objects (formatted for logs) and whether
+// a forced upgrade was issued on this call.
+//
+// It is a no-op while the bucket name is unresolvable: forcing then would
+// re-render the same empty lookup. The bucket name is read from the
+// projector's source Secret rather than from the BucketClaim, so the gate
+// needs no objectstorage RBAC and works for the external-S3 path too.
+func (g *DefaultObjectsGate) Check(ctx context.Context) ([]string, bool, error) {
+	src := &corev1.Secret{}
+	if err := g.Client.Get(ctx, types.NamespacedName{Namespace: g.Config.SourceNamespace, Name: g.Config.SourceSecretName}, src); err != nil {
+		return nil, false, fmt.Errorf("get source credentials Secret %s/%s: %w", g.Config.SourceNamespace, g.Config.SourceSecretName, err)
+	}
+	creds, err := parseSourceSecret(src)
+	if err != nil {
+		return nil, false, err
+	}
+	if creds.bucket == "" {
+		// The bucket is not provisioned yet (or an admin-managed Secret
+		// omits the name). Nothing a re-render could resolve.
+		return nil, false, nil
+	}
+
+	backupClass := &backupsv1alpha1.BackupClass{}
+	if err := g.Client.Get(ctx, client.ObjectKey{Name: g.BackupClassName}, backupClass); err != nil {
+		return nil, false, fmt.Errorf("get BackupClass %s: %w", g.BackupClassName, err)
+	}
+
+	missing, err := g.missingObjects(ctx, backupClass)
+	if err != nil {
+		return nil, false, err
+	}
+	defaultObjectsMissing.WithLabelValues(g.BackupClassName).Set(float64(len(missing)))
+	if len(missing) == 0 {
+		return nil, false, nil
+	}
+
+	now := g.now()
+	if !g.lastForce.IsZero() && now.Sub(g.lastForce) < g.MinForceInterval {
+		return missing, false, nil
+	}
+	if err := g.forceHelmRelease(ctx, now); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Not a Flux-managed install (a plain `helm install` for local
+			// development). There is nothing to force; stay quiet rather
+			// than logging an error every tick.
+			g.lastForce = now
+			return missing, false, nil
+		}
+		return missing, false, fmt.Errorf("force HelmRelease %s: %w", g.HelmRelease.String(), err)
+	}
+	g.lastForce = now
+	defaultObjectsForceReconciles.WithLabelValues(g.HelmRelease.Namespace, g.HelmRelease.Name).Inc()
+	return missing, true, nil
+}
+
+// missingObjects returns a sorted, de-duplicated list of the
+// "<kind>/<name>" objects the BackupClass references that do not exist,
+// plus the Velero BSL when a Velero namespace is configured.
+//
+// An unmappable group/kind (the CRD is not installed) is NOT reported as
+// missing: no Helm re-render can create an object whose CRD is absent, and
+// counting it would keep the gate forcing upgrades forever.
+func (g *DefaultObjectsGate) missingObjects(ctx context.Context, backupClass *backupsv1alpha1.BackupClass) ([]string, error) {
+	seen := map[string]struct{}{}
+	var missing []string
+
+	for _, strategy := range backupClass.Spec.Strategies {
+		name := strategy.StrategyRef.Name
+		kind := strategy.StrategyRef.Kind
+		if name == "" || kind == "" {
+			continue
+		}
+		group := strategyAPIGroup
+		if strategy.StrategyRef.APIGroup != nil && *strategy.StrategyRef.APIGroup != "" {
+			group = *strategy.StrategyRef.APIGroup
+		}
+		key := fmt.Sprintf("%s/%s", kind, name)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		mapping, err := g.RESTMapping(schema.GroupKind{Group: group, Kind: kind})
+		if err != nil {
+			if meta.IsNoMatchError(err) {
+				continue
+			}
+			return nil, fmt.Errorf("map %s/%s: %w", group, kind, err)
+		}
+		// Strategy CRs are cluster-scoped; Namespace("") is correct for
+		// both scopes on the dynamic client.
+		_, err = g.Resource(mapping.Resource).Get(ctx, name, metav1.GetOptions{})
+		switch {
+		case err == nil:
+		case apierrors.IsNotFound(err):
+			missing = append(missing, key)
+		default:
+			return nil, fmt.Errorf("get %s %s: %w", kind, name, err)
+		}
+	}
+
+	if g.VeleroNamespace != "" {
+		_, err := g.Resource(backupStorageLocationGVR).Namespace(g.VeleroNamespace).Get(ctx, defaultBackupStorageLocationName, metav1.GetOptions{})
+		switch {
+		case err == nil:
+		case apierrors.IsNotFound(err):
+			missing = append(missing, fmt.Sprintf("BackupStorageLocation/%s", defaultBackupStorageLocationName))
+		case meta.IsNoMatchError(err):
+			// Velero CRDs absent: nothing to materialise.
+		default:
+			return nil, fmt.Errorf("get BackupStorageLocation %s: %w", defaultBackupStorageLocationName, err)
+		}
+	}
+
+	sort.Strings(missing)
+	return missing, nil
+}
+
+// forceHelmRelease stamps BOTH reconcile.fluxcd.io/forceAt and
+// reconcile.fluxcd.io/requestedAt. requestedAt alone only asks
+// helm-controller to reconcile, which is a no-op for a release whose chart
+// and values are unchanged — it is forceAt that makes it run a real Helm
+// upgrade, and forceAt is only honoured together with requestedAt.
+func (g *DefaultObjectsGate) forceHelmRelease(ctx context.Context, now time.Time) error {
+	stamp := now.UTC().Format(time.RFC3339Nano)
+	patch := fmt.Sprintf(
+		`{"metadata":{"annotations":{"reconcile.fluxcd.io/forceAt":%q,"reconcile.fluxcd.io/requestedAt":%q}}}`,
+		stamp, stamp,
+	)
+	_, err := g.Resource(helmReleaseGVR).Namespace(g.HelmRelease.Namespace).
+		Patch(ctx, g.HelmRelease.Name, types.MergePatchType, []byte(patch), metav1.PatchOptions{})
+	return err
+}

--- a/internal/backupcontroller/default_objects_gate_test.go
+++ b/internal/backupcontroller/default_objects_gate_test.go
@@ -1,0 +1,416 @@
+package backupcontroller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	backupsv1alpha1 "github.com/cozystack/cozystack/api/backups/v1alpha1"
+)
+
+// gateGVKs are the kinds the gate touches in these tests: the
+// strategy.backups.cozystack.io CRs cozy-default routes to, the Velero BSL,
+// and the HelmRelease it patches. The RESTMapper and the dynamic fake's
+// resource registry are both derived from this one list so the plural the
+// gate resolves and the plural the fake serves cannot drift apart.
+var gateGVKs = []schema.GroupVersionKind{
+	{Group: strategyAPIGroup, Version: "v1alpha1", Kind: "CNPG"},
+	{Group: strategyAPIGroup, Version: "v1alpha1", Kind: "Etcd"},
+	{Group: strategyAPIGroup, Version: "v1alpha1", Kind: "Velero"},
+	{Group: "velero.io", Version: "v1", Kind: "BackupStorageLocation"},
+	{Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease"},
+}
+
+func gateScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = backupsv1alpha1.AddToScheme(scheme)
+	return scheme
+}
+
+func gateListKinds() map[schema.GroupVersionResource]string {
+	out := map[schema.GroupVersionResource]string{}
+	for _, gvk := range gateGVKs {
+		gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+		out[gvr] = gvk.Kind + "List"
+	}
+	return out
+}
+
+// gateRESTMapper resolves group+kind (the only coordinates a
+// BackupClass strategyRef carries) to a resource, which is what the gate
+// does in production through the dynamic RESTMapper. The group versions must
+// be passed as defaults: RESTMapping is called without a version.
+func gateRESTMapper() meta.RESTMapper {
+	groupVersions := map[schema.GroupVersion]struct{}{}
+	for _, gvk := range gateGVKs {
+		groupVersions[gvk.GroupVersion()] = struct{}{}
+	}
+	var gvs []schema.GroupVersion
+	for gv := range groupVersions {
+		gvs = append(gvs, gv)
+	}
+	m := meta.NewDefaultRESTMapper(gvs)
+	for _, gvk := range gateGVKs {
+		scope := meta.RESTScopeRoot
+		if gvk.Kind == "BackupStorageLocation" || gvk.Kind == "HelmRelease" {
+			scope = meta.RESTScopeNamespace
+		}
+		m.Add(gvk, scope)
+	}
+	return m
+}
+
+func apiGroup(s string) *string { return &s }
+
+// cozyDefaultBackupClass mirrors the routes the chart's
+// backupclass-default.yaml renders unconditionally: it is the manifest of
+// what must exist, which is exactly why the gate reads it instead of
+// hard-coding a list of Strategy names.
+func cozyDefaultBackupClass() *backupsv1alpha1.BackupClass {
+	ref := func(kind, name string) backupsv1alpha1.BackupClassStrategy {
+		return backupsv1alpha1.BackupClassStrategy{
+			Application: backupsv1alpha1.ApplicationSelector{
+				APIGroup: apiGroup("apps.cozystack.io"),
+				Kind:     kind + "App",
+			},
+			StrategyRef: corev1.TypedLocalObjectReference{
+				APIGroup: apiGroup(strategyAPIGroup),
+				Kind:     kind,
+				Name:     name,
+			},
+		}
+	}
+	return &backupsv1alpha1.BackupClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "cozy-default"},
+		Spec: backupsv1alpha1.BackupClassSpec{
+			Strategies: []backupsv1alpha1.BackupClassStrategy{
+				ref("CNPG", "cozy-default-cnpg"),
+				ref("Etcd", "cozy-default-etcd"),
+				ref("Velero", "cozy-default-velero-vminstance"),
+				ref("Velero", "cozy-default-velero-vmdisk"),
+			},
+		},
+	}
+}
+
+func strategyObject(kind, name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion(strategyAPIGroup + "/v1alpha1")
+	u.SetKind(kind)
+	u.SetName(name)
+	return u
+}
+
+func helmReleaseObject() *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("helm.toolkit.fluxcd.io/v2")
+	u.SetKind("HelmRelease")
+	u.SetNamespace("cozy-backup-controller")
+	u.SetName("backupstrategy-controller")
+	return u
+}
+
+func newGate(t *testing.T, ctrlObjs []client.Object, dynObjs ...runtime.Object) (*DefaultObjectsGate, *dynamicfake.FakeDynamicClient) {
+	t.Helper()
+	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gateListKinds(), dynObjs...)
+	g := &DefaultObjectsGate{
+		Client: fake.NewClientBuilder().WithScheme(gateScheme()).WithObjects(ctrlObjs...).Build(),
+		Config: BackupCredentialsConfig{
+			SourceNamespace:  "tenant-root",
+			SourceSecretName: "bucket-cozy-backups-system-credentials",
+			TargetSecretName: "cozy-backups-creds",
+		},
+		BackupClassName: "cozy-default",
+		HelmRelease: types.NamespacedName{
+			Namespace: "cozy-backup-controller",
+			Name:      "backupstrategy-controller",
+		},
+		VeleroNamespace:  "cozy-velero",
+		MinForceInterval: 5 * time.Minute,
+		now:              func() time.Time { return time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC) },
+	}
+	g.Interface = dyn
+	g.RESTMapper = gateRESTMapper()
+	return g, dyn
+}
+
+func sourceSecret(bucket string) *corev1.Secret {
+	data := map[string][]byte{
+		"accessKey": []byte("AK"),
+		"secretKey": []byte("SK"),
+		"endpoint":  []byte("s3.example.com"),
+	}
+	if bucket != "" {
+		data["bucketName"] = []byte(bucket)
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "tenant-root", Name: "bucket-cozy-backups-system-credentials"},
+		Data:       data,
+	}
+}
+
+func bslObject() *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("velero.io/v1")
+	u.SetKind("BackupStorageLocation")
+	u.SetNamespace("cozy-velero")
+	u.SetName(defaultBackupStorageLocationName)
+	return u
+}
+
+func forceAnnotations(t *testing.T, dyn *dynamicfake.FakeDynamicClient) map[string]string {
+	t.Helper()
+	hr, err := dyn.Resource(helmReleaseGVR).Namespace("cozy-backup-controller").
+		Get(context.Background(), "backupstrategy-controller", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get HelmRelease: %v", err)
+	}
+	return hr.GetAnnotations()
+}
+
+// TestCheckForcesWhenObjectsMissing is the bug this gate exists for: the
+// bucket name resolves, so a Helm re-render WOULD produce the gated
+// templates, but the objects are absent because the install-time lookup was
+// empty and helm-controller never re-rendered. The gate must force a real
+// Helm upgrade — BOTH annotations, because requestedAt alone is a no-op for
+// an unchanged release.
+func TestCheckForcesWhenObjectsMissing(t *testing.T) {
+	g, dyn := newGate(t,
+		[]client.Object{sourceSecret("bucket-1a2b"), cozyDefaultBackupClass()},
+		helmReleaseObject(),
+	)
+
+	missing, forced, err := g.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if !forced {
+		t.Fatal("expected a forced Helm upgrade when default objects are missing")
+	}
+	// 4 strategyRefs (Velero twice under different names) + the BSL.
+	if len(missing) != 5 {
+		t.Fatalf("missing = %v, want 5 entries", missing)
+	}
+	ann := forceAnnotations(t, dyn)
+	forceAt, ok := ann["reconcile.fluxcd.io/forceAt"]
+	if !ok || forceAt == "" {
+		t.Errorf("reconcile.fluxcd.io/forceAt not set: %v", ann)
+	}
+	requestedAt, ok := ann["reconcile.fluxcd.io/requestedAt"]
+	if !ok || requestedAt == "" {
+		t.Errorf("reconcile.fluxcd.io/requestedAt not set: %v", ann)
+	}
+	if forceAt != requestedAt {
+		t.Errorf("forceAt (%q) and requestedAt (%q) must carry the same stamp", forceAt, requestedAt)
+	}
+}
+
+// TestCheckNoopWhenAllPresent pins the steady state: no forced upgrades
+// once the objects exist, otherwise the gate would rewrite the annotation
+// forever and re-run a Helm upgrade every MinForceInterval for the life of
+// the cluster.
+func TestCheckNoopWhenAllPresent(t *testing.T) {
+	g, dyn := newGate(t,
+		[]client.Object{sourceSecret("bucket-1a2b"), cozyDefaultBackupClass()},
+		helmReleaseObject(),
+		strategyObject("CNPG", "cozy-default-cnpg"),
+		strategyObject("Etcd", "cozy-default-etcd"),
+		strategyObject("Velero", "cozy-default-velero-vminstance"),
+		strategyObject("Velero", "cozy-default-velero-vmdisk"),
+		bslObject(),
+	)
+
+	missing, forced, err := g.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if len(missing) != 0 || forced {
+		t.Fatalf("missing = %v, forced = %v, want none", missing, forced)
+	}
+	if ann := forceAnnotations(t, dyn); len(ann) != 0 {
+		t.Errorf("HelmRelease annotated in the steady state: %v", ann)
+	}
+}
+
+// TestCheckSkipsWhileBucketUnresolved pins the precondition. Forcing a
+// re-render before the COSI driver has published a bucket name would just
+// re-run the same empty lookup and burn a Helm upgrade, so the gate waits.
+func TestCheckSkipsWhileBucketUnresolved(t *testing.T) {
+	g, dyn := newGate(t,
+		[]client.Object{sourceSecret(""), cozyDefaultBackupClass()},
+		helmReleaseObject(),
+	)
+
+	missing, forced, err := g.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if len(missing) != 0 || forced {
+		t.Fatalf("missing = %v, forced = %v, want none while the bucket is unresolved", missing, forced)
+	}
+	if ann := forceAnnotations(t, dyn); len(ann) != 0 {
+		t.Errorf("HelmRelease forced before the bucket resolved: %v", ann)
+	}
+}
+
+// TestCheckThrottlesRepeatedForces pins the throttle. A condition a
+// re-render cannot fix (missing CRD, unreachable bucket) must not turn into
+// a hot loop of Helm upgrades against helm-controller.
+func TestCheckThrottlesRepeatedForces(t *testing.T) {
+	g, _ := newGate(t,
+		[]client.Object{sourceSecret("bucket-1a2b"), cozyDefaultBackupClass()},
+		helmReleaseObject(),
+	)
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	g.now = func() time.Time { return base }
+
+	if _, forced, err := g.Check(context.Background()); err != nil || !forced {
+		t.Fatalf("first Check: forced = %v, err = %v; want forced", forced, err)
+	}
+
+	// Well inside MinForceInterval: still missing, but no second upgrade.
+	g.now = func() time.Time { return base.Add(time.Minute) }
+	missing, forced, err := g.Check(context.Background())
+	if err != nil {
+		t.Fatalf("second Check: %v", err)
+	}
+	if forced {
+		t.Error("second Check forced inside MinForceInterval")
+	}
+	if len(missing) == 0 {
+		t.Error("second Check should still report the objects as missing")
+	}
+
+	// Past MinForceInterval: force again, because the objects are still gone.
+	g.now = func() time.Time { return base.Add(6 * time.Minute) }
+	if _, forced, err := g.Check(context.Background()); err != nil || !forced {
+		t.Fatalf("third Check: forced = %v, err = %v; want forced", forced, err)
+	}
+}
+
+// TestMissingObjectsIgnoresUnmappedKinds pins that a strategyRef whose CRD
+// is not installed is not counted as missing. No Helm re-render can create
+// such an object, so counting it would force upgrades forever.
+func TestMissingObjectsIgnoresUnmappedKinds(t *testing.T) {
+	bc := cozyDefaultBackupClass()
+	bc.Spec.Strategies = append(bc.Spec.Strategies, backupsv1alpha1.BackupClassStrategy{
+		Application: backupsv1alpha1.ApplicationSelector{Kind: "Nonexistent"},
+		StrategyRef: corev1.TypedLocalObjectReference{
+			APIGroup: apiGroup(strategyAPIGroup),
+			Kind:     "NotInstalled",
+			Name:     "cozy-default-notinstalled",
+		},
+	})
+	g, _ := newGate(t, []client.Object{sourceSecret("b"), bc},
+		helmReleaseObject(),
+		strategyObject("CNPG", "cozy-default-cnpg"),
+		strategyObject("Etcd", "cozy-default-etcd"),
+		strategyObject("Velero", "cozy-default-velero-vminstance"),
+		strategyObject("Velero", "cozy-default-velero-vmdisk"),
+		bslObject(),
+	)
+
+	missing, err := g.missingObjects(context.Background(), bc)
+	if err != nil {
+		t.Fatalf("missingObjects: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("missing = %v, want none (unmapped kind must be ignored)", missing)
+	}
+}
+
+// TestMissingObjectsSkipsBSLWhenVeleroNamespaceEmpty covers
+// velero.bslEnabled=false: the chart renders no BSL, so its absence is not
+// a defect and must not drive forced upgrades.
+func TestMissingObjectsSkipsBSLWhenVeleroNamespaceEmpty(t *testing.T) {
+	bc := cozyDefaultBackupClass()
+	g, _ := newGate(t, []client.Object{sourceSecret("b"), bc},
+		helmReleaseObject(),
+		strategyObject("CNPG", "cozy-default-cnpg"),
+		strategyObject("Etcd", "cozy-default-etcd"),
+		strategyObject("Velero", "cozy-default-velero-vminstance"),
+		strategyObject("Velero", "cozy-default-velero-vmdisk"),
+	)
+	g.VeleroNamespace = ""
+
+	missing, err := g.missingObjects(context.Background(), bc)
+	if err != nil {
+		t.Fatalf("missingObjects: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("missing = %v, want none when the BSL is disabled", missing)
+	}
+}
+
+// TestCheckSurfacesPatchFailure pins that a failed force is reported rather
+// than silently recorded as done — and that lastForce is NOT advanced, so
+// the next tick retries instead of waiting out MinForceInterval.
+func TestCheckSurfacesPatchFailure(t *testing.T) {
+	g, dyn := newGate(t,
+		[]client.Object{sourceSecret("bucket-1a2b"), cozyDefaultBackupClass()},
+		helmReleaseObject(),
+	)
+	dyn.PrependReactor("patch", "helmreleases", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Group: "helm.toolkit.fluxcd.io", Resource: "helmreleases"}, "backupstrategy-controller", nil)
+	})
+
+	if _, forced, err := g.Check(context.Background()); err == nil || forced {
+		t.Fatalf("forced = %v, err = %v; want an error and forced=false", forced, err)
+	}
+	if !g.lastForce.IsZero() {
+		t.Error("lastForce advanced despite the patch failing; the next tick would be throttled")
+	}
+}
+
+// TestStartDisabledWithoutHelmRelease pins the opt-out: without release
+// coordinates the runnable must return immediately instead of ticking with
+// a nil target.
+func TestStartDisabledWithoutHelmRelease(t *testing.T) {
+	g, _ := newGate(t, []client.Object{sourceSecret("b"), cozyDefaultBackupClass()}, helmReleaseObject())
+	g.HelmRelease = types.NamespacedName{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- g.Start(ctx) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("Start did not return immediately when disabled")
+	}
+}
+
+// TestCheckToleratesAbsentHelmRelease covers a plain `helm install` (local
+// development): there is no HelmRelease to force, which is not an error to
+// report every tick.
+func TestCheckToleratesAbsentHelmRelease(t *testing.T) {
+	g, _ := newGate(t, []client.Object{sourceSecret("bucket-1a2b"), cozyDefaultBackupClass()})
+
+	missing, forced, err := g.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if forced {
+		t.Error("forced reported true with no HelmRelease to patch")
+	}
+	if len(missing) == 0 {
+		t.Error("objects should still be reported as missing")
+	}
+}

--- a/internal/backupcontroller/default_objects_gate_test.go
+++ b/internal/backupcontroller/default_objects_gate_test.go
@@ -410,6 +410,55 @@ func TestMissingObjectsSkipsVeleroWhenNamespaceEmpty(t *testing.T) {
 	}
 }
 
+// TestMissingObjectsSkipsBSLWhenVeleroAPIAbsent covers Velero being removed
+// after bootstrap while bslEnabled=true: the velero.io API is no longer
+// served, so the BSL cannot be re-rendered and must not be counted as
+// missing. Resolving through the RESTMapper turns that into a NoMatch skip;
+// the previous hardcoded-GVR Get returned a NotFound that would have looped
+// the gate forever.
+func TestMissingObjectsSkipsBSLWhenVeleroAPIAbsent(t *testing.T) {
+	bc := cozyDefaultBackupClass()
+	g, _ := newGate(t, []client.Object{sourceSecret("b"), bc},
+		helmReleaseObject(),
+		strategyObject("CNPG", "cozy-default-cnpg"),
+		strategyObject("Etcd", "cozy-default-etcd"),
+		strategyObject("Velero", "cozy-default-velero-vminstance"),
+		strategyObject("Velero", "cozy-default-velero-vmdisk"),
+	)
+	// Rebuild the RESTMapper without BackupStorageLocation: the velero.io API
+	// is not served on this cluster.
+	gvset := map[schema.GroupVersion]struct{}{}
+	var kept []schema.GroupVersionKind
+	for _, gvk := range gateGVKs {
+		if gvk.Kind == "BackupStorageLocation" {
+			continue
+		}
+		gvset[gvk.GroupVersion()] = struct{}{}
+		kept = append(kept, gvk)
+	}
+	var gvs []schema.GroupVersion
+	for gv := range gvset {
+		gvs = append(gvs, gv)
+	}
+	m := meta.NewDefaultRESTMapper(gvs)
+	for _, gvk := range kept {
+		scope := meta.RESTScopeRoot
+		if gvk.Kind == "HelmRelease" {
+			scope = meta.RESTScopeNamespace
+		}
+		m.Add(gvk, scope)
+	}
+	g.RESTMapper = m
+
+	missing, err := g.missingObjects(context.Background(), bc)
+	if err != nil {
+		t.Fatalf("missingObjects: %v", err)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("missing = %v, want none when the Velero API is absent", missing)
+	}
+}
+
 // TestCheckSurfacesPatchFailure pins that a failed force is reported rather
 // than silently recorded as done — and that lastForce is NOT advanced, so
 // the next tick retries instead of waiting out MinForceInterval.

--- a/internal/backupcontroller/default_objects_gate_test.go
+++ b/internal/backupcontroller/default_objects_gate_test.go
@@ -28,7 +28,9 @@ import (
 // gate resolves and the plural the fake serves cannot drift apart.
 var gateGVKs = []schema.GroupVersionKind{
 	{Group: strategyAPIGroup, Version: "v1alpha1", Kind: "CNPG"},
+	{Group: strategyAPIGroup, Version: "v1alpha1", Kind: "MariaDB"},
 	{Group: strategyAPIGroup, Version: "v1alpha1", Kind: "Etcd"},
+	{Group: strategyAPIGroup, Version: "v1alpha1", Kind: "Altinity"},
 	{Group: strategyAPIGroup, Version: "v1alpha1", Kind: "Velero"},
 	{Group: "velero.io", Version: "v1", Kind: "BackupStorageLocation"},
 	{Group: "helm.toolkit.fluxcd.io", Version: "v2", Kind: "HelmRelease"},
@@ -99,7 +101,9 @@ func cozyDefaultBackupClass() *backupsv1alpha1.BackupClass {
 		Spec: backupsv1alpha1.BackupClassSpec{
 			Strategies: []backupsv1alpha1.BackupClassStrategy{
 				ref("CNPG", "cozy-default-cnpg"),
+				ref("MariaDB", "cozy-default-mariadb"),
 				ref("Etcd", "cozy-default-etcd"),
+				ref("Altinity", "cozy-default-altinity"),
 				ref("Velero", "cozy-default-velero-vminstance"),
 				ref("Velero", "cozy-default-velero-vmdisk"),
 			},
@@ -201,9 +205,9 @@ func TestCheckForcesWhenObjectsMissing(t *testing.T) {
 	if !forced {
 		t.Fatal("expected a forced Helm upgrade when default objects are missing")
 	}
-	// 4 strategyRefs (Velero twice under different names) + the BSL.
-	if len(missing) != 5 {
-		t.Fatalf("missing = %v, want 5 entries", missing)
+	// 6 strategyRefs (Velero twice under different names) + the BSL.
+	if len(missing) != 7 {
+		t.Fatalf("missing = %v, want 7 entries", missing)
 	}
 	ann := forceAnnotations(t, dyn)
 	forceAt, ok := ann["reconcile.fluxcd.io/forceAt"]
@@ -228,7 +232,9 @@ func TestCheckNoopWhenAllPresent(t *testing.T) {
 		[]client.Object{sourceSecret("bucket-1a2b"), cozyDefaultBackupClass()},
 		helmReleaseObject(),
 		strategyObject("CNPG", "cozy-default-cnpg"),
+		strategyObject("MariaDB", "cozy-default-mariadb"),
 		strategyObject("Etcd", "cozy-default-etcd"),
+		strategyObject("Altinity", "cozy-default-altinity"),
 		strategyObject("Velero", "cozy-default-velero-vminstance"),
 		strategyObject("Velero", "cozy-default-velero-vmdisk"),
 		bslObject(),
@@ -368,7 +374,9 @@ func TestMissingObjectsIgnoresUnmappedKinds(t *testing.T) {
 	g, _ := newGate(t, []client.Object{sourceSecret("b"), bc},
 		helmReleaseObject(),
 		strategyObject("CNPG", "cozy-default-cnpg"),
+		strategyObject("MariaDB", "cozy-default-mariadb"),
 		strategyObject("Etcd", "cozy-default-etcd"),
+		strategyObject("Altinity", "cozy-default-altinity"),
 		strategyObject("Velero", "cozy-default-velero-vminstance"),
 		strategyObject("Velero", "cozy-default-velero-vmdisk"),
 		bslObject(),
@@ -397,7 +405,9 @@ func TestMissingObjectsSkipsVeleroWhenNamespaceEmpty(t *testing.T) {
 	g, _ := newGate(t, []client.Object{sourceSecret("b"), bc},
 		helmReleaseObject(),
 		strategyObject("CNPG", "cozy-default-cnpg"),
+		strategyObject("MariaDB", "cozy-default-mariadb"),
 		strategyObject("Etcd", "cozy-default-etcd"),
+		strategyObject("Altinity", "cozy-default-altinity"),
 	)
 	g.VeleroNamespace = ""
 
@@ -421,7 +431,9 @@ func TestMissingObjectsSkipsBSLWhenVeleroAPIAbsent(t *testing.T) {
 	g, _ := newGate(t, []client.Object{sourceSecret("b"), bc},
 		helmReleaseObject(),
 		strategyObject("CNPG", "cozy-default-cnpg"),
+		strategyObject("MariaDB", "cozy-default-mariadb"),
 		strategyObject("Etcd", "cozy-default-etcd"),
+		strategyObject("Altinity", "cozy-default-altinity"),
 		strategyObject("Velero", "cozy-default-velero-vminstance"),
 		strategyObject("Velero", "cozy-default-velero-vmdisk"),
 	)

--- a/internal/backupcontroller/default_objects_gate_test.go
+++ b/internal/backupcontroller/default_objects_gate_test.go
@@ -267,6 +267,56 @@ func TestCheckSkipsWhileBucketUnresolved(t *testing.T) {
 	}
 }
 
+// TestCheckSkipsWhileSourceSecretAbsent pins the state one moment earlier than
+// TestCheckSkipsWhileBucketUnresolved: the projector has not created the Secret
+// at all yet. Returning an error here would log a check failure on every tick
+// of the entire bootstrap window, for a state the gate documents as a no-op.
+func TestCheckSkipsWhileSourceSecretAbsent(t *testing.T) {
+	g, dyn := newGate(t,
+		[]client.Object{cozyDefaultBackupClass()},
+		helmReleaseObject(),
+	)
+
+	missing, forced, err := g.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check returned an error for an absent source Secret, want a silent no-op: %v", err)
+	}
+	if len(missing) != 0 || forced {
+		t.Fatalf("missing = %v, forced = %v, want none while the source Secret is absent", missing, forced)
+	}
+	if ann := forceAnnotations(t, dyn); len(ann) != 0 {
+		t.Errorf("HelmRelease forced before the source Secret existed: %v", ann)
+	}
+}
+
+// TestCheckTimeoutStaysBelowPeriod pins the bound on a single check. The ticker
+// loop is sequential and the manager context is only cancelled at shutdown, so
+// an unbounded check that hangs on a stalled API call stops every later check
+// for the life of the pod.
+func TestCheckTimeoutStaysBelowPeriod(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		period time.Duration
+		want   time.Duration
+	}{
+		{"unset falls back to the cap", 0, 30 * time.Second},
+		{"default period halves", time.Minute, 30 * time.Second},
+		{"short period halves", 10 * time.Second, 5 * time.Second},
+		{"long period is capped", time.Hour, 30 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			g := &DefaultObjectsGate{Period: tc.period}
+			got := g.checkTimeout()
+			if got != tc.want {
+				t.Fatalf("checkTimeout() = %v, want %v", got, tc.want)
+			}
+			if tc.period > 0 && got >= tc.period {
+				t.Fatalf("checkTimeout() = %v, must stay below Period %v", got, tc.period)
+			}
+		})
+	}
+}
+
 // TestCheckThrottlesRepeatedForces pins the throttle. A condition a
 // re-render cannot fix (missing CRD, unreachable bucket) must not turn into
 // a hot loop of Helm upgrades against helm-controller.

--- a/internal/backupcontroller/default_objects_gate_test.go
+++ b/internal/backupcontroller/default_objects_gate_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -128,6 +129,23 @@ func helmReleaseObject() *unstructured.Unstructured {
 	return u
 }
 
+// credentialsHelmReleaseObject is the platform bucket's <bucket>-system
+// release: the one that renders the user-credentials Secret the gate reads
+// to resolve the bucket name, behind its own install-time lookup.
+func credentialsHelmReleaseObject() *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetAPIVersion("helm.toolkit.fluxcd.io/v2")
+	u.SetKind("HelmRelease")
+	u.SetNamespace("tenant-root")
+	u.SetName("bucket-cozy-backups-system")
+	return u
+}
+
+func suspended(u *unstructured.Unstructured) *unstructured.Unstructured {
+	_ = unstructured.SetNestedField(u.Object, true, "spec", "suspend")
+	return u
+}
+
 func newGate(t *testing.T, ctrlObjs []client.Object, dynObjs ...runtime.Object) (*DefaultObjectsGate, *dynamicfake.FakeDynamicClient) {
 	t.Helper()
 	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gateListKinds(), dynObjs...)
@@ -142,6 +160,10 @@ func newGate(t *testing.T, ctrlObjs []client.Object, dynObjs ...runtime.Object) 
 		HelmRelease: types.NamespacedName{
 			Namespace: "cozy-backup-controller",
 			Name:      "backupstrategy-controller",
+		},
+		CredentialsHelmRelease: types.NamespacedName{
+			Namespace: "tenant-root",
+			Name:      "bucket-cozy-backups-system",
 		},
 		VeleroNamespace:  "cozy-velero",
 		MinForceInterval: 5 * time.Minute,
@@ -178,10 +200,20 @@ func bslObject() *unstructured.Unstructured {
 
 func forceAnnotations(t *testing.T, dyn *dynamicfake.FakeDynamicClient) map[string]string {
 	t.Helper()
-	hr, err := dyn.Resource(helmReleaseGVR).Namespace("cozy-backup-controller").
-		Get(context.Background(), "backupstrategy-controller", metav1.GetOptions{})
+	return annotationsOf(t, dyn, "cozy-backup-controller", "backupstrategy-controller")
+}
+
+func credentialsForceAnnotations(t *testing.T, dyn *dynamicfake.FakeDynamicClient) map[string]string {
+	t.Helper()
+	return annotationsOf(t, dyn, "tenant-root", "bucket-cozy-backups-system")
+}
+
+func annotationsOf(t *testing.T, dyn *dynamicfake.FakeDynamicClient, namespace, name string) map[string]string {
+	t.Helper()
+	hr, err := dyn.Resource(helmReleaseGVR).Namespace(namespace).
+		Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
-		t.Fatalf("get HelmRelease: %v", err)
+		t.Fatalf("get HelmRelease %s/%s: %v", namespace, name, err)
 	}
 	return hr.GetAnnotations()
 }
@@ -252,46 +284,184 @@ func TestCheckNoopWhenAllPresent(t *testing.T) {
 	}
 }
 
-// TestCheckSkipsWhileBucketUnresolved pins the precondition. Forcing a
-// re-render before the COSI driver has published a bucket name would just
-// re-run the same empty lookup and burn a Helm upgrade, so the gate waits.
-func TestCheckSkipsWhileBucketUnresolved(t *testing.T) {
+// TestCheckForcesCredentialsReleaseWhenSourceSecretAbsent is the second half
+// of the bug. The Secret the gate reads to resolve the bucket name is itself
+// rendered behind an install-time lookup, by the bucket's <bucket>-system
+// release — so it is subject to the identical permanent skip, one release
+// earlier. While it is absent nothing downstream can resolve: no projected
+// credentials, no Strategy CRs, no Velero, and migration 50 has no snapshot
+// target. Forcing THIS chart's release would be useless (its own lookups
+// depend on that Secret); the bucket release is the one to force.
+func TestCheckForcesCredentialsReleaseWhenSourceSecretAbsent(t *testing.T) {
 	g, dyn := newGate(t,
-		[]client.Object{sourceSecret(""), cozyDefaultBackupClass()},
+		[]client.Object{cozyDefaultBackupClass()},
 		helmReleaseObject(),
+		credentialsHelmReleaseObject(),
 	)
 
 	missing, forced, err := g.Check(context.Background())
 	if err != nil {
 		t.Fatalf("Check: %v", err)
 	}
-	if len(missing) != 0 || forced {
-		t.Fatalf("missing = %v, forced = %v, want none while the bucket is unresolved", missing, forced)
+	if !forced {
+		t.Fatal("expected the bucket release to be forced while the credentials Secret is absent")
 	}
+	if len(missing) != 1 || missing[0] != "Secret/bucket-cozy-backups-system-credentials" {
+		t.Fatalf("missing = %v, want the credentials Secret", missing)
+	}
+	ann := credentialsForceAnnotations(t, dyn)
+	if ann["reconcile.fluxcd.io/forceAt"] == "" || ann["reconcile.fluxcd.io/requestedAt"] == "" {
+		t.Errorf("bucket release not forced with both annotations: %v", ann)
+	}
+	// This chart's own release must be left alone: its templates gate on the
+	// same unresolved bucket, so forcing it would burn a Helm upgrade that
+	// re-runs the same empty lookup.
 	if ann := forceAnnotations(t, dyn); len(ann) != 0 {
-		t.Errorf("HelmRelease forced before the bucket resolved: %v", ann)
+		t.Errorf("own HelmRelease forced before the bucket resolved: %v", ann)
 	}
 }
 
-// TestCheckSkipsWhileSourceSecretAbsent pins the state one moment earlier than
-// TestCheckSkipsWhileBucketUnresolved: the projector has not created the Secret
-// at all yet. Returning an error here would log a check failure on every tick
-// of the entire bootstrap window, for a state the gate documents as a no-op.
-func TestCheckSkipsWhileSourceSecretAbsent(t *testing.T) {
+// TestCheckForcesCredentialsReleaseWhenBucketNameEmpty pins the same
+// treatment one state later: the Secret exists but carries no bucket name (a
+// partial render, or a hand-written Secret missing the key). Only a
+// re-render of the producing release can complete it.
+func TestCheckForcesCredentialsReleaseWhenBucketNameEmpty(t *testing.T) {
 	g, dyn := newGate(t,
-		[]client.Object{cozyDefaultBackupClass()},
+		[]client.Object{sourceSecret(""), cozyDefaultBackupClass()},
 		helmReleaseObject(),
+		credentialsHelmReleaseObject(),
 	)
 
 	missing, forced, err := g.Check(context.Background())
 	if err != nil {
-		t.Fatalf("Check returned an error for an absent source Secret, want a silent no-op: %v", err)
+		t.Fatalf("Check: %v", err)
 	}
-	if len(missing) != 0 || forced {
-		t.Fatalf("missing = %v, forced = %v, want none while the source Secret is absent", missing, forced)
+	if !forced || len(missing) != 1 {
+		t.Fatalf("missing = %v, forced = %v; want the credentials Secret forced", missing, forced)
+	}
+	if ann := credentialsForceAnnotations(t, dyn); ann["reconcile.fluxcd.io/forceAt"] == "" {
+		t.Errorf("bucket release not forced: %v", ann)
+	}
+}
+
+// TestCheckReportsCredentialsSecretWithoutBucketRelease covers external S3
+// (backupStorage.provisionBucket=false): the Secret is admin-managed and no
+// release renders it, so there is nothing to force — but it must still be
+// reported missing, because that is the state an operator has to alert on.
+func TestCheckReportsCredentialsSecretWithoutBucketRelease(t *testing.T) {
+	g, dyn := newGate(t,
+		[]client.Object{cozyDefaultBackupClass()},
+		helmReleaseObject(),
+		credentialsHelmReleaseObject(),
+	)
+	g.CredentialsHelmRelease = types.NamespacedName{}
+
+	missing, forced, err := g.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if forced {
+		t.Error("forced a release on the external-S3 path, where none renders the Secret")
+	}
+	if len(missing) != 1 {
+		t.Fatalf("missing = %v, want the credentials Secret reported", missing)
+	}
+	if ann := credentialsForceAnnotations(t, dyn); len(ann) != 0 {
+		t.Errorf("bucket release annotated with no coordinates configured: %v", ann)
+	}
+}
+
+// TestCheckThrottlesTheTwoReleasesIndependently pins that forcing the bucket
+// release does not eat the objects release's throttle budget. The two happen
+// in sequence on a real bootstrap — credentials first, then the objects the
+// resolved bucket unblocks — so a shared timestamp would delay the second
+// force by a full MinForceInterval for no reason.
+func TestCheckThrottlesTheTwoReleasesIndependently(t *testing.T) {
+	base := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	g, dyn := newGate(t,
+		[]client.Object{cozyDefaultBackupClass()},
+		helmReleaseObject(),
+		credentialsHelmReleaseObject(),
+	)
+	g.now = func() time.Time { return base }
+
+	// No source Secret yet: the bucket release is forced.
+	if _, forced, err := g.Check(context.Background()); err != nil || !forced {
+		t.Fatalf("first Check: forced = %v, err = %v; want the bucket release forced", forced, err)
+	}
+
+	// A minute later the Secret lands. The objects are still missing, and
+	// this force must go through despite being well inside MinForceInterval
+	// of the previous one.
+	g.now = func() time.Time { return base.Add(time.Minute) }
+	if err := g.Client.Create(context.Background(), sourceSecret("bucket-1a2b")); err != nil {
+		t.Fatalf("create source Secret: %v", err)
+	}
+	missing, forced, err := g.Check(context.Background())
+	if err != nil {
+		t.Fatalf("second Check: %v", err)
+	}
+	if !forced {
+		t.Fatal("objects release throttled by the earlier credentials force")
+	}
+	if len(missing) != 7 {
+		t.Fatalf("missing = %v, want the 6 strategies + the BSL", missing)
+	}
+	if ann := forceAnnotations(t, dyn); ann["reconcile.fluxcd.io/forceAt"] == "" {
+		t.Errorf("own HelmRelease not forced: %v", ann)
+	}
+}
+
+// TestForceSkipsSuspendedHelmRelease pins the suspend guard. helm-controller
+// ignores forceAt/requestedAt while spec.suspend is true (`cozyhr suspend` is
+// a standard dev workflow), so patching anyway would re-stamp every
+// MinForceInterval for the whole suspension and climb
+// cozystack_backup_default_objects_force_reconciles_total — which the runbook
+// reads as "the forced render is not producing the objects", the wrong
+// diagnosis. The objects must still be reported missing.
+func TestForceSkipsSuspendedHelmRelease(t *testing.T) {
+	g, dyn := newGate(t,
+		[]client.Object{sourceSecret("bucket-1a2b"), cozyDefaultBackupClass()},
+		suspended(helmReleaseObject()),
+	)
+
+	missing, forced, err := g.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if forced {
+		t.Error("forced reported true for a suspended HelmRelease that ignores the annotations")
+	}
+	if len(missing) != 7 {
+		t.Fatalf("missing = %v, want the objects still reported", missing)
 	}
 	if ann := forceAnnotations(t, dyn); len(ann) != 0 {
-		t.Errorf("HelmRelease forced before the source Secret existed: %v", ann)
+		t.Errorf("suspended HelmRelease annotated: %v", ann)
+	}
+}
+
+// TestForceSkipsSuspendedCredentialsHelmRelease pins the same guard on the
+// bucket release, which an operator is far more likely to have suspended:
+// it lives in a tenant namespace and is not part of this chart.
+func TestForceSkipsSuspendedCredentialsHelmRelease(t *testing.T) {
+	g, dyn := newGate(t,
+		[]client.Object{cozyDefaultBackupClass()},
+		helmReleaseObject(),
+		suspended(credentialsHelmReleaseObject()),
+	)
+
+	missing, forced, err := g.Check(context.Background())
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if forced {
+		t.Error("forced reported true for a suspended bucket HelmRelease")
+	}
+	if len(missing) != 1 {
+		t.Fatalf("missing = %v, want the credentials Secret still reported", missing)
+	}
+	if ann := credentialsForceAnnotations(t, dyn); len(ann) != 0 {
+		t.Errorf("suspended bucket HelmRelease annotated: %v", ann)
 	}
 }
 
@@ -488,6 +658,53 @@ func TestCheckSurfacesPatchFailure(t *testing.T) {
 	}
 	if !g.lastForce.IsZero() {
 		t.Error("lastForce advanced despite the patch failing; the next tick would be throttled")
+	}
+}
+
+// TestMissingGaugeCoversTheUnresolvedPath pins the alerting contract. The
+// gauge used to be written only after the bucket resolved, so the state the
+// gate exists to catch — no credentials Secret, therefore no strategies —
+// reported 0 or nothing at all, and an alert on it never fired. Deleting the
+// source Secret later (credential rotation) had the same effect: the gauge
+// froze at its last value.
+func TestMissingGaugeCoversTheUnresolvedPath(t *testing.T) {
+	defaultObjectsMissing.Reset()
+	g, _ := newGate(t,
+		[]client.Object{cozyDefaultBackupClass()},
+		helmReleaseObject(),
+		credentialsHelmReleaseObject(),
+	)
+
+	if _, _, err := g.Check(context.Background()); err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if got := testutil.ToFloat64(defaultObjectsMissing.WithLabelValues("cozy-default")); got != 1 {
+		t.Fatalf("cozystack_backup_default_objects_missing = %v, want 1 while the credentials Secret is absent", got)
+	}
+}
+
+// TestCheckErrorsCounterMarksTheGaugeStale pins the other half of that
+// contract. On an API error the gauge deliberately keeps its last value
+// rather than flapping the alert, which means the gauge alone cannot tell
+// "healthy" from "not evaluated". The errors counter is what closes that
+// gap, and the runbook alerts on both.
+func TestCheckErrorsCounterMarksTheGaugeStale(t *testing.T) {
+	defaultObjectsMissing.Reset()
+	defaultObjectsCheckErrors.Reset()
+	// No BackupClass: the check cannot enumerate what must exist.
+	g, _ := newGate(t,
+		[]client.Object{sourceSecret("bucket-1a2b")},
+		helmReleaseObject(),
+	)
+
+	if _, _, err := g.Check(context.Background()); err == nil {
+		t.Fatal("Check succeeded with no BackupClass, want an error")
+	}
+	if got := testutil.ToFloat64(defaultObjectsCheckErrors.WithLabelValues("cozy-default")); got != 1 {
+		t.Fatalf("cozystack_backup_default_objects_check_errors_total = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(defaultObjectsMissing.WithLabelValues("cozy-default")); got != 0 {
+		t.Fatalf("gauge = %v, want it left untouched by a failed check", got)
 	}
 }
 

--- a/internal/backupcontroller/default_objects_gate_test.go
+++ b/internal/backupcontroller/default_objects_gate_test.go
@@ -383,17 +383,21 @@ func TestMissingObjectsIgnoresUnmappedKinds(t *testing.T) {
 	}
 }
 
-// TestMissingObjectsSkipsBSLWhenVeleroNamespaceEmpty covers
-// velero.bslEnabled=false: the chart renders no BSL, so its absence is not
-// a defect and must not drive forced upgrades.
-func TestMissingObjectsSkipsBSLWhenVeleroNamespaceEmpty(t *testing.T) {
+// TestMissingObjectsSkipsVeleroWhenNamespaceEmpty covers
+// velero.bslEnabled=false: the chart gates BOTH the BSL and the Velero
+// Strategy CRs off the same flag, so neither is rendered and their absence
+// is not a defect. The BackupClass still routes to the Velero strategies
+// unconditionally, which is the trap: without the skip the gate would count
+// the never-rendered Velero CRs as missing and force a Helm upgrade every
+// MinForceInterval forever. The Velero objects are deliberately NOT
+// pre-created here, because with the BSL disabled the chart never renders
+// them on a real cluster.
+func TestMissingObjectsSkipsVeleroWhenNamespaceEmpty(t *testing.T) {
 	bc := cozyDefaultBackupClass()
 	g, _ := newGate(t, []client.Object{sourceSecret("b"), bc},
 		helmReleaseObject(),
 		strategyObject("CNPG", "cozy-default-cnpg"),
 		strategyObject("Etcd", "cozy-default-etcd"),
-		strategyObject("Velero", "cozy-default-velero-vminstance"),
-		strategyObject("Velero", "cozy-default-velero-vmdisk"),
 	)
 	g.VeleroNamespace = ""
 
@@ -402,7 +406,7 @@ func TestMissingObjectsSkipsBSLWhenVeleroNamespaceEmpty(t *testing.T) {
 		t.Fatalf("missingObjects: %v", err)
 	}
 	if len(missing) != 0 {
-		t.Fatalf("missing = %v, want none when the BSL is disabled", missing)
+		t.Fatalf("missing = %v, want none when Velero is disabled", missing)
 	}
 }
 

--- a/packages/system/backupstrategy-controller/templates/_helpers.tpl
+++ b/packages/system/backupstrategy-controller/templates/_helpers.tpl
@@ -27,9 +27,22 @@
       cozystack.bucket-application + cozystack.objectstorage-controller
       ensures the controllers exist before this chart installs, but the
       BucketClaim status is reconciled asynchronously, so the first render
-      sees an unpopulated status and skips. Flux re-renders the
-      HelmRelease on its next reconcile (spec.interval); once COSI has
-      populated status.bucketName, the gated templates materialise.
+      sees an unpopulated status and skips.
+
+      The render CANNOT fail here instead: this chart is the producer of
+      the very Bucket the lookup reads, so a failed render would never
+      apply templates/bucket.yaml and the condition could never resolve.
+
+      Nor does Flux repair the skip on its own. helm-controller does not
+      re-render a release whose chart and values did not change — the
+      interval reconcile is a no-op for a healthy release, and drift
+      detection is off on operator-generated HelmReleases — so the skip is
+      PERMANENT, not a bootstrap window. Convergence is driven instead by
+      the controller's DefaultObjectsGate
+      (internal/backupcontroller/default_objects_gate.go), which forces a
+      real Helm upgrade (reconcile.fluxcd.io/forceAt + requestedAt) once
+      the bucket name is resolvable and any gated object is missing. See
+      backupStorage.reconcileDefaultObjects in values.yaml.
     - bucketNameOverride set → bypass the lookup and use it directly. This
       is the escape hatch for offline `helm template` / `--dry-run` renders
       (CI / local diffs), where lookup returns nil and no apiserver is
@@ -53,11 +66,13 @@
 {{- end -}}
 {{/* When neither path produces a value, emit the empty string.
      Strategy/BSL templates that include this helper must gate
-     themselves on a non-empty result and skip rendering until Flux
-     re-reconciles the HelmRelease (driven by spec.interval) once the
-     BucketClaim's COSI-assigned status.bucketName is populated. The
-     accompanying templates/bucket.yaml ALWAYS renders so the
-     BucketClaim CAN come into existence even on the first install. */}}
+     themselves on a non-empty result and skip rendering until a real
+     Helm upgrade re-runs this lookup with the BucketClaim's
+     COSI-assigned status.bucketName populated. That upgrade is forced by
+     the controller's DefaultObjectsGate — it does NOT happen on the
+     HelmRelease's interval reconcile. The accompanying
+     templates/bucket.yaml ALWAYS renders so the BucketClaim CAN come
+     into existence even on the first install. */}}
 {{- end -}}
 {{- end -}}
 

--- a/packages/system/backupstrategy-controller/templates/backupclass-default.yaml
+++ b/packages/system/backupstrategy-controller/templates/backupclass-default.yaml
@@ -6,9 +6,15 @@
   from Day 1; the Strategy CRs it references stay gated on a populated
   $bucketName because they DO need the COSI-assigned bucket name
   embedded in their template. A BackupJob fired during the bootstrap
-  window surfaces a transient Ready=False/StrategyNotReady in the
-  driver and self-heals once Flux re-renders the chart with the
-  populated BucketClaim status.
+  window surfaces a transient Ready=False/StrategyNotReady in the driver.
+
+  It does NOT self-heal on a Flux reconcile: helm-controller re-renders
+  only when the chart or values change, so the gated Strategy CRs would
+  stay absent forever. The controller's DefaultObjectsGate reads THIS
+  object's strategyRefs as the manifest of what must exist and forces the
+  real Helm upgrade that materialises them (see
+  backupStorage.reconcileDefaultObjects). Adding a route here therefore
+  also adds the referenced Strategy CR to that existence check.
 */}}
 apiVersion: backups.cozystack.io/v1alpha1
 kind: BackupClass

--- a/packages/system/backupstrategy-controller/templates/deployment.yaml
+++ b/packages/system/backupstrategy-controller/templates/deployment.yaml
@@ -50,6 +50,25 @@ spec:
           value: {{ .Values.backupStorage.forcePathStyle | quote }}
         - name: BACKUP_STORAGE_SYSTEM_NAMESPACES
           value: {{ .Values.backupStorage.systemNamespaces | join "," | quote }}
+        {{- if .Values.backupStorage.reconcileDefaultObjects }}
+        # DefaultObjectsGate: the Strategy CRs and the Velero BSL are gated
+        # on a `lookup` of the BucketClaim this same chart creates, so a
+        # fresh install renders them empty — permanently, because
+        # helm-controller does not re-render an unchanged, successful
+        # release. The gate detects the missing objects once the bucket name
+        # is resolvable and forces exactly one real Helm upgrade on THIS
+        # release, which is the only thing that re-runs the lookups.
+        - name: BACKUP_DEFAULT_OBJECTS_BACKUPCLASS
+          value: cozy-default
+        - name: BACKUP_DEFAULT_OBJECTS_HELMRELEASE_NAME
+          value: {{ .Release.Name | quote }}
+        - name: BACKUP_DEFAULT_OBJECTS_HELMRELEASE_NAMESPACE
+          value: {{ .Release.Namespace | quote }}
+        {{- if .Values.velero.bslEnabled }}
+        - name: BACKUP_DEFAULT_OBJECTS_VELERO_NAMESPACE
+          value: {{ .Values.velero.namespace | quote }}
+        {{- end }}
+        {{- end }}
         ports:
         {{- if .Values.backupStrategyController.metrics.enabled }}
         - name: metrics

--- a/packages/system/backupstrategy-controller/templates/deployment.yaml
+++ b/packages/system/backupstrategy-controller/templates/deployment.yaml
@@ -64,6 +64,30 @@ spec:
           value: {{ .Release.Name | quote }}
         - name: BACKUP_DEFAULT_OBJECTS_HELMRELEASE_NAMESPACE
           value: {{ .Release.Namespace | quote }}
+        {{- if .Values.backupStorage.provisionBucket }}
+        # The credentials Secret named by BACKUP_STORAGE_SECRET_NAME is
+        # itself rendered behind an install-time `lookup` — of the COSI
+        # Secret, by packages/system/bucket/templates/user-credentials.yaml —
+        # so it is subject to the same permanent skip, one release earlier in
+        # the chain. While it is missing the projector has no source, every
+        # Strategy CR and the Velero BSL stay gated off, and migration 50
+        # cannot resolve its snapshot target. These coordinates let the gate
+        # force the release that renders it.
+        #
+        # The name is the Bucket CR name carrying the bucket-rd release
+        # prefix (packages/system/bucket-rd/cozyrds/bucket.yaml) plus the
+        # "-system" suffix the parent chart appends
+        # (packages/apps/bucket/templates/helmrelease.yaml), which is exactly
+        # BACKUP_STORAGE_SECRET_NAME minus "-credentials". tests/
+        # default_objects_gate_test.yaml asserts the two stay in lockstep.
+        #
+        # Omitted on provisionBucket=false (external S3): the Secret is
+        # admin-managed there and no release renders it.
+        - name: BACKUP_CREDENTIALS_HELMRELEASE_NAME
+          value: {{ printf "bucket-%s-system" .Values.backupStorage.bucketName | quote }}
+        - name: BACKUP_CREDENTIALS_HELMRELEASE_NAMESPACE
+          value: {{ .Values.backupStorage.namespace | quote }}
+        {{- end }}
         {{- if .Values.velero.bslEnabled }}
         - name: BACKUP_DEFAULT_OBJECTS_VELERO_NAMESPACE
           value: {{ .Values.velero.namespace | quote }}

--- a/packages/system/backupstrategy-controller/templates/rbac.yaml
+++ b/packages/system/backupstrategy-controller/templates/rbac.yaml
@@ -61,10 +61,15 @@ rules:
 - apiGroups: ["cdi.kubevirt.io"]
   resources: ["datavolumes"]
   verbs: ["delete"]
-# HelmReleases: pre-restore suspends HRs; post-restore rename creates new HR and deletes old
+# HelmReleases: pre-restore suspends HRs; post-restore rename creates new HR
+# and deletes old. patch additionally lets the DefaultObjectsGate stamp
+# reconcile.fluxcd.io/forceAt + requestedAt on THIS chart's own release to
+# force the Helm upgrade that materialises the lookup-gated default backup
+# objects (no list/watch: every access is a point Get through the dynamic
+# client, so no cluster-wide HelmRelease informer is started).
 - apiGroups: ["helm.toolkit.fluxcd.io"]
   resources: ["helmreleases"]
-  verbs: ["get", "create", "update", "delete"]
+  verbs: ["get", "create", "update", "patch", "delete"]
 # PVCs and PVs: pre-restore renames PVCs (delete old, create new) and patches PV reclaim policy
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
@@ -76,6 +81,13 @@ rules:
 - apiGroups: ["velero.io"]
   resources: ["backups", "restores", "datauploads"]
   verbs: ["create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"]
+# Velero BackupStorageLocation: the DefaultObjectsGate checks that the
+# cozy-default BSL — rendered by the same lookup-gated template as the
+# Strategy CRs — actually exists. Read-only, and a point Get through the
+# dynamic client, so `get` alone is enough (no informer, no list/watch).
+- apiGroups: ["velero.io"]
+  resources: ["backupstoragelocations"]
+  verbs: ["get"]
 # Velero DeleteBackupRequest: used by BackupReconciler to delete Velero backups with their storage data
 - apiGroups: ["velero.io"]
   resources: ["deletebackuprequests"]

--- a/packages/system/backupstrategy-controller/tests/default_objects_gate_test.yaml
+++ b/packages/system/backupstrategy-controller/tests/default_objects_gate_test.yaml
@@ -41,6 +41,71 @@ tests:
             name: BACKUP_DEFAULT_OBJECTS_VELERO_NAMESPACE
             value: cozy-velero
 
+  # The credentials Secret is rendered one release earlier, by the platform
+  # bucket's <bucket>-system release, behind the same kind of install-time
+  # lookup. Its name is assembled from the bucket-rd release prefix and the
+  # "-system" suffix the parent bucket chart appends, and it must stay in
+  # lockstep with systemSecretName: the gate resolves the bucket name from
+  # that Secret and forces exactly this release when it is absent. Two
+  # independently written strings, so pin the relationship, not just the value.
+  - it: "gate targets the bucket release that renders the credentials Secret"
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_CREDENTIALS_HELMRELEASE_NAME
+            value: bucket-cozy-backups-system
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_CREDENTIALS_HELMRELEASE_NAMESPACE
+            value: tenant-root
+      # BACKUP_STORAGE_SECRET_NAME is exactly the release name above with
+      # "-credentials" appended — that is what makes forcing this release the
+      # thing that creates that Secret.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_STORAGE_SECRET_NAME
+            value: bucket-cozy-backups-system-credentials
+
+  - it: "a renamed bucket moves both the forced release and the Secret together"
+    template: templates/deployment.yaml
+    set:
+      backupStorage.bucketName: platform-backups
+      backupStorage.systemSecretName: bucket-platform-backups-system-credentials
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_CREDENTIALS_HELMRELEASE_NAME
+            value: bucket-platform-backups-system
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_STORAGE_SECRET_NAME
+            value: bucket-platform-backups-system-credentials
+
+  # External S3: the Secret is admin-managed and no release renders it, so
+  # there is nothing to force. Handing the gate stale coordinates would make
+  # it patch a HelmRelease that does not exist every MinForceInterval.
+  - it: "provisionBucket=false: no bucket release to force"
+    template: templates/deployment.yaml
+    set:
+      backupStorage.provisionBucket: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_CREDENTIALS_HELMRELEASE_NAME
+            value: bucket-cozy-backups-system
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_CREDENTIALS_HELMRELEASE_NAMESPACE
+            value: tenant-root
+
   - it: "velero.bslEnabled=false: the BSL is not rendered, so the gate must not look for it"
     template: templates/deployment.yaml
     set:

--- a/packages/system/backupstrategy-controller/tests/default_objects_gate_test.yaml
+++ b/packages/system/backupstrategy-controller/tests/default_objects_gate_test.yaml
@@ -1,0 +1,91 @@
+suite: DefaultObjectsGate wiring — the release the gate forces, and its RBAC
+
+# The Strategy CRs and the Velero BSL are rendered behind a `lookup` of the
+# BucketClaim this same chart creates, so a fresh install renders them empty
+# and helm-controller never re-renders (unchanged chart + values, drift
+# detection off) — the skip is permanent. The controller's DefaultObjectsGate
+# repairs that by forcing a real Helm upgrade on THIS release, so the release
+# coordinates it is given must be this chart's own release, and it must hold
+# the verbs to do it.
+
+templates:
+  - templates/deployment.yaml
+  - templates/rbac.yaml
+
+release:
+  name: backupstrategy-controller
+  namespace: cozy-backup-controller
+
+tests:
+  - it: "gate targets this chart's own HelmRelease and the cozy-default BackupClass"
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_DEFAULT_OBJECTS_HELMRELEASE_NAME
+            value: backupstrategy-controller
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_DEFAULT_OBJECTS_HELMRELEASE_NAMESPACE
+            value: cozy-backup-controller
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_DEFAULT_OBJECTS_BACKUPCLASS
+            value: cozy-default
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_DEFAULT_OBJECTS_VELERO_NAMESPACE
+            value: cozy-velero
+
+  - it: "velero.bslEnabled=false: the BSL is not rendered, so the gate must not look for it"
+    template: templates/deployment.yaml
+    set:
+      velero.bslEnabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_DEFAULT_OBJECTS_VELERO_NAMESPACE
+            value: cozy-velero
+      # The rest of the gate stays wired: the Strategy CRs still need it.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_DEFAULT_OBJECTS_HELMRELEASE_NAME
+            value: backupstrategy-controller
+
+  - it: "reconcileDefaultObjects=false: the gate is fully unwired (main.go disables it on an empty release name)"
+    template: templates/deployment.yaml
+    set:
+      backupStorage.reconcileDefaultObjects: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_DEFAULT_OBJECTS_HELMRELEASE_NAME
+            value: backupstrategy-controller
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BACKUP_DEFAULT_OBJECTS_BACKUPCLASS
+            value: cozy-default
+
+  - it: "ClusterRole grants patch on helmreleases (forceAt stamp) and get on backupstoragelocations"
+    template: templates/rbac.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["helm.toolkit.fluxcd.io"]
+            resources: ["helmreleases"]
+            verbs: ["get", "create", "update", "patch", "delete"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["velero.io"]
+            resources: ["backupstoragelocations"]
+            verbs: ["get"]

--- a/packages/system/backupstrategy-controller/values.yaml
+++ b/packages/system/backupstrategy-controller/values.yaml
@@ -157,10 +157,13 @@ backupStorage:
 # DefaultObjectsGate has forced a real Helm upgrade (an interval reconcile
 # alone does not re-render). Setting this
 # to false is an explicit opt-out for clusters that disable VM backups
-# entirely and want to avoid the cluster-default BSL — in that case the
-# cozy-default-velero-vminstance / -vmdisk strategy CRs still ship but
-# their `storageLocation: cozy-default` reference will not resolve, so
-# VM BackupJobs against cozy-default will fail.
+# entirely and want to avoid the cluster-default BSL. In that case the
+# cozy-default-velero-vminstance / -vmdisk Strategy CRs are gated off the
+# same flag and are NOT rendered either, so the DefaultObjectsGate does
+# not expect them (it would otherwise force a Helm upgrade forever against
+# a render that can never produce them). VM BackupJobs against cozy-default
+# still fail, because the BackupClass keeps routing VMInstance / VMDisk to
+# those absent strategies.
 velero:
   bslEnabled: true
   namespace: cozy-velero

--- a/packages/system/backupstrategy-controller/values.yaml
+++ b/packages/system/backupstrategy-controller/values.yaml
@@ -118,6 +118,30 @@ backupStorage:
   # rendering. Tenants are projected lazily during BackupJob reconcile.
   systemNamespaces:
     - cozy-velero
+  # reconcileDefaultObjects enables the controller's DefaultObjectsGate.
+  #
+  # The Strategy CRs and the Velero BSL below are Helm-templated behind a
+  # `lookup` of the BucketClaim THIS chart creates, because the S3 bucket
+  # name is assigned by the COSI driver (bucket-<claim-UID>) and cannot be
+  # computed at render time. On a fresh install the lookup is empty and those
+  # templates render nothing — and helm-controller does not re-render a
+  # release whose chart and values did not change (drift detection is off on
+  # operator-generated HelmReleases), so the skip is PERMANENT. Clusters have
+  # run for months with only the BackupClass present and no Strategy CRs at
+  # all; recovery needed a hand-stamped reconcile.fluxcd.io/forceAt +
+  # requestedAt, because a plain reconcile request does not re-render.
+  #
+  # With this enabled the controller resolves the bucket name from the
+  # projector's source Secret (no new dependency, no lookup), checks that
+  # every object cozy-default routes to exists, and forces one Helm upgrade
+  # when any is missing — throttled, and a no-op in the steady state. It does
+  # NOT create the objects itself: their bodies are values-driven and Helm
+  # stays their single owner.
+  #
+  # Turn this off only if you manage the default Strategy CRs out of band and
+  # accept that a missed install-time render is never repaired. Watch
+  # cozystack_backup_default_objects_missing if you do.
+  reconcileDefaultObjects: true
 # velero — BSL rendering. The cozy-default BackupStorageLocation is
 # created in cozy-velero by templates/velero-bsl.yaml so endpoint/bucket/
 # region come from the same backupStorage block used by Strategy CRs and
@@ -129,7 +153,9 @@ backupStorage:
 # Velero CRDs are guaranteed to exist by the time this chart installs.
 # The BSL template additionally gates itself on a populated BucketClaim
 # status via the bucketName helper, so on a bootstrap install the BSL
-# materialises only after the platform Bucket reconciles. Setting this
+# materialises only after the platform Bucket reconciles AND the
+# DefaultObjectsGate has forced a real Helm upgrade (an interval reconcile
+# alone does not re-render). Setting this
 # to false is an explicit opt-out for clusters that disable VM backups
 # entirely and want to avoid the cluster-default BSL — in that case the
 # cozy-default-velero-vminstance / -vmdisk strategy CRs still ship but

--- a/packages/system/backupstrategy-controller/values.yaml
+++ b/packages/system/backupstrategy-controller/values.yaml
@@ -131,16 +131,26 @@ backupStorage:
   # all; recovery needed a hand-stamped reconcile.fluxcd.io/forceAt +
   # requestedAt, because a plain reconcile request does not re-render.
   #
-  # With this enabled the controller resolves the bucket name from the
-  # projector's source Secret (no new dependency, no lookup), checks that
-  # every object cozy-default routes to exists, and forces one Helm upgrade
-  # when any is missing — throttled, and a no-op in the steady state. It does
-  # NOT create the objects itself: their bodies are values-driven and Helm
-  # stays their single owner.
+  # The systemSecretName Secret above sits one release earlier in the same
+  # trap: packages/system/bucket/templates/user-credentials.yaml renders it
+  # behind a `lookup` of the COSI Secret, and skips it just as permanently.
+  # Without it the projector has no source at all, so nothing downstream can
+  # resolve — and neither can this gate, which reads the bucket name from it.
+  #
+  # With this enabled the controller repairs both, in order: while the
+  # credentials Secret is missing it forces the bucket's <bucket>-system
+  # release; once the bucket name resolves it checks that every object
+  # cozy-default routes to exists and forces THIS release when any is
+  # missing. Both are throttled, independently, and a no-op in the steady
+  # state. A suspended release is skipped rather than re-stamped forever. The
+  # gate does NOT create the objects itself: their bodies are values-driven
+  # and Helm stays their single owner.
   #
   # Turn this off only if you manage the default Strategy CRs out of band and
   # accept that a missed install-time render is never repaired. Watch
-  # cozystack_backup_default_objects_missing if you do.
+  # cozystack_backup_default_objects_missing (paired with
+  # cozystack_backup_default_objects_check_errors_total, which marks the
+  # gauge stale) if you do.
   reconcileDefaultObjects: true
 # velero — BSL rendering. The cozy-default BackupStorageLocation is
 # created in cozy-velero by templates/velero-bsl.yaml so endpoint/bucket/

--- a/packages/system/bucket/templates/user-credentials.yaml
+++ b/packages/system/bucket/templates/user-credentials.yaml
@@ -1,7 +1,40 @@
+{{/*
+  The human-friendly per-user credentials Secret is derived from the COSI
+  Secret the objectstorage sidecar writes for the matching BucketAccess
+  (packages/apps/bucket/templates/bucketclaim.yaml). That Secret carries a
+  single BucketInfo JSON document with the driver-assigned bucket name and
+  the S3 keys — none of it is knowable at render time, so a `lookup` is
+  unavoidable here.
+
+  What is NOT acceptable is silently skipping the Secret when the lookup is
+  empty. helm-controller does not re-render a release whose chart and values
+  did not change, and drift detection is off by default, so a skip at
+  install time is PERMANENT: the Secret is never created, and every consumer
+  that reads it (the dashboard, and for the platform cozy-backups bucket the
+  backupstrategy-controller credentials projector — hence every default
+  BackupClass strategy and Velero itself) stays broken until somebody forces
+  a real Helm upgrade by hand.
+
+  So fail the render instead. This release retries forever
+  (install/upgrade.remediation.retries: -1 on the <bucket>-system
+  HelmRelease, see packages/apps/bucket/templates/helmrelease.yaml) and
+  every retry re-runs the lookup, so it converges as soon as COSI publishes
+  the Secret. Failing cannot deadlock its own precondition: the BucketAccess
+  that produces the COSI Secret is rendered by the PARENT release, not by
+  this one.
+
+  requireUserCredentials: false is the escape hatch for offline renders
+  (`helm template`, `make show`, CI diffs) where lookup always returns nil
+  and no apiserver is reachable.
+*/}}
 {{- range $name, $user := .Values.users }}
 {{- $secretName := printf "%s-%s" $.Values.bucketName $name }}
 {{- $existingSecret := lookup "v1" "Secret" $.Release.Namespace $secretName }}
-{{- if $existingSecret }}
+{{- if not $existingSecret }}
+{{- if $.Values.requireUserCredentials }}
+{{- fail (printf "COSI credentials Secret %s/%s does not exist yet, so %s-credentials cannot be rendered. This is expected while the bucket is being provisioned: the release retries and converges once the objectstorage sidecar has written the Secret for BucketAccess %s. If it never appears, inspect the BucketClaim/BucketAccess in this namespace and the objectstorage-controller logs. Set requireUserCredentials=false to render this chart offline." $.Release.Namespace $secretName $secretName $secretName) }}
+{{- end }}
+{{- else }}
 {{- $bucketInfo := fromJson (b64dec (index $existingSecret.data "BucketInfo")) }}
 ---
 apiVersion: v1

--- a/packages/system/bucket/templates/user-credentials.yaml
+++ b/packages/system/bucket/templates/user-credentials.yaml
@@ -6,35 +6,38 @@
   the S3 keys — none of it is knowable at render time, so a `lookup` is
   unavoidable here.
 
-  What is NOT acceptable is silently skipping the Secret when the lookup is
-  empty. helm-controller does not re-render a release whose chart and values
-  did not change, and drift detection is off by default, so a skip at
-  install time is PERMANENT: the Secret is never created, and every consumer
-  that reads it (the dashboard, and for the platform cozy-backups bucket the
-  backupstrategy-controller credentials projector — hence every default
-  BackupClass strategy and Velero itself) stays broken until somebody forces
-  a real Helm upgrade by hand.
+  The skip below is NOT self-healing, contrary to what this file used to
+  imply. helm-controller does not re-render a release whose chart and values
+  did not change, and drift detection is off on operator-generated
+  HelmReleases, so a lookup that comes back empty at install time is skipped
+  PERMANENTLY: the Secret is never created, and every consumer that reads it
+  stays broken until somebody forces a real Helm upgrade
+  (reconcile.fluxcd.io/forceAt + requestedAt — a plain `flux reconcile` does
+  not re-render).
 
-  So fail the render instead. This release retries forever
-  (install/upgrade.remediation.retries: -1 on the <bucket>-system
-  HelmRelease, see packages/apps/bucket/templates/helmrelease.yaml) and
-  every retry re-runs the lookup, so it converges as soon as COSI publishes
-  the Secret. Failing cannot deadlock its own precondition: the BucketAccess
-  that produces the COSI Secret is rendered by the PARENT release, not by
-  this one.
+  Failing the render instead is tempting and wrong. Helm cannot render a
+  partial set, so a `fail` inside this range aborts the WHOLE
+  <bucket>-system release — the other users' Secrets, and the bucket UI
+  Deployment/Service/Ingress/HTTPRoute with them. One declared user whose
+  BucketAccess never provisions (a misconfigured bucketAccessClassName, a
+  COSI failure) would then take down every other user of that bucket, and on
+  an already-installed release it would park it in Failed and block every
+  later upgrade, with no per-bucket way out.
 
-  requireUserCredentials: false is the escape hatch for offline renders
-  (`helm template`, `make show`, CI diffs) where lookup always returns nil
-  and no apiserver is reachable.
+  So the repair lives outside the chart, where it is per-object and costs a
+  throttled annotation patch: backupstrategy-controller's DefaultObjectsGate
+  (internal/backupcontroller/default_objects_gate.go) forces this release
+  when the platform bucket's credentials Secret is absent. That covers the
+  cluster-breaking case — the cozy-backups Secret feeds the credentials
+  projector, hence every default BackupClass strategy, Velero, and migration
+  50. Tenant buckets keep the pre-existing behaviour; generalising the gate
+  to every bucket needs a controller that owns them and is tracked
+  separately.
 */}}
 {{- range $name, $user := .Values.users }}
 {{- $secretName := printf "%s-%s" $.Values.bucketName $name }}
 {{- $existingSecret := lookup "v1" "Secret" $.Release.Namespace $secretName }}
-{{- if not $existingSecret }}
-{{- if $.Values.requireUserCredentials }}
-{{- fail (printf "COSI credentials Secret %s/%s does not exist yet, so %s-credentials cannot be rendered. This is expected while the bucket is being provisioned: the release retries and converges once the objectstorage sidecar has written the Secret for BucketAccess %s. If it never appears, inspect the BucketClaim/BucketAccess in this namespace and the objectstorage-controller logs. Set requireUserCredentials=false to render this chart offline." $.Release.Namespace $secretName $secretName $secretName) }}
-{{- end }}
-{{- else }}
+{{- if $existingSecret }}
 {{- $bucketInfo := fromJson (b64dec (index $existingSecret.data "BucketInfo")) }}
 ---
 apiVersion: v1

--- a/packages/system/bucket/tests/user_credentials_test.yaml
+++ b/packages/system/bucket/tests/user_credentials_test.yaml
@@ -1,45 +1,44 @@
-suite: per-user credentials Secret — loud failure instead of a permanent silent skip
+suite: an unresolvable user must not take the rest of the release down
 
 # The <bucket>-<user>-credentials Secret is derived from the COSI Secret the
 # objectstorage sidecar writes, which is only knowable through a `lookup`.
 # helm-unittest renders with no live cluster, so lookup always returns nil —
 # exactly the pre-reconcile install window these cases pin.
 #
-# The old template silently emitted nothing in that window. Because
-# helm-controller does not re-render a release whose chart and values did not
-# change, that skip was permanent: the Secret was never created, and the
-# platform credentials projector (hence every default BackupClass strategy)
-# had no source to read.
-
-templates:
-  - templates/user-credentials.yaml
+# The skip is not self-healing (helm-controller does not re-render an
+# unchanged release), and the repair for the platform bucket lives in
+# backupstrategy-controller's DefaultObjectsGate, which forces this release.
+#
+# What these cases guard is the shape of that decision: the render must stay
+# partial, never fatal. A `fail` here cannot be scoped to one user — Helm
+# renders all or nothing — so it would take the other users' Secrets and the
+# bucket UI down with it, and park an installed release in Failed with no
+# per-bucket way out.
+#
+# _namespace / _cluster are set in every case because helm-unittest renders
+# the whole chart for each one, not only the templates it asserts on: the
+# ingress template dereferences both and would abort the render otherwise.
 
 release:
   name: bucket-cozy-backups
   namespace: tenant-root
 
-tests:
-  - it: "fails the render when a declared user's COSI Secret does not exist yet"
-    set:
-      bucketName: bucket-cozy-backups
-      users:
-        system:
-          readonly: false
-    asserts:
-      - failedTemplate:
-          errorMessage: >-
-            COSI credentials Secret tenant-root/bucket-cozy-backups-system does not exist yet,
-            so bucket-cozy-backups-system-credentials cannot be rendered. This is expected while
-            the bucket is being provisioned: the release retries and converges once the
-            objectstorage sidecar has written the Secret for BucketAccess
-            bucket-cozy-backups-system. If it never appears, inspect the BucketClaim/BucketAccess
-            in this namespace and the objectstorage-controller logs. Set
-            requireUserCredentials=false to render this chart offline.
+set: &base
+  bucketName: bucket-cozy-backups
+  _namespace:
+    host: example.org
+    ingress: tenant-root
+    gateway: ""
+  _cluster:
+    issuer-name: letsencrypt-prod
+    solver: http01
 
-  - it: "requireUserCredentials=false keeps offline renders working (no Secret, no failure)"
+tests:
+  - it: "emits no Secret while a declared user's COSI Secret does not exist yet"
+    templates:
+      - templates/user-credentials.yaml
     set:
-      bucketName: bucket-cozy-backups
-      requireUserCredentials: false
+      <<: *base
       users:
         system:
           readonly: false
@@ -47,10 +46,35 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: "no declared users: nothing to render and nothing to fail on"
+  - it: "no declared users: nothing to render"
+    templates:
+      - templates/user-credentials.yaml
     set:
-      bucketName: bucket-cozy-backups
+      <<: *base
       users: {}
     asserts:
       - hasDocuments:
           count: 0
+
+  # The regression guard. With every user unresolvable — the multi-user
+  # partial-failure case — the rest of the release must still render. If a
+  # `fail` is ever reintroduced in user-credentials.yaml, Helm aborts the
+  # whole chart and this case fails on the aborted render, not on an
+  # assertion.
+  - it: "the bucket UI still renders when no user's COSI Secret resolves"
+    templates:
+      - templates/service.yaml
+    set:
+      <<: *base
+      users:
+        system:
+          readonly: false
+        alice:
+          readonly: true
+    asserts:
+      - equal:
+          path: kind
+          value: Service
+      - equal:
+          path: metadata.name
+          value: bucket-cozy-backups-ui

--- a/packages/system/bucket/tests/user_credentials_test.yaml
+++ b/packages/system/bucket/tests/user_credentials_test.yaml
@@ -1,0 +1,56 @@
+suite: per-user credentials Secret — loud failure instead of a permanent silent skip
+
+# The <bucket>-<user>-credentials Secret is derived from the COSI Secret the
+# objectstorage sidecar writes, which is only knowable through a `lookup`.
+# helm-unittest renders with no live cluster, so lookup always returns nil —
+# exactly the pre-reconcile install window these cases pin.
+#
+# The old template silently emitted nothing in that window. Because
+# helm-controller does not re-render a release whose chart and values did not
+# change, that skip was permanent: the Secret was never created, and the
+# platform credentials projector (hence every default BackupClass strategy)
+# had no source to read.
+
+templates:
+  - templates/user-credentials.yaml
+
+release:
+  name: bucket-cozy-backups
+  namespace: tenant-root
+
+tests:
+  - it: "fails the render when a declared user's COSI Secret does not exist yet"
+    set:
+      bucketName: bucket-cozy-backups
+      users:
+        system:
+          readonly: false
+    asserts:
+      - failedTemplate:
+          errorMessage: >-
+            COSI credentials Secret tenant-root/bucket-cozy-backups-system does not exist yet,
+            so bucket-cozy-backups-system-credentials cannot be rendered. This is expected while
+            the bucket is being provisioned: the release retries and converges once the
+            objectstorage sidecar has written the Secret for BucketAccess
+            bucket-cozy-backups-system. If it never appears, inspect the BucketClaim/BucketAccess
+            in this namespace and the objectstorage-controller logs. Set
+            requireUserCredentials=false to render this chart offline.
+
+  - it: "requireUserCredentials=false keeps offline renders working (no Secret, no failure)"
+    set:
+      bucketName: bucket-cozy-backups
+      requireUserCredentials: false
+      users:
+        system:
+          readonly: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: "no declared users: nothing to render and nothing to fail on"
+    set:
+      bucketName: bucket-cozy-backups
+      users: {}
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/packages/system/bucket/values.yaml
+++ b/packages/system/bucket/values.yaml
@@ -1,2 +1,11 @@
 bucketName: "cozystack"
 users: {}
+# requireUserCredentials makes the render FAIL while a declared user's COSI
+# credentials Secret does not exist yet, instead of silently emitting no
+# <bucket>-<user>-credentials Secret. Keep it true on a live cluster: the
+# release retries (install/upgrade.remediation.retries: -1) and converges,
+# whereas a silent skip is permanent — helm-controller does not re-render an
+# unchanged release, so the Secret would never be created at all.
+# Set to false only for offline renders (`helm template`, `make show`, CI
+# diffs), where `lookup` always returns nil because no apiserver is reachable.
+requireUserCredentials: true

--- a/packages/system/bucket/values.yaml
+++ b/packages/system/bucket/values.yaml
@@ -1,11 +1,2 @@
 bucketName: "cozystack"
 users: {}
-# requireUserCredentials makes the render FAIL while a declared user's COSI
-# credentials Secret does not exist yet, instead of silently emitting no
-# <bucket>-<user>-credentials Secret. Keep it true on a live cluster: the
-# release retries (install/upgrade.remediation.retries: -1) and converges,
-# whereas a silent skip is permanent — helm-controller does not re-render an
-# unchanged release, so the Secret would never be created at all.
-# Set to false only for offline renders (`helm template`, `make show`, CI
-# diffs), where `lookup` always returns nil because no apiserver is reachable.
-requireUserCredentials: true


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Fixes #3518.

Objects in `packages/system/backupstrategy-controller` and `packages/system/bucket` are gated on a Helm `lookup` of an object that is still being created. When the lookup is empty the object is skipped — and since helm-controller does not re-render a release whose chart and values did not change (drift detection is off on operator-generated HelmReleases), **the skip is permanent**, not a bootstrap window. On the reporter's cluster the install-timing window was 4 seconds and the objects were still missing months later:

- the 7 default backup `Strategy` CRs and the Velero `BackupStorageLocation`, gated on `include "backupstrategy-controller.bucketName"` → a `lookup` of `BucketClaim`;
- the `<bucket>-<user>-credentials` Secret (`packages/system/bucket/templates/user-credentials.yaml`), gated on a `lookup` of the COSI Secret.

Only `BackupClass cozy-default` was present, because it renders unconditionally. Its own comment predicted this case while assuming "Flux re-renders the chart", which does not happen — the same trap `packages/core/platform/sources/cozystack-basics.yaml` already documents: *"Drift detection is off on operator-generated HelmReleases, so a capability gate in the templates would render the policy out at first install and never add it back."*

Consequence: migration 50 (etcd adoption, v1.6.0) is fail-closed on the snapshot target. It resolves the target from the projected credentials Secret, which has no source without `<bucket>-<user>-credentials`, so its Job reboots forever and the cluster cannot be upgraded at all.

### 1. `backupstrategy-controller` reconciles the objects into existence

New leader-elected `DefaultObjectsGate` runnable (`internal/backupcontroller/default_objects_gate.go`), modelled on the existing `SystemCredentialsProjector`. Every minute:

- resolves the bucket name from the **projector's source Secret** (`parseSourceSecret`) — no new dependency, no `lookup`, and it covers the external-S3 path too. While it is unresolvable the gate does nothing: forcing then would only re-run the same empty lookup;
- reads `BackupClass cozy-default` as the manifest of what must exist (its `strategyRef`s), plus the `cozy-default` BSL when `velero.bslEnabled`;
- when any is missing, stamps `reconcile.fluxcd.io/forceAt` **and** `requestedAt` on its own HelmRelease. Both are required: `requestedAt` alone only requests a reconcile, which is a no-op for an unchanged release; `forceAt` is what triggers a real Helm upgrade, and it is only honoured together with `requestedAt`;
- throttled to one forced upgrade per 5 minutes, and a no-op in the steady state. A `strategyRef` whose CRD is not installed is not counted as missing, so a missing CRD cannot drive an endless force loop.

Two new metrics: `cozystack_backup_default_objects_missing{backupclass}` — the alert that would have caught this, since it is non-zero regardless of the HelmRelease's `Ready` condition — and `cozystack_backup_default_objects_force_reconciles_total`.

RBAC delta is two lines: `patch` on `helmreleases` (`get` was already there) and `get` on `backupstoragelocations`. Both accesses are point Gets through the dynamic client, so no cluster-wide informer and no `list`/`watch`.

Off switch: `backupStorage.reconcileDefaultObjects: false`.

**Why not a render-time `fail` in this chart:** it would deadlock. `templates/bucket.yaml` in this same chart is the producer of the `Bucket` whose `BucketClaim` the lookup reads, so a failed render never applies it and the condition can never resolve.

**Why not template the objects in Go:** their bodies are values-driven (endpoint, region, `forcePathStyle`, the Altinity strategy's whole PodTemplateSpec). Helm stays their single author; the gate only makes sure the render that produces them actually happens.

**Why not `dependsOn`:** an edge guarantees the `Bucket` CR is *applied*, not that its claim is *reconciled*, so it does not close the race.

### 2. The gate also repairs the credentials Secret, one release earlier

The `<bucket>-<user>-credentials` Secret is the same trap as the Strategy CRs, one release up the chain: `packages/system/bucket/templates/user-credentials.yaml` renders it behind a `lookup` of the COSI Secret, and skips it just as permanently. It is also the *first* domino — the projector reads it, so without it there is no `cozy-backups-creds`, no strategy, no Velero, and no migration 50.

An earlier revision of this PR made that render `fail` so the release would retry and converge. [@IvanHunters pointed out](https://github.com/cozystack/cozystack/pull/3524#issuecomment-5214269078) that Helm cannot render a partial set, so the `fail` aborts the **whole** `<bucket>-system` release — the other users' Secrets and the bucket UI Deployment/Service/Ingress/HTTPRoute with them. One declared user whose `BucketAccess` never provisions would take down every other user of that bucket, and on an installed release park it in `Failed`, blocking every later upgrade. That was a real blast-radius regression on a universal path, and it is gone.

The repair now lives in the gate, where it is per-object:

- while the source Secret is absent, or carries no bucket name, the gate stamps `forceAt` + `requestedAt` on the bucket's `bucket-<name>-system` HelmRelease instead of doing nothing;
- **no self-deadlock:** the `BucketClaim` and the `BucketAccess` whose COSI Secret that lookup reads are rendered unconditionally by the **parent** release (`packages/apps/bucket/templates/bucketclaim.yaml`), not by the one being forced;
- **no RBAC delta:** `patch` on `helmreleases` is already cluster-scoped;
- the two releases are throttled **independently**. They are forced in sequence on a bootstrap (credentials, then the objects the resolved bucket unblocks), so one shared timestamp would delay the second by a full `MinForceInterval` for no reason;
- coordinates come from the chart under `provisionBucket`, and are omitted on external S3, where the Secret is admin-managed and no release renders it.

The bucket chart keeps its partial render. Its comment now explains why the skip is not self-healing and why failing is the wrong lever, and a test renders the UI with *every* user unresolvable so a reintroduced `fail` fails the suite.

**Scope this narrows, deliberately:** tenant buckets keep the pre-existing silent skip. The gate owns only the platform bucket, which is the cluster-breaking path. Generalising the repair to every bucket needs a controller that owns tenant buckets and is a separate change.

Two more corrections from the same review:

- `cozystack_backup_default_objects_missing` was only written on the happy path, so the state this PR exists to catch reported `0` and the documented alert never fired. The credentials Secret now counts in `missing`, so an absent or rotated-away Secret moves the gauge. On an API error the gauge is deliberately left alone rather than flapping, and a new `cozystack_backup_default_objects_check_errors_total` marks it stale; the doc pairs the two instead of overstating the gauge. `force_reconciles_total` gained `namespace`/`name`, since two releases can now be forced.
- `forceHelmRelease` does a point `Get` and skips a release with `spec.suspend: true`. helm-controller ignores both annotations while suspended (`cozyhr suspend` sets exactly that), so the gate was re-stamping every `MinForceInterval` for the whole suspension and climbing the force counter — which the runbook attributes to a render that is not producing the objects. The skip is logged and not counted.

### 3. Corrected comments and docs

`_helpers.tpl`, `backupclass-default.yaml`, `values.yaml` and `docs/operations/backup-classes.md` all claimed the skip self-heals on the HelmRelease interval, and the doc suggested a `flux reconcile` that does not re-render. They now say it does not, and why. The two-release manual recovery for already-affected clusters is documented, including the easy-to-miss part: the credentials Secret is rendered by the `bucket-<name>-system` release, not by `bucket-<name>`.

### Manual recovery for already-affected clusters

Only needed on a version without the gate. A plain `flux reconcile helmrelease` does **nothing** — it does not re-render.

```bash
# 0. Confirm the bucket name is resolvable first — forcing before that
#    just re-runs the same empty lookup.
kubectl -n tenant-root get bucketclaim bucket-cozy-backups -o jsonpath='{.status.bucketName}'

# 1. The credentials Secret. Rendered by the -system release, NOT by
#    bucket-cozy-backups — easy to miss, and the projector (hence every
#    strategy, Velero, and migration 50) has no source without it.
ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
kubectl -n tenant-root annotate helmrelease bucket-cozy-backups-system \
  reconcile.fluxcd.io/forceAt="$ts" reconcile.fluxcd.io/requestedAt="$ts" --overwrite

# 2. The Strategy CRs and the Velero BSL.
ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
kubectl -n cozy-backup-controller annotate helmrelease backupstrategy-controller \
  reconcile.fluxcd.io/forceAt="$ts" reconcile.fluxcd.io/requestedAt="$ts" --overwrite
```

### Validation

- `go test ./internal/... -count=1` — pass, including 15 cases for the gate: force on missing, no-op in the steady state, throttling, unmapped kinds ignored, BSL skipped when disabled, patch failure surfaced without advancing the throttle, absent HelmRelease tolerated, plus force-on-absent-Secret, force-on-empty-bucket-name, external-S3 reports-but-does-not-force, independent throttles, suspend skip on each of the two releases, gauge written on the unresolved path, and errors counter on a failed check.
- `make helm-unit-tests` — pass, with 2 new suites: 3 cases for the bucket chart (partial render preserved, and the UI still renders with every user unresolvable — the guard against reintroducing the `fail`), 7 for the gate's env + RBAC wiring. Those include that `.Release.Name` and `.Release.Namespace` match the HelmRelease the operator generates (`releaseName` becomes the HR's `metadata.name`, and no `spec.releaseName`/`targetNamespace` is set, so the Helm release name equals the HR name), that the bucket release coordinates track a renamed bucket together with `systemSecretName`, and that they are unwired on `provisionBucket: false`.
- `make generate` — no diff.
- `make go-unit-tests rd-presets-check test-check-readiness migrations-target-check` — pass.
- `make bats-unit-tests` — every suite passes except `hack/migration-seaweedfs-db-adopt.bats`, which needs a Docker daemon not available in this environment ("docker is required: these tests run the migrations inside alpine"). Unrelated to this diff.

**Not verified — please read this before approving.** There was still no live-cluster run. What that gap covers is smaller than it was: dropping the chart `fail` removed the universal behaviour change on every bucket's install path, so there is no longer a render-blind failure mode whose convergence has to be observed. What remains is one mechanism — `forceAt` + `requestedAt` on an unchanged release — applied to two releases instead of one, argued from read code rather than an observed install: `Strategy.Name = RetryOnFailure` on operator-generated HelmReleases (`internal/operator/package_reconciler.go`), and `bucketName = "bucket-" + claim.UID` in `packages/system/objectstorage-controller/images/objectstorage/patches/92-bucketclaim-propagate-ready.diff`. It is the same procedure as the manual recovery below, which has been run by hand on the reporter's cluster. Someone with a bootstrap cluster should still confirm that the gate fires within a minute or two of the bucket becoming ready, and that forcing `bucket-<name>-system` materialises the credentials Secret.

### Screenshots

Not applicable: no UI change. This PR touches a controller, two system charts, and docs.

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

Walked file by file against the diff of this PR.

**`website` — affected, follow-up issue opened.** `content/en/docs/next/operations/services/backup-classes.md` mirrors this repo's `docs/operations/backup-classes.md` and carries the exact stale claim this PR corrects, plus a `flux reconcile helmrelease` recovery suggestion that has no effect. `operations/configuration/platform-package.md` enumerates the forwarded `backupStorage` keys, and `reconcileDefaultObjects` is admin-settable through `spec.components.platform.values.backupStorage` (the whole block is deep-merged), so that list becomes incomplete. Filed as an issue rather than a PR because the wording depends on the shape this PR lands in, and whether to touch the frozen `v1.5`/`v1.6` copies is a maintainer call. No existing website issue or PR covered it.

**`terraform-provider-cozystack` — not affected.** Checked, not assumed: `packages/apps/**` is untouched by this diff (`git show --stat HEAD -- packages/apps/` is empty), so no app `values.schema.json`, no `values.yaml` default, no version enum, and no `ApplicationDefinition` `kind`/`plural`/`release.prefix` changed. `reconcileDefaultObjects` is a key on a **system** chart, which has no `values.schema.json` and is not modelled by the provider. (An earlier revision added `requireUserCredentials` to the `bucket` system chart; that is gone, and no key was added to `apps/bucket`, so the app API is untouched.) The `<bucket>-<user>-credentials` Secret the provider looks up by literal name is **not renamed** — this PR only changes whether it gets created, which if anything removes a case where the provider silently read null from a Secret that never existed.

Everything else: no `hack/` layout or make-target change (`ccp`, `external-apps-example`, `cozyhr`), no `ApplicationDefinition` CRD change, no namespace rename, no node prerequisites in `hack/e2e-prepare-cluster.bats` (`talm`, `ansible-cozystack`), no `cozyhr.cozystack.io/values-files` annotation or chart-source-kind change, no `service-proxy-name` / `wholeIP` / `allowICMP` rename (`cozy-proxy`), no telemetry metric or label rename (`cozystack-telemetry-server` — the two metrics here are new, not renamed), no node or network requirement change (`examples`).

- [ ] No downstream repository is affected by this change
- [x] [cozystack/website](https://github.com/cozystack/website) - follow-up: https://github.com/cozystack/website/issues/639
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
fix(backupstrategy-controller): the default backup Strategy CRs, the Velero BackupStorageLocation and the bucket user-credentials Secret were skipped permanently when their install-time Helm `lookup` came back empty, leaving clusters with a BackupClass but no strategies and blocking the v1.6.0 etcd migration. The controller now detects the missing objects and forces the Helm upgrade that creates them, including on the bucket release that renders the credentials Secret.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic detection and recovery for missing default backup resources.
  - Missing resources trigger a throttled Helm upgrade once bucket configuration is available.
  - Added configuration to enable or disable default-object reconciliation.
  - Added validation requiring user credential Secrets during bucket installation by default, with an offline rendering option.

- **Bug Fixes**
  - Improved recovery from incomplete backup and Velero storage configuration.

- **Documentation**
  - Expanded operational guidance, monitoring metrics, alerts, and manual recovery steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
