### PR TITLE
fix(rabbitmq): sanitize vhost name for metadata.name

### DIFF
--- a/packages/apps/rabbitmq/templates/rabbitmq.yaml
+++ b/packages/apps/rabbitmq/templates/rabbitmq.yaml
@@ -68,11 +68,15 @@ stringData:
 {{- end }}
 
 {{- range $host, $h := .Values.vhosts }}
+{{- $sanitized := regexReplaceAll "[^a-z0-9-]" (kebabcase $host) "" | trimAll "-" }}
+{{- $safeHost := $sanitized | default "default" }}
+{{- $hostHash := sha256sum $host | trunc 8 }}
+{{- $uniqueHost := printf "%s-%s" $safeHost $hostHash }}
 ---
 apiVersion: rabbitmq.com/v1beta1
 kind: Vhost
 metadata:
-  name: {{ $.Release.Name }}-{{ kebabcase $host }}
+  name: {{ $.Release.Name }}-{{ $uniqueHost }}
 spec:
   name: {{ $host }}
   rabbitmqClusterReference:
@@ -82,7 +86,7 @@ spec:
 apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
-  name: {{ $.Release.Name }}-{{ kebabcase $host }}-{{ kebabcase $user }}
+  name: {{ $.Release.Name }}-{{ $uniqueHost }}-{{ kebabcase $user }}
 spec:
   vhost: "{{ $host }}"
   user: "{{ $user }}"
@@ -98,7 +102,7 @@ spec:
 apiVersion: rabbitmq.com/v1beta1
 kind: Permission
 metadata:
-  name: {{ $.Release.Name }}-{{ kebabcase $host }}-{{ kebabcase $user }}
+  name: {{ $.Release.Name }}-{{ $uniqueHost }}-{{ kebabcase $user }}
 spec:
   vhost: "{{ $host }}"
   user: "{{ $user }}"


### PR DESCRIPTION
## What this PR does

The default vhost `/` produced invalid Kubernetes resource names like `release-/-app` because kebabcase doesn't strip `/`. This adds a sanitized variable `$safeHost` that strips non-DNS-safe characters and falls back to `default` for empty results.

Fixes #3396

### Screenshots

n/a

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
fix(rabbitmq): sanitize vhost name for metadata.name to allow default vhost "/"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RabbitMQ resource naming by sanitizing host-based names.
  * Added a default name when the host identifier is empty.
  * Added a unique identifier to prevent naming conflicts.
  * Ensured virtual host and permission resources use consistent, valid names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->