### PR TITLE
chore(etcd-operator): bump etcd-operator to v0.5.4

### DIFF
--- a/packages/system/etcd-operator-crds/Makefile
+++ b/packages/system/etcd-operator-crds/Makefile
@@ -4,7 +4,7 @@ export NAMESPACE=cozy-etcd-operator
 include ../../../hack/package.mk
 
 # Pinned ref of github.com/cozystack/etcd-operator to vendor CRDs from.
-ETCD_OPERATOR_REF ?= v0.5.3
+ETCD_OPERATOR_REF ?= v0.5.4
 
 # controller-gen writes the CRDs to charts/etcd-operator/crd-bases/ upstream (there
 # is no config/crd kustomization). Vendor each verbatim and stamp

--- a/packages/system/etcd-operator-crds/templates/etcdmembers.yaml
+++ b/packages/system/etcd-operator-crds/templates/etcdmembers.yaml
@@ -1101,11 +1101,10 @@ spec:
               replicas:
                 default: 1
                 description: |-
-                  Replicas exists only because the PodDisruptionBudget controller
-                  traverses Pods' controllerRef looking for /scale on the parent and
-                  fails closed ("does not implement the scale subresource") if it
-                  isn't there. Each EtcdMember represents exactly one Pod; this field
-                  is locked to 1 by validation and cannot be tuned.
+                  Replicas backs the /scale subresource. The operator's own PDB
+                  (integer minAvailable) never resolves scale; kept because
+                  maxUnavailable or percentage budgets over member Pods fail
+                  without it. Locked to 1: an EtcdMember is exactly one Pod.
                 format: int32
                 maximum: 1
                 minimum: 1
@@ -1677,15 +1676,14 @@ spec:
               replicas:
                 description: |-
                   Replicas exposes via /scale "this EtcdMember owns 1 Pod if it has
-                  a PodName, 0 otherwise". Required by the PodDisruptionBudget
-                  controller to derive expectedPods for the cluster's PDB — without
-                  /scale on the Pod controller-ref it sets the PDB to SyncFailed.
+                  a PodName, 0 otherwise". Unused by the operator's own PDB;
+                  scale-resolving budgets go SyncFailed without it.
                 format: int32
                 type: integer
               selector:
                 description: |-
-                  Selector exposes the label-selector that matches this member's Pod
-                  via /scale (consumed by the PDB controller; not user-facing).
+                  Selector exposes the label-selector matching this member's Pod via
+                  /scale (for scale-resolving disruption budgets; not user-facing).
                 type: string
               version:
                 description: |-

--- a/packages/system/etcd-operator/Chart.yaml
+++ b/packages/system/etcd-operator/Chart.yaml
@@ -3,4 +3,4 @@ name: cozy-etcd-operator
 description: Cozystack etcd-operator (etcd-operator.cozystack.io/v1alpha2) controller-manager
 type: application
 version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process
-appVersion: v0.5.3
+appVersion: v0.5.4

--- a/packages/system/etcd-operator/Makefile
+++ b/packages/system/etcd-operator/Makefile
@@ -8,7 +8,7 @@ include ../../../hack/package.mk
 # domain, VPA), so only the RBAC role is re-vendored; refresh templates/rbac.yaml
 # by hand from config/rbac/role.yaml at this ref. CRDs live in the sibling
 # etcd-operator-crds package.
-ETCD_OPERATOR_REF ?= v0.5.3
+ETCD_OPERATOR_REF ?= v0.5.4
 
 update:
 	@echo "etcd-operator is a cozystack-authored chart; refresh templates/rbac.yaml"

--- a/packages/system/etcd-operator/tests/deployment_test.yaml
+++ b/packages/system/etcd-operator/tests/deployment_test.yaml
@@ -20,12 +20,12 @@ tests:
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: ghcr.io/cozystack/etcd-operator:v0.5.3
+          value: ghcr.io/cozystack/etcd-operator:v0.5.4
       - contains:
           path: spec.template.spec.containers[0].env
           content:
             name: OPERATOR_IMAGE
-            value: ghcr.io/cozystack/etcd-operator:v0.5.3
+            value: ghcr.io/cozystack/etcd-operator:v0.5.4
           any: true
 
   - it: "image.tag overrides the appVersion default for both the container and the agent env"


### PR DESCRIPTION
## What this PR does

Bumps the cozystack etcd-operator packages from **v0.5.3 to v0.5.4**.

`v0.5.4` is a controller bug-fix release — no API, RBAC or values changes:

- fix(controllers): derive `--initial-cluster-state` from phase, not from the seed ([cozystack/etcd-operator#355](https://github.com/cozystack/etcd-operator/pull/355))
- fix(controllers): stop exempting the bootstrap seed from self-heal ([cozystack/etcd-operator#354](https://github.com/cozystack/etcd-operator/pull/354))
- fix(controllers): extend crash-loop self-heal to memory members ([cozystack/etcd-operator#352](https://github.com/cozystack/etcd-operator/pull/352))
- fix(controllers): switch the PDB from `maxUnavailable` to `minAvailable` ([cozystack/etcd-operator#351](https://github.com/cozystack/etcd-operator/pull/351))

Changes in this repo:

- `packages/system/etcd-operator/Chart.yaml` — `appVersion: v0.5.3 → v0.5.4`. The manager image tag defaults to `.Chart.AppVersion` (`values.yaml` keeps `tag: ""`), so this reimages the controller to `ghcr.io/cozystack/etcd-operator:v0.5.4`.
- `packages/system/etcd-operator/Makefile`, `packages/system/etcd-operator-crds/Makefile` — `ETCD_OPERATOR_REF: v0.5.3 → v0.5.4`.
- `packages/system/etcd-operator-crds/templates/etcdmembers.yaml` — re-vendored at v0.5.4 via `make update`. Description-only change to the `/scale` `replicas`/`selector` field docs, tracking the PDB `minAvailable` fix. `etcdclusters` and `etcdsnapshots` are byte-identical to v0.5.3.
- `templates/rbac.yaml` intentionally left as-is: `manager-role-rules.yaml` is byte-identical between v0.5.3 and v0.5.4.

**Upgrade path (PDB switch, cozystack/etcd-operator#351).** This is the one change that rewrites live objects: the operator moves each EtcdCluster's PodDisruptionBudget from `maxUnavailable` to `minAvailable`. Setting both fields is invalid, but upstream `reconcilePDB` handles the migration — it treats a surviving pre-migration `maxUnavailable` as divergence and explicitly clears it (`MaxUnavailable = nil`) before writing `MinAvailable`, so existing clusters are reconciled cleanly on upgrade rather than wedging their PDB.

Verified locally: `helm lint` and `helm template` pass for both packages; rendered manager image resolves to `ghcr.io/cozystack/etcd-operator:v0.5.4`. These `packages/system/*` packages have no `generate:` target and no `values.schema.json`, so there is nothing for `make generate` to regenerate.

### Screenshots

Not applicable — no UI changes.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` file-by-file against the diff:

- The diff touches only `packages/system/etcd-operator*` — no `packages/apps/**` or `packages/extra/**` add/rename/remove, no `packages/core/platform` or `installer` values, no Talos bump, no asset-name or dev-tooling change → **website / ansible-cozystack** not reached.
- The CRD edit is description-only, inside etcd-operator's own `etcd-operator.cozystack.io` CRDs — not the provider's hand-typed `Package`/`Plan`/`RestoreJob` types, and no new managed app → **terraform-provider-cozystack** not reached.
- No `hack/` change, no `packages/system/<name>-rd/cozyrds/**`, no `ApplicationDefinition` CRD / `chartRef.kind` enum change, no `cozyhr`/`package.mk` contract change, no telemetry-metric or proxy-label rename → **ccp / talm / cozyhr / cozy-proxy / telemetry-server / examples / external-apps-example** not reached.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
chore(etcd-operator): bump etcd-operator to v0.5.4 (controller bug-fixes: PDB switched to minAvailable, crash-loop self-heal extended to memory members, --initial-cluster-state derived from phase, seed no longer exempt from self-heal)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the etcd operator to version v0.5.4.
  - Clarified scale-related resource descriptions, including replica counts, selectors, and disruption budget behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->