### PR TITLE
fix(keycloak): keep KeycloakRealmUser roles when spec.roles is unset

### DIFF
--- a/packages/system/keycloak-operator/images/keycloak-operator/patches/keycloakrealmuser-unset-roles.diff
+++ b/packages/system/keycloak-operator/images/keycloak-operator/patches/keycloakrealmuser-unset-roles.diff
@@ -1,0 +1,343 @@
+Backport of epam/edp-keycloak-operator#372 (https://github.com/epam/edp-keycloak-operator/pull/372), which fixes epam/edp-keycloak-operator#371 (https://github.com/epam/edp-keycloak-operator/issues/371): a KeycloakRealmUser that leaves spec.roles out gets every realm role stripped from the Keycloak user, including the default-roles-<realm> that Keycloak grants on creation. After the fix an omitted list means "not managed", and an explicit empty list still removes everything.
+
+Dropping omitempty from the json tags is the other half of the fix. Without it an explicit "roles: []" disappears the first time the operator writes the object back (adding its own finalizer is enough) and comes back indistinguishable from an omitted field, so the nil-vs-empty distinction does not survive a round trip.
+
+Applies to: epam/edp-keycloak-operator @ facbc36, pinned as COMMIT_REF in the Dockerfile one level up.
+
+Six of the eight files are taken from the upstream PR unchanged. internal/controller/keycloakrealmuser/chain/sync_user_roles.go and its test carry the same change rewritten against facbc36, where the generated client package is still called keycloakv2. Upstream renamed it to keycloakapi in b611ea75, after this pin.
+
+Drop this file when COMMIT_REF moves past the upstream merge commit.
+
+diff --git a/api/v1/keycloakclient_types.go b/api/v1/keycloakclient_types.go
+index 28df6eb..74100c6 100644
+--- a/api/v1/keycloakclient_types.go
++++ b/api/v1/keycloakclient_types.go
+@@ -237,7 +237,7 @@ type UserClientRole struct {
+ 	// Roles is a list of client roles names assigned to user.
+ 	// +nullable
+ 	// +optional
+-	Roles []string `json:"roles,omitempty"`
++	Roles []string `json:"roles"` // no omitempty: an empty list has to stay distinguishable from an omitted one
+ }
+ 
+ type ClientRole struct {
+diff --git a/api/v1/keycloakrealmuser_types.go b/api/v1/keycloakrealmuser_types.go
+index 5773150..541b8b8 100644
+--- a/api/v1/keycloakrealmuser_types.go
++++ b/api/v1/keycloakrealmuser_types.go
+@@ -40,12 +40,16 @@ type KeycloakRealmUserSpec struct {
+ 	// +optional
+ 	RequiredUserActions []string `json:"requiredUserActions,omitempty"`
+ 
+-	// Roles is a list of roles assigned to user.
++	// Roles is a list of realm roles assigned to user.
++	// Omitting the field, or setting it to null, leaves the realm roles the user already has untouched,
++	// including the defaults Keycloak grants on creation.
++	// An explicit empty list removes every realm role from the user.
+ 	// +nullable
+ 	// +optional
+-	Roles []string `json:"roles,omitempty"`
++	Roles []string `json:"roles"` // no omitempty: an empty list has to stay distinguishable from an omitted one
+ 
+ 	// ClientRoles is a list of client roles assigned to user.
++	// The same rule as for Roles applies per client: omitting an entry's roles list leaves that client's roles untouched, an empty list removes all of them.
+ 	// +nullable
+ 	// +optional
+ 	ClientRoles []UserClientRole `json:"clientRoles,omitempty"`
+diff --git a/api/v1/keycloakrealmuser_types_test.go b/api/v1/keycloakrealmuser_types_test.go
+new file mode 100644
+index 0000000..18eae79
+--- /dev/null
++++ b/api/v1/keycloakrealmuser_types_test.go
+@@ -0,0 +1,55 @@
++package v1
++
++import (
++	"encoding/json"
++	"testing"
++
++	"github.com/stretchr/testify/assert"
++	"github.com/stretchr/testify/require"
++)
++
++// The user controller reads an omitted role list as "not managed" and an empty one as "remove
++// every role". The controller also rewrites the whole resource when it adds its finalizer or
++// migrates attributes, so an empty list has to survive a marshal/unmarshal cycle: with omitempty
++// on the json tag it would come back as omitted and silently downgrade to "not managed".
++func TestKeycloakRealmUserSpec_EmptyRoleListsSurviveSerialization(t *testing.T) {
++	spec := KeycloakRealmUserSpec{
++		Username: "testuser",
++		Roles:    []string{},
++		ClientRoles: []UserClientRole{
++			{ClientID: "client1", Roles: []string{}},
++		},
++	}
++
++	raw, err := json.Marshal(spec)
++	require.NoError(t, err)
++
++	var decoded KeycloakRealmUserSpec
++
++	require.NoError(t, json.Unmarshal(raw, &decoded))
++
++	assert.NotNil(t, decoded.Roles, "empty spec.roles must not decode back as omitted")
++	assert.Empty(t, decoded.Roles)
++
++	require.Len(t, decoded.ClientRoles, 1)
++	assert.NotNil(t, decoded.ClientRoles[0].Roles, "empty spec.clientRoles[].roles must not decode back as omitted")
++	assert.Empty(t, decoded.ClientRoles[0].Roles)
++}
++
++// An omitted role list must stay omitted, so that "not managed" is not confused with "remove
++// every role" in the other direction either.
++func TestKeycloakRealmUserSpec_OmittedRoleListsStayOmitted(t *testing.T) {
++	raw, err := json.Marshal(KeycloakRealmUserSpec{
++		Username:    "testuser",
++		ClientRoles: []UserClientRole{{ClientID: "client1"}},
++	})
++	require.NoError(t, err)
++
++	var decoded KeycloakRealmUserSpec
++
++	require.NoError(t, json.Unmarshal(raw, &decoded))
++
++	assert.Nil(t, decoded.Roles)
++	require.Len(t, decoded.ClientRoles, 1)
++	assert.Nil(t, decoded.ClientRoles[0].Roles)
++}
+diff --git a/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml b/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
+index 80611b9..de2ab0d 100644
+--- a/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
++++ b/config/crd/bases/v1.edp.epam.com_keycloakrealmusers.yaml
+@@ -63,7 +63,9 @@ spec:
+                 nullable: true
+                 type: object
+               clientRoles:
+-                description: ClientRoles is a list of client roles assigned to user.
++                description: |-
++                  ClientRoles is a list of client roles assigned to user.
++                  The same rule as for Roles applies per client: omitting an entry's roles list leaves that client's roles untouched, an empty list removes all of them.
+                 items:
+                   properties:
+                     clientId:
+@@ -177,7 +179,11 @@ spec:
+                 nullable: true
+                 type: array
+               roles:
+-                description: Roles is a list of roles assigned to user.
++                description: |-
++                  Roles is a list of realm roles assigned to user.
++                  Omitting the field, or setting it to null, leaves the realm roles the user already has untouched,
++                  including the defaults Keycloak grants on creation.
++                  An explicit empty list removes every realm role from the user.
+                 items:
+                   type: string
+                 nullable: true
+diff --git a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
+index 80611b9..de2ab0d 100644
+--- a/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
++++ b/deploy-templates/crds/v1.edp.epam.com_keycloakrealmusers.yaml
+@@ -63,7 +63,9 @@ spec:
+                 nullable: true
+                 type: object
+               clientRoles:
+-                description: ClientRoles is a list of client roles assigned to user.
++                description: |-
++                  ClientRoles is a list of client roles assigned to user.
++                  The same rule as for Roles applies per client: omitting an entry's roles list leaves that client's roles untouched, an empty list removes all of them.
+                 items:
+                   properties:
+                     clientId:
+@@ -177,7 +179,11 @@ spec:
+                 nullable: true
+                 type: array
+               roles:
+-                description: Roles is a list of roles assigned to user.
++                description: |-
++                  Roles is a list of realm roles assigned to user.
++                  Omitting the field, or setting it to null, leaves the realm roles the user already has untouched,
++                  including the defaults Keycloak grants on creation.
++                  An explicit empty list removes every realm role from the user.
+                 items:
+                   type: string
+                 nullable: true
+diff --git a/docs/api.md b/docs/api.md
+index 9013abd..10adc8a 100644
+--- a/docs/api.md
++++ b/docs/api.md
+@@ -7264,7 +7264,8 @@ Each attribute can have multiple values.<br/>
+         <td><b><a href="#keycloakrealmuserspecclientrolesindex">clientRoles</a></b></td>
+         <td>[]object</td>
+         <td>
+-          ClientRoles is a list of client roles assigned to user.<br/>
++          ClientRoles is a list of client roles assigned to user.
++The same rule as for Roles applies per client: omitting an entry's roles list leaves that client's roles untouched, an empty list removes all of them.<br/>
+         </td>
+         <td>false</td>
+       </tr><tr>
+@@ -7365,7 +7366,10 @@ If set to full, user will be created if it does not exist, or updated if it exis
+         <td><b>roles</b></td>
+         <td>[]string</td>
+         <td>
+-          Roles is a list of roles assigned to user.<br/>
++          Roles is a list of realm roles assigned to user.
++Omitting the field, or setting it to null, leaves the realm roles the user already has untouched,
++including the defaults Keycloak grants on creation.
++An explicit empty list removes every realm role from the user.<br/>
+         </td>
+         <td>false</td>
+       </tr></tbody>
+diff --git a/internal/controller/keycloakrealmuser/chain/sync_user_roles.go b/internal/controller/keycloakrealmuser/chain/sync_user_roles.go
+index 8a96543..3ef686d 100644
+--- a/internal/controller/keycloakrealmuser/chain/sync_user_roles.go
++++ b/internal/controller/keycloakrealmuser/chain/sync_user_roles.go
+@@ -49,6 +49,14 @@ func (h *SyncUserRoles) syncRealmRoles(
+ 	desiredRoleNames []string,
+ 	addOnly bool,
+ ) error {
++	// A nil desired list means the field was omitted, so the resource does not manage realm roles
++	// at all and Keycloak is left alone. An empty but non-nil list still means "no roles" and
++	// clears every mapping. Normalising the field anywhere upstream would silently turn
++	// "not managed" into "delete everything".
++	if desiredRoleNames == nil {
++		return nil
++	}
++
+ 	currentRoles, _, err := h.kClientV2.Users.GetUserRealmRoleMappings(ctx, realmName, userID)
+ 	if err != nil {
+ 		return fmt.Errorf("unable to get user realm role mappings: %w", err)
+@@ -113,6 +121,12 @@ func (h *SyncUserRoles) syncClientRoles(
+ 	addOnly bool,
+ ) error {
+ 	for _, cr := range clientRoles {
++		// As in syncRealmRoles, an omitted role list means this client's roles are not managed,
++		// which leaves nothing to do for the entry at all.
++		if cr.Roles == nil {
++			continue
++		}
++
+ 		clients, _, err := h.kClientV2.Clients.GetClients(ctx, realmName, &keycloakv2.GetClientsParams{ClientId: &cr.ClientID})
+ 		if err != nil {
+ 			return fmt.Errorf("unable to get client %q: %w", cr.ClientID, err)
+diff --git a/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go b/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go
+index d7a3cb5..cd1286c 100644
+--- a/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go
++++ b/internal/controller/keycloakrealmuser/chain/sync_user_roles_test.go
+@@ -97,6 +97,87 @@ func TestSyncUserRoles_Serve(t *testing.T) {
+ 			},
+ 			wantErr: require.NoError,
+ 		},
++		{
++			name: "success - unset roles keep existing realm roles (full strategy)",
++			user: &keycloakApi.KeycloakRealmUser{
++				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
++				Spec:       keycloakApi.KeycloakRealmUserSpec{},
++			},
++			userCtx: &UserContext{UserID: "user-unset"},
++			mockSetup: func(_ *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, _ *v2mocks.MockClientsClient) {
++				// Keycloak must not be touched at all: spec.roles is unset, so realm roles
++				// (including the default-roles-<realm> Keycloak grants on creation) are unmanaged.
++			},
++			wantErr: require.NoError,
++		},
++		{
++			name: "success - empty roles remove every realm role (full strategy)",
++			user: &keycloakApi.KeycloakRealmUser{
++				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
++				Spec: keycloakApi.KeycloakRealmUserSpec{
++					Roles: []string{},
++				},
++			},
++			userCtx: &UserContext{UserID: "user-empty"},
++			mockSetup: func(u *v2mocks.MockUsersClient, r *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
++				u.EXPECT().GetUserRealmRoleMappings(context.Background(), "test-realm", "user-empty").
++					Return([]keycloakv2.RoleRepresentation{
++						{Id: ptr.To("id1"), Name: ptr.To("role1")},
++					}, nil, nil)
++				u.EXPECT().DeleteUserRealmRoles(context.Background(), "test-realm", "user-empty", []keycloakv2.RoleRepresentation{
++					{Id: ptr.To("id1"), Name: ptr.To("role1")},
++				}).Return(nil, nil)
++			},
++			wantErr: require.NoError,
++		},
++		{
++			name: "success - unset client roles keep existing client roles (full strategy)",
++			user: &keycloakApi.KeycloakRealmUser{
++				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
++				Spec: keycloakApi.KeycloakRealmUserSpec{
++					ClientRoles: []keycloakApi.UserClientRole{
++						{ClientID: "client-unset"},
++						{ClientID: "client-managed", Roles: []string{"crole1"}},
++					},
++				},
++			},
++			userCtx: &UserContext{UserID: "user-unset-client"},
++			mockSetup: func(u *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
++				// client-unset is skipped whole: not even looked up, so a stale or misspelled
++				// clientId in an unmanaged entry cannot fail the reconciliation.
++				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakv2.GetClientsParams{ClientId: ptr.To("client-managed")}).
++					Return([]keycloakv2.ClientRepresentation{{Id: ptr.To("client-uuid-2")}}, nil, nil)
++				u.EXPECT().GetUserClientRoleMappings(context.Background(), "test-realm", "user-unset-client", "client-uuid-2").
++					Return([]keycloakv2.RoleRepresentation{
++						{Id: ptr.To("crid1"), Name: ptr.To("crole1")},
++					}, nil, nil)
++			},
++			wantErr: require.NoError,
++		},
++		{
++			name: "success - empty client roles remove every client role (full strategy)",
++			user: &keycloakApi.KeycloakRealmUser{
++				ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"},
++				Spec: keycloakApi.KeycloakRealmUserSpec{
++					ClientRoles: []keycloakApi.UserClientRole{
++						{ClientID: "client-empty", Roles: []string{}},
++					},
++				},
++			},
++			userCtx: &UserContext{UserID: "user-empty-client"},
++			mockSetup: func(u *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
++				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakv2.GetClientsParams{ClientId: ptr.To("client-empty")}).
++					Return([]keycloakv2.ClientRepresentation{{Id: ptr.To("client-uuid-1")}}, nil, nil)
++				u.EXPECT().GetUserClientRoleMappings(context.Background(), "test-realm", "user-empty-client", "client-uuid-1").
++					Return([]keycloakv2.RoleRepresentation{
++						{Id: ptr.To("crid1"), Name: ptr.To("crole1")},
++					}, nil, nil)
++				u.EXPECT().DeleteUserClientRoles(context.Background(), "test-realm", "user-empty-client", "client-uuid-1", []keycloakv2.RoleRepresentation{
++					{Id: ptr.To("crid1"), Name: ptr.To("crole1")},
++				}).Return(nil, nil)
++			},
++			wantErr: require.NoError,
++		},
+ 		{
+ 			name: "success - sync client roles",
+ 			user: &keycloakApi.KeycloakRealmUser{
+@@ -109,9 +190,6 @@ func TestSyncUserRoles_Serve(t *testing.T) {
+ 			},
+ 			userCtx: &UserContext{UserID: "user-4"},
+ 			mockSetup: func(u *v2mocks.MockUsersClient, r *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
+-				// no realm roles
+-				u.EXPECT().GetUserRealmRoleMappings(context.Background(), "test-realm", "user-4").
+-					Return(nil, nil, nil)
+ 				// client lookup
+ 				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakv2.GetClientsParams{ClientId: ptr.To("client1")}).
+ 					Return([]keycloakv2.ClientRepresentation{{Id: ptr.To("client-uuid-1")}}, nil, nil)
+@@ -141,8 +219,6 @@ func TestSyncUserRoles_Serve(t *testing.T) {
+ 			},
+ 			userCtx: &UserContext{UserID: "user-5"},
+ 			mockSetup: func(u *v2mocks.MockUsersClient, r *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
+-				u.EXPECT().GetUserRealmRoleMappings(context.Background(), "test-realm", "user-5").
+-					Return(nil, nil, nil)
+ 				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakv2.GetClientsParams{ClientId: ptr.To("client1")}).
+ 					Return([]keycloakv2.ClientRepresentation{{Id: ptr.To("client-uuid-1")}}, nil, nil)
+ 				u.EXPECT().GetUserClientRoleMappings(context.Background(), "test-realm", "user-5", "client-uuid-1").
+@@ -206,9 +282,7 @@ func TestSyncUserRoles_Serve(t *testing.T) {
+ 				},
+ 			},
+ 			userCtx: &UserContext{UserID: "user-err3"},
+-			mockSetup: func(u *v2mocks.MockUsersClient, r *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
+-				u.EXPECT().GetUserRealmRoleMappings(context.Background(), "test-realm", "user-err3").
+-					Return(nil, nil, nil)
++			mockSetup: func(_ *v2mocks.MockUsersClient, _ *v2mocks.MockRolesClient, c *v2mocks.MockClientsClient) {
+ 				c.EXPECT().GetClients(context.Background(), "test-realm", &keycloakv2.GetClientsParams{ClientId: ptr.To("no-such-client")}).
+ 					Return(nil, nil, nil)
+ 			},


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

The vendored keycloak-operator image is built from a pinned upstream commit with `images/keycloak-operator/patches/*.diff` applied at build time. This patch is a backport of epam/edp-keycloak-operator#372 onto that pin, so it is dropped in the same commit that moves `COMMIT_REF` past the upstream merge. The bug is epam/edp-keycloak-operator#371.

Under the default `full` strategy the operator treats `spec.roles` and `spec.clientRoles[].roles` as authoritative sets: after adding what is missing, it deletes every mapping the spec does not list. A resource that manages the user record and leaves those fields out therefore loses all of its realm roles on the first reconcile, `default-roles-<realm>` included, and with it `offline_access`, `uma_authorization` and the `account` client roles. The user keeps logging in and stops being able to do anything.

Upstream fixes this in two halves that only work together. The controller returns early when the desired list is nil, so an omitted field means "not managed" while an explicit `roles: []` keeps its meaning of "remove every role". The json tags on `Roles` and `ClientRoles[].Roles` lose `omitempty`, because with it an explicit empty list is erased the first time the operator writes the object back, which adding its own finalizer already does, and comes back indistinguishable from an omitted field. Take that half away and the distinction holds only until the operator next touches the object.

All eight files from the upstream PR are here. Six apply to the pin unchanged. `sync_user_roles.go` and its test are rewritten against the pinned context, where the generated client package is still named `keycloakv2` (upstream renamed it to `keycloakapi` after the pin, which is the only reason those two do not apply as-is). Tests match upstream: four controller cases for unset and empty realm and client roles, two in `api/v1` for the serialization round trip.

Checked by extracting the pinned tarball, applying every `.diff` in the patches directory in the order the Dockerfile globs them, then `go build ./...` and `go test ./internal/controller/keycloakrealmuser/... ./api/...`, all green. Reverting each of the three conditions in turn fails exactly the tests that cover it, and nothing else.

One caveat a reader deserves up front: this patch does not reach any cluster yet. No CI path rebuilds this package, so `hack/build-matrix.sh` returns an empty matrix for a change confined to it, and `values.yaml` keeps pointing at an image built by hand in March. The same happened to `9c5fbb69a` and `5b9b420ff`, which edited this Dockerfile and left the pin alone, so the running binary is already older than the tree says. That gap is tracked in https://github.com/cozystack/cozystack/issues/3416 and is deliberately not addressed here: the fix for it is a choice between adding these packages to the build list and dropping the in-repo build, and the first option wakes a known mirror gap for split-host references. Landing the patch now means it is in place the moment that is resolved.

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

Not a UI change.

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

Walked the trigger map against the diff. It touches one build-time patch file under `packages/system/keycloak-operator/images/`, adds no package under `packages/apps/` or `packages/extra/`, and changes no values key, schema, enum, default, CRD, `ApplicationDefinition`, namespace, label, annotation, metric, release asset, variant or node prerequisite. Nothing in the map fires.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
fix(keycloak): a `KeycloakRealmUser` that omits `spec.roles` or leaves `roles` out of a `spec.clientRoles` entry no longer has the matching Keycloak role mappings deleted under the default `full` reconciliation strategy. Users keep `default-roles-<realm>` and the `offline_access`, `uma_authorization` and `account` roles it grants. Setting an explicit empty list still removes every role.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Keycloak role management for realm users and client roles.
  * Leaving a role list unspecified now preserves existing roles.
  * Explicitly providing an empty role list now removes all assigned roles.
* **Documentation**
  * Updated API and resource documentation to clarify role-list behavior.
* **Tests**
  * Added coverage for omitted, empty, managed, and unmanaged role configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->