### PR TITLE
[Backport release-1.5] fix(objectstorage-controller): converge BucketClaim readiness and speed up COSI provisioner failover

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -103,6 +103,7 @@ jobs:
               // area/storage
               'seaweedfs':           'area/storage',
               'seaweedfs-cosi-driver': 'area/storage',
+              'objectstorage-controller': 'area/storage',
               'bucket':              'area/storage',
               'linstor':             'area/storage',
               'velero':              'area/storage',

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -31,12 +31,14 @@ EOF
     kubectl -n tenant-test get bucketclaims.objectstorage.k8s.io bucket-${name} -o yaml 2>&1 || true
     echo "=== backend Buckets (cluster-scoped) ==="
     kubectl get buckets.objectstorage.k8s.io -o wide 2>&1 || true
+    echo "=== objectstorage-controller ==="
+    kubectl -n cozy-objectstorage-controller get pods 2>&1 || true
     false
   }
   timeout 60 sh -ec "until kubectl -n tenant-test get bucketaccesses.objectstorage.k8s.io bucket-${name}-admin >/dev/null 2>&1; do sleep 2; done"
-  kubectl -n tenant-test wait bucketaccesses.objectstorage.k8s.io bucket-${name}-admin --timeout=300s --for=jsonpath='{.status.accessGranted}'
+  kubectl -n tenant-test wait bucketaccesses.objectstorage.k8s.io bucket-${name}-admin --timeout=300s --for=jsonpath='{.status.accessGranted}'=true
   timeout 60 sh -ec "until kubectl -n tenant-test get bucketaccesses.objectstorage.k8s.io bucket-${name}-viewer >/dev/null 2>&1; do sleep 2; done"
-  kubectl -n tenant-test wait bucketaccesses.objectstorage.k8s.io bucket-${name}-viewer --timeout=300s --for=jsonpath='{.status.accessGranted}'
+  kubectl -n tenant-test wait bucketaccesses.objectstorage.k8s.io bucket-${name}-viewer --timeout=300s --for=jsonpath='{.status.accessGranted}'=true
 
   # Get admin (readwrite) credentials
   kubectl -n tenant-test get secret bucket-${name}-admin -ojsonpath='{.data.BucketInfo}' | base64 -d > bucket-admin-credentials.json

--- a/hack/e2e-apps/bucket.bats
+++ b/hack/e2e-apps/bucket.bats
@@ -21,7 +21,18 @@ EOF
   # Wait for the bucket to be ready
   kubectl -n tenant-test wait hr bucket-${name} --timeout=5m --for=condition=ready
   timeout 60 sh -ec "until kubectl -n tenant-test get bucketclaims.objectstorage.k8s.io bucket-${name} >/dev/null 2>&1; do sleep 2; done"
-  kubectl -n tenant-test wait bucketclaims.objectstorage.k8s.io bucket-${name} --timeout=300s --for=jsonpath='{.status.bucketReady}'
+  # The COSI controller requeues the BucketClaim until the backend Bucket's
+  # readiness propagates, so this converges within tens of seconds. Assert
+  # bucketReady=true explicitly: a bare jsonpath match also matches the literal
+  # "false", so the unqualified form passed against an unready claim. The tight
+  # bound makes a propagation-race regression fail fast instead of hiding.
+  kubectl -n tenant-test wait bucketclaims.objectstorage.k8s.io bucket-${name} --timeout=120s --for=jsonpath='{.status.bucketReady}'=true || {
+    echo "=== BucketClaim did not converge to bucketReady=true ==="
+    kubectl -n tenant-test get bucketclaims.objectstorage.k8s.io bucket-${name} -o yaml 2>&1 || true
+    echo "=== backend Buckets (cluster-scoped) ==="
+    kubectl get buckets.objectstorage.k8s.io -o wide 2>&1 || true
+    false
+  }
   timeout 60 sh -ec "until kubectl -n tenant-test get bucketaccesses.objectstorage.k8s.io bucket-${name}-admin >/dev/null 2>&1; do sleep 2; done"
   kubectl -n tenant-test wait bucketaccesses.objectstorage.k8s.io bucket-${name}-admin --timeout=300s --for=jsonpath='{.status.accessGranted}'
   timeout 60 sh -ec "until kubectl -n tenant-test get bucketaccesses.objectstorage.k8s.io bucket-${name}-viewer >/dev/null 2>&1; do sleep 2; done"

--- a/hack/e2e-apps/harbor.bats
+++ b/hack/e2e-apps/harbor.bats
@@ -43,13 +43,22 @@ EOF
   timeout 60 sh -ec "until kubectl -n tenant-test get hr $release >/dev/null 2>&1; do sleep 2; done"
   kubectl -n tenant-test wait hr $release --timeout=5m --for=condition=ready
 
-  # Wait for COSI to provision bucket. The driver creates the Bucket and grants
-  # access quickly, but the central COSI controller's propagation of the Bucket's
-  # readiness back onto the namespaced BucketClaim can lag several minutes on a
-  # loaded runner, so allow the same 10m budget the dependent HelmRelease gets.
+  # Wait for COSI to provision the bucket. The driver creates the backend Bucket
+  # and grants access; the central COSI controller requeues the BucketClaim until
+  # the Bucket's readiness has propagated, so it converges within tens of seconds.
+  # A frozen claim (the propagation race this guards against) never converges, so
+  # the tight bound surfaces that regression instead of masking it.
   timeout 60 sh -ec "until kubectl -n tenant-test get bucketclaims.objectstorage.k8s.io $release-registry >/dev/null 2>&1; do sleep 2; done"
   kubectl -n tenant-test wait bucketclaims.objectstorage.k8s.io $release-registry \
-    --timeout=600s --for=jsonpath='{.status.bucketReady}'=true
+    --timeout=120s --for=jsonpath='{.status.bucketReady}'=true || {
+    echo "=== BucketClaim did not converge to bucketReady=true ==="
+    kubectl -n tenant-test get bucketclaims.objectstorage.k8s.io $release-registry -o yaml 2>&1 || true
+    echo "=== backend Buckets (cluster-scoped) ==="
+    kubectl get buckets.objectstorage.k8s.io -o wide 2>&1 || true
+    echo "=== objectstorage-controller ==="
+    kubectl -n cozy-objectstorage-controller get pods 2>&1 || true
+    false
+  }
   timeout 60 sh -ec "until kubectl -n tenant-test get bucketaccesses.objectstorage.k8s.io $release-registry >/dev/null 2>&1; do sleep 2; done"
   kubectl -n tenant-test wait bucketaccesses.objectstorage.k8s.io $release-registry \
     --timeout=60s --for=jsonpath='{.status.accessGranted}'=true

--- a/packages/system/objectstorage-controller/images/objectstorage/patches/92-bucketclaim-propagate-ready.diff
+++ b/packages/system/objectstorage-controller/images/objectstorage/patches/92-bucketclaim-propagate-ready.diff
@@ -1,5 +1,5 @@
 diff --git a/controller/pkg/bucketclaim/bucketclaim.go b/controller/pkg/bucketclaim/bucketclaim.go
-index 2b55c49..e554761 100644
+index 2b55c49..9195195 100644
 --- a/controller/pkg/bucketclaim/bucketclaim.go
 +++ b/controller/pkg/bucketclaim/bucketclaim.go
 @@ -213,8 +213,23 @@ func (b *BucketClaimListener) provisionBucketClaimOperation(ctx context.Context,
@@ -27,7 +27,7 @@ index 2b55c49..e554761 100644
  	}
  
  	// Update status with retry logic for conflict errors
-@@ -282,6 +297,18 @@ func (b *BucketClaimListener) provisionBucketClaimOperation(ctx context.Context,
+@@ -282,6 +297,22 @@ func (b *BucketClaimListener) provisionBucketClaimOperation(ctx context.Context,
  		return b.recordError(inputBucketClaim, v1.EventTypeWarning, v1alpha1.FailedCreateBucket, err)
  	}
  
@@ -38,19 +38,31 @@ index 2b55c49..e554761 100644
 +	// internal/runtime/controller.go) and nothing mutates the BucketClaim after
 +	// this point. So while the Bucket is not ready, return an error to force a
 +	// rate-limited requeue; each retry re-reads the live Bucket above until its
-+	// readiness has been propagated onto the claim.
++	// readiness has been propagated onto the claim. Surface a Warning event so
++	// an operator can see why the claim is still pending (the returned error is
++	// logged at klog.V(3), suppressed at default verbosity); event aggregation
++	// folds the per-requeue repetition into a single counted entry.
 +	if !statusBucketReady {
-+		return fmt.Errorf("backend Bucket %q for BucketClaim %q not ready yet; requeuing", bucketName, bucketClaim.ObjectMeta.Name)
++		err := fmt.Errorf("backend Bucket %q for BucketClaim %q not ready yet; requeuing", bucketName, bucketClaim.ObjectMeta.Name)
++		return b.recordError(inputBucketClaim, v1.EventTypeWarning, v1alpha1.WaitingForBucket, err)
 +	}
 +
  	klog.V(3).Infof("Finished creating Bucket %v", bucketName)
  	return nil
  }
 diff --git a/controller/pkg/bucketclaim/bucketclaim_test.go b/controller/pkg/bucketclaim/bucketclaim_test.go
-index fea6f16..2a8149c 100644
+index fea6f16..837f7e5 100644
 --- a/controller/pkg/bucketclaim/bucketclaim_test.go
 +++ b/controller/pkg/bucketclaim/bucketclaim_test.go
-@@ -379,6 +379,18 @@ func TestRetryOnConflictStatusUpdate(t *testing.T) {
+@@ -3,6 +3,7 @@ package bucketclaim
+ import (
+ 	"context"
+ 	"fmt"
++	"strings"
+ 	"sync"
+ 	"testing"
+ 
+@@ -379,6 +380,18 @@ func TestRetryOnConflictStatusUpdate(t *testing.T) {
  		t.Fatalf("Error occurred when creating BucketClaim: %v", err)
  	}
  
@@ -69,7 +81,7 @@ index fea6f16..2a8149c 100644
  	// Cleanup
  	defer util.DeleteObjects(ctx, client, *bucketClaim, *bucketclass)
  
-@@ -436,8 +448,8 @@ func TestRetryOnConflictStatusUpdate(t *testing.T) {
+@@ -436,8 +449,8 @@ func TestRetryOnConflictStatusUpdate(t *testing.T) {
  		t.Errorf("Expected BucketName %s, got %s", expectedBucketName, updatedClaim.Status.BucketName)
  	}
  
@@ -80,7 +92,7 @@ index fea6f16..2a8149c 100644
  	}
  
  	// Verify finalizer was added
-@@ -445,3 +457,88 @@ func TestRetryOnConflictStatusUpdate(t *testing.T) {
+@@ -445,3 +458,95 @@ func TestRetryOnConflictStatusUpdate(t *testing.T) {
  		t.Errorf("Expected finalizer to be added, but it was not found")
  	}
  }
@@ -116,8 +128,15 @@ index fea6f16..2a8149c 100644
 +
 +		// The controller creates the Bucket with BucketReady=false and nothing
 +		// flips it here, so Add must report an error to force a requeue.
-+		if err := newListener(client).Add(ctx, bucketClaim); err == nil {
++		err = newListener(client).Add(ctx, bucketClaim)
++		if err == nil {
 +			t.Fatal("Add should return an error to requeue while the backend Bucket is not ready")
++		}
++		// Pin the stable substring the production requeue error carries. A
++		// refactor that drops the requeue (returning nil or a different error)
++		// would silently regress convergence; this keeps the contract loud.
++		if !strings.Contains(err.Error(), "not ready yet") {
++			t.Fatalf("Expected requeue error to contain %q, got: %v", "not ready yet", err)
 +		}
 +
 +		updated, err := client.ObjectstorageV1alpha1().BucketClaims(bucketClaim.Namespace).Get(ctx, bucketClaim.Name, metav1.GetOptions{})

--- a/packages/system/objectstorage-controller/images/objectstorage/patches/92-bucketclaim-propagate-ready.diff
+++ b/packages/system/objectstorage-controller/images/objectstorage/patches/92-bucketclaim-propagate-ready.diff
@@ -1,11 +1,11 @@
 diff --git a/controller/pkg/bucketclaim/bucketclaim.go b/controller/pkg/bucketclaim/bucketclaim.go
-index 2b55c49..038cf28 100644
+index 2b55c49..e554761 100644
 --- a/controller/pkg/bucketclaim/bucketclaim.go
 +++ b/controller/pkg/bucketclaim/bucketclaim.go
 @@ -213,8 +213,23 @@ func (b *BucketClaimListener) provisionBucketClaimOperation(ctx context.Context,
  			return b.recordError(inputBucketClaim, v1.EventTypeWarning, v1alpha1.FailedCreateBucket, err)
  		}
-
+ 
 +		// The Bucket for this claim may already exist from an earlier reconcile,
 +		// in which case the sidecar may have provisioned the backend and flipped
 +		// the Bucket to ready in the meantime. The controller does not watch
@@ -25,5 +25,147 @@ index 2b55c49..038cf28 100644
 -		bucketClaim.Status.BucketReady = false
 +		bucketClaim.Status.BucketReady = createdBucket.Status.BucketReady
  	}
-
+ 
  	// Update status with retry logic for conflict errors
+@@ -282,6 +297,18 @@ func (b *BucketClaimListener) provisionBucketClaimOperation(ctx context.Context,
+ 		return b.recordError(inputBucketClaim, v1.EventTypeWarning, v1alpha1.FailedCreateBucket, err)
+ 	}
+ 
++	// The backend Bucket is provisioned asynchronously by the sidecar, which
++	// flips Bucket.status.bucketReady on an object this controller does not
++	// watch. The periodic informer resync cannot re-drive convergence either:
++	// the generic controller drops no-op resync deltas (reflect.DeepEqual in
++	// internal/runtime/controller.go) and nothing mutates the BucketClaim after
++	// this point. So while the Bucket is not ready, return an error to force a
++	// rate-limited requeue; each retry re-reads the live Bucket above until its
++	// readiness has been propagated onto the claim.
++	if !statusBucketReady {
++		return fmt.Errorf("backend Bucket %q for BucketClaim %q not ready yet; requeuing", bucketName, bucketClaim.ObjectMeta.Name)
++	}
++
+ 	klog.V(3).Infof("Finished creating Bucket %v", bucketName)
+ 	return nil
+ }
+diff --git a/controller/pkg/bucketclaim/bucketclaim_test.go b/controller/pkg/bucketclaim/bucketclaim_test.go
+index fea6f16..2a8149c 100644
+--- a/controller/pkg/bucketclaim/bucketclaim_test.go
++++ b/controller/pkg/bucketclaim/bucketclaim_test.go
+@@ -379,6 +379,18 @@ func TestRetryOnConflictStatusUpdate(t *testing.T) {
+ 		t.Fatalf("Error occurred when creating BucketClaim: %v", err)
+ 	}
+ 
++	// Pre-create the backend Bucket already flipped to ready so readiness
++	// propagation lands true and Add completes. This test exercises the
++	// status-update conflict-retry path, not the not-ready requeue path
++	// (the latter is covered by TestProvisionRequeuesUntilBucketReady).
++	readyBucket := &v1alpha1.Bucket{
++		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("bucket-%s", bucketClaim.UID)},
++		Status:     v1alpha1.BucketStatus{BucketReady: true},
++	}
++	if _, err := client.ObjectstorageV1alpha1().Buckets().Create(ctx, readyBucket, metav1.CreateOptions{}); err != nil {
++		t.Fatalf("Error occurred when pre-creating ready Bucket: %v", err)
++	}
++
+ 	// Cleanup
+ 	defer util.DeleteObjects(ctx, client, *bucketClaim, *bucketclass)
+ 
+@@ -436,8 +448,8 @@ func TestRetryOnConflictStatusUpdate(t *testing.T) {
+ 		t.Errorf("Expected BucketName %s, got %s", expectedBucketName, updatedClaim.Status.BucketName)
+ 	}
+ 
+-	if updatedClaim.Status.BucketReady != false {
+-		t.Errorf("Expected BucketReady to be false, got %v", updatedClaim.Status.BucketReady)
++	if updatedClaim.Status.BucketReady != true {
++		t.Errorf("Expected BucketReady to be true, got %v", updatedClaim.Status.BucketReady)
+ 	}
+ 
+ 	// Verify finalizer was added
+@@ -445,3 +457,88 @@ func TestRetryOnConflictStatusUpdate(t *testing.T) {
+ 		t.Errorf("Expected finalizer to be added, but it was not found")
+ 	}
+ }
++
++// TestProvisionRequeuesUntilBucketReady pins the readiness-propagation contract.
++// The controller does not watch Bucket objects and the generic controller drops
++// no-op resync deltas, so the BucketClaim must be driven to ready by the
++// provision path itself: Add returns an error (forcing a rate-limited requeue)
++// while the backend Bucket is not ready, and returns nil with BucketReady=true
++// once the Bucket's readiness has propagated. Without the requeue the claim
++// would stay BucketReady=false forever and BucketAccess would never be granted.
++func TestProvisionRequeuesUntilBucketReady(t *testing.T) {
++	newListener := func(client *fakebucketclientset.Clientset) *BucketClaimListener {
++		l := NewBucketClaimListener()
++		l.InitializeKubeClient(fakekubeclientset.NewSimpleClientset())
++		l.InitializeBucketClient(client)
++		l.InitializeEventRecorder(record.NewFakeRecorder(3))
++		return l
++	}
++
++	t.Run("requeues while backend Bucket is not ready", func(t *testing.T) {
++		ctx, cancel := context.WithCancel(context.Background())
++		defer cancel()
++
++		client := fakebucketclientset.NewSimpleClientset()
++		if _, err := util.CreateBucketClass(ctx, client, &goldClass); err != nil {
++			t.Fatalf("Error occurred when creating BucketClass: %v", err)
++		}
++		bucketClaim, err := util.CreateBucketClaim(ctx, client, &bucketClaim1)
++		if err != nil {
++			t.Fatalf("Error occurred when creating BucketClaim: %v", err)
++		}
++
++		// The controller creates the Bucket with BucketReady=false and nothing
++		// flips it here, so Add must report an error to force a requeue.
++		if err := newListener(client).Add(ctx, bucketClaim); err == nil {
++			t.Fatal("Add should return an error to requeue while the backend Bucket is not ready")
++		}
++
++		updated, err := client.ObjectstorageV1alpha1().BucketClaims(bucketClaim.Namespace).Get(ctx, bucketClaim.Name, metav1.GetOptions{})
++		if err != nil {
++			t.Fatalf("Error occurred when reading BucketClaim: %v", err)
++		}
++		if updated.Status.BucketReady {
++			t.Errorf("Expected BucketReady to stay false while the backend Bucket is not ready")
++		}
++		// Status (name + finalizer) is still persisted before the requeue.
++		if updated.Status.BucketName != fmt.Sprintf("bucket-%s", bucketClaim.UID) {
++			t.Errorf("Expected BucketName to be set even while not ready, got %q", updated.Status.BucketName)
++		}
++	})
++
++	t.Run("converges once the backend Bucket is ready", func(t *testing.T) {
++		ctx, cancel := context.WithCancel(context.Background())
++		defer cancel()
++
++		client := fakebucketclientset.NewSimpleClientset()
++		if _, err := util.CreateBucketClass(ctx, client, &goldClass); err != nil {
++			t.Fatalf("Error occurred when creating BucketClass: %v", err)
++		}
++		bucketClaim, err := util.CreateBucketClaim(ctx, client, &bucketClaim1)
++		if err != nil {
++			t.Fatalf("Error occurred when creating BucketClaim: %v", err)
++		}
++
++		// Simulate the sidecar having already provisioned the backend and
++		// flipped the Bucket to ready before this reconcile.
++		readyBucket := &v1alpha1.Bucket{
++			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("bucket-%s", bucketClaim.UID)},
++			Status:     v1alpha1.BucketStatus{BucketReady: true},
++		}
++		if _, err := client.ObjectstorageV1alpha1().Buckets().Create(ctx, readyBucket, metav1.CreateOptions{}); err != nil {
++			t.Fatalf("Error occurred when pre-creating ready Bucket: %v", err)
++		}
++
++		if err := newListener(client).Add(ctx, bucketClaim); err != nil {
++			t.Fatalf("Add should succeed once the backend Bucket is ready: %v", err)
++		}
++
++		updated, err := client.ObjectstorageV1alpha1().BucketClaims(bucketClaim.Namespace).Get(ctx, bucketClaim.Name, metav1.GetOptions{})
++		if err != nil {
++			t.Fatalf("Error occurred when reading BucketClaim: %v", err)
++		}
++		if !updated.Status.BucketReady {
++			t.Errorf("Expected BucketReady to propagate true once the backend Bucket is ready")
++		}
++	})
++}

--- a/packages/system/objectstorage-controller/images/objectstorage/patches/93-shorten-leaderelection-lease.diff
+++ b/packages/system/objectstorage-controller/images/objectstorage/patches/93-shorten-leaderelection-lease.diff
@@ -1,0 +1,23 @@
+diff --git a/internal/runtime/controller.go b/internal/runtime/controller.go
+index 902116a..4cbe4c3 100644
+--- a/internal/runtime/controller.go
++++ b/internal/runtime/controller.go
+@@ -171,10 +171,14 @@ func NewObjectStorageControllerWithClientset(identity string, leaderLockName str
+ 		threadiness:  threads,
+ 
+ 		ResyncPeriod: 30 * time.Second,
+-		// leader election
+-		LeaseDuration: 150 * time.Second,
+-		RenewDeadline: 120 * time.Second,
+-		RetryPeriod:   60 * time.Second,
++		// Leader election. The COSI controller and the per-driver sidecar both
++		// run single-replica, so leader election provides no HA — it only gates
++		// how fast a freshly recreated pod takes over. Use the standard
++		// Kubernetes leader-election timings instead of the upstream 150/120/60s
++		// so a recreated pod resumes reconciliation in ~15s rather than ~150s.
++		LeaseDuration: 15 * time.Second,
++		RenewDeadline: 10 * time.Second,
++		RetryPeriod:   2 * time.Second,
+ 
+ 		opMap: &sync.Map{},
+ 	}, nil


### PR DESCRIPTION
## What this PR does

Hand-backport of #3034 to `release-1.5`. The `backport` label was applied at merge time but no backport PR was ever opened, so the change never reached this branch — found by auditing the branch with `cmd/backport-audit`, which reported it as `MISSING`.

Every candidate that went missing this way merged before #3155 landed, when `conflict_resolution` was passed as a top-level input instead of nested under `experimental`. The action ignored it and fell back to `fail`, which on a conflicting cherry-pick opens no PR and reports no failure, so these were dropped with no draft to find and no red check to notice.

The six original commits are cherry-picked with `-x`, unchanged and in order. No adaptation was needed: the cherry-pick was clean, and the net diff is identical to the change on `main`.

### Verification

The two `.diff` files are image patches applied at build time against upstream `container-object-storage-interface`, so what matters is that this branch pins the same upstream source. It does — both `release-1.5` and `main` set `ARG COMMIT_REF=v0.2.2` in `images/objectstorage/Dockerfile`, and the resulting patch set on this branch (`91`, `92`, `93`) is byte-identical to `main`'s. Patch `91` was already present here unchanged, so `92` applies over the same base it does on `main`.

The branch differs from `main` only in its builder pins (`golang:1.24` versus `1.26`, unpinned base digests), none of which affect patch application.

### Screenshots

Not applicable — no UI change.

### Release note

```release-note
fix(objectstorage-controller): converge BucketClaim readiness to the backend Bucket and speed up single-replica COSI provisioner failover
```
