### PR TITLE
[Backport release-1.5] fix(velero): add startupProbe so slow startup does not crashloop the install gate

### DIFF
--- a/packages/system/velero/Makefile
+++ b/packages/system/velero/Makefile
@@ -3,9 +3,15 @@ export NAMESPACE=cozy-$(NAME)
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	# Velero
 	helm repo add tanzu https://vmware-tanzu.github.io/helm-charts
 	helm repo update tanzu
-	helm pull tanzu/velero --untar --untardir charts
+	helm pull tanzu/velero --untar --untardir charts --version 11.0.0
+	# Render a startupProbe from .Values.startupProbe (upstream chart omits it),
+	# so a slow server start under heavy parallel install does not trip liveness.
+	patch --no-backup-if-mismatch -p4 < patches/add-startup-probe.patch

--- a/packages/system/velero/charts/velero/templates/deployment.yaml
+++ b/packages/system/velero/charts/velero/templates/deployment.yaml
@@ -199,6 +199,9 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.metrics.enabled }}
+          {{- with .Values.startupProbe }}
+          startupProbe: {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe: {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/packages/system/velero/patches/add-startup-probe.patch
+++ b/packages/system/velero/patches/add-startup-probe.patch
@@ -1,0 +1,14 @@
+diff --git a/packages/system/velero/charts/velero/templates/deployment.yaml b/packages/system/velero/charts/velero/templates/deployment.yaml
+index d2a72639a..a46d73200 100644
+--- a/packages/system/velero/charts/velero/templates/deployment.yaml
++++ b/packages/system/velero/charts/velero/templates/deployment.yaml
+@@ -199,6 +199,9 @@ spec:
+             {{- toYaml . | nindent 12 }}
+           {{- end }}
+           {{- if .Values.metrics.enabled }}
++          {{- with .Values.startupProbe }}
++          startupProbe: {{- toYaml . | nindent 12 }}
++          {{- end }}
+           {{- with .Values.livenessProbe }}
+           livenessProbe: {{- toYaml . | nindent 12 }}
+           {{- end }}

--- a/packages/system/velero/tests/velero_test.yaml
+++ b/packages/system/velero/tests/velero_test.yaml
@@ -1,0 +1,108 @@
+suite: cozy-velero chart rendering invariants
+release:
+  name: velero
+  namespace: cozy-velero
+tests:
+  - it: renders the velero server Deployment on the pinned upstream image
+    template: charts/velero/templates/deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: velero
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: velero/velero:v1.17.0
+
+  - it: pins the backup-plugin initContainers to velero-1.17-compatible releases
+    template: charts/velero/templates/deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: velero
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: velero/velero-plugin-for-aws:v1.12.1
+      - equal:
+          path: spec.template.spec.initContainers[1].image
+          value: quay.io/kubevirt/kubevirt-velero-plugin:v0.8.0
+
+  # Cozystack disables the upgrade-crds Job (upgradeCRDs: false) because CRDs
+  # ship via the chart's crds/ directory, making the Job redundant, and because
+  # on this chart (11.0.0) the Job runs a kubectl image whose tag defaults to the
+  # chart's Kubernetes version and need not match the cluster. Pin that
+  # invariant — it silently regressed once.
+  - it: does not emit the upgrade-crds Job when upgradeCRDs is disabled
+    template: charts/velero/templates/upgrade-crds/upgrade-crds.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  # Velero binds :8085 (http-monitoring) late under a heavy parallel install, so
+  # the upstream liveness probe (initialDelaySeconds 10, ~130s total budget) would
+  # kill it mid-startup and crashloop it out of the install-gate window. A
+  # startupProbe (patched into the upstream chart, which omits one) holds liveness
+  # and readiness off until the server is up, granting 30 * 10s = 300s of startup
+  # grace while leaving steady-state liveness at the tight upstream default. Pin
+  # the startupProbe budget AND that liveness was NOT loosened, so neither
+  # silently regresses.
+  - it: gates startup with a startupProbe and keeps liveness tight
+    template: charts/velero/templates/deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: velero
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.timeoutSeconds
+          value: 5
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.successThreshold
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /metrics
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.port
+          value: http-monitoring
+      # No initialDelaySeconds: the first startup check fires immediately, so the
+      # full 300s budget is spent probing. Pin its absence so a future change
+      # cannot silently re-introduce a delay that eats into the grace window.
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+      # Liveness stays at the tight upstream default — the startupProbe owns the
+      # grace, so loosening liveness would only weaken steady-state crash
+      # detection. Pin the full budget (initialDelay/period/failureThreshold) so a
+      # future change cannot silently re-delay or loosen liveness.
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.initialDelaySeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.periodSeconds
+          value: 30
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.failureThreshold
+          value: 5
+
+  # All three probes live behind {{- if .Values.metrics.enabled }} — :8085 only
+  # exists when metrics are on. Pin that the startupProbe follows the same gate as
+  # liveness/readiness, so disabling metrics drops all probes together and never
+  # leaves a startupProbe pointed at an unbound port.
+  - it: omits all probes (including the startupProbe) when metrics are disabled
+    template: charts/velero/templates/deployment.yaml
+    documentSelector:
+      path: metadata.name
+      value: velero
+    set:
+      velero.metrics.enabled: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].startupProbe
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe

--- a/packages/system/velero/values.yaml
+++ b/packages/system/velero/values.yaml
@@ -30,3 +30,27 @@ velero:
     # Increase timeout for item operations to 24 hours to prevent timeouts
     # during backups of very large volumes. The Velero default is 4 hours.
     defaultItemOperationTimeout: 24h
+
+  # Velero binds its metrics/health endpoint (:8085, http-monitoring) only after
+  # the server finishes loading plugins and connecting to the API server. Under a
+  # heavy parallel platform install that can take minutes, but the upstream
+  # liveness probe starts checking /metrics at initialDelaySeconds=10 and kills
+  # the container after failureThreshold=5 (~130s total) before :8085 is bound.
+  # The kubelet SIGTERMs velero (exitCode 0/Completed), it BackOff-restarts, and
+  # never escapes the loop inside the install-gate window, blocking the gate.
+  #
+  # Give the server an explicit startup budget. While the startupProbe is failing
+  # the kubelet holds off the liveness and readiness probes entirely, so steady-
+  # state liveness stays at the tight upstream default (10s / 30s / 5 failures)
+  # once startup completes. failureThreshold * periodSeconds = 30 * 10s = 300s of
+  # grace. The upstream chart does not render a startupProbe, so the velero
+  # package patches it in (patches/add-startup-probe.patch, re-applied on update).
+  startupProbe:
+    httpGet:
+      path: /metrics
+      port: http-monitoring
+      scheme: HTTP
+    periodSeconds: 10
+    timeoutSeconds: 5
+    successThreshold: 1
+    failureThreshold: 30


### PR DESCRIPTION
## What this PR does

Hand-backport of #3138 to `release-1.5`. The `backport` label was applied at merge time but no backport PR was ever opened, so the change never reached this branch — found by auditing the branch with `cmd/backport-audit`, which reported it as `MISSING`. Like the other items in that set, it merged before #3155 fixed the bot's `conflict_resolution` input, so the conflicting cherry-pick was dropped with no draft and no failing check.

Velero binds its metrics/health endpoint (`:8085`) only after loading plugins and connecting to the API server. Under a heavy parallel platform install the upstream liveness probe starts checking at `initialDelaySeconds=10` and kills the container after `failureThreshold=5`, so velero BackOff-restarts and never escapes the loop inside the install-gate window. Because `backupstrategy-controller` hard-depends on velero, this blocks the gate. The fix adds a `startupProbe`, which holds liveness and readiness off entirely while it is failing, granting `30 * 10s = 300s` of startup grace and then handing over to the unchanged upstream liveness for steady-state crash detection.

### Backport adaptations

This branch vendors velero chart **11.0.0** (appVersion 1.17.0) rather than `main`'s 12.0.3 (1.18.1), so three things differ from the original. All are recorded in the commit message as well.

- **The chart version is not bumped.** Only the patch re-application is added to `update`. The `helm pull` here was previously unpinned, which would have let `update` float to a chart the patch does not apply to, so it is pinned to `11.0.0` — the version already vendored. That makes the new patch step deterministic and leaves the vendored tree byte-identical.
- **The `test:` target is added.** It exists on `main` but not here, so without it the shipped regression guard would never run.
- **The image assertions pin this branch's own versions** (velero `v1.17.0`, `plugin-for-aws` `v1.12.1`, kubevirt plugin `v0.8.0`), and the `upgrade-crds` rationale is restated for chart 11.0.0, where that Job still runs a kubectl image — `main`'s comment about the Job running the velero image natively is true for 12.x only.

The `startupProbe` hunk itself applies to chart 11.0.0's deployment template unchanged, in the same position inside the `metrics.enabled` gate.

### Verification

`helm unittest .` passes 5/5 in `packages/system/velero`. The assertions are mutually corroborating rather than vacuous: the `equal` assertions prove the `startupProbe` path actually renders, and the same paths are asserted absent under `velero.metrics.enabled: false`, proving it follows the same gate as liveness and readiness so disabling metrics can never leave a `startupProbe` pointed at an unbound port.

### Screenshots

Not applicable — no UI change.

### Release note

```release-note
fix(velero): add a startupProbe so a slow velero server start under heavy parallel install no longer crashloops the container and blocks the install gate
```
