### PR TITLE
fix(kubernetes): render the talos-reconcile Job for the default md0 group

### DIFF
--- a/packages/apps/kubernetes/templates/talos/talos-reconcile-job.yaml
+++ b/packages/apps/kubernetes/templates/talos/talos-reconcile-job.yaml
@@ -485,7 +485,14 @@ spec:
        *management* cluster-domain, sourced from .Values._cluster
        (populated by cozystack-controller from the platform config). */}}
 {{- $mgmtClusterDomain := (index .Values._cluster "cluster-domain") | default "cozy.local" }}
-{{- range $groupName, $group := .Values.nodeGroups }}
+{{- /* Iterate the EFFECTIVE node groups (the kubernetes.nodeGroups helper),
+       never the raw .Values.nodeGroups map. The built-in md0 group lives in
+       the helper's else-branch, so a cluster that supplies no nodeGroups has
+       an empty raw map: ranging over it renders zero Jobs, leaving the md0
+       MachineDeployment below pointing at a TalosConfigTemplate that only
+       this Job ever creates. CAPI then blocks every Machine the autoscaler
+       adds. Must stay in lockstep with the loop in cluster.yaml. */}}
+{{- range $groupName, $group := (include "kubernetes.nodeGroups" $ | fromYaml) }}
 {{- /* Mirror the kubelet-reservation computation from cluster.yaml so the
        worker machineconfig the Job applies carries the same numbers the
        MachineDeployment validator was happy with. Auto-computed

--- a/packages/apps/kubernetes/tests/talos_reconcile_nodegroups_test.yaml
+++ b/packages/apps/kubernetes/tests/talos_reconcile_nodegroups_test.yaml
@@ -1,0 +1,131 @@
+suite: talos-reconcile Job covers every effective node group
+
+# Regression guard for cozystack/cozystack#3504. The Job in
+# templates/talos/talos-reconcile-job.yaml is the only producer of the
+# TalosConfigTemplate that each worker MachineDeployment names in
+# `spec.template.spec.bootstrap.configRef` (cluster.yaml renders the reference
+# but not the object). Its loop must therefore iterate the same effective group
+# set as the MachineDeployment loop — the kubernetes.nodeGroups helper — not the
+# raw .Values.nodeGroups map. When the raw map was read, a cluster that supplied
+# no nodeGroups got the helper's built-in md0 MachineDeployment and zero Jobs, so
+# every Machine the autoscaler added to md0 blocked forever on a
+# TalosConfigTemplate nothing would ever create, and the KamajiControlPlane
+# certSANs patch the same Job performs never ran either.
+#
+# The two cases below pin both halves of the helper contract: the default group
+# gets a Job (the bug), and a user-supplied group set stays authoritative — md0
+# must NOT reappear alongside it, which is the removability #2936 introduced.
+#
+# Suite-level `templates` is load-bearing: it limits the render to this one
+# template. Declaring `templates` per test does not filter the render, and the
+# unrelated `lookup` in templates/helmreleases/csi.yaml then fails the suite.
+
+templates:
+  - templates/talos/talos-reconcile-job.yaml
+
+tests:
+  - it: renders a Job for the built-in md0 group when nodeGroups is empty
+    release:
+      name: test-k8s
+      namespace: tenant-test
+    set:
+      _namespace:
+        etcd: etcd
+        ingress: nginx
+        host: example.com
+      _cluster:
+        cluster-domain: cozy.local
+      # nodeGroups intentionally left at the chart default ({}) so the helper
+      # emits the built-in md0 — the case that rendered no Job at all.
+    asserts:
+      # 6 scaffolding documents (ServiceAccount, Role, CiliumNetworkPolicy,
+      # RoleBinding, ClusterRole, ClusterRoleBinding) plus one Job for md0.
+      # Before the fix this was 6: the Job was missing entirely.
+      - hasDocuments:
+          count: 7
+      - isKind:
+          of: Job
+        documentIndex: 6
+      - matchRegex:
+          path: metadata.name
+          pattern: ^test-k8s-talos-reconcile-md0-[0-9a-f]{6}$
+        documentIndex: 6
+      # The Job applies TalosConfigTemplate ${RELEASE}-${GROUP_NAME}, so
+      # GROUP_NAME is what ties it to the MachineDeployment's configRef name
+      # (test-k8s-md0). A Job for the wrong group name would satisfy the
+      # document count above while leaving the MachineDeployment stuck.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GROUP_NAME
+            value: md0
+        documentIndex: 6
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'kind: TalosConfigTemplate'
+        documentIndex: 6
+      # Secondary effect of the missing Job: the KamajiControlPlane certSANs
+      # patch that adds the live apiserver Service ClusterIP never ran.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'patch kamajicontrolplane'
+        documentIndex: 6
+
+  - it: user-supplied node groups stay authoritative — one Job each, no md0
+    release:
+      name: test-k8s
+      namespace: tenant-test
+    set:
+      _namespace:
+        etcd: etcd
+        ingress: nginx
+        host: example.com
+      _cluster:
+        cluster-domain: cozy.local
+      nodeGroups:
+        worker0:
+          minReplicas: 1
+          maxReplicas: 3
+          instanceType: u1.medium
+          diskSize: 20Gi
+          storageClass: ""
+          roles:
+          - ingress-nginx
+          resources: {}
+          gpus: []
+          kubelet: {}
+        worker1:
+          minReplicas: 0
+          maxReplicas: 5
+          instanceType: u1.medium
+          diskSize: 20Gi
+          storageClass: ""
+          roles: []
+          resources: {}
+          gpus: []
+          kubelet: {}
+    asserts:
+      # 6 scaffolding documents + exactly two Jobs. A fix that unconditionally
+      # merged md0 into the loop would render three and fail here.
+      - hasDocuments:
+          count: 8
+      - matchRegex:
+          path: metadata.name
+          pattern: ^test-k8s-talos-reconcile-worker0-[0-9a-f]{6}$
+        documentIndex: 6
+      - matchRegex:
+          path: metadata.name
+          pattern: ^test-k8s-talos-reconcile-worker1-[0-9a-f]{6}$
+        documentIndex: 7
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GROUP_NAME
+            value: worker0
+        documentIndex: 6
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: GROUP_NAME
+            value: worker1
+        documentIndex: 7


### PR DESCRIPTION
## What this PR does

Fixes #3504.

The chart has two loops over worker node groups and they read different sources. `templates/cluster.yaml` iterates the effective set through the `kubernetes.nodeGroups` helper, whose else-branch supplies the built-in `md0` group when the user declares none — that is how #2936 made `md0` removable without a Helm values merge re-adding it. `templates/talos/talos-reconcile-job.yaml` iterated the raw `.Values.nodeGroups` map instead, which is empty in exactly that case.

The consequence is a dangling reference. The chart cannot render the `TalosConfigTemplate` itself — it needs the apiserver Service ClusterIP, the Talos CA and the Kubernetes CA, none of which exist while Helm is executing the template — so `cluster.yaml` deliberately stopped rendering it and the Job became its only producer, while the `MachineDeployment` still names it in `spec.template.spec.bootstrap.configRef`. On a cluster with the default `nodeGroups`, `MachineDeployment/<release>-md0` renders and zero Jobs render, so `TalosConfigTemplate/<release>-md0` is never created and CAPI blocks every Machine that ever joins the group. The same Job also patches `KamajiControlPlane.spec.network.certSANs` with the live Service ClusterIP, so that is skipped too.

Nothing fails at install time, because the built-in group carries `minReplicas: 0`. The failure waits for the first scale-up, which is the documented path rather than a corner: `values.yaml` tells operators that enabling the ingress-nginx addon on a cluster with default `nodeGroups` means waiting for the cluster-autoscaler to bring `md0` up in response to the controller Pods becoming Pending, and the autoscaler is deployed unconditionally whenever the tenant has an etcd DataStore.

The fix is to range over the helper so the Job set tracks the MachineDeployment set exactly. A cluster that declares its own groups renders byte-identically — which is why the pinned content-hash fixtures in `tests/talos_templates_test.yaml` are untouched — and `md0` stays removable, because the fix defers to the helper rather than merging `md0` in unconditionally. On upgrade it is additive: the Job appears where there was none, applies the `TalosConfigTemplate` the MachineDeployment already expects, and the content-hash name suffix means Helm creates a fresh Job rather than attempting to patch an immutable one.

### How this survived

Every helm-unittest fixture and every e2e suite declares `md0` explicitly. `tests/nodegroups_default_test.yaml` does render the empty-`nodeGroups` case, but lists only `templates/cluster.yaml`, so it never looked at a Job. The two OIDC chainsaw lanes do install with an empty map, but assert that the HelmRelease exists rather than that it becomes Ready, so a worker that never boots is invisible to them. Offline `helm template` cannot reach this path at all: `cluster.yaml`'s instanceType validator needs a live `lookup` for `u1.medium`.

`tests/talos_reconcile_nodegroups_test.yaml` closes the gap and pins both halves of the helper contract — an empty map yields exactly one `md0` Job carrying `GROUP_NAME=md0`, and a two-group map yields exactly two Jobs with no `md0` among them, so a future fix that merges `md0` in unconditionally fails here. Reverting the template change fails the first case on the document count, so it guards the behaviour rather than restating it.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff: it is one Helm template loop and one new helm-unittest suite inside `packages/apps/kubernetes`. No package is added, renamed or removed; no `values.yaml`, `values.schema.json`, `ApplicationDefinition`, version enum or default changes; nothing under `hack/`, no namespace, variant, label, annotation or metric renamed. The behaviour now matches what `values.yaml` already documents, so no reference page drifts.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(kubernetes): a tenant Kubernetes cluster created without an explicit `nodeGroups` map now gets a talos-reconcile Job for the built-in `md0` node group. Previously that Job rendered only for explicitly declared groups, so the default `md0` MachineDeployment referenced a TalosConfigTemplate nothing ever created: every worker the cluster-autoscaler added to `md0` stayed stuck waiting for its bootstrap config, and the KamajiControlPlane certSANs patch the same Job performs never ran. Clusters that declare their own node groups were unaffected.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the built-in `md0` node group receives its Talos reconciliation Job when no node groups are configured.
  * Prevented duplicate reconciliation Jobs when custom node groups are specified.
  * Preserved correct group-specific settings and control-plane configuration in generated Jobs.

* **Tests**
  * Added regression coverage for default and custom node-group scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->