### PR TITLE
refactor(controller): remove unused getMonitoredObject helper and its associated tests

### DIFF
--- a/internal/controller/workload_controller.go
+++ b/internal/controller/workload_controller.go
@@ -2,10 +2,7 @@ package controller
 
 import (
 	"context"
-	"strings"
-	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -15,9 +12,6 @@ import (
 	cozyv1alpha1 "github.com/cozystack/cozystack/api/v1alpha1"
 )
 
-const (
-	deletionRequeueDelay = 30 * time.Second
-)
 
 // WorkloadMonitorReconciler reconciles a WorkloadMonitor object
 type WorkloadReconciler struct {
@@ -61,26 +55,4 @@ func (r *WorkloadReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch Workload objects
 		For(&cozyv1alpha1.Workload{}).
 		Complete(r)
-}
-
-func getMonitoredObject(w *cozyv1alpha1.Workload) client.Object {
-	switch {
-	case strings.HasPrefix(w.Name, "pvc-"):
-		obj := &corev1.PersistentVolumeClaim{}
-		obj.Name = strings.TrimPrefix(w.Name, "pvc-")
-		obj.Namespace = w.Namespace
-		return obj
-	case strings.HasPrefix(w.Name, "svc-"):
-		obj := &corev1.Service{}
-		obj.Name = strings.TrimPrefix(w.Name, "svc-")
-		obj.Namespace = w.Namespace
-		return obj
-	case strings.HasPrefix(w.Name, "pod-"):
-		obj := &corev1.Pod{}
-		obj.Name = strings.TrimPrefix(w.Name, "pod-")
-		obj.Namespace = w.Namespace
-		return obj
-	}
-	var obj client.Object
-	return obj
 }

--- a/internal/controller/workload_controller_test.go
+++ b/internal/controller/workload_controller_test.go
@@ -14,23 +14,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func TestUnprefixedMonitoredObjectReturnsNil(t *testing.T) {
-	w := &cozyv1alpha1.Workload{}
-	w.Name = "unprefixed-name"
-	obj := getMonitoredObject(w)
-	if obj != nil {
-		t.Errorf(`getMonitoredObject(&Workload{Name: "%s"}) == %v, want nil`, w.Name, obj)
-	}
-}
-
-func TestPodMonitoredObject(t *testing.T) {
-	w := &cozyv1alpha1.Workload{}
-	w.Name = "pod-mypod"
-	obj := getMonitoredObject(w)
-	if pod, ok := obj.(*corev1.Pod); !ok || pod.Name != "mypod" {
-		t.Errorf(`getMonitoredObject(&Workload{Name: "%s"}) == %v, want &Pod{Name: "mypod"}`, w.Name, obj)
-	}
-}
 
 func TestWorkloadReconciler_DeletesOnMissingMonitor(t *testing.T) {
 	scheme := runtime.NewScheme()
@@ -71,19 +54,14 @@ func TestWorkloadReconciler_KeepsWhenAllExist(t *testing.T) {
 	_ = cozyv1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 
-	// Create a monitor and its backing Pod
+	// Create a monitor and its workload
 	monitor := &cozyv1alpha1.WorkloadMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mon",
 			Namespace: "default",
 		},
 	}
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: "default",
-		},
-	}
+
 	w := &cozyv1alpha1.Workload{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod-foo",
@@ -96,7 +74,7 @@ func TestWorkloadReconciler_KeepsWhenAllExist(t *testing.T) {
 
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(monitor, pod, w).
+		WithObjects(monitor, w).
 		Build()
 	reconciler := &WorkloadReconciler{Client: fakeClient}
 	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: "pod-foo", Namespace: "default"}}


### PR DESCRIPTION
…ests

<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does
Removes the unused getMonitoredObject helper in workload_controller  and its unit tests.

The helper is no longer referenced anywhere in the controller code, so removing it simplifies the codebase without changing behavior.

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
refactor(controller): remove unused getMonitoredObject helper and its associated tests
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified workload monitoring by removing unused object-mapping logic.
  * Streamlined workload persistence handling to focus on monitored workloads without backing pod references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->