### PR TITLE
fix(e2e): capture Talos logs for tenant worker join failures

### DIFF
--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -317,9 +317,9 @@ cozy_prepare_tenant_talosconfig() (
   if ! kubectl_wait_retry -n tenant-test certificate "${certificate}" \
     --for=condition=Ready --timeout=30s; then
     echo "tenant Talos reader Certificate was not issued within 30s" >&2
-    kubectl -n tenant-test describe certificate "${certificate}" >&2 || true
+    kubectl -n tenant-test describe certificate "${certificate}" --request-timeout=30s >&2 || true
     kubectl -n tenant-test get certificaterequests.cert-manager.io \
-      -l cert-manager.io/certificate-name="${certificate}" -o wide >&2 || true
+      -l cert-manager.io/certificate-name="${certificate}" -o wide --request-timeout=30s >&2 || true
     return 1
   fi
 
@@ -414,10 +414,10 @@ cozy_prepare_tenant_talos_diagnostics_pod() {
 
   if ! kubectl -n tenant-test wait pod "${pod_name}" \
     --for=condition=Ready --timeout=60s; then
-    kubectl -n tenant-test describe pod "${pod_name}" >&2 || true
+    kubectl -n tenant-test describe pod "${pod_name}" --request-timeout=30s >&2 || true
     kubectl -n tenant-test get events \
       --field-selector involvedObject.name="${pod_name}" \
-      --sort-by=.lastTimestamp >&2 || true
+      --sort-by=.lastTimestamp --request-timeout=30s >&2 || true
     return 1
   fi
 

--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -179,6 +179,16 @@ cozy_cleanup() {
   # so they don't leak MetalLB IPs from the shared host pool. Labeled by the
   # test so a single selector reaps them all.
   kubectl -n tenant-test delete service -l cozystack-e2e.io/tenant-api-lb --ignore-not-found --wait=false 2>/dev/null || true
+  # A failed node-join capture creates a short-lived reader Certificate and a
+  # hardened helper Pod. They are labelled separately from the tenant API LB:
+  # the Secret contains a Talos client key and must be reaped even if the
+  # diagnostic collector itself returned early.
+  if ! kubectl -n tenant-test delete certificates.cert-manager.io -l cozystack-e2e.io/tenant-talos-diagnostics --ignore-not-found --wait=true --timeout=30s 2>/dev/null; then
+    echo "» WARNING: failed to delete tenant Talos diagnostic Certificates" >&2
+  fi
+  if ! kubectl -n tenant-test delete pod,secret -l cozystack-e2e.io/tenant-talos-diagnostics --ignore-not-found --wait=false 2>/dev/null; then
+    echo "» WARNING: failed to delete tenant Talos diagnostic Pod/Secret" >&2
+  fi
   kubectl -n tenant-test delete kuberneteses.apps.cozystack.io --all --ignore-not-found --wait=false 2>/dev/null || true
   kubectl -n tenant-test wait kuberneteses.apps.cozystack.io --all --for=delete --timeout=5m 2>/dev/null || true
   # The CR delete above finalizes once the Kubernetes CR is gone, which only
@@ -231,6 +241,289 @@ _tenant_snapshot_on_fail() {
     *) echo "» tenant crust-gather snapshot FAILED (exit $_cg_rc); see $_snap/crust-gather-${CURRENT_TENANT_KC}.log" ;;
   esac
 }
+
+# Render name|IP rows for worker VMIs from a `kubectl get ... -o json` document.
+# Kept pure so an absent default interface is represented by an empty IP instead
+# of silently dropping the VMI from the diagnostic report.
+cozy_tenant_worker_vmi_rows() {
+  jq -r '.items[] | [.metadata.name, ([.status.interfaces[]? | select(.name == "default") | .ipAddress][0] // "")] | join("|")'
+}
+
+# Ask cert-manager for a short-lived, read-only Talos client certificate. The
+# tenant chart deliberately uses TalosConfigTemplate generateType=none, so CABPT
+# creates no client talosconfig for this worker-only Kamaji topology. Reusing the
+# existing Talos CA Issuer avoids materialising an os:admin credential or copying
+# the CA private key out of Kubernetes.
+cozy_apply_tenant_talos_reader_certificate() {
+  local test_name="$1"
+  local release="kubernetes-${test_name}"
+  local certificate="${release}-e2e-talos-reader"
+
+  kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ${certificate}
+  namespace: tenant-test
+  labels:
+    cozystack-e2e.io/tenant-talos-diagnostics: "${test_name}"
+spec:
+  duration: 1h
+  renewBefore: 10m
+  secretName: ${certificate}
+  secretTemplate:
+    labels:
+      cozystack-e2e.io/tenant-talos-diagnostics: "${test_name}"
+  subject:
+    organizations:
+    - os:reader
+  privateKey:
+    algorithm: Ed25519
+    rotationPolicy: Always
+  usages:
+  - digital signature
+  - client auth
+  issuerRef:
+    name: ${release}-talos-ca
+    kind: Issuer
+    group: cert-manager.io
+EOF
+}
+
+# Build a local talosconfig from the reader Certificate. All private material
+# stays below workdir, which the caller creates with mode 0700 and removes from
+# a contained subshell EXIT trap; none of it is copied into cozyreport.
+cozy_prepare_tenant_talosconfig() (
+  local test_name="$1"
+  local workdir="$2"
+  local release="kubernetes-${test_name}"
+  local certificate="${release}-e2e-talos-reader"
+
+  umask 077
+  # An interrupted prior run may have left a reader Secret signed by the old
+  # tenant CA. Remove the Certificate first so cert-manager cannot recreate that
+  # Secret between deletion and the new request, then wait for both objects to
+  # disappear before waiting for issuance below.
+  kubectl -n tenant-test delete certificate "${certificate}" \
+    --ignore-not-found --wait=true --timeout=10s >/dev/null 2>&1 || return 1
+  kubectl -n tenant-test delete secret "${certificate}" \
+    --ignore-not-found --wait=true --timeout=10s >/dev/null 2>&1 || return 1
+  cozy_apply_tenant_talos_reader_certificate "${test_name}" || return 1
+
+  # cert-manager issuance is asynchronous. Wait on its actual Ready condition;
+  # on expiry, preserve Certificate diagnostics without ever printing the
+  # generated Secret.
+  if ! kubectl -n tenant-test wait certificate "${certificate}" \
+    --for=condition=Ready --timeout=30s; then
+    echo "tenant Talos reader Certificate was not issued within 30s" >&2
+    kubectl -n tenant-test describe certificate "${certificate}" >&2 || true
+    kubectl -n tenant-test get certificaterequests.cert-manager.io \
+      -l cert-manager.io/certificate-name="${certificate}" -o wide >&2 || true
+    return 1
+  fi
+
+  kubectl -n tenant-test get secret "${release}-talos-ca" \
+    -o go-template='{{index .data "tls.crt" | base64decode}}' >"${workdir}/ca.crt" || return 1
+  kubectl -n tenant-test get secret "${certificate}" \
+    -o go-template='{{index .data "tls.crt" | base64decode}}' >"${workdir}/client.crt" || return 1
+  kubectl -n tenant-test get secret "${certificate}" \
+    -o go-template='{{index .data "tls.key" | base64decode}}' >"${workdir}/client.key" || return 1
+
+  talosctl --talosconfig "${workdir}/talosconfig" config add "${release}" \
+    --ca "${workdir}/ca.crt" --crt "${workdir}/client.crt" \
+    --key "${workdir}/client.key" || return 1
+  talosctl --talosconfig "${workdir}/talosconfig" config context "${release}" || return 1
+  chmod 600 "${workdir}/talosconfig"
+)
+
+# Apply the helper Pod separately from its readiness/copy steps so its security
+# invariants have focused unit coverage. The Pod runs on the management cluster
+# in the same namespace as bridge-networked worker VMIs, which lets talosctl use
+# each real VMI IP as both endpoint and node and keeps server-TLS verification
+# valid. A MetalLB or localhost port-forward address would not be in the Talos
+# serving certificate SANs.
+cozy_apply_tenant_talos_diagnostics_pod() {
+  local test_name="$1"
+  local pod_name="kubernetes-${test_name}-talos-diagnostics"
+
+  kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${pod_name}
+  namespace: tenant-test
+  labels:
+    cozystack-e2e.io/tenant-talos-diagnostics: "${test_name}"
+spec:
+  activeDeadlineSeconds: 900
+  automountServiceAccountToken: false
+  enableServiceLinks: false
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 1
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: diagnostics
+    # talosctl is dynamically linked against glibc; use the same pinned Ubuntu
+    # base as the E2E sandbox rather than an Alpine/musl helper image.
+    image: docker.io/library/ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
+    imagePullPolicy: IfNotPresent
+    command: ["sh", "-c", "sleep 900"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      readOnlyRootFilesystem: true
+    resources:
+      requests:
+        cpu: 10m
+        memory: 16Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+    volumeMounts:
+    - name: tmp
+      mountPath: /tmp
+  volumes:
+  - name: tmp
+    emptyDir: {}
+EOF
+}
+
+# Start the helper Pod and stream talosctl plus the reader talosconfig into its
+# emptyDir. Streaming avoids a Secret volume and keeps the Pod independent of
+# kubectl-cp/tar behavior. The final cleanup selector remains the authoritative
+# backstop if any preparation step fails.
+cozy_prepare_tenant_talos_diagnostics_pod() {
+  local test_name="$1"
+  local talosconfig="$2"
+  local pod_name="kubernetes-${test_name}-talos-diagnostics"
+  local talosctl_bin
+
+  talosctl_bin=$(command -v talosctl) || return 1
+  kubectl -n tenant-test delete pod "${pod_name}" --ignore-not-found \
+    --wait=true --timeout=10s >/dev/null 2>&1 || return 1
+  cozy_apply_tenant_talos_diagnostics_pod "${test_name}" || return 1
+
+  if ! kubectl -n tenant-test wait pod "${pod_name}" \
+    --for=condition=Ready --timeout=60s; then
+    kubectl -n tenant-test describe pod "${pod_name}" >&2 || true
+    kubectl -n tenant-test get events \
+      --field-selector involvedObject.name="${pod_name}" \
+      --sort-by=.lastTimestamp >&2 || true
+    return 1
+  fi
+
+  if ! timeout -k 5 60 kubectl -n tenant-test exec -i "${pod_name}" \
+    -c diagnostics -- sh -ec 'cat > /tmp/talosctl && chmod 500 /tmp/talosctl' \
+    <"${talosctl_bin}"; then
+    echo "failed to stream talosctl into tenant diagnostics Pod" >&2
+    return 1
+  fi
+  if ! timeout -k 5 20 kubectl -n tenant-test exec -i "${pod_name}" \
+    -c diagnostics -- sh -ec 'umask 077; cat > /tmp/talosconfig; chmod 600 /tmp/talosconfig' \
+    <"${talosconfig}"; then
+    echo "failed to stream tenant talosconfig into diagnostics Pod" >&2
+    return 1
+  fi
+}
+
+# Capture one bounded Talos command through the helper Pod and retain the exit
+# status alongside partial output. A timeout or unreachable pre-apid worker is
+# itself useful evidence and must not erase captures from the other worker.
+cozy_capture_tenant_talos_command() {
+  local pod_name="$1"
+  local node_ip="$2"
+  local output="$3"
+  shift 3
+  local rc=0
+
+  timeout -k 5 20 kubectl -n tenant-test exec "${pod_name}" -c diagnostics -- \
+    /tmp/talosctl --talosconfig /tmp/talosconfig \
+    -e "${node_ip}" -n "${node_ip}" "$@" >"${output}" 2>&1 || rc=$?
+  printf '\n[capture exit code: %s]\n' "${rc}" >>"${output}"
+  return "${rc}"
+}
+
+cozy_capture_tenant_talos_node() {
+  local pod_name="$1"
+  local node_ip="$2"
+  local output_dir="$3"
+
+  mkdir -p "${output_dir}"
+  printf 'endpoint: %s\nnode: %s\n' "${node_ip}" "${node_ip}" >"${output_dir}/target.txt"
+  cozy_capture_tenant_talos_command "${pod_name}" "${node_ip}" \
+    "${output_dir}/dmesg.log" dmesg || true
+  cozy_capture_tenant_talos_command "${pod_name}" "${node_ip}" \
+    "${output_dir}/kubelet.log" logs kubelet --tail=500 || true
+}
+
+# Collect the guest-side evidence requested by issue #3513. This runs only after
+# the 18-minute Ready deadline has already failed. The setup budgets 30s for
+# stale-resource deletion, 30s for Certificate issuance, 60s for Pod readiness,
+# bounded copy operations, and at most 40s of Talos calls per VMI. It runs before
+# slower cache diagnostics so the requested guest evidence lands first and stays
+# inside the surrounding Chainsaw timeout even when later collectors exhaust a
+# budget.
+cozy_capture_tenant_talos() (
+  local test_name="$1"
+  local report_dir="${COZY_REPORT_DIR:-/workspace/_out/cozyreport}/snapshots/${COZY_SNAPSHOT_NAME:-kubernetes}/tenant-talos"
+  local selector="cluster.x-k8s.io/cluster-name=kubernetes-${test_name},cluster.x-k8s.io/role=worker"
+  local pod_name="kubernetes-${test_name}-talos-diagnostics"
+  local workdir vmi_name node_ip
+
+  umask 077
+  workdir=$(mktemp -d) || return 1
+  chmod 700 "${workdir}"
+  trap 'rm -rf "${workdir}"' EXIT
+  mkdir -p "${report_dir}"
+
+  if ! kubectl -n tenant-test get virtualmachineinstances.kubevirt.io \
+    -l "${selector}" -o json >"${report_dir}/vmis.json" \
+    2>"${report_dir}/vmis-error.log"; then
+    echo "failed to list tenant worker VMIs for Talos diagnostics" >&2
+    return 1
+  fi
+  cozy_tenant_worker_vmi_rows <"${report_dir}/vmis.json" >"${workdir}/vmis.rows"
+  if [ ! -s "${workdir}/vmis.rows" ]; then
+    echo "no tenant worker VMIs found for Talos diagnostics" >&2
+    printf 'no tenant worker VMIs matched selector %s\n' "${selector}" \
+      >"${report_dir}/setup-error.log"
+    return 1
+  fi
+
+  if ! cozy_prepare_tenant_talosconfig "${test_name}" "${workdir}"; then
+    echo "failed to create short-lived tenant Talos reader config" >&2
+    printf '%s\n' 'failed to create short-lived tenant Talos reader config' \
+      >"${report_dir}/setup-error.log"
+    return 1
+  fi
+  if ! cozy_prepare_tenant_talos_diagnostics_pod \
+    "${test_name}" "${workdir}/talosconfig"; then
+    echo "failed to prepare tenant Talos diagnostics Pod" >&2
+    printf '%s\n' 'failed to prepare tenant Talos diagnostics Pod' \
+      >"${report_dir}/setup-error.log"
+    return 1
+  fi
+
+  while IFS='|' read -r vmi_name node_ip; do
+    if [ -z "${node_ip}" ]; then
+      mkdir -p "${report_dir}/${vmi_name}"
+      printf '%s\n' 'default VMI interface has no reported IP address' \
+        >"${report_dir}/${vmi_name}/capture-error.log"
+      continue
+    fi
+    echo "--- capturing tenant Talos dmesg/kubelet: ${vmi_name} (${node_ip}) ---"
+    cozy_capture_tenant_talos_node "${pod_name}" "${node_ip}" \
+      "${report_dir}/${vmi_name}"
+  done <"${workdir}/vmis.rows"
+)
 
 run_kubernetes_test() {
     local version_expr="$1"
@@ -491,6 +784,16 @@ EOF
     kubectl -n tenant-test get pods -l kubevirt.io=virt-launcher -o wide || true
     kubectl -n tenant-test describe pods -l kubevirt.io=virt-launcher || true
 
+    # (b) In-guest Talos kernel and kubelet logs. The tenant chart intentionally
+    # has no admin talosconfig, so mint a one-hour os:reader client from its
+    # existing cert-manager Issuer and run talosctl from a hardened Pod that can
+    # reach the bridge-networked VMI IPs without weakening TLS verification.
+    # A worker that has not reached apid yet will produce a bounded connection
+    # error while a later-stage worker remains capturable; both outcomes are
+    # retained in cozyreport. Diagnostic setup failures never mask exit 1 below.
+    echo "=== (b) in-guest Talos dmesg + kubelet logs ==="
+    cozy_capture_tenant_talos "${test_name}" || true
+
     # (a2) Worker DataVolume IMPORT stage. A VM stuck "Provisioning" whose
     # DataVolume is ImportInProgress at N/A progress with the importer pod
     # looping on an HTTP error is a distinct sub-mode of 2a that the VM/VMI
@@ -523,17 +826,6 @@ EOF
     kubectl -n tenant-test logs -l kamaji.clastix.io/name="kubernetes-${test_name}" \
       -c talos-csr-signer --tail=200 --prefix || true
 
-    # (b) In-guest Talos/kubelet state from the worker VMs is intentionally NOT
-    # captured here. talosctl needs a client talosconfig for the TENANT cluster,
-    # and the runner has none: the tenant workers are provisioned with their own
-    # Talos PKI whose CA differs from the sandbox's /workspace/talosconfig (which
-    # cozyreport.sh uses to reach the MANAGEMENT nodes only), and the chart
-    # materialises no tenant client talosconfig Secret. Pointing talosctl at the
-    # worker IPs with the management talosconfig would just fail mTLS and capture
-    # nothing, so it is skipped rather than shipped as a misleading no-op. (a) +
-    # (c) carry the 2a-vs-2b split; adding real in-guest capture later requires
-    # wiring a tenant talosconfig into the runner first.
-    echo "=== (b) in-guest Talos/kubelet capture skipped: no tenant talosconfig on the runner (a/c cover the 2a-vs-2b split) ==="
     exit 1
   fi
   kubectl --kubeconfig "tenantkubeconfig-${test_name}" get nodes -o wide

--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -270,6 +270,7 @@ metadata:
 spec:
   duration: 1h
   renewBefore: 10m
+  commonName: ${certificate}
   secretName: ${certificate}
   secretTemplate:
     labels:
@@ -369,9 +370,9 @@ spec:
       type: RuntimeDefault
   containers:
   - name: diagnostics
-    # talosctl is dynamically linked against glibc; use the same pinned Ubuntu
-    # base as the E2E sandbox rather than an Alpine/musl helper image.
-    image: docker.io/library/ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
+    # The E2E sandbox ships the statically linked upstream talosctl release, so
+    # reuse the digest-pinned Alpine helper already pulled by the test setup.
+    image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47
     imagePullPolicy: IfNotPresent
     command: ["sh", "-c", "sleep 900"]
     securityContext:
@@ -465,18 +466,17 @@ cozy_capture_tenant_talos_node() {
 }
 
 # Collect the guest-side evidence requested by issue #3513. This runs only after
-# the 18-minute Ready deadline has already failed. The setup budgets 30s for
-# stale-resource deletion, 30s for Certificate issuance, 60s for Pod readiness,
-# bounded copy operations, and at most 40s of Talos calls per VMI. It runs before
-# slower cache diagnostics so the requested guest evidence lands first and stays
-# inside the surrounding Chainsaw timeout even when later collectors exhaust a
-# budget.
+# the 18-minute Ready deadline has already failed. VMIs without a reported IP
+# are recorded before any Certificate or Pod is created; when at least one IP is
+# available, setup and each Talos command remain bounded. It runs before slower
+# cache diagnostics so the requested guest evidence lands first.
 cozy_capture_tenant_talos() (
   local test_name="$1"
   local report_dir="${COZY_REPORT_DIR:-/workspace/_out/cozyreport}/snapshots/${COZY_SNAPSHOT_NAME:-kubernetes}/tenant-talos"
   local selector="cluster.x-k8s.io/cluster-name=kubernetes-${test_name},cluster.x-k8s.io/role=worker"
   local pod_name="kubernetes-${test_name}-talos-diagnostics"
   local workdir vmi_name node_ip
+  local has_node_ip=false
 
   umask 077
   workdir=$(mktemp -d) || return 1
@@ -498,6 +498,25 @@ cozy_capture_tenant_talos() (
     return 1
   fi
 
+  # Record missing addresses before spending time on Certificate issuance or a
+  # helper Pod. If no worker booted far enough for KubeVirt to report an IP,
+  # guest-side Talos is unreachable and setup cannot produce more evidence.
+  while IFS='|' read -r vmi_name node_ip; do
+    if [ -z "${node_ip}" ]; then
+      mkdir -p "${report_dir}/${vmi_name}"
+      printf '%s\n' 'default VMI interface has no reported IP address' \
+        >"${report_dir}/${vmi_name}/capture-error.log"
+      continue
+    fi
+    has_node_ip=true
+  done <"${workdir}/vmis.rows"
+  if [ "${has_node_ip}" != true ]; then
+    echo "no tenant worker VMI has a reported IP for Talos diagnostics" >&2
+    printf '%s\n' 'no tenant worker VMI has a reported IP for Talos diagnostics' \
+      >"${report_dir}/setup-error.log"
+    return 1
+  fi
+
   if ! cozy_prepare_tenant_talosconfig "${test_name}" "${workdir}"; then
     echo "failed to create short-lived tenant Talos reader config" >&2
     printf '%s\n' 'failed to create short-lived tenant Talos reader config' \
@@ -513,12 +532,7 @@ cozy_capture_tenant_talos() (
   fi
 
   while IFS='|' read -r vmi_name node_ip; do
-    if [ -z "${node_ip}" ]; then
-      mkdir -p "${report_dir}/${vmi_name}"
-      printf '%s\n' 'default VMI interface has no reported IP address' \
-        >"${report_dir}/${vmi_name}/capture-error.log"
-      continue
-    fi
+    [ -n "${node_ip}" ] || continue
     echo "--- capturing tenant Talos dmesg/kubelet: ${vmi_name} (${node_ip}) ---"
     cozy_capture_tenant_talos_node "${pod_name}" "${node_ip}" \
       "${report_dir}/${vmi_name}"

--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -259,7 +259,7 @@ cozy_apply_tenant_talos_reader_certificate() {
   local release="kubernetes-${test_name}"
   local certificate="${release}-e2e-talos-reader"
 
-  kubectl apply -f - <<EOF
+  kubectl apply --request-timeout=30s -f - <<EOF
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -314,7 +314,7 @@ cozy_prepare_tenant_talosconfig() (
   # cert-manager issuance is asynchronous. Wait on its actual Ready condition;
   # on expiry, preserve Certificate diagnostics without ever printing the
   # generated Secret.
-  if ! kubectl -n tenant-test wait certificate "${certificate}" \
+  if ! kubectl_wait_retry -n tenant-test certificate "${certificate}" \
     --for=condition=Ready --timeout=30s; then
     echo "tenant Talos reader Certificate was not issued within 30s" >&2
     kubectl -n tenant-test describe certificate "${certificate}" >&2 || true
@@ -324,11 +324,11 @@ cozy_prepare_tenant_talosconfig() (
   fi
 
   kubectl -n tenant-test get secret "${release}-talos-ca" \
-    -o go-template='{{index .data "tls.crt" | base64decode}}' >"${workdir}/ca.crt" || return 1
+    -o go-template='{{index .data "tls.crt" | base64decode}}' --request-timeout=30s >"${workdir}/ca.crt" || return 1
   kubectl -n tenant-test get secret "${certificate}" \
-    -o go-template='{{index .data "tls.crt" | base64decode}}' >"${workdir}/client.crt" || return 1
+    -o go-template='{{index .data "tls.crt" | base64decode}}' --request-timeout=30s >"${workdir}/client.crt" || return 1
   kubectl -n tenant-test get secret "${certificate}" \
-    -o go-template='{{index .data "tls.key" | base64decode}}' >"${workdir}/client.key" || return 1
+    -o go-template='{{index .data "tls.key" | base64decode}}' --request-timeout=30s >"${workdir}/client.key" || return 1
 
   talosctl --talosconfig "${workdir}/talosconfig" config add "${release}" \
     --ca "${workdir}/ca.crt" --crt "${workdir}/client.crt" \
@@ -347,7 +347,7 @@ cozy_apply_tenant_talos_diagnostics_pod() {
   local test_name="$1"
   local pod_name="kubernetes-${test_name}-talos-diagnostics"
 
-  kubectl apply -f - <<EOF
+  kubectl apply --request-timeout=30s -f - <<EOF
 apiVersion: v1
 kind: Pod
 metadata:
@@ -485,7 +485,7 @@ cozy_capture_tenant_talos() (
   mkdir -p "${report_dir}"
 
   if ! kubectl -n tenant-test get virtualmachineinstances.kubevirt.io \
-    -l "${selector}" -o json >"${report_dir}/vmis.json" \
+    -l "${selector}" -o json --request-timeout=30s >"${report_dir}/vmis.json" \
     2>"${report_dir}/vmis-error.log"; then
     echo "failed to list tenant worker VMIs for Talos diagnostics" >&2
     return 1
@@ -763,7 +763,7 @@ EOF
   # kubernetes-previous failed here at exactly 12m with zero Nodes registered
   # and the tenant cilium HR still mid-install. A less-loaded fleet run passed
   # the same suites unchanged, so this is load-induced slowness, not a stuck
-  # bring-up; 18m restores margin and still sits well inside the 40m step
+  # bring-up; 18m restores margin and still sits well inside the 50m step
   # timeout (the downstream LB/NFS/ouroboros checks add ~10-15m on the happy
   # path).
   if ! timeout 18m bash -c '

--- a/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
@@ -19,7 +19,10 @@ spec:
     try:
     - script:
         # ~25m Kamaji bringup + worker join + LB/NFS/ouroboros assertions.
-        timeout: 40m
+        # The failure path can spend ~5m10s in bounded guest Talos capture and
+        # another 6m30s in its in-process tenant snapshot. Keep the outer op
+        # above those inner budgets with useful scheduling/API-call slack.
+        timeout: 50m
         # Co-locate the tenant crust-gather snapshot (captured by
         # run-kubernetes.sh on failure) under the same snapshots/<test>/ dir as
         # the global .chainsaw.yaml catch's host snapshot.

--- a/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
@@ -13,7 +13,10 @@ spec:
   - name: tenant-kubernetes-previous-version
     try:
     - script:
-        timeout: 40m
+        # The failure path can spend ~5m10s in bounded guest Talos capture and
+        # another 6m30s in its in-process tenant snapshot. Keep the outer op
+        # above those inner budgets with useful scheduling/API-call slack.
+        timeout: 50m
         # Co-locate the tenant crust-gather snapshot (captured by
         # run-kubernetes.sh on failure) under the same snapshots/<test>/ dir as
         # the global .chainsaw.yaml catch's host snapshot.

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -106,6 +106,11 @@
       (..|select(has("containers"))|.containers[]|.image),
       (..|select(has("initContainers"))|.initContainers[]|.image)
     ' "$kubeovn_yaml" "$linstor_yaml" "$certmanager_yaml" > "$images_list"
+  # The failure-only Talos diagnostics Pod can land on any node. The sandbox's
+  # upstream talosctl binary is static, so cache its pinned Alpine base on every
+  # node while the cluster is healthy instead of cold-pulling on a failure path.
+  printf '%s\n' 'docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47' \
+    >> "$images_list"
   hack/e2e-prepull-images.sh < "$images_list"
   rm -f "$kubeovn_yaml" "$linstor_yaml" "$certmanager_yaml" "$images_list"
 }

--- a/hack/run-kubernetes-talos-diagnostics_test.bats
+++ b/hack/run-kubernetes-talos-diagnostics_test.bats
@@ -1,0 +1,221 @@
+#!/usr/bin/env bats
+# Regression coverage for tenant-worker Talos diagnostics in
+# hack/e2e-chainsaw/_lib/run-kubernetes.sh. cozytest.sh ends an @test block at
+# the first bare closing brace, so command mocks stay at top level.
+
+kubectl_calls=/dev/null
+kubectl_manifest=/dev/null
+kubectl_exec_rc=0
+kubectl_vmi_json=
+talosctl_calls=/dev/null
+timeout_calls=/dev/null
+timeout_rc=0
+timeout_fail_node_ip=
+
+kubectl() {
+  printf '%s\n' "$*" >>"${kubectl_calls}"
+
+  if [ "${1:-}" = apply ]; then
+    cat >"${kubectl_manifest}"
+    return 0
+  fi
+
+  if [ "${1:-}" = -n ] && [ "${2:-}" = tenant-test ] \
+    && [ "${3:-}" = get ] && [ "${4:-}" = secret ]; then
+    if [ "${7:-}" = name ]; then
+      printf 'secret/%s\n' "${5}"
+      return 0
+    fi
+    case "${7:-}" in
+      *tls.key*) printf '%s\n' 'mock-client-key' ;;
+      *) printf '%s\n' 'mock-certificate' ;;
+    esac
+    return 0
+  fi
+
+  if [ "${1:-}" = -n ] && [ "${2:-}" = tenant-test ] \
+    && [ "${3:-}" = get ] \
+    && [ "${4:-}" = virtualmachineinstances.kubevirt.io ] \
+    && [ "${8:-}" = json ] && [ -n "${kubectl_vmi_json}" ]; then
+    cat "${kubectl_vmi_json}"
+    return 0
+  fi
+
+  if [ "${3:-}" = exec ] && [ "${4:-}" = deploy/linstor-controller ]; then
+    printf '%s\n' '104857600:satellite-a'
+    return 0
+  fi
+
+  if [ "${3:-}" = exec ]; then
+    printf 'mock capture for %s\n' "$*"
+    return "${kubectl_exec_rc}"
+  fi
+
+  return 0
+}
+
+talosctl() {
+  printf '%s\n' "$*" >>"${talosctl_calls}"
+  if [ "${1:-}" = --talosconfig ] && [ "${3:-}" = config ] \
+    && [ "${4:-}" = add ]; then
+    printf '%s\n' 'mock-talosconfig' >"${2}"
+  fi
+}
+
+timeout() {
+  local command_rc=0
+  printf '%s\n' "$*" >>"${timeout_calls}"
+  [ "${1:-}" = -k ] || return 97
+  shift 3
+  "$@" || command_rc=$?
+  if [ -n "${timeout_fail_node_ip}" ]; then
+    case " $* " in
+      *" -e ${timeout_fail_node_ip} "*) return 124 ;;
+    esac
+  fi
+  [ "${timeout_rc}" -eq 0 ] || return "${timeout_rc}"
+  return "${command_rc}"
+}
+
+@test "worker VMI rows retain names whose default interface has no IP" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  rows=$(printf '%s\n' '{"items":[{"metadata":{"name":"worker-a"},"status":{"interfaces":[{"name":"default","ipAddress":"10.244.1.92"}]}},{"metadata":{"name":"worker-b"},"status":{"interfaces":[{"name":"other","ipAddress":"192.0.2.1"}]}}]}' | cozy_tenant_worker_vmi_rows)
+  [ "${rows}" = "$(printf 'worker-a|10.244.1.92\nworker-b|')" ]
+}
+
+@test "reader Certificate is short-lived and never embeds credential data" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  kubectl_calls="$tmp/kubectl.calls"
+  kubectl_manifest="$tmp/certificate.yaml"
+
+  cozy_apply_tenant_talos_reader_certificate test-latest-version
+
+  rg -Fq 'name: kubernetes-test-latest-version-e2e-talos-reader' "$kubectl_manifest"
+  rg -Fq 'duration: 1h' "$kubectl_manifest"
+  rg -Fq -- '- os:reader' "$kubectl_manifest"
+  rg -Fq 'name: kubernetes-test-latest-version-talos-ca' "$kubectl_manifest"
+  rg -Fq 'cozystack-e2e.io/tenant-talos-diagnostics: "test-latest-version"' "$kubectl_manifest"
+  if rg -q '^[[:space:]]*(tls\.crt|tls\.key|data):' "$kubectl_manifest"; then
+    echo "Certificate manifest must not embed Talos credential material" >&2
+    exit 1
+  fi
+}
+
+@test "talosconfig uses the tenant CA and the issued reader key" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  kubectl_calls="$tmp/kubectl.calls"
+  kubectl_manifest="$tmp/certificate.yaml"
+  talosctl_calls="$tmp/talosctl.calls"
+
+  cozy_prepare_tenant_talosconfig test-latest-version "$tmp"
+
+  [ "$(sed -n '1p' "$kubectl_calls")" = '-n tenant-test delete certificate kubernetes-test-latest-version-e2e-talos-reader --ignore-not-found --wait=true --timeout=10s' ]
+  [ "$(sed -n '2p' "$kubectl_calls")" = '-n tenant-test delete secret kubernetes-test-latest-version-e2e-talos-reader --ignore-not-found --wait=true --timeout=10s' ]
+  rg -Fq -- '-n tenant-test wait certificate kubernetes-test-latest-version-e2e-talos-reader --for=condition=Ready --timeout=30s' "$kubectl_calls"
+  rg -Fq -- '-n tenant-test get secret kubernetes-test-latest-version-talos-ca -o go-template={{index .data "tls.crt" | base64decode}}' "$kubectl_calls"
+  rg -Fq -- '-n tenant-test get secret kubernetes-test-latest-version-e2e-talos-reader -o go-template={{index .data "tls.key" | base64decode}}' "$kubectl_calls"
+  rg -Fq -- "--talosconfig $tmp/talosconfig config add kubernetes-test-latest-version --ca $tmp/ca.crt --crt $tmp/client.crt --key $tmp/client.key" "$talosctl_calls"
+  rg -Fq -- "--talosconfig $tmp/talosconfig config context kubernetes-test-latest-version" "$talosctl_calls"
+  [ "$(stat -c '%a' "$tmp/talosconfig")" = 600 ]
+}
+
+@test "diagnostics Pod has no API token or Secret volume" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  kubectl_calls="$tmp/kubectl.calls"
+  kubectl_manifest="$tmp/pod.yaml"
+
+  cozy_apply_tenant_talos_diagnostics_pod test-latest-version
+
+  rg -Fq 'automountServiceAccountToken: false' "$kubectl_manifest"
+  rg -Fq 'runAsNonRoot: true' "$kubectl_manifest"
+  rg -Fq 'readOnlyRootFilesystem: true' "$kubectl_manifest"
+  rg -Fq 'drop:' "$kubectl_manifest"
+  rg -Fq -- '- ALL' "$kubectl_manifest"
+  rg -Fq 'image: docker.io/library/ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90' "$kubectl_manifest"
+  if rg -q 'secret:|secretName:' "$kubectl_manifest"; then
+    echo "diagnostics Pod must receive credentials only through its emptyDir" >&2
+    exit 1
+  fi
+}
+
+@test "node capture uses the VMI IP for endpoint and node with bounded commands" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+
+  cozy_capture_tenant_talos_node diagnostics-pod 10.244.1.92 "$tmp/node"
+
+  [ -s "$tmp/node/dmesg.log" ]
+  [ -s "$tmp/node/kubelet.log" ]
+  [ "$(sed -n '1p' "$kubectl_calls")" = '-n tenant-test exec diagnostics-pod -c diagnostics -- /tmp/talosctl --talosconfig /tmp/talosconfig -e 10.244.1.92 -n 10.244.1.92 dmesg' ]
+  [ "$(sed -n '2p' "$kubectl_calls")" = '-n tenant-test exec diagnostics-pod -c diagnostics -- /tmp/talosctl --talosconfig /tmp/talosconfig -e 10.244.1.92 -n 10.244.1.92 logs kubelet --tail=500' ]
+  [ "$(sed -n '1p' "$timeout_calls")" = '-k 5 20 kubectl -n tenant-test exec diagnostics-pod -c diagnostics -- /tmp/talosctl --talosconfig /tmp/talosconfig -e 10.244.1.92 -n 10.244.1.92 dmesg' ]
+  [ "$(sed -n '2p' "$timeout_calls")" = '-k 5 20 kubectl -n tenant-test exec diagnostics-pod -c diagnostics -- /tmp/talosctl --talosconfig /tmp/talosconfig -e 10.244.1.92 -n 10.244.1.92 logs kubelet --tail=500' ]
+  case "$(sed -n '1p' "$kubectl_calls")" in
+    *--tail*) echo "dmesg must not receive a --tail flag" >&2; exit 1 ;;
+  esac
+  rg -Fq '[capture exit code: 0]' "$tmp/node/dmesg.log"
+  rg -Fq '[capture exit code: 0]' "$tmp/node/kubelet.log"
+}
+
+@test "a timed-out worker remains recorded and does not block the next capture" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  timeout_rc=124
+
+  cozy_capture_tenant_talos_node diagnostics-pod 10.244.1.93 "$tmp/node"
+
+  [ "$(wc -l < "$kubectl_calls")" -eq 2 ]
+  [ "$(wc -l < "$timeout_calls")" -eq 2 ]
+  rg -Fq '[capture exit code: 124]' "$tmp/node/dmesg.log"
+  rg -Fq '[capture exit code: 124]' "$tmp/node/kubelet.log"
+}
+
+@test "orchestrator continues from a timed-out worker to the next VMI" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  kubectl_calls="$tmp/kubectl.calls"
+  kubectl_manifest="$tmp/manifest.yaml"
+  kubectl_vmi_json="$tmp/vmis.json"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  timeout_fail_node_ip=10.244.1.93
+  COZY_REPORT_DIR="$tmp/report"
+  COZY_SNAPSHOT_NAME=diagnostic-smoke
+  printf '%s\n' '{"items":[{"metadata":{"name":"worker-a"},"status":{"interfaces":[{"name":"default","ipAddress":"10.244.1.93"}]}},{"metadata":{"name":"worker-b"},"status":{"interfaces":[{"name":"default","ipAddress":"10.244.1.94"}]}}]}' >"$kubectl_vmi_json"
+  printf '%s\n' '#!/bin/sh' >"$tmp/talosctl"
+  chmod 755 "$tmp/talosctl"
+  cd "$tmp"
+
+  cozy_capture_tenant_talos test-latest-version
+
+  [ "$(rg -c ' exec kubernetes-test-latest-version-talos-diagnostics ' "$kubectl_calls")" -eq 4 ]
+  rg -Fq '[capture exit code: 124]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-a/dmesg.log"
+  rg -Fq '[capture exit code: 124]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-a/kubelet.log"
+  rg -Fq '[capture exit code: 0]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-b/dmesg.log"
+  rg -Fq '[capture exit code: 0]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-b/kubelet.log"
+}
+
+@test "cleanup deletes diagnostic Certificate before its Pod and Secret" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  kubectl_calls="$tmp/kubectl.calls"
+
+  cozy_cleanup
+
+  [ "$(sed -n '2p' "$kubectl_calls")" = '-n tenant-test delete certificates.cert-manager.io -l cozystack-e2e.io/tenant-talos-diagnostics --ignore-not-found --wait=true --timeout=30s' ]
+  [ "$(sed -n '3p' "$kubectl_calls")" = '-n tenant-test delete pod,secret -l cozystack-e2e.io/tenant-talos-diagnostics --ignore-not-found --wait=false' ]
+}

--- a/hack/run-kubernetes-talos-diagnostics_test.bats
+++ b/hack/run-kubernetes-talos-diagnostics_test.bats
@@ -77,6 +77,27 @@ timeout() {
   return "${command_rc}"
 }
 
+assert_file_contains() {
+  local needle="$1"
+  local file="$2"
+
+  case "$(<"${file}")" in
+    *"${needle}"*) return 0 ;;
+  esac
+  printf 'expected %s to contain: %s\n' "${file}" "${needle}" >&2
+  return 1
+}
+
+assert_file_lacks_pattern() {
+  local pattern="$1"
+  local file="$2"
+
+  if awk -v pattern="${pattern}" '$0 ~ pattern { found = 1 } END { exit found ? 0 : 1 }' "${file}"; then
+    printf 'expected %s not to match: %s\n' "${file}" "${pattern}" >&2
+    return 1
+  fi
+}
+
 @test "worker VMI rows retain names whose default interface has no IP" {
   . hack/e2e-chainsaw/_lib/run-kubernetes.sh
   rows=$(printf '%s\n' '{"items":[{"metadata":{"name":"worker-a"},"status":{"interfaces":[{"name":"default","ipAddress":"10.244.1.92"}]}},{"metadata":{"name":"worker-b"},"status":{"interfaces":[{"name":"other","ipAddress":"192.0.2.1"}]}}]}' | cozy_tenant_worker_vmi_rows)
@@ -92,15 +113,12 @@ timeout() {
 
   cozy_apply_tenant_talos_reader_certificate test-latest-version
 
-  rg -Fq 'name: kubernetes-test-latest-version-e2e-talos-reader' "$kubectl_manifest"
-  rg -Fq 'duration: 1h' "$kubectl_manifest"
-  rg -Fq -- '- os:reader' "$kubectl_manifest"
-  rg -Fq 'name: kubernetes-test-latest-version-talos-ca' "$kubectl_manifest"
-  rg -Fq 'cozystack-e2e.io/tenant-talos-diagnostics: "test-latest-version"' "$kubectl_manifest"
-  if rg -q '^[[:space:]]*(tls\.crt|tls\.key|data):' "$kubectl_manifest"; then
-    echo "Certificate manifest must not embed Talos credential material" >&2
-    exit 1
-  fi
+  assert_file_contains 'name: kubernetes-test-latest-version-e2e-talos-reader' "$kubectl_manifest"
+  assert_file_contains 'duration: 1h' "$kubectl_manifest"
+  assert_file_contains '- os:reader' "$kubectl_manifest"
+  assert_file_contains 'name: kubernetes-test-latest-version-talos-ca' "$kubectl_manifest"
+  assert_file_contains 'cozystack-e2e.io/tenant-talos-diagnostics: "test-latest-version"' "$kubectl_manifest"
+  assert_file_lacks_pattern '^[[:space:]]*(tls[.]crt|tls[.]key|data):' "$kubectl_manifest"
 }
 
 @test "talosconfig uses the tenant CA and the issued reader key" {
@@ -115,11 +133,11 @@ timeout() {
 
   [ "$(sed -n '1p' "$kubectl_calls")" = '-n tenant-test delete certificate kubernetes-test-latest-version-e2e-talos-reader --ignore-not-found --wait=true --timeout=10s' ]
   [ "$(sed -n '2p' "$kubectl_calls")" = '-n tenant-test delete secret kubernetes-test-latest-version-e2e-talos-reader --ignore-not-found --wait=true --timeout=10s' ]
-  rg -Fq -- '-n tenant-test wait certificate kubernetes-test-latest-version-e2e-talos-reader --for=condition=Ready --timeout=30s' "$kubectl_calls"
-  rg -Fq -- '-n tenant-test get secret kubernetes-test-latest-version-talos-ca -o go-template={{index .data "tls.crt" | base64decode}}' "$kubectl_calls"
-  rg -Fq -- '-n tenant-test get secret kubernetes-test-latest-version-e2e-talos-reader -o go-template={{index .data "tls.key" | base64decode}}' "$kubectl_calls"
-  rg -Fq -- "--talosconfig $tmp/talosconfig config add kubernetes-test-latest-version --ca $tmp/ca.crt --crt $tmp/client.crt --key $tmp/client.key" "$talosctl_calls"
-  rg -Fq -- "--talosconfig $tmp/talosconfig config context kubernetes-test-latest-version" "$talosctl_calls"
+  assert_file_contains '-n tenant-test wait certificate kubernetes-test-latest-version-e2e-talos-reader --for=condition=Ready --timeout=30s' "$kubectl_calls"
+  assert_file_contains '-n tenant-test get secret kubernetes-test-latest-version-talos-ca -o go-template={{index .data "tls.crt" | base64decode}}' "$kubectl_calls"
+  assert_file_contains '-n tenant-test get secret kubernetes-test-latest-version-e2e-talos-reader -o go-template={{index .data "tls.key" | base64decode}}' "$kubectl_calls"
+  assert_file_contains "--talosconfig $tmp/talosconfig config add kubernetes-test-latest-version --ca $tmp/ca.crt --crt $tmp/client.crt --key $tmp/client.key" "$talosctl_calls"
+  assert_file_contains "--talosconfig $tmp/talosconfig config context kubernetes-test-latest-version" "$talosctl_calls"
   [ "$(stat -c '%a' "$tmp/talosconfig")" = 600 ]
 }
 
@@ -132,16 +150,13 @@ timeout() {
 
   cozy_apply_tenant_talos_diagnostics_pod test-latest-version
 
-  rg -Fq 'automountServiceAccountToken: false' "$kubectl_manifest"
-  rg -Fq 'runAsNonRoot: true' "$kubectl_manifest"
-  rg -Fq 'readOnlyRootFilesystem: true' "$kubectl_manifest"
-  rg -Fq 'drop:' "$kubectl_manifest"
-  rg -Fq -- '- ALL' "$kubectl_manifest"
-  rg -Fq 'image: docker.io/library/ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90' "$kubectl_manifest"
-  if rg -q 'secret:|secretName:' "$kubectl_manifest"; then
-    echo "diagnostics Pod must receive credentials only through its emptyDir" >&2
-    exit 1
-  fi
+  assert_file_contains 'automountServiceAccountToken: false' "$kubectl_manifest"
+  assert_file_contains 'runAsNonRoot: true' "$kubectl_manifest"
+  assert_file_contains 'readOnlyRootFilesystem: true' "$kubectl_manifest"
+  assert_file_contains 'drop:' "$kubectl_manifest"
+  assert_file_contains '- ALL' "$kubectl_manifest"
+  assert_file_contains 'image: docker.io/library/ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90' "$kubectl_manifest"
+  assert_file_lacks_pattern 'secret:|secretName:' "$kubectl_manifest"
 }
 
 @test "node capture uses the VMI IP for endpoint and node with bounded commands" {
@@ -162,8 +177,8 @@ timeout() {
   case "$(sed -n '1p' "$kubectl_calls")" in
     *--tail*) echo "dmesg must not receive a --tail flag" >&2; exit 1 ;;
   esac
-  rg -Fq '[capture exit code: 0]' "$tmp/node/dmesg.log"
-  rg -Fq '[capture exit code: 0]' "$tmp/node/kubelet.log"
+  assert_file_contains '[capture exit code: 0]' "$tmp/node/dmesg.log"
+  assert_file_contains '[capture exit code: 0]' "$tmp/node/kubelet.log"
 }
 
 @test "a timed-out worker remains recorded and does not block the next capture" {
@@ -178,8 +193,8 @@ timeout() {
 
   [ "$(wc -l < "$kubectl_calls")" -eq 2 ]
   [ "$(wc -l < "$timeout_calls")" -eq 2 ]
-  rg -Fq '[capture exit code: 124]' "$tmp/node/dmesg.log"
-  rg -Fq '[capture exit code: 124]' "$tmp/node/kubelet.log"
+  assert_file_contains '[capture exit code: 124]' "$tmp/node/dmesg.log"
+  assert_file_contains '[capture exit code: 124]' "$tmp/node/kubelet.log"
 }
 
 @test "orchestrator continues from a timed-out worker to the next VMI" {
@@ -201,11 +216,11 @@ timeout() {
 
   cozy_capture_tenant_talos test-latest-version
 
-  [ "$(rg -c ' exec kubernetes-test-latest-version-talos-diagnostics ' "$kubectl_calls")" -eq 4 ]
-  rg -Fq '[capture exit code: 124]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-a/dmesg.log"
-  rg -Fq '[capture exit code: 124]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-a/kubelet.log"
-  rg -Fq '[capture exit code: 0]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-b/dmesg.log"
-  rg -Fq '[capture exit code: 0]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-b/kubelet.log"
+  [ "$(awk '/ exec kubernetes-test-latest-version-talos-diagnostics / { count++ } END { print count + 0 }' "$kubectl_calls")" -eq 4 ]
+  assert_file_contains '[capture exit code: 124]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-a/dmesg.log"
+  assert_file_contains '[capture exit code: 124]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-a/kubelet.log"
+  assert_file_contains '[capture exit code: 0]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-b/dmesg.log"
+  assert_file_contains '[capture exit code: 0]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-b/kubelet.log"
 }
 
 @test "cleanup deletes diagnostic Certificate before its Pod and Secret" {

--- a/hack/run-kubernetes-talos-diagnostics_test.bats
+++ b/hack/run-kubernetes-talos-diagnostics_test.bats
@@ -81,7 +81,7 @@ assert_file_contains() {
   local needle="$1"
   local file="$2"
 
-  case "$(<"${file}")" in
+  case "$(cat "${file}")" in
     *"${needle}"*) return 0 ;;
   esac
   printf 'expected %s to contain: %s\n' "${file}" "${needle}" >&2

--- a/hack/run-kubernetes-talos-diagnostics_test.bats
+++ b/hack/run-kubernetes-talos-diagnostics_test.bats
@@ -115,6 +115,7 @@ assert_file_lacks_pattern() {
 
   assert_file_contains 'name: kubernetes-test-latest-version-e2e-talos-reader' "$kubectl_manifest"
   assert_file_contains 'duration: 1h' "$kubectl_manifest"
+  assert_file_contains 'commonName: kubernetes-test-latest-version-e2e-talos-reader' "$kubectl_manifest"
   assert_file_contains '- os:reader' "$kubectl_manifest"
   assert_file_contains 'name: kubernetes-test-latest-version-talos-ca' "$kubectl_manifest"
   assert_file_contains 'cozystack-e2e.io/tenant-talos-diagnostics: "test-latest-version"' "$kubectl_manifest"
@@ -138,7 +139,10 @@ assert_file_lacks_pattern() {
   assert_file_contains '-n tenant-test get secret kubernetes-test-latest-version-e2e-talos-reader -o go-template={{index .data "tls.key" | base64decode}}' "$kubectl_calls"
   assert_file_contains "--talosconfig $tmp/talosconfig config add kubernetes-test-latest-version --ca $tmp/ca.crt --crt $tmp/client.crt --key $tmp/client.key" "$talosctl_calls"
   assert_file_contains "--talosconfig $tmp/talosconfig config context kubernetes-test-latest-version" "$talosctl_calls"
-  [ "$(stat -c '%a' "$tmp/talosconfig")" = 600 ]
+  case "$(LC_ALL=C ls -ld "$tmp/talosconfig")" in
+    -rw-------*) ;;
+    *) echo "talosconfig permissions are not 0600" >&2; return 1 ;;
+  esac
 }
 
 @test "diagnostics Pod has no API token or Secret volume" {
@@ -155,8 +159,38 @@ assert_file_lacks_pattern() {
   assert_file_contains 'readOnlyRootFilesystem: true' "$kubectl_manifest"
   assert_file_contains 'drop:' "$kubectl_manifest"
   assert_file_contains '- ALL' "$kubectl_manifest"
-  assert_file_contains 'image: docker.io/library/ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90' "$kubectl_manifest"
+  assert_file_contains 'image: docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47' "$kubectl_manifest"
+  assert_file_contains "'docker.io/alpine/k8s:1.36.2@sha256:44ef4942e171939b9c665a4a84beb80e2dcdb9a24330d4651cfdfd2e9deecc47'" hack/e2e-install-cozystack.bats
   assert_file_lacks_pattern 'secret:|secretName:' "$kubectl_manifest"
+}
+
+@test "Kubernetes Chainsaw operations leave room for failure diagnostics" {
+  [ "$(yq 'select(.metadata.name == "kubernetes-latest").spec.steps[0].try[0].script.timeout' hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml)" = 50m ]
+  [ "$(yq 'select(.metadata.name == "kubernetes-previous").spec.steps[0].try[0].script.timeout' hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml)" = 50m ]
+}
+
+@test "orchestrator skips credentials and helper Pod when every VMI lacks an IP" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  trap 'rm -rf "$tmp"' EXIT
+  kubectl_calls="$tmp/kubectl.calls"
+  kubectl_manifest="$tmp/manifest.yaml"
+  kubectl_vmi_json="$tmp/vmis.json"
+  talosctl_calls="$tmp/talosctl.calls"
+  COZY_REPORT_DIR="$tmp/report"
+  COZY_SNAPSHOT_NAME=diagnostic-no-ip
+  printf '%s\n' '{"items":[{"metadata":{"name":"worker-a"},"status":{"interfaces":[{"name":"default"}]}},{"metadata":{"name":"worker-b"},"status":{}}]}' >"$kubectl_vmi_json"
+
+  capture_rc=0
+  cozy_capture_tenant_talos test-latest-version || capture_rc=$?
+
+  [ "$capture_rc" -eq 1 ]
+  assert_file_lacks_pattern '(^|[[:space:]])apply([[:space:]]|$)' "$kubectl_calls"
+  assert_file_lacks_pattern 'delete (certificate|secret|pod)|wait (certificate|pod)|exec' "$kubectl_calls"
+  [ ! -s "$talosctl_calls" ]
+  assert_file_contains 'default VMI interface has no reported IP address' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-a/capture-error.log"
+  assert_file_contains 'default VMI interface has no reported IP address' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-b/capture-error.log"
+  assert_file_contains 'no tenant worker VMI has a reported IP for Talos diagnostics' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/setup-error.log"
 }
 
 @test "node capture uses the VMI IP for endpoint and node with bounded commands" {
@@ -209,7 +243,7 @@ assert_file_lacks_pattern() {
   timeout_fail_node_ip=10.244.1.93
   COZY_REPORT_DIR="$tmp/report"
   COZY_SNAPSHOT_NAME=diagnostic-smoke
-  printf '%s\n' '{"items":[{"metadata":{"name":"worker-a"},"status":{"interfaces":[{"name":"default","ipAddress":"10.244.1.93"}]}},{"metadata":{"name":"worker-b"},"status":{"interfaces":[{"name":"default","ipAddress":"10.244.1.94"}]}}]}' >"$kubectl_vmi_json"
+  printf '%s\n' '{"items":[{"metadata":{"name":"worker-no-ip"},"status":{"interfaces":[{"name":"default"}]}},{"metadata":{"name":"worker-a"},"status":{"interfaces":[{"name":"default","ipAddress":"10.244.1.93"}]}},{"metadata":{"name":"worker-b"},"status":{"interfaces":[{"name":"default","ipAddress":"10.244.1.94"}]}}]}' >"$kubectl_vmi_json"
   printf '%s\n' '#!/bin/sh' >"$tmp/talosctl"
   chmod 755 "$tmp/talosctl"
   cd "$tmp"
@@ -217,6 +251,7 @@ assert_file_lacks_pattern() {
   cozy_capture_tenant_talos test-latest-version
 
   [ "$(awk '/ exec kubernetes-test-latest-version-talos-diagnostics / { count++ } END { print count + 0 }' "$kubectl_calls")" -eq 4 ]
+  assert_file_contains 'default VMI interface has no reported IP address' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-no-ip/capture-error.log"
   assert_file_contains '[capture exit code: 124]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-a/dmesg.log"
   assert_file_contains '[capture exit code: 124]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-a/kubelet.log"
   assert_file_contains '[capture exit code: 0]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-b/dmesg.log"

--- a/hack/run-kubernetes-talos-diagnostics_test.bats
+++ b/hack/run-kubernetes-talos-diagnostics_test.bats
@@ -134,7 +134,7 @@ assert_file_lacks_pattern() {
 
   [ "$(sed -n '1p' "$kubectl_calls")" = '-n tenant-test delete certificate kubernetes-test-latest-version-e2e-talos-reader --ignore-not-found --wait=true --timeout=10s' ]
   [ "$(sed -n '2p' "$kubectl_calls")" = '-n tenant-test delete secret kubernetes-test-latest-version-e2e-talos-reader --ignore-not-found --wait=true --timeout=10s' ]
-  assert_file_contains '-n tenant-test wait certificate kubernetes-test-latest-version-e2e-talos-reader --for=condition=Ready --timeout=30s' "$kubectl_calls"
+  assert_file_contains 'wait -n tenant-test certificate kubernetes-test-latest-version-e2e-talos-reader --for=condition=Ready --timeout=30s' "$kubectl_calls"
   assert_file_contains '-n tenant-test get secret kubernetes-test-latest-version-talos-ca -o go-template={{index .data "tls.crt" | base64decode}}' "$kubectl_calls"
   assert_file_contains '-n tenant-test get secret kubernetes-test-latest-version-e2e-talos-reader -o go-template={{index .data "tls.key" | base64decode}}' "$kubectl_calls"
   assert_file_contains "--talosconfig $tmp/talosconfig config add kubernetes-test-latest-version --ca $tmp/ca.crt --crt $tmp/client.crt --key $tmp/client.key" "$talosctl_calls"


### PR DESCRIPTION
## What this PR does

Addresses #3513.

When tenant Kubernetes workers miss the 18-minute Ready deadline, the E2E runner now mints a one-hour `os:reader` Talos client certificate from the tenant's existing issuer and runs authenticated `talosctl` from a hardened same-namespace diagnostics Pod. It captures bounded `dmesg` and kubelet output for every worker VMI in the cozyreport snapshot, records missing IPs and command exit codes, continues across unreachable workers, and preserves the original test failure.

The diagnostics Pod has no service-account token or Secret volume; credentials are streamed into an `emptyDir`, and the Certificate, Secret, and Pod are labeled for cleanup. Workers that have not reached Talos `apid` can only yield a bounded connection error, while workers that reached `apid` provide guest logs. This adds the evidence needed to distinguish the remaining guest boot failure but does not claim to resolve its underlying cause. The readiness budget and success path are unchanged.

Because this changes a shared E2E helper, test-impact analysis selects the full E2E suite for this PR.

### Screenshots

Not applicable; no UI changes.

### Testing

- `hack/cozytest.sh hack/run-kubernetes-talos-diagnostics_test.bats` (10 tests)
- `hack/cozytest.sh hack/run-kubernetes-drain_test.bats`
- `hack/cozytest.sh hack/cozyreport-talos.bats`
- `bash -n hack/e2e-chainsaw/_lib/run-kubernetes.sh`
- `git diff --check origin/main...HEAD`

The full `make bats-unit-tests` run reached the unrelated `hack/migration-seaweedfs-db-adopt.bats` suite and could not continue because Docker is unavailable in the development environment. A live failure-path run was not performed because the available development environment has no Talos tenant fixture; this PR is intended to exercise that path in Cozystack CI.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(e2e): capture authenticated Talos kernel and kubelet diagnostics when tenant Kubernetes workers miss the Ready deadline
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved troubleshooting when worker nodes fail to join by collecting per-node operating system and kubelet diagnostics.
  * Diagnostics now continue across partial failures and clean up temporary resources afterward.
  * Extended Kubernetes test operation timeouts to allow failure diagnostics to complete reliably.

* **Tests**
  * Added regression coverage for diagnostic collection, timeout handling, multi-worker scenarios, missing node addresses, and cleanup.

* **Chores**
  * Ensured the required diagnostic image is preloaded on nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->