### PR TITLE
fix(kubernetes): retry the tenant CNI install instead of uninstalling it

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
@@ -51,11 +51,30 @@ spec:
   storageNamespace: cozy-cilium
   interval: 5m
   timeout: 10m
+  {{- /* Flux's default install strategy remediates a failed install by
+         uninstalling the release, which takes the tenant's only CNI away
+         between attempts. RetryOnFailure drops that teardown: the manifests
+         stay applied and the failed install is retried as an upgrade. Both
+         actions carry the strategy because that retry runs as an upgrade and
+         would otherwise fall back to upgrade remediation. The cost is that a
+         genuine upgrade failure no longer rolls back either, which is forced,
+         since the controller cannot tell a retried install from a real one,
+         and what it replaces was an unbounded rollback-and-retry flap. This
+         removes an amplifier, not a cause: an install that outruns its budget
+         because no node has registered yet stays a problem. The remediation
+         blocks cover the branches no strategy reaches, an absent release for
+         install and an out-of-sync one for upgrade, so retries: -1 stays. */}}
   install:
     createNamespace: true
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 30s
     remediation:
       retries: -1
   upgrade:
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 30s
     remediation:
       retries: -1
   values:

--- a/packages/apps/kubernetes/tests/cilium_install_retry_test.yaml
+++ b/packages/apps/kubernetes/tests/cilium_install_retry_test.yaml
@@ -1,0 +1,42 @@
+suite: Cilium install retry strategy tests
+templates:
+  - templates/helmreleases/cilium.yaml
+values:
+  - values-ci.yaml
+tests:
+  # Flux's default strategy remediates a failed install by uninstalling the
+  # release, so a missed install budget on the tenant CNI takes the cluster's
+  # only CNI away for the window until the next install applies the manifests
+  # again, once per cycle for as long as retries allows. RetryOnFailure drops
+  # the teardown and retries as an upgrade instead.
+  - it: retries a failed install instead of uninstalling the CNI
+    asserts:
+      - equal:
+          path: spec.install.strategy.name
+          value: RetryOnFailure
+      - equal:
+          path: spec.install.strategy.retryInterval
+          value: 30s
+
+  # The retry of a failed install runs as an upgrade, so without a strategy on
+  # the upgrade action the second attempt falls back to upgrade remediation.
+  - it: keeps retrying on the upgrade action the install retry runs as
+    asserts:
+      - equal:
+          path: spec.upgrade.strategy.name
+          value: RetryOnFailure
+      - equal:
+          path: spec.upgrade.strategy.retryInterval
+          value: 30s
+
+  # The strategy governs a failed release. Two other branches consult the retry
+  # count instead and refuse to act once it is exhausted: an absent release,
+  # which reads the install block, and an out-of-sync one, which reads upgrade.
+  - it: keeps unlimited retries for the branches no strategy reaches
+    asserts:
+      - equal:
+          path: spec.install.remediation.retries
+          value: -1
+      - equal:
+          path: spec.upgrade.remediation.retries
+          value: -1


### PR DESCRIPTION
## What this PR does

The tenant Cilium HelmRelease carried no install strategy, so Flux applied its default, `RemediateOnFailure`, which uninstalls the release between attempts. Cilium is the tenant cluster's only CNI, so every cycle takes it away and gives it back when the next install applies the manifests again, and `retries: -1` lets that repeat without end.

What sets a cycle off is an install that outruns its budget, which can happen while the tenant still has no registered node, since the operator Deployment cannot become Available until one exists. Remediation neither causes that delay nor is fixed by this change: what it adds is a repeated teardown of the CNI on top of a delay that resolves itself once the node arrives. This removes the amplifier, not the cause.

`RetryOnFailure` keeps the applied manifests in place and retries a failed install as an upgrade, so the agent DaemonSet rolls out as soon as a worker registers. Both actions carry the strategy because helm-controller selects the active retry from `.status.lastAttemptedReleaseAction`, and the retry of a failed install runs as an upgrade. With the strategy on `install` alone that retry still happens, but once it is the last attempted action its own failure is handled by upgrade remediation, whose default is a rollback with no previous release to roll back to. The `remediation` blocks stay because two branches consult the retry count rather than the strategy and refuse to act once it is exhausted: an absent release reads the install block, an out-of-sync one reads upgrade. `retries: -1` keeps both open.

The cost is that a genuine upgrade failure no longer rolls back either, it retries on the failed manifests instead. That is forced, since the controller cannot tell a retried install from a real upgrade, and what it replaces was an unbounded rollback-and-retry flap rather than a stable safety net: `upgrade.remediation.retries: -1` with the default rollback strategy already retried forever.

This is the strategy and retry interval that `pkg/registry/apps/application/rest.go` and `internal/operator/package_reconciler.go` already set on every HelmRelease they generate, except that they leave `remediation` nil where this release keeps it. The other tenant addons this chart renders still carry the remediation-only shape; this PR changes the CNI alone, where the teardown removes the cluster's only CNI rather than churning a single component.

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(kubernetes): the tenant Cilium HelmRelease now retries a failed install instead of being uninstalled between attempts, so a failed install no longer takes the tenant cluster's only CNI away while it retries. The same strategy applies to the upgrade action, which it has to: a retried install runs as an upgrade. One consequence is operator-visible, a failed Cilium upgrade in a tenant cluster now retries the new manifests every 30s instead of rolling back to the previous release.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cilium installation and upgrade reliability by automatically retrying failed operations every 30 seconds.
  * Preserved deployed resources during retries and continued supporting unlimited remediation attempts.

* **Tests**
  * Added coverage validating installation and upgrade retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->