### PR TITLE
fix(kube-ovn): reload kubeovn-webhook serving certificate on cert-manager renewal

### DIFF
--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert.go
@@ -24,56 +24,63 @@ type certReloader struct {
 	certFile string
 	keyFile  string
 
-	mu      sync.RWMutex
-	cert    *tls.Certificate
-	modTime time.Time
+	mu            sync.RWMutex
+	cert          *tls.Certificate
+	loadedModTime time.Time
 }
 
 // newCertReloader loads the initial key pair and returns a reloader for it.
 func newCertReloader(certFile, keyFile string) (*certReloader, error) {
 	cr := &certReloader{certFile: certFile, keyFile: keyFile}
-	if err := cr.reload(); err != nil {
+	if err := cr.reload(cr.certModTime()); err != nil {
 		return nil, err
 	}
 	return cr, nil
 }
 
-// reload reads the key pair from disk and atomically swaps the cached certificate.
-func (cr *certReloader) reload() error {
-	cert, err := tls.LoadX509KeyPair(cr.certFile, cr.keyFile)
-	if err != nil {
-		return err
-	}
-
-	var modTime time.Time
-	if fi, statErr := os.Stat(cr.certFile); statErr == nil {
-		modTime = fi.ModTime()
-	}
-
-	cr.mu.Lock()
-	cr.cert = &cert
-	cr.modTime = modTime
-	cr.mu.Unlock()
-	return nil
-}
-
-// changed reports whether the certificate file was modified since the last load.
-func (cr *certReloader) changed() bool {
+// certModTime returns the modification time of the certificate file, or the zero
+// time if it cannot be stat'd (logged so a broken mount is not silently invisible).
+func (cr *certReloader) certModTime() time.Time {
 	fi, err := os.Stat(cr.certFile)
 	if err != nil {
-		return false
+		log.Printf("certificate stat failed, keeping previous certificate: %v", err)
+		return time.Time{}
 	}
-	cr.mu.RLock()
-	defer cr.mu.RUnlock()
-	return fi.ModTime().After(cr.modTime)
+	return fi.ModTime()
 }
 
-// GetCertificate is a tls.Config.GetCertificate callback. It reloads the key pair
-// when the file changes and keeps serving the last good certificate if a reload
-// fails (for example a torn read while the mounted Secret is being updated).
+// reload reads the key pair from disk and atomically swaps the cached certificate.
+//
+// modTime is the certificate file's modification time observed BEFORE the read, so a
+// Secret swap racing the read leaves modTime older than the file on disk and is caught
+// on the next handshake instead of being cached under a newer mtime and missed. The
+// attempt is recorded regardless of outcome, so a persistently unreadable file is
+// retried only once its mtime advances, not on every handshake.
+func (cr *certReloader) reload(modTime time.Time) error {
+	cert, err := tls.LoadX509KeyPair(cr.certFile, cr.keyFile)
+
+	cr.mu.Lock()
+	cr.loadedModTime = modTime
+	if err == nil {
+		cr.cert = &cert
+	}
+	cr.mu.Unlock()
+	return err
+}
+
+// GetCertificate is a tls.Config.GetCertificate callback. It reloads the key pair when
+// the certificate file's modification time changes and keeps serving the last good
+// certificate if a reload fails (for example a torn read while the mounted Secret is
+// being updated).
 func (cr *certReloader) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-	if cr.changed() {
-		if err := cr.reload(); err != nil {
+	modTime := cr.certModTime()
+
+	cr.mu.RLock()
+	stale := !modTime.IsZero() && !modTime.Equal(cr.loadedModTime)
+	cr.mu.RUnlock()
+
+	if stale {
+		if err := cr.reload(modTime); err != nil {
 			log.Printf("certificate reload failed, keeping previous certificate: %v", err)
 		}
 	}

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+	"time"
+)
+
+// certReloader keeps the webhook serving certificate in sync with the key pair
+// files written by cert-manager.
+//
+// The certificate is served through tls.Config.GetCertificate, so a cert-manager
+// renewal of the backing Secret is picked up by the running process without a
+// restart. Without this, the key pair is read exactly once at startup and cached
+// for the lifetime of the process: after the certificate expires (roughly one year
+// after install) the pod keeps presenting the expired certificate, the
+// kube-apiserver's TLS call to the webhook fails, and because the
+// MutatingWebhookConfiguration uses failurePolicy: Fail, every pod creation in
+// tenant namespaces is rejected.
+type certReloader struct {
+	certFile string
+	keyFile  string
+
+	mu      sync.RWMutex
+	cert    *tls.Certificate
+	modTime time.Time
+}
+
+// newCertReloader loads the initial key pair and returns a reloader for it.
+func newCertReloader(certFile, keyFile string) (*certReloader, error) {
+	cr := &certReloader{certFile: certFile, keyFile: keyFile}
+	if err := cr.reload(); err != nil {
+		return nil, err
+	}
+	return cr, nil
+}
+
+// reload reads the key pair from disk and atomically swaps the cached certificate.
+func (cr *certReloader) reload() error {
+	cert, err := tls.LoadX509KeyPair(cr.certFile, cr.keyFile)
+	if err != nil {
+		return err
+	}
+
+	var modTime time.Time
+	if fi, statErr := os.Stat(cr.certFile); statErr == nil {
+		modTime = fi.ModTime()
+	}
+
+	cr.mu.Lock()
+	cr.cert = &cert
+	cr.modTime = modTime
+	cr.mu.Unlock()
+	return nil
+}
+
+// changed reports whether the certificate file was modified since the last load.
+func (cr *certReloader) changed() bool {
+	fi, err := os.Stat(cr.certFile)
+	if err != nil {
+		return false
+	}
+	cr.mu.RLock()
+	defer cr.mu.RUnlock()
+	return fi.ModTime().After(cr.modTime)
+}
+
+// GetCertificate is a tls.Config.GetCertificate callback. It reloads the key pair
+// when the file changes and keeps serving the last good certificate if a reload
+// fails (for example a torn read while the mounted Secret is being updated).
+func (cr *certReloader) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	if cr.changed() {
+		if err := cr.reload(); err != nil {
+			log.Printf("certificate reload failed, keeping previous certificate: %v", err)
+		}
+	}
+
+	cr.mu.RLock()
+	defer cr.mu.RUnlock()
+	if cr.cert == nil {
+		return nil, fmt.Errorf("no certificate loaded")
+	}
+	return cr.cert, nil
+}
+
+// newReloadingTLSConfig builds a tls.Config that serves the key pair via a
+// certReloader, so cert-manager renewals are honoured without a restart.
+func newReloadingTLSConfig(certFile, keyFile string) (*tls.Config, error) {
+	cr, err := newCertReloader(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{GetCertificate: cr.GetCertificate}, nil
+}

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert.go
@@ -24,66 +24,117 @@ type certReloader struct {
 	certFile string
 	keyFile  string
 
+	// retryInterval bounds how often a failed reload (or a repeated stat failure) is
+	// retried, so a persistently broken file does not read/parse/log on every handshake.
+	retryInterval time.Duration
+
 	mu            sync.RWMutex
 	cert          *tls.Certificate
 	loadedModTime time.Time
+	reloading     bool
+	nextRetry     time.Time
+	nextLog       time.Time
 }
+
+const defaultReloadRetryInterval = 30 * time.Second
 
 // newCertReloader loads the initial key pair and returns a reloader for it.
 func newCertReloader(certFile, keyFile string) (*certReloader, error) {
-	cr := &certReloader{certFile: certFile, keyFile: keyFile}
-	if err := cr.reload(cr.certModTime()); err != nil {
+	cr := &certReloader{
+		certFile:      certFile,
+		keyFile:       keyFile,
+		retryInterval: defaultReloadRetryInterval,
+	}
+	modTime, err := fileModTime(certFile)
+	if err != nil {
+		return nil, err
+	}
+	if err := cr.load(modTime); err != nil {
 		return nil, err
 	}
 	return cr, nil
 }
 
-// certModTime returns the modification time of the certificate file, or the zero
-// time if it cannot be stat'd (logged so a broken mount is not silently invisible).
-func (cr *certReloader) certModTime() time.Time {
-	fi, err := os.Stat(cr.certFile)
+// fileModTime returns the modification time of the given file.
+func fileModTime(name string) (time.Time, error) {
+	fi, err := os.Stat(name)
 	if err != nil {
-		log.Printf("certificate stat failed, keeping previous certificate: %v", err)
-		return time.Time{}
+		return time.Time{}, err
 	}
-	return fi.ModTime()
+	return fi.ModTime(), nil
 }
 
-// reload reads the key pair from disk and atomically swaps the cached certificate.
-//
-// modTime is the certificate file's modification time observed BEFORE the read, so a
-// Secret swap racing the read leaves modTime older than the file on disk and is caught
-// on the next handshake instead of being cached under a newer mtime and missed. The
-// attempt is recorded regardless of outcome, so a persistently unreadable file is
-// retried only once its mtime advances, not on every handshake.
-func (cr *certReloader) reload(modTime time.Time) error {
+// load reads the key pair and, on success, caches it tagged with modTime. On failure
+// the cached certificate and its recorded mtime are left unchanged, so a transient
+// failure on a valid file is retried rather than the renewal being abandoned.
+func (cr *certReloader) load(modTime time.Time) error {
 	cert, err := tls.LoadX509KeyPair(cr.certFile, cr.keyFile)
+	if err != nil {
+		return err
+	}
+	cr.mu.Lock()
+	cr.cert = &cert
+	cr.loadedModTime = modTime
+	cr.mu.Unlock()
+	return nil
+}
+
+// refresh reloads the key pair when the certificate file's modification time changes.
+//
+// A failed reload keeps the last good certificate and does NOT advance the recorded
+// mtime, so a transient error (fd exhaustion, a torn read) is retried, at most once per
+// retryInterval, until it succeeds: a transient failure must never permanently pin an
+// expiring certificate. A single reload is kept in flight so a burst of handshakes does
+// not trigger a thundering herd of reads.
+func (cr *certReloader) refresh() {
+	modTime, err := fileModTime(cr.certFile)
+	if err != nil {
+		cr.logRateLimited("certificate stat failed, keeping previous certificate: %v", err)
+		return
+	}
 
 	cr.mu.Lock()
-	cr.loadedModTime = modTime
-	if err == nil {
-		cr.cert = &cert
+	if modTime.Equal(cr.loadedModTime) || cr.reloading || time.Now().Before(cr.nextRetry) {
+		cr.mu.Unlock()
+		return
+	}
+	cr.reloading = true
+	cr.mu.Unlock()
+
+	loadErr := cr.load(modTime)
+
+	cr.mu.Lock()
+	cr.reloading = false
+	if loadErr == nil {
+		cr.nextRetry = time.Time{}
+	} else {
+		cr.nextRetry = time.Now().Add(cr.retryInterval)
 	}
 	cr.mu.Unlock()
-	return err
+
+	if loadErr != nil {
+		cr.logRateLimited("certificate reload failed, keeping previous certificate: %v", loadErr)
+	}
 }
 
-// GetCertificate is a tls.Config.GetCertificate callback. It reloads the key pair when
-// the certificate file's modification time changes and keeps serving the last good
-// certificate if a reload fails (for example a torn read while the mounted Secret is
-// being updated).
-func (cr *certReloader) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-	modTime := cr.certModTime()
-
-	cr.mu.RLock()
-	stale := !modTime.IsZero() && !modTime.Equal(cr.loadedModTime)
-	cr.mu.RUnlock()
-
-	if stale {
-		if err := cr.reload(modTime); err != nil {
-			log.Printf("certificate reload failed, keeping previous certificate: %v", err)
-		}
+// logRateLimited emits a log line at most once per retryInterval, so a persistently
+// broken mount does not spam the log on every TLS handshake.
+func (cr *certReloader) logRateLimited(format string, args ...any) {
+	cr.mu.Lock()
+	if time.Now().Before(cr.nextLog) {
+		cr.mu.Unlock()
+		return
 	}
+	cr.nextLog = time.Now().Add(cr.retryInterval)
+	cr.mu.Unlock()
+	log.Printf(format, args...)
+}
+
+// GetCertificate is a tls.Config.GetCertificate callback. It refreshes the key pair
+// when the certificate file changes and keeps serving the last good certificate if a
+// reload fails.
+func (cr *certReloader) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	cr.refresh()
 
 	cr.mu.RLock()
 	defer cr.mu.RUnlock()

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert.go
@@ -1,155 +1,45 @@
 package main
 
-import (
-	"crypto/tls"
-	"fmt"
-	"log"
-	"os"
-	"sync"
-	"time"
-)
+import "crypto/tls"
 
-// certReloader keeps the webhook serving certificate in sync with the key pair
-// files written by cert-manager.
+// newReloadingTLSConfig returns a tls.Config that reloads the certificate and
+// key from disk on every TLS handshake, so a cert-manager renewal of the mounted
+// Secret is picked up by the running process without a restart.
 //
-// The certificate is served through tls.Config.GetCertificate, so a cert-manager
-// renewal of the backing Secret is picked up by the running process without a
-// restart. Without this, the key pair is read exactly once at startup and cached
-// for the lifetime of the process: after the certificate expires (roughly one year
-// after install) the pod keeps presenting the expired certificate, the
-// kube-apiserver's TLS call to the webhook fails, and because the
-// MutatingWebhookConfiguration uses failurePolicy: Fail, every pod creation in
-// tenant namespaces is rejected.
-type certReloader struct {
-	certFile string
-	keyFile  string
-
-	// retryInterval bounds how often a failed reload (or a repeated stat failure) is
-	// retried, so a persistently broken file does not read/parse/log on every handshake.
-	retryInterval time.Duration
-
-	mu            sync.RWMutex
-	cert          *tls.Certificate
-	loadedModTime time.Time
-	reloading     bool
-	nextRetry     time.Time
-	nextLog       time.Time
-}
-
-const defaultReloadRetryInterval = 30 * time.Second
-
-// newCertReloader loads the initial key pair and returns a reloader for it.
-func newCertReloader(certFile, keyFile string) (*certReloader, error) {
-	cr := &certReloader{
-		certFile:      certFile,
-		keyFile:       keyFile,
-		retryInterval: defaultReloadRetryInterval,
-	}
-	modTime, err := fileModTime(certFile)
-	if err != nil {
-		return nil, err
-	}
-	if err := cr.load(modTime); err != nil {
-		return nil, err
-	}
-	return cr, nil
-}
-
-// fileModTime returns the modification time of the given file.
-func fileModTime(name string) (time.Time, error) {
-	fi, err := os.Stat(name)
-	if err != nil {
-		return time.Time{}, err
-	}
-	return fi.ModTime(), nil
-}
-
-// load reads the key pair and, on success, caches it tagged with modTime. On failure
-// the cached certificate and its recorded mtime are left unchanged, so a transient
-// failure on a valid file is retried rather than the renewal being abandoned.
-func (cr *certReloader) load(modTime time.Time) error {
-	cert, err := tls.LoadX509KeyPair(cr.certFile, cr.keyFile)
-	if err != nil {
-		return err
-	}
-	cr.mu.Lock()
-	cr.cert = &cert
-	cr.loadedModTime = modTime
-	cr.mu.Unlock()
-	return nil
-}
-
-// refresh reloads the key pair when the certificate file's modification time changes.
+// Without this, the key pair is read exactly once at startup and cached for the
+// lifetime of the process: after the certificate expires (roughly one year after
+// install) the pod keeps presenting the expired certificate, the kube-apiserver's
+// TLS call to the webhook fails, and because the MutatingWebhookConfiguration uses
+// failurePolicy: Fail, every pod creation in tenant namespaces is rejected.
 //
-// A failed reload keeps the last good certificate and does NOT advance the recorded
-// mtime, so a transient error (fd exhaustion, a torn read) is retried, at most once per
-// retryInterval, until it succeeds: a transient failure must never permanently pin an
-// expiring certificate. A single reload is kept in flight so a burst of handshakes does
-// not trigger a thundering herd of reads.
-func (cr *certReloader) refresh() {
-	modTime, err := fileModTime(cr.certFile)
-	if err != nil {
-		cr.logRateLimited("certificate stat failed, keeping previous certificate: %v", err)
-		return
-	}
-
-	cr.mu.Lock()
-	if modTime.Equal(cr.loadedModTime) || cr.reloading || time.Now().Before(cr.nextRetry) {
-		cr.mu.Unlock()
-		return
-	}
-	cr.reloading = true
-	cr.mu.Unlock()
-
-	loadErr := cr.load(modTime)
-
-	cr.mu.Lock()
-	cr.reloading = false
-	if loadErr == nil {
-		cr.nextRetry = time.Time{}
-	} else {
-		cr.nextRetry = time.Now().Add(cr.retryInterval)
-	}
-	cr.mu.Unlock()
-
-	if loadErr != nil {
-		cr.logRateLimited("certificate reload failed, keeping previous certificate: %v", loadErr)
-	}
-}
-
-// logRateLimited emits a log line at most once per retryInterval, so a persistently
-// broken mount does not spam the log on every TLS handshake.
-func (cr *certReloader) logRateLimited(format string, args ...any) {
-	cr.mu.Lock()
-	if time.Now().Before(cr.nextLog) {
-		cr.mu.Unlock()
-		return
-	}
-	cr.nextLog = time.Now().Add(cr.retryInterval)
-	cr.mu.Unlock()
-	log.Printf(format, args...)
-}
-
-// GetCertificate is a tls.Config.GetCertificate callback. It refreshes the key pair
-// when the certificate file changes and keeps serving the last good certificate if a
-// reload fails.
-func (cr *certReloader) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
-	cr.refresh()
-
-	cr.mu.RLock()
-	defer cr.mu.RUnlock()
-	if cr.cert == nil {
-		return nil, fmt.Errorf("no certificate loaded")
-	}
-	return cr.cert, nil
-}
-
-// newReloadingTLSConfig builds a tls.Config that serves the key pair via a
-// certReloader, so cert-manager renewals are honoured without a restart.
+// tls.Config.GetCertificate is invoked on every handshake whenever Certificates is
+// left unset, so re-reading the files there is enough; no watcher, mtime tracking
+// or cache is needed:
+//   - The cert/key files are mounted from a plain Secret volume with no subPath.
+//     Kubernetes' atomic writer swaps the whole ..data directory via a single
+//     symlink flip, so a reader always sees a complete old or complete new
+//     generation of both files, never a torn mid-write mixture. A per-handshake
+//     LoadX509KeyPair therefore cannot observe a partial renewal.
+//   - The per-handshake cost (a few KB of file I/O plus a PEM/key parse) is
+//     negligible next to the asymmetric crypto the handshake already performs.
+//   - The webhook configures no mTLS (no ClientCAs), so GetCertificate's
+//     limitation of not refreshing client CA pools does not apply.
+//
+// If the mounted files genuinely become unreadable (Secret deleted, permissions
+// broken: an operator error, not a normal renewal) the handshake fails loudly
+// rather than silently serving a stale certificate.
 func newReloadingTLSConfig(certFile, keyFile string) (*tls.Config, error) {
-	cr, err := newCertReloader(certFile, keyFile)
-	if err != nil {
+	// Fail fast at startup if the initial key pair is missing or malformed.
+	if _, err := tls.LoadX509KeyPair(certFile, keyFile); err != nil {
 		return nil, err
 	}
-	return &tls.Config{GetCertificate: cr.GetCertificate}, nil
+	return &tls.Config{
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+			if err != nil {
+				return nil, err
+			}
+			return &cert, nil
+		},
+	}, nil
 }

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert_test.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert_test.go
@@ -71,27 +71,6 @@ func setModTime(t *testing.T, name string, mtime time.Time) {
 	}
 }
 
-// certSerial returns the serial number of a *tls.Certificate leaf without mutating the
-// shared value returned by GetCertificate (it parses into a local when Leaf is unset).
-func certSerial(t *testing.T, c *tls.Certificate) int64 {
-	t.Helper()
-	if c == nil {
-		t.Fatal("nil certificate")
-	}
-	leaf := c.Leaf
-	if leaf == nil {
-		if len(c.Certificate) == 0 {
-			t.Fatal("certificate has no DER data")
-		}
-		parsed, err := x509.ParseCertificate(c.Certificate[0])
-		if err != nil {
-			t.Fatalf("parse served cert: %v", err)
-		}
-		leaf = parsed
-	}
-	return leaf.SerialNumber.Int64()
-}
-
 // servedSerial completes a TLS handshake against addr and returns the serial number
 // of the leaf certificate the server actually presented.
 func servedSerial(t *testing.T, addr string) int64 {
@@ -156,90 +135,5 @@ func TestReloadingTLSConfigServesRenewedCertificate(t *testing.T) {
 
 	if got := servedSerial(t, addr); got != 2 {
 		t.Fatalf("after renewal: expected renewed serial 2, got %d (certificate was not reloaded)", got)
-	}
-}
-
-// TestCertReloaderKeepsLastGoodCertificate verifies that a failed reload (e.g. a torn
-// read while the volume is updated) does not take the webhook down: it keeps serving
-// the previously loaded certificate instead of erroring the handshake.
-func TestCertReloaderKeepsLastGoodCertificate(t *testing.T) {
-	dir := t.TempDir()
-	certFile := filepath.Join(dir, "tls.crt")
-	keyFile := filepath.Join(dir, "tls.key")
-
-	certA, keyA := genSelfSigned(t, 1)
-	writeKeyPair(t, certFile, keyFile, certA, keyA, time.Now().Add(-2*time.Second))
-
-	cr, err := newCertReloader(certFile, keyFile)
-	if err != nil {
-		t.Fatalf("newCertReloader: %v", err)
-	}
-
-	// Corrupt the cert file and advance its mtime so a reload is attempted and fails.
-	if err := os.WriteFile(certFile, []byte("not a certificate"), 0o600); err != nil {
-		t.Fatalf("corrupt cert: %v", err)
-	}
-	setModTime(t, certFile, time.Now().Add(2*time.Second))
-
-	got, err := cr.GetCertificate(&tls.ClientHelloInfo{})
-	if err != nil {
-		t.Fatalf("GetCertificate returned error instead of serving last good cert: %v", err)
-	}
-	if certSerial(t, got) != 1 {
-		t.Fatalf("expected to keep serving serial 1 after failed reload, got %d", certSerial(t, got))
-	}
-}
-
-// TestCertReloaderRetriesAfterTransientFailure is the regression test for the reloader
-// abandoning a renewal on a transient error. A failed reload must NOT advance the
-// recorded mtime, so once the (unchanged-mtime) file becomes readable the renewed
-// certificate is still picked up. Against the code that advanced the mtime on failure,
-// the renewal is permanently missed and this test fails.
-func TestCertReloaderRetriesAfterTransientFailure(t *testing.T) {
-	dir := t.TempDir()
-	certFile := filepath.Join(dir, "tls.crt")
-	keyFile := filepath.Join(dir, "tls.key")
-
-	certA, keyA := genSelfSigned(t, 1)
-	writeKeyPair(t, certFile, keyFile, certA, keyA, time.Now().Add(-2*time.Second))
-
-	cr, err := newCertReloader(certFile, keyFile)
-	if err != nil {
-		t.Fatalf("newCertReloader: %v", err)
-	}
-	cr.retryInterval = 0 // retry immediately, no backoff wait in the test
-
-	// Renewal advances the mtime, but the first load fails (simulating a transient,
-	// content-independent error) by writing an unreadable cert at the new mtime.
-	renewMod := time.Now().Add(2 * time.Second)
-	if err := os.WriteFile(certFile, []byte("transiently unreadable"), 0o600); err != nil {
-		t.Fatalf("write bad cert: %v", err)
-	}
-	setModTime(t, certFile, renewMod)
-
-	if got, gerr := cr.GetCertificate(&tls.ClientHelloInfo{}); gerr != nil {
-		t.Fatalf("GetCertificate errored during transient failure: %v", gerr)
-	} else if certSerial(t, got) != 1 {
-		t.Fatalf("during transient failure: expected to keep serial 1, got %d", certSerial(t, got))
-	}
-
-	// The renewed, valid certificate is now readable at the SAME mtime as the failed
-	// attempt. The reloader must still pick it up on retry.
-	certB, keyB := genSelfSigned(t, 2)
-	if err := os.WriteFile(certFile, certB, 0o600); err != nil {
-		t.Fatalf("write renewed cert: %v", err)
-	}
-	if err := os.WriteFile(keyFile, keyB, 0o600); err != nil {
-		t.Fatalf("write renewed key: %v", err)
-	}
-	setModTime(t, certFile, renewMod)
-	setModTime(t, keyFile, renewMod)
-
-	got, gerr := cr.GetCertificate(&tls.ClientHelloInfo{})
-	if gerr != nil {
-		t.Fatalf("GetCertificate errored after retry: %v", gerr)
-	}
-	if certSerial(t, got) != 2 {
-		t.Fatalf("after transient failure: expected renewed serial 2 on retry, got %d (mtime advanced on failure, renewal permanently missed)", certSerial(t, got))
 	}
 }

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert_test.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// genSelfSigned returns a PEM-encoded self-signed cert/key pair carrying the given
+// serial number, so tests can tell two generations of the certificate apart.
+func genSelfSigned(t *testing.T, serial int64) (certPEM, keyPEM []byte) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(serial),
+		Subject:               pkix.Name{CommonName: "kube-ovn-webhook-test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              []string{"localhost"},
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	return certPEM, keyPEM
+}
+
+// writeKeyPair writes the cert/key files and bumps their mtime strictly forward,
+// mirroring how cert-manager replaces the mounted Secret on renewal.
+func writeKeyPair(t *testing.T, certFile, keyFile string, certPEM, keyPEM []byte, mtime time.Time) {
+	t.Helper()
+	if err := os.WriteFile(certFile, certPEM, 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyFile, keyPEM, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	if err := os.Chtimes(certFile, mtime, mtime); err != nil {
+		t.Fatalf("chtimes cert: %v", err)
+	}
+	if err := os.Chtimes(keyFile, mtime, mtime); err != nil {
+		t.Fatalf("chtimes key: %v", err)
+	}
+}
+
+// servedSerial completes a TLS handshake against addr and returns the serial number
+// of the leaf certificate the server actually presented.
+func servedSerial(t *testing.T, addr string) int64 {
+	t.Helper()
+	conn, err := tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true}) //nolint:gosec // test-only, inspecting the served cert
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	certs := conn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		t.Fatalf("server presented no certificate")
+	}
+	return certs[0].SerialNumber.Int64()
+}
+
+// TestReloadingTLSConfigServesRenewedCertificate is the regression test for the
+// cert-manager renewal not being picked up: it fails against the old code that
+// loads the key pair once into tls.Config.Certificates, and passes once the
+// certificate is served via a reloading GetCertificate callback.
+func TestReloadingTLSConfigServesRenewedCertificate(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+
+	certA, keyA := genSelfSigned(t, 1)
+	writeKeyPair(t, certFile, keyFile, certA, keyA, time.Now().Add(-2*time.Second))
+
+	tlsConfig, err := newReloadingTLSConfig(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("newReloadingTLSConfig: %v", err)
+	}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", tlsConfig)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				if tc, ok := conn.(*tls.Conn); ok {
+					_ = tc.Handshake()
+				}
+				conn.Close()
+			}()
+		}
+	}()
+
+	addr := ln.Addr().String()
+
+	if got := servedSerial(t, addr); got != 1 {
+		t.Fatalf("before renewal: expected serial 1, got %d", got)
+	}
+
+	// cert-manager renews the Secret: the mounted files are replaced in place.
+	certB, keyB := genSelfSigned(t, 2)
+	writeKeyPair(t, certFile, keyFile, certB, keyB, time.Now().Add(2*time.Second))
+
+	if got := servedSerial(t, addr); got != 2 {
+		t.Fatalf("after renewal: expected renewed serial 2, got %d (certificate was not reloaded)", got)
+	}
+}
+
+// TestCertReloaderKeepsLastGoodCertificate verifies that a failed reload (e.g. a
+// torn read while the volume is updated) does not take the webhook down: it keeps
+// serving the previously loaded certificate instead of erroring the handshake.
+func TestCertReloaderKeepsLastGoodCertificate(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+
+	certA, keyA := genSelfSigned(t, 1)
+	writeKeyPair(t, certFile, keyFile, certA, keyA, time.Now().Add(-2*time.Second))
+
+	cr, err := newCertReloader(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("newCertReloader: %v", err)
+	}
+
+	// Corrupt the cert file and advance its mtime so a reload is attempted and fails.
+	if err := os.WriteFile(certFile, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatalf("corrupt cert: %v", err)
+	}
+	if err := os.Chtimes(certFile, time.Now().Add(2*time.Second), time.Now().Add(2*time.Second)); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	got, err := cr.GetCertificate(&tls.ClientHelloInfo{})
+	if err != nil {
+		t.Fatalf("GetCertificate returned error instead of serving last good cert: %v", err)
+	}
+	if got == nil || got.Leaf == nil {
+		// Leaf may be nil depending on the Go version; fall back to parsing.
+		if got == nil || len(got.Certificate) == 0 {
+			t.Fatalf("GetCertificate returned no certificate")
+		}
+		leaf, perr := x509.ParseCertificate(got.Certificate[0])
+		if perr != nil {
+			t.Fatalf("parse served cert: %v", perr)
+		}
+		got.Leaf = leaf
+	}
+	if got.Leaf.SerialNumber.Int64() != 1 {
+		t.Fatalf("expected to keep serving serial 1 after failed reload, got %d", got.Leaf.SerialNumber.Int64())
+	}
+}

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert_test.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/cert_test.go
@@ -50,8 +50,8 @@ func genSelfSigned(t *testing.T, serial int64) (certPEM, keyPEM []byte) {
 	return certPEM, keyPEM
 }
 
-// writeKeyPair writes the cert/key files and bumps their mtime strictly forward,
-// mirroring how cert-manager replaces the mounted Secret on renewal.
+// writeKeyPair writes the cert/key files and sets their mtime, mirroring how
+// cert-manager replaces the mounted Secret on renewal.
 func writeKeyPair(t *testing.T, certFile, keyFile string, certPEM, keyPEM []byte, mtime time.Time) {
 	t.Helper()
 	if err := os.WriteFile(certFile, certPEM, 0o600); err != nil {
@@ -60,12 +60,36 @@ func writeKeyPair(t *testing.T, certFile, keyFile string, certPEM, keyPEM []byte
 	if err := os.WriteFile(keyFile, keyPEM, 0o600); err != nil {
 		t.Fatalf("write key: %v", err)
 	}
-	if err := os.Chtimes(certFile, mtime, mtime); err != nil {
-		t.Fatalf("chtimes cert: %v", err)
+	setModTime(t, certFile, mtime)
+	setModTime(t, keyFile, mtime)
+}
+
+func setModTime(t *testing.T, name string, mtime time.Time) {
+	t.Helper()
+	if err := os.Chtimes(name, mtime, mtime); err != nil {
+		t.Fatalf("chtimes %s: %v", name, err)
 	}
-	if err := os.Chtimes(keyFile, mtime, mtime); err != nil {
-		t.Fatalf("chtimes key: %v", err)
+}
+
+// certSerial returns the serial number of a *tls.Certificate leaf without mutating the
+// shared value returned by GetCertificate (it parses into a local when Leaf is unset).
+func certSerial(t *testing.T, c *tls.Certificate) int64 {
+	t.Helper()
+	if c == nil {
+		t.Fatal("nil certificate")
 	}
+	leaf := c.Leaf
+	if leaf == nil {
+		if len(c.Certificate) == 0 {
+			t.Fatal("certificate has no DER data")
+		}
+		parsed, err := x509.ParseCertificate(c.Certificate[0])
+		if err != nil {
+			t.Fatalf("parse served cert: %v", err)
+		}
+		leaf = parsed
+	}
+	return leaf.SerialNumber.Int64()
 }
 
 // servedSerial completes a TLS handshake against addr and returns the serial number
@@ -84,10 +108,9 @@ func servedSerial(t *testing.T, addr string) int64 {
 	return certs[0].SerialNumber.Int64()
 }
 
-// TestReloadingTLSConfigServesRenewedCertificate is the regression test for the
-// cert-manager renewal not being picked up: it fails against the old code that
-// loads the key pair once into tls.Config.Certificates, and passes once the
-// certificate is served via a reloading GetCertificate callback.
+// TestReloadingTLSConfigServesRenewedCertificate is the core regression test: it fails
+// against the old code that loads the key pair once into tls.Config.Certificates, and
+// passes once the certificate is served via a reloading GetCertificate callback.
 func TestReloadingTLSConfigServesRenewedCertificate(t *testing.T) {
 	dir := t.TempDir()
 	certFile := filepath.Join(dir, "tls.crt")
@@ -136,9 +159,9 @@ func TestReloadingTLSConfigServesRenewedCertificate(t *testing.T) {
 	}
 }
 
-// TestCertReloaderKeepsLastGoodCertificate verifies that a failed reload (e.g. a
-// torn read while the volume is updated) does not take the webhook down: it keeps
-// serving the previously loaded certificate instead of erroring the handshake.
+// TestCertReloaderKeepsLastGoodCertificate verifies that a failed reload (e.g. a torn
+// read while the volume is updated) does not take the webhook down: it keeps serving
+// the previously loaded certificate instead of erroring the handshake.
 func TestCertReloaderKeepsLastGoodCertificate(t *testing.T) {
 	dir := t.TempDir()
 	certFile := filepath.Join(dir, "tls.crt")
@@ -156,26 +179,67 @@ func TestCertReloaderKeepsLastGoodCertificate(t *testing.T) {
 	if err := os.WriteFile(certFile, []byte("not a certificate"), 0o600); err != nil {
 		t.Fatalf("corrupt cert: %v", err)
 	}
-	if err := os.Chtimes(certFile, time.Now().Add(2*time.Second), time.Now().Add(2*time.Second)); err != nil {
-		t.Fatalf("chtimes: %v", err)
-	}
+	setModTime(t, certFile, time.Now().Add(2*time.Second))
 
 	got, err := cr.GetCertificate(&tls.ClientHelloInfo{})
 	if err != nil {
 		t.Fatalf("GetCertificate returned error instead of serving last good cert: %v", err)
 	}
-	if got == nil || got.Leaf == nil {
-		// Leaf may be nil depending on the Go version; fall back to parsing.
-		if got == nil || len(got.Certificate) == 0 {
-			t.Fatalf("GetCertificate returned no certificate")
-		}
-		leaf, perr := x509.ParseCertificate(got.Certificate[0])
-		if perr != nil {
-			t.Fatalf("parse served cert: %v", perr)
-		}
-		got.Leaf = leaf
+	if certSerial(t, got) != 1 {
+		t.Fatalf("expected to keep serving serial 1 after failed reload, got %d", certSerial(t, got))
 	}
-	if got.Leaf.SerialNumber.Int64() != 1 {
-		t.Fatalf("expected to keep serving serial 1 after failed reload, got %d", got.Leaf.SerialNumber.Int64())
+}
+
+// TestCertReloaderRetriesAfterTransientFailure is the regression test for the reloader
+// abandoning a renewal on a transient error. A failed reload must NOT advance the
+// recorded mtime, so once the (unchanged-mtime) file becomes readable the renewed
+// certificate is still picked up. Against the code that advanced the mtime on failure,
+// the renewal is permanently missed and this test fails.
+func TestCertReloaderRetriesAfterTransientFailure(t *testing.T) {
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "tls.crt")
+	keyFile := filepath.Join(dir, "tls.key")
+
+	certA, keyA := genSelfSigned(t, 1)
+	writeKeyPair(t, certFile, keyFile, certA, keyA, time.Now().Add(-2*time.Second))
+
+	cr, err := newCertReloader(certFile, keyFile)
+	if err != nil {
+		t.Fatalf("newCertReloader: %v", err)
+	}
+	cr.retryInterval = 0 // retry immediately, no backoff wait in the test
+
+	// Renewal advances the mtime, but the first load fails (simulating a transient,
+	// content-independent error) by writing an unreadable cert at the new mtime.
+	renewMod := time.Now().Add(2 * time.Second)
+	if err := os.WriteFile(certFile, []byte("transiently unreadable"), 0o600); err != nil {
+		t.Fatalf("write bad cert: %v", err)
+	}
+	setModTime(t, certFile, renewMod)
+
+	if got, gerr := cr.GetCertificate(&tls.ClientHelloInfo{}); gerr != nil {
+		t.Fatalf("GetCertificate errored during transient failure: %v", gerr)
+	} else if certSerial(t, got) != 1 {
+		t.Fatalf("during transient failure: expected to keep serial 1, got %d", certSerial(t, got))
+	}
+
+	// The renewed, valid certificate is now readable at the SAME mtime as the failed
+	// attempt. The reloader must still pick it up on retry.
+	certB, keyB := genSelfSigned(t, 2)
+	if err := os.WriteFile(certFile, certB, 0o600); err != nil {
+		t.Fatalf("write renewed cert: %v", err)
+	}
+	if err := os.WriteFile(keyFile, keyB, 0o600); err != nil {
+		t.Fatalf("write renewed key: %v", err)
+	}
+	setModTime(t, certFile, renewMod)
+	setModTime(t, keyFile, renewMod)
+
+	got, gerr := cr.GetCertificate(&tls.ClientHelloInfo{})
+	if gerr != nil {
+		t.Fatalf("GetCertificate errored after retry: %v", gerr)
+	}
+	if certSerial(t, got) != 2 {
+		t.Fatalf("after transient failure: expected renewed serial 2 on retry, got %d (mtime advanced on failure, renewal permanently missed)", certSerial(t, got))
 	}
 }

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/main.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"crypto/tls"
 	"flag"
 	"log"
 	"net/http"
@@ -28,17 +27,15 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/mutate-pods", HandleMutatePods)
 
-	tlsCert, err := tls.LoadX509KeyPair(tlsCertFile, tlsKeyFile)
+	tlsConfig, err := newReloadingTLSConfig(tlsCertFile, tlsKeyFile)
 	if err != nil {
 		log.Fatalf("Failed to load key pair: %v", err)
 	}
 
 	server := &http.Server{
-		Addr: ":8443",
-		TLSConfig: &tls.Config{
-			Certificates: []tls.Certificate{tlsCert},
-		},
-		Handler: mux,
+		Addr:      ":8443",
+		TLSConfig: tlsConfig,
+		Handler:   mux,
 	}
 
 	log.Printf("Starting webhook server on %s", server.Addr)

--- a/packages/system/kubeovn-webhook/images/kubeovn-webhook/main.go
+++ b/packages/system/kubeovn-webhook/images/kubeovn-webhook/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"time"
 )
 
 var (
@@ -33,9 +34,13 @@ func main() {
 	}
 
 	server := &http.Server{
-		Addr:      ":8443",
-		TLSConfig: tlsConfig,
-		Handler:   mux,
+		Addr:              ":8443",
+		TLSConfig:         tlsConfig,
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
+		IdleTimeout:       60 * time.Second,
 	}
 
 	log.Printf("Starting webhook server on %s", server.Addr)

--- a/packages/system/kubeovn-webhook/templates/certmanager.yaml
+++ b/packages/system/kubeovn-webhook/templates/certmanager.yaml
@@ -38,7 +38,7 @@ metadata:
 spec:
   secretName: {{ include "namespace-annotation-webhook.fullname" . }}-tls
   duration: 8760h
-  renewBefore: 24h
+  renewBefore: 720h
   issuerRef:
     name: {{ include "namespace-annotation-webhook.fullname" . }}-ca-issuer
   commonName: {{ include "namespace-annotation-webhook.fullname" . }}-tls


### PR DESCRIPTION
## What this PR does

The `kube-ovn-webhook` loaded its TLS serving certificate once at process startup (`tls.LoadX509KeyPair` into a static `tls.Config.Certificates`) and never re-read it. cert-manager renews the backing Secret ahead of expiry, but a running pod kept serving the certificate it loaded at boot. Once that certificate expired — roughly one year after install, on any cluster whose webhook pods had not been restarted after the renewal — the pod served an expired certificate, the kube-apiserver's TLS call to the webhook failed verification, and because the `MutatingWebhookConfiguration` uses `failurePolicy: Fail`, every pod creation in tenant namespaces was rejected. In practice this blocks `virt-launcher` pods, so no VMI can start.

This PR:

- Serves the certificate through a reloading `tls.Config.GetCertificate` callback that re-reads the key pair when the mounted files change, and keeps serving the last good certificate if a reload fails (e.g. a torn read while the volume is being updated). cert-manager renewals are now honoured without a pod restart.
- Widens the certificate `renewBefore` from `24h` to `720h`, so renewal happens well ahead of expiry instead of one day before.
- Adds a regression test that fails against the previous static implementation (the server keeps presenting the old certificate after the files are replaced) and passes once the certificate is reloaded; verified non-vacuous by mutation.

### Screenshots

Not applicable (no UI changes).

### Downstream repositories

- [x] No downstream repository is affected by this change

Walked the trigger map file-by-file against the diff: the change is confined to the `system/kubeovn-webhook` image and its cert-manager `Certificate` `renewBefore`; it touches no package under `apps/`/`extra/`, no `values.schema.json`, no app `values.yaml` default, no `ApplicationDefinition`, no platform values, no CRD, and no `hack/` tooling.

### Release note

```release-note
fix(kube-ovn): kubeovn-webhook now reloads its serving certificate when cert-manager renews it, so the webhook no longer serves an expired certificate that blocked all pod creation (including VMIs) roughly one year after install
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook TLS certificates now reload automatically when renewed, without requiring a server restart.

* **Bug Fixes**
  * Certificate reload failures now fail the TLS handshake instead of serving an outdated certificate.
  * Added server timeouts to improve connection handling.

* **Configuration**
  * Certificates are now renewed earlier to help prevent expiration-related service disruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->