### PR TITLE
fix(e2e): select catch pod logs by the nested release instance label

### DIFF
--- a/hack/e2e-chainsaw/_lib/pod-label-census.sh
+++ b/hack/e2e-chainsaw/_lib/pod-label-census.sh
@@ -1,0 +1,109 @@
+# shellcheck shell=sh
+# Sourced by the chainsaw app Tests after `cd` to the repo root. Provides:
+#   lookup_report           — tell a diagnostic lookup's three outcomes apart,
+#                             with the wording left to the caller; no cluster
+#   pod_label_census_report — lookup_report with the census wording
+#   pod_label_census        — print app.kubernetes.io/instance for every pod in
+#                             a namespace, keeping the outcomes apart
+# Sourcing has no side effects: it defines three functions and nothing else.
+# None uses `local`, which is not POSIX and so unavailable to the `sh` that
+# Chainsaw runs these steps under; the `_plc_` prefix is what keeps the
+# variables from colliding with a caller's names.
+#
+# Why this exists. A `podLogs` collector selects on a label, and it cannot
+# report that it matched nothing — an empty capture and a selector that has
+# gone stale look identical in the artifact. This prints the values that
+# actually exist, so a reader can see whether the selector above it can match.
+# Deliberately no selector is repeated here: a copy would only prove itself
+# right, and would keep matching after the collector's own selector drifted.
+#
+# The three outcomes are kept apart because each means something different and
+# two of them are easy to misread as the third:
+#
+#   - the lookup did not run          — NOT the same as "no pods"; saying so
+#                                       would report an unreachable apiserver
+#                                       as a healthy empty namespace
+#   - it ran and matched nothing      — a real, informative answer
+#   - it ran and returned rows        — the census proper
+#
+# stderr is kept apart from the captured value rather than folded in with
+# `2>&1`, and that is the load-bearing part. kubectl exits 0 while logging a
+# klog line about an API group it could not reach, and an aggregated APIService
+# in that state is what a failed run usually looks like (see
+# docs/agents/e2e-testing.md). Folded into the value, that line makes the
+# "no pods" branch unreachable and prints under the census heading as though it
+# were a pod. Separated, it becomes what it is: a caveat that the census may be
+# partial, printed alongside the answer rather than instead of it.
+#
+# `--request-timeout` bounds each attempt because on a degraded cluster kubectl
+# otherwise retries discovery until something kills the script. Measured
+# against an unreachable apiserver, a bounded call costs about five times the
+# flag, since kubectl retries discovery five times before it gives up; the
+# caller's op timeout is sized above that.
+#
+# The report half is separated from the kubectl call precisely so it can be
+# tested without a cluster — see hack/pod-label-census_test.bats, matching how
+# hack/e2e-chainsaw/_lib/etcd-probe.sh is covered.
+
+# lookup_report RC STDOUT STDERR FAILED_MSG EMPTY_MSG ROWS_HEADING
+#
+# The outcome logic, with the wording left to the caller. Every diagnostic
+# lookup in a `catch` has the same three answers to keep apart and the same two
+# ways of confusing them, so they share one implementation and one set of tests
+# rather than a copy per call site.
+#
+# Always returns 0: this runs inside a `catch`, where a non-zero exit would mask
+# the test's own error.
+lookup_report() {
+    _plc_rc=$1
+    _plc_out=$2
+    _plc_err=$3
+    _plc_failed=$4
+    _plc_empty=$5
+    _plc_heading=$6
+
+    if [ "$_plc_rc" -ne 0 ]; then
+        echo "$_plc_failed"
+        [ -n "$_plc_err" ] && echo "$_plc_err"
+        return 0
+    fi
+
+    if [ -z "$_plc_out" ]; then
+        echo "$_plc_empty"
+    else
+        echo "$_plc_heading"
+        echo "$_plc_out"
+    fi
+
+    if [ -n "$_plc_err" ]; then
+        echo "the lookup also logged this, so the result above may be partial:"
+        echo "$_plc_err"
+    fi
+    return 0
+}
+
+# pod_label_census_report RC STDOUT STDERR NAMESPACE
+pod_label_census_report() {
+    lookup_report "$1" "$2" "$3" \
+        "pod label census FAILED (the lookup did not run; this is not 'no pods'):" \
+        "pod label census: no pods in $4" \
+        "pod label census, app.kubernetes.io/instance per pod:"
+}
+
+# pod_label_census NAMESPACE
+pod_label_census() {
+    _plc_ns=$1
+    _plc_errfile=$(mktemp)
+
+    if _plc_stdout=$(kubectl -n "$_plc_ns" --request-timeout=15s get pods \
+            -o 'custom-columns=POD:.metadata.name,INSTANCE:.metadata.labels.app\.kubernetes\.io/instance' \
+            --no-headers 2>"$_plc_errfile"); then
+        _plc_status=0
+    else
+        _plc_status=1
+    fi
+
+    pod_label_census_report "$_plc_status" "$_plc_stdout" "$(cat "$_plc_errfile")" "$_plc_ns"
+    rm -f "$_plc_errfile"
+    return 0
+}

--- a/hack/e2e-chainsaw/harbor/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/harbor/chainsaw-test.yaml
@@ -34,16 +34,79 @@ spec:
       format: yaml
   - script:
       content: kubectl -n cozy-objectstorage-controller get pods
+  # The app chart wraps the workload in a nested HelmRelease named
+  # `<release>-system`, and the chart behind it stamps
+  # app.kubernetes.io/instance from its own release name. So the Harbor pods
+  # carry `harbor-test-system`, and the unsuffixed value this collector used to
+  # hold reached none of them, on every failed run.
+  #
+  # Coverage boundary, so the absence of a component here is not read as its
+  # health: this selector reaches the workload of the nested release — core,
+  # registry, portal, jobservice, nginx, exporter, and trivy when it is
+  # enabled (the manifest for this suite disables it). The Redis pods carry
+  # `harbor-test-redis`, so this selector misses them, but the script below
+  # collects their logs by `rf[rs]-` name prefix. The CNPG database is covered
+  # by the podLogs op below, on a different label.
+  #
+  # Nothing here collects the parent chart's post-delete cleanup Job, which
+  # labels its pod template with the unsuffixed parent release name. That is
+  # not an oversight: this suite has no `delete` op, so the parent release is
+  # uninstalled only in Chainsaw's cleanup phase, and catch cannot observe it
+  # -- catch is a defer inside the step, while the cleaner runs from t.Cleanup,
+  # after the test function has returned. A collector on the unsuffixed value
+  # would be a permanently-empty capture, the defect these selectors exist to
+  # avoid. The qdrant suite deletes inside a `try:`, so there the Job is at
+  # least in scope, and that suite carries the collector with its own note on
+  # how narrow the window is.
   - podLogs:
-      selector: app.kubernetes.io/instance=harbor-test
+      selector: app.kubernetes.io/instance=harbor-test-system
       tail: 50
+  # harbor-test readiness gates on this database, so its logs are the evidence
+  # for a whole class of failed runs. Selected on `cnpg.io/cluster`, CNPG's own
+  # primary label, rather than on app.kubernetes.io/instance, which CNPG only
+  # derives from the Cluster name: the primary label has nothing to drift from,
+  # and it is what the postgres suite and the WorkloadMonitors already use.
+  - podLogs:
+      selector: cnpg.io/cluster=harbor-test-db
+      tail: 50
+  # podLogs cannot report that it matched nothing, so an empty capture above and
+  # a selector that has gone stale look identical. Print the instance label of
+  # every pod in the namespace instead. Deliberately no selector is repeated
+  # here: a copy would only prove itself right, and would keep matching after
+  # the collector's own selector drifted. The census shows the values that
+  # actually exist, so a reader can see whether the selector above can match.
+  #
+  # What is and is not guarded, so the next reader does not assume more:
+  # the `-system` value above is also pinned on a resource in a `steps:` assert
+  # below, so the chart renaming that label turns a step red -- that is the
+  # drift this pin exists to catch. It does NOT catch a wrong value typed into the
+  # selector here: the assert pins the label on the resource, this pins it in
+  # the collector, and they are two literals. It also catches nothing when the
+  # run fails before reaching that assert. The census below covers neither, and
+  # is not meant to -- it answers what the labels actually are.
+  # The `cnpg.io/cluster` selector has no pin at all; it rides on CNPG's
+  # primary label instead, which is the reason for choosing it.
+  - script:
+      # The helper bounds each kubectl attempt with --request-timeout, which on
+      # a degraded cluster costs about five times the flag; one call is ~75s at
+      # worst, and this op timeout sits above that so an inner budget is what
+      # fires. A SIGKILL at the op boundary would take the census out mid-write
+      # and yield nothing, where a kubectl that gives up leaves an error to
+      # print. The helper carries the rest of the rationale and is unit-tested
+      # in hack/pod-label-census_test.bats.
+      timeout: 2m
+      content: |
+        set -eu
+        cd ../../..
+        . hack/e2e-chainsaw/_lib/pod-label-census.sh
+        pod_label_census "$NAMESPACE"
   # harbor-test readiness is gated by the inline RedisFailover
   # harbor-test-redis: its three sentinels stay NotReady until the spotahome
   # redis-operator elects a master and rewrites their monitored-master config.
-  # None of the collectors above see that path: the harbor-test instance
-  # selector matches neither the operator (namespace cozy-redis-operator) nor
-  # the rfr-/rfs- pods, and the RedisFailover CRD ships no status subresource,
-  # so there is nothing to assert on declaratively.
+  # None of the collectors above see that path: the instance selector above
+  # matches neither the operator (namespace cozy-redis-operator) nor the
+  # rfr-/rfs- pods, which carry `harbor-test-redis`, and the RedisFailover CRD
+  # ships no status subresource, so there is nothing to assert on declaratively.
   - describe:
       apiVersion: databases.spotahome.com/v1
       kind: RedisFailover
@@ -141,6 +204,16 @@ spec:
           kind: Deployment
           metadata:
             name: harbor-test-core
+          # Pins the label the catch collector selects on. Harbor's matchLabels
+          # carry only release+app, so pin the pod template, which is what
+          # podLogs actually matches. Asserts are subset matches, so this costs
+          # nothing and turns a silent drift of the instance label into a red
+          # step instead of an empty capture.
+          spec:
+            template:
+              metadata:
+                labels:
+                  app.kubernetes.io/instance: harbor-test-system
           status:
             (conditions[?type == 'Available']):
             - status: "True"

--- a/hack/e2e-chainsaw/openbao/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/openbao/chainsaw-test.yaml
@@ -15,9 +15,41 @@ spec:
       apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: openbao-test
+  # The app chart wraps the workload in a nested HelmRelease named
+  # `<release>-system`, and the chart behind it stamps
+  # app.kubernetes.io/instance from its own release name. So the pods carry
+  # `openbao-test-system`, not `openbao-test`; the latter matches nothing.
   - podLogs:
-      selector: app.kubernetes.io/instance=openbao-test
+      selector: app.kubernetes.io/instance=openbao-test-system
       tail: 100
+  # podLogs cannot report that it matched nothing, so an empty capture above and
+  # a selector that has gone stale look identical. Print the instance label of
+  # every pod in the namespace instead. Deliberately no selector is repeated
+  # here: a copy would only prove itself right, and would keep matching after
+  # the collector's own selector drifted.
+  #
+  # What is and is not guarded, so the next reader does not assume more:
+  # the `-system` value above is also pinned on a resource in a `steps:` assert
+  # below, so the chart renaming that label turns a step red -- that is the
+  # drift this pin exists to catch. It does NOT catch a wrong value typed into the
+  # selector here: the assert pins the label on the resource, this pins it in
+  # the collector, and they are two literals. It also catches nothing when the
+  # run fails before reaching that assert. The census below covers neither, and
+  # is not meant to -- it answers what the labels actually are.
+  - script:
+      # The helper bounds each kubectl attempt with --request-timeout, which on
+      # a degraded cluster costs about five times the flag; one call is ~75s at
+      # worst, and this op timeout sits above that so an inner budget is what
+      # fires. A SIGKILL at the op boundary would take the census out mid-write
+      # and yield nothing, where a kubectl that gives up leaves an error to
+      # print. The helper carries the rest of the rationale and is unit-tested
+      # in hack/pod-label-census_test.bats.
+      timeout: 2m
+      content: |
+        set -eu
+        cd ../../..
+        . hack/e2e-chainsaw/_lib/pod-label-census.sh
+        pod_label_census "$NAMESPACE"
   steps:
   - name: create-openbao
     try:
@@ -58,6 +90,11 @@ spec:
           kind: Pod
           metadata:
             name: openbao-test-0
+            # Pins the label the catch collector selects on. Asserts are subset
+            # matches, so this costs nothing and turns a silent drift of the
+            # instance label into a red step instead of an empty capture.
+            labels:
+              app.kubernetes.io/instance: openbao-test-system
           (status.containerStatuses[0].started): true
 
   - name: init-and-unseal

--- a/hack/e2e-chainsaw/qdrant/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/qdrant/chainsaw-test.yaml
@@ -10,9 +10,60 @@ spec:
       apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
       name: qdrant-test
+  # The app chart wraps the workload in a nested HelmRelease named
+  # `<release>-system`, and the chart behind it stamps
+  # app.kubernetes.io/instance from its own release name. So the Qdrant pods
+  # carry `qdrant-test-system`, which the unsuffixed value never matched.
+  - podLogs:
+      selector: app.kubernetes.io/instance=qdrant-test-system
+      tail: 50
+  # The unsuffixed value stays, as a second collector rather than as the one
+  # that was replaced: the parent chart's PVC-cleanup Job
+  # (templates/hooks/cleanup-pvc.yaml) labels its pod template with the PARENT
+  # release name, so it is the one thing the old selector did reach, and the
+  # delete below happens inside a `try:`, so the Job is in scope while the test
+  # is still running.
+  #
+  # What this does NOT reach, so the capture is not read as the whole story:
+  # that hook always exits 0 -- no `set -e`, the delete is guarded by
+  # `|| echo "WARNING: PVC cleanup failed"`, and the script ends on an
+  # unconditional echo. Helm therefore marks it succeeded and
+  # `hook-delete-policy: hook-succeeded` takes the pod away, warning and all.
+  # What is left is the case where the uninstall hangs and Helm is still
+  # waiting on the hook: the pod is alive then, and its log is the only account
+  # of where it stopped. The `get jobs,pods` in the cleanup step below lists
+  # the objects but reads no log.
   - podLogs:
       selector: app.kubernetes.io/instance=qdrant-test
       tail: 50
+  # podLogs cannot report that it matched nothing, so an empty capture above and
+  # a selector that has gone stale look identical. Print the instance label of
+  # every pod in the namespace instead. Deliberately no selector is repeated
+  # here: a copy would only prove itself right, and would keep matching after
+  # the collector's own selector drifted.
+  #
+  # What is and is not guarded, so the next reader does not assume more:
+  # the `-system` value above is also pinned on a resource in a `steps:` assert
+  # below, so the chart renaming that label turns a step red -- that is the
+  # drift this pin exists to catch. It does NOT catch a wrong value typed into the
+  # selector here: the assert pins the label on the resource, this pins it in
+  # the collector, and they are two literals. It also catches nothing when the
+  # run fails before reaching that assert. The census below covers neither, and
+  # is not meant to -- it answers what the labels actually are.
+  - script:
+      # The helper bounds each kubectl attempt with --request-timeout, which on
+      # a degraded cluster costs about five times the flag; one call is ~75s at
+      # worst, and this op timeout sits above that so an inner budget is what
+      # fires. A SIGKILL at the op boundary would take the census out mid-write
+      # and yield nothing, where a kubectl that gives up leaves an error to
+      # print. The helper carries the rest of the rationale and is unit-tested
+      # in hack/pod-label-census_test.bats.
+      timeout: 2m
+      content: |
+        set -eu
+        cd ../../..
+        . hack/e2e-chainsaw/_lib/pod-label-census.sh
+        pod_label_census "$NAMESPACE"
   steps:
   - name: create-qdrant
     try:
@@ -51,6 +102,13 @@ spec:
           kind: StatefulSet
           metadata:
             name: qdrant-test
+          # Pins the label the catch collector selects on. Asserts are subset
+          # matches, so this costs nothing and turns a silent drift of the
+          # instance label into a red step instead of an empty capture.
+          spec:
+            selector:
+              matchLabels:
+                app.kubernetes.io/instance: qdrant-test-system
           status:
             readyReplicas: 1
     - assert:
@@ -85,6 +143,49 @@ spec:
             name: qdrant-storage-qdrant-test-0
     catch:
     - script:
+        # Same budgeting as the census in the test-wide catch, sized for this
+        # script: it makes up to three bounded calls, so ~240s at worst rather
+        # than the census's ~75s, and the op timeout is 5m rather than 2m to
+        # stay above that. Above the inner budgets either way, so an inner one
+        # is what fires instead of a SIGKILL that would yield nothing.
+        timeout: 5m
         content: |
-          kubectl -n "$NAMESPACE" get pvc -o wide
-          kubectl -n "$NAMESPACE" get jobs,pods -l app.kubernetes.io/instance=qdrant-test -o wide
+          # `set -u` but NOT `set -e`: every lookup below is best-effort, the
+          # way the sibling redis script in the harbor suite already is. Under
+          # `-e` a failing `get pvc` would abort the script before the report
+          # runs, so the degraded cluster -- the only case this catch exists
+          # for -- is exactly the one that would produce no diagnosis at all.
+          set -u
+          cd ../../..
+          . hack/e2e-chainsaw/_lib/pod-label-census.sh
+          kubectl -n "$NAMESPACE" --request-timeout=15s get pvc -o wide || true
+          # `qdrant-test` here, unsuffixed. This runs after the parent Qdrant is
+          # deleted, and what it looks for is the parent chart's PVC-cleanup Job
+          # (templates/hooks/cleanup-pvc.yaml), which is labelled with the PARENT
+          # release name. The nested `-system` release owns the Qdrant workload,
+          # not this Job. The test-wide catch reads that Job's log on the same
+          # unsuffixed value; this reports whether the objects are there at all.
+          #
+          # The three outcomes are told apart by the shared helper rather than
+          # by a second copy of that branching: an empty `kubectl get -l` exits
+          # zero, so a stale selector here would print nothing and read as
+          # "cleanup finished", and kubectl also exits zero while logging to
+          # stderr, which folded into the value would print as a leftover
+          # object. One call feeds the report; the `-o wide` re-listing below is
+          # extra detail on objects already known to exist, not a second attempt
+          # at the question.
+          sel=app.kubernetes.io/instance=qdrant-test
+          errf=$(mktemp)
+          if found=$(kubectl -n "$NAMESPACE" --request-timeout=15s get jobs,pods -l "$sel" -o name 2>"$errf"); then
+            rc=0
+          else
+            rc=1
+          fi
+          lookup_report "$rc" "$found" "$(cat "$errf")" \
+            "cleanup lookup FAILED — it did not run, which is not the same as 'nothing left':" \
+            "cleanup selector '$sel' matched no objects: either cleanup completed, or the parent chart's label changed" \
+            "cleanup objects still present:"
+          if [ "$rc" -eq 0 ] && [ -n "$found" ]; then
+            kubectl -n "$NAMESPACE" --request-timeout=15s get jobs,pods -l "$sel" -o wide || true
+          fi
+          rm -f "$errf"

--- a/hack/pod-label-census_test.bats
+++ b/hack/pod-label-census_test.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Unit tests for the pod-label census in
+# hack/e2e-chainsaw/_lib/pod-label-census.sh.
+#
+# The census exists because a `podLogs` collector cannot report that its
+# selector matched nothing: an empty capture and a stale selector are the same
+# artifact. It prints the instance labels that actually exist, so a reader can
+# tell the two apart.
+#
+# What these tests pin is the discrimination between its three outcomes, which
+# is where the value is and where it is easy to lose. In particular the fourth
+# case below: kubectl exits 0 while logging a klog line about an API group it
+# could not reach, which is the normal shape of a degraded cluster and so the
+# normal shape of a run where this catch fires at all. An earlier form captured
+# with `2>&1`, and that klog line then made the value non-empty -- the "no pods"
+# branch became unreachable and the error printed under the census heading as
+# though it were a pod. Separating the streams is the fix; these tests are what
+# keeps it separated.
+#
+# The report half is a pure function of (rc, stdout, stderr, namespace), so it
+# needs no cluster. The last test drives the kubectl-calling half through a stub
+# on PATH, to prove the streams stay apart end to end rather than only in the
+# half that never touches kubectl.
+#
+# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
+# own line; there is no bats `run` or `$status`, and setup()/teardown() are not
+# honored. Each test runs under `set -eu -x`; assertions are direct shell tests
+# that exit non-zero on failure. Titles are delimited by ASCII double quotes and
+# only [A-Za-z0-9] survives into the generated function name, so keep them
+# distinctive in their alphanumeric run.
+#
+# Run with: hack/cozytest.sh hack/pod-label-census_test.bats
+# -----------------------------------------------------------------------------
+
+HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
+# shellcheck source=/dev/null
+. "$HACK_DIR/e2e-chainsaw/_lib/pod-label-census.sh"
+
+@test "census prints the rows it was given under the census heading" {
+    out="$(pod_label_census_report 0 "pod-a  harbor-test-system" "" tenant-test)"
+    echo "$out" | grep -q 'app.kubernetes.io/instance per pod'
+    echo "$out" | grep -q 'pod-a  harbor-test-system'
+}
+
+@test "census names the namespace when the lookup ran and matched nothing" {
+    out="$(pod_label_census_report 0 "" "" tenant-test)"
+    echo "$out" | grep -q 'no pods in tenant-test'
+    # An empty result is an answer, not a failure: saying FAILED here would
+    # report a healthy empty namespace as an unreachable apiserver.
+    #
+    # Counted rather than written `! ... | grep -q`: POSIX exempts a command
+    # whose status is inverted with `!` from `set -e`, so that form cannot fail
+    # a test here -- it would pass whatever the output said.
+    [ "$(echo "$out" | grep -c 'FAILED')" -eq 0 ]
+}
+
+@test "census says the lookup did not run and does not call it no pods" {
+    out="$(pod_label_census_report 1 "" "Unable to connect to the server" tenant-test)"
+    echo "$out" | grep -q 'FAILED'
+    echo "$out" | grep -q 'Unable to connect to the server'
+    # The distinction this whole helper exists for: a lookup that never
+    # returned must not be reported as an empty namespace. Counted, not
+    # `! ... | grep -q`, for the reason given in the empty-result test above.
+    #
+    # Matched on the empty-result sentence rather than on "no pods": the FAILED
+    # line quotes that phrase itself, to say what it is not.
+    [ "$(echo "$out" | grep -c 'no pods in')" -eq 0 ]
+}
+
+@test "census keeps a zero exit with a klog line out of the rows" {
+    klog='E0805 memcache.go:265 Unhandled Error: couldnt get API group list'
+    out="$(pod_label_census_report 0 "" "$klog" tenant-test)"
+    # The regression: with the streams folded together this printed the klog
+    # line under the census heading, as if the API error were a pod.
+    echo "$out" | grep -q 'no pods in tenant-test'
+    echo "$out" | grep -q 'may be partial'
+    echo "$out" | grep -q 'memcache.go'
+}
+
+@test "census marks rows as possibly partial when kubectl also logged an error" {
+    klog='E0805 memcache.go:265 Unhandled Error: couldnt get API group list'
+    out="$(pod_label_census_report 0 "pod-a  harbor-test-system" "$klog" tenant-test)"
+    echo "$out" | grep -q 'pod-a  harbor-test-system'
+    echo "$out" | grep -q 'may be partial'
+}
+
+@test "shared report keeps the three outcomes apart for the cleanup wording too" {
+    # The qdrant cleanup catch feeds the same helper with its own messages, so
+    # the discrimination is tested once and used twice rather than living
+    # inline in YAML where nothing can pin it.
+    failed="cleanup lookup FAILED"
+    empty="matched no objects"
+    heading="cleanup objects still present:"
+
+    out="$(lookup_report 1 "" "Unable to connect to the server" "$failed" "$empty" "$heading")"
+    echo "$out" | grep -q 'cleanup lookup FAILED'
+    # A lookup that never ran must not read as "nothing left to clean up".
+    [ "$(echo "$out" | grep -c 'matched no objects')" -eq 0 ]
+
+    out="$(lookup_report 0 "" "" "$failed" "$empty" "$heading")"
+    echo "$out" | grep -q 'matched no objects'
+
+    out="$(lookup_report 0 "job.batch/qdrant-test-qdrant-cleanup" "" "$failed" "$empty" "$heading")"
+    echo "$out" | grep -q 'cleanup objects still present'
+    echo "$out" | grep -q 'job.batch/qdrant-test-qdrant-cleanup'
+}
+
+@test "shared report flags a zero exit with stderr as possibly partial for any wording" {
+    klog='E0805 memcache.go:265 Unhandled Error'
+    out="$(lookup_report 0 "" "$klog" "FAILED-MSG" "EMPTY-MSG" "ROWS-MSG")"
+    # Same regression as the census case: folded into the value this klog line
+    # would suppress the empty branch and print as though it were a result.
+    echo "$out" | grep -q 'EMPTY-MSG'
+    echo "$out" | grep -q 'may be partial'
+    [ "$(echo "$out" | grep -c 'ROWS-MSG')" -eq 0 ]
+}
+
+@test "census driven through a kubectl stub keeps stderr out of the value" {
+    stubdir="$(mktemp -d)"
+    printf '#!/bin/sh\necho "E0805 memcache.go:265 Unhandled Error" >&2\nexit 0\n' \
+        > "$stubdir/kubectl"
+    chmod +x "$stubdir/kubectl"
+    out="$(PATH="$stubdir:$PATH" pod_label_census tenant-test)"
+    rm -rf "$stubdir"
+    # End to end: kubectl exited 0 and wrote only to stderr, so the namespace
+    # really is empty and the klog line is a caveat, not a row.
+    echo "$out" | grep -q 'no pods in tenant-test'
+    echo "$out" | grep -q 'may be partial'
+}
+
+@test "census returns zero even when the lookup failed so a catch cannot mask the real error" {
+    stubdir="$(mktemp -d)"
+    printf '#!/bin/sh\necho "Unable to connect to the server" >&2\nexit 1\n' \
+        > "$stubdir/kubectl"
+    chmod +x "$stubdir/kubectl"
+    # The call goes in the `if` condition, not on a line of its own: these
+    # tests run under `set -e`, which exempts a condition but would abort the
+    # test before a following `rc=$?` could ever read a non-zero. Read after
+    # the fact, that assertion could only ever see 0 and would pass whatever
+    # the function returned.
+    if PATH="$stubdir:$PATH" pod_label_census tenant-test > /dev/null; then
+        rc=0
+    else
+        rc=1
+    fi
+    rm -rf "$stubdir"
+    [ "$rc" -eq 0 ]
+}


### PR DESCRIPTION
## What this PR does

The harbor, openbao and qdrant catch blocks selected pod logs on the app release name. Each of these charts deploys its workload through a nested HelmRelease named `<release>-system` and passes `fullnameOverride: <release>` down to it, so the inner chart stamps `app.kubernetes.io/instance` from its own release name, with the suffix, while object names come from the override, without it. The selector matched no pods, and a failed run collected nothing.

- points the three `podLogs` catch collectors at the `-system` instance label
- adds a `podLogs` collector for Harbor's CNPG database, which no collector reached before, selected on `cnpg.io/cluster` rather than on the instance label CNPG merely derives from the Cluster name
- pins the instance label on a resource in an assert each suite already runs, so a chart renaming that label fails a step instead of quietly emptying a capture
- prints the instance label of every pod in the namespace from each test-wide catch, because `podLogs` cannot report that it matched nothing
- keeps the unsuffixed value as a second collector in qdrant only, because the parent chart's PVC-cleanup Job labels its pod template with the parent release name and that suite deletes the parent inside a `try:`

Harbor renders the same hook and deliberately does not get the same collector: it has no `delete` op, so its parent release is uninstalled only in Chainsaw's cleanup phase, which no catch can observe: catch is a defer inside the step, while the cleaner runs from `t.Cleanup`, after the test function returns. A comment records that asymmetry so the next reader does not restore the collector for symmetry.

Each comment states what the pin does and does not cover: it does not catch a wrong value typed into a selector, and it catches nothing when a run fails before reaching the assert. The qdrant comment is equally explicit about how narrow its collector's window is, because the hook always exits 0, so Helm calls it succeeded and `hook-succeeded` takes the pod away; what remains is an uninstall that hangs with Helm still waiting.

Telling a lookup's outcomes apart is one helper under `hack/e2e-chainsaw/_lib/` rather than a copy per call site, with the outcome logic split from the kubectl call so it can be pinned without a cluster — the shape `_lib/etcd-probe.sh` already uses. Both the census and the qdrant cleanup listing report through it, differing only in wording. Each lookup keeps stderr apart from the value it captures: kubectl exits 0 while logging that it could not reach an API group, and an aggregated APIService in that state is what a failed run usually looks like, so folding the streams would make the "nothing found" branch unreachable and print that log line as though it were a result.

Note what the extraction costs in CI: touching the shared `_lib/` and adding a top-level `hack/*.bats` escalates test-impact analysis from the three suites this change edits to the full Chainsaw suite, so this PR runs everything and is exposed to the whole spread of known flakes. A red suite unrelated to harbor, openbao or qdrant is that exposure, not a defect in this diff.

## Testing

- `hack/pod-label-census_test.bats`, 9 cases over the helper's outcomes, run via `hack/cozytest.sh` and picked up by `make unit-tests` through the existing `BATS_UNIT_FILES` glob
- mutation-checked rather than assumed: folding stderr back into the captured value, propagating kubectl's exit code out of the helper, and collapsing the failed/empty distinction each turn the suite red, and each is green again on revert
- `chainsaw lint test --file` on each of the three suites, and `chainsaw test --no-cluster --config hack/e2e-chainsaw/.chainsaw.yaml --include-test-regex '^$'` over all three, both with v0.2.15, the version the sandbox image pins
- `shellcheck --shell=sh` on the helper and on the catch scripts extracted from the YAML
- the qdrant step catch driven against a stub kubectl that fails: it reports the failed lookup rather than dying on it
- every selector, pin and comment claim checked against the chart that stamps it

### Screenshots

Not applicable.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(e2e): collect harbor, openbao and qdrant pod logs on a failed run
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pod-label census diagnostics to improve visibility into workload labels during test failures.
  * Enhanced failure diagnostics for Harbor, OpenBao, and Qdrant by collecting relevant workload and database logs.
  * Added bounded reporting for missing pods, lookup failures, and incomplete cleanup resources.

* **Bug Fixes**
  * Updated diagnostic selectors and readiness checks to match chart-generated instance labels.
  * Improved PVC cleanup diagnostics with clearer reporting of remaining resources.

* **Tests**
  * Added coverage for successful, empty, failed, and partial diagnostic results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->