### PR TITLE
fix(ci): stop labeled events from cancelling and re-running backports

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -4,9 +4,69 @@ on:
   pull_request_target:
     types: [closed, labeled]   # fires when PR is closed (merged) or labeled
 
+# Two mechanisms here, answering two different failures.
+#
+# A run joins its concurrency group before any job-level `if` is evaluated, so
+# `prepare`'s guard below cannot stop a label event from disturbing the run
+# already backporting this PR; it only decides what the label run does after the
+# damage. Labels set with the default GITHUB_TOKEN start no run, but labels set
+# by third-party GitHub Apps do, and they arrive in bursts. Under a plain
+# `cancel-in-progress: true` each one cancelled the backport the merge had just
+# started, and nothing reports that beyond a cancelled run sitting next to a
+# green one.
+#
+# The delivery survived anyway, because the old guard admitted a run on the PR's
+# cumulative labels: the last label of a burst requalified and redid the work.
+# `prepare`'s narrowing below removes that accidental safety net, so the two
+# changes land together — narrowing alone would turn a noisy delivery into an
+# absent one.
+#
+# So the group key moves a label event that is NOT a backport request aside, and
+# `cancel-in-progress` stops one that IS from cancelling rather than queuing.
+# Both are load-bearing. `backport` and `backport-previous` are separate requests
+# that both have to complete, so they share the main group and must not cancel
+# each other; every other label does no work here and only has to stay out of
+# the way.
+#
+# That is also why this file does not simply copy pull-requests.yaml, which
+# splits the key and leaves cancellation unconditional: a discarded label run
+# there publishes nothing, so isolating it is the whole fix.
+#
+# Queuing protects a pending run from the run ahead of it and never from the one
+# behind: the group holds a single pending run, and a newer one evicts it. With
+# the split in place that costs nothing, and for the same reason the fan-out
+# below is harmless — the only events left in this group are backport requests,
+# the evictor is by definition the newer of the two, and `prepare`'s `Check which
+# labels are present` step reads the cumulative label set. So the survivor covers
+# a superset of what the evicted run would have delivered, for any sequence that
+# only adds labels. Removing one in between is the exception and needs no cover:
+# the evictor then carries less because the request was withdrawn.
+#
+# That is exactly what the split buys. Without it the evictor could be any label
+# at all, and a run that does not qualify delivers nothing in place of the
+# request it displaced.
+#
+# `queue: max` raises the single pending slot to a hundred and is the obvious
+# thing to reach for instead of the split. Taking it means giving up the
+# conditional cancel, because `queue: max` and `cancel-in-progress: true` are a
+# validation error together and this key still evaluates to true on a merge.
+# The trade is available and was not taken: eviction is what keeps a burst to one
+# surviving run rather than a hundred queued ones, and the feature only shipped
+# 2026-05-07, on a path that delivers fixes to release lines.
 concurrency:
-  group: backport-${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+  group: backport-${{ github.workflow }}-${{ github.event.pull_request.number }}${{ (github.event.action == 'labeled' && github.event.label.name != 'backport' && github.event.label.name != 'backport-previous') && '-label' || '' }}
+  # Stated positively, matching the group key above. `!= 'labeled'` is equivalent
+  # only while `types:` holds exactly these two, and that form fails open: adding
+  # `unlabeled` or `reopened` there would hand those events cancellation in the
+  # main group, which is the behaviour this file exists to remove.
+  #
+  # The positive form removes the cancelling, not the occupying. A third type
+  # still lands in the main group, still takes its single pending slot, and its
+  # `prepare` still skips — so it can evict a genuine backport request and
+  # deliver nothing in its place. `types:` is load-bearing for that reason and is
+  # pinned in hack/release-freeze-contract.bats; widening it needs the group key
+  # widened with it.
+  cancel-in-progress: ${{ github.event.action == 'closed' }}
 
 # Top-level token defaults to read-only. A job-level block replaces this one
 # rather than adding to it, so each job restates every scope it needs.
@@ -16,16 +76,59 @@ permissions:
 jobs:
   # Determine which backports are needed
   prepare:
+    # This guard admits each action on the labels it is entitled to. `closed`
+    # carries no label of its own, so it reads the set the PR ended up with.
+    # `labeled` reads only the label just added: matching the cumulative set
+    # here means every later unrelated label on a merged PR that still carries
+    # `backport` re-enters this job to redo a backport already delivered.
+    #
+    # Scope, so this is not read as covering the whole job: the `Check which
+    # labels are present` step below still reads the cumulative set, so a
+    # `backport-previous` event on a PR also carrying `backport` fans out to
+    # both matrix legs. That is deliberate, and each state a re-entered leg can
+    # find is already accounted for: delivered is skipped by the merged-backport
+    # guard, still open is skipped by backport-action on the 422, and closed
+    # unmerged gets a fresh backport PR, which is the retry that guard
+    # deliberately preserves rather than an accident. What the narrowing here
+    # decides is whether the job RUNS, not which targets it picks.
     if: |
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
       (
-        contains(github.event.pull_request.labels.*.name, 'backport') ||
-        contains(github.event.pull_request.labels.*.name, 'backport-previous') ||
+        (github.event.action == 'closed' && (contains(github.event.pull_request.labels.*.name, 'backport') || contains(github.event.pull_request.labels.*.name, 'backport-previous'))) ||
         (github.event.action == 'labeled' && (github.event.label.name == 'backport' || github.event.label.name == 'backport-previous'))
       )
     # GitHub API calls only — no docker, no repo toolchain: GitHub-hosted.
     runs-on: ubuntu-latest
+    # Queuing gives a stuck run a way to hurt the next one that a cancelling key
+    # did not: the label event that used to kill it now waits behind it rather
+    # than clearing it.
+    #
+    # This ceiling bounds a stuck JOB, which is the case it can reach. A run can
+    # also wedge at the RUN level with every job already finished, and no
+    # job-level key expires that one; it holds the group until GitHub retires the
+    # run. Rare but real: run 31232645133 has been `in_progress` since
+    # 2026-08-08 with `prepare` and `backport` both skipped. Nothing here
+    # reaches that state, so docs/release.md tells an operator to look for a run
+    # still in flight and clear it before re-applying the label.
+    #
+    # What it bounds is EXECUTION, not the wait for a runner. GitHub's limits
+    # page says "job execution time" for the 6-hour job cap while spelling out
+    # that the 35-day run cap "includes execution duration, and time spent on
+    # waiting and approval" — the contrast is deliberate — and
+    # orgs/community#50926 shows a job sitting six hours on "Waiting for a runner
+    # to pick up this job" under `timeout-minutes: 5`. So queue time is a third
+    # unbounded case alongside the run-level wedge, not something this covers.
+    #
+    # 30 is therefore generous rather than calculated. Execution on run
+    # 29844315422 was 6s for `prepare` and 2s and 16s for the two matrix legs,
+    # against 9m24s, 5m28s and 5m45s of queue for the same three jobs. Every
+    # execution measured on this workflow has been seconds, and no maximum is
+    # quoted on purpose: an absolute maximum over a growing set is stale as soon
+    # as a slower run lands. The value leaves room for a cherry-pick far larger
+    # than anything seen while replacing the 6-hour default, and nothing here is
+    # sized against the queue because nothing here can be.
+    timeout-minutes: 30
     permissions:
       contents: read
     outputs:
@@ -111,6 +214,10 @@ jobs:
       (needs.prepare.outputs.backport_current == 'true' || needs.prepare.outputs.backport_previous == 'true')
     # git cherry-picks via backport-action — no docker, no repo toolchain: GitHub-hosted.
     runs-on: ubuntu-latest
+    # See `prepare` above: a queued request waits on this one, so it needs a
+    # ceiling rather than the 6-hour default. Bounds this job's execution only;
+    # the wait for a runner is outside it either way.
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write

--- a/docs/release.md
+++ b/docs/release.md
@@ -353,6 +353,8 @@ The fix (PR #2584): both job `if:` blocks gate on `github.event.pull_request.bas
 
 ### When the bot fails
 
+If the run triggered by the merge dies without opening a backport PR, look for a run of this workflow that has not finished before retrying — `gh run list --workflow backport.yaml --branch <the PR's head branch>` — and clear it, because the retry queues behind it rather than replacing it. Do not filter by status: a run whose jobs are waiting for a runner, or which is held behind the concurrency group, is not `in_progress`, and filtering it out is how you conclude nothing is running. `--branch` narrows the list but does not identify the PR, since head branch names are not unique across forks and `gh run list` has no PR filter, so confirm which PR a run belongs to before cancelling it or you cancel someone else's backport. If cancelling does not clear the run it holds the group until GitHub retires it and the retry keeps queueing; that case has not been exercised here. A run whose jobs have all finished can still sit `in_progress`, which looks the same from the PR as a run that died. Then remove whichever backport label the PR already carries and add it back: a label event is the only other trigger, and it qualifies on the label it carries, so re-applying it is what starts a fresh attempt.
+
 Conflicting cherry-picks produce a draft PR via `conflict_resolution: draft_commit_conflicts`. Look for the bot's comment with the merge-conflict diff. You either:
 
 - Resolve in the draft branch and undraft, or

--- a/hack/release-freeze-contract.bats
+++ b/hack/release-freeze-contract.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
-# Contract for the rc freeze and the backport target resolution that depends on
-# it. Like promote-gate-contract.bats, these tests pin executable/structural
+# Contract for the rc freeze, the backport target resolution that depends on it,
+# and the triggering and concurrency rules that decide whether a backport runs at
+# all. Like promote-gate-contract.bats, these tests pin executable/structural
 # workflow lines rather than prose: a commented-out gate or a guard demoted to a
 # comment must never satisfy the contract.
 #
@@ -370,4 +371,200 @@ closed-merged=true"
     echo "backport.yaml's guard no longer uses prs.some(p => p.merged_at !== null)." >&2; exit 1; }
 
   rm -rf "$tmp"
+}
+
+# ── backport concurrency ─────────────────────────────────────────────────────
+# A run joins its concurrency group before `prepare`'s guard is evaluated, so
+# nothing in that guard can keep a label event from disturbing the run already
+# backporting the PR. The group key and `cancel-in-progress` close different
+# halves of that and are pinned separately: either one alone still leaves a
+# live failure, and neither reads load-bearing on its own.
+
+@test "the trigger surface the concurrency key is built for does not widen" {
+  # Both halves of the key are written against one trigger delivering `closed` or
+  # `labeled`, and neither degrades safely if anything else arrives. The group key
+  # routes only `labeled` aside, so a new event lands in the main group;
+  # `cancel-in-progress` is positive, so it does not cancel there; and `prepare`
+  # does not qualify it. The result occupies the single pending slot, evicts a
+  # genuine backport request, and delivers nothing.
+  #
+  # Pinned as the whole surface rather than just the types list, because a SIBLING
+  # trigger reaches the same harm without touching `types:` at all: anything
+  # carrying a `pull_request` payload resolves the PR number and so lands in the
+  # same per-PR group. `pull_request_review` is the realistic one.
+  #
+  # Deliberately strict: this also fails on a widening that would be harmless,
+  # `workflow_dispatch` for instance, whose payload carries no `pull_request` so
+  # the key degenerates to a shared group holding no genuine request. Separating
+  # the harmless case needs a list of which triggers carry that payload, and that
+  # list drifts. A red here means read the block above, not that the pin is wrong.
+  triggers="$(awk '/^on:/{inside=1;next} /^[a-z]/{inside=0} inside && /^  [a-z_]+:/{print $1}' "$BACKPORT")"
+  [ -n "$triggers" ]
+  [ "$(printf '%s\n' "$triggers" | wc -l | tr -d ' ')" -eq 1 ]
+  printf '%s\n' "$triggers" | grep -qF 'pull_request_target:'
+
+  printf '%s\n' "$(code_lines < "$BACKPORT")" | grep -qF 'types: [closed, labeled]'
+}
+
+@test "a label event that requests no backport gets its own concurrency group" {
+  line="$(code_lines < "$BACKPORT" | grep '^  group: backport-')"
+  [ -n "$line" ]
+
+  # The per-PR discriminator, first: without it every PR's backport shares one
+  # group, and since a merge still cancels in that group, merging one PR kills
+  # another's in-flight backport. The assertions below all describe how a label
+  # event is separated from a merge WITHIN one PR, and every one of them stays
+  # green with the PR number deleted, so the widest failure of the three is the
+  # one nothing else here would notice.
+  printf '%s\n' "$line" | grep -qF 'backport-${{ github.workflow }}-${{ github.event.pull_request.number }}${{'
+
+  count="$(printf '%s\n' "$line" | grep -o "github\.event\.action == 'labeled'" | wc -l | tr -d ' ')"
+  [ "${count:-0}" -eq 1 ]
+
+  # The split is on the label NAMES, not on the action alone. Routing EVERY label
+  # event aside would move `backport` and `backport-previous` out of the group
+  # holding the run they have to queue behind, and one request could then evict
+  # the other.
+  #
+  # Pinned as the literal pair, not as a count of `label.name != '`. That count
+  # measures the operator and says nothing about the operands, so renaming one
+  # name here and not in `prepare` — the half-finished rename — left it at two
+  # and stayed green, while a real `backport-previous` event took the `-label`
+  # branch and became free to cherry-pick alongside the merge run.
+  # Including the conjunction that joins the action check to the name checks.
+  # `&&` binds tighter than `||` in GitHub expressions, so flipping this one
+  # operator reads as `action == 'labeled' || (name != … && name != …)`, and on a
+  # `closed` event `github.event.label` is absent, both name checks are true, and
+  # EVERY event takes the suffix. A constant suffix is exactly as vacuous as no
+  # split at all. Every operand here was pinned before this line existed; the
+  # operator joining them was not.
+  printf '%s\n' "$line" | grep -qF "github.event.action == 'labeled' && github.event.label.name != 'backport' && github.event.label.name != 'backport-previous'"
+
+  # And exactly two of them. The literal above is a substring check, so appending
+  # a third exclusion satisfies it unchanged — and a third exclusion is not
+  # cosmetic: the named label stops being routed aside, lands in the main group,
+  # takes its single pending slot, skips in `prepare`, and evicts a genuine
+  # backport request while delivering nothing. Same harm as widening `types:`.
+  # Presence and count answer different questions; this test needs both.
+  count="$(printf '%s\n' "$line" | grep -o "github\.event\.label\.name != '" | wc -l | tr -d ' ')"
+  [ "${count:-0}" -eq 2 ]
+
+  # The suffix the condition selects, not only the condition. Asserting the
+  # operands alone leaves the whole split deletable — collapsing the tail to
+  # `&& '' || ''` puts every label back in the main group with the condition
+  # still reading correctly above it. Inverting it to `&& '' || '-label'` is
+  # worse than deleting it, because that moves the two backport requests aside
+  # and leaves the irrelevant labels sharing the group with the run in flight,
+  # which is the arrangement this file exists to prevent. Both survive every
+  # other assertion here.
+  printf '%s\n' "$line" | grep -qF "&& '-label' || ''"
+}
+
+@test "a labeled event queues behind the backport in flight instead of cancelling it" {
+  # Labels set with the default GITHUB_TOKEN start no run, but labels set by
+  # third-party GitHub Apps do, and they arrive in bursts. Under a plain `true`
+  # each one killed the backport the merge had just started, leaving a cancelled
+  # run next to a green one and the work repeated by whichever label came last.
+  # With `prepare` now narrowed, no burst label requalifies to repeat it,
+  # so dropping this arm does not restore the old noisy delivery — it loses the
+  # backport. `cancel-in-progress: true` is the obvious thing for the next reader
+  # to normalise this back to, so pin its absence too.
+  count="$(code_lines < "$BACKPORT" | grep -cF "  cancel-in-progress: \${{ github.event.action == 'closed' }}" || true)"
+  [ "${count:-0}" -eq 1 ]
+
+  # Positively, not as `!= 'labeled'`. The two are equivalent only while `types:`
+  # holds exactly `closed` and `labeled`; the negative form hands cancellation to
+  # any third type added later, in the main group, which is the behaviour this
+  # arm removes.
+  count="$(code_lines < "$BACKPORT" | grep -c "cancel-in-progress:.*!= 'labeled'" || true)"
+  [ "${count:-0}" -eq 0 ]
+
+  count="$(code_lines < "$BACKPORT" | grep -c '^  cancel-in-progress: true$' || true)"
+  [ "${count:-0}" -eq 0 ]
+}
+
+@test "both backport jobs bound how long a queued request can wait" {
+  # These ceilings exist because of the queuing above, not for their own sake. A
+  # cancelling key disposed of a stuck run by killing it; queuing makes the next
+  # genuine request wait behind it instead, and an unbounded job on the 6-hour
+  # default turns one wedged job into a six-hour hole in the release line.
+  # Nothing else in this file makes them look load-bearing, so a tidy-up that
+  # drops them reads as harmless.
+  #
+  # Scope, since the test name says "how long a queued request can wait": what is
+  # bounded here is a stuck JOB. A run can wedge at the RUN level with every job
+  # already finished, and `timeout-minutes` is job-level with no run-level
+  # equivalent, so that state holds the group until the run is cancelled. These
+  # ceilings do not reach it and are not meant to.
+  # Asserted as a bound, not as presence. The hazard is the SIZE of the wait, so
+  # a pin that only checks the key exists is satisfied by `timeout-minutes: 355`,
+  # which restores the hole to within five minutes of the default it was written
+  # against.
+  #
+  # Bounded on BOTH sides, because both directions break it. Too high restores
+  # the hole; too low cancels a real backport that was only waiting for a runner,
+  # and an upper-bound-only assertion stays green at `timeout-minutes: 1`.
+  #
+  # The floor is judgement, not measurement, and says so. `timeout-minutes`
+  # bounds execution, and every execution measured on this workflow has been
+  # seconds, so no observation argues for any particular floor. No maximum is
+  # quoted deliberately: a superlative over a growing set goes stale on the next
+  # slower run. What the floor guards is a ceiling set low enough to cancel a
+  # cherry-pick much larger than anything seen yet; ten minutes is far above
+  # every leg measured. Per JOB, not per run, and not over the runner queue,
+  # which no `timeout-minutes` reaches.
+  for job in prepare backport; do
+    block="$(job_block "$job" "$BACKPORT" | code_lines)"
+    [ -n "$block" ]
+    minutes="$(printf '%s\n' "$block" | grep -o '^    timeout-minutes: [0-9][0-9]*' | grep -o '[0-9][0-9]*$')"
+    [ -n "$minutes" ]
+    [ "$minutes" -ge 10 ]
+    [ "$minutes" -le 30 ]
+  done
+}
+
+@test "each backport trigger reads only the labels it is entitled to" {
+  block="$(job_block prepare "$BACKPORT" | code_lines)"
+  [ -n "$block" ]
+
+  # The cumulative label set answers for the merge and for nothing else. Left
+  # ungated it re-enters this job on every later unrelated label — an automated
+  # size/* or kind/* — for a merged PR still carrying `backport`, redoing a
+  # backport that has already been delivered.
+  printf '%s\n' "$block" | grep -qF "(github.event.action == 'closed' && (contains(github.event.pull_request.labels.*.name, 'backport') || contains(github.event.pull_request.labels.*.name, 'backport-previous')))"
+
+  # And the guard reads that set exactly twice, both of them inside the gated
+  # disjunct above, so it cannot be joined by an ungated one that quietly
+  # restores the old behaviour while the assertion above stays green.
+  #
+  # Counted as OCCURRENCES, not lines. `grep -c` counts matching lines, and both
+  # reads live on one line here, so it answers 1 and keeps answering 1 when a
+  # third read is appended to that same line — which is exactly the restoration
+  # this is meant to catch. Only an append on a NEW line would have moved it.
+  count="$(printf '%s\n' "$block" | grep -o 'contains(github\.event\.pull_request\.labels' | wc -l | tr -d ' ')"
+  [ "${count:-0}" -eq 2 ]
+
+  # A label event answers for the label it carries.
+  printf '%s\n' "$block" | grep -qF "(github.event.action == 'labeled' && (github.event.label.name == 'backport' || github.event.label.name == 'backport-previous'))"
+
+  # The two conjuncts the label logic hangs off, which the label assertions above
+  # would not miss. `base.ref == 'main'` is what stops the bot backporting its own
+  # output: its PRs target release-X.Y, so they cannot satisfy it however often a
+  # labeler re-applies `backport` to a `[Backport release-X.Y]` title. docs/release.md
+  # calls that architectural protection, which is only true while the line is here.
+  # With their trailing conjunctions, for the reason the group-key test spells
+  # out: flipping either `&&` to `||` turns the guard into a disjunction that
+  # fires on every merge to main and on labels applied to open PRs. That one does
+  # not produce a wrong backport, because the `backport` job re-checks both
+  # independently, but it runs the job when nothing asked for it.
+  # In BOTH jobs, because docs/release.md rests the architectural protection on
+  # both `if:` blocks. Losing either copy alone is survivable (the other still
+  # skips, and `backport` needs `prepare`), so this pins a duplicate rather than
+  # a hole — but an untested duplicate is how a duplicate stops being one.
+  for job in prepare backport; do
+    b="$(job_block "$job" "$BACKPORT" | code_lines)"
+    [ -n "$b" ]
+    printf '%s\n' "$b" | grep -qF "github.event.pull_request.base.ref == 'main' &&"
+    printf '%s\n' "$b" | grep -qF 'github.event.pull_request.merged == true &&'
+  done
 }


### PR DESCRIPTION
## What this PR does

A run joins its concurrency group before any job-level `if` is evaluated, so `prepare`'s guard in `backport.yaml` is too late to help. By the time it works out that a label event is irrelevant, that run has already cancelled whatever was in flight for the same PR. Labels set with the default `GITHUB_TOKEN` start no run, which is why the in-repo labelers never showed this. Third-party GitHub Apps do start runs, and they arrive in bursts.

The delivery survived, which is why this went unnoticed for so long. The old guard admitted a run on the PR's cumulative label set, so the last label of a burst, the one nothing cancels, requalified and redid the work. In the bursts on record the kill lands within seconds of the merge run starting, well before the cherry-pick, so the cost was a restart rather than a lost backport, recorded as nothing more than a cancelled run sitting next to a green one.

Two changes to the concurrency key, and both are needed. A label event that requests no backport now goes into a group of its own, so it can neither cancel nor displace the run doing the work. A label event that does request one queues behind that run instead of killing it, because `backport` and `backport-previous` are separate requests and both have to finish. Splitting alone would let `backport` cancel the merge-triggered run. Queuing alone would let an unrelated label evict a pending request, since the group holds a single pending run and a newer one replaces it.

`prepare`'s condition is scoped in the same commit. It read the PR's cumulative label set, so once a merged PR carried `backport`, any later unrelated label re-entered the job to redo a backport already delivered. That run used to get cancelled by the next label in the burst. After the change above it runs to completion, so the scoping has to land here rather than as a follow-up.

The coupling runs the other way too, and it is the sharper half. That redundant run is exactly what redelivered the backport the burst had just killed, so narrowing the guard on its own would convert a noisy delivery into a missing one. Neither change is safe to land without the other.

Both jobs also gain a `timeout-minutes` ceiling, which is a consequence of the queuing rather than housekeeping. A cancelling key disposed of a stuck run by killing it; queuing makes the next genuine request wait behind it instead, on the six-hour job default, which turns one wedged job into a six-hour hole in the release line. That ceiling reaches a stuck job and nothing else: a run can also wedge at the run level with every job already finished, and `timeout-minutes` has no run-level equivalent, so nothing in the workflow reaches that state. `docs/release.md` now tells an operator to look for a run still in flight and clear it before re-applying the label, because the retry queues behind it rather than replacing it. The ceiling bounds execution, not the wait for a runner, and thirty minutes is generous rather than calculated. Execution on run 29844315422 was six seconds for `prepare` and two and sixteen for the matrix legs, against 9m24s, 5m28s and 5m45s of runner queue for the same three jobs. That queue is a third unbounded case: GitHub's limits page says "job execution time" for the six-hour job cap while spelling out that the 35-day run cap "includes execution duration, and time spent on waiting and approval", and [orgs/community#50926](https://github.com/orgs/community/discussions/50926) shows a job sitting six hours on "Waiting for a runner to pick up this job" under `timeout-minutes: 5`. So the value is picked to leave room for a cherry-pick far larger than any on record while replacing the six-hour default, and nothing here is sized against the queue, because nothing here can be.

This removes a mitigation, and the trade is worth naming on both sides. Under an unconditional cancel a run wedged at the run level cleared itself, because the next event killed whatever was sitting in the group. That is the same behaviour that killed live backports, so the mitigation is inseparable from the bug being fixed: keeping it means keeping label events that cancel a backport in flight. What it buys is a change of failure mode rather than one fewer failure. A backport lost silently, discovered weeks later as a fix missing from a release line, becomes a delay the operator can see in the run list, with the recovery written into `docs/release.md`. There is no lossless alternative here: `queue: max` removes the eviction but only by dropping the conditional cancel entirely, and the group key cannot tell a manual retry from a second genuine request.

The run cited above, 31232645133, is still live and retained on purpose: it is the only observed instance of the run-level wedge, so clearing it would remove the evidence for the paragraph that describes it. Its exposure is one pull request, #3262, which carries no backport label, so nothing is queued behind it.

The old condition also carried a disjunct that could never decide anything. A `labeled` payload already lists the new label in `pull_request.labels`, so `contains` was true whenever the explicit `github.event.label.name` check was, and the name check only ever agreed with a `contains` that had already matched. The restructure drops it by construction rather than by deletion: the name check is now the whole of what a `labeled` event may match on.

### Why this no longer touches `pull-requests.yaml`

`main` fixed it there by splitting the group key, then refined that so a `full-e2e` label stays in the main group instead of publishing a second `E2E Tests` status on one SHA. That is the better mechanism, it neither queues nor delays, and `gate-concurrency-contract.bats` now pins `cancel-in-progress: true` in that file, so what this PR originally did would turn it red. Nothing was left to add there, so the hunk is dropped and its pin with it. The split-key idea is applied in `backport.yaml` instead, where it did not exist.

One claim from the earlier description is withdrawn. It said the leftover risk was a duplicate backport PR, opened when the original had merged and its branch had been deleted before the queued run pushed. `main` has since gained a guard that lists closed PRs on the `backport-<n>-to-<target>` branch and skips the target when one of them merged. Branch deletion does not defeat it: `GET /branches/backport-3510-to-release-1.6` is 404 while the same head filter on `/pulls?state=closed` still returns the merged PR. So a redundant run only cost runner minutes, and the scoping above removes the run.

### Screenshots

Not applicable, no UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff. The only workflow it cites is `tags.yaml`, for the release-prep behaviour `cozystack/ccp` documents. Every `hack/` trigger it lists either names a specific file another repository mirrors or gates on, or covers moving and renaming under `hack/`. This PR appends tests to a contract file the map does not name, and moves nothing. No package, chart, values file, CRD, image reference, namespace, variant or node prerequisite in the diff.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(ci): stop `labeled` pull request events from cancelling the automatic backport run already in flight. A burst of labels from a third-party app could previously kill the backport the merge had just started, leaving the work to be redone by whichever label arrived last.
```
