### PR TITLE
fix(backups): clear useSystemBucket on Postgres in-place restore

### DIFF
--- a/internal/backupcontroller/cnpgstrategy_controller.go
+++ b/internal/backupcontroller/cnpgstrategy_controller.go
@@ -1102,6 +1102,12 @@ func buildPostgresAppRestorePatch(
 
 	patched.Spec.Backup.DestinationPath = sourceDestinationPath
 	patched.Spec.Backup.EndpointURL = sourceEndpointURL
+	// Clear useSystemBucket: an app created with backup.useSystemBucket=true
+	// keeps that flag server-side, which combined with the explicit
+	// coordinates written above trips the chart's `bootstrap.enabled +
+	// useSystemBucket` render guard, so bootstrap.recovery never renders and
+	// the restore can't converge (#3327).
+	patched.Spec.Backup.UseSystemBucket = false
 	// Switching to s3CredentialsSecret means inline keys must not survive
 	// on the CR .spec; otherwise tenants who switch credential modes leave
 	// cleartext keys behind in etcd and audit logs.

--- a/internal/backupcontroller/cnpgstrategy_controller_test.go
+++ b/internal/backupcontroller/cnpgstrategy_controller_test.go
@@ -548,6 +548,44 @@ func TestBuildPostgresAppRestorePatch_NoSecretRefIsSkipped(t *testing.T) {
 	}
 }
 
+// TestBuildPostgresAppRestorePatch_ClearsUseSystemBucket locks in the fix for
+// issue #3327. A target app created with the platform-recommended
+// backup.useSystemBucket=true cannot be restored in place: the driver writes
+// explicit backup coordinates and flips bootstrap.enabled=true, but if the
+// server-side useSystemBucket=true survives, the chart fails the render on its
+// `bootstrap.enabled + useSystemBucket` guard and the HelmRelease never
+// re-renders bootstrap.recovery, so the restore can never converge.
+//
+// The patch must (1) set the field to false on the struct AND (2) actually
+// carry that false into the JSON merge patch. Point (2) is the subtle half:
+// with `omitempty` the false zero-value is dropped from the marshalled patch,
+// the server's true is left untouched, and the bug reappears. Asserting on the
+// raw merge-patch bytes guards that specific regression.
+func TestBuildPostgresAppRestorePatch_ClearsUseSystemBucket(t *testing.T) {
+	app := newPostgresApp("pg", "tenant")
+	app.Spec.Backup.UseSystemBucket = true
+
+	creds := &strategyv1alpha1.S3CredentialsTemplate{
+		SecretRef: corev1.LocalObjectReference{Name: "creds"},
+	}
+	patched := buildPostgresAppRestorePatch(app, "src", "s3://b/", "https://s3", "", creds, nil, nil, nil)
+
+	if patched.Spec.Backup.UseSystemBucket {
+		t.Errorf("spec.backup.useSystemBucket must be cleared on restore; got true")
+	}
+
+	// The merge patch computed against the original (useSystemBucket=true) app
+	// must serialise the false so it overwrites the server value. If it does
+	// not appear here, the server keeps true and the chart guard wedges.
+	data, err := client.MergeFrom(app).Data(patched)
+	if err != nil {
+		t.Fatalf("computing merge patch: %v", err)
+	}
+	if !strings.Contains(string(data), `"useSystemBucket":false`) {
+		t.Errorf("merge patch must overwrite useSystemBucket with false; patch was: %s", data)
+	}
+}
+
 // TestCNPGPurgeNeeded locks in the dual-guard against re-purging the
 // freshly-recovered Cluster on a status-update failure. The controller used
 // to rely solely on a Status condition: if the post-purge Status().Update

--- a/internal/backupcontroller/postgresapp/types.go
+++ b/internal/backupcontroller/postgresapp/types.go
@@ -78,8 +78,12 @@ type Bootstrap struct {
 }
 
 type Backup struct {
-	DestinationPath     string              `json:"destinationPath,omitempty"`
-	EndpointURL         string              `json:"endpointURL,omitempty"`
+	DestinationPath string `json:"destinationPath,omitempty"`
+	EndpointURL     string `json:"endpointURL,omitempty"`
+	// Omits `omitempty` on purpose: restore must overwrite a server-side
+	// `true` with false, but a JSON merge patch drops omitempty zero-values,
+	// so the false has to be serialised to win (#3327).
+	UseSystemBucket     bool                `json:"useSystemBucket"`
 	S3AccessKey         string              `json:"s3AccessKey,omitempty"`
 	S3SecretKey         string              `json:"s3SecretKey,omitempty"`
 	S3CredentialsSecret S3CredentialsSecret `json:"s3CredentialsSecret,omitempty"`


### PR DESCRIPTION
## What this PR does

Fixes #3327.

A Postgres app created with the platform-recommended `backup.useSystemBucket=true`
flow **cannot be restored in place** on `main`. The failure is by construction:

1. The CNPG restore driver (`buildPostgresAppRestorePatch`) writes explicit backup
   coordinates onto the target CR (`destinationPath` / `endpointURL` /
   `s3CredentialsSecret` / `endpointCA`) and flips `bootstrap.enabled=true` — i.e.
   it converts the app to the explicit-coordinates (legacy) backup flow, which is
   exactly what the chart's `bootstrap.recovery` + `externalClusters` block needs.
2. But the driver never cleared the server-side `backup.useSystemBucket=true`. The
   partial `postgresapp.Backup` struct had no such field, so the JSON merge patch
   left it untouched.
3. On the next render the chart trips its own guard
   (`bootstrap.enabled=true is incompatible with backup.useSystemBucket=true`,
   `packages/apps/postgres/templates/db.yaml`). The HelmRelease drops into a
   permanent render-error, `bootstrap.recovery` never renders, and the RestoreJob
   can never converge — precisely the "cannot converge" symptom in the issue.

**Fix:** clear `backup.useSystemBucket` in the restore patch so the chart receives a
self-consistent value set (explicit coordinates, no system-bucket flag, recovery on).
The new `postgresapp.Backup.UseSystemBucket` field intentionally omits `omitempty`:
otherwise the `false` zero-value is dropped from the merge patch, the server's `true`
survives, and the bug persists. The chart guard is left in place — it is still correct
defensive behavior for a genuinely broken combo; this change stops the driver from
producing that combo.

### Verification

- Unit tests: new `TestBuildPostgresAppRestorePatch_ClearsUseSystemBucket` asserts both
  the struct flip **and** that the raw merge patch serializes `"useSystemBucket":false`
  (guards the `omitempty` regression directly). Full `internal/backupcontroller`
  package green; `go vet` clean.
- `helm template` of `packages/apps/postgres` with the exact values the driver now
  produces (`bootstrap.enabled=true`, `useSystemBucket=false`, explicit coords):
  - **before / bug** (`useSystemBucket=true`) → render fails on the guard at
    `db.yaml:150`.
  - **after / fixed** (`useSystemBucket=false`) → renders the full recovery topology:
    `bootstrap.recovery.source`, `externalClusters` → `-recovery` ObjectStore, plus the
    ongoing backup ObjectStore.

### Screenshots

n/a — controller-internal change, no UI.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` file-by-file against the diff.
The change touches only `internal/backupcontroller/` (the CNPG restore driver and its
partial mirror struct) — no CRD (`Package`/`Plan`/`RestoreJob` are untouched), no chart
values (`useSystemBucket` already exists in the postgres chart), no annotation and no
telemetry metric. Nothing downstream is affected.

- [x] No downstream repository is affected by this change

### Release note

```release-note
fix(backups): a Postgres application using the platform `backup.useSystemBucket=true` flow can now be restored in place — the CNPG restore driver clears `useSystemBucket` so the chart's bootstrap guard no longer wedges the HelmRelease in a permanent render error.
```
