### PR TITLE
feat(ci): auto-apply triage labels to issues

### DIFF
--- a/.github/workflows/issue-triage.yaml
+++ b/.github/workflows/issue-triage.yaml
@@ -1,0 +1,325 @@
+name: Issue triage
+
+# Every open issue should carry a triage/* label marking its lifecycle stage.
+# The issue templates apply `triage/needs-triage` from their front matter, but
+# that only covers issues created through the web form: issues created via
+# the API or `gh issue create` bypass templates and arrive unlabeled. The
+# `issues` events below label those on arrival; the daily sweep is the
+# backstop for removed labels and for the pre-existing backlog.
+on:
+  issues:
+    types: [opened, reopened]
+  schedule:
+    - cron: '53 5 * * *'  # daily at 05:53 UTC, after stale (04:37)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log what would be labeled without applying'
+        type: boolean
+        # On by default, so the one entry point a human can reach writes
+        # nothing until somebody unchecks it. The scheduled sweep reads no
+        # inputs and is unaffected: it writes.
+        default: true
+
+# Top-level token defaults to read-only. A job-level block replaces this one
+# rather than adding to it, so the job below holds `issues: write` and
+# nothing else.
+permissions:
+  contents: read
+
+# One queue for every run of this workflow, on purpose. GitHub keeps a
+# single pending run per group, so issues filed while a sweep is running
+# lose all but the last of their own runs and wait for the next sweep,
+# which is what the sweep is there for. Splitting the group per issue would
+# save that wait at the price of a real bug: a sweep works from a listing
+# taken when it started, so it and a concurrent per-issue run can read the
+# same issue differently and leave it holding two contradictory triage
+# labels, which nothing later removes.
+#
+# The queue closes that door against a second run of this workflow, not
+# against a maintainer labeling an issue by hand while a sweep is running:
+# the sweep classifies from the listing it took when it started, so a label
+# applied during its paced writes is invisible to it and the issue ends up
+# carrying a second triage label that the already-triaged skip then keeps
+# every later sweep from revisiting. Losing that race costs the spurious
+# `triage/needs-triage`, which a maintainer deletes and no later sweep
+# re-adds, because the label it raced against is still on the issue. That
+# was judged cheaper than re-reading every issue immediately before every
+# write: that would double the request budget the write cap below is derived
+# against. Deleting is the repair for this one case and not a general undo:
+# an issue left carrying no triage label at all is relabeled by the next
+# sweep, which is what AGENTS.md's labeling bullet warns about.
+concurrency:
+  group: issue-triage
+  cancel-in-progress: false
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    # A run that reaches the write cap paces roughly seven minutes of work, so
+    # anything near this ceiling is a call that hung rather than a long sweep.
+    # Without it the default is six hours, and the queue above means one hung
+    # run holds every issue filed behind it for all six.
+    timeout-minutes: 20
+    permissions:
+      issues: write
+    steps:
+      - name: Apply triage labels
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            // Labels applied with the workflow's GITHUB_TOKEN do not trigger
+            // other workflows (GitHub's recursion prevention), so this job
+            // cannot re-enter itself or wake any `labeled`-subscribed workflow.
+            //
+            // Adding a label bumps the issue's `updated_at`, which stale.yaml
+            // reads as fresh activity: the stale bot un-marks `lifecycle/stale`
+            // and restarts its 60-day clock on the next run. For issues labeled
+            // on arrival that is moot; for the sweep over the historical
+            // backlog it is a deliberate one-time reset. Triage first, then
+            // let staleness take its course.
+            //
+            // `triage/accepted` is also on stale.yaml's exempt-issue-labels,
+            // so applying it is more than a clock reset: the issue stops
+            // being auto-closable at all. For every label in
+            // ACCEPTED_SIGNAL_LABELS that changes nothing, because each one
+            // is on the same exempt list already. An assignee is the single
+            // signal that is not a label and not already exempt, so an issue
+            // whose only accepted-signal is an assignee gains something it
+            // did not have. That is new, and it is the
+            // intended reading rather than a side effect: somebody took
+            // ownership, which makes the issue a known long-tail task and
+            // not an abandoned one — the same argument stale.yaml's own
+            // comment makes for exempting `triage/accepted`. Part of the
+            // backlog this reaches is marked stale today, some of it inside
+            // the 14-day close window, and the sweep spares it.
+            const NEEDS_TRIAGE = 'triage/needs-triage';
+            const ACCEPTED = 'triage/accepted';
+
+            // Label-shaped accepted-signals, admitted on two conditions.
+            // Necessary: the label is on stale.yaml's exempt-issue-labels,
+            // because `triage/accepted` is itself exempt and awarding it for
+            // a label that is not would hand the issue a permanent reprieve
+            // as a side effect — which is why `priority/backlog`, the tier
+            // stale.yaml leaves reapable, is not a signal. Not sufficient:
+            // a `lifecycle/*` label states what the stale bot may do and
+            // nothing about whether anyone reviewed the issue, so exempt
+            // `lifecycle/frozen` is still not a signal here. Freezing an
+            // untriaged issue to keep the bot off it is exactly the case
+            // where that inference would be false.
+            const ACCEPTED_SIGNAL_LABELS = [
+              'priority/critical-urgent',
+              'priority/important-soon',
+              'priority/important-longterm',
+              'epic',
+            ];
+
+            // The sweep is the only place this workflow writes in bulk, and
+            // GitHub's secondary rate limits allow 80 content-generating
+            // requests a minute and 500 an hour. This client has no
+            // throttling plugin and no retries, and a throttled write
+            // answers 403, which is exempt from retry anyway: an unpaced
+            // sweep does not slow down when it is throttled, it fails the
+            // job and leaves the backlog half labeled. Pace the writes
+            // under the per-minute ceiling, and stop short of the hourly
+            // one instead of walking into it. Whatever a run leaves behind
+            // stays unlabeled, so the next one picks it up.
+            //
+            // Those are the secondary limits. GITHUB_TOKEN also carries a
+            // primary one of 1000 requests an hour for the whole repository,
+            // shared with every other workflow, and a run that reaches the
+            // cap spends a large part of it. That is affordable at 05:53 and
+            // only while the backlog drains, but it is the ceiling to lower
+            // the cap against if this ever moves to a busier slot.
+            const WRITE_INTERVAL_MS = 1000;
+            const MAX_WRITES_PER_RUN = 400;
+            const sleep = (ms) =>
+              new Promise((resolve) => setTimeout(resolve, ms));
+
+            // Returns the label to add, or null when the item needs nothing.
+            // The signals stand for a maintainer decision already recorded on
+            // the issue, a weaker claim than the one `triage/accepted` makes
+            // in .github/labels.yml: `priority/important-longterm` says
+            // outright the work may not be staffed. Of the two labels this
+            // workflow writes it is still the closer one — `needs-triage` on
+            // an issue somebody prioritised or took asks for a triage that
+            // already happened — and a maintainer who disagrees replaces it.
+            const classify = (issue) => {
+              if (issue.pull_request) return null; // listForRepo returns PRs too
+              const labels = (issue.labels || []).map((l) =>
+                typeof l === 'string' ? l : l.name
+              );
+              if (labels.some((n) => n.startsWith('triage/'))) return null;
+              const looked = // somebody has already looked at this one
+                (issue.assignees || []).length > 0 ||
+                labels.some((n) => ACCEPTED_SIGNAL_LABELS.includes(n));
+              return looked ? ACCEPTED : NEEDS_TRIAGE;
+            };
+
+            const apply = async (issue, label, dryRun) => {
+              if (dryRun) {
+                core.info(`[dry-run] #${issue.number}: would add ${label}`);
+                return;
+              }
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: [label],
+              });
+              core.info(`#${issue.number}: added ${label}`);
+            };
+
+            if (context.eventName === 'issues') {
+              const issue = context.payload.issue;
+              const label = classify(issue);
+              if (label) {
+                await apply(issue, label, false);
+              } else {
+                core.info(`#${issue.number}: already triaged, nothing to do`);
+              }
+              return;
+            }
+
+            // schedule / workflow_dispatch: sweep every open issue.
+            // workflow_dispatch inputs arrive as strings in the webhook
+            // payload even when declared `type: boolean`.
+            //
+            // Keyed on the event rather than on the input alone, so both
+            // unknown cases fail safe: `schedule` is the one event that
+            // writes without being asked, so any trigger added here later
+            // starts out dry rather than writing on its first run, and a
+            // dispatch sending anything but the literal `false` gets a dry
+            // run. The declared default above is what a human sees in the
+            // form; this does not depend on it reaching the payload.
+            const dryRun =
+              context.eventName !== 'schedule' &&
+              String(context.payload.inputs?.dry_run ?? 'true') !== 'false';
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const acceptedIssues = [];
+            const needsTriageIssues = [];
+            let skipped = 0;
+            let deferred = 0;
+            let failed = 0;
+            let refused = 0;
+            let writes = 0;
+            // Listing index a refusal stopped the run on. The remainder it
+            // yields is counted in listing entries, not in issues left
+            // needing a label — most of any remainder is pull requests and
+            // already-triaged issues the loop would have skipped. It is
+            // reported so that a run which stopped early cannot read as one
+            // that reached the end of the listing; `deferred` is the write
+            // cap's own remainder and does not cover this.
+            let stoppedAt = -1;
+            for (const [index, issue] of issues.entries()) {
+              const label = classify(issue);
+              if (!label) {
+                skipped += 1;
+                continue;
+              }
+              // The cap counts in dry-run too, so a dry run predicts what a
+              // real one would do rather than a longer list nobody gets.
+              if (writes >= MAX_WRITES_PER_RUN) {
+                deferred += 1;
+                continue;
+              }
+              if (writes > 0 && !dryRun) {
+                await sleep(WRITE_INTERVAL_MS);
+              }
+              writes += 1;
+              try {
+                await apply(issue, label, dryRun);
+              } catch (err) {
+                // 403 is what a secondary rate limit and a token without
+                // `issues: write` both answer; 429 is the other throttle
+                // shape. Those two are the only statuses that stop the run.
+                // Every other status carries on, and that is the whole of
+                // the else: the 404 or 410 of an issue transferred or
+                // deleted mid-sweep, but a 422 or a 5xx just the same,
+                // because a failure about one issue says nothing about the
+                // next one and the next sweep retries it. A refusal is the
+                // opposite kind: it applies to every write left in the run,
+                // and repeating a rejected request up to the cap is what
+                // gets an integration banned, so stop at the first one. The
+                // remainder stays unlabeled and the next run takes it,
+                // exactly like the write cap's own deferral.
+                if (err.status === 403 || err.status === 429) {
+                  refused += 1;
+                  stoppedAt = index;
+                  core.warning(
+                    `#${issue.number}: ${label} refused ` +
+                      `(${err.status}); stopping the sweep`
+                  );
+                  break;
+                }
+                // One issue that cannot be labeled, because it was moved or
+                // deleted mid-sweep, must not cost the run the rest of the
+                // backlog and the summary with it. It stays unlabeled, so
+                // the next run picks it up like any other. Counted below the
+                // refusal branch rather than above it, so that one refusal
+                // reports as one problem instead of also inflating the
+                // failed count it is already reported by.
+                failed += 1;
+                core.warning(`#${issue.number}: ${label} failed: ${err.message}`);
+                continue;
+              }
+              if (label === ACCEPTED) {
+                acceptedIssues.push(issue.number);
+              } else {
+                needsTriageIssues.push(issue.number);
+              }
+            }
+
+            // A sweep over the backlog logs one line per issue, which is a
+            // page nobody reads to find out what a run did. Every row is
+            // printed whether or not it is zero: a table that hides its empty
+            // rows makes "no writes failed" and "the count was never taken"
+            // look alike.
+            const unexamined =
+              stoppedAt < 0 ? 0 : issues.length - 1 - stoppedAt;
+            const numbers = (ns) =>
+              ns.length ? ns.map((n) => `#${n}`).join(', ') : 'none';
+            const report = [
+              `## Issue triage${dryRun ? ' — dry run, nothing written' : ''}`,
+              '',
+              '| outcome | issues |',
+              '| --- | --- |',
+              `| \`${ACCEPTED}\` | ${acceptedIssues.length} |`,
+              `| \`${NEEDS_TRIAGE}\` | ${needsTriageIssues.length} |`,
+              `| already triaged, or a pull request | ${skipped} |`,
+              `| deferred, this run hit its write cap of ${MAX_WRITES_PER_RUN} | ${deferred} |`,
+              `| write failed, left for the next run | ${failed} |`,
+              `| write refused, which stopped the sweep | ${refused} |`,
+              `| listing entries never reached, the sweep stopped at a refusal | ${unexamined} |`,
+              '',
+              `\`${ACCEPTED}\`: ${numbers(acceptedIssues)}`,
+              '',
+              `\`${NEEDS_TRIAGE}\`: ${numbers(needsTriageIssues)}`,
+              '',
+            ].join('\n');
+            core.info(report);
+            // `write()` is async: unawaited, the step can end green with an
+            // empty summary panel. `addRaw` appends no newline of its own.
+            await core.summary.addRaw(report).write();
+            // An issue that vanished mid-sweep is benign however many times
+            // it happens, and the next run simply does not see it. A refusal
+            // is not benign even once: it means the token lost `issues:
+            // write`, or the pacing above stopped being enough and the sweep
+            // is into the secondary rate limit. Discriminating on the status
+            // rather than on a count keeps the alarm live once the backlog is
+            // drained and a run writes to a handful of issues at most, which
+            // is the regime this workflow spends almost all of its life in.
+            if (refused > 0) {
+              core.setFailed(
+                `A label write was refused after ${writes} attempted, so ` +
+                  `the sweep stopped early; check the job's issues: write ` +
+                  `permission and the log for rate-limit responses`
+              );
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ This file provides structured guidance for AI coding assistants and agents worki
 - **Issue and PR labeling, triage** (e.g., "label this issue", "what label should I use", "triage this", "categorize")
   - Read: [`.github/labels.yml`](./.github/labels.yml)
   - Action: Use labels defined there. Conventions follow the Kubernetes scheme — `kind/*` (type), `area/*` (subsystem), `priority/*` (urgency), `triage/*` (review state), `lifecycle/*` (auto-close), `do-not-merge/*` (PR blockers), `security/*` (severity)
+  - For `triage/*`: `.github/workflows/issue-triage.yaml` labels an issue on arrival and sweeps daily for any open issue carrying none, so change a triage decision by replacing the label rather than removing it — remove the only `triage/*` label an issue has and the next sweep puts one back
   - For `area/*`: accuracy outweighs reuse. If no existing `area/*` truly fits the change, propose a new one via PR (extend `.github/labels.yml` and the scope mapping in `.github/workflows/pr-labeler.yaml`) — do not shoehorn the change into a wrong area. `area/uncategorized` is the auto-labeler fallback; treat it as a signal to pick a fit, create a new area, or correct the PR title
   - PR titles: a Conventional Commits header (`type(scope): description`, types from [`contributing.md`](./docs/agents/contributing.md)) auto-applies `kind/*` and `area/*` via `.github/workflows/pr-labeler.yaml`. Append `!` (or add a `BREAKING CHANGE:` footer) to apply `kind/breaking-change`
 

--- a/hack/issue-triage-contract.bats
+++ b/hack/issue-triage-contract.bats
@@ -1,0 +1,431 @@
+#!/usr/bin/env bats
+
+# Contract for the issue triage labeler. Like promote-gate-contract.bats and
+# release-freeze-contract.bats, these tests pin executable/structural workflow
+# lines rather than prose: a guard demoted to a comment must never satisfy the
+# contract. The workflow's own comments name every API and constant asserted
+# below, so the JS block is filtered on `//` as well as `#`.
+#
+# No PR lane can exercise this workflow. It runs on `issues`, on a daily cron
+# and on workflow_dispatch, so the first real execution is a sweep over every
+# open issue in the repository, writing a label to each. The lines pinned here
+# are the ones that bound that blast radius: the skip that keeps pull requests
+# out of it, the skip that keeps an already-triaged issue out of it, the pacing
+# and the per-run cap that keep the sweep inside GitHub's secondary rate limits,
+# the pinned action, and the token scopes. Each is a single deletion away from a
+# repository-wide mess that nothing reports — drop the pull-request skip and
+# every open PR is told it needs triage; drop the pacing and the sweep is
+# throttled and dies half done.
+#
+# The rate-limit tests assert the invariant (stay under GitHub's published
+# ceilings) rather than today's constants, so tuning the pacing within the safe
+# band does not need a test edit, while leaving it does go red.
+#
+# Known ceiling of the approach: these are structural greps, so they prove a
+# guard is present and executable, not that it is reachable. Wrapping the block
+# around a guard in `if (false)` satisfies every pin here, because each matches
+# the guard's own line and nothing above it; editing the pinned line itself does
+# not, so `if (false && issue.pull_request)` goes red. Behavioural coverage of the script
+# would need a JS runtime, and `checks` runs where none is guaranteed, so a
+# harness would go silently green wherever node is missing.
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
+WF="$REPO_ROOT/.github/workflows/issue-triage.yaml"
+STALE="$REPO_ROOT/.github/workflows/stale.yaml"
+LABELS="$REPO_ROOT/.github/labels.yml"
+
+# GitHub's documented secondary rate limits for content-generating requests.
+# https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+WRITES_PER_MINUTE=80
+WRITES_PER_HOUR=500
+
+# Strip YAML comments. POSIX `grep` only: the unit-test runner has no ripgrep.
+# grep exits 1 when nothing is selected (legitimate for an all-comment block)
+# and 2 on a real error. Do not read the `rc` check below as what catches that,
+# here or in script_lines: neither helper is ever the last stage of a pipeline
+# in this file, so ordinary (non-pipefail) pipe semantics discard whatever it
+# returns, and `hack/cozytest.sh`'s translator appends `return 0` to every line
+# that is exactly `}`, both helpers' closing braces included. What catches a
+# real grep error is the OUTPUT, and only for one class of pin: the error
+# empties the stream, so a pin requiring something to be present in it fails on
+# that. A pin demanding an absence stays blind, because an emptied stream
+# produces the same count of zero the pin was written to assert. The
+# `[ -n "$block" ]` guard at the top of a test is not that check either: it
+# runs on the raw awk extraction, upstream of both helpers, and cannot see
+# either of them fail.
+code_lines() {
+  local rc=0
+  grep -v '^[[:space:]]*#' || rc=$?
+  [ "$rc" -le 1 ]
+}
+
+# Strip JavaScript comments. The labeling logic lives in a github-script
+# `script: |` block whose comments discuss the pull_request skip, the cap and
+# the pacing by name, so filtering on `#` alone would let a comment satisfy a
+# pin.
+script_lines() {
+  local rc=0
+  grep -v '^[[:space:]]*//' || rc=$?
+  [ "$rc" -le 1 ]
+}
+
+# Body of one job, up to the next top-level job key.
+job_block() {
+  awk -v job="  $1:" '
+    $0 == job { inside = 1; next }
+    /^  [a-z0-9_-]+:$/ { inside = 0 }
+    inside' "$2"
+}
+
+# Integer on the right of the first `=` on the first matching line. Callers
+# assert the plain-literal form first, because this strips non-digits rather
+# than evaluating: `= 60 * 1000;` would read as 601000 and quietly satisfy a
+# bound it never computed.
+number_after_eq() {
+  awk -F'=' 'NR == 1 { gsub(/[^0-9]/, "", $2); print $2 }'
+}
+
+# The declaration this file can read: one integer literal, no arithmetic.
+literal_const() { # <name> <block>
+  printf '%s\n' "$2" | script_lines | grep -qE "const $1 = [0-9]+;[[:space:]]*$"
+}
+
+# The accepted-signal list, one label per line.
+signal_labels() {
+  script_lines < "$WF" |
+    awk '/const ACCEPTED_SIGNAL_LABELS = \[/ { inside = 1; next } /\];/ { inside = 0 } inside' |
+    sed -n "s/^[[:space:]]*'\([^']*\)'.*/\1/p"
+}
+
+# Minutes past midnight for a 5-field cron, from its first two fields.
+cron_minutes() {
+  sed "s/^[^']*'//; s/'.*$//" | awk 'NR == 1 { print $2 * 60 + $1 }'
+}
+
+@test "the workflow under contract exists" {
+  [ -f "$WF" ]
+}
+
+# ── what the sweep must not touch ────────────────────────────────────────────
+# listForRepo returns pull requests alongside issues, and the sweep re-reads
+# every open issue every day. Both skips below are the difference between a
+# no-op pass and a repository-wide mislabeling that no run reports as an error.
+
+@test "pull requests are skipped by the classifier" {
+  block="$(job_block triage "$WF")"
+  [ -n "$block" ]
+
+  # Losing this tells every open pull request it needs triage, on the first
+  # sweep, with a green job.
+  printf '%s\n' "$block" | script_lines | grep -qF 'if (issue.pull_request) return null'
+}
+
+@test "an issue that already carries a triage label is left alone" {
+  block="$(job_block triage "$WF")"
+  [ -n "$block" ]
+
+  # The sweep is additive and never removes a label, so without this skip a
+  # daily pass re-adds a second, contradictory triage/* label to issues a
+  # maintainer has already classified.
+  printf '%s\n' "$block" | script_lines | grep -qF "labels.some((n) => n.startsWith('triage/'))"
+}
+
+# ── staying inside GitHub's secondary rate limits ────────────────────────────
+# The sweep is the only bulk writer in the tree. The action's client carries no
+# throttling plugin, its retry default is off, and a throttled write answers
+# 403, which is exempt from retry anyway: an unpaced sweep does not slow down
+# when it is throttled, it fails the job partway and leaves the backlog half
+# labeled.
+
+@test "writes are paced under the per-minute ceiling" {
+  block="$(job_block triage "$WF")"
+  [ -n "$block" ]
+
+  # The wait has to be executed, not merely declared.
+  printf '%s\n' "$block" | script_lines | grep -qF 'await sleep(WRITE_INTERVAL_MS)'
+
+  literal_const WRITE_INTERVAL_MS "$block"
+  interval="$(printf '%s\n' "$block" | script_lines | grep -F 'const WRITE_INTERVAL_MS' | number_after_eq)"
+  [ -n "$interval" ]
+  [ "$interval" -gt 0 ]
+
+  # 60000 / interval is the resulting writes-per-minute. Strictly under, for
+  # the same reason the hourly cap below is: the event-driven writes share this
+  # ceiling, so a sweep sized exactly to it leaves them nothing.
+  rate="$(awk -v i="$interval" 'BEGIN { print int(60000 / i) }')"
+  [ "$rate" -lt "$WRITES_PER_MINUTE" ]
+}
+
+@test "a single run cannot exceed the hourly ceiling" {
+  block="$(job_block triage "$WF")"
+  [ -n "$block" ]
+
+  # The cap has to gate the loop, not just exist as a constant.
+  printf '%s\n' "$block" | script_lines | grep -qF 'if (writes >= MAX_WRITES_PER_RUN)'
+
+  literal_const MAX_WRITES_PER_RUN "$block"
+  cap="$(printf '%s\n' "$block" | script_lines | grep -F 'const MAX_WRITES_PER_RUN' | number_after_eq)"
+  [ -n "$cap" ]
+  [ "$cap" -gt 0 ]
+  # Strictly under: a run sized exactly to the ceiling leaves no room for the
+  # event-driven writes that share the same hourly budget.
+  [ "$cap" -lt "$WRITES_PER_HOUR" ]
+}
+
+@test "a hung run cannot hold the queue for the default six hours" {
+  block="$(job_block triage "$WF")"
+  [ -n "$block" ]
+
+  # Every run of this workflow shares one concurrency group, so a call that
+  # hangs blocks each issue filed behind it until the job times out. A capped
+  # run paces roughly seven minutes, so the bound is generous and still far
+  # under the 360-minute default.
+  minutes="$(printf '%s\n' "$block" | code_lines | grep -F 'timeout-minutes:' | awk -F: 'NR == 1 { gsub(/[^0-9]/, "", $2); print $2 }')"
+  [ -n "$minutes" ]
+  [ "$minutes" -gt 0 ]
+  [ "$minutes" -lt 60 ]
+}
+
+@test "the manual entry point defaults to dry-run" {
+  # Bounded by indentation: nothing below the input is a key at this level, so
+  # a stop condition matching the next sibling key would run to end of file and
+  # call the rest of the workflow part of the block.
+  block="$(code_lines < "$WF" | awk '
+    /^      dry_run:$/ { inside = 1; next }
+    inside && !/^        / { exit }
+    inside')"
+  [ -n "$block" ]
+
+  # workflow_dispatch is the only way a human starts a repository-wide write,
+  # and this is the whole of what stands between clicking Run and one. Every
+  # other guard of that class is pinned above; this one is a single word away
+  # from writing to every open issue on the first click, which is exactly the
+  # shape the rest of this file exists to catch.
+  default="$(printf '%s\n' "$block" | awk '/^[[:space:]]*default:/ { print $2; exit }')"
+  [ "$default" = "true" ]
+
+  # The declared default is what the form shows. It is deliberately not what
+  # makes this safe: the derivation keys on the event and treats an absent or
+  # unrecognised input as a dry run, which is why it is pinned separately.
+  # Pinning only the default would leave `const dryRun = false;` green.
+  wf="$(job_block triage "$WF")"
+  printf '%s\n' "$wf" | script_lines | grep -qF "context.eventName !== 'schedule' &&"
+  printf '%s\n' "$wf" | script_lines | grep -qF "String(context.payload.inputs?.dry_run ?? 'true') !== 'false'"
+}
+
+@test "a failed write neither aborts the sweep nor passes unnoticed" {
+  block="$(job_block triage "$WF")"
+  [ -n "$block" ]
+
+  # Without the catch, one issue transferred or deleted mid-sweep costs the run
+  # the rest of the backlog and its summary line with it.
+  printf '%s\n' "$block" | script_lines | grep -qF 'catch (err)'
+
+  # A refusal is the other kind of failure and wants the opposite reaction: 403
+  # is what both a lost `issues: write` and the secondary rate limit answer, 429
+  # is the other throttle shape. The status is what separates them from the
+  # benign 404 of a vanished issue, so the discrimination has to be on status.
+  printf '%s\n' "$block" | script_lines | grep -qE "err\.status === 403.*err\.status === 429|err\.status === 429.*err\.status === 403"
+
+  # And one refusal has to be enough to go red. Counting instead would make the
+  # alarm dead in the regime the sweep lives in once the backlog is drained,
+  # where a whole run writes to only a handful of issues.
+  printf '%s\n' "$block" | script_lines | grep -qF 'if (refused > 0)'
+  printf '%s\n' "$block" | script_lines | grep -qF 'core.setFailed'
+
+  # And the run has to stop at the first refusal rather than carry on. A
+  # refusal applies to every write left, so continuing repeats a rejected
+  # request up to the cap, which is what gets an integration banned and what
+  # burns the repository's hourly budget on a permission regression.
+  # -A10 rather than -A5: the warning between the two is prose and gains a
+  # line whenever it is reworded, which would fail this on a no-op edit.
+  printf '%s\n' "$block" | script_lines | grep -A10 -F 'refused += 1;' | grep -qF 'break;'
+}
+
+@test "the sweep reports what it did in a job summary" {
+  block="$(job_block triage "$WF")"
+  [ -n "$block" ]
+
+  # A sweep over the backlog logs a line per issue, so the summary is the only
+  # place a reader gets the outcome without paging through it. `write()` is
+  # async: unawaited, the promise can go unflushed and the step ends green with
+  # an empty panel, which is indistinguishable from a run that did nothing.
+  printf '%s\n' "$block" | script_lines | grep -qF 'await core.summary'
+  printf '%s\n' "$block" | script_lines | grep -qF '.write();'
+
+  # Every outcome a run can end on has to reach it, at zero as much as at ten:
+  # reporting the writes and dropping the rest is what makes a run that stopped
+  # early read as one that got to the end. The refusal itself is pinned by the
+  # failure test above; what is pinned here is that the table accounts for it,
+  # because otherwise the rows silently fail to sum to the listing.
+  printf '%s\n' "$block" | script_lines | grep -qF '${deferred}'
+  printf '%s\n' "$block" | script_lines | grep -qF '${unexamined}'
+  printf '%s\n' "$block" | script_lines | grep -qF '${refused}'
+}
+
+# ── supply chain and token scope ─────────────────────────────────────────────
+
+@test "every action is pinned to a digest" {
+  # zizmor gates this tree-wide, but this file is the one that fails on the
+  # workflow that has issues: write, so it pins its own.
+  # Asserted as "every `uses:` is a digest" rather than "no tag matches a
+  # tag-shaped pattern", because every such pattern has a gap: `@main` is
+  # neither `@v7` nor `@1.2.3`, and a branch is the most mutable of the three.
+  # Counting digests rather than naming the one action keeps a second, properly
+  # pinned step from going red for no reason. A repo-local `./.github/actions/`
+  # step would need an exemption here; it is not the same class of risk.
+  total="$(code_lines < "$WF" | grep -cE '^[[:space:]]*(-[[:space:]]*)?uses:' || true)"
+  pinned="$(code_lines < "$WF" | grep -cE '^[[:space:]]*(-[[:space:]]*)?uses:.*@[0-9a-f]{40}([[:space:]]|$)' || true)"
+  [ "${total:-0}" -gt 0 ]
+  [ "${total:-0}" -eq "${pinned:-0}" ]
+}
+
+@test "the token is read-only except for one job that writes issues" {
+  # A job-level block replaces the top-level one rather than extending it, so
+  # the two assertions below are the whole permission surface.
+  code_lines < "$WF" | grep -qF 'contents: read'
+
+  # Anchored to the YAML key, not matched as a substring. `code_lines` strips
+  # `#` comments only, and `issues: write` also appears inside the script block
+  # in a `//` comment and in a `core.setFailed` string, so a substring match is
+  # satisfied by prose and stays green when the job's one scope is swapped for
+  # `contents: write`. The count below does not catch that either: the swapped
+  # line is still exactly one `write`.
+  printf '%s\n' "$(job_block triage "$WF")" | code_lines |
+    grep -qE '^[[:space:]]+issues:[[:space:]]*write[[:space:]]*(#.*)?$'
+
+  # Nothing else is writable. This is what keeps a labeling workflow from
+  # quietly acquiring contents: write or pull-requests: write later. The
+  # trailing-comment form is matched too, because a permission gets added
+  # with its justification on the same line, which is exactly the shape an
+  # assertion anchored at `write$` would wave through.
+  count="$(code_lines < "$WF" | grep -cE '^[[:space:]]+[a-z-]+:[[:space:]]*write[[:space:]]*(#.*)?$' || true)"
+  [ "${count:-0}" -eq 1 ]
+}
+
+# ── interaction with the rest of the tree ────────────────────────────────────
+
+@test "runs are serialised and never cancelled" {
+  # A sweep works from a listing taken when it started. Letting a second run
+  # overlap it lets the two read the same issue differently and leave it
+  # holding two contradictory labels; cancelling one mid-sweep leaves the
+  # backlog half labeled with a green-looking cancelled run.
+  block="$(code_lines < "$WF" | awk '/^concurrency:/ { inside = 1; next } /^[a-z]/ { inside = 0 } inside')"
+  [ -n "$block" ]
+  printf '%s\n' "$block" | grep -qF 'cancel-in-progress: false'
+}
+
+@test "no accepted-signal label widens the stale exemption set" {
+  [ -f "$STALE" ]
+
+  # `triage/accepted` is itself on exempt-issue-labels, so awarding it for a
+  # label that is NOT on that list quietly grants a permanent reprieve the
+  # stale policy withheld — which is what treating every `priority/*` tier as
+  # a signal did, `priority/backlog` being the tier stale.yaml leaves reapable.
+  # An assignee is deliberately not covered here: it is not a label, and its
+  # exemption is the one the workflow argues for out loud.
+  exempt="$(awk '
+    /^[[:space:]]*exempt-issue-labels:/ { inside = 1; next }
+    /^[[:space:]]*[a-z-]+:/ { inside = 0 }
+    inside' "$STALE")"
+  [ -n "$exempt" ]
+
+  # One entry per line, so the containment check below can be exact. The value
+  # is a folded scalar: comma-separated entries wrapped across several indented
+  # lines, each line carrying a trailing comma. Matching a signal label as a
+  # substring of that block would pass one that is merely a prefix of an exempt
+  # entry — `priority/important` against `priority/important-soon` — and that
+  # prefix is a label the stale policy never exempted.
+  exempt_labels="$(printf '%s\n' "$exempt" | tr ',' '\n' |
+    sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '^$')"
+  [ -n "$exempt_labels" ]
+
+  signals="$(signal_labels)"
+
+  # Non-vacuous: an empty list, or a classifier that stopped reading it, must
+  # not let this pass by having nothing to check. One, not a higher floor —
+  # a floor above the stated purpose fails on a legitimate removal that keeps
+  # the list non-empty, which is a test edit with no contract behind it. This
+  # branch shortened the list once already.
+  count="$(printf '%s\n' "$signals" | grep -c . || true)"
+  [ "${count:-0}" -ge 1 ]
+  printf '%s\n' "$(job_block triage "$WF")" | script_lines | grep -qF 'ACCEPTED_SIGNAL_LABELS.includes(n)'
+
+  for label in $signals; do
+    printf '%s\n' "$exempt_labels" | grep -qxF "$label"
+  done
+}
+
+@test "no lifecycle label sits in the accepted-signal list" {
+  # Membership of stale.yaml's exempt list is necessary for a signal but not
+  # sufficient, and the test above can only check the necessary half. A
+  # `lifecycle/*` label states what the stale bot may do with an issue and
+  # nothing about whether anybody reviewed it, so `lifecycle/frozen` is exempt
+  # and still not a signal: freezing an untriaged issue to keep the bot off it
+  # is exactly the case where reading it as accepted is false.
+  #
+  # `priority/backlog` is excluded for a different reason and needs no assertion
+  # of its own, because it is not on the exempt list and the test above already
+  # rejects it. That is a coincidence of the stale policy rather than a decision
+  # taken here, and it stops covering the tier the moment somebody exempts it.
+  signals="$(signal_labels)"
+
+  # Guards the assertion below against passing on an empty list, which is what
+  # a broken extraction and a compliant workflow would otherwise look like.
+  [ -n "$signals" ]
+
+  # Capture grep's status instead of writing `! grep -q ...`, which cannot fail
+  # a test here. Two mechanisms, and the second is the one that carries this
+  # case: `set -e` ignores a pipeline led by `!`, so such an assertion mid-body
+  # never aborts, and `hack/cozytest.sh`'s translator appends `return 0` to
+  # every line that is exactly `}`, so one written as the body's last statement
+  # does not decide the status either. Under real bats the trailing form does
+  # go red, which is the only position where the two runners differ at all: a
+  # negated assertion with anything after it is green under both. So the rule
+  # is not "bats is the honest runner", it is that no position is safe. Every
+  # negative assertion in this file takes this shape, and a mutation ladder
+  # proving otherwise has to run the runner CI uses.
+  rc=0
+  printf '%s\n' "$signals" | grep -q '^lifecycle/' || rc=$?
+  [ "$rc" -ne 0 ]
+}
+
+@test "the sweep runs after the stale bot, not before it" {
+  [ -f "$STALE" ]
+
+  # Labeling bumps updated_at, which the stale bot reads as activity. Running
+  # first would hand every issue it is about to label a fresh clock in the same
+  # morning, so the sweep goes second and lets that day's stale pass complete
+  # on the state it was scheduled against.
+  # `-e`, because the pattern opens with a dash and grep would read it as one.
+  sweep="$(code_lines < "$WF" | grep -F -e '- cron:' | cron_minutes)"
+  stale="$(code_lines < "$STALE" | grep -F -e '- cron:' | cron_minutes)"
+  [ -n "$sweep" ] && [ -n "$stale" ]
+  [ "$sweep" -gt "$stale" ]
+}
+
+@test "both labels the workflow applies are declared in the repository" {
+  [ -f "$LABELS" ]
+
+  # addLabels creates a label that does not exist, with a default colour and no
+  # description, so a typo here is invisible until someone notices two triage
+  # labels with almost the same name.
+  #
+  # Whole-line match, for the same reason the exempt-list check above splits its
+  # block one entry per line: a substring match accepts a truncation, and a
+  # truncation is exactly what a typo looks like. `name: triage/needs-triag`
+  # occurs inside `- name: triage/needs-triage`, so `grep -F` alone reports the
+  # misspelled label as declared and the sweep then creates it on first write.
+  # `-e`, because the whole-line pattern opens with the list dash and grep would
+  # otherwise read it as an option, the same reason the cron check above needs it.
+  #
+  # The trailing comment is stripped before the match rather than allowed by the
+  # pattern, so the check stays a fixed-string one: the label is interpolated,
+  # and a regex would give whatever it contains meaning it does not have. A
+  # declaration carrying its justification inline is the shape the permission
+  # count above already tolerates, and there is no contract against it here.
+  for label in $(script_lines < "$WF" | grep -E "const (NEEDS_TRIAGE|ACCEPTED) = " | sed "s/^[^']*'//; s/'.*$//"); do
+    code_lines < "$LABELS" | sed 's/[[:space:]]*#.*$//; s/[[:space:]]*$//' |
+      grep -qxF -e "- name: $label"
+  done
+}


### PR DESCRIPTION
## What this PR does

Issues that arrive through the API or `gh issue create` bypass the issue templates, so they carry no `triage/*` label and nothing in the repository adds one afterwards. Listing every open issue through the same endpoint the workflow uses, `gh api --paginate "/repos/cozystack/cozystack/issues?state=open&per_page=100"`, returns 567 entries, 171 of them pull requests, at the time of writing. That leaves 396 open issues, and 252 of them carry no triage label at all. Every count in this description is a point-in-time reading of a backlog that keeps moving, so a later run of the same query will differ by a few. The triage queue is impossible to filter on in that state, and there is no way to see how much of the backlog nobody has looked at.

This adds a workflow that labels an issue when it is opened or reopened, plus a daily sweep that backstops labels removed by hand and works through the existing backlog. An issue somebody has assigned, or marked with one of `priority/critical-urgent`, `priority/important-soon`, `priority/important-longterm` or `epic`, gets `triage/accepted`, since a maintainer has already looked at it. Everything else gets `triage/needs-triage`. An issue already carrying any `triage/*` label is left alone, so the sweep never overwrites a decision someone made by hand, and pull requests returned by the same listing endpoint are skipped. Against the listing above, the sweep applies `triage/accepted` to 39 issues and `triage/needs-triage` to 213, and touches none of the 144 that are already triaged.

Deleting a triage label by hand does not undo any of this. An issue left carrying no `triage/*` label is relabeled by the next sweep, so a triage decision is changed by replacing the label. `AGENTS.md`'s labeling section now says so, because that is the file somebody reads before labeling by hand.

Two conditions decide what counts as a signal. Membership of `stale.yaml`'s `exempt-issue-labels` is necessary: `triage/accepted` is itself on that list, so applying it does more than reset a clock, the issue stops being auto-closable, and a signal that is not already exempt would hand out that permanent reprieve as a side effect of being labeled. `priority/backlog`, the one tier `stale.yaml` deliberately leaves reapable, is excluded for exactly that reason.

Membership is not sufficient, which is why the signal list is not simply the exempt list. `lifecycle/frozen` is exempt and still not a signal: a `lifecycle/*` label states what the stale bot may do with an issue and says nothing about whether anybody reviewed it. Freezing an untriaged issue to keep the bot off it is the case where reading it as accepted is wrong. Of the five open issues whose only signal would have been `lifecycle/frozen`, one is blocked on an upstream project and carries `help wanted`, and one is an older feature request that an open epic now covers. Neither is ready to be worked on, and stamping either accepted would have kept it out of triage for good, since the sweep never revisits an issue that already carries a triage label. `epic` passes the same test from the other side: it is a maintainer-authored planning artifact rather than an inbound report, and all eight open issues whose only signal is `epic` are roadmap trackers that `needs-triage` would describe falsely. A contract test pins the rule and not the instance, so no label from the `lifecycle/*` namespace can quietly become a signal later. `security/*` stays out on the same grounds, though the case is closer: those labels record what is known about a vulnerability rather than whether anyone triaged the report, and the cost of being wrong runs the cheap way, since a `needs-triage` on a confirmed report is one click to remove while a wrong `accepted` is permanent because the sweep never revisits.

One caveat stated plainly: the signals stand for a maintainer decision already recorded on the issue, which is a weaker claim than the one `triage/accepted` makes in `.github/labels.yml`, and `priority/important-longterm` says outright that the work may not be staffed. Of the two labels this workflow can write it is still the closer one, since `needs-triage` on an issue somebody already prioritised or took asks for a triage that has happened, and a maintainer who disagrees replaces the label in one click. An assignee is the single signal that is neither a label nor already exempt, so an issue whose only signal is an assignee does gain a permanent reprieve. That is the intended reading rather than a side effect: somebody took ownership, which makes it a known long-tail task rather than an abandoned one, and it is the same argument `stale.yaml`'s own comment makes for exempting `triage/accepted` in the first place.

Three operational details. First, the sweep paces its writes a second apart and caps a run at 400, because GitHub allows 80 content-generating requests a minute and 500 an hour, this client carries no throttling plugin and no retries, and a throttled write answers `403`, which is exempt from retry anyway. Unpaced, the first pass over the backlog would not slow down when throttled, it would fail the job partway and leave the backlog half labeled. Whatever a run leaves behind stays unlabeled, so the next one picks it up. Second, adding a label bumps an issue's `updated_at`, which `stale.yaml` reads as activity, so the first sweep restarts the 60-day staleness clock on every issue it writes to, all 252 of them, and un-marks the 32 that carry `lifecycle/stale` today. Both are deliberate and one-time: the backlog gets triaged now and ages again from there, rather than being closed unread while it is still unlabeled. Third, a run writes a job summary with the counts, the issue numbers under each label, and both remainders it can leave behind: the write cap's deferral, and how much of the listing it never reached when a refusal stopped it early. A sweep over the backlog logs a line per issue, and the summary is what makes the outcome readable without paging through the 252 the current backlog produces.

A write that fails does not take the rest of the run with it, but the two failure shapes are told apart rather than counted together. Any status other than a `403` or `429` lets the run carry on, most often a `404` or `410` from an issue transferred or deleted mid-sweep, since a failure about one issue says nothing about the next. A `403` or `429` means the token lost `issues: write` or the pacing stopped being enough, which applies to every write left in the run, so the sweep stops at the first one and the job fails loudly. Repeating a rejected request up to the cap is what gets an integration throttled harder.

`workflow_dispatch` takes a `dry_run` input that logs what would be labeled without writing anything. It is on by default, so a manual run writes nothing until somebody unchecks the box, and `schedule` is the one event that writes without being asked. The cap applies in dry-run too, so a dry run predicts what a real one would do instead of printing a longer list nobody gets. The job asks for `issues: write` and everything else is read-only, the action it uses is pinned by digest, and a 20-minute timeout keeps a hung call from holding the queue for the default six hours.

No pull request lane can exercise this workflow, so its first real execution is a sweep over every open issue with nothing having run it before. `hack/issue-triage-contract.bats` pins the executable lines that bound that blast radius: the pull-request skip, the already-triaged skip, the pacing rate and the write cap, the job timeout, the failure handling, the digest-pinned action, the token scopes, the serialised queue, the dry-run default and the derivation that does not depend on it, the cron ordering against `stale.yaml`, that both labels it writes exist in `.github/labels.yml`, that no accepted-signal label sits outside `stale.yaml`'s exempt list or inside the `lifecycle/*` namespace, and that the summary is written with the `await` that makes it flush and accounts for every outcome a run can end on. Each assertion was checked against a mutated copy of the workflow to confirm it goes red rather than merely existing, with the mutations run through `hack/cozytest.sh` rather than `bats`. The two runners disagree about negated assertions, so a pin that `bats` reports as live can be dead under the runner CI actually uses, and every negative assertion in the file captures grep's status instead of leading with `!`.

Suggested first step after merge: run the workflow by hand and read the summary before the 05:53 cron arms itself. The box arrives checked, so that run costs nothing.

### Screenshots

Not a UI change, so there is nothing to show.

### Downstream repositories

I walked the trigger map in `docs/agents/contributing.md` against the diff. The diff adds two files, `.github/workflows/issue-triage.yaml` and `hack/issue-triage-contract.bats`, and appends one line to `AGENTS.md`. No row matches: it adds and renames no package, changes no chart values, no schema, no version enum, no `ApplicationDefinition`, no CRD, no namespace, no variant or bundle, no label or annotation any downstream repository matches on, no metric and no release asset. Its `hack/` rows name `hack/upload-assets.sh`, `hack/e2e-prepare-cluster.bats`, `hack/package.mk`, `hack/update-crd.sh` and `hack/common-envs.mk`, which downstream repositories copy, anchor on or mirror by hand, plus one row for moving or renaming anything under `hack/`; a new bats file added next to them is none of those. The map has no row for the agent documentation, and no downstream repository copies `AGENTS.md`.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
feat(ci): new and reopened issues now get a `triage/*` label automatically, and a daily sweep labels any open issue that has none: `triage/accepted` when it is assigned or carries an `epic` or a priority above `priority/backlog`, `triage/needs-triage` otherwise.
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated issue triage triggered by new or reopened issues, scheduled reviews, or manual runs.
  * Issues can be labeled as needing triage or accepted, with pull requests and already-triaged items excluded.
  * Added dry-run support and reporting for triage results.

* **Documentation**
  * Added guidance for replacing existing triage labels when making decisions.

* **Tests**
  * Added coverage for workflow behavior, permissions, scheduling, failure handling, and safety limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->