### PR TITLE
fix(e2e): budget tenant scheduling separately from workload readiness

### DIFF
--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -104,6 +104,94 @@ cozy_wait_tenant_drained() {
   done
 }
 
+# Pure predicate for ONE node row of the capture cozy_has_schedulable_node
+# scans. Encodes the scheduler's own admission rule for a Pod that tolerates
+# nothing: the NodeUnschedulable plugin rejects a node whose
+# .spec.unschedulable is set (what `kubectl get nodes` renders as
+# SchedulingDisabled), and the TaintToleration plugin rejects one carrying any
+# taint with effect NoSchedule or NoExecute. PreferNoSchedule only lowers the
+# node's score, so it is deliberately not treated as blocking. Ready is checked
+# explicitly rather than left to the not-ready taint, so the gate does not
+# depend on how promptly the node-lifecycle controller applies that taint.
+#
+# The backend Pod is not literally toleration-free: DefaultTolerationSeconds
+# admission gives every Pod a 300s NoExecute toleration for
+# node.kubernetes.io/not-ready and node.kubernetes.io/unreachable. So for those
+# two taints this predicate is stricter than the scheduler and would keep
+# waiting where the Pod could in fact be placed. That errs toward waiting,
+# never toward releasing the gate early, and requiring Ready makes the case
+# nearly unreachable anyway.
+cozy_node_accepts_pods() {
+  # $1 Ready condition status, $2 .spec.unschedulable, $3 taint effects
+  if [ "$1" != True ]; then
+    return 1
+  fi
+  case "$2" in
+    true | True) return 1 ;;
+  esac
+  case ",$3," in
+    *,NoSchedule,* | *,NoExecute,*) return 1 ;;
+  esac
+  return 0
+}
+
+# Pure exit-condition for the tenant scheduling gate
+# (cozy_wait_schedulable_node). The single argument is the capture of a
+# `kubectl get nodes --no-headers -o custom-columns=NAME,READY,UNSCHEDULABLE,TAINTS`,
+# one whitespace-separated row per node. custom-columns renders an absent field
+# as the literal "<none>" and joins several taint effects with a comma, so both
+# are matched as text. Returns 0 as soon as one row describes a node that would
+# accept a Pod that tolerates nothing. A failed probe leaves the capture empty,
+# which reports not-schedulable rather than schedulable, so an API blip can
+# never release the gate (same guard as cozy_tenant_drained). The scan runs in
+# the subshell on the right of the pipeline, so its `exit` ends that subshell
+# and becomes the function's status -- it never leaves the caller. Pure text
+# logic, unit-tested in hack/run-kubernetes-schedulable_test.bats.
+cozy_has_schedulable_node() {
+  printf '%s\n' "$1" | {
+    while read -r _name _ready _unschedulable _taints _rest; do
+      if [ -z "$_name" ]; then
+        continue
+      fi
+      if cozy_node_accepts_pods "$_ready" "$_unschedulable" "$_taints"; then
+        exit 0
+      fi
+    done
+    exit 1
+  }
+}
+
+# Block until the tenant cluster has at least one node that actually accepts a
+# Pod, then print the node table it decided on (the same table the failure path
+# prints, so the two outcomes are read the same way). The node-join gate in
+# run_kubernetes_test establishes that two nodes are Ready, which is a weaker
+# guarantee: a Ready node still carries `node.cilium.io/agent-not-ready` until
+# the tenant's cilium agent claims it, and a node the bringup has not finished
+# with is Ready,SchedulingDisabled.
+# Scheduling against such a set is not stuck, only slow, and the time it takes
+# is variable -- so it belongs in a budget of its own rather than inside the
+# workload's readiness budget, where it is indistinguishable from a slow image
+# pull or a failing probe.
+cozy_wait_schedulable_node() {
+  _kc="$1"
+  _timeout="${2:-300}"
+  _deadline=$(( $(date +%s) + _timeout ))
+  while :; do
+    _nodes=$(kubectl --kubeconfig "$_kc" get nodes --no-headers -o custom-columns='NAME:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status,UNSCHEDULABLE:.spec.unschedulable,TAINTS:.spec.taints[*].effect' 2>/dev/null) || _nodes=""
+    if cozy_has_schedulable_node "$_nodes"; then
+      echo "» tenant has a node that accepts Pods:"
+      printf '%s\n' "$_nodes" | sed 's/^/  node: /'
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$_deadline" ]; then
+      echo "» no tenant node became schedulable (Ready, not cordoned, no NoSchedule/NoExecute taint) within ${_timeout}s" >&2
+      printf '%s\n' "${_nodes:-<the node probe returned nothing>}" | sed 's/^/  node: /' >&2
+      return 1
+    fi
+    sleep 5
+  done
+}
+
 # Block until every ZFS storage pool on every LINSTOR satellite reports at
 # least _min_free_gib of FreeCapacity. Motivation is proven from a
 # cozyreport artefact captured by hack/cozyreport.sh (see PR #3044 run
@@ -575,7 +663,43 @@ EOF
   kubectl delete service --kubeconfig "tenantkubeconfig-${test_name}" "${test_name}-backend" \
     -n tenant-test --ignore-not-found --timeout=60s || true
 
+  # Start the workload's clock from a node that accepts Pods, not from a node
+  # that is merely Ready. Both instances of run 31020254620 spent 2m18s and
+  # 1m57s of the 300s readiness budget below on FailedScheduling, against nodes
+  # that were Ready but carried `node.cilium.io/agent-not-ready` or were
+  # SchedulingDisabled, and then ran out while the image was still being
+  # pulled. This gate is not extra waiting on the happy path: it spends the
+  # seconds the Pod would otherwise spend Pending (plus at most one 5s poll
+  # interval) and moves them out of a budget that has a different job. 300s is
+  # more than twice the longest scheduling delay observed, and the gate prints
+  # the node table on both outcomes so a timeout names the taint that held it.
+  # The two budgets do stack on a failing run: one that spends the full 300s
+  # here and then overruns the readiness wait gives up at ~600s where it used
+  # to give up at 300s. That sits inside the enclosing 40m Chainsaw script op,
+  # which the kubernetes-* suites document as a ~25m bringup.
+  if ! cozy_wait_schedulable_node "tenantkubeconfig-${test_name}" 300; then
+    echo "=== tenant scheduling gate failed: no node became schedulable within 300s — diagnostics follow ==="
+    kubectl --kubeconfig "tenantkubeconfig-${test_name}" describe nodes || true
+    kubectl -n tenant-test get hr || true
+    exit 1
+  fi
+
   # Backend 1
+  #
+  # nginx is pinned by digest. The tenant workers reach no registry mirror --
+  # hack/e2e-talos-image-cache.yaml serves the Talos worker OS disk image over
+  # HTTP and is not one, and nothing else in the tree mirrors container images
+  # for a tenant -- so this is pulled from Docker Hub on every run either way.
+  # The digest does not remove that pull, it fixes what the pull returns: a
+  # floating `nginx:alpine` silently changes size and layer count under the
+  # readiness budget below, and supplies whatever content the tag points at on
+  # the day. The digest is the OCI index, not a per-architecture manifest, so
+  # the kubelet still selects the image for the worker's own architecture.
+  # Nothing will bump it: renovate's enabledManagers are gomod, dockerfile,
+  # github-actions and custom.regex, and both custom managers match packages/
+  # paths only, so no manager reads this file. That is the intent rather than an
+  # oversight -- the point of the pin is that the bytes stay the same run to
+  # run, and this is a throwaway test workload, not an image the platform ships.
   kubectl apply --kubeconfig "tenantkubeconfig-${test_name}" -f- <<EOF
 apiVersion: apps/v1
 kind: Deployment
@@ -596,7 +720,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:alpine
+        image: nginx:1.31.3-alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752
         ports:
         - containerPort: 80
         readinessProbe:
@@ -624,8 +748,20 @@ spec:
     targetPort: 80
 EOF
 
-  # Wait for pods readiness
-  kubectl wait deployment --kubeconfig "tenantkubeconfig-${test_name}" "${test_name}-backend" -n tenant-test --for=condition=Available --timeout=300s
+  # Wait for pods readiness. With scheduling gated above, these 300s start from
+  # a node that accepts Pods, so they cover placement, sandbox setup, the image
+  # pull and the probe -- and no longer the wait for a node to stop rejecting
+  # the Pod, which now has a budget and a message of its own. The events in the
+  # diagnostics below tell the remaining consumers apart. The number is
+  # unchanged from when it also had to absorb scheduling; the pull alone
+  # measured 1m42s in run 31020254620.
+  if ! kubectl wait deployment --kubeconfig "tenantkubeconfig-${test_name}" "${test_name}-backend" -n tenant-test --for=condition=Available --timeout=300s; then
+    echo "=== backend readiness failed: the Pod was schedulable but did not become Available within 300s — diagnostics follow ==="
+    kubectl --kubeconfig "tenantkubeconfig-${test_name}" -n tenant-test describe deployment "${test_name}-backend" || true
+    kubectl --kubeconfig "tenantkubeconfig-${test_name}" -n tenant-test describe pods -l "backend=${test_name}-backend" || true
+    kubectl --kubeconfig "tenantkubeconfig-${test_name}" -n tenant-test get events --sort-by=.lastTimestamp || true
+    exit 1
+  fi
 
   # Wait for LoadBalancer to be provisioned (IP or hostname)
   timeout 90 sh -ec "

--- a/hack/run-kubernetes-schedulable_test.bats
+++ b/hack/run-kubernetes-schedulable_test.bats
@@ -1,0 +1,293 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Unit tests for cozy_node_accepts_pods and cozy_has_schedulable_node in
+# hack/e2e-chainsaw/_lib/run-kubernetes.sh
+#
+# Together they are the pure exit-condition of the tenant scheduling gate
+# (cozy_wait_schedulable_node), which runs before the backend workload is
+# created so that scheduling delay is charged to its own budget instead of the
+# workload's readiness budget. The input is the capture of
+#   kubectl get nodes --no-headers -o custom-columns=NAME,READY,UNSCHEDULABLE,TAINTS
+# where TAINTS is `.spec.taints[*].effect`, so custom-columns renders an absent
+# field as the literal "<none>" and joins several effects with a comma. The
+# rows below are shaped exactly as kubectl emits them.
+#
+# The predicate is the scheduler's own rule for a Pod with no tolerations:
+# Ready, not SchedulingDisabled, and no NoSchedule/NoExecute taint.
+# PreferNoSchedule only lowers the node's score and must not block.
+#
+# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
+# own line; there is no bats `run` or `$status`. Assertions are expressed as
+# direct shell tests that exit non-zero on failure.
+#
+# Run with: hack/cozytest.sh hack/run-kubernetes-schedulable_test.bats
+# -----------------------------------------------------------------------------
+
+@test "a Ready node with no taints accepts pods" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    if ! cozy_node_accepts_pods True '<none>' '<none>'; then
+        echo "expected a Ready, untainted, schedulable node to accept pods" >&2
+        exit 1
+    fi
+}
+
+@test "a NotReady node does not accept pods" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    if cozy_node_accepts_pods False '<none>' '<none>'; then
+        echo "expected a node whose Ready condition is False to be rejected" >&2
+        exit 1
+    fi
+}
+
+@test "an Unknown Ready condition does not accept pods" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    if cozy_node_accepts_pods Unknown '<none>' '<none>'; then
+        echo "expected a node whose Ready condition is Unknown to be rejected" >&2
+        exit 1
+    fi
+}
+
+@test "a cordoned node does not accept pods" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    if cozy_node_accepts_pods True true '<none>' ; then
+        echo "expected a node with .spec.unschedulable=true to be rejected" >&2
+        exit 1
+    fi
+}
+
+@test "a NoSchedule taint does not accept pods" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    if cozy_node_accepts_pods True '<none>' NoSchedule; then
+        echo "expected a NoSchedule-tainted node to be rejected" >&2
+        exit 1
+    fi
+}
+
+@test "a NoExecute taint does not accept pods" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    if cozy_node_accepts_pods True '<none>' NoExecute; then
+        echo "expected a NoExecute-tainted node to be rejected" >&2
+        exit 1
+    fi
+}
+
+@test "a blocking effect anywhere in a comma-joined list is found" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    if cozy_node_accepts_pods True '<none>' PreferNoSchedule,NoExecute; then
+        echo "expected a trailing NoExecute in a joined effect list to be found" >&2
+        exit 1
+    fi
+    if cozy_node_accepts_pods True '<none>' NoSchedule,PreferNoSchedule; then
+        echo "expected a leading NoSchedule in a joined effect list to be found" >&2
+        exit 1
+    fi
+}
+
+@test "PreferNoSchedule alone still accepts pods" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    if ! cozy_node_accepts_pods True '<none>' PreferNoSchedule; then
+        echo "expected PreferNoSchedule to lower the score, not block scheduling" >&2
+        exit 1
+    fi
+    if ! cozy_node_accepts_pods True '<none>' PreferNoSchedule,PreferNoSchedule; then
+        echo "expected several PreferNoSchedule taints not to block scheduling" >&2
+        exit 1
+    fi
+}
+
+@test "a Ready untainted node reports the tenant schedulable" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    nodes=$(printf '%s\n' \
+        'kubernetes-test-latest-version-md0-abcde   True   <none>   <none>')
+    if ! cozy_has_schedulable_node "$nodes"; then
+        echo "expected a Ready, untainted node to release the gate" >&2
+        exit 1
+    fi
+}
+
+@test "the observed cilium/cordon node pair reports not-schedulable" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    nodes=$(printf '%s\n%s\n' \
+        'kubernetes-test-latest-version-md0-abcde   True   <none>   NoSchedule' \
+        'kubernetes-test-latest-version-md0-fghij   True   true     NoSchedule')
+    if cozy_has_schedulable_node "$nodes"; then
+        echo "expected agent-not-ready + SchedulingDisabled nodes to hold the gate" >&2
+        exit 1
+    fi
+}
+
+@test "one free node among blocked ones reports schedulable" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    nodes=$(printf '%s\n%s\n' \
+        'kubernetes-test-latest-version-md0-abcde   True   <none>   NoSchedule' \
+        'kubernetes-test-latest-version-md0-fghij   True   <none>   <none>')
+    if ! cozy_has_schedulable_node "$nodes"; then
+        echo "expected the second, untainted node to release the gate" >&2
+        exit 1
+    fi
+}
+
+@test "a node still becoming Ready reports not-schedulable" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    nodes=$(printf '%s\n' \
+        'kubernetes-test-latest-version-md0-abcde   False   <none>   NoSchedule,NoExecute')
+    if cozy_has_schedulable_node "$nodes"; then
+        echo "expected a NotReady node to hold the gate" >&2
+        exit 1
+    fi
+}
+
+@test "an empty capture is never misread as schedulable" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    if cozy_has_schedulable_node ""; then
+        echo "expected a failed or empty node probe to hold the gate" >&2
+        exit 1
+    fi
+}
+
+@test "a whitespace-only capture is never misread as schedulable" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    blank=$(printf '\n   \n')
+    if cozy_has_schedulable_node "$blank"; then
+        echo "expected a blank node probe to hold the gate" >&2
+        exit 1
+    fi
+}
+
+@test "the scheduling gate runs before the backend Deployment is applied" {
+    lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    # Ordering is the fix: a gate placed after the apply would charge the
+    # scheduling delay to the workload's readiness budget again, which is the
+    # arrangement that failed. Nothing else in the suite can catch that.
+    gate=$(grep -n 'cozy_wait_schedulable_node "tenantkubeconfig-' "$lib" | head -n 1 | cut -d: -f1)
+    deploy=$(grep -n 'name: "\${test_name}-backend"' "$lib" | head -n 1 | cut -d: -f1)
+    if [ -z "$gate" ]; then
+        echo "expected run_kubernetes_test to gate on a schedulable tenant node" >&2
+        exit 1
+    fi
+    if [ -z "$deploy" ]; then
+        echo "expected to find the backend Deployment in $lib" >&2
+        exit 1
+    fi
+    if [ "$gate" -ge "$deploy" ]; then
+        echo "expected the scheduling gate (line $gate) before the backend Deployment (line $deploy)" >&2
+        exit 1
+    fi
+}
+
+@test "the tenant backend workload image is pinned by digest" {
+    lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    # The tenant workers reach no registry mirror, so this image is fetched
+    # from Docker Hub inside the readiness budget on every run. A floating tag
+    # puts content of unknown size under a fixed deadline.
+    ref=$(grep -E '^[[:space:]]*image: nginx' "$lib" | head -n 1)
+    if [ -z "$ref" ]; then
+        echo "expected the backend workload to declare an nginx image" >&2
+        exit 1
+    fi
+    case "$ref" in
+        *@sha256:*) ;;
+        *)  echo "expected the backend workload image to be pinned by digest: $ref" >&2
+            exit 1 ;;
+    esac
+}
+
+@test "the probe asks for the columns in the order the predicate parses them" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    # A shell function shadows the PATH lookup, so the gate's own kubectl call
+    # lands here with no stub binary and nothing to put on PATH. The gate reads
+    # the probe through a command substitution, which is a subshell, so what
+    # the stub records has to travel through a file rather than a variable.
+    argfile=$(mktemp)
+    kubectl() {
+        printf '%s\n' "$*" > "$argfile"
+        printf 'kubernetes-test-latest-version-md0-abcde   True   <none>   <none>\n'
+    }
+    cozy_wait_schedulable_node tenantkubeconfig-test-latest-version 0 > /dev/null
+    args=$(cat "$argfile")
+    rm -f "$argfile"
+    case "$args" in
+        *"--kubeconfig tenantkubeconfig-test-latest-version"*) ;;
+        *)  echo "expected the probe to carry the tenant kubeconfig: $args" >&2
+            exit 1 ;;
+    esac
+    case "$args" in
+        *--no-headers*) ;;
+        *)  echo "expected --no-headers, or a header row is parsed as a node: $args" >&2
+            exit 1 ;;
+    esac
+    # Column order is the predicate's argument order; reordering the query
+    # without reordering the parse would compare a taint effect against Ready.
+    case "$args" in
+        *'NAME:.metadata.name,READY:.status.conditions[?(@.type=="Ready")].status,UNSCHEDULABLE:.spec.unschedulable,TAINTS:.spec.taints[*].effect'*) ;;
+        *)  echo "expected NAME,READY,UNSCHEDULABLE,TAINTS in that order: $args" >&2
+            exit 1 ;;
+    esac
+}
+
+@test "the gate releases on a later poll once the taint clears" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    callfile=$(mktemp)
+    printf '0\n' > "$callfile"
+    kubectl() {
+        _calls=$(( $(cat "$callfile") + 1 ))
+        printf '%s\n' "$_calls" > "$callfile"
+        if [ "$_calls" -eq 1 ]; then
+            printf 'kubernetes-test-latest-version-md0-abcde   True   <none>   NoSchedule\n'
+        else
+            printf 'kubernetes-test-latest-version-md0-abcde   True   <none>   <none>\n'
+        fi
+    }
+    rc=0
+    cozy_wait_schedulable_node tenantkubeconfig-test-latest-version 60 > /dev/null || rc=$?
+    calls=$(cat "$callfile")
+    rm -f "$callfile"
+    if [ "$rc" -ne 0 ]; then
+        echo "expected the gate to release once the taint cleared" >&2
+        exit 1
+    fi
+    if [ "$calls" -lt 2 ]; then
+        echo "expected the gate to poll again rather than accept the first answer" >&2
+        exit 1
+    fi
+}
+
+@test "a tainted node holds the gate to its own deadline" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    kubectl() {
+        printf 'kubernetes-test-latest-version-md0-abcde   True   <none>   NoSchedule\n'
+    }
+    if cozy_wait_schedulable_node tenantkubeconfig-test-latest-version 0 > /dev/null 2>&1; then
+        echo "expected an elapsed deadline with a tainted node to fail the gate" >&2
+        exit 1
+    fi
+}
+
+@test "a failing probe holds the gate rather than releasing it" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    kubectl() {
+        echo 'Unable to connect to the server' >&2
+        return 1
+    }
+    if cozy_wait_schedulable_node tenantkubeconfig-test-latest-version 0 > /dev/null 2>&1; then
+        echo "expected an unreachable tenant API to hold the gate, not release it" >&2
+        exit 1
+    fi
+}
+
+@test "the scan reports a hit without exiting its caller" {
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    nodes=$(printf '%s\n' \
+        'kubernetes-test-latest-version-md0-abcde   True   <none>   <none>')
+    # The scan signals a hit with `exit 0`, which is contained only because it
+    # runs in the subshell on the right of a pipeline. Rewritten to read the
+    # capture in the current shell (a heredoc, say) that same `exit` would end
+    # the caller mid-test, silently skipping everything after the gate. The
+    # command substitution below is itself a subshell, so a leaked exit kills
+    # it before the marker is written.
+    reached=$( ( cozy_has_schedulable_node "$nodes"; printf reached ) )
+    if [ "$reached" != reached ]; then
+        echo "expected the scan to return to its caller, not exit it" >&2
+        exit 1
+    fi
+}


### PR DESCRIPTION
## What this PR does

The tenant backend Deployment in the kubernetes suites had one 300s budget to reach `condition=Available`, and two unrelated variable costs shared it.

The first is scheduling. What the suite establishes before that point is two tenant nodes Ready, which is weaker than schedulable: a Ready node still carries `node.cilium.io/agent-not-ready` until the tenant cilium agent claims it, and a node the bringup has not finished with is `SchedulingDisabled`. In the run recorded in #3577 scheduling took 2m18s and 1m57s in the two suites, which left the image pull to finish inside what remained. It did not, and both suites reported the same `timed out waiting for the condition` for what were two different shortfalls.

So this waits for a node that actually accepts a Pod before creating the workload, on its own budget and its own failure message. The gate encodes the scheduler's rule for a Pod that tolerates nothing (Ready, not unschedulable, no `NoSchedule` or `NoExecute` taint) over a `custom-columns` probe, prints the node table on both outcomes so a timeout names the taint that held it, and treats a failed probe as not-schedulable so an API blip cannot release it. On the happy path it adds no wall time: it spends the seconds the Pod would otherwise spend Pending, plus at most one 5s poll interval. On a failing run the two budgets stack, so a run that exhausts both now gives up at ~600s where it used to give up at 300s, inside the 40m Chainsaw script op the suites document as a ~25m bringup. The readiness wait keeps its 300s, now starting from a schedulable node, and dumps deployment, pod and event state when it runs out.

The workload image is also pinned by digest. The tenant workers reach no Docker Hub mirror (`hack/e2e-talos-image-cache.yaml` serves the Talos worker OS disk image over HTTP and is not a registry mirror), so nginx is pulled from Docker Hub on every run either way. The digest does not take the pull off the critical path; it fixes what that pull returns instead of leaving a floating tag free to change size and content under a fixed deadline. Preloading the image would need infrastructure this tree does not have, and is not attempted here. Nothing will bump the pin: no renovate manager reads `hack/`, and the comment says so, because for a throwaway test workload the freeze is the point.

What this does not claim: it removes two measured consumers from a fixed budget, both taken from the events of a single run. Whether that budget was the only thing making those suites red is not established from one run, so this is not offered as the fix for a red pipeline.

`hack/run-kubernetes-schedulable_test.bats` covers the new logic: every branch of the predicate, the multi-node scan, the poll-again path, the deadline, and a probe that fails. Each test was verified by mutating the helper and checking that the intended test, and no other, went red.

Note for whoever reviews alongside #3575: that branch mirrors `ghcr.io` for tenant worker pulls, not `docker.io`, so it does not change the Docker Hub pull described here. `git merge-tree` reports no conflict between the two, nor with #3548.

Observed in #3577.

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

The trigger map was walked against the diff. The change is confined to `hack/e2e-chainsaw/_lib/run-kubernetes.sh` and one new `hack/*.bats` unit test. It moves and renames nothing under `hack/`, changes no make target, and does not touch `hack/e2e-prepare-cluster.bats`, any package, any CRD or any namespace name, so none of the listed repositories are reached.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes deployment readiness by waiting for a suitable, schedulable node before timing backend startup.
  * Added clearer diagnostics when nodes are unavailable or backend readiness fails.
  * Replaced the floating backend container image tag with a fixed, verified version.

* **Tests**
  * Added coverage for node readiness, cordoning, taints, polling, timeouts, probe failures, and deployment sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->