### PR TITLE
fix(kubernetes): retry the tenant CSI install instead of uninstalling it

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/csi.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/csi.yaml
@@ -21,11 +21,36 @@ spec:
       key: super-admin.svc
   targetNamespace: cozy-csi
   storageNamespace: cozy-csi
+  {{- /* Flux defaults to the RemediateOnFailure strategy, and install
+         remediation is always an uninstall, so an install that outruns the
+         spec.timeout above is torn down between attempts: the tenant loses
+         its CSI node plugin and the StorageClasses this release propagates,
+         and the next attempt restarts the DaemonSet rollout instead of
+         resuming one already under way. RetryOnFailure keeps the manifests
+         in place and retries the failed release. Both actions carry it
+         because the controller picks the active retry by
+         .status.lastAttemptedReleaseAction and performs that retry as an
+         upgrade, so on install alone the retry's own failure falls through
+         to upgrade remediation, a rollback with no previous release to
+         reach. The cost is that a real upgrade failure retries rather than
+         rolls back, which gives up no stable safety net: with retries: -1
+         and the default rollback strategy, upgrade remediation already
+         rolled back and retried without end. The remediation blocks stay
+         for a different reason, that an absent release
+         consults install and an out-of-sync one consults upgrade, both by
+         retry count rather than by strategy, so retries: -1 keeps them
+         open. */}}
   install:
     createNamespace: true
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 30s
     remediation:
       retries: -1
   upgrade:
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 30s
     remediation:
       retries: -1
   values:

--- a/packages/apps/kubernetes/tests/csi_install_retry_test.yaml
+++ b/packages/apps/kubernetes/tests/csi_install_retry_test.yaml
@@ -1,0 +1,54 @@
+suite: csi.yaml install retry strategy
+
+templates:
+  - templates/helmreleases/csi.yaml
+
+values:
+  - values/common.yaml
+
+tests:
+  # Install remediation is an uninstall in every case Flux offers, so under the
+  # default strategy an install that misses its budget takes the tenant's CSI
+  # node plugin and propagated StorageClasses away until a later attempt lands
+  # them again. RetryOnFailure keeps the manifests applied and retries instead.
+  - it: retries a failed install instead of uninstalling the tenant CSI
+    release:
+      name: kubernetes-test
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: spec.install.strategy.name
+          value: RetryOnFailure
+      - equal:
+          path: spec.install.strategy.retryInterval
+          value: 30s
+
+  # The controller performs the retry of a failed install as an upgrade, so
+  # without a strategy here that retry's own failure falls through to upgrade
+  # remediation instead of retrying again.
+  - it: carries the strategy on the upgrade action the retry runs as
+    release:
+      name: kubernetes-test
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: spec.upgrade.strategy.name
+          value: RetryOnFailure
+      - equal:
+          path: spec.upgrade.strategy.retryInterval
+          value: 30s
+
+  # The strategy governs a failed release. An absent release and an out-of-sync
+  # one take different branches, which consult the retry count instead and stop
+  # acting once it is exhausted.
+  - it: keeps unlimited retries for the branches the strategy does not reach
+    release:
+      name: kubernetes-test
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: spec.install.remediation.retries
+          value: -1
+      - equal:
+          path: spec.upgrade.remediation.retries
+          value: -1


### PR DESCRIPTION
## What this PR does

The tenant CSI HelmRelease carried `remediation.retries: -1` with no strategy, so Flux applied its default, `RemediateOnFailure`. Install remediation is an uninstall in every case the API offers, so an install that missed its budget was torn down between attempts: the tenant lost its CSI node plugin and the StorageClasses this release propagates until a later attempt applied them again, and that attempt restarted the DaemonSet rollout instead of resuming one already under way.

That teardown races the rollout it exists to recover, and the run recorded in #3576 shows how narrowly. Both DaemonSet pods were scheduled at the same second on both workers, so nothing was waiting on capacity; the ten minutes went to image pulls. The slower worker started its last container six seconds after the install timeout fired, and the uninstall removed it one second after that.

`RetryOnFailure` leaves the manifests applied and retries the failed release. Both actions carry it because the controller picks the active retry from `.status.lastAttemptedReleaseAction` and performs that retry as an upgrade: set on install alone, the retry still happens, but its own failure is then handled by upgrade remediation, whose default is a rollback with no previous release to roll back to. The `remediation` blocks stay, because an absent release consults `install.remediation` and an out-of-sync one consults `upgrade`, both by retry count rather than by strategy. This is the change #3552 makes for the tenant CNI, and the reason for putting the strategy on both actions is the one given there. It is also the shape upstream prescribes: the "Recommended settings" block in the [HelmRelease spec shipped with the helm-controller this installs](https://github.com/fluxcd/helm-controller/blob/v1.5.1/docs/spec/v2/helmreleases.md#recommended-settings) puts `strategy.name: RetryOnFailure` under both `install` and `upgrade` for production deployments.

Nothing changes on the test side, and that is deliberate rather than deferred. Because no manifest is removed at the attempt boundary, the rollout continues across it and the kubelet finishes what it started, while the retry re-applies the same manifests every 30s. The release therefore reports Ready once the rollout completes rather than once a whole attempt has fit inside the timeout, so what the existing e2e wait has to outlast is the rollout and no longer an attempt boundary that discards it. That widens what the wait tolerates without making it unbounded: a rollout slower than the wait itself still fails, and this does not claim otherwise.

Scope. #3576 records more than this fixes, so this does not close it. The other tenant addon HelmReleases this chart renders keep the remediation-only shape; CSI is the one this changes.

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

The trigger map was walked against the diff. The change is a HelmRelease template and a chart test, not a `values.schema.json` field, a `values.yaml` default, a version enum, a `release.prefix`, an `ApplicationDefinition`, a chart source kind or a namespace.

### Release note

```release-note
fix(kubernetes): the tenant CSI HelmRelease now retries a failed install instead of being uninstalled between attempts, so a failed install no longer takes the tenant's CSI node plugin and its propagated StorageClasses away while it retries. The same strategy applies to the upgrade action, which it has to: a retried install runs as an upgrade. One consequence is operator-visible — a failed CSI upgrade in a tenant cluster now retries the new manifests every 30s instead of rolling back to the previous release.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when installing or upgrading the CSI component by automatically retrying failed actions every 30 seconds.
  * Retains unlimited remediation retries to help recover from transient failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->