### PR TITLE
feat(kubernetes): default gpu-operator to an OS-provided driver on Talos

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/gpu-operator.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/gpu-operator.yaml
@@ -1,31 +1,91 @@
 {{- define "cozystack.defaultGpuOperatorValues" -}}
 {{- /*
-  GPU passthrough default: cozystack passes individual SXM GPUs (e.g.
-  H200) into tenant worker VMs WITHOUT the NVSwitches. The nvidia driver
-  then waits forever for an NVLink fabric that can never come up (no
-  NVSwitch / fabricmanager), leaving Fabric State: In Progress — every
-  CUDA call fails with "system not yet initialized" and the
-  nvidia-operator-validator crashloops. Loading the kernel module with
-  NVreg_NvLinkDisable=1 flips Fabric State to N/A so CUDA initializes.
-  This is correct for per-GPU passthrough since there is no in-VM
-  NVLink/NVSwitch peering anyway.
+  OS-provided-driver default, for the Talos workers that tenant clusters have
+  run since 1.6.0. The driver is supplied by a Talos system extension baked
+  into the worker image, not by the operator's driver container, and that
+  changes what every other component has to be told.
 
-  The upstream chart only references an existing ConfigMap by name; the
-  wrapper chart (packages/system/gpu-operator) renders that ConfigMap
-  when kernelModuleConfig.create is true. Overridable via
-  addons.gpuOperator.valuesOverride (mergeOverwrite below keeps user
-  values winning).
+  This replaces the previous default, which assumed the Ubuntu shape: the
+  operator's driver container compiling and loading the module inside the
+  worker VM, with NVreg_NvLinkDisable=1 fed to it through the
+  nvidia-kernel-module-params ConfigMap. On Talos that container is off, so
+  the ConfigMap was mounted by nothing and the parameter never applied. It now
+  travels through the machine config instead, as
+  nodeGroups.<name>.kernelModules, which is where a Talos node takes module
+  parameters from.
+
+  driver.enabled: false — the module comes from the extension. The operator's
+  driver container would try to load its own and clash with it.
+
+  toolkit.enabled: false — the toolkit container rewrites
+  /etc/containerd/config.toml, which on Talos is machine-config-owned. Talos
+  already registers the `nvidia` containerd runtime and sets
+  enable_cdi = true with cdi_spec_dirs = ['/run/cdi'].
+
+  validator.driver.env — the driver validator looks for a driver container's
+  install and finds none, so it never writes its sentinel and the device
+  plugin stays blocked behind toolkit-validation. Pointing DRIVER_ROOT and
+  NVIDIA_DRIVER_ROOT at / makes it inspect the host root, where the extension
+  put the driver. DISABLE_DEV_CHAR_SYMLINK_CREATION stops it trying to create
+  /dev/char symlinks that the extension already owns.
+
+  devicePlugin.env — tenant pods carry no runtimeClassName and did not need
+  one on Ubuntu, where the toolkit made `nvidia` the default containerd
+  runtime. Talos does not, so CUDA libraries reach a pod only through CDI:
+  cdi-annotations makes the plugin annotate pods for CDI injection, and
+  NVIDIA_CTK_PATH points it at the host's nvidia-ctk so it can generate the
+  spec into the /run/cdi that containerd already reads. DEVICE_ID_STRATEGY
+  uuid is what CDI device names key on. CDI_ANNOTATION_PREFIX matches the
+  plugin's own default and is pinned so an upstream change cannot move it out
+  from under containerd. NOTE: CDI injection is decided at pod admission, so
+  pods created before a node is working never receive anything and have to be
+  recreated.
+
+  Every value here is the configuration validated in production on a Talos
+  GPU node group, minus the parts that only mattered while the driver
+  container was in play.
+
+  Overridable via addons.gpuOperator.valuesOverride — mergeOverwrite below
+  keeps operator values winning. Mind that mergeOverwrite replaces a list
+  wholesale rather than merging it: an override that sets devicePlugin.env to
+  add one variable drops the defaults above with it, and CDI stops working.
+  Restate the full list when overriding it.
 */}}
-kernelModuleConfig:
-  create: true
 gpu-operator:
   driver:
-    kernelModuleConfig:
-      name: nvidia-kernel-module-params
-{{- if .Values.addons.hami.enabled }}
+    enabled: false
+  toolkit:
+    enabled: false
+  validator:
+    driver:
+      env:
+        - name: DRIVER_ROOT
+          value: "/"
+        - name: NVIDIA_DRIVER_ROOT
+          value: "/"
+        - name: DISABLE_DEV_CHAR_SYMLINK_CREATION
+          value: "true"
   devicePlugin:
+{{- if .Values.addons.hami.enabled }}
+    {{- /* HAMi ships its own device plugin and serves the GPUs itself; the
+           operator's must stay off so the two do not both advertise
+           nvidia.com/gpu. The env below is inert while this is false, and is
+           emitted anyway so the values stay coherent if HAMi is turned off
+           later. HAMi's own plugin needs its own CDI wiring on Talos, which
+           this default does not attempt. */}}
     enabled: false
 {{- end }}
+    env:
+      - name: DEVICE_LIST_STRATEGY
+        value: cdi-annotations
+      - name: DEVICE_ID_STRATEGY
+        value: uuid
+      - name: NVIDIA_DRIVER_ROOT
+        value: "/"
+      - name: NVIDIA_CTK_PATH
+        value: /usr/local/bin/nvidia-ctk
+      - name: CDI_ANNOTATION_PREFIX
+        value: cdi.k8s.io/
 {{- end }}
 
 {{- if and .Values.addons.gpuOperator.enabled .Values._namespace.etcd }}

--- a/packages/apps/kubernetes/tests/gpu_operator_hami_test.yaml
+++ b/packages/apps/kubernetes/tests/gpu_operator_hami_test.yaml
@@ -18,7 +18,14 @@ tests:
           path: spec.values.gpu-operator.devicePlugin.enabled
           value: false
 
-  - it: should default the NvLinkDisable kernel module config even when hami is disabled
+  # The default targets the Talos workers tenant clusters have run since 1.6.0,
+  # where the driver comes from a system extension rather than the operator's
+  # driver container. These three asserts are the whole contract: the operator
+  # must not try to own the driver or containerd, the driver validator must look
+  # at the host root instead of a driver container that does not exist, and the
+  # device plugin must route CUDA libraries through CDI because tenant pods carry
+  # no runtimeClassName and Talos does not make `nvidia` the default runtime.
+  - it: configures the operator for a driver provided by the OS
     set:
       addons:
         gpuOperator:
@@ -29,34 +36,81 @@ tests:
           valuesOverride: {}
     asserts:
       - equal:
-          path: spec.values.kernelModuleConfig.create
-          value: true
+          path: spec.values.gpu-operator.driver.enabled
+          value: false
       - equal:
-          path: spec.values.gpu-operator.driver.kernelModuleConfig.name
-          value: nvidia-kernel-module-params
-      - notExists:
-          path: spec.values.gpu-operator.devicePlugin
+          path: spec.values.gpu-operator.toolkit.enabled
+          value: false
+      # gap 3: without these the validator never writes its sentinel and the
+      # device plugin stays blocked behind toolkit-validation.
+      - contains:
+          path: spec.values.gpu-operator.validator.driver.env
+          content:
+            name: DRIVER_ROOT
+            value: "/"
+      - contains:
+          path: spec.values.gpu-operator.validator.driver.env
+          content:
+            name: DISABLE_DEV_CHAR_SYMLINK_CREATION
+            value: "true"
+      # gap 4: without these the pod gets the device and no CUDA libraries.
+      - contains:
+          path: spec.values.gpu-operator.devicePlugin.env
+          content:
+            name: DEVICE_LIST_STRATEGY
+            value: cdi-annotations
+      - contains:
+          path: spec.values.gpu-operator.devicePlugin.env
+          content:
+            name: NVIDIA_CTK_PATH
+            value: /usr/local/bin/nvidia-ctk
 
-  - it: should let user override the kernel module config name
+  # The previous default fed NVreg_NvLinkDisable=1 to the operator's driver
+  # container through the nvidia-kernel-module-params ConfigMap. With the driver
+  # container off that ConfigMap is mounted by nothing, so the parameter now
+  # travels through the machine config as nodeGroups.<name>.kernelModules. Pin
+  # its absence so the dead default cannot come back and offer a second, inert
+  # source for the same setting.
+  - it: no longer renders the driver-container kernel module ConfigMap
+    set:
+      addons:
+        gpuOperator:
+          enabled: true
+          valuesOverride: {}
+        hami:
+          enabled: false
+          valuesOverride: {}
+    asserts:
+      - notExists:
+          path: spec.values.kernelModuleConfig
+      - notExists:
+          path: spec.values.gpu-operator.driver.kernelModuleConfig
+
+  # mergeOverwrite replaces a list rather than merging it, so an operator adding
+  # one variable to devicePlugin.env silently drops the CDI defaults with it.
+  # That is Helm's list semantics and cannot be fixed here, so pin it: the
+  # behaviour is documented in the template and a reader who finds this test
+  # knows the override has to restate the full list.
+  - it: lets an operator replace the device plugin env wholesale
     set:
       addons:
         gpuOperator:
           enabled: true
           valuesOverride:
             gpu-operator:
-              driver:
-                kernelModuleConfig:
-                  name: my-custom-kmc
+              devicePlugin:
+                env:
+                  - name: DEVICE_LIST_STRATEGY
+                    value: envvar
         hami:
           enabled: false
           valuesOverride: {}
     asserts:
       - equal:
-          path: spec.values.gpu-operator.driver.kernelModuleConfig.name
-          value: my-custom-kmc
-      - equal:
-          path: spec.values.kernelModuleConfig.create
-          value: true
+          path: spec.values.gpu-operator.devicePlugin.env
+          value:
+            - name: DEVICE_LIST_STRATEGY
+              value: envvar
 
   - it: should apply hami defaults when valuesOverride key is omitted
     set:

--- a/packages/apps/kubernetes/tests/gpu_operator_hami_test.yaml
+++ b/packages/apps/kubernetes/tests/gpu_operator_hami_test.yaml
@@ -64,6 +64,33 @@ tests:
           content:
             name: NVIDIA_CTK_PATH
             value: /usr/local/bin/nvidia-ctk
+      # The remaining three are just as load-bearing as the two above: CDI device
+      # names key on the UUID strategy, the plugin resolves the driver from
+      # NVIDIA_DRIVER_ROOT, and the annotation prefix has to be the one containerd
+      # reads. A regression in any of them breaks device resolution while the two
+      # assertions above still pass.
+      - contains:
+          path: spec.values.gpu-operator.devicePlugin.env
+          content:
+            name: DEVICE_ID_STRATEGY
+            value: uuid
+      - contains:
+          path: spec.values.gpu-operator.devicePlugin.env
+          content:
+            name: NVIDIA_DRIVER_ROOT
+            value: "/"
+      - contains:
+          path: spec.values.gpu-operator.devicePlugin.env
+          content:
+            name: CDI_ANNOTATION_PREFIX
+            value: cdi.k8s.io/
+      # Same for the validator: NVIDIA_DRIVER_ROOT alongside DRIVER_ROOT is what
+      # the driver-validation init container reads.
+      - contains:
+          path: spec.values.gpu-operator.validator.driver.env
+          content:
+            name: NVIDIA_DRIVER_ROOT
+            value: "/"
 
   # The previous default fed NVreg_NvLinkDisable=1 to the operator's driver
   # container through the nvidia-kernel-module-params ConfigMap. With the driver

--- a/packages/system/gpu-operator/values.yaml
+++ b/packages/system/gpu-operator/values.yaml
@@ -32,10 +32,15 @@ gpu-operator:
 # true this wrapper chart renders the ConfigMap into the release
 # namespace so the params actually land. The driver entrypoint reads
 # ${base}/nvidia.conf and appends each line to the nvidia modprobe
-# options. Used by tenant Kubernetes clusters to set
-# NVreg_NvLinkDisable=1 (see packages/apps/kubernetes gpu-operator
-# HelmRelease defaults); off by default for host-level passthrough/vgpu
-# variants where the in-host driver is disabled.
+# options, so it only does anything when driver.enabled is true.
+#
+# No variant enables it any more. Tenant Kubernetes clusters used to, to set
+# NVreg_NvLinkDisable=1, but their workers run Talos since 1.6.0: the driver
+# comes from a system extension, the operator's driver container is off, and
+# that parameter now travels through the worker machine config instead
+# (nodeGroups.<name>.kernelModules in packages/apps/kubernetes). Kept for an
+# operator who re-enables the driver container through valuesOverride, which
+# then also has to set create: true here.
 kernelModuleConfig:
   create: false
   name: nvidia-kernel-module-params


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Closes the gpu-operator half of #3563 — gap 3 (the operator cannot validate a driver it did not install) and gap 4 (nothing routes CUDA libraries to a tenant pod).

Tenant clusters have run Talos workers since 1.6.0, where the NVIDIA driver comes from a system extension baked into the worker image rather than from the operator's driver container. The addon default still described the Ubuntu shape, so a GPU node group came up with the operator fighting the OS for the driver and no path at all for the CUDA libraries.

Three changes, each closing one silent failure:

| Change | Without it |
|---|---|
| `driver.enabled: false`, `toolkit.enabled: false` | the driver container loads its own module and clashes with the extension's; the toolkit container rewrites `/etc/containerd/config.toml`, which Talos owns and which already registers the `nvidia` runtime with `enable_cdi = true` and `cdi_spec_dirs = ['/run/cdi']` |
| `validator.driver.env`: `DRIVER_ROOT=/`, `NVIDIA_DRIVER_ROOT=/`, `DISABLE_DEV_CHAR_SYMLINK_CREATION=true` | the driver validator looks for a driver-container install, finds none, never writes its sentinel, and the device plugin stays blocked behind `toolkit-validation` — the loop on `Attempting to validate a driver container installation` (**gap 3**) |
| `devicePlugin.env`: `DEVICE_LIST_STRATEGY=cdi-annotations`, `NVIDIA_CTK_PATH=/usr/local/bin/nvidia-ctk`, plus `DEVICE_ID_STRATEGY`, `NVIDIA_DRIVER_ROOT`, `CDI_ANNOTATION_PREFIX` | tenant pods carry no `runtimeClassName` and did not need one on Ubuntu, where the toolkit made `nvidia` the default containerd runtime. Talos does not, so CDI is the only route: the pod gets the device and no CUDA libraries (**gap 4**) |

Every value is the configuration validated on a production Talos GPU node group, minus the parts that only mattered while the driver container was in play. No DaemonSet, no new image, no new package — the fix is values.

### The removed default

The previous default fed `NVreg_NvLinkDisable=1` to the driver container through the `nvidia-kernel-module-params` ConfigMap. With that container off the ConfigMap is mounted by nothing, so this removes the default and the parameter travels through the worker machine config instead, as `nodeGroups.<name>.kernelModules` (#3571). The wrapper chart keeps the ConfigMap feature for an operator who re-enables the driver container through `valuesOverride`, with its comment corrected to say nothing uses it by default any more. A test pins the absence so the dead default cannot come back and offer a second, inert source for the same setting.

### Relationship to #3571

Independent files, no conflict, but only useful together: this makes `driver.enabled: false` correct, and #3571 is what actually loads the modules the extension ships. Merged alone, this changes a GPU node group from "operator fights the OS" to "operator stays out of the way and the modules still are not loaded" — better, but not yet working. #3571 alone leaves the operator fighting for the driver. Either order is safe; both are needed for a GPU node group to work.

### What is verified, and what is not

Verified here: the rendered HelmRelease values, that `valuesOverride` still wins over each new key, and that the removed default is gone. The individual values are the ones running in production today, applied by hand through `addons.gpuOperator.valuesOverride`.

Not verified here: this exact default exercised end-to-end as the chart's own output. That needs a Talos GPU node group whose modules load, which needs #3571 released. I would rather say so than imply a green e2e that does not exist — happy to hold this as draft until I have run a single-node L40S cluster against the chart default, and I will report the result on this PR either way.

### Not covered

HAMi. When `addons.hami.enabled` the operator's device plugin stays off and HAMi serves the GPUs; HAMi's own plugin needs equivalent CDI wiring on Talos, which this default does not attempt. Flagging rather than guessing — the production cluster this was derived from runs HAMi disabled, so I have no validated configuration for that path. Worth its own issue if a maintainer confirms the shape.

Also not in scope, and unchanged from the merge base: `talos.installerRepository` and `talos.version` reach the worker machine config unvalidated (being tracked separately by @lexfrei), and the `nvidia-operator-validator` chain for the *management* cluster's own passthrough/vgpu variants, which never load the host driver at all.

### Screenshots

No UI changes.

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [ ] No downstream repository is affected by this change
- [x] [cozystack/website](https://github.com/cozystack/website) - follow-up: https://github.com/cozystack/website/issues/643
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
feat(kubernetes): The GPU Operator addon of tenant Kubernetes clusters now defaults to a driver provided by the operating system, which is the shape of the Talos workers these clusters have run since 1.6.0. `driver` and `toolkit` are disabled (the driver comes from a Talos system extension, and containerd configuration belongs to the machine config), the driver validator is pointed at the host root so it stops looping on "Attempting to validate a driver container installation", and the device plugin is switched to CDI (`DEVICE_LIST_STRATEGY=cdi-annotations`) so tenant pods receive the CUDA libraries — previously they received the GPU device and nothing else, since Talos does not make `nvidia` the default containerd runtime. The previous default, which fed `NVreg_NvLinkDisable=1` to the operator's driver container through a ConfigMap, is removed because that container is disabled; the parameter is now carried by the worker machine config through `nodeGroups.<name>.kernelModules`. Operators who overrode `addons.gpuOperator.valuesOverride` to work around this by hand can drop those overrides. NOTE: an override that sets `devicePlugin.env` replaces the list rather than merging it, so restate the full list when overriding it or CDI stops working. HAMi is not covered: when `addons.hami.enabled` the operator's device plugin stays off and HAMi's own plugin needs equivalent CDI wiring, which this change does not attempt.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU workloads on Talos workers now use NVIDIA drivers provided by the host operating system.
  * Improved GPU device discovery through CDI annotations and UUID-based device identification.
  * Enhanced compatibility with host-installed NVIDIA tooling and driver paths.

* **Bug Fixes**
  * Prevented unnecessary GPU driver containers and kernel module configuration from being enabled by default.
  * Updated validation and symlink handling for host-provided drivers.

* **Documentation**
  * Clarified GPU driver configuration options and advanced re-enablement requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->