### PR TITLE
fix(kubernetes): keep tenant addon CRDs when a release is uninstalled

### DIFF
--- a/packages/system/gateway-api-crds/Makefile
+++ b/packages/system/gateway-api-crds/Makefile
@@ -3,7 +3,21 @@ export NAMESPACE=cozy-$(NAME)
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
+# Stamp helm.sh/resource-policy: keep on every CustomResourceDefinition so a
+# chart uninstall never garbage-collects the CRDs and, with them, every Gateway,
+# HTTPRoute, GRPCRoute and ReferenceGrant in the cluster. The experimental
+# kustomization also emits a ValidatingAdmissionPolicy and its binding, which
+# hold no user data and are left unannotated.
+# The stamp goes into the CRD's existing metadata.annotations block; a CRD that
+# arrives without one is skipped, and the chart's helm-unittest suite is what
+# catches that.
 update:
 	rm -rf templates
 	mkdir templates
 	kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.5.1" > templates/crds-experimental.yaml
+	@set -e; f=templates/crds-experimental.yaml; tmp=$$(mktemp); \
+	  awk '/^    helm.sh\/resource-policy: keep$$/{next} /^kind: /{kind=$$2} /^  annotations:$$/ && kind=="CustomResourceDefinition"{print; print "    helm.sh/resource-policy: keep"; next} {print}' "$$f" > "$$tmp"; \
+	  cat "$$tmp" > "$$f"; rm -f "$$tmp"

--- a/packages/system/gateway-api-crds/templates/crds-experimental.yaml
+++ b/packages/system/gateway-api-crds/templates/crds-experimental.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: experimental
@@ -1421,6 +1422,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: experimental
@@ -1937,6 +1939,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: experimental
@@ -5267,6 +5270,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: experimental
@@ -7547,6 +7551,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: experimental
@@ -16103,6 +16108,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: experimental
@@ -16884,6 +16890,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: experimental
@@ -17238,6 +17245,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: experimental
@@ -17995,6 +18003,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: experimental
@@ -20366,6 +20375,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: experimental
@@ -21123,6 +21133,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: experimental
@@ -21732,6 +21743,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/4530
     gateway.networking.k8s.io/bundle-version: v1.5.1
     gateway.networking.k8s.io/channel: experimental

--- a/packages/system/gateway-api-crds/tests/resource_policy_test.yaml
+++ b/packages/system/gateway-api-crds/tests/resource_policy_test.yaml
@@ -1,0 +1,141 @@
+# The tenant addon HelmRelease that ships this chart remediates a failed
+# install by uninstalling the release, and an uninstall deletes whatever the
+# chart rendered. Deleting a CRD makes the API server garbage-collect every
+# custom resource of that kind, so an unannotated CRD here costs the cluster
+# every Gateway, HTTPRoute and ReferenceGrant it holds.
+#
+# The first case selects every CustomResourceDefinition at once, so a CRD that
+# `make update` starts rendering is covered without being listed here. The
+# ValidatingAdmissionPolicy pair the experimental kustomization also emits
+# holds no user data and is deliberately left out of that selection. The named
+# cases below pin each CRD individually, so a failure says which one lost the
+# annotation. A selector that matches nothing fails with "document not found"
+# rather than passing on an empty document set.
+suite: Gateway API CRDs survive a release uninstall
+templates:
+  - templates/crds-experimental.yaml
+tests:
+  - it: annotates every CustomResourceDefinition the chart renders
+    documentSelector:
+      path: kind
+      value: CustomResourceDefinition
+      matchMany: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  # Pins the rendered document count, so a change in what the kustomization
+  # emits is visible here rather than only in whichever case happens to break.
+  - it: renders twelve CRDs and the admission policy pair
+    asserts:
+      - hasDocuments:
+          count: 14
+
+  - it: keeps the backendtlspolicies CRD
+    documentSelector:
+      path: metadata.name
+      value: backendtlspolicies.gateway.networking.k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the gatewayclasses CRD
+    documentSelector:
+      path: metadata.name
+      value: gatewayclasses.gateway.networking.k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the gateways CRD
+    documentSelector:
+      path: metadata.name
+      value: gateways.gateway.networking.k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the grpcroutes CRD
+    documentSelector:
+      path: metadata.name
+      value: grpcroutes.gateway.networking.k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the httproutes CRD
+    documentSelector:
+      path: metadata.name
+      value: httproutes.gateway.networking.k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the listenersets CRD
+    documentSelector:
+      path: metadata.name
+      value: listenersets.gateway.networking.k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the referencegrants CRD
+    documentSelector:
+      path: metadata.name
+      value: referencegrants.gateway.networking.k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the tcproutes CRD
+    documentSelector:
+      path: metadata.name
+      value: tcproutes.gateway.networking.k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the tlsroutes CRD
+    documentSelector:
+      path: metadata.name
+      value: tlsroutes.gateway.networking.k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the udproutes CRD
+    documentSelector:
+      path: metadata.name
+      value: udproutes.gateway.networking.k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the xbackendtrafficpolicies CRD
+    documentSelector:
+      path: metadata.name
+      value: xbackendtrafficpolicies.gateway.networking.x-k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the xmeshes CRD
+    documentSelector:
+      path: metadata.name
+      value: xmeshes.gateway.networking.x-k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep

--- a/packages/system/prometheus-operator-crds/Makefile
+++ b/packages/system/prometheus-operator-crds/Makefile
@@ -3,6 +3,9 @@ export NAMESPACE=cozy-victoria-metrics-operator
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 update:
 	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	helm repo update prometheus-community

--- a/packages/system/prometheus-operator-crds/tests/resource_policy_test.yaml
+++ b/packages/system/prometheus-operator-crds/tests/resource_policy_test.yaml
@@ -1,0 +1,142 @@
+# The tenant addon HelmRelease that ships this chart remediates a failed
+# install by uninstalling the release, and an uninstall deletes whatever the
+# chart rendered. Deleting a CRD makes the API server garbage-collect every
+# custom resource of that kind, so an unannotated CRD here costs the cluster
+# every ServiceMonitor, PodMonitor, PrometheusRule and ScrapeConfig it holds.
+#
+# The CRDs come from a vendored subchart that `make update` re-pulls, so the
+# annotation is set through values rather than by editing the templates. The
+# first case scopes to no template at all, so it holds every document the
+# chart renders, including a CRD the subchart starts shipping later. The named
+# cases pin the document count and the CRD name, so an assertion cannot pass
+# against a document it was not meant to inspect.
+suite: Prometheus Operator CRDs survive a release uninstall
+tests:
+  - it: annotates every CustomResourceDefinition the chart renders
+    asserts:
+      - equal:
+          path: kind
+          value: CustomResourceDefinition
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the alertmanagerconfigs CRD
+    template: charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: alertmanagerconfigs.monitoring.coreos.com
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the alertmanagers CRD
+    template: charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagers.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: alertmanagers.monitoring.coreos.com
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the podmonitors CRD
+    template: charts/prometheus-operator-crds/charts/crds/templates/crd-podmonitors.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: podmonitors.monitoring.coreos.com
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the probes CRD
+    template: charts/prometheus-operator-crds/charts/crds/templates/crd-probes.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: probes.monitoring.coreos.com
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the prometheusagents CRD
+    template: charts/prometheus-operator-crds/charts/crds/templates/crd-prometheusagents.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: prometheusagents.monitoring.coreos.com
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the prometheuses CRD
+    template: charts/prometheus-operator-crds/charts/crds/templates/crd-prometheuses.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: prometheuses.monitoring.coreos.com
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the prometheusrules CRD
+    template: charts/prometheus-operator-crds/charts/crds/templates/crd-prometheusrules.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: prometheusrules.monitoring.coreos.com
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the scrapeconfigs CRD
+    template: charts/prometheus-operator-crds/charts/crds/templates/crd-scrapeconfigs.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: scrapeconfigs.monitoring.coreos.com
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the servicemonitors CRD
+    template: charts/prometheus-operator-crds/charts/crds/templates/crd-servicemonitors.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: servicemonitors.monitoring.coreos.com
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the thanosrulers CRD
+    template: charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: thanosrulers.monitoring.coreos.com
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep

--- a/packages/system/prometheus-operator-crds/values.yaml
+++ b/packages/system/prometheus-operator-crds/values.yaml
@@ -1,0 +1,9 @@
+prometheus-operator-crds:
+  crds:
+    # Keep the CRDs on a chart uninstall. Without this a failed install that
+    # remediates by uninstalling takes the definitions with it, and the API
+    # server then garbage-collects every ServiceMonitor, PodMonitor,
+    # PrometheusRule and ScrapeConfig in the cluster. Removing this release on
+    # purpose now leaves the definitions behind to be deleted by hand.
+    annotations:
+      helm.sh/resource-policy: keep

--- a/packages/system/vertical-pod-autoscaler-crds/Makefile
+++ b/packages/system/vertical-pod-autoscaler-crds/Makefile
@@ -3,5 +3,17 @@ export NAMESPACE=cozy-$(NAME)
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
+# Stamp helm.sh/resource-policy: keep on every CustomResourceDefinition so a
+# chart uninstall never garbage-collects the CRDs and, with them, every
+# VerticalPodAutoscaler and VerticalPodAutoscalerCheckpoint in the cluster.
+# The stamp goes into the CRD's existing metadata.annotations block; a CRD that
+# arrives without one is skipped, and the chart's helm-unittest suite is what
+# catches that.
 update:
 	curl -o ./templates/vpa-v1-crd-gen.yaml https://raw.githubusercontent.com/kubernetes/autoscaler/refs/heads/master/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+	@set -e; f=./templates/vpa-v1-crd-gen.yaml; tmp=$$(mktemp); \
+	  awk '/^    helm.sh\/resource-policy: keep$$/{next} /^kind: /{kind=$$2} /^  annotations:$$/ && kind=="CustomResourceDefinition"{print; print "    helm.sh/resource-policy: keep"; next} {print}' "$$f" > "$$tmp"; \
+	  cat "$$tmp" > "$$f"; rm -f "$$tmp"

--- a/packages/system/vertical-pod-autoscaler-crds/templates/vpa-v1-crd-gen.yaml
+++ b/packages/system/vertical-pod-autoscaler-crds/templates/vpa-v1-crd-gen.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes/kubernetes/pull/63797
     controller-gen.kubebuilder.io/version: v0.16.5
   name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
@@ -224,6 +225,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: https://github.com/kubernetes/kubernetes/pull/63797
     controller-gen.kubebuilder.io/version: v0.16.5
   name: verticalpodautoscalers.autoscaling.k8s.io

--- a/packages/system/vertical-pod-autoscaler-crds/tests/resource_policy_test.yaml
+++ b/packages/system/vertical-pod-autoscaler-crds/tests/resource_policy_test.yaml
@@ -1,0 +1,47 @@
+# The tenant addon HelmRelease that ships this chart remediates a failed
+# install by uninstalling the release, and an uninstall deletes whatever the
+# chart rendered. Deleting a CRD makes the API server garbage-collect every
+# custom resource of that kind, so an unannotated CRD here costs the cluster
+# every VerticalPodAutoscaler it holds, along with the recommendation history
+# in the checkpoints.
+#
+# The first case scopes to no template at all, so it holds every document the
+# chart renders. The named cases pin each CRD by name: a selector that matches
+# nothing fails with "document not found" rather than passing on an empty
+# document set.
+suite: VerticalPodAutoscaler CRDs survive a release uninstall
+tests:
+  - it: annotates every CustomResourceDefinition the chart renders
+    asserts:
+      - equal:
+          path: kind
+          value: CustomResourceDefinition
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  # Pins the rendered document count so a CRD added upstream by `make update`
+  # turns this red instead of arriving untested.
+  - it: renders both CRDs
+    template: templates/vpa-v1-crd-gen.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: keeps the VerticalPodAutoscaler CRD
+    documentSelector:
+      path: metadata.name
+      value: verticalpodautoscalers.autoscaling.k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the VerticalPodAutoscalerCheckpoint CRD
+    documentSelector:
+      path: metadata.name
+      value: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep

--- a/packages/system/vsnap-crd/Makefile
+++ b/packages/system/vsnap-crd/Makefile
@@ -3,9 +3,23 @@ export NAMESPACE=cozy-$(NAME)
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
+# Stamp helm.sh/resource-policy: keep on every CustomResourceDefinition so a
+# chart uninstall never garbage-collects the CRDs and, with them, every
+# VolumeSnapshot and VolumeSnapshotContent in the cluster — the objects that
+# hold the only reference to a snapshot on the storage backend.
+# The stamp goes into the CRD's existing metadata.annotations block; a CRD that
+# arrives without one is skipped, and the chart's helm-unittest suite is what
+# catches that.
 update:
 	rm -rf templates
 	mkdir templates
 	wget -O ./templates/volumesnapshotclasses.yaml https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/refs/tags/v8.3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
 	wget -O ./templates/volumesnapshotcontents.yaml https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/refs/tags/v8.3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
 	wget -O ./templates/volumesnapshots.yaml https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/refs/tags/v8.3.0/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+	@set -e; tmp=$$(mktemp); for f in ./templates/*.yaml; do \
+	  awk '/^    helm.sh\/resource-policy: keep$$/{next} /^kind: /{kind=$$2} /^  annotations:$$/ && kind=="CustomResourceDefinition"{print; print "    helm.sh/resource-policy: keep"; next} {print}' "$$f" > "$$tmp"; \
+	  cat "$$tmp" > "$$f"; \
+	done; rm -f "$$tmp"

--- a/packages/system/vsnap-crd/templates/volumesnapshotclasses.yaml
+++ b/packages/system/vsnap-crd/templates/volumesnapshotclasses.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
     controller-gen.kubebuilder.io/version: v0.15.0
   name: volumesnapshotclasses.snapshot.storage.k8s.io

--- a/packages/system/vsnap-crd/templates/volumesnapshotcontents.yaml
+++ b/packages/system/vsnap-crd/templates/volumesnapshotcontents.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.15.0
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/955"
   name: volumesnapshotcontents.snapshot.storage.k8s.io

--- a/packages/system/vsnap-crd/templates/volumesnapshots.yaml
+++ b/packages/system/vsnap-crd/templates/volumesnapshots.yaml
@@ -3,6 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    helm.sh/resource-policy: keep
     controller-gen.kubebuilder.io/version: v0.15.0
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/814"
   name: volumesnapshots.snapshot.storage.k8s.io

--- a/packages/system/vsnap-crd/tests/resource_policy_test.yaml
+++ b/packages/system/vsnap-crd/tests/resource_policy_test.yaml
@@ -1,0 +1,57 @@
+# The tenant addon HelmRelease that ships this chart remediates a failed
+# install by uninstalling the release, and an uninstall deletes whatever the
+# chart rendered. Deleting a CRD makes the API server garbage-collect every
+# custom resource of that kind, so an unannotated CRD here costs the cluster
+# every VolumeSnapshot it holds — the objects that carry the only reference to
+# a snapshot on the storage backend.
+#
+# The first case scopes to no template at all, so it holds every document the
+# chart renders, including a CRD that arrives in a file `make update` starts
+# fetching later. The named cases below pin which CRD each file carries, so an
+# assertion cannot pass against a document it was not meant to inspect.
+suite: volumesnapshot CRDs survive a release uninstall
+tests:
+  - it: annotates every CustomResourceDefinition the chart renders
+    asserts:
+      - equal:
+          path: kind
+          value: CustomResourceDefinition
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the VolumeSnapshotClass CRD
+    template: templates/volumesnapshotclasses.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: volumesnapshotclasses.snapshot.storage.k8s.io
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the VolumeSnapshotContent CRD
+    template: templates/volumesnapshotcontents.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: volumesnapshotcontents.snapshot.storage.k8s.io
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: keeps the VolumeSnapshot CRD
+    template: templates/volumesnapshots.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: volumesnapshots.snapshot.storage.k8s.io
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep


### PR DESCRIPTION
## What this PR does

Four tenant addon HelmReleases render their CRDs from a chart's `templates/` directory and remediate a failed install by uninstalling the release. An uninstall deletes what the chart rendered, and deleting a CRD makes the API server garbage-collect every custom resource of that kind, so a failed reinstall takes every Gateway, VerticalPodAutoscaler, ServiceMonitor or VolumeSnapshot in the tenant cluster with it. This annotates the CRDs of the four packages behind them, `gateway-api-crds`, `vertical-pod-autoscaler-crds`, `prometheus-operator-crds` and `vsnap-crd` (that last one is declared by `helmreleases/volumesnapshot-crd.yaml`), with `helm.sh/resource-policy: keep`, which is what `cert-manager-crds` and `etcd-operator-crds` already carry in this tree.

Three of the four regenerate `templates/` from upstream on `make update`: two delete the directory outright and the third overwrites its file. So the annotation is written into the vendored files and reapplied by a step in each `update:` target. Without that second half the next regeneration drops it silently, with nothing reporting the loss. I ran `make update` for real to check the pair holds: `gateway-api-crds` and `vsnap-crd` come back byte-identical to what is committed here, and `vertical-pod-autoscaler-crds` reproduces the annotation on both of its CRDs. The rest of the VPA diff is upstream drift, because that package's `update:` tracks a branch rather than a pinned ref; the bump itself is not in this PR. The step is idempotent, so running it twice does not stack a second annotation into the same mapping.

`prometheus-operator-crds` ships its CRDs in a vendored subchart that `make update` re-pulls, so nothing under `charts/` is edited. The upstream template already renders `.Values.annotations` onto every CRD it emits, and the annotation is set through the package's `values.yaml`.

The Gateway API kustomization also emits a `ValidatingAdmissionPolicy` and its binding. Those hold no user data, so the stamping step selects on `kind: CustomResourceDefinition` and leaves them alone.

Each package gains a helm-unittest suite and the `test:` target that `hack/helm-unit-tests.sh` requires before it will run a suite at all. Every suite asserts the annotation across all CRDs its chart renders, not only the ones listed by name, so a CRD arriving in a later upstream bump is covered without editing the test.

The annotation has a cost worth stating plainly: uninstalling one of these releases on purpose now leaves the CRDs behind, to be removed by hand. That is the same trade-off `cert-manager-crds` already carries.

This covers the first of the two directions in #3555. The second one, setting `install.strategy.name: RetryOnFailure` on these releases, is a separate decision with a different blast radius and is not part of this PR.

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

I walked the trigger map in `docs/agents/contributing.md` against the file list of this diff. It touches four packages under `packages/system/` and nothing else: no `hack/package.mk`, no app `values.schema.json`, no platform values, no `ApplicationDefinition`, no release asset names. The one line that looked close is the website's "developer tooling (the package Makefiles)" trigger, so I read `content/en/docs/next/development.md` in the website repo: it documents `make update` and `make test` in general terms, and neither goes stale from this change.

### Release note

```release-note
fix(kubernetes): tenant addon CRDs for Gateway API, VerticalPodAutoscaler, Prometheus Operator and VolumeSnapshot now carry `helm.sh/resource-policy: keep`. A failed install that remediates by uninstalling the release no longer deletes those CRDs and, with them, every custom resource of those kinds in the tenant cluster. In exchange, uninstalling one of these releases on purpose now leaves the CRDs in the cluster to be removed by hand.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom Resource Definitions for Gateway API, Prometheus Operator, Vertical Pod Autoscaler, and VolumeSnapshot are now retained when their Helm charts are uninstalled.
  * Prevents loss of custom resources and related configuration during chart lifecycle operations.
* **Tests**
  * Added automated validation confirming all included CRDs receive the retention policy.
  * Added chart test commands to simplify verification of CRD updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->