### PR TITLE
test(tests): pin the keep annotation on cert-manager and etcd-operator CRDs

### DIFF
--- a/packages/system/cert-manager-crds/Makefile
+++ b/packages/system/cert-manager-crds/Makefile
@@ -3,3 +3,6 @@ export NAMESPACE=cozy-cert-manager
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+

--- a/packages/system/cert-manager-crds/tests/resource_policy_test.yaml
+++ b/packages/system/cert-manager-crds/tests/resource_policy_test.yaml
@@ -1,0 +1,24 @@
+# These CRDs carry helm.sh/resource-policy: keep, which is what stops a release
+# uninstall from deleting them and taking every Certificate, Issuer and Order in
+# the cluster with them. This suite pins it.
+#
+# The annotation comes from the upstream template, emitted under
+# `{{- if .Values.crds.keep }}`, and the value that switches it on is ours. The
+# templates themselves are refilled from the vendored upstream chart by
+# packages/system/cert-manager on its own `make update`.
+#
+# The wildcard scope covers a CRD that upstream starts shipping without editing
+# this file. The kind assertion catches a non-CRD document that carries the
+# annotation, which the annotation assertion on its own accepts.
+suite: cert-manager CRDs survive a release uninstall
+templates:
+  - templates/*.yaml
+tests:
+  - it: annotates every CustomResourceDefinition the chart renders
+    asserts:
+      - equal:
+          path: kind
+          value: CustomResourceDefinition
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep

--- a/packages/system/etcd-operator-crds/Makefile
+++ b/packages/system/etcd-operator-crds/Makefile
@@ -3,6 +3,9 @@ export NAMESPACE=cozy-etcd-operator
 
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 # Pinned ref of github.com/cozystack/etcd-operator to vendor CRDs from.
 ETCD_OPERATOR_REF ?= v0.5.4
 

--- a/packages/system/etcd-operator-crds/tests/resource_policy_test.yaml
+++ b/packages/system/etcd-operator-crds/tests/resource_policy_test.yaml
@@ -1,0 +1,23 @@
+# These CRDs carry helm.sh/resource-policy: keep, which is what stops a release
+# uninstall from deleting them and taking every EtcdCluster, EtcdMember and
+# EtcdSnapshot in the cluster with them. This suite pins it.
+#
+# The annotation is stamped by the awk step in `make update`, anchored on the
+# controller-gen.kubebuilder.io/version: line the upstream CRDs carry. If that
+# line stops being emitted, the step matches nothing and exits zero.
+#
+# The wildcard scope covers a CRD added to the vendoring list without editing
+# this file. The kind assertion catches a non-CRD document that carries the
+# annotation, which the annotation assertion on its own accepts.
+suite: etcd-operator CRDs survive a release uninstall
+templates:
+  - templates/*.yaml
+tests:
+  - it: annotates every CustomResourceDefinition the chart renders
+    asserts:
+      - equal:
+          path: kind
+          value: CustomResourceDefinition
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep


### PR DESCRIPTION
## What this PR does

`cert-manager-crds` and `etcd-operator-crds` are the two packages this repository points at as the in-tree precedent for protecting CRDs with `helm.sh/resource-policy: keep`. Both carry the annotation, neither had a test, so it could be lost with nothing reporting the loss. This adds a suite to each, plus the `test:` target that `hack/helm-unit-tests.sh` needs before it will run one. No annotation is added and no rendered output changes: the point is to close the way of losing what is already there.

The two are exposed differently, so the suites say so instead of sharing one explanation. In `etcd-operator-crds` the annotation is ours. `make update` stamps it with an awk step anchored on the `controller-gen.kubebuilder.io/version:` line that the upstream CRDs carry. If a future controller-gen stops emitting that line, the step matches nothing, writes the CRDs out unstamped and exits zero.

In `cert-manager-crds` the annotation comes from the upstream template, emitted under `{{- if .Values.crds.keep }}`, and the value that switches it on is ours. That is two independent ways to lose it. The templates are also not maintained in that package: `packages/system/cert-manager/Makefile` deletes and refills its `templates/` directory during its own `make update`, so a cert-manager bump rewrites a neighbouring package that whoever runs the bump has no reason to open.

Each suite is scoped with the wildcard `templates/*.yaml` and asserts across every document rendered under it, rather than listing CRD names or pinning a document count, so a CRD that upstream starts shipping is covered without editing the test. Each also asserts the kind, because the annotation assertion on its own would accept a non-CRD document that happened to carry it. Both charts render only CRDs today, checked with `helm template`.

The `test:` target is load-bearing rather than boilerplate. `hack/helm-unit-tests.sh` runs a package's suite only when its Makefile defines that target. With the target present, breaking a chart makes the whole run exit 1 and name the directory. With the fixtures present but the target removed, the same broken chart gives exit 0 and "All Helm unit tests passed", having executed the suite zero times.

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

I walked the trigger map in `docs/agents/contributing.md` against the file list of this diff. It adds two test files and two `test:` targets under `packages/system/`, and touches nothing else: no `hack/package.mk`, no app `values.schema.json`, no platform values, no `ApplicationDefinition`, no release asset names. The website's "developer tooling (the package Makefiles)" trigger is the one worth checking, so I read `content/en/docs/next/development.md` there: it documents `make test` in general terms and does not go stale from a package gaining that target.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated validation for cert-manager and etcd operator CRD charts.
  * Confirmed rendered resources are correctly identified as CustomResourceDefinitions.
  * Verified CRDs retain the required `keep` resource policy during Helm operations.

* **Chores**
  * Added convenient test commands for running Helm chart validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->