### PR TITLE
fix(apps): make the post-delete cleanup hooks report failure

### DIFF
--- a/hack/app-cleanup-hooks_test.bats
+++ b/hack/app-cleanup-hooks_test.bats
@@ -1,0 +1,513 @@
+#!/usr/bin/env bats
+# Behavioural tests for the two post-delete cleanup hooks that reclaim storage
+# and ACME objects when an app release is uninstalled:
+#
+#   packages/apps/qdrant/templates/hooks/cleanup-pvc.yaml
+#   packages/apps/harbor/templates/hooks/cleanup.yaml
+#
+# The scripts are extracted from the rendered charts and RUN against a fake
+# kubectl, because the property under test is the container's exit code and no
+# amount of matching against the manifest text establishes it. The helm-unittest
+# suites in packages/apps/*/tests/ match the source text instead.
+#
+# What is pinned here:
+#   * a delete that failed makes the hook exit non-zero. Without that, Helm
+#     records the hook as succeeded and the hook-succeeded delete policy removes
+#     the Job together with the pod that held the only account of the failure;
+#   * one failed delete does not skip the deletes that follow it;
+#   * an object that is already gone stays a success, so a re-run over an
+#     already-clean namespace exits 0;
+#   * a listing that FAILED is distinguishable from one that returned nothing.
+#
+# Run via hack/cozytest.sh from the repo root (make bats-unit-tests); relative
+# paths resolve against that cwd. The runner has no setup/teardown, so each
+# @test builds its own fixture and removes it at the end of the body. No EXIT
+# trap: docs/agents/e2e-testing.md bans them in hack/*.bats, and under the bats
+# binary a test that installs one and then fails prints no TAP line at all.
+
+QDRANT_CHART=packages/apps/qdrant
+HARBOR_CHART=packages/apps/harbor
+
+# render_hook <chart> <release> <namespace> <job-name> <out> [extra helm args…]
+# Extract the named Job's shell script from the rendered chart into <out>. The
+# non-empty check must be an early `return 1`: hack/cozytest.sh rewrites every
+# line matching ^}$ into `return 0` plus `}`, helpers included, so a check left
+# in last-command position has its status discarded.
+render_hook() {
+  chart=$1 release=$2 namespace=$3 job=$4 out=$5
+  shift 5
+  helm template "$release" "$chart" --namespace "$namespace" "$@" \
+    | yq eval "select(.kind == \"Job\" and .metadata.name == \"$job\") | .spec.template.spec.containers[0].command[2]" - > "$out"
+  [ -s "$out" ] || return 1
+}
+
+# write_fake_kubectl <dir>
+# Emit a fake `kubectl` that logs every call to $KLOG and models the three
+# kubectl behaviours these hooks depend on:
+#   * a listing prints the fixture held in $PVC_LIST / $CHALLENGE_LIST /
+#     $SOLVER_LIST and exits 0 — or, when its kind is named in $FAIL_GET, prints
+#     an error and exits 1 having printed nothing, which is what makes "the
+#     listing failed" and "the listing was empty" different events;
+#   * a delete whose kind is named in $FAIL_DELETE exits 1;
+#   * a delete of an object absent from $EXISTING is a NotFound: exit 0 under
+#     --ignore-not-found, exit 1 without it. Dropping that flag from a hook
+#     therefore turns the already-gone cases red rather than passing silently.
+# A label-selector delete matches whatever is present and always exits 0, as
+# kubectl's does. No line below is a bare column-0 `}`, so cozytest.sh's parser
+# leaves the fixture intact.
+write_fake_kubectl() {
+  cat > "$1/kubectl" <<'KEOF'
+#!/bin/sh
+echo "$*" >> "$KLOG"
+verb=$1
+kind=${2:-}
+
+# The by-name deletes put the object name last. Flags and the value that
+# follows -n / -l are skipped, so what survives is the trailing positional.
+obj=""
+skip=0
+for a in "$@"; do
+  if [ "$skip" = 1 ]; then skip=0; continue; fi
+  case "$a" in
+    -n|-l) skip=1 ;;
+    -*) ;;
+    *) obj=$a ;;
+  esac
+done
+
+if [ "$verb" = get ]; then
+  case " ${FAIL_GET:-} " in
+    *" $kind "*) echo "error: the server could not list $kind" >&2; exit 1 ;;
+  esac
+  case "$kind" in
+    pvc) printf '%s' "${PVC_LIST:-}" ;;
+    challenge) printf '%s' "${CHALLENGE_LIST:-}" ;;
+    ingress) printf '%s' "${SOLVER_LIST:-}" ;;
+    *) echo "fake kubectl: unexpected get kind $kind" >&2; exit 64 ;;
+  esac
+  exit 0
+fi
+
+if [ "$verb" != delete ]; then
+  echo "fake kubectl: unexpected verb $verb" >&2
+  exit 64
+fi
+
+# qdrant deletes through xargs as `delete -n NS --ignore-not-found <name>…`, so
+# there is no kind argument on that call; it is always a PVC delete.
+case "$kind" in -*) kind=pvc ;; esac
+
+case " ${FAIL_DELETE:-} " in
+  *" $kind "*) echo "Error from server: failed to delete $kind $obj" >&2; exit 1 ;;
+esac
+case "$*" in *" -l "*) exit 0 ;; esac
+case " ${EXISTING:-} " in
+  *" $obj "*) exit 0 ;;
+esac
+case "$*" in
+  *--ignore-not-found*) exit 0 ;;
+esac
+echo "Error from server (NotFound): $obj not found" >&2
+exit 1
+KEOF
+  chmod 0755 "$1/kubectl"
+}
+
+@test "a render that produces no script fails instead of passing as a no-op" {
+  # Guards the guard: every test below runs whatever render_hook produced, so an
+  # empty render would satisfy the exit-0 assertions without exercising a line
+  # of the hook. This also fails if the emptiness check is ever moved into
+  # last-command position, where cozytest.sh's `return 0` rewrite swallows it.
+  tmp=$(mktemp -d)
+  if render_hook "$tmp/no-such-chart" r ns r-cleanup "$tmp/hook.sh" 2>/dev/null; then
+    echo "FAIL: render_hook reported success with no chart to render"
+    false
+  fi
+  if render_hook "$QDRANT_CHART" qdrant-test tenant-test no-such-job "$tmp/hook.sh"; then
+    echo "FAIL: render_hook reported success for a Job name the chart never emits"
+    false
+  fi
+  rm -rf "$tmp"
+}
+
+@test "qdrant hook exits 0 and deletes exactly the release's data PVCs" {
+  tmp=$(mktemp -d)
+  write_fake_kubectl "$tmp"
+  render_hook "$QDRANT_CHART" qdrant-test tenant-test qdrant-test-qdrant-cleanup "$tmp/hook.sh"
+
+  export KLOG="$tmp/calls"
+  # Two of this release's data PVCs, one belonging to the sibling release
+  # "qdrant-test-2", and one unrelated claim.
+  export PVC_LIST='persistentvolumeclaim/qdrant-storage-qdrant-test-0
+persistentvolumeclaim/qdrant-storage-qdrant-test-1
+persistentvolumeclaim/qdrant-storage-qdrant-test-2-0
+persistentvolumeclaim/db-qdrant-test-0'
+  export EXISTING='persistentvolumeclaim/qdrant-storage-qdrant-test-0 persistentvolumeclaim/qdrant-storage-qdrant-test-1'
+
+  rc=0
+  PATH="$tmp:$PATH" sh "$tmp/hook.sh" > "$tmp/out" 2> "$tmp/err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL: hook exited $rc when every delete succeeded"
+    cat "$tmp/out" "$tmp/err"
+    false
+  fi
+  if ! grep -q 'PVC cleanup complete' "$tmp/out"; then
+    echo "FAIL: hook did not report completion"
+    cat "$tmp/out" "$tmp/err"
+    false
+  fi
+  if ! grep -q 'delete .*qdrant-storage-qdrant-test-0' "$tmp/calls"; then
+    echo "FAIL: the release's data PVCs were never deleted"
+    cat "$tmp/calls"
+    false
+  fi
+  if grep -q 'qdrant-storage-qdrant-test-2-0' "$tmp/calls"; then
+    echo "FAIL: the sibling release's PVC was included in the delete"
+    cat "$tmp/calls"
+    false
+  fi
+  rm -rf "$tmp"
+}
+
+@test "qdrant hook exits 0 when the data PVCs are already gone" {
+  # The idempotent re-run: uninstalling twice, or uninstalling a release whose
+  # storage was reclaimed by hand, must not be reported as a failed cleanup.
+  # Covered in both shapes it takes — nothing matched the selector at all, and
+  # the delete itself came back NotFound.
+  tmp=$(mktemp -d)
+  write_fake_kubectl "$tmp"
+  render_hook "$QDRANT_CHART" qdrant-test tenant-test qdrant-test-qdrant-cleanup "$tmp/hook.sh"
+
+  export KLOG="$tmp/calls"
+  export PVC_LIST=''
+  export EXISTING=''
+
+  rc=0
+  PATH="$tmp:$PATH" sh "$tmp/hook.sh" > "$tmp/out" 2> "$tmp/err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL: hook exited $rc with no matching PVCs in the namespace"
+    cat "$tmp/out" "$tmp/err"
+    false
+  fi
+  if ! grep -q 'nothing to delete' "$tmp/out"; then
+    echo "FAIL: hook did not report an empty namespace"
+    cat "$tmp/out"
+    false
+  fi
+
+  # Same release, but the PVCs are listed and disappear before the delete lands.
+  : > "$tmp/calls"
+  export PVC_LIST='persistentvolumeclaim/qdrant-storage-qdrant-test-0'
+  rc=0
+  PATH="$tmp:$PATH" sh "$tmp/hook.sh" > "$tmp/out2" 2> "$tmp/err2" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL: hook exited $rc on a NotFound delete, which --ignore-not-found makes a success"
+    cat "$tmp/out2" "$tmp/err2"
+    false
+  fi
+  if ! grep -q 'delete .*qdrant-storage-qdrant-test-0' "$tmp/calls"; then
+    echo "FAIL: the delete was never attempted, so the NotFound path was not exercised"
+    cat "$tmp/calls"
+    false
+  fi
+  rm -rf "$tmp"
+}
+
+@test "qdrant hook exits non-zero and names the PVCs when the delete fails" {
+  tmp=$(mktemp -d)
+  write_fake_kubectl "$tmp"
+  render_hook "$QDRANT_CHART" qdrant-test tenant-test qdrant-test-qdrant-cleanup "$tmp/hook.sh"
+
+  export KLOG="$tmp/calls"
+  export PVC_LIST='persistentvolumeclaim/qdrant-storage-qdrant-test-0'
+  export EXISTING="$PVC_LIST"
+  export FAIL_DELETE='pvc'
+
+  rc=0
+  PATH="$tmp:$PATH" sh "$tmp/hook.sh" > "$tmp/out" 2> "$tmp/err" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL: hook exited 0 although the PVC delete failed"
+    cat "$tmp/out" "$tmp/err"
+    false
+  fi
+  # The message must name what was left behind, not merely that something was.
+  # Anchored on the hook's own `ERROR: ` prefix: the fake kubectl names the
+  # object in its own diagnostic too, so an unanchored match is satisfied by
+  # the fake and stays green even when the hook stops naming anything.
+  if ! grep -q '^ERROR: .*qdrant-storage-qdrant-test-0' "$tmp/err"; then
+    echo "FAIL: the failure was not attributed to a named PVC"
+    cat "$tmp/err"
+    false
+  fi
+  if grep -q 'PVC cleanup complete' "$tmp/out"; then
+    echo "FAIL: hook reported completion after a failed delete"
+    cat "$tmp/out"
+    false
+  fi
+  rm -rf "$tmp"
+}
+
+@test "qdrant hook exits non-zero when the PVC listing fails instead of reporting nothing to delete" {
+  # A failed listing used to reach the filter as an empty string, so the hook
+  # announced an empty namespace and exited 0 without having looked.
+  tmp=$(mktemp -d)
+  write_fake_kubectl "$tmp"
+  render_hook "$QDRANT_CHART" qdrant-test tenant-test qdrant-test-qdrant-cleanup "$tmp/hook.sh"
+
+  export KLOG="$tmp/calls"
+  export PVC_LIST=''
+  export EXISTING=''
+  export FAIL_GET='pvc'
+
+  rc=0
+  PATH="$tmp:$PATH" sh "$tmp/hook.sh" > "$tmp/out" 2> "$tmp/err" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL: hook exited 0 although it never managed to list the PVCs"
+    cat "$tmp/out" "$tmp/err"
+    false
+  fi
+  if grep -q 'nothing to delete' "$tmp/out"; then
+    echo "FAIL: a failed listing was reported as an empty namespace"
+    cat "$tmp/out"
+    false
+  fi
+  if ! grep -q 'failed to list PVCs' "$tmp/err"; then
+    echo "FAIL: the failed listing was not named"
+    cat "$tmp/err"
+    false
+  fi
+  rm -rf "$tmp"
+}
+
+@test "harbor hook exits 0 and sweeps PVCs, Certificate and ACME solvers" {
+  tmp=$(mktemp -d)
+  write_fake_kubectl "$tmp"
+  render_hook "$HARBOR_CHART" harbor-test tenant-test harbor-test-cleanup "$tmp/hook.sh" \
+    --set '_namespace.host=example.org' --set '_cluster.solver=http01'
+
+  export KLOG="$tmp/calls"
+  export CHALLENGE_LIST='harbor-test-cert-1 '
+  export SOLVER_LIST='cm-acme-http-solver-abcde '
+  export EXISTING='harbor-test-ingress-tls harbor-test-cert-1 cm-acme-http-solver-abcde'
+
+  rc=0
+  PATH="$tmp:$PATH" sh "$tmp/hook.sh" > "$tmp/out" 2> "$tmp/err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL: hook exited $rc when every delete succeeded"
+    cat "$tmp/out" "$tmp/err"
+    false
+  fi
+  if ! grep -q 'Cleanup complete' "$tmp/out"; then
+    echo "FAIL: hook did not report completion"
+    cat "$tmp/out" "$tmp/err"
+    false
+  fi
+  for expected in 'delete pvc' 'delete certificate' 'delete challenge' 'delete ingress'; do
+    if ! grep -q "$expected" "$tmp/calls"; then
+      echo "FAIL: the hook never issued: $expected"
+      cat "$tmp/calls"
+      false
+    fi
+  done
+  rm -rf "$tmp"
+}
+
+@test "harbor hook exits 0 when every object is already gone" {
+  # No in-flight ACME challenge and no solver Ingress is the ordinary case, and
+  # the Certificate is usually collected with the release before the hook runs.
+  # All of it must stay a success.
+  tmp=$(mktemp -d)
+  write_fake_kubectl "$tmp"
+  render_hook "$HARBOR_CHART" harbor-test tenant-test harbor-test-cleanup "$tmp/hook.sh" \
+    --set '_namespace.host=example.org' --set '_cluster.solver=http01'
+
+  export KLOG="$tmp/calls"
+  export CHALLENGE_LIST=''
+  export SOLVER_LIST=''
+  export EXISTING=''
+
+  rc=0
+  PATH="$tmp:$PATH" sh "$tmp/hook.sh" > "$tmp/out" 2> "$tmp/err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL: hook exited $rc on an already-clean namespace"
+    cat "$tmp/out" "$tmp/err"
+    false
+  fi
+  # The Certificate delete is the one that actually reaches a NotFound here, so
+  # it has to have been attempted for this test to mean anything.
+  if ! grep -q 'delete certificate .*harbor-test-ingress-tls' "$tmp/calls"; then
+    echo "FAIL: the Certificate delete was never attempted"
+    cat "$tmp/calls"
+    false
+  fi
+  rm -rf "$tmp"
+}
+
+@test "harbor hook reports a failed delete, names the object and still runs the later sweeps" {
+  tmp=$(mktemp -d)
+  write_fake_kubectl "$tmp"
+  render_hook "$HARBOR_CHART" harbor-test tenant-test harbor-test-cleanup "$tmp/hook.sh" \
+    --set '_namespace.host=example.org' --set '_cluster.solver=http01'
+
+  export KLOG="$tmp/calls"
+  export CHALLENGE_LIST='harbor-test-cert-1 '
+  export SOLVER_LIST='cm-acme-http-solver-abcde '
+  export EXISTING='harbor-test-ingress-tls harbor-test-cert-1 cm-acme-http-solver-abcde'
+  export FAIL_DELETE='pvc'
+
+  rc=0
+  PATH="$tmp:$PATH" sh "$tmp/hook.sh" > "$tmp/out" 2> "$tmp/err" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL: hook exited 0 although the PVC delete failed"
+    cat "$tmp/out" "$tmp/err"
+    false
+  fi
+  if ! grep -q '^ERROR: .*release=harbor-test-system' "$tmp/err"; then
+    echo "FAIL: the failure was not attributed to the objects it left behind"
+    cat "$tmp/err"
+    false
+  fi
+  # The first failure must not cost the release its Certificate and solver
+  # cleanup: those run to completion and the exit code is decided at the end.
+  for expected in 'delete certificate' 'delete challenge' 'delete ingress'; do
+    if ! grep -q "$expected" "$tmp/calls"; then
+      echo "FAIL: the sweep stopped at the first failure, skipping: $expected"
+      cat "$tmp/calls"
+      false
+    fi
+  done
+  if grep -q 'Cleanup complete' "$tmp/out"; then
+    echo "FAIL: hook reported completion after a failed delete"
+    cat "$tmp/out"
+    false
+  fi
+  rm -rf "$tmp"
+}
+
+@test "harbor hook reports every ACME delete that failed, each by name" {
+  # The PVC sweep is only one of harbor's failure paths; the Certificate and the
+  # two per-object ACME deletes are three more, and #3566 names each of them
+  # separately. Covered together, with the PVC delete deliberately succeeding,
+  # so this test fails if ANY of the three stops reporting — reverting one of
+  # them to `|| echo "WARNING …"` is the exact defect being fixed.
+  tmp=$(mktemp -d)
+  write_fake_kubectl "$tmp"
+  render_hook "$HARBOR_CHART" harbor-test tenant-test harbor-test-cleanup "$tmp/hook.sh" \
+    --set '_namespace.host=example.org' --set '_cluster.solver=http01'
+
+  export KLOG="$tmp/calls"
+  export CHALLENGE_LIST='harbor-test-cert-1 '
+  export SOLVER_LIST='cm-acme-http-solver-abcde '
+  export EXISTING='harbor-test-ingress-tls harbor-test-cert-1 cm-acme-http-solver-abcde'
+  export FAIL_DELETE='certificate challenge ingress'
+
+  rc=0
+  PATH="$tmp:$PATH" sh "$tmp/hook.sh" > "$tmp/out" 2> "$tmp/err" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL: hook exited 0 although three ACME deletes failed"
+    cat "$tmp/out" "$tmp/err"
+    false
+  fi
+  # Anchored on the hook's own ERROR: prefix — the fake kubectl names the object
+  # in its own diagnostic too, so an unanchored match would be satisfied by the
+  # fixture and stay green with the hook reporting nothing.
+  for object in 'Certificate tenant-test/harbor-test-ingress-tls' \
+                'Challenge tenant-test/harbor-test-cert-1' \
+                'solver Ingress tenant-test/cm-acme-http-solver-abcde'; do
+    if ! grep -q "^ERROR: .*$object" "$tmp/err"; then
+      echo "FAIL: the hook did not report the failed delete of: $object"
+      cat "$tmp/err"
+      false
+    fi
+  done
+  if grep -q 'Cleanup complete' "$tmp/out"; then
+    echo "FAIL: hook reported completion after three failed deletes"
+    cat "$tmp/out"
+    false
+  fi
+  rm -rf "$tmp"
+}
+
+@test "harbor hook reports a failed solver Ingress listing, the second of its two loops" {
+  # The Challenge listing is covered below; this is the other loop. Both have
+  # the same shape and each needs its own case, because a revert of one is
+  # invisible to a test that only exercises the other.
+  tmp=$(mktemp -d)
+  write_fake_kubectl "$tmp"
+  render_hook "$HARBOR_CHART" harbor-test tenant-test harbor-test-cleanup "$tmp/hook.sh" \
+    --set '_namespace.host=example.org' --set '_cluster.solver=http01'
+
+  export KLOG="$tmp/calls"
+  export CHALLENGE_LIST='harbor-test-cert-1 '
+  export SOLVER_LIST=''
+  export EXISTING='harbor-test-ingress-tls harbor-test-cert-1'
+  export FAIL_GET='ingress'
+
+  rc=0
+  PATH="$tmp:$PATH" sh "$tmp/hook.sh" > "$tmp/out" 2> "$tmp/err" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL: hook exited 0 although it never managed to list the solver Ingresses"
+    cat "$tmp/out" "$tmp/err"
+    false
+  fi
+  if ! grep -q '^ERROR: .*failed to list solver Ingresses' "$tmp/err"; then
+    echo "FAIL: the failed solver Ingress listing was not reported by the hook"
+    cat "$tmp/err"
+    false
+  fi
+  # The Challenge sweep runs before it and must have completed normally: this
+  # failure is counted, not fatal.
+  if ! grep -q 'delete challenge .*harbor-test-cert-1' "$tmp/calls"; then
+    echo "FAIL: the Challenge sweep preceding the failed listing did not run"
+    cat "$tmp/calls"
+    false
+  fi
+  if grep -q 'Cleanup complete' "$tmp/out"; then
+    echo "FAIL: hook reported completion after a failed listing"
+    cat "$tmp/out"
+    false
+  fi
+  rm -rf "$tmp"
+}
+
+@test "harbor hook exits non-zero when a listing fails instead of sweeping nothing" {
+  # Iterating $(kubectl get …) directly cannot tell a failed listing from an
+  # empty one: both leave the loop body unexecuted, so the sweep reported
+  # success without having looked.
+  tmp=$(mktemp -d)
+  write_fake_kubectl "$tmp"
+  render_hook "$HARBOR_CHART" harbor-test tenant-test harbor-test-cleanup "$tmp/hook.sh" \
+    --set '_namespace.host=example.org' --set '_cluster.solver=http01'
+
+  export KLOG="$tmp/calls"
+  export CHALLENGE_LIST=''
+  export SOLVER_LIST='cm-acme-http-solver-abcde '
+  export EXISTING='harbor-test-ingress-tls cm-acme-http-solver-abcde'
+  export FAIL_GET='challenge'
+
+  rc=0
+  PATH="$tmp:$PATH" sh "$tmp/hook.sh" > "$tmp/out" 2> "$tmp/err" || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    echo "FAIL: hook exited 0 although it never managed to list the Challenges"
+    cat "$tmp/out" "$tmp/err"
+    false
+  fi
+  if ! grep -q 'failed to list Challenges' "$tmp/err"; then
+    echo "FAIL: the failed listing was not named"
+    cat "$tmp/err"
+    false
+  fi
+  # A failed listing is counted, not fatal: the solver Ingress sweep after it
+  # still runs and still deletes what it finds.
+  if ! grep -q 'delete ingress .*cm-acme-http-solver-abcde' "$tmp/calls"; then
+    echo "FAIL: the failed listing aborted the solver Ingress sweep that follows it"
+    cat "$tmp/calls"
+    false
+  fi
+  if grep -q 'Cleanup complete' "$tmp/out"; then
+    echo "FAIL: hook reported completion after a failed listing"
+    cat "$tmp/out"
+    false
+  fi
+  rm -rf "$tmp"
+}

--- a/hack/e2e-chainsaw/harbor/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/harbor/chainsaw-test.yaml
@@ -57,7 +57,7 @@ spec:
   # would be a permanently-empty capture, the defect these selectors exist to
   # avoid. The qdrant suite deletes inside a `try:`, so there the Job is at
   # least in scope, and that suite carries the collector with its own note on
-  # how narrow the window is.
+  # when it captures anything.
   - podLogs:
       selector: app.kubernetes.io/instance=harbor-test-system
       tail: 50

--- a/hack/e2e-chainsaw/qdrant/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/qdrant/chainsaw-test.yaml
@@ -24,15 +24,16 @@ spec:
   # delete below happens inside a `try:`, so the Job is in scope while the test
   # is still running.
   #
-  # What this does NOT reach, so the capture is not read as the whole story:
-  # that hook always exits 0 -- no `set -e`, the delete is guarded by
-  # `|| echo "WARNING: PVC cleanup failed"`, and the script ends on an
-  # unconditional echo. Helm therefore marks it succeeded and
-  # `hook-delete-policy: hook-succeeded` takes the pod away, warning and all.
-  # What is left is the case where the uninstall hangs and Helm is still
-  # waiting on the hook: the pod is alive then, and its log is the only account
-  # of where it stopped. The `get jobs,pods` in the cleanup step below lists
-  # the objects but reads no log.
+  # What this reaches, and when, so the capture is read for what it is: the hook
+  # exits non-zero when a delete or a listing failed, and
+  # `hook-delete-policy: hook-succeeded` does not fire for a hook that failed --
+  # so on exactly the runs worth investigating the pod is still there, and this
+  # is the account of what the cleanup could not remove. It also reaches a hook
+  # that is still running, where the uninstall hangs and Helm is still waiting.
+  # On a clean uninstall the hook succeeds and its pod is collected away, so an
+  # empty capture here is the ordinary case rather than a stale selector -- the
+  # instance-label listing below is what tells those two apart. The
+  # `get jobs,pods` in the cleanup step below lists the objects but reads no log.
   - podLogs:
       selector: app.kubernetes.io/instance=qdrant-test
       tail: 50

--- a/packages/apps/harbor/templates/hooks/cleanup.yaml
+++ b/packages/apps/harbor/templates/hooks/cleanup.yaml
@@ -11,6 +11,18 @@ metadata:
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  # One retry — not the Kubernetes default of six, and not zero. Every delete
+  # below is idempotent and carries --ignore-not-found, so a second attempt
+  # re-issues an API call rather than re-running any logic, and one short
+  # backoff is what separates a transient apiserver error from a real one.
+  # That distinction is the whole point here: this hook's failures become
+  # visible for the first time with this change, and a signal that fires on
+  # noise stops being read — including on the day it is right. Six is the far
+  # end of the same mistake: the Job would spend about ten minutes backing off
+  # across seven pods, outlasting the hook timeout, and Helm would report that
+  # timeout instead of the hook's own error. Load-bearing only since the script
+  # gained a non-zero exit; before that the script could not report one.
+  backoffLimit: 1
   template:
     metadata:
       labels:
@@ -54,6 +66,29 @@ spec:
             - -c
             - |
               set -u
+              # A delete that did not happen must reach Helm as a non-zero exit.
+              # Otherwise the hook-succeeded delete policy garbage-collects this
+              # Job and the pod that carried the only account of the failure, and
+              # an uninstall that left resources behind is indistinguishable from
+              # one that had nothing to reclaim. Failures are counted and the
+              # exit code is set at the end rather than with `set -e`, so a
+              # failure in the PVC sweep does not skip the ACME sweep below it.
+              # An object that is already gone is not a failure: every delete
+              # below passes --ignore-not-found, which exits 0 in that case, so
+              # re-running this hook over an already-clean namespace still
+              # succeeds. Cost: on failure the Job and its pods stay in the
+              # namespace, which is the point — they hold the log. Nothing
+              # collects them on its own: before-hook-creation deletes the
+              # previous copy only when this hook runs again, and a post-delete
+              # hook runs only on an uninstall. They stay until a release of
+              # this name is installed and uninstalled again, or until the
+              # namespace goes.
+              failures=0
+              fail() {
+                failures=$((failures + 1))
+                echo "ERROR: $*" >&2
+              }
+
               # Harbor's jobservice and trivy PVCs are annotated with
               # helm.sh/resource-policy: keep by the upstream subchart
               # (persistence.resourcePolicy: keep), so Helm/Flux deliberately
@@ -70,7 +105,7 @@ spec:
               echo "Deleting orphaned PVCs for {{ .Release.Name }}-system..."
               kubectl delete pvc -n {{ .Release.Namespace }} \
                 -l release={{ .Release.Name }}-system --ignore-not-found \
-                || echo "WARNING: PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
+                || fail "failed to delete PVCs matching release={{ .Release.Name }}-system in {{ .Release.Namespace }}; orphaned PVCs may remain"
 
               # Remove the cert-manager Certificate owned by this release's
               # Ingress so an in-flight http01 challenge does not leave a
@@ -88,7 +123,7 @@ spec:
               echo "Deleting ACME Certificate for {{ .Release.Name }}-ingress..."
               kubectl delete certificate -n {{ .Release.Namespace }} \
                 {{ .Release.Name }}-ingress-tls --ignore-not-found \
-                || echo "WARNING: cert-manager cleanup failed for {{ .Release.Name }}; orphaned ACME resources may remain" >&2
+                || fail "failed to delete Certificate {{ .Release.Namespace }}/{{ .Release.Name }}-ingress-tls; orphaned ACME resources may remain"
 
               # Belt-and-braces sweep for ACME http01 solver objects that
               # cert-manager may have orphaned (e.g. the Certificate was
@@ -103,18 +138,37 @@ spec:
               # issued for this release's single Harbor host only.
               HOST="{{ $harborHost }}"
               echo "Sweeping orphaned ACME http01 solvers for host $HOST..."
-              for ch in $(kubectl get challenge -n {{ .Release.Namespace }} \
-                -o jsonpath="{range .items[?(@.spec.dnsName=='$HOST')]}{.metadata.name} {end}" 2>/dev/null); do
-                kubectl delete challenge -n {{ .Release.Namespace }} "$ch" --ignore-not-found \
-                  || echo "WARNING: failed to delete challenge $ch for {{ .Release.Name }}; orphaned solver may remain" >&2
-              done
-              for ing in $(kubectl get ingress -n {{ .Release.Namespace }} \
+              # Each listing is captured before it is iterated. Iterating
+              # $(kubectl get ...) directly cannot distinguish a failed listing
+              # from an empty one: both leave the loop with nothing to do, so a
+              # sweep that never got to look reads exactly like a sweep that
+              # found nothing to sweep. kubectl's own diagnostic is left on
+              # stderr for the same reason — it is the only account of why the
+              # listing failed.
+              if challenges=$(kubectl get challenge -n {{ .Release.Namespace }} \
+                -o jsonpath="{range .items[?(@.spec.dnsName=='$HOST')]}{.metadata.name} {end}"); then
+                for ch in $challenges; do
+                  kubectl delete challenge -n {{ .Release.Namespace }} "$ch" --ignore-not-found \
+                    || fail "failed to delete Challenge {{ .Release.Namespace }}/$ch for host $HOST; orphaned solver may remain"
+                done
+              else
+                fail "failed to list Challenges in {{ .Release.Namespace }} for host $HOST; orphaned ACME solvers may remain"
+              fi
+              if solvers=$(kubectl get ingress -n {{ .Release.Namespace }} \
                 -l acme.cert-manager.io/http01-solver=true \
-                -o jsonpath="{range .items[?(@.spec.rules[0].host=='$HOST')]}{.metadata.name} {end}" 2>/dev/null); do
-                kubectl delete ingress -n {{ .Release.Namespace }} "$ing" --ignore-not-found \
-                  || echo "WARNING: failed to delete solver ingress $ing for {{ .Release.Name }}; orphaned solver may remain" >&2
-              done
+                -o jsonpath="{range .items[?(@.spec.rules[0].host=='$HOST')]}{.metadata.name} {end}"); then
+                for ing in $solvers; do
+                  kubectl delete ingress -n {{ .Release.Namespace }} "$ing" --ignore-not-found \
+                    || fail "failed to delete solver Ingress {{ .Release.Namespace }}/$ing for host $HOST; orphaned solver may remain"
+                done
+              else
+                fail "failed to list solver Ingresses in {{ .Release.Namespace }} for host $HOST; orphaned ACME solvers may remain"
+              fi
 
+              if [ "$failures" -ne 0 ]; then
+                echo "Cleanup FAILED for {{ .Release.Name }}: $failures operation(s) did not complete; see the errors above." >&2
+                exit 1
+              fi
               echo "Cleanup complete."
           volumeMounts:
             - name: tmp

--- a/packages/apps/harbor/tests/cleanup_hook_test.yaml
+++ b/packages/apps/harbor/tests/cleanup_hook_test.yaml
@@ -37,6 +37,22 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: harbor-test-cleanup
+      # The script exits non-zero when a delete or a listing failed, so the Job
+      # can now fail. Under the Kubernetes default of 6 it would back off across
+      # seven pods for about ten minutes and outlast the hook timeout, and Helm
+      # would report that timeout instead of the hook's own error.
+      - equal:
+          path: spec.backoffLimit
+          value: 1
+      # Pinned exactly, because the whole point of the non-zero exit is that the
+      # failed Job survives to be read. Adding hook-failed here hands the Job
+      # straight back to Helm to delete on failure, destroying the only account
+      # of what was left behind — and until this assert existed, that one-line
+      # reversal left this chart's whole suite green, because nothing else here
+      # read the annotation.
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
 
   - it: targets both kept PVCs (jobservice + trivy) via the shared release label and ACME objects
     documentSelector:

--- a/packages/apps/qdrant/templates/hooks/cleanup-pvc.yaml
+++ b/packages/apps/qdrant/templates/hooks/cleanup-pvc.yaml
@@ -10,6 +10,18 @@ metadata:
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
+  # One retry — not the Kubernetes default of six, and not zero. Every delete
+  # below is idempotent and carries --ignore-not-found, so a second attempt
+  # re-issues an API call rather than re-running any logic, and one short
+  # backoff is what separates a transient apiserver error from a real one.
+  # That distinction is the whole point here: this hook's failures become
+  # visible for the first time with this change, and a signal that fires on
+  # noise stops being read — including on the day it is right. Six is the far
+  # end of the same mistake: the Job would spend about ten minutes backing off
+  # across seven pods, outlasting the hook timeout, and Helm would report that
+  # timeout instead of the hook's own error. Load-bearing only since the script
+  # gained a non-zero exit; before that the script could not report one.
+  backoffLimit: 1
   template:
     metadata:
       labels:
@@ -46,6 +58,29 @@ spec:
             - /bin/sh
             - -c
             - |
+              set -u
+              # A delete that did not happen must reach Helm as a non-zero exit.
+              # Otherwise the hook-succeeded delete policy garbage-collects this
+              # Job and the pod that carried the only account of the failure, and
+              # an uninstall that left storage behind is indistinguishable from
+              # one that had nothing to reclaim. Failures are counted and the
+              # exit code is set at the end rather than with `set -e`, so one
+              # failed delete does not skip the work that follows it. An object
+              # that is already gone is not a failure: every delete below passes
+              # --ignore-not-found, which exits 0 in that case, so re-running
+              # this hook over an already-clean namespace still succeeds.
+              # Cost: on failure the Job and its pods stay in the namespace,
+              # which is the point — they hold the log. Nothing collects them
+              # on its own: before-hook-creation deletes the previous copy only
+              # when this hook runs again, and a post-delete hook runs only on
+              # an uninstall. They stay until a release of this name is
+              # installed and uninstalled again, or until the namespace goes.
+              failures=0
+              fail() {
+                failures=$((failures + 1))
+                echo "ERROR: $*" >&2
+              }
+
               # StatefulSet-templated data PVCs are named
               # qdrant-storage-<release>-<ordinal> (volumeClaimTemplate name
               # "qdrant-storage" + StatefulSet name <release> + pod ordinal).
@@ -59,13 +94,26 @@ spec:
               # vs "qdrant-test-2") never matches the sibling's PVCs and deletes
               # its data. See #3059.
               echo "Deleting orphaned data PVCs for release {{ .Release.Name }}..."
-              pvcs=$(kubectl get pvc -n {{ .Release.Namespace }} -o name \
-                | grep -E "^persistentvolumeclaim/qdrant-storage-{{ .Release.Name }}-[0-9]+$" || true)
-              if [ -z "$pvcs" ]; then
-                echo "No data PVCs found for release {{ .Release.Name }}; nothing to delete."
+              # The listing is captured on its own line and the filter applied
+              # to the result. Piping the two together reports grep's status,
+              # under which a failed `kubectl get` yields an empty match and
+              # reads exactly like a namespace that holds no data PVCs.
+              if all_pvcs=$(kubectl get pvc -n {{ .Release.Namespace }} -o name); then
+                pvcs=$(echo "$all_pvcs" \
+                  | grep -E "^persistentvolumeclaim/qdrant-storage-{{ .Release.Name }}-[0-9]+$" || true)
+                if [ -z "$pvcs" ]; then
+                  echo "No data PVCs found for release {{ .Release.Name }}; nothing to delete."
+                else
+                  echo "$pvcs" | xargs kubectl delete -n {{ .Release.Namespace }} --ignore-not-found \
+                    || fail "failed to delete data PVCs of {{ .Release.Name }} in {{ .Release.Namespace }} ($(echo "$pvcs" | tr '\n' ' ')); orphaned PVCs may remain"
+                fi
               else
-                echo "$pvcs" | xargs kubectl delete -n {{ .Release.Namespace }} --ignore-not-found \
-                  || echo "WARNING: PVC cleanup failed for {{ .Release.Name }}; orphaned PVCs may remain" >&2
+                fail "failed to list PVCs in {{ .Release.Namespace }}; cannot tell whether data PVCs of {{ .Release.Name }} remain"
+              fi
+
+              if [ "$failures" -ne 0 ]; then
+                echo "PVC cleanup FAILED for {{ .Release.Name }}: $failures operation(s) did not complete; see the errors above." >&2
+                exit 1
               fi
               echo "PVC cleanup complete."
           volumeMounts:

--- a/packages/apps/qdrant/tests/cleanup_pvc_test.yaml
+++ b/packages/apps/qdrant/tests/cleanup_pvc_test.yaml
@@ -35,6 +35,22 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: qdrant-test-qdrant-cleanup
+      # The script exits non-zero when a delete or a listing failed, so the Job
+      # can now fail. Under the Kubernetes default of 6 it would back off across
+      # seven pods for about ten minutes and outlast the hook timeout, and Helm
+      # would report that timeout instead of the hook's own error.
+      - equal:
+          path: spec.backoffLimit
+          value: 1
+      # Pinned exactly, because the whole point of the non-zero exit is that the
+      # failed Job survives to be read. Adding hook-failed here hands the Job
+      # straight back to Helm to delete on failure, destroying the only account
+      # of what was left behind — and until this assert existed, that one-line
+      # reversal left this chart's whole suite green, because nothing else here
+      # read the annotation.
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: "kubectl get pvc -n tenant-test -o name"


### PR DESCRIPTION
## What this PR does

The qdrant and harbor post-delete cleanup hooks could not fail. Every delete was guarded by `|| echo "WARNING: ..." >&2`, neither script set `-e`, and both ended on an unconditional completion message, so the container exited 0 on every path. Helm read that as a successful hook, `helm.sh/hook-delete-policy: hook-succeeded` removed the Job together with the pod that held the warning, and an uninstall that reclaimed nothing looked exactly like one that had nothing to reclaim. Written up in #3566.

Both hooks now count failures and set the exit code at the end. `set -e` would abort at the first failed delete and skip the rest of the sweep, which is the opposite of what is wanted: every remaining object should still be attempted and the outcome reported once. Already-gone objects stay a success, since every delete keeps `--ignore-not-found`. Each failure message names the object it left behind. `packages/apps/mariadb` already uses this shape.

Both hooks also consumed `kubectl get` output directly: harbor by iterating `$(kubectl get ...)`, qdrant by piping it into `grep`, whose status the pipeline then reports. A failed listing arrived as an empty list, and the sweep reported success without having looked. Each listing is now captured before it is used.

#3566 attributes that shape to harbor's two loops alone. qdrant has it too: `pvcs=$(kubectl get pvc ... | grep -E ... || true)` reports grep's status, so a `kubectl get` that failed left `$pvcs` empty and the hook announced "no data PVCs found; nothing to delete". Both instances are fixed here.

### The cost

A hook that exits non-zero keeps its Job and its pods, because `hook-succeeded` does not fire for it. That is the point, the pods hold the log, but it means a failed uninstall now leaves objects behind where it previously left none. Nothing collects them on its own: `before-hook-creation` only fires when the hook runs again, and a `post-delete` hook runs only on an uninstall, so they stay until a release of that name is installed and uninstalled again, or until the namespace goes.

The release itself is not stranded. Helm appends the post-delete hook error to its error list instead of returning on it, marks the release uninstalled, purges it from storage anyway, and only then reports `uninstallation completed with N error(s)`. The failure surfaces once and the app still goes away.

Both Jobs get one retry instead of the Kubernetes default of six, and instead of none. Every delete is idempotent, so a second attempt re-issues an API call rather than re-running any logic, and one short backoff separates a transient apiserver error from a real one. These failures become visible for the first time with this change, and a signal that fires on noise stops being read, including on the day it is right. Six is the far end of the same mistake: ten minutes of backoff across seven pods outlasts the hook timeout, so Helm reports that timeout instead of the hook's own error.

`packages/apps/clickhouse` and `packages/apps/mariadb` already exit non-zero from their cleanup hooks and set no retry limit, so a real failure in either spends the full backoff and reaches the operator as a timeout rather than as the error the hook wrote. Adding the exit code without the cap reproduces that.

One limitation is deliberate. harbor's ACME sweep cannot tell "this kind is not served" from "I could not look". If cert-manager is torn down before the release, `kubectl get challenge` fails and the uninstall is reported failed with nothing to sweep. cert-manager is a hard dependency of the bundle harbor ships in, so the window is narrow, and a CRD-existence probe would add a second silent-skip path of its own: it would swallow a discovery failure the way this change stops swallowing a listing failure.

### Tests

`hack/app-cleanup-hooks_test.bats` renders each hook's script out of its chart and runs it against a fake `kubectl`, because the property under test is the container's exit code and matching against manifest text cannot establish it. There are eight failure paths across the two hooks, six in harbor and two in qdrant, and each has a case that goes red when that one path alone is reverted to a swallowed warning. Also covered: a clean delete, and an object that is already gone in both its shapes, an empty listing and a `NotFound` on the delete itself.

The fake `kubectl` models `--ignore-not-found` instead of exiting 0 unconditionally, so dropping that flag from a hook turns the already-gone cases red. Message assertions are anchored on the hook's own `ERROR: ` prefix, because the fake names the object in its own diagnostic too, and an unanchored match is satisfied by the fixture.

Two manifest fields are pinned in each chart's existing helm-unittest suite, where manifest fields belong. The retry cap is one. The other is `helm.sh/hook-delete-policy`: adding `hook-failed` to that annotation hands the failed Job straight back to Helm to delete, which undoes the whole change. I checked that before adding the assert, and the reversal left both suites fully green.

The qdrant Chainsaw suite explained its post-delete pod collector by quoting the guard string this change removes, and concluded that Helm always collects the pod away. That conclusion inverts here, so the note is rewritten, along with the sentence in the harbor suite that points at it.

### Screenshots

Not a UI change.

### Downstream repositories

I walked the trigger map in `docs/agents/contributing.md` against the diff, file by file. It touches two app chart templates and adds one file under `hack/`. No package added, renamed or removed, no `values.schema.json`, no `values.yaml` default, no version enum, no `ApplicationDefinition`, no namespace, no node prerequisite, and neither `hack/package.mk` nor `hack/update-crd.sh`.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(apps): the qdrant and harbor post-delete cleanup hooks now exit non-zero when a delete or a listing fails, instead of reporting success on every path. `helm uninstall` reports the failure rather than returning clean, and the hook Job and its pods stay in the namespace so the log survives to be read. Nothing collects them on its own: they remain until a release of that name is installed and uninstalled again, or until the namespace is removed.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Harbor and Qdrant cleanup reliability by detecting listing and deletion failures.
  - Cleanup jobs now retry once and report failures with a non-zero status.
  - Cleanup continues processing remaining resources after individual failures.
  - Successful cleanup remains safe and repeatable, including when resources are already missing.
  - Harbor cleanup remains limited to resources associated with the configured Harbor host.

- **Tests**
  - Added comprehensive coverage for successful, repeated, partial, and failed cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->