### PR TITLE
fix(etcd): fail the CRD vendoring when the keep stamp misses

### DIFF
--- a/packages/system/etcd-operator-crds/Makefile
+++ b/packages/system/etcd-operator-crds/Makefile
@@ -10,13 +10,18 @@ ETCD_OPERATOR_REF ?= v0.5.4
 # is no config/crd kustomization). Vendor each verbatim and stamp
 # helm.sh/resource-policy: keep so a chart uninstall never garbage-collects the
 # CRDs and, with them, every EtcdCluster/EtcdMember/EtcdSnapshot in the cluster.
+# The stamp is anchored on a line upstream controls, so count the result: one
+# annotation per CRD, or the update fails. templates/ is replaced only after
+# every CRD has been counted, so a failure leaves the vendored files as they
+# were.
 CRDS = etcdclusters etcdmembers etcdsnapshots
 update:
-	rm -rf templates
-	mkdir templates
-	@set -e; for c in $(CRDS); do \
-	  src=$$(mktemp); \
-	  curl -fsSL "https://raw.githubusercontent.com/cozystack/etcd-operator/$(ETCD_OPERATOR_REF)/charts/etcd-operator/crd-bases/etcd-operator.cozystack.io_$$c.yaml" -o "$$src"; \
-	  awk '/^    controller-gen.kubebuilder.io\/version:/{print; print "    helm.sh/resource-policy: keep"; next} {print}' "$$src" > templates/$$c.yaml; \
-	  rm -f "$$src"; \
-	done
+	@set -e; tmp=$$(mktemp -d); trap 'rm -rf "$$tmp"' EXIT; \
+	for c in $(CRDS); do \
+	  curl -fsSL "https://raw.githubusercontent.com/cozystack/etcd-operator/$(ETCD_OPERATOR_REF)/charts/etcd-operator/crd-bases/etcd-operator.cozystack.io_$$c.yaml" -o "$$tmp/$$c.src"; \
+	  awk '/^    controller-gen.kubebuilder.io\/version:/{print; print "    helm.sh/resource-policy: keep"; next} {print}' "$$tmp/$$c.src" > "$$tmp/$$c.yaml"; \
+	  n=$$(grep -c '^    helm.sh/resource-policy: keep$$' "$$tmp/$$c.yaml" || true); \
+	  [ "$$n" -eq 1 ] || { echo "$$c: stamped $$n keep annotations, expected 1" >&2; exit 1; }; \
+	done; \
+	rm -rf templates; mkdir templates; \
+	for c in $(CRDS); do mv "$$tmp/$$c.yaml" templates/$$c.yaml; done


### PR DESCRIPTION
## What this PR does

`make update` in `packages/system/etcd-operator-crds` vendors three CRDs and stamps `helm.sh/resource-policy: keep` onto each with an awk step anchored on the `controller-gen.kubebuilder.io/version:` line. That line is upstream's to emit. If a future controller-gen stops writing it, the awk matches nothing, writes the CRD out unstamped and exits zero, so the regeneration reports success and the CRDs land without the annotation that keeps a chart uninstall from deleting them, and with them every EtcdCluster, EtcdMember and EtcdSnapshot in the cluster.

The step now counts what it produced and requires exactly one annotation per CRD. Zero means the anchor is gone; more than one means it matched somewhere unintended. Every CRD is staged in a temporary directory and `templates/` is replaced only after all of them have been counted, so a failure on any one leaves the vendored files exactly as they were rather than wiping the directory and refilling part of the set.

I checked it by substituting the upstream response, so what ran was the recipe that ships rather than a copy of its logic: a CRD with no controller-gen line fails with `stamped 0 keep annotations, expected 1`, a CRD carrying that line twice fails with 2, a failure on the second of the three leaves all three committed files untouched, and the real upstream still vendors byte-identical output, with `make update` leaving `git status` showing nothing but this Makefile.

On `main` today this is the only thing guarding those three CRDs. A helm-unittest suite that fails when one of them renders without the annotation is in #3590, which is open and not merged. Once that lands the two catch the same loss at different moments: the suite on a test run, this step in front of whoever ran the regeneration.

The same stamping shape exists in three more packages, but only on the branch of #3586, which adds it to `gateway-api-crds`, `vsnap-crd` and `vertical-pod-autoscaler-crds`. There is nothing to guard there on `main` yet, so they are deliberately out of this change and need the same step once #3586 merges.

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

I walked the trigger map in `docs/agents/contributing.md` against the file list of this diff, which is one package Makefile and nothing else. `hack/package.mk` is untouched, so the `ccp` and `external-apps-example` triggers that key on it do not fire, and the website's "developer tooling (the package Makefiles)" line is the only near miss: `content/en/docs/next/development.md` describes `make update` in general terms and does not go stale from a package validating its own output.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CRD update validation to ensure generated definitions include the required preservation annotation.
  * Prevented incomplete or invalid updates from replacing existing CRD templates.
  * Added automatic cleanup of temporary update files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->