### PR TITLE
fix(tenant): bound the pre-delete cleanup waits and the hook Job

### DIFF
--- a/hack/tenant-pre-delete-hook.bats
+++ b/hack/tenant-pre-delete-hook.bats
@@ -1,0 +1,297 @@
+#!/usr/bin/env bats
+# Behavioural tests for the pre-delete cleanup hook of packages/apps/tenant: the
+# script is extracted from the rendered Job and executed against a stub kubectl.
+# The helm-unittest cases in packages/apps/tenant/tests/cleanup_role_watch_test.yaml
+# assert the Job's shape — the deadline and the attempt count — which is what
+# the script cannot observe about itself.
+#
+# What a stub can and cannot show. `--timeout` is implemented inside kubectl, so
+# no stub can make that deadline actually elapse; what the stub can do is record
+# whether the flag reached kubectl at all, and answer for the run that follows a
+# delete which gave up. Those are the two halves below: one test reads the
+# arguments, the rest inject the non-zero exit an expired delete produces.
+#
+# Run via hack/cozytest.sh from the repo root (make bats-unit-tests); relative
+# paths resolve against that cwd. The runner has no setup/teardown, so each
+# @test builds its own fixture and removes it at the end of the body. No EXIT
+# traps: a test that dies inside one prints neither `not ok` nor a reason, and
+# the suite reads green. A failing test therefore leaves its temp directory
+# behind, which is what you want when reading the rendered script afterwards.
+
+CHART=packages/apps/tenant
+
+# The two waves, told apart by their label selector. `*tenantmodule=true*` does
+# not match the applications wave: that one spells the selector
+# `tenantmodule!=true`, which contains no `tenantmodule=true` substring.
+WAVE_APPS='*tenantmodule!=true*'
+WAVE_MODULES='*tenantmodule=true*'
+
+# Render the pre-delete Job into $1. The release name has to start with
+# `tenant-` and carry no second dash (templates/tenant.yaml enforces it), and
+# `_cluster` normally arrives from the cozystack-values Secret, so the one key
+# templates/keycloakgroups.yaml indexes is supplied here as a string.
+#
+# The emptiness check must be an early `return 1`: hack/cozytest.sh rewrites
+# every line matching ^}$ into `return 0` plus `}`, helpers included, so a check
+# left in last position has its status discarded. helm's stderr is kept rather
+# than dropped, because it carries the reason a render failed; only the
+# per-render notice about the charts/cozy-lib symlink is filtered out.
+render_job() {
+  helm template tenant-test "$CHART" \
+    --namespace tenant-root \
+    --set-string '_cluster.oidc-enabled=false' \
+    --show-only templates/cleanup-job.yaml 2>"$1.err" |
+    yq 'select(.kind == "Job")' - > "$1"
+  if [ ! -s "$1" ]; then
+    echo "FAIL: the chart rendered no pre-delete Job" >&2
+    grep -v 'found symbolic link in path' "$1.err" >&2 || true
+    return 1
+  fi
+}
+
+# A stub kubectl in $1. Every invocation is logged; those matching a glob in
+# $KUBECTL_FAIL exit non-zero with the wording kubectl itself prints when a
+# `--wait` deadline expires, which is the only outcome the script can tell apart
+# from success.
+#
+# The closing brace of the helper inside the heredoc is indented on purpose:
+# cozytest.sh rewrites every line matching ^}$ anywhere in this file, the
+# heredoc included, and a `return 0` spliced into the stub would make every
+# injected failure disappear.
+make_kubectl() {
+  mkdir -p "$1"
+  cat > "$1/kubectl" <<'STUB'
+#!/bin/sh
+args="$*"
+echo "$args" >> "${KUBECTL_LOG:-/dev/null}"
+
+matches() {
+  [ -n "$1" ] || return 1
+  oldifs=$IFS
+  IFS='
+'
+  for pat in $1; do
+    case "$args" in
+      $pat) IFS=$oldifs; return 0 ;;
+    esac
+  done
+  IFS=$oldifs
+  return 1
+  }
+
+if matches "${KUBECTL_FAIL:-}"; then
+  echo "error: timed out waiting for the condition on helmreleases.helm.toolkit.fluxcd.io" >&2
+  exit 1
+fi
+exit 0
+STUB
+  chmod 0755 "$1/kubectl"
+}
+
+# Fixture: $tmp holds the rendered Job, its script, and the stub kubectl.
+setup_case() {
+  tmp=$(mktemp -d) || return 1
+  render_job "$tmp/job.yaml" || return 1
+  yq '.spec.template.spec.containers[0].command[2]' "$tmp/job.yaml" > "$tmp/s.sh" || return 1
+  [ -s "$tmp/s.sh" ] || return 1
+  make_kubectl "$tmp/bin" || return 1
+}
+
+# Run the hook with the failures injected by $1, leaving merged output in
+# $tmp/out, the invocations in $tmp/kubectl.log and the exit status in $rc. The
+# status must not abort the test: it is itself one of the things under test.
+# KUBECONFIG is neutered so a stub that stopped being found on PATH cannot reach
+# a real cluster.
+run_hook() {
+  rc=0
+  : > "$tmp/kubectl.log"
+  KUBECONFIG=/dev/null \
+  KUBECTL_LOG="$tmp/kubectl.log" \
+  KUBECTL_FAIL="$1" \
+  PATH="$tmp/bin:$PATH" sh "$tmp/s.sh" > "$tmp/out" 2>&1 || rc=$?
+  # The stub has to have been reached, or the assertions below measured
+  # something other than this script driving kubectl.
+  [ -s "$tmp/kubectl.log" ] || return 1
+}
+
+@test "a run where both waves completed reports success" {
+  setup_case
+  run_hook ""
+
+  [ "$rc" = 0 ]
+  grep -qF 'Cleanup completed successfully' "$tmp/out"
+  # Both waves have to have run, or the success claim is about a script that
+  # deleted nothing and the tests below have no baseline to differ from.
+  grep -q 'tenantmodule!=true' "$tmp/kubectl.log"
+  grep -q 'tenantmodule=true' "$tmp/kubectl.log"
+
+  rm -rf "$tmp"
+}
+
+@test "every delete reaches kubectl with a wall-clock bound" {
+  # The defect this pins. kubectl reads the default `--timeout=0` as wait
+  # forever and substitutes a week, so a delete that arrives without the flag
+  # hangs the hook for as long as any child HelmRelease cannot finalize — and
+  # helm returns from the uninstall before removing anything, leaving the
+  # release in storage to be retried. Read from the arguments the stub actually
+  # received rather than from the template text, so a flag that stops being
+  # passed cannot pass here by still being written somewhere in the file.
+  setup_case
+  run_hook ""
+
+  deletes=$(grep -c 'delete helmreleases' "$tmp/kubectl.log" || true)
+  [ "$deletes" = 2 ]
+  # A bound of zero is the unbounded case spelled explicitly, so the value has
+  # to start with a non-zero digit rather than merely be present.
+  bounded=$(grep 'delete helmreleases' "$tmp/kubectl.log" |
+    grep -c -- '--timeout=[1-9][0-9]*s' || true)
+  if [ "$bounded" != "$deletes" ]; then
+    echo "FAIL: $bounded of $deletes deletes carried a non-zero --timeout"
+    cat "$tmp/kubectl.log"
+    return 1
+  fi
+
+  rm -rf "$tmp"
+}
+
+@test "the waits, the Job deadline and the uninstall budget stay in order" {
+  # Four numbers, one ordering, and both ends of it are load-bearing.
+  #
+  # Waves under the deadline: activeDeadlineSeconds is the outer stop, and only
+  # a backstop while the waits inside it can finish first. Raise a wave past the
+  # remainder and the deadline starts cutting runs that were going to succeed.
+  #
+  # Deadline plus termination under the uninstall budget: flux takes that budget
+  # from spec.uninstall.timeout / spec.timeout, and cozystack-api generates the
+  # tenant HelmRelease with neither, so it is helm-controller's 300s default. The
+  # deadline is measured from the Job's startTime and helm's budget from just
+  # before it creates the Job, so at 300 helm gives up first — on a Job that is
+  # still running, which is the state this whole change exists to end.
+  #
+  # The termination period belongs on the same side of that comparison as the
+  # deadline. Since 1.31 the Job controller withholds the terminal condition
+  # until every pod has finished terminating, so what helm waits for is the sum
+  # rather than the deadline alone — and the sum is what is actually spent here,
+  # because PID 1 is a shell running a multi-command script: it never execs into
+  # kubectl, and a default disposition sent to PID 1 is discarded by the kernel
+  # with no handler installed to catch it. Comparing the deadline alone would
+  # call a Job that reports its failure at 300 correctly bounded at 270.
+  UNINSTALL_BUDGET=300
+  setup_case
+
+  waits=0
+  for seconds in $(grep -o -- '--timeout=[0-9]*s' "$tmp/s.sh" |
+    sed -e 's|--timeout=||' -e 's|s$||'); do
+    waits=$((waits + seconds))
+  done
+  # Non-zero, or the comparison below is satisfied by a script with no waits at
+  # all to measure.
+  [ "$waits" -gt 0 ]
+
+  deadline=$(yq '.spec.activeDeadlineSeconds' "$tmp/job.yaml")
+  # Checked before it is compared. Both comparisons below sit inside `if`, where
+  # a status is a verdict rather than an error, so `[ 180 -ge null ]` reads as
+  # "false" and a Job with no deadline at all passes every ordering check here.
+  case "$deadline" in
+    '' | *[!0-9]*)
+      echo "FAIL: the Job carries no numeric activeDeadlineSeconds (read: '$deadline')"
+      echo "      and then nothing bounds a run whose kubectl call never returns"
+      return 1
+      ;;
+  esac
+  if [ "$waits" -ge "$deadline" ]; then
+    echo "FAIL: ${waits}s of bounded waits against an activeDeadlineSeconds of ${deadline}s"
+    echo "      leaves nothing for scheduling, the image pull and the delete calls"
+    return 1
+  fi
+
+  grace=$(yq '.spec.template.spec.terminationGracePeriodSeconds' "$tmp/job.yaml")
+  # Read before it is added, for the same reason the deadline is: `null` here
+  # would make the sum below a string comparison away from meaning nothing, and
+  # an absent period is the 30s default rather than zero — the case that puts
+  # the failure at exactly the budget.
+  case "$grace" in
+    '' | *[!0-9]*)
+      echo "FAIL: the pod carries no numeric terminationGracePeriodSeconds (read: '$grace')"
+      echo "      so it defaults to 30s and the Job reports its failure at ${deadline}s+30s"
+      return 1
+      ;;
+  esac
+  if [ "$((deadline + grace))" -ge "$UNINSTALL_BUDGET" ]; then
+    echo "FAIL: an activeDeadlineSeconds of ${deadline}s plus a termination period of"
+    echo "      ${grace}s reaches ${UNINSTALL_BUDGET}s of uninstall budget, so helm gives up"
+    echo "      before the Job it is waiting on reports the failure"
+    return 1
+  fi
+
+  rm -rf "$tmp"
+}
+
+@test "an applications wave that did not finish ends the run" {
+  # Nothing stands behind these deletes, so a wave that gave up must not be
+  # reported as done. The closing line is unreachable under `set -e`, and it has
+  # to stay that way: a `|| echo` appended here would reinstate the exact defect
+  # this file exists to stop — a cleanup that did not happen, claimed as one
+  # that did, after which helm goes on to tear the tenant namespace down over
+  # HelmReleases that are still there.
+  setup_case
+  run_hook "$WAVE_APPS"
+
+  if [ "$rc" = 0 ]; then
+    echo "FAIL: a wave that could not finish left the hook reporting success"
+    cat "$tmp/out"
+    return 1
+  fi
+  if grep -qF 'Cleanup completed successfully' "$tmp/out"; then
+    echo "FAIL: the hook claimed success with applications still undeleted"
+    cat "$tmp/out"
+    return 1
+  fi
+
+  rm -rf "$tmp"
+}
+
+@test "an applications wave that did not finish does not go on to the modules" {
+  # The ordering the two waves exist for. Tenant modules — etcd, monitoring,
+  # ingress, seaweedfs, the gateway — are what the applications above run on,
+  # and deleting them out from under applications that are still terminating
+  # makes the namespace harder to remove, not easier.
+  setup_case
+  run_hook "$WAVE_APPS"
+
+  # The first wave has to have been attempted, or the absence below is the
+  # absence of a script that ran nothing.
+  grep -q 'tenantmodule!=true' "$tmp/kubectl.log"
+  if grep -q 'tenantmodule=true' "$tmp/kubectl.log"; then
+    echo "FAIL: the tenant modules were deleted after the applications wave gave up"
+    cat "$tmp/kubectl.log"
+    return 1
+  fi
+
+  rm -rf "$tmp"
+}
+
+@test "a tenant modules wave that did not finish ends the run" {
+  # The second wave is the last thing the script does, so a guard appended to it
+  # would be invisible to every assertion about what runs afterwards. Only the
+  # exit status and the closing line separate a swallowed failure from a real
+  # completion here.
+  setup_case
+  run_hook "$WAVE_MODULES"
+
+  # Both waves ran: the failure being injected is the second one, not the first.
+  grep -q 'tenantmodule!=true' "$tmp/kubectl.log"
+  grep -q 'tenantmodule=true' "$tmp/kubectl.log"
+  if [ "$rc" = 0 ]; then
+    echo "FAIL: a tenant modules wave that could not finish left the hook reporting success"
+    cat "$tmp/out"
+    return 1
+  fi
+  if grep -qF 'Cleanup completed successfully' "$tmp/out"; then
+    echo "FAIL: the hook claimed success with tenant modules still undeleted"
+    cat "$tmp/out"
+    return 1
+  fi
+
+  rm -rf "$tmp"
+}

--- a/packages/apps/tenant/templates/cleanup-job.yaml
+++ b/packages/apps/tenant/templates/cleanup-job.yaml
@@ -51,6 +51,50 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
     helm.sh/hook-weight: "0"
 spec:
+  # A pre-delete hook that never finishes is worse than one that fails: helm
+  # returns from Uninstall.Run before it deletes anything, so the release stays
+  # in storage, flux keeps the finalizer, and the same teardown is retried. The
+  # budget for the whole attempt is spec.uninstall.timeout / spec.timeout on the
+  # tenant HelmRelease; cozystack-api generates it with neither, so it is
+  # helm-controller's 300s default.
+  #
+  # 270s, not 300s. This deadline runs from the Job's startTime and helm's
+  # budget from just before it creates the Job, so equal values would have helm
+  # give up first — and it would give up on a Job that is still running, which is
+  # today's behaviour rather than a fix for it. The 90s above the two bounded
+  # waits inside is what a cold image pull gets to spend before the deadline
+  # starts cutting runs that were going to finish.
+  #
+  # The 30s below the budget is not all margin: helm learns of the failure at
+  # the deadline plus the pod's termination period, because since 1.31 the Job
+  # controller withholds the terminal condition until the pods have finished
+  # terminating. terminationGracePeriodSeconds below is set against this number
+  # for that reason, and the two are only meaningful together — raising either
+  # without the other is what puts the failure back outside the budget.
+  #
+  # Some bound is needed regardless of the waits: the waits bound the watch
+  # phase, not the DELETE calls themselves, which carry kubectl's default
+  # --request-timeout of 0.
+  #
+  # What the remainder buys is not exact. Past the SIGKILL there is still the
+  # kubelet status update and the pod object going away before the condition
+  # lands, and none of that is visible from a rendered manifest, so the test
+  # checks deadline + grace against the budget and stops there. Treat the tail
+  # as unmeasured rather than as slack.
+  #
+  # This path also costs the diagnosis: on DeadlineExceeded the Job controller
+  # deletes the active pods, so the wave that hung leaves no log behind. The
+  # expected path is the wave's own --timeout below, where the script exits and
+  # the failed pod keeps its output until ttlSecondsAfterFinished reaps it. The
+  # deadline is the backstop for a kubectl that never returns at all.
+  activeDeadlineSeconds: 270
+  # One attempt, so the script's exit status is the Job's. At the default of 6
+  # the failure never reaches helm inside the budget: the operator gets a bare
+  # "timed out waiting for the condition" instead of the wave that could not
+  # finish. Needed under either restartPolicy — 6 restarts in place under
+  # OnFailure, 6 fresh pods under Never — so it is not implied by the policy
+  # below.
+  backoffLimit: 0
   ttlSecondsAfterFinished: 300
   template:
     metadata:
@@ -59,7 +103,32 @@ spec:
         policy.cozystack.io/allow-to-apiserver: "true"
     spec:
       serviceAccountName: {{ include "tenant.name" . }}-cleanup
-      restartPolicy: OnFailure
+      # Never, so that "one attempt" is the truth rather than the intent. Under
+      # OnFailure the pod survives its own failure and the kubelet re-runs the
+      # container in place; the Job controller only learns of it afterwards, by
+      # summing restartCount, and caps the Job then. The script therefore starts
+      # over — re-entering the applications wave that just expired — and is cut
+      # down mid-run once the controller catches up. Never leaves a failed pod
+      # the controller sees directly, with nothing re-executed in between.
+      restartPolicy: Never
+      # Part of the deadline, not a detail of it. Since 1.31 the Job controller
+      # withholds the terminal Failed condition until every pod has finished
+      # terminating, so what helm waits for is the deadline plus however long
+      # this pod takes to die. The default 30s would put that at 270+30 — level
+      # with helm's budget, which is the state activeDeadlineSeconds above is
+      # set 30s under the budget to avoid.
+      #
+      # The full period is spent, not merely bounded by. The SIGTERM goes to
+      # PID 1, which is the /bin/sh below: the script runs several commands, so
+      # the shell never execs into kubectl and stays PID 1 itself. A signal
+      # carrying its default disposition is discarded by the kernel when the
+      # target is PID 1, and a non-interactive shell installs no SIGTERM
+      # handler, so nothing acts on it. kubectl is a child and was not
+      # signalled at all. The pod ends on the SIGKILL that closes this period,
+      # every time. Nothing in the script needs to finish gracefully — the
+      # DELETE calls are already sent, and the process is only watching — so a
+      # short period costs nothing and keeps the failure inside the budget.
+      terminationGracePeriodSeconds: 10
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -72,6 +141,19 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+        # Requests, because backoffLimit above removed the second chance this
+        # pod used to have. With no requests it is BestEffort and first in line
+        # under node pressure; previously an eviction was absorbed by a retry
+        # inside the same Job, and now it fails the whole uninstall attempt.
+        # Values match the sibling hook in packages/apps/kubernetes, which runs
+        # the same image doing the same kind of work.
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 128Mi
         command:
         - /bin/sh
         - -c
@@ -81,14 +163,49 @@ spec:
           
           echo "Cleaning up HelmReleases in namespace: $NAMESPACE"
           
+          # --timeout is not optional here: kubectl reads the default of 0 as
+          # "wait forever" and substitutes a week, so --wait on its own hangs
+          # this hook for as long as any child HelmRelease cannot finalize. Two
+          # bounded waits of 90s leave the rest of the Job's deadline to
+          # scheduling, the image pull and the delete calls themselves.
+          #
+          # 90s is not enough for every tenant, and is not meant to be. An
+          # applications wave holding a nested Tenant, or an app of kind
+          # Kubernetes whose own pre-delete hook spends two 120s waits before it
+          # starts working, expires here on the first attempt and converges
+          # across flux's uninstall retries instead. Neither of those fits the
+          # 300s budget as it stands either, so for them the bound costs
+          # nothing that works today.
+          #
+          # Between the two there is a band that does pay. Every generated child
+          # HelmRelease carries a wait strategy, so a wave inherits its slowest
+          # child; one that settles in, say, 95s completes inside the 300s
+          # budget today and will expire here instead, trading a clean single
+          # attempt for one extra flux retry. That is the price of the bound,
+          # and it is worth it against the alternative — an unbounded wave does
+          # not fail, it consumes the whole budget and leaves helm reporting a
+          # timeout with nothing named in it. If the band turns out to be
+          # populated in practice, raise the waits and the deadline together:
+          # hack/tenant-pre-delete-hook.bats pins their ordering, not their
+          # values.
+          #
+          # Neither is guarded, deliberately. Nothing stands behind these two
+          # deletes — they are the cleanup, not a backstop in front of one — so
+          # a wave that did not finish has to end the run under `set -e` rather
+          # than report success it cannot claim. Ending it also keeps the
+          # ordering the two waves exist for: the tenant modules below are what
+          # the applications above run on, and tearing them out from under
+          # applications that are still deleting makes the namespace harder to
+          # remove, not easier. Whatever did get deleted stays deleted, so the
+          # next uninstall attempt resumes from there.
           echo "Deleting Applications"
           kubectl delete helmreleases.helm.toolkit.fluxcd.io -n "$NAMESPACE" \
             -l 'apps.cozystack.io/application.kind,internal.cozystack.io/tenantmodule!=true' \
-            --ignore-not-found=true --wait=true
+            --ignore-not-found=true --wait=true --timeout=90s
 
           echo "Deleting Tenant Modules"
           kubectl delete helmreleases.helm.toolkit.fluxcd.io -n "$NAMESPACE" \
             -l 'apps.cozystack.io/application.kind,internal.cozystack.io/tenantmodule=true' \
-            --ignore-not-found=true --wait=true
+            --ignore-not-found=true --wait=true --timeout=90s
           
           echo "Cleanup completed successfully"

--- a/packages/apps/tenant/tests/cleanup_role_watch_test.yaml
+++ b/packages/apps/tenant/tests/cleanup_role_watch_test.yaml
@@ -11,6 +11,11 @@ suite: tenant cleanup pre-delete hook
 # and pin the command interpreter to a shell that image actually ships
 # (clastix/kubectl is Alpine — /bin/sh only, no /bin/bash) so the container
 # can exec at all.
+#
+# The two fields that stop the hook outliving the uninstall attempt are pinned
+# here because they describe the Job rather than the script, and the script
+# cannot observe them about itself. hack/tenant-pre-delete-hook.bats covers the
+# script's own behaviour by running it.
 
 # Restrict rendering to the cleanup template so the chart's namespace.yaml
 # `lookup` (which errors under helm-unittest) is not evaluated.
@@ -57,6 +62,92 @@ tests:
         equal:
           path: spec.template.spec.containers[0].command[0]
           value: /bin/sh
+
+  - it: cleanup Job cannot outlive the uninstall attempt that created it
+    # flux takes the uninstall budget from spec.uninstall.timeout / spec.timeout
+    # on the tenant HelmRelease, and cozystack-api generates it with neither, so
+    # the budget is helm-controller's 300s default. At or above that value helm
+    # gives up first and the Job outlives the attempt it belongs to: it is still
+    # running, so it has not finished, so ttlSecondsAfterFinished has not begun
+    # to count, and helm.sh/hook-delete-policy carries no hook-failed either.
+    # Nothing removes it until the next attempt's before-hook-creation sweep.
+    # hack/tenant-pre-delete-hook.bats holds the same ceiling as an ordering
+    # over the four numbers; this pins the value the chart ships.
+    asserts:
+      - template: templates/cleanup-job.yaml
+        documentIndex: 3
+        isKind:
+          of: Job
+      - template: templates/cleanup-job.yaml
+        documentIndex: 3
+        equal:
+          path: spec.activeDeadlineSeconds
+          value: 270
+
+  - it: cleanup Job pod is not BestEffort, since it gets a single attempt
+    # backoffLimit 0 removed the retry that used to absorb an eviction, so a pod
+    # that is first in line under node pressure now fails the whole uninstall
+    # attempt rather than one run inside it. Requests are what take it out of
+    # the BestEffort class; the values match the sibling hook in
+    # packages/apps/kubernetes running the same image.
+    asserts:
+      - template: templates/cleanup-job.yaml
+        documentIndex: 3
+        equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 10m
+      - template: templates/cleanup-job.yaml
+        documentIndex: 3
+        equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 64Mi
+
+  - it: cleanup Job pod terminates well inside the uninstall budget
+    # Since 1.31 the Job controller withholds the terminal condition until every
+    # pod has finished terminating, so helm learns of the failure at
+    # activeDeadlineSeconds plus this period, not at the deadline. The full
+    # period is spent rather than bounded by: PID 1 is a shell running a
+    # multi-command script, so it never execs into kubectl, and a default
+    # disposition sent to PID 1 is discarded by the kernel while a
+    # non-interactive shell installs no handler for it. Nothing acts on the
+    # SIGTERM and the pod ends on the SIGKILL that closes this window. Left
+    # unset, the 30s default lands the failure at 270+30 — level with the
+    # budget, which is what the deadline is set under the budget to avoid.
+    asserts:
+      - template: templates/cleanup-job.yaml
+        documentIndex: 3
+        isKind:
+          of: Job
+      - template: templates/cleanup-job.yaml
+        documentIndex: 3
+        equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 10
+
+  - it: cleanup Job makes a single attempt so its failure reaches helm
+    # Both halves are load-bearing and neither implies the other. At the default
+    # backoffLimit of 6 none of the retries fits in what is left of the deadline,
+    # so helm never sees a failed Job and the operator gets a bare "timed out
+    # waiting for the condition" instead of the wave that could not finish. And
+    # under restartPolicy OnFailure the cap is applied only after the fact, by
+    # summing restartCount, so the kubelet re-runs the script in place first and
+    # the wave that just expired is re-entered before the Job controller cuts it
+    # down. Never puts a failed pod in front of the controller directly.
+    asserts:
+      - template: templates/cleanup-job.yaml
+        documentIndex: 3
+        isKind:
+          of: Job
+      - template: templates/cleanup-job.yaml
+        documentIndex: 3
+        equal:
+          path: spec.backoffLimit
+          value: 0
+      - template: templates/cleanup-job.yaml
+        documentIndex: 3
+        equal:
+          path: spec.template.spec.restartPolicy
+          value: Never
 
   - it: cleanup Job runs non-root under a restrictive securityContext
     asserts:


### PR DESCRIPTION
## What this PR does

The tenant pre-delete hook deletes the tenant's HelmReleases in two waves with `kubectl delete --wait=true` and no `--timeout`. kubectl reads `--timeout=0` as "wait forever" and substitutes a week, so a wave hangs for as long as any child HelmRelease cannot finalize. helm then returns from the uninstall without deleting anything: the release stays in storage, flux keeps the finalizer, and the same teardown gets retried. The delete policy carries no `hook-failed`, so the waiting Job survives between attempts too.

Each wave now gets 90s. Neither is guarded, on purpose. Nothing stands behind these deletes, so a wave that did not finish ends the run instead of reporting a cleanup that never happened. That also keeps the order the two waves exist for, since the tenant modules are what the applications run on. Whatever got deleted stays deleted, so the next attempt resumes from there.

The Job gets `activeDeadlineSeconds: 270`. It bounds what the waits do not, since the DELETE calls carry kubectl's default `--request-timeout` of 0, and it sits under the 300s uninstall budget flux applies when the HelmRelease has no timeout of its own. That is the budget for tenants cozystack-api generates; `tenant-root` is the exception, a static release in `cozystack-basics` carrying `timeout: 15m0s`, and the ordering holds there too since 280 is under 900. The 30s gap is not cosmetic. The deadline runs from the Job's `.status.startTime` while helm's budget runs from before the Job is created, so at equal values helm gives up first, on a Job that is still running. That is the state this change is meant to end, and it would look fixed, because a number would be there.

`terminationGracePeriodSeconds: 10` is part of the same arithmetic. Since 1.31 the Job controller holds back the terminal condition until every pod has finished terminating, so what helm waits for is the deadline plus the termination. At the 30s default that lands on 270+30, level with the budget, which is the gap the deadline was set to buy. That period gets spent in full, every time. The SIGTERM goes to PID 1, which is the shell: the script runs several commands, so the shell never execs into kubectl and stays PID 1 itself. A signal carrying its default disposition is discarded by the kernel when the target is PID 1, and a non-interactive shell installs no SIGTERM handler, so nothing acts on it. kubectl is a child and was not signalled at all. The pod ends on SIGKILL. Nothing in that script needs to finish gracefully, the DELETE calls are already sent and the process is only watching.

The pod also gets resource requests, matching the sibling hook in `packages/apps/kubernetes`. Without them it is BestEffort and first to go under node pressure, which mattered less when a retry inside the Job absorbed an eviction. With a single attempt it does not.

`backoffLimit: 0` and `restartPolicy: Never` go together, and neither implies the other. At the default limit of 6 the Job does not reach `Failed` inside the budget, so helm falls back on its own timeout with the same nameless "timed out waiting for the condition" as before. Under `OnFailure` the pod survives its own failure and the kubelet re-runs the container in place, and the Job controller finds out afterwards by summing `restartCount`. The script starts over, re-enters the applications wave that just expired, and gets cut down mid-run when the controller catches up. `Never` puts a failed pod in front of the controller directly.

## What this PR does not do

No remedy behind the bounded waits. The `packages/apps/kubernetes` hook force-clears child finalizers when its own wait expires. That needs `patch` on HelmReleases in the Role, and it is only safe there because the whole tenant control plane is going away in the same run. Here a wave that expires ends the attempt. `packages/apps/kubernetes/templates/delete.yaml` is untouched.

It does not make a doomed teardown converge. A tenant whose children cannot finalize still gets its uninstall retried. What changes is that each attempt ends in bounded time, instead of eating the whole uninstall budget and leaving a pod behind.

90s is a guess, and it is tight. The first wave deletes every application HelmRelease in the namespace, including kinds that are slow to tear down: a nested Tenant runs this same hook one level down before its release finalizes, and an app of kind Kubernetes tears a control plane down. Either one can outrun 90s. The bound is what is left once the Job deadline sits under helm's budget instead of level with it, split between the two waves.

The 90s the deadline keeps back for scheduling and the image pull is not calibrated either, and I would rather say so than imply it was. `docker.io/clastix/kubectl:v1.32` comes from Docker Hub with no mirror in front of it, and this repo has measured Docker Hub pulls of a smaller image at about 1m42s in CI. So that remainder is roughly the observed worst case rather than comfortably above it. A cold pull that slow lands on the `activeDeadlineSeconds` path, which is the one that deletes the pod and leaves nothing to read.

There is a band that pays for this, and I would rather name it than round it off. Neither shape above fits inside 300s today, so for them the bound costs nothing that works. But every generated child HelmRelease carries a wait strategy, so a wave inherits its slowest child, and a wave that settles in something like 95s does complete inside the budget today. After this change it expires instead, and that tenant trades one clean attempt for an extra flux retry. In wall clock that retry is about five minutes, since `helmrelease-interval` defaults to `5m`, so a tenant in that band takes noticeably longer to delete than it does now. I think that is the right side of the trade: an unbounded wave does not fail, it spends the whole budget and leaves helm reporting a timeout that names nothing. If the band turns out to be populated, the waits and the deadline move together, and the bats suite pins their ordering rather than their values.

One caveat on the diagnostics, since the comments in the chart used to promise more than they deliver. The failing wave leaves its output in the failed pod, which `ttlSecondsAfterFinished: 300` then reaps while flux's uninstall backoff is still climbing. And on the `activeDeadlineSeconds` path there is no log at all, because the Job controller deletes the active pods when the deadline expires. That path is the backstop for a kubectl that never returns; the expected path is the wave's own `--timeout`, where the script exits on its own and the pod survives to be read.

## Tests

`hack/tenant-pre-delete-hook.bats` renders the chart, pulls the hook script out of the Job and runs it against a stub `kubectl` on `PATH`. It covers a clean run reporting success, every delete reaching kubectl with a non-zero bound, the ordering of the four numbers, and a wave that gave up ending the run without going on to the next one. `--timeout` is implemented inside kubectl, so no stub can make that deadline actually elapse. The tests read the arguments that reached kubectl and inject the non-zero exit an expired delete produces. No EXIT traps.

The ordering test reads the numbers out of the rendered Job instead of pinning them, so moving a value keeps it honest while a value that breaks the ordering still fails. An absent deadline or termination period is rejected explicitly, otherwise `null` satisfies the numeric comparison and a Job with no bound at all passes.

The Job's own shape is pinned in the chart's helm-unittest suite, since the script cannot observe that about itself.

Both suites are green locally, and I mutated each pinned value to confirm they fail for the right reason: dropping either `--timeout`, dropping `activeDeadlineSeconds`, dropping `terminationGracePeriodSeconds`, dropping the requests, `backoffLimit` back to 6, `restartPolicy` back to `OnFailure`, and a `|| echo` appended to the applications wave. Each one goes red in the test that claims that ground.

Worth flagging so the check marks are not read as more than they are: `make bats-unit-tests` is red at the merge base, unrelated to this branch, and the loop it runs exits on the first failing file. `hack/cozyreport.bats` sorts ahead of this suite, so on CI the new bats file is not reached at all right now. It is not failing, it is not running. The helm-unittest cases are unaffected and do execute.

### Screenshots

None. This changes a Job manifest and its tests, with no user-visible surface.

### Downstream repositories

Walked the trigger map against the diff. The diff is one Job manifest inside the tenant chart, its helm-unittest suite, and a new `hack/*.bats` file. No package is added, renamed or removed; no `values.schema.json`, `values.yaml` default or version enum changes; no `ApplicationDefinition` semantics, namespace, variant or release asset changes; nothing under `hack/` is moved or renamed and no make target changes behaviour, since `bats-unit-tests` already globs `hack/*.bats`.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(tenant): bound the pre-delete cleanup hook's HelmRelease deletions and give its Job a wall-clock deadline, so a tenant whose children cannot finalize no longer leaves the hook waiting indefinitely and blocking the uninstall
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Tenant cleanup jobs now enforce execution deadlines and terminate gracefully.
  * Cleanup operations have bounded deletion timeouts and no automatic retries.
  * Failed cleanup steps now stop subsequent operations and correctly report failure.
  * Cleanup jobs now specify CPU and memory resource requirements.

* **Tests**
  * Added comprehensive coverage for cleanup behavior, timeouts, failure handling, and job lifecycle settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->