### PR TITLE
fix(api): drop caller-supplied internal.cozystack.io labels in tenantsecret writes

### DIFF
--- a/pkg/registry/core/tenantsecret/rest.go
+++ b/pkg/registry/core/tenantsecret/rest.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -43,9 +44,25 @@ const (
 	singularName         = "tenantsecret"
 	kindTenantSecret     = "TenantSecret"
 	kindTenantSecretList = "TenantSecretList"
+
+	// internalPrefix namespaces the labels and annotations the platform owns:
+	// the lineage webhook's tenantresource verdict, the cacert controller's
+	// tenant-ca selector and its ownership markers. They are the platform's
+	// answer to "may this tenant see this Secret", and an ApplicationDefinition
+	// selects on them, so a caller writing through this API must not be able to
+	// plant or strip one on the backing Secret. The guard is on the prefix
+	// rather than on a list of keys so a platform key added later is protected
+	// without anyone remembering to come back here.
+	internalPrefix = "internal.cozystack.io/"
 )
 
-func stripInternal(m map[string]string) map[string]string {
+// isInternalKey reports whether a metadata key belongs to the platform.
+func isInternalKey(k string) bool { return strings.HasPrefix(k, internalPrefix) }
+
+// stripTenantMarker hides the tenant-resource marker, and only that key. The
+// read side is deliberately narrower than the write side: a tenant may see the
+// platform's other verdicts, tenant-ca among them, it just cannot write them.
+func stripTenantMarker(m map[string]string) map[string]string {
 	if m == nil {
 		return nil
 	}
@@ -93,7 +110,7 @@ func secretToTenant(sec *corev1.Secret) *corev1alpha1.TenantSecret {
 			UID:               sec.UID,
 			ResourceVersion:   sec.ResourceVersion,
 			CreationTimestamp: sec.CreationTimestamp,
-			Labels:            stripInternal(sec.Labels),
+			Labels:            stripTenantMarker(sec.Labels),
 			Annotations:       sec.Annotations,
 		},
 		Type:       string(sec.Type),
@@ -115,6 +132,14 @@ func tenantToSecret(ts *corev1alpha1.TenantSecret, cur *corev1.Secret) *corev1.S
 	}
 	out.Labels[tsLabelKey] = tsLabelValue
 	for k, v := range ts.Labels {
+		// Platform keys are dropped rather than rejected: a caller that GETs an
+		// object, edits it and PUTs it back sends them straight back at us, and
+		// failing that round-trip would break `kubectl edit` for no gain. On an
+		// update out starts as a copy of the stored Secret, so ignoring the
+		// caller here also means a platform key cannot be stripped.
+		if isInternalKey(k) {
+			continue
+		}
 		out.Labels[k] = v
 	}
 
@@ -122,6 +147,9 @@ func tenantToSecret(ts *corev1alpha1.TenantSecret, cur *corev1.Secret) *corev1.S
 		out.Annotations = map[string]string{}
 	}
 	for k, v := range ts.Annotations {
+		if isInternalKey(k) {
+			continue
+		}
 		out.Annotations[k] = v
 	}
 
@@ -147,10 +175,13 @@ func nsFrom(ctx context.Context) (string, error) {
 // -----------------------------------------------------------------------------
 
 var (
-	_ rest.Creater              = &REST{}
-	_ rest.Getter               = &REST{}
-	_ rest.Lister               = &REST{}
-	_ rest.Updater              = &REST{}
+	_ rest.Creater = &REST{}
+	_ rest.Getter  = &REST{}
+	_ rest.Lister  = &REST{}
+	_ rest.Updater = &REST{}
+	// rest.Patcher is Getter+Updater: a PATCH request is decoded against the
+	// object Get returns and applied through Update, so there is no separate
+	// patch entry point and the guard in tenantToSecret covers PATCH too.
 	_ rest.Patcher              = &REST{}
 	_ rest.GracefulDeleter      = &REST{}
 	_ rest.Watcher              = &REST{}
@@ -398,53 +429,6 @@ func (r *REST) Delete(
 	}
 	err = r.c.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name}}, &client.DeleteOptions{Raw: opts})
 	return nil, err == nil, err
-}
-
-func (r *REST) Patch(
-	ctx context.Context,
-	name string,
-	pt types.PatchType,
-	data []byte,
-	opts *metav1.PatchOptions,
-	subresources ...string,
-) (runtime.Object, error) {
-	if len(subresources) > 0 {
-		return nil, fmt.Errorf("TenantSecret does not have subresources")
-	}
-	ns, err := nsFrom(ctx)
-	if err != nil {
-		return nil, err
-	}
-	current := &corev1.Secret{}
-	if err := r.c.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, current, &client.GetOptions{Raw: &metav1.GetOptions{}}); err != nil {
-		return nil, err
-	}
-	if current.Labels == nil || current.Labels[tsLabelKey] != tsLabelValue {
-		return nil, apierrors.NewNotFound(r.gvr.GroupResource(), name)
-	}
-	out := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns,
-			Name:      name,
-		},
-	}
-	patch := client.RawPatch(pt, data)
-	err = r.c.Patch(ctx, out, patch, &client.PatchOptions{Raw: opts})
-	if err != nil {
-		return nil, err
-	}
-
-	// Ensure tenant secret label is preserved
-	if out.Labels == nil {
-		out.Labels = make(map[string]string)
-	}
-
-	if out.Labels[tsLabelKey] != tsLabelValue {
-		out.Labels[tsLabelKey] = tsLabelValue
-		_ = r.c.Update(ctx, out, &client.UpdateOptions{Raw: &metav1.UpdateOptions{}})
-	}
-
-	return secretToTenant(out), nil
 }
 
 // -----------------------------------------------------------------------------

--- a/pkg/registry/core/tenantsecret/rest.go
+++ b/pkg/registry/core/tenantsecret/rest.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -43,9 +44,55 @@ const (
 	singularName         = "tenantsecret"
 	kindTenantSecret     = "TenantSecret"
 	kindTenantSecretList = "TenantSecretList"
+
+	// internalPrefix namespaces the labels and annotations the platform owns:
+	// the lineage webhook's tenantresource verdict, the cacert controller's
+	// tenant-ca selector and its ownership markers. They are the platform's
+	// answer to "may this tenant see this Secret", and an ApplicationDefinition
+	// selects on them, so a caller writing through this API must not be able to
+	// plant or strip one on the backing Secret. The guard is on the prefix
+	// rather than on a list of keys so a platform key added later is protected
+	// without anyone remembering to come back here.
+	internalPrefix = "internal.cozystack.io/"
 )
 
-func stripInternal(m map[string]string) map[string]string {
+// isInternalKey reports whether a metadata key belongs to the platform.
+func isInternalKey(k string) bool { return strings.HasPrefix(k, internalPrefix) }
+
+// restoreInternal rewrites the platform-owned entries of m to exactly those of
+// cur, leaving every other entry alone, and reports whether m changed. It is
+// the repair half of the guard, for the write path that reaches the backing
+// Secret without passing through tenantToSecret.
+func restoreInternal(m, cur map[string]string) (map[string]string, bool) {
+	changed := false
+	for k := range m {
+		if !isInternalKey(k) {
+			continue
+		}
+		if _, keep := cur[k]; !keep {
+			delete(m, k)
+			changed = true
+		}
+	}
+	for k, v := range cur {
+		if !isInternalKey(k) {
+			continue
+		}
+		if got, ok := m[k]; !ok || got != v {
+			if m == nil {
+				m = map[string]string{}
+			}
+			m[k] = v
+			changed = true
+		}
+	}
+	return m, changed
+}
+
+// stripTenantMarker hides the tenant-resource marker, and only that key. The
+// read side is deliberately narrower than the write side: a tenant may see the
+// platform's other verdicts, tenant-ca among them, it just cannot write them.
+func stripTenantMarker(m map[string]string) map[string]string {
 	if m == nil {
 		return nil
 	}
@@ -93,7 +140,7 @@ func secretToTenant(sec *corev1.Secret) *corev1alpha1.TenantSecret {
 			UID:               sec.UID,
 			ResourceVersion:   sec.ResourceVersion,
 			CreationTimestamp: sec.CreationTimestamp,
-			Labels:            stripInternal(sec.Labels),
+			Labels:            stripTenantMarker(sec.Labels),
 			Annotations:       sec.Annotations,
 		},
 		Type:       string(sec.Type),
@@ -115,6 +162,14 @@ func tenantToSecret(ts *corev1alpha1.TenantSecret, cur *corev1.Secret) *corev1.S
 	}
 	out.Labels[tsLabelKey] = tsLabelValue
 	for k, v := range ts.Labels {
+		// Platform keys are dropped rather than rejected: a caller that GETs an
+		// object, edits it and PUTs it back sends them straight back at us, and
+		// failing that round-trip would break `kubectl edit` for no gain. On an
+		// update out starts as a copy of the stored Secret, so ignoring the
+		// caller here also means a platform key cannot be stripped.
+		if isInternalKey(k) {
+			continue
+		}
 		out.Labels[k] = v
 	}
 
@@ -122,6 +177,9 @@ func tenantToSecret(ts *corev1alpha1.TenantSecret, cur *corev1.Secret) *corev1.S
 		out.Annotations = map[string]string{}
 	}
 	for k, v := range ts.Annotations {
+		if isInternalKey(k) {
+			continue
+		}
 		out.Annotations[k] = v
 	}
 
@@ -434,14 +492,27 @@ func (r *REST) Patch(
 		return nil, err
 	}
 
-	// Ensure tenant secret label is preserved
-	if out.Labels == nil {
-		out.Labels = make(map[string]string)
-	}
-
-	if out.Labels[tsLabelKey] != tsLabelValue {
-		out.Labels[tsLabelKey] = tsLabelValue
-		_ = r.c.Update(ctx, out, &client.UpdateOptions{Raw: &metav1.UpdateOptions{}})
+	// This method is not what serves a PATCH request: rest.Patcher is
+	// Getter+Updater, so the endpoint installer routes PATCH through Update,
+	// and the guard that covers it is the one in tenantToSecret. Nothing
+	// reaches this code today. It is kept in step anyway rather than left as
+	// the weaker of two doors — the raw patch here lands on the backing Secret
+	// without any conversion, so the platform keys have to be put back
+	// afterwards, the tenant-resource marker among them.
+	lbls, lblsChanged := restoreInternal(out.Labels, current.Labels)
+	anns, annsChanged := restoreInternal(out.Annotations, current.Annotations)
+	if lblsChanged || annsChanged {
+		out.Labels, out.Annotations = lbls, anns
+		// Carry the caller's options over: this repair now fires on any platform
+		// key, not just a missing marker, so a dry-run patch would otherwise
+		// commit it for real.
+		raw := &metav1.UpdateOptions{}
+		if opts != nil {
+			raw.DryRun, raw.FieldManager, raw.FieldValidation = opts.DryRun, opts.FieldManager, opts.FieldValidation
+		}
+		if err := r.c.Update(ctx, out, &client.UpdateOptions{Raw: raw}); err != nil {
+			return nil, err
+		}
 	}
 
 	return secretToTenant(out), nil

--- a/pkg/registry/core/tenantsecret/rest_write_test.go
+++ b/pkg/registry/core/tenantsecret/rest_write_test.go
@@ -1,0 +1,446 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package tenantsecret
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	corev1alpha1 "github.com/cozystack/cozystack/pkg/apis/core/v1alpha1"
+)
+
+// Platform-owned keys, spelled out here rather than imported so the test pins
+// the literal strings the controllers and the admission webhook agree on.
+const (
+	tenantCALabel      = "internal.cozystack.io/tenant-ca"
+	caCopyLabel        = "internal.cozystack.io/ca-cert-copy"
+	caSourceAnnotation = "internal.cozystack.io/ca-cert-source"
+)
+
+func testCtx() context.Context {
+	return request.WithNamespace(context.Background(), testNamespace)
+}
+
+// backingSecret reads the Secret the registry actually wrote.
+func backingSecret(t *testing.T, r *REST, name string) *corev1.Secret {
+	t.Helper()
+	sec := &corev1.Secret{}
+	if err := r.c.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: name}, sec); err != nil {
+		t.Fatalf("get backing Secret %q: %v", name, err)
+	}
+	return sec
+}
+
+func TestCreate_DropsCallerSuppliedInternalLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   map[string]string
+	}{
+		{
+			name:   "no labels keeps only the tenant-resource marker",
+			labels: nil,
+			want:   map[string]string{tsLabelKey: tsLabelValue},
+		},
+		{
+			name:   "ordinary labels are preserved",
+			labels: map[string]string{"apps.cozystack.io/application.kind": "Bucket", "team": "blue"},
+			want: map[string]string{
+				tsLabelKey:                           tsLabelValue,
+				"apps.cozystack.io/application.kind": "Bucket",
+				"team":                               "blue",
+			},
+		},
+		{
+			name:   "spoofed tenant-ca selector is dropped",
+			labels: map[string]string{tenantCALabel: "true", "team": "blue"},
+			want:   map[string]string{tsLabelKey: tsLabelValue, "team": "blue"},
+		},
+		{
+			name:   "spoofed ca-cert-copy ownership marker is dropped",
+			labels: map[string]string{caCopyLabel: "true"},
+			want:   map[string]string{tsLabelKey: tsLabelValue},
+		},
+		{
+			name:   "tenant-resource verdict cannot be forged",
+			labels: map[string]string{tsLabelKey: "false"},
+			want:   map[string]string{tsLabelKey: tsLabelValue},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestREST(t)
+			in := &corev1alpha1.TenantSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "creds",
+					Namespace: testNamespace,
+					Labels:    tt.labels,
+				},
+				Type: string(corev1.SecretTypeOpaque),
+			}
+
+			if _, err := r.Create(testCtx(), in, nil, &metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Create returned error: %v", err)
+			}
+
+			if got := backingSecret(t, r, "creds").Labels; !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("backing Secret labels: got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreate_DropsCallerSuppliedInternalAnnotations(t *testing.T) {
+	r := newTestREST(t)
+	in := &corev1alpha1.TenantSecret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "creds",
+			Namespace: testNamespace,
+			Annotations: map[string]string{
+				caSourceAnnotation: "tenant-root/forged",
+				"team.io/owner":    "blue",
+			},
+		},
+		Type: string(corev1.SecretTypeOpaque),
+	}
+
+	if _, err := r.Create(testCtx(), in, nil, &metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	want := map[string]string{"team.io/owner": "blue"}
+	if got := backingSecret(t, r, "creds").Annotations; !reflect.DeepEqual(got, want) {
+		t.Fatalf("backing Secret annotations: got %v, want %v", got, want)
+	}
+}
+
+func TestUpdate_KeepsPlatformLabelsCallerCannotSee(t *testing.T) {
+	existing := makeTenantSecret("creds", map[string]string{
+		tenantCALabel: "true",
+		"team":        "blue",
+	})
+	existing.Annotations = map[string]string{caSourceAnnotation: "cozy-system/root-ca"}
+
+	tests := []struct {
+		name            string
+		labels          map[string]string
+		annotations     map[string]string
+		wantLabels      map[string]string
+		wantAnnotations map[string]string
+	}{
+		{
+			name:   "omitting a platform label does not strip it",
+			labels: map[string]string{"team": "blue"},
+			wantLabels: map[string]string{
+				tsLabelKey:    tsLabelValue,
+				tenantCALabel: "true",
+				"team":        "blue",
+			},
+			wantAnnotations: map[string]string{caSourceAnnotation: "cozy-system/root-ca"},
+		},
+		{
+			name:   "overwriting the tenant-ca selector is ignored",
+			labels: map[string]string{tenantCALabel: "false"},
+			wantLabels: map[string]string{
+				tsLabelKey:    tsLabelValue,
+				tenantCALabel: "true",
+				"team":        "blue",
+			},
+			wantAnnotations: map[string]string{caSourceAnnotation: "cozy-system/root-ca"},
+		},
+		{
+			name:   "overwriting the tenant-resource verdict is ignored",
+			labels: map[string]string{tsLabelKey: "false"},
+			wantLabels: map[string]string{
+				tsLabelKey:    tsLabelValue,
+				tenantCALabel: "true",
+				"team":        "blue",
+			},
+			wantAnnotations: map[string]string{caSourceAnnotation: "cozy-system/root-ca"},
+		},
+		{
+			name:   "planting a new platform label is ignored, ordinary labels land",
+			labels: map[string]string{caCopyLabel: "true", "tier": "gold"},
+			wantLabels: map[string]string{
+				tsLabelKey:    tsLabelValue,
+				tenantCALabel: "true",
+				"team":        "blue",
+				"tier":        "gold",
+			},
+			wantAnnotations: map[string]string{caSourceAnnotation: "cozy-system/root-ca"},
+		},
+		{
+			name:            "overwriting a platform annotation is ignored",
+			annotations:     map[string]string{caSourceAnnotation: "tenant-root/forged", "team.io/owner": "blue"},
+			wantLabels:      map[string]string{tsLabelKey: tsLabelValue, tenantCALabel: "true", "team": "blue"},
+			wantAnnotations: map[string]string{caSourceAnnotation: "cozy-system/root-ca", "team.io/owner": "blue"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestREST(t, existing.DeepCopy())
+			in := &corev1alpha1.TenantSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "creds",
+					Namespace:   testNamespace,
+					Labels:      tt.labels,
+					Annotations: tt.annotations,
+				},
+				Type: string(corev1.SecretTypeOpaque),
+			}
+
+			_, _, err := r.Update(testCtx(), "creds", rest.DefaultUpdatedObjectInfo(in), nil, nil, false, &metav1.UpdateOptions{})
+			if err != nil {
+				t.Fatalf("Update returned error: %v", err)
+			}
+
+			sec := backingSecret(t, r, "creds")
+			if !reflect.DeepEqual(sec.Labels, tt.wantLabels) {
+				t.Fatalf("backing Secret labels: got %v, want %v", sec.Labels, tt.wantLabels)
+			}
+			if !reflect.DeepEqual(sec.Annotations, tt.wantAnnotations) {
+				t.Fatalf("backing Secret annotations: got %v, want %v", sec.Annotations, tt.wantAnnotations)
+			}
+		})
+	}
+}
+
+// PATCH is served out of Update — rest.Patcher is Getter+Updater — so the guard
+// that covers it is the one in tenantToSecret. This pins Update against a caller
+// sending only the keys it wants set, which is the shape a patched object takes
+// by the time it reaches the merge inside tenantToSecret.
+func TestUpdate_PatchShapedObjectCannotPlantPlatformLabels(t *testing.T) {
+	r := newTestREST(t, makeTenantSecret("creds", map[string]string{tenantCALabel: "true"}))
+	patched := &corev1alpha1.TenantSecret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "creds",
+			Namespace: testNamespace,
+			Labels:    map[string]string{caCopyLabel: "true"},
+		},
+	}
+
+	_, _, err := r.Update(testCtx(), "creds", rest.DefaultUpdatedObjectInfo(patched), nil, nil, false, &metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+
+	want := map[string]string{tsLabelKey: tsLabelValue, tenantCALabel: "true"}
+	if got := backingSecret(t, r, "creds").Labels; !reflect.DeepEqual(got, want) {
+		t.Fatalf("backing Secret labels: got %v, want %v", got, want)
+	}
+}
+
+// A write reaches the backing Secret exactly once, so a write that fails leaves
+// the stored object as it was and the caller's keys never become visible to a
+// controller or a List. A path that committed the caller's object first and
+// repaired it afterwards would open that window, and leave it open for good
+// when the repair failed.
+func TestUpdate_FailedWriteLeavesTheBackingSecretIntact(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(makeTenantSecret("creds", map[string]string{tenantCALabel: "true"})).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(context.Context, client.WithWatch, client.Object, ...client.UpdateOption) error {
+				return errors.New("boom")
+			},
+		}).
+		Build()
+	r := &REST{c: fc, w: fc, gvr: schema.GroupVersionResource{
+		Group: corev1alpha1.GroupName, Version: "v1alpha1", Resource: "tenantsecrets",
+	}}
+
+	in := &corev1alpha1.TenantSecret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "creds",
+			Namespace: testNamespace,
+			Labels:    map[string]string{tsLabelKey: "false", tenantCALabel: "false", "team": "blue"},
+		},
+	}
+	if _, _, err := r.Update(testCtx(), "creds", rest.DefaultUpdatedObjectInfo(in), nil, nil, false, &metav1.UpdateOptions{}); err == nil {
+		t.Fatal("Update reported success although the write to the backing Secret failed")
+	}
+
+	want := map[string]string{tsLabelKey: tsLabelValue, tenantCALabel: "true"}
+	if got := backingSecret(t, r, "creds").Labels; !reflect.DeepEqual(got, want) {
+		t.Fatalf("backing Secret labels after a failed write: got %v, want %v", got, want)
+	}
+}
+
+// The drop-rather-than-reject decision rests on this round trip: a tenant sees
+// the platform's keys on read, so `kubectl edit` sends them straight back, and
+// that write has to be accepted with the stored values, and the payload, intact.
+func TestUpdate_UnchangedRoundTripKeepsPlatformKeys(t *testing.T) {
+	existing := makeTenantSecret("creds", map[string]string{
+		tenantCALabel: "true",
+		"team":        "blue",
+	})
+	existing.Annotations = map[string]string{
+		caSourceAnnotation: "cozy-system/root-ca",
+		"team.io/owner":    "blue",
+	}
+	existing.Data = map[string][]byte{"password": []byte("s3cr3t")}
+	r := newTestREST(t, existing)
+
+	obj, err := r.Get(testCtx(), "creds", &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	got, ok := obj.(*corev1alpha1.TenantSecret)
+	if !ok {
+		t.Fatalf("expected *TenantSecret, got %T", obj)
+	}
+
+	_, _, err = r.Update(testCtx(), "creds", rest.DefaultUpdatedObjectInfo(got), nil, nil, false, &metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Update of an unmodified object returned error: %v", err)
+	}
+
+	sec := backingSecret(t, r, "creds")
+	wantLabels := map[string]string{
+		tsLabelKey:    tsLabelValue,
+		tenantCALabel: "true",
+		"team":        "blue",
+	}
+	wantAnnotations := map[string]string{
+		caSourceAnnotation: "cozy-system/root-ca",
+		"team.io/owner":    "blue",
+	}
+	if !reflect.DeepEqual(sec.Labels, wantLabels) {
+		t.Fatalf("backing Secret labels after a round trip: got %v, want %v", sec.Labels, wantLabels)
+	}
+	if !reflect.DeepEqual(sec.Annotations, wantAnnotations) {
+		t.Fatalf("backing Secret annotations after a round trip: got %v, want %v", sec.Annotations, wantAnnotations)
+	}
+	// The read hands back both Data and its base64 rendering in StringData; a
+	// round trip that took the StringData branch would re-encode the payload.
+	if got := string(sec.Data["password"]); got != "s3cr3t" {
+		t.Fatalf("backing Secret payload after a round trip: got %q, want %q", got, "s3cr3t")
+	}
+}
+
+// Every case above names a key some controller writes today, and an
+// implementation that filtered that list instead of the prefix would pass all
+// of them. Only a key nobody has claimed yet tells the two apart, so each write
+// path gets one.
+func TestWrites_DropUnclaimedInternalKeys(t *testing.T) {
+	const (
+		futureLabel      = "internal.cozystack.io/some-future-marker"
+		futureAnnotation = "internal.cozystack.io/some-future-source"
+	)
+
+	forged := func(labels map[string]string) *corev1alpha1.TenantSecret {
+		return &corev1alpha1.TenantSecret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "creds",
+				Namespace:   testNamespace,
+				Labels:      labels,
+				Annotations: map[string]string{futureAnnotation: "forged", "team.io/owner": "blue"},
+			},
+			Type: string(corev1.SecretTypeOpaque),
+		}
+	}
+
+	tests := []struct {
+		name       string
+		seed       bool
+		write      func(t *testing.T, r *REST)
+		wantLabels map[string]string
+	}{
+		{
+			name: "create",
+			write: func(t *testing.T, r *REST) {
+				t.Helper()
+				in := forged(map[string]string{futureLabel: "true", "team": "blue"})
+				if _, err := r.Create(testCtx(), in, nil, &metav1.CreateOptions{}); err != nil {
+					t.Fatalf("Create returned error: %v", err)
+				}
+			},
+			wantLabels: map[string]string{tsLabelKey: tsLabelValue, "team": "blue"},
+		},
+		{
+			name: "update",
+			seed: true,
+			write: func(t *testing.T, r *REST) {
+				t.Helper()
+				in := forged(map[string]string{futureLabel: "true", "team": "blue"})
+				_, _, err := r.Update(testCtx(), "creds", rest.DefaultUpdatedObjectInfo(in), nil, nil, false, &metav1.UpdateOptions{})
+				if err != nil {
+					t.Fatalf("Update returned error: %v", err)
+				}
+			},
+			wantLabels: map[string]string{tsLabelKey: tsLabelValue, tenantCALabel: "true", "team": "blue"},
+		},
+		{
+			name: "patch-shaped update carrying nothing but the forged keys",
+			seed: true,
+			write: func(t *testing.T, r *REST) {
+				t.Helper()
+				in := forged(map[string]string{futureLabel: "true"})
+				in.Annotations = map[string]string{futureAnnotation: "forged"}
+				_, _, err := r.Update(testCtx(), "creds", rest.DefaultUpdatedObjectInfo(in), nil, nil, false, &metav1.UpdateOptions{})
+				if err != nil {
+					t.Fatalf("Update returned error: %v", err)
+				}
+			},
+			wantLabels: map[string]string{tsLabelKey: tsLabelValue, tenantCALabel: "true"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r *REST
+			if tt.seed {
+				r = newTestREST(t, makeTenantSecret("creds", map[string]string{tenantCALabel: "true"}))
+			} else {
+				r = newTestREST(t)
+			}
+
+			tt.write(t, r)
+
+			sec := backingSecret(t, r, "creds")
+			if !reflect.DeepEqual(sec.Labels, tt.wantLabels) {
+				t.Fatalf("backing Secret labels: got %v, want %v", sec.Labels, tt.wantLabels)
+			}
+			if _, ok := sec.Annotations[futureAnnotation]; ok {
+				t.Fatalf("unclaimed platform annotation survived the write: %v", sec.Annotations)
+			}
+		})
+	}
+}
+
+// Reads are not filtered beyond the tenant-resource marker: a tenant is allowed
+// to see the platform's verdicts, it just cannot write them.
+func TestGet_KeepsPlatformLabelsVisible(t *testing.T) {
+	r := newTestREST(t, makeTenantSecret("creds", map[string]string{tenantCALabel: "true"}))
+
+	obj, err := r.Get(testCtx(), "creds", &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	ts, ok := obj.(*corev1alpha1.TenantSecret)
+	if !ok {
+		t.Fatalf("expected *TenantSecret, got %T", obj)
+	}
+	if ts.Labels[tenantCALabel] != "true" {
+		t.Fatalf("tenant-ca label hidden from the tenant: got %v", ts.Labels)
+	}
+}

--- a/pkg/registry/core/tenantsecret/rest_write_test.go
+++ b/pkg/registry/core/tenantsecret/rest_write_test.go
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package tenantsecret
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	corev1alpha1 "github.com/cozystack/cozystack/pkg/apis/core/v1alpha1"
+)
+
+// Platform-owned keys, spelled out here rather than imported so the test pins
+// the literal strings the controllers and the admission webhook agree on.
+const (
+	tenantCALabel      = "internal.cozystack.io/tenant-ca"
+	caCopyLabel        = "internal.cozystack.io/ca-cert-copy"
+	caSourceAnnotation = "internal.cozystack.io/ca-cert-source"
+)
+
+func testCtx() context.Context {
+	return request.WithNamespace(context.Background(), testNamespace)
+}
+
+// backingSecret reads the Secret the registry actually wrote.
+func backingSecret(t *testing.T, r *REST, name string) *corev1.Secret {
+	t.Helper()
+	sec := &corev1.Secret{}
+	if err := r.c.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: name}, sec); err != nil {
+		t.Fatalf("get backing Secret %q: %v", name, err)
+	}
+	return sec
+}
+
+func TestCreate_DropsCallerSuppliedInternalLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		labels map[string]string
+		want   map[string]string
+	}{
+		{
+			name:   "no labels keeps only the tenant-resource marker",
+			labels: nil,
+			want:   map[string]string{tsLabelKey: tsLabelValue},
+		},
+		{
+			name:   "ordinary labels are preserved",
+			labels: map[string]string{"apps.cozystack.io/application.kind": "Bucket", "team": "blue"},
+			want: map[string]string{
+				tsLabelKey:                           tsLabelValue,
+				"apps.cozystack.io/application.kind": "Bucket",
+				"team":                               "blue",
+			},
+		},
+		{
+			name:   "spoofed tenant-ca selector is dropped",
+			labels: map[string]string{tenantCALabel: "true", "team": "blue"},
+			want:   map[string]string{tsLabelKey: tsLabelValue, "team": "blue"},
+		},
+		{
+			name:   "spoofed ca-cert-copy ownership marker is dropped",
+			labels: map[string]string{caCopyLabel: "true"},
+			want:   map[string]string{tsLabelKey: tsLabelValue},
+		},
+		{
+			name:   "tenant-resource verdict cannot be forged",
+			labels: map[string]string{tsLabelKey: "false"},
+			want:   map[string]string{tsLabelKey: tsLabelValue},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestREST(t)
+			in := &corev1alpha1.TenantSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "creds",
+					Namespace: testNamespace,
+					Labels:    tt.labels,
+				},
+				Type: string(corev1.SecretTypeOpaque),
+			}
+
+			if _, err := r.Create(testCtx(), in, nil, &metav1.CreateOptions{}); err != nil {
+				t.Fatalf("Create returned error: %v", err)
+			}
+
+			if got := backingSecret(t, r, "creds").Labels; !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("backing Secret labels: got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreate_DropsCallerSuppliedInternalAnnotations(t *testing.T) {
+	r := newTestREST(t)
+	in := &corev1alpha1.TenantSecret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "creds",
+			Namespace: testNamespace,
+			Annotations: map[string]string{
+				caSourceAnnotation: "tenant-root/forged",
+				"team.io/owner":    "blue",
+			},
+		},
+		Type: string(corev1.SecretTypeOpaque),
+	}
+
+	if _, err := r.Create(testCtx(), in, nil, &metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	want := map[string]string{"team.io/owner": "blue"}
+	if got := backingSecret(t, r, "creds").Annotations; !reflect.DeepEqual(got, want) {
+		t.Fatalf("backing Secret annotations: got %v, want %v", got, want)
+	}
+}
+
+func TestUpdate_KeepsPlatformLabelsCallerCannotSee(t *testing.T) {
+	existing := makeTenantSecret("creds", map[string]string{
+		tenantCALabel: "true",
+		"team":        "blue",
+	})
+	existing.Annotations = map[string]string{caSourceAnnotation: "cozy-system/root-ca"}
+
+	tests := []struct {
+		name            string
+		labels          map[string]string
+		annotations     map[string]string
+		wantLabels      map[string]string
+		wantAnnotations map[string]string
+	}{
+		{
+			name:   "omitting a platform label does not strip it",
+			labels: map[string]string{"team": "blue"},
+			wantLabels: map[string]string{
+				tsLabelKey:    tsLabelValue,
+				tenantCALabel: "true",
+				"team":        "blue",
+			},
+			wantAnnotations: map[string]string{caSourceAnnotation: "cozy-system/root-ca"},
+		},
+		{
+			name:   "overwriting the tenant-ca selector is ignored",
+			labels: map[string]string{tenantCALabel: "false"},
+			wantLabels: map[string]string{
+				tsLabelKey:    tsLabelValue,
+				tenantCALabel: "true",
+				"team":        "blue",
+			},
+			wantAnnotations: map[string]string{caSourceAnnotation: "cozy-system/root-ca"},
+		},
+		{
+			name:   "overwriting the tenant-resource verdict is ignored",
+			labels: map[string]string{tsLabelKey: "false"},
+			wantLabels: map[string]string{
+				tsLabelKey:    tsLabelValue,
+				tenantCALabel: "true",
+				"team":        "blue",
+			},
+			wantAnnotations: map[string]string{caSourceAnnotation: "cozy-system/root-ca"},
+		},
+		{
+			name:   "planting a new platform label is ignored, ordinary labels land",
+			labels: map[string]string{caCopyLabel: "true", "tier": "gold"},
+			wantLabels: map[string]string{
+				tsLabelKey:    tsLabelValue,
+				tenantCALabel: "true",
+				"team":        "blue",
+				"tier":        "gold",
+			},
+			wantAnnotations: map[string]string{caSourceAnnotation: "cozy-system/root-ca"},
+		},
+		{
+			name:            "overwriting a platform annotation is ignored",
+			annotations:     map[string]string{caSourceAnnotation: "tenant-root/forged", "team.io/owner": "blue"},
+			wantLabels:      map[string]string{tsLabelKey: tsLabelValue, tenantCALabel: "true", "team": "blue"},
+			wantAnnotations: map[string]string{caSourceAnnotation: "cozy-system/root-ca", "team.io/owner": "blue"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestREST(t, existing.DeepCopy())
+			in := &corev1alpha1.TenantSecret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "creds",
+					Namespace:   testNamespace,
+					Labels:      tt.labels,
+					Annotations: tt.annotations,
+				},
+				Type: string(corev1.SecretTypeOpaque),
+			}
+
+			_, _, err := r.Update(testCtx(), "creds", rest.DefaultUpdatedObjectInfo(in), nil, nil, false, &metav1.UpdateOptions{})
+			if err != nil {
+				t.Fatalf("Update returned error: %v", err)
+			}
+
+			sec := backingSecret(t, r, "creds")
+			if !reflect.DeepEqual(sec.Labels, tt.wantLabels) {
+				t.Fatalf("backing Secret labels: got %v, want %v", sec.Labels, tt.wantLabels)
+			}
+			if !reflect.DeepEqual(sec.Annotations, tt.wantAnnotations) {
+				t.Fatalf("backing Secret annotations: got %v, want %v", sec.Annotations, tt.wantAnnotations)
+			}
+		})
+	}
+}
+
+// PATCH is served out of Update — rest.Patcher is Getter+Updater — so the guard
+// that covers it is the one in tenantToSecret, not the Patch method further
+// down. This pins Update against a caller sending only the keys it wants set,
+// which is the shape that reaches the merge inside tenantToSecret.
+func TestUpdate_PatchShapedObjectCannotPlantPlatformLabels(t *testing.T) {
+	r := newTestREST(t, makeTenantSecret("creds", map[string]string{tenantCALabel: "true"}))
+	patched := &corev1alpha1.TenantSecret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "creds",
+			Namespace: testNamespace,
+			Labels:    map[string]string{caCopyLabel: "true"},
+		},
+	}
+
+	_, _, err := r.Update(testCtx(), "creds", rest.DefaultUpdatedObjectInfo(patched), nil, nil, false, &metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+
+	want := map[string]string{tsLabelKey: tsLabelValue, tenantCALabel: "true"}
+	if got := backingSecret(t, r, "creds").Labels; !reflect.DeepEqual(got, want) {
+		t.Fatalf("backing Secret labels: got %v, want %v", got, want)
+	}
+}
+
+// A PATCH request does not land here — rest.Patcher is Getter+Updater, so the
+// endpoint installer serves PATCH through Update, which the case above covers.
+// This method is a second write path all the same, and it reaches the backing
+// Secret without any conversion, so it restores the platform keys afterwards.
+func TestPatch_RestoresPlatformLabels(t *testing.T) {
+	existing := makeTenantSecret("creds", map[string]string{tenantCALabel: "true"})
+	existing.Annotations = map[string]string{caSourceAnnotation: "cozy-system/root-ca"}
+
+	tests := []struct {
+		name            string
+		patch           string
+		wantLabels      map[string]string
+		wantAnnotations map[string]string
+	}{
+		{
+			name:  "planting a platform label is reverted",
+			patch: `{"metadata":{"labels":{"` + caCopyLabel + `":"true","team":"blue"}}}`,
+			wantLabels: map[string]string{
+				tsLabelKey:    tsLabelValue,
+				tenantCALabel: "true",
+				"team":        "blue",
+			},
+			wantAnnotations: map[string]string{caSourceAnnotation: "cozy-system/root-ca"},
+		},
+		{
+			name:  "stripping platform labels is reverted",
+			patch: `{"metadata":{"labels":{"` + tsLabelKey + `":null,"` + tenantCALabel + `":null}}}`,
+			wantLabels: map[string]string{
+				tsLabelKey:    tsLabelValue,
+				tenantCALabel: "true",
+			},
+			wantAnnotations: map[string]string{caSourceAnnotation: "cozy-system/root-ca"},
+		},
+		{
+			name:            "rewriting a platform annotation is reverted",
+			patch:           `{"metadata":{"annotations":{"` + caSourceAnnotation + `":"tenant-root/forged"}}}`,
+			wantLabels:      map[string]string{tsLabelKey: tsLabelValue, tenantCALabel: "true"},
+			wantAnnotations: map[string]string{caSourceAnnotation: "cozy-system/root-ca"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestREST(t, existing.DeepCopy())
+
+			if _, err := r.Patch(testCtx(), "creds", types.MergePatchType, []byte(tt.patch), &metav1.PatchOptions{}); err != nil {
+				t.Fatalf("Patch returned error: %v", err)
+			}
+
+			sec := backingSecret(t, r, "creds")
+			if !reflect.DeepEqual(sec.Labels, tt.wantLabels) {
+				t.Fatalf("backing Secret labels: got %v, want %v", sec.Labels, tt.wantLabels)
+			}
+			if !reflect.DeepEqual(sec.Annotations, tt.wantAnnotations) {
+				t.Fatalf("backing Secret annotations: got %v, want %v", sec.Annotations, tt.wantAnnotations)
+			}
+		})
+	}
+}
+
+// A patch whose platform keys could not be put back must not come back as a
+// success: the caller would take it as accepted and the spoofed key would sit
+// on the backing Secret unreported.
+func TestPatch_FailedRestoreIsReported(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(makeTenantSecret("creds", nil)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(context.Context, client.WithWatch, client.Object, ...client.UpdateOption) error {
+				return errors.New("boom")
+			},
+		}).
+		Build()
+	r := &REST{c: fc, w: fc, gvr: schema.GroupVersionResource{
+		Group: corev1alpha1.GroupName, Version: "v1alpha1", Resource: "tenantsecrets",
+	}}
+
+	patch := []byte(`{"metadata":{"labels":{"` + tsLabelKey + `":null}}}`)
+	if _, err := r.Patch(testCtx(), "creds", types.MergePatchType, patch, &metav1.PatchOptions{}); err == nil {
+		t.Fatal("Patch reported success although the platform labels could not be restored")
+	}
+}
+
+// Reads are not filtered beyond the tenant-resource marker: a tenant is allowed
+// to see the platform's verdicts, it just cannot write them.
+func TestGet_KeepsPlatformLabelsVisible(t *testing.T) {
+	r := newTestREST(t, makeTenantSecret("creds", map[string]string{tenantCALabel: "true"}))
+
+	obj, err := r.Get(testCtx(), "creds", &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	ts, ok := obj.(*corev1alpha1.TenantSecret)
+	if !ok {
+		t.Fatalf("expected *TenantSecret, got %T", obj)
+	}
+	if ts.Labels[tenantCALabel] != "true" {
+		t.Fatalf("tenant-ca label hidden from the tenant: got %v", ts.Labels)
+	}
+}


### PR DESCRIPTION
## What this PR does

Labels and annotations under `internal.cozystack.io/` belong to the platform. The lineage webhook stamps `internal.cozystack.io/tenantresource` to decide whether a Secret is visible through this API at all, and the cacert controller stamps `internal.cozystack.io/tenant-ca`, which an `ApplicationDefinition` selects on in `spec.secrets` to hand a trust anchor to the tenant. The registry copied every caller-supplied key onto the backing Secret as is, so anyone with write access to `tenantsecrets` could plant either marker on a Secret of their choice, or strip one to take an object out of the platform's view.

`tenantToSecret` is the only place the write verbs go through, PATCH included, because `rest.Patcher` is `Getter`+`Updater` and the endpoint installer serves PATCH out of `Update`. It now skips keys with that prefix. The update target starts as a copy of the stored Secret, so a platform key cannot be removed either. The guard is on the whole prefix, so a platform key added later is covered without anyone touching this code again.

Reads are unchanged. A tenant can see the platform's verdicts, it just cannot write them. Keys are dropped silently instead of rejected, otherwise a GET, edit and PUT round trip would break `kubectl edit` for no gain.

Nothing writes through this API today. Every `tenantsecrets` grant in `cozystack-basics` is `get`/`list`/`watch`, and the console only lists and watches. That read-only RBAC is what keeps the hole inert, and it lives in a different package from the registry that implements the write verbs, which is why I would rather close it here than keep relying on it.

Two things I found next to the diff and did not fix. The `Patch` method on this type is never reached: its signature is the `client-go` shape and matches no interface the endpoint installer asserts, so no request lands there. I gave it the same guard instead of leaving the weaker of two doors, but deleting it is probably the better answer and I would rather that call was yours. A repair after the write is weaker than the conversion anyway: the forged key is live between the patch and the repair, and forcing the object back to a pre-patch snapshot drops a key that a controller stamped inside that window. Second one, and the reason none of this is easy to spot: `Update` passes `nil` where the handler hands the storage the current object, so `hasUID` reports false and the patch mechanism takes its create-new-object branch. For JSON Patch, merge patch and strategic merge patch that branch returns `NotFound`, so all three get a 404 against an existing TenantSecret. Apply is the exception. `applyPatcher.createNewObject` builds a fresh object of the kind and applies onto that, so an apply does reach `Update`, carrying only the fields the caller sent, and the merge in `tenantToSecret` is what keeps the stored labels. Passing `secretToTenant(previous)` instead of `nil` is the fix and it belongs in its own change, since it makes the other three patch types live. Tell me if you want issues for either.

Closes #3464

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

Walked the trigger map against the diff: two Go files under `pkg/registry/core/tenantsecret/`, no package added, no chart, values schema, CRD, `ApplicationDefinition` field, namespace, `hack/` target or release asset touched. Nothing in the map fires.

### Release note

```release-note
fix(api): TenantSecret writes no longer accept caller-supplied `internal.cozystack.io/*` labels and annotations, so a principal with write access to the API can neither plant nor strip the platform markers that decide tenant visibility on the backing Secret.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened protection of platform-managed metadata during tenant-secret creation and updates.
  * Prevented tenant-provided platform-owned labels and annotations from overwriting protected values.
  * Preserved standard metadata while hiding sensitive resource markers.
  * Improved patch-based update handling and protected metadata consistency across changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
