### PR TITLE
fix(tests): freeze the EXIT-trap count for run-kubernetes-talos-diagnostics_test.bats

### DIFF
--- a/hack/cozyreport.bats
+++ b/hack/cozyreport.bats
@@ -2551,7 +2551,7 @@ STUB
   # converted: all of them are owned by other branches, and a conflict there costs
   # more than an uncovered trap. What the freeze buys is that none of this arrived
   # silently.
-  frozen='build-matrix_test.bats=14 capture-dataplane.bats=1 e2e-test-openapi.bats=1 multus-install-cni-plugins.bats=12 nightly-mirror_test.bats=5 overlay-main-images_test.bats=11 release-changelog-behaviour.bats=9 release-changelog-contract.bats=1 select-e2e_test.bats=15 '
+  frozen='build-matrix_test.bats=14 capture-dataplane.bats=1 e2e-test-openapi.bats=1 multus-install-cni-plugins.bats=12 nightly-mirror_test.bats=5 overlay-main-images_test.bats=11 release-changelog-behaviour.bats=9 release-changelog-contract.bats=1 run-kubernetes-talos-diagnostics_test.bats=8 select-e2e_test.bats=15 '
 
   found=""
   for f in "$HACK_DIR"/*.bats; do


### PR DESCRIPTION
## What this PR does

`hack/run-kubernetes-talos-diagnostics_test.bats` landed on main carrying eight EXIT traps and was not added to the frozen set in `hack/cozyreport.bats`, so `found` and `frozen` differ by exactly that one entry and the guard fails on every branch cut from main since then.

This adds the entry. That is what the comment above the guard prescribes for a file that did not exist when the freeze was written: the counts are expected to move, and the file is updated rather than converted, because it is owned by another branch. The guard behaved correctly here, it noticed.

## Why it is worth fixing on its own rather than waiting

The red check is the smallest part of the cost.

`hack/cozytest.sh` stops at the first failing test in a file, and this guard is test 83 of 166 in `cozyreport.bats`, so the remaining 83 never run. The Makefile loop is `for f in $(BATS_UNIT_FILES); do hack/cozytest.sh "$f" || exit 1; done`, which aborts the whole loop rather than the single file, and `cozyreport.bats` sorts fourteenth of forty-two, so twenty-eight further files never run either. `finalize` needs `checks`, and the e2e job needs `finalize`, so `E2E Tests` ends up skipped rather than executed, and a skipped required context satisfies branch protection.

The practical effect is that a PR can be green enough to merge while neither its new unit tests nor e2e have run.

## Verification

`bats` walks past a failure where `cozytest.sh` stops, so running the file under `bats` shows what is behind the cut. With this entry present, `cozyreport.bats` is 166 of 166.

I also ran the twenty-eight files that sort after it: 368 tests pass and 15 fail, all 15 confined to `migration-seaweedfs-db-adopt.bats` and `seaweedfs-naming-audit.bats`, both for local reasons on macOS (a docker bind mount that does not resolve, and BSD versus GNU column formatting). Both are pre-existing on main and unrelated to this change, so nothing has rotted behind the cut while it was unreachable.

## Note on overlap

`#3575` carries the same one-line change as part of a larger feature. This PR exists so that main can be unblocked without waiting for that one, and the two will resolve to the same line.

### Downstream repositories

Walked the trigger map against the diff. This changes one string inside a bats guard that exists only in this repository, so nothing downstream sees it.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the inventory of unconverted diagnostic tests to include an additional test file containing an exit trap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->