### PR TITLE
fix(kubernetes): bound the remaining pre-delete hook deletions

### DIFF
--- a/packages/apps/kubernetes/templates/delete.yaml
+++ b/packages/apps/kubernetes/templates/delete.yaml
@@ -8,6 +8,37 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
   name: {{ .Release.Name }}-pre-cleanup
 spec:
+  # One attempt. restartPolicy Never turns the default of 6 into seven pods in
+  # series, each restarting the script from Step 1 and each paying its own image
+  # pull, which outlives the uninstall budget: helm then times out on its own
+  # instead of reporting which step failed.
+  #
+  # Zero and not one, because a second attempt does not fit. Both waits below
+  # are guarded, so an attempt can spend all of its budget without failing and a
+  # retry starts from Step 1 with the clock already there; on a nodeless tenant
+  # it also re-pays Step 4, since attempt one leaves the TenantControlPlane
+  # terminating. The failure a retry would cover is an eviction (this pod
+  # tolerates control-plane taints), which is not bounded in time and costs most
+  # when it arrives late. The price is that such an eviction fails the whole
+  # attempt and flux repeats it on its own interval — slower, and predictable.
+  backoffLimit: 0
+  # No activeDeadlineSeconds, for arithmetic rather than oversight. A deadline
+  # has to sit above the sum of the waits below, or it cuts runs that were going
+  # to finish, and far enough under helm-controller's uninstall budget to be
+  # what helm reports rather than what it waits through. Those two bounds do not
+  # currently leave a gap, and the image pull comes from Docker Hub with no
+  # mirror in front of it.
+  #
+  # Note that the sum is a whole-Job figure only while backoffLimit is 0:
+  # activeDeadlineSeconds runs from status.startTime and a retry does not reset
+  # it, so allowing retries means the deadline has to clear all of them.
+  #
+  # Room comes from raising spec.uninstall.timeout on the generated HelmRelease,
+  # not from squeezing the waits further.
+  # packages/apps/bucket/templates/hooks/cleanup-acme.yaml is the shape to copy
+  # then: same image, with the deadline and the retry budget set together, and
+  # --request-timeout on each call so an unresponsive apiserver is bounded too,
+  # which --wait=false below does not cover.
   template:
     metadata:
       labels:
@@ -90,8 +121,21 @@ spec:
               fi
 
               echo "Step 3: Deleting KamajiControlPlane {{ .Release.Name }}"
+              # --wait is spelled out because kubectl defaults it to true, and a
+              # --timeout it does not carry defaults to 0, which kubectl reads
+              # as "wait forever" and turns into a week.
+              #
+              # false rather than a bound, because there is nothing here worth
+              # waiting for. What matters downstream is the TenantControlPlane,
+              # and Step 4 deletes that one directly and waits for it; blocking
+              # on the KamajiControlPlane first only adds a second place for a
+              # CAPI finalizer to stall the hook. Not waiting also keeps this
+              # step under `set -e` with no guard: with no timeout to expire,
+              # every remaining non-zero exit is a real failure — the API
+              # rejecting the request, discovery breaking, RBAC being wrong —
+              # and none of those should be reported as a cleanup that happened.
               kubectl -n {{ .Release.Namespace }} delete kamajicontrolplanes.controlplane.cluster.x-k8s.io {{ .Release.Name }} \
-                --ignore-not-found=true
+                --ignore-not-found=true --wait=false
 
               echo "Step 4: Deleting TenantControlPlane {{ .Release.Name }} and waiting for it to be removed"
               # --wait=true blocks until the TenantControlPlane object is fully
@@ -137,16 +181,24 @@ spec:
                 echo "  Secret {{ .Release.Name }}-datastore-config not present; nothing to do"
               fi
 
+              # Steps 5 and 6 do not wait. Both defaulted to --wait=true with no
+              # --timeout, so either one parked this hook for a week on a single
+              # stuck finalizer: a DataVolume held by a CDI importer or a PVC
+              # finalizer is the reachable case. Waiting buys nothing here.
+              # Nothing after these steps reads their result, and the DELETE has
+              # already been accepted either way — an expired wait and
+              # --wait=false leave the same cluster state, with the same objects
+              # finalizing in the background once the hook has moved on.
               echo "Step 5: Cleaning up DataVolumes"
               kubectl -n {{ .Release.Namespace }} delete datavolumes \
                 -l "cluster.x-k8s.io/cluster-name={{ .Release.Name }}" \
-                --ignore-not-found=true
+                --ignore-not-found=true --wait=false
 
               echo "Step 6: Cleaning up LoadBalancer Services"
               kubectl -n {{ .Release.Namespace }} delete services \
                 -l "cluster.x-k8s.io/cluster-name={{ .Release.Name }}" \
                 --field-selector spec.type=LoadBalancer \
-                --ignore-not-found=true
+                --ignore-not-found=true --wait=false
 
               echo "Cleanup completed successfully"
           volumeMounts:
@@ -184,6 +236,9 @@ rules:
       - watch
       - patch
       - delete
+  # watch is granted only where a delete still waits: Step 2 on helmreleases and
+  # Step 4 on tenantcontrolplanes. The other three deletes pass --wait=false, so
+  # kubectl never opens a watch for them and the verb would be unexercised.
   - apiGroups:
       - "controlplane.cluster.x-k8s.io"
     resources:
@@ -191,7 +246,6 @@ rules:
     verbs:
       - get
       - list
-      - watch
       - delete
   - apiGroups:
       - "kamaji.clastix.io"
@@ -209,7 +263,6 @@ rules:
     verbs:
       - get
       - list
-      - watch
       - delete
   - apiGroups:
       - ""
@@ -218,7 +271,6 @@ rules:
     verbs:
       - get
       - list
-      - watch
       - delete
   # Scoped to the single Kamaji datastore connection Secret so Step 4b can
   # strip the leftover finalizer.kamaji.clastix.io/datastore-secret finalizer

--- a/packages/apps/kubernetes/tests/delete_hook_test.yaml
+++ b/packages/apps/kubernetes/tests/delete_hook_test.yaml
@@ -68,3 +68,124 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: 'get tenantcontrolplanes\.kamaji\.clastix\.io test-k8s[\s\S]*still present[\s\S]*patch secret test-k8s-datastore-config'
+
+  # The remaining tests pin the wall-clock bounds on every delete in the hook.
+  # kubectl defaults --wait to true and reads --timeout=0 as a week, so a delete
+  # written with neither flag is one stuck finalizer away from parking this hook
+  # for 168 hours.
+
+  - it: every delete in the hook carries a wall-clock bound
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      # Each pattern walks only continuation lines — the ones ending in a
+      # backslash — so it stays inside the command it names. A cross-line
+      # wildcard reaches a flag belonging to the next command instead, and RE2,
+      # which helm-unittest matches with, has no lookahead to exclude the echo
+      # in between.
+      #
+      # None of the three waits, so none of them needs a guard to swallow an
+      # expired one — which matters, because a guard cannot tell a timeout from
+      # a rejected request and would report both as cleanup that happened.
+      #
+      # Step 3. What matters downstream is the TenantControlPlane, which Step 4
+      # deletes and waits for; waiting here only adds a second place for a CAPI
+      # finalizer to stall.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete kamajicontrolplanes\.controlplane\.cluster\.x-k8s\.io test-k8s(?:[^\n]*\\\n)*[^\n]*--wait=false'
+      # Steps 5 and 6: nothing after them reads the result, and a DELETE that
+      # has been accepted is not made more complete by watching it. --wait=false
+      # and an expired --wait leave the same cluster state, one of them sooner.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete datavolumes(?:[^\n]*\\\n)*[^\n]*--wait=false'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete services(?:[^\n]*\\\n)*[^\n]*--wait=false'
+      # And the two that were already bounded stay bounded. --wait=false and
+      # --timeout bound the waiting, not the request: --request-timeout is still
+      # 0 on every call here, so an apiserver that stops answering hangs this
+      # hook the same as before. That is a different failure from the stuck
+      # finalizer these bounds are for, and it wants one answer across all the
+      # calls rather than a flag on the deletes.
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete helmreleases\.helm\.toolkit\.fluxcd\.io(?:[^\n]*\\\n)*[^\n]*--timeout=[1-9][0-9]*s'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete tenantcontrolplanes\.kamaji\.clastix\.io test-k8s(?:[^\n]*\\\n)*[^\n]*--timeout=[1-9][0-9]*s'
+
+  - it: cleanup Role keeps watch on exactly the two resources whose deletes wait
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      # kubectl opens a watch only on the wait path, so watch is granted to the
+      # two resources Steps 2 and 4 wait on and to no others. Removing it from
+      # either of those does not error — the delete hangs instead, which is the
+      # failure mode that is hardest to read from the outside, so it is pinned
+      # rather than left to the reviewer of the next RBAC change.
+      #
+      # Whole-rule contains, not per-index verb assertions. notContains passes
+      # when its path does not resolve, so an index-addressed "and nowhere else"
+      # goes quiet the moment the rules list is reordered or shortened — the
+      # failure it is written to prevent would take the assertion with it.
+      # Matching the entire rule pins the verb set in both directions and names
+      # the resource when it fails; lengthEqual is what closes the remaining
+      # hole, a sixth rule appended past everything asserted here.
+      - lengthEqual:
+          path: rules
+          count: 6
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["helm.toolkit.fluxcd.io"]
+            resources: ["helmreleases"]
+            verbs: ["get", "list", "watch", "patch", "delete"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["kamaji.clastix.io"]
+            resources: ["tenantcontrolplanes"]
+            verbs: ["get", "list", "watch", "delete"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["controlplane.cluster.x-k8s.io"]
+            resources: ["kamajicontrolplanes"]
+            verbs: ["get", "list", "delete"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["cdi.kubevirt.io"]
+            resources: ["datavolumes"]
+            verbs: ["get", "list", "delete"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: ["services"]
+            verbs: ["get", "list", "delete"]
+
+  - it: pre-delete Job makes a single attempt
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      # restartPolicy is Never, so the default backoffLimit of 6 allows seven
+      # pods in series, each re-running every step from the top and each paying
+      # its own image pull. That outlives the uninstall budget, and helm gives
+      # up on its own timeout without reporting which step failed.
+      #
+      # Zero and not one: both remaining waits are guarded, so an attempt can
+      # spend its full 240s without failing, and a retry starts from Step 1 with
+      # the clock already there. On a nodeless tenant it also re-pays Step 4's
+      # 120s, because attempt 1 leaves the TenantControlPlane still terminating.
+      - equal:
+          path: spec.backoffLimit
+          value: 0
+      - equal:
+          path: spec.template.spec.restartPolicy
+          value: Never


### PR DESCRIPTION
## What this PR does

Three of the six steps in the `kubernetes` pre-delete hook call `kubectl delete` with neither `--wait=false` nor `--timeout`. `--wait` defaults to true and `--timeout=0` is implemented as a week, so the KamajiControlPlane delete in step 3, the DataVolume delete in step 5 and the LoadBalancer Service delete in step 6 each park the hook for 168 hours on one stuck finalizer. A DataVolume held by a CDI importer or a PVC finalizer is the reachable case.

The waits in steps 2 and 4 were bounded earlier, in response to a report that named the child-HelmRelease wait and nothing else. The fix stopped where the report did, so the shape it described stayed in the three steps nobody had looked at.

None of the three waits now. Nothing downstream reads the result of steps 5 and 6. What matters after step 3 is the TenantControlPlane, and step 4 deletes that one directly and waits for it, so blocking on the KamajiControlPlane first only adds a second place for a finalizer to stall. An expired wait and `--wait=false` leave the same cluster state, with the same objects finalizing in the background.

Not waiting also keeps these steps under `set -e` with no guard, which matters more than it looks. A guard cannot tell an expired wait from a rejected request, so it would report a failed delete as cleanup that happened. With no timeout to expire, every non-zero exit left is a real failure.

The `watch` verb goes away for those three resources. kubectl opens a watch only on the wait path, so the grant was unexercised. `helmreleases` and `tenantcontrolplanes` keep it because steps 2 and 4 still wait, and there the verb is load-bearing in a way that is easy to miss: removing it does not produce an error, it hangs the delete. That is the failure this repo already hit once at the tenant level, so the whole rule set is pinned rather than left to the next reviewer of this Role.

`backoffLimit` goes to 0, against a default of 6 that `restartPolicy: Never` turns into seven pods in series, each restarting the script from step 1 and each paying its own image pull.

## What this PR does not do

It does not add `activeDeadlineSeconds`, and that is arithmetic rather than oversight. A deadline has to sit above the sum of the remaining waits, or it cuts runs that were going to finish, and far enough under helm-controller's uninstall budget to be the thing helm reports rather than something helm waits through. Those two bounds do not currently leave a gap, and the image pull comes from Docker Hub with no mirror in front of it. Room comes from raising `spec.uninstall.timeout` on the generated HelmRelease first; squeezing the waits further is the wrong direction.

Worth stating plainly, because it is the one change here that is not purely a tightening: with `backoffLimit: 0` a pod eviction now fails the whole uninstall attempt, where six retries previously absorbed it. That is deliberate. Both remaining waits are guarded, so an attempt can spend its entire budget without failing, and a retry would restart from step 1 with the clock already there; on a nodeless tenant it would also re-pay step 4, since the first attempt leaves the TenantControlPlane still terminating. The failure a retry would cover is an eviction, which is not bounded in time and costs most when it arrives late. Flux still repeats the uninstall on its own interval, so the end state is preserved and the trade is wall-clock for predictability.

It does not bound the requests. `--wait=false` and `--timeout` bound the waiting, so an apiserver that accepts the connection and then stops answering hangs this hook exactly as before. That is a different failure from the stuck finalizer, it is not made worse here, and it wants one answer across every call rather than a flag on the deletes.

## Tests

`packages/apps/kubernetes/tests/delete_hook_test.yaml` gains cases for the bounds and for the Role. Every delete in the hook is asserted to carry one, the Job is pinned to a single attempt, and the rule set is pinned whole.

The regex patterns walk only continuation lines, the ones ending in a backslash, so each stays inside the command it names. A cross-line wildcard reaches a flag belonging to the next command instead, and RE2 has no lookahead to exclude the `echo` in between.

The Role assertions use whole-rule `contains` plus `lengthEqual` rather than per-index verb checks. `notContains` passes when its path does not resolve, so an index-addressed "and nowhere else" goes quiet the moment the rules list is reordered or shortened, which is exactly the edit it exists to catch. Matching the entire rule pins the verb set in both directions and names the resource when it fails.

Every pinned value was mutation-tested: dropping `--wait=false` from each of the three deletes, dropping `--timeout` from either of the two that still wait, `backoffLimit` in both directions, adding `watch` back, removing `watch` from a resource that waits, appending a rule past everything asserted, and reordering the rules list. Each one fails the assertion that claims that ground and no other.

### Screenshots

None. This changes a Job manifest and its tests, with no user-visible surface.

### Downstream repositories

Walked the trigger map against the diff. The diff is one Job manifest inside the kubernetes chart and its helm-unittest suite. No package is added, renamed or removed; no `values.schema.json`, `values.yaml` default or version enum changes; no `ApplicationDefinition` semantics, namespace, variant or release asset changes; nothing under `hack/` is touched and no make target changes behaviour.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(kubernetes): bound the pre-delete hook's remaining unbounded deletions and limit its Job to a single attempt, so a stuck finalizer on a DataVolume, LoadBalancer Service or KamajiControlPlane no longer parks the hook and blocks the uninstall
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes resource cleanup during deletion to avoid indefinite waits.
  * Cleanup operations now complete with bounded waiting and fewer retry attempts, improving reliability and responsiveness.
  * Removed unnecessary access permissions from cleanup operations, strengthening security.
* **Tests**
  * Added coverage to verify deletion timeouts, retry behavior, and required permissions across supported resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->