### PR TITLE
test(backupstrategy-controller): anchor the metrics-absence guard to its container

### DIFF
--- a/packages/system/backupstrategy-controller/tests/deployment_test.yaml
+++ b/packages/system/backupstrategy-controller/tests/deployment_test.yaml
@@ -28,6 +28,15 @@ tests:
     set:
       backupStrategyController.metrics.enabled: false
     asserts:
+      # Anchor first: the two assertions below address a container by index, and
+      # notContains passes whenever its path resolves to something without the
+      # forbidden content — including a different container. A sidecar inserted
+      # ahead of this one would leave both of them green while the flag they
+      # exist to forbid came back on the controller. This equal is what fails in
+      # that case; the negatives cannot.
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: backupstrategy-controller
       - notContains:
           path: spec.template.spec.containers[0].args
           content: --metrics-bind-address=:8443


### PR DESCRIPTION
## What this PR does

The `metrics.enabled=false` case in `deployment_test.yaml` guards against the `metrics.enable` typo regression by asserting that the metrics arg and port are absent. Both assertions address the controller by index, and `notContains` passes whenever its path resolves to something that lacks the forbidden content. A different container at that index qualifies, so a sidecar placed ahead of the controller leaves the guard green while the flag it exists to forbid comes back on the real container.

This adds an `equal` on `containers[0].name` ahead of the two negatives. It fails when the index stops pointing at the controller, which is the case the negatives structurally cannot see.

Verified rather than argued. Rendering a sidecar ahead of the controller against the current tests leaves the case green and reddens only the two neighbouring tests, which use positive `contains` and defend themselves; the guard that exists for this scenario is not among them. With the anchor, the case fails on the anchor.

This is not a new convention. `packages/system/opensearch-operator/tests/leader_election_test.yaml` and `packages/system/dashboard/tests/gatekeeper_test.yaml` already anchor index-addressed negatives the same way, the second with the reasoning spelled out in a comment. This brings one more package in line with what the tree already does.

## What this PR does not do

It does not switch the assertions to a name filter. helm-unittest resolves `containers[?(@.name=="...")]`, but `notContains` against a filter that matches nothing passes just as quietly, so that trade swaps "wrong container" for "no container" inside the same family of silent green.

It does not touch the other two cases in the file. Both are positive `contains`, both went red under the same injection, so they anchor themselves.

## Tests

The change is itself a test fix. Package suite is green: 11 tests, 3 suites.

### Screenshots

None. This changes a test file.

### Downstream repositories

Walked the trigger map against the diff. One helm-unittest file, nine added lines, no chart output changes.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved deployment validation by confirming the correct container is targeted when metrics are disabled.
  * Added checks that metrics-related arguments and ports are absent in this configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->