### PR TITLE
test(apps): anchor index-addressed negative asserts to what they name

### DIFF
--- a/packages/apps/kafka/tests/dashboard-resourcemap_test.yaml
+++ b/packages/apps/kafka/tests/dashboard-resourcemap_test.yaml
@@ -60,6 +60,16 @@ tests:
     set:
       external: false
     asserts:
+      # Anchor the rule before asserting about it. notContains passes whenever
+      # its path resolves to something that lacks the content, and a different
+      # rule at [0] qualifies, so reordering the Role would leave this green
+      # while the external bootstrap Service came back on the rule it names.
+      # A rule has no name to pin, so the anchor is the Service this rule must
+      # keep.
+      - contains:
+          path: rules[0].resourceNames
+          content: test-kafka-kafka-bootstrap
+        documentIndex: 0
       - notContains:
           path: rules[0].resourceNames
           content: test-kafka-kafka-external-bootstrap
@@ -128,6 +138,16 @@ tests:
       tls:
         enabled: true
     asserts:
+      # Anchor the rule before asserting about it. notContains passes whenever
+      # its path resolves to something that lacks the content, and a different
+      # rule at [0] qualifies, so reordering the Role would leave this green
+      # while the external bootstrap Service came back on the rule it names.
+      # A rule has no name to pin, so the anchor is the Service this rule must
+      # keep.
+      - contains:
+          path: rules[0].resourceNames
+          content: test-kafka-kafka-bootstrap
+        documentIndex: 0
       - notContains:
           path: rules[0].resourceNames
           content: test-kafka-kafka-external-bootstrap
@@ -143,6 +163,16 @@ tests:
       tls:
         enabled: false
     asserts:
+      # Anchor the rule before asserting about it. notContains passes whenever
+      # its path resolves to something that lacks the content, and a different
+      # rule at [0] qualifies, so reordering the Role would leave this green
+      # while the external bootstrap Service came back on the rule it names.
+      # A rule has no name to pin, so the anchor is the Service this rule must
+      # keep.
+      - contains:
+          path: rules[0].resourceNames
+          content: test-kafka-kafka-bootstrap
+        documentIndex: 0
       - notContains:
           path: rules[0].resourceNames
           content: test-kafka-kafka-external-bootstrap

--- a/packages/apps/opensearch/tests/opensearch_test.yaml
+++ b/packages/apps/opensearch/tests/opensearch_test.yaml
@@ -245,6 +245,18 @@ tests:
         ingest: true
         ml: false
     asserts:
+      # Anchor the pool before asserting about it. notContains passes whenever
+      # its path resolves to something lacking the content, and a different
+      # nodePool at [0] qualifies, so a pool added ahead of this one would leave
+      # the guard green while cluster_manager came back on the pool it names.
+      #
+      # The anchor is the component, not a role: roles are shared between pools,
+      # so a second data-bearing pool inserted ahead of this one would satisfy a
+      # role-based anchor while the assertion below read the wrong pool.
+      - equal:
+          path: spec.nodePools[0].component
+          value: nodes
+        documentIndex: 0
       - notContains:
           path: spec.nodePools[0].roles
           content: cluster_manager


### PR DESCRIPTION
## What this PR does

Four negative assertions in two suites address an element by index. `notContains` passes whenever its path resolves to something that simply lacks the forbidden content, and a different element at the same index qualifies. So if the Kafka Role's rule order changed, or a nodePool were added ahead of the one the OpenSearch test names, those guards would go green while the resource they forbid was live on the element they meant.

This asserts the addressed element before asserting what it must not have. The Kafka Role rules carry no identifier, so the anchor is the in-cluster bootstrap Service that rule must keep. The OpenSearch pool does have one, `component`, and that is what is pinned rather than a role: roles are shared between pools, so a role-based anchor would be satisfied by a second data-bearing pool inserted ahead of this one.

The anchors turn out to cover more than the ordering shift they were written for. `contains` fails on a path that does not resolve, where `notContains` passes, so a positive assert on the same path also catches the document-index half of the same defect. Swap the Role and RoleBinding documents in the Kafka template and all three guards go red, where before they stayed green.

## What this PR does not do

It does not raise the guards above the index. A `rules[0]`-scoped assertion cannot express "the Role must not grant this Service at all", because a grant reappearing on a rule appended further down satisfies both the anchor and the negative. That ceiling is inherent to index-scoped assertions and is unchanged here.

It does not touch the two cases in these files that were already paired with a positive assert on the same path, and it does not extend to the pure-negative tests elsewhere in the same suites, which are tracked as their own sweep.

## Tests

The change is itself a test fix. Both suites pass: kafka 35/35, opensearch 58/58.

Each anchor was checked against the shift it exists to catch and against the same shift with the anchor removed. Without them the blocks stay green while the forbidden content is live on the element they name; with them the blocks fail. The OpenSearch mutation deliberately inserts a data-bearing pool, which is what distinguishes the `component` anchor from a role-based one.

### Screenshots

None. This changes test files.

### Downstream repositories

Walked the trigger map against the diff. Two helm-unittest files, additive only, no chart output changes.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of Kafka resource mappings by confirming the intended internal service rule before checking external-service restrictions.
  * Strengthened OpenSearch node-role checks by confirming the intended node pool before validating its supported roles.
  * These updates reduce the risk of false-positive test results when configuration rules or components are reordered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->