### PR TITLE
fix(cozy-proxy): give the DaemonSet its node name

### DIFF
--- a/packages/system/cozy-proxy/charts/cozy-proxy/templates/daemonset.yaml
+++ b/packages/system/cozy-proxy/charts/cozy-proxy/templates/daemonset.yaml
@@ -21,6 +21,16 @@ spec:
         - name: cozy-proxy
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            # Scopes the nftables rules to the backends hosted on this node.
+            # Without it cozy-proxy programs every service on every node, and a
+            # node that does not host the backend rewrites the destination of a
+            # packet merely leaving it, which desynchronises conntrack on the
+            # owning node and gets the reply dropped by port_filter.
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
           securityContext:
             privileged: true
             capabilities:


### PR DESCRIPTION
## What this PR does

`cozy-proxy` scopes its nftables rules to the backends hosted on the node it runs on, and reads that node from `NODE_NAME`. The chart never set it, so every DaemonSet pod programs every service cluster-wide.

A node that does not host the backend then rewrites the destination of a packet that is merely leaving it. The owning node records a conntrack tuple that the SNATed reply can no longer match (`egress_snat` runs at prerouting priority `raw`, before conntrack), so the reply is not `established` and `port_filter` drops it — the initiator's ephemeral port is of course not in its own `allowed_ports`.

Concretely: a VM in PortList mode (`networking.cozystack.io/wholeIP: "false"`) cannot open a connection to another cozy-proxy managed backend **on a different node**. The SYN arrives, the SYN-ACK is generated and silently dropped, the caller hangs. Same node works, egress to the internet works, and ingress from outside works — which makes it look like a tenant isolation problem rather than a datapath one.

This injects `NODE_NAME` from `spec.nodeName`. It is **inert with the pinned `v0.3.0`**, which ignores the variable, and takes effect once the image is bumped to a release carrying cozystack/cozy-proxy#18. Nothing breaks in the meantime, so this can land independently of the image bump.

Verified with `helm template`, and end to end on a 3-node lab plus a 12-node production cluster: per-node mappings drop from "every service in the cluster" to the local backends only, cross-node managed-to-managed traffic is restored, and port filtering from outside is unchanged (declared port open, undeclared port filtered).

### Downstream repositories

- [ ] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [x] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up: https://github.com/cozystack/cozy-proxy/pull/18
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

This is the chart half of cozystack/cozy-proxy#18; that PR is the code half and is the one that consumes `NODE_NAME`. Left as a draft until #18 is reviewed, since merging this alone only adds an unused variable.

### Release note

```release-note
fix(cozy-proxy): pass NODE_NAME to the cozy-proxy DaemonSet so its nftables rules are scoped to the backends hosted on each node. Without it, a node that does not host the backend rewrote the destination of transit packets, which desynchronised conntrack on the owning node and caused replies to be dropped: a VM using externalMethod PortList could not open connections to another externally exposed workload running on a different node.
```