### PR TITLE
ci(backport): skip a target whose backport already merged

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -133,15 +133,47 @@ jobs:
             echo "Target branch: ${{ needs.prepare.outputs.previous_branch }}"
           fi
       
-      # 2. Checkout (required by backport‑action)
-      - name: Checkout repository
+      # 2. Skip if this target already has a merged backport.
+      #
+      # The action's backport branch name is deterministic,
+      # backport-<pull_number>-to-<target_branch>. A merged PR with that head
+      # means an earlier run already delivered this change to the target — a
+      # second label event (e.g. backport-previous added after backport
+      # already merged) would re-enter this job and cherry-pick commits the
+      # target branch already has. Git reports that as an empty pick (exit 1)
+      # rather than a conflict, which draft_commit_conflicts below misreads
+      # as a real conflict and reports as a failed backport on the original
+      # PR. Skipping here avoids the false report; it does not touch the
+      # empty-pick behavior itself, which lives in the action.
+      - name: Check for existing merged backport
+        id: guard
         if: steps.target.outcome == 'success'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const targetBranch = '${{ steps.target.outputs.branch }}';
+            const head = `backport-${context.payload.pull_request.number}-to-${targetBranch}`;
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              head: `${context.repo.owner}:${head}`,
+            });
+            const alreadyMerged = prs.some(p => p.merged_at !== null);
+            core.setOutput('already_merged', alreadyMerged ? 'true' : 'false');
+            if (alreadyMerged) {
+              console.log(`Skipping backport to ${targetBranch}: ${head} already merged.`);
+            }
+
+      # 3. Checkout (required by backport‑action)
+      - name: Checkout repository
+        if: steps.target.outcome == 'success' && steps.guard.outputs.already_merged != 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      # 3. Create the back‑port pull request
+      # 4. Create the back‑port pull request
       - name: Create back‑port PR
         id: backport
-        if: steps.target.outcome == 'success'
+        if: steps.target.outcome == 'success' && steps.guard.outputs.already_merged != 'true'
         uses: korthout/backport-action@0193454f0c5947491d348f33a275c119f30eb736 # v3.2.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/hack/release-freeze-contract.bats
+++ b/hack/release-freeze-contract.bats
@@ -274,3 +274,100 @@ step_line() {
   # And the head of that sort is what `backport` uses.
   printf '%s\n' "$block" | script_lines | grep -qF 'lines[0].name'
 }
+
+# ── skip a target whose backport already merged ─────────────────────────────
+# A second label event on a PR whose first backport already merged (e.g.
+# backport-previous added after backport merged) re-enters this job for the
+# already-delivered target. The cherry-pick is then empty, which the action's
+# draft_commit_conflicts handling misreads as a real conflict and reports as a
+# failed backport on the original PR — this guard skips the re-run instead.
+
+@test "the guard checks merged, not just closed, PRs on the deterministic branch" {
+  block="$(job_block backport "$BACKPORT")"
+  [ -n "$block" ]
+
+  # The branch name the action itself would have used. Checking anything else
+  # answers a different question than "did THIS backport already land".
+  printf '%s\n' "$block" | script_lines | grep -qF 'backport-${context.payload.pull_request.number}-to-${targetBranch}'
+
+  # Closed alone is not enough: a closed-without-merge PR is a stale or
+  # abandoned attempt, not proof the change reached the target. Loosening this
+  # to any closed PR would skip a real retry after a conflict was closed
+  # unmerged.
+  printf '%s\n' "$block" | script_lines | grep -qF "state: 'closed'"
+  printf '%s\n' "$block" | script_lines | grep -qF 'p.merged_at !== null'
+}
+
+@test "both the checkout and the backport-action step are gated on the guard" {
+  block="$(job_block backport "$BACKPORT")"
+  [ -n "$block" ]
+
+  # Losing the gate on either step still runs the action against a target that
+  # already has the change, reproducing the false comment the guard exists to
+  # prevent.
+  count="$(printf '%s\n' "$block" | code_lines | grep -cF "steps.guard.outputs.already_merged != 'true'" || true)"
+  [ "${count:-0}" -eq 2 ]
+}
+
+@test "the guard runs before the checkout and the backport-action step" {
+  guard="$(step_line 'Check for existing merged backport' "$BACKPORT")"
+  checkout="$(step_line 'Checkout repository' "$BACKPORT")"
+  create="$(step_line 'Create back‑port PR' "$BACKPORT")"
+  [ -n "$guard" ] && [ -n "$checkout" ] && [ -n "$create" ]
+
+  [ "$guard" -lt "$checkout" ]
+  [ "$guard" -lt "$create" ]
+}
+
+# Mirrors release-changelog-behaviour.bats's convention for a github-script
+# snippet: extract the decision expression verbatim in shape and execute it
+# under node, because a grep for "merged_at" cannot tell an `.some()` from an
+# `.every()` or a flipped comparison. Two cases are the ones that matter and
+# are NOT interchangeable: the first-ever run (branch never existed, so the
+# API returns an empty list) and a real retry (someone closed a conflicting
+# backport PR without merging it). Both must NOT skip, or either the very
+# first backport attempt or a legitimate re-creation after a manual close
+# never runs.
+@test "the guard's merged decision is correct on empty, closed-unmerged and closed-merged lists" {
+  command -v node >/dev/null || { echo "node unavailable; skipping"; return 0; }
+  tmp="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$tmp'" EXIT
+
+  cat > "$tmp/guard.js" <<'JS'
+function alreadyMerged(prs) {
+  return prs.some(p => p.merged_at !== null);
+}
+const cases = {
+  'first-run-empty': [],
+  'closed-unmerged': [{ merged_at: null }],
+  'closed-merged':   [{ merged_at: '2026-01-01T00:00:00Z' }],
+};
+const lines = Object.entries(cases).map(([name, prs]) => name + '=' + alreadyMerged(prs));
+require('fs').writeFileSync(1, lines.join('\n') + '\n');
+JS
+
+  node "$tmp/guard.js" > "$tmp/out.txt" 2>"$tmp/err.txt" || {
+    echo "node failed:" >&2; cat "$tmp/err.txt" >&2; exit 1; }
+
+  want="first-run-empty=false
+closed-unmerged=false
+closed-merged=true"
+  got="$(cat "$tmp/out.txt")"
+  [ "$got" = "$want" ] || {
+    echo "guard decision table is wrong." >&2
+    echo "want:" >&2; printf '%s\n' "$want" | sed 's/^/  /' >&2
+    echo "got:"  >&2; printf '%s\n' "$got"  | sed 's/^/  /' >&2
+    exit 1
+  }
+
+  # The mirror must match the real guard's exact decision expression, not just
+  # the presence of "merged_at" somewhere in the step. Wrapped like the other
+  # tests in this file's final assertion: a bare failing command here, under a
+  # trap-installed EXIT handler, has been observed to abort the whole bats run
+  # instead of just this test on macOS.
+  block="$(job_block backport "$BACKPORT")"
+  [ -n "$block" ]
+  printf '%s\n' "$block" | script_lines | grep -qF 'prs.some(p => p.merged_at !== null)' || {
+    echo "backport.yaml's guard no longer uses prs.some(p => p.merged_at !== null)." >&2; exit 1; }
+}


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Adds a guard step to the `backport` job in `.github/workflows/backport.yaml` that looks up whether a merged pull request already exists on a target's deterministic backport branch (`backport-<pr>-to-<target>`) and skips the checkout and the backport-action step for that leg when one does.

A second label event on a PR whose first backport already merged, for example `backport-previous` added shortly after `backport` merged, re-enters this job for the already-delivered target, and cherry-picking the same commits onto a branch that already has them produces an empty pick, which git still reports with a non-zero exit code. Under the `draft_commit_conflicts` setting this workflow already passes to the action, that non-zero exit is read as a real conflict, and the action's attempt to commit the (empty) working tree fails too, surfacing as a "Backport failed" comment on the original PR, for a branch the change has been on for a while. Relates to #3588, which has the full mechanism and a reproduction.

The guard only treats a target as done when a PR on that branch actually merged, so a real retry after someone manually closed a conflicting, unmerged backport PR still runs normally; both cases are covered by the new tests.

This workflow triggers on `pull_request_target`, which, like `workflow_run`, executes the workflow definition from the PR's base branch (the default branch for the PRs this fires on), not from the PR head, for the same fork-isolation reason. That means this guard only takes effect once this PR merges to `main`; a `labeled` event on an in-flight PR before that still runs whatever version of `backport.yaml` is currently on `main`.

The empty-cherry-pick-reported-as-conflict behavior itself lives in `korthout/backport-action` and stays out of scope here; issue #3588 links the upstream report.

### Screenshots

Not applicable, no UI change.

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
ci(backport): skip re-running a backport whose target already has the merged change, instead of posting a false failure comment
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate backport pull requests by detecting matching merged backports before creating new ones.
  * Preserved the existing backport flow when no merged backport is found.

* **Tests**
  * Added coverage for merged, closed, and empty pull request scenarios.
  * Verified that duplicate checks run before checkout and backport creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->