### PR TITLE
docs(hack): fix a wrong claim about grep-error propagation in two contract tests

### DIFF
--- a/hack/promote-gate-contract.bats
+++ b/hack/promote-gate-contract.bats
@@ -34,7 +34,18 @@ input_block() {
 # runner has no ripgrep, and a missing filter used to be swallowed by `|| true`,
 # silently reducing every pin to "0 matches" instead of failing on the real
 # cause. grep exits 1 when nothing is selected (legitimate for an empty block)
-# and 2 on an actual error, so only the latter propagates.
+# and 2 on an actual error. Do not read the `rc` check below as what catches
+# that: code_lines is never the last stage of a pipeline in this file, so
+# ordinary (non-pipefail) pipe semantics discard whatever it itself returns,
+# and `hack/cozytest.sh`'s translator appends `return 0` to every line that is
+# exactly `}`, code_lines' closing brace included, making its own exit status
+# even less trustworthy as a signal. What catches a real grep error is the
+# OUTPUT, and only for one class of pin: the error empties code_lines' stream,
+# so a pin that requires something to be present in that stream fails on it. A
+# pin demanding an absence stays blind, because an exact count of zero is what
+# an emptied stream produces anyway, and what the pin was written to assert.
+# The `[ -n "$block" ]` guard at the top of a test is not that check: it runs
+# on the raw awk extraction, upstream of code_lines, and cannot see it fail.
 code_lines() {
   local rc=0
   grep -v '^[[:space:]]*#' || rc=$?

--- a/hack/release-freeze-contract.bats
+++ b/hack/release-freeze-contract.bats
@@ -20,8 +20,19 @@ CUT="$REPO_ROOT/.github/workflows/cut-prerelease.yaml"
 BACKPORT="$REPO_ROOT/.github/workflows/backport.yaml"
 
 # Strip YAML comments. POSIX `grep` only: the unit-test runner has no ripgrep.
-# grep exits 1 when nothing is selected (legitimate for an all-comment block) and
-# 2 on a real error, so only the latter propagates.
+# grep exits 1 when nothing is selected (legitimate for an all-comment block)
+# and 2 on a real error. Do not read the `rc` check below as what catches
+# that: code_lines is never the last stage of a pipeline in this file, so
+# ordinary (non-pipefail) pipe semantics discard whatever it itself returns,
+# and `hack/cozytest.sh`'s translator appends `return 0` to every line that is
+# exactly `}`, code_lines' closing brace included, making its own exit status
+# even less trustworthy as a signal. What catches a real grep error is the
+# OUTPUT, and only for one class of pin: the error empties code_lines' stream,
+# so a pin that requires something to be present in that stream fails on it. A
+# pin demanding an absence stays blind, because an exact count of zero is what
+# an emptied stream produces anyway, and what the pin was written to assert.
+# The `[ -n "$block" ]` guard at the top of a test is not that check: it runs
+# on the raw awk extraction, upstream of code_lines, and cannot see it fail.
 code_lines() {
   local rc=0
   grep -v '^[[:space:]]*#' || rc=$?


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

`hack/promote-gate-contract.bats` and `hack/release-freeze-contract.bats` both carried the same wrong comment above their `code_lines` helper: it said a real grep error (exit 2) fails a pin through the helper's own exit status, distinct from an empty match (exit 1).

That was never actually the mechanism. `code_lines` is always piped into a further `grep` in both files, never the last stage of a pipeline, so ordinary (no `pipefail`) pipe semantics discard whatever it returns on its own, regardless of runner. `hack/cozytest.sh`, the runner these tests actually execute under in CI, also appends a `return 0` to every line that is exactly `}`, `code_lines`' closing brace included, making that exit status even less trustworthy as a signal.

What catches a real grep error is the output, and only for one class of pin. The error empties `code_lines`' stream, so a pin that requires something to be present in that stream fails on it. A pin demanding an absence stays blind: an exact count of zero is what an emptied stream produces anyway, and what the pin was written to assert. Both files hold pins of that shape. Nor is the `[ -n "$block" ]` guard at the top of each test the backstop: a block here is a bare awk extraction, upstream of `code_lines`. The new comment says both things and stops there.

Comment-only: `code_lines`'s body is untouched in both files, and all tests pass under both `bats` and `hack/cozytest.sh` before and after.

Known limitation of the wording: the comment says the top-of-test `[ -n "$block" ]` guard cannot see a filter failure, which is true, but both files also carry non-empty guards on values that did pass through `code_lines` (`promote-gate-contract.bats:72,73,165` and `release-freeze-contract.bats:166,236,327` via `step_line`), and those do fail on an emptied stream. The discriminator is whether the guarded value came through the filter, not where the guard sits in the test.

### Screenshots

Not applicable, no UI change.

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified comments describing how code-line filtering errors are detected.
  * Documented pipeline status behavior and why output-based assertions are used instead of relying solely on command status codes.
  * No user-facing behavior or executable logic changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

