### PR TITLE
test(cozystack-controller): guard the Secret grant by effective permission

### DIFF
--- a/hack/cozystack-controller-secret-rbac.bats
+++ b/hack/cozystack-controller-secret-rbac.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Semantic guard on what packages/system/cozystack-controller grants over core
+# Secrets.
+#
+# The union is over every ClusterRole and Role the chart renders; bindings are
+# never consulted. Today that is the same question as "what does the controller's
+# own ServiceAccount hold", because the chart's ClusterRoleBinding and RoleBinding
+# both name the cozystack-controller ServiceAccount and nothing else. A role added
+# here for some other subject would fold into the union too, which errs toward
+# refusing a grant rather than missing one.
+#
+# Two reconcilers share one Secret write grant: WildcardSecretReconciler
+# replicates the operator wildcard TLS Secret into each tenant namespace, and
+# CACertReconciler writes -- and withdraws -- the key-free "<release>.tenant-ca"
+# projection. The controller is cluster-scoped, so any verb it holds on Secrets
+# it holds on every Secret in every tenant namespace. That is why the set is
+# pinned rather than merely bounded from above: a widening reaches all tenants,
+# and a narrowing breaks both reconcilers.
+#
+# The check reads effective permission off the rendered manifests, not manifest
+# text. A rule reaches core Secrets when its apiGroups admit "" and its
+# resources admit "secrets" -- by name or via "*" on either axis -- and a "*" in
+# its verbs expands to the verb set the API server defines for a namespaced
+# resource. The union over every ClusterRole and Role the chart renders must
+# equal the declared set exactly.
+#
+# Expansion is what makes the guard hold on the chart as it stands: the chart
+# ends with a blanket `apiGroups: ['*'] resources: ['*'] verbs: [get,list,watch]`
+# read rule, which does reach Secrets and whose verbs are already inside the
+# declared set. A guard written as "no wildcard anywhere near secrets" would be
+# red on an unmodified tree.
+#
+# The union is over the chart's default rendering: `helm template` is invoked
+# with no --values, so a rule that appeared only under some values file would go
+# unseen. templates/rbac.yaml carries no templating at all today, so nothing is
+# gated behind a value; render the variants here too if that changes.
+#
+# The check lives here rather than beside the chart's helm-unittest suite because
+# helm-unittest compares every field it is handed by value equality. `any: true`
+# changes which fields are compared, not how they are compared, so neither the
+# whole-rule form nor the `any: true` one can bound what a verbs list may hold --
+# `verbs: ["get", "*"]` slips past both. That primitive is the right one for
+# pinning a rule as written, which tests/rbac_test.yaml does, and it cannot
+# express an upper bound: a wildcard in resources, a wildcard in apiGroups, a "*"
+# appended to the declared verb list, an extra field beside the verbs, and a
+# wider grant added as a separate rule while the declared one stays untouched all
+# pass it.
+#
+# resourceNames is deliberately ignored. A rule scoped to named Secrets that
+# grants "*" on them is still a wildcard verb grant, so the union counts it.
+#
+# An aggregated ClusterRole is the one widening this cannot see: it renders with
+# no `rules` of its own, so whatever the aggregation confers stays outside the
+# union. This chart declares no aggregationRule; a rule set assembled that way
+# would need its own check.
+#
+# The assertion is an equality against a non-empty expected set, so a chart that
+# fails to render, or a yq/jq breakage that yields nothing, fails the test
+# rather than passing it vacuously.
+#
+# Requires: helm, yq (mikefarah v4+), jq -- the same three
+# hack/admin-kubeconfig-invariant.bats needs to render and inspect a chart.
+#
+# Run with: hack/cozytest.sh hack/cozystack-controller-secret-rbac.bats
+# -----------------------------------------------------------------------------
+
+# What "*" in a rule's verbs means for a namespaced resource such as Secret.
+VERB_UNIVERSE='["create","delete","deletecollection","get","list","patch","update","watch"]'
+
+# The grant the chart declares, as a sorted set: read for both reconcilers plus
+# the writes the two of them need. Sorted because the comparison below is on
+# `unique`d jq output, which is sorted.
+DECLARED_SECRET_VERBS="create,delete,get,list,patch,update,watch"
+
+@test "cozystack-controller grants exactly the declared verb set on core Secrets in any spelling" {
+  chart="packages/system/cozystack-controller"
+  [ -d "$chart" ]
+
+  tmp=$(mktemp -d)
+
+  # helm's stderr is left alone: this chart renders silently, so there is nothing
+  # to suppress, and a chart that stops rendering should say why in the log
+  # rather than fail this line mutely.
+  helm template cozystack-controller "$chart" \
+    --namespace cozy-system \
+    > "$tmp/rendered.yaml"
+
+  # yq streams one JSON object per rendered document; jq -s slurps the stream so
+  # the rules of every ClusterRole and Role are one collection.
+  yq --output-format=json eval-all '.' "$tmp/rendered.yaml" \
+    | jq -s '
+        map(select(.kind == "ClusterRole" or .kind == "Role"))
+        | map(.rules // []) | add // []
+        | map(select(
+            ((.apiGroups // []) | any(. == "" or . == "*")) and
+            ((.resources // []) | any(. == "secrets" or . == "*"))
+          ))
+      ' > "$tmp/secret-rules.json"
+
+  effective=$(
+    jq --raw-output --argjson universe "$VERB_UNIVERSE" '
+      map(if ((.verbs // []) | any(. == "*")) then $universe else (.verbs // []) end)
+      | add // [] | unique | join(",")
+    ' "$tmp/secret-rules.json"
+  )
+
+  if [ "$effective" != "$DECLARED_SECRET_VERBS" ]; then
+    echo "Effective verb set on core Secrets is not the declared one." >&2
+    echo "  declared: $DECLARED_SECRET_VERBS" >&2
+    echo "  rendered: $effective" >&2
+    echo "Rules reaching core Secrets:" >&2
+    cat "$tmp/secret-rules.json" >&2
+    exit 1
+  fi
+
+  echo "Effective verbs on core Secrets: $effective"
+  rm -rf "$tmp"
+}

--- a/packages/system/cozystack-controller/tests/rbac_test.yaml
+++ b/packages/system/cozystack-controller/tests/rbac_test.yaml
@@ -9,6 +9,17 @@ release:
 # One Secret write grant serves two reconcilers (WildcardSecret replication and
 # CACert projection, including "delete"); it scopes the platform controller's own
 # ServiceAccount and widens no tenant's RBAC. This rule gates both features, so pin it.
+#
+# This suite pins the rule as written and nothing more. helm-unittest compares
+# every field it is handed by value equality -- `any: true` changes which fields
+# are compared, not how -- which is what a positive pin wants and what an upper
+# bound on the grant cannot use: no spelling of `notContains` bounds what a verbs
+# list may hold, so `verbs: ["get", "*"]` satisfies every one of them. The upper
+# bound therefore lives in
+# hack/cozystack-controller-secret-rbac.bats, which unions the verbs every
+# rendered rule confers on core Secrets and compares that set with the declared
+# one. Extend that file, not this one, when the question is what the controller
+# may do to a Secret.
 
 tests:
   - it: grants the ClusterRole every verb both reconcilers need, including delete
@@ -25,15 +36,3 @@ tests:
             apiGroups: [""]
             resources: ["secrets"]
             verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-
-  - it: does not grant a blanket wildcard verb on secrets
-    documentSelector:
-      path: kind
-      value: ClusterRole
-    asserts:
-      - notContains:
-          path: rules
-          content:
-            apiGroups: [""]
-            resources: ["secrets"]
-            verbs: ["*"]


### PR DESCRIPTION
## What this PR does

`packages/system/cozystack-controller/tests/rbac_test.yaml` has a test named "does not grant a blanket wildcard verb on secrets" that does not guard that. Its only assert is a `notContains` on `path: rules` holding a rule object. helm-unittest compares every field it is given by value equality, and `any: true` only changes which fields get compared, so nothing in that assert bounds what a verbs list may hold. `verbs: ["get", "*"]` passes every spelling of it.

Each row below is a mutation of `templates/rbac.yaml`, confirmed visible in `helm template` output before I read any verdict.

| # | widened Secret grant | whole suite | the test named as the guard |
| --- | --- | --- | --- |
| 1 | `verbs: ["*"]` on `""`/secrets, the exact object it names | red | red |
| 2 | `resources: ["*"]`, `verbs: ["*"]` in the core group | red (positive pin) | green |
| 3 | `apiGroups: ["*"]`, secrets, `verbs: ["*"]` | red (positive pin) | green |
| 4 | `"*"` appended to the declared verb list | red (positive pin) | green |
| 5 | the exact named object added as a second rule | red | red |
| 6 | `verbs: ["*"]` plus a `resourceNames` field | red (positive pin) | green |
| 7 | `deletecollection` spelled out | red (positive pin) | green |
| 8 | declared rule kept, `apiGroups:['*'] resources:['*'] verbs:['*']` appended | green, 2 passed 2 total | green |
| 9 | declared rule kept, `secrets: [deletecollection]` appended | green, 2 passed 2 total | green |

Rows 8 and 9 are the bad ones. The declared rule stays untouched, so the positive pin is happy, the suite reports a clean pass, and the controller holds every verb on every Secret in every tenant namespace.

The replacement is `hack/cozystack-controller-secret-rbac.bats`, which reads effective permission instead of manifest text. It renders the chart, unions the verbs every ClusterRole and Role rule confers on core Secrets, expands a `*` on any of the three axes, and compares that union against the declared set. All nine rows above are red under it, and so are widening the namespaced `Role`, bundling `secrets` with another resource under `verbs: ["*"]`, and dropping `delete` from the set. That last one is deliberate: the comparison is an equality rather than a ceiling, because both reconcilers need every verb in it and the controller is cluster-scoped, so a widening reaches every tenant. Reflowing the rule to block style changes the text and nothing else, and stays green. Green on `main` under both `bats` and `hack/cozytest.sh`.

Expanding wildcards is what makes it hold at all. The chart ends with a blanket `apiGroups: ['*'] resources: ['*'] verbs: [get, list, watch]` rule that does reach Secrets, so a guard phrased as "no wildcard near secrets" would be red on `main` today. That rule predates this branch and is tracked separately in #3625. This guard stays green either way, whether the blanket rule is narrowed or left alone, as long as Secret access matches the declared set.

The positive `contains` pin stays. Value equality is the right primitive for pinning a rule as written and the wrong one for bounding what the rule may become.

The same shape exists in `packages/system/cozystack-api/tests/rbac_test.yaml` and `packages/extra/seaweedfs/tests/cleanup_client_test.yaml`, and more weakly in `packages/system/etcd-operator/tests/selector-fix-hook_test.yaml`, which matches a scalar inside `rules[0].verbs`. Out of scope here, listing them so they are not lost.

`BATS_UNIT_FILES` picks the new file up on its own (`hack/*.bats`, no `e2e-` prefix), so `make unit-tests` runs it with no Makefile change. It needs helm, yq and jq, the same three `hack/admin-kubeconfig-invariant.bats` already needs.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map against the diff. The only entry that looks at `hack/` is cozystack/ccp, which triggers on moving or renaming something there, or on changing what a make target does. This adds a file and touches neither `hack/package.mk`, `hack/common-envs.mk`, nor any target.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```
