### PR TITLE
fix(tenant): retry failed etcd and seaweedfs installs in place

### DIFF
--- a/packages/apps/tenant/templates/etcd.yaml
+++ b/packages/apps/tenant/templates/etcd.yaml
@@ -28,10 +28,40 @@ spec:
     namespace: cozy-system
   interval: 5m
   timeout: 30m
+  {{- /* Flux's default install strategy remediates a failed install by
+         uninstalling, and install remediation is an uninstall in every case
+         Flux offers. This release does not disable hooks on it, so that
+         uninstall runs the etcd chart's post-delete cleanup Job, which deletes
+         the data-etcd-<ordinal> PVCs by name because the etcd-operator does not
+         reclaim them when the EtcdCluster goes. An install that misses its
+         budget therefore destroys the datastore the tenant control planes keep
+         their state in, and the next attempt starts from an empty cluster
+         rather than resuming the one already converging. RetryOnFailure keeps
+         the manifests applied and retries the failed release, so no uninstall
+         happens and the cleanup Job never runs. Both actions carry the strategy
+         because the controller performs that retry as an upgrade, so on install
+         alone the retry's own failure falls through to upgrade remediation.
+         Two things are traded away. A genuine upgrade failure now retries
+         rather than rolls back, which gives up no stable safety net: with
+         retries: -1 and the default strategy, upgrade remediation already
+         rolled back and retried without end. And the uninstall was the only
+         automatic clean slate, so an install wedged on a bad resource state
+         retries against that state until an operator removes the release. For
+         a release that owns data that is the right exchange, because lost data
+         does not come back and a wedged install does. The remediation blocks
+         stay because an absent release consults
+         install and an out-of-sync one consults upgrade, both by retry count
+         rather than by strategy. */}}
   install:
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 30s
     remediation:
       retries: -1
   upgrade:
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 30s
     remediation:
       retries: -1
   valuesFrom:

--- a/packages/apps/tenant/templates/seaweedfs.yaml
+++ b/packages/apps/tenant/templates/seaweedfs.yaml
@@ -19,10 +19,40 @@ spec:
     namespace: cozy-system
   interval: 5m
   timeout: 10m
+  {{- /* Flux's default install strategy remediates a failed install by
+         uninstalling, and install remediation is an uninstall in every case
+         Flux offers. This release does not disable hooks on it, so that
+         uninstall runs the seaweedfs chart's post-delete cleanup Job, which
+         deletes the volume PVCs by label and explicitly reclaims the
+         keep-protected CNPG Cluster holding the filer metadata, precisely
+         because nothing else removes it. An install that misses its budget
+         therefore destroys the object store's data and the metadata database
+         that indexes it, and the next attempt starts from nothing rather than
+         resuming. RetryOnFailure keeps the manifests applied and retries the
+         failed release, so no uninstall happens and the cleanup Job never runs.
+         Both actions carry the strategy because the controller performs that
+         retry as an upgrade, so on install alone the retry's own failure falls
+         through to upgrade remediation. Two things are traded away. A genuine
+         upgrade failure now retries rather than rolls back, which gives up no
+         stable safety net: with retries: -1 and the default strategy, upgrade
+         remediation already rolled back and retried without end. And the
+         uninstall was the only automatic clean slate, so an install wedged on a
+         bad resource state retries against that state until an operator removes
+         the release. For a release that owns data that is the right exchange,
+         because lost data does not come back and a wedged install does. The
+         remediation blocks stay because an absent release consults install and
+         an out-of-sync one consults upgrade, both by retry count rather than by
+         strategy. */}}
   install:
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 30s
     remediation:
       retries: -1
   upgrade:
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 30s
     remediation:
       retries: -1
   valuesFrom:

--- a/packages/apps/tenant/tests/volume_owner_install_retry_test.yaml
+++ b/packages/apps/tenant/tests/volume_owner_install_retry_test.yaml
@@ -1,0 +1,102 @@
+suite: etcd and seaweedfs tenant HelmReleases retry a failed install in place
+
+# Named after the two releases rather than after the class they belong to. The
+# tenant's monitoring release owns storage as well and its own post-delete Job
+# deletes it, and that release is outside this suite, so a class-shaped title
+# would print as PASS over members it never looked at.
+#
+# Restrict rendering to the two templates asserted on, so a template this suite
+# makes no claim about cannot fail it. That is not hypothetical: at the time of
+# writing, dropping the restriction reds all four tests on keycloakgroups.yaml,
+# which errors with "index of untyped nil" on the `.Values._cluster` the
+# platform injects and this suite has no reason to set. Adding a template to
+# the list below is safe.
+templates:
+  - templates/etcd.yaml
+  - templates/seaweedfs.yaml
+
+release:
+  name: tenant-test
+  namespace: tenant-test
+
+set:
+  etcd: true
+  seaweedfs: true
+  host: ""
+
+tests:
+  # Install remediation is an uninstall in every case Flux offers, and neither
+  # release disables hooks on it, so a remediated install runs each chart's
+  # post-delete cleanup Job. Those Jobs delete data on purpose: the etcd one
+  # removes the data-etcd-<ordinal> PVCs by name, because the etcd-operator does
+  # not reclaim them when the EtcdCluster goes. An install that misses its
+  # budget therefore destroys the datastore the tenant control planes keep their
+  # state in, rather than merely restarting.
+  - it: retries a failed etcd install instead of deleting the datastore
+    asserts:
+      - template: templates/etcd.yaml
+        equal:
+          path: spec.install.strategy.name
+          value: RetryOnFailure
+      - template: templates/etcd.yaml
+        equal:
+          path: spec.install.strategy.retryInterval
+          value: 30s
+
+  # The seaweedfs cleanup Job deletes the volume PVCs by label and explicitly
+  # reclaims the keep-protected CNPG Cluster holding the filer metadata, which
+  # nothing else removes. Same consequence for a remediated install.
+  - it: retries a failed seaweedfs install instead of deleting the filer metadata
+    asserts:
+      - template: templates/seaweedfs.yaml
+        equal:
+          path: spec.install.strategy.name
+          value: RetryOnFailure
+      - template: templates/seaweedfs.yaml
+        equal:
+          path: spec.install.strategy.retryInterval
+          value: 30s
+
+  # The controller performs the retry of a failed install as an upgrade, so
+  # without a strategy here that retry's own failure falls through to upgrade
+  # remediation instead of retrying again.
+  - it: carries the strategy on the upgrade action the retry runs as
+    asserts:
+      - template: templates/etcd.yaml
+        equal:
+          path: spec.upgrade.strategy.name
+          value: RetryOnFailure
+      - template: templates/etcd.yaml
+        equal:
+          path: spec.upgrade.strategy.retryInterval
+          value: 30s
+      - template: templates/seaweedfs.yaml
+        equal:
+          path: spec.upgrade.strategy.name
+          value: RetryOnFailure
+      - template: templates/seaweedfs.yaml
+        equal:
+          path: spec.upgrade.strategy.retryInterval
+          value: 30s
+
+  # The strategy governs a failed release. An absent release and an out-of-sync
+  # one take different branches, which consult the retry count instead and stop
+  # acting once it is exhausted.
+  - it: keeps unlimited retries for the branches the strategy does not reach
+    asserts:
+      - template: templates/etcd.yaml
+        equal:
+          path: spec.install.remediation.retries
+          value: -1
+      - template: templates/etcd.yaml
+        equal:
+          path: spec.upgrade.remediation.retries
+          value: -1
+      - template: templates/seaweedfs.yaml
+        equal:
+          path: spec.install.remediation.retries
+          value: -1
+      - template: templates/seaweedfs.yaml
+        equal:
+          path: spec.upgrade.remediation.retries
+          value: -1


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

The tenant chart renders the etcd and seaweedfs releases with no install strategy, so they get Flux's default, and install remediation is an uninstall in every case Flux offers. Neither release sets `spec.uninstall.disableHooks`, which defaults to false, so that uninstall runs the app chart's `post-delete` cleanup Job. Nothing unusual is configured anywhere along that chain: fail early, uninstall, hooks.

Those Jobs delete data on purpose. The etcd one removes the `data-etcd-<ordinal>` PVCs by name, because the etcd-operator does not reclaim them when the EtcdCluster goes. The seaweedfs one removes the volume PVCs by label and explicitly reclaims the keep-protected CNPG Cluster holding the filer metadata, because nothing else would. Both are right for a real uninstall, and neither hook is at fault here. Remediation is what calls them, on a release that is only starting slowly.

So an install that misses its budget does not restart. It destroys the datastore the tenant control planes keep their state in, or the object store's data together with the metadata database that indexes it, and the next attempt begins from nothing.

That budget is not a comfortable margin. The seaweedfs release has `timeout: 10m`, and `hack/e2e-install-cozystack.bats` already records that on a loaded runner the tenant stack only starts creating pods around 9 to 10 minutes in. The window CI observes and the window that triggers this are the same window.

`RetryOnFailure` keeps the manifests applied and retries the failed release as an upgrade. No uninstall happens, so neither cleanup Job runs and the install already under way carries on instead of starting over.

Both actions carry the strategy. The controller runs the retry of a failed install as an upgrade, so with install alone the retry's own failure falls through to upgrade remediation. The remediation blocks stay: an absent release consults install, an out-of-sync one consults upgrade, both by retry count rather than by strategy.

One trade is that a real upgrade failure retries instead of rolling back. That costs no stable safety net. With `retries: -1` and the default strategy, upgrade remediation was already rolling back and retrying without end, so the release never rested in the rolled-back state either.

The other side of the trade is that the uninstall was also the only automatic clean slate. On a tenant holding no data yet, an install that wedges on a bad resource state now retries against that state until an operator removes the release. For a release that owns data that is the right exchange, because lost data does not come back and a wedged install does.

This covers two of the tenant's data-owning releases. The monitoring release carries the same default and a cleanup Job that deletes its PVCs as well, and is left for its own change, as is the rest of the catalog, whose nested releases want the question asked one at a time. Same shape as #3552 and #3581. Relates to #3555 and #3576.

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
fix(tenant): retry a failed etcd or seaweedfs install instead of uninstalling the release, so a slow first install no longer runs the cleanup hooks that delete the etcd data volumes, the SeaweedFS volumes and the filer metadata database
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Improved installation and upgrade recovery for etcd and SeaweedFS by automatically retrying failed operations every 30 seconds.
  * Preserved ongoing remediation attempts to help services recover without uninstalling or rolling back after failures.

* **Tests**
  * Added coverage to verify retry behavior and remediation settings for both services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->