### PR TITLE
fix(tests): fail when a chart runs no Helm unit test suites

### DIFF
--- a/docs/agents/overview.md
+++ b/docs/agents/overview.md
@@ -100,7 +100,7 @@ Package `values.yaml` files carry annotations (`@param`, `@typedef`, `@field`, `
 
 ## Testing
 
-- **Helm unit tests:** `make helm-unit-tests` (runs `hack/helm-unit-tests.sh` over every package that defines a `test` target). `make unit-tests` runs the full unit suite — Helm, BATS, Go, and the preset/readiness checks.
+- **Helm unit tests:** `make helm-unit-tests` (runs `hack/helm-unit-tests.sh` over every package that defines a `test` target). A `test` target is expected to run helm-unittest: the sweep fails a package whose run reports no suite, because exiting 0 having asserted nothing is indistinguishable from passing. A target that drives something else belongs under another name, as `packages/core/testing` already does with its sandbox flow. `make unit-tests` runs the full unit suite — Helm, BATS, Go, and the preset/readiness checks.
 - **E2E tests:** Kyverno Chainsaw suites in `hack/e2e-chainsaw/` (one directory per app), run with `chainsaw test`. Cluster bootstrap (`hack/e2e-install-cozystack.bats`) and the OpenAPI checks (`hack/e2e-test-openapi.bats`) remain BATS. Conventions for writing and stabilising them — and the CI that runs them — live in [`e2e-testing.md`](./e2e-testing.md).
 - **Go tests:** standard `go test`, with Ginkgo/Gomega for controllers.
 

--- a/hack/helm-unit-tests.bats
+++ b/hack/helm-unit-tests.bats
@@ -1,32 +1,344 @@
 #!/usr/bin/env bats
 # -----------------------------------------------------------------------------
-# Unit tests for hack/helm-unit-tests.sh
+# Unit tests for hack/helm-unit-tests.sh, which decides per package directory
+# whether to run `make test` and turns the results into one exit code.
 #
-# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
-# own line; there is no bats `run` or `$status`. Each test runs as a shell
-# function under `set -eu -x`, so assertions are direct shell tests that exit
-# non-zero on failure. setup()/teardown() are not honored — each test creates
-# and cleans its own scratch dir, and cleanup is the last statement of the body
-# rather than a `trap ... EXIT`: that trap replaces the one the bats binary
-# installs for its own bookkeeping, and a test failing under it can print no TAP
-# line at all. Last, not before the assertions, so a failure leaves the scratch
-# tree behind for inspection.
+# The script judges a package by that exit code alone, and exit 0 has two very
+# different meanings. helm-unittest is fail-closed on a suite it cannot parse
+# and on a suite declaring `tests: []`, but fail-open on suites that are not
+# there at all: it prints "Test Suites: 0 passed, 0 total" and exits 0. So a
+# chart whose suites were deleted, moved, or renamed past the `tests/*_test.yaml`
+# glob reports success having asserted nothing. The other way in is the
+# discovery gate: `make -C dir -n test` succeeds for a file-backed target too, so
+# a path named `test` beside a package Makefile whose `test:` rule is not phony
+# makes both the gate and the run exit 0 without the recipe firing.
 #
-# The sweep resolves its package directories relative to the working directory,
-# so each test runs it from a synthetic tree holding nothing but the packages it
-# is about. That keeps the assertions exact and keeps the real repo's suites,
-# which take minutes, out of a unit test.
+# Every one of those checks runs INSIDE a directory the sweep already reached,
+# so a package that never enters the loop escapes all of them at once. That is a
+# separate failure, and the tests naming packages/tests are the ones covering it.
+#
+# The fixtures below stub `make` output rather than invoking helm, so the tests
+# stay hermetic and need no plugin installed. What they exercise is the script's
+# own reaction to each shape of output. The sweep resolves its package
+# directories relative to the working directory, so each test runs it from a
+# synthetic tree holding nothing but the packages it is about. That keeps the
+# assertions exact and keeps the real repo's suites, which take minutes, out of
+# a unit test.
+#
+# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` at column
+# 0, and injects `set -e`, so exit statuses are captured explicitly; there is no
+# bats `run` or `$status`. setup()/teardown() are not honored, so each test
+# creates and removes its own scratch dir inline rather than through a
+# `trap ... EXIT`: that trap replaces the one the bats binary installs for its
+# own bookkeeping, and a test failing under it can print no TAP line at all.
 #
 # Run with: hack/cozytest.sh hack/helm-unit-tests.bats
 # -----------------------------------------------------------------------------
 
-SWEEP="$PWD/hack/helm-unit-tests.sh"
+# Build a throwaway tree with one package whose `make test` prints $1 and exits
+# $2. Echoes the tree root.
+_tree() {
+    _t=$(mktemp -d)
+    mkdir -p "$_t/packages/apps/sample"
+    printf 'test:\n\t@printf "%%s\\n" "%s"\n\t@exit %s\n' "$1" "$2" \
+        > "$_t/packages/apps/sample/Makefile"
+    printf '%s' "$_t"
+}
 
-# A package whose `test` target announces itself, so "the sweep reached this
-# directory" and "the suite actually ran" are two separate observations.
+# A package at an arbitrary path whose `test` target announces itself, so "the
+# sweep reached this directory" and "the recipe actually ran" stay two separate
+# observations. It also emits the line a real helm-unittest run emits, because
+# the script refuses a package that reports no suite: without that line the
+# fixture would be rejected for a reason unrelated to the claim under test.
 make_package() {
     mkdir -p "$1"
-    printf 'test:\n\t@echo %s\n' "$2" > "$1/Makefile"
+    printf 'test:\n\t@echo %s\n\t@printf "%%s\\n" "Test Suites: 1 passed, 1 total"\n' \
+        "$2" > "$1/Makefile"
+}
+
+@test "a chart reporting zero test suites fails instead of passing silently" {
+    repo=$(pwd)
+    t=$(_tree "Test Suites: 0 passed, 0 total" 0)
+
+    rc=0
+    out=$(cd "$t" && sh "$repo/hack/helm-unit-tests.sh" 2>&1) || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        echo "helm-unit-tests.sh exited 0 for a chart that ran no suites:" >&2
+        echo "$out" >&2
+        echo "a chart whose suite files vanished would report success" >&2
+        rm -rf "$t"
+        exit 1
+    fi
+
+    # Assert on this check's own wording, so the test cannot stay green on a
+    # refusal that came from somewhere else.
+    case "$out" in
+        *"ran no test suites"*) ;;
+        *)
+            echo "refused, but not by the zero-suite check:" >&2
+            echo "$out" >&2
+            rm -rf "$t"
+            exit 1
+            ;;
+    esac
+
+    rm -rf "$t"
+}
+
+@test "a shadowed test target is refused before it can no-op" {
+    # `make -n test` succeeds against a file-backed target, so the discovery
+    # gate cannot tell a real recipe from one make will skip. The script has to
+    # notice the colliding path itself.
+    repo=$(pwd)
+    t=$(_tree "Test Suites: 1 passed, 1 total" 0)
+    touch "$t/packages/apps/sample/test"
+
+    rc=0
+    out=$(cd "$t" && sh "$repo/hack/helm-unit-tests.sh" 2>&1) || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        echo "helm-unit-tests.sh exited 0 with a path named 'test' beside the Makefile:" >&2
+        echo "$out" >&2
+        echo "make would report the target up to date and skip the recipe" >&2
+        rm -rf "$t"
+        exit 1
+    fi
+
+    case "$out" in
+        *"reported up to date"*) ;;
+        *)
+            echo "refused, but not by the shadowed-target check:" >&2
+            echo "$out" >&2
+            rm -rf "$t"
+            exit 1
+            ;;
+    esac
+
+    rm -rf "$t"
+}
+
+@test "a colliding path is tolerated when the target is declared phony" {
+    # The check has to key on what make reports, not on the path existing: a
+    # package declaring `.PHONY: test` runs its recipe regardless of what sits
+    # beside the Makefile, so rejecting it would be a false failure — and would
+    # contradict the remedy the other check names.
+    repo=$(pwd)
+    t=$(mktemp -d)
+    mkdir -p "$t/packages/apps/sample"
+    printf '.PHONY: test\ntest:\n\t@printf "%%s\\n" "Test Suites: 1 passed, 1 total"\n' \
+        > "$t/packages/apps/sample/Makefile"
+    touch "$t/packages/apps/sample/test"
+
+    rc=0
+    out=$(cd "$t" && sh "$repo/hack/helm-unit-tests.sh" 2>&1) || rc=$?
+
+    if [ "$rc" -ne 0 ]; then
+        echo "helm-unit-tests.sh rejected a phony target whose recipe does run:" >&2
+        echo "$out" >&2
+        rm -rf "$t"
+        exit 1
+    fi
+
+    # Tolerating a package means it was reached and not refused. The exit status
+    # alone cannot tell that from never having been reached, because the early
+    # exit above the failure summary also returns 0. Written out here rather
+    # than shared through a helper: cozytest.sh rewrites a function's closing
+    # brace into `return 0`, so an assertion returning a status would pass
+    # unconditionally under that runner.
+    case "$out" in
+        *"All Helm unit tests passed"*) ;;
+        *)
+            echo "the run never reached its summary, so nothing was evaluated:" >&2
+            echo "$out" >&2
+            rm -rf "$t"
+            exit 1
+            ;;
+    esac
+
+    rm -rf "$t"
+}
+
+@test "a sub-make reporting another target up to date is not mistaken for ours" {
+    # The shadowed-target check keys on make's wording, so it has to distinguish
+    # our target from any other whose name merely ends in "test". A package that
+    # delegates to a sub-make can legitimately print such a line while its own
+    # suites run.
+    repo=$(pwd)
+    t=$(mktemp -d)
+    mkdir -p "$t/packages/apps/sample"
+    {
+        printf 'test:\n'
+        printf '\t@printf "%%s\\n" "make[1]: '"'"'unittest'"'"' is up to date."\n'
+        printf '\t@printf "%%s\\n" "Test Suites: 2 passed, 2 total"\n'
+    } > "$t/packages/apps/sample/Makefile"
+
+    rc=0
+    out=$(cd "$t" && sh "$repo/hack/helm-unit-tests.sh" 2>&1) || rc=$?
+
+    if [ "$rc" -ne 0 ]; then
+        echo "helm-unit-tests.sh refused a package over an unrelated target:" >&2
+        echo "$out" >&2
+        rm -rf "$t"
+        exit 1
+    fi
+
+    # As above: prove the package was reached, or a run that evaluated nothing
+    # satisfies this test too.
+    case "$out" in
+        *"All Helm unit tests passed"*) ;;
+        *)
+            echo "the run never reached its summary, so nothing was evaluated:" >&2
+            echo "$out" >&2
+            rm -rf "$t"
+            exit 1
+            ;;
+    esac
+
+    rm -rf "$t"
+}
+
+@test "a chart that runs suites still passes" {
+    # Guards against the two checks above being satisfied by refusing everything.
+    repo=$(pwd)
+    t=$(_tree "Test Suites: 3 passed, 3 total" 0)
+
+    rc=0
+    out=$(cd "$t" && sh "$repo/hack/helm-unit-tests.sh" 2>&1) || rc=$?
+
+    if [ "$rc" -ne 0 ]; then
+        echo "helm-unit-tests.sh rejected a chart that ran three suites:" >&2
+        echo "$out" >&2
+        rm -rf "$t"
+        exit 1
+    fi
+
+    # As above: this is the test that stops the three refusals being satisfied
+    # by rejecting everything, so it has to prove the chart was reached rather
+    # than merely that the run returned 0.
+    case "$out" in
+        *"All Helm unit tests passed"*) ;;
+        *)
+            echo "the run never reached its summary, so nothing was evaluated:" >&2
+            echo "$out" >&2
+            rm -rf "$t"
+            exit 1
+            ;;
+    esac
+
+    rm -rf "$t"
+}
+
+@test "a recipe that runs no suites at all is refused" {
+    # The shape neither marker can catch. A `test:` rule whose recipe never
+    # invokes helm-unittest, or that make finds nothing to do for, prints no
+    # marker of any kind and exits 0, which is why the script asks for the line
+    # a real run emits instead of enumerating the ways of emitting nothing.
+    repo=$(pwd)
+    t=$(mktemp -d)
+    mkdir -p "$t/packages/apps/sample"
+    printf 'test:\n\t@true\n' > "$t/packages/apps/sample/Makefile"
+
+    rc=0
+    out=$(cd "$t" && sh "$repo/hack/helm-unit-tests.sh" 2>&1) || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        echo "helm-unit-tests.sh exited 0 for a recipe that ran nothing:" >&2
+        echo "$out" >&2
+        rm -rf "$t"
+        exit 1
+    fi
+
+    case "$out" in
+        *"reported no test suite that ran"*) ;;
+        *)
+            echo "refused, but not by the positive-evidence check:" >&2
+            echo "$out" >&2
+            rm -rf "$t"
+            exit 1
+            ;;
+    esac
+
+    rm -rf "$t"
+}
+
+@test "a package whose tests fail is still reported" {
+    # Pins the exit-status branch specifically, which needs a fixture whose run
+    # both exits non-zero AND prints a passing suite marker. Without the marker
+    # the positive-evidence check refuses the package first, the exit status is
+    # never what decided the outcome, and deleting the branch leaves this green.
+    # Not a hypothetical shape: a `test` target that runs helm-unittest and then
+    # a second step — a render-parity script, a vendored-version guard, go tests
+    # — prints the marker and still fails, and the exit status is the only thing
+    # that catches it.
+    repo=$(pwd)
+    t=$(_tree "Test Suites: 5 passed, 5 total" 1)
+
+    rc=0
+    out=$(cd "$t" && sh "$repo/hack/helm-unit-tests.sh" 2>&1) || rc=$?
+
+    if [ "$rc" -eq 0 ]; then
+        echo "helm-unit-tests.sh exited 0 for a package whose tests failed:" >&2
+        echo "$out" >&2
+        rm -rf "$t"
+        exit 1
+    fi
+
+    # Anchored on the summary's "  - " prefix, not the bare path: the script
+    # announces "Running tests in $dir" before it runs anything, so the bare
+    # path is in the output whatever the summary later does or omits.
+    case "$out" in
+        *"- packages/apps/sample"*) ;;
+        *)
+            echo "the failing package was not named in the summary:" >&2
+            echo "$out" >&2
+            rm -rf "$t"
+            exit 1
+            ;;
+    esac
+
+    rm -rf "$t"
+}
+
+@test "a package with no test target is skipped, not failed" {
+    # The script must stay silent about the many packages that define no `test`
+    # rule at all, or every run turns red on packages that never had suites.
+    #
+    # The tree carries a second package that does run a suite, and that is what
+    # gives this test the ability to fail at all. With only the target-less
+    # package present, `tests_found` stays 0 and the script takes its early exit
+    # above the failure summary, so the run returns 0 whether or not the package
+    # was recorded as failed: green for a reason that has nothing to do with the
+    # claim in the title.
+    repo=$(pwd)
+    t=$(_tree "Test Suites: 1 passed, 1 total" 0)
+    mkdir -p "$t/packages/apps/notests"
+    printf 'build:\n\t@echo nothing\n' > "$t/packages/apps/notests/Makefile"
+
+    rc=0
+    out=$(cd "$t" && sh "$repo/hack/helm-unit-tests.sh" 2>&1) || rc=$?
+
+    if [ "$rc" -ne 0 ]; then
+        echo "helm-unit-tests.sh failed on a package that defines no test target:" >&2
+        echo "$out" >&2
+        rm -rf "$t"
+        exit 1
+    fi
+
+    # Reaching the summary is the part that proves the early exit was not taken.
+    # Asserting only on the exit status would pass on a run that evaluated
+    # nothing at all, which is how this test was vacuous before.
+    case "$out" in
+        *"All Helm unit tests passed"*) ;;
+        *)
+            echo "the run never reached its summary, so nothing was evaluated:" >&2
+            echo "$out" >&2
+            rm -rf "$t"
+            exit 1
+            ;;
+    esac
+
+    rm -rf "$t"
 }
 
 @test "the sweep runs the suites under packages/tests" {
@@ -38,20 +350,48 @@ make_package() {
     # still printing "All Helm unit tests passed", because the no-suites
     # backstop was satisfied by the other package directories.
     #
-    # Nothing else in the sweep could have caught it. Every check it makes —
-    # the Makefile test, the `make -n test` probe, the failure collection —
-    # runs inside a directory it already visited, so a package that drops out
-    # of the loop takes all of them with it and leaves only the backstop,
-    # which counts suites across the whole run rather than per package.
+    # Nothing else in the sweep could have caught it. Every check it makes — the
+    # Makefile test, the `make -n test` probe, the per-package suite checks, the
+    # failure collection — runs inside a directory it already visited, so a
+    # package that drops out of the loop takes all of them with it and leaves
+    # only the backstop, which counts suites across the whole run rather than
+    # per package.
+    repo=$(pwd)
     tmp=$(mktemp -d)
     make_package "$tmp/packages/tests/cozy-lib-tests" SWEEP_REACHED_TESTS
-    output=$(cd "$tmp" && "$SWEEP" 2>/dev/null)
-    if ! printf '%s\n' "$output" | grep -q "Running tests in packages/tests/cozy-lib-tests"; then
-        echo "the sweep never visited packages/tests; it printed:" >&2
-        printf '%s\n' "$output" >&2
+
+    rc=0
+    out=$(cd "$tmp" && sh "$repo/hack/helm-unit-tests.sh" 2>&1) || rc=$?
+
+    if [ "$rc" -ne 0 ]; then
+        echo "the sweep refused a package under packages/tests that ran a suite:" >&2
+        echo "$out" >&2
+        rm -rf "$tmp"
         exit 1
     fi
-    printf '%s\n' "$output" | grep -q SWEEP_REACHED_TESTS
+
+    case "$out" in
+        *"Running tests in packages/tests/cozy-lib-tests"*) ;;
+        *)
+            echo "the sweep never visited packages/tests; it printed:" >&2
+            echo "$out" >&2
+            rm -rf "$tmp"
+            exit 1
+            ;;
+    esac
+
+    # Reaching the directory and running the recipe are separate claims, so the
+    # marker is asserted on its own rather than folded into the line above.
+    case "$out" in
+        *SWEEP_REACHED_TESTS*) ;;
+        *)
+            echo "the sweep announced packages/tests but never ran the recipe:" >&2
+            echo "$out" >&2
+            rm -rf "$tmp"
+            exit 1
+            ;;
+    esac
+
     rm -rf "$tmp"
 }
 
@@ -59,14 +399,31 @@ make_package() {
     # Visiting the directory is worth nothing if a red suite there is swallowed:
     # the delegation line the sweep is replacing propagated the failure, and the
     # replacement has to as well.
+    repo=$(pwd)
     tmp=$(mktemp -d)
     mkdir -p "$tmp/packages/tests/cozy-lib-tests"
     printf 'test:\n\t@exit 1\n' > "$tmp/packages/tests/cozy-lib-tests/Makefile"
+
     rc=0
-    (cd "$tmp" && "$SWEEP" >/dev/null 2>&1) || rc=$?
+    out=$(cd "$tmp" && sh "$repo/hack/helm-unit-tests.sh" 2>&1) || rc=$?
+
     if [ "$rc" -eq 0 ]; then
         echo "a failing suite under packages/tests left the sweep green" >&2
+        echo "$out" >&2
+        rm -rf "$tmp"
         exit 1
     fi
+
+    # Anchored on the summary's "  - " prefix, for the reason given above.
+    case "$out" in
+        *"- packages/tests/cozy-lib-tests"*) ;;
+        *)
+            echo "the failing package was not named in the summary:" >&2
+            echo "$out" >&2
+            rm -rf "$tmp"
+            exit 1
+            ;;
+    esac
+
     rm -rf "$tmp"
 }

--- a/hack/helm-unit-tests.sh
+++ b/hack/helm-unit-tests.sh
@@ -10,10 +10,10 @@ set -eu
 #
 # packages/tests is on the list because every check below runs INSIDE a
 # directory the loop already reached — the Makefile test, the `make -n test`
-# probe, the failure collection. A package that never enters the loop takes all
-# of them with it and leaves only tests_found, which counts suites across the
-# whole run rather than per package, so it stays satisfied by the other
-# directories. That is what happened here, silently:
+# probe, the per-package suite checks, the failure collection. A package that
+# never enters the loop takes all of them with it and leaves only tests_found,
+# which counts suites across the whole run rather than per package, so it stays
+# satisfied by the other directories. That is what happened here, silently:
 # packages/tests/cozy-lib-tests ran only via a delegating 'test' target in
 # packages/library/cozy-lib/Makefile, and deleting that line dropped the
 # library's entire coverage while this sweep stayed green and still reported
@@ -24,7 +24,8 @@ set -eu
 # `Running tests in ...` lines in the log is expected rather than a bug.
 
 FAILED_DIRS_FILE="$(mktemp)"
-trap 'rm -f "$FAILED_DIRS_FILE"' EXIT
+OUTPUT_FILE="$(mktemp)"
+trap 'rm -f "$FAILED_DIRS_FILE" "$OUTPUT_FILE"' EXIT
 
 tests_found=0
 
@@ -39,7 +40,81 @@ check_and_run_test() {
     if make -C "$dir" -n test >/dev/null 2>&1; then
         echo "Running tests in $dir"
         tests_found=$((tests_found + 1))
-        if ! make -C "$dir" test; then
+
+        # LC_ALL=C because all three checks below match English wording, one on
+        # make's and two on helm-unittest's, and a localized make would disarm
+        # the first of them silently, which is the failure mode this whole guard
+        # exists to remove. It reaches every package's recipe, not just make, so
+        # the recipes run under a fixed locale too; that is the determinism-safe
+        # direction and the tree is green under it.
+        #
+        # Capturing to a file rather than streaming is deliberate: the checks
+        # below have to read the whole output, and a pipeline's exit status in
+        # POSIX sh reports the last command rather than make. The cost is that a
+        # package killed mid-run prints nothing, where a stream would have shown
+        # the partial run, and that make's stderr is folded into stdout.
+        rc=0
+        LC_ALL=C make -C "$dir" test > "$OUTPUT_FILE" 2>&1 || rc=$?
+        cat "$OUTPUT_FILE"
+
+        if [ "$rc" -ne 0 ]; then
+            printf '%s\n' "$dir" >> "$FAILED_DIRS_FILE"
+            return 1
+        fi
+
+        # The discovery gate above succeeds against a file-backed target too, so
+        # it cannot tell a real recipe from one make will skip. Match what make
+        # actually reports rather than looking for a colliding path, because a
+        # package that declares the target phony runs its recipe regardless of
+        # what sits next to the Makefile. The quoting around the target name
+        # differs between make 3.x and 4.x, so accept either opening quote;
+        # anchoring on the trailing quote alone would also match a sub-make
+        # reporting some other target whose name ends in "test".
+        if grep -qE "[\`']test' is up to date" "$OUTPUT_FILE"; then
+            echo "ERROR: a 'test' target was reported up to date while testing" >&2
+            echo "       $dir, so its recipe was skipped. The target is shadowed by" >&2
+            echo "       a file or directory of that name, here or in a sub-make" >&2
+            echo "       this package invokes. Remove the path, or declare the" >&2
+            echo "       target phony in the Makefile that defines it." >&2
+            printf '%s\n' "$dir" >> "$FAILED_DIRS_FILE"
+            return 1
+        fi
+
+        # helm-unittest is fail-closed on a suite it cannot parse and on one
+        # declaring `tests: []`, but fail-open on suites that are absent: it
+        # reports zero of them and exits 0. Charts whose suites were deleted,
+        # moved, or renamed past the tests/*_test.yaml glob land here.
+        if grep -qE 'Test Suites:[[:space:]]+0 passed,[[:space:]]+0 total' "$OUTPUT_FILE"; then
+            echo "ERROR: $dir ran no test suites. Its Makefile declares a 'test'" >&2
+            echo "       target, so suite files are expected under tests/ matching" >&2
+            echo "       *_test.yaml; helm-unittest exits 0 when it finds none." >&2
+            printf '%s\n' "$dir" >> "$FAILED_DIRS_FILE"
+            return 1
+        fi
+
+        # Then require positive evidence, because the two checks above match
+        # shapes of running nothing and there is no reason to believe that list
+        # is complete. A recipe that never invokes helm-unittest, and a `test:`
+        # rule make finds nothing to do for, both print no marker at all, so no
+        # further match could catch them. Asking instead for the line a real run
+        # always emits turns the question round: every way of asserting nothing
+        # exits 0, so the run has to say what it asserted. Kept after the two
+        # specific checks, which name a cause and a remedy where they apply,
+        # rather than replacing them.
+        #
+        # The tradeoff is that a `test` target which legitimately runs no
+        # helm-unittest would have to be renamed or given an opt-out. That is
+        # the same bargain the zero-suite check already strikes, and no package
+        # is in that position today.
+        if ! grep -qE 'Test Suites:[[:space:]]+[1-9][0-9]* passed' "$OUTPUT_FILE"; then
+            echo "ERROR: $dir reported no test suite that ran. Its Makefile" >&2
+            echo "       declares a 'test' target, so its recipe is expected to" >&2
+            echo "       run helm-unittest over suites under tests/ matching" >&2
+            echo "       *_test.yaml. A recipe that runs something else, and a" >&2
+            echo "       rule make had nothing to do for, both exit 0 in silence." >&2
+            echo "       If every package fails this way at once, suspect the" >&2
+            echo "       summary wording instead: this matches helm-unittest's" >&2
+            echo "       own, and a plugin upgrade can change it." >&2
             printf '%s\n' "$dir" >> "$FAILED_DIRS_FILE"
             return 1
         fi


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

`helm unittest` is fail-closed on a suite it cannot parse and on one declaring `tests: []`, and fail-open on suites that are not there at all: it prints `Test Suites: 0 passed, 0 total` and exits 0. `hack/helm-unit-tests.sh` judges each package by that exit code alone, so a chart whose suites were deleted, moved, or renamed past the `tests/*_test.yaml` glob reports success having asserted nothing.

That is measurable in both directions rather than argued. Move `packages/system/velero/tests/velero_test.yaml` aside and run the script as it exists on main today:

```text
Running tests in packages/system/velero
helm unittest .

### Chart [ cozy-velero ] .


Charts:      1 passed, 1 total
Test Suites: 0 passed, 0 total
Tests:       0 passed, 0 total
```

The run ends with `All Helm unit tests passed.` and exit 0. The chart passed, and the count of things it checked was zero. With this PR the same tree exits 1 and names the package and the reason. Neither `--strict` nor an explicit non-matching `-f` glob changes this on its own; all three forms exit 0, checked against plugin 1.1.1.

So the script now reads the captured output and fails the package when the zero-suite line appears.

Matching that line names a cause and a remedy where it applies, but the set of ways to run nothing is not closed. A recipe that never invokes `helm unittest`, and a `test:` rule that make finds nothing to do for, print no marker of any kind and exit 0, so no additional match reaches them; enumerating absences leaves a fresh hole every time a new shape turns up. So the script also requires the line a real run always emits, a `Test Suites:` count of at least one. That turns the question round: every way of asserting nothing exits 0, and "what did this run assert" is the question that has an answer. All 76 packages the script visits emit that line today. The tradeoff is that a `test` target which legitimately runs no `helm unittest` would need renaming or an opt-out, which is the same bargain the zero-suite check already strikes.

The discovery gate has the same shape from the other side. `make -C dir -n test` succeeds against a file-backed target, so a path named `test` beside a package Makefile whose rule is not phony would make both the gate and the run exit 0 without the recipe ever firing. The check keys on what make reports rather than on the path existing, because a package that declares the target phony runs its recipe whatever sits next to it, and refusing that would be a false failure. The quoting around the target name differs between make 3.x and 4.x, so it accepts either opening quote; anchoring on the trailing quote alone would also match a sub-make reporting some other target whose name ends in `test`.

That second check is guarding a live gap rather than a hypothetical one. `hack/package.mk` line 2 reads `.PHONY=help show diff apply delete update image`, which is a variable assignment and not a target declaration, so it makes nothing phony. Of the packages the script visits that define a `test` rule, 18 declare it phony in their own Makefile; the rest are unprotected if a path of that name ever appears. No such path exists today. Fixing the shared include is #3353 and is not this PR.

One deliberate non-change, stated so it is not rediscovered as an oversight. Running the suite now captures output instead of streaming it, because a pipeline's exit status in POSIX `sh` reports the last command rather than `make`. Streaming reads better and loses the status, so it stays buffered.

The run is pinned to `LC_ALL=C`, since both checks match English wording and a localized `make` would disarm one of them silently, which is the failure mode the whole change exists to remove.

The guard is all-or-nothing, which is worth stating plainly. A chart that loses four of its five suites still reports `Test Suites: 1 passed` and passes; only total disappearance is caught. Tying the expected count to what each chart actually has would be a per-chart number to maintain, and a number maintained in one place while the suites move in another is the failure this repo has been paying for elsewhere, so the cheap check that catches the total loss is the one worth having.

One behaviour worth stating because the message does not: a suite in which every test carries `skip:` reports `Test Suites: 0 passed, 1 skipped, 1 total` and exits 0, and the positive-evidence check refuses it. That refusal is intended, since a wholly skipped suite asserted nothing, but the message talks about suites expected under `tests/`, which in that case are present and skipped on purpose. No package is in that state today. Partial skips are unaffected: `2 passed, 1 skipped, 3 total` satisfies the check.

Three known gaps in what the change ships, none of them a wrong statement. The positive-evidence message explains its cause but stops short of naming a remedy, where the other two messages both end in an action; the remedy for the legitimate case, renaming the target or giving it an opt-out, currently lives only in the code comment. That same message enumerates two ways a run reports nothing, and the skipped-suite case above is a third, so it reads as a diagnosis where it is really a list of the common causes. And no document in the tree states the convention this tightens: `docs/agents/overview.md` still describes the script accurately as running over every package that defines a `test` target, but the contract is now that such a package must also report at least one passing suite. All three are improvements to make on the next touch of these files rather than reasons to hold the change.

One adjacent gap stays open, and it is worth naming rather than leaving someone to assume otherwise. This catches a chart whose suite *files* vanished; it does not catch a package that loses its `test:` rule along with them. Nothing ties the presence of `tests/*_test.yaml` to the presence of a `test` target, so a change that removes both is skipped in silence, and the script only complains when no package in the tree has a `test` target at all. The test named `a package with no test target is skipped, not failed` pins that permissiveness deliberately, because the many packages that legitimately define no `test` rule would otherwise turn every run red. Closing it needs an instrument keyed on the suite files rather than on the Makefile target, which is a separate change.

`hack/helm-unit-tests.bats` adds eight tests, picked up automatically by the `hack/*.bats` glob in `make unit-tests`. Three pin the new refusals, and each matches its own message so none can stay green on a refusal that came from another. Two pin what must not be refused: a phony target with a colliding path, and a sub-make reporting an unrelated target up to date. One pins that a chart which does run suites still passes, which is what stops the refusals being satisfied by rejecting everything. Two pin behaviour that was already there, namely that a failing package is still reported by name and that a package with no `test` rule is skipped rather than failed. That last one builds a tree carrying a second package that does run a suite: with only the target-less package present, the script takes an early exit above the failure summary and the assertion would hold whatever the script had done. The fixtures stub `make` output instead of invoking helm, so they need no plugin installed.

Relates to #3453.

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
fix(tests): `make helm-unit-tests` now fails a chart that runs no Helm unit test suites, instead of reporting success for a chart whose suite files were deleted, moved, or renamed out of the `tests/*_test.yaml` glob
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Helm test validation to detect skipped test recipes, zero discovered suites, and runs without evidence of a passing suite.
  * Helm test failures now provide clearer diagnostics, including affected directories and failed commands.
  * Test output is consistently captured and replayed for easier troubleshooting.

* **Tests**
  * Added comprehensive coverage for successful, failed, skipped, empty, and invalid Helm test scenarios.
  * Expanded coverage across package test targets, including phony and unrelated sub-make behavior.

* **Documentation**
  * Clarified requirements for package test targets and suite reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->