### PR TITLE
test(redis): add Helm unit coverage

### DIFF
--- a/packages/apps/redis/Makefile
+++ b/packages/apps/redis/Makefile
@@ -7,3 +7,6 @@ generate:
 update:
 	hack/update-versions.sh
 	make generate
+
+test:
+	helm unittest .

--- a/packages/apps/redis/tests/dashboard_test.yaml
+++ b/packages/apps/redis/tests/dashboard_test.yaml
@@ -1,4 +1,5 @@
 suite: Redis dashboard resources
+
 templates:
   - templates/dashboard-resourcemap.yaml
 
@@ -20,6 +21,22 @@ tests:
       - equal:
           path: metadata.name
           value: redis-test-dashboard-resources
+
+      - contains:
+          path: rules[0].resourceNames
+          content: rfs-redis-test
+
+      - contains:
+          path: rules[0].resourceNames
+          content: rfrm-redis-test
+
+      - contains:
+          path: rules[0].resourceNames
+          content: rfrs-redis-test
+
+      - contains:
+          path: rules[0].resourceNames
+          content: redis-test-external-lb
 
       - contains:
           path: rules[1].resourceNames

--- a/packages/apps/redis/tests/dashboard_test.yaml
+++ b/packages/apps/redis/tests/dashboard_test.yaml
@@ -1,0 +1,51 @@
+suite: Redis dashboard resources
+templates:
+  - templates/dashboard-resourcemap.yaml
+
+release:
+  name: redis-test
+  namespace: tenant-test
+
+tests:
+  - it: renders dashboard RBAC resources
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: renders dashboard Role
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - equal:
+          path: metadata.name
+          value: redis-test-dashboard-resources
+
+      - contains:
+          path: rules[1].resourceNames
+          content: redis-test-auth
+
+      - contains:
+          path: rules[2].resourceNames
+          content: redis-test-redis
+
+      - contains:
+          path: rules[2].resourceNames
+          content: redis-test-sentinel
+
+  - it: renders dashboard RoleBinding
+    documentSelector:
+      path: kind
+      value: RoleBinding
+    asserts:
+      - equal:
+          path: metadata.name
+          value: redis-test-dashboard-resources
+
+      - equal:
+          path: roleRef.name
+          value: redis-test-dashboard-resources
+
+      - equal:
+          path: roleRef.kind
+          value: Role

--- a/packages/apps/redis/tests/monitoring_test.yaml
+++ b/packages/apps/redis/tests/monitoring_test.yaml
@@ -1,0 +1,51 @@
+suite: Redis monitoring
+templates:
+  - templates/servicescrape.yaml
+
+release:
+  name: redis-test
+  namespace: tenant-test
+
+tests:
+  - it: renders monitoring resources
+    asserts:
+      - hasDocuments:
+          count: 2
+
+  - it: renders VMServiceScrape
+    documentSelector:
+      path: kind
+      value: VMServiceScrape
+    asserts:
+      - equal:
+          path: metadata.name
+          value: redis-test
+
+      - equal:
+          path: spec.namespaceSelector.matchNames[0]
+          value: tenant-test
+
+      - equal:
+          path: spec.endpoints[0].port
+          value: metrics
+
+  - it: renders metrics service
+    documentSelector:
+      path: kind
+      value: Service
+    asserts:
+      - equal:
+          path: metadata.name
+          value: redis-test-metrics
+
+      - equal:
+          path: spec.ports[0].name
+          value: metrics
+
+      - equal:
+          path: spec.ports[0].port
+          value: 9121
+
+      - equal:
+          path: spec.ports[0].targetPort
+          value: metrics

--- a/packages/apps/redis/tests/monitoring_test.yaml
+++ b/packages/apps/redis/tests/monitoring_test.yaml
@@ -1,4 +1,5 @@
 suite: Redis monitoring
+
 templates:
   - templates/servicescrape.yaml
 
@@ -29,6 +30,10 @@ tests:
           path: spec.endpoints[0].port
           value: metrics
 
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: redis-test-metrics
+
   - it: renders metrics service
     documentSelector:
       path: kind
@@ -37,6 +42,17 @@ tests:
       - equal:
           path: metadata.name
           value: redis-test-metrics
+
+      - equal:
+          path: metadata.labels.app
+          value: redis-test-metrics
+
+      - equal:
+          path: spec.selector
+          value:
+            app.kubernetes.io/component: redis
+            app.kubernetes.io/name: redis-test
+            app.kubernetes.io/part-of: redis-failover
 
       - equal:
           path: spec.ports[0].name

--- a/packages/apps/redis/tests/redisfailover_test.yaml
+++ b/packages/apps/redis/tests/redisfailover_test.yaml
@@ -1,0 +1,135 @@
+suite: Redis failover
+templates:
+  - templates/redisfailover.yaml
+
+release:
+  name: redis-test
+  namespace: tenant-test
+
+tests:
+  - it: renders all default Redis resources
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: renders RedisFailover with default values
+    documentSelector:
+      path: kind
+      value: RedisFailover
+    asserts:
+      - equal:
+          path: metadata.name
+          value: redis-test
+
+      - equal:
+          path: spec.redis.replicas
+          value: 2
+
+      - equal:
+          path: spec.sentinel.replicas
+          value: 3
+
+      - equal:
+          path: spec.redis.storage.persistentVolumeClaim.spec.resources.requests.storage
+          value: 1Gi
+
+      - equal:
+          path: spec.redis.auth.secretPath
+          value: redis-test-auth
+
+  - it: renders authentication secret by default
+    documentSelector:
+      path: metadata.name
+      value: redis-test-auth
+    asserts:
+      - isKind:
+          of: Secret
+
+      - exists:
+          path: data.password
+
+  - it: renders Redis workload monitor
+    documentSelector:
+      path: metadata.name
+      value: redis-test-redis
+    asserts:
+      - isKind:
+          of: WorkloadMonitor
+
+      - equal:
+          path: spec.replicas
+          value: 2
+
+      - equal:
+          path: spec.minReplicas
+          value: 1
+
+      - equal:
+          path: spec.kind
+          value: redis
+
+      - equal:
+          path: spec.type
+          value: redis
+
+  - it: renders Sentinel workload monitor
+    documentSelector:
+      path: metadata.name
+      value: redis-test-sentinel
+    asserts:
+      - isKind:
+          of: WorkloadMonitor
+
+      - equal:
+          path: spec.replicas
+          value: 3
+
+      - equal:
+          path: spec.minReplicas
+          value: 2
+
+      - equal:
+          path: spec.kind
+          value: redis
+
+      - equal:
+          path: spec.type
+          value: sentinel
+
+  - it: applies custom replica and storage values
+    set:
+      replicas: 4
+      size: 10Gi
+      storageClass: fast
+    documentSelector:
+      path: kind
+      value: RedisFailover
+    asserts:
+      - equal:
+          path: spec.redis.replicas
+          value: 4
+
+      - equal:
+          path: spec.redis.storage.persistentVolumeClaim.spec.resources.requests.storage
+          value: 10Gi
+
+      - equal:
+          path: spec.redis.storage.persistentVolumeClaim.spec.storageClassName
+          value: fast
+
+  - it: does not render authentication secret when auth is disabled
+    set:
+      authEnabled: false
+    asserts:
+      - hasDocuments:
+          count: 3
+
+  - it: removes Redis authentication configuration when auth is disabled
+    set:
+      authEnabled: false
+    documentSelector:
+      path: kind
+      value: RedisFailover
+    asserts:
+      - notExists:
+          path: spec.redis.auth

--- a/packages/apps/redis/tests/redisfailover_test.yaml
+++ b/packages/apps/redis/tests/redisfailover_test.yaml
@@ -34,7 +34,7 @@ tests:
           value: 1Gi
 
       - equal:
-          path: spec.redis.auth.secretPath
+          path: spec.auth.secretPath
           value: redis-test-auth
 
   - it: renders authentication secret by default
@@ -132,4 +132,4 @@ tests:
       value: RedisFailover
     asserts:
       - notExists:
-          path: spec.redis.auth
+          path: spec.auth

--- a/packages/apps/redis/tests/service_test.yaml
+++ b/packages/apps/redis/tests/service_test.yaml
@@ -1,0 +1,43 @@
+suite: Redis external service
+templates:
+  - templates/service.yaml
+
+release:
+  name: redis-test
+  namespace: tenant-test
+
+tests:
+  - it: does not render external service by default
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders a LoadBalancer service when external access is enabled
+    set:
+      external: true
+    asserts:
+      - hasDocuments:
+          count: 1
+
+      - isKind:
+          of: Service
+
+      - equal:
+          path: metadata.name
+          value: redis-test-external-lb
+
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+
+      - equal:
+          path: spec.externalTrafficPolicy
+          value: Local
+
+      - equal:
+          path: spec.ports[0].port
+          value: 6379
+
+      - equal:
+          path: spec.ports[0].targetPort
+          value: redis


### PR DESCRIPTION
## What this PR does

Part of #3631.

Adds Helm unit test coverage for the Redis application chart and adds the standard `test: helm unittest .` target to the Redis Makefile.

The tests cover:

* RedisFailover default configuration
* Redis and Sentinel WorkloadMonitors
* Authentication Secret behavior
* Replica and storage configuration
* External LoadBalancer Service behavior
* Monitoring resources
* Dashboard RBAC resources

I was unable to run the Helm unit tests locally due to issues setting up the required testing environment/tooling.

I reviewed the test definitions and the existing Redis chart templates manually. The changes are ready for CI validation, and I can address any failures or requested adjustments.

Screenshots

Not applicable — test-only change.

Downstream repositories

* [x] No downstream repository is affected by this change
* [ ] https://github.com/cozystack/website - follow-up:
* [ ] https://github.com/cozystack/terraform-provider-cozystack - follow-up:
* [ ] https://github.com/cozystack/ansible-cozystack - follow-up:
* [ ] https://github.com/cozystack/ccp - follow-up:
* [ ] https://github.com/cozystack/talm - follow-up:
* [ ] https://github.com/cozystack/cozyhr - follow-up:
* [ ] https://github.com/cozystack/cozy-proxy - follow-up:
* [ ] https://github.com/cozystack/cozystack-telemetry-server - follow-up:
* [ ] https://github.com/cozystack/external-apps-example - follow-up:
* [ ] https://github.com/cozystack/examples - follow-up:

### Release note

release-note
Test-only change. Adds Helm unit test coverage for the Redis application chart.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated validation for Redis dashboard, monitoring, failover, and service resources.
  * Added coverage for authentication, replica and storage settings, workload monitoring, and external access configurations.
  * Added a command to run the Redis Helm chart test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->