### PR TITLE
test(tenant, harbor, seaweedfs, api): anchor guards that pass on a missing document

### DIFF
--- a/packages/apps/harbor/tests/cleanup_hook_test.yaml
+++ b/packages/apps/harbor/tests/cleanup_hook_test.yaml
@@ -8,13 +8,22 @@ release:
 
 # The cleanup hook scopes its ACME solver sweep to this release's TLS host,
 # which defaults to "<release>.<_namespace.host>".
+#
+# The template renders a Job, a ServiceAccount, a Role and a RoleBinding, each
+# unique by kind, so every test names the one it wants instead of counting
+# positions. Document indices are assigned in template source order rather than
+# the kind-sorted order `helm template` prints, which makes them easy to get
+# wrong by reading the rendered output, and a document added ahead silently
+# shifts every later index onto the wrong object.
 set:
   _namespace:
     host: example.org
 
 tests:
   - it: renders the cleanup Job as a post-delete hook
-    documentIndex: 0
+    documentSelector:
+      path: kind
+      value: Job
     asserts:
       - equal:
           path: kind
@@ -30,7 +39,9 @@ tests:
           value: harbor-test-cleanup
 
   - it: targets both kept PVCs (jobservice + trivy) via the shared release label and ACME objects
-    documentIndex: 0
+    documentSelector:
+      path: kind
+      value: Job
     asserts:
       # The upstream Harbor subchart runs as the "<release>-system"
       # HelmRelease. Its kept PVCs must be selected by release=<release>-system:
@@ -50,7 +61,9 @@ tests:
           pattern: harbor-test-ingress-tls
 
   - it: scopes the ACME solver sweep to this release's TLS host
-    documentIndex: 0
+    documentSelector:
+      path: kind
+      value: Job
     asserts:
       # The solver sweep must be scoped to this release's host, not a
       # namespace-wide label sweep, so sibling apps' in-flight challenges in
@@ -75,7 +88,9 @@ tests:
           pattern: kubectl delete[^\n]*-l acme.cert-manager.io/http01-solver=true
 
   - it: pins the cleanup image by digest and routes it through the images registry
-    documentIndex: 0
+    documentSelector:
+      path: kind
+      value: Job
     asserts:
       # The image must be digest-pinned (immutable) rather than a moving tag,
       # and must NOT hardcode docker.io so a mirrored/air-gapped registry can be
@@ -89,7 +104,9 @@ tests:
           pattern: docker\.io
 
   - it: prefixes the cleanup image with the cluster images registry when set
-    documentIndex: 0
+    documentSelector:
+      path: kind
+      value: Job
     set:
       _cluster:
         images-registry: registry.example.com
@@ -101,7 +118,9 @@ tests:
           pattern: ^registry\.example\.com/clastix/kubectl:v[0-9]+\.[0-9]+(\.[0-9]+)?@sha256:[0-9a-f]{64}$
 
   - it: leaves no leading slash when the images registry is empty (default)
-    documentIndex: 0
+    documentSelector:
+      path: kind
+      value: Job
     asserts:
       # With images-registry defaulting to "", the rendered ref must still be a
       # valid image reference (no leading "/") so a standard install resolves it.
@@ -114,7 +133,9 @@ tests:
           pattern: ^/
 
   - it: does not emit a double slash when the images registry has a trailing slash
-    documentIndex: 0
+    documentSelector:
+      path: kind
+      value: Job
     set:
       _cluster:
         images-registry: registry.example.com/
@@ -129,7 +150,9 @@ tests:
           pattern: //
 
   - it: sets resource requests and limits on the cleanup container
-    documentIndex: 0
+    documentSelector:
+      path: kind
+      value: Job
     asserts:
       - equal:
           path: spec.template.spec.containers[0].resources.requests.cpu
@@ -145,7 +168,9 @@ tests:
           value: 128Mi
 
   - it: creates a ServiceAccount for the cleanup job
-    documentIndex: 1
+    documentSelector:
+      path: kind
+      value: ServiceAccount
     asserts:
       - equal:
           path: kind
@@ -155,7 +180,9 @@ tests:
           value: harbor-test-cleanup
 
   - it: grants RBAC for PVCs and cert-manager ACME resources
-    documentIndex: 2
+    documentSelector:
+      path: kind
+      value: Role
     asserts:
       - equal:
           path: kind
@@ -214,7 +241,9 @@ tests:
             verbs: ["get", "list", "delete"]
 
   - it: binds the Role to the cleanup ServiceAccount
-    documentIndex: 3
+    documentSelector:
+      path: kind
+      value: RoleBinding
     asserts:
       - equal:
           path: kind

--- a/packages/apps/harbor/tests/jobservice_storageclass_test.yaml
+++ b/packages/apps/harbor/tests/jobservice_storageclass_test.yaml
@@ -11,8 +11,12 @@ release:
 # class when one is found; under `helm template`/unittest the cluster lookup
 # returns empty, so these cases exercise the fresh-install fallback path.
 #
-# The rendered HelmRelease (documentIndex 1) carries the values that the
-# cozy-harbor chart forwards to the upstream harbor subchart.
+# The rendered HelmRelease carries the values that the cozy-harbor chart forwards
+# to the upstream harbor subchart. templates/harbor.yaml also renders a Secret and
+# three WorkloadMonitors, so the release is selected by kind rather than by
+# document index: a template gaining a document ahead of it moves the index onto
+# another object, and a selector that matches nothing fails loudly instead of
+# quietly asserting against the wrong document.
 # helm-unittest renders every template in the chart, so the platform-injected
 # globals consumed by the ingress/httproute/bucket templates must be supplied
 # even though only templates/harbor.yaml is asserted on.
@@ -28,7 +32,9 @@ set:
 tests:
   - it: forwards storageClass to jobservice jobLog on a fresh install
     template: templates/harbor.yaml
-    documentIndex: 1
+    documentSelector:
+      path: kind
+      value: HelmRelease
     set:
       storageClass: local-3rep
     asserts:
@@ -38,7 +44,9 @@ tests:
 
   - it: still forwards storageClass to trivy alongside jobservice
     template: templates/harbor.yaml
-    documentIndex: 1
+    documentSelector:
+      path: kind
+      value: HelmRelease
     set:
       storageClass: local-3rep
     asserts:
@@ -48,14 +56,18 @@ tests:
 
   - it: omits the jobservice block when storageClass is unset
     template: templates/harbor.yaml
-    documentIndex: 1
+    documentSelector:
+      path: kind
+      value: HelmRelease
     asserts:
       - notExists:
           path: spec.values.harbor.persistence.persistentVolumeClaim.jobservice
 
   - it: emits no persistentVolumeClaim block when storageClass is unset and trivy is disabled
     template: templates/harbor.yaml
-    documentIndex: 1
+    documentSelector:
+      path: kind
+      value: HelmRelease
     set:
       trivy:
         enabled: false

--- a/packages/apps/tenant/tests/no_upgrade_force_test.yaml
+++ b/packages/apps/tenant/tests/no_upgrade_force_test.yaml
@@ -1,12 +1,31 @@
-suite: tenant HelmReleases carry no deprecated upgrade.force
+suite: tenant HelmReleases set no upgrade.force
 
-# Flux v2.8 / helm-controller v1.5 deprecates `upgrade.force: true` and rejects
-# it under Server-Side Apply. The flux-bump PR swept the flag off every tenant
-# HelmRelease; gateway.yaml was missed in the first pass. This suite pins the
-# invariant across all swept HRs so a stray `force: true` cannot creep back in.
+# Every tenant HelmRelease was swept clear of `upgrade.force`, and this suite pins
+# that it stays off. gateway.yaml was missed in the first pass, which is why the
+# cover is per-template rather than one spot check.
+#
+# helm-controller does not deprecate this field. Flux is pinned at 2.8.x in
+# packages/system/fluxcd/values.yaml, and the CRD vendored at
+# internal/fluxinstall/manifests/fluxcd.yaml describes force as "Force forces
+# resource updates through a replacement strategy" with no deprecation marker —
+# `recreate` is the neighbouring field that carries one. Later upstream
+# documentation adds that force "is ignored for server-side apply (which always
+# forces conflicts with other field managers)"; that sentence is not in the
+# pinned CRD, so do not go looking for it there. Either way the flag is a no-op
+# under SSA, and under client-side apply it replaces resources rather than
+# patching them, which is the downtime the sweep removed.
+#
+# Each test pins the HelmRelease name before asserting the absence, because
+# `notExists` on its own is vacuous: it passes on a template that renders no
+# document at all. Rename the value gating one of these releases and it renders
+# nothing, leaving the bare assertion green while the release it guards is gone.
 
-# Restrict rendering to the swept HelmRelease templates so the chart's
-# namespace.yaml `lookup` (which errors under helm-unittest) is not evaluated.
+# Render only the swept templates. The earlier reason given here — that
+# namespace.yaml's `lookup` errors under helm-unittest — is not true; it returns
+# empty offline and the template renders, which is what its own header says and
+# what tests/namespace_ancestor_labels_test.yaml relies on. The list stays for a
+# different reason: it keeps an unrelated template breaking out of this suite's
+# result, so what reddens here is the flag it guards.
 templates:
   - templates/etcd.yaml
   - templates/info.yaml
@@ -14,6 +33,7 @@ templates:
   - templates/monitoring.yaml
   - templates/seaweedfs.yaml
   - templates/gateway.yaml
+  - templates/computeplane.yaml
 
 release:
   name: tenant-test
@@ -29,11 +49,16 @@ set:
   monitoring: true
   seaweedfs: true
   gateway: true
+  computeplane: true
   host: ""
 
 tests:
   - it: etcd HR has no upgrade.force
     asserts:
+      - template: templates/etcd.yaml
+        equal:
+          path: metadata.name
+          value: etcd
       - template: templates/etcd.yaml
         notExists:
           path: spec.upgrade.force
@@ -41,11 +66,19 @@ tests:
   - it: info HR has no upgrade.force
     asserts:
       - template: templates/info.yaml
+        equal:
+          path: metadata.name
+          value: info
+      - template: templates/info.yaml
         notExists:
           path: spec.upgrade.force
 
   - it: ingress HR has no upgrade.force
     asserts:
+      - template: templates/ingress.yaml
+        equal:
+          path: metadata.name
+          value: ingress
       - template: templates/ingress.yaml
         notExists:
           path: spec.upgrade.force
@@ -53,11 +86,19 @@ tests:
   - it: monitoring HR has no upgrade.force
     asserts:
       - template: templates/monitoring.yaml
+        equal:
+          path: metadata.name
+          value: monitoring
+      - template: templates/monitoring.yaml
         notExists:
           path: spec.upgrade.force
 
   - it: seaweedfs HR has no upgrade.force
     asserts:
+      - template: templates/seaweedfs.yaml
+        equal:
+          path: metadata.name
+          value: seaweedfs
       - template: templates/seaweedfs.yaml
         notExists:
           path: spec.upgrade.force
@@ -65,5 +106,19 @@ tests:
   - it: gateway HR has no upgrade.force
     asserts:
       - template: templates/gateway.yaml
+        equal:
+          path: metadata.name
+          value: gateway
+      - template: templates/gateway.yaml
+        notExists:
+          path: spec.upgrade.force
+
+  - it: computeplane HR has no upgrade.force
+    asserts:
+      - template: templates/computeplane.yaml
+        equal:
+          path: metadata.name
+          value: computeplane
+      - template: templates/computeplane.yaml
         notExists:
           path: spec.upgrade.force

--- a/packages/extra/seaweedfs/tests/cleanup_client_test.yaml
+++ b/packages/extra/seaweedfs/tests/cleanup_client_test.yaml
@@ -34,14 +34,20 @@ tests:
       path: kind
       value: Role
     asserts:
-      - notContains:
-          path: rules
-          content:
-            apiGroups: ["postgresql.cnpg.io"]
-            resources: ["clusters"]
-            verbs: ["get", "delete"]
-            resourceNames:
-              - seaweedfs-db
+      # Bound the Role by shape instead of naming one spelling of the forbidden
+      # rule. A Client renders exactly two rules, both in the core group. The
+      # cnpg grant is gated between them in the template, so ungating it adds a
+      # third rule whatever its spelling — other verbs, a wildcard resource, a
+      # different resourceNames list — and rules[2] exists. The rules themselves
+      # are left unpinned because the secret list is long and churns on its own.
+      - equal:
+          path: rules[0].apiGroups
+          value: [""]
+      - equal:
+          path: rules[1].apiGroups
+          value: [""]
+      - notExists:
+          path: rules[2]
 
   - it: does not delete any database in a Client instance's cleanup command
     set: *client

--- a/packages/system/cozystack-api/tests/rbac_test.yaml
+++ b/packages/system/cozystack-api/tests/rbac_test.yaml
@@ -13,6 +13,17 @@ release:
 # forbidden and List silently drops those dropdowns (Get returns 500). The
 # bare cozystack.io grant does NOT cover backups.cozystack.io — RBAC matches
 # the API group string exactly.
+#
+# The last two tests bound the role from two directions, and neither covers the
+# other. The count bound pins the list at exactly sixteen: templates/rbac.yaml
+# carries no template directives, so anything appended makes rules[16] exist and
+# anything dropped takes rules[15] away, whatever the rule is called. It says
+# nothing about a grant swapped in for an existing one, because the count does
+# not move under a swap. The spelling assert catches that case for the one rule
+# it names, and misses every other wording of it, because helm-unittest compares
+# each field it is handed by value equality and `any: true` only selects which
+# fields are compared. Changing the rule count on purpose means moving both
+# indices below, which is the review this role should get.
 
 tests:
   - it: grants read on backups.cozystack.io plans and backups for the plan/backup providers
@@ -24,6 +35,15 @@ tests:
             resources: ["backupclasses", "plans", "backups"]
             verbs: ["get", "watch", "list"]
 
+  - it: grants full access on cilium.io ciliumnetworkpolicies for SecurityGroup storage
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["cilium.io"]
+            resources: ["ciliumnetworkpolicies"]
+            verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+
   - it: does not grant objectstorage.k8s.io bucketclasses (no provider reads it)
     asserts:
       - notContains:
@@ -33,11 +53,11 @@ tests:
             resources: ["bucketclasses"]
             verbs: ["get", "watch", "list"]
 
-  - it: grants full access on cilium.io ciliumnetworkpolicies for SecurityGroup storage
+  - it: ships exactly the sixteen rules this role is pinned to
     asserts:
-      - contains:
-          path: rules
-          content:
-            apiGroups: ["cilium.io"]
-            resources: ["ciliumnetworkpolicies"]
-            verbs: ["get", "watch", "list", "create", "update", "patch", "delete"]
+      # Both directions. A dropped grant is the failure this suite is about:
+      # the apiserver returns forbidden and List silently drops the dropdown.
+      - exists:
+          path: rules[15]
+      - notExists:
+          path: rules[16]


### PR DESCRIPTION
## What this PR does

Five helm-unittest suites asserted things that stayed green when the thing they guard disappeared. No chart or template logic changes here — only the tests, and each fix is measured in both directions.

**tenant `no_upgrade_force_test.yaml`.** Every test asserted `notExists: spec.upgrade.force` and nothing else. A `notExists` passes on a template that renders no document at all, so renaming the value that gates one of these releases leaves its test green while the release it guards is gone. Measured on `etcd.yaml`: with the gate renamed, the suite reported 6 passed and a sibling suite's `equal` was the only thing in the chart that noticed. Each test now pins the HelmRelease name alongside the absence.

The same file also covers `computeplane.yaml` now. Seven templates in this chart render a HelmRelease and the list held six; the module landed after the suite was written. The invariant holds there today, so this closes an unguarded template rather than a live regression. That is the gap that produced this suite in the first place, when the first sweep missed `gateway.yaml`.

Two rationales in that header were wrong and are corrected. The template list was said to be there because `namespace.yaml`'s `lookup` errors under helm-unittest; it does not, it returns empty offline and the template renders, which is what `namespace.yaml`'s own header says and what `namespace_ancestor_labels_test.yaml` relies on. Removing the whole list leaves the chart's suites passing, so the list stays for the reason that actually applies. And helm-controller does not deprecate `upgrade.force`: the CRD vendored at `internal/fluxinstall/manifests/fluxcd.yaml`, which is what the pinned Flux 2.8.x ships, describes it as a replacement strategy with no deprecation marker. `recreate` is the neighbouring field that carries one.

**harbor, both suites.** Both addressed their subject by document index. An index is a position, so a template that gains a document ahead of the one under test moves every later assertion onto a different object. Measured by inserting one document at the head of each template: the cleanup suite reddens outright, while two of the four jobservice tests keep passing: the two `notExists` ones, satisfied against an object that never had the path. Every document these suites assert on is unique by kind within its template, so each test now names its subject. A selector that matches nothing fails loudly, including on the `notExists` tests.

Indices are also easy to get wrong by hand: helm-unittest numbers documents in template source order while `helm template` prints them sorted by kind, so the rendered output is not the order being counted.

**seaweedfs and cozystack-api.** Both forbade a rule by naming it in full, and helm-unittest compares every field it is handed by value equality, so one respelling walks past. For seaweedfs that is not theoretical: ungating the cnpg block and adding a verb to the rule is the same grant and more, and the guard stayed green while a Client instance held delete on another app's Postgres cluster. The Role is now bounded by shape. A Client renders exactly two rules, both in the core group, and the cnpg grant is gated between them, so ungating it adds a third whatever its spelling.

For cozystack-api the count bound sits beside the existing named-rule assert rather than replacing it. Neither covers the other: `templates/rbac.yaml` carries no template directives, so the list is pinned at exactly sixteen rules from both sides, while a grant swapped in for an existing one leaves the count where it was and only the named-rule assert sees it. Measured on all three: append, delete, and swap.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map against the diff. It touches five files, all under `packages/*/*/tests/`, and no chart, template, values file or tooling. Nothing in the map keys on test files.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved validation of rendered Kubernetes resources across Harbor, tenant, SeaweedFS, and system API configurations.
  - Tests now identify resources by kind and relevant properties, making checks more reliable when rendered document ordering changes.
  - Expanded coverage for tenant upgrade settings, compute plane resources, storage class propagation, cleanup permissions, and network policy access.
  - Added stricter assertions for expected resource counts, names, rules, and omitted settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->