### PR TITLE
fix(hack): arm cozytest cluster captures for e2e suites only

### DIFF
--- a/hack/cozytest-capture-gate.bats
+++ b/hack/cozytest-capture-gate.bats
@@ -1,0 +1,145 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Behavioural tests for the cluster-capture gate in hack/cozytest.sh.
+#
+# The runner arms its on-failure cluster captures from an EXIT trap. Those
+# captures belong to the e2e suites, which run against a live cluster; a unit
+# suite has no cluster to snapshot, so arming them there buys an empty capture
+# and pays the capture's timeouts for it. The gate therefore keys on which kind
+# of suite is running rather than on whether a kubectl binary happens to be
+# installed, because a unit runner has the binary and no cluster.
+#
+# Both directions are asserted, and they share one fixture generator that
+# differs only in the fixture's filename. That pairing is the point: the
+# unit-side assertion is a negative one, and a negative assertion passes just as
+# well when the harness is broken and nothing ran at all. The e2e-side test is
+# the positive control for exactly that failure, and the unit-side test
+# additionally pins that the run did fail, so "no captures" cannot be satisfied
+# by "no test".
+#
+# The stub kubectl is what makes this a real test of the gate: with no kubectl
+# on PATH every capture leg is skipped for a second reason and both directions
+# would agree for the wrong cause.
+#
+# awk-transform constraint (hack/cozytest.sh rewrites this file before sourcing
+# it): it turns any line beginning `@test "` into a function header, and any
+# line that is exactly `}` into `return 0` plus the brace. Neither rule knows
+# what a heredoc is. So a fixture written as a heredoc here has its own `@test`
+# line harvested into THIS suite: the runner registers a phantom extra test,
+# runs it first, and the fixture's `false` ends the run before any real test
+# executes. Checked by building that variant rather than reasoned about -- it
+# fails loudly rather than silently, but it fails the wrong thing, and the gate
+# is then covered by nothing. The fixtures are built with printf, which puts the
+# `@test` text inside a format string where no rule matches it.
+#
+# Title syntax constraints (also inherited from that parser):
+#   - Titles delimited by ASCII double quotes; embedded quotes truncate.
+#   - Only [A-Za-z0-9] from the title survives into the function name, so keep
+#     titles distinctive in their alphanumeric run.
+#
+# Run with: hack/cozytest.sh hack/cozytest-capture-gate.bats
+# -----------------------------------------------------------------------------
+
+HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
+RUNNER="$HACK_DIR/cozytest.sh"
+
+# Marker printed by the runner's data-plane capture leg. Chosen as one probe
+# because the runner echoes it before invoking the capture, so the assertion
+# reads the gate's decision rather than the capture's outcome.
+DATAPLANE_MARKER='capturing host->pod data-plane'
+
+# The gate covers three legs, and each leaves a distinct artefact under the
+# snapshot directory. Pinning all three from the report tree is what keeps any
+# one of them from being ungated without a test noticing: the echo above covers
+# only the data-plane leg, and the crust-gather leg is the one whose cost is
+# worst, since it needs no reachable cluster to fire, only an ambient
+# KUBECONFIG.
+assert_legs_armed() {
+  _rdir=$1 _name=$2
+  [ -f "$_rdir/snapshots/$_name/crust-gather.log" ]
+  [ -d "$_rdir/snapshots/$_name/dataplane" ]
+  [ -f "$_rdir/snapshots/$_name/previous-logs/capture-notes.txt" ]
+}
+
+assert_legs_disarmed() {
+  _rdir=$1 _name=$2
+  for _leg in crust-gather.log dataplane previous-logs; do
+    if [ -e "$_rdir/snapshots/$_name/$_leg" ]; then
+      echo "cluster capture leg $_leg fired for a unit suite"
+      exit 1
+    fi
+  done
+}
+
+# Build a scratch dir holding stub cluster tools and a single-test fixture whose
+# test fails. $1 is the fixture's path relative to the scratch dir, which is the
+# only thing that differs between the directions under test.
+#
+# Both kubectl and crust-gather are stubbed, and crust-gather is not optional:
+# the runner invokes it directly rather than through a script that needs
+# kubectl output first, so a kubectl-only stub leaves that leg reaching for the
+# real binary against the ambient KUBECONFIG. On a machine that has both -- a
+# maintainer's laptop, the e2e sandbox image -- `make unit-tests` would then
+# snapshot whatever cluster happens to be current, for up to the leg's 390s.
+# That is the same bill this change exists to stop paying.
+make_fixture_dir() {
+  _dir=$(mktemp -d)
+  mkdir -p "$_dir/bin" "$_dir/$(dirname "$1")"
+  for _tool in kubectl crust-gather; do
+    printf '#!/bin/sh\nexit 0\n' >"$_dir/bin/$_tool"
+    chmod +x "$_dir/bin/$_tool"
+  done
+  printf '@test "fixture fails on purpose" {\n  false\n}\n' >"$_dir/$1"
+  printf '%s' "$_dir"
+}
+
+# Run the runner against a fixture with the stub kubectl first on PATH and the
+# report directory redirected into the scratch dir, so a capture that does fire
+# writes there instead of into the worktree. The output goes to a file rather
+# than a variable on purpose: these suites run under `set -x`, and a variable
+# holding the fixture's output gets expanded into the trace of whatever command
+# reads it, printing the fixture's deliberate "Test failed" line into the job
+# log where it reads as a real failure.
+run_fixture() {
+  _fdir=$1 _fname=$2
+  PATH="$_fdir/bin:$PATH" COZY_REPORT_DIR="$_fdir/report" \
+    "$RUNNER" "$_fdir/$_fname" >"$_fdir/out" 2>&1 || true
+}
+
+@test "an e2e suite failing still arms the cluster captures" {
+  dir=$(make_fixture_dir e2e-gate-fixture.bats)
+  run_fixture "$dir" e2e-gate-fixture.bats
+  # Positive control for the negative assertion in the last test: same fixture,
+  # same stubs, e2e filename.
+  grep -qF "$DATAPLANE_MARKER" "$dir/out"
+  assert_legs_armed "$dir/report" e2e-gate-fixture
+  rm -rf "$dir"
+}
+
+@test "a live cluster suite under an e2e directory keeps its captures" {
+  # hack/e2e-apps/ holds suites whose own filenames carry no prefix. Matching
+  # the basename alone disarms them, which takes the captures away from a suite
+  # that runs against a real cluster and therefore has state worth capturing.
+  dir=$(make_fixture_dir e2e-apps/plain-named-suite.bats)
+  run_fixture "$dir" e2e-apps/plain-named-suite.bats
+  grep -qF "$DATAPLANE_MARKER" "$dir/out"
+  assert_legs_armed "$dir/report" plain-named-suite
+  rm -rf "$dir"
+}
+
+@test "a unit suite failing does not arm the cluster captures" {
+  dir=$(make_fixture_dir plain-gate-fixture.bats)
+  run_fixture "$dir" plain-gate-fixture.bats
+  # The run must have failed, or "no captures" would be satisfied by "no test".
+  grep -qF 'Test failed' "$dir/out"
+  # Spelled as an if rather than `! grep ...`: `set -e` is specified to ignore a
+  # command whose status is inverted with `!`, so the negated form would report
+  # success even when the marker is present, which is the whole thing this test
+  # exists to catch.
+  if grep -qF "$DATAPLANE_MARKER" "$dir/out"; then
+    echo "cluster captures were armed for a unit suite"
+    exit 1
+  fi
+  assert_legs_disarmed "$dir/report" plain-gate-fixture
+  rm -rf "$dir"
+}

--- a/hack/cozytest.sh
+++ b/hack/cozytest.sh
@@ -93,6 +93,52 @@ TMP_SH=$(mktemp) || { echo "Failed to create temp file" >&2; exit 1; }
 # forward — so a test that creates tenant clusters (run-kubernetes.sh) captures
 # them from its OWN in-subshell EXIT trap, while the forward is still alive.
 COZY_REPORT_DIR="${COZY_REPORT_DIR:-_out/cozyreport}"
+# Which suites get the cluster captures below. They read cluster state, so they
+# belong to the e2e suites and to nothing else. `command -v kubectl` does not
+# tell the two apart: a unit runner has the binary and no cluster, so a red unit
+# test used to walk into the legs below on its way out.
+#
+# What that costs depends on how kubectl fails. Against an endpoint that refuses
+# immediately it is a second; against one that hangs -- an unreachable address, a
+# context left pointing at a torn-down cluster -- it was measured at ~28s for the
+# previous-logs leg, which self-bounds its pod list and so never reaches the 300s
+# ceiling set below it, plus the full 600s for the data-plane leg, whose first
+# pod list carries no bound of its own. Ten minutes of dead waiting inside a job
+# budget, for a failure that should cost seconds.
+#
+# Where crust-gather is installed as well the bill stops being empty and starts
+# being wrong: that leg does not need a reachable cluster to be pointless, it
+# needs an ambient KUBECONFIG, and it will spend up to 360s snapshotting whatever
+# cluster the current context happens to name.
+#
+# The discriminator is the e2e- prefix, on the suite's own name or on the
+# directory holding it. At the top level the prefix is what the project already
+# sorts on: the Makefile builds BATS_UNIT_FILES as
+# $(filter-out hack/e2e-%.bats,$(wildcard hack/*.bats)), so a top-level e2e-*
+# suite is precisely one `make unit-tests` refuses to run and
+# packages/core/testing/Makefile runs against a live cluster instead.
+#
+# That wildcard is not recursive, so it says nothing about subdirectories, and
+# hack/e2e-apps/ holds live-cluster suites whose own filenames carry no prefix.
+# Matching the directory too keeps them armed; matching only the basename would
+# take the captures away from suites that need them, which is the opposite of
+# the fix. Neither test is a claim that every future live-cluster suite will be
+# named this way -- it is the only signal the runner has, and a suite placed
+# outside both shapes gets no captures.
+#
+# Deliberately not a reachability probe. Gating on "can I talk to an apiserver"
+# would disarm the captures in the case they exist for: a failing e2e run is
+# often one whose apiserver is degraded, and a probe answering "no" there would
+# skip the snapshot precisely when it is the evidence.
+case "$(basename "$TEST_FILE")" in
+  e2e-*) _cozy_cluster_captures=1 ;;
+  *)
+    case "$(basename "$(dirname "$TEST_FILE")")" in
+      e2e-*) _cozy_cluster_captures=1 ;;
+      *)     _cozy_cluster_captures=0 ;;
+    esac
+    ;;
+esac
 _cozy_on_exit() {
   _rc=$?
   if [ "$_rc" -ne 0 ]; then
@@ -107,7 +153,7 @@ _cozy_on_exit() {
     # per pod by default, so each further restart of a still-looping pod drops
     # the instance we are here to read — and the snapshot leg alone can hold the
     # trap for 390s. The other two captures read state that keeps.
-    if command -v kubectl >/dev/null 2>&1 && [ -x "$(dirname "$0")/e2e-capture-previous-logs.sh" ]; then
+    if [ "$_cozy_cluster_captures" -eq 1 ] && command -v kubectl >/dev/null 2>&1 && [ -x "$(dirname "$0")/e2e-capture-previous-logs.sh" ]; then
       _prev_rc=0
       timeout -k 30 300 "$(dirname "$0")/e2e-capture-previous-logs.sh" \
         "$_snap/previous-logs" "${COZY_TEST_NAMESPACE:-tenant-test}" 2>&1 || _prev_rc=$?
@@ -124,7 +170,7 @@ _cozy_on_exit() {
         echo "» previous-instance capture INCOMPLETE (exit $_prev_rc); kept what landed in $_snap/previous-logs"
       fi
     fi
-    if command -v crust-gather >/dev/null 2>&1; then
+    if [ "$_cozy_cluster_captures" -eq 1 ] && command -v crust-gather >/dev/null 2>&1; then
       echo "» capturing crust-gather snapshot of failed $(basename "$TEST_FILE") -> $_snap"
       # Bound with a timeout: crust-gather collect has hung indefinitely on a
       # contended/degraded cluster (e.g. streaming logs from a crashlooping pod),
@@ -163,7 +209,7 @@ _cozy_on_exit() {
     # capture is time-boxed and `|| true`, and the whole run is wrapped in a
     # wall-clock backstop so it cannot stall the job. It no-ops when there are no
     # affected pods or when kubectl/the tooling is absent.
-    if command -v kubectl >/dev/null 2>&1; then
+    if [ "$_cozy_cluster_captures" -eq 1 ] && command -v kubectl >/dev/null 2>&1; then
       echo "» capturing host->pod data-plane for NotReady pods -> $_snap/dataplane"
       timeout -k 30 600 "$(dirname "$0")/e2e-capture-dataplane.sh" "$_snap/dataplane" 2>&1 || true
     fi


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

`hack/cozytest.sh` arms three cluster captures from its on-failure EXIT trap, and gates each on a binary being installed rather than on there being a cluster to read. A unit runner has kubectl and no cluster, so a red unit test walked into those legs on its way out and paid for snapshots of nothing.

What that costs turns on how kubectl fails, which is why the defect survived: against an endpoint that refuses it is a second, and locally that is what happens. Against one that hangs, which is what a runner with a context pointing at a torn-down cluster has, I measured ~28s for the previous-logs leg and the full 600s for the data-plane one. The 28s is the leg self-bounding its own pod list, so it never reaches the 300s ceiling above it; the 600s is real, because that leg's first pod list carries no bound of its own. Ten minutes of dead waiting for a failure that should have cost seconds.

Where crust-gather is installed too, the bill stops being empty and starts being wrong. That leg needs no reachable cluster to fire, only an ambient KUBECONFIG, and it will spend up to 360s snapshotting whatever cluster the current context happens to name.

The gate now keys on the `e2e-` prefix, read from the suite's own name or from the directory holding it. At the top level that is the split the project already sorts on: the Makefile builds `BATS_UNIT_FILES` as `$(filter-out hack/e2e-%.bats,$(wildcard hack/*.bats))`, so a top-level `e2e-*` suite is exactly the one `make unit-tests` refuses to run and `packages/core/testing/Makefile` runs against a live cluster. That wildcard is not recursive, and `hack/e2e-apps/` holds live-cluster suites whose own filenames carry no prefix, so the directory is checked too. Matching the basename alone would take the captures away from suites that need them, which is the opposite of the point. Every leg, bound and message on the e2e path is unchanged.

It is deliberately not a reachability probe, though a probe would also tell a cluster from a bare binary. A failing e2e run is frequently one whose apiserver is degraded, and a probe answering "no" there would skip the snapshot in precisely the case the snapshot exists for. A diagnostic should not condition itself on the health of the thing it diagnoses.

The test drives the runner as a subprocess over fixtures that differ only in where they sit, with stub kubectl and crust-gather on PATH so neither direction is decided by a binary being absent. Each leg is pinned by the artefact it leaves in the report tree rather than by the one leg that echoes, so no single leg can be ungated without a test going red; that was checked by ungating each in turn. The two armed cases are the positive control for the disarmed one, whose assertion is negative and would otherwise pass just as well against a harness that ran nothing.

Relates to #3626.

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
fix(hack): cozytest.sh no longer arms its cluster-capture hooks for unit BATS suites, so a failing unit test fails fast instead of waiting out capture timeouts against a cluster that is not there
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster diagnostics are now collected only for end-to-end test suites.
  * Unit tests no longer trigger unnecessary Kubernetes or cluster-capture operations.
  * End-to-end suites nested under application directories are correctly recognized.
  * Diagnostic capture remains subject to existing tool availability and timeout checks.

* **Tests**
  * Added coverage verifying diagnostic artifacts are collected for end-to-end failures and omitted for unit-test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->