### PR TITLE
fix(cozy-lib): make the cozyconfig helpers survive uninjected values

### DIFF
--- a/packages/library/cozy-lib/templates/_cozyconfig.tpl
+++ b/packages/library/cozy-lib/templates/_cozyconfig.tpl
@@ -8,7 +8,7 @@ Get the root host for the cluster.
 Usage: {{ include "cozy-lib.root-host" . }}
 */}}
 {{- define "cozy-lib.root-host" -}}
-{{- (index .Values._cluster "root-host") | default "" }}
+{{- (index (.Values._cluster | default dict) "root-host") | default "" }}
 {{- end }}
 
 {{/*
@@ -16,7 +16,7 @@ Get the bundle name for the cluster.
 Usage: {{ include "cozy-lib.bundle-name" . }}
 */}}
 {{- define "cozy-lib.bundle-name" -}}
-{{- (index .Values._cluster "bundle-name") | default "" }}
+{{- (index (.Values._cluster | default dict) "bundle-name") | default "" }}
 {{- end }}
 
 {{/*
@@ -53,7 +53,7 @@ Get the ipv4 cluster CIDR.
 Usage: {{ include "cozy-lib.ipv4-cluster-cidr" . }}
 */}}
 {{- define "cozy-lib.ipv4-cluster-cidr" -}}
-{{- (index .Values._cluster "ipv4-cluster-cidr") | default "" }}
+{{- (index (.Values._cluster | default dict) "ipv4-cluster-cidr") | default "" }}
 {{- end }}
 
 {{/*
@@ -61,7 +61,7 @@ Get the ipv4 service CIDR.
 Usage: {{ include "cozy-lib.ipv4-service-cidr" . }}
 */}}
 {{- define "cozy-lib.ipv4-service-cidr" -}}
-{{- (index .Values._cluster "ipv4-service-cidr") | default "" }}
+{{- (index (.Values._cluster | default dict) "ipv4-service-cidr") | default "" }}
 {{- end }}
 
 {{/*
@@ -69,7 +69,7 @@ Get the ipv4 join CIDR.
 Usage: {{ include "cozy-lib.ipv4-join-cidr" . }}
 */}}
 {{- define "cozy-lib.ipv4-join-cidr" -}}
-{{- (index .Values._cluster "ipv4-join-cidr") | default "" }}
+{{- (index (.Values._cluster | default dict) "ipv4-join-cidr") | default "" }}
 {{- end }}
 
 {{/*
@@ -78,8 +78,9 @@ Usage: {{ include "cozy-lib.scheduling" . }}
 Returns: YAML string of scheduling configuration
 */}}
 {{- define "cozy-lib.scheduling" -}}
-{{- if .Values._cluster.scheduling }}
-{{- .Values._cluster.scheduling | toYaml }}
+{{- $scheduling := (.Values._cluster | default dict).scheduling }}
+{{- if $scheduling }}
+{{- $scheduling | toYaml }}
 {{- end }}
 {{- end }}
 
@@ -89,8 +90,9 @@ Usage: {{ include "cozy-lib.branding" . }}
 Returns: YAML string of branding configuration
 */}}
 {{- define "cozy-lib.branding" -}}
-{{- if .Values._cluster.branding }}
-{{- .Values._cluster.branding | toYaml }}
+{{- $branding := (.Values._cluster | default dict).branding }}
+{{- if $branding }}
+{{- $branding | toYaml }}
 {{- end }}
 {{- end }}
 
@@ -104,7 +106,7 @@ Get the host for this namespace.
 Usage: {{ include "cozy-lib.ns-host" . }}
 */}}
 {{- define "cozy-lib.ns-host" -}}
-{{- .Values._namespace.host | default "" }}
+{{- (.Values._namespace | default dict).host | default "" }}
 {{- end }}
 
 {{/*
@@ -112,7 +114,7 @@ Get the etcd namespace reference.
 Usage: {{ include "cozy-lib.ns-etcd" . }}
 */}}
 {{- define "cozy-lib.ns-etcd" -}}
-{{- .Values._namespace.etcd | default "" }}
+{{- (.Values._namespace | default dict).etcd | default "" }}
 {{- end }}
 
 {{/*
@@ -120,7 +122,7 @@ Get the ingress namespace reference.
 Usage: {{ include "cozy-lib.ns-ingress" . }}
 */}}
 {{- define "cozy-lib.ns-ingress" -}}
-{{- .Values._namespace.ingress | default "" }}
+{{- (.Values._namespace | default dict).ingress | default "" }}
 {{- end }}
 
 {{/*
@@ -128,7 +130,7 @@ Get the monitoring namespace reference.
 Usage: {{ include "cozy-lib.ns-monitoring" . }}
 */}}
 {{- define "cozy-lib.ns-monitoring" -}}
-{{- .Values._namespace.monitoring | default "" }}
+{{- (.Values._namespace | default dict).monitoring | default "" }}
 {{- end }}
 
 {{/*
@@ -136,7 +138,7 @@ Get the seaweedfs namespace reference.
 Usage: {{ include "cozy-lib.ns-seaweedfs" . }}
 */}}
 {{- define "cozy-lib.ns-seaweedfs" -}}
-{{- .Values._namespace.seaweedfs | default "" }}
+{{- (.Values._namespace | default dict).seaweedfs | default "" }}
 {{- end }}
 
 {{/*

--- a/packages/tests/cozy-lib-tests/templates/tests/cozyconfig.yaml
+++ b/packages/tests/cozy-lib-tests/templates/tests/cozyconfig.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-cozyconfig
+data:
+  root-host: {{ include "cozy-lib.root-host" . | quote }}
+  bundle-name: {{ include "cozy-lib.bundle-name" . | quote }}
+  images-registry: {{ include "cozy-lib.images-registry" . | quote }}
+  ipv4-cluster-cidr: {{ include "cozy-lib.ipv4-cluster-cidr" . | quote }}
+  ipv4-service-cidr: {{ include "cozy-lib.ipv4-service-cidr" . | quote }}
+  ipv4-join-cidr: {{ include "cozy-lib.ipv4-join-cidr" . | quote }}
+  scheduling: {{ include "cozy-lib.scheduling" . | quote }}
+  branding: {{ include "cozy-lib.branding" . | quote }}
+  ns-host: {{ include "cozy-lib.ns-host" . | quote }}
+  ns-etcd: {{ include "cozy-lib.ns-etcd" . | quote }}
+  ns-ingress: {{ include "cozy-lib.ns-ingress" . | quote }}
+  ns-monitoring: {{ include "cozy-lib.ns-monitoring" . | quote }}
+  ns-seaweedfs: {{ include "cozy-lib.ns-seaweedfs" . | quote }}

--- a/packages/tests/cozy-lib-tests/tests/cozyconfig_test.yaml
+++ b/packages/tests/cozy-lib-tests/tests/cozyconfig_test.yaml
@@ -1,0 +1,81 @@
+# ./tests/cozyconfig_test.yaml
+suite: cozyconfig helpers survive an uninjected _cluster and _namespace
+
+templates:
+  - templates/tests/cozyconfig.yaml
+
+# `_cluster` and `_namespace` are injected by the platform through valuesFrom on
+# the cozystack-values Secret. A chart rendered on its own therefore has neither,
+# which is the state of `helm lint`, a plain `helm template`, and any suite that
+# does not set them. These helpers must degrade to their empty defaults there
+# rather than abort the render, because every consumer of this library inherits
+# whatever they do.
+
+tests:
+  - it: returns empty defaults when the platform injected nothing
+    # No `set:` at all: this is the uninjected state, and it needs no mocking.
+    asserts:
+      - equal: {path: 'data["root-host"]', value: ""}
+      - equal: {path: 'data["bundle-name"]', value: ""}
+      - equal: {path: 'data["images-registry"]', value: ""}
+      - equal: {path: 'data["ipv4-cluster-cidr"]', value: ""}
+      - equal: {path: 'data["ipv4-service-cidr"]', value: ""}
+      - equal: {path: 'data["ipv4-join-cidr"]', value: ""}
+      - equal: {path: 'data["scheduling"]', value: ""}
+      - equal: {path: 'data["branding"]', value: ""}
+      - equal: {path: 'data["ns-host"]', value: ""}
+      - equal: {path: 'data["ns-etcd"]', value: ""}
+      - equal: {path: 'data["ns-ingress"]', value: ""}
+      - equal: {path: 'data["ns-monitoring"]', value: ""}
+      - equal: {path: 'data["ns-seaweedfs"]', value: ""}
+
+  - it: returns the injected values unchanged when the platform did inject them
+    # The other half of the guard: making the helpers survive an absent map must
+    # not change what they return when the map is present.
+    set:
+      _cluster:
+        root-host: example.com
+        bundle-name: paas-full
+        images-registry: registry.example.com
+        ipv4-cluster-cidr: 10.244.0.0/16
+        ipv4-service-cidr: 10.96.0.0/16
+        ipv4-join-cidr: 100.64.0.0/16
+        scheduling:
+          nodeSelector:
+            node-role.kubernetes.io/worker: ""
+        branding:
+          logo:
+            light: /logos/light.svg
+      _namespace:
+        host: tenant.example.com
+        etcd: etcd-ns
+        ingress: ingress-ns
+        monitoring: monitoring-ns
+        seaweedfs: seaweedfs-ns
+    asserts:
+      - equal: {path: 'data["root-host"]', value: "example.com"}
+      - equal: {path: 'data["bundle-name"]', value: "paas-full"}
+      - equal: {path: 'data["images-registry"]', value: "registry.example.com"}
+      - equal: {path: 'data["ipv4-cluster-cidr"]', value: "10.244.0.0/16"}
+      - equal: {path: 'data["ipv4-service-cidr"]', value: "10.96.0.0/16"}
+      - equal: {path: 'data["ipv4-join-cidr"]', value: "100.64.0.0/16"}
+      - equal: {path: 'data["ns-host"]', value: "tenant.example.com"}
+      - equal: {path: 'data["ns-etcd"]', value: "etcd-ns"}
+      - equal: {path: 'data["ns-ingress"]', value: "ingress-ns"}
+      - equal: {path: 'data["ns-monitoring"]', value: "monitoring-ns"}
+      - equal: {path: 'data["ns-seaweedfs"]', value: "seaweedfs-ns"}
+      # scheduling and branding are the two helpers whose body was rewritten
+      # rather than wrapped, so they need the present-map half most. Their
+      # value is a whole YAML document, and it is pinned as one: a substring
+      # match here would survive the loss of the `toYaml` that produces it,
+      # because the key name also appears in Go's default map formatting.
+      - equal:
+          path: 'data["scheduling"]'
+          value: |-
+            nodeSelector:
+              node-role.kubernetes.io/worker: ""
+      - equal:
+          path: 'data["branding"]'
+          value: |-
+            logo:
+              light: /logos/light.svg


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

`_cluster` and `_namespace` reach a chart through valuesFrom on the cozystack-values Secret, so they are absent whenever a chart is rendered on its own: `helm lint`, a plain `helm template`, and any helm-unittest suite that does not set them. Twelve of the helpers in `_cozyconfig.tpl` read straight through the missing map and abort the render instead of returning the empty default they document.

Two spellings, one cause. `index .Values._cluster "root-host"` raises `index of untyped nil`; `.Values._namespace.host` raises `nil pointer evaluating interface {}.host`. In both, the trailing `| default ""` never runs, because it applies to the result and there is no result, only an error. That default covered a key missing from a map that exists, never a missing map.

The guard goes on the map, which is what `cozy-lib.images-registry` in this same file already did:

```
(index (.Values._cluster | default dict) "root-host") | default ""
```

`index` on an empty map returns nil harmlessly, so the trailing default applies as it always read, and with the map present `| default dict` returns it untouched.

**This fixes no chart that is failing today.** The charts that cannot render standalone read the injected values directly in their own templates rather than through these helpers, so a change to the library does not reach them; they are handled where they live. Worth being blunt about the same point from the other side: twelve of the thirteen helpers here currently have no callers anywhere in `packages/`. Only `cozy-lib.images-registry` is reached, from `cozy-lib.image`, and it was already guarded. The guard is still worth having on the rest, because they are the library's public surface, they are what a chart author copies when reaching for cluster configuration, and a broken spelling propagates by being read. `cozy-lib.image` is called from four templates, so these helpers do get adopted once they exist.

**Rendered output does not change, and that is measured rather than argued.** All 34 charts that symlink cozy-lib were rendered before and after, both with the injected values populated and with them set to empty maps, and every result is byte-identical. That check needs a control: the first comparison showed eight charts differing, which looks like a regression in a library change. Rendering the *unchanged* tree twice reproduces exactly those eight, because they generate passwords. Subtracting the control leaves zero real differences.

The suite lives in `cozy-lib-tests`, which is where library behaviour is pinned, since a library chart renders nothing of its own. One case covers the uninjected state, which needs no mocking because neither key appears in any values file, and one covers the injected state so the guard cannot quietly change what a populated map returns. The injected case pins `scheduling` and `branding` as whole YAML documents rather than by substring: those two had their bodies restructured rather than wrapped, and a substring assertion survives the loss of the `toYaml` that produces the document, because the key name also appears in Go's default map formatting. Against the unguarded helpers the first case fails with `index of untyped nil`.

Three things left deliberately undone, so they are not mistaken for oversights. The header comments in `_cozyconfig.tpl` say where these values come from but not what the helpers now do when they are absent, which is the contract this change creates and would be better stated next to the helpers than only in the suite. `Chart.yaml` in cozy-lib-tests still carries `name: quota` from when that chart covered one helper family, so the runner prints `### Chart [ quota ]` for a suite that now covers three. And the mixed state, one map injected and the other not, has no case of its own; the two guards are independent so composition covers it, and a third case would pin nothing new.

Relates to #3646.

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
fix(cozy-lib): the cozyconfig helpers now return their documented empty defaults when the platform has not injected `_cluster` / `_namespace`, instead of aborting the render, so a chart using them can be rendered and unit-tested on its own
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration handling when cluster or namespace settings are missing, preventing template rendering errors.
  - Preserved existing configuration values for scheduling, branding, networking, registries, and component namespaces.

- **Tests**
  - Added coverage for configurations with missing platform values.
  - Added validation that injected cluster and namespace settings render correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->