### PR TITLE
test(tenant): give these template lists their real reason

### DIFF
--- a/packages/apps/tenant/tests/cleanup_role_watch_test.yaml
+++ b/packages/apps/tenant/tests/cleanup_role_watch_test.yaml
@@ -17,8 +17,11 @@ suite: tenant cleanup pre-delete hook
 # cannot observe them about itself. hack/tenant-pre-delete-hook.bats covers the
 # script's own behaviour by running it.
 
-# Restrict rendering to the cleanup template so the chart's namespace.yaml
-# `lookup` (which errors under helm-unittest) is not evaluated.
+# Render only the cleanup template. The reason given here was that
+# namespace.yaml's `lookup` errors under helm-unittest; it does not. This suite
+# sets no values, so for as long as keycloakgroups.yaml indexes
+# `.Values._cluster` unguarded on its first line, rendering the whole chart
+# fails with "index of untyped nil".
 templates:
   - templates/cleanup-job.yaml
 

--- a/packages/apps/tenant/tests/vmo_webhook_dependson_test.yaml
+++ b/packages/apps/tenant/tests/vmo_webhook_dependson_test.yaml
@@ -11,8 +11,10 @@ suite: tenant HelmReleases gate on the victoria-metrics-operator
 # rejects with connection refused, the install fails and rolls back. Pin the
 # dependsOn so the gate cannot regress.
 
-# Restrict rendering to the gated HelmRelease templates so the chart's
-# namespace.yaml `lookup` (which errors under helm-unittest) is not evaluated.
+# Render only the HelmRelease templates this suite asserts on. The reason given
+# here was that namespace.yaml's `lookup` errors under helm-unittest; it does
+# not. This suite sets `_cluster`, so the chart renders without the list; it
+# stays only to scope the suite.
 templates:
   - templates/etcd.yaml
   - templates/ingress.yaml


### PR DESCRIPTION
## What this PR does

Two helm-unittest suites in `packages/apps/tenant/tests/` said they restrict rendering because `namespace.yaml`'s `lookup` errors under helm-unittest. It does not. The lookup returns empty offline and the template renders, which `namespace.yaml`'s own header states and which `tests/namespace_ancestor_labels_test.yaml` depends on.

I measured what each list actually does by removing it, and the two suites turned out to be different cases rather than two copies of one.

In `cleanup_role_watch_test.yaml` the list is load-bearing, for a template the comment never mentioned. That suite sets no values, and `keycloakgroups.yaml` indexes `.Values._cluster` on its first line, so the whole-chart render fails with `index of untyped nil` and all 8 tests error. The comment now says that, and says it conditionally: a guard on that index is already in flight, and once it lands the list stops being load-bearing. I checked that too, by applying the guard and re-running with the list removed, which passes 8/8.

In `vmo_webhook_dependson_test.yaml` the list is not load-bearing at all. That suite sets `_cluster`, the chart renders without the list, and all 5 tests pass. It stays only to scope the suite, and the comment says so instead of inventing a technical reason.

Each comment now states what holds for its own file and nothing wider.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map against the diff. It touches two files, both under `packages/apps/tenant/tests/`, and no chart, template, values file or tooling. Nothing in the map keys on test files.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified test-rendering rationale and suite-scoping comments.
  * Documented that rendering requires `_cluster` values and that template lists control test scope.
* **Tests**
  * Updated explanatory comments only; test behavior and configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->