### PR TITLE
test(tenant): anchor the operator-gate absence and refresh a spent reason

### DIFF
--- a/packages/apps/tenant/tests/cleanup_role_watch_test.yaml
+++ b/packages/apps/tenant/tests/cleanup_role_watch_test.yaml
@@ -17,11 +17,10 @@ suite: tenant cleanup pre-delete hook
 # cannot observe them about itself. hack/tenant-pre-delete-hook.bats covers the
 # script's own behaviour by running it.
 
-# Render only the cleanup template. The reason given here was that
-# namespace.yaml's `lookup` errors under helm-unittest; it does not. This suite
-# sets no values, so for as long as keycloakgroups.yaml indexes
-# `.Values._cluster` unguarded on its first line, rendering the whole chart
-# fails with "index of untyped nil".
+# Render only the cleanup template. The list keeps an unrelated template breaking
+# out of this suite's result, so what reddens here is the hook it guards.
+# (namespace.yaml's `lookup` is not the reason: the lookup returns empty offline
+# and the template renders.)
 templates:
   - templates/cleanup-job.yaml
 

--- a/packages/apps/tenant/tests/vmo_webhook_dependson_test.yaml
+++ b/packages/apps/tenant/tests/vmo_webhook_dependson_test.yaml
@@ -11,10 +11,10 @@ suite: tenant HelmReleases gate on the victoria-metrics-operator
 # rejects with connection refused, the install fails and rolls back. Pin the
 # dependsOn so the gate cannot regress.
 
-# Render only the HelmRelease templates this suite asserts on. The reason given
-# here was that namespace.yaml's `lookup` errors under helm-unittest; it does
-# not. This suite sets `_cluster`, so the chart renders without the list; it
-# stays only to scope the suite.
+# Render only the HelmRelease templates this suite asserts on. The list keeps an
+# unrelated template breaking out of this suite's result, so what reddens here is
+# the gate it guards. (namespace.yaml's `lookup` is not the reason: the lookup
+# returns empty offline and the template renders.)
 templates:
   - templates/etcd.yaml
   - templates/ingress.yaml
@@ -69,14 +69,24 @@ tests:
   # The gate is intentionally narrow: only the releases that create VM* custom
   # resources carry it. Tenant releases that create none (seaweedfs, gateway)
   # must not be needlessly blocked on the operator.
+  # The name pin is what makes the absence mean something: a bare `notExists`
+  # passes on a template that renders no document at all.
   - it: seaweedfs HR carries no operator gate
     asserts:
+      - template: templates/seaweedfs.yaml
+        equal:
+          path: metadata.name
+          value: seaweedfs
       - template: templates/seaweedfs.yaml
         notExists:
           path: spec.dependsOn
 
   - it: gateway HR carries no operator gate
     asserts:
+      - template: templates/gateway.yaml
+        equal:
+          path: metadata.name
+          value: gateway
       - template: templates/gateway.yaml
         notExists:
           path: spec.dependsOn


### PR DESCRIPTION
## What this PR does

Two tests in `packages/apps/tenant/tests/vmo_webhook_dependson_test.yaml` say the seaweedfs and gateway HelmReleases deliberately carry no operator gate, and assert that with `notExists: spec.dependsOn` and nothing else. A bare absence assert also passes when the template renders no document at all, so both stayed green with those two releases switched off entirely. With `seaweedfs: false, gateway: false` the suite still reported 5 of 5 passing; pinning `metadata.name` next to the absence turns the same run into 2 failures.

An earlier check on these asserts injected a `dependsOn` and watched them redden. That proves they catch an added gate, which is the other direction. For a negative assert the direction that matters is the document going away, and that one was never covered.

Pairing `equal: metadata.name` with the absence is not a new idiom introduced here. `no_upgrade_force_test.yaml`, in the same directory, already anchors all seven of its releases that way, and this brings the last two suites in the chart into line with it.

Both suite headers also carried a reason for their `templates:` list that has expired: that rendering the whole chart fails because `keycloakgroups.yaml` indexes `.Values._cluster` unguarded. #3636 added the guard, so a no-values render of the chart now succeeds. The list is still load-bearing, for the reason `no_upgrade_force_test.yaml` already records — it keeps an unrelated template breaking out of this suite's result. Checked by adding a nil dereference to a template neither suite asserts on: both suites stay green with their lists and error without them.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map against the diff. It touches two files, both under `packages/apps/tenant/tests/`, and no chart, template, values file or tooling. Nothing in the map keys on test files.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```
