### PR TITLE
fix(e2e): stop the data-plane capture reporting what it never observed

### DIFF
--- a/hack/capture-dataplane.bats
+++ b/hack/capture-dataplane.bats
@@ -11,7 +11,7 @@
 #   - lb_first_ready_endpoint -- pick the first addressed, non-NotReady endpoint;
 #   - lb_announcer_node       -- the speaker node of the most recent announce;
 #   - lb_capture_decision     -- capture when probes failed, skip when one
-#                               succeeded or none ran, unknown when none could run.
+#                               succeeded, unknown when none ran or none could.
 #   - pod_filter_affected     -- retain scheduled NotReady pods even without IPs,
 #                               and only from whole rows.
 #
@@ -276,8 +276,12 @@ EOF
   [ "$(printf 'ok\n' | lb_capture_decision)" = "skip" ]
 }
 
-@test "lb_capture_decision returns skip when no probe ran at all" {
-  [ "$(printf '' | lb_capture_decision)" = "skip" ]
+@test "lb_capture_decision returns unknown when no probe ran at all" {
+  # Zero outcomes means nothing was ever attempted -- no probe client in the
+  # host netns, or an exec that could not run. Folding that into skip put a
+  # reachability verdict about the address into the artifact with not one probe
+  # behind it, which on a minimal image is every LB in the cluster.
+  [ "$(printf '' | lb_capture_decision)" = "unknown" ]
 }
 
 @test "lb_budget_ok yes below the cap and no once it is reached" {
@@ -938,6 +942,11 @@ STUB
     exit 1
   fi
   grep -q 'is unknown' "$d/out/lb-tenant-web.txt"
+  # And this is the branch that MAY name the lookup, because here it genuinely
+  # did not answer. Pinning it positively is what keeps the two negative pins
+  # in the empty-outcome tests below from going vacuous: the phrase has to stay
+  # reachable somewhere for its absence elsewhere to mean anything.
+  grep -q 'the cni-server lookup did not answer' "$d/out/lb-tenant-web.txt"
   rm -rf "$d"
 }
 
@@ -1122,6 +1131,191 @@ STUB
     exit 1
   fi
   grep -q 'endpoint node unknown' "$d/out/lb-tenant-web.txt"
+  rm -rf "$d"
+}
+
+@test "an LB whose probe answers is still recorded as reachable" {
+  # Positive control for the three unprobed cases below and for the cut-off one
+  # further up: each of those asserts the ABSENCE of the reachable line, and a
+  # change that routed every LB to unknown would satisfy all four while
+  # destroying the distinction they exist to protect. A probe that answers must
+  # still produce the reachable line and must still skip the heavy capture.
+  d=$(mktemp -d)
+  mkdir -p "$d/bin"
+  cat >"$d/bin/kubectl" <<'STUB'
+#!/bin/sh
+for a in "$@"; do
+  case $a in
+    pods) exit 0 ;;
+    svc) echo 'tenant|web|LoadBalancer|192.0.2.10|80|30080|Cluster'; exit 0 ;;
+    endpointslices) echo '10.0.0.1|node-a|tenant-test|wedged|true'; exit 0 ;;
+  esac
+done
+case "$*" in
+  *'app=kube-ovn-cni'*) echo 'cni-abc'; exit 0 ;;
+  *'nc -z'*) echo ok; exit 0 ;;
+esac
+exit 0
+STUB
+  chmod +x "$d/bin/kubectl"
+  PATH="$d/bin:$PATH" timeout 60 "$SCRIPT" "$d/out" >"$d/log" 2>&1 || true
+  grep -q -- '-- reachable, skipped' "$d/out/lb-tenant-web.txt"
+  if [ -f "$d/out/lb-tenant-web.tcpdump-endpoint.txt" ]; then
+    echo "a reachable LB got the heavy capture anyway:"
+    ls -1 "$d/out"
+    exit 1
+  fi
+  rm -rf "$d"
+}
+
+@test "an LB with no probe client in the host netns is not recorded as reachable" {
+  # The headline unprobed input: the exec runs, finds no nc/curl/wget, prints
+  # nothing and exits 0. Zero outcomes used to read as "nothing failed", so a
+  # minimal e2e image stamped every LB reachable and skipped the whole heavy
+  # capture -- which reads as a healthy datapath.
+  d=$(mktemp -d)
+  mkdir -p "$d/bin"
+  cat >"$d/bin/kubectl" <<'STUB'
+#!/bin/sh
+for a in "$@"; do
+  case $a in
+    pods) exit 0 ;;
+    svc) echo 'tenant|web|LoadBalancer|192.0.2.10|80|30080|Cluster'; exit 0 ;;
+    endpointslices) echo '10.0.0.1|node-a|tenant-test|wedged|true'; exit 0 ;;
+  esac
+done
+case "$*" in
+  *'app=kube-ovn-cni'*) echo 'cni-abc'; exit 0 ;;
+  # The probe exec itself: no client in the image, so it emits nothing and
+  # succeeds. A stub that answered ok or fail here would never reach the branch.
+  *'nc -z'*) exit 0 ;;
+esac
+exit 0
+STUB
+  chmod +x "$d/bin/kubectl"
+  PATH="$d/bin:$PATH" timeout 60 "$SCRIPT" "$d/out" >"$d/log" 2>&1 || true
+  # Positive control: the LB was enumerated and the probe leg was reached.
+  grep -q 'probing 1 LoadBalancer service' "$d/log"
+  [ -f "$d/out/lb-tenant-web.txt" ]
+  if grep -q -- '-- reachable, skipped' "$d/out/lb-tenant-web.txt"; then
+    echo "an LB no probe could be run against was recorded as reachable:"
+    cat "$d/out/lb-tenant-web.txt"
+    exit 1
+  fi
+  # The reason has to survive contact with what actually happened: the lookup
+  # answered and named a pod, and the exec ran -- it found nothing to run. A
+  # line blaming the lookup would be a cause this script never observed, the
+  # same rule dp_read_outcome states for the reads.
+  grep -q 'no probe outcome from node-a' "$d/out/lb-tenant-web.txt"
+  if grep -q 'the cni-server lookup did not answer' "$d/out/lb-tenant-web.txt"; then
+    echo "the artifact blames a lookup that answered:"
+    cat "$d/out/lb-tenant-web.txt"
+    exit 1
+  fi
+  rm -rf "$d"
+}
+
+@test "an LB whose probe node runs no cni-server is not blamed on the lookup" {
+  # The fifth zero-probe input, and the one missing from the enumeration until
+  # now: the lookup ANSWERS, and its answer is that the node has no
+  # kube-ovn-cni pod. host_http_probe returns without emitting an outcome, so
+  # this lands in the same empty-outcome branch as a missing probe client --
+  # but "the lookup did not answer" is false here in the most direct way.
+  d=$(mktemp -d)
+  mkdir -p "$d/bin"
+  cat >"$d/bin/kubectl" <<'STUB'
+#!/bin/sh
+for a in "$@"; do
+  case $a in
+    pods) exit 0 ;;
+    svc) echo 'tenant|web|LoadBalancer|192.0.2.10|80|30080|Cluster'; exit 0 ;;
+    endpointslices) echo '10.0.0.1|node-a|tenant-test|wedged|true'; exit 0 ;;
+  esac
+done
+case "$*" in
+  # Answers, and the answer is "no such pod": status 0, empty output.
+  *'app=kube-ovn-cni'*) exit 0 ;;
+esac
+exit 0
+STUB
+  chmod +x "$d/bin/kubectl"
+  PATH="$d/bin:$PATH" timeout 60 "$SCRIPT" "$d/out" >"$d/log" 2>&1 || true
+  grep -q 'probing 1 LoadBalancer service' "$d/log"
+  [ -f "$d/out/lb-tenant-web.txt" ]
+  if grep -q -- '-- reachable, skipped' "$d/out/lb-tenant-web.txt"; then
+    echo "an LB with no cni-server to probe from was recorded as reachable:"
+    cat "$d/out/lb-tenant-web.txt"
+    exit 1
+  fi
+  grep -q 'no probe outcome from node-a' "$d/out/lb-tenant-web.txt"
+  if grep -q 'the cni-server lookup did not answer' "$d/out/lb-tenant-web.txt"; then
+    echo "the artifact blames a lookup that answered 'no such pod':"
+    cat "$d/out/lb-tenant-web.txt"
+    exit 1
+  fi
+  rm -rf "$d"
+}
+
+@test "an LB with no node to probe from is not recorded as reachable" {
+  # Second unprobed input: neither the announcer nor the endpoint node resolved,
+  # so the probe block never ran. The decision defaulted to skip, and the
+  # artifact asserted reachability of an address the script never touched.
+  d=$(mktemp -d)
+  mkdir -p "$d/bin"
+  cat >"$d/bin/kubectl" <<'STUB'
+#!/bin/sh
+for a in "$@"; do
+  case $a in
+    pods) exit 0 ;;
+    svc) echo 'tenant|web|LoadBalancer|192.0.2.10|80|30080|Cluster'; exit 0 ;;
+  esac
+done
+# Everything else answers empty: no endpointslices, so no endpoint node, and no
+# metallb speakers, so no announcer.
+exit 0
+STUB
+  chmod +x "$d/bin/kubectl"
+  PATH="$d/bin:$PATH" timeout 60 "$SCRIPT" "$d/out" >"$d/log" 2>&1 || true
+  grep -q 'probing 1 LoadBalancer service' "$d/log"
+  [ -f "$d/out/lb-tenant-web.txt" ]
+  if grep -q -- '-- reachable, skipped' "$d/out/lb-tenant-web.txt"; then
+    echo "an LB with nowhere to probe from was recorded as reachable:"
+    cat "$d/out/lb-tenant-web.txt"
+    exit 1
+  fi
+  grep -q 'nowhere to probe from' "$d/out/lb-tenant-web.txt"
+  rm -rf "$d"
+}
+
+@test "an LB whose Service names no port is not recorded as reachable" {
+  # Third unprobed input: the port column is empty, the probe block is gated on
+  # a non-zero port, and the same default carried a reachability verdict out.
+  d=$(mktemp -d)
+  mkdir -p "$d/bin"
+  cat >"$d/bin/kubectl" <<'STUB'
+#!/bin/sh
+for a in "$@"; do
+  case $a in
+    pods) exit 0 ;;
+    svc) echo 'tenant|web|LoadBalancer|192.0.2.10||30080|Cluster'; exit 0 ;;
+    endpointslices) echo '10.0.0.1|node-a|tenant-test|wedged|true'; exit 0 ;;
+  esac
+done
+case "$*" in
+  *'app=kube-ovn-cni'*) echo 'cni-abc'; exit 0 ;;
+esac
+exit 0
+STUB
+  chmod +x "$d/bin/kubectl"
+  PATH="$d/bin:$PATH" timeout 60 "$SCRIPT" "$d/out" >"$d/log" 2>&1 || true
+  grep -q 'probing 1 LoadBalancer service' "$d/log"
+  [ -f "$d/out/lb-tenant-web.txt" ]
+  if grep -q -- '-- reachable, skipped' "$d/out/lb-tenant-web.txt"; then
+    echo "an LB with no port to probe was recorded as reachable:"
+    cat "$d/out/lb-tenant-web.txt"
+    exit 1
+  fi
+  grep -q 'no port to probe' "$d/out/lb-tenant-web.txt"
   rm -rf "$d"
 }
 

--- a/hack/capture-dataplane.bats
+++ b/hack/capture-dataplane.bats
@@ -6,12 +6,14 @@
 # unreachable while its backend stays Ready (the NotReady-pod path never sees
 # this case). Only the pure logic is unit-testable here:
 #
-#   - lb_filter_services      -- keep only LoadBalancer rows with an ingress IP;
+#   - lb_filter_services      -- keep only whole LoadBalancer rows that carry an
+#                               ingress IP;
 #   - lb_first_ready_endpoint -- pick the first addressed, non-NotReady endpoint;
 #   - lb_announcer_node       -- the speaker node of the most recent announce;
 #   - lb_capture_decision     -- capture when probes failed, skip when one
 #                               succeeded or none ran, unknown when none could run.
-#   - pod_filter_affected     -- retain scheduled NotReady pods even without IPs.
+#   - pod_filter_affected     -- retain scheduled NotReady pods even without IPs,
+#                               and only from whole rows.
 #
 # The tests come in two shapes, and neither needs a cluster.
 #
@@ -112,6 +114,45 @@ EOF
   if printf '%s\n' "$out" | grep -q 'pending'; then echo "FAIL: lb_filter_services must drop the pending (no external IP) row"; false; fi
 }
 
+@test "lb_filter_services drops a Service row cut off mid-record" {
+  # A bounded or interrupted list stops mid-record, and the fragment it leaves
+  # behind still satisfies a filter that only looks at values: what remains of
+  # `192.0.2.53` here is `192.0.2.5`, an address the cluster never had, and the
+  # row carrying it would be probed and written up as a Service. The jsonpath
+  # emits a fixed seven fields per Service, so a shorter row is a fragment by
+  # construction rather than by guess.
+  rows="$(printf '%s\n' \
+    'tenant|app|LoadBalancer|192.0.2.50|80|31000|Cluster' \
+    'tenant|db|LoadBalancer|192.0.2.5')"
+
+  out="$(printf '%s\n' "$rows" | lb_filter_services)"
+
+  [ "$(printf '%s\n' "$out" | grep -c .)" -eq 1 ]
+  # `! cmd` is vacuous under cozytest's `set -e`, hence the if/false form used
+  # by the sibling filter test above.
+  if printf '%s\n' "$out" | grep -q 'tenant|db'; then
+    echo "FAIL: lb_filter_services must drop the row cut off mid-record"
+    false
+  fi
+}
+
+@test "pod_filter_affected drops a pod row cut off mid-record" {
+  # The same cut over the six-field pod jsonpath. The fragment ends inside the
+  # nodeName column, so the half-parsed `nod` reads as a scheduled pod on a node
+  # of that name, and the capture opens a node-nod.txt for it.
+  rows="$(printf '%s\n' \
+    'tenant|wedged|192.0.2.80|node-b|False|Running' \
+    'tenant|cut||nod')"
+
+  out="$(printf '%s\n' "$rows" | pod_filter_affected)"
+
+  [ "$(printf '%s\n' "$out" | grep -c .)" -eq 1 ]
+  if printf '%s\n' "$out" | grep -q 'tenant|cut'; then
+    echo "FAIL: pod_filter_affected must drop the row cut off mid-record"
+    false
+  fi
+}
+
 @test "lb_first_ready_endpoint picks the first addressed endpoint that is not NotReady" {
   eps="$(printf '%s\n' \
     '||tenant|virt-launcher-x|true' \
@@ -130,6 +171,20 @@ EOF
   out="$(printf '%s\n' "$eps" | lb_first_ready_endpoint)"
 
   [ "$out" = "192.0.2.70|worker-9|tenant|app-0" ]
+}
+
+@test "lb_first_ready_endpoint drops an endpoint row cut off mid-record" {
+  # The third record filter over a bounded list, and the same cut: the fragment
+  # has to come first, because this one stops at the first row it accepts. A
+  # half-parsed node name would otherwise be the node every endpoint-side
+  # capture in the LB section is aimed at.
+  eps="$(printf '%s\n' \
+    '192.0.2.60|worker-' \
+    '192.0.2.61|worker-2|tenant|app-1|true')"
+
+  out="$(printf '%s\n' "$eps" | lb_first_ready_endpoint)"
+
+  [ "$out" = "192.0.2.61|worker-2|tenant|app-1" ]
 }
 
 @test "lb_announcer_node returns the speaker node of the most recent announce" {

--- a/hack/capture-dataplane.bats
+++ b/hack/capture-dataplane.bats
@@ -621,6 +621,52 @@ STUB
   rm -rf "$d"
 }
 
+@test "a partially answered endpointslice read is not called an unread one" {
+  # The same shape as the service list above, at the two EndpointSlice reads: a
+  # bound firing mid-stream leaves rows on stdout and 124 in $?. The backend is
+  # then parsed from what did arrive and printed by name, so a note asserting
+  # what the artifact will say -- rather than what is missing from it -- lands
+  # two lines from a block that contradicts it. The sibling notes in this file
+  # avoid that by naming the omission, and pod_on_node names no consequence at
+  # all because it serves callers that do different things with the answer.
+  d=$(mktemp -d)
+  mkdir -p "$d/bin"
+  cat >"$d/bin/kubectl" <<'STUB'
+#!/bin/sh
+for a in "$@"; do
+  case $a in
+    pods) exit 0 ;;
+    svc) echo 'tenant|web|LoadBalancer|192.0.2.10|80|30080|Cluster'; exit 0 ;;
+    # Complete rows AND a bound's status: the read answered in part.
+    endpointslices) echo '10.0.0.1|node-a|tenant-test|wedged|true'; exit 124 ;;
+  esac
+done
+exit 0
+STUB
+  chmod +x "$d/bin/kubectl"
+  PATH="$d/bin:$PATH" timeout 60 "$SCRIPT" "$d/out" >"$d/log" 2>&1 || true
+  # The rows that did arrive are used, so the artifact names a backend ...
+  grep -q 'ip=10.0.0.1' "$d/out/lb-tenant-web.txt"
+  # ... and the cut is on the record beside it.
+  grep -q 'was cut off' "$d/out/capture-notes.txt"
+  # Neither note may claim the value went in as unknown while the block above
+  # names it. Scoped to each note's own line: 'unknown' appears legitimately
+  # elsewhere in this file, including on the announcer line of this very block.
+  if grep 'endpointslices of tenant/web' "$d/out/capture-notes.txt" | grep -q 'unknown'; then
+    echo "the note calls the backend unknown while the capture names it:"
+    cat "$d/out/lb-tenant-web.txt"
+    grep 'endpointslices of tenant/web' "$d/out/capture-notes.txt"
+    exit 1
+  fi
+  if grep 'target port of tenant/web' "$d/out/capture-notes.txt" | grep -q 'unknown'; then
+    echo "the note calls the target port unknown while the capture names one:"
+    cat "$d/out/lb-tenant-web.txt"
+    grep 'target port of tenant/web' "$d/out/capture-notes.txt"
+    exit 1
+  fi
+  rm -rf "$d"
+}
+
 @test "a note does not claim a step was skipped when the step runs" {
   # A lookup can fail after naming what it was asked for. Both of these notes
   # used to state the consequence unconditionally, so the log said the OVN dump
@@ -892,6 +938,78 @@ STUB
     exit 1
   fi
   grep -q 'is unknown' "$d/out/lb-tenant-web.txt"
+  rm -rf "$d"
+}
+
+@test "an unread endpointslice is written as unknown rather than as none" {
+  # The two EndpointSlice reads discarded stderr and were interpreted by
+  # emptiness alone, so a refused read produced the same `<none>` a Service with
+  # no endpoints does. A reader working from the artifact gets the assertion and
+  # never sees that nothing was read.
+  d=$(mktemp -d)
+  mkdir -p "$d/bin"
+  cat >"$d/bin/kubectl" <<'STUB'
+#!/bin/sh
+for a in "$@"; do
+  case $a in
+    pods) exit 0 ;;
+    svc) echo 'tenant|web|LoadBalancer|192.0.2.10|80|30080|Cluster'; exit 0 ;;
+    endpointslices) echo 'Error from server (Forbidden): endpointslices is forbidden' >&2; exit 1 ;;
+  esac
+done
+exit 0
+STUB
+  chmod +x "$d/bin/kubectl"
+  PATH="$d/bin:$PATH" timeout 60 "$SCRIPT" "$d/out" >"$d/log" 2>&1 || true
+  [ -f "$d/out/lb-tenant-web.txt" ]
+  grep -q 'ip=<unknown>' "$d/out/lb-tenant-web.txt"
+  grep -q 'targetPort=<unknown>' "$d/out/lb-tenant-web.txt"
+  if grep -q 'ip=<none>' "$d/out/lb-tenant-web.txt"; then
+    echo "a read that never answered was recorded as an absent endpoint:"
+    cat "$d/out/lb-tenant-web.txt"
+    exit 1
+  fi
+  # And the reason ships beside the capture, not only in the job log.
+  grep -q 'endpointslices' "$d/out/capture-notes.txt"
+  rm -rf "$d"
+}
+
+@test "a Service with no endpointslices at all is not called an unread one" {
+  # The other direction, and a landmine the status threading arms: client-go's
+  # evalArray has no allowMissingKeys escape, so a jsonpath indexing [0] into an
+  # empty list is a hard error and kubectl exits 1, while [*] yields nothing and
+  # exits 0. With the status now reported, an ordinary Service without endpoints
+  # would start reporting as a failed read unless the read asks with [*].
+  d=$(mktemp -d)
+  mkdir -p "$d/bin"
+  cat >"$d/bin/kubectl" <<'STUB'
+#!/bin/sh
+for a in "$@"; do
+  case $a in
+    pods) exit 0 ;;
+    svc) echo 'tenant|web|LoadBalancer|192.0.2.10|80|30080|Cluster'; exit 0 ;;
+  esac
+done
+# The endpointslice reads fall through to here: an empty list, answered.
+case "$*" in
+  *'items[0]'*) echo 'error: array index out of bounds: index 0, length 0' >&2; exit 1 ;;
+esac
+exit 0
+STUB
+  chmod +x "$d/bin/kubectl"
+  PATH="$d/bin:$PATH" timeout 60 "$SCRIPT" "$d/out" >"$d/log" 2>&1 || true
+  [ -f "$d/out/lb-tenant-web.txt" ]
+  grep -q 'targetPort=<none>' "$d/out/lb-tenant-web.txt"
+  if grep -q 'targetPort=<unknown>' "$d/out/lb-tenant-web.txt"; then
+    echo "an empty endpointslice list was recorded as a read that never answered:"
+    cat "$d/out/lb-tenant-web.txt"
+    exit 1
+  fi
+  if grep -q 'endpointslices' "$d/out/capture-notes.txt"; then
+    echo "an empty endpointslice list was noted as a failed read:"
+    cat "$d/out/capture-notes.txt"
+    exit 1
+  fi
   rm -rf "$d"
 }
 

--- a/hack/capture-dataplane.bats
+++ b/hack/capture-dataplane.bats
@@ -1331,3 +1331,42 @@ STUB
   # A success still wins: the address answered, whatever else could not be tried.
   [ "$(printf 'unknown\nok\n' | lb_capture_decision)" = "skip" ]
 }
+
+@test "the Chainsaw caller also reports a capture its backstop cut short" {
+  # This collector has two callers, and the honesty contract has to hold at both
+  # or the reader learns to distrust the one that keeps it. hack/cozytest.sh's
+  # side is covered behaviourally in cozytest-capture-gate.bats; this runs the
+  # Chainsaw catch itself, extracted from the config it lives in, so neither
+  # side can quietly stop reporting. The Chainsaw backstop is the shorter of the
+  # two -- 300s against 600s, because it shares an op envelope with the snapshot
+  # leg -- so it is the likelier of the pair to fire.
+  #
+  # The backstop is simulated with a `timeout` on PATH that exits 124, for the
+  # same reason the cozytest.sh-side test does it: the call site sees a non-zero
+  # status and whatever landed, whichever way the kill arrived.
+  # Named here rather than left to fail downstream: without it a missing yq
+  # surfaces as the extraction guard below going red, which reads as the catch
+  # op having been renamed. Same form the other yq-using suites use.
+  command -v yq >/dev/null || { echo "yq (mikefarah v4+) is required to read the Chainsaw catch script" >&2; exit 1; }
+  d=$(mktemp -d)
+  mkdir -p "$d/bin" "$d/hack/e2e-chainsaw/suite"
+  printf '#!/bin/sh\nexit 124\n' >"$d/bin/timeout"
+  printf '#!/bin/sh\nexit 0\n' >"$d/bin/crust-gather"
+  # The catch resolves this collector as ../../e2e-capture-dataplane.sh from the
+  # failing suite's own directory, and gates the leg on it being executable.
+  printf '#!/bin/sh\nexit 0\n' >"$d/hack/e2e-capture-dataplane.sh"
+  chmod +x "$d/bin/timeout" "$d/bin/crust-gather" "$d/hack/e2e-capture-dataplane.sh"
+  yq -r '.spec.error.catch[] | select(.description == "crust-gather host snapshot on failure") | .script.content' \
+    "$HACK_DIR/e2e-chainsaw/.chainsaw.yaml" >"$d/catch.sh"
+  # The extraction found the right op: a renamed description would otherwise
+  # leave an empty script that satisfies nothing and reports nothing.
+  grep -q 'e2e-capture-dataplane.sh' "$d/catch.sh"
+  ( cd "$d/hack/e2e-chainsaw/suite" \
+    && PATH="$d/bin:$PATH" COZY_REPORT_DIR="$d/report" TEST_NAME=fixture sh "$d/catch.sh" ) \
+    >"$d/out" 2>&1 || true
+  # Positive control: the leg was reached, so the line below is about what it
+  # said and not about the catch having stopped earlier.
+  grep -q 'capturing host->pod data-plane' "$d/out"
+  grep -q 'data-plane capture INCOMPLETE (exit 124)' "$d/out"
+  rm -rf "$d"
+}

--- a/hack/capture-dataplane.bats
+++ b/hack/capture-dataplane.bats
@@ -895,6 +895,118 @@ STUB
   rm -rf "$d"
 }
 
+@test "an unknown announcer does not point the tcpdump at a pending pod" {
+  # pod_on_node builds `--field-selector spec.nodeName=$3`, so an empty node
+  # asks for pods whose nodeName is EMPTY -- the unscheduled ones. The announcer
+  # is unknown exactly when MetalLB is misbehaving, which is when this leg
+  # matters, and an unguarded lookup then hands the first pending kube-ovn-cni
+  # pod to a tcpdump labelled ANNOUNCER. The sibling uses of the announcer node
+  # in this same block are all guarded; this one was not.
+  d=$(mktemp -d)
+  mkdir -p "$d/bin"
+  cat >"$d/bin/kubectl" <<'STUB'
+#!/bin/sh
+for a in "$@"; do
+  case $a in
+    pods) exit 0 ;;
+    svc) echo 'tenant|web|LoadBalancer|192.0.2.10|80|30080|Cluster'; exit 0 ;;
+    endpointslices) echo '10.0.0.1|node-a|tenant-test|wedged|true'; exit 0 ;;
+  esac
+done
+case "$*" in
+  *--field-selector*) echo "$*" >>"$STUB_CALLS" ;;
+esac
+case "$*" in
+  # Answers every per-node cni lookup, INCLUDING one made with an empty node --
+  # which is what an apiserver holding a pending pod returns for that selector.
+  # A stub that answered nothing there would hide the bug behind an empty result.
+  *'app=kube-ovn-cni'*) echo 'cni-abc'; exit 0 ;;
+  # The LB must probe UNREACHABLE or the heavy capture that carries the tcpdumps
+  # never runs and the test asserts nothing.
+  *'nc -z'*) echo fail; exit 0 ;;
+esac
+exit 0
+STUB
+  chmod +x "$d/bin/kubectl"
+  STUB_CALLS="$d/calls" PATH="$d/bin:$PATH" timeout 90 "$SCRIPT" "$d/out" >"$d/log" 2>&1 || true
+  # Positive controls: the heavy capture ran, and it ran with no announcer --
+  # no speaker logs were produced, so lb_announcer_node reported nothing.
+  grep -q 'UNREACHABLE' "$d/log"
+  grep -q 'announcer node: <unknown>' "$d/out/lb-tenant-web.txt"
+  # The lookup itself must not go out with an empty node. Trailing space, so this
+  # does not also match the endpoint node's own `spec.nodeName=node-a` lookup.
+  if grep -q -- '--field-selector spec.nodeName= ' "$d/calls"; then
+    echo "the announcer lookup was issued with an empty node selector:"
+    grep -- 'spec.nodeName=' "$d/calls"
+    exit 1
+  fi
+  # And no ANNOUNCER tcpdump artifact may exist for a node nobody identified.
+  if [ -f "$d/out/lb-tenant-web.tcpdump-announcer.txt" ]; then
+    echo "an announcer tcpdump ran with no announcer node:"
+    cat "$d/out/lb-tenant-web.tcpdump-announcer.txt"
+    exit 1
+  fi
+  # The skip is stated rather than silent: absence of a block is not a reason.
+  grep -q 'announcer node unknown' "$d/out/lb-tenant-web.txt"
+  rm -rf "$d"
+}
+
+@test "an unknown endpoint node does not point the tcpdump at a pending pod" {
+  # The endpoint half of the same defect, on the same block: an LB whose
+  # announcer IS known but whose Service has no ready endpoint reaches the heavy
+  # capture with an empty endpoint node, and the two lookups on that side --
+  # the cni-server pod and the backend's OVS interface -- both go out with
+  # `spec.nodeName=`, which matches unscheduled pods. No ready endpoint is
+  # exactly the shape of an LB outage, so this is not a rare corner of the leg.
+  d=$(mktemp -d)
+  mkdir -p "$d/bin"
+  cat >"$d/bin/kubectl" <<'STUB'
+#!/bin/sh
+for a in "$@"; do
+  case $a in
+    pods) exit 0 ;;
+    svc) echo 'tenant|web|LoadBalancer|192.0.2.10|80|30080|Cluster'; exit 0 ;;
+    # No ready endpoint: the Service is enumerated, its backend is not.
+    endpointslices) exit 0 ;;
+    # The announcer, so the probe has somewhere to run from and the capture is
+    # reached with only the ENDPOINT side unknown.
+    logs) echo '{"event":"serviceAnnounced","ips":["192.0.2.10"],"node":"node-a"}'; exit 0 ;;
+  esac
+done
+case "$*" in
+  *'component=speaker'*) echo 'speaker-0|node-a'; exit 0 ;;
+esac
+case "$*" in
+  *--field-selector*) echo "$*" >>"$STUB_CALLS" ;;
+esac
+case "$*" in
+  # Answers every cni lookup, the one with an empty node included -- what an
+  # apiserver holding a pending pod returns for that selector.
+  *'app=kube-ovn-cni'*) echo 'cni-abc'; exit 0 ;;
+  *'nc -z'*) echo fail; exit 0 ;;
+esac
+exit 0
+STUB
+  chmod +x "$d/bin/kubectl"
+  STUB_CALLS="$d/calls" PATH="$d/bin:$PATH" timeout 90 "$SCRIPT" "$d/out" >"$d/log" 2>&1 || true
+  # Positive controls: the heavy capture ran, the announcer side was identified
+  # and did run, so what follows is about the endpoint side alone.
+  grep -q 'UNREACHABLE' "$d/log"
+  [ -f "$d/out/lb-tenant-web.tcpdump-announcer.txt" ]
+  if grep -q -- '--field-selector spec.nodeName= ' "$d/calls"; then
+    echo "an endpoint-side lookup was issued with an empty node selector:"
+    grep -- 'spec.nodeName=' "$d/calls"
+    exit 1
+  fi
+  if [ -f "$d/out/lb-tenant-web.tcpdump-endpoint.txt" ]; then
+    echo "an endpoint tcpdump ran with no endpoint node:"
+    cat "$d/out/lb-tenant-web.tcpdump-endpoint.txt"
+    exit 1
+  fi
+  grep -q 'endpoint node unknown' "$d/out/lb-tenant-web.txt"
+  rm -rf "$d"
+}
+
 @test "lb_capture_decision keeps failures visible when one probe could not run" {
   # An unrun probe adds no reason to doubt the ones that failed, so the mix must
   # not read as reachable. Collapsing it toward skip is what stamps the artifact

--- a/hack/cozytest-capture-gate.bats
+++ b/hack/cozytest-capture-gate.bats
@@ -112,7 +112,65 @@ run_fixture() {
   # Positive control for the negative assertion in the last test: same fixture,
   # same stubs, e2e filename.
   grep -qF "$DATAPLANE_MARKER" "$dir/out"
+  # The capture ran to its own end here -- the stub kubectl answers instantly --
+  # so the incompleteness line the next test pins must NOT appear. Without this
+  # the same line would satisfy that test whether it tracked the leg's status or
+  # was printed unconditionally.
+  if grep -qF 'data-plane capture INCOMPLETE' "$dir/out"; then
+    echo "a capture that finished was reported as cut short:"
+    cat "$dir/out"
+    exit 1
+  fi
   assert_legs_armed "$dir/report" e2e-gate-fixture
+  rm -rf "$dir"
+}
+
+@test "a data-plane capture cut short by its backstop says so" {
+  # The collector names every read of its own that could not finish, which
+  # leaves the outer backstop here as the one way its leg can still die without
+  # a word -- and a truncated dataplane/ then reads exactly like a complete one
+  # that found little. The sibling previous-logs leg has reported this since it
+  # was added; this is the same discipline at the third leg.
+  #
+  # The backstop is simulated with a `timeout` on PATH that exits 124 rather
+  # than by making the collector overrun a real 600s bound. The call site
+  # cannot tell the difference: it sees a non-zero status from `timeout` and
+  # whatever had been written before the kill, which is the whole input to the
+  # behaviour under test.
+  dir=$(make_fixture_dir e2e-backstop-fixture.bats)
+  printf '#!/bin/sh\nexit 124\n' >"$dir/bin/timeout"
+  chmod +x "$dir/bin/timeout"
+  run_fixture "$dir" e2e-backstop-fixture.bats
+  # Positive control: the leg was armed and reached, so the assertion below is
+  # about what the leg said and not about the gate having skipped it.
+  grep -qF "$DATAPLANE_MARKER" "$dir/out"
+  grep -qF 'data-plane capture INCOMPLETE (exit 124)' "$dir/out"
+  rm -rf "$dir"
+}
+
+@test "a data-plane collector that is not there is not reported as a capture" {
+  # This leg is gated on kubectl alone, while the previous-logs leg beside it
+  # requires its collector to be executable and so does the Chainsaw caller.
+  # The asymmetry cost nothing while the status was discarded; now that a
+  # non-zero status prints "kept what landed in <dir>", a tree without the
+  # collector claims a partial capture in a directory nothing ever created.
+  dir=$(make_fixture_dir e2e-nocollector-fixture.bats)
+  # The runner resolves both collectors relative to its own path, so copying it
+  # somewhere without its siblings is what makes them absent -- nothing in the
+  # worktree is touched.
+  mkdir -p "$dir/hack"
+  cp "$RUNNER" "$dir/hack/cozytest.sh"
+  PATH="$dir/bin:$PATH" COZY_REPORT_DIR="$dir/report" \
+    "$dir/hack/cozytest.sh" "$dir/e2e-nocollector-fixture.bats" >"$dir/out" 2>&1 || true
+  # Positive controls: the fixture failed, so the handler ran, and the gate
+  # armed -- otherwise the absence below would be satisfied by nothing running.
+  grep -qF 'Test failed' "$dir/out"
+  [ -f "$dir/report/snapshots/e2e-nocollector-fixture/crust-gather.log" ]
+  if grep -qF 'data-plane capture INCOMPLETE' "$dir/out"; then
+    echo "a collector that was never there was reported as a capture cut short:"
+    cat "$dir/out"
+    exit 1
+  fi
   rm -rf "$dir"
 }
 

--- a/hack/cozytest.sh
+++ b/hack/cozytest.sh
@@ -209,12 +209,27 @@ _cozy_on_exit() {
     # delegates host->local-pod routing to kube-ovn/ovn0) can be root-caused
     # from the uploaded artifact. crust-gather captures object state but not the
     # node's L3 forwarding state. This NEVER affects the test outcome: every
-    # capture is time-boxed and `|| true`, and the whole run is wrapped in a
-    # wall-clock backstop so it cannot stall the job. It no-ops when there are no
-    # affected pods or when kubectl/the tooling is absent.
-    if [ "$_cozy_cluster_captures" -eq 1 ] && command -v kubectl >/dev/null 2>&1; then
+    # capture inside is time-boxed and `|| true`, the whole run is wrapped in a
+    # wall-clock backstop so it cannot stall the job, and the backstop's own
+    # status is read only to print a line. It no-ops when there are no affected
+    # pods or when kubectl/the tooling is absent.
+    # The `-x` check matches the previous-logs leg above and the Chainsaw
+    # caller, and it stopped being cosmetic once the status below is printed: a
+    # tree without the collector would otherwise report "INCOMPLETE (exit 127);
+    # kept what landed" about a directory nothing ever created.
+    if [ "$_cozy_cluster_captures" -eq 1 ] && command -v kubectl >/dev/null 2>&1 && [ -x "$(dirname "$0")/e2e-capture-dataplane.sh" ]; then
       echo "» capturing host->pod data-plane for NotReady pods -> $_snap/dataplane"
-      timeout -k 30 600 "$(dirname "$0")/e2e-capture-dataplane.sh" "$_snap/dataplane" 2>&1 || true
+      _dp_rc=0
+      timeout -k 30 600 "$(dirname "$0")/e2e-capture-dataplane.sh" "$_snap/dataplane" 2>&1 || _dp_rc=$?
+      # Read, not propagated: the status still cannot change the job's outcome,
+      # it only gets a line. The collector names every read of its own that it
+      # could not finish, which leaves this backstop as the one remaining way
+      # for that leg to die silently -- and a truncated dataplane/ is otherwise
+      # indistinguishable from a complete one that found little. Same discipline
+      # as the previous-logs leg above, whose comment carries the arithmetic.
+      if [ "$_dp_rc" -ne 0 ]; then
+        echo "» data-plane capture INCOMPLETE (exit $_dp_rc); kept what landed in $_snap/dataplane"
+      fi
     fi
   fi
   if command -v cozy_cleanup >/dev/null 2>&1; then

--- a/hack/e2e-capture-dataplane.sh
+++ b/hack/e2e-capture-dataplane.sh
@@ -3,9 +3,13 @@
 #
 # DIAGNOSTIC ONLY. This script collects extra evidence on an already-failed
 # test; it never mutates the cluster and never changes the test's pass/fail
-# outcome. cozytest.sh invokes it from its on-failure hook, AFTER the
-# crust-gather snapshot and only when a test has already failed, writing into
-# the same snapshot dir so the output lands in the uploaded cozyreport artifact.
+# outcome. Two callers invoke it, each from its own on-failure path and each
+# AFTER the crust-gather snapshot: the cozytest.sh EXIT trap and the Chainsaw
+# global catch in hack/e2e-chainsaw/.chainsaw.yaml. Both write into the same
+# snapshot dir so the output lands in the uploaded cozyreport artifact, and both
+# wrap this script in a wall-clock backstop -- but not the same one (600s and
+# 300s respectively), so a change sized against one caller can still overrun the
+# other. The MAX_LBS note below carries that arithmetic.
 #
 # Why this exists: a recurrent install failure is a CNI host->local-pod
 # data-plane transient -- kubelet on a node reaches a *local* pod's
@@ -89,7 +93,7 @@
 #     In-guest capture INSIDE the worker VMI (tenant `cilium-dbg bpf lb list` /
 #     `tcpdump eth0`) is the one hop this cannot reach from the host; it is left
 #     as a documented stretch at the call site (it needs a tenant
-#     kubeconfig/virtctl this EXIT-trap diagnostic does not have). The host-side
+#     kubeconfig/virtctl that neither caller of this diagnostic has). The host-side
 #     ANNOUNCER/ENDPOINT split is the deliverable and already localises the
 #     failing hop to host-cilium vs kube-ovn delivery.
 #
@@ -97,7 +101,7 @@
 # no retries, no behavior change, no traps. Every live capture is time-boxed,
 # and no command can fail or stall the job: most are `|| true`, and the few
 # whose status is read take it into a variable and use it only to say why a
-# read produced nothing. A wall-clock backstop wraps the whole run at the call
+# read produced nothing. A wall-clock backstop wraps the whole run at each call
 # site. It no-ops cleanly when there are no affected pods.
 #
 # Why a read produced nothing is written to capture-notes.txt beside the
@@ -269,9 +273,9 @@ dp_read_outcome() {
 
 # Sourcing guard: hack/capture-dataplane.bats sets E2E_CAPTURE_DATAPLANE_LIB and
 # sources this file purely to reach the helpers above; return before touching $1
-# or running any capture so the unit test never needs a cluster. The script's
-# only executing caller (the cozytest.sh EXIT trap) never sets this, so the
-# guard is a no-op there.
+# or running any capture so the unit test never needs a cluster. Neither
+# executing caller sets it -- not the cozytest.sh EXIT trap, not the Chainsaw
+# global catch -- so the guard is a no-op for both.
 if [ -n "${E2E_CAPTURE_DATAPLANE_LIB:-}" ]; then
   return 0 2>/dev/null
 fi
@@ -1041,8 +1045,8 @@ capture_lb_datapath() {
       #       tenant-side miss from a host-side delivery miss);
       #     - `tcpdump -ni eth0 port <tenant-nodePort>` -- did the packet even
       #       arrive on the VMI's NIC?
-      #   Deferred because it needs a tenant kubeconfig/virtctl that this EXIT-
-      #   trap diagnostic does not have; the host-side ANNOUNCER/ENDPOINT split
+      #   Deferred because it needs a tenant kubeconfig/virtctl that neither
+      #   caller of this diagnostic has; the host-side ANNOUNCER/ENDPOINT split
       #   already localises the failing hop to host-cilium vs kube-ovn delivery.
     done
     log "LoadBalancer-datapath capture complete"

--- a/hack/e2e-capture-dataplane.sh
+++ b/hack/e2e-capture-dataplane.sh
@@ -124,8 +124,24 @@ set -u
 # (one Service per line, as emitted by the kubectl jsonpath in main). Emits only
 # the rows that are type=LoadBalancer AND carry a status ingress IP -- i.e. the
 # Services that actually have an external datapath to characterise.
+#
+# NF == 7 first, because a truncated list is exactly what a bounded or
+# interrupted read leaves behind and a fragment passes a value-only test: an IP
+# cut mid-octet still looks like an IP, and the row it sits in would be probed
+# and written up as a Service that has no such address. The jsonpath emits a
+# fixed seven fields per record, so anything shorter is a cut rather than a
+# Service. Dropping it loses nothing a reader needs -- the read's own note
+# already says the list did not finish.
+#
+# What a field count cannot catch: a cut inside the LAST field still delivers
+# every separator, so `...|30080|Clus` counts seven and passes, and nothing
+# in-band separates a truncated final value from a short one. Here the last
+# column is display-only. In the two filters below it is a decision column
+# (`phase`, `ready`), where a truncated value matches neither state being
+# excluded and the row is kept -- over-capturing rather than dropping evidence,
+# and the read's own cut-off note is what tells the reader the list ended early.
 lb_filter_services() {
-  awk -F'|' '$3 == "LoadBalancer" && $4 != "" { print }'
+  awk -F'|' 'NF == 7 && $3 == "LoadBalancer" && $4 != "" { print }'
 }
 
 # lb_first_ready_endpoint: stdin = `ip|node|targetNs|targetName|ready` rows (one
@@ -133,8 +149,14 @@ lb_filter_services() {
 # first endpoint that has an address and is not explicitly NotReady, then stops.
 # A blank `ready` (slice without conditions) counts as ready; only "false" is
 # excluded. This is the backend the LB IP is supposed to reach.
+#
+# NF == 5 for the reason the two row filters carry their own counts, and it
+# matters more here: this one stops at the first row it accepts, so a fragment
+# at the head of the list is not one bad row among many -- it is the backend,
+# and its half-parsed node is the node every endpoint-side capture below aims
+# at. Five fields per endpoint is what the jsonpath emits.
 lb_first_ready_endpoint() {
-  awk -F'|' '$1 != "" && $5 != "false" { print $1 "|" $2 "|" $3 "|" $4; exit }'
+  awk -F'|' 'NF == 5 && $1 != "" && $5 != "false" { print $1 "|" $2 "|" $3 "|" $4; exit }'
 }
 
 # lb_announcer_node <lbip>: stdin = MetalLB speaker logs, each line prefixed with
@@ -229,8 +251,14 @@ lb_budget_ok() {
 # cilium endpointManager leak this collector diagnoses can strand a pod before
 # an IP is assigned, and the node-global Cilium/OVN state plus pod events remain
 # useful in that state. IP-specific commands are gated later at their call sites.
+#
+# NF == 6 for the reason lb_filter_services carries NF == 7: a list cut
+# mid-record leaves a fragment whose remaining columns still read as values, and
+# a cut landing inside the nodeName column produces a half-parsed node this
+# capture would then open a node-<name>.txt for. Six fields per record is what
+# the jsonpath emits.
 pod_filter_affected() {
-  awk -F'|' '$4 != "" && $5 != "True" && $6 != "Succeeded" && $6 != "Failed"'
+  awk -F'|' 'NF == 6 && $4 != "" && $5 != "True" && $6 != "Succeeded" && $6 != "Failed"'
 }
 
 # How a cutoff should be described, mirroring prevlog_cutoff_desc in the sibling
@@ -900,6 +928,15 @@ capture_lb_datapath() {
     log "listing metallb speakers $(dp_read_outcome "$_speakers_rc" "$DP_READ_TIMEOUT" "$DP_BOUND" "$DP_ERR"); any speaker it did not name is missing from the announcer lookup"
   fi
   if [ -n "$_speakers" ] && [ -n "$_speakerlog" ]; then
+    # No field-count check here, unlike the three record filters above, and the
+    # absence is the answer rather than an oversight. These records carry two
+    # fields. A cut in the first leaves no separator at all, so the emptiness
+    # test below already rejects it. A cut in the second delivers every
+    # separator, so a count sees a whole record: `speaker-1|nod` and
+    # `speaker-1|nodeA` are the same shape, and nothing in-band tells a
+    # truncated node name from a short one. The test below is therefore as far
+    # as any check here can reach -- adding NF == 2 would reject no input it
+    # accepts, while reading as a closed gap.
     printf '%s\n' "$_speakers" | while IFS='|' read -r _sp _spnode; do
       [ -n "$_sp" ] && [ -n "$_spnode" ] || continue
       timeout 15 kubectl logs -n "$METALLB_NS" "$_sp" -c speaker --tail=2000 2>/dev/null \

--- a/hack/e2e-capture-dataplane.sh
+++ b/hack/e2e-capture-dataplane.sh
@@ -351,10 +351,9 @@ DP_READ_GRACE=2
 
 # Resolved once. Empty when `timeout` is absent: the reads then run unbounded
 # rather than every call exiting 127 with its output swallowed, which would
-# report that kubectl failed when kubectl never ran. The seven reads that carry
-# a note say which of the two happened; the two EndpointSlice reads inside
-# capture_lb_datapath still send stderr to /dev/null and report nothing either
-# way.
+# report that kubectl failed when kubectl never ran. Every read that carries a
+# note says which of the two happened, the two EndpointSlice reads inside
+# capture_lb_datapath included.
 if command -v timeout >/dev/null 2>&1; then
   DP_BOUND="timeout -k $DP_READ_GRACE $DP_READ_TIMEOUT"
   DP_LIST_BOUND="timeout -k $DP_READ_GRACE $DP_LIST_TIMEOUT"
@@ -955,20 +954,59 @@ capture_lb_datapath() {
       _lbport="${_port:-0}"
 
       # EndpointSlice backend for this Service (first ready, addressed endpoint).
+      # The status is kept beside the value, as the per-node pod lookups do:
+      # these two reads are interpreted by emptiness alone, and without the
+      # status a read that never answered writes the same `<none>` into the
+      # artifact as a Service that genuinely has no endpoint. The reader who has
+      # the uploaded report and not the run cannot then tell the two apart.
+      #
+      # Neither note asserts a consequence a partial read can falsify. A bound
+      # firing mid-stream leaves output on stdout and 124 in $?, so a read that
+      # failed can still have named the backend printed below, and a note
+      # claiming the value went in as unknown would contradict the block two
+      # lines above it.
+      #
+      # The two say it differently because the reads fail differently. The row
+      # read names what is MISSING: a record it never finished is dropped by the
+      # filter, so it is genuinely absent from the block. The scalar read cannot
+      # borrow that wording -- a number cut mid-token still prints, and `80` cut
+      # from `8080` is indistinguishable from a real 80 -- so its note names
+      # where the printed value came from instead. The service and pod lists are
+      # worded like the first; pod_on_node names no consequence at all.
       # shellcheck disable=SC2086  # empty DP_BOUND must vanish, not become ""
       _eps=$($DP_BOUND kubectl get endpointslices -n "$_ns" \
         -l "kubernetes.io/service-name=$_name" \
         -o jsonpath='{range .items[*]}{range .endpoints[*]}{.addresses[0]}{"|"}{.nodeName}{"|"}{.targetRef.namespace}{"|"}{.targetRef.name}{"|"}{.conditions.ready}{"\n"}{end}{end}' \
-        2>/dev/null)
+        2>"${DP_ERR:-/dev/null}")
+      _eps_rc=$?
+      if [ "$_eps_rc" -ne 0 ]; then
+        log "listing the endpointslices of $_ns/$_name $(dp_read_outcome "$_eps_rc" "$DP_READ_TIMEOUT" "$DP_BOUND" "$DP_ERR"); any endpoint it did not name is missing from the backend line below"
+      fi
       _backend=$(printf '%s\n' "$_eps" | lb_first_ready_endpoint)
       _epip=$(printf '%s' "$_backend" | cut -d'|' -f1)
       _epnode=$(printf '%s' "$_backend" | cut -d'|' -f2)
       _eptns=$(printf '%s' "$_backend" | cut -d'|' -f3)
       _eptname=$(printf '%s' "$_backend" | cut -d'|' -f4)
+      # items[*]/ports[*], not items[0]/ports[0], for the reason pod_on_node
+      # spells out: client-go's evalArray has no allowMissingKeys escape, so
+      # indexing [0] into an empty list is a hard error and kubectl exits 1. A
+      # Service without endpointslices is an ordinary answer here, and now that
+      # the status is reported it would otherwise arrive as a failed read. The
+      # wildcard yields nothing and exits 0; several ports collapse to the first,
+      # the same way the pod lookups take the first name.
       # shellcheck disable=SC2086  # empty DP_BOUND must vanish, not become ""
       _eptport=$($DP_BOUND kubectl get endpointslices -n "$_ns" \
         -l "kubernetes.io/service-name=$_name" \
-        -o jsonpath='{.items[0].ports[0].port}' 2>/dev/null)
+        -o jsonpath='{.items[*].ports[*].port}' 2>"${DP_ERR:-/dev/null}")
+      _eptport_rc=$?
+      _eptport=${_eptport%% *}
+      if [ "$_eptport_rc" -ne 0 ]; then
+        log "reading the target port of $_ns/$_name $(dp_read_outcome "$_eptport_rc" "$DP_READ_TIMEOUT" "$DP_BOUND" "$DP_ERR"); the port below is what arrived before it stopped, which may be nothing at all or a value cut short"
+      fi
+      # Absent versus never-read, once per value, in the vocabulary the per-node
+      # captures already use.
+      _ep_absent=$([ "$_eps_rc" -eq 0 ] && echo '<none>' || echo '<unknown>')
+      _eptport_absent=$([ "$_eptport_rc" -eq 0 ] && echo '<none>' || echo '<unknown>')
 
       # Announcer node = node of the most recent serviceAnnounced for the IP.
       _annode=$(lb_announcer_node "$_lbip" < "${_speakerlog:-/dev/null}")
@@ -977,7 +1015,7 @@ capture_lb_datapath() {
       {
         echo "################################################################"
         echo "# LB $_ns/$_name  ip=$_lbip port=$_lbport nodePort=${_np:-<none>} etp=${_etp:-<default>}"
-        echo "# backend: ip=${_epip:-<none>} node=${_epnode:-<none>} pod=${_eptns:-?}/${_eptname:-?} targetPort=${_eptport:-<none>}"
+        echo "# backend: ip=${_epip:-$_ep_absent} node=${_epnode:-$_ep_absent} pod=${_eptns:-$_ep_absent}/${_eptname:-$_ep_absent} targetPort=${_eptport:-$_eptport_absent}"
         echo "# announcer node: ${_annode:-<unknown>}"
         echo "################################################################"
       } > "$_of" 2>&1 || true

--- a/hack/e2e-capture-dataplane.sh
+++ b/hack/e2e-capture-dataplane.sh
@@ -66,7 +66,8 @@
 #   datapath (the suspected failing path) is never characterised. This section
 #   closes that gap. It is gated by a LIVE reachability probe so it only does the
 #   heavy capture for an LB that is actually broken; reachable LBs are enumerated
-#   and explicitly recorded as "reachable, skipped".
+#   and explicitly recorded as "reachable, skipped", and an LB no probe could be
+#   run against is recorded as unprobed rather than as either of those.
 #     - Enumerate every Service type=LoadBalancer that has a status ingress IP.
 #       For each, derive: the EndpointSlice backend (endpoint IP + node +
 #       targetPort), the Service nodePort + externalTrafficPolicy, and the
@@ -208,18 +209,18 @@ lb_announcer_node() {
 #     genuinely failed (the LB IP is unreachable -- the symptom we want
 #     characterised). A failure alongside an unrun probe still counts: the
 #     failures are evidence, and the unrun one adds no reason to doubt them;
-#   - "skip" when any probe succeeded (LB reachable) OR no probe ran at all (no
-#     HTTP/TCP client in the host netns -> cannot conclude unreachable, so only
-#     the cheap metadata is kept, never the heavy capture);
-#   - "unknown" when every outcome is unknown, i.e. nothing was ever attempted
-#     because the lookups behind the probe did not answer. Collapsing that into
-#     either of the other two would put a verdict about the address into the
-#     artifact without a single probe behind it.
+#   - "skip" when any probe succeeded, i.e. the LB is reachable and only the
+#     cheap metadata is worth keeping;
+#   - "unknown" when nothing was ever attempted -- no outcome at all (no
+#     HTTP/TCP client in the host netns, or an exec that could not run), or
+#     every outcome unknown because the lookups behind the probe did not
+#     answer. Collapsing either into skip would put a verdict about the address
+#     into the artifact without a single probe behind it.
 lb_capture_decision() {
   awk '
     { if ($0 == "") next; n++; if ($0 == "ok") ok++; if ($0 == "unknown") unk++ }
     END {
-      if (n == 0) { print "skip"; exit }
+      if (n == 0) { print "unknown"; exit }
       # Only a wholly unknown set is unknown. One unrun probe beside real
       # failures must not erase them: the failures are the evidence this
       # capture exists to characterise, and merge-base behaviour for that mix
@@ -781,8 +782,10 @@ fi
 # LB IP from <node>'s host netns (via the hostNetwork kube-ovn cni-server, so the
 # probe traverses the same host->cross-node->backend datapath the flake breaks).
 # Echoes "ok" / "fail" per the result, "unknown" when the cni-server lookup did
-# not answer so no probe could be attempted, or nothing when the image ships
-# no probe client (the decision helper treats no-attempt as skip). Prefers a pure
+# not answer so no probe could be attempted, or nothing when the lookup answered
+# that the node has no cni-server pod, when the image ships no probe client, or
+# when the exec itself could not run (the decision helper reads an empty set as
+# unknown too, and the caller tells the two shapes apart). Prefers a pure
 # TCP connect (nc -z) so a non-HTTP backend is not misread as unreachable; the
 # curl/wget fallbacks send HTTP and so fail-toward-capture on a non-HTTP port,
 # the safe direction (capture is cheap; a missed broken LB is not). Doubles as
@@ -790,10 +793,17 @@ fi
 host_http_probe() {
   _hp_node=$1; _hp_ip=$2; _hp_port=$3
   _hp_cni=$(pod_on_node "$KUBEOVN_NS" app=kube-ovn-cni "$_hp_node"); _hp_rc=$?
-  # A lookup that never answered is not a node without a cni-server. Emitting
-  # nothing here is indistinguishable from a probe that ran and said nothing,
-  # and the caller reads zero outcomes as "reachable" -- a verdict about an
-  # address this script never reached. The token says so instead.
+  # A lookup that never answered is not a node without a cni-server, and the
+  # two have to leave different traces. This emits an explicit unknown; the
+  # "no such pod" answer below emits nothing, as do a missing probe client and
+  # a failed exec. The caller reads exactly that difference: an outcome set
+  # that is present but wholly unknown names the lookup, an empty one names the
+  # three ways a probe can fail after the lookup answered.
+  #
+  # The decision helper reaches the same verdict from either shape -- an
+  # all-unknown set and an empty set both come back unknown -- so for
+  # capture-or-skip this token changes nothing. It exists for the caller's
+  # reason line, which is the only place the distinction reaches a reader.
   if [ "$_hp_rc" -ne 0 ]; then
     echo unknown
     return 0
@@ -1022,24 +1032,63 @@ capture_lb_datapath() {
 
       # Gate: probe the LB IP from the announcer node's host netns (fall back to
       # the endpoint node if the announcer is unknown). Reachable -> record and
-      # skip the heavy capture; unreachable -> characterise both hops.
+      # skip the heavy capture; unreachable -> characterise both hops; nothing
+      # probed -> say that, and say which of the ways it happened.
+      #
+      # Every path that runs zero probes ends on the unknown outcome, carrying
+      # the reason that path can actually support. Five of them used to arrive
+      # at the "reachable, skipped" line: no node to probe from, a Service with
+      # no port, a probe node the lookup says runs no kube-ovn-cni pod, a host
+      # netns with no TCP/HTTP client, and an exec that could not run at all. A
+      # sixth, the lookup itself not answering, already reported unknown and
+      # still does. None of the five observed the address. Inferring reachability from an
+      # unattempted probe is what this section must never write down -- an image
+      # without nc/curl/wget alone would stamp every LB in the cluster reachable
+      # and skip the entire heavy capture, which reads as a healthy datapath.
       _probenode="${_annode:-$_epnode}"
-      _decision=skip
-      if [ -n "$_probenode" ] && [ "$_lbport" != "0" ]; then
-        _decision=$( { host_http_probe "$_probenode" "$_lbip" "$_lbport"
+      _decision=unknown
+      if [ -z "$_probenode" ]; then
+        _why="nowhere to probe from -- neither an announcer nor an endpoint node is known"
+      elif [ "$_lbport" = "0" ]; then
+        _why="the Service names no port to probe"
+      else
+        # Held in a variable rather than piped straight in, because the SHAPE of
+        # the outcome set is the only place the two routes to an unknown verdict
+        # stay apart, and the reason line has to name a cause that was actually
+        # observed. host_http_probe emits an explicit unknown only when the
+        # cni-server lookup did not answer; everything else that stops a probe
+        # emits nothing.
+        _outcomes=$( { host_http_probe "$_probenode" "$_lbip" "$_lbport"
                        host_http_probe "$_probenode" "$_lbip" "$_lbport"
-                       host_http_probe "$_probenode" "$_lbip" "$_lbport"; } | lb_capture_decision )
+                       host_http_probe "$_probenode" "$_lbip" "$_lbport"; } )
+        _decision=$(printf '%s\n' "$_outcomes" | lb_capture_decision)
+        if [ -z "$_outcomes" ]; then
+          # Three ways in, and this script genuinely cannot tell them apart: the
+          # lookup answered that the node runs no kube-ovn-cni pod, its host
+          # netns ships no nc/curl/wget, or the exec could not run at all (no
+          # timeout on its PATH, exec denied, the pod gone mid-probe). The
+          # exec's status is swallowed by design -- this collector never fails a
+          # job -- so they are reported as the set they are rather than guessed
+          # apart. What is NOT said here is that the lookup went unanswered: it
+          # answered, and pod_on_node keeps that distinction for its callers.
+          _why="no probe outcome from $_probenode -- no kube-ovn-cni pod there, or no TCP/HTTP client in its host netns, or the exec into it could not run"
+        else
+          # Outcomes exist and the verdict is still unknown, which the decision
+          # helper only returns when every one of them is unknown -- and that
+          # token has exactly one source.
+          _why="no probe could be attempted from $_probenode -- the cni-server lookup did not answer"
+        fi
       fi
 
       if [ "$_decision" = "unknown" ]; then
-        echo "probe: whether the LB is reachable from ${_probenode:-<none>} is unknown -- the cni-server lookup did not answer, so no probe ran (no heavy capture)" >> "$_of" 2>&1 || true
-        log "LB $_ns/$_name ($_lbip) not probed -- the cni-server lookup did not answer"
+        echo "probe: whether the LB is reachable is unknown -- $_why (no heavy capture)" >> "$_of" 2>&1 || true
+        log "LB $_ns/$_name ($_lbip) not probed -- $_why"
         continue
       fi
 
       if [ "$_decision" != "capture" ]; then
-        echo "probe: LB reachable or not probeable from ${_probenode:-<none>} -- reachable, skipped (no heavy capture)" >> "$_of" 2>&1 || true
-        log "LB $_ns/$_name ($_lbip) reachable or not probeable -- skipped"
+        echo "probe: at least one probe from $_probenode succeeded -- reachable, skipped (no heavy capture)" >> "$_of" 2>&1 || true
+        log "LB $_ns/$_name ($_lbip) reachable -- skipped"
         continue
       fi
 

--- a/hack/e2e-capture-dataplane.sh
+++ b/hack/e2e-capture-dataplane.sh
@@ -1034,12 +1034,34 @@ capture_lb_datapath() {
       # Live tcpdump on both hops WHILE the probe is replayed: announcer geneve
       # tunnel egress + endpoint backend tap ingress. Shows whether the packet
       # crosses announcer->endpoint and reaches the backend's host-side iface.
-      _an_cni=$(pod_on_node "$KUBEOVN_NS" app=kube-ovn-cni "${_annode:-}")
-      _en_cni=$(pod_on_node "$KUBEOVN_NS" app=kube-ovn-cni "${_epnode:-}")
+      # Guarded like the announcer capture above, and for a reason the empty
+      # string hides: pod_on_node turns its third argument into
+      # `--field-selector spec.nodeName=<node>`, so an empty node asks for pods
+      # whose nodeName is EMPTY -- the unscheduled ones. An unknown announcer
+      # would then hand the first pending kube-ovn-cni pod to a tcpdump stamped
+      # ANNOUNCER, pointing the reader away from the actual problem at the one
+      # moment this leg matters: the announcer is unknown exactly when MetalLB
+      # is misbehaving.
+      _an_cni=""
+      if [ -n "$_annode" ]; then
+        _an_cni=$(pod_on_node "$KUBEOVN_NS" app=kube-ovn-cni "$_annode")
+      else
+        echo "(announcer node unknown -- announcer-side tcpdump skipped)" >> "$_of" 2>&1 || true
+      fi
+      # Same guard on the endpoint side, and it is not the rarer case: a Service
+      # with no ready endpoint is the ordinary shape of an LB outage, and both
+      # lookups here -- the cni-server pod and the backend's OVS interface --
+      # reach pod_on_node with the node in hand.
+      _en_cni=""
       _en_iface="$GENEVE_IFACE"
-      if [ -n "$_eptname" ] && [ -n "$_eptns" ]; then
-        _cand=$(ovs_iface_for "${_epnode:-}" "$_eptname.$_eptns")
-        [ -n "$_cand" ] && _en_iface="$_cand"
+      if [ -n "$_epnode" ]; then
+        _en_cni=$(pod_on_node "$KUBEOVN_NS" app=kube-ovn-cni "$_epnode")
+        if [ -n "$_eptname" ] && [ -n "$_eptns" ]; then
+          _cand=$(ovs_iface_for "$_epnode" "$_eptname.$_eptns")
+          [ -n "$_cand" ] && _en_iface="$_cand"
+        fi
+      else
+        echo "(endpoint node unknown -- endpoint-side tcpdump skipped)" >> "$_of" 2>&1 || true
       fi
 
       _an_pcap="$OUT/lb-$_ns-$_name.tcpdump-announcer.txt"

--- a/hack/e2e-chainsaw/.chainsaw.yaml
+++ b/hack/e2e-chainsaw/.chainsaw.yaml
@@ -188,7 +188,18 @@ spec:
           # op, so it keeps the wider budget.
           if [ -x ../../e2e-capture-dataplane.sh ]; then
             echo "» capturing host->pod data-plane for NotReady pods -> ${snap}/dataplane"
-            timeout -k 30 300 ../../e2e-capture-dataplane.sh "${snap}/dataplane" 2>&1 || true
+            timeout -k 30 300 ../../e2e-capture-dataplane.sh "${snap}/dataplane" 2>&1
+            dp_rc=$?
+            # Read, not propagated: the `exit 0` below still stands. The
+            # collector names every read of its own it could not finish, so this
+            # backstop is the last way its leg can die without a word, and a
+            # truncated dataplane/ then reads exactly like a complete one that
+            # found little. The 300s here cuts sooner than the 600s the
+            # cozytest.sh call site allows, so this is the likelier of the two
+            # to fire, and the previous-logs leg above already reports its own.
+            if [ "${dp_rc}" -ne 0 ]; then
+              echo "» data-plane capture INCOMPLETE (exit ${dp_rc}); kept what landed in ${snap}/dataplane"
+            fi
           fi
           # A non-zero collector must not fail the catch and bury the test's own
           # error, which is the thing worth reading.


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Six fixes to the e2e host->pod data-plane collector and the two call sites that invoke it, all of one class: a diagnostic that states a fact it never observed. Every one of them makes a failed run look healthier than it was, which is the worst direction for a tool that only ever runs on an already-failed test.

- A list cut mid-record parsed as a valid record. Three `awk -F'|'` row filters selected by field value and never checked the field count, so an IP cut mid-octet still looked like an IP and a cut inside a nodeName still looked like a scheduled pod. The capture then probed an address the cluster never had and opened a per-node file for a node that does not exist. Each jsonpath emits a fixed field count per record, so a shorter row is a fragment by construction.
- Five distinct paths ran zero probes and all reported "reachable, skipped": no node to probe from, a Service with no port, a probe node with no `kube-ovn-cni` pod, a host netns with no `nc`/`curl`/`wget`, and an exec that could not run. An image without a probe client alone would stamp every LoadBalancer in the cluster reachable and skip the whole heavy capture. They now report unprobed, each with a reason the run can actually support.
- Both EndpointSlice reads discarded stderr and were read by emptiness alone, so a refused read wrote the same `<none>` a Service with no endpoints writes. They now carry their status. That change armed a landmine the silence had hidden: the target port was read with `{.items[0]...}`, and client-go's `evalArray` has no `allowMissingKeys` escape, so an endpoint-less Service is a hard error rather than an empty answer. The read now asks with `{.items[*]...}`.
- `pod_on_node` turns its node argument into `--field-selector spec.nodeName=<node>`, so an empty node asks for pods whose nodeName is empty, i.e. unscheduled ones. Both tcpdump legs could hand a pending pod to a capture stamped ANNOUNCER or ENDPOINT. Each leg is now guarded and says in the artifact that it was skipped.
- Both callers wrapped the collector in a wall-clock backstop and discarded the result, while the previous-logs leg beside each of them reports "INCOMPLETE (exit N)". A truncated `dataplane/` directory was indistinguishable from a complete one that found little.
- The file's own header credited one caller where two exist, under different backstops (600s and 300s), so a change sized against the named one can overrun the omitted one.

Diagnostics only. No retries, no cluster mutation, no change to any test's pass/fail outcome: the statuses that are now read are used to print a line and nothing else.

Every behavioural change is pinned by a test in the existing bats surface, verified red against the committed tree before the fix. The two suites run 53 and 5 tests.

Known limits and deliberate omissions, named so the next reader does not have to rediscover them:

- A field count cannot catch a cut inside a record's LAST field, since every separator has already arrived. The comment on the first filter says so and says where it lands for each of the three. The MetalLB speaker loop is left without a count for the same reason: its records carry two fields, and `speaker-1|nod` is indistinguishable from a genuinely short node name, so a count there would reject nothing while reading as a closed gap.
- The backstop lines report any non-zero status as `INCOMPLETE (exit N)`. Exit 127 (no `timeout` on PATH) means nothing ran, so "kept what landed" overstates it. Left alone deliberately: the same wording ships on the previous-logs and crust-gather legs beside them, and splitting only the two new ones would create the asymmetry this PR exists to remove. All four want the same treatment together.
- When a probe's cni-server lookup fails once and then succeeds while no probe client is present, the reason line names the lookup for all three attempts. The named cause did occur, so nothing false reaches the artifact, but it is narrower than what happened.
- `hack/capture-dataplane.bats` now needs `yq` for one test, and unlike three sibling suites it does not declare that at the top of the file.

The fan-out caps are sized in units of work while the backstops are wall-clock, and the worst case exceeds both by multiples. That predates this branch and is unchanged by it, but the new INCOMPLETE line is what will make it visible in an artifact for the first time. Tracked separately in #3671.

relates to #3658 #3660 #3654 #3657 #3663 #3649

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
fix(e2e): the host->pod data-plane capture no longer reports absence or reachability it never observed -- truncated list records are dropped instead of parsed, a LoadBalancer no probe reached is recorded as unprobed rather than reachable, an unread EndpointSlice backend is distinguished from an absent one, a tcpdump leg whose node was never identified is skipped instead of aimed at an unscheduled pod, and both callers report a capture their backstop cut short
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data-plane capture reliability and reporting for timeouts, failed or partial reads, and missing collectors.
  * Prevented incomplete records and unknown probe results from being treated as valid or reachable.
  * Avoided capturing from unintended nodes when node information is unavailable.
  * Preserved partial diagnostic output while clearly reporting incomplete captures.

* **Tests**
  * Expanded coverage for capture outcomes, artifact accuracy, timeout handling, and guarded node selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->