### PR TITLE
test(release): clean up the guard test's scratch dir without an EXIT trap

### DIFF
--- a/hack/release-freeze-contract.bats
+++ b/hack/release-freeze-contract.bats
@@ -331,8 +331,6 @@ step_line() {
 @test "the guard's merged decision is correct on empty, closed-unmerged and closed-merged lists" {
   command -v node >/dev/null || { echo "node unavailable; skipping"; return 0; }
   tmp="$(mktemp -d)"
-  # shellcheck disable=SC2064
-  trap "rm -rf '$tmp'" EXIT
 
   cat > "$tmp/guard.js" <<'JS'
 function alreadyMerged(prs) {
@@ -370,4 +368,6 @@ closed-merged=true"
   [ -n "$block" ]
   printf '%s\n' "$block" | script_lines | grep -qF 'prs.some(p => p.merged_at !== null)' || {
     echo "backport.yaml's guard no longer uses prs.some(p => p.merged_at !== null)." >&2; exit 1; }
+
+  rm -rf "$tmp"
 }


### PR DESCRIPTION
## What this PR does

`make unit-tests` fails on a clean `main`: `hack/bats-no-exit-trap.bats` reports `release-freeze-contract.bats` as holding one EXIT trap with no declaration.

Neither change that produced this was wrong on its own. The per-file trap guard replaced a frozen global count with declarations carried by each file, and the backport guard test arrived with an EXIT trap from a branch that predated the guard. Each was green against its own base; together they are red.

The fix follows the convention the guard exists to promote rather than declaring fresh debt: the scratch directory is removed on the last line of the test body. That also preserves the behaviour the rule is for, since a failing test never reaches the cleanup and leaves its directory behind for inspection.

## Testing

`hack/release-freeze-contract.bats` and `hack/bats-no-exit-trap.bats` both pass on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved cleanup of temporary test files after release-freeze validation.
  - Preserved existing validation of release-freeze guard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->