### PR TITLE
fix(e2e): budget each linstor wait separately in post-install-prep

### DIFF
--- a/hack/e2e-post-install-prep.sh
+++ b/hack/e2e-post-install-prep.sh
@@ -13,28 +13,80 @@
 # (timeout 60 / timeout 300) were anchored to this script's start, so they
 # raced that reconcile latency; when one lost (linstor HR appeared at ~+70s
 # against a 60s budget) `set -e` aborted the whole script and the install
-# failed. Instead, drive every wait off one shared deadline -- the same 15m
-# window the installer's `kubectl wait hr --all` uses -- and tolerate
-# not-yet-created objects without aborting, while still failing hard if a
-# resource never becomes ready inside the budget.
+# failed. So every wait below tolerates a not-yet-created object without
+# aborting, and each gets its own budget, started when the link before it
+# completed rather than when this script did -- the same shape the LINSTOR
+# node and MetalLB CRD waits further down already have.
+#
+# One budget shared by the whole chain instead fails the install whenever the
+# chain merely runs long, because the head of it eats the window and the tail
+# inherits the remainder. Both halves were observed inside a single 15m window
+# on one run: the linstor HR went Ready 452s in, and the Deployment needed a
+# further ~520s because the controller's DB migration lost its connection to
+# the apiserver and retried four times before succeeding. Neither figure is
+# anomalous and neither exceeds the budget on its own; only their sum did, and
+# the install failed naming the Deployment as though it were broken.
+#
+# What a per-link budget buys is not speed but a guarantee: every link gets its
+# whole allowance no matter what the links ahead of it spent, so the tail of the
+# chain can no longer be failed by the head merely being slow. Detecting a link
+# that is genuinely stuck does not get faster, and for the second link it gets
+# slower, because its budget starts when the first one finished: a Deployment
+# that never converges is reported later by however long the HelmRelease took.
+# A first link that never becomes Ready is reported at the same moment as
+# before, since its budget still starts with the script.
+#
+# The cost is the ceiling: two waits at LINK_BUDGET each put the worst case at
+# twice that figure rather than once, ahead of the 300s node wait and the 300s
+# MetalLB wait below, and still well inside the timeout the job carries.
 set -eu
 
-DEADLINE=$(( $(date +%s) + 900 ))
+# Per-link budget in seconds, applied by wait_for_linstor to each link separately.
+LINK_BUDGET=900
 
-# wait_for <description> <kubectl-wait-args...>
-# Polls `kubectl wait` until it succeeds or the shared deadline elapses.
+# wait_for_linstor <description> <kubectl-wait-args...>
+# Polls `kubectl wait` until it succeeds or this link's budget elapses. The
+# name says linstor because the timeout diagnostics below read cozy-linstor
+# unconditionally: the wait itself is generic over its kubectl arguments, but
+# what it dumps on the way out is not, and a caller elsewhere would get the
+# wrong namespace's pods presented as evidence.
 # kubectl wait exits non-zero immediately when the object does not exist yet,
 # so the loop tolerates "not created yet" without the set -e cliff that a bare
 # `kubectl wait` would trigger on a NotFound. The per-attempt timeout shrinks
 # to the budget remaining, so the final attempt can consume the rest of it.
-wait_for() {
+wait_for_linstor() {
   desc=$1
   shift
   echo "[post-install-prep] waiting for ${desc}"
+  deadline=$(( $(date +%s) + LINK_BUDGET ))
   while :; do
-    remaining=$(( DEADLINE - $(date +%s) ))
+    remaining=$(( deadline - $(date +%s) ))
     if [ "$remaining" -le 0 ]; then
-      echo "[post-install-prep] timed out waiting for ${desc}" >&2
+      echo "[post-install-prep] timed out after ${LINK_BUDGET}s waiting for ${desc}" >&2
+      # The description names the object waited on, not the link of the chain
+      # that held it up, and those differ: the same "Deployment not Available"
+      # has been reached with the controller pod crash-looping its migration
+      # init container and with that pod unschedulable because cert-manager had
+      # not issued its client TLS Secret yet. The pod list separates the two,
+      # and the namespace events carry the reason a volume or an image failed.
+      # `kubectl events` rather than `kubectl get events`: it orders by when an
+      # event was last seen, so a condition that has been repeating for minutes
+      # -- which is what a stuck mount looks like -- stays inside the window
+      # instead of being pushed out of it by newer one-off events. It also has
+      # no --sort-by, so it cannot fail the whole read the way a sort key does
+      # when it is absent from any single item; .lastTimestamp is unset on an
+      # Event written through events.k8s.io/v1, and that failure prints nothing
+      # at all. Both reads keep their stderr, because a diagnostic that fails
+      # silently is indistinguishable from a namespace with nothing to report
+      # -- the very distinction being drawn here. Both are bounded, since the
+      # caller is blocked in `wait` and a wedged apiserver would otherwise hold
+      # the install open until the job's own timeout; the client budget is
+      # strictly the smaller of the two, so kubectl gets to name the reason
+      # before the outer kill takes it away.
+      timeout -k 5 30 kubectl get pods -n cozy-linstor -o wide \
+        --request-timeout=10s 2>&1 | tail -n 30 >&2
+      timeout -k 5 30 kubectl events -n cozy-linstor \
+        --request-timeout=10s 2>&1 | tail -n 30 >&2
       return 1
     fi
     if kubectl wait "$@" --timeout="${remaining}s" 2>/dev/null; then
@@ -57,9 +109,9 @@ controller_reachable() {
     -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null)" ]
 }
 
-wait_for "linstor HelmRelease to be Ready" \
+wait_for_linstor "linstor HelmRelease to be Ready" \
   helmrelease/linstor -n cozy-linstor --for=condition=Ready
-wait_for "linstor-controller Deployment to be Available" \
+wait_for_linstor "linstor-controller Deployment to be Available" \
   deployment/linstor-controller -n cozy-linstor --for=condition=available
 
 # Wait for 3 satellites to register Online, but gate every probe on a ready

--- a/hack/post-install-prep.bats
+++ b/hack/post-install-prep.bats
@@ -1,0 +1,255 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Unit tests for the wait budgets in hack/e2e-post-install-prep.sh.
+#
+# The script drives a serial reconcile chain -- cozystack-operator -> platform
+# HR -> linstor HR -> piraeus-operator -> cert-manager issues the controller
+# TLS -> linstor-controller Deployment -- and every link of it is waited on in
+# order. What these tests pin is how the waits are budgeted: each link gets its
+# own window measured from the moment the link before it completed, so a long
+# but healthy head cannot starve the tail, while a link that never converges
+# still fails inside one window rather than running forever.
+#
+# Strategy: the script is run end to end against a stub PATH carrying a virtual
+# clock. `date` reads a counter file, `sleep` advances it, and `kubectl` decides
+# each wait from that same counter -- so a 15-minute budget elapses in a few
+# hundred forks and the timings are exact rather than wall-clock approximate.
+# The stub also records every kubectl invocation, which is how the timeout
+# diagnostics are asserted. Mock IPs use the RFC 5737 documentation range.
+#
+# The convergence times fed in are the ones measured on the two runs that
+# motivated this: the linstor HelmRelease went Ready 452s after the script
+# started, and the Deployment became Available a further ~520s later.
+#
+# Title syntax constraints (inherited from cozytest.sh's awk parser):
+#   - Titles delimited by ASCII double quotes; embedded quotes truncate.
+#   - Only [A-Za-z0-9] from the title survives into the function name, so keep
+#     titles distinctive in their alphanumeric run.
+#   - A line that is exactly `}` is rewritten, so stub bodies below use `case`
+#     rather than nested functions.
+#
+# Run with: hack/cozytest.sh hack/post-install-prep.bats
+# -----------------------------------------------------------------------------
+
+HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
+SCRIPT="$HACK_DIR/e2e-post-install-prep.sh"
+
+# prep_sandbox <dir> -- lay down the stub PATH and the virtual clock.
+#
+# STUB_HR_READY_AT / STUB_DEPLOY_READY_AT are virtual-clock seconds at which
+# the corresponding `kubectl wait` starts succeeding, or the string `never`.
+# Every other kubectl call succeeds, so the script's post-LINSTOR tail (storage
+# pools, StorageClasses, MetalLB) runs through without a cluster.
+prep_sandbox() {
+  d=$1
+  mkdir -p "$d/bin"
+  echo 0 > "$d/clock"
+  : > "$d/calls"
+
+  cat > "$d/bin/date" <<'STUB'
+#!/bin/sh
+cat "$STUB_CLOCK"
+STUB
+
+  # Advancing the clock in `sleep` is what makes a 900s budget cost ~180 forks
+  # instead of 15 minutes. The ceiling is a runaway guard: if the script under
+  # test loses its deadline check entirely, the wait loop would otherwise spin
+  # forever, and a hung unit test is worse than a failing one. It has to stay
+  # low enough to trip in seconds -- a guard that itself takes minutes to fire
+  # is the hang it was meant to prevent -- and above every budget under test.
+  cat > "$d/bin/sleep" <<'STUB'
+#!/bin/sh
+now=$(cat "$STUB_CLOCK")
+now=$(( now + ${1%%.*} ))
+echo "$now" > "$STUB_CLOCK"
+[ "$now" -lt 5000 ]
+STUB
+
+  # Records the parsed bound and then runs the real command, so a wrapped call
+  # still reaches the kubectl stub and the existing call assertions hold. The
+  # duration is parsed here rather than in the test because `timeout [-k G] N`
+  # puts two numbers on the line and only the second one is the wall clock.
+  cat > "$d/bin/timeout" <<'STUB'
+#!/bin/sh
+grace=""
+dur=""
+while [ $# -gt 0 ]; do
+  case $1 in
+    -k) grace=$2; shift 2 ;;
+    [0-9]*) dur=$1; shift; break ;;
+    *) break ;;
+  esac
+done
+printf 'timeout dur=%s grace=%s -- %s\n' "$dur" "$grace" "$*" >> "$STUB_CALLS"
+exec "$@"
+STUB
+
+  cat > "$d/bin/kubectl" <<'STUB'
+#!/bin/sh
+now=$(cat "$STUB_CLOCK")
+printf '%s\n' "$*" >> "$STUB_CALLS"
+case "$*" in
+  'wait helmrelease/linstor '*)
+    [ "$STUB_HR_READY_AT" != never ] && [ "$now" -ge "$STUB_HR_READY_AT" ] ;;
+  'wait deployment/linstor-controller '*)
+    [ "$STUB_DEPLOY_READY_AT" != never ] && [ "$now" -ge "$STUB_DEPLOY_READY_AT" ] ;;
+  'get endpoints '*) echo 192.0.2.11 ;;
+  'get pods '*)
+    if [ -n "${STUB_PODS_FAIL:-}" ]; then
+      echo "Error from server (Forbidden): pods is forbidden" >&2
+      exit 1
+    fi
+    echo "STUB-POD linstor-controller 0/1 Init:CrashLoopBackOff" ;;
+  'events '*|'get events '*)
+    # Model the failure the real sorter has: an Event written through
+    # events.k8s.io/v1 reaches the core API with .lastTimestamp unset, and
+    # kubectl fails the whole read rather than skipping that item. A
+    # diagnostic that dies this way prints nothing, which reads exactly like
+    # a namespace with no events -- so the assertion below is on the content
+    # arriving, not on the call being made.
+    case "$*" in
+      *--sort-by=.lastTimestamp*)
+        echo "error: couldn't find any field with path {.lastTimestamp}" >&2
+        exit 1 ;;
+    esac
+    # Any other reason the read can fail -- RBAC, a wedged apiserver, a
+    # renamed namespace. Kept separate from the sort-key case above so the
+    # cause and the consequence are pinned by different tests.
+    if [ -n "${STUB_EVENTS_FAIL:-}" ]; then
+      echo "Error from server (Forbidden): events is forbidden" >&2
+      exit 1
+    fi
+    echo "STUB-EVENT MountVolume.SetUp failed for volume client-tls" ;;
+  *'linstor node list') printf 'Online\nOnline\nOnline\n' ;;
+  *) exit 0 ;;
+esac
+STUB
+
+  chmod +x "$d/bin/date" "$d/bin/sleep" "$d/bin/kubectl" "$d/bin/timeout"
+}
+
+# run_prep <dir> <hr-ready-at> <deploy-ready-at> [events-fail] [pods-fail]
+# Runs the script under the stubs, capturing stdout, stderr and the exit status
+# without tripping set -e. The last two are non-empty to make the corresponding
+# diagnostic read fail; pass an empty string for the fourth to reach the fifth.
+run_prep() {
+  d=$1
+  STUB_CLOCK="$d/clock" STUB_CALLS="$d/calls" \
+  STUB_HR_READY_AT=$2 STUB_DEPLOY_READY_AT=$3 \
+  STUB_EVENTS_FAIL="${4:-}" STUB_PODS_FAIL="${5:-}" \
+  PATH="$d/bin:$PATH" \
+    "$SCRIPT" > "$d/out" 2> "$d/err" && echo 0 > "$d/rc" || echo $? > "$d/rc"
+}
+
+@test "the Deployment wait keeps its full budget after a slow HelmRelease wait" {
+  tmp=$(mktemp -d)
+  prep_sandbox "$tmp"
+
+  run_prep "$tmp" 452 972
+
+  cat "$tmp/err" >&2
+  [ "$(cat "$tmp/rc")" -eq 0 ]
+  grep -q '\[post-install-prep\] done' "$tmp/out"
+  # The Deployment converged past the point where a single chain-wide 15m
+  # window anchored at script start would already have expired.
+  [ "$(cat "$tmp/clock")" -ge 972 ]
+  rm -rf "$tmp"
+}
+
+@test "a Deployment that never becomes Available fails inside one budget" {
+  tmp=$(mktemp -d)
+  prep_sandbox "$tmp"
+
+  run_prep "$tmp" 0 never
+
+  [ "$(cat "$tmp/rc")" -ne 0 ]
+  # One budget, not two and not unbounded: the wait started at 0 and gave up
+  # at 900. The upper bound allows a single 5s poll interval beyond that and
+  # nothing more, so a second budget would fail it.
+  final=$(cat "$tmp/clock")
+  [ "$final" -ge 900 ]
+  [ "$final" -le 905 ]
+  rm -rf "$tmp"
+}
+
+@test "the Deployment timeout reports the linstor pods and events" {
+  tmp=$(mktemp -d)
+  prep_sandbox "$tmp"
+
+  run_prep "$tmp" 0 never
+
+  [ "$(cat "$tmp/rc")" -ne 0 ]
+  grep -q 'timed out' "$tmp/err"
+  grep -q 'linstor-controller Deployment to be Available' "$tmp/err"
+  # Which link was actually blocking -- a crash-looping init container versus a
+  # Secret cert-manager has not issued yet -- is only visible in the pods and
+  # the namespace events, so the timeout has to read both.
+  grep -q '^get pods -n cozy-linstor' "$tmp/calls"
+  grep -q '^events -n cozy-linstor' "$tmp/calls"
+  # And their content has to reach the log, not merely be asked for: a read
+  # that fails prints nothing, which is the same shape as a namespace with
+  # nothing wrong in it.
+  grep -q 'STUB-POD' "$tmp/err"
+  grep -q 'STUB-EVENT' "$tmp/err"
+  # Both reads carry a wall-clock bound, and the client budget inside each is
+  # strictly smaller than it. Equal values would put the outer kill first, so
+  # kubectl would never get to say why it could not read -- which is the whole
+  # point of reading at all on this path.
+  for what in 'get pods' 'events'; do
+    line=$(grep "^timeout dur=.* kubectl $what -n cozy-linstor" "$tmp/calls" | head -1)
+    [ -n "$line" ]
+    outer=${line#timeout dur=}
+    outer=${outer%% *}
+    inner=$(printf '%s' "$line" | sed -n 's/.*--request-timeout=\([0-9]*\)s.*/\1/p')
+    [ -n "$outer" ]
+    [ -n "$inner" ]
+    [ "$inner" -lt "$outer" ]
+  done
+  rm -rf "$tmp"
+}
+
+@test "an events read that fails names its reason instead of going quiet" {
+  tmp=$(mktemp -d)
+  prep_sandbox "$tmp"
+
+  run_prep "$tmp" 0 never fail-events
+
+  [ "$(cat "$tmp/rc")" -ne 0 ]
+  # Silence here would be read as "the namespace had nothing to say", which is
+  # the opposite of what happened. The reason has to survive to the log.
+  grep -q 'Forbidden' "$tmp/err"
+  rm -rf "$tmp"
+}
+
+@test "a leg that fails does not take the other leg down with it" {
+  tmp=$(mktemp -d)
+  prep_sandbox "$tmp"
+
+  # The pods read runs first, so failing it is the only way to ask whether the
+  # events read still happens. Failing the events read instead proves nothing:
+  # the pods output has already been emitted by then either way.
+  run_prep "$tmp" 0 never '' fail-pods
+
+  [ "$(cat "$tmp/rc")" -ne 0 ]
+  grep -q 'Forbidden' "$tmp/err"
+  grep -q 'STUB-EVENT' "$tmp/err"
+  rm -rf "$tmp"
+}
+
+@test "a HelmRelease that never goes Ready fails before the Deployment is waited on" {
+  tmp=$(mktemp -d)
+  prep_sandbox "$tmp"
+
+  run_prep "$tmp" never 0
+
+  [ "$(cat "$tmp/rc")" -ne 0 ]
+  grep -q 'linstor HelmRelease to be Ready' "$tmp/err"
+  final=$(cat "$tmp/clock")
+  [ "$final" -ge 900 ]
+  [ "$final" -le 905 ]
+  if grep -q '^wait deployment/linstor-controller' "$tmp/calls"; then
+    echo "the Deployment was waited on after the HelmRelease wait failed" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}


### PR DESCRIPTION
## What this PR does

Both waits in `hack/e2e-post-install-prep.sh` ran off one 15-minute deadline anchored at the script's start, so the head of the chain ate the window and the tail got whatever was left. Two runs on 2026-08-09 failed that way. The linstor HelmRelease went Ready 452s in, and the Deployment needed a further ~520s because its DB migration lost the apiserver and retried four times. Neither figure passes 900s alone. Their sum does, and the install reported the Deployment as broken.

Each wait now gets its own budget, started when the previous link finished. Same shape as the node wait and the MetalLB CRD wait further down the same file. What it buys is that every link gets its whole allowance regardless of what the links ahead of it spent.

The cost is on both sides and I measured it. Worst case goes from one 15m window to 900 + 900 + 300 + 300 = 40m, against the 180m the e2e job carries. A Deployment that never converges is now reported at 1355s instead of 900s, from the 452s above plus the loop's 5s poll. A HelmRelease that never goes Ready is still reported at 900s, which I checked by running the new suite against the pre-change script.

The timeout now dumps the pods and recent events of `cozy-linstor`. The same "Deployment not Available" has come from a crash-looping migration init container and from a pod waiting on a client TLS Secret cert-manager had not issued yet, and telling those apart used to need the run's bundle. Events come from `kubectl events`, which sorts by last-seen and carries no `--sort-by` to fail on a key some item lacks. Both reads keep their stderr and are bounded, with the client budget smaller than the outer one so kubectl gets to say why before the kill lands.

`hack/post-install-prep.bats` runs the script end to end against a stub PATH with a virtual clock, so a 15-minute budget elapses in a few hundred forks and the timings are exact. Four of its six tests fail against the pre-change script. The other two guard the bound that stays.

### Known gaps in the new tests

Dropping the `2>&1` from either diagnostic read leaves all six tests green, because the harness catches the script's own stderr into the same file the assertion reads. The property holds in production anyway, since the caller merges both streams into one log, but nothing catches the removal. The test for "one failing read does not suppress the other" needs the pods read to run first; swap the two reads and it passes vacuously. Its comment says so at the point where someone would make that change.

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

Walked the map against the diff. Two files, both under `hack/`. The `ccp` trigger is about moving or renaming things under `hack/` or changing what a make target does, and its anchors `hack/package.mk` and `hack/common-envs.mk` are untouched. `talm` and `ansible-cozystack` key off node prerequisites in `hack/e2e-prepare-cluster.bats`, a different file.

### Related

Same family, found while working here and filed instead of folded in. #3707 and #3708 for unbounded reads elsewhere in this script, #3712 for the `--sort-by=.lastTimestamp` form in fourteen other places, #3713 for the wait loop dropping kubectl's stderr for its whole budget, #3714 for the MetalLB CRD wait failing without a message.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LINSTOR readiness checks by giving each prerequisite its own 15-minute wait period.
  * Added clearer timeout diagnostics, including relevant pod and event information.
  * Ensured subsequent readiness checks are skipped when an earlier HelmRelease check fails.

* **Tests**
  * Added end-to-end coverage for timeout handling, sequential failures, diagnostic errors, and readiness behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->