### PR TITLE
fix(velero): apply CRD updates on upgrade via CreateReplace

### DIFF
--- a/packages/core/platform/sources/velero.yaml
+++ b/packages/core/platform/sources/velero.yaml
@@ -21,3 +21,4 @@ spec:
         privileged: true
         namespace: cozy-velero
         releaseName: velero
+        upgradeCRDs: CreateReplace

--- a/packages/core/platform/tests/sources_velero_crds_test.yaml
+++ b/packages/core/platform/tests/sources_velero_crds_test.yaml
@@ -1,0 +1,22 @@
+suite: velero applies CRD updates on upgrade
+# velero evolves its CRD schema between versions (v1.18 adds the Queued and
+# ReadyToStart backup phases). Helm never upgrades CRDs shipped in crds/, and
+# the velero package disables the chart's upgrade-crds Job, so the PackageSource
+# must opt into CreateReplace; without it the server binary upgrades while the
+# live CRDs stay at first-install state, the apiserver rejects the new phases,
+# and backups sit in New while the HelmRelease stays green. Pin the policy so an
+# upgrade cannot silently regress.
+templates:
+  - templates/sources.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  - it: velero PackageSource sets upgradeCRDs to CreateReplace
+    documentSelector:
+      path: metadata.name
+      value: cozystack.velero
+    asserts:
+      - equal:
+          path: spec.variants[0].components[0].install.upgradeCRDs
+          value: CreateReplace

--- a/packages/system/velero/tests/velero_test.yaml
+++ b/packages/system/velero/tests/velero_test.yaml
@@ -26,11 +26,10 @@ tests:
           path: spec.template.spec.initContainers[1].image
           value: quay.io/kubevirt/kubevirt-velero-plugin:v0.9.0
 
-  # Cozystack disables the upgrade-crds Job (upgradeCRDs: false) because CRDs
-  # ship via the chart's crds/ directory, making the Job redundant. (The old
-  # kubectl-image-compatibility rationale is obsolete in velero 12.x, where the
-  # Job now runs the velero image natively.) Pin that invariant — it silently
-  # regressed once.
+  # Cozystack disables the upgrade-crds Job (upgradeCRDs: false): CRD lifecycle
+  # is owned by the generated HelmRelease (upgradeCRDs: CreateReplace on the
+  # velero PackageSource), making the Job redundant. Pin that invariant — it
+  # silently regressed once.
   - it: does not emit the upgrade-crds Job when upgradeCRDs is disabled
     template: charts/velero/templates/upgrade-crds/upgrade-crds.yaml
     asserts:

--- a/packages/system/velero/values.yaml
+++ b/packages/system/velero/values.yaml
@@ -1,8 +1,8 @@
 velero:
-  # Disable the upgrade-crds Job: CRDs ship via the chart's crds/ directory, so
-  # the Job is redundant. (The old kubectl-image-compatibility rationale is
-  # obsolete in velero 12.x — the Job now runs the velero image natively, not a
-  # kubectl one — but it stays disabled because cozystack manages CRDs via crds/.)
+  # Disable the upgrade-crds Job: CRD lifecycle is owned by the generated
+  # HelmRelease instead (upgradeCRDs: CreateReplace on the velero PackageSource),
+  # which applies the chart's crds/ directory on install and on every upgrade,
+  # so the Job is redundant.
   upgradeCRDs: false
   initContainers:
     - name: velero-plugin-for-aws


### PR DESCRIPTION
## What this PR does

Velero CRDs stayed frozen at whatever version was first installed: Helm never touches the chart's `crds/` directory on upgrade, the generated HelmRelease left `spec.upgrade.crds` at the helm-controller default (Skip), and the package disables the upstream upgrade-crds Job. When the velero image moved to v1.18.1, which added the `Queued` and `ReadyToStart` backup phases, the apiserver rejected every phase transition against the stale CRDs (`status.phase: Unsupported value: "Queued"`) and backups silently stopped while the HelmRelease stayed green.

This opts the velero PackageSource into `upgradeCRDs: CreateReplace`, the same policy mongodb-operator already uses, adds a platform test pinning it, and corrects the stale Job-disable rationale in the package. CreateReplace is safe here: velero only extends the phase enums between versions.

Closes #3726

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(velero): apply Velero CRD updates on upgrade; previously CRDs stayed at their first-install version, so after the image moved to v1.18.1 backups could silently stop with `status.phase: Unsupported value: "Queued"` while the HelmRelease stayed green
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Velero now automatically creates or replaces its Custom Resource Definitions during installation and upgrades.
* **Bug Fixes**
  * Improved Velero CRD lifecycle handling to ensure updated definitions are applied reliably.
* **Tests**
  * Added coverage verifying the CRD upgrade configuration and updated validation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->