### PR TITLE
chore(codeowners): keep architects as owners in every non-governance rule

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,14 @@
 # from broad to specific. The API review gate block stays last so it cannot be
 # overridden.
 #
+# Matching is NOT additive: the last matching rule fully REPLACES every broader
+# one, including the * catch-all. There is no way to say "these people can
+# review anything" other than repeating their handles in every rule — a scoped
+# rule that omits them silently strips their ownership for that path, exactly
+# like the write-access pitfall below, just with valid handles. Policy: @kvaps
+# and @lllamnyp are listed in every rule, except the governance block which is
+# deliberately owned by @tym83 @kvaps alone.
+#
 # "Require review from Code Owners" is already enabled on main, so these rules
 # gate merges from the moment this file lands — they are not an intention to be
 # tightened later. That makes an unhonoured owner worse than a wrong one: GitHub
@@ -21,13 +29,13 @@
 *                                            @kvaps @lllamnyp
 
 # --- Dashboards, examples, tests (largest fall-throughs to the default) ---
-/dashboards/                                 @myasnikovdaniil @IvanHunters
-/examples/                                   @lllamnyp @myasnikovdaniil
-/examples/backups/                           @androndo @lllamnyp
-/test/                                       @myasnikovdaniil
+/dashboards/                                 @myasnikovdaniil @IvanHunters @kvaps @lllamnyp
+/examples/                                   @lllamnyp @myasnikovdaniil @kvaps
+/examples/backups/                           @androndo @lllamnyp @kvaps
+/test/                                       @myasnikovdaniil @kvaps @lllamnyp
 
 # --- All packages: general owners (overridden by the specific areas below) ---
-/packages/                                   @lexfrei @IvanHunters @myasnikovdaniil @sircthulhu
+/packages/                                   @lexfrei @IvanHunters @myasnikovdaniil @sircthulhu @kvaps @lllamnyp
 
 # --- Go source: general owners (specific cmd/pkg areas overridden below) ---
 /cmd/                                        @kvaps @lllamnyp @sircthulhu @lexfrei
@@ -35,22 +43,22 @@
 /pkg/                                        @kvaps @lllamnyp @sircthulhu @lexfrei
 
 # --- Apps: default owners (specific apps overridden below) ---
-/packages/apps/                              @lexfrei @IvanHunters @myasnikovdaniil @scooby87
+/packages/apps/                              @lexfrei @IvanHunters @myasnikovdaniil @scooby87 @kvaps @lllamnyp
 /packages/apps/vm-instance/                  @scooby87 @lllamnyp @kvaps @myasnikovdaniil
 /packages/apps/vm-disk/                      @scooby87 @lllamnyp @kvaps @myasnikovdaniil
 /packages/apps/vpc/                          @kvaps @lllamnyp
 
 # --- Managed Kubernetes: app chart, node pools, resource definitions, control plane, CAPI ---
-/packages/apps/kubernetes/                   @IvanHunters @kvaps @myasnikovdaniil @lexfrei
-/packages/apps/kubernetes-nodes/             @IvanHunters @kvaps @myasnikovdaniil @lexfrei
-/packages/system/kubernetes-rd/              @IvanHunters @kvaps @myasnikovdaniil @lexfrei
-/packages/system/kubernetes-nodes-rd/        @IvanHunters @kvaps @myasnikovdaniil @lexfrei
-/packages/system/kamaji/                     @IvanHunters @kvaps @myasnikovdaniil @lexfrei
-/packages/system/capi-operator/              @IvanHunters @kvaps @myasnikovdaniil @lexfrei
-/packages/system/capi-providers-core/        @IvanHunters @kvaps @myasnikovdaniil @lexfrei
-/packages/system/capi-providers-bootstrap/   @IvanHunters @kvaps @myasnikovdaniil @lexfrei
-/packages/system/capi-providers-cpprovider/  @IvanHunters @kvaps @myasnikovdaniil @lexfrei
-/packages/system/capi-providers-infraprovider/ @IvanHunters @kvaps @myasnikovdaniil @lexfrei
+/packages/apps/kubernetes/                   @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
+/packages/apps/kubernetes-nodes/             @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
+/packages/system/kubernetes-rd/              @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
+/packages/system/kubernetes-nodes-rd/        @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
+/packages/system/kamaji/                     @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
+/packages/system/capi-operator/              @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
+/packages/system/capi-providers-core/        @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
+/packages/system/capi-providers-bootstrap/   @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
+/packages/system/capi-providers-cpprovider/  @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
+/packages/system/capi-providers-infraprovider/ @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
 
 # --- Extra apps ---
 /packages/extra/                             @kvaps @lllamnyp @IvanHunters @lexfrei @myasnikovdaniil
@@ -68,24 +76,24 @@
 /packages/system/vm-default-images/          @scooby87 @lllamnyp @kvaps @myasnikovdaniil
 
 # --- Backups ---
-/packages/system/backup-controller/          @androndo @lllamnyp @lexfrei
-/packages/system/backupstrategy-controller/  @androndo @lllamnyp
-/packages/system/velero/                     @androndo @lllamnyp @lexfrei
-/cmd/backup-controller/                      @androndo @lllamnyp
-/cmd/backupstrategy-controller/              @androndo @lllamnyp
+/packages/system/backup-controller/          @androndo @lllamnyp @lexfrei @kvaps
+/packages/system/backupstrategy-controller/  @androndo @lllamnyp @kvaps
+/packages/system/velero/                     @androndo @lllamnyp @lexfrei @kvaps
+/cmd/backup-controller/                      @androndo @lllamnyp @kvaps
+/cmd/backupstrategy-controller/              @androndo @lllamnyp @kvaps
 
 # --- Flux ---
 /packages/system/fluxcd/                     @kingdonb @kvaps @lllamnyp @myasnikovdaniil
 /packages/system/fluxcd-operator/            @kingdonb @kvaps @lllamnyp @myasnikovdaniil
 
 # --- GPU ---
-/packages/system/hami/                       @lexfrei @kvaps
-/packages/system/gpu-operator/               @lexfrei @kvaps
-/dashboards/gpu/                             @lexfrei @kvaps
+/packages/system/hami/                       @lexfrei @kvaps @lllamnyp
+/packages/system/gpu-operator/               @lexfrei @kvaps @lllamnyp
+/dashboards/gpu/                             @lexfrei @kvaps @lllamnyp
 
 # --- SeaweedFS ---
-/packages/system/seaweedfs/                  @IvanHunters @lexfrei @myasnikovdaniil
-/packages/extra/seaweedfs/                   @sircthulhu @lexfrei @myasnikovdaniil
+/packages/system/seaweedfs/                  @IvanHunters @lexfrei @myasnikovdaniil @kvaps @lllamnyp
+/packages/extra/seaweedfs/                   @sircthulhu @lexfrei @myasnikovdaniil @kvaps @lllamnyp
 
 # --- cozystack-api / controller / lineage webhook ---
 /packages/system/cozystack-api/              @IvanHunters @kvaps @lllamnyp @lexfrei
@@ -96,9 +104,9 @@
 /cmd/lineage-controller-webhook/             @IvanHunters @kvaps @lllamnyp @lexfrei
 
 # --- Keycloak ---
-/packages/system/keycloak/                   @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil
-/packages/system/keycloak-operator/          @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil
-/packages/system/keycloak-configure/         @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil
+/packages/system/keycloak/                   @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil @kvaps @lllamnyp
+/packages/system/keycloak-operator/          @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil @kvaps @lllamnyp
+/packages/system/keycloak-configure/         @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil @kvaps @lllamnyp
 
 # --- API surface (architects): API types, aggregated apiserver, registry ---
 /api/                                        @kvaps @lllamnyp
@@ -120,13 +128,13 @@
 /packages/system/*/cozyrds/
 
 # --- Docs ---
-/docs/                                       @lexfrei @myasnikovdaniil
+/docs/                                       @lexfrei @myasnikovdaniil @kvaps @lllamnyp
 
 # --- CI / automation ---
-/.github/                                    @myasnikovdaniil @lexfrei
-/hack/                                       @myasnikovdaniil @lexfrei
-/Makefile                                    @myasnikovdaniil @lexfrei
-/.pre-commit-config.yaml                     @myasnikovdaniil @lexfrei
+/.github/                                    @myasnikovdaniil @lexfrei @kvaps @lllamnyp
+/hack/                                       @myasnikovdaniil @lexfrei @kvaps @lllamnyp
+/Makefile                                    @myasnikovdaniil @lexfrei @kvaps @lllamnyp
+/.pre-commit-config.yaml                     @myasnikovdaniil @lexfrei @kvaps @lllamnyp
 
 # --- Governance, licensing, project docs ---
 /LICENSE                                     @tym83 @kvaps

--- a/hack/codeowners-invariant.bats
+++ b/hack/codeowners-invariant.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Coverage invariant for .github/CODEOWNERS.
+#
+# CODEOWNERS applies only the LAST matching rule, and matching is not
+# additive: a scoped rule fully replaces the * catch-all instead of extending
+# it. The only way to keep the default owners able to review everything is to
+# repeat their handles in every scoped rule. A rule that omits them silently
+# carves its path out from under the catch-all — that is how /hack/,
+# /.github/, /Makefile, /.pre-commit-config.yaml and /docs/ ended up owned by
+# exactly two people, deadlocking every PR one of them authored while the
+# other was away ("Require review from Code Owners" is enforced on main, and
+# stale reviews are dismissed on push, so there is no way around a missing
+# owner short of an admin override).
+#
+# The invariant: every rule that lists owners must include every owner of the
+# * catch-all. Two deliberate exceptions:
+#   - ownerless rules — generated files whose review is waived on purpose;
+#   - the governance roster, owned by exactly @tym83 @kvaps. It is identified
+#     by that owner set rather than by its position in the file, so the
+#     exemption cannot leak to rules appended under other sections.
+#
+# Changing the catch-all owners or growing the governance roster is a policy
+# change; this test failing on such a change is the point — adjust the
+# expectation here in the same PR, with the policy discussion linked.
+# -----------------------------------------------------------------------------
+
+@test "every CODEOWNERS rule that lists owners repeats the catch-all owners (governance excepted)" {
+  [ -f .github/CODEOWNERS ]
+
+  awk '
+    /^[[:space:]]*(#|$)/ { next }
+    $1 == "*" { for (i = 2; i <= NF; i++) defaults[$i]; ndef = NF - 1; next }
+    NF < 2 { next }
+    NF == 3 && (($2 == "@tym83" && $3 == "@kvaps") || ($2 == "@kvaps" && $3 == "@tym83")) { next }
+    {
+      for (d in defaults) {
+        found = 0
+        for (i = 2; i <= NF; i++) if ($i == d) found = 1
+        if (!found) { printf "line %d: rule %s is missing default owner %s\n", FNR, $1, d; bad = 1 }
+      }
+    }
+    END {
+      if (ndef == 0) { print "no * catch-all rule with owners found"; exit 1 }
+      exit bad
+    }
+  ' .github/CODEOWNERS
+}


### PR DESCRIPTION
## What this PR does

CODEOWNERS applies only the **last** matching rule, and matching is not additive: a scoped rule fully replaces the `*` catch-all instead of extending it. As a result `@kvaps` and `@lllamnyp` were not code owners for most scoped paths (21 and 36 of the 76 owner-bearing rules, respectively), and several paths (`/hack/`, `/.github/`, `/Makefile`, `/.pre-commit-config.yaml`, `/docs/`) were owned by exactly two people — with "Require review from Code Owners" enforced on `main`, a PR authored by one of them could only be approved by the other.

This PR:

- appends `@kvaps` and `@lllamnyp` to every rule that lists owners, keeping existing owners and their order; the governance block deliberately stays with `@tym83 @kvaps`, and the ownerless rules for generated files stay ownerless;
- spells out the non-additive last-match semantics in the file header;
- adds `hack/codeowners-invariant.bats` (auto-discovered by `make bats-unit-tests`), so a future scoped rule that omits the catch-all owners fails unit tests instead of silently carving its path out from under them.

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
chore(codeowners): @kvaps and @lllamnyp are now code owners for every path except governance files, removing single-approver review bottlenecks; a unit test guards the invariant
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership rules across dashboards, packages, Kubernetes components, backups, GPU and SeaweedFS components, Keycloak, documentation, and CI files.
  * Expanded area-specific review ownership while preserving existing governance and API review assignments.

* **Tests**
  * Added automated validation to ensure ownership rules include the required default reviewers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->