### PR TITLE
fix(manifestutil): report one message when the CRD wait is cancelled

### DIFF
--- a/internal/manifestutil/crd.go
+++ b/internal/manifestutil/crd.go
@@ -45,19 +45,38 @@ func WaitForCRDsEstablished(ctx context.Context, k8sClient client.Client, crdNam
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
+	// The CRD named if the wait is cut short. Until a poll observes the set
+	// nothing is known about which one lags, so the first of it stands in;
+	// after that it holds the CRD the last poll stopped on.
+	pendingCRD := crdNames[0]
+
+	// Cancellation leaves the loop from two places and reads the same from
+	// both, which is the point rather than an accident. When the deadline and
+	// a tick come ready together, select picks between them at random, so any
+	// difference between the two exits would reach the operator at random too.
+	cancelled := func() error {
+		return fmt.Errorf("context cancelled while waiting for CRD %q to be established: %w", pendingCRD, ctx.Err())
+	}
+
 	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("context cancelled while waiting for CRDs to be established: %w", ctx.Err())
-		default:
+		// Polling a dead context spends a Get to learn nothing: a client
+		// refuses it, and the refusal would land on the first name in the list
+		// whichever CRD is actually lagging, renaming what gets reported.
+		if ctx.Err() != nil {
+			return cancelled()
 		}
 
 		allEstablished := true
-		var pendingCRD string
 		for _, name := range crdNames {
 			crd := &unstructured.Unstructured{}
 			crd.SetGroupVersionKind(crdGVK)
 			if err := k8sClient.Get(ctx, types.NamespacedName{Name: name}, crd); err != nil {
+				// The poll was entered on a live context, so this is the CRD
+				// it stopped on and not whichever name a blanket refusal
+				// reached first. A context dying inside the poll still lands
+				// here and does record the first name to fail: this branch
+				// cannot tell a refused request from a CRD status, which is
+				// the wider problem it has for RBAC and connection errors too.
 				allEstablished = false
 				pendingCRD = name
 				break
@@ -97,7 +116,7 @@ func WaitForCRDsEstablished(ctx context.Context, k8sClient client.Client, crdNam
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("context cancelled while waiting for CRD %q to be established: %w", pendingCRD, ctx.Err())
+			return cancelled()
 		case <-ticker.C:
 		}
 	}

--- a/internal/manifestutil/crd_test.go
+++ b/internal/manifestutil/crd_test.go
@@ -18,7 +18,10 @@ package manifestutil
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -187,6 +190,274 @@ func TestWaitForCRDsEstablished_timeout(t *testing.T) {
 	if !strings.Contains(err.Error(), "packages.cozystack.io") {
 		t.Errorf("error should mention stuck CRD name, got: %v", err)
 	}
+	// The only deadline-driven test here, so it is the only one that can catch
+	// the cause being reported as something other than what ended the wait.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("error should wrap the deadline cause, got: %v", err)
+	}
+}
+
+// crdObject builds a CustomResourceDefinition for the fake client. Passing nil
+// conditions leaves status unset, which is one of the two shapes the wait reads
+// as "not established yet"; the other is a status carrying conditions that do
+// not include an established one.
+func crdObject(name string, conditions []interface{}) *unstructured.Unstructured {
+	obj := map[string]interface{}{
+		"apiVersion": "apiextensions.k8s.io/v1",
+		"kind":       "CustomResourceDefinition",
+		"metadata":   map[string]interface{}{"name": name},
+	}
+	if conditions != nil {
+		obj["status"] = map[string]interface{}{"conditions": conditions}
+	}
+	return &unstructured.Unstructured{Object: obj}
+}
+
+func establishedConditions() []interface{} {
+	return []interface{}{map[string]interface{}{"type": "Established", "status": "True"}}
+}
+
+func unestablishedConditions() []interface{} {
+	return []interface{}{map[string]interface{}{"type": "NamesAccepted", "status": "True"}}
+}
+
+// cancellationScheme returns the scheme the cancellation tests share.
+func cancellationScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add apiextensions to scheme: %v", err)
+	}
+	return scheme
+}
+
+// assertCancelled checks the whole message, not just the CRD in it. The point
+// of the fix is that every way out of the wait reports cancellation the same
+// way, so a second message that happens to carry a name is still the defect;
+// comparing the text is what makes that observable to a test.
+func assertCancelled(t *testing.T, err error, wantCRD string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("WaitForCRDsEstablished() expected error on cancelled context, got nil")
+	}
+	want := fmt.Sprintf("context cancelled while waiting for CRD %q to be established: %v", wantCRD, context.Canceled)
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+	// Callers wrap this error again, so the cause has to survive for anyone
+	// matching on it rather than on the text.
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("error should wrap the context cause, got: %v", err)
+	}
+}
+
+// TestWaitForCRDsEstablished_cancelledBeforeFirstPoll covers the interleaving
+// the timeout test above cannot reach: the context is already cancelled when
+// the function is entered, so no poll ever observes the set and the name in
+// the message can only be the one the wait starts with. The client answers
+// regardless of the context, so a wait that polled anyway would settle on the
+// second CRD and be visible here rather than passing by accident.
+func TestWaitForCRDsEstablished_cancelledBeforeFirstPoll(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(cancellationScheme(t)).
+		WithObjects(
+			crdObject("established.cozystack.io", establishedConditions()),
+			crdObject("packages.cozystack.io", nil),
+		).
+		Build()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = log.IntoContext(ctx, log.FromContext(context.Background()))
+	cancel()
+
+	err := WaitForCRDsEstablished(ctx, fakeClient, []string{"established.cozystack.io", "packages.cozystack.io"})
+	assertCancelled(t, err, "established.cozystack.io")
+}
+
+// TestWaitForCRDsEstablished_cancelledMidPollNamesUncheckedCRD pins which CRD
+// the message names when the deadline lands inside a poll. The poll walks past
+// one CRD it confirms established and is cut off on the next, which is the one
+// whose state is genuinely unknown and the one worth reporting. A third name
+// behind it keeps "the first Get to fail" apart from "the last one tried",
+// which two CRDs cannot tell apart.
+func TestWaitForCRDsEstablished_cancelledMidPollNamesUncheckedCRD(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = log.IntoContext(ctx, log.FromContext(context.Background()))
+
+	// The first Get is served, so the first CRD is confirmed established. The
+	// deadline then lands on the second, the way it would against a live
+	// client: cancelled first, refused second.
+	gets := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(cancellationScheme(t)).
+		WithObjects(
+			crdObject("established.cozystack.io", establishedConditions()),
+			crdObject("packages.cozystack.io", nil),
+			crdObject("later.cozystack.io", nil),
+		).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				gets++
+				if gets > 1 {
+					cancel()
+					return context.Canceled
+				}
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	err := WaitForCRDsEstablished(ctx, fakeClient, []string{"established.cozystack.io", "packages.cozystack.io", "later.cozystack.io"})
+	assertCancelled(t, err, "packages.cozystack.io")
+}
+
+// TestWaitForCRDsEstablished_cancelledAfterPollKeepsName pins that the name a
+// completed poll settled on survives the wait that follows it. The two cases
+// are the two shapes of "not established yet", which the loop records from
+// different branches.
+func TestWaitForCRDsEstablished_cancelledAfterPollKeepsName(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	for _, tc := range []struct {
+		name       string
+		conditions []interface{}
+	}{
+		{name: "status absent", conditions: nil},
+		{name: "no established condition", conditions: unestablishedConditions()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ctx = log.IntoContext(ctx, log.FromContext(context.Background()))
+
+			// Both Gets are served, so the poll completes and settles on the
+			// second CRD. The context then dies while the loop waits for a tick.
+			gets := 0
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(cancellationScheme(t)).
+				WithObjects(
+					crdObject("established.cozystack.io", establishedConditions()),
+					crdObject("packages.cozystack.io", tc.conditions),
+				).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						if err := ctx.Err(); err != nil {
+							return err
+						}
+						err := c.Get(ctx, key, obj, opts...)
+						gets++
+						if gets == 2 {
+							cancel()
+						}
+						return err
+					},
+				}).
+				Build()
+
+			err := WaitForCRDsEstablished(ctx, fakeClient, []string{"established.cozystack.io", "packages.cozystack.io"})
+			assertCancelled(t, err, "packages.cozystack.io")
+		})
+	}
+}
+
+// reenteringContext forces the loop to start an iteration on a context that is
+// already cancelled. Against a real context that needs the bottom select to
+// have taken the tick while both cases were ready, which is a coin toss no test
+// can hold still. Done stays open for the single read that select makes in the
+// iteration where cancellation lands, so the tick wins by construction; every
+// read after that returns a closed channel, so the next iteration sees a
+// context cancelled through both Done and Err, the way a real one is. The
+// standard library guarantees that pairing rather than merely happening to
+// provide it: cancelCtx.Err reads <-c.Done() before returning a non-nil error.
+type reenteringContext struct {
+	context.Context
+	dead    *atomic.Bool
+	tickWon *atomic.Bool
+	open    chan struct{}
+	closed  chan struct{}
+}
+
+func newReenteringContext(parent context.Context) reenteringContext {
+	closed := make(chan struct{})
+	close(closed)
+	return reenteringContext{
+		Context: parent,
+		dead:    &atomic.Bool{},
+		tickWon: &atomic.Bool{},
+		open:    make(chan struct{}),
+		closed:  closed,
+	}
+}
+
+func (c reenteringContext) Done() <-chan struct{} {
+	if c.dead.Load() && !c.tickWon.CompareAndSwap(false, true) {
+		return c.closed
+	}
+	return c.open
+}
+
+func (c reenteringContext) Err() error {
+	if c.dead.Load() && c.tickWon.Load() {
+		return context.Canceled
+	}
+	return nil
+}
+
+// TestWaitForCRDsEstablished_cancelledOnLoopReentryKeepsName pins that the CRD
+// name survives into the next iteration. One poll completes and settles on the
+// second CRD, the context dies during the wait, and the loop re-enters and
+// leaves through the check at the top. That check has no poll of its own to
+// take a name from, so the one it reports has to be the one carried over.
+func TestWaitForCRDsEstablished_cancelledOnLoopReentryKeepsName(t *testing.T) {
+	log.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	base := log.IntoContext(context.Background(), log.FromContext(context.Background()))
+	reCtx := newReenteringContext(base)
+
+	gets := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(cancellationScheme(t)).
+		WithObjects(
+			crdObject("established.cozystack.io", establishedConditions()),
+			crdObject("packages.cozystack.io", nil),
+		).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				err := c.Get(ctx, key, obj, opts...)
+				gets++
+				if gets == 2 {
+					reCtx.dead.Store(true)
+				}
+				return err
+			},
+		}).
+		Build()
+
+	// The double answers Done from a fixed script, so a loop that stops reading
+	// it the expected number of times never leaves. Bound the call: a hang here
+	// costs the whole package's CI timeout, a failure costs one line.
+	done := make(chan error, 1)
+	go func() {
+		done <- WaitForCRDsEstablished(reCtx, fakeClient, []string{"established.cozystack.io", "packages.cozystack.io"})
+	}()
+
+	select {
+	case err := <-done:
+		assertCancelled(t, err, "packages.cozystack.io")
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForCRDsEstablished() never returned: the loop stopped taking the cancellation exits this fixture scripts")
+	}
 }
 
 func TestWaitForCRDsEstablished_empty(t *testing.T) {
@@ -199,4 +470,3 @@ func TestWaitForCRDsEstablished_empty(t *testing.T) {
 		t.Fatalf("WaitForCRDsEstablished() with empty names should return nil, got: %v", err)
 	}
 }
-


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

`WaitForCRDsEstablished` reported a cancelled context two different ways. The check at the top of the poll loop returned a message with no CRD name, the `select` at the bottom named the CRD the poll had stopped on. When a tick and the deadline come ready in the same instant, `select` picks between the ready cases at random, so one cancellation reached the operator either way.

Both callers wrap this as `CRDs not established after apply`, so the CRD name is what makes that log line actionable, and whether it is there was a coin toss. `TestWaitForCRDsEstablished_timeout` asserts on the name, which is where this surfaced: its 2s deadline is an exact multiple of the 500ms ticker, so the two channels come ready together on the fourth tick and the assertion failed at random.

The message is now built in one place and returned from both exits, so the two are indistinguishable by construction rather than by inspection. The name is carried across iterations, because a cancellation noticed at the top of the loop has no poll of its own to take one from, and it starts as the first CRD of the set for a wait cancelled before any poll observed anything. That start value is a stand-in rather than an observation, and the comment on it says so; the alternative, an empty name and a second phrasing for it, would leave the loop-top message with nothing to assert against and no test able to catch its return to the unnamed form.

Deleting the top check instead, so there is literally one exit, is the smaller diff and it moves the name to the head of the list in the very interleaving this PR is about. A client refuses `Get` on a dead context at the first name in the list whichever CRD is actually lagging, so a poll entered on a cancelled context renames the report to that first name. That premise is about the production client, `client.New` at `cmd/cozystack-operator/main.go:176`, uncached, so the request is rejected before it is issued, and it is worth saying that nothing in the test surface pins it: replacing the `ctx` passed to `Get` with `context.Background()` survives the whole package, and the fixtures that need a context-honouring client check `ctx.Err()` by hand. That line predates this change and is untouched by it. Measured with a client that honours the context: with the check, a wait that re-enters the loop after the deadline keeps the name its last poll settled on; without it, the report moves to the head of the list. The check closes that window and no more than that. A context that dies part-way through a poll still records the first `Get` to fail, exactly as merge base does, because this branch cannot tell a refused request from a CRD status. That is unchanged here and written up separately.

Four tests cover the ways this wait can end on a cancelled context: before any poll has observed the set, cut off inside a poll, cancelled while waiting for the next tick, and re-entering the loop on a context that died during that wait. Two of them are red on merge base and are the regression pins for the defect above, both deterministically rather than by repetition: merge base answers a wait that starts cancelled, and a wait that re-enters the loop cancelled, with the unnamed message every time. Its loop-top exit is a `select` whose `Done` case is ready, and a ready case always beats `default`. The middle two are green on merge base, which gets those cases right; they are here because each catches a specific way of breaking the fix. Every one of the four is the sole killer of at least one mutation, which is the property worth having: it says none of them is redundant. They compare the whole message rather than searching it for a name, because a second exit that happens to carry a name is still the defect being fixed here, and a test that only looks for the name cannot see it.

The re-entry test needs the bottom `select` to take the tick while cancellation is already pending, which against a real context is the same coin toss the bug rides on. The double it uses hands out an open `Done` for the single read that `select` makes in that iteration and a closed one for every read after, so the tick wins by construction and the next iteration sees a context cancelled through both `Done` and `Err`, the way a real one is. That pairing is guaranteed rather than incidental: `cancelCtx.Err` reads `<-c.Done()` before returning a non-nil error, so a double that reported cancellation through `Err` alone would be modelling a state no context can be in, and would pin the shape of the check rather than its behaviour. One property of that double is worth knowing before editing the loop: it hands out its open and closed channels per read, so a `Done()` read added inside the poll would consume the open one and leave the bottom `select` a closed channel, quietly turning this into a second bottom-exit test that still passes. The failure direction there is false-green, which is the worse half, and the cheap guard is a lower bound on elapsed time inside that test, a run that leaves through the loop top spends a ticker interval getting there, one that leaves at the bottom of the first iteration does not. Not done here, because the test is correct today and provably kills the mutation it exists for, so the hazard is conditional on a future edit.

The timeout test does reproduce locally under load: 6 failures across 400 runs on the unfixed code while I was measuring, spread over five batches, the last of which saw none. #3719 reports that it does not reproduce locally, so this is worth writing down before someone spends an evening re-testing that. That spread is also why the number is an order of magnitude and not a rate.

`TestInstall_crdNotEstablished` in `internal/crdinstall` has the same 2s deadline against the same 500ms ticker. It asserts on the `CRDs not established` wrapper the caller adds, and both messages carried that wrapper, so this coin flip could not reach it and nothing here touches it.

I left the 2s deadline where it is. Moving it off the tick boundary would have hidden the coin flip and left the second message in place. The new tests catch a reintroduced second message deterministically, which is what that job now rests on rather than the timeout test's roughly one-in-sixty.

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
fix(manifestutil): a CRD wait cut short by a cancelled context now reports one error naming the CRD it was waiting on, where before the name was present or missing depending on which of two exits the scheduler happened to pick
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling while waiting for custom resources to become established.
  * Cancelled operations now stop before issuing unnecessary requests and identify the affected resource.
  * Timeout errors remain distinguishable from cancellation errors.

* **Tests**
  * Added coverage for cancellation before, during, after, and between polling attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->