### PR TITLE
fix(e2e): stop the sandbox cluster CIDR overlapping the pod range

### DIFF
--- a/hack/e2e-cilium-endpoint-leak-healer.sh
+++ b/hack/e2e-cilium-endpoint-leak-healer.sh
@@ -208,6 +208,14 @@ while true; do
     # never count it toward or trigger the agent restart. Gated on an EXACT match
     # (ip_is_node_ingress; an empty ingress IP never matches) so a false positive
     # can never suppress a restart that would clear a real in-memory leak.
+    #
+    # In the sandbox this branch should now be unreachable: the Kubernetes
+    # cluster CIDR the ingress IP is carved from no longer overlaps the range
+    # kube-ovn allocates pod addresses out of, so no pod can be handed it
+    # (hack/sandbox-cidr-disjoint.bats pins that). The branch stays because the
+    # separation is a property of the sandbox configuration, not of cilium, and
+    # a cluster whose ranges do overlap still reaches it. A SURFACE line for an
+    # ingress IP appearing in the sandbox again means that separation broke.
     ingress_ip=$(kubectl get ciliumnode "$node" -o jsonpath='{.spec.ingress.ipv4}' 2>/dev/null)
     if ip_is_node_ingress "$ip" "$ingress_ip"; then
       log "SURFACE node=$node ip=$ip wedged=$ns/$pod: IP is this node's Cilium ingress IP (CiliumNode.spec.ingress.ipv4), held by the reserved:ingress endpoint -- genuine infra/pod double-allocation from the upstream host-scope IPAM + Gateway API restore-window race. Agent restart cannot clear a re-derived reserved IP and can re-trigger the race, so Tier-2 is skipped; rescheduling the wedged pod best-effort."

--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -188,8 +188,18 @@ cluster:
     cni:
       name: none
     dnsDomain: cozy.local
+    # Deliberately NOT the kube-ovn POD_CIDR (10.244.0.0/16, set as
+    # networking.podCIDR by the install step). kube-ovn owns pod IPAM and
+    # allocates flat from POD_CIDR; cilium is chained behind it and allocates
+    # no pod addresses, but it still carves its own per-node router and
+    # Ingress IPs out of Node.spec.podCIDR, which kube-controller-manager
+    # slices from this value. Overlap and kube-ovn eventually hands a pod an
+    # address cilium already holds. hack/sandbox-cidr-disjoint.bats guards it.
+    # Picking a replacement: 100.64.0.0/16 is the kube-ovn join range and
+    # 100.66.0.0/16 is kilo's transit range, so the free slot in this corner of
+    # RFC 6598 is the one below.
     podSubnets:
-    - 10.244.0.0/16
+    - 100.65.0.0/16
     serviceSubnets:
     - 10.96.0.0/16
 EOF

--- a/hack/sandbox-cidr-disjoint.bats
+++ b/hack/sandbox-cidr-disjoint.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+# Asserts that the sandbox Kubernetes cluster CIDR overlaps none of the address
+# ranges the sandbox platform is configured with (pod, service and join).
+#
+# Two allocators are live on this datapath and neither knows about the other.
+# kube-ovn owns pod IPAM and allocates flat from POD_CIDR across all nodes.
+# Cilium allocates nothing for pods -- it is chained behind kube-ovn -- but it
+# does carve its own per-node infrastructure addresses out of
+# Node.spec.podCIDR, which kube-controller-manager slices from the cluster
+# CIDR: the router IP on cilium_host, and the per-node Ingress IP that Gateway
+# API brings with it. Let the two ranges overlap and kube-ovn eventually hands
+# a pod an address cilium already holds.
+#
+# On the Ingress IP that is loud: the agent refuses the sandbox with "IP
+# ipv4:<addr> is already in use". Cilium never relents on the address, so the
+# pod recovers only if something puts it on a different one. Whether that
+# happens is not a property of this collision: hack/e2e-cilium-endpoint-leak-
+# healer.sh records deleting the wedged pod landing it on a clean address, and
+# in the failure this guard comes from the same address was refused seven times
+# across six distinct pod UIDs before the suite ran out of budget. On the
+# router IP it is silent instead: the endpoint is created, the pod runs, and
+# only host-to-pod traffic breaks, because to the node's own kernel that
+# address is local.
+#
+# Cilium picks those offsets by random scan over the node's range, so excluding
+# a fixed set of addresses on the kube-ovn side does not work -- the ranges
+# have to be disjoint.
+#
+# The invariant is checked, not the literals: any of the values may move, and
+# this still passes as long as none of them overlap. An extraction that comes
+# up empty, duplicated or misshapen fails the test instead of shrinking the
+# comparison, and comments and blank lines inside the list are skipped rather
+# than read as the end of it. This is not a YAML parser, though. Anything it
+# does not read as a bare dotted quad fails the shape validation rather than
+# being understood, and that set is wider than the exotic shapes: an anchor, a
+# nested flow mapping, but also a plainly quoted scalar. Quoting is asymmetric
+# between the two sides as well -- a platform key is read only when its value
+# is double-quoted, a Talos entry only when its value is not. All of those are
+# legal reformats and all of them turn the guard red with the offending value
+# in the message, which is the safe direction but not the same promise.
+#
+# Harness note: the CI path is hack/cozytest.sh, NOT real bats. There is no
+# `run`, `$status`, `$output`, `skip`, or setup()/teardown(); each test runs as
+# a shell function under `set -eu -x`, so a non-zero exit is the failure. A
+# `!`-negated command never trips errexit, so every assertion below is written
+# as an explicit `if ... return 1`. A top-level helper function would have
+# `return 0` injected before its closing brace by the runner's awk, which is
+# why the arithmetic is inlined instead. Paths are repo-root-relative.
+#
+# Run with: hack/cozytest.sh hack/sandbox-cidr-disjoint.bats
+
+@test "sandbox cluster CIDR overlaps no platform range" {
+  talos_file=hack/e2e-prepare-cluster.bats
+  install_file=hack/e2e-install-cozystack.bats
+
+  # Talos cluster.network.podSubnets: every list item under the key, including
+  # ones separated from the first by a comment or a blank line, so a second
+  # entry cannot slip past unexamined. An IPv6 entry does not get an overlap
+  # check, it fails the shape validation below; teaching this guard dual-stack
+  # means extending it, not just adding the value.
+  cluster_cidrs=$(awk '
+    /^[[:space:]]*podSubnets:[[:space:]]*$/ { inlist = 1; next }
+    inlist && /^[[:space:]]*-[[:space:]]+[^[:space:]]/ { print $2; next }
+    # A comment or a blank line between two entries is not the end of the
+    # list. Treating it as the end would drop every entry below it and still
+    # leave a non-empty result, which is the one way this extraction could go
+    # green while checking less than it says. The block comment that landed
+    # above podSubnets alongside this guard makes that the likely shape rather
+    # than a rare one; the guard does not require that comment, it just has to
+    # survive it and whatever gets written next to it later.
+    inlist && /^[[:space:]]*(#|$)/ { next }
+    inlist { inlist = 0 }
+  ' "$talos_file")
+
+  if [ -z "$cluster_cidrs" ]; then
+    echo "found no podSubnets entries in $talos_file" >&2
+    echo "the extraction below is keyed on 'podSubnets:' followed by a list" >&2
+    return 1
+  fi
+
+  # The ranges the install step hands the platform chart. podCIDR is the one
+  # that collides today; serviceCIDR and joinCIDR are here because the cluster
+  # CIDR must miss all three, and picking a replacement that lands on the join
+  # range instead is the obvious next way to get this wrong. These three are
+  # the allocator ranges and nothing else: the sandbox node network, the
+  # load-balancer pool and the transit range of an off-by-default component
+  # are not read here, so this list is not a complete map of what the cluster
+  # CIDR must avoid.
+  platform_cidrs=
+  for key in podCIDR serviceCIDR joinCIDR; do
+    # `|| true`: grep -c exits 1 when it counts zero, and under the runner's
+    # errexit that kills the test on the assignment, before the message below
+    # can name which key went missing. The outcome is red either way; this is
+    # only about saying why.
+    count=$(grep -cE "^[[:space:]]*${key}:[[:space:]]*\"" "$install_file" || true)
+    # grep exits 2 with no stdout when the file itself is gone, which leaves
+    # count empty and turns the arithmetic below into "integer expression
+    # expected". Still red, but named after the wrong thing.
+    count=${count:-0}
+    if [ "$count" -ne 1 ]; then
+      echo "expected exactly one $key key in $install_file, found $count" >&2
+      return 1
+    fi
+    value=$(awk -F'"' -v k="$key" '$0 ~ "^[[:space:]]*" k ":[[:space:]]*\"" { print $2; exit }' "$install_file")
+    # A present-but-empty value passes the count check above, then disappears
+    # in the unquoted word split below, dropping that range from the
+    # comparison with nothing to show for it. Refuse instead.
+    if [ -z "$value" ]; then
+      echo "$key in $install_file is present but empty" >&2
+      return 1
+    fi
+    platform_cidrs="$platform_cidrs $value"
+  done
+
+  for cidr in $cluster_cidrs $platform_cidrs; do
+    if printf '%s\n' "$cidr" | grep -qvE '^[0-9]{1,3}(\.[0-9]{1,3}){3}/[0-9]{1,2}$'; then
+      echo "extracted value is not an IPv4 CIDR: '$cidr'" >&2
+      return 1
+    fi
+  done
+
+  for cluster_cidr in $cluster_cidrs; do
+    for platform_cidr in $platform_cidrs; do
+      # Two prefixes overlap when, masked to the shorter of the two lengths,
+      # their network addresses are equal. Symmetric by construction: neither
+      # argument is privileged, so containment is caught whichever way round
+      # it is. awk arithmetic is IEEE double, exact well past the 2^32 needed.
+      if printf '%s\n%s\n' "$cluster_cidr" "$platform_cidr" | awk '
+        function toint(a,   p) {
+          split(a, p, ".")
+          return ((p[1] * 256 + p[2]) * 256 + p[3]) * 256 + p[4]
+        }
+        NR == 1 { split($0, a, "/"); ip1 = toint(a[1]); len1 = a[2] }
+        NR == 2 { split($0, b, "/"); ip2 = toint(b[1]); len2 = b[2] }
+        END {
+          shorter = (len1 < len2 ? len1 : len2)
+          block = 2 ^ (32 - shorter)
+          exit (int(ip1 / block) == int(ip2 / block)) ? 0 : 1
+        }
+      '; then
+        echo "sandbox cluster CIDR $cluster_cidr ($talos_file)" >&2
+        echo "overlaps platform range $platform_cidr ($install_file)" >&2
+        echo "cilium carves its per-node router and Ingress addresses out of the cluster CIDR." >&2
+        echo "Pick a cluster CIDR that misses every range the platform is configured with." >&2
+        return 1
+      fi
+    done
+  done
+}


### PR DESCRIPTION
## What this PR does

The sandbox Talos config and the platform install step both used `10.244.0.0/16`, one as the Kubernetes cluster CIDR and the other as the kube-ovn `POD_CIDR`, so two allocators drew from one range.

kube-ovn owns pod IPAM and allocates flat from `POD_CIDR`. Cilium is chained behind it (`generic-veth`, target `kube-ovn`) and allocates no pod addresses at all, but it still carves its own per-node router IP and Ingress IP out of `Node.spec.podCIDR`, which kube-controller-manager slices from the cluster CIDR. Sooner or later kube-ovn hands a pod an address cilium already holds. When that address is the Ingress IP the agent refuses the sandbox with `IP ipv4:<addr> is already in use`, and cilium never relents on it, so the pod proceeds only if something reschedules it onto a different address; in the run this was filed from, the same address was refused seven times across six pod UIDs before the suite ran out of budget. When it is the router IP nothing complains and only host-to-pod traffic breaks.

This moves the sandbox cluster CIDR to `100.65.0.0/16`, which no other range in the tree uses, and adds a guard so the two cannot be brought back together by accident.

Pod addresses do not change. They still come from kube-ovn out of `10.244.0.0/16`, and cilium does not require a chained endpoint's address to sit inside its own allocation CIDR, so only cilium's two per-node infrastructure addresses move.

The quiet variant gets fixed twice over, which is worth spelling out because only half of it was obvious. Under `ipam.mode: kubernetes` cilium also installs a route for the node's own pod CIDR via `cilium_host`. On the current default that route covers `10.244.a.0/24` on a node whose pods actually live behind `ovn0`, so it shadows real pod addresses. Moving the cluster CIDR both stops the router IP from ever being handed to a pod and retargets that route at `100.65.a.0/24`, where it shadows nothing.

Excluding the addresses on the kube-ovn side instead is not an option: cilium picks its offsets by random scan over the node's range, so there is no static set to exclude.

The collision shows up in two shapes, and both have been seen. Loudly, on the Ingress IP, where the agent names the address in the event, which is the failure https://github.com/cozystack/cozystack/issues/3736 was filed for. Quietly, on the router IP, where the pod comes up and the only symptom is `connection refused` on a kubelet probe, with `ip route get <podIP>` on the node resolving to `local ... dev lo`; that variant is documented in https://github.com/cozystack/cozystack/issues/3445 and https://github.com/cozystack/cozystack/issues/3615. They were being tracked as unrelated flakes in different suites before the shared cause was identified.

## What the guard covers, and what it does not

`hack/sandbox-cidr-disjoint.bats` pins the configuration, not the behaviour. It reads the values out of the tree and fails when they overlap. It does not reproduce the collision, which needs a running cluster.

It checks the invariant rather than the literals, so either value may move as long as they stay disjoint, and it checks the cluster CIDR against the service and join ranges too, because landing on one of those instead is the next way to get this wrong. An extraction that comes up empty, duplicated or misshapen fails the test instead of shrinking the comparison, and comments and blank lines inside the list are skipped rather than read as the end of it. It is not a YAML parser, though: anything it does not read as a bare dotted quad fails the shape validation rather than being understood, which is the safe direction but not the same promise.

Those three are the allocator ranges and nothing more. The sandbox node network, the load-balancer pool and the transit range of a component that is off by default are not read, so the guard is not a complete map of what the cluster CIDR has to avoid. An IPv6 entry fails the shape validation rather than getting an overlap check, so dual-stack means extending the guard rather than passing through it.

## Residual risk

I did not prove from source that cilium is the only consumer of `Node.spec.podCIDR` in this topology. What I did check is that kube-proxy is disabled and that `local-ccm` runs the node-lifecycle controller only, with no route controller.

This diff selects the full e2e suite, 21 Chainsaw suites with `gateway` and `mongodb` among them, so a consumer I missed surfaces as a red run on this PR rather than staying an assumption.

Split of what covers what: the static checks and the unit guard cover the configuration, and the e2e run covers the behaviour. Nothing short of a green suite answers whether cilium's router and Ingress addresses behave once they sit outside the range kube-ovn allocates from.

## A check that is not "the suite went green"

`hack/e2e-cilium-endpoint-leak-healer.sh` already prints a line of its own for this exact collision, so there is a signal to read that does not depend on the overall verdict. In the `cozyreport` artifact it lands at `snapshots/<suite>/host/namespaces/kube-system/v1/pod/cilium-leak-healer-*/healer/current.log`, and the lines to grep for are `IP is this node's Cilium ingress IP`. In the run this was filed from there are 42 of them, all naming the same address.

After this change that line cannot be produced by an address inside the kube-ovn range, because there is no longer an address that is in both. So the expectation is zero from the first run, not zero on average: one occurrence contradicts the change rather than being noise, and is worth stopping on. A green suite can be green for many reasons; this line disappearing has only one.

## Scope

This fixes the sandbox and nothing else. For a real installation the cluster CIDR lives in the operator's own machine configuration, outside this repository, so the same collision is still reachable there. https://github.com/cozystack/cozystack/issues/3740 tracks the product side, including the finding that the install documentation does not merely allow the overlap but instructs operators to create it, by requiring `podCIDR` to match the cluster's pod CIDR.

There is a tradeoff in this worth naming rather than leaving to be discovered. Talos defaults `podSubnets` to `10.244.0.0/16` (`DefaultIPv4PodNet`, `pkg/machinery/constants/constants.go:888` at v1.13.6, the version this tree ships), and the platform defaults `networking.podCIDR` to the same value, so an operator who takes both defaults gets the overlap. Until now the sandbox shared that topology and was the one place the bug surfaced where anyone would see it. After this change it no longer reproduces the operator-facing form, and nothing else does either. That is the right call for CI, which should not be wedged by a defect it did not introduce, but it does mean the production exposure loses its only accidental detector.

Closes https://github.com/cozystack/cozystack/issues/3736

To be explicit about what closing that issue does and does not mean: this removes the reproduction in the sandbox and leaves the product configuration untouched. The collision is still reachable for users, and https://github.com/cozystack/cozystack/issues/3740 is where that lives. The issue text describes the root mechanism, which is wider than its title, so the closure covers the e2e failure it was filed for and not the platform default.

### Screenshots

Not a UI change.

### Downstream repositories

No box is ticked deliberately, and no follow-up PR is opened, so a human decides.

Walking the trigger map against this diff: both `hack/e2e-prepare-cluster.bats` entries in it are scoped to node prerequisites, the kernel modules a node must load, the containerd settings, the LVM `global_filter` and the cluster domain. This diff changes none of those, it changes a network range, so no entry fires literally.

The underlying constraint does reach several of them all the same. `cozystack/talm` sets `podSubnets: [10.244.0.0/16]` in `charts/cozystack/values.yaml`, the same range the platform uses for `networking.podCIDR`, so the documented Talos bootstrap produces the overlap this PR removes from the sandbox. `cozystack/ansible-cozystack` reaches it from the other side: `roles/cozystack/defaults/main.yml` sets `cozystack_pod_cidr: "10.42.0.0/16"` and renders it into `networking.podCIDR`, while its inventories set `cluster-cidr: 10.42.0.0/16`, so those two are identical as well. And `cozystack/website` prescribes the equality outright, `install/kubernetes/generic.md` stating that `podCIDR` and `serviceCIDR` must match the Kubernetes cluster configuration.

No issue is filed there yet on purpose: which side moves is not decided, and asking talm to change `podSubnets` would be the wrong request if the platform ends up moving instead. That decision belongs to https://github.com/cozystack/cozystack/issues/3740.

- [ ] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated cluster networking ranges to avoid conflicts with Kubernetes, kube-ovn, kilo, and Cilium networks.
  - Added validation to detect missing, invalid, or overlapping cluster and platform CIDR ranges.
  - Preserved safeguards for environments where network ranges overlap, with clearer diagnostic logging.

- **Documentation**
  - Documented network separation requirements and clarified expected sandbox networking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->