### PR TITLE
fix(platform): stop the bundle prologue from swallowing the doc separator

### DIFF
--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.bundles.system.enabled }}
 
 # Networking
-{{- if eq .Values.bundles.system.variant "isp-full" }}
+{{ if eq .Values.bundles.system.variant "isp-full" }}
 {{- $networkingComponents := dict -}}
 {{- if .Values.networking -}}
 {{- $kubeovnIpv4 := dict


### PR DESCRIPTION
## What this PR does

Fixes the `# Networking` comment in `packages/core/platform/templates/bundles/system.yaml` left-trimming the newline before the first `cozystack.platform.package` helper's `---` separator, which merges the comment and the separator into `# Networking---` so YAML parses it as a single comment and drops the document separator. This is harmless today only because nothing precedes `# Networking` in the file, so the merged text still starts the first document. It stops being harmless the moment a future change emits a `Package` earlier in the file: the two `Package` documents would fuse into one YAML mapping, and Flux's post-renderer (or plain YAML parsing) would fail with `mapping key already defined` for `apiVersion`/`kind`/`metadata`/`spec`.

The fix drops the left-trim dash on that one `if` tag (`{{- if eq .Values.bundles.system.variant "isp-full" }}` to `{{ if eq ... }}`), preserving the newline after the `# Networking` comment so the helper's leading `---` always lands on its own line. This matches how the file's other two variant blocks (`isp-hosted`, `isp-full-generic`) already behave, since each is preceded by a real blank line, and matches the untrimmed `{{ if ... }}` style already used elsewhere in the file for the same reason.

Verified by temporarily inserting a synthetic `Package` include before the `# Networking` line and running `helm unittest packages/core/platform -f 'tests/bundles_networking_encryption_test.yaml'`, which failed with the same `mapping key already defined` error described above; the same command passed once this fix was applied with the synthetic marker still in place. After removing the synthetic marker, the full suite `helm unittest packages/core/platform` passed 29/29 suites, 132/132 tests, with no regressions or stray blank lines. `make show` and a cluster install/e2e were not run, since neither is needed to validate a pure Go-template whitespace fix with no runtime/cluster-state dependency.

### Screenshots

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(platform): stop the bundle prologue from swallowing the doc separator, which could otherwise fuse two Package documents in the rendered system bundle into one invalid YAML mapping
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #2475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected whitespace rendering before the `isp-full` conditional block in system bundle output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->