### PR TITLE
fix(platform,monitoring-agents): match control-plane nodes by label existence, not equality

### DIFF
--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -144,13 +144,6 @@
 
 # Cozystack Engine
 {{- $cozystackEngineComponents := dict -}}
-{{- /* For generic k8s, DaemonSets with control-plane nodeSelector need value "true" */ -}}
-{{- if eq .Values.bundles.system.variant "isp-full-generic" -}}
-{{- $genericNodeSelector := dict "node-role.kubernetes.io/control-plane" "true" -}}
-{{- /* cozystack-api DaemonSet */ -}}
-{{- $apiValues := dict "cozystackAPI" (dict "nodeSelector" $genericNodeSelector) -}}
-{{- $_ := set $cozystackEngineComponents "cozystack-api" (dict "values" $apiValues) -}}
-{{- end -}}
 {{- if .Values.authentication.oidc.enabled }}
 {{include "cozystack.platform.package" (list "cozystack.cozystack-engine" "oidc" $ $cozystackEngineComponents) }}
 {{include "cozystack.platform.package.default" (list "cozystack.keycloak" $) }}

--- a/packages/core/platform/tests/bundles_generic_cozystack_api_nodeselector_test.yaml
+++ b/packages/core/platform/tests/bundles_generic_cozystack_api_nodeselector_test.yaml
@@ -1,0 +1,28 @@
+suite: isp-full-generic no longer stamps a dead cozystackAPI.nodeSelector override
+
+# cozystack-api's own Deployment (packages/system/cozystack-api/templates/deployment.yaml)
+# never reads .Values.cozystackAPI.nodeSelector — it schedules onto control-plane
+# nodes via a soft nodeAffinity preference plus a blanket toleration instead. The
+# isp-full-generic branch of this bundle set cozystackAPI.nodeSelector anyway, an
+# override with no consumer. Worse, being an equality match on
+# node-role.kubernetes.io/control-plane=true it would have been wrong on
+# kubeadm/Talos/OpenShift (empty label value) had anything ever read it. Assert the
+# dead override is gone rather than merely inert.
+templates:
+  - templates/bundles/system.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  - it: emits no components block for cozystack-api on isp-full-generic
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full-generic
+    documentSelector:
+      path: metadata.name
+      value: cozystack.cozystack-engine
+    asserts:
+      - notExists:
+          path: spec.components.cozystack-api

--- a/packages/system/monitoring-agents/templates/etcd-proxy-scrape.yaml
+++ b/packages/system/monitoring-agents/templates/etcd-proxy-scrape.yaml
@@ -27,8 +27,17 @@ spec:
     spec:
       serviceAccountName: kube-rbac-proxy
       hostNetwork: true
-      nodeSelector:
-        node-role.kubernetes.io/control-plane: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
       containers:
       - name: kube-rbac-proxy
         image: quay.io/brancz/kube-rbac-proxy:v0.22.0

--- a/packages/system/monitoring-agents/tests/etcd_proxy_scrape_affinity_test.yaml
+++ b/packages/system/monitoring-agents/tests/etcd_proxy_scrape_affinity_test.yaml
@@ -1,0 +1,37 @@
+suite: etcd-proxy-scrape DaemonSet matches control-plane nodes by label existence
+
+# The equality nodeSelector node-role.kubernetes.io/control-plane: "" only
+# matches the kubeadm/Talos/OpenShift convention (empty label value). On
+# k3s/RKE2 the same label carries value "true", so the equality match fails
+# and the DaemonSet never schedules there, leaving etcd unscraped. Switching
+# to a key-existence nodeAffinity matches every distribution regardless of
+# the label's value, and the added toleration lets it land on nodes that
+# carry the default control-plane NoSchedule taint (kubeadm/Talos/OpenShift/
+# RKE2; k3s has none by default, where the toleration is simply inert).
+release:
+  name: monitoring-agents
+  namespace: cozy-monitoring
+tests:
+  - it: requires the control-plane label to exist rather than equal a specific value
+    template: templates/etcd-proxy-scrape.yaml
+    documentIndex: 0
+    set:
+      scrapeRules:
+        etcd:
+          enabled: true
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0]
+          value:
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
+      - equal:
+          path: spec.template.spec.tolerations[0]
+          value:
+            key: node-role.kubernetes.io/control-plane
+            operator: Exists
+            effect: NoSchedule
+      - notExists:
+          path: spec.template.spec.nodeSelector


### PR DESCRIPTION
## What this PR does

Cozystack-authored templates select control-plane nodes with an equality-match `nodeSelector` on `node-role.kubernetes.io/control-plane`, but the label's value differs by distribution: empty string on kubeadm/Talos/OpenShift, `"true"` on k3s/RKE2. An equality nodeSelector can only satisfy one of the two cohorts at a time.

- `packages/system/monitoring-agents/templates/etcd-proxy-scrape.yaml`: the kube-rbac-proxy DaemonSet (scrapes etcd metrics on control-plane nodes) swapped its equality nodeSelector for a required nodeAffinity `Exists` match on the label key, plus an explicit toleration for the control-plane `NoSchedule` taint. This is the same nodeAffinity/toleration pattern already used by `packages/system/cozystack-api/templates/deployment.yaml` for the identical problem. It fixes scheduling on k3s/RKE2 (label value `"true"`) while remaining correct on kubeadm/Talos/OpenShift (empty value), and adds a toleration the DaemonSet previously lacked.
- `packages/core/platform/templates/bundles/system.yaml`: deleted the `isp-full-generic` override that set `cozystackAPI.nodeSelector` to `node-role.kubernetes.io/control-plane=true`. A repo-wide grep for `cozystackAPI.nodeSelector` confirms cozystack-api's own Deployment never reads that value (it schedules via a soft nodeAffinity preference plus a blanket toleration instead), so the override was dead scaffolding with no effect on the rendered cluster state.

Scope note: the issue also flags kube-ovn's own nodeSelector logic in `packages/system/kubeovn/charts/kube-ovn/templates/*.yaml`. Those templates are vendored upstream chart content regenerated by `make update`, so fixing them belongs in a separate change that goes through that vendoring path rather than a direct hand-edit here. This change is scoped to the two cozystack-authored templates only.

Validation: `helm unittest .` in `packages/system/monitoring-agents` (2/2 suites, 3/3 tests) and `packages/core/platform` (30/30 suites, 133/133 tests) passes with no regressions. Two targeted helm-unittest cases were added that exercise exactly the changed behavior — `packages/system/monitoring-agents/tests/etcd_proxy_scrape_affinity_test.yaml` asserts the DaemonSet carries the nodeAffinity `Exists` match and the control-plane toleration and no longer carries an equality nodeSelector, and `packages/core/platform/tests/bundles_generic_cozystack_api_nodeselector_test.yaml` asserts the `isp-full-generic` `cozystack.cozystack-engine` Package no longer carries the dead `cozystackAPI.nodeSelector` override. Both were confirmed to fail against the pre-fix templates and pass against the post-fix templates. `helm lint` was also run on both charts: `packages/core/platform` is clean; `packages/system/monitoring-agents` shows a pre-existing dependency-metadata lint error unrelated to this change.

This is a template-rendering fix validated with helm-unittest, not a live multi-distro cluster reproduction: no kubeadm/k3s/RKE2 cluster was stood up to observe actual pod scheduling. The rendered PodSpec primitives (nodeAffinity `Exists`, a scoped toleration) are the same ones already relied on elsewhere in this repo for the identical distro-portability problem.

Report: https://github.com/cozystack/cozystack/issues/2567

### Screenshots

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(platform,monitoring-agents): match control-plane nodes by label existence instead of equality, so the etcd metrics scraper and control-plane scheduling work on k3s/RKE2 (where `node-role.kubernetes.io/control-plane` is `"true"`) as well as kubeadm/Talos/OpenShift (where it is empty)
```

---
AI assistance: this change was drafted with Claude Code.

Fixes #2567

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved etcd metrics collection by ensuring the proxy runs on control-plane nodes, including tainted nodes.
  * Removed an unnecessary control-plane scheduling override from the generic system bundle.

* **Tests**
  * Added validation for control-plane scheduling, taint tolerance, and removal of unused node selector settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->