### PR TITLE
fix(clickhouse): assign DB_LIST so backup retention cleanup runs

### DIFF
--- a/packages/apps/clickhouse/templates/backup-script.yaml
+++ b/packages/apps/clickhouse/templates/backup-script.yaml
@@ -18,7 +18,7 @@ stringData:
     
     JOB_ID="job-$(uuidgen|cut -f1 -d-)"
     TABLE_LIST=$(clickhouse-client --host "$CLICKHOUSE_HOST" -q 'SHOW TABLES;' | grep -v '^.inner.' || true)
-    echo DB_LIST=$(echo "$TABLE_LIST" | shuf) # shuffle list
+    DB_LIST=$(echo "$TABLE_LIST" | shuf) # shuffle list
     echo "Job ID: $JOB_ID"
     echo "Target repo: $REPO_PREFIX"
     echo "Cleanup strategy: $CLEANUP_STRATEGY"

--- a/packages/apps/clickhouse/tests/backup_test.yaml
+++ b/packages/apps/clickhouse/tests/backup_test.yaml
@@ -15,6 +15,7 @@ templates:
   - templates/clickhouse.yaml
   - templates/backup-strategy-secret.yaml
   - templates/backup-secret.yaml
+  - templates/backup-script.yaml
 
 release:
   name: ch-test
@@ -244,3 +245,24 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "clickhouse: backup.s3PathOverride is incompatible with backup.useSystemBucket=true. The platform flow scopes the S3 path to <namespace>/<release> automatically; clear s3PathOverride or disable useSystemBucket. To restore from another release's prefix, use a backups.cozystack.io/RestoreJob with spec.targetApplicationRef."
+
+  # Regression for #3758. The legacy per-instance backup script's retention
+  # cleanup loop iterates $DB_LIST, which must be assigned from the table list.
+  # A prior `echo DB_LIST=$(...)` typo left DB_LIST unset, so the cleanup loop
+  # ran zero iterations and `restic forget`/`restic prune` never executed —
+  # snapshots accumulated in object storage forever while the Job still
+  # reported success. Assert the assignment is present and the echo typo is gone.
+  - it: "legacy backup script: DB_LIST is assigned so retention cleanup runs (#3758)"
+    template: templates/backup-script.yaml
+    set:
+      backup:
+        enabled: true
+        schedule: "0 3 * * *"
+        useSystemBucket: false
+    asserts:
+      - matchRegex:
+          path: stringData["backup.sh"]
+          pattern: '(?m)^\s*DB_LIST=\$\(echo "\$TABLE_LIST"'
+      - notMatchRegex:
+          path: stringData["backup.sh"]
+          pattern: 'echo DB_LIST='


### PR DESCRIPTION
## What this PR does

The legacy per-instance ClickHouse backup CronJob (rendered when `backup.enabled=true`, `backup.schedule` is set and `backup.useSystemBucket=false`) never applied its retention policy. `packages/apps/clickhouse/templates/backup-script.yaml` printed `echo DB_LIST=$(...)` instead of assigning `DB_LIST`, so the variable stayed unset and the cleanup loop `for db in $DB_LIST` ran zero iterations — `restic forget` and `restic prune` were never invoked, snapshots accumulated in object storage indefinitely despite the configured `cleanupStrategy`, and the Job still exited 0 so nothing surfaced the failure. This drops the stray `echo` so `DB_LIST` is assigned from the table list and the retention cleanup runs as configured. MariaDB's equivalent backup script already assigns `DB_LIST` correctly; this brings ClickHouse in line. A helm-unittest regression over the rendered `backup.sh` asserts the assignment is present and the `echo DB_LIST=` typo is gone. Verified with `make -C packages/apps/clickhouse test` (18/18 pass). Fixes #3758.

### Screenshots

<!-- No UI changes. -->

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff. The change is a one-line shell fix inside a Helm template plus a helm-unittest case — it touches no `values.yaml`, `values.schema.json`, `README.md`, `ApplicationDefinition`, version enum, variant/bundle, release asset, `hack/` layout or namespace. No downstream repository restates any of this.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(clickhouse): ClickHouse backup retention now prunes old snapshots. The scheduled backup job's cleanup step never ran because `DB_LIST` was left unset, so snapshots accumulated in object storage indefinitely; it now honors the configured retention (`cleanupStrategy` / `--keep-last=N`).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed backup processing so table lists are assigned correctly, allowing retention cleanup to run as expected.
  * Removed unintended output of the shuffled table list during backups.

* **Tests**
  * Added regression coverage to verify correct backup list assignment and prevent the previous malformed assignment from recurring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->