### PR TITLE
test(e2e): warm the ghcr.io mirror before the tenant suites need it

### DIFF
--- a/hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+++ b/hack/e2e-chainsaw/_lib/ghcr-mirror.sh
@@ -32,6 +32,371 @@
 GHCR_MIRROR_SVC_URL="${GHCR_MIRROR_SVC_URL:-http://ghcr-mirror.kube-system.svc}"
 _GHCR_MIRROR_DECISION_FILE="${_GHCR_MIRROR_DECISION_FILE:-/tmp/e2e-ghcr-mirror-endpoint}"
 GHCR_MIRROR_MANIFEST="${GHCR_MIRROR_MANIFEST:-hack/e2e-ghcr-mirror.yaml}"
+GHCR_WARM_VERSIONS_FILE="${GHCR_WARM_VERSIONS_FILE:-packages/apps/kubernetes/files/versions.yaml}"
+GHCR_WARM_JOB_NAME="${GHCR_WARM_JOB_NAME:-ghcr-mirror-warm}"
+GHCR_WARM_REPO="${GHCR_WARM_REPO:-siderolabs/kubelet}"
+GHCR_WARM_READY_TIMEOUT="${GHCR_WARM_READY_TIMEOUT:-600}"
+# How many minors to warm. Two, because the kubernetes-latest and
+# kubernetes-previous suites resolve the top two keys and no other suite spins a
+# tenant on a third. Raise it if a suite starts selecting deeper; the cost is
+# ~61 MiB of upstream fetch per extra tag on the leg this feature exists for
+# (one platform's config plus layers, measured for v1.35.6 against ghcr.io).
+GHCR_WARM_TAG_COUNT="${GHCR_WARM_TAG_COUNT:-2}"
+
+# ghcr_warm_tags: print the kubelet image tags worth pre-fetching, one per line,
+# newest minor first.
+#
+# Read from the chart's own version map rather than a list kept here. The suites
+# pick their Kubernetes version out of that same file at runtime, so a copy would
+# drift silently on the next version bump: the tenant would boot on a tag nothing
+# warmed and the first worker would pay the cold upstream fetch this exists to
+# remove, with no signal that the warm-up had missed.
+#
+# Ordered by minor, highest first, which is the order the suites resolve: they pass
+# `keys | sort_by(.) | .[-1]` and `.[-2]` to run_kubernetes_test. Sorting here rather
+# than reading the file's own order is not a guard against the file being written
+# some other way -- packages/apps/kubernetes/hack/update-versions.sh regenerates it
+# through `sort -V -r`, so highest-first is what the generator guarantees and a new
+# minor lands at the top, not the bottom. It is so that this list and the suites
+# agree by construction instead of by both happening to read the same file the same
+# way. The caller warms a prefix of this, so the order decides what gets warmed.
+ghcr_warm_tags() {
+  if ! command -v yq >/dev/null 2>&1; then
+    echo "yq is not installed, so the kubelet version map could not be read" >&2
+    return 1
+  fi
+  yq 'to_entries | sort_by(.key) | reverse | .[].value' \
+    "$GHCR_WARM_VERSIONS_FILE"
+}
+
+# ghcr_warm_job_manifest <image> <tag>...: print the warm-up Job, or fail.
+#
+# Pure string builder, kept separate so it can be unit-tested, same reason
+# talos-image-cache.sh keeps its probe overrides out of the caller.
+#
+# The Job asks the mirror for each tag's index, every manifest the index lists, and
+# every blob those manifests reference, discarding the bytes. distribution's proxy
+# populates its blobstore on the way past, so the tenant worker's later pull is a
+# local cache hit instead of a live fetch across the leg that stalls.
+#
+# "On the way past" is not free, and the cost is worth stating exactly. In
+# distribution 2.8 a local miss reads the blob from upstream TWICE: ServeBlob starts
+# `go storeLocal(...)`, which copies remote -> local, and separately runs
+# copyContent(ctx, dgst, w) to serve the client; both open remoteStore. There is no
+# tee. So a warm-up blob GET crosses the throttled leg twice.
+#
+# What keeps that from being a net addition is warming ONE platform per tag -- the
+# one the workers run. Then the Job fetches the same blobs the first worker would
+# have fetched, and the 2x is paid once either way: by the Job now, or by the worker
+# later inside its node-Ready budget. Walking both platforms broke exactly this: the
+# arm64 half is bytes nobody in the sandbox pulls, so it was a true addition to the
+# leg, and the claim that the total was unchanged was false while it was there.
+#
+# The byte figures below are image sizes, not measurements of the mirror's upstream
+# side, so read them as a lower bound on install-time egress.
+#
+# Selecting linux/amd64 out of the index stays a grep because digest and platform
+# share a record: normalise the whitespace, split on record boundaries, take the
+# record that names the architecture. Pulling every sha256 out of a document is a grep,
+# and a digest that turns out not to be a blob answers 404. That is free on the
+# manifest leg, where the walk just moves on; on the blob leg a 404 counts as a miss
+# and fails the Job, which is what a single-arch tag would do -- its config and layer
+# digests are not manifests, so the walk finds no index to descend.
+ghcr_warm_job_manifest() {
+  local image="$1" tag tags=""
+  shift
+  [ "$#" -gt 0 ] || return 1
+  # An empty endpoint or repo does not fail anything downstream, which is why it has
+  # to fail here. The Job would still build, run, exit 0, and print "index
+  # unavailable" for every tag while the cache stayed cold -- and from inside the
+  # Pod that is indistinguishable from a mirror that is simply unreachable.
+  [ -n "$GHCR_MIRROR_SVC_URL" ] || return 1
+  [ -n "$GHCR_WARM_REPO" ] || return 1
+  for tag in "$@"; do
+    # Refuse anything that is not a bare version. These tags land in a `for tag in
+    # ...` inside the container's shell, where a substitution would run as the Job.
+    # The version map is in-tree today, which is why the guard is cheap to add now
+    # and expensive to retrofit later. No real kubelet tag is rejected by this.
+    # Character class first, regex second. `grep -q` succeeds when ANY line of its
+    # input matches and `$` anchors end-of-LINE, so a value whose first line is a
+    # bare version passes the pattern while everything after the newline is pasted
+    # into the heredoc as shell. The earlier list of rejected inputs enumerated ways
+    # to inject -- $(), backticks, semicolon, space -- and missed this one, because
+    # it was reasoned about as "more than one token" rather than as what the anchor
+    # treats as a boundary. This case does not depend on that.
+    case "$tag" in
+      *[!v0-9.]*) return 1 ;;
+    esac
+    printf '%s' "$tag" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || return 1
+    tags="${tags}${tags:+ }${tag}"
+  done
+  cat <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${GHCR_WARM_JOB_NAME}
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: ${GHCR_WARM_JOB_NAME}
+spec:
+  # Bounded two ways, because retries alone are not a bound here. The fetches are
+  # slow by nature on the leg this exists for, so a Job with only backoffLimit can
+  # sit pulling on a sandbox node for hours after the suites it was meant to help
+  # have finished, competing for the CPU the tenant guests are already short of.
+  backoffLimit: 3
+  activeDeadlineSeconds: 3600
+  # Outlives the suites on purpose. The node-join failure block is the only reader
+  # of this Job's outcome and it fires 18m into a suite that starts tens of minutes
+  # after install; a shorter TTL deletes the Job and its log before the one moment
+  # anybody asks whether the warm-up worked.
+  ttlSecondsAfterFinished: 14400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ${GHCR_WARM_JOB_NAME}
+    spec:
+      restartPolicy: Never
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: warm
+          image: ${image}
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              root="${GHCR_MIRROR_SVC_URL}"
+              base="\$root/v2/${GHCR_WARM_REPO}"
+              acc='Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json'
+              # -U names this traffic in the registry's access log. The node-join
+              # diagnostic counts GETs for the kubelet image to answer "did a worker
+              # pull through the mirror"; without a way to tell the two apart, this
+              # Job's own 50-odd requests would make that answer yes on every run.
+              get() { wget -q -U ${GHCR_WARM_JOB_NAME} "\$@"; }
+              digests() { grep -o 'sha256:[0-9a-f]\{64\}' | sort -u; }
+              # Wait for the mirror to serve before concluding anything. This Job is
+              # created seconds after the mirror Deployment, the registry image is
+              # deliberately not in the pre-pull set, and the readiness probe adds
+              # its own delay -- so at submit time the Service usually has no
+              # endpoints at all. Treating that as "nothing to warm" is how a
+              # warm-up silently no-ops on the run it was needed for.
+              # The bound is the loop condition, not a branch inside the loop. A shape
+              # that loops until the fetch succeeds and exits from an "over budget"
+              # arm inside the body puts termination in something removable, and
+              # removing it does not fail anything: it hangs, which is worse than
+              # either outcome and takes whatever is watching down with it.
+              #
+              # No backticks anywhere in this heredoc. It is unquoted, so a backtick
+              # in a COMMENT is still command substitution at render time, and the
+              # first version of this note contained a shell snippet that expanded
+              # into an endless loop -- the builder hung, and every structural test
+              # passed because the YAML it never finished printing was still valid.
+              # A real clock, not a per-attempt constant. How long an attempt
+              # costs is not knowable here: Cilium answers a Service with no
+              # ready endpoints by rejecting (serviceNoBackendResponse defaults
+              # to reject), so the connect fails instantly and the -T budget is
+              # never spent, while a mirror that is up but slow spends all of
+              # it. A constant is wrong in both regimes, and it was wrong in
+              # both directions across two attempts at guessing it.
+              ready=0
+              start=\$(date +%s)
+              while [ \$(( \$(date +%s) - start )) -lt ${GHCR_WARM_READY_TIMEOUT} ]; do
+                if get -T 10 -O /dev/null "\$root/v2/"; then
+                  ready=1
+                  break
+                fi
+                sleep 5
+              done
+              if [ "\$ready" -ne 1 ]; then
+                echo "warm: mirror did not start serving within ${GHCR_WARM_READY_TIMEOUT}s"
+                exit 1
+              fi
+              # Pick the one platform the workers run. The index lists digest and
+              # platform inside the SAME record, so normalising whitespace and
+              # splitting on record boundaries keeps this a grep -- no JSON parser,
+              # which the mirror's image does not carry.
+              #
+              # Walking both platforms instead is what the earlier version did, and
+              # it was wrong twice over: arm64 is bytes nobody in the sandbox ever
+              # pulls, and the digest sort orders manifests by hex, which put arm64 first
+              # for both warmed tags. On the 40 KB/s floor this feature exists for,
+              # that spent the first half of the Job's deadline on an architecture
+              # the workers do not use and left the second tag cold.
+              select_amd64() {
+                tr -d ' \t\n' |
+                  sed 's/},{/}\n{/g' |
+                  grep -E '"architecture":"amd64"' |
+                  grep -o 'sha256:[0-9a-f]\{64\}' |
+                  head -1
+              }
+              failed=0
+              got=0
+              warmed=""
+              missed=""
+              for tag in ${tags}; do
+                idx=\$(get -T 120 -O - --header "\$acc" "\$base/manifests/\$tag") || {
+                  echo "warm: index for \$tag unavailable"
+                  failed=\$((failed + 1))
+                  missed="\$missed \$tag"
+                  continue
+                }
+                before=\$got
+                tag_failed=0
+                # A single-arch tag has no platform record: the response IS the
+                # manifest, so walk it directly rather than looking for an index
+                # entry that does not exist.
+                sel=\$(printf '%s' "\$idx" | select_amd64)
+                if [ -n "\$sel" ]; then
+                  bodies=\$(get -T 120 -O - --header "\$acc" "\$base/manifests/\$sel") || bodies=""
+                else
+                  bodies="\$idx"
+                fi
+                if [ -n "\$bodies" ]; then
+                  for blob in \$(printf '%s' "\$bodies" | digests); do
+                    # "fetched", not "cached": a successful GET says the mirror
+                    # answered, which is equally true of a cache hit and of a live
+                    # upstream fetch. The blobstore write is distribution's business
+                    # and this Job cannot observe it.
+                    if get -T 600 -O /dev/null "\$base/blobs/\$blob"; then
+                      got=\$((got + 1))
+                      echo "warm: \$tag \$blob fetched"
+                    else
+                      failed=\$((failed + 1))
+                      tag_failed=\$((tag_failed + 1))
+                      echo "warm: \$tag \$blob failed"
+                    fi
+                  done
+                fi
+                # "warmed" has to mean every blob of the tag landed. A live run
+                # showed why: three of four blobs failed on an upstream reset and the
+                # tag still reported warmed, because the counter asked whether ANY
+                # blob arrived. A partially cached tag still makes the worker fetch
+                # the rest across the slow leg, which is the thing being measured.
+                if [ "\$got" -gt "\$before" ] && [ "\$tag_failed" -eq 0 ]; then
+                  warmed="\$warmed \$tag"
+                else
+                  missed="\$missed \$tag"
+                fi
+              done
+              # Per-tag, not just a total: a Job that hits its deadline halfway warms
+              # one suite and not the other, and a bare count cannot say which.
+              echo "warm: warmed:\$warmed"
+              echo "warm: not warmed:\$missed"
+              echo "warm: fetched \$got, failed \$failed"
+              # One question, about the subject: is every selected tag fully warm.
+              # The counters are proxies for it and both turned out to be strictly
+              # weaker -- a failed blob or a failed index already puts its tag in the
+              # missed list, and a zero fetch count with nothing missed would need zero
+              # tags, which the builder refuses. Keeping them as extra conjuncts made
+              # their own mutations survive: anything they would have caught, this
+              # catches first. A proxy also misses whatever path forgets to update it,
+              # and that is how a cold tag rode out on a Complete Job.
+              [ -z "\$missed" ]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
+              ephemeral-storage: 64Mi
+EOF
+}
+
+# warm_ghcr_mirror: start the warm-up Job. Best-effort and never fails the caller:
+# it runs during install, and the run has to survive without it exactly as it did
+# before the warm-up existed.
+warm_ghcr_mirror() {
+  local out image tags manifest
+  if ! out=$(kubectl -n kube-system get deploy ghcr-mirror 2>&1); then
+    # Only the API's own NotFound means the mirror was never applied here. A missing
+    # kubectl, a bad context and an apiserver blip all fail this read too, and the
+    # captured message is the only place their cause exists -- the same distinction
+    # resolve_ghcr_mirror_endpoint documents below.
+    case "$out" in
+      *NotFound*)
+        echo "ghcr-mirror not deployed -- nothing to warm" >&2 ;;
+      *)
+        echo "WARNING: could not query the ghcr-mirror Deployment; skipping the warm-up. Reason: ${out:-none reported}" >&2 ;;
+    esac
+    return 0
+  fi
+  # Warm only the minors a suite can actually select. The suites resolve `.[-1]` and
+  # `.[-2]` of the sorted keys, ghcr_warm_tags emits that same order, so a prefix of
+  # it is exactly their set without restating their expression here.
+  #
+  # The whole map would be ~300 MiB at the walk this file ships: five tags at ~61 MiB
+  # each for the single platform the Job fetches. (634 MiB was the measured figure
+  # while the walk still covered both platforms of every tag; quoting it against
+  # one-platform code was the same accounting slip the paragraph above pins on the
+  # platform walk itself.) It crosses the one leg
+  # this feature exists because of, the one the access log measures at 40-165 KB/s and
+  # which answers 500 mid-stream. Warming
+  # tags nothing selects spends that leg on nothing while the install and the
+  # pre-pull step are still using it.
+  # No 2>/dev/null. Command substitution captures stdout only, so ghcr_warm_tags'
+  # complaint about a missing yq cannot reach $tags in the first place -- redirecting
+  # it merely deleted the one line that names the cause, leaving the caller to blame
+  # versions.yaml for a tool that is not installed.
+  tags=$(ghcr_warm_tags | head -n "$GHCR_WARM_TAG_COUNT") || tags=""
+  if [ -z "$tags" ]; then
+    echo "WARNING: could not read kubelet tags from ${GHCR_WARM_VERSIONS_FILE}; skipping the warm-up" >&2
+    return 0
+  fi
+  # Reuse the mirror's own image so there is one place to bump. It is NOT already
+  # cached on the nodes: hack/e2e-ghcr-mirror.yaml keeps it out of the pre-pull set
+  # on purpose, and the pre-pull step runs after this one anyway. The Job's own wait
+  # for the mirror to serve is what absorbs that.
+  if ! image=$(kubectl -n kube-system get deploy ghcr-mirror \
+    -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null); then
+    image=""
+  fi
+  if [ -z "$image" ]; then
+    echo "WARNING: could not read the ghcr-mirror image; skipping the warm-up" >&2
+    return 0
+  fi
+  # The image is the only builder input that arrives from the cluster, and it is
+  # interpolated into the Job YAML. Writing it needs Deployment write access, so this
+  # is not a trust boundary. The point is narrower: the endpoint and the repository
+  # are checked and the tags are pattern-matched, so leaving the one input that comes
+  # from outside unchecked reads as an oversight. Other locally-set values
+  # (GHCR_WARM_JOB_NAME, GHCR_WARM_READY_TIMEOUT) also reach the script unquoted and
+  # are equally unchecked -- they are set in this file and nowhere else.
+  # Reference characters only.
+  case "$image" in
+    *[!A-Za-z0-9./:@_-]*)
+      echo "WARNING: the ghcr-mirror image reads as [$image], which is not an image reference; skipping the warm-up" >&2
+      return 0 ;;
+  esac
+  # Capture the manifest with stderr NOT folded in. `2>&1` here would put anything
+  # written to stderr inside the YAML, and under a runner that traces the body (the
+  # bats runner does) that is the trace itself: the Job then fails to parse for a
+  # reason that has nothing to do with the Job. The builder communicates through its
+  # exit status, so there is nothing on stderr worth keeping.
+  #
+  # shellcheck disable=SC2086 # tags is a builder-validated whitespace-separated list
+  if ! manifest=$(ghcr_warm_job_manifest "$image" $tags 2>/dev/null); then
+    echo "WARNING: refused to build the warm-up Job (a tag is not a plain version); skipping" >&2
+    return 0
+  fi
+  if ! out=$(printf '%s\n' "$manifest" | kubectl apply -f - 2>&1); then
+    echo "WARNING: could not start the ghcr-mirror warm-up; tenant workers may pay a cold fetch. Reason: ${out:-none reported}" >&2
+    return 0
+  fi
+  echo "ghcr-mirror warm-up started for: $(printf '%s' "$tags" | tr '\n' ' ')" >&2
+  return 0
+}
 
 # ghcr_registry_mirrors_block: pure string builder. Given a mirror endpoint URL
 # ($1, may be empty), print the `registryMirrors:` sub-block for a tenant Kubernetes
@@ -254,11 +619,11 @@ ghcr_mirror_diagnose() {
     # served it. --tail=-1 is explicit because kubectl defaults a label-selected
     # read to the last 10 lines, not to the whole log. It is the wall clock, not the
     # line count, that bounds this read: --tail=-1 stays, timeout caps the time.
-    echo "--- did a worker pull the kubelet image through the mirror? ---"
+    echo "--- did a worker pull ${GHCR_WARM_REPO} through the mirror? ---"
     # Read and filter as separate steps. Piping them would make an unreadable log
     # and a log with no kubelet request produce the same 0, and the second is a
     # finding about the workers while the first is a statement about nothing.
-    local log_rc=0
+    local log_rc=0 durations=''
     if command -v timeout >/dev/null 2>&1; then
       log=$(timeout -k "$grace" "$to" \
         kubectl -n kube-system logs -l app.kubernetes.io/name=ghcr-mirror \
@@ -268,15 +633,76 @@ ghcr_mirror_diagnose() {
         --tail=-1 2>/dev/null) || log_rc=$?
     fi
     if [ "$log_rc" -eq 0 ]; then
-      hits=$(printf '%s\n' "$log" | grep -cF '/v2/siderolabs/kubelet') || hits=0
+      # Exclude the warm-up's own requests. It asks for the same paths from
+      # kube-system before any tenant exists, so counting them would make "workers
+      # did reach it" true of every run and retire the only signal that tells a
+      # served pull from a worker that fell back to public ghcr.io. The warm-up
+      # names itself with -U; see ghcr_warm_job_manifest.
+      #
+      # Count access lines, not every line carrying the path. registry:2.8.3 writes
+      # three lines per GET against the pinned image -- a logrus "response completed",
+      # an upstream-challenge line, and one nginx-combined access line -- so matching
+      # the path alone counted one request as three. The combined line is the only
+      # shape that appears exactly once per request, which makes this a request count
+      # rather than a line count, and it is also the shape whose user-agent field is
+      # positional and always present.
+      #
+      # GET and HEAD both count. containerd resolves a manifest with a HEAD before it
+      # GETs anything, and the combined access line records HEAD in the same shape
+      # (measured on the pinned image with a containerd user-agent), so a filter
+      # anchored on GET alone drops the first request of every pull -- and on a log
+      # holding only that HEAD it declares the worker absent while the duration
+      # section below prints that same request's timing. The warm-up issues only GETs,
+      # so counting HEAD reintroduces none of its traffic.
+      hits=$(printf '%s\n' "$log" \
+        | grep -F -e "\"GET /v2/${GHCR_WARM_REPO}" -e "\"HEAD /v2/${GHCR_WARM_REPO}" \
+        | grep -vcF "$GHCR_WARM_JOB_NAME") || hits=0
       if [ "${hits:-0}" -gt 0 ]; then
-        echo "the mirror served ${hits} kubelet-image request(s), so workers did reach it"
+        echo "a worker pulled ${GHCR_WARM_REPO} through the mirror (${hits} request(s), excluding the warm-up's own)"
       else
-        echo "no kubelet-image request reached the mirror: workers either fell back to public ghcr.io or never got as far as the pull"
+        echo "no ${GHCR_WARM_REPO} request appears in the mirror's access log; whether workers fell back to public ghcr.io or never got as far as the pull, this log cannot tell apart"
+      fi
+      # How long the mirror took to answer the worker. This is the only signal that
+      # separates a warm cache from a cold one after the fact: distribution serves a
+      # cached blob from disk in milliseconds and streams a missed one from ghcr.io for
+      # minutes, and nothing else in the artifacts distinguishes them. A warm-up that
+      # reports success is not proof the blob reached the blobstore -- the proxy stores
+      # in the background, so a completed GET and a stored blob are different events.
+      # The warm-up's own requests are excluded for the same reason as above.
+      #
+      # Filter here rather than handing the log to `sh -c` as an argument. Linux caps
+      # a single argv element at MAX_ARG_STRLEN, 131072 bytes, and that cap is
+      # independent of ARG_MAX and of how much room the rest of the command line
+      # leaves: measured on 6.8, an argument of 131000 bytes execve()s and one of
+      # 131072 fails with E2BIG. The readiness probe writes an access line every 5s,
+      # so this log passes that after roughly twenty minutes of mirror uptime -- which
+      # is always true here, since the mirror is created during install and this runs
+      # 18m into a suite that starts long after it. As an argument the read would have
+      # failed on every real run and succeeded only against a fixture small enough to
+      # fit, which is the one case the tests exercise.
+      echo "--- how long did the mirror take to answer the worker? ---"
+      durations=$(printf '%s\n' "$log" | grep -F "/v2/${GHCR_WARM_REPO}" \
+        | grep -F 'http.response.duration' \
+        | grep -vF "$GHCR_WARM_JOB_NAME" \
+        | grep -oE 'http\.response\.duration=[^ ]+' \
+        | tail -5) || durations=''
+      if [ -n "$durations" ]; then
+        printf '%s\n' "$durations"
+      else
+        echo "no timed request for ${GHCR_WARM_REPO} outside the warm-up's own; the durations that separate a warm cache from a cold one were not observed"
       fi
     else
       echo "could not read the mirror's log; this says nothing either way about whether workers used it"
     fi
+
+    # Whether the warm-up itself got anywhere. Without this the exclusion above makes
+    # the run unfalsifiable: a red suite looks identical whether the cache was warm
+    # and the guest still starved, or the warm-up never came up at all.
+    echo "--- did the warm-up populate the cache? ---"
+    _ghcr_mirror_bounded_read 'warm-up Job status' \
+      kubectl -n kube-system get job "$GHCR_WARM_JOB_NAME" -o wide
+    _ghcr_mirror_bounded_read 'warm-up Job result' \
+      kubectl -n kube-system logs "job/${GHCR_WARM_JOB_NAME}" --tail=5
     echo "--- registry access log (last 50 lines, for context) ---"
     _ghcr_mirror_bounded_read 'registry access log (last 50 lines)' \
       kubectl -n kube-system logs -l app.kubernetes.io/name=ghcr-mirror \

--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -1908,8 +1908,8 @@ cozy_report_node_join_failure() {
   # and this one waits, whichever of them is cheaper. Cheaper than the
   # talos-image-cache re-probe below, which creates a Pod and waits on curl
   # retries, so it goes ahead of it.
-  if cozy_diag_phase_has_time 'ghcr-mirror state + access log'; then
-    echo "--- ghcr-mirror state + access log ---"
+  if cozy_diag_phase_has_time 'ghcr-mirror state, access log and warm-up Job'; then
+    echo "--- ghcr-mirror state, access log and warm-up Job ---"
     ghcr_mirror_diagnose || true
   fi
 

--- a/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
@@ -35,7 +35,7 @@ spec:
         #   worker CPU throttling counters
         #   serial-console family (~5m50s at worst, ~3m30s at the pool's minimum)
         #   guest Talos capture
-        #   ghcr-mirror state + access log dump
+        #   ghcr-mirror state, access log and warm-up Job
         #   talos-image-cache diagnosis
         # and then, after the phase rather than inside it, the in-process tenant
         # crust-gather snapshot.

--- a/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
@@ -29,7 +29,7 @@ spec:
         #   worker CPU throttling counters
         #   serial-console family (~5m50s at worst, ~3m30s at the pool's minimum)
         #   guest Talos capture
-        #   ghcr-mirror state + access log dump
+        #   ghcr-mirror state, access log and warm-up Job
         #   talos-image-cache diagnosis
         # and then, after the phase rather than inside it, the in-process tenant
         # crust-gather snapshot.

--- a/hack/e2e-ghcr-mirror.yaml
+++ b/hack/e2e-ghcr-mirror.yaml
@@ -50,8 +50,10 @@
 # context here (non-root 65532, read-only rootfs, dropped caps) and to serve
 # ghcr.io/siderolabs/kubelet manifests and blobs as an anonymous pull-through. It is
 # deliberately NOT in the pre-pull set: hack/e2e-install-cozystack.bats applies this
-# manifest before the pre-pull DaemonSet runs, and one replica pulls it once, so
-# adding it there would cache it after the only pull that matters.
+# manifest before the pre-pull DaemonSet runs, so adding it there would cache it
+# after the pulls that matter. Two Pods now pull it in that window -- this
+# Deployment and the warm-up Job the same install step starts -- and the Job carries
+# no affinity, so it may land on a second node and pull it again.
 apiVersion: v1
 kind: Service
 metadata:

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -93,6 +93,25 @@
   else
     echo "WARNING: ghcr-mirror Deployment NOT created — tenant workers will pull ghcr.io directly"
   fi
+  # Start filling the cache now, not when the first tenant worker asks for it.
+  # An empty pull-through cache makes the first pull a live fetch from ghcr.io, and
+  # that leg is what the tenant worker cannot afford: measured at 40-165 KB/s for a
+  # 61 MiB image against an 18m node-Ready budget, with some blob streams dying
+  # mid-transfer. The kubernetes suites start tens of
+  # minutes after this step, so a background Job has time to finish.
+  #
+  # What is guaranteed: a warm-up that fails, times out or never starts does not
+  # fail this step, and the suites behave as they did before it existed.
+  #
+  # What is NOT guaranteed, because it would be untrue: that this is free. The Job
+  # pulls the two selected kubelet tags across the same throttled egress the rest of
+  # the install and the pre-pull step below are using, and if a worker cannot reach
+  # the mirror (assumption 2 in hack/e2e-ghcr-mirror.yaml) Talos falls back to public
+  # ghcr.io and the two then compete for it. That is why the warm set is the suites'
+  # two minors (~61 MiB each, one platform) rather than the whole version map, which
+  # would be ~300 MiB at the same one-platform walk.
+  . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+  warm_ghcr_mirror || true
 }
 
 @test "Required installer chart exists" {

--- a/hack/ghcr-mirror_test.bats
+++ b/hack/ghcr-mirror_test.bats
@@ -37,9 +37,21 @@ stub_avail="False"
 stub_avail_rc=0
 stub_log_rc=0
 stub_apply_err=""
+stub_image="registry:test"
+stub_apply_capture=""
+stub_job_log=""
+stub_job_log_rc=0
+stub_job_status=""
 
 kubectl() {
     case "$*" in
+        # Before the plain `get deploy` arm: the warm-up reads the mirror's image
+        # with a jsonpath on that same command, and the arm below would answer it
+        # with the human-readable table instead.
+        *jsonpath*containers*)
+            [ -z "${stub_image}" ] || printf '%s' "${stub_image}"
+            return 0
+            ;;
         *conditions*)
             [ -z "${stub_avail}" ] || printf '%s' "${stub_avail}"
             return "${stub_avail_rc}"
@@ -52,12 +64,30 @@ kubectl() {
             return "${stub_rollout_rc}"
             ;;
         *apply*)
-            cat >/dev/null
+            # Capture what was applied when a test asks, so the happy path can be
+            # asserted on the object rather than on the fact that apply was reached.
+            if [ -n "${stub_apply_capture}" ]; then
+                cat > "${stub_apply_capture}"
+            else
+                cat >/dev/null
+            fi
             # To stderr, as the real kubectl reports errors: the code under test
             # captures the reason via the braced group's 2>&1, and a stub that
             # printed it to stdout would have it eaten by kubectl's >/dev/null.
             [ -z "${stub_apply_err}" ] || printf '%s\n' "${stub_apply_err}" >&2
             return "${stub_apply_rc}"
+            ;;
+        *"logs job/"*)
+            # Distinct payload from the registry log: the access-log read at the end
+            # of ghcr_mirror_diagnose prints stub_log_lines too, so a test asserting
+            # the warm-up's result against that shared value passes with the Job read
+            # deleted. Two mutations survived on exactly that.
+            [ -z "${stub_job_log}" ] || printf '%s\n' "${stub_job_log}"
+            return "${stub_job_log_rc}"
+            ;;
+        *"get job "*)
+            [ -z "${stub_job_status}" ] || printf '%s\n' "${stub_job_status}"
+            return 0
             ;;
         *logs*)
             [ "${stub_log_rc}" -eq 0 ] || return "${stub_log_rc}"
@@ -259,9 +289,9 @@ timeout() {
     probe_lines=$(i=0; while [ "$i" -lt 300 ]; do echo '10.244.0.1 - - [09/Aug/2026:01:18:00 +0000] "GET /v2/ HTTP/1.1" 200 2'; i=$((i+1)); done)
     stub_log_lines=$(printf '%s\n%s' "$kubelet_line" "$probe_lines")
     out=$(ghcr_mirror_diagnose 2>&1)
-    printf '%s' "$out" | grep -q 'the mirror served 1 kubelet-image request' || {
+    printf '%s' "$out" | grep -q 'a worker pulled siderolabs/kubelet through the mirror' || {
         echo "diagnose did not find the kubelet pull behind the probe log; it reported:" >&2
-        printf '%s\n' "$out" | grep -i 'kubelet-image' >&2
+        printf '%s\n' "$out" | grep -iE 'through the mirror|reached the mirror' >&2
         exit 1
     }
 }
@@ -273,9 +303,29 @@ timeout() {
     # not be reported the same way as the case above, which is the whole point.
     stub_log_lines=$(i=0; while [ "$i" -lt 50 ]; do echo '10.244.0.1 - - [09/Aug/2026:01:18:00 +0000] "GET /v2/ HTTP/1.1" 200 2'; i=$((i+1)); done)
     out=$(ghcr_mirror_diagnose 2>&1)
-    printf '%s' "$out" | grep -q 'no kubelet-image request reached the mirror' || {
+    printf '%s' "$out" | grep -qF "no $GHCR_WARM_REPO request appears in the mirror" || {
         echo "diagnose did not report the empty case distinctly" >&2
-        printf '%s\n' "$out" | grep -i 'kubelet-image' >&2
+        printf '%s\n' "$out" | grep -iE 'through the mirror|reached the mirror' >&2
+        exit 1
+    }
+}
+
+@test "a worker's manifest HEAD alone counts as reaching the mirror" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    stub_get_rc=0
+    # containerd resolves a manifest with a HEAD before it GETs anything, and the
+    # registry writes that HEAD as a combined access line of the same shape (measured
+    # on the pinned image with a containerd user-agent). A pull that got as far as the
+    # HEAD and died before the GET is exactly the run this diagnostic exists for, and
+    # a GET-anchored count would report it as "no request appears" while the duration
+    # section below prints that same request's timing -- the two halves of one output
+    # contradicting each other.
+    stub_log_lines='10.244.1.92 - - [11/Aug/2026:23:17:27 +0000] "HEAD /v2/siderolabs/kubelet/manifests/v1.35.6 HTTP/1.1" 200 683 "" "containerd/2.2.4+unknown"'
+    out=$(ghcr_mirror_diagnose 2>&1)
+    stub_log_lines=""
+    printf '%s' "$out" | grep -qF "a worker pulled $GHCR_WARM_REPO through the mirror (1 request(s)" || {
+        echo "a manifest HEAD was not counted as a worker reaching the mirror" >&2
+        printf '%s\n' "$out" | grep -iE 'through the mirror|appears in the mirror' >&2
         exit 1
     }
 }
@@ -337,10 +387,10 @@ timeout() {
     out=$(ghcr_mirror_diagnose 2>&1)
     printf '%s' "$out" | grep -q 'could not read the mirror' || {
         echo "an unreadable log must not be reported as a finding about the workers" >&2
-        printf '%s\n' "$out" | grep -iE 'kubelet-image|could not read' >&2
+        printf '%s\n' "$out" | grep -iE 'reached the mirror|could not read' >&2
         exit 1
     }
-    printf '%s' "$out" | grep -q 'no kubelet-image request reached the mirror' && {
+    printf '%s' "$out" | grep -qF "no $GHCR_WARM_REPO request appears in the mirror" && {
         echo "an unreadable log was reported as zero pulls" >&2
         exit 1
     }
@@ -411,6 +461,1037 @@ timeout() {
     [ -n "$block" ] || { echo "no @test block in $f applies hack/e2e-ghcr-mirror.yaml" >&2; exit 1; }
     printf '%s\n' "$block" | grep -qF "select(.kind != \"CiliumClusterwideNetworkPolicy\")" || {
         echo "the install-time apply no longer excludes the CiliumClusterwideNetworkPolicy" >&2
+        exit 1
+    }
+}
+
+@test "the warm-up covers every kubelet tag the chart can select" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    # The tags come from the chart's own version map, not from a list kept here.
+    # A copy would drift the moment a version is added: the suite would boot a
+    # tenant on a tag nothing warmed, the first worker would pay the cold upstream
+    # fetch again, and nothing would report that the warm-up had missed it.
+    want=$(yq '.[]' packages/apps/kubernetes/files/versions.yaml | sort)
+    got=$(ghcr_warm_tags | sort)
+    [ "$got" = "$want" ] || {
+        echo "warm-up tag list drifted from the chart version map" >&2
+        echo "want: $want" >&2
+        echo "got:  $got" >&2
+        exit 1
+    }
+}
+
+@test "a fully warm run exits zero" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    mkdir -p "$work/bin"
+    # The failure half of the exit contract is pinned by five tests; this is the
+    # missing success half. Every other test that runs the emitted script swallows
+    # its status with `|| true`, so a script that always exited non-zero passed the
+    # whole suite -- and in the cluster that is a Job going Failed after its
+    # backoffLimit on every run, with the node-join diagnostic then reporting a
+    # failed warm-up on runs where the cache was warm: the mirror image of the
+    # cold-tag-on-Complete bug the exit condition was rewritten to fix.
+    #
+    # The stub answers every request with success and gives manifests a record that
+    # carries both the amd64 platform and a digest, so the walk completes: index,
+    # platform manifest, blob, all warm, missed empty.
+    {
+        echo '#!/bin/sh'
+        echo 'case "$*" in *manifests*) echo "{\"platform\":{\"architecture\":\"amd64\"},\"digest\":\"sha256:'"$(printf 'a%.0s' $(seq 64))"'\"}";; esac'
+        echo 'exit 0'
+    } > "$work/bin/wget"
+    chmod +x "$work/bin/wget"
+    ghcr_warm_job_manifest registry:test v1.35.6 > "$work/job.yaml"
+    yq '.spec.template.spec.containers[0].args[0]' "$work/job.yaml" > "$work/warm.sh"
+    if ! PATH="$work/bin:$PATH" sh -e "$work/warm.sh" >/dev/null 2>&1; then
+        echo "a run that warmed every tag exited non-zero" >&2
+        PATH="$work/bin:$PATH" sh "$work/warm.sh" 2>&1 | tail -8 >&2
+        rm -rf "$work"; exit 1
+    fi
+    rm -rf "$work"
+}
+
+@test "every request the warm-up makes goes to the mirror, not to ghcr.io" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    mkdir -p "$work/bin"
+    # Run the emitted script against a wget that records the URLs it is asked for.
+    # Asserting on the URLs the script actually builds survives a refactor of how
+    # the base is assembled; the earlier version of this test pinned one literal
+    # concatenation and went red the moment that moved into a variable, while
+    # saying nothing about where the requests went.
+    {
+        echo '#!/bin/sh'
+        echo 'for a in "$@"; do case "$a" in http*) echo "$a" >> "'"$work"'/urls";; esac; done'
+        echo 'case "$*" in *manifests*) echo "{\"x\":\"sha256:'"$(printf 'a%.0s' $(seq 64))"'\"}";; esac'
+        echo 'exit 0'
+    } > "$work/bin/wget"
+    chmod +x "$work/bin/wget"
+    ghcr_warm_job_manifest registry:test v1.35.6 > "$work/job.yaml"
+    yq '.spec.template.spec.containers[0].args[0]' "$work/job.yaml" > "$work/warm.sh"
+    PATH="$work/bin:$PATH" sh -e "$work/warm.sh" >/dev/null 2>&1 || true
+    [ -s "$work/urls" ] || { echo "the warm-up requested nothing at all" >&2; rm -rf "$work"; exit 1; }
+    # The point of the Job is to populate the mirror's blobstore. Fetching from
+    # ghcr.io directly would move the same bytes, leave the cache empty, and still
+    # look like it worked.
+    while read -r u; do
+        case "$u" in
+            "$GHCR_MIRROR_SVC_URL"/*) ;;
+            *) echo "warm-up requested [$u], which is not on the mirror" >&2; rm -rf "$work"; exit 1 ;;
+        esac
+    done < "$work/urls"
+    grep -q 'ghcr\.io' "$work/urls" && { echo "warm-up reached ghcr.io directly" >&2; rm -rf "$work"; exit 1; }
+    # And it asked for the kubelet repository, not something else on the mirror.
+    grep -qF "/v2/$GHCR_WARM_REPO/" "$work/urls" || {
+        echo "warm-up never addressed $GHCR_WARM_REPO" >&2
+        rm -rf "$work"; exit 1
+    }
+    # And a blob, which is the only thing that lands in the cache. Every other
+    # assertion here is satisfied by a run that fetches the tag manifest and stops:
+    # the exit-status tests all pass too, because a run that requested nothing fails
+    # on the `got > 0` half either way. Breaking the digest extraction -- the one
+    # regex holding this together, inside an unquoted heredoc -- left all 53 tests
+    # green, which is the failure the comments in that file warn about three times.
+    grep -q '/blobs/sha256:' "$work/urls" || {
+        echo "the warm-up asked for no blob, so nothing would land in the cache" >&2
+        rm -rf "$work"; exit 1
+    }
+    rm -rf "$work"
+}
+
+@test "the warm-up Job requests every tag it was given" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    out=$(ghcr_warm_job_manifest registry:test v1.35.6 v1.34.9)
+    for tag in v1.35.6 v1.34.9; do
+        printf '%s' "$out" | grep -qF "$tag" || {
+            echo "warm-up Job never mentions $tag" >&2
+            exit 1
+        }
+    done
+}
+
+@test "the warm-up Job is a valid single Job in the mirror's namespace" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    manifest=hack/e2e-ghcr-mirror.yaml
+    work=$(mktemp -d)
+    ghcr_warm_job_manifest registry:test v1.35.6 > "$work/job.yaml"
+    kinds=$(yq '.kind' "$work/job.yaml" | grep -vc '^---$')
+    [ "$kinds" -eq 1 ] || { echo "expected exactly one document, got $kinds" >&2; rm -rf "$work"; exit 1; }
+    [ "$(yq '.kind' "$work/job.yaml")" = "Job" ] || { echo "not a Job" >&2; rm -rf "$work"; exit 1; }
+    # Same namespace as the mirror: the Job talks to a ClusterIP, and kube-system is
+    # where the mirror already lives, so no cross-namespace egress question arises.
+    ns=$(yq 'select(.kind == "Deployment") | .metadata.namespace' "$manifest")
+    [ "$(yq '.metadata.namespace' "$work/job.yaml")" = "$ns" ] || {
+        echo "warm-up Job is not in the mirror's namespace ($ns)" >&2
+        rm -rf "$work"; exit 1
+    }
+    rm -rf "$work"
+}
+
+@test "the warm-up Job carries the image it was given and gives up eventually" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    ghcr_warm_job_manifest registry:test v1.35.6 > "$work/job.yaml"
+    [ "$(yq '.spec.template.spec.containers[0].image' "$work/job.yaml")" = "registry:test" ] || {
+        echo "warm-up Job does not run the image it was given" >&2
+        rm -rf "$work"; exit 1
+    }
+    # A warm-up that retried forever would keep hammering the same flaky upstream leg
+    # for the whole run and keep a Pod on a sandbox node that is already short of CPU.
+    [ "$(yq '.spec.template.spec.restartPolicy' "$work/job.yaml")" = "Never" ] || {
+        echo "warm-up Pod restarts in place instead of failing the Job" >&2
+        rm -rf "$work"; exit 1
+    }
+    limit=$(yq '.spec.backoffLimit' "$work/job.yaml")
+    case "$limit" in
+        ''|*[!0-9]*) echo "backoffLimit is not a plain number: [$limit]" >&2; rm -rf "$work"; exit 1 ;;
+    esac
+    rm -rf "$work"
+}
+
+@test "the warm-up Job runs PSS-restricted like the mirror it feeds" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    ghcr_warm_job_manifest registry:test v1.35.6 > "$work/job.yaml"
+    p='.spec.template.spec'
+    [ "$(yq "$p.securityContext.runAsNonRoot" "$work/job.yaml")" = "true" ] || { echo "not runAsNonRoot" >&2; rm -rf "$work"; exit 1; }
+    [ "$(yq "$p.securityContext.seccompProfile.type" "$work/job.yaml")" = "RuntimeDefault" ] || { echo "no RuntimeDefault seccomp" >&2; rm -rf "$work"; exit 1; }
+    [ "$(yq "$p.automountServiceAccountToken" "$work/job.yaml")" = "false" ] || { echo "SA token mounted for a Job that only speaks HTTP" >&2; rm -rf "$work"; exit 1; }
+    c="$p.containers[0].securityContext"
+    [ "$(yq "$c.allowPrivilegeEscalation" "$work/job.yaml")" = "false" ] || { echo "priv-esc allowed" >&2; rm -rf "$work"; exit 1; }
+    [ "$(yq "$c.readOnlyRootFilesystem" "$work/job.yaml")" = "true" ] || { echo "writable rootfs" >&2; rm -rf "$work"; exit 1; }
+    [ "$(yq "$c.capabilities.drop[0]" "$work/job.yaml")" = "ALL" ] || { echo "capabilities not dropped" >&2; rm -rf "$work"; exit 1; }
+    rm -rf "$work"
+}
+
+@test "a tag that is not a plain version is refused rather than pasted into the Job" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    # The tags reach a `for tag in ...` inside the container's shell script. Anything
+    # that is not a bare version there is command substitution running as the Job.
+    # The chart's version map is in-tree today, which is exactly why the guard is
+    # cheap now and the audit is expensive later. Refusing beats quoting: there is
+    # no legitimate kubelet tag this rejects.
+    # The last entry is the newline twin of the space-separated case above it. It
+    # passed the guard for a while: `grep -q` matches per line and `$` anchors
+    # end-of-line, so a value whose FIRST line is a bare version satisfied the
+    # pattern and the remainder landed in the heredoc as shell.
+    nl=$(printf 'v1.35.6\nid')
+    # v1.35.6.7 and v1.35 are the shape-only cases: every character in them is one
+    # the class check allows, so they are refused by the regex anchors alone. Without
+    # them the ladder's "drop the end anchor" mutation survives, because the class
+    # check happens to cover every other entry in this list.
+    for bad in 'v1.35.6$(id)' 'v1.35.6;id' 'v1.35.6 v1.34.9' '`id`' '' '../../etc' "$nl" 'v1.35.6.7' 'v1.35'; do
+        if out=$(ghcr_warm_job_manifest registry:test "$bad" 2>/dev/null); then
+            echo "builder accepted a tag it should refuse: [$bad]" >&2
+            exit 1
+        fi
+        [ -z "$out" ] || { echo "builder printed a Job for a refused tag: [$bad]" >&2; exit 1; }
+    done
+}
+
+@test "an empty mirror endpoint or repo is refused instead of warming nothing" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    keep_url="$GHCR_MIRROR_SVC_URL"
+    keep_repo="$GHCR_WARM_REPO"
+    # Found by running the emitted script against a real pull-through registry: with
+    # an empty endpoint the Job still builds, still runs, still exits 0, and prints
+    # "index unavailable" for every tag. The cache stays cold and the run reports a
+    # warm-up that happened. The Job cannot detect this -- an unreachable mirror
+    # looks the same from inside -- so the builder has to.
+    GHCR_MIRROR_SVC_URL=""
+    if out=$(ghcr_warm_job_manifest registry:test v1.35.6 2>/dev/null); then
+        GHCR_MIRROR_SVC_URL="$keep_url"
+        echo "builder accepted an empty mirror endpoint" >&2
+        exit 1
+    fi
+    [ -z "$out" ] || { GHCR_MIRROR_SVC_URL="$keep_url"; echo "builder printed a Job with no endpoint" >&2; exit 1; }
+    GHCR_MIRROR_SVC_URL="$keep_url"
+    GHCR_WARM_REPO=""
+    if out=$(ghcr_warm_job_manifest registry:test v1.35.6 2>/dev/null); then
+        GHCR_WARM_REPO="$keep_repo"
+        echo "builder accepted an empty repository" >&2
+        exit 1
+    fi
+    [ -z "$out" ] || { GHCR_WARM_REPO="$keep_repo"; echo "builder printed a Job with no repository" >&2; exit 1; }
+    GHCR_WARM_REPO="$keep_repo"
+}
+
+@test "the builder emits nothing when given no tags" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    out=$(ghcr_warm_job_manifest registry:test 2>/dev/null) && {
+        echo "builder succeeded with no tags to warm" >&2
+        exit 1
+    }
+    [ -z "$out" ] || { echo "builder printed a Job with nothing to warm" >&2; exit 1; }
+}
+
+@test "the warm-up runs the image the cluster reports, not one written down here" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    # Behavioural, not a grep over the source: the earlier version of this test
+    # searched this file for a second `image:` pin, which would have passed with
+    # warm_ghcr_mirror deleted outright. Assert on what gets applied instead.
+    stub_get_rc=0
+    stub_image="example.test/registry@sha256:feedface"
+    stub_apply_capture="$work/applied.yaml"
+    warm_ghcr_mirror >/dev/null 2>&1
+    stub_apply_capture=""
+    stub_image="registry:test"
+    [ -s "$work/applied.yaml" ] || { echo "nothing was applied" >&2; rm -rf "$work"; exit 1; }
+    got=$(yq '.spec.template.spec.containers[0].image' "$work/applied.yaml")
+    [ "$got" = "example.test/registry@sha256:feedface" ] || {
+        echo "applied Job runs [$got], not the image the Deployment reported" >&2
+        rm -rf "$work"; exit 1
+    }
+    rm -rf "$work"
+}
+
+@test "the warm-up applies a Job carrying exactly the tags the suites select" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    # The happy path had no test at all: every earlier case exercised a refusal.
+    # This pins that a Job reaches kubectl, that the tag list word-splits into one
+    # argument per version rather than arriving as one blob, and that the set is
+    # the suites' set. Warming the whole map would be ~300 MiB at the one-platform
+    # walk the Job ships, all of it across the leg this feature exists because of,
+    # three fifths for minors no suite can select.
+    stub_get_rc=0
+    stub_apply_capture="$work/applied.yaml"
+    warm_ghcr_mirror >/dev/null 2>&1
+    stub_apply_capture=""
+    [ "$(yq '.kind' "$work/applied.yaml")" = "Job" ] || { echo "applied object is not a Job" >&2; rm -rf "$work"; exit 1; }
+    script=$(yq '.spec.template.spec.containers[0].args[0]' "$work/applied.yaml")
+    want_line=$(printf '%s' "$script" | grep -o 'for tag in [^;]*' | head -1)
+    a=$(yq 'keys | sort_by(.) | .[-1]' packages/apps/kubernetes/files/versions.yaml)
+    b=$(yq 'keys | sort_by(.) | .[-2]' packages/apps/kubernetes/files/versions.yaml)
+    for tag in $(yq ".[\"$a\"], .[\"$b\"]" packages/apps/kubernetes/files/versions.yaml); do
+        printf '%s' "$want_line" | grep -qF "$tag" || {
+            echo "applied Job does not warm $tag, which a suite selects: [$want_line]" >&2
+            rm -rf "$work"; exit 1
+        }
+    done
+    n=$(printf '%s' "$want_line" | tr ' ' '\n' | grep -c '^v[0-9]')
+    # Count what the suites actually ask for, from the suites. Comparing against
+    # GHCR_WARM_TAG_COUNT would be the test reading the bound it guards: raising the
+    # knob to 5 would move both sides together and the assertion would hold while
+    # the warm set quietly grew to the whole map. That mutation survived until this
+    # line stopped referring to the knob.
+    suites=$(grep -ho "run_kubernetes_test '[^']*'" hack/e2e-chainsaw/kubernetes-*/chainsaw-test.yaml \
+        | sort -u | wc -l | tr -d ' ')
+    [ "$suites" -ge 2 ] || { echo "could not read the suites' version selectors" >&2; rm -rf "$work"; exit 1; }
+    [ "$n" -eq "$suites" ] || {
+        echo "applied Job warms $n tags, but the suites select $suites distinct versions: [$want_line]" >&2
+        rm -rf "$work"; exit 1
+    }
+    rm -rf "$work"
+}
+
+@test "the pull count follows the configured repository" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    keep="$GHCR_WARM_REPO"
+    stub_get_rc=0
+    # The filter and the warm-up have to name the same repository. Both read
+    # GHCR_WARM_REPO at HEAD, which makes a mutation back to the literal
+    # siderolabs/kubelet behaviourally identical -- correctly green, since the value
+    # is the same. What that mutation would cost is only visible if the knob moves:
+    # point it elsewhere and a hardcoded filter counts zero while the warm-up and the
+    # workers both use the new name.
+    GHCR_WARM_REPO="example/other"
+    stub_log_lines='10.244.1.92 - - [10/Aug/2026:04:33:54 +0000] "GET /v2/example/other/blobs/sha256:cc HTTP/1.1" 200 19455163 "" "containerd/2.2.4+unknown"'
+    out=$(ghcr_mirror_diagnose 2>&1)
+    # Capture what the run was configured with BEFORE restoring, or the assertion
+    # compares the output against the value that was put back.
+    used="$GHCR_WARM_REPO"
+    GHCR_WARM_REPO="$keep"
+    stub_log_lines=""
+    printf '%s' "$out" | grep -qF "a worker pulled $used through the mirror" || {
+        echo "the count did not follow GHCR_WARM_REPO; a renamed repository reports zero pulls" >&2
+        printf '%s\n' "$out" | grep -i 'kubelet' >&2
+        exit 1
+    }
+}
+
+@test "the failure path surfaces how long the mirror took to answer the worker" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    stub_get_rc=0
+    # Warm and cold are indistinguishable in every other artifact: the Job reports
+    # success either way, because distribution stores the blob in the background and
+    # a completed GET is a different event from a stored blob. Server-side duration
+    # is the one number that separates them -- milliseconds off disk against minutes
+    # streamed from ghcr.io -- and it only exists in this log.
+    stub_log_lines=$(printf '%s\n%s' \
+        'time="2026-08-11T04:33:54Z" level=info msg="response completed" http.request.uri="/v2/siderolabs/kubelet/blobs/sha256:bb" http.response.duration=1m57.479642915s http.request.useragent="containerd/2.2.4+unknown"' \
+        'time="2026-08-11T03:10:00Z" level=info msg="response completed" http.request.uri="/v2/siderolabs/kubelet/blobs/sha256:aa" http.response.duration=12.2ms http.request.useragent=ghcr-mirror-warm')
+    # xtrace off: this runner traces test bodies, the trace goes to the same stderr
+    # this captures, and the traced command line contains the whole fixture -- both
+    # durations included. The assertion would then read the tracer rather than the
+    # section. Not turned back on, for the reason the apply-failure test gives.
+    set +x
+    out=$(ghcr_mirror_diagnose 2>&1)
+    stub_log_lines=""
+    # Scope the assertion to this section. The raw access-log dump further down
+    # legitimately contains every line, warm-up included, so asserting over the whole
+    # output would read the dump and call it a leak -- the assertion has to see what
+    # the section printed, not what the function printed.
+    section=$(printf '%s\n' "$out" | awk '/how long did the mirror take/{f=1;next} /^--- /{f=0} f')
+    printf '%s' "$section" | grep -qF 'http.response.duration=1m57.479642915s' || {
+        echo "the worker request duration is not surfaced" >&2
+        printf '%s\n' "$out" | tail -12 >&2
+        exit 1
+    }
+    # The warm-up's own timings must not be mixed in: they say nothing about what the
+    # worker experienced, and a millisecond figure next to a minutes-long one reads
+    # as though the cache was warm.
+    # `if`, not a trailing `cmd && { ...; exit 1; }`. This runner injects `return 0`
+    # before every closing brace, so a body's status is always 0 and both forms look
+    # the same here; real bats takes the status of the body's last command, where an
+    # AND-list returns 1 exactly when the guarded command did not fire -- that is,
+    # on the passing path. The form is only fatal in final position, which is why it
+    # is harmless elsewhere in this file.
+    if printf '%s' "$section" | grep -q 'duration=12.2ms'; then
+        echo "the warm-up's own duration leaked into the worker measurement" >&2
+        printf '%s\n' "$section" >&2
+        exit 1
+    fi
+}
+
+@test "the duration filter reads a log larger than one execve argument" {
+    # xtrace off before the fixture exists rather than after: this runner traces test
+    # bodies, and the fixture below is a megabyte. Tracing its construction would put
+    # that megabyte into the log of every run, green ones included.
+    set +x
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    stub_get_rc=0
+    # Size is the subject here. Linux caps a single argv element at MAX_ARG_STRLEN,
+    # 131072 bytes, independently of ARG_MAX -- measured on 6.8, 131000 bytes go
+    # through and 131072 fail with E2BIG -- while macOS caps the whole argv at
+    # kern.argmax, a megabyte. By the time this diagnostic runs the log is past both:
+    # the readiness probe writes an access line every 5s and the mirror has been up
+    # since install. So a filter that receives the log as an argument fails on every
+    # real failing run and succeeds only against a fixture small enough to fit, which
+    # is the shape every other test here has. Pad past a megabyte so this bites on
+    # both kernels rather than only on the CI one.
+    worker='time="2026-08-11T04:33:54Z" level=info msg="response completed" http.request.uri="/v2/siderolabs/kubelet/blobs/sha256:bb" http.response.duration=1m57.479642915s http.request.useragent="containerd/2.2.4+unknown"'
+    probe=$(awk 'BEGIN{ l="10.244.0.1 - - [09/Aug/2026:01:18:00 +0000] \"GET /v2/ HTTP/1.1\" 200 2"; n=int(1100000/(length(l)+1))+1; for(i=0;i<n;i++) print l }')
+    stub_log_lines=$(printf '%s\n%s' "$worker" "$probe")
+    # The fixture has to prove it is over the limit. A padding expression that
+    # silently produced 80 KiB would leave this test green for the wrong reason and
+    # pin nothing at all.
+    [ "${#stub_log_lines}" -gt 1048576 ] || {
+        echo "fixture is ${#stub_log_lines} bytes, under the macOS argv limit it is meant to exceed" >&2
+        exit 1
+    }
+    out=$(ghcr_mirror_diagnose 2>&1)
+    stub_log_lines=""
+    section=$(printf '%s\n' "$out" | awk '/how long did the mirror take/{f=1;next} /^--- /{f=0} f')
+    printf '%s' "$section" | grep -qF 'http.response.duration=1m57.479642915s' || {
+        echo "the worker duration was lost in a log of realistic size" >&2
+        printf '%s\n' "$out" | grep -iE 'how long|worker request durations|Argument list' >&2
+        exit 1
+    }
+}
+
+@test "a log carrying only the warm-up's own timings says so rather than printing nothing" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    stub_get_rc=0
+    # The exclusion above can empty this section legitimately: the warm-up ran, the
+    # worker never did. An empty section under a header is the same ambiguity the
+    # unreadable-log case has, so the absence has to be stated rather than left as
+    # blank space the reader fills in.
+    stub_log_lines='time="2026-08-11T03:10:00Z" level=info msg="response completed" http.request.uri="/v2/siderolabs/kubelet/blobs/sha256:aa" http.response.duration=12.2ms http.request.useragent=ghcr-mirror-warm'
+    set +x
+    out=$(ghcr_mirror_diagnose 2>&1)
+    stub_log_lines=""
+    section=$(printf '%s\n' "$out" | awk '/how long did the mirror take/{f=1;next} /^--- /{f=0} f')
+    printf '%s' "$section" | grep -q 'were not observed' || {
+        echo "an empty duration section did not say why it was empty" >&2
+        printf '%s\n' "$section" >&2
+        exit 1
+    }
+}
+
+@test "a log that could not be read prints no duration section" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    stub_get_rc=0
+    stub_log_rc=1
+    out=$(ghcr_mirror_diagnose 2>&1)
+    stub_log_rc=0
+    # A header with nothing under it reads as "the mirror answered no worker", which
+    # is a finding about the cluster. The log was never read, so the honest output is
+    # no section at all -- the same discipline the pull count above follows when it
+    # says the unreadable log says nothing either way.
+    if printf '%s' "$out" | grep -qF 'how long did the mirror take'; then
+        echo "the duration section was printed against a log that was never read" >&2
+        printf '%s\n' "$out" | tail -12 >&2
+        exit 1
+    fi
+}
+
+@test "the failure path reports whether the warm-up itself got anywhere" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    stub_get_rc=0
+    # Payloads only these two reads can produce. Asserting the warm-up's result
+    # against stub_log_lines instead would pass with both reads deleted, because the
+    # registry access-log read at the end of the same function prints that value.
+    stub_job_status='ghcr-mirror-warm   Complete   1/1   4m2s'
+    stub_job_log='warm: fetched 16, failed 0'
+    out=$(ghcr_mirror_diagnose 2>&1)
+    stub_job_status=""
+    stub_job_log=""
+    # Excluding the warm-up from the pull count without reporting the warm-up leaves
+    # the run unfalsifiable: a red suite looks the same whether the cache was warm
+    # and the guest still starved, or the warm-up never came up. This is the reader
+    # that tells those apart, and it runs on the node-join failure path where the
+    # question is actually asked.
+    printf '%s' "$out" | grep -q 'did the warm-up populate the cache' || {
+        echo "the failure path says nothing about the warm-up" >&2
+        exit 1
+    }
+    printf '%s' "$out" | grep -q 'warm: fetched 16, failed 0' || {
+        echo "the warm-up's own result is not surfaced" >&2
+        printf '%s\n' "$out" | tail -8 >&2
+        exit 1
+    }
+    printf '%s' "$out" | grep -q 'Complete   1/1' || {
+        echo "the warm-up Job's status is not surfaced, so a Job that never ran looks the same" >&2
+        printf '%s\n' "$out" | tail -8 >&2
+        exit 1
+    }
+}
+
+@test "the warm-up Job outlives the suites that would ask about it" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    ghcr_warm_job_manifest registry:test v1.35.6 > "$work/job.yaml"
+    ttl=$(yq '.spec.ttlSecondsAfterFinished' "$work/job.yaml")
+    dl=$(yq '.spec.activeDeadlineSeconds' "$work/job.yaml")
+    # The only reader of this Job's outcome is the node-join failure block, which
+    # fires 18m into a suite that starts tens of minutes after install. A TTL that
+    # expires first deletes the evidence before the one moment it is wanted.
+    [ "$ttl" -gt "$dl" ] || {
+        echo "ttlSecondsAfterFinished ($ttl) does not outlast activeDeadlineSeconds ($dl)" >&2
+        rm -rf "$work"; exit 1
+    }
+    [ "$ttl" -ge 7200 ] || {
+        echo "ttlSecondsAfterFinished ($ttl) is shorter than the gap to the suites that read it" >&2
+        rm -rf "$work"; exit 1
+    }
+    rm -rf "$work"
+}
+
+@test "the caller's log names a missing yq, not an empty version map" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    stub_get_rc=0
+    # The reason has to reach the log of the function an operator reads, not just the
+    # helper that produced it. The earlier version of this pinned ghcr_warm_tags
+    # directly and passed while warm_ghcr_mirror silently swallowed the line with a
+    # 2>/dev/null and blamed versions.yaml instead.
+    set +x
+    err=$(PATH="$work" warm_ghcr_mirror 2>&1 >/dev/null) || true
+    printf '%s' "$err" | grep -q 'yq is not installed' || {
+        echo "warm_ghcr_mirror did not surface the missing yq; it reported:" >&2
+        printf '%s\n' "$err" >&2
+        rm -rf "$work"; exit 1
+    }
+    rm -rf "$work"
+}
+
+@test "a missing yq is not reported as an empty version map" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    # Same distinction the kubectl path already makes: "the file says nothing" and
+    # "the tool that reads the file is absent" are different causes, and only the
+    # message carries which. An empty map would send the reader to versions.yaml.
+    set +x
+    err=$(PATH="$work" ghcr_warm_tags 2>&1 >/dev/null) || true
+    printf '%s' "$err" | grep -q 'yq is not installed' || {
+        echo "a missing yq was not named; the caller would blame the version map" >&2
+        printf '%s\n' "$err" >&2
+        rm -rf "$work"; exit 1
+    }
+    rm -rf "$work"
+}
+
+@test "an image reference that is not one is refused rather than interpolated" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    stub_get_rc=0
+    # The image is the only builder input that comes from the cluster, and it lands in
+    # the Job YAML. Reading it requires no privilege but writing it does, so this is
+    # not a trust boundary -- it is symmetry: both locally-set inputs are checked and
+    # the tags are pattern-matched, and leaving the third unchecked reads as though
+    # the builder validates nothing.
+    stub_image='registry:test;id'
+    out=$(warm_ghcr_mirror 2>&1)
+    stub_image="registry:test"
+    printf '%s' "$out" | grep -q 'is not an image reference' || {
+        echo "a non-reference image was accepted:" >&2
+        printf '%s\n' "$out" >&2
+        exit 1
+    }
+}
+
+@test "the warm-up says so when it cannot read the mirror image" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    stub_get_rc=0
+    stub_image=""
+    out=$(warm_ghcr_mirror 2>&1)
+    stub_image="registry:test"
+    printf '%s' "$out" | grep -q 'could not read the ghcr-mirror image' || {
+        echo "an unreadable image was not reported" >&2
+        printf '%s\n' "$out" >&2
+        exit 1
+    }
+}
+
+@test "a transient lookup failure is not reported as an absent mirror" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    stub_get_rc=1
+    stub_get_out='Error from server: etcdserver: request timed out'
+    out=$(warm_ghcr_mirror 2>&1)
+    stub_get_rc=0
+    stub_get_out=""
+    # resolve_ghcr_mirror_endpoint in this same file documents at length why only the
+    # API's own NotFound means "never applied here". Saying "not deployed" after an
+    # apiserver blip, a bad context or a missing kubectl blames the wrong thing in
+    # the log, and the captured message is the only place the real cause exists.
+    printf '%s' "$out" | grep -q 'not deployed' && {
+        echo "a transient failure was reported as an absent mirror" >&2
+        printf '%s\n' "$out" >&2
+        exit 1
+    }
+    printf '%s' "$out" | grep -q 'etcdserver' || {
+        echo "the real reason was discarded" >&2
+        printf '%s\n' "$out" >&2
+        exit 1
+    }
+}
+
+@test "warm-up tags come out in the order the suites select them" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    keep="$GHCR_WARM_VERSIONS_FILE"
+    work=$(mktemp -d)
+    # The loop is serial, so order decides how long the tag the suite needs waits.
+    # A new minor is appended at the bottom of versions.yaml -- that is what the
+    # bump path does -- and file order then puts it last while `keys | sort_by(.) |
+    # .[-1]` puts it first. Warming in file order would leave the one tag that
+    # matters behind every tag that does not, with no signal that it happened.
+    printf '"v1.34": "v1.34.9"\n"v1.33": "v1.33.13"\n"v1.36": "v1.36.1"\n' > "$work/versions.yaml"
+    GHCR_WARM_VERSIONS_FILE="$work/versions.yaml"
+    first=$(ghcr_warm_tags | head -1)
+    GHCR_WARM_VERSIONS_FILE="$keep"
+    [ "$first" = "v1.36.1" ] || {
+        echo "warm-up starts with [$first]; the suites would ask for v1.36.1 first" >&2
+        rm -rf "$work"; exit 1
+    }
+    # And on the real file the first two must be exactly what the two suites pick.
+    a=$(yq 'keys | sort_by(.) | .[-1]' packages/apps/kubernetes/files/versions.yaml)
+    b=$(yq 'keys | sort_by(.) | .[-2]' packages/apps/kubernetes/files/versions.yaml)
+    want=$(yq ".[\"$a\"], .[\"$b\"]" packages/apps/kubernetes/files/versions.yaml)
+    got=$(ghcr_warm_tags | head -2)
+    [ "$got" = "$want" ] || {
+        echo "first two warmed tags [$got] are not the two the suites select [$want]" >&2
+        rm -rf "$work"; exit 1
+    }
+    rm -rf "$work"
+}
+
+@test "an unreachable mirror fails the warm-up Job instead of completing it" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    mkdir -p "$work/bin"
+    # Stub wget rather than talk to a real socket: this pins the script's own
+    # control flow, which is where the defect was. Every fetch fails, exactly as it
+    # does when the mirror has no endpoints yet -- the Job is submitted seconds
+    # after the Deployment is created and the registry image is not in the pre-pull
+    # set, so it has to pull before it can serve.
+    printf '#!/bin/sh\nexit 1\n' > "$work/bin/wget"
+    chmod +x "$work/bin/wget"
+    keep_ready="${GHCR_WARM_READY_TIMEOUT:-}"
+    GHCR_WARM_READY_TIMEOUT=1
+    ghcr_warm_job_manifest registry:test v1.35.6 > "$work/job.yaml"
+    GHCR_WARM_READY_TIMEOUT="$keep_ready"
+    yq '.spec.template.spec.containers[0].args[0]' "$work/job.yaml" > "$work/warm.sh"
+    # A script that exits 0 here makes backoffLimit dead: the Job goes Complete,
+    # ttlSecondsAfterFinished deletes it, and nothing ever retries the warm-up.
+    if PATH="$work/bin:$PATH" sh -e "$work/warm.sh" >/dev/null 2>&1; then
+        echo "the warm-up script reported success with every fetch failing" >&2
+        rm -rf "$work"; exit 1
+    fi
+    rm -rf "$work"
+}
+
+@test "a mirror that answers but cannot deliver blobs also fails the Job" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    mkdir -p "$work/bin"
+    # The sibling test covers the mirror being unreachable, which exits inside the
+    # readiness wait. That left the FINAL exit status unpinned: a mutation replacing
+    # it with `true` survived, because no test reached it. This is the live-mirror
+    # half -- /v2/ answers, manifests answer, blobs do not -- which is exactly the
+    # upstream failure the access log showed (HTTP 500 mid-blob after 7-8 MiB).
+    {
+        echo '#!/bin/sh'
+        echo 'case "$*" in'
+        echo '  *"/v2/ "*|*"/v2/"|*"/v2/ -"*) exit 0 ;;'
+        echo '  *manifests*) echo "{\"d\":\"sha256:'"$(printf 'b%.0s' $(seq 64))"'\"}"; exit 0 ;;'
+        echo '  *blobs*) exit 1 ;;'
+        echo 'esac'
+        echo 'exit 0'
+    } > "$work/bin/wget"
+    chmod +x "$work/bin/wget"
+    ghcr_warm_job_manifest registry:test v1.35.6 > "$work/job.yaml"
+    yq '.spec.template.spec.containers[0].args[0]' "$work/job.yaml" > "$work/warm.sh"
+    if PATH="$work/bin:$PATH" sh -e "$work/warm.sh" >/dev/null 2>&1; then
+        echo "the Job reported success with every blob fetch failing" >&2
+        rm -rf "$work"; exit 1
+    fi
+    rm -rf "$work"
+}
+
+@test "building the Job runs nothing and says nothing" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    # The Job's script lives in an UNQUOTED heredoc, so every backtick and $(...)
+    # in it -- including inside comments -- is command substitution at render time.
+    # A shell snippet quoted in a comment there once expanded into an endless loop:
+    # the builder hung, and every structural assertion still passed, because the
+    # YAML it never finished printing was valid as far as it got. Silence on stderr
+    # is the cheap observable for "nothing was executed while rendering".
+    #
+    # xtrace off first, and not turned back on, for the reason the apply-failure test
+    # below gives: this runner traces test bodies, that trace goes to the same stderr
+    # this assertion reads, and it would then report the tracer rather than the
+    # builder. Under plain bats a `set -x` here would enable tracing that was never
+    # on, and a failing test after that hangs the runner instead of reporting.
+    set +x
+    ghcr_warm_job_manifest registry:test v1.35.6 >"$work/out.yaml" 2>"$work/err"
+    [ ! -s "$work/err" ] || {
+        echo "rendering the Job wrote to stderr, so something ran:" >&2
+        head -5 "$work/err" >&2
+        rm -rf "$work"; exit 1
+    }
+    [ "$(yq '.kind' "$work/out.yaml")" = "Job" ] || { echo "render produced no Job" >&2; rm -rf "$work"; exit 1; }
+    rm -rf "$work"
+}
+
+@test "the Job heredoc carries no backticks at all" {
+    f=hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    # Structural companion to the test above, and the reason both exist: a
+    # substitution that HANGS cannot be caught by observing output, because there
+    # is none and the runner never returns. This one fails instead of hanging.
+    body=$(awk '/cat <<EOF$/{f=1;next} /^EOF$/{f=0} f' "$f")
+    [ -n "$body" ] || { echo "could not isolate the heredoc body" >&2; exit 1; }
+    if printf '%s\n' "$body" | grep -q '`'; then
+        echo "the unquoted heredoc contains a backtick, which runs at render time:" >&2
+        printf '%s\n' "$body" | grep -n '`' >&2
+        exit 1
+    fi
+}
+
+@test "a cold tag among several fails the Job even when the counters stay clean" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    mkdir -p "$work/bin"
+    # Two tags, the second one's platform manifest unavailable. That path moved
+    # neither counter -- no blob was attempted for it, and the index fetch succeeded
+    # -- so the Job completed with one suite's tag cold and reported "failed 0".
+    # Every other exit-status test here is single-tag, which is why it survived.
+    amd=sha256:2222222222222222222222222222222222222222222222222222222222222222
+    gone=sha256:9999999999999999999999999999999999999999999999999999999999999999
+    {
+        echo '#!/bin/sh'
+        echo 'case "$*" in'
+        echo "  *manifests/v1.35.6*) printf '{ \"manifests\": [ { \"digest\": \"$amd\", \"platform\": { \"architecture\": \"amd64\", \"os\": \"linux\" } } ] }' ;;"
+        echo "  *manifests/v1.34.9*) printf '{ \"manifests\": [ { \"digest\": \"$gone\", \"platform\": { \"architecture\": \"amd64\", \"os\": \"linux\" } } ] }' ;;"
+        echo "  *manifests/$amd*) echo '{\"layers\":[{\"digest\":\"sha256:3333333333333333333333333333333333333333333333333333333333333333\"}]}' ;;"
+        echo "  *manifests/$gone*) exit 1 ;;"
+        echo 'esac'
+        echo 'exit 0'
+    } > "$work/bin/wget"
+    chmod +x "$work/bin/wget"
+    ghcr_warm_job_manifest registry:test v1.35.6 v1.34.9 > "$work/job.yaml"
+    yq '.spec.template.spec.containers[0].args[0]' "$work/job.yaml" > "$work/warm.sh"
+    if PATH="$work/bin:$PATH" sh -e "$work/warm.sh" >"$work/out" 2>&1; then
+        echo "the Job completed with a selected tag left cold:" >&2
+        grep '^warm: ' "$work/out" >&2
+        rm -rf "$work"; exit 1
+    fi
+    grep -qF 'not warmed: v1.34.9' "$work/out" || {
+        echo "the cold tag is not named in the report" >&2
+        rm -rf "$work"; exit 1
+    }
+    rm -rf "$work"
+}
+
+@test "a partly fetched tag is not reported as warmed" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    mkdir -p "$work/bin"
+    # One blob lands, the next fails -- the shape a live run produced when the
+    # upstream reset mid-transfer. Counting "did any blob arrive" called that tag
+    # warmed, and a half-cached tag still sends the worker across the slow leg for
+    # the rest, which is the whole thing being measured.
+    ok=sha256:4444444444444444444444444444444444444444444444444444444444444444
+    bad=sha256:5555555555555555555555555555555555555555555555555555555555555555
+    {
+        echo '#!/bin/sh'
+        echo 'case "$*" in'
+        echo "  *manifests/v1.35.6*) echo '{\"layers\":[{\"digest\":\"$ok\"},{\"digest\":\"$bad\"}]}' ;;"
+        echo "  *blobs/$bad*) exit 1 ;;"
+        echo 'esac'
+        echo 'exit 0'
+    } > "$work/bin/wget"
+    chmod +x "$work/bin/wget"
+    ghcr_warm_job_manifest registry:test v1.35.6 > "$work/job.yaml"
+    yq '.spec.template.spec.containers[0].args[0]' "$work/job.yaml" > "$work/warm.sh"
+    out=$(PATH="$work/bin:$PATH" sh -e "$work/warm.sh" 2>&1) || true
+    printf '%s' "$out" | grep -q 'warm: warmed: *$' || {
+        echo "a tag with a failed blob was reported as warmed:" >&2
+        printf '%s\n' "$out" | grep '^warm: ' >&2
+        rm -rf "$work"; exit 1
+    }
+    printf '%s' "$out" | grep -qF 'not warmed: v1.35.6' || {
+        echo "the partly fetched tag is not listed as missed" >&2
+        printf '%s\n' "$out" | grep '^warm: ' >&2
+        rm -rf "$work"; exit 1
+    }
+    rm -rf "$work"
+}
+
+@test "only the platform the workers run is fetched, and it is not chosen by luck" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    mkdir -p "$work/bin"
+    # A two-platform index in the shape a registry actually returns: pretty-printed,
+    # arm64 listed first. Walking every manifest in the index fetched both, and the
+    # digest sort put arm64 ahead of amd64 for both warmed tags, so on the slow leg
+    # this feature exists for the Job spent its first half on an architecture nothing
+    # in the sandbox pulls and left the second tag cold.
+    arm=sha256:1111111111111111111111111111111111111111111111111111111111111111
+    amd=sha256:2222222222222222222222222222222222222222222222222222222222222222
+    {
+        echo '#!/bin/sh'
+        echo 'for a in "$@"; do case "$a" in http*) echo "$a" >> "'"$work"'/urls";; esac; done'
+        echo 'case "$*" in'
+        echo "  *manifests/v1.35.6*) printf '{\\n  \"manifests\": [\\n    { \"digest\": \"$arm\", \"platform\": { \"architecture\": \"arm64\", \"os\": \"linux\" } },\\n    { \"digest\": \"$amd\", \"platform\": { \"architecture\": \"amd64\", \"os\": \"linux\" } }\\n  ]\\n}' ;;"
+        echo "  *manifests/$amd*) echo '{\"layers\":[{\"digest\":\"sha256:3333333333333333333333333333333333333333333333333333333333333333\"}]}' ;;"
+        echo 'esac'
+        echo 'exit 0'
+    } > "$work/bin/wget"
+    chmod +x "$work/bin/wget"
+    ghcr_warm_job_manifest registry:test v1.35.6 > "$work/job.yaml"
+    yq '.spec.template.spec.containers[0].args[0]' "$work/job.yaml" > "$work/warm.sh"
+    PATH="$work/bin:$PATH" sh -e "$work/warm.sh" >/dev/null 2>&1 || true
+    grep -qF "$amd" "$work/urls" || {
+        echo "the amd64 manifest was never requested" >&2
+        rm -rf "$work"; exit 1
+    }
+    grep -qF "$arm" "$work/urls" && {
+        echo "the arm64 manifest was fetched; that is bytes no worker in the sandbox pulls" >&2
+        rm -rf "$work"; exit 1
+    }
+    rm -rf "$work"
+}
+
+@test "a run that fetched nothing is a failure, not a quiet success" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    mkdir -p "$work/bin"
+    # Every request succeeds and the manifests carry no digests, so no blob is ever
+    # asked for: failed stays 0 and so does the fetched count. Guarding only on
+    # "nothing failed" calls that a warm cache. A mutation dropping the `got > 0`
+    # half survived the rest of the suite, which is what this pins.
+    #
+    # Not hypothetical for a pull-through proxy: a 200 carrying an error document,
+    # or a manifest for a platform set this repo does not use, both land here.
+    {
+        echo '#!/bin/sh'
+        echo 'case "$*" in *manifests*) echo "{}" ;; esac'
+        echo 'exit 0'
+    } > "$work/bin/wget"
+    chmod +x "$work/bin/wget"
+    ghcr_warm_job_manifest registry:test v1.35.6 > "$work/job.yaml"
+    yq '.spec.template.spec.containers[0].args[0]' "$work/job.yaml" > "$work/warm.sh"
+    if PATH="$work/bin:$PATH" sh -e "$work/warm.sh" >/dev/null 2>&1; then
+        echo "the Job reported success after fetching zero blobs" >&2
+        rm -rf "$work"; exit 1
+    fi
+    rm -rf "$work"
+}
+
+@test "the warm-up waits for the mirror instead of concluding on the first refusal" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    mkdir -p "$work/bin"
+    # Count the readiness attempts: the Job is submitted seconds after the mirror
+    # Deployment, so a single probe would decide "not serving" while the registry is
+    # still pulling its own image. This pins that the wait retries rather than that
+    # some particular line of shell exists.
+    {
+        echo '#!/bin/sh'
+        echo 'case "$*" in'
+        echo '  *"/v2/"*) echo x >> "'"$work"'/probes"; exit 1 ;;'
+        echo 'esac'
+        echo 'exit 1'
+    } > "$work/bin/wget"
+    chmod +x "$work/bin/wget"
+    keep="${GHCR_WARM_READY_TIMEOUT:-}"
+    # The wait is a wall clock and each attempt costs only its 5s sleep (Cilium
+    # rejects a Service with no ready endpoints, so the bounded fetch returns at
+    # once), which means the test sleeps for the whole budget. 15s buys three tries,
+    # enough to tell a loop that retries from one that concludes on the first
+    # refusal, and does not add 45s to the file for no extra discrimination.
+    # 20, not 15: at 15 the derived bound equals two while the loop makes three
+    # probes, so one slow iteration on a loaded runner eats the whole margin.
+    budget=20
+    GHCR_WARM_READY_TIMEOUT="$budget"
+    ghcr_warm_job_manifest registry:test v1.35.6 > "$work/job.yaml"
+    GHCR_WARM_READY_TIMEOUT="$keep"
+    yq '.spec.template.spec.containers[0].args[0]' "$work/job.yaml" > "$work/warm.sh"
+    t0=$(date +%s)
+    PATH="$work/bin:$PATH" sh -e "$work/warm.sh" >/dev/null 2>&1 || true
+    elapsed=$(( $(date +%s) - t0 ))
+    n=$(wc -l < "$work/probes" 2>/dev/null || echo 0)
+    # The elapsed clock is the claim itself, the probe count below is only its
+    # shadow. At this budget the derived count collapses to a number a hardcoded
+    # three-iteration loop can also produce -- a count-only assertion is vacuous
+    # exactly at the budget the test can afford to run. A loop that counts
+    # iterations instead of watching the clock finishes in 3x5s and fails here;
+    # a loop that watches the clock cannot leave before the budget is spent.
+    [ "$elapsed" -ge "$budget" ] || {
+        echo "the readiness wait gave up after ${elapsed}s of a ${budget}s budget; it is not keeping a wall clock" >&2
+        rm -rf "$work"; exit 1
+    }
+    # Against the budget, not a magic 2. Cilium rejects a Service with no ready
+    # endpoints instead of dropping (serviceNoBackendResponse defaults to reject), so
+    # each attempt costs the 5s sleep and nothing else -- a 45s budget is nine tries.
+    # A `>= 2` assertion tolerated an accounting bug that gave up after 16s while the
+    # message still said 45; asking for most of the budget catches that direction.
+    # Derived from the same variable that sets the budget, so the two cannot drift.
+    want=$(( budget / 5 - 1 ))
+    [ "$n" -ge "$want" ] || {
+        echo "readiness was probed $n time(s) inside a ${budget}s budget; expected at least $want" >&2
+        rm -rf "$work"; exit 1
+    }
+    rm -rf "$work"
+}
+
+@test "the blob fetch timeout stays sized for the throttled leg" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    out=$(ghcr_warm_job_manifest registry:test v1.35.6)
+    # 600 is a decision, not a default: the leg this Job crosses runs at 40-165 KB/s
+    # with streams that stall mid-blob, and a short inactivity timeout converts a
+    # slow-but-alive transfer into a failed one -- on exactly the runs the warm-up
+    # exists for. Structural on purpose: the emitted script is data here, and the
+    # claim is that the value does not drift silently, not that busybox wget
+    # interprets it one way or another.
+    # In the emitted manifest the heredoc's \$ is already resolved: the script text
+    # carries a literal $blob, not a backslash. Grepping for the source file's
+    # spelling here finds nothing and fails the healthy code.
+    line=$(printf '%s' "$out" | grep -F 'blobs/$blob' | grep -o 'get -T [0-9]*' | head -1)
+    to=${line#get -T }
+    [ -n "$to" ] || {
+        echo "could not find the blob fetch timeout in the emitted script" >&2
+        exit 1
+    }
+    [ "$to" -ge 600 ] || {
+        echo "the blob fetch timeout is ${to}s; a stalled-but-alive transfer on the throttled leg needs at least 600" >&2
+        exit 1
+    }
+}
+
+@test "the warm-up identifies itself so the pull diagnostic can exclude it" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    out=$(ghcr_warm_job_manifest registry:test v1.35.6)
+    printf '%s' "$out" | grep -qF -- "-U ${GHCR_WARM_JOB_NAME}" || {
+        echo "warm-up requests are indistinguishable from a worker's in the access log" >&2
+        exit 1
+    }
+}
+
+@test "the diagnostic does not count its own warm-up as a worker pull" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    stub_get_rc=0
+    # After the warm-up ships, every run has 50+ `GET /v2/siderolabs/kubelet/...`
+    # lines from kube-system before any tenant exists. Counting those turns "the
+    # mirror served N requests for the image, so workers did reach it" into a
+    # sentence that is true of every run and therefore says nothing. These runs are
+    # already hard to attribute from outside the guest; a signal that is always
+    # positive removes the last one that distinguishes them.
+    # The real three-line shape per GET, measured against the pinned registry image:
+    # a challenge line, a "response completed" line, and one nginx-combined access
+    # line. All three carry the user-agent -- the structured pair as
+    # http.request.useragent=, the combined line positionally -- which is what makes
+    # the exclusion able to be complete. A one-line-per-GET fixture would let this
+    # test pass on a filter that misses two thirds of the traffic.
+    warm=$(i=0; while [ "$i" -lt 40 ]; do
+        echo 'time="2026-08-10T03:10:00Z" level=info msg="Challenge established with upstream" http.request.uri="/v2/siderolabs/kubelet/blobs/sha256:aa" http.request.useragent=ghcr-mirror-warm'
+        echo 'time="2026-08-10T03:10:00Z" level=info msg="response completed" http.request.uri="/v2/siderolabs/kubelet/blobs/sha256:aa" http.request.useragent=ghcr-mirror-warm'
+        echo '10.244.0.5 - - [10/Aug/2026:03:10:00 +0000] "GET /v2/siderolabs/kubelet/blobs/sha256:aa HTTP/1.1" 200 19455163 "" "ghcr-mirror-warm"'
+        i=$((i+1)); done)
+    stub_log_lines="$warm"
+    out=$(ghcr_mirror_diagnose 2>&1)
+    printf '%s' "$out" | grep -qF "no $GHCR_WARM_REPO request appears in the mirror" || {
+        echo "warm-up traffic was counted as a worker pull" >&2
+        printf '%s\n' "$out" | grep -iE 'through the mirror|reached the mirror' >&2
+        exit 1
+    }
+    # And a real worker pull mixed into the same log must still be found.
+    # Three lines per request, which is what the pinned registry image actually
+    # writes for one GET; a one-line-per-request fixture is a shape the wire never
+    # produces, and it would let a count-based assertion look right for the wrong
+    # reason.
+    worker=$(printf '%s\n%s\n%s' \
+        'time="2026-08-10T04:33:54Z" level=info msg="response completed" http.request.uri="/v2/siderolabs/kubelet/blobs/sha256:bb" http.request.useragent="containerd/2.2.4+unknown"' \
+        '10.244.1.92 - - [10/Aug/2026:04:33:54 +0000] "GET /v2/siderolabs/kubelet/blobs/sha256:bb HTTP/1.1" 200 19455163 "" "containerd/2.2.4+unknown"' \
+        'time="2026-08-10T04:33:54Z" level=info msg="Challenge established with upstream" http.request.uri="/v2/siderolabs/kubelet/blobs/sha256:bb" http.request.useragent=containerd/2.2.4+unknown')
+    stub_log_lines=$(printf '%s\n%s' "$warm" "$worker")
+    out=$(ghcr_mirror_diagnose 2>&1)
+    printf '%s' "$out" | grep -q 'a worker pulled siderolabs/kubelet through the mirror' || {
+        echo "a worker pull was lost when warm-up lines were excluded" >&2
+        printf '%s\n' "$out" | grep -iE 'kubelet' >&2
+        exit 1
+    }
+    # One request, three log lines. Counting lines reported three, which is why the
+    # count is taken off the access-line shape that appears exactly once per request.
+    printf '%s' "$out" | grep -q '(1 request(s)' || {
+        echo "the count is not a request count:" >&2
+        printf '%s\n' "$out" | grep -i 'pulled the kubelet' >&2
+        exit 1
+    }
+    stub_log_lines=""
+}
+
+@test "the warm-up Job cannot run past the step that waits for it to be irrelevant" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    ghcr_warm_job_manifest registry:test v1.35.6 > "$work/job.yaml"
+    # Bounded wall clock, not just bounded retries: the fetches are slow by nature
+    # on the leg this exists for, so a Job with only backoffLimit can sit pulling
+    # on a sandbox node for hours after the suites it was meant to help are done.
+    d=$(yq '.spec.activeDeadlineSeconds' "$work/job.yaml")
+    case "$d" in
+        ''|null|*[!0-9]*) echo "no numeric activeDeadlineSeconds: [$d]" >&2; rm -rf "$work"; exit 1 ;;
+    esac
+    rm -rf "$work"
+}
+
+@test "a warm-up that cannot be applied does not fail the caller" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    stub_get_rc=0
+    stub_apply_rc=1
+    # Best-effort by construction: this runs during install, and the run is expected
+    # to survive without it exactly as it did before the warm-up existed.
+    warm_ghcr_mirror >/dev/null 2>&1 || {
+        echo "a failed warm-up apply propagated to the caller" >&2
+        stub_apply_rc=0
+        exit 1
+    }
+    stub_apply_rc=0
+}
+
+@test "the warm-up is skipped when the mirror was never deployed" {
+    . hack/e2e-chainsaw/_lib/ghcr-mirror.sh
+    work=$(mktemp -d)
+    stub_get_rc=1
+    stub_get_out='Error from server (NotFound): deployments.apps "ghcr-mirror" not found'
+    # A valid image and an apply capture, deliberately: with only the message
+    # asserted, deleting the early return after "not deployed" survived the suite,
+    # because the flow then died further down on an unreadable image and still
+    # applied nothing. The test's name promises a skip; the assertion has to be
+    # "nothing was applied", and the fixture has to remove every later obstacle so
+    # that a deleted return actually reaches kubectl.
+    stub_image='mirror.gcr.io/library/registry:2.8.3@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    stub_apply_capture="$work/applied.yaml"
+    out=$(warm_ghcr_mirror 2>&1)
+    stub_get_rc=0
+    stub_get_out=""
+    stub_image=""
+    stub_apply_capture=""
+    printf '%s' "$out" | grep -q 'not deployed' || {
+        echo "warm-up did not say why it did nothing" >&2
+        printf '%s\n' "$out" >&2
+        rm -rf "$work"; exit 1
+    }
+    if [ -s "$work/applied.yaml" ]; then
+        echo "warm-up said 'not deployed' and then applied a Job anyway:" >&2
+        head -5 "$work/applied.yaml" >&2
+        rm -rf "$work"; exit 1
+    fi
+    rm -rf "$work"
+}
+
+@test "install starts the warm-up in the same step that deploys the mirror" {
+    f=hack/e2e-install-cozystack.bats
+    # The warm-up only pays off if it runs tens of minutes before the kubernetes
+    # suites. Anywhere later and the first tenant worker still races a cold cache,
+    # which is the failure it exists to remove.
+    block=$(awk '/^@test /{b=""} {b=b ORS $0} /^}$/ && b ~ /e2e-ghcr-mirror\.yaml/ {print b; exit}' "$f")
+    [ -n "$block" ] || { echo "no @test block in $f applies hack/e2e-ghcr-mirror.yaml" >&2; exit 1; }
+    printf '%s\n' "$block" | grep -qF 'warm_ghcr_mirror' || {
+        echo "the mirror is deployed without starting its warm-up" >&2
         exit 1
     }
 }

--- a/hack/run-kubernetes-node-join_test.bats
+++ b/hack/run-kubernetes-node-join_test.bats
@@ -516,7 +516,7 @@ assert_file_contains() {
   assert_file_contains '(b) in-guest Talos dmesg + kubelet logs: not collected' "$tmp/out"
   assert_file_contains 're-probe talos-image-cache ClusterIP + cacher debug bundle: not collected' "$tmp/out"
   assert_file_contains '(d) tenant worker CPU throttling: not collected' "$tmp/out"
-  assert_file_contains 'ghcr-mirror state + access log: not collected' "$tmp/out"
+  assert_file_contains 'ghcr-mirror state, access log and warm-up Job: not collected' "$tmp/out"
   rm -rf "$tmp"
 }
 


### PR DESCRIPTION
## What this PR does

The most expensive e2e flake, cozystack/cozystack#3513, is a tenant worker missing the 18m node-Ready budget with zero Nodes registered. The in-guest capture in cozystack/cozystack#3548 diagnosed one variant: the worker's kubelet image pull crawls to ghcr.io at 40-165 KB/s over the runner egress and does not finish inside the budget, Talos holds the kubelet service until its image arrives, so the node never registers and the tenant cilium HelmRelease then fails for want of a schedulable node rather than for any fault of its own.

The sandbox already runs an in-cluster pull-through mirror for ghcr.io, but a pull-through cache fetches a blob only when a client first asks for it, so the first tenant worker pays the cold fetch inside its node-Ready budget. Measured with the same fetch script against a local instance of the same registry image: 32m47s cold, 1.1s warm, for the same tags the failing runs stalled on.

This PR fills the cache from a Job started by the same install step that deploys the mirror, tens of minutes before the kubernetes suites run. It warms the two kubelet tags the suites actually select, resolved from the chart's version map in the same order the suites resolve it, and one platform per tag (the one the workers run, ~61 MiB each) - warming what nobody pulls would be a true addition to the same throttled egress the install itself is using.

The warm-up is best-effort by construction: a Job that fails, times out or never starts does not fail the install, and the suites behave exactly as they did before it existed. The Job itself exits non-zero on any missed tag, so its status stays honest.

The node-join failure diagnostics now answer the questions a red run used to leave open: whether a worker pulled through the mirror at all (counting GET and HEAD access lines per request, excluding the warm-up's own requests, which name themselves via user-agent), how long the mirror took to answer (server-side `http.response.duration` is the only after-the-fact signal separating a warm cache from a cold one, since the proxy stores blobs in the background and the Job reports success either way), and whether the warm-up itself got anywhere. The diagnostic section grows from five to seven bounded reads, moving its worst case from roughly 100s to roughly 150s inside the existing phase budget gate; unbudgeted diagnostic residuals stay tracked in cozystack/cozystack#3666.

This addresses one variant of cozystack/cozystack#3513 and does not close it: the zero-CSR class remains untouched, and a green suite after this change is not evidence the flake is gone. The 18m node-Ready budget is not raised.

Covered by 65 unit tests in `hack/ghcr-mirror_test.bats`: tag selection and ordering against the suites' own expressions, rejection of malformed and injected tag values, Job shape and restricted security context, the readiness wait as a wall clock, every failure path of the new diagnostics including an over-1-MiB log fixture that pins the duration filter against real log sizes, and the exclusion of the warm-up's own traffic from both the request count and the duration report.

### Screenshots

No UI changes.

### Downstream repositories

The diff is confined to e2e infrastructure under `hack/`: the mirror manifest, the warm-up library and its tests, the install step, and diagnostic labels. Walked the trigger map file by file - no chart values, no APIs, no documentation content, nothing any downstream repository consumes.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added best-effort GHCR mirror warm-up during installation.
  * Preloads selected Kubernetes image manifests and blobs to improve cache readiness.
  * Warm-up failures safely fall back to direct image pulls.

* **Diagnostics**
  * Improved request classification, timing, repository identification, and reporting of warm-up status and logs.

* **Tests**
  * Expanded coverage for warm-up behavior, validation, retries, security settings, caching, logging, installation, and diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
