### PR TITLE
fix(ingress-nginx): pull the protobuf-exporter from the project namespace

### DIFF
--- a/hack/promote-retag.sh
+++ b/hack/promote-retag.sh
@@ -145,7 +145,7 @@ for raw in $(collect_refs); do
   # a skopeo copy can succeed. Everything else is vendored by digest from a
   # registry this job cannot push to, and a copy there would fail and (under
   # set -e) abort the whole promotion. What this drops today:
-  #   - third-party hosts: docker.io/clastix/kubectl, ghcr.io/kvaps/...,
+  #   - third-party hosts: docker.io/clastix/kubectl,
   #     ghcr.io/lexfrei/{kuberture,ouroboros} (deliberately not mirrored under
   #     ghcr.io/cozystack — see those packages' values.yaml)
   #   - ghcr.io/cozystack/ingress-nginx-with-protobuf-exporter/*, which is a

--- a/packages/system/ingress-nginx/values.yaml
+++ b/packages/system/ingress-nginx/values.yaml
@@ -16,7 +16,7 @@ ingress-nginx:
       enabled: true
     extraContainers:
     - name: protobuf-exporter
-      image: ghcr.io/kvaps/ingress-nginx-with-protobuf-exporter/protobuf-exporter:v1.11.2@sha256:6d9235a9ee6f2be1921db4687afbdcd85d145b087dd916b5a96455bdb5cff560
+      image: ghcr.io/cozystack/ingress-nginx-with-protobuf-exporter/protobuf-exporter:v1.11.2@sha256:6d9235a9ee6f2be1921db4687afbdcd85d145b087dd916b5a96455bdb5cff560
       args:
       - --server.telemetry-address=0.0.0.0:9090
       - --server.exporter-address=0.0.0.0:9091


### PR DESCRIPTION
## What this PR does

Points the `protobuf-exporter` sidecar at the project's registry.

The sidecar was still pulled from `ghcr.io/kvaps/...` while the controller beside it — built from the same repository, pinned to the same `v1.11.2` — already came from `ghcr.io/cozystack/...`. The repository moved to the organisation some time ago and the image reference did not follow. It is the last thing in the tree that ships a Cozystack-owned component out of an individual's namespace, which is a Required item on the Incubation checklist ("All project metadata and resources are vendor-neutral").

The image is the same bytes: `v1.11.2` was copied into the organisation namespace with the manifest digest preserved, so `sha256:6d9235a9…` is unchanged here. Nothing is rebuilt and nothing is upgraded.

The version is deliberately not bumped. `v1.11.5` exists in the organisation namespace, but the tag tracks the upstream ingress-nginx version and the controller sits on `v1.11.2`; bumping only the sidecar would split the pair.

The comment in `hack/promote-retag.sh` loses its `ghcr.io/kvaps/...` entry, because that path now falls under the bullet below it — a cozystack-org repository outside `$REGISTRY` (`ghcr.io/cozystack/cozystack`). Selector behaviour is unchanged; `hack/promote-retag_test.bats` passes, 11/11.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff. The two files touched are a package `values.yaml` image reference and a comment in `hack/promote-retag.sh` — no trigger matches. In particular the `ccp` trigger is a move, a rename, or a change to what a make target does; this is neither, and its anchors (`hack/package.mk`, `hack/common-envs.mk`) are untouched.

- [x] No downstream repository is affected by this change

### Release note

```release-note
fix(ingress-nginx): the protobuf-exporter sidecar is now pulled from ghcr.io/cozystack instead of a personal namespace. Same image and digest; no version change.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the protobuf exporter image source to the new container registry location.
  * Refreshed image promotion guidance to remove an outdated third-party registry example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->