### PR TITLE
test(tests): make negated BATS assertions able to fail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ This file provides structured guidance for AI coding assistants and agents worki
 
 - **E2E tests and E2E CI** (e.g., "write/fix an e2e test", "stabilize a flaky test", "add a bats test", "change the e2e workflow", "why did e2e fail")
   - Read: [`e2e-testing.md`](./docs/agents/e2e-testing.md)
-  - Action: Read the entire file and follow the conventions exactly — no new retries on deterministic steps, event-driven backstops before every `kubectl wait`, no test-level `EXIT`/`RETURN` traps (a self-contained one inside a Chainsaw `script` step or an explicit subshell is fine — see the doc), fail-fast on HelmRelease readiness
+  - Action: Read the entire file and follow the conventions exactly — no new retries on deterministic steps, event-driven backstops before every `kubectl wait`, no test-level `EXIT`/`RETURN` traps (a self-contained one inside a Chainsaw `script` step or an explicit subshell is fine — see the doc), no assertion beginning with `!` (errexit exempts an inverted status, so it cannot fail — write `if cmd; then echo "FAIL: …"; false; fi`), fail-fast on HelmRelease readiness
 
 - **General questions about contributing**
   - Read: [`contributing.md`](./docs/agents/contributing.md)

--- a/docs/agents/e2e-testing.md
+++ b/docs/agents/e2e-testing.md
@@ -142,6 +142,12 @@ Consequences to keep in mind when touching either workflow:
 
 **Security prerequisite (repo setting).** The split is only safe if fork runs require maintainer approval before they execute. The repository must keep **Settings → Actions → "Require approval for all outside collaborators"** enabled, so a fork's `pull_request` run — which produces the artifacts `e2e-fork.yaml` consumes — cannot run untrusted code (or feed the privileged run) without a maintainer's go-ahead.
 
+### 11. Never negate a BATS assertion with `!`
+
+An assertion spelled `! cmd` inside an `@test` body cannot fail, whichever runner executes it. POSIX exempts a command whose return value is inverted with `!` from `set -e`, so the failing status is dropped where it is produced. `hack/cozytest.sh` then appends `return 0` to every test function, so it never resurfaces as the test's own status. The `bats` binary looks stricter and mostly is not: its ERR trap carries the identical exemption, and `bash -c 'set -eE; trap "echo TRAP" ERR; ! true; echo REACHED'` prints `REACHED`, runs no trap, and exits zero. The one shape `bats` does catch is a negated assertion standing **last** in the body, where the inverted status is what the function returns — put any statement below it and `bats` passes the test too. This is the same family as the `EXIT`-trap ban in §3, and unlike that one it is not settled by preferring the stricter runner, because there is no stricter runner to prefer.
+
+The exemption is also wider than the "negated pipeline" phrasing found in older comments: a bare `! true`, a negated `[ … ]`, one inside a `for` body, and one following `;`, `&&` or `||` all pass. Write the absence so that it fails — `if cmd; then echo "FAIL: <what must not have happened>"; false; fi` — and let the `false` carry the verdict. `hack/bats-no-negated-assert.bats` enforces this across every `hack/**/*.bats`, subdirectories included. Inverted **conditions** (`if !`, `elif !`, `while !`, `until !`) are untouched, because `set -e` is not what decides a condition. `[ ! -f x ]` is untouched for a different reason and stays a normal, failing assertion: the `!` there is an operator of `test`, not negation of a command, so nothing exempts its status. The scan is lexical, with the limits that implies: a statement assembled at runtime is invisible to it, and the form is counted inside a heredoc or a fixture string where no command exists — which reports a file holding nothing rather than passing one that does, and is why that guard's own fixtures build the token from a separate `printf` argument.
+
 ## Chainsaw v0.2.15 gotchas
 
 The suite is pinned to Chainsaw **v0.2.15** (the latest release as of May 2026); none of the traps below are fixed upstream yet, so the workarounds stay until a bump is possible. Each one has already cost a debugging session — this is the "no one gets it right the first time" list, worth a read before writing a new assert.
@@ -165,6 +171,7 @@ The suite is pinned to Chainsaw **v0.2.15** (the latest release as of May 2026);
 6. Standard HR-Ready assert timeout is **5–6m**; longer waits (harbor 10m, NFS 10m, VM image pulls, platform-wide install 15m) are justified in-line.
 7. Failure path attaches scoped diagnostics via a `catch:` block, never a silent pass.
 8. If it touches parent-HR behavior, add the `status.history` remediation guard (`hack/e2e-chainsaw/_lib/remediation-guard.sh`).
+9. No BATS assertion begins with `!` — an inverted status is exempt from `set -e` and the assertion cannot fail; use `if cmd; then echo "FAIL: …"; false; fi`.
 
 ## In-flight direction (not yet the merged standard)
 

--- a/docs/agents/e2e-testing.md
+++ b/docs/agents/e2e-testing.md
@@ -154,6 +154,12 @@ Consequences to keep in mind when touching either workflow:
 
 **Security prerequisite (repo setting).** The split is only safe if fork runs require maintainer approval before they execute. The repository must keep **Settings → Actions → "Require approval for all outside collaborators"** enabled, so a fork's `pull_request` run — which produces the artifacts `e2e-fork.yaml` consumes — cannot run untrusted code (or feed the privileged run) without a maintainer's go-ahead.
 
+### 11. Never negate a BATS assertion with `!`
+
+An assertion spelled `! cmd` inside an `@test` body cannot fail, whichever runner executes it. POSIX exempts a command whose return value is inverted with `!` from `set -e`, so the failing status is dropped where it is produced. `hack/cozytest.sh` then appends `return 0` to every test function, so it never resurfaces as the test's own status. The `bats` binary looks stricter and mostly is not: its ERR trap carries the identical exemption, and `bash -c 'set -eE; trap "echo TRAP" ERR; ! true; echo REACHED'` prints `REACHED`, runs no trap, and exits zero. The one shape `bats` does catch is a negated assertion standing **last** in the body, where the inverted status is what the function returns — put any statement below it and `bats` passes the test too. This is the same family as the ban on test-level `EXIT`/`RETURN` traps, and unlike that one it is not settled by preferring the stricter runner, because there is no stricter runner to prefer.
+
+The exemption is also wider than the "negated pipeline" phrasing found in older comments: a bare `! true`, a negated `[ … ]`, one inside a `for` body, and one following `;`, `&&` or `||` all pass. Write the absence so that it fails — `if cmd; then echo "FAIL: <what must not have happened>"; false; fi` — and let the `false` carry the verdict. `hack/bats-no-negated-assert.bats` enforces this across every `hack/**/*.bats`, subdirectories included. Inverted **conditions** (`if !`, `elif !`, `while !`, `until !`) are untouched, because `set -e` is not what decides a condition. `[ ! -f x ]` is untouched for a different reason and stays a normal, failing assertion: the `!` there is an operator of `test`, not negation of a command, so nothing exempts its status. The scan is lexical, with the limits that implies: a statement assembled at runtime is invisible to it, and the form is counted inside a heredoc or a fixture string where no command exists — which reports a file holding nothing rather than passing one that does, and is why that guard's own fixtures build the token from a separate `printf` argument.
+
 ## Chainsaw v0.2.15 gotchas
 
 The suite is pinned to Chainsaw **v0.2.15** (the latest release as of May 2026); none of the traps below are fixed upstream yet, so the workarounds stay until a bump is possible. Each one has already cost a debugging session — this is the "no one gets it right the first time" list, worth a read before writing a new assert.
@@ -177,6 +183,7 @@ The suite is pinned to Chainsaw **v0.2.15** (the latest release as of May 2026);
 6. Standard HR-Ready assert timeout is **5–6m**; longer waits (harbor 10m, NFS 10m, VM image pulls, platform-wide install 15m) are justified in-line.
 7. Failure path attaches scoped diagnostics via a `catch:` block, never a silent pass. The node-join deadline is no exception, and no longer has one: with the soft-red marker gone it fails its suite like any other deadline and its diagnostics run from the same `catch:`.
 8. If it touches parent-HR behavior, add the `status.history` remediation guard (`hack/e2e-chainsaw/_lib/remediation-guard.sh`).
+9. No BATS assertion begins with `!` — an inverted status is exempt from `set -e` and the assertion cannot fail; use `if cmd; then echo "FAIL: …"; false; fi`.
 
 ## The container lane: what the srv nodes are, and what that costs
 

--- a/hack/bats-no-negated-assert.bats
+++ b/hack/bats-no-negated-assert.bats
@@ -1,0 +1,389 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# The ban on `!`-negated assertions in .bats files, and why the form that reads
+# most naturally is the one form that cannot fail.
+#
+# POSIX exempts a command whose return value is inverted with `!` from errexit,
+# and neither runner this repository uses recovers what that throws away.
+#
+# hack/cozytest.sh turns each @test into a shell function with `set -e` at the
+# top and `return 0` at the bottom, so a failing `! cmd` neither aborts the
+# function nor survives as its return value: it prints a pass whatever the
+# assertion found. The bats binary looks stricter and mostly is not. Its ERR
+# trap carries the same exemption -- `set -eE; trap ... ERR; ! true` runs the
+# trap not at all and exits zero -- so the only negated assertion it reports is
+# one standing LAST in the body, where the inverted status becomes the test
+# function's own. Move an `echo` below it and bats passes the test too.
+#
+# So this is not a disagreement between runners to be settled by picking the
+# stricter one. Measured on a fixture where each assertion must fail: bare
+# `! true`, a negated pipeline, a negated `[ ... ]`, one inside a `for` body,
+# and one following `;`, `&&` or `||` all pass under both, and the tail-position
+# case is the single shape the two answer differently.
+#
+# The damage is concentrated rather than spread, because `!` is the natural way
+# to spell "this must NOT appear", and an absence is precisely what no other
+# assertion in the test covers. A suite can hold a full set of them and be, on
+# that half of its contract, a suite that passes on any input.
+#
+# Write the absence so that it fails:
+#
+#     if grep -q FORBIDDEN "$log"; then echo "FAIL: <what must not be there>"; false; fi
+#
+# The `false` is what the runner sees. This is already the form used wherever
+# the trap was noticed one file at a time; the rule only makes it universal.
+#
+# No exception for `! cmd || { echo ...; exit 1; }`, which does work -- the `||`
+# reads the inverted status and the `exit` leaves the test. Admitting it means
+# the scan has to parse the tail of every statement to tell a guarded negation
+# from a bare one, over a set of working spellings that is open-ended, and a
+# scan that guesses wrong there is green on a real one. One rule, no tail.
+#
+# `if !`, `elif !`, `while !` and `until !` are untouched: errexit is not what
+# decides a condition, and inverting one is ordinary shell. `[ ! -f x ]` and
+# `!=` are not negated commands at all.
+#
+# The scan is lexical, with the limits that implies. A statement assembled at
+# runtime is invisible to it. In the other direction the form is counted where
+# no command exists -- inside a heredoc, or in a string a test compares against
+# -- which reports a file that holds nothing rather than passing one that does,
+# and is why the fixture writers below build the token from a separate argument.
+#
+# It knows the statement boundaries written into it and no others, so the test
+# below names the shapes it was measured against rather than claiming the
+# language. Those are the POSIX separators -- `;` `&` `&&` `||` `{` `(` the `)`
+# closing a case pattern, and the words `then` `do` `else`. Four known
+# over-counts come with that and are left alone, all erring loud: `( ! cmd )`
+# does propagate its status and is reported anyway; a `!` after a `&` used as a
+# redirection rather than a separator would be too, if one ever began a
+# statement; `x=$(true || ! false)` is reported although the `||` reads the
+# inverted status and the assignment takes it; and a condition continued by a
+# trailing `&&` rather than a backslash -- `if foo &&` on one line, `! bar; then`
+# on the next -- is reported because the strip only recognises a condition it
+# can see the end of. Each costs a rewrite; the opposite error costs a silent
+# pass, which is why the list grows by naming rather than by narrowing.
+#
+# The verdict travels on stdout and not in an exit status. cozytest.sh appends
+# `return 0` before every closing brace at column zero, plain helper functions
+# included, so a helper whose answer is the status of its LAST command returns
+# success under this runner and its real status under bats. An explicit `return`
+# from inside the body still carries -- it runs first -- which is what makes the
+# masked case easy to write by accident and hard to see. A guard whose result
+# fell out of its final command would be green unconditionally: the same defect
+# it exists to ban, one level up.
+# -----------------------------------------------------------------------------
+
+# The directory to audit. Under the bats binary this file's own location; under
+# cozytest.sh, which sets no BATS_TEST_FILENAME, `$0` is the runner, and the
+# answer agrees only because the runner lives beside the files it runs. The
+# first test refuses to pass on an enumeration that missed this file, so a wrong
+# answer here fails instead of auditing nothing.
+BATS_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
+RUNNER="$BATS_DIR/cozytest.sh"
+
+# Report each statement in file $1 whose first token is `!`, one line each,
+# naming the physical line the statement STARTS on. Whole-line comments are
+# blanked rather than dropped so the numbering survives them, and backslash
+# continuations are folded so a statement split across lines is read as one.
+cnb_scan() {
+  awk -v name="${2:-$1}" '
+    {
+      raw = $0
+      if (raw ~ /^[[:space:]]*#/) raw = ""
+      if (buf == "") start = FNR
+      buf = buf raw
+      if (buf ~ /\\$/) { sub(/\\$/, " ", buf); next }
+      line = buf; buf = ""
+
+      if (line ~ /^[[:space:]]*(if|elif|while|until)[[:space:]]/) {
+        if (match(line, /;[[:space:]]*(then|do)([[:space:]]|$)/))
+          line = substr(line, RSTART + RLENGTH)
+        else
+          next
+      }
+
+      # A keyword may be preceded only by whitespace or by `;` -- every other
+      # separator in front of `then`, `do` or `else` is a shell syntax error,
+      # checked with `sh -n` rather than recalled -- so those two characters are
+      # the complete set and the class is closed rather than patched. The leading
+      # space covers a keyword in column zero, which has nothing in front of it
+      # at all. Miss either and the negation after the keyword never opens a
+      # segment, which is silent, and this scan errs loud or not at all. No
+      # apostrophes in here: the awk program is single-quoted.
+      line = " " line
+      n = split(line, seg, /(&&|&|\|\||;|\{|\(|\)|[[:space:];](then|do|else)[[:space:]])/)
+      for (i = 1; i <= n; i++)
+        if (seg[i] ~ /^[[:space:]]*![[:space:]]/) {
+          s = seg[i]; sub(/^[[:space:]]*/, "", s)
+          print name ":" start ": " s
+          break
+        }
+    }
+  ' "$1"
+}
+
+# Every offending statement under directory $1, and nothing when there are none.
+cnb_audit() {
+  find "$1" -name '*.bats' | sort | while IFS= read -r _f; do
+    [ -e "$_f" ] || continue
+    cnb_scan "$_f" "${_f#"$1"/}"
+  done
+  return 0
+}
+
+# Fixture writers. The token arrives as a separate argument on purpose: this
+# file is read by the scan it defines, and a fixture spelled out literally would
+# be reported as an offence in the guard's own source.
+cnb_new_fixture() {
+  printf '%s\n' '#!/usr/bin/env bats' > "$1/subject.bats"
+  return 0
+}
+
+cnb_append() {
+  _dir=$1; shift
+  printf "$@" >> "$_dir/subject.bats"
+  return 0
+}
+
+@test "the audit resolves its root to this file's own directory" {
+  files="$(find "$BATS_DIR" -name '*.bats' | wc -l)"
+  [ "$files" -gt 1 ]
+  # Reaching SOME file is not the claim -- reaching this one is, because a root
+  # resolved from the runner instead of the suite would still enumerate a
+  # plausible directory and report an audit of somewhere else as clean.
+  find "$BATS_DIR" -name '*.bats' | grep -qF 'bats-no-negated-assert.bats'
+}
+
+@test "the audit recurses, and reports a subdirectory by its relative path" {
+  # Through cnb_audit and not through a second copy of its find expression. An
+  # assertion that retypes the command it means to check holds a copy: the
+  # function can lose its recursion with the copy still passing, and then the
+  # audit returns empty for a subdirectory and empty reads as a clean tree --
+  # this file's own subject, one level up.
+  #
+  # hack/e2e-apps/ is what makes recursion load-bearing: BATS_UNIT_FILES is a
+  # non-recursive wildcard, so that directory is the one place a negated
+  # assertion can live where `make unit-tests` never looks. The proof is a
+  # fixture rather than that directory, which is emptying as suites move to
+  # Chainsaw -- pinning against it would turn this test red for a reason that
+  # has nothing to do with recursion.
+  dir="$(mktemp -d)"
+  mkdir -p "$dir/sub"
+  cnb_new_fixture "$dir/sub"
+  cnb_append "$dir/sub" '@test "a" {\n'
+  cnb_append "$dir/sub" '  %s true\n' '!'
+  cnb_append "$dir/sub" '}\n'
+
+  report="$(cnb_audit "$dir")"
+  # One report line and no more. An EMPTY report also satisfies this, because
+  # `printf '%s\n' ""` emits a newline -- the grep below is what rejects it,
+  # and that division of labour is the same in the continuation test.
+  [ "$(printf '%s\n' "$report" | wc -l)" -eq 1 ]
+  # Relative to the audited root, so hack/foo.bats and hack/e2e-apps/foo.bats
+  # cannot report under the same name.
+  printf '%s\n' "$report" | grep -q '^sub/subject.bats:3: '
+  rm -rf "$dir"
+}
+
+@test "no suite states an absence in a form that cannot fail" {
+  report="$(cnb_audit "$BATS_DIR")"
+  if [ -n "$report" ]; then
+    echo 'A statement whose first token is `!` has its status exempted from errexit,'
+    echo 'so the assertion below passes whatever it finds. Spell the absence as:'
+    echo '    if cmd; then echo "FAIL: <what must not have happened>"; false; fi'
+    printf '%s\n' "$report"
+    false
+  fi
+}
+
+@test "the scan reports a negated statement in every shape measured here" {
+  # Every shape below was run under the runner and reported a pass while its
+  # assertion must have failed, so each is a live hole the scan has to close.
+  # The name claims what this fixture holds and nothing wider: a lexical scan
+  # over shell cannot promise it has enumerated the language.
+  dir="$(mktemp -d)"
+  cnb_new_fixture "$dir"
+  cnb_append "$dir" '@test "a" {\n'
+  cnb_append "$dir" '  %s true\n' '!'
+  cnb_append "$dir" '  %s printf x | grep -q x\n' '!'
+  cnb_append "$dir" '  echo one; %s true\n' '!'
+  cnb_append "$dir" '  true && %s true\n' '!'
+  cnb_append "$dir" '  false || %s true\n' '!'
+  cnb_append "$dir" '  for f in a b; do\n    %s true\n  done\n' '!'
+  cnb_append "$dir" '  if true; then %s true; fi\n' '!'
+  # A case branch: the `)` closing the pattern is a statement boundary like any
+  # other, and `case` already appears inside test bodies and stubs in this tree.
+  cnb_append "$dir" '  case "$v" in\n    yes) %s true ;;\n  esac\n' '!'
+  # After a background `&`, which separates statements exactly as `;` does.
+  cnb_append "$dir" '  true & %s true\n' '!'
+  # A brace group takes the exemption with it: the group reports the inverted
+  # status as its own, so the whole thing passes. A subshell does not, which is
+  # why only this one is here.
+  cnb_append "$dir" '  { %s true; }\n' '!'
+  # The same keywords at column zero. Every other occurrence of `then`, `do` and
+  # `else` in a test body is indented, which is what made the missing space
+  # before them invisible: without it the keyword opens the segment and the
+  # negation after it is never a segment's first token. All three are vacuous
+  # under the runner, so the miss was silent -- the direction this file says it
+  # will not err in.
+  cnb_append "$dir" '  for f in a b\n'
+  cnb_append "$dir" 'do %s true\n' '!'
+  cnb_append "$dir" '  done\n'
+  cnb_append "$dir" '  if false\n'
+  cnb_append "$dir" 'then %s true\n' '!'
+  cnb_append "$dir" 'else %s true\n' '!'
+  cnb_append "$dir" '  fi\n'
+  # The same keywords with no space after the `;`. Valid shell, vacuous under
+  # the runner, and missed until the separator class admitted `;` in front of a
+  # keyword as well as whitespace.
+  cnb_append "$dir" '  for f in a;do %s true;done\n' '!'
+  cnb_append "$dir" '  if x; then :;else %s true; fi\n' '!'
+  cnb_append "$dir" '}\n'
+
+  found="$(cnb_scan "$dir/subject.bats" | wc -l)"
+  [ "$found" -eq 15 ]
+  rm -rf "$dir"
+}
+
+@test "the scan folds a continuation and names the line the statement opens on" {
+  dir="$(mktemp -d)"
+  cnb_new_fixture "$dir"
+  cnb_append "$dir" '@test "a" {\n'
+  # The negation has to land on the CONTINUATION line, not the line that opens
+  # it. Put it on the opening line and the report says line 3 whether the fold
+  # ran or not, so the assertion below passes with the folding deleted -- which
+  # is the shape this whole suite exists to ban. Here folded reports 3 and
+  # unfolded reports 4, so removing the fold turns the test red.
+  #
+  # `\\\n` and not `\\\\\n`: printf collapses each pair, so the doubled form
+  # emits two backslashes -- an escaped literal, which is an ordinary argument
+  # rather than a continuation. Check the bytes with `od -c` when editing this.
+  cnb_append "$dir" '  echo start \\\n'
+  cnb_append "$dir" '    ; %s grep -q x "$file"\n' '!'
+  cnb_append "$dir" '}\n'
+
+  report="$(cnb_scan "$dir/subject.bats")"
+  # One report line and no more. An empty report satisfies this too -- one
+  # newline out of printf -- so the grep below is what rules empty out, not
+  # this line.
+  [ "$(printf '%s\n' "$report" | wc -l)" -eq 1 ]
+  printf '%s\n' "$report" | grep -q ':3: '
+  rm -rf "$dir"
+}
+
+@test "the scan leaves an inverted condition and an inverted test operator alone" {
+  dir="$(mktemp -d)"
+  cnb_new_fixture "$dir"
+  cnb_append "$dir" '@test "a" {\n'
+  cnb_append "$dir" '  if %s command -v act >/dev/null; then echo none; fi\n' '!'
+  cnb_append "$dir" '  if %s foo || %s bar; then echo none; fi\n' '!' '!'
+  cnb_append "$dir" '  while %s ready; do sleep 1; done\n' '!'
+  cnb_append "$dir" '  until %s done_yet; do sleep 1; done\n' '!'
+  # The two lines above cannot tell whether `while` and `until` are in the
+  # condition-strip: splitting on `;` and ` do ` already leaves `!` in the
+  # middle of segment 1, so they report nothing either way. These two put the
+  # negation where only the strip can save it -- drop either keyword from the
+  # alternation and the line becomes a report.
+  cnb_append "$dir" '  while foo && %s bar; do sleep 1; done\n' '!'
+  cnb_append "$dir" '  until foo && %s bar; do sleep 1; done\n' '!'
+  cnb_append "$dir" '  [ %s -f /nowhere ]\n' '!'
+  cnb_append "$dir" '  [ "$a" %s= "$b" ]\n' '!'
+  cnb_append "$dir" '  # a comment naming %s grep -q x file\n' '!'
+  cnb_append "$dir" '}\n'
+
+  found="$(cnb_scan "$dir/subject.bats" | wc -l)"
+  [ "$found" -eq 0 ]
+  # An empty report is what a scan that reads nothing returns too, so the same
+  # fixture has to produce one when the offence is present.
+  cnb_append "$dir" '@test "b" {\n'
+  cnb_append "$dir" '  %s true\n' '!'
+  cnb_append "$dir" '}\n'
+  found="$(cnb_scan "$dir/subject.bats" | wc -l)"
+  [ "$found" -eq 1 ]
+  rm -rf "$dir"
+}
+
+@test "a negated assertion still passes under this runner whatever it finds" {
+  # The premise the ban rests on, pinned rather than described: the day the
+  # runner starts propagating an inverted status, this test fails and the rule
+  # above can be reconsidered instead of outliving its reason.
+  dir="$(mktemp -d)"
+  {
+    printf '@test "an assertion that must not hold" {\n'
+    printf '  %s true\n' '!'
+    printf '}\n'
+  } > "$dir/pin.bats"
+
+  rc=0
+  "$RUNNER" "$dir/pin.bats" > "$dir/out" 2>&1 || rc=$?
+  # Both halves: the runner reported success, AND a test actually ran to produce
+  # it. Without the second, a fixture the runner refused to parse would satisfy
+  # the first and pin nothing.
+  [ "$rc" -eq 0 ]
+  grep -qF 'Test OK' "$dir/out"
+  rm -rf "$dir"
+}
+
+@test "the form this ban prescribes does fail, under both runners" {
+  # The mirror of the test above, and the half more worth pinning. Every absence
+  # converted in this tree rests on `false` inside a `then` body reaching the
+  # runner as a failure. If that ever stopped -- a stray `set +e`, a change to
+  # the `return 0` insertion in cozytest.sh -- the test above would still pass,
+  # because a negated assertion would still be vacuous, while every converted
+  # absence went silently green. The ban would then be prescribing a form that
+  # checks nothing, which is the defect it exists to remove.
+  #
+  # Under both runners because their disagreement is the reason this class
+  # exists at all: a remedy that only propagates under one of them is not a
+  # remedy for the suites CI runs.
+  dir="$(mktemp -d)"
+  {
+    printf '@test "an assertion that must fail" {\n'
+    printf '  if true; then echo "FAIL: the prescribed form fired"; false; fi\n'
+    printf '  echo PAST-THE-FORM\n'
+    printf '}\n'
+  } > "$dir/pin.bats"
+
+  rc=0
+  "$RUNNER" "$dir/pin.bats" > "$dir/out" 2>&1 || rc=$?
+  [ "$rc" -ne 0 ]
+  # It has to fail AT the form. A run that died earlier -- an unparsable
+  # fixture, a missing runner -- would satisfy the status check and pin nothing.
+  grep -qF 'the prescribed form fired' "$dir/out"
+  if grep -qF 'PAST-THE-FORM' "$dir/out"; then
+    echo "FAIL: execution continued past the prescribed form"
+    false
+  fi
+
+  if command -v bats >/dev/null 2>&1; then
+    rc=0
+    bats "$dir/pin.bats" > "$dir/bats-out" 2>&1 || rc=$?
+    [ "$rc" -ne 0 ]
+    grep -qE '^not ok ' "$dir/bats-out"
+  else
+    echo "bats binary absent — the prescribed form NOT verified under it in this run." >&2
+  fi
+  rm -rf "$dir"
+}
+
+@test "neither errexit nor the ERR trap sees an inverted status" {
+  # The half of the premise that says switching runners does not lift the ban.
+  # Pinned at the shell rather than through the bats binary, because this is
+  # where the exemption lives -- bats builds its reporting on exactly these two
+  # mechanisms, so a suite host without bats installed can still hold the claim
+  # honest. A shell without `bash` cannot run bats either, which is the only
+  # case this skips.
+  # `skip` is a bats builtin that cozytest.sh does not provide, so the note goes
+  # out the way the other suites here report an unmet dependency.
+  if ! command -v bash >/dev/null 2>&1; then
+    echo "bash unavailable — the errexit and ERR-trap exemptions NOT verified in this run." >&2
+    return 0
+  fi
+  # Assembled rather than written out, for the reason the header gives: spelled
+  # literally, this string is a statement the scan reports against its own file.
+  prog="$(printf 'set -eE; trap "echo TRAP-RAN" ERR; %s true; echo REACHED' '!')"
+  out="$(bash -c "$prog" 2>&1)"
+  # Reached the line below the failing assertion, and the trap never fired:
+  # either alone would leave the other half unpinned.
+  [ "$out" = "REACHED" ]
+}

--- a/hack/bats-no-negated-assert.bats
+++ b/hack/bats-no-negated-assert.bats
@@ -1,0 +1,419 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# The ban on `!`-negated assertions in .bats files, and why the form that reads
+# most naturally is the one form that cannot fail.
+#
+# POSIX exempts a command whose return value is inverted with `!` from errexit,
+# and neither runner this repository uses recovers what that throws away.
+#
+# hack/cozytest.sh turns each @test into a shell function with `set -e` at the
+# top and `return 0` at the bottom, so a failing `! cmd` neither aborts the
+# function nor survives as its return value: it prints a pass whatever the
+# assertion found. The bats binary looks stricter and mostly is not. Its ERR
+# trap carries the same exemption -- `set -eE; trap ... ERR; ! true` runs the
+# trap not at all and exits zero -- so the only negated assertion it reports is
+# one standing LAST in the body, where the inverted status becomes the test
+# function's own. Move an `echo` below it and bats passes the test too.
+#
+# So this is not a disagreement between runners to be settled by picking the
+# stricter one. Measured on a fixture where each assertion must fail: bare
+# `! true`, a negated pipeline, a negated `[ ... ]`, one inside a `for` body,
+# and one following `;`, `&&` or `||` all pass under both, and the tail-position
+# case is the single shape the two answer differently.
+#
+# The damage is concentrated rather than spread, because `!` is the natural way
+# to spell "this must NOT appear", and an absence is precisely what no other
+# assertion in the test covers. A suite can hold a full set of them and be, on
+# that half of its contract, a suite that passes on any input.
+#
+# Write the absence so that it fails:
+#
+#     if grep -q FORBIDDEN "$log"; then echo "FAIL: <what must not be there>"; false; fi
+#
+# The `false` is what the runner sees. This is already the form used wherever
+# the trap was noticed one file at a time; the rule only makes it universal.
+#
+# No exception for `! cmd || { echo ...; exit 1; }`, which does work -- the `||`
+# reads the inverted status and the `exit` leaves the test. Admitting it means
+# the scan has to parse the tail of every statement to tell a guarded negation
+# from a bare one, over a set of working spellings that is open-ended, and a
+# scan that guesses wrong there is green on a real one. One rule, no tail.
+#
+# `if !`, `elif !`, `while !` and `until !` are untouched: errexit is not what
+# decides a condition, and inverting one is ordinary shell. `[ ! -f x ]` and
+# `!=` are not negated commands at all.
+#
+# The scan is lexical, with the limits that implies. A statement assembled at
+# runtime is invisible to it. In the other direction the form is counted where
+# no command exists -- inside a heredoc, or in a string a test compares against
+# -- which reports a file that holds nothing rather than passing one that does,
+# and is why the fixture writers below build the token from a separate argument.
+#
+# It knows the statement boundaries written into it and no others, so the test
+# below names the shapes it was measured against rather than claiming the
+# language. Those are the POSIX separators -- `;` `&` `&&` `||` `{` `(` the `)`
+# closing a case pattern, and the words `then` `do` `else`. Four known
+# over-counts come with that and are left alone, all erring loud: `( ! cmd )`
+# does propagate its status and is reported anyway; a `!` after a `&` used as a
+# redirection rather than a separator would be too, if one ever began a
+# statement; `x=$(true || ! false)` is reported although the `||` reads the
+# inverted status and the assignment takes it; and a condition continued by a
+# trailing `&&` rather than a backslash -- `if foo &&` on one line, `! bar; then`
+# on the next -- is reported because the strip only recognises a condition it
+# can see the end of. Each costs a rewrite; the opposite error costs a silent
+# pass, which is why the list grows by naming rather than by narrowing.
+#
+# The verdict travels on stdout and not in an exit status. cozytest.sh appends
+# `return 0` before every closing brace at column zero, plain helper functions
+# included, so a helper whose answer is the status of its LAST command returns
+# success under this runner and its real status under bats. An explicit `return`
+# from inside the body still carries -- it runs first -- which is what makes the
+# masked case easy to write by accident and hard to see. A guard whose result
+# fell out of its final command would be green unconditionally: the same defect
+# it exists to ban, one level up.
+# -----------------------------------------------------------------------------
+
+# The directory to audit. Under the bats binary this file's own location; under
+# cozytest.sh, which sets no BATS_TEST_FILENAME, `$0` is the runner, and the
+# answer agrees only because the runner lives beside the files it runs. The
+# first test refuses to pass on an enumeration that missed this file, so a wrong
+# answer here fails instead of auditing nothing.
+BATS_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
+RUNNER="$BATS_DIR/cozytest.sh"
+
+# Report each statement in file $1 whose first token is `!`, one line each,
+# naming the physical line the statement STARTS on. Whole-line comments are
+# blanked rather than dropped so the numbering survives them, and backslash
+# continuations are folded so a statement split across lines is read as one.
+cnb_scan() {
+  awk -v name="${2:-$1}" '
+    {
+      raw = $0
+      if (raw ~ /^[[:space:]]*#/) raw = ""
+      if (buf == "") start = FNR
+      buf = buf raw
+      if (buf ~ /\\$/) { sub(/\\$/, " ", buf); next }
+      line = buf; buf = ""
+
+      if (line ~ /^[[:space:]]*(if|elif|while|until)[[:space:]]/) {
+        if (match(line, /;[[:space:]]*(then|do)([[:space:]]|$)/))
+          line = substr(line, RSTART + RLENGTH)
+        else
+          next
+      }
+
+      # A keyword may be preceded only by whitespace or by `;` -- every other
+      # separator in front of `then`, `do` or `else` is a shell syntax error,
+      # checked with `sh -n` rather than recalled -- so those two characters are
+      # the complete set and the class is closed rather than patched. The leading
+      # space covers a keyword in column zero, which has nothing in front of it
+      # at all. Miss either and the negation after the keyword never opens a
+      # segment, which is silent, and this scan errs loud or not at all. No
+      # apostrophes in here: the awk program is single-quoted.
+      line = " " line
+      n = split(line, seg, /(&&|&|\|\||;|\{|\(|\)|[[:space:];](then|do|else)[[:space:]])/)
+      for (i = 1; i <= n; i++)
+        if (seg[i] ~ /^[[:space:]]*![[:space:]]/) {
+          s = seg[i]; sub(/^[[:space:]]*/, "", s)
+          print name ":" start ": " s
+          break
+        }
+    }
+  ' "$1"
+}
+
+# Every offending statement under directory $1, and nothing when there are none.
+cnb_audit() {
+  find "$1" -name '*.bats' | sort | while IFS= read -r _f; do
+    [ -e "$_f" ] || continue
+    cnb_scan "$_f" "${_f#"$1"/}"
+  done
+  return 0
+}
+
+# Fixture writers. The token arrives as a separate argument on purpose: this
+# file is read by the scan it defines, and a fixture spelled out literally would
+# be reported as an offence in the guard's own source.
+cnb_new_fixture() {
+  printf '%s\n' '#!/usr/bin/env bats' > "$1/subject.bats"
+  return 0
+}
+
+cnb_append() {
+  _dir=$1; shift
+  printf "$@" >> "$_dir/subject.bats"
+  return 0
+}
+
+@test "the audit resolves its root to this file's own directory" {
+  files="$(find "$BATS_DIR" -name '*.bats' | wc -l)"
+  [ "$files" -gt 1 ]
+  # Reaching SOME file is not the claim -- reaching this one is, because a root
+  # resolved from the runner instead of the suite would still enumerate a
+  # plausible directory and report an audit of somewhere else as clean.
+  find "$BATS_DIR" -name '*.bats' | grep -qF 'bats-no-negated-assert.bats'
+}
+
+@test "the audit recurses, and reports a subdirectory by its relative path" {
+  # Through cnb_audit and not through a second copy of its find expression. An
+  # assertion that retypes the command it means to check holds a copy: the
+  # function can lose its recursion with the copy still passing, and then the
+  # audit returns empty for a subdirectory and empty reads as a clean tree --
+  # this file's own subject, one level up.
+  #
+  # hack/e2e-apps/ is what makes recursion load-bearing: BATS_UNIT_FILES is a
+  # non-recursive wildcard, so that directory is the one place a negated
+  # assertion can live where `make unit-tests` never looks. The proof is a
+  # fixture rather than that directory, which is emptying as suites move to
+  # Chainsaw -- pinning against it would turn this test red for a reason that
+  # has nothing to do with recursion.
+  dir="$(mktemp -d)"
+  mkdir -p "$dir/sub"
+  cnb_new_fixture "$dir/sub"
+  cnb_append "$dir/sub" '@test "a" {\n'
+  cnb_append "$dir/sub" '  %s true\n' '!'
+  cnb_append "$dir/sub" '}\n'
+
+  report="$(cnb_audit "$dir")"
+  # One report line and no more. An EMPTY report also satisfies this, because
+  # `printf '%s\n' ""` emits a newline -- the grep below is what rejects it,
+  # and that division of labour is the same in the continuation test.
+  [ "$(printf '%s\n' "$report" | wc -l)" -eq 1 ]
+  # Relative to the audited root, so hack/foo.bats and hack/e2e-apps/foo.bats
+  # cannot report under the same name.
+  printf '%s\n' "$report" | grep -q '^sub/subject.bats:3: '
+  rm -rf "$dir"
+}
+
+@test "no suite states an absence in a form that cannot fail" {
+  report="$(cnb_audit "$BATS_DIR")"
+  if [ -n "$report" ]; then
+    echo 'A statement whose first token is `!` has its status exempted from errexit,'
+    echo 'so the assertion below passes whatever it finds. Spell the absence as:'
+    echo '    if cmd; then echo "FAIL: <what must not have happened>"; false; fi'
+    printf '%s\n' "$report"
+    false
+  fi
+}
+
+@test "the scan reports a negated statement in every shape measured here" {
+  # Every shape below was run under the runner and reported a pass while its
+  # assertion must have failed, so each is a live hole the scan has to close.
+  # The name claims what this fixture holds and nothing wider: a lexical scan
+  # over shell cannot promise it has enumerated the language.
+  dir="$(mktemp -d)"
+  cnb_new_fixture "$dir"
+  cnb_append "$dir" '@test "a" {\n'
+  cnb_append "$dir" '  %s true\n' '!'
+  cnb_append "$dir" '  %s printf x | grep -q x\n' '!'
+  cnb_append "$dir" '  echo one; %s true\n' '!'
+  cnb_append "$dir" '  true && %s true\n' '!'
+  cnb_append "$dir" '  false || %s true\n' '!'
+  cnb_append "$dir" '  for f in a b; do\n    %s true\n  done\n' '!'
+  cnb_append "$dir" '  if true; then %s true; fi\n' '!'
+  # A case branch: the `)` closing the pattern is a statement boundary like any
+  # other, and `case` already appears inside test bodies and stubs in this tree.
+  cnb_append "$dir" '  case "$v" in\n    yes) %s true ;;\n  esac\n' '!'
+  # After a background `&`, which separates statements exactly as `;` does.
+  cnb_append "$dir" '  true & %s true\n' '!'
+  # A brace group takes the exemption with it: the group reports the inverted
+  # status as its own, so the whole thing passes. A subshell does not, which is
+  # why only this one is here.
+  cnb_append "$dir" '  { %s true; }\n' '!'
+  # The same keywords at column zero. Every other occurrence of `then`, `do` and
+  # `else` in a test body is indented, which is what made the missing space
+  # before them invisible: without it the keyword opens the segment and the
+  # negation after it is never a segment's first token. All three are vacuous
+  # under the runner, so the miss was silent -- the direction this file says it
+  # will not err in.
+  cnb_append "$dir" '  for f in a b\n'
+  cnb_append "$dir" 'do %s true\n' '!'
+  cnb_append "$dir" '  done\n'
+  cnb_append "$dir" '  if false\n'
+  cnb_append "$dir" 'then %s true\n' '!'
+  cnb_append "$dir" 'else %s true\n' '!'
+  cnb_append "$dir" '  fi\n'
+  # The same keywords with no space after the `;`. Valid shell, vacuous under
+  # the runner, and missed until the separator class admitted `;` in front of a
+  # keyword as well as whitespace.
+  cnb_append "$dir" '  for f in a;do %s true;done\n' '!'
+  cnb_append "$dir" '  if x; then :;else %s true; fi\n' '!'
+  cnb_append "$dir" '}\n'
+
+  found="$(cnb_scan "$dir/subject.bats" | wc -l)"
+  [ "$found" -eq 15 ]
+  rm -rf "$dir"
+}
+
+@test "the scan reports a subshell negation, and that stays an over-count" {
+  # `( ! cmd )` is not a hole. The subshell takes the exemption and hands the
+  # inverted status up as its own, and the caller is not exempt, so the
+  # assertion does fail. The scan reports it regardless, because admitting the
+  # shape means telling a guarded negation from a bare one by reading what
+  # follows, over a set of working spellings with no end to it.
+  #
+  # This is the only fixture that reaches `(` in the separator class. Every
+  # other shape above carries a second boundary on its own line and would still
+  # be reported with `(` dropped from that class, so without this the branch is
+  # one nothing here can see removed.
+  dir="$(mktemp -d)"
+  cnb_new_fixture "$dir"
+  cnb_append "$dir" '@test "a" {\n'
+  cnb_append "$dir" '  ( %s true )\n' '!'
+  cnb_append "$dir" '}\n'
+
+  report="$(cnb_scan "$dir/subject.bats")"
+  [ "$(printf '%s\n' "$report" | wc -l)" -eq 1 ]
+  printf '%s\n' "$report" | grep -q ':3: '
+  rm -rf "$dir"
+
+  # The other half of the word "over-count": the shape has to actually work,
+  # or what is pinned above is a second hole wearing the name of a false
+  # positive. Assembled rather than written out, for the reason the header
+  # gives.
+  prog="$(printf 'set -e; ( %s true ); echo REACHED' '!')"
+  [ -z "$(sh -c "$prog" 2>&1)" ]
+}
+
+@test "the scan folds a continuation and names the line the statement opens on" {
+  dir="$(mktemp -d)"
+  cnb_new_fixture "$dir"
+  cnb_append "$dir" '@test "a" {\n'
+  # The negation has to land on the CONTINUATION line, not the line that opens
+  # it. Put it on the opening line and the report says line 3 whether the fold
+  # ran or not, so the assertion below passes with the folding deleted -- which
+  # is the shape this whole suite exists to ban. Here folded reports 3 and
+  # unfolded reports 4, so removing the fold turns the test red.
+  #
+  # `\\\n` and not `\\\\\n`: printf collapses each pair, so the doubled form
+  # emits two backslashes -- an escaped literal, which is an ordinary argument
+  # rather than a continuation. Check the bytes with `od -c` when editing this.
+  cnb_append "$dir" '  echo start \\\n'
+  cnb_append "$dir" '    ; %s grep -q x "$file"\n' '!'
+  cnb_append "$dir" '}\n'
+
+  report="$(cnb_scan "$dir/subject.bats")"
+  # One report line and no more. An empty report satisfies this too -- one
+  # newline out of printf -- so the grep below is what rules empty out, not
+  # this line.
+  [ "$(printf '%s\n' "$report" | wc -l)" -eq 1 ]
+  printf '%s\n' "$report" | grep -q ':3: '
+  rm -rf "$dir"
+}
+
+@test "the scan leaves an inverted condition and an inverted test operator alone" {
+  dir="$(mktemp -d)"
+  cnb_new_fixture "$dir"
+  cnb_append "$dir" '@test "a" {\n'
+  cnb_append "$dir" '  if %s command -v act >/dev/null; then echo none; fi\n' '!'
+  cnb_append "$dir" '  if %s foo || %s bar; then echo none; fi\n' '!' '!'
+  cnb_append "$dir" '  while %s ready; do sleep 1; done\n' '!'
+  cnb_append "$dir" '  until %s done_yet; do sleep 1; done\n' '!'
+  # The two lines above cannot tell whether `while` and `until` are in the
+  # condition-strip: splitting on `;` and ` do ` already leaves `!` in the
+  # middle of segment 1, so they report nothing either way. These two put the
+  # negation where only the strip can save it -- drop either keyword from the
+  # alternation and the line becomes a report.
+  cnb_append "$dir" '  while foo && %s bar; do sleep 1; done\n' '!'
+  cnb_append "$dir" '  until foo && %s bar; do sleep 1; done\n' '!'
+  cnb_append "$dir" '  [ %s -f /nowhere ]\n' '!'
+  cnb_append "$dir" '  [ "$a" %s= "$b" ]\n' '!'
+  cnb_append "$dir" '  # a comment naming %s grep -q x file\n' '!'
+  cnb_append "$dir" '}\n'
+
+  found="$(cnb_scan "$dir/subject.bats" | wc -l)"
+  [ "$found" -eq 0 ]
+  # An empty report is what a scan that reads nothing returns too, so the same
+  # fixture has to produce one when the offence is present.
+  cnb_append "$dir" '@test "b" {\n'
+  cnb_append "$dir" '  %s true\n' '!'
+  cnb_append "$dir" '}\n'
+  found="$(cnb_scan "$dir/subject.bats" | wc -l)"
+  [ "$found" -eq 1 ]
+  rm -rf "$dir"
+}
+
+@test "a negated assertion still passes under this runner whatever it finds" {
+  # The premise the ban rests on, pinned rather than described: the day the
+  # runner starts propagating an inverted status, this test fails and the rule
+  # above can be reconsidered instead of outliving its reason.
+  dir="$(mktemp -d)"
+  {
+    printf '@test "an assertion that must not hold" {\n'
+    printf '  %s true\n' '!'
+    printf '}\n'
+  } > "$dir/pin.bats"
+
+  rc=0
+  "$RUNNER" "$dir/pin.bats" > "$dir/out" 2>&1 || rc=$?
+  # Both halves: the runner reported success, AND a test actually ran to produce
+  # it. Without the second, a fixture the runner refused to parse would satisfy
+  # the first and pin nothing.
+  [ "$rc" -eq 0 ]
+  grep -qF 'Test OK' "$dir/out"
+  rm -rf "$dir"
+}
+
+@test "the form this ban prescribes does fail, under both runners" {
+  # The mirror of the test above, and the half more worth pinning. Every absence
+  # converted in this tree rests on `false` inside a `then` body reaching the
+  # runner as a failure. If that ever stopped -- a stray `set +e`, a change to
+  # the `return 0` insertion in cozytest.sh -- the test above would still pass,
+  # because a negated assertion would still be vacuous, while every converted
+  # absence went silently green. The ban would then be prescribing a form that
+  # checks nothing, which is the defect it exists to remove.
+  #
+  # Under both runners because their disagreement is the reason this class
+  # exists at all: a remedy that only propagates under one of them is not a
+  # remedy for the suites CI runs.
+  dir="$(mktemp -d)"
+  {
+    printf '@test "an assertion that must fail" {\n'
+    printf '  if true; then echo "FAIL: the prescribed form fired"; false; fi\n'
+    printf '  echo PAST-THE-FORM\n'
+    printf '}\n'
+  } > "$dir/pin.bats"
+
+  rc=0
+  "$RUNNER" "$dir/pin.bats" > "$dir/out" 2>&1 || rc=$?
+  [ "$rc" -ne 0 ]
+  # It has to fail AT the form. A run that died earlier -- an unparsable
+  # fixture, a missing runner -- would satisfy the status check and pin nothing.
+  grep -qF 'the prescribed form fired' "$dir/out"
+  if grep -qF 'PAST-THE-FORM' "$dir/out"; then
+    echo "FAIL: execution continued past the prescribed form"
+    false
+  fi
+
+  if command -v bats >/dev/null 2>&1; then
+    rc=0
+    bats "$dir/pin.bats" > "$dir/bats-out" 2>&1 || rc=$?
+    [ "$rc" -ne 0 ]
+    grep -qE '^not ok ' "$dir/bats-out"
+  else
+    echo "bats binary absent — the prescribed form NOT verified under it in this run." >&2
+  fi
+  rm -rf "$dir"
+}
+
+@test "neither errexit nor the ERR trap sees an inverted status" {
+  # The half of the premise that says switching runners does not lift the ban.
+  # Pinned at the shell rather than through the bats binary, because this is
+  # where the exemption lives -- bats builds its reporting on exactly these two
+  # mechanisms, so a suite host without bats installed can still hold the claim
+  # honest. A shell without `bash` cannot run bats either, which is the only
+  # case this skips.
+  # `skip` is a bats builtin that cozytest.sh does not provide, so the note goes
+  # out the way the other suites here report an unmet dependency.
+  if ! command -v bash >/dev/null 2>&1; then
+    echo "bash unavailable — the errexit and ERR-trap exemptions NOT verified in this run." >&2
+    return 0
+  fi
+  # Assembled rather than written out, for the reason the header gives: spelled
+  # literally, this string is a statement the scan reports against its own file.
+  prog="$(printf 'set -eE; trap "echo TRAP-RAN" ERR; %s true; echo REACHED' '!')"
+  out="$(bash -c "$prog" 2>&1)"
+  # Reached the line below the failing assertion, and the trap never fired:
+  # either alone would leave the other half unpinned.
+  [ "$out" = "REACHED" ]
+}

--- a/hack/build-matrix_test.bats
+++ b/hack/build-matrix_test.bats
@@ -17,9 +17,10 @@
 
 @test "talos and installer are excluded from the parallel matrix" {
   out=$(hack/build-matrix.sh)
-  # `! cmd` would be vacuous: cozytest.sh runs each @test under `set -e`, which
-  # is suppressed for a `!`-negated pipeline, so a regression that wrongly
-  # included these paths would not fail the test. Assert via `if cmd; then ...`.
+  # `! cmd` would be vacuous: cozytest.sh runs each @test under `set -e`,
+  # which is suppressed for any command whose status is inverted with `!`, so
+  # a regression that wrongly included these paths would not fail the test.
+  # Assert via `if cmd; then ...`.
   if echo "$out" | grep -q '"packages/core/talos"'; then echo "FAIL: packages/core/talos must be excluded from the parallel matrix"; false; fi
   if echo "$out" | grep -q '"packages/core/installer"'; then echo "FAIL: packages/core/installer must be excluded from the parallel matrix"; false; fi
 }

--- a/hack/capture-dataplane.bats
+++ b/hack/capture-dataplane.bats
@@ -235,9 +235,10 @@ EOF
   [ "$(printf '%s\n' "$out" | grep -c .)" -eq 2 ]
   printf '%s\n' "$out" | grep -q '^tenant|app|LoadBalancer|192.0.2.50|'
   printf '%s\n' "$out" | grep -q '^tenant|db|LoadBalancer|192.0.2.51|'
-  # `! cmd` is vacuous under cozytest's `set -e` (errexit is suppressed for a
-  # `!`-negated pipeline), so a filter regression that let these rows through
-  # would not fail the test. Assert the absence via `if cmd; then ...; false`.
+  # `! cmd` is vacuous under cozytest's `set -e` (errexit is suppressed for
+  # any command whose status is inverted with `!`), so a filter regression
+  # that let these rows through would not fail the test. Assert the absence
+  # via `if cmd; then ...; false`.
   if printf '%s\n' "$out" | grep -q 'kube-dns'; then echo "FAIL: lb_filter_services must drop the kube-dns row"; false; fi
   if printf '%s\n' "$out" | grep -q 'pending'; then echo "FAIL: lb_filter_services must drop the pending (no external IP) row"; false; fi
 }

--- a/hack/capture-previous-logs.bats
+++ b/hack/capture-previous-logs.bats
@@ -55,9 +55,10 @@ E2E_CAPTURE_PREVLOGS_LIB=1
   [ "$(printf '%s\n' "$out" | grep -c .)" -eq 2 ]
   printf '%s\n' "$out" | grep -q '^tenant-test|mariadb-test-0|mariadb|container|3$'
   printf '%s\n' "$out" | grep -q '^tenant-test|mariadb-test-0|init-datadir|init|2$'
-  # `! cmd` is vacuous under cozytest's `set -e` (errexit is suppressed for a
-  # `!`-negated pipeline), so a filter regression that let these rows through
-  # would not fail the test. Assert the absence via `if cmd; then ...; false`.
+  # `! cmd` is vacuous under cozytest's `set -e` (errexit is suppressed for
+  # any command whose status is inverted with `!`), so a filter regression
+  # that let these rows through would not fail the test. Assert the absence
+  # via `if cmd; then ...; false`.
   if printf '%s\n' "$out" | grep -q 'mariadb-test-1'; then echo "FAIL: must drop the zero-restart replica"; false; fi
   if printf '%s\n' "$out" | grep -q 'cozy-system'; then echo "FAIL: must drop the zero-restart system pod"; false; fi
 }

--- a/hack/capture-previous-logs.bats
+++ b/hack/capture-previous-logs.bats
@@ -60,9 +60,10 @@ E2E_CAPTURE_PREVLOGS_LIB=1
   [ "$(printf '%s\n' "$out" | grep -c .)" -eq 2 ]
   printf '%s\n' "$out" | grep -q '^tenant-test|mariadb-test-0|mariadb|container|3|$'
   printf '%s\n' "$out" | grep -q '^tenant-test|mariadb-test-0|init-datadir|init|2|$'
-  # `! cmd` is vacuous under cozytest's `set -e` (errexit is suppressed for a
-  # `!`-negated pipeline), so a filter regression that let these rows through
-  # would not fail the test. Assert the absence via `if cmd; then ...; false`.
+  # `! cmd` is vacuous under cozytest's `set -e` (errexit is suppressed for
+  # any command whose status is inverted with `!`), so a filter regression
+  # that let these rows through would not fail the test. Assert the absence
+  # via `if cmd; then ...; false`.
   if printf '%s\n' "$out" | grep -q 'mariadb-test-1'; then echo "FAIL: must drop the zero-restart replica"; false; fi
   if printf '%s\n' "$out" | grep -q 'cozy-system'; then echo "FAIL: must drop the zero-restart system pod"; false; fi
 }

--- a/hack/common-envs_test.bats
+++ b/hack/common-envs_test.bats
@@ -17,8 +17,9 @@
 # relative `make -C packages/...` calls resolve against that cwd. This is NOT
 # real bats — no run/$status/$output/setup(); use plain $(...) capture + grep,
 # and the build-matrix_test.bats `if grep -q …; then echo FAIL; false; fi`
-# negation idiom (cozytest runs each @test under `set -e`, which suppresses a
-# bare `!`-negated pipeline, so a regression would silently pass a `! grep`).
+# negation idiom (cozytest runs each @test under `set -e`, which suppresses any
+# command whose status is inverted with `!`, so a regression would silently pass
+# a `! grep`).
 
 @test "cozystack-controller exports one OCI archive and never pushes under OCI_EXPORT_DIR" {
   out=$(make -n -C packages/system/cozystack-controller image OCI_EXPORT_DIR=/tmp/ocitest IMAGE_TAG=pr-1-abc BUILDER=b)

--- a/hack/cozyreport.bats
+++ b/hack/cozyreport.bats
@@ -1394,9 +1394,10 @@ STUB
 @test "pods not ready drops a fully ready running pod" {
   out="$(printf '%s\n' "$SNAPSHOT" | cozyreport_pods_not_ready)"
 
-  # `! cmd` is vacuous under cozytest's `set -e` (errexit is suppressed for a
-  # `!`-negated pipeline), so a regression that let this row through would not
-  # fail the test. Assert the absence via `if cmd; then ...; false`.
+  # `! cmd` is vacuous under cozytest's `set -e` (errexit is suppressed for
+  # any command whose status is inverted with `!`), so a regression that let
+  # this row through would not fail the test. Assert the absence via
+  # `if cmd; then ...; false`.
   if printf '%s\n' "$out" | grep -q 'coredns-abc'; then echo "FAIL: a ready pod must not be collected"; false; fi
 }
 

--- a/hack/cozyreport.bats
+++ b/hack/cozyreport.bats
@@ -1334,9 +1334,10 @@ STUB
 @test "pods not ready drops a fully ready running pod" {
   out="$(printf '%s\n' "$SNAPSHOT" | cozyreport_pods_not_ready)"
 
-  # `! cmd` is vacuous under cozytest's `set -e` (errexit is suppressed for a
-  # `!`-negated pipeline), so a regression that let this row through would not
-  # fail the test. Assert the absence via `if cmd; then ...; false`.
+  # `! cmd` is vacuous under cozytest's `set -e` (errexit is suppressed for
+  # any command whose status is inverted with `!`), so a regression that let
+  # this row through would not fail the test. Assert the absence via
+  # `if cmd; then ...; false`.
   if printf '%s\n' "$out" | grep -q 'coredns-abc'; then echo "FAIL: a ready pod must not be collected"; false; fi
 }
 

--- a/hack/e2e-apps/monitoring-oidc-customconfig.bats
+++ b/hack/e2e-apps/monitoring-oidc-customconfig.bats
@@ -120,8 +120,12 @@ EOF
   # exists. Chart-owned KeycloakRealmGroups were removed entirely (see
   # design note in docs/oidc-grafana.md) so no group assertions here.
   sleep 5
-  ! kubectl -n tenant-test get keycloakclient.v1.edp.epam.com "${CID}" 2>/dev/null
-  ! kubectl -n tenant-test get keycloakclientscope.v1.edp.epam.com "${CID}-audience" 2>/dev/null
+  if kubectl -n tenant-test get keycloakclient.v1.edp.epam.com "${CID}" 2>/dev/null; then
+    echo "FAIL: no KeycloakClient must exist in the cozy realm"; false
+  fi
+  if kubectl -n tenant-test get keycloakclientscope.v1.edp.epam.com "${CID}-audience" 2>/dev/null; then
+    echo "FAIL: no KeycloakClientScope must exist in the cozy realm"; false
+  fi
 }
 
 @test "secretRef variant mounts operator Secret under /etc/grafana/oidc" {

--- a/hack/e2e-apps/monitoring-oidc-customconfig.bats
+++ b/hack/e2e-apps/monitoring-oidc-customconfig.bats
@@ -120,10 +120,25 @@ EOF
   # exists. Chart-owned KeycloakRealmGroups were removed entirely (see
   # design note in docs/oidc-grafana.md) so no group assertions here.
   sleep 5
-  if kubectl -n tenant-test get keycloakclient.v1.edp.epam.com "${CID}" 2>/dev/null; then
+  # `kubectl get` exits 1 for a NotFound and 1 for a connection, auth or
+  # discovery failure, so deciding on the status alone reads an api-server the
+  # test cannot reach as proof the object is gone. `--ignore-not-found`
+  # collapses the NotFound alone into success with empty output, which leaves
+  # the status to mean what it says. stdout only: kubectl writes deprecation
+  # and throttling notices to stderr on a successful call, and folding those
+  # into the value under test would report an object that is not there.
+  if ! found=$(kubectl -n tenant-test get keycloakclient.v1.edp.epam.com "${CID}" \
+      --ignore-not-found -o name); then
+    echo "FAIL: reading KeycloakClient ${CID} did not answer"; false
+  fi
+  if [ -n "$found" ]; then
     echo "FAIL: no KeycloakClient must exist in the cozy realm"; false
   fi
-  if kubectl -n tenant-test get keycloakclientscope.v1.edp.epam.com "${CID}-audience" 2>/dev/null; then
+  if ! found=$(kubectl -n tenant-test get keycloakclientscope.v1.edp.epam.com "${CID}-audience" \
+      --ignore-not-found -o name); then
+    echo "FAIL: reading KeycloakClientScope ${CID}-audience did not answer"; false
+  fi
+  if [ -n "$found" ]; then
     echo "FAIL: no KeycloakClientScope must exist in the cozy realm"; false
   fi
 }

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -515,8 +515,9 @@ EOF
   echo "$output" | grep -q "tenant names must"
   # And assert kubectl did NOT report creation — if validation regressed
   # into a "warn" variant, the server could still accept the object. A bare
-  # `! echo | grep` is vacuous under cozytest's `set -e` (suppressed for a `!`
-  # pipeline), so the regression would slip through; assert via `if ...; false`.
+  # `! echo | grep` is vacuous under cozytest's `set -e` (suppressed for any
+  # command whose status is inverted with `!`), so the regression would slip
+  # through; assert via `if ...; false`.
   if echo "$output" | grep -qi "created"; then echo "FAIL: kubectl reported the tenant as created — validation must reject it, not warn"; false; fi
 
   # Post-condition cleanup: even though we expect validation to reject the
@@ -633,8 +634,9 @@ EOF
     -o jsonpath='{.data.version}')
   kubectl delete configmap cozystack-version -n cozy-system
   # A bare `! kubectl get` is vacuous under cozytest's `set -e` (errexit is
-  # suppressed for a `!` pipeline), so a delete that silently failed would not
-  # fail the test; assert the absence via `if kubectl get; then ...; false`.
+  # suppressed for any command whose status is inverted with `!`), so a
+  # delete that silently failed would not fail the test; assert the absence
+  # via `if kubectl get; then ...; false`.
   if kubectl get configmap cozystack-version -n cozy-system 2>/dev/null; then echo "FAIL: cozystack-version configmap must be gone after delete with the no-delete label removed"; false; fi
   # Reconstruct: declarative apply matches the chart template at
   # packages/core/platform/templates/cozystack-version.yaml — same label set

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -596,9 +596,16 @@ EOF
   kubectl delete configmap cozystack-version -n cozy-system
   # A bare `! kubectl get` is vacuous under cozytest's `set -e` (errexit is
   # suppressed for any command whose status is inverted with `!`), so a
-  # delete that silently failed would not fail the test; assert the absence
-  # via `if kubectl get; then ...; false`.
-  if kubectl get configmap cozystack-version -n cozy-system 2>/dev/null; then echo "FAIL: cozystack-version configmap must be gone after delete with the no-delete label removed"; false; fi
+  # delete that silently failed would not fail the test. Nor may the absence
+  # rest on the exit status alone: `kubectl get` exits 1 for a NotFound and 1
+  # for a connection, auth or discovery failure, so an api-server the test
+  # cannot reach would read as proof the delete worked. `--ignore-not-found`
+  # collapses the NotFound alone into success with empty output, leaving the
+  # status free to mean a failed read.
+  if ! still_there=$(kubectl get configmap cozystack-version -n cozy-system --ignore-not-found -o name); then
+    echo "FAIL: reading the cozystack-version configmap did not answer"; false
+  fi
+  if [ -n "$still_there" ]; then echo "FAIL: cozystack-version configmap must be gone after delete with the no-delete label removed"; false; fi
   # Reconstruct: declarative apply matches the chart template at
   # packages/core/platform/templates/cozystack-version.yaml — same label set
   # AND the helm.sh/resource-policy: keep annotation that pins the ConfigMap

--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -476,8 +476,9 @@ EOF
   echo "$output" | grep -q "tenant names must"
   # And assert kubectl did NOT report creation — if validation regressed
   # into a "warn" variant, the server could still accept the object. A bare
-  # `! echo | grep` is vacuous under cozytest's `set -e` (suppressed for a `!`
-  # pipeline), so the regression would slip through; assert via `if ...; false`.
+  # `! echo | grep` is vacuous under cozytest's `set -e` (suppressed for any
+  # command whose status is inverted with `!`), so the regression would slip
+  # through; assert via `if ...; false`.
   if echo "$output" | grep -qi "created"; then echo "FAIL: kubectl reported the tenant as created — validation must reject it, not warn"; false; fi
 
   # Post-condition cleanup: even though we expect validation to reject the
@@ -594,8 +595,9 @@ EOF
     -o jsonpath='{.data.version}')
   kubectl delete configmap cozystack-version -n cozy-system
   # A bare `! kubectl get` is vacuous under cozytest's `set -e` (errexit is
-  # suppressed for a `!` pipeline), so a delete that silently failed would not
-  # fail the test; assert the absence via `if kubectl get; then ...; false`.
+  # suppressed for any command whose status is inverted with `!`), so a
+  # delete that silently failed would not fail the test; assert the absence
+  # via `if kubectl get; then ...; false`.
   if kubectl get configmap cozystack-version -n cozy-system 2>/dev/null; then echo "FAIL: cozystack-version configmap must be gone after delete with the no-delete label removed"; false; fi
   # Reconstruct: declarative apply matches the chart template at
   # packages/core/platform/templates/cozystack-version.yaml — same label set

--- a/hack/kubectl-wait-retry_test.bats
+++ b/hack/kubectl-wait-retry_test.bats
@@ -55,7 +55,7 @@ prep() {
   # A real failure still aborts, is not retried, and the error is visible.
   [ "$rc" -ne 0 ]
   echo "$out" | grep -q 'NotFound'
-  ! echo "$out" | grep -q 'SCRIPT-REACHED-END'
+  if echo "$out" | grep -q 'SCRIPT-REACHED-END'; then echo "FAIL: the script must not have run on past a NotFound"; false; fi
   [ "$(grep -c . "$FAKE_CMDLOG")" -eq 1 ]
   rm -rf "$WORK"
 }

--- a/hack/kubernetes-nodes-unpin-hook.bats
+++ b/hack/kubernetes-nodes-unpin-hook.bats
@@ -56,7 +56,7 @@ prep() {
   sh "$WORK/unpin.sh" >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"
   [ "$rc" -eq 0 ]
-  ! grep -q 'annotate' "$FAKE_CMDLOG"
+  if grep -q 'annotate' "$FAKE_CMDLOG"; then echo "FAIL: no annotate must be issued when the objects are absent"; false; fi
   rm -rf "$WORK"
 }
 
@@ -73,7 +73,7 @@ prep() {
   cat "$WORK/out"
   [ "$rc" -ne 0 ]
   grep -q 'request timed out' "$WORK/out"
-  ! grep -q 'annotate' "$FAKE_CMDLOG"
+  if grep -q 'annotate' "$FAKE_CMDLOG"; then echo "FAIL: no annotate must be issued after a read failure"; false; fi
   rm -rf "$WORK"
 }
 
@@ -88,7 +88,7 @@ prep() {
   sh "$WORK/unpin.sh" >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"
   [ "$rc" -ne 0 ]
-  ! grep -q 'annotate' "$FAKE_CMDLOG"
+  if grep -q 'annotate' "$FAKE_CMDLOG"; then echo "FAIL: no annotate must be issued after a read failure"; false; fi
   rm -rf "$WORK"
 }
 
@@ -102,7 +102,7 @@ prep() {
   sh "$WORK/unpin.sh" >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"
   [ "$rc" -ne 0 ]
-  ! grep -q 'annotate' "$FAKE_CMDLOG"
+  if grep -q 'annotate' "$FAKE_CMDLOG"; then echo "FAIL: no annotate must be issued after a failed KMT listing"; false; fi
   unset FAKE_LIST_FAIL
   rm -rf "$WORK"
 }
@@ -118,7 +118,7 @@ prep() {
   sh "$WORK/unpin.sh" >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"
   [ "$rc" -eq 0 ]
-  ! grep -q 'annotate' "$FAKE_CMDLOG"
+  if grep -q 'annotate' "$FAKE_CMDLOG"; then echo "FAIL: a warning on stderr must not be read as a pinned object"; false; fi
   unset FAKE_WARN_STDERR
   rm -rf "$WORK"
 }
@@ -138,7 +138,7 @@ prep() {
   grep -q 'annotate .*workloadmonitor.cozystack.io/kubernetes-myk8s-md0 helm.sh/resource-policy-' "$FAKE_CMDLOG"
   grep -q 'annotate .*kubevirtmachinetemplate.infrastructure.cluster.x-k8s.io/kubernetes-myk8s-md0-abc123 helm.sh/resource-policy-' "$FAKE_CMDLOG"
   # ...but the sibling pool md0-large's KMT is left alone (6-hex anchor).
-  ! grep -q 'md0-large-def456' "$FAKE_CMDLOG"
+  if grep -q 'md0-large-def456' "$FAKE_CMDLOG"; then echo "FAIL: the sibling pool's KubevirtMachineTemplate must not be unpinned"; false; fi
   rm -rf "$WORK"
 }
 
@@ -149,6 +149,6 @@ prep() {
   sh "$WORK/unpin.sh" >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"
   [ "$rc" -eq 0 ]
-  ! grep -q 'annotate' "$FAKE_CMDLOG"
+  if grep -q 'annotate' "$FAKE_CMDLOG"; then echo "FAIL: an object without the keep annotation must not be unpinned"; false; fi
   rm -rf "$WORK"
 }

--- a/hack/migration-50-etcd-adopt.bats
+++ b/hack/migration-50-etcd-adopt.bats
@@ -80,7 +80,7 @@ lineno() {
   # are upgrading FROM and its plaintext in-cluster default cannot be reached.
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   echo "$apply" | grep -qF -- "--backup-s3-endpoint=https://s3.example.com"
-  ! echo "$apply" | grep -qF -- "seaweedfs-s3.tenant-root.svc.cozy.local:8333"
+  if echo "$apply" | grep -qF -- "seaweedfs-s3.tenant-root.svc.cozy.local:8333"; then echo "FAIL: --apply must not carry the in-cluster S3 endpoint"; false; fi
   # https is forced because a BucketClaim is provisioned into exactly the bucket
   # the creds advertise, not because the projected endpoint happens to exist.
   grep -qF -- "BUCKETCLAIM-LIST" "$FAKE_CMDLOG"
@@ -90,7 +90,7 @@ lineno() {
   echo "$apply" | grep -qF -- "--backup-s3-force-path-style"
   # snapshots land under a system key prefix, not a tenant <ns>/<name>/ path.
   echo "$apply" | grep -qF -- "--backup-s3-key=cozy-system/etcd-adoption/"
-  ! echo "$apply" | grep -qF -- "--skip-backup"
+  if echo "$apply" | grep -qF -- "--skip-backup"; then echo "FAIL: --apply must not carry --skip-backup"; false; fi
   # --agent-image is explicit (the scaled-down Deployment is still the legacy operator).
   echo "$apply" | grep -qF -- "--agent-image=ghcr.io/cozystack/etcd-operator:v0.5.2"
 
@@ -143,7 +143,7 @@ lineno() {
   cat "$WORK/out"
   cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
-  ! grep -qF -- "APPLY-CRDS" "$FAKE_CMDLOG"
+  if grep -qF -- "APPLY-CRDS" "$FAKE_CMDLOG"; then echo "FAIL: no CRDs must have been applied"; false; fi
   # Adoption still proceeds.
   grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
   rm -rf "$WORK"
@@ -190,7 +190,7 @@ lineno() {
   [ "$s_down" -lt "$s_apply" ]
   [ "$s_apply" -lt "$s_up" ]
   # The version must NOT be stamped on a failed adoption (the Job retries).
-  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  if grep -qF -- "STAMP" "$FAKE_CMDLOG"; then echo "FAIL: no version must have been stamped"; false; fi
   rm -rf "$WORK"
 }
 
@@ -214,9 +214,9 @@ lineno() {
   grep -qF -- "package.cozystack.io cozystack.cozystack-platform" "$WORK/out"
   grep -qF -- "etcdAdoptSkipBackup: true" "$WORK/out"
   # Nothing destructive must have run: no scale-down, no --apply, no version stamp.
-  ! grep -qF -- "SCALE 0" "$FAKE_CMDLOG"
-  ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
-  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  if grep -qF -- "SCALE 0" "$FAKE_CMDLOG"; then echo "FAIL: the operator must not have been scaled down"; false; fi
+  if grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"; then echo "FAIL: etcd-migrate --apply must not have run"; false; fi
+  if grep -qF -- "STAMP" "$FAKE_CMDLOG"; then echo "FAIL: no version must have been stamped"; false; fi
   rm -rf "$WORK"
 }
 
@@ -233,13 +233,13 @@ lineno() {
   cat "$WORK/out"
   cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
-  ! grep -qF -- "refusing to adopt" "$WORK/out"
+  if grep -qF -- "refusing to adopt" "$WORK/out"; then echo "FAIL: adoption must not have been refused"; false; fi
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   echo "$apply" | grep -qF -- "--backup-s3-endpoint=https://s3.example.com"
   echo "$apply" | grep -qF -- "--backup-s3-bucket=cozy-backups-7f3a"
   echo "$apply" | grep -qF -- "--backup-s3-region=us-east-1"
   echo "$apply" | grep -qF -- "--backup-s3-force-path-style"
-  ! echo "$apply" | grep -qF -- "--skip-backup"
+  if echo "$apply" | grep -qF -- "--skip-backup"; then echo "FAIL: --apply must not carry --skip-backup"; false; fi
   grep -qF -- "STAMP" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }
@@ -276,10 +276,10 @@ lineno() {
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   echo "$apply" | grep -qF -- "--backup-s3-endpoint=http://minio.internal:9000"
   # The projected bare host must NOT be promoted to https.
-  ! echo "$apply" | grep -qF -- "https://minio.internal:9000"
+  if echo "$apply" | grep -qF -- "https://minio.internal:9000"; then echo "FAIL: the projected bare host must not be promoted to https"; false; fi
   echo "$apply" | grep -qF -- "--backup-s3-bucket=minio-bucket"
   # A missing CRD is answered, not retried: the list is never even attempted.
-  ! grep -qF -- "BUCKETCLAIM-LIST" "$FAKE_CMDLOG"
+  if grep -qF -- "BUCKETCLAIM-LIST" "$FAKE_CMDLOG"; then echo "FAIL: BucketClaims must not have been listed"; false; fi
   rm -rf "$WORK"
 }
 
@@ -313,8 +313,8 @@ lineno() {
   echo "$apply" | grep -qF -- "--backup-s3-region=us-east-1"
   echo "$apply" | grep -qF -- "--backup-s3-force-path-style"
   # Not one projected coordinate may leak into the external destination.
-  ! echo "$apply" | grep -qF -- "stale-secret-bucket"
-  ! echo "$apply" | grep -qF -- "eu-west-9"
+  if echo "$apply" | grep -qF -- "stale-secret-bucket"; then echo "FAIL: --apply must not carry the stale bucket from the Secret"; false; fi
+  if echo "$apply" | grep -qF -- "eu-west-9"; then echo "FAIL: --apply must not carry the stale region from the Secret"; false; fi
   rm -rf "$WORK"
 }
 
@@ -333,7 +333,7 @@ lineno() {
   [ "$rc" -eq 0 ]
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   echo "$apply" | grep -qF -- "--backup-s3-bucket=cozy-backups-7f3a"
-  ! echo "$apply" | grep -qF -- "cr-bucket-should-lose"
+  if echo "$apply" | grep -qF -- "cr-bucket-should-lose"; then echo "FAIL: --apply must not carry the bucket from the Strategy CR"; false; fi
   rm -rf "$WORK"
 }
 
@@ -358,7 +358,7 @@ lineno() {
   [ "$rc" -eq 0 ]
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   echo "$apply" | grep -qF -- "--backup-s3-endpoint=http://minio.internal:9000"
-  ! echo "$apply" | grep -qF -- "https://minio.internal:9000"
+  if echo "$apply" | grep -qF -- "https://minio.internal:9000"; then echo "FAIL: the projected bare host must not be promoted to https"; false; fi
   rm -rf "$WORK"
 }
 
@@ -379,7 +379,7 @@ lineno() {
   [ "$rc" -eq 0 ]
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   echo "$apply" | grep -qF -- "--backup-s3-endpoint=https://s3.example.com"
-  ! echo "$apply" | grep -qF -- "seaweedfs-s3.tenant-root.svc.cozy.local:8333"
+  if echo "$apply" | grep -qF -- "seaweedfs-s3.tenant-root.svc.cozy.local:8333"; then echo "FAIL: --apply must not carry the in-cluster S3 endpoint"; false; fi
   rm -rf "$WORK"
 }
 
@@ -408,7 +408,7 @@ lineno() {
   echo "$apply" | grep -qF -- "--backup-s3-endpoint=https://s3.example.com"
   echo "$apply" | grep -qF -- "--backup-s3-bucket=bucket-0bb5096a-956e-4630-91f4-e1d265de5f51"
   # The v1.5.x CR endpoint must never be what a large cluster falls back to.
-  ! echo "$apply" | grep -qF -- "seaweedfs-s3.tenant-root.svc.cozy.local:8333"
+  if echo "$apply" | grep -qF -- "seaweedfs-s3.tenant-root.svc.cozy.local:8333"; then echo "FAIL: --apply must not carry the in-cluster S3 endpoint"; false; fi
   rm -rf "$WORK"
 }
 
@@ -433,12 +433,12 @@ lineno() {
   grep -qF -- "TERMINATING BucketClaim" "$WORK/out"
   grep -qF -- "could not determine" "$WORK/out"
   # It must not have silently taken either branch.
-  ! grep -qF -- "treating as external S3" "$WORK/out"
-  ! grep -qF -- "forcing https" "$WORK/out"
+  if grep -qF -- "treating as external S3" "$WORK/out"; then echo "FAIL: the endpoint must not have been treated as external S3"; false; fi
+  if grep -qF -- "forcing https" "$WORK/out"; then echo "FAIL: the endpoint scheme must not have been forced to https"; false; fi
   # Nothing destructive ran.
-  ! grep -qF -- "SCALE 0" "$FAKE_CMDLOG"
-  ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
-  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  if grep -qF -- "SCALE 0" "$FAKE_CMDLOG"; then echo "FAIL: the operator must not have been scaled down"; false; fi
+  if grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"; then echo "FAIL: etcd-migrate --apply must not have run"; false; fi
+  if grep -qF -- "STAMP" "$FAKE_CMDLOG"; then echo "FAIL: no version must have been stamped"; false; fi
   rm -rf "$WORK"
 }
 
@@ -456,7 +456,7 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   [ "$rc" -eq 0 ]
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   echo "$apply" | grep -qF -- "--backup-s3-endpoint=https://s3.example.com"
-  ! grep -qF -- "TERMINATING BucketClaim" "$WORK/out"
+  if grep -qF -- "TERMINATING BucketClaim" "$WORK/out"; then echo "FAIL: no terminating BucketClaim must have been reported"; false; fi
   rm -rf "$WORK"
 }
 
@@ -471,9 +471,9 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   cat "$WORK/out"
   [ "$rc" -ne 0 ]
   grep -qF -- "unexpected BucketClaim list shape" "$WORK/out"
-  ! grep -qF -- "treating as external S3" "$WORK/out"
-  ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
-  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  if grep -qF -- "treating as external S3" "$WORK/out"; then echo "FAIL: the endpoint must not have been treated as external S3"; false; fi
+  if grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"; then echo "FAIL: etcd-migrate --apply must not have run"; false; fi
+  if grep -qF -- "STAMP" "$FAKE_CMDLOG"; then echo "FAIL: no version must have been stamped"; false; fi
   rm -rf "$WORK"
 }
 
@@ -493,11 +493,11 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   grep -qF -- "could not determine" "$WORK/out"
   grep -qF -- "refusing to adopt" "$WORK/out"
   # It must NOT have silently taken the external path.
-  ! grep -qF -- "treating as external S3" "$WORK/out"
+  if grep -qF -- "treating as external S3" "$WORK/out"; then echo "FAIL: the endpoint must not have been treated as external S3"; false; fi
   # Nothing destructive ran.
-  ! grep -qF -- "SCALE 0" "$FAKE_CMDLOG"
-  ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
-  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  if grep -qF -- "SCALE 0" "$FAKE_CMDLOG"; then echo "FAIL: the operator must not have been scaled down"; false; fi
+  if grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"; then echo "FAIL: etcd-migrate --apply must not have run"; false; fi
+  if grep -qF -- "STAMP" "$FAKE_CMDLOG"; then echo "FAIL: no version must have been stamped"; false; fi
   rm -rf "$WORK"
 }
 
@@ -511,8 +511,8 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   cat "$WORK/out"
   [ "$rc" -ne 0 ]
   grep -qF -- "could not determine" "$WORK/out"
-  ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
-  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  if grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"; then echo "FAIL: etcd-migrate --apply must not have run"; false; fi
+  if grep -qF -- "STAMP" "$FAKE_CMDLOG"; then echo "FAIL: no version must have been stamped"; false; fi
   rm -rf "$WORK"
 }
 
@@ -531,7 +531,7 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   [ "$rc" -eq 0 ]
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   # No scheme-only endpoint reaches etcd-migrate...
-  ! echo "$apply" | grep -qE -- "--backup-s3-endpoint=https://( |$)"
+  if echo "$apply" | grep -qE -- "--backup-s3-endpoint=https://( |$)"; then echo "FAIL: --apply must not carry an endpoint whose host is empty"; false; fi
   # ...and the CR supplies the real one instead.
   echo "$apply" | grep -qF -- "--backup-s3-endpoint=http://seaweedfs-s3.tenant-root.svc.cozy.local:8333"
   rm -rf "$WORK"
@@ -550,7 +550,7 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   [ "$rc" -eq 0 ]
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   echo "$apply" | grep -qF -- "--backup-s3-bucket=cozy-backups-7f3a"
-  ! echo "$apply" | grep -qF -- "--skip-backup"
+  if echo "$apply" | grep -qF -- "--skip-backup"; then echo "FAIL: --apply must not carry --skip-backup"; false; fi
   grep -qF -- "STAGE tenant-foo" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }
@@ -569,9 +569,9 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   [ "$rc" -eq 0 ]
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   echo "$apply" | grep -qF -- "--skip-backup"
-  ! echo "$apply" | grep -qF -- "--backup-s3-endpoint"
+  if echo "$apply" | grep -qF -- "--backup-s3-endpoint"; then echo "FAIL: --apply must not carry a backup S3 endpoint"; false; fi
   # No snapshot Job runs, so no credentials are staged.
-  ! grep -qF -- "STAGE " "$FAKE_CMDLOG"
+  if grep -qF -- "STAGE " "$FAKE_CMDLOG"; then echo "FAIL: no credentials must have been staged"; false; fi
   # Adoption still runs and stamps: scale down -> --apply -> scale up -> stamp.
   grep -qF -- "SCALE 0" "$FAKE_CMDLOG"
   grep -qF -- "STAMP" "$FAKE_CMDLOG"
@@ -592,8 +592,8 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   [ "$rc" -eq 0 ]
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   echo "$apply" | grep -qF -- "--skip-backup"
-  ! echo "$apply" | grep -qF -- "--backup-s3-endpoint"
-  ! grep -qF -- "STAGE " "$FAKE_CMDLOG"
+  if echo "$apply" | grep -qF -- "--backup-s3-endpoint"; then echo "FAIL: --apply must not carry a backup S3 endpoint"; false; fi
+  if grep -qF -- "STAGE " "$FAKE_CMDLOG"; then echo "FAIL: no credentials must have been staged"; false; fi
   rm -rf "$WORK"
 }
 
@@ -608,7 +608,7 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   cat "$WORK/out"
   [ "$rc" -eq 0 ]
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
-  ! echo "$apply" | grep -qF -- "--skip-backup"
+  if echo "$apply" | grep -qF -- "--skip-backup"; then echo "FAIL: --apply must not carry --skip-backup"; false; fi
   echo "$apply" | grep -qF -- "--backup-s3-endpoint=https://s3.example.com"
   rm -rf "$WORK"
 }
@@ -628,7 +628,7 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   cat "$WORK/out"
   cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
-  ! grep -qF -- "refusing to adopt" "$WORK/out"
+  if grep -qF -- "refusing to adopt" "$WORK/out"; then echo "FAIL: adoption must not have been refused"; false; fi
   apply=$(grep -F -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG")
   echo "$apply" | grep -qF -- "--skip-backup"
   grep -qF -- "STAMP" "$FAKE_CMDLOG"
@@ -645,9 +645,9 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   grep -qF -- "STAMP" "$FAKE_CMDLOG"
-  ! grep -qF -- "SCALE 0" "$FAKE_CMDLOG"
-  ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
-  ! grep -qF -- "STAGE " "$FAKE_CMDLOG"
+  if grep -qF -- "SCALE 0" "$FAKE_CMDLOG"; then echo "FAIL: the operator must not have been scaled down"; false; fi
+  if grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"; then echo "FAIL: etcd-migrate --apply must not have run"; false; fi
+  if grep -qF -- "STAGE " "$FAKE_CMDLOG"; then echo "FAIL: no credentials must have been staged"; false; fi
   rm -rf "$WORK"
 }
 
@@ -660,8 +660,8 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   grep -qF -- "STAMP" "$FAKE_CMDLOG"
-  ! grep -qF -- "SCALE 0" "$FAKE_CMDLOG"
-  ! grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"
+  if grep -qF -- "SCALE 0" "$FAKE_CMDLOG"; then echo "FAIL: the operator must not have been scaled down"; false; fi
+  if grep -qF -- "ETCD-MIGRATE --apply" "$FAKE_CMDLOG"; then echo "FAIL: etcd-migrate --apply must not have run"; false; fi
   rm -rf "$WORK"
 }
 
@@ -709,7 +709,7 @@ tenant-old bucket-dead bucket-dead-uuid 2026-07-17T09:00:00Z"
   # authenticates via the SA token file + CA.
   [ -s "$ETCD_MIGRATE_KUBECONFIG" ]
   grep -qF -- "server: https://kubernetes.default.svc" "$ETCD_MIGRATE_KUBECONFIG"
-  ! grep -qF -- "fd00::1" "$ETCD_MIGRATE_KUBECONFIG"
+  if grep -qF -- "fd00::1" "$ETCD_MIGRATE_KUBECONFIG"; then echo "FAIL: the synthesized kubeconfig must not name the bare IPv6 host"; false; fi
   grep -qF -- "tokenFile: $sa/token" "$ETCD_MIGRATE_KUBECONFIG"
   grep -qF -- "certificate-authority: $sa/ca.crt" "$ETCD_MIGRATE_KUBECONFIG"
   rm -rf "$WORK"

--- a/hack/migration-56-adopt-path.bats
+++ b/hack/migration-56-adopt-path.bats
@@ -62,7 +62,7 @@ OBJS
   # The pool's own KMT (6-hex suffix) is adopted...
   grep -qE 'annotate kubevirtmachinetemplate.* kubernetes-test3-md0-abc123 ' "$FAKE_CMDLOG"
   # ...but the sibling pool md0-large's KMT is NOT (anchor stops the mis-adopt).
-  ! grep -qE 'kubernetes-test3-md0-large-def456' "$FAKE_CMDLOG"
+  if grep -qE 'kubernetes-test3-md0-large-def456' "$FAKE_CMDLOG"; then echo "FAIL: the sibling pool's KubevirtMachineTemplate must not be adopted"; false; fi
   rm -rf "$WORK"
 }
 
@@ -78,7 +78,7 @@ OBJS
   cat "$WORK/out"
   [ "$rc" -eq 0 ]
   # Already adopted -> no annotate issued at all.
-  ! grep -qE 'annotate ' "$FAKE_CMDLOG"
+  if grep -qE 'annotate ' "$FAKE_CMDLOG"; then echo "FAIL: an already-adopted pool must not be annotated again"; false; fi
   rm -rf "$WORK"
 }
 
@@ -108,7 +108,7 @@ OBJS
   # The foreign-owned MD is pinned with keep so the parent cannot prune it...
   grep -qE 'annotate machinedeployment.* kubernetes-test3-md0 .*resource-policy=keep' "$FAKE_CMDLOG"
   # ...but it is never re-annotated onto the child release (ownership untouched).
-  ! grep -qE 'annotate machinedeployment.* meta.helm.sh/release-name=kubernetes-nodes-test3-md0' "$FAKE_CMDLOG"
+  if grep -qE 'annotate machinedeployment.* meta.helm.sh/release-name=kubernetes-nodes-test3-md0' "$FAKE_CMDLOG"; then echo "FAIL: a foreign-owned MachineDeployment must not be re-annotated onto the child release"; false; fi
   # The sibling parent-owned MHC still adopts, and the run stamps.
   grep -qE 'annotate machinehealthcheck.* meta.helm.sh/release-name=kubernetes-nodes-test3-md0' "$FAKE_CMDLOG"
   grep -qF -- "STAMP" "$FAKE_CMDLOG"
@@ -138,7 +138,7 @@ JSON
   [ "$rc" -eq 0 ]
   grep -qiE 'not a valid RFC-1123 label' "$WORK/out"
   # The invalid child HelmRelease is never applied.
-  ! grep -q 'APPLY-HR' "$FAKE_CMDLOG"
+  if grep -q 'APPLY-HR' "$FAKE_CMDLOG"; then echo "FAIL: no child HelmRelease must be applied for an invalid pool name"; false; fi
   rm -rf "$WORK"
 }
 
@@ -157,7 +157,7 @@ JSON
   cat "$WORK/out"
   [ "$rc" -eq 0 ]
   grep -qiE 'non-object value' "$WORK/out"
-  ! grep -q 'APPLY-HR' "$FAKE_CMDLOG"
+  if grep -q 'APPLY-HR' "$FAKE_CMDLOG"; then echo "FAIL: no child HelmRelease must be applied for a non-object value"; false; fi
   rm -rf "$WORK"
 }
 
@@ -175,7 +175,7 @@ JSON
   cat "$WORK/out"
   [ "$rc" -eq 0 ]
   grep -qiE 'not an object' "$WORK/out"
-  ! grep -q 'APPLY-HR' "$FAKE_CMDLOG"
+  if grep -q 'APPLY-HR' "$FAKE_CMDLOG"; then echo "FAIL: no child HelmRelease must be applied for a non-object nodeGroups"; false; fi
   rm -rf "$WORK"
 }
 
@@ -211,9 +211,9 @@ OBJS
   grep -qE 'annotate kubevirtmachinetemplate.* kubernetes-test3-md0-abc123 .*resource-policy=keep' "$FAKE_CMDLOG"
   grep -qE 'annotate machinedeployment.* kubernetes-test3-md1 .*resource-policy=keep' "$FAKE_CMDLOG"
   grep -qE 'annotate kubevirtmachinetemplate.* kubernetes-test3-md1-def456 .*resource-policy=keep' "$FAKE_CMDLOG"
-  ! grep -qE 'meta.helm.sh/release-name' "$FAKE_CMDLOG"
+  if grep -qE 'meta.helm.sh/release-name' "$FAKE_CMDLOG"; then echo "FAIL: no ownership must be transferred"; false; fi
   # Adoption skipped, run completes.
-  ! grep -q 'APPLY-HR' "$FAKE_CMDLOG"
+  if grep -q 'APPLY-HR' "$FAKE_CMDLOG"; then echo "FAIL: no child HelmRelease must be applied"; false; fi
   grep -qF -- "STAMP" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }
@@ -249,9 +249,9 @@ OBJS
   grep -qE 'annotate machinehealthcheck.* kubernetes-test3-md0 .*resource-policy=keep' "$FAKE_CMDLOG"
   grep -qE 'annotate workloadmonitor.* kubernetes-test3-md0 .*resource-policy=keep' "$FAKE_CMDLOG"
   grep -qE 'annotate kubevirtmachinetemplate.* kubernetes-test3-md0-abc123 .*resource-policy=keep' "$FAKE_CMDLOG"
-  ! grep -qE 'meta.helm.sh/release-name' "$FAKE_CMDLOG"
+  if grep -qE 'meta.helm.sh/release-name' "$FAKE_CMDLOG"; then echo "FAIL: no ownership must be transferred"; false; fi
   # Adoption skipped, run completes and stamps.
-  ! grep -q 'APPLY-HR' "$FAKE_CMDLOG"
+  if grep -q 'APPLY-HR' "$FAKE_CMDLOG"; then echo "FAIL: no child HelmRelease must be applied"; false; fi
   grep -qF -- "STAMP" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }
@@ -288,9 +288,9 @@ OBJS
   grep -qE 'annotate machinehealthcheck.* kubernetes-production-eu-central-analytics01-md0 .*resource-policy=keep' "$FAKE_CMDLOG"
   grep -qE 'annotate workloadmonitor.* kubernetes-production-eu-central-analytics01-md0 .*resource-policy=keep' "$FAKE_CMDLOG"
   grep -qE 'annotate kubevirtmachinetemplate.* kubernetes-production-eu-central-analytics01-md0-abc123 .*resource-policy=keep' "$FAKE_CMDLOG"
-  ! grep -qE 'meta.helm.sh/release-name' "$FAKE_CMDLOG"
+  if grep -qE 'meta.helm.sh/release-name' "$FAKE_CMDLOG"; then echo "FAIL: no ownership must be transferred"; false; fi
   # Adoption skipped (no child HR applied), run completes and stamps.
-  ! grep -q 'APPLY-HR' "$FAKE_CMDLOG"
+  if grep -q 'APPLY-HR' "$FAKE_CMDLOG"; then echo "FAIL: no child HelmRelease must be applied"; false; fi
   grep -qF -- "STAMP" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }
@@ -324,7 +324,7 @@ OBJS
   cat "$WORK/out"
   [ "$rc" -ne 0 ]
   grep -q 'ERROR: reading machinedeployment' "$WORK/out"
-  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  if grep -qF -- "STAMP" "$FAKE_CMDLOG"; then echo "FAIL: the version must not be stamped after a read error"; false; fi
   unset FAKE_GET_FAIL
   rm -rf "$WORK"
 }
@@ -348,7 +348,7 @@ OBJS
   cat "$WORK/out"
   [ "$rc" -ne 0 ]
   grep -q 'ERROR: listing KubevirtMachineTemplates' "$WORK/out"
-  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  if grep -qF -- "STAMP" "$FAKE_CMDLOG"; then echo "FAIL: the version must not be stamped after a listing error"; false; fi
   unset FAKE_GET_FAIL
   rm -rf "$WORK"
 }
@@ -371,7 +371,7 @@ JSON
   cat "$WORK/out"
   [ "$rc" -ne 0 ]
   grep -q 'ERROR: reading machinedeployment' "$WORK/out"
-  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  if grep -qF -- "STAMP" "$FAKE_CMDLOG"; then echo "FAIL: the version must not be stamped after a read error"; false; fi
   unset FAKE_GET_FAIL
   rm -rf "$WORK"
 }
@@ -393,7 +393,7 @@ JSON
   [ "$rc" -eq 0 ]
   grep -qiE 'not a valid RFC-1123 label' "$WORK/out"
   grep -qi 'nothing to pin' "$WORK/out"
-  ! grep -q 'APPLY-HR' "$FAKE_CMDLOG"
+  if grep -q 'APPLY-HR' "$FAKE_CMDLOG"; then echo "FAIL: no child HelmRelease must be applied"; false; fi
   grep -qF -- "STAMP" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }
@@ -418,7 +418,7 @@ OBJS
   cat "$WORK/out"
   [ "$rc" -eq 0 ]
   grep -qE 'annotate machinedeployment.* meta.helm.sh/release-name=kubernetes-nodes-test3-md0' "$FAKE_CMDLOG"
-  ! grep -qi 'refusing' "$WORK/out"
+  if grep -qi 'refusing' "$WORK/out"; then echo "FAIL: a warning on stderr must not make the owner guard refuse"; false; fi
   grep -qF -- "STAMP" "$FAKE_CMDLOG"
   unset FAKE_WARN_STDERR
   rm -rf "$WORK"
@@ -438,7 +438,7 @@ OBJS
   bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"
   [ "$rc" -ne 0 ]
-  ! grep -qF -- "STAMP" "$FAKE_CMDLOG"
+  if grep -qF -- "STAMP" "$FAKE_CMDLOG"; then echo "FAIL: the version must not be stamped after a transient read failure"; false; fi
   unset FAKE_GET_FAIL FAKE_GET_FAIL_MSG
   rm -rf "$WORK"
 }
@@ -459,7 +459,7 @@ JSON
   [ "$rc" -eq 0 ]
   grep -qiE 'not a valid RFC-1123 label' "$WORK/out"
   # Neither 'my' nor 'pool' is ever applied as a child release.
-  ! grep -q 'APPLY-HR' "$FAKE_CMDLOG"
+  if grep -q 'APPLY-HR' "$FAKE_CMDLOG"; then echo "FAIL: no child HelmRelease must be applied"; false; fi
   rm -rf "$WORK"
 }
 
@@ -481,6 +481,6 @@ JSON
   grep -qiE 'non-scalar value' "$WORK/out"
   grep -q 'storageClass' "$WORK/out"
   # The pool is pinned+skipped, never applied as a child release.
-  ! grep -q 'APPLY-HR' "$FAKE_CMDLOG"
+  if grep -q 'APPLY-HR' "$FAKE_CMDLOG"; then echo "FAIL: the pinned-and-skipped pool must not be applied as a child release"; false; fi
   rm -rf "$WORK"
 }

--- a/hack/migration-56-adopt-values.bats
+++ b/hack/migration-56-adopt-values.bats
@@ -219,7 +219,7 @@ JSON
   rc=0
   bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
   [ "$rc" -eq 0 ]
-  ! grep -qE 'label helmrelease' "$FAKE_CMDLOG"
+  if grep -qE 'label helmrelease' "$FAKE_CMDLOG"; then echo "FAIL: no HelmRelease must be labelled"; false; fi
   rm -rf "$WORK"
 }
 
@@ -249,7 +249,7 @@ JSON
   rc=0
   bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
   [ "$rc" -eq 0 ]
-  ! grep -qF -- "APPLY-UNADOPTED-CM" "$FAKE_CMDLOG"
+  if grep -qF -- "APPLY-UNADOPTED-CM" "$FAKE_CMDLOG"; then echo "FAIL: no unadopted ConfigMap must be applied"; false; fi
   grep -qF -- "STAMP" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }
@@ -304,6 +304,6 @@ JSON
   rc=0
   bash "$MIG" >"$WORK/out" 2>&1 || rc=$?
   [ "$rc" -eq 0 ]
-  ! grep -qE 'label helmrelease kubernetes-decoy' "$FAKE_CMDLOG"
+  if grep -qE 'label helmrelease kubernetes-decoy' "$FAKE_CMDLOG"; then echo "FAIL: the decoy HelmRelease must not be labelled"; false; fi
   rm -rf "$WORK"
 }

--- a/hack/migration-seaweedfs-db-adopt.bats
+++ b/hack/migration-seaweedfs-db-adopt.bats
@@ -217,7 +217,7 @@ tenant-named foo-db keep"
   run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
-  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  if grep -q 'ANNOTATE' "$FAKE_CMDLOG"; then echo "FAIL: no Cluster must have been re-annotated"; false; fi
   grep -qF -- "STAMP 54" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }
@@ -231,7 +231,7 @@ tenant-named foo-db keep"
   run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
-  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  if grep -q 'ANNOTATE' "$FAKE_CMDLOG"; then echo "FAIL: no Cluster must have been re-annotated"; false; fi
   grep -qF -- "carries no meta.helm.sh/release-name" "$WORK/out"
   rm -rf "$WORK"
 }
@@ -243,7 +243,7 @@ tenant-named foo-db keep"
   run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
-  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  if grep -q 'ANNOTATE' "$FAKE_CMDLOG"; then echo "FAIL: no Cluster must have been re-annotated"; false; fi
   grep -qF -- "owned by unrelated release" "$WORK/out"
   rm -rf "$WORK"
 }
@@ -258,7 +258,7 @@ tenant-named foo-db keep"
   run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
-  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  if grep -q 'ANNOTATE' "$FAKE_CMDLOG"; then echo "FAIL: no Cluster must have been re-annotated"; false; fi
   grep -qF -- "no instance name" "$WORK/out"
   rm -rf "$WORK"
 }
@@ -275,7 +275,7 @@ tenant-named foo-db keep"
   # Must propagate: the Job retries rather than advancing the version.
   [ "$rc" -ne 0 ]
   grep -qF -- "refusing to stamp past an unverified fleet" "$WORK/out"
-  ! grep -q 'STAMP' "$FAKE_CMDLOG"
+  if grep -q 'STAMP' "$FAKE_CMDLOG"; then echo "FAIL: no version must have been stamped"; false; fi
   rm -rf "$WORK"
 }
 
@@ -288,7 +288,7 @@ tenant-named foo-db keep"
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -ne 0 ]
   grep -qF -- "cannot read the Helm owner" "$WORK/out"
-  ! grep -q 'STAMP' "$FAKE_CMDLOG"
+  if grep -q 'STAMP' "$FAKE_CMDLOG"; then echo "FAIL: no version must have been stamped"; false; fi
   rm -rf "$WORK"
 }
 
@@ -300,7 +300,7 @@ tenant-named foo-db keep"
   run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -ne 0 ]
-  ! grep -q 'STAMP' "$FAKE_CMDLOG"
+  if grep -q 'STAMP' "$FAKE_CMDLOG"; then echo "FAIL: no version must have been stamped"; false; fi
   rm -rf "$WORK"
 }
 
@@ -315,7 +315,7 @@ tenant-named foo-db keep"
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   grep -qF -- "resource type is not served" "$WORK/out"
-  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  if grep -q 'ANNOTATE' "$FAKE_CMDLOG"; then echo "FAIL: no Cluster must have been re-annotated"; false; fi
   grep -qF -- "STAMP 54" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }
@@ -327,7 +327,7 @@ tenant-named foo-db keep"
   run_migration 53 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
-  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  if grep -q 'ANNOTATE' "$FAKE_CMDLOG"; then echo "FAIL: no Cluster must have been re-annotated"; false; fi
   grep -qF -- "STAMP 54" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }

--- a/hack/nightly-mirror_test.bats
+++ b/hack/nightly-mirror_test.bats
@@ -175,17 +175,17 @@ _make_tree() {
   grep -q 'docker://iad.ocir.io/idyksih5sir9/cozystack/digesthost@sha256:.* docker://ghcr.io/cozystack/cozystack/digesthost:0.0.0-nightly.test' "$tmp/out"
   grep -q 'docker://iad.ocir.io/idyksih5sir9/cozystack/globalreg@sha256:.* docker://ghcr.io/cozystack/cozystack/globalreg:0.0.0-nightly.test' "$tmp/out"
   # The digest-less sibling under global.images is not invented into a ref.
-  ! grep -q '/other' "$tmp/out"
+  if grep -q '/other' "$tmp/out"; then echo "FAIL: a digest-less entry must not be invented into a ref"; false; fi
   # An owned ref sharing a file with a map-typed `repository` survives.
   grep -q 'docker://ghcr.io/cozystack/cozystack/survivor:0.0.0-nightly.test' "$tmp/out"
   # A floating tag is moved alongside the pinned version.
   grep -q 'docker://ghcr.io/cozystack/cozystack/foo:nightly' "$tmp/out"
 
   # Third-party images never appear in the copy plan.
-  ! grep -q 'docker.io/clastix' "$tmp/out"
-  ! grep -q 'docker.io/vendor' "$tmp/out"
+  if grep -q 'docker.io/clastix' "$tmp/out"; then echo "FAIL: a third-party image must not be mirrored"; false; fi
+  if grep -q 'docker.io/vendor' "$tmp/out"; then echo "FAIL: a third-party image must not be mirrored"; false; fi
   # The cozystack-packages artifact is excluded — it is rebuilt downstream.
-  ! grep -qE 'skopeo copy.*cozystack-packages' "$tmp/out"
+  if grep -qE 'skopeo copy.*cozystack-packages' "$tmp/out"; then echo "FAIL: the packages artifact must not be mirrored"; false; fi
 
   # The host rewrite is planned source->dest.
   grep -q "s|iad.ocir.io/idyksih5sir9/cozystack/|ghcr.io/cozystack/cozystack/|g" "$tmp/out"
@@ -280,7 +280,7 @@ _make_tree() {
   # the whole-value host is rewritten, and the repository beside it is untouched
   grep -q '^    address: ghcr.io/cozystack/cozystack$' "$tmp/tree/system/globalreg/values.yaml"
   grep -q '^      repository: globalreg$' "$tmp/tree/system/globalreg/values.yaml"
-  ! grep -q 'iad.ocir.io' "$tmp/tree/system/globalreg/values.yaml"
+  if grep -q 'iad.ocir.io' "$tmp/tree/system/globalreg/values.yaml"; then echo "FAIL: the source registry host must not survive the rewrite"; false; fi
 
   # a contiguous ref is still rewritten exactly once, not double-prefixed
   grep -q '^image: ghcr.io/cozystack/cozystack/foo:main@sha256:' "$tmp/tree/system/foo/values.yaml"

--- a/hack/promote-retag_test.bats
+++ b/hack/promote-retag_test.bats
@@ -170,7 +170,7 @@ EOF
   # The stable tag is in the copy plan...
   grep -qE 'docker://ghcr\.io/cozystack/cozystack/[^ ]*:v9\.9\.9' "$tmp/out"
   # ...but nothing moves :latest.
-  ! grep -qE 'docker://[^ ]+:latest' "$tmp/out"
+  if grep -qE 'docker://[^ ]+:latest' "$tmp/out"; then echo "FAIL: no :latest tag must have been planned"; false; fi
   rm -rf "$tmp"
 }
 
@@ -256,7 +256,7 @@ EOF
 
   grep -q "already at ${digest}; skipping stable copy" "$tmp/out"
   [ "$(grep -c '^inspect --raw ' "$tmp/skopeo.log")" -eq 2 ]
-  ! grep -q '^copy ' "$tmp/skopeo.log"
+  if grep -q '^copy ' "$tmp/skopeo.log"; then echo "FAIL: no image must have been copied"; false; fi
   rm -rf "$tmp"
 }
 
@@ -329,7 +329,7 @@ EOF
   [ "$rc" -ne 0 ]
   grep -q "already exists at '${published_digest}'; refusing to move it to '${rc_digest}'" "$tmp/err"
   # The refusal must happen BEFORE any write.
-  ! grep -q '^copy ' "$tmp/skopeo.log"
+  if grep -q '^copy ' "$tmp/skopeo.log"; then echo "FAIL: no image must have been copied"; false; fi
   [ "$(grep -c '^inspect --raw ' "$tmp/skopeo.log")" -eq 1 ]
   rm -rf "$tmp"
 }
@@ -355,10 +355,10 @@ EOF
   # an overwrite of a published stable tag.
   [ "$rc" -ne 0 ]
   grep -q 'returned no manifest bytes' "$tmp/err"
-  ! grep -q '^copy ' "$tmp/skopeo.log"
+  if grep -q '^copy ' "$tmp/skopeo.log"; then echo "FAIL: no image must have been copied"; false; fi
   [ "$(grep -c '^inspect --raw ' "$tmp/skopeo.log")" -eq 1 ]
   # The empty-input hash must never appear: that is the guard being absent.
-  ! grep -q 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' "$tmp/err"
+  if grep -q 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' "$tmp/err"; then echo "FAIL: the empty-manifest digest must not reach the diagnostic"; false; fi
   rm -rf "$tmp"
 }
 
@@ -384,6 +384,6 @@ EOF
   [ "$rc" -ne 0 ]
   grep -q 'cannot be treated as unpublished' "$tmp/err"
   grep -q '429' "$tmp/err"
-  ! grep -q '^copy ' "$tmp/skopeo.log"
+  if grep -q '^copy ' "$tmp/skopeo.log"; then echo "FAIL: no image must have been copied"; false; fi
   rm -rf "$tmp"
 }

--- a/hack/release-changelog-contract.bats
+++ b/hack/release-changelog-contract.bats
@@ -400,33 +400,33 @@ code_lines() { grep -vE '^[[:space:]]*#'; }
   trap "rm -rf '$tmp'" EXIT
 
   printf '   \n\n  \n' > "$tmp/whitespace.md"
-  ! "$REPO_ROOT/hack/validate-changelog.sh" "$tmp/whitespace.md" 1.6.0 >/dev/null 2>&1 || {
+  if "$REPO_ROOT/hack/validate-changelog.sh" "$tmp/whitespace.md" 1.6.0 >/dev/null 2>&1; then
     echo "Validator accepted a whitespace-only file — it would publish as blank release notes." >&2
     exit 1
-  }
+  fi
 
   : > "$tmp/empty.md"
-  ! "$REPO_ROOT/hack/validate-changelog.sh" "$tmp/empty.md" 1.6.0 >/dev/null 2>&1 || {
-    echo "Validator accepted an empty file." >&2; exit 1; }
+  if "$REPO_ROOT/hack/validate-changelog.sh" "$tmp/empty.md" 1.6.0 >/dev/null 2>&1; then
+    echo "Validator accepted an empty file." >&2; exit 1; fi
 
-  ! "$REPO_ROOT/hack/validate-changelog.sh" "$tmp/absent.md" 1.6.0 >/dev/null 2>&1 || {
-    echo "Validator accepted a nonexistent file." >&2; exit 1; }
+  if "$REPO_ROOT/hack/validate-changelog.sh" "$tmp/absent.md" 1.6.0 >/dev/null 2>&1; then
+    echo "Validator accepted a nonexistent file." >&2; exit 1; fi
 
   # Truncated mid-stream: head intact, tail (the compare link) lost. This is the
   # realistic AI failure — a timeout or quota cutoff partway through the write.
   head -8 "$REPO_ROOT/docs/changelogs/v1.5.1.md" > "$tmp/truncated.md"
-  ! "$REPO_ROOT/hack/validate-changelog.sh" "$tmp/truncated.md" 1.5.1 >/dev/null 2>&1 || {
+  if "$REPO_ROOT/hack/validate-changelog.sh" "$tmp/truncated.md" 1.5.1 >/dev/null 2>&1; then
     echo "Validator accepted a truncated changelog — a fragment would be published" >&2
     echo "verbatim as the release body." >&2
     exit 1
-  }
+  fi
 
   # Right shape, wrong version: a stale file left by a previous promotion, or a
   # changelog generated against the rc tag instead of the stable one.
-  ! "$REPO_ROOT/hack/validate-changelog.sh" "$REPO_ROOT/docs/changelogs/v1.5.1.md" 1.6.0 >/dev/null 2>&1 || {
+  if "$REPO_ROOT/hack/validate-changelog.sh" "$REPO_ROOT/docs/changelogs/v1.5.1.md" 1.6.0 >/dev/null 2>&1; then
     echo "Validator accepted v1.5.1's changelog as v1.6.0's release body." >&2
     exit 1
-  }
+  fi
 }
 
 # 12. The workflow must actually call the script. Keeping the predicates in a

--- a/hack/seaweedfs-guard-parity.bats
+++ b/hack/seaweedfs-guard-parity.bats
@@ -37,6 +37,64 @@ detection_block() {
   sed -n '/\$renamedVol := include/,/\$systemGen := or/p' "$1"
 }
 
+# template_code <file> -- the file with its {{/* ... */}} spans removed.
+#
+# A discriminator is forbidden as template LOGIC, and both charts carry long
+# comment blocks arguing why these particular signals were rejected. Grepping the
+# raw file cannot tell the argument from the thing argued against, so it reports
+# a chart for documenting the rule it obeys.
+#
+# The span and not the line. Dropping every line that opens a comment is one
+# character shorter and silently loses `{{- $x := .creationTimestamp }} {{/* why
+# */}}`: the discriminator leaves with the comment, the checks below find
+# nothing, and the balance count stays even because that line opens and closes.
+# Neither the balance nor the canary sees it -- the only symptom is a chart that
+# classifies on a forbidden signal and a test that says it does not.
+template_code() {
+  awk '
+    {
+      line = $0; out = ""
+      while (1) {
+        if (!inc) {
+          if (match(line, /\{\{-? *\/\*/)) {
+            out = out substr(line, 1, RSTART - 1)
+            line = substr(line, RSTART + RLENGTH); inc = 1
+          } else { out = out line; break }
+        } else {
+          if (match(line, /\*\/ *-?\}\}/)) { line = substr(line, RSTART + RLENGTH); inc = 0 }
+          else break
+        }
+      }
+      if (out ~ /[^[:space:]]/) print out
+    }
+  ' "$1"
+}
+
+@test "the comment strip removes the span, not the line that opens it" {
+  # Pins the difference between the two spellings, because on today's charts
+  # they agree: no line carries both a discriminator and a comment opener, so
+  # the weaker version passes every check below. It is the shape that would go
+  # wrong silently -- a chart classifying on a forbidden signal and this suite
+  # reporting that it does not -- so it gets a fixture rather than trust.
+  tmp="$(mktemp)"
+  printf '%s\n' \
+    '{{- $renamedVol := include "x" . }}' \
+    '{{- $bad := .metadata.creationTimestamp }} {{/* why this is fine */}}' \
+    '{{- /* a whole-line block' \
+    '   mentioning readyReplicas */}}' > "$tmp"
+
+  code="$(template_code "$tmp")"
+  # A comment-only block still goes.
+  if printf '%s\n' "$code" | grep -q 'readyReplicas'; then
+    echo "FAIL: a comment-only block survived the strip"
+    false
+  fi
+  # The code sharing a line with an opener does not.
+  printf '%s\n' "$code" | grep -q 'creationTimestamp'
+  printf '%s\n' "$code" | grep -q 'renamedVol'
+  rm -f "$tmp"
+}
+
 @test "both charts detect naming generations with byte-identical logic" {
   a=$(mktemp); b=$(mktemp)
   detection_block "$SYS"   > "$a"
@@ -104,10 +162,38 @@ detection_block() {
   # readyReplicas is likewise only a snapshot, not proof a duplicate never
   # served. Neither may come back as a discriminator.
   for f in "$SYS" "$EXTRA"; do
-    ! grep -qF -- 'creationTimestamp' "$f"
-    ! grep -qF -- 'readyReplicas' "$f"
-    ! grep -qF -- '$systemOldest' "$f"
-    ! grep -qF -- '$legacyOldest' "$f"
+    # The strip trusts every `{{/*` to be an opener. One inside a quoted string
+    # -- these charts carry long `fail (printf ...)` messages -- would swallow
+    # the rest of the file and leave the checks below reading nothing. Balance
+    # is the precondition, so assert it rather than the output: a canary token
+    # can only prove that whatever precedes IT survived, and the block most
+    # likely to do the swallowing is the last one in the file.
+    # `grep -o | wc -l` and not `grep -c`: grep -c counts matching LINES, so a
+    # line carrying two openers and one closer reads as balanced while the
+    # strip is left mid-comment, swallowing the rest of the file. Counting
+    # occurrences is what the comparison below actually means. Unreachable in
+    # either chart today -- no line holds more than one delimiter -- so nothing
+    # here pins it; it is a correction to what the count means, not a fix for
+    # an observed failure.
+    #
+    # No `|| true` is needed. `wc -l` closes the pipeline and always exits 0,
+    # so a chart with no comment blocks at all reports 0 = 0 and reaches the
+    # comparison rather than dying on the assignment. `grep`'s own exit 1 would
+    # only reach the status under `pipefail`, which neither runner sets.
+    opens=$(grep -o '{{-\? *\/\*' "$f" | wc -l)
+    closes=$(grep -o '\*\/ *-\?}}' "$f" | wc -l)
+    if [ "$opens" -ne "$closes" ]; then
+      echo "FAIL: $f has $opens comment openers and $closes closers, so the strip below cannot be trusted"
+      false
+    fi
+    code=$(template_code "$f")
+    printf '%s\n' "$code" | grep -qF -- '$renamedVol'
+    for signal in 'creationTimestamp' 'readyReplicas' '$systemOldest' '$legacyOldest'; do
+      if printf '%s\n' "$code" | grep -qF -- "$signal"; then
+        echo "FAIL: $f classifies on $signal, which cannot establish which generation holds the data"
+        false
+      fi
+    done
   done
 }
 

--- a/hack/seaweedfs-guard-parity.bats
+++ b/hack/seaweedfs-guard-parity.bats
@@ -37,6 +37,118 @@ detection_block() {
   sed -n '/\$renamedVol := include/,/\$systemGen := or/p' "$1"
 }
 
+# template_code <file> -- the file with its {{/* ... */}} spans removed.
+#
+# A discriminator is forbidden as template LOGIC, and both charts carry long
+# comment blocks arguing why these particular signals were rejected. Grepping the
+# raw file cannot tell the argument from the thing argued against, so it reports
+# a chart for documenting the rule it obeys.
+#
+# The span and not the line. Dropping every line that opens a comment is one
+# character shorter and silently loses `{{- $x := .creationTimestamp }} {{/* why
+# */}}`: the discriminator leaves with the comment and the checks below find
+# nothing. Nothing downstream sees it either -- that line both opens and closes,
+# so the strip finishes cleanly and every canary token survives. The only
+# symptom is a chart that classifies on a forbidden signal and a test that says
+# it does not.
+#
+# A file that ends inside a comment is reported on stdout, not through an exit
+# status. Every `{{/*` is read as an opener, including one inside a quoted
+# string -- these charts carry long `fail (printf ...)` messages -- and a lone
+# opener swallows the rest of the file, leaving the checks reading nothing.
+# hack/cozytest.sh rewrites every `}` at column 0 into `return 0; }`, which is
+# this function's closing brace too, so its exit status never reaches the
+# caller: a status the runner discards is a check that is not there.
+#
+# Counting delimiters cannot stand in for the state the strip already carries.
+# Go template comments do not nest -- the first `*/}}` closes the block -- so
+# `{{/* the opener is spelled {{/* */}}` is a comment Helm renders, while its
+# two openers against one closer read as an imbalance that is not one.
+template_code() {
+  awk '
+    {
+      line = $0; out = ""
+      while (1) {
+        if (!inc) {
+          if (match(line, /\{\{-? *\/\*/)) {
+            out = out substr(line, 1, RSTART - 1)
+            line = substr(line, RSTART + RLENGTH); inc = 1
+          } else { out = out line; break }
+        } else {
+          if (match(line, /\*\/ *-?\}\}/)) { line = substr(line, RSTART + RLENGTH); inc = 0 }
+          else break
+        }
+      }
+      if (out ~ /[^[:space:]]/) print out
+    }
+    END { if (inc) print "__TEMPLATE_COMMENT_LEFT_OPEN__" }
+  ' "$1"
+}
+
+@test "the comment strip removes the span, not the line that opens it" {
+  # Pins the difference between the two spellings, because on today's charts
+  # they agree: no line carries both a discriminator and a comment opener, so
+  # the weaker version passes every check below. It is the shape that would go
+  # wrong silently -- a chart classifying on a forbidden signal and this suite
+  # reporting that it does not -- so it gets a fixture rather than trust.
+  tmp="$(mktemp)"
+  printf '%s\n' \
+    '{{- $renamedVol := include "x" . }}' \
+    '{{- $bad := .metadata.creationTimestamp }} {{/* why this is fine */}}' \
+    '{{- /* a whole-line block' \
+    '   mentioning readyReplicas */}}' > "$tmp"
+
+  code="$(template_code "$tmp")"
+  # A comment-only block still goes.
+  if printf '%s\n' "$code" | grep -q 'readyReplicas'; then
+    echo "FAIL: a comment-only block survived the strip"
+    false
+  fi
+  # The code sharing a line with an opener does not.
+  printf '%s\n' "$code" | grep -q 'creationTimestamp'
+  printf '%s\n' "$code" | grep -q 'renamedVol'
+  rm -f "$tmp"
+}
+
+@test "the comment strip reads a quoted opener as text and reports one left open" {
+  # Go template comments do not nest -- the first `*/}}` closes the block -- so
+  # a comment documenting the opener syntax is one Helm renders. The strip is
+  # already inside a comment when the second opener arrives, so it reads that
+  # opener as comment text; counting delimiters reads the same line as two
+  # openers against one closer and refuses a chart that is fine.
+  tmp="$(mktemp)"
+  printf '%s\n' \
+    '{{- $renamedVol := include "x" . }}' \
+    '{{/* the opener is spelled {{/* and mentions readyReplicas */}}' > "$tmp"
+  code="$(template_code "$tmp")"
+  printf '%s\n' "$code" | grep -q 'renamedVol'
+  if printf '%s\n' "$code" | grep -q 'readyReplicas'; then
+    echo "FAIL: the comment quoting an opener survived the strip"
+    false
+  fi
+  if printf '%s\n' "$code" | grep -qF -- '__TEMPLATE_COMMENT_LEFT_OPEN__'; then
+    echo "FAIL: a comment that closes was reported as left open"
+    false
+  fi
+
+  # An opener with no closer leaves the strip mid-comment at EOF -- the shape
+  # that silently swallows every check below it -- and that is what the marker
+  # is for.
+  printf '%s\n' \
+    '{{- $renamedVol := include "x" . }}' \
+    '{{- fail (printf "the opener is spelled {{/* in the docs") }}' \
+    '{{- $bad := .metadata.creationTimestamp }}' > "$tmp"
+  code="$(template_code "$tmp")"
+  printf '%s\n' "$code" | grep -qF -- '__TEMPLATE_COMMENT_LEFT_OPEN__'
+  # The swallowing is real, not just announced: the line after the lone opener
+  # is gone from the output.
+  if printf '%s\n' "$code" | grep -q 'creationTimestamp'; then
+    echo "FAIL: the fixture does not reproduce the swallow it claims to pin"
+    false
+  fi
+  rm -f "$tmp"
+}
+
 @test "both charts detect naming generations with byte-identical logic" {
   a=$(mktemp); b=$(mktemp)
   detection_block "$SYS"   > "$a"
@@ -104,10 +216,25 @@ detection_block() {
   # readyReplicas is likewise only a snapshot, not proof a duplicate never
   # served. Neither may come back as a discriminator.
   for f in "$SYS" "$EXTRA"; do
-    ! grep -qF -- 'creationTimestamp' "$f"
-    ! grep -qF -- 'readyReplicas' "$f"
-    ! grep -qF -- '$systemOldest' "$f"
-    ! grep -qF -- '$legacyOldest' "$f"
+    # Whether the strip finished is the precondition for reading what it
+    # returned. A lone `{{/*` -- one inside a quoted string, and these charts
+    # carry long `fail (printf ...)` messages -- swallows the rest of the file,
+    # and the checks below would then find nothing and report a clean chart.
+    # It has to be asked here rather than covered by a canary token: a token
+    # only proves that whatever precedes IT survived, and the block most likely
+    # to do the swallowing is the last one in the file.
+    code=$(template_code "$f")
+    if printf '%s\n' "$code" | grep -qF -- '__TEMPLATE_COMMENT_LEFT_OPEN__'; then
+      echo "FAIL: $f ends inside a template comment, so the strip cannot be trusted"
+      false
+    fi
+    printf '%s\n' "$code" | grep -qF -- '$renamedVol'
+    for signal in 'creationTimestamp' 'readyReplicas' '$systemOldest' '$legacyOldest'; do
+      if printf '%s\n' "$code" | grep -qF -- "$signal"; then
+        echo "FAIL: $f classifies on $signal, which cannot establish which generation holds the data"
+        false
+      fi
+    done
   done
 }
 

--- a/hack/select-e2e_test.bats
+++ b/hack/select-e2e_test.bats
@@ -203,7 +203,10 @@ assert_full_suite() {
     echo "$output" | grep -q "kubernetes-latest"
     echo "$output" | grep -q "kubernetes-previous"
     # OIDC System -> CustomConfig lifecycle coverage is folded into latest.
-    ! echo "$output" | grep -q "kubernetes-oidc-"
+    if echo "$output" | grep -q "kubernetes-oidc-"; then
+        echo "FAIL: no kubernetes-oidc- suite must be selected"
+        false
+    fi
 }
 
 @test "dashboards-only diff selects nothing (path is plural)" {


### PR DESCRIPTION
## What this PR does

Seventy-seven assertions across seven BATS suites begin with `!`. Seventy-two of them pass no matter what they find. POSIX exempts a command whose return value is inverted with `!` from `set -e`, so the failing status is dropped where it is produced, and `hack/cozytest.sh` closes each test function with `return 0`, so it never resurfaces as the test's own status either. The other five are followed by `|| { ... exit 1; }`, which reads the inverted status and does work; they are rewritten too, because telling the two apart needs the tail of every statement parsed, and a guard that guesses wrong there is green on a real one.

Switching to the `bats` binary does not rescue the seventy-two, which is the part worth knowing before reviewing this. Its ERR trap carries the identical exemption: `bash -c 'set -eE; trap "echo TRAP" ERR; ! true; echo REACHED'` prints `REACHED`, runs no trap and exits zero. The only negated assertion `bats` reports is one standing last in the test body, where the inverted status happens to be what the function returns. One of the seventy-two stood last; seventy-one did not.

What was lost is specific rather than diffuse. `!` is how you spell "this must not appear", and an absence is what no other assertion in a test covers. The affected suites assert that a migration ran nothing destructive, that no image was copied, that a flag was not passed, that an object does not exist. On that half of their contract they held for any input.

Each site is now written as `if cmd; then echo "FAIL: ..."; false; fi`, the form already used in the files where this had been noticed one at a time, and each carries a message naming what must not have happened. `hack/bats-no-negated-assert.bats` scans every `hack/**/*.bats` and refuses the old form, so a new one cannot be added silently. Inverted conditions (`if !`, `while !`, `until !`) are untouched, because `set -e` is not what decides a condition. `[ ! -f x ]` is untouched for a different reason and remains an ordinary failing assertion: the `!` there is an operator of `test`, not negation of a command, so nothing exempts its status.

The guard pins its own premise instead of describing it, on both sides. One test asserts the runner still passes a bare negated assertion; a second, that neither `set -e` nor the ERR trap sees an inverted status; a third, that the prescribed `if cmd; then ...; false; fi` does fail, under both runners, and *at* the form rather than somewhere before it, since a run that died early would satisfy a bare status check and pin nothing.

The third is the one every rewrite here rests on, and its failure mode is the reason it exists rather than being left implied. Were `false` inside a `then` body ever to stop propagating, the first test would still pass, because a negated assertion would still be vacuous, while all seventy-seven converted absences went silently green. A ban that prescribes a replacement owes an observer on the replacement, or it is the defect it removes, one level up.

Every claim the guard makes is pinned by removing the thing it claims, because on this file reading was repeatedly not enough. The recursion is exercised *through* the audit function against a fixture in a subdirectory, not through a second copy of its `find` expression: a copy keeps passing while the function loses its recursion, and an audit that returns empty reads as a clean tree. `hack/e2e-apps/` is what makes recursion matter, since `BATS_UNIT_FILES` is a non-recursive `wildcard` and that directory is the one place `make unit-tests` never reaches. It is not what the test pins against, though, because it is emptying as suites move to Chainsaw and would eventually fail the test for a reason unrelated to recursion.

The rule's surface was checked in the other direction too. The same shape appears nowhere in `hack/**/*.sh` (including the libraries bats files source) or in the Chainsaw `script:` steps, so `.bats` is the whole surface rather than the part that was convenient to guard. Both zeros were taken twice, line-by-line and with continuations folded, because a line-oriented search cannot see a statement split across a continuation. The first attempt at the folded pass disagreed until its `if`-context filter was restored, which is why the answer is stated as measured twice rather than as measured.

The scan is lexical, so its header names the statement boundaries it owns rather than implying it understands shell: `;` `&` `&&` `||` `{` `(`, the `)` closing a case pattern, and the words `then` `do` `else`, each measured against the runner before being added. A keyword may legally be preceded only by whitespace or by `;`, since every other separator in front of `then`, `do` or `else` is a shell syntax error, checked with `sh -n` rather than recalled. The scan therefore admits exactly those two, and that part of the class is closed rather than patched one spelling at a time. All three keywords are vacuous after either spelling, so missing one is a silent miss, the single direction this scan must not err in, given that its whole design trades noise for safety.

Four over-counts remain and are deliberate, each named in the header: `( ! cmd )` does propagate its inverted status and is reported anyway; so would a `!` opening a statement after a redirection `&`; `x=$(true || ! false)` is reported although the `||` reads the inverted status; and a condition continued by a trailing `&&` instead of a backslash is reported, because the strip only recognises a condition whose end it can see. Each costs one rewritten line, where the opposite error costs a silent pass. They are enumerated rather than engineered away on purpose, because a removed error leaves no trace while a listed one tells the next reader what they are looking at. For the same reason, the one place the scan errs *quiet* is named too: a file cut off midway through a line continuation loses its last buffered statement. That input is not a runnable test, since `sh -n` rejects it with `unexpected end of file`, so nothing executable can hide there. The header still claims the scan errs loud or not at all, and this is the exception to that claim rather than to its coverage. The test naming the shapes claims only what its fixture holds. A lexical scan over shell cannot promise it has enumerated the language, and a name that promised it would be false whether or not a gap existed today.

The branch name is narrower than the subject and I am leaving it as it is rather than churn it. This is not a defect in `hack/cozytest.sh` that moving to the `bats` binary would fix. It is a POSIX rule both runners inherit, and moving to `bats` would close one of the seventy-two sites.

One suite went red for real once its assertions could fail. `seaweedfs-guard-parity` forbids four mutable discriminators by grepping each chart, and both charts carry a template comment block arguing why those signals were rejected, so the grep matched the argument and would have reported a chart for documenting the rule it follows. The charts are correct; the assertion was not. It now strips `{{/* ... */}}` before matching. Two details there are load-bearing and neither is obvious. The strip removes the comment *span*, not the line that opens it: dropping the line is shorter and silently loses a discriminator sharing a line with a comment, which is a chart classifying on a forbidden signal and a test reporting that it does not. And the delimiters are checked to balance first, because every `{{/*` is read as an opener, so one inside a quoted string (these charts carry long `fail (printf ...)` messages) would swallow the rest of the file and leave the checks reading nothing.

A last commit widens six comments that explained this trap as applying to a "negated pipeline". It is not about pipelines, and the narrower wording invites the conclusion that the other shapes are safe. Comment text only; each of those files already uses the working form.

### Verification

`make bats-unit-tests` passes 556 tests and then stops at `migration-seaweedfs-db-adopt`, so the suites ordered after it were run in a second pass: 387 more, 943 green in total, measured in a worktree separate from the one being edited.

Three suites are red on this macOS host and each one reproduces at the merge base, so none is this branch's. `migration-seaweedfs-db-adopt`: its container cannot write into the bind-mounted temp directory. `seaweedfs-naming-audit`: fails the same test with the same counts at the merge base. `release-changelog-behaviour`: gated on `command -v act` and `docker info`, it skipped silently while this host had no Docker running, and began failing once Docker came up, on an `act` incompatibility with the Colima socket path. That last red is a property of the host having Docker at all, which is worth knowing before reading a local run as a regression.

Each suite whose assertions changed and that runs on this host was measured before the edit and matches that baseline now. The six suites that received only a reworded comment were run after the change and not before, which is the weaker claim and the true one, since nothing executable in them was touched.

`migration-seaweedfs-db-adopt` was then run on Linux, where it passes 15 of 15. Its nine rewritten sites also carry a two-sided check, because a suite that goes green proves nothing on its own: with the pattern swapped for one the same test proves is present, the rewritten form fails the suite and the original `!` form passes it. Same file, same test, same pattern, same runner, only the spelling differs.

Two sites are still unverified and I would rather say so than imply otherwise: both are in `e2e-apps/monitoring-oidc-customconfig`, which needs a live cluster. It will not get one soon either, because the directory holding it is wired into no workflow, no `Makefile` target and no suite selector, a leftover of the move to Chainsaw that is filed as #3786. Those two assertions were vacuous before this change and are real now, so whichever way that issue is resolved, they stop lying in the meantime.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map against the diff file by file. The change touches seven BATS suites, adds one, and adds a convention to `docs/agents/e2e-testing.md`. It does not touch `hack/e2e-prepare-cluster.bats`, which is the node contract `ansible-cozystack` and `talm` restate; it moves and renames nothing under `hack/` and changes no make target's behaviour, which is what `ccp` gates on; and it touches no package, schema, enum, default, CRD, label, annotation or metric.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance prohibiting negated Bats assertions that can mask test failures.
  * Documented the required explicit conditional failure pattern and updated the reviewer checklist.

* **Tests**
  * Added automated checks to detect unsafe negated assertions in end-to-end tests.
  * Updated existing tests with clearer failure messages and more reliable conditional checks.
  * Expanded Helm template comment handling coverage in SeaweedFS guard tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->