### PR TITLE
fix(telemetry): make the documented opt-out cover both collectors

### DIFF
--- a/packages/core/installer/values.yaml
+++ b/packages/core/installer/values.yaml
@@ -14,6 +14,13 @@ cozystackOperator:
   # to the value baked at build time. The Makefile sets this for the
   # kubectl-apply release artifacts (_out/assets/cozystack-operator-*.yaml).
   platformVersion: ""
+  # Stop the operator sending cluster telemetry (nodes, storage, packages) to
+  # https://telemetry.cozystack.io. This covers the OPERATOR only. The second
+  # collector, cozystack-controller, reports application counts and is
+  # configured through the platform Package — set telemetry.disabled there as
+  # well, or the opt-out is partial. Declared here rather than left implicit
+  # because the documented opt-out is a `--set` against this key.
+  disableTelemetry: false
   image: ghcr.io/cozystack/cozystack/cozystack-operator:v1.6.0@sha256:93b305f78823b070c59ca631b213e39bd9d8a256d5c520f156a03f5f72f57a5d
   platformSourceUrl: 'oci://ghcr.io/cozystack/cozystack/cozystack-packages'
   platformSourceRef: 'digest=sha256:bf68208730860fa8e47f378a0260e79a0262e0783fa63ba4f7f97f57a48b2d23'

--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -151,6 +151,18 @@
 {{- $apiValues := dict "cozystackAPI" (dict "nodeSelector" $genericNodeSelector) -}}
 {{- $_ := set $cozystackEngineComponents "cozystack-api" (dict "values" $apiValues) -}}
 {{- end -}}
+{{- /* Telemetry is collected by TWO components: cozystack-operator (cluster
+       facts) and cozystack-controller (application counts). The operator is
+       switched off at install time via cozystackOperator.disableTelemetry on
+       the cozy-installer chart, which cannot reach a package deployed by the
+       platform. Threading it here gives the controller half of the opt-out a
+       platform-level key, so `telemetry.disabled: true` plus the installer
+       flag silences both. Without this, an operator who followed the
+       documented opt-out kept sending cozy_application_count. */ -}}
+{{- if .Values.telemetry.disabled -}}
+{{- $controllerValues := dict "cozystackController" (dict "disableTelemetry" true) -}}
+{{- $_ := set $cozystackEngineComponents "cozystack-controller" (dict "values" $controllerValues) -}}
+{{- end -}}
 {{- if .Values.authentication.oidc.enabled }}
 {{include "cozystack.platform.package" (list "cozystack.cozystack-engine" "oidc" $ $cozystackEngineComponents) }}
 {{include "cozystack.platform.package.default" (list "cozystack.keycloak" $) }}

--- a/packages/core/platform/tests/bundles_telemetry_optout_test.yaml
+++ b/packages/core/platform/tests/bundles_telemetry_optout_test.yaml
@@ -1,0 +1,85 @@
+suite: telemetry opt-out bundle wiring
+templates:
+  - templates/bundles/system.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  # Telemetry has two senders: cozystack-operator (cluster facts) and
+  # cozystack-controller (application counts). The operator is switched off on
+  # the cozy-installer chart, which cannot reach a package the platform
+  # deploys — so without the wiring asserted here, an operator who followed the
+  # documented opt-out kept sending cozy_application_count indefinitely, with
+  # nothing failing to signal it. The regression is silent by construction,
+  # which is why it is pinned.
+  - it: threads disableTelemetry into cozystack-controller when telemetry.disabled is set (isp-full)
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+      telemetry:
+        disabled: true
+    documentSelector:
+      path: metadata.name
+      value: cozystack.cozystack-engine
+    asserts:
+      - equal:
+          path: spec.components.cozystack-controller.values.cozystackController.disableTelemetry
+          value: true
+
+  - it: leaves the controller untouched by default, so telemetry stays opt-out (isp-full)
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+    documentSelector:
+      path: metadata.name
+      value: cozystack.cozystack-engine
+    asserts:
+      - notExists:
+          path: spec.components
+
+  - it: threads the flag on the oidc variant too (isp-full)
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+      authentication:
+        oidc:
+          enabled: true
+      telemetry:
+        disabled: true
+    documentSelector:
+      path: metadata.name
+      value: cozystack.cozystack-engine
+    asserts:
+      - equal:
+          path: spec.variant
+          value: oidc
+      - equal:
+          path: spec.components.cozystack-controller.values.cozystackController.disableTelemetry
+          value: true
+
+  # isp-full-generic already carries a cozystack-api override. The telemetry
+  # key must be added beside it, not replace it.
+  - it: coexists with the generic variant's cozystack-api nodeSelector override
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full-generic
+      telemetry:
+        disabled: true
+    documentSelector:
+      path: metadata.name
+      value: cozystack.cozystack-engine
+    asserts:
+      - equal:
+          path: spec.components.cozystack-controller.values.cozystackController.disableTelemetry
+          value: true
+      - equal:
+          path: spec.components.cozystack-api.values.cozystackAPI.nodeSelector["node-role.kubernetes.io/control-plane"]
+          value: "true"

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -420,6 +420,19 @@ publishing:
         tsigAlgorithm: HMACSHA256
         secretName: ""
         secretKey: tsig-secret-key
+# Telemetry reported by platform components.
+#
+# Two components report: cozystack-operator (cluster facts — nodes, storage,
+# packages) and cozystack-controller (application counts). This key covers the
+# CONTROLLER, which the platform deploys. The operator is deployed by the
+# cozy-installer chart and is switched off separately, with
+# cozystackOperator.disableTelemetry=true — a full opt-out needs both, because
+# the two components are installed by two different charts.
+#
+# What is collected, and why, is documented at
+# https://cozystack.io/docs/operations/configuration/telemetry/
+telemetry:
+  disabled: false
 # Authentication configuration
 authentication:
   oidc:


### PR DESCRIPTION
## What this PR does

Telemetry is reported by two components — `cozystack-operator` (cluster facts) and `cozystack-controller` (application counts) — but only the operator had a reachable switch.

The documented opt-out sets `cozystackOperator.disableTelemetry` on the `cozy-installer` chart. That chart deploys the operator; it cannot reach a package the platform deploys. `packages/system/cozystack-controller` has its own independent `disableTelemetry` key that nothing propagated to, so after an operator had followed the published procedure the controller kept posting `cozy_application_count` every 15 minutes. Nothing failed, and nothing indicated the opt-out was partial.

Two changes:

- `packages/core/platform` gains a `telemetry.disabled` key and threads it into the `cozystack-controller` component of the `cozystack.cozystack-engine` Package — the same mechanism the bundle already uses for cilium, multus and linstor values.
- `packages/core/installer/values.yaml` declares `cozystackOperator.disableTelemetry`. It was only ever referenced from the template, so the `--set` target the documentation names did not appear in the chart's own values.

Both keys default to `false`. Nobody who has not opted out sees a behaviour change.

The opt-out remains two steps, because the two collectors are installed by two different charts. Collapsing it into one knob would mean the operator writing the value into the platform Package it does not own, which is a design change rather than a fix.

`helm unittest` on the platform chart: 137 passed (133 before, plus the four added here). `helm lint` clean on both charts.

### Screenshots

Not a UI change.

### Downstream repositories

Trigger map walked against the diff. `packages/core/platform/values.yaml` changed, which the map routes to the website's hand-written platform-package table; the same change also makes the published opt-out procedure wrong, so the docs follow-up covers both.

- [ ] No downstream repository is affected by this change
- [x] [cozystack/website](https://github.com/cozystack/website) - follow-up: https://github.com/cozystack/website/pull/651
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(telemetry): the documented telemetry opt-out now covers both collectors. Setting `cozystackOperator.disableTelemetry=true` alone left `cozystack-controller` reporting application counts; the platform gains a `telemetry.disabled` key that silences it. Both default to false.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a platform telemetry opt-out setting, disabled by default.
  * Added a separate operator telemetry opt-out setting, also disabled by default.
  * Applying the platform setting now disables telemetry reporting for the relevant controller.

* **Bug Fixes**
  * Ensured telemetry settings are correctly applied across supported platform variants while preserving existing configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->