### PR TITLE
fix(linstor): use severity warning instead of warn in piraeus-datastore alerts

### DIFF
--- a/hack/alert-severity-contract.bats
+++ b/hack/alert-severity-contract.bats
@@ -3,20 +3,54 @@
 ALERT_SEVERITY_ALLOWED=" security critical major minor warning indeterminate informational normal ok cleared debug trace unknown "
 
 alert_severity_rows() {
-  cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." || return 1
-  git ls-files 'packages/*/*/alerts/*.yaml' | while IFS= read -r file; do
-    yq "select(.kind == \"PrometheusRule\" or .kind == \"VMRule\") | .spec.groups[]? | .rules[]? | select(has(\"alert\")) | [\"$file\", .alert, ((.labels.severity // \"<missing>\") | tostring)] | @tsv" "$file"
-  done | grep -v '^[[:space:]]*$'
+  severity_root=${ALERT_SEVERITY_ROOT:-"$(dirname "${BATS_TEST_FILENAME:-$0}")/.."}
+  severity_files=$(mktemp) || return 1
+  severity_rows=$(mktemp) || {
+    rm -f "$severity_files"
+    return 1
+  }
+
+  if ! (cd "$severity_root" && git ls-files 'packages/*/*/alerts/*.yaml' > "$severity_files"); then
+    rm -f "$severity_files" "$severity_rows"
+    return 1
+  fi
+
+  if ! : > "$severity_rows"; then
+    rm -f "$severity_files" "$severity_rows"
+    return 1
+  fi
+  while IFS= read -r file; do
+    if ! (cd "$severity_root" && FILE="$file" yq 'select(.kind == "PrometheusRule" or .kind == "VMRule") | .spec.groups[]? | .rules[]? | select(has("alert")) | [strenv(FILE), .alert, ((.labels.severity // "<missing>") | tostring)] | @tsv' "$file") >> "$severity_rows"; then
+      echo "$file: failed to parse alert rules" >&2
+      rm -f "$severity_files" "$severity_rows"
+      return 1
+    fi
+  done < "$severity_files"
+
+  if ! sed '/^[[:space:]]*$/d' "$severity_rows"; then
+    rm -f "$severity_files" "$severity_rows"
+    return 1
+  fi
+  rm -f "$severity_files" "$severity_rows"
 }
 
 @test "alert rules are discovered" {
-  count=$(alert_severity_rows | wc -l | tr -d ' ')
+  rows=$(mktemp) || return 1
+  if ! alert_severity_rows > "$rows"; then
+    rm -f "$rows"
+    return 1
+  fi
+  count=$(wc -l < "$rows" | tr -d ' ')
+  rm -f "$rows"
   [ "$count" -gt 0 ]
 }
 
 @test "every alert rule carries a severity the alert sink accepts" {
-  rows=$(mktemp)
-  alert_severity_rows > "$rows"
+  rows=$(mktemp) || return 1
+  if ! alert_severity_rows > "$rows"; then
+    rm -f "$rows"
+    return 1
+  fi
   bad=0
   tab=$(printf '\t')
   while IFS="$tab" read -r file alert severity; do
@@ -30,4 +64,32 @@ alert_severity_rows() {
   done < "$rows"
   rm -f "$rows"
   [ "$bad" -eq 0 ]
+}
+
+@test "a parser failure cannot leave the contract green" {
+  fixture=$(mktemp -d)
+  mkdir -p "$fixture/packages/system/example/alerts"
+  printf '%s\n' \
+    'apiVersion: operator.victoriametrics.com/v1beta1' \
+    'kind: VMRule' \
+    'spec:' \
+    '  groups:' \
+    '  - name: valid' \
+    '    rules:' \
+    '    - alert: ValidAlert' \
+    '      labels:' \
+    '        severity: warning' \
+    > "$fixture/packages/system/example/alerts/00-valid.yaml"
+  printf '%s\n' \
+    'apiVersion: operator.victoriametrics.com/v1beta1' \
+    'kind: VMRule' \
+    'spec: [' \
+    > "$fixture/packages/system/example/alerts/99-malformed.yaml"
+  git -C "$fixture" init -q
+  git -C "$fixture" add packages/system/example/alerts/00-valid.yaml packages/system/example/alerts/99-malformed.yaml
+
+  parser_succeeded=0
+  ALERT_SEVERITY_ROOT="$fixture" alert_severity_rows >/dev/null 2>&1 || parser_succeeded=$?
+  rm -rf "$fixture"
+  [ "$parser_succeeded" -ne 0 ]
 }

--- a/hack/alert-severity-contract.bats
+++ b/hack/alert-severity-contract.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+ALERT_SEVERITY_ALLOWED=" security critical major minor warning indeterminate informational normal ok cleared debug trace unknown "
+
+alert_severity_rows() {
+  cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." || return 1
+  git ls-files 'packages/*/*/alerts/*.yaml' | while IFS= read -r file; do
+    yq "select(.kind == \"PrometheusRule\" or .kind == \"VMRule\") | .spec.groups[]? | .rules[]? | select(has(\"alert\")) | [\"$file\", .alert, ((.labels.severity // \"<missing>\") | tostring)] | @tsv" "$file"
+  done | grep -v '^[[:space:]]*$'
+}
+
+@test "alert rules are discovered" {
+  count=$(alert_severity_rows | wc -l | tr -d ' ')
+  [ "$count" -gt 0 ]
+}
+
+@test "every alert rule carries a severity the alert sink accepts" {
+  rows=$(mktemp)
+  alert_severity_rows > "$rows"
+  bad=0
+  tab=$(printf '\t')
+  while IFS="$tab" read -r file alert severity; do
+    case "$ALERT_SEVERITY_ALLOWED" in
+      *" $severity "*) ;;
+      *)
+        echo "$file: $alert -> '$severity'" >&2
+        bad=$((bad + 1))
+        ;;
+    esac
+  done < "$rows"
+  rm -f "$rows"
+  [ "$bad" -eq 0 ]
+}

--- a/packages/system/piraeus-operator/alerts/piraeus-datastore.yaml
+++ b/packages/system/piraeus-operator/alerts/piraeus-datastore.yaml
@@ -63,7 +63,7 @@ spec:
               Storage pool "{{ $labels.storage_pool }}" on node "{{ $labels.node }}" ({{ $labels.driver }}={{ $labels.backing_pool }}) has less than 20% free space available.
           expr: ( linstor_storage_pool_capacity_free_bytes / linstor_storage_pool_capacity_total_bytes ) < 0.20
           labels:
-            severity: warn
+            severity: warning
     - name: drbd.rules
       rules:
         - alert: drbdReactorOffline
@@ -79,14 +79,14 @@ spec:
               DRBD Resource "{{ $labels.name }}" on "{{ $labels.node }}" is not connected to "{{ $labels.conn_name }}": {{ $labels.drbd_connection_state }}.
           expr: drbd_connection_state{drbd_connection_state!="Connected"} > 0
           labels:
-            severity: warn
+            severity: warning
         - alert: drbdDeviceNotUpToDate
           annotations:
             description: |
               DRBD device "{{ $labels.name }}" on "{{ $labels.node }}" has unexpected device state "{{ $labels.drbd_device_state }}".
           expr: drbd_device_state{drbd_device_state!~"UpToDate|Diskless"} > 0
           labels:
-            severity: warn
+            severity: warning
         - alert: drbdDeviceUnintentionalDiskless
           annotations:
             description: |
@@ -94,7 +94,7 @@ spec:
               This usually indicates IO errors reported on the backing device. Check the kernel log.
           expr: drbd_device_unintentionaldiskless > 0
           labels:
-            severity: warn
+            severity: warning
         - alert: drbdDeviceWithoutQuorum
           annotations:
             description: |
@@ -102,7 +102,7 @@ spec:
               This usually indicates connectivity issues.
           expr: drbd_device_quorum == 0
           labels:
-            severity: warn
+            severity: warning
         - alert: drbdResourceSuspended
           annotations:
             description: |
@@ -110,7 +110,7 @@ spec:
           for: 1m
           expr: drbd_resource_suspended > 0
           labels:
-            severity: warn
+            severity: warning
         - alert: drbdResourceResyncWithoutProgress
           annotations:
             description: |
@@ -118,7 +118,7 @@ spec:
               This may indicate there is no connection to UpToDate data, or a stuck resync.
           expr: drbd_device_state{drbd_device_state="Inconsistent"} and delta(drbd_peerdevice_outofsync_bytes[5m]) >= 0
           labels:
-            severity: warn
+            severity: warning
         - alert: drbdResourceWithNoUpToDateReplicas
           annotations:
             description: |


### PR DESCRIPTION
## What this PR does

Seven of the piraeus-datastore alert rules label themselves `severity: warn`. Alerta, which the monitoring package ships as the alert sink, validates that value and `warn` is not on its list — every webhook delivery for these alerts dies with a 500:

```
Severity (warn) is not one of security, critical, major, minor, warning,
indeterminate, informational, normal, ok, cleared, debug, trace, unknown
```

Alertmanager retries seven times and drops the notification, and the alert never shows up anywhere. The affected rules are the LINSTOR/DRBD ones — storage pool at capacity, lost quorum, unintentional diskless, stuck resync — exactly the alerts you least want silently dropped.

Found this on a v1.4.6 cluster where `linstorStoragePoolAtCapacity` was genuinely firing: 153 dropped notifications in 40 minutes and nothing in Alerta. Renaming the label to `warning`, which the other three rules in the same file already use, stopped the failures immediately and the alerts came through.

The same labels sit on `main` and in `v1.6.1`, so a backport to `release-1.6` would be appreciated.

The test commits add a bats guard so the next one gets caught in CI: it walks every `PrometheusRule` and `VMRule` under `packages/` outside vendored `charts/`, helm templates included, and fails on a severity outside Alerta's default alarm model, which is exactly where `warn`, `info`, `error` and `fatal` fall. Helm actions are stripped before the file is read, so a rule behind a `{{- if }}` or an unquoted `{{ .Release.Namespace }}` is checked rather than skipped, and a file that still does not parse fails the contract instead of thinning it out. On the current tree that is 194 rules across 41 files.

The guard found one more on `main`: `DatabaseAutoscalerAtMax` in `packages/system/keda/templates/alerts.yaml` carries `severity: info`, which Alerta refuses the same way. It is renamed to `informational`, the value the model has for that level and the one seven other rules in the tree already use.

Fixes #2411.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map against the diff: severity labels inside `packages/system/piraeus-operator/alerts/` and `packages/system/keda/templates/`, plus a bats file under `hack/` — no package added or renamed, no values schema, no CRD, no tooling the satellites gate on, no node contract. Nothing downstream restates these labels.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(linstor): LINSTOR/DRBD alerts carried severity `warn`, which Alerta rejects, so they were never delivered; they now use the standard `warning` severity, and the keda at-max autoscaler alert moves from `info` to `informational` for the same reason
```
