### PR TITLE
fix(e2e): capture both ends of the worker byte path on node-join failure

### DIFF
--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -552,14 +552,23 @@ cozy_prepare_tenant_talos_diagnostics_pod() {
 # Capture one bounded Talos command through the helper Pod and retain the exit
 # status alongside partial output. A timeout or unreachable pre-apid worker is
 # itself useful evidence and must not erase captures from the other worker.
+#
+# The bound is the caller's rather than a constant here because the reads differ
+# in kind: two of them stream (a kernel ring buffer, five hundred lines of
+# service log) and two are single tabular RPCs that a reachable apid answers at
+# once. The whole walk sits inside the collector the diagnostics phase budget is
+# sized against, so a second spent here is a second the collectors gated after
+# it do not get -- and a bound picked for the streams, applied to the tabular
+# reads, buys nothing and costs that.
 cozy_capture_tenant_talos_command() {
   local pod_name="$1"
   local node_ip="$2"
   local output="$3"
-  shift 3
+  local bound="$4"
+  shift 4
   local rc=0
 
-  timeout -k 5 20 kubectl -n tenant-test exec "${pod_name}" -c diagnostics -- \
+  timeout -k 5 "${bound}" kubectl -n tenant-test exec "${pod_name}" -c diagnostics -- \
     /tmp/talosctl --talosconfig /tmp/talosconfig \
     -e "${node_ip}" -n "${node_ip}" "$@" >"${output}" 2>&1 || rc=$?
   printf '\n[capture exit code: %s]\n' "${rc}" >>"${output}"
@@ -570,13 +579,64 @@ cozy_capture_tenant_talos_node() {
   local pod_name="$1"
   local node_ip="$2"
   local output_dir="$3"
+  local answered=0
 
   mkdir -p "${output_dir}"
   printf 'endpoint: %s\nnode: %s\n' "${node_ip}" "${node_ip}" >"${output_dir}/target.txt"
   cozy_capture_tenant_talos_command "${pod_name}" "${node_ip}" \
-    "${output_dir}/dmesg.log" dmesg || true
+    "${output_dir}/dmesg.log" 20 dmesg && answered=$((answered + 1))
   cozy_capture_tenant_talos_command "${pod_name}" "${node_ip}" \
-    "${output_dir}/kubelet.log" logs kubelet --tail=500 || true
+    "${output_dir}/kubelet.log" 20 logs kubelet --tail=500 && answered=$((answered + 1))
+  # The service state machine, which answers what the kubelet log cannot when
+  # there is no kubelet log to read. Talos creates a service's log buffer when
+  # its runner opens the log writer, which the runner does as it starts the
+  # process -- so a kubelet still Waiting on its volumes, on time sync, or on
+  # the container runtime reporting healthy has never reached its runner, has no
+  # buffer, and `logs kubelet` fails with `log "kubelet" was not registered`.
+  # That is a true statement about the log and says nothing about the service,
+  # while the state and the condition being waited on are the finding. One call
+  # covers every service, so the runtime the kubelet is waiting for arrives in
+  # the same file.
+  cozy_capture_tenant_talos_command "${pod_name}" "${node_ip}" \
+    "${output_dir}/services.log" 10 services && answered=$((answered + 1))
+  # Read as yaml because MTU lives in the LinkStatus spec and not among the
+  # resource's print columns, so the default table omits the one field this is
+  # read for: a guest at 1500 over an encapsulated fabric drops the large
+  # segments and passes the small ones, which is the signature a stalled
+  # transfer beside a healthy probe presents.
+  cozy_capture_tenant_talos_command "${pod_name}" "${node_ip}" \
+    "${output_dir}/links.yaml.log" 10 get links -o yaml && answered=$((answered + 1))
+  # Stated for the worker rather than per read, because per read it is already
+  # stated and still invisible: with apid refusing the connection each log holds
+  # its own rpc error and an exit code, accurate one file at a time and adding
+  # up to a directory that looks like a worker with little to report. Written
+  # only when nothing completed, so a worker that answered one read of the four
+  # is not written up as unreachable.
+  #
+  # `answered` counts reads that COMPLETED, and the wording below is bounded by
+  # that rather than claiming more. A read killed at its bound has already
+  # written what it managed to read, so the directory can hold real evidence
+  # while nothing in it exited zero -- which is the slow-apid worker, the shape
+  # this capture is most often reached on. A marker saying nothing was observed
+  # would be the collector making exactly the unsupported claim the arms above
+  # exist to prevent, one directory up.
+  if [ "${answered}" -eq 0 ]; then
+    # `|| true` on the write, not only `return 0` below: under a live errexit a
+    # failing redirect aborts AT the redirect, so a trailing return never runs
+    # and cannot be what carries the guarantee. A full scratch directory on the
+    # runner is how this fails.
+    printf '%s\n' \
+      'no Talos read completed for this worker: all four failed or were cut short, so this directory holds no whole capture -- what is here is whatever arrived before a read was killed, or the error a read returned, and each log carries its own reason and exit code' \
+      >"${output_dir}/CAPTURE-FAILED.txt" || true
+  fi
+  # Defensive rather than load-bearing today, and worth saying which: the one
+  # call site reaches this through `cozy_capture_tenant_talos ... || true`, and
+  # that suppression covers the whole subshell and everything it calls, so no
+  # status returned from here can end the worker walk. What this pair buys is
+  # that the guarantee survives a caller that drops the `|| true` -- the walk
+  # continues to the next worker because nothing in here fails, rather than
+  # because of how the call happens to be written.
+  return 0
 }
 
 # Name the console experiment's own failure before the noise starts. Enabling
@@ -900,6 +960,391 @@ cozy_capture_tenant_serial_console() {
   fi
 }
 
+# One bounded read of a node's cAdvisor stream, shared by every worker counter
+# capture and deliberately subject-agnostic: it fetches and reports a status,
+# and says nothing about which series the caller is after. The reasoning about
+# what each capture reads, and why from the kubelet rather than from inside the
+# container, belongs to the captures and is written above each of them.
+_cozy_cadvisor_node_stream() {
+  local node="$1"
+  local stream="$2"
+  local node_err="$3"
+  local rc=0
+
+  # One read per capture, so a node's stream is fetched once per subject rather
+  # than once in total. That is a real cost -- bounded by the read bound and the
+  # node cap at up to 100s, a ceiling those numbers impose rather than a measured
+  # duration -- and it is declined for a reason that outlives any particular way
+  # of sharing the read.
+  #
+  # Sharing it means the two captures becoming one walk, and that is not done
+  # here for scope rather than for merit: one walk behind the first of the two
+  # gates would be cheaper AND collect more. The gate is a deadline checked with
+  # date, not a per-collector allowance, so the pair yields both, the first
+  # alone, or neither -- and a merged walk admitted at the first gate turns the
+  # first-alone case into both while leaving neither unchanged. Anyone weighing
+  # this should read that as an argument for merging, not against it.
+  #
+  # A cross-phase cache avoids the merge and was tried; it is not what stands
+  # here, and the reason is not the cost above but that a cache publishes a
+  # local write failure as a statement about the cluster -- the one thing this
+  # collector may not do.
+  #
+  # The timeout-absent fallback is the sibling collectors': bounding with a
+  # binary that is not there turns every read into an exit 127 and every note
+  # into "the kubelet refused".
+  if command -v timeout >/dev/null 2>&1; then
+    timeout -k "${COZY_DIAG_READ_GRACE}" "${COZY_DIAG_READ_TIMEOUT}" \
+      kubectl get --raw "/api/v1/nodes/${node}/proxy/metrics/cadvisor" \
+      "--request-timeout=${COZY_DIAG_READ_TIMEOUT}s" \
+      >"${stream}" 2>"${node_err}" || rc=$?
+  else
+    kubectl get --raw "/api/v1/nodes/${node}/proxy/metrics/cadvisor" \
+      "--request-timeout=${COZY_DIAG_READ_TIMEOUT}s" \
+      >"${stream}" 2>"${node_err}" || rc=$?
+  fi
+  printf '%s\n' "${rc}"
+}
+
+# _cozy_capture_worker_cadvisor <subdir> <label> <subject> <series> <tmp-prefix> <tail-hook> <metric-re>
+#
+# The body both worker counter captures share. It was two near-identical copies
+# differing in a report subdirectory, a regex, a subject phrase and a trailing
+# note, and the copies cost more than duplication normally does: the block-level
+# bound audit pins each collector by something only it produces, and two
+# collectors issuing identical reads left neither with anything of its own, so
+# stubbing one out of the audit went unnoticed. One body removes that. It does
+# not remove the second fetch -- each capture still reads the node itself, at
+# the price the budget comment states -- and why that saving is declined is
+# given where the read is.
+#
+# <subject> is the clause every "unknown" note opens with, and <series> the word
+# naming what the kubelet did or did not report. Splitting them is what keeps
+# each note a sentence about this collector's question rather than a generic one
+# -- a note that says only "no series" leaves the reader to guess which.
+_cozy_capture_worker_cadvisor() {
+  local subdir="$1"
+  local label="$2"
+  local subject="$3"
+  local series="$4"
+  local tmp_prefix="$5"
+  local tail_hook="$6"
+  local metric_re="$7"
+  # The label reads "<noun> capture" at both call sites, and three sentences
+  # want the two halves differently: "failed to list ... for <label>" wants the
+  # whole thing, while "capturing worker <noun>" and "worker <noun> capture
+  # stopped" want the noun alone. Splitting it here keeps all three grammatical
+  # without an eighth parameter that would have to agree with the seventh.
+  local subject_noun="${label% capture}"
+  local report_dir="${COZY_REPORT_DIR:-/workspace/_out/cozyreport}/snapshots/${COZY_SNAPSHOT_NAME:-kubernetes}/${subdir}"
+  local nodes node rc
+  local seen=0
+  local node_err raw stream matched filter_err filter_rc tenant_seen had_series
+  # The counters are per container but the endpoint is per node, so the walk is
+  # over nodes and not over Pods: one read covers every worker the node hosts.
+  # Three is the sandbox's management node count, so this cap is the whole
+  # cluster rather than a sample of it.
+  #
+  # A literal and not a knob, unlike the time bound, and the difference is what
+  # lowering would mean. Lowering a time bound costs detail inside a read that
+  # still happened; lowering this one drops nodes silently, and the capture then
+  # answers for part of the cluster while reading like it answered for all of it.
+  local max_nodes=3
+
+  mkdir -p "${report_dir}"
+  # Re-validated here rather than trusted, for the reason cozy_diag_read gives
+  # for doing the same: a value assigned after this file is sourced -- which is
+  # how both a caller and a test set it -- would otherwise reach `timeout`
+  # unchecked, and zero there disables the bound outright.
+  COZY_DIAG_READ_TIMEOUT=$(_cozy_diag_seconds "${COZY_DIAG_READ_TIMEOUT-}" "$COZY_DIAG_READ_TIMEOUT_DEFAULT" COZY_DIAG_READ_TIMEOUT positive)
+  COZY_DIAG_READ_GRACE=$(_cozy_diag_seconds "${COZY_DIAG_READ_GRACE-}" "$COZY_DIAG_READ_GRACE_DEFAULT" COZY_DIAG_READ_GRACE)
+
+  nodes=$(_cozy_cadvisor_worker_nodes "${report_dir}" "${label}") || return 1
+
+  for node in ${nodes}; do
+    seen=$((seen + 1))
+    if [ "${seen}" -gt "${max_nodes}" ]; then
+      echo "--- worker ${subject_noun} capture stopped at ${max_nodes} nodes ---"
+      printf 'capture stopped after %s nodes; %s carried a worker in total\n' \
+        "${max_nodes}" "$(printf '%s\n' "${nodes}" | wc -l | tr -d ' ')" \
+        >"${report_dir}/COLLECTION-TRUNCATED.txt"
+      break
+    fi
+    echo "--- capturing worker ${subject_noun}: ${node} ---"
+    node_err="${report_dir}/${node}.read-error.log"
+    raw="${report_dir}/${node}.txt"
+    # Outside report_dir on purpose. `rm -f` below clears it on every path this
+    # function controls, but a hard kill during the read does not run it, and a
+    # node's full cAdvisor dump is megabytes; left inside the report it would be
+    # uploaded as though it were a capture. A scratch directory is the runner's,
+    # not the artifact tree's, so a kill there costs nothing anyone reads.
+    #
+    # The template is explicit rather than a bare `mktemp`, and that is not
+    # style: BSD mktemp with no template ignores TMPDIR outright and always
+    # lands in the system directory, while GNU honours it. Given a template both
+    # put the file where the template says, so this is the only spelling whose
+    # location is the same on a developer's machine and on the runner.
+    stream=$(mktemp "${TMPDIR:-/tmp}/${tmp_prefix}.XXXXXX") \
+      || stream="${report_dir}/${node}.stream.tmp"
+    matched=$(mktemp "${TMPDIR:-/tmp}/${tmp_prefix}-m.XXXXXX") \
+      || matched="${report_dir}/${node}.matched.tmp"
+    filter_err="${report_dir}/${node}.filter-error.log"
+    # Captured whole and filtered afterwards. Piped straight into grep the
+    # status would be grep's, `timeout`'s 124 could never reach this variable,
+    # and a kubelet that never answered would arrive looking like a node with no
+    # tenant container on it.
+    #
+    # A missing RBAC grant on nodes/proxy arrives as a non-zero exit with the
+    # 403 on stderr, so it lands in the same branch as an unreachable kubelet,
+    # and the error log is what says which of them happened.
+    # Defaulted because the status now arrives through a command substitution
+    # rather than from a local set ahead of the read: a subshell killed outright
+    # returns nothing, and an empty rc turns every `[ "${rc}" -ne 0 ]` below into
+    # a shell error instead of a branch.
+    #
+    # Defaulted to 137 rather than 0, and the direction is the whole point. The
+    # case this covers is a read that was killed, and 0 is the one value that
+    # means "the kubelet answered" -- so a zero default would take the single
+    # outcome this collector may never manufacture and manufacture it. 137 is
+    # what a kill produces anyway, and the note it selects says the read did not
+    # finish, which is what was observed.
+    rc=$(_cozy_cadvisor_node_stream "${node}" "${stream}" "${node_err}")
+    rc=${rc:-137}
+    # The filter's own failure is kept apart from "matched nothing". grep exits
+    # 1 when nothing matched and 2 when it could not read -- a full TMPDIR on
+    # the runner reaches the second -- and folded together they land in the arm
+    # that says the kubelet answered and carried no series, which is the one
+    # conflation this collector exists to prevent.
+    #
+    # All three stages are run apart rather than piped for the same reason the
+    # read above is: a pipeline carries only its LAST command's status, so a
+    # stage that could not read its input hands an empty stream to the next one,
+    # which then exits 1 for having matched nothing.
+    filter_rc=0
+    grep -E "${metric_re}" "${stream}" >"${matched}" 2>"${filter_err}" || filter_rc=$?
+    if [ "${filter_rc}" -lt 2 ]; then
+      grep 'namespace="tenant-test"' "${matched}" >"${stream}" 2>>"${filter_err}" || filter_rc=$?
+    fi
+    if [ "${filter_rc}" -lt 2 ]; then
+      grep 'pod="virt-launcher-' "${stream}" >"${raw}" 2>>"${filter_err}" || filter_rc=$?
+    fi
+    rm -f "${matched}"
+    # Read before the sink is removed, because an empty capture has two causes
+    # here and only stage 2's output separates them: a node carrying nothing of
+    # this namespace, and a namespace whose containers are none of them workers.
+    tenant_seen=0
+    if [ -s "${stream}" ]; then
+      tenant_seen=1
+    fi
+    rm -f "${stream}"
+    [ -s "${filter_err}" ] || rm -f "${filter_err}"
+    if [ ! -s "${node_err}" ]; then
+      rm -f "${node_err}"
+      node_err=
+    elif [ "${rc}" -eq 0 ]; then
+      mv "${node_err}" "${report_dir}/${node}.READ-WARNINGS.txt" 2>/dev/null || true
+      node_err=
+    fi
+    # Tested before anything is appended, or nothing is ever empty. An empty
+    # capture here is the dangerous outcome rather than a neutral one: zero
+    # bytes reads as a healthy worker, which is the very conclusion this
+    # collector was added to stop a reader reaching by default.
+    #
+    # Which arm fires is decided by the STATUS, never by whether anything landed
+    # on stderr. `timeout` kills its child without a word and kubectl dies on
+    # SIGTERM the same way, so the dominant failure here -- a wedged kubelet --
+    # arrives non-zero with an empty error log; keyed on stderr it would fall
+    # through to the arm that says the kubelet answered, and the artifact would
+    # state the opposite of what happened.
+    had_series=0
+    if [ -s "${raw}" ]; then
+      had_series=1
+    fi
+    if [ ! -s "${raw}" ] && [ "${rc}" -ne 0 ]; then
+      if [ -n "${node_err}" ]; then
+        printf '%s\n' \
+          "${subject} is unknown: the kubelet was not read; see read-error.log" \
+          >>"${raw}"
+      else
+        printf '%s\n' \
+          "${subject} is unknown: the kubelet was not read, and the read died without a word on either stream" \
+          >>"${raw}"
+      fi
+    elif [ ! -s "${raw}" ] && [ "${filter_rc}" -ge 2 ]; then
+      # Between the two kubelet rungs on purpose. The read may well have
+      # succeeded -- this says nothing about it either way, because the failure
+      # is local to this runner: grep could not read back the stream it was
+      # given. Folded into the rung below, it would assert that the kubelet
+      # answered and carried no series.
+      if [ -s "${filter_err}" ]; then
+        printf '%s\n' \
+          "${subject} is unknown: the metric stream could not be read back on this runner; see filter-error.log" \
+          >>"${raw}"
+      else
+        printf '%s\n' \
+          "${subject} is unknown: the metric stream could not be read back on this runner, and the filter said nothing about why" \
+          >>"${raw}"
+      fi
+    elif [ ! -s "${raw}" ] && [ "${tenant_seen}" -eq 1 ]; then
+      # The namespace was there and the worker Pods were not, which is what an
+      # upstream rename of the virt-launcher prefix looks like from inside. The
+      # rung below is the scheduling reading instead, and the two are fixed by
+      # looking in different places.
+      printf '%s\n' \
+        "${subject} is unknown: the kubelet answered and reported ${series} series for this namespace, none of them from a worker Pod named virt-launcher-*" \
+        >>"${raw}"
+    elif [ ! -s "${raw}" ]; then
+      printf '%s\n' \
+        "${subject} is unknown: the kubelet answered and reported no ${series} series for a tenant-test worker on this node" \
+        >>"${raw}"
+    elif [ "${rc}" -ne 0 ]; then
+      if [ -n "${node_err}" ]; then
+        printf '%s\n' \
+          'these counters are incomplete: the read was cut short part way through the metric stream; see read-error.log' \
+          >>"${raw}"
+      else
+        printf '%s\n' \
+          'these counters are incomplete: the read was cut short part way through the metric stream, without a word on either stream' \
+          >>"${raw}"
+      fi
+    elif [ "${filter_rc}" -ge 2 ]; then
+      # The same truncation one layer down: series arrived, the read was fine,
+      # and a filter stage stopped part way. A write error is where that happens
+      # -- grep emits what it had flushed and exits 2, which is how a full disk
+      # arrives. Reached only with something already in the file.
+      if [ -s "${filter_err}" ]; then
+        printf '%s\n' \
+          'these counters are incomplete: the metric stream could not be read back past this point on this runner; see filter-error.log' \
+          >>"${raw}"
+      else
+        printf '%s\n' \
+          'these counters are incomplete: the metric stream could not be read back past this point on this runner, and the filter said nothing about why' \
+          >>"${raw}"
+      fi
+    fi
+    # kubectl exits 1 for a refused connection as readily as for a 403 or a
+    # NotFound node, so the status alone names none of them and the error log is
+    # the only thing that can.
+    if [ "${rc}" -eq 124 ]; then
+      printf '%s\n' \
+        '[exit 124: this collector timing out and the read exiting 124 on its own cannot be told apart]' \
+        >>"${raw}"
+    fi
+    # 128+SIGKILL. The grace signal produces it, and so does anything else that
+    # kills the read -- an OOM killer on a loaded runner, a teardown signalling
+    # the process group -- so the note says what the status establishes and
+    # stops there. cozy_diag_read refuses the same wording for the same reason.
+    if [ "${rc}" -eq 137 ]; then
+      printf '%s\n' \
+        '[exit 137: the read was killed rather than stopping on its own; the status does not say what killed it]' \
+        >>"${raw}"
+    fi
+    # `|| true` because the hook is called bare inside the walk: a hook whose
+    # last statement is a false test returns non-zero, and under a live errexit
+    # that ends the walk part way through a node rather than at a boundary. The
+    # hooks today end on an `if` that returns 0 when its condition is false, so
+    # this changes nothing now and removes the requirement that they always will.
+    "${tail_hook}" "${raw}" "${rc}" "${filter_rc}" "${had_series}" || true
+    printf '\n[capture exit code: %s]\n' "${rc}" >>"${raw}"
+  done
+}
+
+# The worker node listing, shared by both captures as code and issued fresh by
+# each of them: they ask the same question of the same apiserver, and the answer
+# is deliberately not carried between them, for the reason given at the read.
+# Echoes the node names and returns non-zero when there is no walk to make, with
+# the reason written where the reader of that capture will look for it.
+_cozy_cadvisor_worker_nodes() {
+  local report_dir="$1"
+  local label="$2"
+  local err_log="${report_dir}/COLLECTION-FAILED.txt"
+  local warn_log="${report_dir}/READ-WARNINGS.txt"
+  local raw_nodes nodes
+  local list_rc=0
+
+  # stderr is kept out of the captured stdout so a warning on an otherwise
+  # healthy call is never read back as a node name, and which file it lands in
+  # is decided by the exit status rather than by something having been written:
+  # kubectl writes deprecation and partial-result warnings with a zero exit.
+  # Read first, filter after. A pipeline reports its LAST command's status, so
+  # folding the sort into this assignment would hand list_rc to `sort` and make
+  # a listing that never answered indistinguishable from a namespace with no
+  # workers in it -- the one conflation these collectors must not make.
+  if command -v timeout >/dev/null 2>&1; then
+    raw_nodes=$(timeout -k "${COZY_DIAG_READ_GRACE}" "${COZY_DIAG_READ_TIMEOUT}" \
+      kubectl -n tenant-test get pods -l kubevirt.io=virt-launcher \
+      -o jsonpath='{range .items[*]}{.spec.nodeName}{"\n"}{end}' \
+      "--request-timeout=${COZY_DIAG_READ_TIMEOUT}s" 2>"${warn_log}") || list_rc=$?
+  else
+    raw_nodes=$(kubectl -n tenant-test get pods -l kubevirt.io=virt-launcher \
+      -o jsonpath='{range .items[*]}{.spec.nodeName}{"\n"}{end}' \
+      "--request-timeout=${COZY_DIAG_READ_TIMEOUT}s" 2>"${warn_log}") || list_rc=$?
+  fi
+  if [ "${list_rc}" -ne 0 ]; then
+    echo "failed to list tenant virt-launcher Pods for ${label}" >&2
+    mv "${warn_log}" "${err_log}" 2>/dev/null || true
+    printf '%s\n' \
+      "failed to list tenant virt-launcher Pods for ${label} (exit ${list_rc})" \
+      >>"${err_log}"
+    return 1
+  fi
+  [ -s "${warn_log}" ] || rm -f "${warn_log}"
+  nodes=$(printf '%s\n' "${raw_nodes}" | sort -u | grep -v '^$' || true)
+  if [ -z "${nodes}" ]; then
+    echo "no virt-launcher Pod with a node assigned for ${label}" >&2
+    printf '%s\n' \
+      'no virt-launcher Pod with a node assigned in namespace tenant-test; an unscheduled Pod has no kubelet to ask' \
+      >"${err_log}"
+    return 1
+  fi
+  printf '%s\n' "${nodes}"
+}
+
+# The one answer here that is not a failure, and until it is written down the
+# only one a reader has to derive. A capture holding the period alone, at a
+# clean exit, is a container with no CPU limit -- but it is also the shape a
+# truncated read leaves, and every other outcome gets a sentence precisely so
+# that this one is not read as that one. Keyed on the quota's absence rather
+# than on a line count, because that absence is the condition cAdvisor itself
+# gates the whole capped set on. Tested for exactly 1, which is grep's "read it,
+# no match": a bare `!` would also accept 2, and the artifact would then claim a
+# ceiling that a failed local read had merely not found.
+#
+# Decided over the whole node file rather than per container, and the file holds
+# every container of every worker Pod on that node. One quota line anywhere in
+# it suppresses the note. That is deliberately the conservative direction: the
+# note is only ever printed when nothing in the file is capped, so it cannot
+# claim "uncapped" over a file that shows a ceiling.
+_cozy_cpu_throttle_tail_note() {
+  local raw="$1" rc="$2" filter_rc="$3" had_series="$4"
+  local quota_rc=0
+
+  grep -q '^container_spec_cpu_quota{' "${raw}" || quota_rc=$?
+  if [ "${had_series}" -eq 1 ] && [ "${rc}" -eq 0 ] && [ "${filter_rc}" -lt 2 ] \
+    && [ "${quota_rc}" -eq 1 ]; then
+    printf '%s\n' \
+      'these workers are running uncapped: cAdvisor publishes the quota and the CFS counters only for a container whose quota is non-zero, so a period with neither beside it is a container with no CPU limit rather than a short read' \
+      >>"${raw}"
+  fi
+}
+
+# Said in the file because the number invites the one reading it cannot support.
+# Every family here is cumulative from the Pod's sandbox starting, so a drop
+# count says nothing about the window the node-join deadline covered: a link
+# that dropped nothing while the pull stalled and one that dropped throughout
+# carry the same total whenever the earlier traffic matched. A rate needs a
+# second capture of the same stream to subtract from, and the sample time each
+# row carries as its third field is what makes two captures pairable.
+_cozy_network_counters_tail_note() {
+  local raw="$1" had_series="$4"
+
+  if [ "${had_series}" -eq 1 ]; then
+    printf '%s\n' \
+      'these counters are cumulative since the Pod sandbox started, not a rate over the failure: a second capture of the same stream is what turns them into one' \
+      >>"${raw}"
+  fi
+}
+
 # Read each tenant worker's CPU throttling counters and its CFS ceiling from
 # the kubelet's cAdvisor endpoint on the node the worker runs on.
 #
@@ -966,33 +1411,13 @@ cozy_capture_tenant_serial_console() {
 # survive a filter that fails half way, because the whole point is to be believed
 # when it reports nothing.
 cozy_capture_tenant_worker_cpu_throttle() {
-  local report_dir="${COZY_REPORT_DIR:-/workspace/_out/cozyreport}/snapshots/${COZY_SNAPSHOT_NAME:-kubernetes}/tenant-cpu-throttle"
-  local nodes raw_nodes node rc
-  local list_rc=0
-  local seen=0
-  local node_err raw stream matched filter_err filter_rc tenant_seen had_series quota_rc
-  # The counters are per container but the endpoint is per node, so the walk is
-  # over nodes and not over Pods: one read covers every worker the node hosts.
-  # Three is the sandbox's management node count, so this cap is the whole
-  # cluster rather than a sample of it.
-  #
-  # A literal and not a knob, unlike the time bound below and unlike the sibling
-  # importer walk, and the difference is what lowering would mean. Lowering a
-  # time bound costs detail inside a read that still happened; lowering this one
-  # drops nodes silently, and the capture then answers for part of the cluster
-  # while reading like it answered for all of it. The runaway it guards against
-  # is a listing that returns something absurd, which a fixed ceiling stops
-  # better than a configurable one.
-  local max_nodes=3
-  local err_log="${report_dir}/COLLECTION-FAILED.txt"
-  local warn_log="${report_dir}/READ-WARNINGS.txt"
   # Anchored on the metric names so a series whose name merely contains one of
   # them cannot pass. The namespace alone is NOT a worker filter and must not be
   # used as one: tenant-test also carries the Kamaji control plane, whose
   # apiserver and etcd have CPU limits of their own and can be genuinely
-  # throttled, plus the CDI importer Pods this block walks elsewhere. Under a
-  # heading that says "worker", a throttled apiserver answers the question with
-  # the wrong subject, so the Pod name carries the second half of the filter.
+  # throttled, plus the CDI importer Pods. Under a heading that says "worker", a
+  # throttled apiserver answers the question with the wrong subject, so the Pod
+  # name carries the second half of the filter.
   #
   # Note the asymmetry, since it is the one soft spot here: the listing selects
   # Pods by the authoritative label kubevirt.io=virt-launcher, while this matches
@@ -1000,302 +1425,40 @@ cozy_capture_tenant_worker_cpu_throttle() {
   # the series carries. KubeVirt derives that prefix from the Pod it creates, so
   # it holds today; a rename upstream would silently empty this capture rather
   # than break it loudly.
-  local metric_re='^container_(cpu_cfs_(periods_total|throttled_periods_total|throttled_seconds_total)|spec_cpu_(period|quota))\{'
+  _cozy_capture_worker_cadvisor \
+    tenant-cpu-throttle \
+    'CPU throttling counters capture' \
+    'whether these workers were throttled' \
+    CPU \
+    cozy-cpu-throttle \
+    _cozy_cpu_throttle_tail_note \
+    '^container_(cpu_cfs_(periods_total|throttled_periods_total|throttled_seconds_total)|spec_cpu_(period|quota))\{'
+}
 
-  mkdir -p "${report_dir}"
-  # Re-validated here rather than trusted, for the reason cozy_diag_read gives
-  # for doing the same: a value assigned after this file is sourced -- which is
-  # how both a caller and a test set it -- would otherwise reach `timeout`
-  # unchecked, and zero there disables the bound outright.
-  COZY_DIAG_READ_TIMEOUT=$(_cozy_diag_seconds "${COZY_DIAG_READ_TIMEOUT-}" "$COZY_DIAG_READ_TIMEOUT_DEFAULT" COZY_DIAG_READ_TIMEOUT positive)
-  COZY_DIAG_READ_GRACE=$(_cozy_diag_seconds "${COZY_DIAG_READ_GRACE-}" "$COZY_DIAG_READ_GRACE_DEFAULT" COZY_DIAG_READ_GRACE)
-  # stderr is kept out of the captured stdout so a warning on an otherwise
-  # healthy call is never read back as a node name, and which file it lands in
-  # is decided by the exit status rather than by something having been written:
-  # kubectl writes deprecation and partial-result warnings with a zero exit.
-  # Read first, filter after. A pipeline reports its LAST command's status, so
-  # folding the sort into this assignment would hand list_rc to `sort` and make
-  # a listing that never answered indistinguishable from a namespace with no
-  # workers in it -- the one conflation this collector must not make.
-  if command -v timeout >/dev/null 2>&1; then
-    raw_nodes=$(timeout -k "${COZY_DIAG_READ_GRACE}" "${COZY_DIAG_READ_TIMEOUT}" \
-      kubectl -n tenant-test get pods -l kubevirt.io=virt-launcher \
-      -o jsonpath='{range .items[*]}{.spec.nodeName}{"\n"}{end}' \
-      "--request-timeout=${COZY_DIAG_READ_TIMEOUT}s" 2>"${warn_log}") || list_rc=$?
-  else
-    raw_nodes=$(kubectl -n tenant-test get pods -l kubevirt.io=virt-launcher \
-      -o jsonpath='{range .items[*]}{.spec.nodeName}{"\n"}{end}' \
-      "--request-timeout=${COZY_DIAG_READ_TIMEOUT}s" 2>"${warn_log}") || list_rc=$?
-  fi
-  if [ "${list_rc}" -ne 0 ]; then
-    echo "failed to list tenant virt-launcher Pods for CPU throttling capture" >&2
-    mv "${warn_log}" "${err_log}" 2>/dev/null || true
-    printf '%s\n' \
-      "failed to list tenant virt-launcher Pods for CPU throttling capture (exit ${list_rc})" \
-      >>"${err_log}"
-    return 1
-  fi
-  [ -s "${warn_log}" ] || rm -f "${warn_log}"
-  nodes=$(printf '%s\n' "${raw_nodes}" | sort -u | grep -v '^$' || true)
-  if [ -z "${nodes}" ]; then
-    echo "no virt-launcher Pod with a node assigned for CPU throttling capture" >&2
-    printf '%s\n' \
-      'no virt-launcher Pod with a node assigned in namespace tenant-test; an unscheduled Pod has no kubelet to ask' \
-      >"${err_log}"
-    return 1
-  fi
-
-  for node in ${nodes}; do
-    seen=$((seen + 1))
-    if [ "${seen}" -gt "${max_nodes}" ]; then
-      echo "--- worker CPU throttling capture stopped at ${max_nodes} nodes ---"
-      printf 'capture stopped after %s nodes; %s carried a worker in total\n' \
-        "${max_nodes}" "$(printf '%s\n' "${nodes}" | wc -l | tr -d ' ')" \
-        >"${report_dir}/COLLECTION-TRUNCATED.txt"
-      break
-    fi
-    echo "--- capturing worker CPU throttling counters: ${node} ---"
-    rc=0
-    node_err="${report_dir}/${node}.read-error.log"
-    raw="${report_dir}/${node}.txt"
-    # Outside report_dir on purpose. `rm -f` below clears it on every path this
-    # function controls, but a hard kill during the read does not run it, and a
-    # node's full cAdvisor dump is megabytes; left inside the report it would be
-    # uploaded as though it were a capture. A scratch directory is the runner's,
-    # not the artifact tree's, so a kill there costs nothing anyone reads.
-    #
-    # The template is explicit rather than a bare `mktemp`, and that is not
-    # style: BSD mktemp with no template ignores TMPDIR outright and always
-    # lands in the system directory, while GNU honours it. Given a template both
-    # put the file where the template says, so this is the only spelling whose
-    # location is the same on a developer's machine and on the runner -- and the
-    # only one a test can point somewhere it can look afterwards.
-    stream=$(mktemp "${TMPDIR:-/tmp}/cozy-cpu-throttle.XXXXXX") \
-      || stream="${report_dir}/${node}.stream.tmp"
-    matched=$(mktemp "${TMPDIR:-/tmp}/cozy-cpu-throttle-m.XXXXXX") \
-      || matched="${report_dir}/${node}.matched.tmp"
-    filter_err="${report_dir}/${node}.filter-error.log"
-    # Bounded here rather than through cozy_diag_read, which always returns 0 by
-    # design so that a collector cannot replace its caller's exit. This one has
-    # to tell "the kubelet did not answer" from "the kubelet answered and this
-    # container was not in it", and only the exit status separates them, so the
-    # status has to survive. The bound is the block's own knob rather than a
-    # literal that happens to equal it today, so lowering the knob lowers this
-    # read too; there is nothing to deviate, because the read runs against the
-    # kubelet rather than inside the cgroup under measurement. The
-    # timeout-absent fallback is the importer listing's, for its reason: bounding
-    # with a binary that is not there turns every read into an exit 127 and
-    # every note into "the kubelet refused".
-    #
-    # Captured whole and filtered afterwards, for the reason the listing above
-    # gives and which bites harder here: piped straight into grep the status
-    # would be grep's, `timeout`'s 124 could never reach this variable, and a
-    # kubelet that never answered would arrive looking like a node with no
-    # tenant container on it.
-    #
-    # A missing RBAC grant on nodes/proxy is a failure mode this read has and an
-    # in-container read did not. It arrives as a non-zero exit with the 403 on
-    # stderr, so it lands in the same branch as an unreachable kubelet, and the
-    # error log is what says which of them happened.
-    if command -v timeout >/dev/null 2>&1; then
-      timeout -k "${COZY_DIAG_READ_GRACE}" "${COZY_DIAG_READ_TIMEOUT}" \
-        kubectl get --raw "/api/v1/nodes/${node}/proxy/metrics/cadvisor" \
-        "--request-timeout=${COZY_DIAG_READ_TIMEOUT}s" \
-        >"${stream}" 2>"${node_err}" || rc=$?
-    else
-      kubectl get --raw "/api/v1/nodes/${node}/proxy/metrics/cadvisor" \
-        "--request-timeout=${COZY_DIAG_READ_TIMEOUT}s" \
-        >"${stream}" 2>"${node_err}" || rc=$?
-    fi
-    # The filter's own failure is kept apart from "matched nothing". grep exits 1
-    # when nothing matched and 2 when it could not read -- a full TMPDIR on the
-    # runner reaches the second -- and folded together they land in the arm that
-    # says the kubelet answered and carried no series, which is the one
-    # conflation this collector exists to prevent. The regex is a constant, so
-    # the unparseable case cannot arrive at runtime; the unreadable one can.
-    #
-    # All three stages are run apart rather than piped for the same reason the
-    # kubelet read above is: a pipeline carries only its LAST command's status,
-    # so a stage that could not read its input hands an empty stream to the next
-    # one, which then exits 1 for having matched nothing -- and the failure that
-    # this split exists to surface would arrive dressed as an empty capture. The
-    # stages narrow the same stream, so any of them exiting 2 says exactly the
-    # same thing about the artifact and shares the one status. The kubelet
-    # stream is reused as the stage-2 sink because stage 1 has finished reading
-    # it by then, which keeps the scratch file count at what it was.
-    filter_rc=0
-    grep -E "${metric_re}" "${stream}" >"${matched}" 2>"${filter_err}" || filter_rc=$?
-    if [ "${filter_rc}" -lt 2 ]; then
-      grep 'namespace="tenant-test"' "${matched}" >"${stream}" 2>>"${filter_err}" || filter_rc=$?
-    fi
-    if [ "${filter_rc}" -lt 2 ]; then
-      grep 'pod="virt-launcher-' "${stream}" >"${raw}" 2>>"${filter_err}" || filter_rc=$?
-    fi
-    rm -f "${matched}"
-    # Read before the sink is removed, because an empty capture has two causes
-    # here and only stage 2's output separates them: a node carrying nothing of
-    # this namespace, and a namespace whose containers are none of them workers.
-    # The second is what an upstream rename of the virt-launcher prefix looks
-    # like from inside, and it is a filter problem wearing the appearance of a
-    # scheduling one. Only meaningful while the stages actually ran: with
-    # filter_rc >= 2 the sink may still hold whatever the failed stage left, and
-    # the arm that fires then does not consult this.
-    tenant_seen=0
-    if [ -s "${stream}" ]; then
-      tenant_seen=1
-    fi
-    rm -f "${stream}"
-    [ -s "${filter_err}" ] || rm -f "${filter_err}"
-    if [ ! -s "${node_err}" ]; then
-      rm -f "${node_err}"
-      node_err=
-    elif [ "${rc}" -eq 0 ]; then
-      mv "${node_err}" "${report_dir}/${node}.READ-WARNINGS.txt" 2>/dev/null || true
-      node_err=
-    fi
-    # Tested before anything is appended, or nothing is ever empty. An empty
-    # capture here is the dangerous outcome rather than a neutral one: zero
-    # bytes reads as a container that never hit its ceiling, which is the very
-    # conclusion this collector was added to stop a reader reaching by default.
-    #
-    # Which arm fires is decided by the STATUS, never by whether anything landed
-    # on stderr. `timeout` kills its child without a word and kubectl dies on
-    # SIGTERM the same way, so the dominant failure here -- a wedged kubelet --
-    # arrives non-zero with an empty error log; keyed on stderr it would fall
-    # through to the arm that says the kubelet answered, and the artifact would
-    # state the opposite of what happened. stderr only chooses whether the line
-    # can point at a log, because naming a file that was never written sends the
-    # reader after evidence that does not exist.
-    had_series=0
-    if [ -s "${raw}" ]; then
-      had_series=1
-    fi
-    if [ ! -s "${raw}" ] && [ "${rc}" -ne 0 ]; then
-      if [ -n "${node_err}" ]; then
-        printf '%s\n' \
-          'whether these workers were throttled is unknown: the kubelet was not read; see read-error.log' \
-          >>"${raw}"
-      else
-        printf '%s\n' \
-          'whether these workers were throttled is unknown: the kubelet was not read, and the read died without a word on either stream' \
-          >>"${raw}"
-      fi
-    elif [ ! -s "${raw}" ] && [ "${filter_rc}" -ge 2 ]; then
-      # Between the two kubelet rungs on purpose. The read may well have
-      # succeeded -- this says nothing about it either way, because the failure
-      # is local to this runner: grep could not read back the stream it was
-      # given. Folded into the rung below, it would assert that the kubelet
-      # answered and carried no series, which is the conflation this collector
-      # exists to prevent; folded into the rung above, it would blame a read
-      # that may have been fine. The exit code footer still reports the read.
-      if [ -s "${filter_err}" ]; then
-        printf '%s\n' \
-          'whether these workers were throttled is unknown: the metric stream could not be read back on this runner; see filter-error.log' \
-          >>"${raw}"
-      else
-        printf '%s\n' \
-          'whether these workers were throttled is unknown: the metric stream could not be read back on this runner, and the filter said nothing about why' \
-          >>"${raw}"
-      fi
-    elif [ ! -s "${raw}" ] && [ "${tenant_seen}" -eq 1 ]; then
-      # The namespace was there and the worker Pods were not. Naming the
-      # namespace instead would be false here and would cost a reader the
-      # actual finding, since the two states are fixed in different places:
-      # this one by looking at what the prefix is now, the one below by
-      # looking at where the workers were scheduled.
-      printf '%s\n' \
-        'whether these workers were throttled is unknown: the kubelet answered and reported CPU series for this namespace, none of them from a worker Pod named virt-launcher-*' \
-        >>"${raw}"
-    elif [ ! -s "${raw}" ]; then
-      printf '%s\n' \
-        'whether these workers were throttled is unknown: the kubelet answered and reported no CPU series for a tenant-test container on this node' \
-        >>"${raw}"
-    elif [ "${rc}" -ne 0 ]; then
-      # Series arrived and the read then died, so this block may be missing
-      # whichever family the endpoint had not reached. The quota is the one that
-      # must not go missing unnoticed, since its absence otherwise reads as a
-      # container running uncapped.
-      if [ -n "${node_err}" ]; then
-        printf '%s\n' \
-          'these counters are incomplete: the read was cut short part way through the metric stream; see read-error.log' \
-          >>"${raw}"
-      else
-        printf '%s\n' \
-          'these counters are incomplete: the read was cut short part way through the metric stream, without a word on either stream' \
-          >>"${raw}"
-      fi
-    elif [ "${filter_rc}" -ge 2 ]; then
-      # The same truncation one layer down, and the layer is the whole
-      # difference: series arrived, the read was fine, and a filter stage
-      # stopped part way. A write error is where that happens -- grep emits what
-      # it had flushed and exits 2, which is how a full disk arrives. Reached
-      # only with something already in the file, since an empty capture is
-      # claimed by the rung above; without this rung a truncated capture carries
-      # no note at all and reads as a whole one. Says nothing about the read,
-      # which by here is known to have exited zero.
-      if [ -s "${filter_err}" ]; then
-        printf '%s\n' \
-          'these counters are incomplete: the metric stream could not be read back past this point on this runner; see filter-error.log' \
-          >>"${raw}"
-      else
-        printf '%s\n' \
-          'these counters are incomplete: the metric stream could not be read back past this point on this runner, and the filter said nothing about why' \
-          >>"${raw}"
-      fi
-    fi
-    # kubectl exits 1 for a refused connection as readily as for a 403 or a
-    # NotFound node, so the status alone names none of them and the error log is
-    # the only thing that can.
-    if [ "${rc}" -eq 124 ]; then
-      printf '%s\n' \
-        '[exit 124: this collector timing out and the read exiting 124 on its own cannot be told apart]' \
-        >>"${raw}"
-    fi
-    # 128+SIGKILL. The grace signal produces it, and so does anything else that
-    # kills the read -- an OOM killer on a loaded runner, a teardown signalling
-    # the process group -- so the note says what the status establishes and
-    # stops there. On the fallback arm above the grace period is the one cause
-    # it cannot have been, there being no `timeout` in that call at all.
-    # cozy_diag_read refuses the same wording for the same reason.
-    if [ "${rc}" -eq 137 ]; then
-      printf '%s\n' \
-        '[exit 137: the read was killed rather than stopping on its own; the status does not say what killed it]' \
-        >>"${raw}"
-    fi
-    # The one answer here that is not a failure, and until it is written down the
-    # only one a reader has to derive. A capture holding the period alone, at a
-    # clean exit, is a container with no CPU limit -- but it is also the shape a
-    # truncated read leaves, and every other outcome in this function gets a
-    # sentence precisely so that this one is not read as that one. Keyed on the
-    # quota's absence rather than on a line count, because that absence is the
-    # condition cAdvisor itself gates the whole capped set on. Tested for
-    # exactly 1, which is grep's "read it, no match": a bare `!` would also
-    # accept 2, and the artifact would then claim a ceiling that a failed local
-    # read had merely not found.
-    #
-    # Decided over the whole node file rather than per container, and the file
-    # holds every container of every worker Pod on that node -- compute and the
-    # container-disk and guest-console-log sidecars beside it. One quota line
-    # anywhere in it suppresses the note. That is deliberately the conservative
-    # direction: the note is only ever printed when nothing in the file is
-    # capped, so it cannot claim "uncapped" over a file that shows a ceiling.
-    # It also makes the note rare, and from one trigger rather than two: a
-    # tenant that declares quotas gets both a LimitRange defaulting any
-    # container without a limit of its own to 250m and a ResourceQuota, and it
-    # is that ResourceQuota carrying limits.cpu that makes KubeVirt stamp the
-    # compute limit as well.
-    # Rare and honest beats frequent and approximate here, because the note is
-    # a positive claim about the ceiling.
-    quota_rc=0
-    grep -q '^container_spec_cpu_quota{' "${raw}" || quota_rc=$?
-    if [ "${had_series}" -eq 1 ] && [ "${rc}" -eq 0 ] && [ "${filter_rc}" -lt 2 ] \
-      && [ "${quota_rc}" -eq 1 ]; then
-      printf '%s\n' \
-        'these workers are running uncapped: cAdvisor publishes the quota and the CFS counters only for a container whose quota is non-zero, so a period with neither beside it is a container with no CPU limit rather than a short read' \
-        >>"${raw}"
-    fi
-    printf '\n[capture exit code: %s]\n' "${rc}" >>"${raw}"
-  done
+# Two properties of the network family are invisible to anyone writing this
+# filter from the metric documentation, and both fail by capturing nothing:
+#
+#   - The dropped-packet families are spelled packets_dropped. There is no
+#     *_drops_total, which is the spelling the shorter name suggests.
+#   - Every row carries container="", including the per-Pod ones. cAdvisor
+#     publishes network counters on the Pod's sandbox cgroup, so the Pod is
+#     named by `pod` and the container label is empty on the whole family. A
+#     filter borrowed from the CPU capture above, whose rows do carry a
+#     container name, therefore matches nothing at all -- and nothing at all
+#     reads as a worker that moved no bytes.
+#
+# The node's own interfaces arrive in these same families with pod="" and
+# namespace="", which the namespace stage already excludes; worth knowing before
+# that stage looks redundant next to the Pod-name one.
+cozy_capture_tenant_worker_network_counters() {
+  _cozy_capture_worker_cadvisor \
+    tenant-network-counters \
+    'network counters capture' \
+    'how many bytes reached these workers' \
+    network \
+    cozy-net-counters \
+    _cozy_network_counters_tail_note \
+    '^container_network_(receive|transmit)_(bytes|packets|packets_dropped|errors)_total\{'
 }
 
 # Collect the guest-side evidence requested by issue #3513. This runs only after
@@ -1366,7 +1529,7 @@ cozy_capture_tenant_talos() (
 
   while IFS='|' read -r vmi_name node_ip; do
     [ -n "${node_ip}" ] || continue
-    echo "--- capturing tenant Talos dmesg/kubelet: ${vmi_name} (${node_ip}) ---"
+    echo "--- capturing tenant Talos dmesg/kubelet/services/links: ${vmi_name} (${node_ip}) ---"
     cozy_capture_tenant_talos_node "${pod_name}" "${node_ip}" \
       "${report_dir}/${vmi_name}"
   done <"${workdir}/vmis.rows"
@@ -1440,11 +1603,11 @@ _cozy_diag_seconds() {
 # count rather than confidence: those bound a single read or a short walk, while the
 # block below issues a dozen back to back, so the same per-read bound would put the
 # block's own ceiling ahead of the tenant crust-gather snapshot it exists to reach.
-# The worker CPU throttling capture is the exception and deliberately so: it is a
-# short walk by that measure, and it still takes this knob rather than a higher
-# literal, because a bound that does not follow the knob is a bound nobody can
-# lower. Read the sentence above as describing the collectors that predate the
-# knob, not as a rule for new ones.
+# The two worker counter captures are the exception and deliberately so: they
+# share one body that is a short walk by that measure, and it still takes this
+# knob rather than a higher literal, because a bound that does not follow the
+# knob is a bound nobody can lower. Read the sentence above as describing the
+# collectors that predate the knob, not as a rule for new ones.
 # Every read here is one get/describe/logs against a small tenant or a handful of
 # cluster-scoped objects, which an apiserver that answers at all answers in under a
 # second.
@@ -1458,7 +1621,47 @@ _cozy_diag_seconds() {
 COZY_DIAG_READ_TIMEOUT_DEFAULT=20
 COZY_DIAG_READ_GRACE_DEFAULT=5
 COZY_DIAG_MAX_IMPORTERS_DEFAULT=3
-COZY_DIAG_PHASE_BUDGET_DEFAULT=480
+# Lowered from 480 when the guest-Talos walk grew the service list and the link
+# table. That collector is the `largest` term of the inequality below, the
+# inequality had ten seconds of slack, and the two reads cost sixty across the
+# minimum pool -- so the budget is what had to give. 420 rather than the 430 the
+# arithmetic allows, because the guard compares the comment in both
+# kubernetes-*/chainsaw-test.yaml against whole minutes, and a budget that is
+# not one leaves that comment rounded rather than true.
+#
+# What that leaves is ten seconds, and it is worth knowing here rather than
+# after the fact: the next collector added to the guest-Talos walk does not fit
+# without re-deriving this number, because that walk is the `largest` term and
+# ten seconds buys no bounded read at any bound this file uses. Adding one means
+# lowering the budget again, and the paragraphs below are what that costs. The
+# same arithmetic bounds the host-side walk, which is why a collector added
+# there is priced against this number too rather than against the phase budget
+# alone.
+#
+# What it costs is worth stating where the number is, not only in the change
+# that moved it, and it is two costs rather than one.
+#
+# A shorter budget declines more, and what it declines first is what is gated
+# last -- ghcr_mirror_diagnose and talos_image_cache_diagnose. Neither loses its
+# subject entirely. The mirror's state is partly recoverable from the request
+# counts and response durations the mirror capture records against its own log,
+# and from the kube-system snapshot the host report takes; the image cache's
+# re-probe has no substitute and is the collector this budget gives up first,
+# which was already true at 480.
+#
+# The second cost lands on the guest captures rather than on the tail. The two
+# worker captures each read the node's metric stream, so (d2) spends a listing
+# plus one read per node AHEAD of (b1) and (b) -- up to 100s at the read bound
+# and the three-node cap, a ceiling those numbers impose rather than a duration
+# measured on a live cluster. Between that and the sixty seconds off the budget,
+# the console and guest-Talos captures reach their gate with less left than
+# before; they are still ahead of the tail in the order, so they are not first
+# to go, but a run that was marginal for them is likelier to decline them now.
+#
+# That second read is not shared away in this change, and the reason is scope
+# rather than merit -- the note at the read says why, and says that merging
+# would improve both the cost and what a tight run collects.
+COZY_DIAG_PHASE_BUDGET_DEFAULT=420
 COZY_DIAG_READ_TIMEOUT=$(_cozy_diag_seconds "${COZY_DIAG_READ_TIMEOUT:-$COZY_DIAG_READ_TIMEOUT_DEFAULT}" "$COZY_DIAG_READ_TIMEOUT_DEFAULT" COZY_DIAG_READ_TIMEOUT positive)
 # Validated too, though a suffix is not what breaks it: `timeout -k abc 20` exits 125
 # before running the command at all, so a non-numeric grace makes every read in the
@@ -1546,13 +1749,16 @@ cozy_diag_phase_start() {
   # cozystack/cozystack#3666; the warning names both halves rather than promising the
   # better one for all of them.
   #
-  # The worker CPU throttling capture belongs to neither half: it calls `timeout`
-  # directly AND carries the same fallback, so on a runner without the binary it
-  # runs unbounded rather than exiting 127. That is the opposite failure from the
-  # one the sentence above would lead a reader to, and it is the half with the
-  # snapshot behind it, so it is named here rather than left to be inferred.
+  # The worker CPU throttling and network counter captures belong to neither
+  # half: they call `timeout` directly AND carry the same fallback, so on a
+  # runner without the binary they run unbounded rather than exiting 127. That
+  # is the opposite failure from the one the sentence above would lead a reader
+  # to, and it is the half with the snapshot behind it, so they are named here
+  # rather than left to be inferred. The list is derived from the source by
+  # hack/run-kubernetes-node-join_test.bats, so a collector that joins this
+  # group without joining the sentence fails there.
   command -v timeout >/dev/null 2>&1 || \
-    echo "» WARNING: timeout is not on PATH; the bounded reads below run UNBOUNDED, so one that hangs can still take the op and the tenant snapshot with it, and the collectors that call timeout directly (wedge check, serial console, guest Talos) exit 127 and collect nothing; the ones that guard the call with command -v -- the worker CPU throttling, ghcr-mirror and talos-image-cache captures -- keep collecting instead, unbounded" >&2
+    echo "» WARNING: timeout is not on PATH; the bounded reads below run UNBOUNDED, so one that hangs can still take the op and the tenant snapshot with it, and the collectors that call timeout directly (wedge check, serial console, guest Talos) exit 127 and collect nothing; the ones that guard the call with command -v -- the worker CPU throttling, worker network counter, ghcr-mirror and talos-image-cache captures -- keep collecting instead, unbounded" >&2
   # Re-checked here, not only at assignment: a value set after this file is sourced
   # -- which is how a test sets it -- would otherwise reach the arithmetic below
   # unvalidated, and that is the one failure that costs the whole block.
@@ -1862,6 +2068,43 @@ cozy_report_node_join_failure() {
     cozy_capture_tenant_worker_cpu_throttle || true
   fi
 
+  # (d2) Worker network counters, from the same endpoint and at the same cost as
+  # (d), and here for the same two reasons: four bounded reads rather than the
+  # minutes (b1) and (b) can spend between them, and an answer with no other
+  # source in this artifact. What it settles is which side of the worker's image
+  # pull is slow. The guest reports its own progress and cannot see the bytes
+  # that never became progress, so a pull that keeps restarting and one that
+  # crawls look identical from in there. The host side counts both, and the gap
+  # between it and the guest's progress is the discriminator.
+  #
+  # WHICH ROW answers that is not obvious and getting it wrong inverts the
+  # reading, so it is written here rather than left to the reader. cAdvisor
+  # publishes one row per interface in the Pod's network namespace, and a
+  # bridge-bound worker has four of them:
+  #
+  #   eth0      a DUMMY holding the Pod IP so the kubelet's check still passes.
+  #             It carries no traffic, so its counters sit at zero -- and it is
+  #             the row a reader reaches for first, by name, where zero reads as
+  #             a worker that received nothing.
+  #   eth0-nic  the Pod's real NIC, renamed and enslaved to the bridge. Its
+  #             RECEIVE is what arrived from the cluster network, and that is
+  #             the number this capture exists to produce.
+  #   k6t-eth0  the bridge; the same bytes again as they cross it.
+  #   tap0      the host side of the tap to the guest, whose counters are named
+  #             from the host's end, so traffic toward the guest is its
+  #             transmit rather than its receive.
+  #
+  # The filter deliberately carries no interface predicate: all four rows reach
+  # the artifact so the reader can tell them apart, and dropping three of them
+  # here would decide the question in the collector on the strength of names
+  # that KubeVirt, not this file, chooses.
+  # Placed after the guest captures it would be the first thing declined on
+  # exactly the slow runs this failure comes from.
+  if cozy_diag_phase_has_time '(d2) tenant worker network counters'; then
+    echo "=== (d2) tenant worker network counters (management cluster, ns tenant-test) ==="
+    cozy_capture_tenant_worker_network_counters || true
+  fi
+
   # (b1) Guest serial console, read from the management cluster. First of the
   # in-guest captures because it is the only one that survives a worker which
   # never reached apid — the dominant shape of this failure, where no Node
@@ -1887,8 +2130,13 @@ cozy_report_node_join_failure() {
   # A worker that has not reached apid yet will produce a bounded connection
   # error while a later-stage worker remains capturable; both outcomes are
   # retained in cozyreport.
-  if cozy_diag_phase_has_time '(b) in-guest Talos dmesg + kubelet logs'; then
-    echo "=== (b) in-guest Talos dmesg + kubelet logs ==="
+  # The label names all four reads because the phase reuses it verbatim in the
+  # decline line, and a decline that names two of them reports the other two as
+  # lost to nobody: the service states are the finding on the shape of this
+  # failure where no kubelet log exists to read at all, so a note that does not
+  # mention them loses them silently rather than out loud.
+  if cozy_diag_phase_has_time '(b) in-guest Talos dmesg + kubelet logs + service states + links'; then
+    echo "=== (b) in-guest Talos dmesg + kubelet logs + service states + links ==="
     cozy_capture_tenant_talos "${test_name}" || true
   fi
 

--- a/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
@@ -19,7 +19,7 @@ spec:
     try:
     - script:
         # ~25m Kamaji bringup + worker join + LB/NFS/ouroboros assertions.
-        # The on-failure diagnostics phase carries its own 8m wall-clock budget
+        # The on-failure diagnostics phase carries its own 7m wall-clock budget
         # (COZY_DIAG_PHASE_BUDGET in _lib/run-kubernetes.sh): once it is spent, the
         # collectors that have not started are declined out loud rather than
         # attempted, so the in-process tenant crust-gather snapshot, the one the
@@ -33,6 +33,7 @@ spec:
         # than the reads that discriminate between failure modes:
         #   node-join diagnostics reads
         #   worker CPU throttling counters
+        #   worker network counters
         #   serial-console family (~5m50s at worst, ~3m30s at the pool's minimum)
         #   guest Talos capture
         #   ghcr-mirror state, access log and warm-up Job

--- a/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
@@ -13,7 +13,7 @@ spec:
   - name: tenant-kubernetes-previous-version
     try:
     - script:
-        # The on-failure diagnostics phase carries its own 8m wall-clock budget
+        # The on-failure diagnostics phase carries its own 7m wall-clock budget
         # (COZY_DIAG_PHASE_BUDGET in _lib/run-kubernetes.sh): once it is spent, the
         # collectors that have not started are declined out loud rather than
         # attempted, so the in-process tenant crust-gather snapshot, the one the
@@ -27,6 +27,7 @@ spec:
         # than the reads that discriminate between failure modes:
         #   node-join diagnostics reads
         #   worker CPU throttling counters
+        #   worker network counters
         #   serial-console family (~5m50s at worst, ~3m30s at the pool's minimum)
         #   guest Talos capture
         #   ghcr-mirror state, access log and warm-up Job

--- a/hack/run-kubernetes-cpu-throttle_test.bats
+++ b/hack/run-kubernetes-cpu-throttle_test.bats
@@ -478,7 +478,15 @@ run_capture() {
   # copy of it and falsifies silently; a cap the code carries as a literal can
   # be pinned against the code itself, which is what this does.
   lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
-  fn=$(awk '/^cozy_capture_tenant_worker_cpu_throttle\(\)/,/^}/' "$lib")
+  # The walk and the read moved into the body this capture now shares with the
+  # network counters, so the subject of these assertions is the code the
+  # collector runs rather than the function that carries its name -- which is
+  # now a six-line call. Reading only the named function would leave every
+  # assertion below vacuously true against a body it no longer contains.
+  fn=$(awk '/^cozy_capture_tenant_worker_cpu_throttle\(\)/,/^}/' "$lib"
+      awk '/^_cozy_capture_worker_cadvisor\(\)/,/^}/' "$lib"
+      awk '/^_cozy_cadvisor_node_stream\(\)/,/^}/' "$lib"
+      awk '/^_cozy_cadvisor_worker_nodes\(\)/,/^}/' "$lib")
   case "$fn" in
     *'max_nodes=3'*) ;;
     *) echo "expected the collector to cap the walk at the 3 nodes the comments state" >&2; return 1 ;;
@@ -1085,7 +1093,7 @@ container_cpu_cfs_throttled_periods_total{container="compute",namespace="tenant-
   # Both empty-capture arms open with "the kubelet answered", so the line above
   # cannot tell them apart on its own. This one is about a node carrying nothing
   # of the namespace, and the sibling arm's wording is what it must not be.
-  assert_file_contains 'no CPU series for a tenant-test container' "$capture"
+  assert_file_contains 'no CPU series for a tenant-test worker' "$capture"
   assert_file_lacks_pattern 'none of them from a worker Pod' "$capture"
   rm -rf "$tmp"
 }

--- a/hack/run-kubernetes-network-counters_test.bats
+++ b/hack/run-kubernetes-network-counters_test.bats
@@ -1,0 +1,604 @@
+#!/usr/bin/env bats
+# Regression coverage for the tenant-worker network counter capture in
+# hack/e2e-chainsaw/_lib/run-kubernetes.sh. cozytest.sh ends an @test block at
+# the first bare closing brace, so command mocks stay at top level.
+#
+# What this capture answers, and why the guest cannot answer it: a worker that
+# misses the node-Ready deadline while its image pull crawls has two mechanisms
+# behind the same guest-visible symptom. The link is slow, or the pull keeps
+# restarting and discarding what it fetched. From inside the guest both read as
+# a progress line that barely moves. The host-side byte counters separate them,
+# because they count every byte that crossed into the Pod including the ones a
+# restart threw away. cAdvisor reads these inside the Pod's network namespace
+# and publishes one row per interface, and a bridge-bound worker has four --
+# the number that answers is the renamed NIC's receive, while the interface
+# still named eth0 is a dummy holding the Pod IP and reads zero. A capture that
+# reports an unread kubelet as a quiet link would hand the next reader that same
+# ambiguity while looking like it had settled it, so these tests pin the
+# separation rather than the reading.
+#
+# The fixtures below are real kubelet output with the identifying labels
+# rewritten, not lines composed from the metric documentation. That choice is
+# the subject of two of the tests: the family carries no container name and is
+# spelled packets_dropped, and both are invisible to anyone writing the filter
+# from memory.
+
+kubectl_calls=/dev/null
+kubectl_node_names=
+kubectl_list_rc=0
+kubectl_list_stderr=
+kubectl_raw_rc=0
+kubectl_raw_stderr=
+
+# One worker Pod's set as the kubelet serves it: eight families, one row each
+# per interface, every one of them carrying container="" and cAdvisor's own
+# sample timestamp as the third field. Trimmed to the labels the filter reads
+# plus the ones that make the shape recognisable; the id/name digests are
+# synthetic and the image is the upstream pause reference rather than whichever
+# mirror the cluster it was taken from happened to use.
+#
+# Two different provenances here, and the difference matters enough to state.
+# The row shape and its values are real kubelet output with the identifying
+# labels rewritten. The four INTERFACE NAMES are not measured: they are what
+# KubeVirt bridge binding produces in a worker Pod netns -- a dummy carrying the
+# original name and the Pod IP, the real NIC renamed with a -nic suffix, the
+# bridge, and the tap -- read from the generators in the version this repo
+# ships. A virt-launcher Pod was not available to sample, so the names are
+# derived rather than observed, and the counters attached to them are
+# illustrative of direction, not of magnitude.
+worker_pod='virt-launcher-kubernetes-test-latest-version-md0-abc12-xyz34'
+worker_labels_for() {
+  printf 'container="",id="/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod0000000a_0000_0000_0000_00000000000b.slice/cri-containerd-0000000000000000000000000000000000000000000000000000000000000001.scope",image="registry.k8s.io/pause:3.10",interface="%s",name="0000000000000000000000000000000000000000000000000000000000000001",namespace="tenant-test",pod="%s"' "$1" "${worker_pod}"
+}
+worker_labels="$(worker_labels_for eth0)"
+kubectl_raw_output=
+
+# Built rather than pasted so the eight families cannot drift apart by a typo in
+# one of them, and so a test that needs one family can name it.
+worker_series() {
+  local labels="$1"
+  local rx_bytes="${2:-4.4040192e+07}"
+  local rx_packets="${3:-31284}"
+  printf 'container_network_receive_bytes_total{%s} %s 1786657157281\n' "${labels}" "${rx_bytes}"
+  printf 'container_network_receive_packets_total{%s} %s 1786657157281\n' "${labels}" "${rx_packets}"
+  printf 'container_network_receive_packets_dropped_total{%s} 0 1786657157281\n' "${labels}"
+  printf 'container_network_receive_errors_total{%s} 0 1786657157281\n' "${labels}"
+  printf 'container_network_transmit_bytes_total{%s} 1.820267529e+09 1786657157281\n' "${labels}"
+  printf 'container_network_transmit_packets_total{%s} 932294 1786657157281\n' "${labels}"
+  printf 'container_network_transmit_packets_dropped_total{%s} 285 1786657157281\n' "${labels}"
+  printf 'container_network_transmit_errors_total{%s} 0 1786657157281\n' "${labels}"
+}
+
+# The four interfaces a bridge-bound worker Pod presents. eth0 is the dummy and
+# reports zero; eth0-nic is the NIC whose receive answers the question. Both
+# have to survive the filter, or the artifact holds a number the reader cannot
+# interpret -- or worse, only the zero.
+bridge_bound_worker() {
+  worker_series "$(worker_labels_for eth0)" 0 0
+  worker_series "$(worker_labels_for eth0-nic)" 4.4040192e+07 31284
+  worker_series "$(worker_labels_for k6t-eth0)" 4.4040192e+07 31284
+  worker_series "$(worker_labels_for tap0)" 1.2e+05 900
+}
+
+# The node's own interfaces arrive in the same families with both selector
+# labels empty. Kept in the default fixture rather than staged only where it is
+# asserted: it is what the wire actually carries, and a filter that lets it
+# through would report the sandbox node's uplink under a worker heading.
+node_series() {
+  printf 'container_network_receive_bytes_total{container="",id="/",image="",interface="eth0",name="",namespace="",pod=""} 1.066300417297e+12 1786657157281\n'
+  printf 'container_network_transmit_bytes_total{container="",id="/",image="",interface="cilium_host",name="",namespace="",pod=""} 27870 1786657157281\n'
+}
+
+timeout_calls=/dev/null
+timeout_fail_node=
+
+kubectl() {
+  printf '%s\n' "$*" >>"${kubectl_calls}"
+
+  if [ "${3:-}" = get ] && [ "${4:-}" = pods ]; then
+    [ -z "${kubectl_list_stderr}" ] || printf '%s\n' "${kubectl_list_stderr}" >&2
+    [ "${kubectl_list_rc}" -eq 0 ] || return "${kubectl_list_rc}"
+    [ -z "${kubectl_node_names}" ] || printf '%s\n' ${kubectl_node_names}
+    return 0
+  fi
+
+  if [ "${1:-}" = get ] && [ "${2:-}" = --raw ]; then
+    [ -z "${kubectl_raw_stderr}" ] || printf '%s\n' "${kubectl_raw_stderr}" >&2
+    # Output before status, for the reason the sibling suite gives: a read cut
+    # off part way has already written what it managed to read, and a stub that
+    # returns first makes the branch labelling a partial capture unreachable in
+    # tests while it stays the likeliest one in production.
+    [ -z "${kubectl_raw_output}" ] || printf '%s\n' "${kubectl_raw_output}"
+    return "${kubectl_raw_rc}"
+  fi
+
+  return 0
+}
+
+timeout() {
+  local command_rc=0
+  printf '%s\n' "$*" >>"${timeout_calls}"
+  # Return 97 rather than running the command when the wrapper is not the
+  # bounded form: a read that lost its ceiling must not pass as a read.
+  [ "${1:-}" = -k ] || return 97
+  shift 3
+  "$@" || command_rc=$?
+  if [ -n "${timeout_fail_node}" ]; then
+    case " $* " in
+      *"${timeout_fail_node}"*) return 124 ;;
+    esac
+  fi
+  return "${command_rc}"
+}
+
+assert_file_contains() {
+  local needle="$1"
+  local file="$2"
+
+  if [ ! -f "${file}" ]; then
+    printf 'expected %s to exist so it could be checked for: %s\n' "${file}" "${needle}" >&2
+    return 1
+  fi
+  case "$(cat "${file}")" in
+    *"${needle}"*) return 0 ;;
+  esac
+  printf 'expected %s to contain: %s\n' "${file}" "${needle}" >&2
+  return 1
+}
+
+assert_file_lacks_pattern() {
+  local pattern="$1"
+  local file="$2"
+
+  # A missing file must fail rather than vacuously pass: a bare `! grep -q`
+  # succeeds on an unreadable path, which is indistinguishable from "the file
+  # exists and does not carry the label".
+  if [ ! -f "${file}" ]; then
+    printf 'expected %s to exist so it could be checked for: %s\n' "${file}" "${pattern}" >&2
+    return 1
+  fi
+  # Branched on awk's exact status. awk exits 1 for "no line matched" and 2 for
+  # "I could not evaluate this"; folded into an `if`, both land in the passing
+  # branch and the assertion "this is absent" is satisfied by the matcher giving
+  # up. Every negative claim in this file rests on the three-way split.
+  local _rc=0
+  awk -v pattern="${pattern}" '$0 ~ pattern { found = 1 } END { exit found ? 0 : 1 }' "${file}" || _rc=$?
+  case "${_rc}" in
+    0)
+      printf 'expected %s not to match: %s\n' "${file}" "${pattern}" >&2
+      return 1
+      ;;
+    1) return 0 ;;
+    *)
+      printf 'awk could not evaluate pattern %s against %s\n' "${pattern}" "${file}" >&2
+      return 1
+      ;;
+  esac
+}
+
+# The function under test redirects a command's stderr into a report file and
+# decides which artifact to write from it. cozytest.sh runs under `set -x`, so
+# the tracer's own line for that command lands on the very stderr being
+# redirected, and every assertion about those files would be reading the tracer.
+# Call through this wrapper so the sinks hold what production writes.
+run_capture() {
+  local _rc=0
+  ( set +x; cozy_capture_tenant_worker_network_counters ) || _rc=$?
+  return "${_rc}"
+}
+
+@test "a negative assertion fails when its own matcher cannot evaluate" {
+  # The helper under every "must not appear" claim in this file. What rides on
+  # it is the collector's contract stated negatively: that an unread kubelet was
+  # not written up as a quiet link, that a node interface did not land under a
+  # worker heading. A matcher that fails open turns each of those into a
+  # sentence nobody checked.
+  tmp=$(mktemp -d)
+  printf 'anything\n' >"$tmp/subject"
+
+  if assert_file_lacks_pattern '*(' "$tmp/subject" 2>/dev/null; then
+    echo "FAIL: an unparseable pattern was reported as absent" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+  assert_file_lacks_pattern 'absent-string' "$tmp/subject"
+  if assert_file_lacks_pattern 'anything' "$tmp/subject" 2>/dev/null; then
+    echo "FAIL: a present pattern was reported as absent" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "the eight families of a worker Pod are captured, packets_dropped included" {
+  # The positive control every negative claim below is measured against. It
+  # names the eight families one by one rather than counting lines, because a
+  # count passes while a family is silently missing from the filter -- and the
+  # dropped-packet families are the ones a filter written from memory loses,
+  # since the obvious spelling for them is *_drops_total, which does not exist.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(node_series; worker_series "$worker_labels")"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-network-counters/node-a.txt"
+  for family in \
+    container_network_receive_bytes_total \
+    container_network_receive_packets_total \
+    container_network_receive_packets_dropped_total \
+    container_network_receive_errors_total \
+    container_network_transmit_bytes_total \
+    container_network_transmit_packets_total \
+    container_network_transmit_packets_dropped_total \
+    container_network_transmit_errors_total; do
+    assert_file_contains "${family}{" "$out"
+  done
+  # And the value, so a filter that kept the family name while dropping the row
+  # it was on cannot pass: 285 is the transmit drop count in the fixture.
+  assert_file_contains ' 285 ' "$out"
+  rm -rf "$tmp"
+}
+
+@test "the filter does not select on the container label, which is always empty here" {
+  # The trap this collector is likeliest to acquire on its next edit. The CPU
+  # counters beside it carry a real container name, so a filter copied from
+  # there and tightened with container="compute" matches nothing at all -- and
+  # nothing at all reads as a worker that moved no bytes. Every row of this
+  # family carries container="", measured against a live kubelet, so the guard
+  # is that the fixture's empty-container rows survive.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_series "$worker_labels")"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-network-counters/node-a.txt"
+  assert_file_contains 'container=""' "$out"
+  rm -rf "$tmp"
+}
+
+@test "node interfaces and foreign namespaces are dropped, workers are kept" {
+  # The node's own uplink arrives in the same eight families with pod="" and
+  # namespace="", so a filter on the family name alone reports the sandbox
+  # node's traffic under a heading that says worker. A Pod of another namespace
+  # and a non-worker Pod of this one are the other two rows that must not pass.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  other_ns=$(printf 'container="",interface="eth0",namespace="cozy-system",pod="virt-launcher-elsewhere"')
+  other_pod=$(printf 'container="",interface="eth0",namespace="tenant-test",pod="kubernetes-test-latest-version-kube-apiserver-0"')
+  kubectl_raw_output="$(node_series; worker_series "$worker_labels"; worker_series "$other_ns"; worker_series "$other_pod")"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-network-counters/node-a.txt"
+  assert_file_contains "pod=\"${worker_pod}\"" "$out"
+  assert_file_lacks_pattern 'pod=""' "$out"
+  assert_file_lacks_pattern 'cozy-system' "$out"
+  assert_file_lacks_pattern 'kube-apiserver' "$out"
+  rm -rf "$tmp"
+}
+
+@test "a kubelet that never answered is reported as unknown, not as a link that moved nothing" {
+  # The conflation this collector exists to prevent. Zero bytes captured is the
+  # same bytes on disk whether the worker received nothing or the kubelet was
+  # never read, and only the note tells them apart. Keyed on the exit status
+  # rather than on stderr, because `timeout` kills its child without a word and
+  # kubectl dies on SIGTERM the same way, so the dominant failure arrives
+  # non-zero with an empty error log.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output=
+  kubectl_raw_rc=1
+  kubectl_raw_stderr='Error from server (Forbidden): nodes "node-a" is forbidden'
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-network-counters/node-a.txt"
+  assert_file_contains 'is unknown' "$out"
+  assert_file_contains 'the kubelet was not read' "$out"
+  assert_file_lacks_pattern 'reported no network series' "$out"
+  # The trailing note is gated on series having arrived, and only the "it
+  # appears" direction was pinned. Ungated it would attach "these counters are
+  # cumulative..." to a capture holding no counters, which reads as counters
+  # that exist. The CPU sibling pins its own note both ways for this reason.
+  assert_file_lacks_pattern 'cumulative' "$out"
+  assert_file_contains 'forbidden' \
+    "$tmp/snapshots/kubernetes-latest/tenant-network-counters/node-a.read-error.log"
+  rm -rf "$tmp"
+}
+
+@test "a kubelet that answered without worker rows says which of the two shapes it saw" {
+  # Two empty results with different fixes. A namespace present but carrying no
+  # virt-launcher-* Pod is a filter problem -- what an upstream rename of the
+  # prefix looks like from inside -- and is fixed by looking at what the prefix
+  # is now. A node with none of this namespace on it is a scheduling reading and
+  # is fixed by looking at where the workers went. Naming the wrong one costs
+  # the reader the finding.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  renamed=$(printf 'container="",interface="eth0",namespace="tenant-test",pod="compute-launcher-md0-abc12-xyz34"')
+  kubectl_raw_output="$(worker_series "$renamed")"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-network-counters/node-a.txt"
+  assert_file_contains 'none of them from a worker Pod named virt-launcher-*' "$out"
+  assert_file_lacks_pattern 'no network series for a tenant-test worker' "$out"
+
+  # And the other shape, on a node carrying nothing of this namespace.
+  rm -rf "$tmp/snapshots"
+  kubectl_raw_output="$(node_series)"
+  run_capture
+  assert_file_contains 'reported no network series for a tenant-test worker on this node' "$out"
+  assert_file_lacks_pattern 'none of them from a worker Pod' "$out"
+  rm -rf "$tmp"
+}
+
+@test "a filter that could not read its input is not reported as a kubelet with nothing to say" {
+  # grep exits 1 for "read it, no match" and 2 for "could not read" -- a full
+  # scratch directory on the runner reaches the second. Folded together they
+  # land in the arm asserting the kubelet answered and carried no worker series,
+  # which is a claim about the cluster manufactured by a local failure.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_series "$worker_labels")"
+  # grep 2 is what an unreadable input produces; the stub stands in for it
+  # without needing a full disk. Scoped to the calls that read a FILE, which is
+  # what the three filter stages do -- the node listing pipes through a grep of
+  # its own, and failing that one instead would empty the walk and test nothing.
+  grep() {
+    local _last
+    eval "_last=\${$#}"
+    if [ -f "${_last}" ]; then
+      return 2
+    fi
+    command grep "$@"
+  }
+
+  run_capture
+  unset -f grep
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-network-counters/node-a.txt"
+  assert_file_contains 'could not be read back on this runner' "$out"
+  assert_file_lacks_pattern 'reported no network series' "$out"
+  rm -rf "$tmp"
+}
+
+@test "the counters are labelled as totals since the sandbox started, not as a rate" {
+  # The reading this capture is most likely to be misread as. Every family here
+  # is cumulative from the Pod's sandbox coming up, so a drop count of 285 says
+  # nothing about the minutes the node-join deadline covered -- a link that
+  # dropped nothing during the failure and a link that dropped throughout carry
+  # the same total if the earlier traffic was the same. Saying so in the file is
+  # the whole mitigation: a rate needs a second capture of the same stream, and
+  # nothing in the artifact would otherwise say the number is not one.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_series "$worker_labels")"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-network-counters/node-a.txt"
+  assert_file_contains 'cumulative' "$out"
+  rm -rf "$tmp"
+}
+
+@test "a listing that never answered is not reported as a namespace with no workers" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_list_rc=1
+  kubectl_list_stderr='Unable to connect to the server'
+
+  rc=0
+  run_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  err="$tmp/snapshots/kubernetes-latest/tenant-network-counters/COLLECTION-FAILED.txt"
+  assert_file_contains 'failed to list' "$err"
+  assert_file_contains 'Unable to connect to the server' "$err"
+  rm -rf "$tmp"
+}
+
+@test "a namespace with no scheduled worker says so instead of writing an empty tree" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names=
+
+  rc=0
+  run_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  assert_file_contains 'no kubelet to ask' \
+    "$tmp/snapshots/kubernetes-latest/tenant-network-counters/COLLECTION-FAILED.txt"
+  rm -rf "$tmp"
+}
+
+@test "the node walk stops at its cap and says how many carried a worker" {
+  # A cap that drops nodes silently answers for part of the cluster while
+  # reading as though it answered for all of it.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a node-b node-c node-d"
+  kubectl_raw_output="$(worker_series "$worker_labels")"
+
+  run_capture
+
+  dir="$tmp/snapshots/kubernetes-latest/tenant-network-counters"
+  assert_file_contains '4 carried a worker in total' "$dir/COLLECTION-TRUNCATED.txt"
+  [ ! -f "$dir/node-d.txt" ]
+  rm -rf "$tmp"
+}
+
+@test "the read is bounded and the timeout-absent fallback still reads" {
+  # Bounding with a binary that is not there turns every read into an exit 127
+  # and every note into "the kubelet refused" -- a missing local dependency
+  # reported as the cluster failing. The sibling collectors guard the call with
+  # command -v for that reason and this one is held to the same shape.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_series "$worker_labels")"
+
+  run_capture
+
+  # Bounded: the wrapper saw the raw read, in the -k form the stub demands.
+  grep -q 'metrics/cadvisor' "$timeout_calls"
+  out="$tmp/snapshots/kubernetes-latest/tenant-network-counters/node-a.txt"
+  assert_file_contains 'container_network_receive_bytes_total{' "$out"
+
+  # And without `timeout` on PATH the read still happens rather than exiting 127.
+  rm -rf "$tmp/snapshots"
+  command() {
+    if [ "${1:-}" = -v ] && [ "${2:-}" = timeout ]; then
+      return 1
+    fi
+    builtin command "$@"
+  }
+  run_capture
+  unset -f command
+  assert_file_contains 'container_network_receive_bytes_total{' "$out"
+  assert_file_lacks_pattern 'is unknown' "$out"
+  rm -rf "$tmp"
+}
+
+@test "a read cut short keeps what arrived and marks it incomplete" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_series "$worker_labels")"
+  timeout_fail_node=node-a
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-network-counters/node-a.txt"
+  assert_file_contains 'these counters are incomplete' "$out"
+  assert_file_contains 'container_network_receive_bytes_total{' "$out"
+  assert_file_contains '[exit 124:' "$out"
+  rm -rf "$tmp"
+}
+
+@test "a node read whose status never arrived is not written up as a kubelet that answered" {
+  # The default behind `rc=${rc:-137}`, and the only route to it. The status
+  # comes back through a command substitution now, so a subshell killed outright
+  # returns nothing at all -- and the value chosen for that case decides which
+  # sentence the artifact carries. Zero is the one value meaning "the kubelet
+  # answered", so defaulting there would take the single conclusion this
+  # collector may never manufacture and manufacture it from a local failure.
+  #
+  # Written because the default had none: flipping it back to `:-0` left every
+  # suite in this tree green while a killed read was reported as a quiet link.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  # Writes the sinks and returns nothing on stdout: what a killed substitution
+  # leaves behind. Stubbed at the helper because no mock of kubectl can produce
+  # an empty command substitution while the function still runs.
+  _cozy_cadvisor_node_stream() { : >"$2"; : >"$3"; }
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-network-counters/node-a.txt"
+  assert_file_contains 'the kubelet was not read' "$out"
+  assert_file_contains '[exit 137:' "$out"
+  assert_file_lacks_pattern 'reported no network series' "$out"
+  # And the trailing note stays away from a capture that holds no counters: it
+  # describes numbers that are not there, and beside an unknown it reads as
+  # counters that exist.
+  assert_file_lacks_pattern 'cumulative' "$out"
+  rm -rf "$tmp"
+}
+
+@test "every interface of a bridge-bound worker survives the filter, dummy and NIC alike" {
+  # The reading this capture is most easily inverted by. A bridge-bound worker
+  # presents four interfaces in its Pod netns, and the one named eth0 is a dummy
+  # that holds the Pod IP and carries no traffic -- so it reports zero, and it is
+  # the row a reader reaches for first because of its name. The number that
+  # answers is the renamed NIC's receive.
+  #
+  # The filter therefore carries no interface predicate, and this pins that:
+  # keeping only one interface would either drop the answer or leave the reader
+  # holding the zero. Which row means what is stated where the collector is
+  # gated; what this test guarantees is that both are in the artifact to compare.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(node_series; bridge_bound_worker)"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-network-counters/node-a.txt"
+  for iface in eth0 eth0-nic k6t-eth0 tap0; do
+    assert_file_contains "interface=\"${iface}\"" "$out"
+  done
+  # The dummy really is staged at zero and the NIC is not, so "both survive" is
+  # a statement about two distinguishable rows rather than two copies.
+  grep -q "^container_network_receive_bytes_total{.*interface=\"eth0\".*} 0 " "$out"
+  grep -q "^container_network_receive_bytes_total{.*interface=\"eth0-nic\".*} 4.4040192e+07 " "$out"
+  # And the node's own interfaces still do not reach a worker heading.
+  assert_file_lacks_pattern 'pod=""' "$out"
+  rm -rf "$tmp"
+}

--- a/hack/run-kubernetes-node-join_test.bats
+++ b/hack/run-kubernetes-node-join_test.bats
@@ -152,8 +152,8 @@ use_temp_report_dir() {
   export COZY_REPORT_DIR="$1/report"
 }
 
-# The block calls six collectors that have their own suites and their own
-# bounds. Four of them are stubbed here; the other two are stubbed only where
+# The block calls seven collectors that have their own suites and their own
+# bounds. Four of them are stubbed here; the other three are stubbed only where
 # the test is about the budget rather than the reads, for the reason given
 # under stub_gated_collectors below. Stubbed after sourcing so these tests are
 # about the block's own reads; left un-stubbed they would drag a Certificate, a
@@ -165,23 +165,25 @@ stub_collectors() {
   talos_image_cache_diagnose() { printf 'image-cache-stub\n'; }
 }
 
-# The two collectors below are deliberately NOT in stub_collectors, and that is
+# The collectors below are deliberately NOT in stub_collectors, and that is
 # load-bearing rather than an omission. The block-level audit above --
 # "no node join diagnostic read escapes a wall clock bound" -- works by letting
 # the real collectors run against the kubectl mock and failing on any read that
 # reached it outside a `timeout` wrapper. Stubbing a collector there does not
 # make that test pass more easily; it removes the collector from the audit
 # entirely, and the test stays green because there is nothing left to audit.
-# Both of these carry reads the audit is the only instrument that sees:
-# ghcr_mirror_diagnose issues five, and the throttle capture issues its Pod
-# listing. Their own suites substitute a grep over the source, which by
-# construction cannot see a read that was added without a bound.
+# Each of them carries reads the audit is the only instrument that sees:
+# ghcr_mirror_diagnose issues five, and the two cadvisor captures issue a Pod
+# listing and a node read apiece. Their own suites substitute a grep over the
+# source, which by construction cannot see a read that was added without a
+# bound.
 #
 # They are stubbed only where the test is about the phase budget rather than
 # about the reads, which is the one place their real bodies would drown the
 # signal.
 stub_gated_collectors() {
   cozy_capture_tenant_worker_cpu_throttle() { printf 'cpu-throttle-stub\n'; }
+  cozy_capture_tenant_worker_network_counters() { printf 'network-counters-stub\n'; }
   ghcr_mirror_diagnose() { printf 'ghcr-mirror-stub\n'; }
 }
 
@@ -220,20 +222,36 @@ assert_file_contains() {
   # And the block did read: without this the check above passes just as well on
   # an implementation that reads nothing at all.
   [ "$(grep -c . "$kubectl_calls")" -ge 11 ]
-  # Named reads, not just a count. The two gated collectors below are the ones
-  # this audit is the only instrument for, and both are one line away from
-  # vanishing from it: moving their stubs into stub_collectors takes them out
-  # of the run entirely, and every suite stays green because the audit has
-  # nothing left to look at. A count cannot notice that -- eleven other reads
-  # keep it satisfied -- so each is pinned by a read only it issues.
+  # Named collectors, not just a count. The gated collectors below are the ones
+  # this audit is the only instrument for, and each is one line away from
+  # vanishing from it: moving its stub into stub_collectors takes it out of the
+  # run entirely, and every suite stays green because the audit has nothing left
+  # to look at. A count cannot notice that -- the other reads keep it satisfied
+  # -- so each collector is pinned individually.
+  #
+  # Pinned by the report directory each capture writes, not by a read only it
+  # issues. The two cAdvisor captures run one shared body, so their Pod listing
+  # and node read are byte-identical and neither has a read of its own: a
+  # listing-keyed pin is satisfied by whichever of them ran, and stays green
+  # with the other absent from the audit entirely. The directory is the one
+  # thing each produces alone.
   if ! grep -q 'get deploy ghcr-mirror' "$kubectl_calls"; then
     echo "FAIL: ghcr_mirror_diagnose did not run, so its reads were not audited" >&2
     false
   fi
-  if ! grep -q 'kubevirt.io=virt-launcher.*spec.nodeName' "$kubectl_calls"; then
-    echo "FAIL: the CPU throttling capture did not run, so its listing was not audited" >&2
-    false
-  fi
+  # Keyed on the directory having CONTENT, not on the directory existing. Each
+  # capture mkdir -p's its report directory before it lists anything, so an
+  # empty one is exactly what a capture that issued no read leaves behind -- and
+  # that is the state this pin has to reject, since a capture missing from the
+  # audit is a capture whose reads nobody bounded.
+  for subdir in tenant-cpu-throttle tenant-network-counters; do
+    dir="$COZY_REPORT_DIR/snapshots/kubernetes/$subdir"
+    if [ -z "$(find "$dir" -type f 2>/dev/null | head -n 1)" ]; then
+      echo "FAIL: $subdir produced no file, so that capture issued no read and its reads were not audited" >&2
+      ls -la "$COZY_REPORT_DIR/snapshots/kubernetes" >&2 || true
+      false
+    fi
+  done
   rm -rf "$tmp"
 }
 
@@ -489,13 +507,13 @@ assert_file_contains() {
     cat "$kubectl_calls" >&2
     false
   fi
-  # The five gates whose collectors are stubbed here are the mechanism, not a
+  # The six gates whose collectors are stubbed here are the mechanism, not a
   # detail: declining the heaviest guest-Talos capture is what the budget
   # derivation is for, and a stub issues no kubectl, so the check above cannot
   # see it run. That is the whole reason the count is over the stubbed ones and
   # not over every gate in the block -- the importer listing is gated too, and
   # it reads for real, so the check above already covers it. Each stub prints a
-  # marker; none of the five may appear, and each must have said why. The count
+  # marker; none of the six may appear, and each must have said why. The count
   # is load-bearing rather than descriptive -- a stubbed gate added without a
   # line here is a collector that may run past the deadline while this test
   # stays green, which is exactly what the empty-kubectl_calls check above
@@ -506,16 +524,18 @@ assert_file_contains() {
   # the bound audit at the top of this file, which needs it to run for real.
   # A rule written for additions does not catch a removal, so both directions
   # are named here.
-  for marker in serial-console-stub talos-stub image-cache-stub cpu-throttle-stub ghcr-mirror-stub; do
+  for marker in serial-console-stub talos-stub image-cache-stub cpu-throttle-stub \
+    network-counters-stub ghcr-mirror-stub; do
     if grep -q "$marker" "$tmp/out"; then
       echo "FAIL: $marker ran after the phase ran out of budget" >&2
       false
     fi
   done
   assert_file_contains '(b1) tenant worker guest serial console: not collected' "$tmp/out"
-  assert_file_contains '(b) in-guest Talos dmesg + kubelet logs: not collected' "$tmp/out"
+  assert_file_contains '(b) in-guest Talos dmesg + kubelet logs + service states + links: not collected' "$tmp/out"
   assert_file_contains 're-probe talos-image-cache ClusterIP + cacher debug bundle: not collected' "$tmp/out"
   assert_file_contains '(d) tenant worker CPU throttling: not collected' "$tmp/out"
+  assert_file_contains '(d2) tenant worker network counters: not collected' "$tmp/out"
   assert_file_contains 'ghcr-mirror state, access log and warm-up Job: not collected' "$tmp/out"
   rm -rf "$tmp"
 }
@@ -667,6 +687,7 @@ assert_file_contains() {
       cozy_capture_tenant_talos() { :; }
       talos_image_cache_diagnose() { :; }
       cozy_capture_tenant_worker_cpu_throttle() { :; }
+      cozy_capture_tenant_worker_network_counters() { :; }
       ghcr_mirror_diagnose() { :; }
       kubectl() { :; }
       cozy_report_node_join_failure test-latest-version
@@ -732,6 +753,7 @@ assert_file_contains() {
     cozy_capture_tenant_talos() { :; }
     talos_image_cache_diagnose() { :; }
     cozy_capture_tenant_worker_cpu_throttle() { :; }
+    cozy_capture_tenant_worker_network_counters() { :; }
     ghcr_mirror_diagnose() { :; }
     kubectl() { printf "KUBECTL_RAN\n" >&2; }
     PATH='"$tmp"'/bin
@@ -788,6 +810,7 @@ assert_file_contains() {
     cozy_capture_tenant_talos() { :; }
     talos_image_cache_diagnose() { :; }
     cozy_capture_tenant_worker_cpu_throttle() { :; }
+    cozy_capture_tenant_worker_network_counters() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_report_node_join_failure test-latest-version
   ' 2>&1) || true
@@ -819,6 +842,7 @@ assert_file_contains() {
     cozy_capture_tenant_talos() { :; }
     talos_image_cache_diagnose() { :; }
     cozy_capture_tenant_worker_cpu_throttle() { :; }
+    cozy_capture_tenant_worker_network_counters() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_report_node_join_failure test-latest-version
   ' 2>&1) || true
@@ -906,6 +930,266 @@ assert_file_contains() {
   fi
 }
 
+@test "the byte-path counters run with the cheap reads, ahead of everything that costs minutes" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # Where this collector sits is a decision, not a placement, and the phase
+  # budget is what makes it one: admission gates when a collector may START, so
+  # what runs last is what gets declined, and a collector's position is its
+  # priority.
+  #
+  # It goes with the cheap reads for the same two reasons the CPU counters
+  # beside it do. It costs four bounded reads rather than the minutes the
+  # console walk and the guest capture can spend between them, and its answer
+  # exists nowhere else in the artifact: the bytes that arrived at the Pod, set
+  # against the progress the guest reported, separate a pull that kept
+  # restarting from a slow link, and no other collector here separates those
+  # two. Which of the Pod's four interfaces carries that number, and which one
+  # is the dummy that reads zero, is stated where the collector is gated. Placed
+  # after the guest captures it would be the first thing declined on exactly the
+  # slow runs that produce this failure.
+  #
+  # It goes AFTER the CPU counters rather than before them, and that ordering is
+  # the weaker of the two claims: both are four bounded reads of the same
+  # endpoint, so the pair could be swapped without changing what a tight run
+  # collects. What decides it is that the CPU capture's placement was argued on
+  # its own terms and this one has no argument for displacing it -- and "the
+  # last red run made the network question look more urgent" is not one, since
+  # the next red run picks a different subsystem and the order would follow it
+  # around.
+  cpu=$(grep -n 'cozy_capture_tenant_worker_cpu_throttle || true' "$lib" | head -n 1 | cut -d: -f1)
+  net=$(grep -n 'cozy_capture_tenant_worker_network_counters || true' "$lib" | head -n 1 | cut -d: -f1)
+  console=$(grep -n 'cozy_capture_tenant_serial_console || true' "$lib" | head -n 1 | cut -d: -f1)
+  talos=$(grep -n 'cozy_capture_tenant_talos "${test_name}" || true' "$lib" | head -n 1 | cut -d: -f1)
+  mirror=$(grep -n 'ghcr_mirror_diagnose || true' "$lib" | head -n 1 | cut -d: -f1)
+  cache=$(grep -n 'talos_image_cache_diagnose || true' "$lib" | head -n 1 | cut -d: -f1)
+  for v in cpu net console talos mirror cache; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to locate $v in $lib" >&2
+      exit 1
+    fi
+  done
+  if [ "$cpu" -ge "$net" ]; then
+    echo "the CPU counters (line $cpu) keep their argued place ahead of the network counters ($net)" >&2
+    exit 1
+  fi
+  for later in console talos mirror cache; do
+    eval "n=\$$later"
+    if [ "$net" -ge "$n" ]; then
+      echo "the network counters (line $net) must precede $later (line $n), or a tight run declines them" >&2
+      exit 1
+    fi
+  done
+}
+
+@test "every collector that survives a missing timeout is named in the warning that says so" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # The warning an operator reads when `timeout` is absent splits the collectors
+  # into the ones that then exit 127 and collect nothing and the ones that run
+  # unbounded instead, and it names the second group. An enumeration is only
+  # true until the next collector joins the group, and a reader who trusts a
+  # stale one draws the opposite conclusion about whichever collector is
+  # missing from it. So the list is derived here rather than restated: every
+  # function that guards its bounded call with `command -v timeout` has to
+  # appear in that sentence.
+  warn=$(grep -n 'timeout is not on PATH' "$lib" | head -n 1 | cut -d: -f1)
+  if [ -z "$warn" ]; then
+    echo "expected the phase to still warn when timeout is missing" >&2
+    exit 1
+  fi
+  line=$(sed -n "${warn}p" "$lib")
+  # The guarded collectors, found by walking the source: a `command -v timeout`
+  # test inside a function body puts that function in the group. awk tracks the
+  # enclosing definition so the name reported is the function's, not the line's.
+  #
+  # Over the sourced libraries as well as this file, and the list of them is
+  # read from the source rather than written out here. Two of the four captures
+  # the sentence names -- the ghcr-mirror and talos-image-cache diagnoses --
+  # live in libraries this file sources, so a scan of this file alone finds
+  # neither, and their arms in the table below sat unreachable while reading as
+  # coverage. A guarded read added to any sourced library is what this has to
+  # see, and hardcoding today's two would put the next library outside the scan
+  # in exactly the same silent way.
+  libs="$lib $(awk '/^\. hack\/e2e-chainsaw\/_lib\/[a-z-]+\.sh$/ { print $2 }' "$lib")"
+  for f in $libs; do
+    if [ ! -f "$f" ]; then
+      echo "the scan was pointed at $f, which does not exist" >&2
+      exit 1
+    fi
+  done
+  # Two directions, because the sentence goes stale two ways.
+  #
+  # `guarded` is the set of functions that carry the guard, read off the source.
+  # The `^}` reset matters: without it a guard appearing at top level after a
+  # definition is filed under the preceding function, which is a wrong name in
+  # the group rather than a missing one.
+  #
+  # What is deliberately NOT here is a call-graph closure from each capture down
+  # to a guarded read. Deriving one from shell text means matching callee names
+  # inside bodies that also contain comments and strings, and a matcher loose
+  # enough to find the calls reports functions that make none -- green while
+  # naming nothing. A guard that has to parse shell to be right is a guard that
+  # will be wrong; the explicit table below says the same thing in a form that
+  # cannot drift silently, because every name in it must appear in `guarded` or
+  # the test fails.
+  guarded=$(awk '
+    /^[a-z_]+\(\) *[({] *$/ { fn = $0; sub(/\(\).*/, "", fn); next }
+    /^[})]$/ { fn = ""; next }
+    /command -v timeout >\/dev\/null 2>&1; then/ { if (fn != "") print fn }
+  ' $libs | sort -u)
+  if [ -z "$guarded" ]; then
+    echo "found no function carrying the timeout guard, so this test checked nothing" >&2
+    exit 1
+  fi
+  # Direction one: for each capture the sentence names, the functions whose
+  # guard is what makes that sentence true of it. The two cAdvisor captures do
+  # not carry the guard themselves -- it lives in the body they share -- and
+  # naming that body here is what the closure was trying and failing to derive.
+  # A helper renamed or a guard removed drops it out of `guarded`, and this
+  # fails; a capture dropped from the warning fails on the phrase check below.
+  for entry in \
+    'cozy_capture_tenant_worker_cpu_throttle:CPU throttling:_cozy_cadvisor_node_stream _cozy_cadvisor_worker_nodes' \
+    'cozy_capture_tenant_worker_network_counters:network counter:_cozy_cadvisor_node_stream _cozy_cadvisor_worker_nodes' \
+    'ghcr_mirror_diagnose:ghcr-mirror:ghcr_mirror_diagnose _ghcr_mirror_bounded_read' \
+    'talos_image_cache_diagnose:talos-image-cache:talos_image_cache_diagnose _talos_image_cache_bounded_read'; do
+    fn=${entry%%:*}
+    rest=${entry#*:}
+    phrase=${rest%%:*}
+    carriers=${rest#*:}
+    for carrier in $carriers; do
+      case "
+${guarded}
+" in
+        *"
+${carrier}
+"*) ;;
+        *)
+          echo "$fn is named in the warning as surviving a missing timeout, but $carrier carries no command -v guard; the sentence is claiming behaviour the code no longer has" >&2
+          exit 1
+          ;;
+      esac
+    done
+    case "$line" in
+      *"$phrase"*) ;;
+      *)
+        echo "the warning does not name $fn (expected the phrase: $phrase)" >&2
+        exit 1
+        ;;
+    esac
+  done
+  # Direction two: every function carrying the guard is either one of those
+  # captures or exempt for a stated reason. One with no entry here fails rather
+  # than being skipped, because a silent skip is how the enumeration went stale.
+  for fn in $guarded; do
+    case "$fn" in
+      cozy_capture_tenant_worker_cpu_throttle) phrase='CPU throttling' ;;
+      cozy_capture_tenant_worker_network_counters) phrase='network counter' ;;
+      ghcr_mirror_diagnose) phrase='ghcr-mirror' ;;
+      talos_image_cache_diagnose) phrase='talos-image-cache' ;;
+      # The sentence enumerates the CAPTURES. Two other kinds of function guard
+      # the same way and are deliberately not in it, each exempt for a stated
+      # reason rather than by omission: the shared bounded-read helpers, and the
+      # individual reads belonging to a capture the sentence already names.
+      # Both are covered by the comment directly above the warning, and putting
+      # them in the sentence too would be a second copy of that claim to keep in
+      # step. A function that is neither still fails below, which is what makes
+      # this a list of exemptions rather than a list of everything.
+      cozy_diag_read | _ghcr_mirror_bounded_read | _talos_image_cache_bounded_read) continue ;;
+      _cozy_cadvisor_node_stream | _cozy_cadvisor_worker_nodes) continue ;;
+      cozy_report_node_join_failure | _talos_image_cache_deploy_state) continue ;;
+      *)
+        echo "$fn guards its call with command -v but this test has no phrase for it; add one here and to the warning" >&2
+        exit 1
+        ;;
+    esac
+    case "$line" in
+      *"$phrase"*) ;;
+      *)
+        echo "the warning does not name $fn (expected the phrase: $phrase)" >&2
+        exit 1
+        ;;
+    esac
+  done
+}
+
+@test "the spend order both chainsaw suites document matches the order the block runs" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # Those comments are where a reader checks what the phase budget covers and in
+  # what order it is spent, which makes them the one place a collector added to
+  # the phase is most useful and most easily forgotten -- the ceiling line four
+  # lines above gets edited because a test compares it, and the list below it
+  # did not because nothing did. This is that nothing.
+  #
+  # Position, not just presence. The list's whole subject is the ORDER, since
+  # what a spent budget declines is whatever has not started; a presence check
+  # would accept the new collector appended at the bottom next to the two
+  # collectors it is deliberately ahead of, and the comment would then describe
+  # the opposite of what the block does.
+  #
+  # Both sides are derived. The call order comes from the source, and each
+  # collector with no entry in the phrase table fails here rather than being
+  # skipped, which is how the list went stale in the first place.
+  #
+  # Keyed on the `|| true` call suffix rather than on cozy_diag_phase_has_time,
+  # and the two sets are not identical: cozy_report_guest_console_wedge is
+  # called that way and is NOT behind the gate, which is why it needs an arm of
+  # its own below. The call suffix is what this test can order; the gate is a
+  # separate line from the call it guards.
+  gated=$(grep -nE '^ *(cozy_(capture|report)_[a-z_]+|[a-z_]+_diagnose) [^|]*\|\| true|^ *(cozy_(capture|report)_[a-z_]+|[a-z_]+_diagnose) \|\| true' "$lib" \
+    | sed -E 's/:[[:space:]]*/:/; s/(:[a-z_]+) .*/\1/; s/\|\|.*//')
+  if [ -z "$gated" ]; then
+    echo "found no gated collector at all, so this test checked nothing" >&2
+    exit 1
+  fi
+  expected=
+  for entry in $gated; do
+    fn=${entry#*:}
+    case "$fn" in
+      cozy_capture_tenant_worker_cpu_throttle) phrase='worker CPU throttling counters' ;;
+      cozy_capture_tenant_worker_network_counters) phrase='worker network counters' ;;
+      cozy_capture_tenant_serial_console) phrase='serial-console family' ;;
+      cozy_capture_tenant_talos) phrase='guest Talos capture' ;;
+      ghcr_mirror_diagnose) phrase='ghcr-mirror state' ;;
+      talos_image_cache_diagnose) phrase='talos-image-cache diagnosis' ;;
+      # Called with the same suffix but not behind the phase gate: it runs ahead
+      # of the headline so the console experiment's own failure is named before
+      # the wording that matches the bug it studies, and it is not part of what
+      # the budget covers.
+      cozy_report_guest_console_wedge) continue ;;
+      *)
+        echo "$fn runs in the diagnostics block but this test has no phrase for it; add one here and to both chainsaw comments" >&2
+        exit 1
+        ;;
+    esac
+    expected="${expected}${phrase}
+"
+  done
+  for f in hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml \
+    hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml; do
+    actual=
+    while IFS= read -r phrase; do
+      [ -n "$phrase" ] || continue
+      line=$(grep -n "$phrase" "$f" | head -n 1 | cut -d: -f1)
+      if [ -z "$line" ]; then
+        echo "$f does not list the spend-order entry: $phrase" >&2
+        exit 1
+      fi
+      actual="${actual}${line} ${phrase}
+"
+    done <<EOF
+$expected
+EOF
+    # Sorting the located lines numerically must reproduce the call order. A
+    # mismatch means the comment and the block disagree about which collector
+    # the budget gives up first, which is the only thing this list is read for.
+    if [ "$(printf '%s' "$actual" | sort -n | sed -E 's/^[0-9]+ //')" != "$(printf '%s' "$actual" | sed -E 's/^[0-9]+ //')" ]; then
+      echo "$f lists the collectors in a different order than the block runs them" >&2
+      printf '%s\n' "$actual" >&2
+      exit 1
+    fi
+  done
+}
+
 @test "the declined path leaves no shell error in the diagnostics log" {
   # The chainsaw script that calls this runs under `set -eu`, and the declined
   # path is where a variable assigned only inside the phase gate gets read
@@ -938,6 +1222,7 @@ assert_file_contains() {
     cozy_capture_tenant_talos() { :; }
     talos_image_cache_diagnose() { :; }
     cozy_capture_tenant_worker_cpu_throttle() { :; }
+    cozy_capture_tenant_worker_network_counters() { :; }
     ghcr_mirror_diagnose() { :; }
     kubectl() { :; }
     COZY_DIAG_PHASE_BUDGET=0
@@ -981,7 +1266,15 @@ assert_file_contains() {
   # nothing makes one move it. Those are the residuals, and the first two exist
   # today rather than hypothetically. All are tracked in cozystack/cozystack#3666.
   bringup=1500
-  largest=620
+  # 620 was this figure while the guest-Talos walk ran two commands per worker.
+  # It now runs four: the service list and the link table were added at a 10s
+  # bound with the usual 5s kill grace, which is 2 x 2 x 15 = 60 more seconds
+  # across the two-worker minimum pool. Derived as a delta on the previous
+  # number rather than recomputed from the walk, deliberately: a fresh
+  # enumeration that missed a step would LOWER this term and loosen the guard
+  # while looking like it had tightened it, and the delta is the part this
+  # change is answerable for.
+  largest=680
   lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
   # Read from the named default rather than from the `:-` expansion: the defaults are
   # declared once as constants, so that is where the number lives now.

--- a/hack/run-kubernetes-talos-diagnostics_test.bats
+++ b/hack/run-kubernetes-talos-diagnostics_test.bats
@@ -20,6 +20,15 @@ talosctl_calls=/dev/null
 timeout_calls=/dev/null
 timeout_rc=0
 timeout_fail_node_ip=
+# Per-read failure, which the two knobs above cannot express: one is global and
+# the other selects a whole node. The marker below is decided by how many of a
+# worker's four reads answered, so every interesting case is a mix -- and with
+# only all-or-nothing knobs the boundary between them cannot be reached at all,
+# which is how it went untested while a test named for it passed.
+#
+# Space-separated tokens matched against the composed command; each of the four
+# reads carries one the others do not (dmesg, kubelet, links, services).
+timeout_fail_commands=
 
 kubectl() {
   printf '%s\n' "$*" >>"${kubectl_calls}"
@@ -82,6 +91,12 @@ timeout() {
       *" -e ${timeout_fail_node_ip} "*) return 124 ;;
     esac
   fi
+  local _tok
+  for _tok in ${timeout_fail_commands}; do
+    case " $* " in
+      *" ${_tok}"*) return 1 ;;
+    esac
+  done
   [ "${timeout_rc}" -eq 0 ] || return "${timeout_rc}"
   return "${command_rc}"
 }
@@ -224,6 +239,182 @@ assert_file_lacks_pattern() {
   rm -rf "$tmp"
 }
 
+@test "the service state machine is captured, so a kubelet that never ran is legible" {
+  # The log this collector took before was not the whole answer, and on the
+  # dominant shape of this failure it is not an answer at all. Talos creates a
+  # service's log buffer when its runner opens the log writer, as it starts the
+  # process, so a kubelet held in Waiting -- for its volumes, for time sync, or
+  # for the container runtime to report healthy -- never reached its runner, has
+  # no log to read, and `logs kubelet` fails naming a log never registered.
+  # That error is a true statement about the log and says
+  # nothing about the service, so a reader gets an unexplained failure where the
+  # actual finding is the state and the condition it is waiting on. ServiceList
+  # carries both, for every service at once, and the reader role is allowed to
+  # call it.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+
+  cozy_capture_tenant_talos_node diagnostics-pod 10.244.1.92 "$tmp/node"
+
+  [ -s "$tmp/node/services.log" ]
+  assert_file_contains ' 10.244.1.92 services' "$kubectl_calls"
+  assert_file_contains '[capture exit code: 0]' "$tmp/node/services.log"
+  rm -rf "$tmp"
+}
+
+@test "the guest link table is captured as yaml, because MTU is not a printed column" {
+  # MTU is the value that decides whether the PMTU reading of a stalled transfer
+  # is alive: a guest at 1500 over an encapsulated fabric drops exactly the large
+  # segments while the small ones pass. LinkStatus carries it in the spec and
+  # not in the resource's print columns, so the table form -- which is what the
+  # command prints by default -- omits the one field this is read for.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+
+  cozy_capture_tenant_talos_node diagnostics-pod 10.244.1.92 "$tmp/node"
+
+  # Named .yaml.log, not .yaml, and the suffix is the assertion. Every capture
+  # here gets `[capture exit code: N]` appended by the shared helper, so a file
+  # promising YAML would not parse as YAML -- and a reader who reaches for yq
+  # and gets a parse error learns something about the tool rather than about the
+  # cluster. The .log suffix matches every other consumer of that footer.
+  [ -s "$tmp/node/links.yaml.log" ]
+  [ ! -e "$tmp/node/links.yaml" ]
+  assert_file_contains ' 10.244.1.92 get links -o yaml' "$kubectl_calls"
+  rm -rf "$tmp"
+}
+
+@test "the two added reads carry the tighter bound and the two older ones do not" {
+  # The phase budget is what makes this a decision rather than a detail. These
+  # two reads sit inside the collector the budget's own guard sizes itself
+  # against, so every second added here is a second taken from the collectors
+  # gated after it. Both are single tabular RPCs that a reachable apid answers
+  # at once, which is not the shape of the two reads beside them: a kernel ring
+  # buffer and five hundred lines of service log are streams, and cutting those
+  # to ten seconds would lose evidence on exactly the slow-apid worker the
+  # capture exists for.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+
+  cozy_capture_tenant_talos_node diagnostics-pod 10.244.1.92 "$tmp/node"
+
+  while IFS= read -r line; do
+    case "$line" in
+      *' dmesg') [ "${line#-k 5 20 }" != "$line" ] || { echo "dmesg lost its 20s bound: $line" >&2; exit 1 ;} ;;
+      *'logs kubelet --tail=500') [ "${line#-k 5 20 }" != "$line" ] || { echo "kubelet log lost its 20s bound: $line" >&2; exit 1 ;} ;;
+      *' services') [ "${line#-k 5 10 }" != "$line" ] || { echo "services must carry the tighter bound: $line" >&2; exit 1 ;} ;;
+      *'get links -o yaml') [ "${line#-k 5 10 }" != "$line" ] || { echo "links must carry the tighter bound: $line" >&2; exit 1 ;} ;;
+      *) echo "unexpected bounded call: $line" >&2; exit 1 ;;
+    esac
+  done <"$timeout_calls"
+  [ "$(wc -l < "$timeout_calls")" -eq 4 ]
+  rm -rf "$tmp"
+}
+
+@test "a worker that produced no guest evidence at all says so in its own directory" {
+  # The gap this closes is a directory that looks like a worker with nothing to
+  # report. When apid refuses the connection every read fails and each log holds
+  # its own rpc error plus an exit code, which is accurate per file and adds up
+  # to nothing a reader scanning the tree can see: the directory has the same
+  # shape as one whose reads returned little. The marker states the outcome for
+  # the worker rather than for each read, and it is written only when NOTHING
+  # succeeded, so a worker that answered one read out of four is not written up
+  # as unreachable.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  timeout_rc=1
+
+  rc=0
+  cozy_capture_tenant_talos_node diagnostics-pod 10.244.1.93 "$tmp/node" || rc=$?
+
+  # A zero status on the all-fail path, which is the ordinary shape of an
+  # unreachable worker. Note what this assertion does NOT establish: the call
+  # above uses `|| rc=$?`, which suppresses errexit for everything it covers, so
+  # a failing statement inside the function would not abort here either way.
+  # That the function keeps its caller's walk alive under a live errexit is a
+  # property of the `|| true` on the marker write, and it is not observable from
+  # this suite -- reaching it needs a bare call in a shell this file does not
+  # provide.
+  [ "$rc" -eq 0 ]
+  assert_file_contains 'no Talos read completed for this worker' "$tmp/node/CAPTURE-FAILED.txt"
+  # The per-read logs stay: they carry the reason, and the marker only points.
+  assert_file_contains '[capture exit code: 1]' "$tmp/node/dmesg.log"
+  rm -rf "$tmp"
+}
+
+@test "a worker that answered even one read carries no capture-failed marker" {
+  # The positive control for the marker above, and it has to sit at the
+  # BOUNDARY rather than at the easy end. The marker's contract is "nothing
+  # answered", so the case that distinguishes it from every nearby threshold is
+  # one read answering and three failing -- not four answering, which is what
+  # this test used to stage and which any `answered < N` would also satisfy.
+  # Measured: with the all-succeed staging, changing the condition to
+  # `-lt 4` left this file green while a worker that answered three reads of
+  # four was written up as having produced no guest evidence at all, which is
+  # the false statement the marker exists to prevent.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  # Everything but the service list fails, so exactly one read answers.
+  timeout_fail_commands="dmesg kubelet links"
+
+  cozy_capture_tenant_talos_node diagnostics-pod 10.244.1.92 "$tmp/node"
+
+  [ ! -f "$tmp/node/CAPTURE-FAILED.txt" ]
+  # Not vacuous: the staging really did leave three reads failing and one
+  # answering, so the absence above is the boundary rather than an easy case.
+  assert_file_contains '[capture exit code: 1]' "$tmp/node/dmesg.log"
+  assert_file_contains '[capture exit code: 0]' "$tmp/node/services.log"
+  rm -rf "$tmp"
+}
+
+@test "every one of the four reads counts toward the tally, not just the last" {
+  # The other direction of the same boundary, and it has to walk all four
+  # readings rather than restage the one above. The marker is decided by a COUNT
+  # over four reads, so a read that stops contributing is invisible in any
+  # staging where some other read answers -- it only changes which staging
+  # reaches zero. Measured before this test existed: dropping the tally from
+  # three of the four reads at once left the whole file green, because the one
+  # staging in use happened to keep the fourth.
+  #
+  # So each read takes a turn as the sole answering one. Dropping any single
+  # read's contribution makes its own turn report a worker that answered
+  # nothing, while its own log in the same directory holds a clean capture.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  for sole in dmesg kubelet links services; do
+    tmp=$(mktemp -d)
+    kubectl_calls="$tmp/kubectl.calls"
+    timeout_calls="$tmp/timeout.calls"
+    timeout_fail_commands=$(printf '%s\n' dmesg kubelet links services | grep -v "^${sole}$" | tr '\n' ' ')
+
+    cozy_capture_tenant_talos_node diagnostics-pod 10.244.1.92 "$tmp/node"
+
+    case "$sole" in
+      dmesg) log="dmesg.log" ;;
+      kubelet) log="kubelet.log" ;;
+      links) log="links.yaml.log" ;;
+      services) log="services.log" ;;
+    esac
+    # Not vacuous: the staging really did leave this read as the only answer.
+    assert_file_contains '[capture exit code: 0]' "$tmp/node/$log"
+    if [ -f "$tmp/node/CAPTURE-FAILED.txt" ]; then
+      echo "FAIL: with $sole the only answering read, the worker was declared to have produced nothing" >&2
+      rm -rf "$tmp"
+      false
+    fi
+    rm -rf "$tmp"
+  done
+}
+
 @test "a timed-out worker remains recorded and does not block the next capture" {
   . hack/e2e-chainsaw/_lib/run-kubernetes.sh
   tmp=$(mktemp -d)
@@ -233,10 +424,11 @@ assert_file_lacks_pattern() {
 
   cozy_capture_tenant_talos_node diagnostics-pod 10.244.1.93 "$tmp/node"
 
-  [ "$(wc -l < "$kubectl_calls")" -eq 2 ]
-  [ "$(wc -l < "$timeout_calls")" -eq 2 ]
+  [ "$(wc -l < "$kubectl_calls")" -eq 4 ]
+  [ "$(wc -l < "$timeout_calls")" -eq 4 ]
   assert_file_contains '[capture exit code: 124]' "$tmp/node/dmesg.log"
   assert_file_contains '[capture exit code: 124]' "$tmp/node/kubelet.log"
+  assert_file_contains '[capture exit code: 124]' "$tmp/node/services.log"
   rm -rf "$tmp"
 }
 
@@ -259,7 +451,7 @@ assert_file_lacks_pattern() {
 
   cozy_capture_tenant_talos test-latest-version
 
-  [ "$(awk '/ exec kubernetes-test-latest-version-talos-diagnostics / { count++ } END { print count + 0 }' "$kubectl_calls")" -eq 4 ]
+  [ "$(awk '/ exec kubernetes-test-latest-version-talos-diagnostics / { count++ } END { print count + 0 }' "$kubectl_calls")" -eq 8 ]
   assert_file_contains 'default VMI interface has no reported IP address' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-no-ip/capture-error.log"
   assert_file_contains '[capture exit code: 124]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-a/dmesg.log"
   assert_file_contains '[capture exit code: 124]' "$COZY_REPORT_DIR/snapshots/$COZY_SNAPSHOT_NAME/tenant-talos/worker-a/kubelet.log"
@@ -283,5 +475,31 @@ assert_file_lacks_pattern() {
 
   [ "$(sed -n '2p' "$kubectl_calls")" = '-n tenant-test delete certificates.cert-manager.io -l cozystack-e2e.io/tenant-talos-diagnostics --ignore-not-found --wait=true --timeout=30s' ]
   [ "$(sed -n '3p' "$kubectl_calls")" = '-n tenant-test delete pod,secret -l cozystack-e2e.io/tenant-talos-diagnostics --ignore-not-found --wait=false' ]
+  rm -rf "$tmp"
+}
+
+@test "a worker whose reads were cut short is not told its directory is empty" {
+  # The slow-apid worker, and the shape this capture is most often reached on:
+  # every read is killed at its bound after writing part of what it fetched, so
+  # nothing exits zero and the tally reads nothing-completed -- while the
+  # directory holds real evidence. A marker saying nothing was observed would be
+  # this collector making the unsupported claim its own status arms exist to
+  # prevent, one directory up.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  # Output first, then the non-zero status: what `timeout` does to a stream it
+  # kills, and the reason the mock cannot return before writing.
+  timeout_rc=124
+
+  cozy_capture_tenant_talos_node diagnostics-pod 10.244.1.93 "$tmp/node"
+
+  # Not vacuous: a read really did leave content behind before it was killed.
+  assert_file_contains 'mock capture for' "$tmp/node/dmesg.log"
+  assert_file_contains '[capture exit code: 124]' "$tmp/node/dmesg.log"
+  # The marker still fires -- nothing completed -- but says only that.
+  assert_file_contains 'no Talos read completed for this worker' "$tmp/node/CAPTURE-FAILED.txt"
+  assert_file_lacks_pattern 'nothing here was observed' "$tmp/node/CAPTURE-FAILED.txt"
   rm -rf "$tmp"
 }


### PR DESCRIPTION
## What this PR does

A tenant worker that misses the node-Ready deadline while its kubelet image pull crawls leaves two mechanisms behind one symptom, and the failure artifact could not tell them apart: either the link is slow, or the pull keeps restarting and discarding what it fetched. From inside the guest both are a progress line that barely moves. This adds the host-side counters that separate them, and the guest-side reads that explain a kubelet which never got as far as pulling at all.

**Host side.** A per-worker network capture reads the eight `container_network_*` families from the same kubelet cAdvisor endpoint the CPU throttling capture already uses. cAdvisor builds them from the interface counters inside the Pod's own network namespace and publishes one row per interface, so what arrived at the worker is counted there in full, including the bytes a restart threw away, set against the progress the guest reported, that separates a pull which kept restarting from a slow link.

Which row answers is not obvious, and getting it wrong inverts the reading, so the collector states it rather than leaving it to the reader. A bridge-bound worker presents four interfaces in its Pod netns: the one still named `eth0` is a dummy that holds the Pod IP so the kubelet's check passes and carries no traffic, so it reports zero, and it is the row a reader reaches for first, by name, where zero reads as a worker that received nothing. The number that answers is the renamed NIC's receive; the bridge counts the same bytes again, and the tap's counters are named from the host's end. The filter deliberately carries no interface predicate, so all four reach the artifact and can be told apart.

Two further properties of the family fail by capturing nothing rather than loudly, so both are stated where the filter is: the dropped-packet series are spelled `packets_dropped` and there is no `*_drops_total`, and every row carries an empty container label because cAdvisor publishes them on the Pod sandbox, which means a filter borrowed from the CPU counters beside it matches nothing at all.

The fixture's row shape and values are real kubelet output with the identifying labels rewritten. Its four interface names are derived rather than observed: no virt-launcher Pod was available to sample, so they are read from the name generators in the KubeVirt version this repo ships, and the counters attached to them illustrate direction rather than magnitude.

**Guest side.** The Talos capture gains the service state machine and the link table. Talos creates a service's log buffer when its runner opens the log writer, as it starts the process, so a kubelet still waiting on its volumes, on time sync, or on the container runtime reporting healthy never reached its runner and has no log at all, and `talosctl logs kubelet` then fails naming a log that was never registered, which is true about the log and silent about the service. `talosctl services` answers with the state and the condition being waited on, in one call for every service, so the runtime a kubelet is blocked behind arrives in the same file. The link table is read as YAML because MTU lives in the `LinkStatus` spec and not among the resource's printed columns, and it is the value that decides whether a path-MTU reading of a stalled transfer survives.

Both new reads are made with the short-lived `os:reader` credential the capture already mints; neither needs a wider role.

**A worker that answered nothing now says so once, for the worker.** Each read already carried its own error and exit code, which is accurate per file and adds up to a directory indistinguishable from a worker that simply had little to report.

### What this does not do

This collects evidence; it fixes nothing and is not expected to change any suite's outcome. The comparison it enables is not symmetric either, and the source says so: the host side reports bytes on an interface, while the guest side reports an image pull's own progress, which is unpacking rather than arrival. They bound each other; they are not two measurements of one quantity.

### Cost

The diagnostics phase budget drops from 8m to 7m. That is forced rather than chosen: the inequality that keeps the tenant crust-gather snapshot reachable had ten seconds of slack, and the two added guest reads cost sixty across the minimum worker pool. A shorter budget declines more, and what it declines first is what is gated last: the mirror capture, whose subject is partly recoverable elsewhere, and the image-cache re-probe, which has no substitute and was already first to go. The new network capture also spends a listing and one read per node ahead of the guest captures, so those reach their gate with less headroom than before. All of it is priced where the number lives, as a ceiling the read bounds impose rather than a duration measured on a live cluster, and a collector the budget declines says so in the log rather than going quiet.

The remaining slack is ten seconds, which is worth knowing before the next collector is added rather than after: it buys no bounded read at any bound this file uses, so adding one means re-deriving the budget again.

### Testing

`hack/run-kubernetes-network-counters_test.bats` is new (15 tests). The node-join, Talos-diagnostics and CPU-throttle suites gain coverage for the phase ordering, the per-worker marker boundary, the spend-order comments in both Chainsaw suites, and the enumeration of collectors that survive a missing `timeout`. Every claim the two Chainsaw comment blocks make about spend order is derived from the source rather than restated, so a collector added without a line there fails.

The two cAdvisor captures now run one shared body. They previously carried near-identical copies, and the copies cost more than duplication normally does: the block-level bound audit pins each collector by something only it produces, and two collectors issuing identical reads left neither with anything of its own, so removing one from the audit went unnoticed. Each is now pinned by the report directory it writes.

Verified with `hack/cozytest.sh` across eleven suites, checking that the number of tests executed matches the number declared, because an exit code answers "did anything fail", never "did anything run". Each behavioural change was confirmed by mutating the source and observing the intended test fail.

### Screenshots

No UI changes.

### Downstream repositories

Walked the trigger map file by file against the diff. All seven changed files live under `hack/`, and the change adds one file and modifies six; no repository file is moved, renamed or deleted. The `ccp` entry is the only one that keys on `hack/` at all, and it keys on `hack/package.mk`, `hack/common-envs.mk` and `hack/update-crd.sh` as anchors for `make generate`; none of those is touched, and no make target changes behaviour. Nothing here is a package, a chart value, an `ApplicationDefinition`, a CRD, a release asset, a namespace, a variant, or a node prerequisite, so no other entry applies.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added worker network-counter diagnostics with interface-level and cumulative traffic data.
  * Expanded Talos diagnostics with service-state and link-state information.
* **Bug Fixes**
  * Improved reporting for partial captures, timeouts, unavailable data, and zero-traffic workers.
  * Clarified failure reporting and fallback messages when timeout controls are unavailable.
* **Documentation**
  * Updated diagnostic timing and collector documentation for the seven-minute budget and new metrics.
* **Tests**
  * Added comprehensive coverage for network counters, filtering, truncation, and expanded Talos diagnostic scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->