### PR TITLE
fix(api): declare OpenAPIModelName for core and sdn types

### DIFF
--- a/pkg/apis/core/v1alpha1/doc.go
+++ b/pkg/apis/core/v1alpha1/doc.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 // +k8s:openapi-gen=true
+// +k8s:openapi-model-package=com.github.cozystack.cozystack.pkg.apis.core.v1alpha1
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=github.com/cozystack/cozystack/pkg/apis/core
 // +k8s:conversion-gen=k8s.io/apiextensions-apiserver/pkg/apis/apiextensions

--- a/pkg/apis/core/v1alpha1/model_name.go
+++ b/pkg/apis/core/v1alpha1/model_name.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// OpenAPIModelName pins the OpenAPI model name for the core.cozystack.io types.
+// This is hand-written (not generated) on purpose.
+//
+// Without it, openapi-gen keys the generated definition map on the Go import
+// path ("github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.Option"), and
+// since Kubernetes 0.35 the apiserver's DefinitionNamer.GetDefinitionName
+// returns whatever name it is given verbatim instead of converting it to the
+// "friendly" reversed-path form. The published document then keys the definition
+// on the raw path while every $ref to it is JSON pointer escaped
+// ("#/definitions/github.com~1cozystack~1…v1alpha1.OptionSpec", ~1 being a
+// slash), and clients resolve a $ref by trimming "#/definitions/" without
+// unescaping. The two spellings never meet, so the reference dangles and
+// client-side validation fails on every resource in the group, not only the one
+// named in the error:
+//
+//	error validating data: SchemaError(…core/v1alpha1.Option.spec):
+//	unknown model in reference: "github.com~1cozystack~1…v1alpha1.OptionSpec"
+//
+// Declaring the dotted name here makes GetCanonicalTypeName,
+// Scheme.ToOpenAPIDefinitionName and the generated openapi map key all agree on
+// a name with no slash in it, so nothing needs escaping and every $ref resolves.
+// The same agreement is what lets DefinitionNamer attach the
+// x-kubernetes-group-version-kind extension, which server-side apply needs to
+// resolve a kind (see the apps package, where its absence broke SSA instead).
+//
+// code-generator's openapi-gen could emit these via --output-model-name-file,
+// but that also rewrites zz_generated.model_name.go in the read-only apimachinery
+// / apiextensions module-cache packages the shared gen_openapi helper always
+// passes as inputs, which fails on any consumer (including CI) that vendors deps
+// from the module cache. Keeping the methods here sidesteps that.
+//
+// The +k8s:openapi-model-package marker in doc.go makes openapi-gen emit
+// Type{}.OpenAPIModelName() for every type in this package it generates a schema
+// or a reference for, so a new core.cozystack.io type without a method here
+// fails the build rather than silently reintroducing a Go-path name. The
+// returned string must be the dotted form Scheme.ToOpenAPIDefinitionName derives
+// from the type's Go package path, which is the marker's value plus the type
+// name. See https://github.com/cozystack/cozystack/issues/3806.
+
+func (in Option) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.core.v1alpha1.Option"
+}
+
+func (in OptionItem) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.core.v1alpha1.OptionItem"
+}
+
+func (in OptionList) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.core.v1alpha1.OptionList"
+}
+
+func (in OptionSpec) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.core.v1alpha1.OptionSpec"
+}
+
+func (in TenantModule) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.core.v1alpha1.TenantModule"
+}
+
+func (in TenantModuleList) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.core.v1alpha1.TenantModuleList"
+}
+
+func (in TenantModuleStatus) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.core.v1alpha1.TenantModuleStatus"
+}
+
+func (in TenantNamespace) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.core.v1alpha1.TenantNamespace"
+}
+
+func (in TenantNamespaceList) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.core.v1alpha1.TenantNamespaceList"
+}
+
+func (in TenantSecret) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.core.v1alpha1.TenantSecret"
+}
+
+func (in TenantSecretList) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.core.v1alpha1.TenantSecretList"
+}

--- a/pkg/apis/sdn/v1alpha1/doc.go
+++ b/pkg/apis/sdn/v1alpha1/doc.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 // +k8s:openapi-gen=true
+// +k8s:openapi-model-package=com.github.cozystack.cozystack.pkg.apis.sdn.v1alpha1
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=github.com/cozystack/cozystack/pkg/apis/sdn
 // +k8s:conversion-gen=k8s.io/apiextensions-apiserver/pkg/apis/apiextensions

--- a/pkg/apis/sdn/v1alpha1/model_name.go
+++ b/pkg/apis/sdn/v1alpha1/model_name.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// OpenAPIModelName pins the OpenAPI model name for the sdn.cozystack.io types.
+// This is hand-written (not generated) on purpose.
+//
+// Without it, openapi-gen keys the generated definition map on the Go import
+// path ("github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.SecurityGroup"),
+// and since Kubernetes 0.35 the apiserver's DefinitionNamer.GetDefinitionName
+// returns whatever name it is given verbatim instead of converting it to the
+// "friendly" reversed-path form. The published document then keys the definition
+// on the raw path while every $ref to it is JSON pointer escaped
+// ("#/definitions/github.com~1cozystack~1…v1alpha1.SecurityGroupSpec", ~1 being
+// a slash), and clients resolve a $ref by trimming "#/definitions/" without
+// unescaping. The two spellings never meet, so the reference dangles and
+// client-side validation fails on every resource in the group, not only the one
+// named in the error:
+//
+//	error validating data: SchemaError(…sdn/v1alpha1.SecurityGroup.spec):
+//	unknown model in reference: "github.com~1cozystack~1…v1alpha1.SecurityGroupSpec"
+//
+// Declaring the dotted name here makes GetCanonicalTypeName,
+// Scheme.ToOpenAPIDefinitionName and the generated openapi map key all agree on
+// a name with no slash in it, so nothing needs escaping and every $ref resolves.
+// The same agreement is what lets DefinitionNamer attach the
+// x-kubernetes-group-version-kind extension, which server-side apply needs to
+// resolve a kind (see the apps package, where its absence broke SSA instead).
+//
+// code-generator's openapi-gen could emit these via --output-model-name-file,
+// but that also rewrites zz_generated.model_name.go in the read-only apimachinery
+// / apiextensions module-cache packages the shared gen_openapi helper always
+// passes as inputs, which fails on any consumer (including CI) that vendors deps
+// from the module cache. Keeping the methods here sidesteps that.
+//
+// The +k8s:openapi-model-package marker in doc.go makes openapi-gen emit
+// Type{}.OpenAPIModelName() for every type in this package it generates a schema
+// or a reference for, so a new sdn.cozystack.io type without a method here fails
+// the build rather than silently reintroducing a Go-path name. The returned
+// string must be the dotted form Scheme.ToOpenAPIDefinitionName derives from the
+// type's Go package path, which is the marker's value plus the type name. See
+// https://github.com/cozystack/cozystack/issues/3806.
+
+func (in ApplicationReference) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.sdn.v1alpha1.ApplicationReference"
+}
+
+func (in EgressRule) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.sdn.v1alpha1.EgressRule"
+}
+
+func (in FQDNSelector) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.sdn.v1alpha1.FQDNSelector"
+}
+
+func (in IngressRule) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.sdn.v1alpha1.IngressRule"
+}
+
+func (in PortProtocol) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.sdn.v1alpha1.PortProtocol"
+}
+
+func (in PortRule) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.sdn.v1alpha1.PortRule"
+}
+
+func (in SecurityGroup) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.sdn.v1alpha1.SecurityGroup"
+}
+
+func (in SecurityGroupList) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.sdn.v1alpha1.SecurityGroupList"
+}
+
+func (in SecurityGroupSpec) OpenAPIModelName() string {
+	return "com.github.cozystack.cozystack.pkg.apis.sdn.v1alpha1.SecurityGroupSpec"
+}

--- a/pkg/generated/openapi/definitions_test.go
+++ b/pkg/generated/openapi/definitions_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapi
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"k8s.io/kube-openapi/pkg/common"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+)
+
+// The two tests below guard the published OpenAPI document against the class of
+// defect in https://github.com/cozystack/cozystack/issues/3806: a definition
+// name that is a Go import path rather than a dotted Kubernetes model name.
+//
+// Since Kubernetes 0.35 the apiserver's DefinitionNamer.GetDefinitionName
+// returns the model name it was given verbatim — it no longer converts the Go
+// import-path form into the "friendly" reversed-path form — so whatever name
+// this generated map uses becomes both the published definition key and, JSON
+// pointer escaped, the $ref that points at it. A name containing "/" therefore
+// ships as a definition keyed on the raw path while every reference to it is
+// spelled with "~1" in place of each slash, and clients resolve a $ref by
+// trimming "#/definitions/" without unescaping (kube-openapi
+// pkg/util/proto/document.go). The two spellings never meet, so the reference
+// dangles and client-side validation fails on every resource of the group:
+//
+//	error validating data: SchemaError(…core/v1alpha1.Option.spec):
+//	unknown model in reference: "github.com~1cozystack~1…v1alpha1.OptionSpec"
+//
+// The fix for a group is the +k8s:openapi-model-package marker in its doc.go
+// plus an OpenAPIModelName method per type (see each package's model_name.go).
+// Nothing asserted that, which is why the core and sdn groups shipped broken in
+// v1.6.0 and v1.6.1. These tests assert the invariant rather than today's set of
+// names, so a future group that omits the marker fails here instead of in a
+// cluster.
+
+// buildDefinitions builds the generated definition map, recording every model
+// name the generated code passes to the reference callback. Refs are built
+// exactly as kube-openapi's builder builds them, so the recorded name and the
+// emitted $ref differ in the same way they do in the served document.
+func buildDefinitions() (defs map[string]common.OpenAPIDefinition, refNames []string) {
+	defs = GetOpenAPIDefinitions(func(path string) spec.Ref {
+		refNames = append(refNames, path)
+		return spec.MustCreateRef("#/definitions/" + common.EscapeJsonPointer(path))
+	})
+	return defs, refNames
+}
+
+// sortedKeys returns the definition names in a stable order so failures are
+// reproducible rather than map-iteration ordered.
+func sortedKeys(defs map[string]common.OpenAPIDefinition) []string {
+	out := make([]string, 0, len(defs))
+	for name := range defs {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestDefinitionNamesAreDottedModelNames asserts that no published definition
+// name contains a slash. A slash-bearing name is a Go import path that escaped
+// as-is, which means the group it belongs to is missing its
+// +k8s:openapi-model-package marker and its OpenAPIModelName methods.
+func TestDefinitionNamesAreDottedModelNames(t *testing.T) {
+	defs, _ := buildDefinitions()
+
+	// Guard against the assertion going vacuous: the map must be populated and
+	// must actually cover cozystack's own types, not only the vendored
+	// apimachinery and apiextensions models that already declare their names.
+	if len(defs) == 0 {
+		t.Fatal("GetOpenAPIDefinitions returned no definitions; this test is asserting nothing")
+	}
+	own := 0
+	for _, name := range sortedKeys(defs) {
+		if strings.Contains(name, "cozystack") {
+			own++
+		}
+	}
+	if own == 0 {
+		t.Fatal("no cozystack-owned definitions found; this test is asserting nothing")
+	}
+
+	for _, name := range sortedKeys(defs) {
+		if strings.Contains(name, "/") {
+			t.Errorf("definition %q is a Go import path, not a dotted model name: "+
+				"every $ref to it is escaped with ~1 and will not resolve. Add "+
+				"+k8s:openapi-model-package=<dotted package> to that package's doc.go and an "+
+				"OpenAPIModelName method for the type in its model_name.go, then re-run make generate",
+				name)
+		}
+	}
+}
+
+// TestDefinitionRefsResolve asserts that every $ref the generated document
+// emits resolves to a published definition, resolving it the way a client does:
+// trim "#/definitions/" and look the remainder up verbatim, with no
+// unescaping. This is the failure the user sees, so it is checked directly
+// rather than only through the slash-freedom proxy above; it also catches a
+// group whose types disagree with each other (some named, some not) and a ref
+// to a model that is not published at all.
+func TestDefinitionRefsResolve(t *testing.T) {
+	defs, refNames := buildDefinitions()
+
+	if len(refNames) == 0 {
+		t.Fatal("generated definitions emitted no $ref; this test is asserting nothing")
+	}
+
+	// Index the published definitions under the key a client sees, which is the
+	// definition name exactly as published.
+	published := make(map[string]struct{}, len(defs))
+	for name := range defs {
+		published[name] = struct{}{}
+	}
+
+	seen := make(map[string]struct{}, len(refNames))
+	for _, modelName := range refNames {
+		// The served $ref, built the way kube-openapi's builder builds it.
+		ref := "#/definitions/" + common.EscapeJsonPointer(modelName)
+		// The lookup a client performs on it.
+		resolved := strings.TrimPrefix(ref, "#/definitions/")
+		if _, ok := published[resolved]; ok {
+			continue
+		}
+		if _, dup := seen[resolved]; dup {
+			continue
+		}
+		seen[resolved] = struct{}{}
+		t.Errorf("$ref %q does not resolve: no definition is published under %q (model name %q)",
+			ref, resolved, modelName)
+	}
+
+	// Dependencies must agree with the refs: the generated code lists them from
+	// the same set, and consumers walk them to build the transitive closure.
+	for _, name := range sortedKeys(defs) {
+		for _, dep := range defs[name].Dependencies {
+			if _, ok := published[dep]; !ok {
+				t.Errorf("definition %q declares dependency %q, which is not published", name, dep)
+			}
+		}
+	}
+}

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -23,6 +23,8 @@ package openapi
 
 import (
 	v1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
+	corev1alpha1 "github.com/cozystack/cozystack/pkg/apis/core/v1alpha1"
+	sdnv1alpha1 "github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,110 +36,110 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		v1alpha1.Application{}.OpenAPIModelName():                                   schema_pkg_apis_apps_v1alpha1_Application(ref),
-		v1alpha1.ApplicationList{}.OpenAPIModelName():                               schema_pkg_apis_apps_v1alpha1_ApplicationList(ref),
-		v1alpha1.ApplicationStatus{}.OpenAPIModelName():                             schema_pkg_apis_apps_v1alpha1_ApplicationStatus(ref),
-		"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.Option":              schema_pkg_apis_core_v1alpha1_Option(ref),
-		"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.OptionItem":          schema_pkg_apis_core_v1alpha1_OptionItem(ref),
-		"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.OptionList":          schema_pkg_apis_core_v1alpha1_OptionList(ref),
-		"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.OptionSpec":          schema_pkg_apis_core_v1alpha1_OptionSpec(ref),
-		"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantModule":        schema_pkg_apis_core_v1alpha1_TenantModule(ref),
-		"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantModuleList":    schema_pkg_apis_core_v1alpha1_TenantModuleList(ref),
-		"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantModuleStatus":  schema_pkg_apis_core_v1alpha1_TenantModuleStatus(ref),
-		"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantNamespace":     schema_pkg_apis_core_v1alpha1_TenantNamespace(ref),
-		"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantNamespaceList": schema_pkg_apis_core_v1alpha1_TenantNamespaceList(ref),
-		"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantSecret":        schema_pkg_apis_core_v1alpha1_TenantSecret(ref),
-		"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantSecretList":    schema_pkg_apis_core_v1alpha1_TenantSecretList(ref),
-		"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.ApplicationReference": schema_pkg_apis_sdn_v1alpha1_ApplicationReference(ref),
-		"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.EgressRule":           schema_pkg_apis_sdn_v1alpha1_EgressRule(ref),
-		"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.FQDNSelector":         schema_pkg_apis_sdn_v1alpha1_FQDNSelector(ref),
-		"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.IngressRule":          schema_pkg_apis_sdn_v1alpha1_IngressRule(ref),
-		"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.PortProtocol":         schema_pkg_apis_sdn_v1alpha1_PortProtocol(ref),
-		"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.PortRule":             schema_pkg_apis_sdn_v1alpha1_PortRule(ref),
-		"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.SecurityGroup":        schema_pkg_apis_sdn_v1alpha1_SecurityGroup(ref),
-		"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.SecurityGroupList":    schema_pkg_apis_sdn_v1alpha1_SecurityGroupList(ref),
-		"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.SecurityGroupSpec":    schema_pkg_apis_sdn_v1alpha1_SecurityGroupSpec(ref),
-		v1.ConversionRequest{}.OpenAPIModelName():                                   schema_pkg_apis_apiextensions_v1_ConversionRequest(ref),
-		v1.ConversionResponse{}.OpenAPIModelName():                                  schema_pkg_apis_apiextensions_v1_ConversionResponse(ref),
-		v1.ConversionReview{}.OpenAPIModelName():                                    schema_pkg_apis_apiextensions_v1_ConversionReview(ref),
-		v1.CustomResourceColumnDefinition{}.OpenAPIModelName():                      schema_pkg_apis_apiextensions_v1_CustomResourceColumnDefinition(ref),
-		v1.CustomResourceConversion{}.OpenAPIModelName():                            schema_pkg_apis_apiextensions_v1_CustomResourceConversion(ref),
-		v1.CustomResourceDefinition{}.OpenAPIModelName():                            schema_pkg_apis_apiextensions_v1_CustomResourceDefinition(ref),
-		v1.CustomResourceDefinitionCondition{}.OpenAPIModelName():                   schema_pkg_apis_apiextensions_v1_CustomResourceDefinitionCondition(ref),
-		v1.CustomResourceDefinitionList{}.OpenAPIModelName():                        schema_pkg_apis_apiextensions_v1_CustomResourceDefinitionList(ref),
-		v1.CustomResourceDefinitionNames{}.OpenAPIModelName():                       schema_pkg_apis_apiextensions_v1_CustomResourceDefinitionNames(ref),
-		v1.CustomResourceDefinitionSpec{}.OpenAPIModelName():                        schema_pkg_apis_apiextensions_v1_CustomResourceDefinitionSpec(ref),
-		v1.CustomResourceDefinitionStatus{}.OpenAPIModelName():                      schema_pkg_apis_apiextensions_v1_CustomResourceDefinitionStatus(ref),
-		v1.CustomResourceDefinitionVersion{}.OpenAPIModelName():                     schema_pkg_apis_apiextensions_v1_CustomResourceDefinitionVersion(ref),
-		v1.CustomResourceSubresourceScale{}.OpenAPIModelName():                      schema_pkg_apis_apiextensions_v1_CustomResourceSubresourceScale(ref),
-		v1.CustomResourceSubresourceStatus{}.OpenAPIModelName():                     schema_pkg_apis_apiextensions_v1_CustomResourceSubresourceStatus(ref),
-		v1.CustomResourceSubresources{}.OpenAPIModelName():                          schema_pkg_apis_apiextensions_v1_CustomResourceSubresources(ref),
-		v1.CustomResourceValidation{}.OpenAPIModelName():                            schema_pkg_apis_apiextensions_v1_CustomResourceValidation(ref),
-		v1.ExternalDocumentation{}.OpenAPIModelName():                               schema_pkg_apis_apiextensions_v1_ExternalDocumentation(ref),
-		v1.JSON{}.OpenAPIModelName():                                                schema_pkg_apis_apiextensions_v1_JSON(ref),
-		v1.JSONSchemaProps{}.OpenAPIModelName():                                     schema_pkg_apis_apiextensions_v1_JSONSchemaProps(ref),
-		v1.JSONSchemaPropsOrArray{}.OpenAPIModelName():                              schema_pkg_apis_apiextensions_v1_JSONSchemaPropsOrArray(ref),
-		v1.JSONSchemaPropsOrBool{}.OpenAPIModelName():                               schema_pkg_apis_apiextensions_v1_JSONSchemaPropsOrBool(ref),
-		v1.JSONSchemaPropsOrStringArray{}.OpenAPIModelName():                        schema_pkg_apis_apiextensions_v1_JSONSchemaPropsOrStringArray(ref),
-		v1.SelectableField{}.OpenAPIModelName():                                     schema_pkg_apis_apiextensions_v1_SelectableField(ref),
-		v1.ServiceReference{}.OpenAPIModelName():                                    schema_pkg_apis_apiextensions_v1_ServiceReference(ref),
-		v1.ValidationRule{}.OpenAPIModelName():                                      schema_pkg_apis_apiextensions_v1_ValidationRule(ref),
-		v1.WebhookClientConfig{}.OpenAPIModelName():                                 schema_pkg_apis_apiextensions_v1_WebhookClientConfig(ref),
-		v1.WebhookConversion{}.OpenAPIModelName():                                   schema_pkg_apis_apiextensions_v1_WebhookConversion(ref),
-		resource.Quantity{}.OpenAPIModelName():                                      schema_apimachinery_pkg_api_resource_Quantity(ref),
-		metav1.APIGroup{}.OpenAPIModelName():                                        schema_pkg_apis_meta_v1_APIGroup(ref),
-		metav1.APIGroupList{}.OpenAPIModelName():                                    schema_pkg_apis_meta_v1_APIGroupList(ref),
-		metav1.APIResource{}.OpenAPIModelName():                                     schema_pkg_apis_meta_v1_APIResource(ref),
-		metav1.APIResourceList{}.OpenAPIModelName():                                 schema_pkg_apis_meta_v1_APIResourceList(ref),
-		metav1.APIVersions{}.OpenAPIModelName():                                     schema_pkg_apis_meta_v1_APIVersions(ref),
-		metav1.ApplyOptions{}.OpenAPIModelName():                                    schema_pkg_apis_meta_v1_ApplyOptions(ref),
-		metav1.Condition{}.OpenAPIModelName():                                       schema_pkg_apis_meta_v1_Condition(ref),
-		metav1.CreateOptions{}.OpenAPIModelName():                                   schema_pkg_apis_meta_v1_CreateOptions(ref),
-		metav1.DeleteOptions{}.OpenAPIModelName():                                   schema_pkg_apis_meta_v1_DeleteOptions(ref),
-		metav1.Duration{}.OpenAPIModelName():                                        schema_pkg_apis_meta_v1_Duration(ref),
-		metav1.FieldSelectorRequirement{}.OpenAPIModelName():                        schema_pkg_apis_meta_v1_FieldSelectorRequirement(ref),
-		metav1.FieldsV1{}.OpenAPIModelName():                                        schema_pkg_apis_meta_v1_FieldsV1(ref),
-		metav1.GetOptions{}.OpenAPIModelName():                                      schema_pkg_apis_meta_v1_GetOptions(ref),
-		metav1.GroupKind{}.OpenAPIModelName():                                       schema_pkg_apis_meta_v1_GroupKind(ref),
-		metav1.GroupResource{}.OpenAPIModelName():                                   schema_pkg_apis_meta_v1_GroupResource(ref),
-		metav1.GroupVersion{}.OpenAPIModelName():                                    schema_pkg_apis_meta_v1_GroupVersion(ref),
-		metav1.GroupVersionForDiscovery{}.OpenAPIModelName():                        schema_pkg_apis_meta_v1_GroupVersionForDiscovery(ref),
-		metav1.GroupVersionKind{}.OpenAPIModelName():                                schema_pkg_apis_meta_v1_GroupVersionKind(ref),
-		metav1.GroupVersionResource{}.OpenAPIModelName():                            schema_pkg_apis_meta_v1_GroupVersionResource(ref),
-		metav1.InternalEvent{}.OpenAPIModelName():                                   schema_pkg_apis_meta_v1_InternalEvent(ref),
-		metav1.LabelSelector{}.OpenAPIModelName():                                   schema_pkg_apis_meta_v1_LabelSelector(ref),
-		metav1.LabelSelectorRequirement{}.OpenAPIModelName():                        schema_pkg_apis_meta_v1_LabelSelectorRequirement(ref),
-		metav1.List{}.OpenAPIModelName():                                            schema_pkg_apis_meta_v1_List(ref),
-		metav1.ListMeta{}.OpenAPIModelName():                                        schema_pkg_apis_meta_v1_ListMeta(ref),
-		metav1.ListOptions{}.OpenAPIModelName():                                     schema_pkg_apis_meta_v1_ListOptions(ref),
-		metav1.ManagedFieldsEntry{}.OpenAPIModelName():                              schema_pkg_apis_meta_v1_ManagedFieldsEntry(ref),
-		metav1.MicroTime{}.OpenAPIModelName():                                       schema_pkg_apis_meta_v1_MicroTime(ref),
-		metav1.ObjectMeta{}.OpenAPIModelName():                                      schema_pkg_apis_meta_v1_ObjectMeta(ref),
-		metav1.OwnerReference{}.OpenAPIModelName():                                  schema_pkg_apis_meta_v1_OwnerReference(ref),
-		metav1.PartialObjectMetadata{}.OpenAPIModelName():                           schema_pkg_apis_meta_v1_PartialObjectMetadata(ref),
-		metav1.PartialObjectMetadataList{}.OpenAPIModelName():                       schema_pkg_apis_meta_v1_PartialObjectMetadataList(ref),
-		metav1.Patch{}.OpenAPIModelName():                                           schema_pkg_apis_meta_v1_Patch(ref),
-		metav1.PatchOptions{}.OpenAPIModelName():                                    schema_pkg_apis_meta_v1_PatchOptions(ref),
-		metav1.Preconditions{}.OpenAPIModelName():                                   schema_pkg_apis_meta_v1_Preconditions(ref),
-		metav1.RootPaths{}.OpenAPIModelName():                                       schema_pkg_apis_meta_v1_RootPaths(ref),
-		metav1.ServerAddressByClientCIDR{}.OpenAPIModelName():                       schema_pkg_apis_meta_v1_ServerAddressByClientCIDR(ref),
-		metav1.Status{}.OpenAPIModelName():                                          schema_pkg_apis_meta_v1_Status(ref),
-		metav1.StatusCause{}.OpenAPIModelName():                                     schema_pkg_apis_meta_v1_StatusCause(ref),
-		metav1.StatusDetails{}.OpenAPIModelName():                                   schema_pkg_apis_meta_v1_StatusDetails(ref),
-		metav1.Table{}.OpenAPIModelName():                                           schema_pkg_apis_meta_v1_Table(ref),
-		metav1.TableColumnDefinition{}.OpenAPIModelName():                           schema_pkg_apis_meta_v1_TableColumnDefinition(ref),
-		metav1.TableOptions{}.OpenAPIModelName():                                    schema_pkg_apis_meta_v1_TableOptions(ref),
-		metav1.TableRow{}.OpenAPIModelName():                                        schema_pkg_apis_meta_v1_TableRow(ref),
-		metav1.TableRowCondition{}.OpenAPIModelName():                               schema_pkg_apis_meta_v1_TableRowCondition(ref),
-		metav1.Time{}.OpenAPIModelName():                                            schema_pkg_apis_meta_v1_Time(ref),
-		metav1.Timestamp{}.OpenAPIModelName():                                       schema_pkg_apis_meta_v1_Timestamp(ref),
-		metav1.TypeMeta{}.OpenAPIModelName():                                        schema_pkg_apis_meta_v1_TypeMeta(ref),
-		metav1.UpdateOptions{}.OpenAPIModelName():                                   schema_pkg_apis_meta_v1_UpdateOptions(ref),
-		metav1.WatchEvent{}.OpenAPIModelName():                                      schema_pkg_apis_meta_v1_WatchEvent(ref),
-		runtime.RawExtension{}.OpenAPIModelName():                                   schema_k8sio_apimachinery_pkg_runtime_RawExtension(ref),
-		runtime.TypeMeta{}.OpenAPIModelName():                                       schema_k8sio_apimachinery_pkg_runtime_TypeMeta(ref),
-		runtime.Unknown{}.OpenAPIModelName():                                        schema_k8sio_apimachinery_pkg_runtime_Unknown(ref),
-		version.Info{}.OpenAPIModelName():                                           schema_k8sio_apimachinery_pkg_version_Info(ref),
+		v1alpha1.Application{}.OpenAPIModelName():                 schema_pkg_apis_apps_v1alpha1_Application(ref),
+		v1alpha1.ApplicationList{}.OpenAPIModelName():             schema_pkg_apis_apps_v1alpha1_ApplicationList(ref),
+		v1alpha1.ApplicationStatus{}.OpenAPIModelName():           schema_pkg_apis_apps_v1alpha1_ApplicationStatus(ref),
+		corev1alpha1.Option{}.OpenAPIModelName():                  schema_pkg_apis_core_v1alpha1_Option(ref),
+		corev1alpha1.OptionItem{}.OpenAPIModelName():              schema_pkg_apis_core_v1alpha1_OptionItem(ref),
+		corev1alpha1.OptionList{}.OpenAPIModelName():              schema_pkg_apis_core_v1alpha1_OptionList(ref),
+		corev1alpha1.OptionSpec{}.OpenAPIModelName():              schema_pkg_apis_core_v1alpha1_OptionSpec(ref),
+		corev1alpha1.TenantModule{}.OpenAPIModelName():            schema_pkg_apis_core_v1alpha1_TenantModule(ref),
+		corev1alpha1.TenantModuleList{}.OpenAPIModelName():        schema_pkg_apis_core_v1alpha1_TenantModuleList(ref),
+		corev1alpha1.TenantModuleStatus{}.OpenAPIModelName():      schema_pkg_apis_core_v1alpha1_TenantModuleStatus(ref),
+		corev1alpha1.TenantNamespace{}.OpenAPIModelName():         schema_pkg_apis_core_v1alpha1_TenantNamespace(ref),
+		corev1alpha1.TenantNamespaceList{}.OpenAPIModelName():     schema_pkg_apis_core_v1alpha1_TenantNamespaceList(ref),
+		corev1alpha1.TenantSecret{}.OpenAPIModelName():            schema_pkg_apis_core_v1alpha1_TenantSecret(ref),
+		corev1alpha1.TenantSecretList{}.OpenAPIModelName():        schema_pkg_apis_core_v1alpha1_TenantSecretList(ref),
+		sdnv1alpha1.ApplicationReference{}.OpenAPIModelName():     schema_pkg_apis_sdn_v1alpha1_ApplicationReference(ref),
+		sdnv1alpha1.EgressRule{}.OpenAPIModelName():               schema_pkg_apis_sdn_v1alpha1_EgressRule(ref),
+		sdnv1alpha1.FQDNSelector{}.OpenAPIModelName():             schema_pkg_apis_sdn_v1alpha1_FQDNSelector(ref),
+		sdnv1alpha1.IngressRule{}.OpenAPIModelName():              schema_pkg_apis_sdn_v1alpha1_IngressRule(ref),
+		sdnv1alpha1.PortProtocol{}.OpenAPIModelName():             schema_pkg_apis_sdn_v1alpha1_PortProtocol(ref),
+		sdnv1alpha1.PortRule{}.OpenAPIModelName():                 schema_pkg_apis_sdn_v1alpha1_PortRule(ref),
+		sdnv1alpha1.SecurityGroup{}.OpenAPIModelName():            schema_pkg_apis_sdn_v1alpha1_SecurityGroup(ref),
+		sdnv1alpha1.SecurityGroupList{}.OpenAPIModelName():        schema_pkg_apis_sdn_v1alpha1_SecurityGroupList(ref),
+		sdnv1alpha1.SecurityGroupSpec{}.OpenAPIModelName():        schema_pkg_apis_sdn_v1alpha1_SecurityGroupSpec(ref),
+		v1.ConversionRequest{}.OpenAPIModelName():                 schema_pkg_apis_apiextensions_v1_ConversionRequest(ref),
+		v1.ConversionResponse{}.OpenAPIModelName():                schema_pkg_apis_apiextensions_v1_ConversionResponse(ref),
+		v1.ConversionReview{}.OpenAPIModelName():                  schema_pkg_apis_apiextensions_v1_ConversionReview(ref),
+		v1.CustomResourceColumnDefinition{}.OpenAPIModelName():    schema_pkg_apis_apiextensions_v1_CustomResourceColumnDefinition(ref),
+		v1.CustomResourceConversion{}.OpenAPIModelName():          schema_pkg_apis_apiextensions_v1_CustomResourceConversion(ref),
+		v1.CustomResourceDefinition{}.OpenAPIModelName():          schema_pkg_apis_apiextensions_v1_CustomResourceDefinition(ref),
+		v1.CustomResourceDefinitionCondition{}.OpenAPIModelName(): schema_pkg_apis_apiextensions_v1_CustomResourceDefinitionCondition(ref),
+		v1.CustomResourceDefinitionList{}.OpenAPIModelName():      schema_pkg_apis_apiextensions_v1_CustomResourceDefinitionList(ref),
+		v1.CustomResourceDefinitionNames{}.OpenAPIModelName():     schema_pkg_apis_apiextensions_v1_CustomResourceDefinitionNames(ref),
+		v1.CustomResourceDefinitionSpec{}.OpenAPIModelName():      schema_pkg_apis_apiextensions_v1_CustomResourceDefinitionSpec(ref),
+		v1.CustomResourceDefinitionStatus{}.OpenAPIModelName():    schema_pkg_apis_apiextensions_v1_CustomResourceDefinitionStatus(ref),
+		v1.CustomResourceDefinitionVersion{}.OpenAPIModelName():   schema_pkg_apis_apiextensions_v1_CustomResourceDefinitionVersion(ref),
+		v1.CustomResourceSubresourceScale{}.OpenAPIModelName():    schema_pkg_apis_apiextensions_v1_CustomResourceSubresourceScale(ref),
+		v1.CustomResourceSubresourceStatus{}.OpenAPIModelName():   schema_pkg_apis_apiextensions_v1_CustomResourceSubresourceStatus(ref),
+		v1.CustomResourceSubresources{}.OpenAPIModelName():        schema_pkg_apis_apiextensions_v1_CustomResourceSubresources(ref),
+		v1.CustomResourceValidation{}.OpenAPIModelName():          schema_pkg_apis_apiextensions_v1_CustomResourceValidation(ref),
+		v1.ExternalDocumentation{}.OpenAPIModelName():             schema_pkg_apis_apiextensions_v1_ExternalDocumentation(ref),
+		v1.JSON{}.OpenAPIModelName():                              schema_pkg_apis_apiextensions_v1_JSON(ref),
+		v1.JSONSchemaProps{}.OpenAPIModelName():                   schema_pkg_apis_apiextensions_v1_JSONSchemaProps(ref),
+		v1.JSONSchemaPropsOrArray{}.OpenAPIModelName():            schema_pkg_apis_apiextensions_v1_JSONSchemaPropsOrArray(ref),
+		v1.JSONSchemaPropsOrBool{}.OpenAPIModelName():             schema_pkg_apis_apiextensions_v1_JSONSchemaPropsOrBool(ref),
+		v1.JSONSchemaPropsOrStringArray{}.OpenAPIModelName():      schema_pkg_apis_apiextensions_v1_JSONSchemaPropsOrStringArray(ref),
+		v1.SelectableField{}.OpenAPIModelName():                   schema_pkg_apis_apiextensions_v1_SelectableField(ref),
+		v1.ServiceReference{}.OpenAPIModelName():                  schema_pkg_apis_apiextensions_v1_ServiceReference(ref),
+		v1.ValidationRule{}.OpenAPIModelName():                    schema_pkg_apis_apiextensions_v1_ValidationRule(ref),
+		v1.WebhookClientConfig{}.OpenAPIModelName():               schema_pkg_apis_apiextensions_v1_WebhookClientConfig(ref),
+		v1.WebhookConversion{}.OpenAPIModelName():                 schema_pkg_apis_apiextensions_v1_WebhookConversion(ref),
+		resource.Quantity{}.OpenAPIModelName():                    schema_apimachinery_pkg_api_resource_Quantity(ref),
+		metav1.APIGroup{}.OpenAPIModelName():                      schema_pkg_apis_meta_v1_APIGroup(ref),
+		metav1.APIGroupList{}.OpenAPIModelName():                  schema_pkg_apis_meta_v1_APIGroupList(ref),
+		metav1.APIResource{}.OpenAPIModelName():                   schema_pkg_apis_meta_v1_APIResource(ref),
+		metav1.APIResourceList{}.OpenAPIModelName():               schema_pkg_apis_meta_v1_APIResourceList(ref),
+		metav1.APIVersions{}.OpenAPIModelName():                   schema_pkg_apis_meta_v1_APIVersions(ref),
+		metav1.ApplyOptions{}.OpenAPIModelName():                  schema_pkg_apis_meta_v1_ApplyOptions(ref),
+		metav1.Condition{}.OpenAPIModelName():                     schema_pkg_apis_meta_v1_Condition(ref),
+		metav1.CreateOptions{}.OpenAPIModelName():                 schema_pkg_apis_meta_v1_CreateOptions(ref),
+		metav1.DeleteOptions{}.OpenAPIModelName():                 schema_pkg_apis_meta_v1_DeleteOptions(ref),
+		metav1.Duration{}.OpenAPIModelName():                      schema_pkg_apis_meta_v1_Duration(ref),
+		metav1.FieldSelectorRequirement{}.OpenAPIModelName():      schema_pkg_apis_meta_v1_FieldSelectorRequirement(ref),
+		metav1.FieldsV1{}.OpenAPIModelName():                      schema_pkg_apis_meta_v1_FieldsV1(ref),
+		metav1.GetOptions{}.OpenAPIModelName():                    schema_pkg_apis_meta_v1_GetOptions(ref),
+		metav1.GroupKind{}.OpenAPIModelName():                     schema_pkg_apis_meta_v1_GroupKind(ref),
+		metav1.GroupResource{}.OpenAPIModelName():                 schema_pkg_apis_meta_v1_GroupResource(ref),
+		metav1.GroupVersion{}.OpenAPIModelName():                  schema_pkg_apis_meta_v1_GroupVersion(ref),
+		metav1.GroupVersionForDiscovery{}.OpenAPIModelName():      schema_pkg_apis_meta_v1_GroupVersionForDiscovery(ref),
+		metav1.GroupVersionKind{}.OpenAPIModelName():              schema_pkg_apis_meta_v1_GroupVersionKind(ref),
+		metav1.GroupVersionResource{}.OpenAPIModelName():          schema_pkg_apis_meta_v1_GroupVersionResource(ref),
+		metav1.InternalEvent{}.OpenAPIModelName():                 schema_pkg_apis_meta_v1_InternalEvent(ref),
+		metav1.LabelSelector{}.OpenAPIModelName():                 schema_pkg_apis_meta_v1_LabelSelector(ref),
+		metav1.LabelSelectorRequirement{}.OpenAPIModelName():      schema_pkg_apis_meta_v1_LabelSelectorRequirement(ref),
+		metav1.List{}.OpenAPIModelName():                          schema_pkg_apis_meta_v1_List(ref),
+		metav1.ListMeta{}.OpenAPIModelName():                      schema_pkg_apis_meta_v1_ListMeta(ref),
+		metav1.ListOptions{}.OpenAPIModelName():                   schema_pkg_apis_meta_v1_ListOptions(ref),
+		metav1.ManagedFieldsEntry{}.OpenAPIModelName():            schema_pkg_apis_meta_v1_ManagedFieldsEntry(ref),
+		metav1.MicroTime{}.OpenAPIModelName():                     schema_pkg_apis_meta_v1_MicroTime(ref),
+		metav1.ObjectMeta{}.OpenAPIModelName():                    schema_pkg_apis_meta_v1_ObjectMeta(ref),
+		metav1.OwnerReference{}.OpenAPIModelName():                schema_pkg_apis_meta_v1_OwnerReference(ref),
+		metav1.PartialObjectMetadata{}.OpenAPIModelName():         schema_pkg_apis_meta_v1_PartialObjectMetadata(ref),
+		metav1.PartialObjectMetadataList{}.OpenAPIModelName():     schema_pkg_apis_meta_v1_PartialObjectMetadataList(ref),
+		metav1.Patch{}.OpenAPIModelName():                         schema_pkg_apis_meta_v1_Patch(ref),
+		metav1.PatchOptions{}.OpenAPIModelName():                  schema_pkg_apis_meta_v1_PatchOptions(ref),
+		metav1.Preconditions{}.OpenAPIModelName():                 schema_pkg_apis_meta_v1_Preconditions(ref),
+		metav1.RootPaths{}.OpenAPIModelName():                     schema_pkg_apis_meta_v1_RootPaths(ref),
+		metav1.ServerAddressByClientCIDR{}.OpenAPIModelName():     schema_pkg_apis_meta_v1_ServerAddressByClientCIDR(ref),
+		metav1.Status{}.OpenAPIModelName():                        schema_pkg_apis_meta_v1_Status(ref),
+		metav1.StatusCause{}.OpenAPIModelName():                   schema_pkg_apis_meta_v1_StatusCause(ref),
+		metav1.StatusDetails{}.OpenAPIModelName():                 schema_pkg_apis_meta_v1_StatusDetails(ref),
+		metav1.Table{}.OpenAPIModelName():                         schema_pkg_apis_meta_v1_Table(ref),
+		metav1.TableColumnDefinition{}.OpenAPIModelName():         schema_pkg_apis_meta_v1_TableColumnDefinition(ref),
+		metav1.TableOptions{}.OpenAPIModelName():                  schema_pkg_apis_meta_v1_TableOptions(ref),
+		metav1.TableRow{}.OpenAPIModelName():                      schema_pkg_apis_meta_v1_TableRow(ref),
+		metav1.TableRowCondition{}.OpenAPIModelName():             schema_pkg_apis_meta_v1_TableRowCondition(ref),
+		metav1.Time{}.OpenAPIModelName():                          schema_pkg_apis_meta_v1_Time(ref),
+		metav1.Timestamp{}.OpenAPIModelName():                     schema_pkg_apis_meta_v1_Timestamp(ref),
+		metav1.TypeMeta{}.OpenAPIModelName():                      schema_pkg_apis_meta_v1_TypeMeta(ref),
+		metav1.UpdateOptions{}.OpenAPIModelName():                 schema_pkg_apis_meta_v1_UpdateOptions(ref),
+		metav1.WatchEvent{}.OpenAPIModelName():                    schema_pkg_apis_meta_v1_WatchEvent(ref),
+		runtime.RawExtension{}.OpenAPIModelName():                 schema_k8sio_apimachinery_pkg_runtime_RawExtension(ref),
+		runtime.TypeMeta{}.OpenAPIModelName():                     schema_k8sio_apimachinery_pkg_runtime_TypeMeta(ref),
+		runtime.Unknown{}.OpenAPIModelName():                      schema_k8sio_apimachinery_pkg_runtime_Unknown(ref),
+		version.Info{}.OpenAPIModelName():                         schema_k8sio_apimachinery_pkg_version_Info(ref),
 	}
 }
 
@@ -321,14 +323,14 @@ func schema_pkg_apis_core_v1alpha1_Option(ref common.ReferenceCallback) common.O
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
-							Ref:     ref("github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.OptionSpec"),
+							Ref:     ref(corev1alpha1.OptionSpec{}.OpenAPIModelName()),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.OptionSpec", metav1.ObjectMeta{}.OpenAPIModelName()},
+			corev1alpha1.OptionSpec{}.OpenAPIModelName(), metav1.ObjectMeta{}.OpenAPIModelName()},
 	}
 }
 
@@ -408,7 +410,7 @@ func schema_pkg_apis_core_v1alpha1_OptionList(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.Option"),
+										Ref:     ref(corev1alpha1.Option{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -419,7 +421,7 @@ func schema_pkg_apis_core_v1alpha1_OptionList(ref common.ReferenceCallback) comm
 			},
 		},
 		Dependencies: []string{
-			"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.Option", metav1.ListMeta{}.OpenAPIModelName()},
+			corev1alpha1.Option{}.OpenAPIModelName(), metav1.ListMeta{}.OpenAPIModelName()},
 	}
 }
 
@@ -437,7 +439,7 @@ func schema_pkg_apis_core_v1alpha1_OptionSpec(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.OptionItem"),
+										Ref:     ref(corev1alpha1.OptionItem{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -447,7 +449,7 @@ func schema_pkg_apis_core_v1alpha1_OptionSpec(ref common.ReferenceCallback) comm
 			},
 		},
 		Dependencies: []string{
-			"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.OptionItem"},
+			corev1alpha1.OptionItem{}.OpenAPIModelName()},
 	}
 }
 
@@ -489,14 +491,14 @@ func schema_pkg_apis_core_v1alpha1_TenantModule(ref common.ReferenceCallback) co
 						SchemaProps: spec.SchemaProps{
 							Description: "Status contains the module status",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantModuleStatus"),
+							Ref:         ref(corev1alpha1.TenantModuleStatus{}.OpenAPIModelName()),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantModuleStatus", metav1.ObjectMeta{}.OpenAPIModelName()},
+			corev1alpha1.TenantModuleStatus{}.OpenAPIModelName(), metav1.ObjectMeta{}.OpenAPIModelName()},
 	}
 }
 
@@ -534,7 +536,7 @@ func schema_pkg_apis_core_v1alpha1_TenantModuleList(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantModule"),
+										Ref:     ref(corev1alpha1.TenantModule{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -545,7 +547,7 @@ func schema_pkg_apis_core_v1alpha1_TenantModuleList(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantModule", metav1.ListMeta{}.OpenAPIModelName()},
+			corev1alpha1.TenantModule{}.OpenAPIModelName(), metav1.ListMeta{}.OpenAPIModelName()},
 	}
 }
 
@@ -654,7 +656,7 @@ func schema_pkg_apis_core_v1alpha1_TenantNamespaceList(ref common.ReferenceCallb
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantNamespace"),
+										Ref:     ref(corev1alpha1.TenantNamespace{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -665,7 +667,7 @@ func schema_pkg_apis_core_v1alpha1_TenantNamespaceList(ref common.ReferenceCallb
 			},
 		},
 		Dependencies: []string{
-			"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantNamespace", metav1.ListMeta{}.OpenAPIModelName()},
+			corev1alpha1.TenantNamespace{}.OpenAPIModelName(), metav1.ListMeta{}.OpenAPIModelName()},
 	}
 }
 
@@ -772,7 +774,7 @@ func schema_pkg_apis_core_v1alpha1_TenantSecretList(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantSecret"),
+										Ref:     ref(corev1alpha1.TenantSecret{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -783,7 +785,7 @@ func schema_pkg_apis_core_v1alpha1_TenantSecretList(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.TenantSecret", metav1.ListMeta{}.OpenAPIModelName()},
+			corev1alpha1.TenantSecret{}.OpenAPIModelName(), metav1.ListMeta{}.OpenAPIModelName()},
 	}
 }
 
@@ -839,7 +841,7 @@ func schema_pkg_apis_sdn_v1alpha1_EgressRule(ref common.ReferenceCallback) commo
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.ApplicationReference"),
+										Ref:     ref(sdnv1alpha1.ApplicationReference{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -883,7 +885,7 @@ func schema_pkg_apis_sdn_v1alpha1_EgressRule(ref common.ReferenceCallback) commo
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.FQDNSelector"),
+										Ref:     ref(sdnv1alpha1.FQDNSelector{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -897,7 +899,7 @@ func schema_pkg_apis_sdn_v1alpha1_EgressRule(ref common.ReferenceCallback) commo
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.PortRule"),
+										Ref:     ref(sdnv1alpha1.PortRule{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -907,7 +909,7 @@ func schema_pkg_apis_sdn_v1alpha1_EgressRule(ref common.ReferenceCallback) commo
 			},
 		},
 		Dependencies: []string{
-			"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.ApplicationReference", "github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.FQDNSelector", "github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.PortRule"},
+			sdnv1alpha1.ApplicationReference{}.OpenAPIModelName(), sdnv1alpha1.FQDNSelector{}.OpenAPIModelName(), sdnv1alpha1.PortRule{}.OpenAPIModelName()},
 	}
 }
 
@@ -953,7 +955,7 @@ func schema_pkg_apis_sdn_v1alpha1_IngressRule(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.ApplicationReference"),
+										Ref:     ref(sdnv1alpha1.ApplicationReference{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -997,7 +999,7 @@ func schema_pkg_apis_sdn_v1alpha1_IngressRule(ref common.ReferenceCallback) comm
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.PortRule"),
+										Ref:     ref(sdnv1alpha1.PortRule{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -1007,7 +1009,7 @@ func schema_pkg_apis_sdn_v1alpha1_IngressRule(ref common.ReferenceCallback) comm
 			},
 		},
 		Dependencies: []string{
-			"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.ApplicationReference", "github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.PortRule"},
+			sdnv1alpha1.ApplicationReference{}.OpenAPIModelName(), sdnv1alpha1.PortRule{}.OpenAPIModelName()},
 	}
 }
 
@@ -1053,7 +1055,7 @@ func schema_pkg_apis_sdn_v1alpha1_PortRule(ref common.ReferenceCallback) common.
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.PortProtocol"),
+										Ref:     ref(sdnv1alpha1.PortProtocol{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -1063,7 +1065,7 @@ func schema_pkg_apis_sdn_v1alpha1_PortRule(ref common.ReferenceCallback) common.
 			},
 		},
 		Dependencies: []string{
-			"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.PortProtocol"},
+			sdnv1alpha1.PortProtocol{}.OpenAPIModelName()},
 	}
 }
 
@@ -1098,14 +1100,14 @@ func schema_pkg_apis_sdn_v1alpha1_SecurityGroup(ref common.ReferenceCallback) co
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec describes the applications this SecurityGroup attaches to and the traffic it allows.",
 							Default:     map[string]interface{}{},
-							Ref:         ref("github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.SecurityGroupSpec"),
+							Ref:         ref(sdnv1alpha1.SecurityGroupSpec{}.OpenAPIModelName()),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.SecurityGroupSpec", metav1.ObjectMeta{}.OpenAPIModelName()},
+			sdnv1alpha1.SecurityGroupSpec{}.OpenAPIModelName(), metav1.ObjectMeta{}.OpenAPIModelName()},
 	}
 }
 
@@ -1143,7 +1145,7 @@ func schema_pkg_apis_sdn_v1alpha1_SecurityGroupList(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.SecurityGroup"),
+										Ref:     ref(sdnv1alpha1.SecurityGroup{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -1154,7 +1156,7 @@ func schema_pkg_apis_sdn_v1alpha1_SecurityGroupList(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.SecurityGroup", metav1.ListMeta{}.OpenAPIModelName()},
+			sdnv1alpha1.SecurityGroup{}.OpenAPIModelName(), metav1.ListMeta{}.OpenAPIModelName()},
 	}
 }
 
@@ -1173,7 +1175,7 @@ func schema_pkg_apis_sdn_v1alpha1_SecurityGroupSpec(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.ApplicationReference"),
+										Ref:     ref(sdnv1alpha1.ApplicationReference{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -1187,7 +1189,7 @@ func schema_pkg_apis_sdn_v1alpha1_SecurityGroupSpec(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.IngressRule"),
+										Ref:     ref(sdnv1alpha1.IngressRule{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -1201,7 +1203,7 @@ func schema_pkg_apis_sdn_v1alpha1_SecurityGroupSpec(ref common.ReferenceCallback
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
 										Default: map[string]interface{}{},
-										Ref:     ref("github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.EgressRule"),
+										Ref:     ref(sdnv1alpha1.EgressRule{}.OpenAPIModelName()),
 									},
 								},
 							},
@@ -1211,7 +1213,7 @@ func schema_pkg_apis_sdn_v1alpha1_SecurityGroupSpec(ref common.ReferenceCallback
 			},
 		},
 		Dependencies: []string{
-			"github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.ApplicationReference", "github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.EgressRule", "github.com/cozystack/cozystack/pkg/apis/sdn/v1alpha1.IngressRule"},
+			sdnv1alpha1.ApplicationReference{}.OpenAPIModelName(), sdnv1alpha1.EgressRule{}.OpenAPIModelName(), sdnv1alpha1.IngressRule{}.OpenAPIModelName()},
 	}
 }
 


### PR DESCRIPTION
## What this PR does

Fixes #3806.

Declares `OpenAPIModelName` for the `core` and `sdn` API groups the way #3273 already did for `apps`, so every published OpenAPI definition name is the dotted Kubernetes model name rather than a Go import path.

Worth noting the two are the same event. #3273 landed the k8s 0.35 work, hit the loud half of this in server-side apply where no apps kind resolved at all, fixed `apps`, and left `core` and `sdn` with the quieter half. Its merge commit `960d85370` is exactly where the window opens: 190 failed-E2E logs from 2026-06-25 to 07-19 carry no occurrence, and the first one is 11 hours after it.

Before this, 20 definitions shipped under names like `github.com/cozystack/cozystack/pkg/apis/core/v1alpha1.Option`, while every `$ref` pointing at them spelled each slash `~1`. Clients resolve a `$ref` by trimming `#/definitions/` and looking the remainder up verbatim with no unescaping, so the two spellings never meet and the reference dangles. `kubectl apply --validate` against a cluster running a `cozystack-api` built after 2026-07-21 therefore fails on any resource, and in e2e the platform install fails on `cozy-backup-controller/backupstrategy-controller` and never completes.

The mechanism is a Kubernetes 0.35 change: `DefinitionNamer.GetDefinitionName` now returns the model name verbatim, where it previously converted the Go import-path form into the friendly reversed-path form. So whatever name the generated map uses becomes both the published key and the escaped `$ref`, and slash-freedom stops being a nice-to-have and becomes the correctness condition.

### Why hand-written methods

openapi-gen can emit these with `--output-model-name-file`, but that also rewrites `zz_generated.model_name.go` inside the read-only apimachinery and apiextensions module-cache packages that the shared `gen_openapi` helper always passes as inputs, which fails for any consumer that vendors deps from the cache, CI included. The `apps` group settled this the same way and the reasoning is repeated in each new `model_name.go` so nobody simplifies it back into the flag.

Once a package carries `+k8s:openapi-model-package`, openapi-gen emits `Type{}.OpenAPIModelName()` for every type it writes a schema or a `$ref` for, so a missing method is a build failure rather than a silent skip. That makes a future omission inside these groups loud by construction, and the new tests make an omission on a future group loud at the group level.

### Guard tests

`pkg/generated/openapi/definitions_test.go` adds two, both asserting the invariant rather than today's 20 names, and both refusing to pass on an empty or cozystack-free definition map so they cannot go vacuously green.

`TestDefinitionNamesAreDottedModelNames` fails on any definition name containing a slash, naming the offender and the fix. `TestDefinitionRefsResolve` builds each `$ref` the way kube-openapi's builder does and resolves it the way a client does, which checks the failure directly rather than through the slash-freedom proxy, and also catches a group whose types disagree with each other.

Nothing asserted this before, which is why the defect reached v1.6.0 and v1.6.1 unnoticed.

### Screenshots

Not applicable.

### Downstream repositories

Walked the trigger map against the diff. Published model names change, so I swept for consumers pinning the old form: every hit on `github.com/cozystack/cozystack/pkg/apis` in the tree is a Go import, which is unaffected because the package path does not change, and `api/api-rules/cozystack_api_violation_exceptions.list` keys off the Go package path in its own format and was unchanged by regeneration. No string literal anywhere pins the old model-name form, and `apiPrefix` in `pkg/cmd/server/openapi.go` is an apps-only const that this does not touch.

- [x] No downstream repository is affected by this change

### Testing

- `go build ./... && go vet ./...`
- `go test ./...`
- `make generate && git diff --exit-code`, clean and idempotent
- `pre-commit run --all-files`
- Both guard tests run against the pre-fix tree first: `TestDefinitionNamesAreDottedModelNames` named all 20 offenders and `TestDefinitionRefsResolve` reproduced the reported error string with 15 dangling refs, fewer than 20 because some of the 20 are only referenced-from and never referencing.
- An independent check driving the real `openapi.NewDefinitionNamer(apiserver.Scheme)` reports 104 published definitions with 0 slashes, 106 emitted refs with 0 dangling, and all 23 cozystack kinds resolving to a published definition carrying `x-kubernetes-group-version-kind`, which also confirms the `apps` server-side-apply fix still holds.

`make unit-tests` aborts at `hack/ghcr-mirror_test.bats`, which fails on a pristine `origin/main` in my environment while passing in CI, so I ran the chain standalone: the other 60 bats files pass, as do `helm-unit-tests`, `go-unit-tests`, `rd-presets-check`, `test-check-readiness` and `migrations-target-check`.

### Release note

```release-note
fix(api): publish OpenAPI model names for the core and sdn API groups as dotted Kubernetes names, so `$ref`s resolve and client-side validation works again against the aggregated apiserver
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added OpenAPI metadata for Core v1alpha1 API models.
  * Added OpenAPI metadata for SDN v1alpha1 API models.
  * API schemas now provide consistent canonical model names, supporting more reliable documentation and schema references.
  * Added package-level OpenAPI markers to improve API discovery and tooling compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->