### PR TITLE
fix(linstor,velero): exempt the JVM and the backup agent from a memory limit

### DIFF
--- a/packages/system/linstor/templates/satellites-cozy.yaml
+++ b/packages/system/linstor/templates/satellites-cozy.yaml
@@ -14,27 +14,9 @@ spec:
       containers:
       - name: linstor-satellite
         image: {{ .Values.piraeusServer.image.repository }}:{{ .Values.piraeusServer.image.tag }}
-        # The satellite DaemonSet ran BestEffort on every storage node, which
-        # made it a standing victim for the Talos userspace OOM handler
-        # (v1.12+): that handler only ever kills cgroups with no memory.max, and
-        # picks by QoS class rather than by what caused the pressure. A tenant
-        # workload thrashing against its own limit would get the satellite
-        # killed, taking DRBD connections down with it.
-        #
-        # Requests only, no limit: the same call linstor-controller makes in
-        # values.yaml, and for the same reason, because this is the same JVM.
-        # images/piraeus-server/Dockerfile installs default-jre-headless and
-        # starts this container with `startSatellite`, the distribution the
-        # controller runs with `startController`. A memory.max is what a
-        # container-aware JVM reads to size its heap, so a limit here shrinks the
-        # heap rather than only capping RSS. This moves the ceiling rather than
-        # removing it: with the LimitRange the operator maintains in every system
-        # namespace (#3494, which must merge with or before this) admission
-        # defaults this container to --system-namespace-memory-limit, 4Gi, so the
-        # pod does get memory.max and the heap is derived from one operator-facing
-        # knob instead of a per-chart guess. Without that LimitRange the container
-        # really is limit-free and the pod stays in the victim set.
-        # Full account, and what would settle the sizing: tests/satellites_test.yaml.
+        # Deliberately no memory limit: this is the same JVM as linstor-controller,
+        # which values.yaml exempts for the same reason. Full account, and what
+        # would settle the sizing: packages/system/linstor/tests/satellites_test.yaml.
         # 14d peak 368Mi on a 3-node dev cluster; grows with resource count.
         resources:
           requests:

--- a/packages/system/linstor/templates/satellites-cozy.yaml
+++ b/packages/system/linstor/templates/satellites-cozy.yaml
@@ -27,10 +27,14 @@ spec:
         # starts this container with `startSatellite`, the distribution the
         # controller runs with `startController`. A memory.max is what a
         # container-aware JVM reads to size its heap, so a limit here shrinks the
-        # heap rather than only capping RSS. The cost is that the pod cgroup gets
-        # no memory.max, so this pod stays in the OOM handler's victim set; closing
-        # that needs a peak measured on a high-resource-count cluster plus an
-        # explicit heap share, not a guessed ceiling.
+        # heap rather than only capping RSS. This moves the ceiling rather than
+        # removing it: with the LimitRange the operator maintains in every system
+        # namespace (#3494, which must merge with or before this) admission
+        # defaults this container to --system-namespace-memory-limit, 4Gi, so the
+        # pod does get memory.max and the heap is derived from one operator-facing
+        # knob instead of a per-chart guess. Without that LimitRange the container
+        # really is limit-free and the pod stays in the victim set.
+        # Full account, and what would settle the sizing: tests/satellites_test.yaml.
         # 14d peak 368Mi on a 3-node dev cluster; grows with resource count.
         resources:
           requests:

--- a/packages/system/linstor/templates/satellites-cozy.yaml
+++ b/packages/system/linstor/templates/satellites-cozy.yaml
@@ -21,17 +21,21 @@ spec:
         # workload thrashing against its own limit would get the satellite
         # killed, taking DRBD connections down with it.
         #
-        # Note this is the opposite call from linstor-controller, which is
-        # deliberately left limit-free in values.yaml (a JVM that must not be
-        # OOM-killed mid-operation). The satellite is a Go binary with a bounded
-        # working set, so a generous limit costs nothing and buys immunity.
+        # Requests only, no limit: the same call linstor-controller makes in
+        # values.yaml, and for the same reason, because this is the same JVM.
+        # images/piraeus-server/Dockerfile installs default-jre-headless and
+        # starts this container with `startSatellite`, the distribution the
+        # controller runs with `startController`. A memory.max is what a
+        # container-aware JVM reads to size its heap, so a limit here shrinks the
+        # heap rather than only capping RSS. The cost is that the pod cgroup gets
+        # no memory.max, so this pod stays in the OOM handler's victim set; closing
+        # that needs a peak measured on a high-resource-count cluster plus an
+        # explicit heap share, not a guessed ceiling.
         # 14d peak 368Mi on a 3-node dev cluster; grows with resource count.
         resources:
           requests:
             cpu: 100m
             memory: 128Mi
-          limits:
-            memory: 2Gi
         startupProbe:
           tcpSocket:
             port: linstor

--- a/packages/system/linstor/templates/satellites-cozy.yaml
+++ b/packages/system/linstor/templates/satellites-cozy.yaml
@@ -15,8 +15,11 @@ spec:
       - name: linstor-satellite
         image: {{ .Values.piraeusServer.image.repository }}:{{ .Values.piraeusServer.image.tag }}
         # Deliberately no memory limit: this is the same JVM as linstor-controller,
-        # which values.yaml exempts for the same reason. Full account, and what
-        # would settle the sizing: packages/system/linstor/tests/satellites_test.yaml.
+        # which values.yaml exempts for the same reason. Its heap ceiling is an
+        # explicit -Xmx2G from linstor-server, not derived from the cgroup, so a
+        # limit only caps RSS — and the 2Gi limit this replaces was exactly that
+        # ceiling, leaving nothing for non-heap. Full account, and what would settle
+        # the sizing: packages/system/linstor/tests/satellites_test.yaml.
         # 14d peak 368Mi on a 3-node dev cluster; grows with resource count.
         resources:
           requests:

--- a/packages/system/linstor/templates/satellites-plunger.yaml
+++ b/packages/system/linstor/templates/satellites-plunger.yaml
@@ -12,10 +12,11 @@ spec:
       containers:
       - name: plunger
         image: {{ .Values.piraeusServer.image.repository }}:{{ .Values.piraeusServer.image.tag }}
-        # Sidecars in the satellite pod. Every container needs a memory limit
-        # for the pod cgroup to get memory.max, which is what keeps the pod out
-        # of the Talos userspace OOM handler's victim set — one limit-free
-        # sidecar is enough to put the whole satellite pod back in it.
+        # Sidecars in the satellite pod. These limits bound a runaway sidecar,
+        # they do not buy the pod immunity: the satellite container beside them
+        # is deliberately limit-free because it is a JVM, so the pod cgroup gets
+        # no memory.max either way and the pod stays in the Talos userspace OOM
+        # handler's victim set. See satellites-cozy.yaml.
         # 14d peaks on a 3-node dev cluster: plunger 18Mi, drbd-logger 5Mi.
         resources:
           requests:

--- a/packages/system/linstor/templates/satellites-plunger.yaml
+++ b/packages/system/linstor/templates/satellites-plunger.yaml
@@ -12,14 +12,10 @@ spec:
       containers:
       - name: plunger
         image: {{ .Values.piraeusServer.image.repository }}:{{ .Values.piraeusServer.image.tag }}
-        # Sidecars in the satellite pod. These limits bound a runaway sidecar at
-        # 128Mi rather than at the far looser ceiling it would otherwise take;
-        # what completes the set for the pod cgroup is not them. The satellite
-        # container beside them carries no chart-level limit because it is a JVM,
-        # so the pod's memory.max arrives from the system-namespace LimitRange
-        # default (#3494) — and without that LimitRange the pod has none whatever
-        # these sidecars declare, and stays in the Talos userspace OOM handler's
-        # victim set. See satellites-cozy.yaml.
+        # Sidecars in the satellite pod. These limits bound a runaway sidecar;
+        # they are not what puts memory.max on the pod cgroup, because the
+        # satellite container beside them is deliberately limit-free.
+        # See satellites-cozy.yaml and tests/satellites_test.yaml.
         # 14d peaks on a 3-node dev cluster: plunger 18Mi, drbd-logger 5Mi.
         resources:
           requests:

--- a/packages/system/linstor/templates/satellites-plunger.yaml
+++ b/packages/system/linstor/templates/satellites-plunger.yaml
@@ -12,11 +12,14 @@ spec:
       containers:
       - name: plunger
         image: {{ .Values.piraeusServer.image.repository }}:{{ .Values.piraeusServer.image.tag }}
-        # Sidecars in the satellite pod. These limits bound a runaway sidecar,
-        # they do not buy the pod immunity: the satellite container beside them
-        # is deliberately limit-free because it is a JVM, so the pod cgroup gets
-        # no memory.max either way and the pod stays in the Talos userspace OOM
-        # handler's victim set. See satellites-cozy.yaml.
+        # Sidecars in the satellite pod. These limits bound a runaway sidecar at
+        # 128Mi rather than at the far looser ceiling it would otherwise take;
+        # what completes the set for the pod cgroup is not them. The satellite
+        # container beside them carries no chart-level limit because it is a JVM,
+        # so the pod's memory.max arrives from the system-namespace LimitRange
+        # default (#3494) — and without that LimitRange the pod has none whatever
+        # these sidecars declare, and stays in the Talos userspace OOM handler's
+        # victim set. See satellites-cozy.yaml.
         # 14d peaks on a 3-node dev cluster: plunger 18Mi, drbd-logger 5Mi.
         resources:
           requests:

--- a/packages/system/linstor/tests/satellites_test.yaml
+++ b/packages/system/linstor/tests/satellites_test.yaml
@@ -12,24 +12,37 @@ suite: satellite pod resource limits
 # — images/piraeus-server/Dockerfile installs default-jre-headless and starts this
 # container with `startSatellite`, the same distribution the controller runs with
 # `startController` — and it matters because the sizing this replaced was chosen on
-# the premise that the satellite is a Go binary with a bounded working set. A
-# memory.max is what a container-aware JVM reads to size its heap, so a limit
-# shrinks the heap rather than only capping RSS, and the 368Mi peak behind the
-# request grows with DRBD resource count and was measured on three nodes.
+# the premise that the satellite is a Go binary with a bounded working set. The
+# 368Mi peak behind the request grows with DRBD resource count and was measured on
+# three nodes.
+#
+# The heap is not sized from the limit. linstor-server's build.gradle bakes
+# `-Xms32M -Xmx2G -XX:+CrashOnOutOfMemoryError` into the Satellite start script it
+# generates (jvmSatelliteOpts, handed to defaultJvmOpts; the controller gets -Xmx8G
+# by the same route), and an explicit -Xmx means the JVM never reads memory.max to
+# size its heap — container awareness only chooses a default maximum when -Xmx is
+# absent. Makefile's LINSTOR_VERSION pins which linstor-server that is, and
+# images/piraeus-server/Dockerfile is what checks it out and builds it.
+#
+# So a limit here caps RSS and nothing else, and the 2Gi limit this replaced was the
+# wrong number for that job: 2Gi is exactly -Xmx2G, leaving nothing for metaspace,
+# thread stacks, code cache, GC structures and direct buffers. A satellite growing
+# into its own heap ceiling would be OOM-killed by the kernel before the JVM got
+# there — and getting there is meant to be a deliberate, diagnosable crash
+# (-XX:+CrashOnOutOfMemoryError), not a silent kill.
 #
 # The exemption moves the ceiling, it does not remove it, and the distinction is
 # what makes it safe. With the LimitRange the operator maintains in every system
 # namespace (#3494, which must merge with or before this) admission defaults this
-# container to --system-namespace-memory-limit, 4Gi by default, so the pod does get
-# memory.max and the JVM derives its heap from one operator-facing knob instead of a
-# 2Gi per-chart guess. Without that LimitRange, or with the knob cleared, the
+# container to --system-namespace-memory-limit, 4Gi by default, which clears the 2G
+# heap with room left over for non-heap, set once as an operator-facing knob instead
+# of guessed per chart. Without that LimitRange, or with the knob cleared, the
 # container really is limit-free and the pod stays in the OOM handler's victim set —
 # which is what it does today, so this is not a regression, just not yet the fix.
 #
-# 4Gi still derives a capped heap, so this mitigates the heap-shrinking concern
-# rather than settling it. Settling it needs a peak measured on a high-resource-count
-# cluster plus an explicit heap share, and that is also what reverting the exemption
-# to a fitted per-chart limit would need first.
+# What a fitted per-chart limit would need is therefore not an explicit heap share,
+# which already exists, but a peak measured on a high-resource-count cluster: that
+# is what says how much non-heap to add on top of the 2G ceiling.
 #
 # The plunger limits below therefore do real work, but not the work of taking the pod
 # out of the victim set: they bound a runaway sidecar at 128Mi rather than at whatever

--- a/packages/system/linstor/tests/satellites_test.yaml
+++ b/packages/system/linstor/tests/satellites_test.yaml
@@ -13,10 +13,23 @@ suite: satellite pod resource limits
 # and the 368Mi peak behind the request grows with DRBD resource count and was
 # measured on three nodes.
 #
-# The consequence is pinned rather than left implicit: with the satellite container
-# limit-free the pod cgroup gets no memory.max, so the plunger limits below bound a
-# runaway sidecar and nothing more. Reverting the exemption means measuring on a
-# high-resource-count cluster first.
+# The exemption moves the ceiling, it does not remove it, and the distinction is
+# what makes it safe. With the LimitRange the operator maintains in every system
+# namespace (#3494, which must merge with or before this) admission defaults this
+# container to --system-namespace-memory-limit, 4Gi by default, so the pod does get
+# memory.max and the JVM derives its heap from one operator-facing knob instead of a
+# 2Gi per-chart guess. Without that LimitRange, or with the knob cleared, the
+# container really is limit-free and the pod stays in the OOM handler's victim set —
+# which is what it does today, so this is not a regression, just not yet the fix.
+#
+# 4Gi still derives a capped heap, so this mitigates the heap-shrinking concern
+# rather than settling it. Settling it needs a peak measured on a high-resource-count
+# cluster plus an explicit heap share, and that is also what reverting the exemption
+# to a fitted per-chart limit would need first.
+#
+# The plunger limits below therefore do real work, but not the work of taking the pod
+# out of the victim set: they bound a runaway sidecar at 128Mi rather than at whatever
+# the pod's defaulted ceiling is.
 
 templates:
   - templates/satellites-cozy.yaml

--- a/packages/system/linstor/tests/satellites_test.yaml
+++ b/packages/system/linstor/tests/satellites_test.yaml
@@ -6,27 +6,34 @@ suite: satellite pod resource limits
 # pressure. A tenant workload thrashing against its own limit would get the
 # satellite killed, taking DRBD connections on that node down with it.
 #
-# Every container in the pod needs a limit for the pod cgroup to get memory.max,
-# so the plunger sidecars are pinned alongside the satellite itself — one
-# limit-free sidecar is enough to put the whole pod back in the victim set.
+# The satellite is the exception and this suite pins it as one: it is the same JVM
+# as linstor-controller, which cluster_test.yaml pins as deliberately limit-free,
+# so it carries a request and no limit. A memory.max is what a container-aware JVM
+# reads to size its heap, so a limit shrinks the heap rather than only capping RSS,
+# and the 368Mi peak behind the request grows with DRBD resource count and was
+# measured on three nodes.
 #
-# Note this is the opposite call from linstor-controller, which cluster_test.yaml
-# pins as deliberately limit-free (a JVM that must not be OOM-killed mid-operation).
+# The consequence is pinned rather than left implicit: with the satellite container
+# limit-free the pod cgroup gets no memory.max, so the plunger limits below bound a
+# runaway sidecar and nothing more. Reverting the exemption means measuring on a
+# high-resource-count cluster first.
 
 templates:
   - templates/satellites-cozy.yaml
   - templates/satellites-plunger.yaml
 
 tests:
-  - it: satellite declares a memory limit and request
+  - it: satellite declares a memory request and deliberately no limit
     template: templates/satellites-cozy.yaml
     asserts:
       - equal:
-          path: spec.podTemplate.spec.containers[?(@.name=="linstor-satellite")].resources.limits.memory
-          value: 2Gi
-      - equal:
           path: spec.podTemplate.spec.containers[?(@.name=="linstor-satellite")].resources.requests.memory
           value: 128Mi
+      - equal:
+          path: spec.podTemplate.spec.containers[?(@.name=="linstor-satellite")].resources.requests.cpu
+          value: 100m
+      - notExists:
+          path: spec.podTemplate.spec.containers[?(@.name=="linstor-satellite")].resources.limits
 
   - it: plunger sidecars declare memory limits
     template: templates/satellites-plunger.yaml

--- a/packages/system/linstor/tests/satellites_test.yaml
+++ b/packages/system/linstor/tests/satellites_test.yaml
@@ -8,10 +8,14 @@ suite: satellite pod resource limits
 #
 # The satellite is the exception and this suite pins it as one: it is the same JVM
 # as linstor-controller, which cluster_test.yaml pins as deliberately limit-free,
-# so it carries a request and no limit. A memory.max is what a container-aware JVM
-# reads to size its heap, so a limit shrinks the heap rather than only capping RSS,
-# and the 368Mi peak behind the request grows with DRBD resource count and was
-# measured on three nodes.
+# so it carries a request and no limit. That it is the same JVM is not an inference
+# — images/piraeus-server/Dockerfile installs default-jre-headless and starts this
+# container with `startSatellite`, the same distribution the controller runs with
+# `startController` — and it matters because the sizing this replaced was chosen on
+# the premise that the satellite is a Go binary with a bounded working set. A
+# memory.max is what a container-aware JVM reads to size its heap, so a limit
+# shrinks the heap rather than only capping RSS, and the 368Mi peak behind the
+# request grows with DRBD resource count and was measured on three nodes.
 #
 # The exemption moves the ceiling, it does not remove it, and the distinction is
 # what makes it safe. With the LimitRange the operator maintains in every system

--- a/packages/system/multus/patches/customize-deployment.patch
+++ b/packages/system/multus/patches/customize-deployment.patch
@@ -41,30 +41,11 @@
    labels:
      tier: node
      app: multus
-@@ -157,13 +158,33 @@
+@@ -157,13 +158,14 @@
          - name: kube-multus
            image: ghcr.io/k8snetworkplumbingwg/multus-cni:snapshot-thick
            command: [ "/usr/src/multus-cni/bin/multus-daemon" ]
-+          # Upstream sets 50Mi for both the request and the limit. This patch
-+          # already raised the request to 100Mi and DELETED the memory limit
-+          # outright, leaving only the CPU one -- which left the pod cgroup with
-+          # no memory.max, and the Talos userspace OOM handler (v1.12+) only
-+          # ever kills cgroups that lack it. So dropping the limit to survive
-+          # 50Mi is what made multus an eviction candidate on every node.
-+          #
-+          # Restore a limit, sized as a backstop rather than a ceiling: 14d peak
-+          # is 230Mi on a 3-node dev cluster and this grows with pods per node,
-+          # so upstream's 50Mi was never survivable and a fitted value would
-+          # trade a rare pressure-driven kill for a deterministic one.
-+          #
-+          # 1Gi rather than a tighter multiple of that peak, because the peak is
-+          # the part least worth trusting here: multus-daemon holds per-pod
-+          # state and a 3-node dev cluster understates pods per node more than
-+          # it understates anything else measured for this change. The scar this
-+          # avoids is the vertical-pod-autoscaler updater, which OOM-looped at a
-+          # 110Mi limit for the same reason -- it scaled with pods in the
-+          # cluster -- and was given a limit 2.5x its measured request to stop
-+          # it. A limit costs nothing until it is hit; only the request reserves.
++          # Memory sizing rationale: packages/system/multus/tests/multus_test.yaml
            resources:
              requests:
                cpu: "100m"
@@ -77,7 +58,7 @@
            securityContext:
              privileged: true
            terminationMessagePolicy: FallbackToLogsOnError
-@@ -209,10 +230,14 @@
+@@ -209,10 +211,14 @@
              - "/host/opt/cni/bin"
              - "-t"
              - "thick"
@@ -92,7 +73,7 @@
            securityContext:
              privileged: true
            terminationMessagePolicy: FallbackToLogsOnError
-@@ -220,6 +245,81 @@
+@@ -220,6 +226,81 @@
              - name: cnibin
                mountPath: /host/opt/cni/bin
                mountPropagation: Bidirectional

--- a/packages/system/multus/templates/multus-daemonset-thick.yml
+++ b/packages/system/multus/templates/multus-daemonset-thick.yml
@@ -158,26 +158,7 @@ spec:
         - name: kube-multus
           image: ghcr.io/cozystack/cozystack/multus-cni:v1.6.0@sha256:0a92e861ead179dd6b46f475fd8878d44b3cfa40ce4d7a8ff92f790d54250d25
           command: [ "/usr/src/multus-cni/bin/multus-daemon" ]
-          # Upstream sets 50Mi for both the request and the limit. This patch
-          # already raised the request to 100Mi and DELETED the memory limit
-          # outright, leaving only the CPU one -- which left the pod cgroup with
-          # no memory.max, and the Talos userspace OOM handler (v1.12+) only
-          # ever kills cgroups that lack it. So dropping the limit to survive
-          # 50Mi is what made multus an eviction candidate on every node.
-          #
-          # Restore a limit, sized as a backstop rather than a ceiling: 14d peak
-          # is 230Mi on a 3-node dev cluster and this grows with pods per node,
-          # so upstream's 50Mi was never survivable and a fitted value would
-          # trade a rare pressure-driven kill for a deterministic one.
-          #
-          # 1Gi rather than a tighter multiple of that peak, because the peak is
-          # the part least worth trusting here: multus-daemon holds per-pod
-          # state and a 3-node dev cluster understates pods per node more than
-          # it understates anything else measured for this change. The scar this
-          # avoids is the vertical-pod-autoscaler updater, which OOM-looped at a
-          # 110Mi limit for the same reason -- it scaled with pods in the
-          # cluster -- and was given a limit 2.5x its measured request to stop
-          # it. A limit costs nothing until it is hit; only the request reserves.
+          # Memory sizing rationale: packages/system/multus/tests/multus_test.yaml
           resources:
             requests:
               cpu: "100m"

--- a/packages/system/multus/tests/multus_test.yaml
+++ b/packages/system/multus/tests/multus_test.yaml
@@ -27,6 +27,29 @@ tests:
   # container's contract lives; the two below complete the set for a default
   # render. Keep all three: dropping any one silently returns the whole pod to
   # the victim set while the other assertions still pass.
+  #
+  # Where the numbers come from — this is what the one-line pointer in
+  # templates/multus-daemonset-thick.yml refers to, kept here rather than in the
+  # template because a template comment is copied verbatim into the rendered
+  # object in every cluster and goes stale the moment a value changes, while this
+  # file cannot: changing a value means changing an assertion.
+  #
+  # Upstream sets 50Mi for both the request and the limit. The cozystack patch
+  # already raised the request to 100Mi and DELETED the memory limit outright,
+  # leaving only the CPU one — which is what left the pod cgroup with no
+  # memory.max and made multus an eviction candidate on every node. So the limit
+  # is restored rather than introduced.
+  #
+  # 1Gi is a backstop, not a fitted ceiling. The 14d peak is 230Mi on a 3-node
+  # dev cluster and it grows with pods per node, which is the measurement least
+  # worth trusting here: multus-daemon holds per-pod state and a 3-node cluster
+  # understates pods per node more than it understates anything else measured for
+  # this change. A tighter multiple of that peak would trade a rare
+  # pressure-driven kill for a deterministic one. The scar this avoids is the
+  # vertical-pod-autoscaler updater, which OOM-looped at a 110Mi limit for the
+  # same reason — it scaled with pods in the cluster — and was given a limit 2.5x
+  # its measured request to stop it. A limit costs nothing until it is hit; only
+  # the request reserves, which is why the request stays at 100Mi below the peak.
   - it: kube-multus and its binary installer declare memory limits
     template: templates/multus-daemonset-thick.yml
     documentSelector:

--- a/packages/system/velero/tests/velero_test.yaml
+++ b/packages/system/velero/tests/velero_test.yaml
@@ -112,20 +112,41 @@ tests:
   # candidate on every node whatever caused the pressure, and killing it
   # mid-backup fails the backup.
   #
-  # The limit is deliberately loose rather than fitted: measured usage is at
-  # idle, and the agent streams volume data during a backup, which is exactly
-  # when it must not be killed. Set from the umbrella values against the
-  # vendored subchart, so an upstream bump that moves the key would render
-  # nothing and leave no other trace; that is what this pins against.
-  - it: node-agent declares a memory limit and request
+  # It is nonetheless exempted from a limit, the same call linstor-controller and
+  # the satellite make, because its memory is driven by the data it moves rather
+  # than by cluster size: during a PodVolumeBackup kopia/restic walk, hash and
+  # index the volume's file tree, so demand scales with file count and volume
+  # size on that node. The 121Mi 14d peak is an idle figure and nothing measured
+  # on a 3-node dev cluster bounds the backup case, so a ceiling written here
+  # would be a guess — and a guess on this workload trades a kill that happens
+  # only when the node is genuinely short of memory for one that happens on a
+  # healthy node mid-backup, the single moment the agent has to survive.
+  #
+  # The ceiling is not dropped, it moves: the default LimitRange the operator
+  # maintains in every system namespace defaults container memory in cozy-velero,
+  # so the pod still gets memory.max and the value is tunable once, centrally,
+  # on the cluster whose backups need more. Before that LimitRange exists
+  # node-agent is limit-free and stays in the victim set — which is what it does
+  # today, so no regression, just not yet the fix.
+  #
+  # What would settle a fitted limit instead: a peak measured under a
+  # PodVolumeBackup of a large, many-file volume on a real cluster.
+  #
+  # Set from the umbrella values against the vendored subchart, so an upstream
+  # bump that moves the key would render nothing and leave no other trace; that
+  # is what the request assertions pin against, and notExists pins the exemption
+  # so a ceiling cannot come back quietly.
+  - it: node-agent declares a memory request and deliberately no limit
     template: charts/velero/templates/node-agent-daemonset.yaml
     documentSelector:
       path: kind
       value: DaemonSet
     asserts:
       - equal:
-          path: spec.template.spec.containers[?(@.name=="node-agent")].resources.limits.memory
-          value: 2Gi
-      - equal:
           path: spec.template.spec.containers[?(@.name=="node-agent")].resources.requests.memory
           value: 128Mi
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="node-agent")].resources.requests.cpu
+          value: 50m
+      - notExists:
+          path: spec.template.spec.containers[?(@.name=="node-agent")].resources.limits

--- a/packages/system/velero/values.yaml
+++ b/packages/system/velero/values.yaml
@@ -20,19 +20,17 @@ velero:
 
   deployNodeAgent: true
   nodeAgent:
-    # node-agent is a DaemonSet and ran BestEffort. A memory limit is what sets
-    # memory.max on the pod cgroup, and the Talos userspace OOM handler (v1.12+)
-    # only ever kills cgroups that lack one — so it was an eviction candidate on
-    # every node, independent of what caused the pressure. Killing it mid-backup
-    # fails the backup, so the limit is deliberately loose: 14d peak is 121Mi at
-    # idle on a dev cluster, but the agent streams volume data during a backup
-    # and that is exactly when it must not be killed.
+    # Requests only, deliberately no limit — the same call linstor-controller and
+    # the satellite make. node-agent's memory is driven by the data it moves, not
+    # by cluster size, so there is no dev-cluster figure to size a ceiling from:
+    # the 121Mi 14d peak is idle. The ceiling comes from the default LimitRange
+    # the operator maintains in every system namespace instead, which is one
+    # operator-facing value rather than a guess per package.
+    # Full reasoning, and the assertion that pins it: tests/velero_test.yaml.
     resources:
       requests:
         cpu: 50m
         memory: 128Mi
-      limits:
-        memory: 2Gi
   configuration:
     # defaultVolumesToFsBackup: true
     # cozy-default BackupStorageLocation lives in the


### PR DESCRIPTION
Follow-up to #3495, which merged before these landed. It reverses one decision that PR made, so the reasoning is here rather than in a commit body.

## The satellite was sized on a premise that is not true

`#3495` gave `linstor-satellite` a 2Gi memory limit, and the comment justifying it said the satellite is "a Go binary with a bounded working set, so a generous limit costs nothing and buys immunity". It is not a Go binary. `packages/system/linstor/images/piraeus-server/Dockerfile` installs `default-jre-headless` at line 134 and ends `CMD ["startSatellite"]` at line 173, the same `linstor-server` distribution the controller runs with `startController`.

That matters in the direction the sizing went, because a `memory.max` is not only an RSS ceiling for a JVM, it is what container-aware heap sizing reads. A 2Gi limit therefore yields a heap of roughly a quarter of that, while the 368Mi peak the comment quotes is already whole-process RSS measured on three nodes, and the same comment says it grows with DRBD resource count. On a storage node with a large resource count that trades a rare pressure-driven kill for an `OutOfMemoryError` or GC thrash in the middle of a DRBD operation, which is the failure `linstor-controller` is already exempted to avoid: `values.yaml` gives it requests and no limit, and `tests/cluster_test.yaml` pins that with `notExists`.

So the satellite now matches the controller, and `tests/satellites_test.yaml` pins the exemption the same way.

`#3495` was reviewed and approved on the state that carried the 2Gi limit, and the approval explicitly recorded that the satellite, plunger and drbd-logger all carry limits. This changes that, deliberately, on the evidence above rather than on a preference.

## The exemption moves the ceiling rather than removing it

Worth being precise, because an earlier draft of these comments got it wrong. With the LimitRange from #3494 present, admission defaults a container that declares no limit to `--system-namespace-memory-limit`, 4Gi by default, so the pod does get `memory.max` and the JVM derives its heap from one operator-facing knob instead of a per-chart guess. Without #3494, or with the knob cleared, the container really is limit-free and the pod stays in the OOM handler's victim set, which is what it does on `main` today. 4Gi still derives a capped heap, so this mitigates the heap-sizing problem rather than settling it, and settling it needs a peak measured at a high DRBD resource count plus an explicit heap share.

## velero node-agent, same call for a different reason

`#3495` sized its 2Gi limit from a figure the comment itself labels as idle, 121Mi. node-agent is the one workload in that set whose demand is driven by user data rather than cluster size: kopia and restic walk, hash and index a volume's file tree during a `PodVolumeBackup`, so no measurement on a development cluster bounds it. The kill a ceiling prevents happens only when the node is genuinely short of memory. The kill a ceiling introduces happens on a healthy node in the middle of a backup, on clusters whose large backups completed while node-agent was unlimited. It is exempted, pinned with `notExists`, and what would settle it is a peak measured under a backup of a large many-file volume.

## The narrative comments come out of the rendered manifests

`#3495`'s review asked for this and it did not make the merge. `#` comments are not stripped at render, so the 20-line block at `multus-daemonset-thick.yml:161-180` and the block beside the satellite resources were copied verbatim into the rendered object in every cluster, and went stale the moment a number changed. Both are now a short pointer at the stanza with the account in the test suite beside the assertions, which cannot drift out of step with the values because changing one means changing the other. The measurement lines stay at the stanza, since that is what a person changing a request needs in front of them.

The multus template and its patch under `patches/` are kept consistent: the patch was regenerated rather than hand-edited, reverse-applied to recover the pristine upstream manifest first, then forward-applied to confirm the result is byte-identical to the committed template.

## Testing

Both exemptions are pinned with `notExists` on `resources.limits`, so re-adding a ceiling fails the suite rather than passing quietly, and both were mutation-checked in that direction. The multus change adds no assertions, so the existing limit pin was mutated instead to prove it still bites after the comment move. `helm unittest` passes for linstor, velero and multus, `hack/multus-install-cni-plugins.bats` passes because it extracts the init script from the same template, and `pre-commit run --all-files` leaves a clean tree.

## One thing not addressed here

`packages/system/linstor/tests/cluster_test.yaml` says the controller has "no limits: avoid throttling / OOM-killing the JVM". The throttling half is about the absent CPU limit and is fine. The OOM half now carries the same imprecision this PR corrects for the satellite, since with #3494 in the namespace the container is defaulted rather than unbounded. It predates both PRs, so it is left for whichever change next touches that file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multus resources now run in the dedicated `cozy-multus` namespace with updated resource sizing.
  * Added optional CNI plugin installation during deployment, including safe handling of installation conflicts and failures.

* **Bug Fixes**
  * Removed fixed 2Gi memory limits from Linstor satellite and Velero node-agent workloads.
  * Preserved resource requests and sidecar protections for more flexible runtime sizing.

* **Tests**
  * Updated resource validation to reflect the revised memory and CPU configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->