### PR TITLE
test(e2e): stop the mongodb backup suite before the restore leg

### DIFF
--- a/examples/backups/mongodb/30-restorejob-to-copy.yaml
+++ b/examples/backups/mongodb/30-restorejob-to-copy.yaml
@@ -4,10 +4,11 @@
 # source backup's S3 destination, so the operator replays the logical dump into
 # the target while mongodb-src stays running and untouched.
 #
-# Driven for the same-namespace happy path by run-all.sh in this directory (and
-# the mongodb-2-backup-roundtrip Chainsaw suite); also applicable manually with
-# kubectl apply -f. The cross-tenant variant stays manual; see the README for
-# the network-policy reason.
+# Driven for the same-namespace happy path by run-all.sh in this directory; also
+# applicable manually with kubectl apply -f. The mongodb-2-backup-roundtrip
+# Chainsaw suite stops before this step while #3832 is open, so nothing in CI
+# exercises it. The cross-tenant variant stays manual; see the README for the
+# network-policy reason.
 ---
 apiVersion: backups.cozystack.io/v1alpha1
 kind: RestoreJob

--- a/examples/backups/mongodb/README.md
+++ b/examples/backups/mongodb/README.md
@@ -81,6 +81,8 @@ and asserts the sentinel round-tripped through S3 into the restored copy while
 the source is left untouched. Set `SKIP_RESTORE=1` to stop after a successful
 backup.
 
+The to-copy restore currently ends with the target holding the source cluster's system users, so the target's own credentials stop authenticating and that last assertion fails; #3832 tracks it, and `SKIP_RESTORE=1` stops before that step.
+
 Same-namespace flows are the supported path. Cross-tenant restores (target in
 `tenant-test`, source's seaweedfs in `tenant-root`) are blocked by the per-tenant
 Cilium egress policy and stay a manual / dev-cluster flow.
@@ -93,3 +95,5 @@ Analysis whenever the mongodb app or the suite changes, and on every release
 cut. It runs in `tenant-root` against the in-cluster seaweedfs endpoint — the
 isolated e2e tenant cannot reach it across the Cilium egress policy, and the
 external ingress endpoint is an unroutable placeholder in the sandbox.
+
+It drives `run-all.sh` with `SKIP_RESTORE=1` and stops once the BackupJob succeeds, so the restore steps are not covered by CI while #3832 is open: a to-copy restore replays the source cluster's system users into the target, after which the target's own credentials no longer authenticate and the sentinel cannot be read back.

--- a/examples/backups/mongodb/run-all.sh
+++ b/examples/backups/mongodb/run-all.sh
@@ -90,6 +90,8 @@ BACKUP_NAME=$(kubectl -n "$NAMESPACE" get backupjobs.backups.cozystack.io "$BACK
 log_success "Backup artefact: ${BACKUP_NAME}"
 
 if [[ "${SKIP_RESTORE:-0}" == "1" ]]; then
+    # hack/e2e-chainsaw/mongodb/ asserts this line to prove the skip really
+    # happened, so rewording it reds that suite with a bare match failure.
     log_warning "SKIP_RESTORE=1: stopping after a successful backup."
     exit 0
 fi

--- a/hack/e2e-chainsaw/mongodb/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/mongodb/chainsaw-test.yaml
@@ -61,15 +61,23 @@ spec:
           status:
             readyReplicas: 1
 ---
-# Full logical-dump backup -> to-copy RestoreJob round-trip, driving the
-# validated example scripts (examples/backups/mongodb) as the harness so the
-# test and the documented flow can never drift. run-all.sh runs Bucket ->
-# source MongoDB (backup.enabled) + sentinel document -> ad-hoc BackupJob
-# against the cozy-default BackupClass (waits Succeeded) -> empty target MongoDB
-# + to-copy RestoreJob (waits Succeeded) and asserts the sentinel round-tripped
-# through S3 into the restored copy while the source stays untouched — the
-# in-cluster witness that a psmdb-operator backup is both taken and restorable
-# end to end. Same harness-driving shape as mariadb-2-backup-roundtrip
+# Logical-dump backup half of the MongoDB backup flow, driving the validated
+# example scripts (examples/backups/mongodb) as the harness so the test and the
+# documented flow can never drift. run-all.sh runs Bucket -> source MongoDB
+# (backup.enabled) + sentinel document -> ad-hoc BackupJob against the
+# cozy-default BackupClass (waits Succeeded), and SKIP_RESTORE=1 stops it there
+# — the in-cluster witness that a psmdb-operator backup is actually taken.
+#
+# The to-copy restore half is deliberately uncovered. A to-copy restore replays
+# the source cluster's system users into the target, so the target's own
+# generated credentials stop authenticating and the harness cannot read the
+# sentinel back out of the restored copy (#3832). Returning full round-trip
+# coverage once that is fixed means dropping both SKIP_RESTORE below and the
+# marker check beside it: the complete flow never prints that line, so removing
+# only the variable trades this failure for a marker mismatch. The test keeps
+# its round-trip name for that return.
+#
+# Same harness-driving shape as mariadb-2-backup-roundtrip
 # (hack/e2e-chainsaw/mariadb/chainsaw-test.yaml): a single run step pre-cleans
 # any leftover state, drives run-all.sh, and drains in an always-reached finally.
 #
@@ -134,12 +142,14 @@ spec:
           NAMESPACE="$NAMESPACE" examples/backups/mongodb/cleanup.sh
         check:
           ($error == null): true
-    # The 30m budget is the whole documented flow: bucket provisioning, a
+    # The 30m budget covers what this step drives: bucket provisioning, a
     # single-replica source MongoDB coming up (psmdb reconcile, PVC bind, image
-    # pull, pbm-agent sidecars), the logical dump to S3, an empty target, and
-    # the to-copy restore + verify (convention 6: justified in-line). run-all.sh
-    # fails fast on terminal BackupJob/RestoreJob phases and stalled
-    # HelmReleases rather than polling out the budget.
+    # pull, pbm-agent sidecars) and the logical dump to S3 (convention 6:
+    # justified in-line). It is not lowered for the skipped restore because
+    # run-all.sh's own per-wait budgets up to the backup already exceed it, so
+    # this is the ceiling that fires either way. run-all.sh fails fast on a
+    # terminal BackupJob phase and stalled HelmReleases rather than polling out
+    # the budget.
     - script:
         timeout: 30m
         content: |
@@ -147,9 +157,15 @@ spec:
           cd ../../..
           [ -x examples/backups/mongodb/run-all.sh ] || { echo "mongodb backup example scripts not found at examples/backups/mongodb" >&2; exit 1; }
           NAMESPACE="$NAMESPACE" S3_ENDPOINT="https://seaweedfs-s3.tenant-root:8333" \
-            examples/backups/mongodb/run-all.sh
+            SKIP_RESTORE=1 examples/backups/mongodb/run-all.sh
         check:
           ($error == null): true
+          # Exit zero alone is also what a completed round-trip returns, so the
+          # marker is what tells the skipped flow from the full one — and what
+          # fails the step if SKIP_RESTORE stops reaching the harness. run-all.sh
+          # logs through stderr. The phrase is the skip branch's own line, minus
+          # its colon, which YAML would read as a mapping separator in the key.
+          (contains($stderr, 'stopping after a successful backup')): true
     finally:
     # Removes every resource the harness created (chainsaw did not apply them,
     # so they are not part of automatic cleanup) — including the operator-side


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

The `mongodb-2-backup-roundtrip` suite now drives its harness with `SKIP_RESTORE=1`, so it stops once the ad-hoc `BackupJob` reaches `Succeeded` instead of continuing into the to-copy restore.

A to-copy restore replays the source cluster's system users into the target. The target's own generated credentials stop authenticating afterwards, so the harness cannot read its sentinel document back out of the restored copy, and the psmdb operator loses access to the cluster it just restored. That behaviour is tracked in #3832 and is not addressed here; this change only stops the suite from asserting a flow that cannot currently succeed.

What the suite still proves is unchanged and is the larger half: bucket provisioning, a source MongoDB coming up with backups enabled, a sentinel document written into it, and an ad-hoc `BackupJob` against the `cozy-default` BackupClass completing against S3.

The skip is pinned rather than assumed. Exiting zero is also what a completed round-trip does, so a `SKIP_RESTORE` that stopped reaching the harness would be indistinguishable from one that worked. The step therefore also asserts the skip branch's own log line, which the harness writes to stderr.

Two places already told the reader that CI covers the restore, and this change is what makes them wrong, so both now say where coverage ends: the header of `30-restorejob-to-copy.yaml` and the example README. The asserted log line is annotated where it is printed, since rewording it would fail the suite on a bare match with nothing pointing at the cause.

Coverage returns by dropping `SKIP_RESTORE=1` together with the assertion on that line, once #3832 is fixed. Dropping only the variable would trade this failure for a marker mismatch, so the suite comment spells out both. The test keeps its round-trip name, matching `etcd-2-backup-roundtrip`, which is gated out of CI under the same convention.

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

Not a UI change.

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

Walked against the diff, which is one Chainsaw suite (`hack/e2e-chainsaw/mongodb/chainsaw-test.yaml`) and three files under `examples/backups/mongodb/` (`run-all.sh`, `30-restorejob-to-copy.yaml`, `README.md`). No package is added, renamed or removed; no `values.schema.json`, version enum, chart default, `ApplicationDefinition` or CRD changes; nothing under `hack/` moves or is renamed and no make target changes behaviour; no telemetry metric changes; and the only entry for `cozystack/examples` is the node and network requirements, which are untouched.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
test(e2e): the MongoDB backup suite now stops after a successful BackupJob; the to-copy restore leg stays uncovered until the credential handling behind it is fixed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MongoDB backup and restore guidance to clarify current restore limitations.
  * Documented how to skip restore operations when needed.
  * Clarified which restore scenarios are automated and which require manual handling.

* **Tests**
  * MongoDB end-to-end coverage now validates successful backups while restore testing is temporarily skipped.
  * Added verification that the test harness stops after a successful backup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->