### PR TITLE
test(e2e): TEMPORARY probe for worker CPU usage on node-join failure

### DIFF
--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -1318,6 +1318,7 @@ _cozy_cadvisor_worker_nodes() {
 _cozy_cpu_throttle_tail_note() {
   local raw="$1" rc="$2" filter_rc="$3" had_series="$4"
   local quota_rc=0
+  local derived derived_rc=0
 
   grep -q '^container_spec_cpu_quota{' "${raw}" || quota_rc=$?
   if [ "${had_series}" -eq 1 ] && [ "${rc}" -eq 0 ] && [ "${filter_rc}" -lt 2 ] \
@@ -1325,6 +1326,117 @@ _cozy_cpu_throttle_tail_note() {
     printf '%s\n' \
       'these workers are running uncapped: cAdvisor publishes the quota and the CFS counters only for a container whose quota is non-zero, so a period with neither beside it is a container with no CPU limit rather than a short read' \
       >>"${raw}"
+  fi
+
+  # The usage total is the one family here a reader cannot use as it stands:
+  # it is CPU-seconds accumulated since the container started, so a single
+  # scrape of it is a number with no denominator. The denominator arrives in
+  # the same scrape -- container_start_time_seconds -- and the division is done
+  # here rather than left to the reader, because the reading this whole
+  # collector exists to produce IS that quotient and an artifact that stops one
+  # step short of it is what produced the last misreading.
+  #
+  # Per container, and that is the second thing being fixed. The filter narrows
+  # by namespace and by the virt-launcher Pod-name prefix and never by
+  # container, so every container of the Pod lands in this file -- the
+  # guest-console-log sidecar, whose own limit is a small fraction of a core,
+  # beside the `compute` container that runs the guest. Rows carrying different
+  # subjects under one heading is how the counters above were read wrong. No
+  # container predicate is added to the filter instead: the three-stage filter
+  # belongs to the body this capture shares with the network counters, whose
+  # rows all carry container="" and would be emptied by one, and narrowing here
+  # would also drop the throttling counters of the other containers that this
+  # capture returns today and that its own tests pin.
+  #
+  # Gated on had_series alone, unlike the note above. A truncated capture still
+  # says whatever the rows that did arrive support, and the sentences above
+  # already say the file is short; suppressing the reading there would lose it
+  # on exactly the runs where the read was slow.
+  if [ "${had_series}" -eq 1 ]; then
+    # `now` is the fallback denominator and nothing more. Every row from the
+    # kubelet's cAdvisor endpoint carries its own sample time as a third field,
+    # which is the timestamp used when it is there; this runner's clock stands
+    # in when it is not, at the cost of the housekeeping lag between the sample
+    # and the read -- tens of seconds against an uptime of tens of minutes.
+    # Which of the two produced a line is printed on the line.
+    derived=$(awk -v now="$(date +%s 2>/dev/null || true)" '
+      /^container_(cpu_usage_seconds_total|start_time_seconds|spec_cpu_(quota|period))[{]/ {
+        metric = substr($0, 1, index($0, "{") - 1)
+        ctr = ""
+        pod = ""
+        if (match($0, /[,{]container="[^"]*"/))
+          ctr = substr($0, RSTART + 12, RLENGTH - 13)
+        if (match($0, /[,{]pod="[^"]*"/))
+          pod = substr($0, RSTART + 6, RLENGTH - 7)
+        # Value and sample time are whatever follows the LAST closing brace on
+        # the line. Splitting the whole line on whitespace picks the wrong
+        # field on any row whose label set carries a space, and the image label
+        # is where that happens.
+        close_at = 0
+        for (i = length($0); i > 0; i--)
+          if (substr($0, i, 1) == "}") { close_at = i; break }
+        if (close_at == 0) next
+        n = split(substr($0, close_at + 1), fld, " ")
+        if (n < 1) next
+        key = pod "\t" ctr
+        if (metric == "container_cpu_usage_seconds_total") {
+          if (!(key in usage)) order[++keys] = key
+          usage[key] = fld[1] + 0
+          stamp[key] = (n >= 2 ? fld[2] + 0 : 0)
+          kpod[key] = pod
+          kctr[key] = ctr
+        } else if (metric == "container_start_time_seconds") {
+          started[key] = fld[1] + 0
+        } else if (metric == "container_spec_cpu_quota") {
+          quota[key] = fld[1] + 0
+        } else if (metric == "container_spec_cpu_period") {
+          period[key] = fld[1] + 0
+        }
+      }
+      END {
+        if (keys == 0) {
+          print "how much CPU these workers actually got is not answered here: no container_cpu_usage_seconds_total row for them reached this file, and without it a container held at its ceiling and a container losing contended host CPU look the same"
+          exit
+        }
+        print "how much CPU each container actually got, worked out here so nobody has to divide, and one line per container so no two are read as one:"
+        for (i = 1; i <= keys; i++) {
+          key = order[i]
+          ceiling = ""
+          if ((key in quota) && (key in period) && quota[key] > 0 && period[key] > 0)
+            ceiling = sprintf("ceiling %.3f CPU", quota[key] / period[key])
+          else
+            ceiling = "no CPU limit of its own"
+          if (!(key in started)) {
+            printf "  pod=%s container=\"%s\": %.1f CPU-seconds since it started, but no container_start_time_seconds row came with it, so this total is not yet a rate (%s)\n", kpod[key], kctr[key], usage[key], ceiling
+            continue
+          }
+          if (stamp[key] > 0) {
+            nowsec = stamp[key] / 1000
+            src = "the sample time on the row"
+          } else {
+            nowsec = now + 0
+            src = "this runner clock at capture"
+          }
+          up = nowsec - started[key]
+          if (up <= 0) {
+            printf "  pod=%s container=\"%s\": %.1f CPU-seconds since it started, but %s is not later than its start time, so this total is not yet a rate (%s)\n", kpod[key], kctr[key], usage[key], src, ceiling
+            continue
+          }
+          printf "  pod=%s container=\"%s\": %.1f CPU-seconds used over %.0fs of uptime = %.3f CPU-seconds per second (%s; uptime from %s)\n", kpod[key], kctr[key], usage[key], up, usage[key] / up, ceiling, src
+        }
+        print "read each line against the ceiling on it: a rate at or near the ceiling is a container held AT its limit, where the vCPU count is the lever; a rate far below the ceiling while the guest made no progress is a container losing contended host CPU to its neighbours, where the CPU request is the lever"
+      }
+    ' "${raw}") || derived_rc=$?
+    if [ "${derived_rc}" -ne 0 ]; then
+      # Same rule as every other outcome in this collector: a reading that was
+      # never computed is said out loud rather than left as an absence, which
+      # in this file reads as a question nobody asked.
+      printf '%s\n' \
+        'how much CPU each container actually got was not worked out here: awk did not run on this runner, so the file carries the raw usage counters and nothing derived from them' \
+        >>"${raw}"
+    else
+      printf '%s\n' "${derived}" >>"${raw}"
+    fi
   fi
 }
 
@@ -1366,33 +1478,60 @@ _cozy_network_counters_tail_note() {
 # without the ceiling it was measured against, and a reader should not have to
 # carry a figure back from an earlier section to divide by it.
 #
-# Five families carry the answer, and cAdvisor publishes them ready to read, so
-# no arithmetic is done here and none is needed:
+# Seven families carry the answer, five of them read as published and two of
+# them divided into each other at the end of the capture:
 #
 #   container_cpu_cfs_periods_total            periods the group was scheduled
 #   container_cpu_cfs_throttled_periods_total  of those, periods it was stopped
 #   container_cpu_cfs_throttled_seconds_total  how long it was stopped for
 #   container_spec_cpu_period                  the ceiling's period
 #   container_spec_cpu_quota                   the ceiling itself
+#   container_cpu_usage_seconds_total          CPU it actually got, cumulative
+#   container_start_time_seconds               what that total is cumulative over
 #
 # The throttled counters alone say a container hit some ceiling, not which one,
 # and a VM capped at one core and a VM capped at eight are the same number
 # without the quota beside them.
 #
-# Four of those five are gated, and on the same condition. cAdvisor emits the
-# quota series and all three CFS counters only for a container whose quota is
+# The last two are here because the CFS counters cannot separate the two live
+# explanations of a worker that misses the node-Ready deadline, and were read as
+# though they could (cozystack/cozystack#3513). Throttling fires only AT the
+# ceiling, so it says the guest reached its limit sometimes and says nothing
+# about what it got the rest of the time -- and a container held far below its
+# ceiling by competition for host CPU is throttled barely at all. Usage over
+# wall-clock is the series that decides it: near one CPU-second per second is a
+# guest at its ceiling, where the vCPU count is the lever, and far below that
+# while the guest makes no progress is a guest losing contended host CPU, where
+# the CPU request is. The reading is derived in the tail note rather than left
+# to whoever opens the file, and the reasoning for doing it there is beside it.
+#
+# The start time is captured rather than a second scrape taken, and that is a
+# cost decision with a correctness half. Cost: both new families arrive in the
+# scrape the other five already come in, so the collector's ceiling is the same
+# four bounded reads it was before -- one Pod listing plus up to three node
+# reads -- and the phase budget sees no change at all; a second scrape would add
+# three more node reads and the interval between them, out of a 420s budget this
+# collector is deliberately first in. Correctness: this capture runs only after
+# the node-Ready deadline has already failed, so the container's whole lifetime
+# IS the window under investigation, and a mean over its uptime is a mean over
+# the stall rather than a sample of some interval inside it.
+#
+# Four of the first five are gated, and on the same condition. cAdvisor emits
+# the quota series and all three CFS counters only for a container whose quota is
 # non-zero; container_spec_cpu_period is the one it emits for any container with
 # a CPU spec at all. So a container that reports one puts two shapes on the
 # wire and no third: all five when it is capped, the period alone when it is
 # not. (A container with no CPU spec contributes none of the five, and reaches
 # this capture as the same silence as a node with no worker on it.) The second
 # is a reading rather than a gap -- it is the question this collector was added
-# to answer, and it arrives without being computed.
+# to answer, and it arrives without being computed. The usage and start-time
+# families are outside that gate: cAdvisor publishes both for every container it
+# sees, capped or not, so they are present in both shapes.
 #
 # Worth stating because a one-line capture is also what a truncated read looks
 # like, and this function spends its whole length making that difference legible.
-# A reader who expected five families and found one would reach for the wrong
-# conclusion with the artifact agreeing.
+# A reader who expected the whole set and found one line would reach for the
+# wrong conclusion with the artifact agreeing.
 #
 # Read from the kubelet rather than from inside the container on purpose. A
 # reader that runs inside the container shares the cgroup it is measuring, so
@@ -1432,7 +1571,7 @@ cozy_capture_tenant_worker_cpu_throttle() {
     CPU \
     cozy-cpu-throttle \
     _cozy_cpu_throttle_tail_note \
-    '^container_(cpu_cfs_(periods_total|throttled_periods_total|throttled_seconds_total)|spec_cpu_(period|quota))\{'
+    '^container_(cpu_cfs_(periods_total|throttled_periods_total|throttled_seconds_total)|cpu_usage_seconds_total|spec_cpu_(period|quota)|start_time_seconds)\{'
 }
 
 # Two properties of the network family are invisible to anyone writing this

--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -2545,7 +2545,32 @@ EOF
   # bring-up; 18m restores margin and still sits well inside the 50m step
   # timeout (the downstream LB/NFS/ouroboros checks add ~10-15m on the happy
   # path).
-  if ! timeout 18m bash -c '
+  # ###########################################################################
+  # ##  TEMPORARY — MUST NEVER MERGE.  DELETE THIS COMMIT BEFORE ANYTHING    ##
+  # ##  ELSE ON THIS BRANCH IS TAKEN SERIOUSLY.                              ##
+  # ###########################################################################
+  #
+  # The budget below is deliberately cut from 18m to 6m so that this suite
+  # FAILS ON PURPOSE. It is not a fix, a tuning change or an experiment about
+  # the right budget — it is a switch that forces the node-join diagnostics to
+  # run, so the CPU-usage capture added on the commit before this one produces
+  # its numbers on every run instead of only on the ~1 red run in 3 that
+  # happens to hit the flake, at ~3h a run (cozystack/cozystack#3513).
+  #
+  # Every node-join failure this produces is manufactured by this line. Do not
+  # read a red run on this branch as evidence about node-join at all; read only
+  # the CPU-usage figures in
+  # snapshots/<test>/tenant-cpu-throttle/<node>.txt.
+  #
+  # Deliberately a hardcoded literal and not a knob, an env var or a
+  # conditional: it has to be impossible to miss in review and a one-line
+  # delete to remove. The diagnostics headline downstream still says "within
+  # 18m" and is left alone on purpose — that wording is quoted verbatim in two
+  # other comments, and this commit is meant to be deleted whole rather than
+  # spread across the files that would then need deleting too.
+  #
+  # RESTORE: `timeout 18m`. The reasoning for that number is directly above.
+  if ! timeout 6m bash -c '
     until [ "$(kubectl --kubeconfig tenantkubeconfig-'"${test_name}"' get nodes --no-headers 2>/dev/null | grep -cw Ready)" -ge 2 ]; do
       sleep 5
     done

--- a/hack/run-kubernetes-cpu-throttle_test.bats
+++ b/hack/run-kubernetes-cpu-throttle_test.bats
@@ -20,16 +20,25 @@ kubectl_list_stderr=
 kubectl_raw_rc=0
 kubectl_raw_stderr=
 # Two of the fixtures in this file claim to be wire shapes, and the rest do not.
-# This one and the uncapped test's single line are the two cAdvisor can actually
-# produce -- all five families for a capped container, the period alone for one
-# with no limit, the two sides of the same Quota != 0 gate. Every other fixture
-# below stages only the lines its own assertion needs, so a missing sibling
-# series there means "not relevant here" rather than "absent on the wire".
-kubectl_raw_output='container_cpu_cfs_periods_total{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 51200
-container_cpu_cfs_throttled_periods_total{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 4211
-container_cpu_cfs_throttled_seconds_total{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 12.5
-container_spec_cpu_quota{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 100000
-container_spec_cpu_period{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 100000'
+# This one and the uncapped test's are the two cAdvisor can actually produce --
+# the capped shape and the uncapped one, the two sides of the same Quota != 0
+# gate. What that gate covers is the quota and the three CFS counters; the usage
+# total and the start time sit outside it and are published for every container,
+# which is why both fixtures carry them. Every other fixture below stages only
+# the lines its own assertion needs, so a missing sibling series there means
+# "not relevant here" rather than "absent on the wire".
+#
+# The trailing millisecond field on each row is cAdvisor's own sample time,
+# which the kubelet publishes on every row it serves. It is what the capture
+# divides the usage total by, so a fixture without it would exercise the
+# fallback clock on every test rather than the path production takes.
+kubectl_raw_output='container_cpu_cfs_periods_total{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 51200 1755200000000
+container_cpu_cfs_throttled_periods_total{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 4211 1755200000000
+container_cpu_cfs_throttled_seconds_total{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 12.5 1755200000000
+container_spec_cpu_quota{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 100000 1755200000000
+container_spec_cpu_period{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 100000 1755200000000
+container_cpu_usage_seconds_total{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 145.2 1755200000000
+container_start_time_seconds{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 1755198920 1755200000000'
 timeout_calls=/dev/null
 timeout_fail_node=
 
@@ -240,6 +249,23 @@ run_capture() {
   # says whether a small ratio was a long stall.
   assert_file_contains 'container_cpu_cfs_periods_total' "$capture"
   assert_file_contains 'container_cpu_cfs_throttled_seconds_total' "$capture"
+  # The pair that answers cozystack/cozystack#3513. The CFS counters fire only
+  # AT the ceiling, so on their own they say the guest reached its limit
+  # sometimes and nothing about what it got the rest of the time -- which is the
+  # half that separates a guest held at its ceiling from one losing contended
+  # host CPU. Dropped from the filter, the capture goes on looking complete.
+  #
+  # Pinned as a series ROW, with its opening brace and a label, not as a bare
+  # metric name: both names also appear in the sentences this capture writes
+  # when the row is missing ("no container_cpu_usage_seconds_total row ...
+  # reached this file"), so a name-only assertion is satisfied by the note
+  # reporting the series absent -- it was, before this line was written this
+  # way, and it passed the red-phase check for exactly that reason.
+  assert_file_contains 'container_cpu_usage_seconds_total{container="compute"' "$capture"
+  # And its denominator. A cumulative total with nothing to divide it by is a
+  # number the reader cannot use, so losing this alternative costs the answer
+  # just as surely as losing the total itself.
+  assert_file_contains 'container_start_time_seconds{container="compute"' "$capture"
   # The negative half of the labels. A complete capture that tells the reader
   # its answer is missing, while the answer sits in the same file, is the same
   # "capture misreads itself" harm as silence reported as an answer -- just
@@ -649,14 +675,17 @@ run_capture() {
   kubectl_calls="$tmp/kubectl.calls"
   timeout_calls="$tmp/timeout.calls"
   kubectl_node_names="srv1"
-  # One line, and it is the whole shape: cAdvisor gates the quota series and all
-  # three CFS counters on the same non-zero quota, so an uncapped container puts
-  # the period on the wire and nothing else. Staging a CFS counter beside it
-  # would be a shape the endpoint cannot produce, and the test would then pass
-  # on a fixture rather than on the contract. It is an answer, not a short read:
-  # filed as "nothing was collected" it would send the reader looking for a
-  # ceiling that does not exist.
-  kubectl_raw_output='container_spec_cpu_period{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 100000'
+  # The whole uncapped shape: cAdvisor gates the quota series and all three CFS
+  # counters on the same non-zero quota, so an uncapped container puts the period
+  # on the wire and no CFS counter at all. Staging one beside it would be a shape
+  # the endpoint cannot produce, and the test would then pass on a fixture rather
+  # than on the contract. The usage total and the start time are outside that
+  # gate and are published for an uncapped container like any other, so they
+  # belong here. It is an answer, not a short read: filed as "nothing was
+  # collected" it would send the reader looking for a ceiling that does not exist.
+  kubectl_raw_output='container_spec_cpu_period{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 100000 1755200000000
+container_cpu_usage_seconds_total{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 145.2 1755200000000
+container_start_time_seconds{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 1755198920 1755200000000'
   COZY_REPORT_DIR="$tmp/report"
   COZY_SNAPSHOT_NAME=throttle-smoke
 
@@ -671,6 +700,79 @@ run_capture() {
   # sentence -- so the one answer it was built to deliver cannot be the one that
   # gets none.
   assert_file_contains 'running uncapped' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the file says how much CPU each container got, per container and without arithmetic" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="srv1"
+  # Both containers of one virt-launcher Pod, which is what the filter returns:
+  # it narrows by namespace and by the Pod-name prefix and never by container.
+  # `compute` runs the guest at a one-core ceiling; guest-console-log is the
+  # sidecar at 15m. Their rows are interleaved on the wire exactly like this,
+  # and reading the sidecar's numbers as the guest's is how the counters in this
+  # capture were misread before the usage total was added to it.
+  kubectl_raw_output='container_cpu_usage_seconds_total{container="compute",namespace="tenant-test",pod="virt-launcher-worker-a-11111"} 145.2 1755200000000
+container_start_time_seconds{container="compute",namespace="tenant-test",pod="virt-launcher-worker-a-11111"} 1755198920 1755200000000
+container_spec_cpu_quota{container="compute",namespace="tenant-test",pod="virt-launcher-worker-a-11111"} 100000 1755200000000
+container_spec_cpu_period{container="compute",namespace="tenant-test",pod="virt-launcher-worker-a-11111"} 100000 1755200000000
+container_cpu_usage_seconds_total{container="guest-console-log",namespace="tenant-test",pod="virt-launcher-worker-a-11111"} 3.6 1755200000000
+container_start_time_seconds{container="guest-console-log",namespace="tenant-test",pod="virt-launcher-worker-a-11111"} 1755198920 1755200000000
+container_spec_cpu_quota{container="guest-console-log",namespace="tenant-test",pod="virt-launcher-worker-a-11111"} 15000 1755200000000
+container_spec_cpu_period{container="guest-console-log",namespace="tenant-test",pod="virt-launcher-worker-a-11111"} 100000 1755200000000'
+  COZY_REPORT_DIR="$tmp/report"
+  COZY_SNAPSHOT_NAME=throttle-usage
+
+  run_capture
+
+  capture="$COZY_REPORT_DIR/snapshots/throttle-usage/tenant-cpu-throttle/srv1.txt"
+  # 145.2 CPU-seconds over 1080s of uptime is 0.134 of a CPU against a ceiling of
+  # one, which is the share-starved reading. A raw cumulative total leaves that
+  # division to whoever opens the artifact, and the division not being done is
+  # what this whole addition is for -- so it is the quotient that is pinned, not
+  # the presence of the series it comes from.
+  assert_file_contains 'container="compute": 145.2 CPU-seconds used over 1080s of uptime = 0.134 CPU-seconds per second' "$capture"
+  # The ceiling on the same line as the rate. Read against a different ceiling
+  # the same rate says the opposite thing, and a reader who has to carry the
+  # quota down from the rows above is the reader who picks up the wrong one.
+  assert_file_contains 'ceiling 1.000 CPU' "$capture"
+  # The sidecar gets its own line at its own ceiling rather than being averaged
+  # into the guest's or silently dropped. This is the ambiguity that produced
+  # the earlier misreading, and one line per container is what removes it.
+  assert_file_contains 'container="guest-console-log": 3.6 CPU-seconds used over 1080s of uptime = 0.003 CPU-seconds per second' "$capture"
+  assert_file_contains 'ceiling 0.150 CPU' "$capture"
+  # And the sentence that turns the two numbers into a verdict. Without it the
+  # file states a rate and leaves the reading to be reconstructed from the
+  # issue, which is where the ambiguity came from in the first place.
+  assert_file_contains 'held AT its limit' "$capture"
+  assert_file_contains 'losing contended host CPU' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a usage total with nothing to divide it by is not presented as a rate" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="srv1"
+  # The total arrived and its denominator did not -- the shape a read cut off
+  # between the two families leaves. A cumulative total printed as though it
+  # were a rate is the one output here that would be read as an answer while
+  # being none, and it is the direction that matters: a fabricated 145 CPU-
+  # seconds per second reads as a guest pinned at its ceiling.
+  kubectl_raw_output='container_cpu_usage_seconds_total{container="compute",namespace="tenant-test",pod="virt-launcher-worker-a-11111"} 145.2 1755200000000'
+  COZY_REPORT_DIR="$tmp/report"
+  COZY_SNAPSHOT_NAME=throttle-usage
+
+  run_capture
+
+  capture="$COZY_REPORT_DIR/snapshots/throttle-usage/tenant-cpu-throttle/srv1.txt"
+  assert_file_contains 'not yet a rate' "$capture"
+  assert_file_contains 'no container_start_time_seconds row came with it' "$capture"
+  assert_file_lacks_pattern 'CPU-seconds per second' "$capture"
   rm -rf "$tmp"
 }
 


### PR DESCRIPTION
## Do not merge

This is a throwaway diagnostic PR for #3513. It deliberately makes the tenant Kubernetes suites fail. It exists to produce one artifact and will be closed once it has.

## What it measures and why

#3513 has two live hypotheses for why a tenant worker misses the node-Ready budget while its kubelet image trickles in, and the instrument we have cannot tell them apart.

The first is that the guest is ceiling-bound. The virt-launcher `compute` container runs at `limit 1` and the guest has one vCPU, so it cannot go faster no matter what else is idle.

The second is that the guest is share-starved. That container carries `request 100m`, which is the guest vCPU count divided by the platform `cpuAllocationRatio` of 10, and the request is what becomes `cpu.weight`. Under contention the kernel divides time by that weight, so the guest can be held near a tenth of a core while its ceiling sits a full core above.

The CFS throttle counters already in the artifact cannot decide between them. On nightly 31662393360 they showed 853 to 1151 throttled periods out of about 9000 at a `quota/period` of 1.0, which says the guest reached its ceiling sometimes and says nothing at all about how much CPU it got the rest of the time. Throttling fires only at the ceiling, and a container held far below its ceiling by competition barely throttles.

`container_cpu_usage_seconds_total` on that container is the series that settles it. Read against wall clock across the capture: usage tracking near 1.0 CPU-seconds per second means ceiling-bound and the CPU request is irrelevant, and usage sitting well below 1.0 while the guest is visibly stalled means share-starved and the request is the lever.

## Why it forces a failure

The node-join diagnostics only run when node-Ready fails, so a PR that merely adds the series produces nothing unless it happens to catch the flake, which appears in roughly a third of red runs at about three hours each. The second commit therefore cuts the node-Ready budget from 18m to 6m so the capture fires on every run.

That also buys something on a healthy worker rather than only on a sick one. If a worker that would have joined fine shows usage near 1.0 throughout its image pull, the workload is ceiling-bound by nature and the request hypothesis is dead without ever needing to catch the flake.

The two changes are separate commits on purpose. The measurement is worth keeping, the budget cut is not.

## Release note

```release-note
NONE
```
