### PR TITLE
test(e2e): measure tenant worker CPU as a rate, and the sandbox nodes under it

### DIFF
--- a/docs/agents/e2e-testing.md
+++ b/docs/agents/e2e-testing.md
@@ -37,6 +37,7 @@ A Chainsaw `assert` polls until the resource matches its expected shape or the p
 
 - Condition checks use the **filter-as-list** form `(conditions[?type == 'Ready'])`. Chainsaw v0.2.15 throws "field not found" on the indexed `(...)[0]` form.
 - Imperative checks that no Kubernetes API condition models — S3 reachability through a port-forward, an external LB HTTP path, MetalLB advertisement — stay in a `script` step. A bare `sleep N` inside such a script is allowed **only** when nothing better models the wait; annotate it with a `TODO(e2e-replace-fixed-timeouts):` comment. The bootstrap BATS (`hack/e2e-install-cozystack.bats`, `hack/e2e-chainsaw/_lib/run-kubernetes.sh`) carries the sanctioned `until kubectl get` exceptions.
+- A **measurement interval** is not one of those waits and does not take the marker. The rule above governs a `sleep` standing in for a condition nobody wrote a wait for, and the marker means "replace this once something models it". A gap between two readings of a cumulative counter models nothing and is the quantity itself: the diagnostics phase in `hack/e2e-chainsaw/_lib/run-kubernetes.sh` reads the tenant worker CPU counters and the sandbox nodes' `/proc/stat` on either side of one `COZY_DIAG_RATE_INTERVAL` wait, because a single reading of a counter that accumulates from container start is an average over the whole uptime and no rate at all. There is no event to wait for instead, so a `TODO` there would promise a replacement that cannot exist. Carve-outs are named here rather than judged case by case, and this is the only measurement-interval one.
 
 ### 3. Let Chainsaw own cleanup; no test-level EXIT/RETURN traps
 
@@ -153,7 +154,7 @@ The suite is pinned to Chainsaw **v0.2.15** (the latest release as of May 2026);
 
 1. No new retry loop unless the step is pure infra (image pull / VM boot / network).
 2. Resource readiness uses a Chainsaw `assert` (not an imperative `until kubectl get …; kubectl wait`); condition checks use the filter-as-list form `(conditions[?type == 'Ready'])`.
-3. Imperative-only waits live in a `script` step; any bare `sleep` carries a `TODO(e2e-replace-fixed-timeouts):` justification.
+3. Imperative-only waits live in a `script` step; any bare `sleep` carries a `TODO(e2e-replace-fixed-timeouts):` justification, unless it is a measurement interval, which §2 carves out by name and which takes no marker because no event can replace it.
 4. No test-level `EXIT`/`RETURN` trap — rely on Chainsaw cleanup; a self-contained trap is allowed inside a single `script` step (port-forward / temp dir), and inside an explicit subshell within a BATS `@test`, where it does not displace the runner's own handler. A BATS file that still carries test-level traps declares the count itself in `# EXIT-TRAP DEBT: N`; do not ask for one to be removed without checking that line, because the count is exact in both directions.
 5. Controller-created artifacts the test cannot reclaim are pruned explicitly; nested tenants delete child → parent with a wait-for-deletion between.
 6. Standard HR-Ready assert timeout is **5–6m**; longer waits (harbor 10m, NFS 10m, VM image pulls, platform-wide install 15m) are justified in-line.

--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -972,8 +972,9 @@ _cozy_cadvisor_node_stream() {
   local rc=0
 
   # One read per capture, so a node's stream is fetched once per subject rather
-  # than once in total. That is a real cost -- bounded by the read bound and the
-  # node cap at up to 100s, a ceiling those numbers impose rather than a measured
+  # than once in total, and once per SAMPLE where a subject is read twice. That
+  # is a real cost -- bounded by the read bound and the node cap at up to 100s
+  # per invocation, a ceiling those numbers impose rather than a measured
   # duration -- and it is declined for a reason that outlives any particular way
   # of sharing the read.
   #
@@ -1039,7 +1040,7 @@ _cozy_capture_worker_cadvisor() {
   local report_dir="${COZY_REPORT_DIR:-/workspace/_out/cozyreport}/snapshots/${COZY_SNAPSHOT_NAME:-kubernetes}/${subdir}"
   local nodes node rc
   local seen=0
-  local node_err raw stream matched filter_err filter_rc tenant_seen had_series
+  local node_err raw stream matched filter_err filter_rc tenant_seen had_series read_at read_done
   # The counters are per container but the endpoint is per node, so the walk is
   # over nodes and not over Pods: one read covers every worker the node hosts.
   # Three is the sandbox's management node count, so this cap is the whole
@@ -1108,7 +1109,25 @@ _cozy_capture_worker_cadvisor() {
     # outcome this collector may never manufacture and manufacture it. 137 is
     # what a kill produces anyway, and the note it selects says the read did not
     # finish, which is what was observed.
+    # Stamped on both sides of the read, and this is what makes a pair of
+    # captures subtractable. One stamp would leave the sampling instant
+    # somewhere inside a read whose duration is exactly what goes wrong on the
+    # run this collector exists for: a bound-length read stamped at its start
+    # and one stamped at its end differ by that bound, and the error lands in
+    # the interval a rate divides by. Two stamps make the uncertainty visible
+    # rather than absent, and on a healthy read they are the same second.
+    #
+    # The knob names how long this collector WAITS between its two passes,
+    # which is not the interval between two readings of
+    # the same node: each pass also walks its nodes and the pass of the other
+    # subject runs in between, so the real gap is the wait plus whatever those
+    # cost -- seconds on a healthy run and up to the read bound per read on the
+    # run this collector exists for, which is exactly the run where a rate
+    # computed from the advertised number would be wrong. Reading it off the
+    # captures needs no assumption about either.
+    read_at=$(date -u +%s)
     rc=$(_cozy_cadvisor_node_stream "${node}" "${stream}" "${node_err}")
+    read_done=$(date -u +%s)
     rc=${rc:-137}
     # The filter's own failure is kept apart from "matched nothing". grep exits
     # 1 when nothing matched and 2 when it could not read -- a full TMPDIR on
@@ -1245,6 +1264,19 @@ _cozy_capture_worker_cadvisor() {
     # hooks today end on an `if` that returns 0 when its condition is false, so
     # this changes nothing now and removes the requirement that they always will.
     "${tail_hook}" "${raw}" "${rc}" "${filter_rc}" "${had_series}" || true
+    # Sample-agnostic on purpose. This body is shared, and only one of its two
+    # callers takes a second sample: telling the reader of the other one to
+    # subtract a sibling would name a file that does not exist and contradict
+    # that capture's own tail note in the line above it. What is true for both
+    # is when the read happened, so that is what this says, and the instruction
+    # to pair it belongs to the capture that has a pair.
+    # The bracket only, with no claim about what was sampled inside it. When the
+    # read was attempted is true on every arm, including the ones that just said
+    # nothing was read; that counters exist between the two instants is not, and
+    # the arms above are what decide that. The note that does make the claim
+    # sits behind the same clean-read gate as the pairing note.
+    printf '[read attempted from %s to %s epoch seconds]\n' \
+      "${read_at}" "${read_done}" >>"${raw}"
     printf '\n[capture exit code: %s]\n' "${rc}" >>"${raw}"
   done
 }
@@ -1301,9 +1333,9 @@ _cozy_cadvisor_worker_nodes() {
 }
 
 # The one answer here that is not a failure, and until it is written down the
-# only one a reader has to derive. A capture holding the period alone, at a
-# clean exit, is a container with no CPU limit -- but it is also the shape a
-# truncated read leaves, and every other outcome gets a sentence precisely so
+# only one a reader has to derive. A capture carrying no quota, at a clean exit,
+# is a container with no CPU limit -- but it is also the shape a truncated read
+# leaves, and every other outcome gets a sentence precisely so
 # that this one is not read as that one. Keyed on the quota's absence rather
 # than on a line count, because that absence is the condition cAdvisor itself
 # gates the whole capped set on. Tested for exactly 1, which is grep's "read it,
@@ -1323,7 +1355,22 @@ _cozy_cpu_throttle_tail_note() {
   if [ "${had_series}" -eq 1 ] && [ "${rc}" -eq 0 ] && [ "${filter_rc}" -lt 2 ] \
     && [ "${quota_rc}" -eq 1 ]; then
     printf '%s\n' \
-      'these workers are running uncapped: cAdvisor publishes the quota and the CFS counters only for a container whose quota is non-zero, so a period with neither beside it is a container with no CPU limit rather than a short read' \
+      'these workers are running uncapped: cAdvisor publishes the quota and the CFS counters only for a container whose quota is non-zero, so a period without them beside it is a container with no CPU limit rather than a short read' \
+      >>"${raw}"
+  fi
+  # Said here rather than in the shared walk, because this is the capture that
+  # has a sibling to subtract from. Every family above is cumulative from the
+  # container starting, so one file is an average over an uptime; the stamp on
+  # the line below and the same node's file under the other sample directory are
+  # what turn the pair into a rate.
+  # Withheld from a read that did not finish, the way the sandbox capture
+  # withholds its column legend from one. An instruction to subtract two files
+  # is a statement that both hold a whole reading, and a capture already marked
+  # incomplete does not; the two captures in this pair answer that question the
+  # same way rather than each on its own terms.
+  if [ "${had_series}" -eq 1 ] && [ "${rc}" -eq 0 ] && [ "${filter_rc}" -lt 2 ]; then
+    printf '%s\n' \
+      'these counters are cumulative since the container started: subtract this node file from its sibling under the other sample directory, and the stamps below from each other, to get a rate. The counters were sampled somewhere inside each read, so that interval is exact to the width of the two brackets' \
       >>"${raw}"
   fi
 }
@@ -1366,9 +1413,10 @@ _cozy_network_counters_tail_note() {
 # without the ceiling it was measured against, and a reader should not have to
 # carry a figure back from an earlier section to divide by it.
 #
-# Five families carry the answer, and cAdvisor publishes them ready to read, so
+# Six families carry the answer, and cAdvisor publishes them ready to read, so
 # no arithmetic is done here and none is needed:
 #
+#   container_cpu_usage_seconds_total          CPU time the group actually got
 #   container_cpu_cfs_periods_total            periods the group was scheduled
 #   container_cpu_cfs_throttled_periods_total  of those, periods it was stopped
 #   container_cpu_cfs_throttled_seconds_total  how long it was stopped for
@@ -1377,21 +1425,27 @@ _cozy_network_counters_tail_note() {
 #
 # The throttled counters alone say a container hit some ceiling, not which one,
 # and a VM capped at one core and a VM capped at eight are the same number
-# without the quota beside them.
+# without the quota beside them. Nor do they say what the container got: being
+# stopped at a ceiling and never being scheduled onto a physical CPU are
+# different failures that both leave throttled periods behind, and the usage
+# counter is the only one of the six that separates them. It costs a wider
+# filter rather than another read, since cAdvisor puts it on the stream this
+# capture already fetches.
 #
-# Four of those five are gated, and on the same condition. cAdvisor emits the
+# Four of the six are gated, and on the same condition. cAdvisor emits the
 # quota series and all three CFS counters only for a container whose quota is
-# non-zero; container_spec_cpu_period is the one it emits for any container with
-# a CPU spec at all. So a container that reports one puts two shapes on the
-# wire and no third: all five when it is capped, the period alone when it is
-# not. (A container with no CPU spec contributes none of the five, and reaches
-# this capture as the same silence as a node with no worker on it.) The second
-# is a reading rather than a gap -- it is the question this collector was added
-# to answer, and it arrives without being computed.
+# non-zero; container_spec_cpu_period and container_cpu_usage_seconds_total are
+# the two it emits for any container with a CPU spec at all. So a container
+# that reports anything puts two shapes on the wire and no third: all six when
+# it is capped, the period and the usage when it is not. (A container cAdvisor
+# knows nothing about contributes none of them, and reaches this capture as the
+# same silence as a node with no worker on it.) The second is a reading rather
+# than a gap -- it is the question this collector was added to answer, and it
+# arrives without being computed.
 #
-# Worth stating because a one-line capture is also what a truncated read looks
+# Worth stating because a short capture is also what a truncated read looks
 # like, and this function spends its whole length making that difference legible.
-# A reader who expected five families and found one would reach for the wrong
+# A reader who expected six families and found two would reach for the wrong
 # conclusion with the artifact agreeing.
 #
 # Read from the kubelet rather than from inside the container on purpose. A
@@ -1410,7 +1464,16 @@ _cozy_network_counters_tail_note() {
 # the workers, tell a kubelet that never answered from a node carrying none, and
 # survive a filter that fails half way, because the whole point is to be believed
 # when it reports nothing.
+#
+# Takes the sample number it is writing, because it is called twice: the
+# counters are cumulative since the container started, so one reading gives an
+# average over the whole uptime and no reading of the failure window. Two
+# readings a fixed interval apart give a rate, and a rate is what the burst
+# profile needs -- a guest that freezes for tens of seconds and then runs at its
+# ceiling produces a low average and a high instantaneous figure, and only the
+# second of those distinguishes it from a guest that is simply capped.
 cozy_capture_tenant_worker_cpu_throttle() {
+  local sample="$1"
   # Anchored on the metric names so a series whose name merely contains one of
   # them cannot pass. The namespace alone is NOT a worker filter and must not be
   # used as one: tenant-test also carries the Kamaji control plane, whose
@@ -1426,13 +1489,224 @@ cozy_capture_tenant_worker_cpu_throttle() {
   # it holds today; a rename upstream would silently empty this capture rather
   # than break it loudly.
   _cozy_capture_worker_cadvisor \
-    tenant-cpu-throttle \
+    "tenant-cpu-throttle/sample-${sample}" \
     'CPU throttling counters capture' \
-    'whether these workers were throttled' \
+    'what these workers got and whether they were throttled' \
     CPU \
     cozy-cpu-throttle \
     _cozy_cpu_throttle_tail_note \
-    '^container_(cpu_cfs_(periods_total|throttled_periods_total|throttled_seconds_total)|spec_cpu_(period|quota))\{'
+    '^container_(cpu_(usage_seconds_total|cfs_(periods_total|throttled_periods_total|throttled_seconds_total))|spec_cpu_(period|quota))\{'
+}
+
+# Read each sandbox node's own CPU accounting, straight from its kernel.
+#
+# The captures above are about the tenant worker's cgroup: what it was allowed
+# and what it got. Neither can see the layer under the sandbox. A worker whose
+# vCPU thread is runnable and simply not scheduled looks, from the cgroup, like
+# a worker that asked for nothing -- and the two candidate explanations for that
+# are a sandbox node oversubscribed from inside and a sandbox node not given its
+# own turn by the machine running the runner. Only the second leaves a trace,
+# and it leaves it here: `steal` counts the time this kernel was runnable while
+# the hypervisor beneath it ran somebody else.
+#
+# There is no kubelet or cAdvisor route to it. The kubelet's cAdvisor and
+# summary endpoints publish container and node utilisation and neither carries a
+# steal column, which cost one measurement window already; the node's own
+# /proc/stat is the only surface with the number. crust-gather's node-shell Pod
+# is refused by PodSecurity in this cluster, so the Talos API is what remains,
+# and it is already how the report reaches these nodes for dmesg.
+#
+# Captured verbatim rather than reduced to a percentage, and the column legend
+# is written beside it rather than folded into arithmetic here. In /proc/stat's
+# cpu rows the eighth number after the label is steal and the ninth is guest,
+# guest is enormous on a node running VMs and is already counted inside user,
+# and reading the ninth as the eighth turns a fraction of a percent into
+# twenty-odd. The legend states which is which where the numbers are, so the
+# next reader does not repeat that.
+cozy_capture_sandbox_node_cpu_time() {
+  local sample="$1"
+  local report_dir="${COZY_REPORT_DIR:-/workspace/_out/cozyreport}/snapshots/${COZY_SNAPSHOT_NAME:-kubernetes}/sandbox-host-cpu-time/sample-${sample}"
+  local err_log="${report_dir}/COLLECTION-FAILED.txt"
+  local warn_log="${report_dir}/READ-WARNINGS.txt"
+  # The sandbox container carries TALOSCONFIG in its environment, so this is the
+  # path talosctl would have used on its own; naming it is what lets an absent
+  # config be reported as an absent config rather than as a node that refused.
+  local talosconfig="${TALOSCONFIG:-talosconfig}"
+  local rows node addr rc node_err raw read_at read_done
+  local list_rc=0
+  local seen=0
+  # Three is the sandbox's node count, so this cap is the whole cluster rather
+  # than a sample of it -- the same literal and the same reasoning as the walk
+  # over worker-carrying nodes above.
+  local max_nodes=3
+
+  mkdir -p "${report_dir}"
+  # Re-validated here for the reason every collector re-validates them: a value
+  # assigned after this file is sourced never passed the assignment-time check,
+  # and zero reaches `timeout` as no bound at all.
+  COZY_DIAG_READ_TIMEOUT=$(_cozy_diag_seconds "${COZY_DIAG_READ_TIMEOUT-}" "$COZY_DIAG_READ_TIMEOUT_DEFAULT" COZY_DIAG_READ_TIMEOUT positive)
+  COZY_DIAG_READ_GRACE=$(_cozy_diag_seconds "${COZY_DIAG_READ_GRACE-}" "$COZY_DIAG_READ_GRACE_DEFAULT" COZY_DIAG_READ_GRACE)
+
+  # Both preconditions are reported rather than returned into silence. An empty
+  # directory here would read as a sandbox that lost no time to its hypervisor,
+  # which is a statement about the cluster this collector never made.
+  if ! command -v talosctl >/dev/null 2>&1; then
+    echo "talosctl is not on PATH, so the sandbox nodes' CPU time was not read" >&2
+    printf '%s\n' \
+      'talosctl is not on PATH on the machine running this suite; the sandbox nodes were never asked, which is not a reading that they lost no time' \
+      >"${err_log}"
+    return 1
+  fi
+  if [ ! -f "${talosconfig}" ]; then
+    echo "no sandbox talosconfig at ${talosconfig}, so the sandbox nodes' CPU time was not read" >&2
+    printf '%s\n' \
+      "no sandbox talosconfig at ${talosconfig}; the sandbox nodes were never asked, which is not a reading that they lost no time" \
+      >"${err_log}"
+    return 1
+  fi
+
+  # Name and address in one row: the address is what the Talos API is reached
+  # on, and the name is what pairs this file with the worker captures above.
+  # stderr is kept out of the captured stdout so a warning is never read back as
+  # an address, and which file it lands in is decided by the exit status, since
+  # kubectl writes warnings with a zero exit.
+  if command -v timeout >/dev/null 2>&1; then
+    rows=$(timeout -k "${COZY_DIAG_READ_GRACE}" "${COZY_DIAG_READ_TIMEOUT}" \
+      kubectl get nodes \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.status.addresses[?(@.type=="InternalIP")].address}{"\n"}{end}' \
+      "--request-timeout=${COZY_DIAG_READ_TIMEOUT}s" 2>"${warn_log}") || list_rc=$?
+  else
+    rows=$(kubectl get nodes \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.status.addresses[?(@.type=="InternalIP")].address}{"\n"}{end}' \
+      "--request-timeout=${COZY_DIAG_READ_TIMEOUT}s" 2>"${warn_log}") || list_rc=$?
+  fi
+  if [ "${list_rc}" -ne 0 ]; then
+    echo "failed to list sandbox nodes for the CPU time capture" >&2
+    mv "${warn_log}" "${err_log}" 2>/dev/null || true
+    printf '%s\n' \
+      "failed to list sandbox nodes for the CPU time capture (exit ${list_rc})" \
+      >>"${err_log}"
+    return 1
+  fi
+  [ -s "${warn_log}" ] || rm -f "${warn_log}"
+  if [ -z "${rows}" ]; then
+    echo "the sandbox node listing answered and named no node" >&2
+    printf '%s\n' \
+      'the node listing answered and named no node at all, so nothing was asked; a cluster with nodes cannot produce this' \
+      >"${err_log}"
+    return 1
+  fi
+
+  # Split on the separator rather than on whitespace. A node with more than one
+  # InternalIP -- a dual-stack cluster -- puts both addresses in the same field,
+  # space separated, and a whitespace walk would turn the second one into a row
+  # of its own: a bogus per-node file, counted against the cap, displacing a real
+  # node. The first address is the one used, and it is taken explicitly.
+  while IFS='|' read -r node addr; do
+    [ -n "${node}" ] || continue
+    addr="${addr%% *}"
+    seen=$((seen + 1))
+    if [ "${seen}" -gt "${max_nodes}" ]; then
+      echo "--- sandbox node CPU time capture stopped at ${max_nodes} nodes ---"
+      # Counted over lines, with the expansion quoted, for the same reason the
+      # walk above strips all but the first address: one row is one node, and a
+      # dual-stack node carries two addresses in it. Unquoted this counts
+      # addresses, so the marker that exists to say "truncated, not small"
+      # would overstate the pool it truncated.
+      printf 'capture stopped after %s nodes; %s were listed in total\n' \
+        "${max_nodes}" "$(printf '%s\n' "${rows}" | grep -c . || true)" \
+        >"${report_dir}/COLLECTION-TRUNCATED.txt"
+      break
+    fi
+    raw="${report_dir}/${node}.txt"
+    # A node with no InternalIP is a finding rather than a node to skip: the
+    # Talos API is reached on that address, so its absence is why this node was
+    # not read, and an absent file would say nothing at all.
+    if [ -z "${addr}" ]; then
+      printf '%s\n' \
+        'this node reports no InternalIP, and the Talos API is reached on that address, so it was not asked' \
+        >"${raw}"
+      continue
+    fi
+    echo "--- capturing sandbox node CPU time: ${node} (${addr}) ---"
+    node_err="${report_dir}/${node}.read-error.log"
+    rc=0
+    # Stamped before the read for the reason the sibling capture states at its
+    # own stamp, and here it is the only timing there is: a cAdvisor row carries
+    # its own sample time and a /proc/stat row carries none, so without this the
+    # gap between two readings of this node is unrecoverable from the artifact.
+    read_at=$(date -u +%s)
+    # The endpoint and the node are both the address: the e2e talosconfig
+    # carries no endpoints, which is why the report's own Talos reads pass -e
+    # and -n together, and one without the other reaches nothing.
+    if command -v timeout >/dev/null 2>&1; then
+      # stdin closed explicitly: this walk is driven by a heredoc, so anything
+      # here that read stdin would eat the remaining rows and the walk would
+      # stop after one node with no truncation marker -- answering for part of
+      # the cluster while reading like it answered for all of it, which is the
+      # outcome the cap above exists to make impossible. talosctl does not read
+      # stdin today; this costs nothing and does not depend on that staying true.
+      timeout -k "${COZY_DIAG_READ_GRACE}" "${COZY_DIAG_READ_TIMEOUT}" \
+        talosctl --talosconfig "${talosconfig}" -e "${addr}" -n "${addr}" \
+        read /proc/stat >"${raw}" 2>"${node_err}" </dev/null || rc=$?
+    else
+      talosctl --talosconfig "${talosconfig}" -e "${addr}" -n "${addr}" \
+        read /proc/stat >"${raw}" 2>"${node_err}" </dev/null || rc=$?
+    fi
+    read_done=$(date -u +%s)
+    if [ ! -s "${node_err}" ]; then
+      rm -f "${node_err}"
+      node_err=
+    elif [ "${rc}" -eq 0 ]; then
+      mv "${node_err}" "${report_dir}/${node}.READ-WARNINGS.txt" 2>/dev/null || true
+      node_err=
+    fi
+    # Tested before anything is appended, or nothing is ever empty. Which arm
+    # fires is decided by the status and not by whether stderr holds anything:
+    # `timeout` kills its child without a word, so the dominant failure arrives
+    # non-zero with an empty error log, and keyed on stderr it would land in the
+    # arm that says the node answered.
+    if [ ! -s "${raw}" ] && [ "${rc}" -ne 0 ]; then
+      if [ -n "${node_err}" ]; then
+        printf '%s\n' \
+          'this node CPU time is unknown: the Talos API was not read; see the read-error.log beside this file, named for the same node' \
+          >>"${raw}"
+      else
+        printf '%s\n' \
+          'this node CPU time is unknown: the Talos API was not read, and the read died without a word on either stream' \
+          >>"${raw}"
+      fi
+    elif [ ! -s "${raw}" ]; then
+      printf '%s\n' \
+        'this node CPU time is unknown: the read succeeded and returned nothing, which /proc/stat on a running kernel cannot produce' \
+        >>"${raw}"
+    elif [ "${rc}" -ne 0 ]; then
+      printf '%s\n' \
+        'these counters are incomplete: the read was cut short part way through /proc/stat' \
+        >>"${raw}"
+    else
+      printf '%s\n' \
+        '[the cpu rows above are, after the label: user nice system idle iowait irq softirq steal guest guest_nice, in USER_HZ. The eighth number is steal and the ninth is guest; guest is large on a node running VMs and is already counted inside user, so reading the ninth as the eighth turns a fraction of a percent of steal into twenty-odd. A steal of zero here means this node was given every turn it asked for, not that the column is unavailable: the sandbox VMs are started with accel=kvm and -cpu host by hack/e2e-prepare-cluster.bats, where KVM exposes steal-time accounting to the guest]' \
+        >>"${raw}"
+      # Only here, beside the legend, and for the reason the legend is only
+      # here. Telling a reader to subtract two files asserts that both hold a
+      # whole reading. On the arm above it the file holds a prefix, and the
+      # difference understates the counter by whatever the read did not return;
+      # on the arms above that it holds no counters at all, and the difference
+      # is the sibling's entire cumulative value read as a delta -- a steal
+      # figure inflated to the node's whole uptime, which is the finding this
+      # collector exists to look for. The cpu-throttle side withholds its own
+      # pairing note on the same condition.
+      printf '%s\n' \
+        'subtracting this node file from its sibling under the other sample directory, and the stamps below from each other, gives a rate. The counters were sampled somewhere inside each read, so that interval is exact to the width of the two brackets' \
+        >>"${raw}"
+    fi
+    printf '[read attempted from %s to %s epoch seconds]\n' \
+      "${read_at}" "${read_done}" >>"${raw}"
+    printf '\n[capture exit code: %s]\n' "${rc}" >>"${raw}"
+  done <<EOF
+${rows}
+EOF
 }
 
 # Two properties of the network family are invisible to anyone writing this
@@ -1575,9 +1849,16 @@ cozy_capture_tenant_talos() (
 # `--request-timeout=0s` means "no timeout" to kubectl -- the defect this change
 # exists to remove, reachable through the knob it adds. The phase budget must keep
 # accepting zero: the suite uses it to mean "already spent".
+#
+# A fifth argument replaces the parenthetical that says why zero is refused, and it
+# exists because the flag now has more than one caller and they refuse zero for
+# different reasons. For a bound, zero removes the ceiling. For the sampling
+# interval it removes nothing and leaves two readings taken at the same instant --
+# a pair that looks collected and divides to nothing. One sentence covering both
+# would have to say neither.
 _cozy_diag_seconds() {
   if [ -n "${4:-}" ] && [ "${1}" = 0 ]; then
-    echo "» WARNING: ignoring ${3}='${1}' (zero disables the bound instead of tightening it); using ${2}" >&2
+    echo "» WARNING: ignoring ${3}='${1}' (${5:-zero disables the bound instead of tightening it}); using ${2}" >&2
     printf '%s\n' "${2}"
     return 0
   fi
@@ -1621,6 +1902,29 @@ _cozy_diag_seconds() {
 COZY_DIAG_READ_TIMEOUT_DEFAULT=20
 COZY_DIAG_READ_GRACE_DEFAULT=5
 COZY_DIAG_MAX_IMPORTERS_DEFAULT=3
+# The wait between the two passes over the counters that only mean something as
+# a pair. Every counter those two collectors read is cumulative, so a single
+# reading divides out to an average over the container's whole uptime and says
+# nothing about the window the deadline covered; the difference between two
+# readings does.
+#
+# It is the WAIT and not the interval those readings span: each pass also walks
+# its nodes, and the other subject's pass falls between a subject's two
+# readings. The captures stamp themselves for that reason, and a rate is
+# computed from the stamps rather than from this number.
+#
+# Short on purpose, and this is the one number here chosen for what it measures
+# rather than for what it costs. The profile being separated is a guest that
+# freezes for tens of seconds and then runs flat out, and a window long enough
+# to contain both halves averages them back into the figure that could not tell
+# them apart in the first place. A window of this size lands inside one half or
+# the other, which is what makes the pair a discriminator rather than a second
+# copy of the average.
+#
+# It is also the whole wall-clock cost this pair adds to a failing run, since
+# the two collectors share it: both take their first reading, the interval
+# passes once, and both take their second.
+COZY_DIAG_RATE_INTERVAL_DEFAULT=12
 # Lowered from 480 when the guest-Talos walk grew the service list and the link
 # table. That collector is the `largest` term of the inequality below, the
 # inequality had ten seconds of slack, and the two reads cost sixty across the
@@ -1649,14 +1953,19 @@ COZY_DIAG_MAX_IMPORTERS_DEFAULT=3
 # re-probe has no substitute and is the collector this budget gives up first,
 # which was already true at 480.
 #
-# The second cost lands on the guest captures rather than on the tail. The two
-# worker captures each read the node's metric stream, so (d2) spends a listing
-# plus one read per node AHEAD of (b1) and (b) -- up to 100s at the read bound
-# and the three-node cap, a ceiling those numbers impose rather than a duration
-# measured on a live cluster. Between that and the sixty seconds off the budget,
-# the console and guest-Talos captures reach their gate with less left than
-# before; they are still ahead of the tail in the order, so they are not first
-# to go, but a run that was marginal for them is likelier to decline them now.
+# The second cost lands on the guest captures rather than on the tail. One
+# collector reads the node's metric stream ahead of the console: (d2) spends a
+# listing plus one read per node -- up to 100s at the read bound and the
+# three-node cap, a ceiling those numbers impose rather than a duration measured
+# on a live cluster. Between that and the sixty seconds off the budget, the
+# console and guest-Talos captures reach their gate with less left than before;
+# they are still ahead of the tail in the order, so they are not first to go,
+# but a run that was marginal for them is likelier to decline them now.
+#
+# What is deliberately NOT ahead of the console is the two-sample CPU pair,
+# whose own ceiling is several times this one. What sits ahead of the console
+# bounds what the console can lose, so that figure is the one to keep small; the
+# ordering argument at the pair says the rest.
 #
 # That second read is not shared away in this change, and the reason is scope
 # rather than merit -- the note at the read says why, and says that merging
@@ -1675,6 +1984,10 @@ COZY_DIAG_READ_GRACE=$(_cozy_diag_seconds "${COZY_DIAG_READ_GRACE:-$COZY_DIAG_RE
 # and a walk that hits the cap says so with both counts rather than leaving the
 # shortfall implicit.
 COZY_DIAG_MAX_IMPORTERS=$(_cozy_diag_seconds "${COZY_DIAG_MAX_IMPORTERS:-$COZY_DIAG_MAX_IMPORTERS_DEFAULT}" "$COZY_DIAG_MAX_IMPORTERS_DEFAULT" COZY_DIAG_MAX_IMPORTERS)
+# Rejected as `positive` for a reason the other bounds do not have: zero here is
+# not a disabled bound but two readings taken at the same instant, which divide
+# to nothing and leave a pair that looks collected and answers no question.
+COZY_DIAG_RATE_INTERVAL=$(_cozy_diag_seconds "${COZY_DIAG_RATE_INTERVAL:-$COZY_DIAG_RATE_INTERVAL_DEFAULT}" "$COZY_DIAG_RATE_INTERVAL_DEFAULT" COZY_DIAG_RATE_INTERVAL positive "zero puts both readings at the same instant, so the pair divides to nothing")
 
 # Wall-clock budget for the on-failure diagnostics phase as a whole, on top of the
 # per-read bounds above, because the two buy different things. A per-read bound
@@ -1749,16 +2062,17 @@ cozy_diag_phase_start() {
   # cozystack/cozystack#3666; the warning names both halves rather than promising the
   # better one for all of them.
   #
-  # The worker CPU throttling and network counter captures belong to neither
-  # half: they call `timeout` directly AND carry the same fallback, so on a
-  # runner without the binary they run unbounded rather than exiting 127. That
+  # The worker CPU throttling, worker network counter and sandbox node CPU time
+  # captures belong to neither half: they call `timeout` directly AND carry the
+  # same fallback, so on a runner without the binary they run unbounded rather
+  # than exiting 127. That
   # is the opposite failure from the one the sentence above would lead a reader
   # to, and it is the half with the snapshot behind it, so they are named here
   # rather than left to be inferred. The list is derived from the source by
   # hack/run-kubernetes-node-join_test.bats, so a collector that joins this
   # group without joining the sentence fails there.
   command -v timeout >/dev/null 2>&1 || \
-    echo "» WARNING: timeout is not on PATH; the bounded reads below run UNBOUNDED, so one that hangs can still take the op and the tenant snapshot with it, and the collectors that call timeout directly (wedge check, serial console, guest Talos) exit 127 and collect nothing; the ones that guard the call with command -v -- the worker CPU throttling, worker network counter, ghcr-mirror and talos-image-cache captures -- keep collecting instead, unbounded" >&2
+    echo "» WARNING: timeout is not on PATH; the bounded reads below run UNBOUNDED, so one that hangs can still take the op and the tenant snapshot with it, and the collectors that call timeout directly (wedge check, serial console, guest Talos) exit 127 and collect nothing; the ones that guard the call with command -v -- the worker CPU throttling, worker network counter, sandbox node CPU time, ghcr-mirror and talos-image-cache captures -- keep collecting instead, unbounded" >&2
   # Re-checked here, not only at assignment: a value set after this file is sourced
   # -- which is how a test sets it -- would otherwise reach the arithmetic below
   # unvalidated, and that is the one failure that costs the whole block.
@@ -1902,7 +2216,7 @@ cozy_report_node_join_failure() {
   # inside the phase gate, and bash under `set -u` aborts on the read that
   # follows when the gate declined it.
   local importer_list='' importer_names importer_rc=0 importer_seen=0 importer_total=0
-  local importer_listed=0 _p
+  local importer_listed=0 _p _sample
 
   cozy_diag_phase_start
 
@@ -2039,39 +2353,18 @@ cozy_report_node_join_failure() {
   # declined -- and (c) is the discriminator for mode 2b, the failure this whole
   # artifact exists to let someone fix. Cheap reads first, then the collectors
   # that cost minutes. Everything ahead of this line is bounded reads and a capped
-  # walk, which together fit inside the budget with room left, while (b1) and
-  # (b) below can exhaust it between them on a slow run. Putting the
-  # heavy pair first, as this block used to, spends the budget on them and
-  # declines the two 25s reads that answer the question.
+  # walk, which together fit inside the budget with room left, while the gated
+  # collectors below can exhaust it between them on a slow run. Putting the
+  # heavy ones first, as this block used to, spends the budget on them and
+  # declines the two 25s reads that answer the question. The same rule decides
+  # the order among the gated collectors themselves: each one's ceiling bounds
+  # what everything after it can lose, so a collector goes above the console
+  # only if its ceiling is small enough to be worth risking the console for.
   #
-  # (d) Worker CPU throttling counters. Gated like everything below it and put
-  # ahead of all of them, for the two reasons the order above is built on. Its
-  # own ceiling is four bounded reads rather than the minutes (b1) and (b) can
-  # spend between them, so the budget it leaves behind is the largest. Two
-  # more legs sit below those, gated by the same budget and costing
-  # differently again: the ghcr-mirror capture is bounded read by read like
-  # this one, while the image-cache diagnosis makes seven unbounded
-  # management-cluster calls of its own. And its question is the one with no
-  # other answer here: the ceiling is already carried by (a), but whether the
-  # guest ever hit it is recorded nowhere else, while (b1) and (b) describe a
-  # guest that at least reports something on its own. (a) shows a Running VMI
-  # on a healthy virt-launcher, which is where mode 2a stops being the answer
-  # and the question becomes why a healthy VM made no progress -- a node
-  # sitting at half its capacity does not settle that, and these counters do.
-  #
-  # Note what the gate does and does not promise, since it reads like a fit
-  # check and is not one: it admits a collector whose start is inside the
-  # budget, so one admitted late still runs to completion and overruns. Being
-  # first is therefore worth more than being cheap is worth on its own.
-  if cozy_diag_phase_has_time '(d) tenant worker CPU throttling'; then
-    echo "=== (d) tenant worker CPU throttling counters (management cluster, ns tenant-test) ==="
-    cozy_capture_tenant_worker_cpu_throttle || true
-  fi
-
-  # (d2) Worker network counters, from the same endpoint and at the same cost as
-  # (d), and here for the same two reasons: four bounded reads rather than the
-  # minutes (b1) and (b) can spend between them, and an answer with no other
-  # source in this artifact. What it settles is which side of the worker's image
+  # (d2) Worker network counters, first of the gated collectors and cheapest of
+  # them: one listing and one read per node, four bounded reads against the
+  # minutes every collector below can spend between them. Its answer also has no
+  # other source in this artifact. What it settles is which side of the worker's image
   # pull is slow. The guest reports its own progress and cannot see the bytes
   # that never became progress, so a pull that keeps restarting and one that
   # crawls look identical from in there. The host side counts both, and the gap
@@ -2123,6 +2416,91 @@ cozy_report_node_join_failure() {
     cozy_capture_tenant_serial_console || true
   fi
 
+  # (d) What the workers got, what they were denied, and what the sandbox nodes
+  # under them lost to their own hypervisor. Its question has no other answer
+  # here: the ceiling is already carried by (a), but whether the guest ever met
+  # it, and whether it was ever scheduled at all, are recorded nowhere else,
+  # while (b1) above and (b) below describe a guest that at least reports
+  # something on its own. (a) shows a Running VMI on a healthy virt-launcher,
+  # which is where mode 2a stops being the answer and the question becomes why a
+  # healthy VM made no progress -- a node sitting at half its capacity does not
+  # settle that, and these counters do.
+  #
+  # It sits BELOW the console, and its ceiling rather than its worth is the
+  # reason. Each collector spends a listing plus up to three node reads per
+  # sample, so the pair is sixteen bounded reads and one interval: at the read
+  # bound and the three-node cap that is most of the phase budget on its own. In
+  # practice it costs the interval plus a handful of reads that an apiserver or
+  # an apid answering at all answers in under a second -- but the run where
+  # those reads DO approach their bound is a wedged kubelet, which is the
+  # failure this whole block is written for. So the ceiling is not a remote
+  # case here, and a collector carrying one that large must not sit ahead of the
+  # single capture that survives a worker which never reached apid: ahead of the
+  # console it could take the console with it, and below it the worst it can
+  # spend is its own time and the legs after it. The gate's promise is the same
+  # either way and is worth stating, since it reads like a fit check and is not
+  # one: it admits a collector whose start is inside the budget, so one admitted
+  # late still runs to completion and overruns.
+  #
+  # That overrun is already budgeted for, and the number is worth putting here
+  # because it is the first question this pair invites. The phase budget is
+  # derived as budget + largest overshoot + snapshot <= op - bringup, where the
+  # overshoot term is exactly "one collector admitted a moment before the
+  # deadline runs its whole cost". This pair's ceiling is sixteen bounded reads
+  # plus the interval; the term is the guest-Talos walk, which is larger. So a
+  # pair admitted at the last second finishes inside the room already left for
+  # the tenant crust-gather snapshot rather than pushing it past the op.
+  # hack/run-kubernetes-node-join_test.bats holds that against both numbers, so
+  # a later change to the cap, the read bound or the interval cannot quietly
+  # make this pair the binding term.
+  #
+  # Both collectors are read twice with one wait between the passes, and the
+  # wait is shared: the counters on both sides are cumulative, so one reading of
+  # either is an average over an uptime rather than a rate over the failure.
+  # Taking the first reading of both, waiting once, and taking the second of
+  # both costs the wait once rather than twice.
+  #
+  # What the knob does NOT give is the interval either subject's counters span.
+  # The worker's two readings are separated by the wait plus the sandbox pass
+  # between them, the sandbox's by the wait plus the worker pass, and on the run
+  # this exists for those passes are the slow part rather than the wait. So each
+  # capture stamps the moment it was read and the reader subtracts stamps rather
+  # than assuming the knob. The two subjects' windows overlap and are offset by
+  # one pass; they are not identical, and treating them as identical is the
+  # error the stamps remove.
+  #
+  # This `sleep` is not the fixed-timeout kind the e2e conventions rule out.
+  # Those stand in for a condition nobody wrote a wait for; this one is the
+  # measurement interval, and there is no event to wait for instead of it. The
+  # doc carves it out by name rather than leaving the reader to judge.
+  #
+  # Re-validated here rather than trusted from the assignment, like every other
+  # knob in this block, because a value set after this file is sourced never
+  # passed that check -- and zero, the value the flag rejects, would put both
+  # readings at the same instant and leave a pair that divides to nothing.
+  COZY_DIAG_RATE_INTERVAL=$(_cozy_diag_seconds "${COZY_DIAG_RATE_INTERVAL-}" "$COZY_DIAG_RATE_INTERVAL_DEFAULT" COZY_DIAG_RATE_INTERVAL positive "zero puts both readings at the same instant, so the pair divides to nothing")
+  if cozy_diag_phase_has_time '(d) tenant worker CPU counters and sandbox node CPU time'; then
+    echo "=== (d) tenant worker CPU counters + sandbox node CPU time, two samples with a ${COZY_DIAG_RATE_INTERVAL}s wait between the passes; each capture carries the time it was read ==="
+    for _sample in 1 2; do
+      # Guarded like every other external here, and for a sharper reason than
+      # the reads: this call is not wrapped in `|| true`, and the block runs
+      # under `set -eu` inside the chainsaw script, so `sleep: command not
+      # found` exits 127 and takes everything after it -- including two of the
+      # five collectors the phase's own missing-timeout warning promises keep
+      # collecting. Degrading to back-to-back readings is honest rather than
+      # lossy: the interval a rate divides by is read off the two stamps in each
+      # capture, not off this knob, so a wait that did not happen yields a
+      # tighter window rather than an unreadable pair.
+      if [ "${_sample}" != 1 ] && command -v sleep >/dev/null 2>&1; then
+        sleep "${COZY_DIAG_RATE_INTERVAL}"
+      elif [ "${_sample}" != 1 ]; then
+        echo "» WARNING: sleep is not on PATH; the two readings are taken back to back, so the pair spans only what the first pass took -- the stamps inside each capture say how much" >&2
+      fi
+      cozy_capture_tenant_worker_cpu_throttle "${_sample}" || true
+      cozy_capture_sandbox_node_cpu_time "${_sample}" || true
+    done
+  fi
+
   # (b) In-guest Talos kernel and kubelet logs. The tenant chart intentionally
   # has no admin talosconfig, so mint a one-hour os:reader client from its
   # existing cert-manager Issuer and run talosctl from a hardened Pod that can
@@ -2145,13 +2523,13 @@ cozy_report_node_join_failure() {
   # whether the worker's kubelet-image pull reached the mirror or fell back to
   # public ghcr.io, which the node-join failure alone cannot distinguish. Gated
   # like its neighbours, and after the guest captures. Bounded read by read
-  # like the collector at (d), but five of them at COZY_DIAG_READ_TIMEOUT plus
+  # like the collector at (d2), but five of them at COZY_DIAG_READ_TIMEOUT plus
   # grace, so it can spend a quarter of the phase budget -- and time is the
   # only thing the gate rations, so a quarter spent here is a quarter the
   # guest captures do not get. Cost is not what settles the order, though, or
-  # (d) would sit here too: what settles it is whether the answer survives
+  # (d2) would sit here too: what settles it is whether the answer survives
   # being declined. The console evidence this would starve is irreplaceable
-  # and (d)'s question has no other answer in the tree, while the mirror's
+  # and (d2)'s question has no other answer in the tree, while the mirror's
   # state is partly recoverable from the reads above -- so those two go first
   # and this one waits, whichever of them is cheaper. Cheaper than the
   # talos-image-cache re-probe below, which creates a Pod and waits on curl

--- a/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
@@ -32,9 +32,12 @@ spec:
         # so that a budget running out drops the collectors that cost minutes rather
         # than the reads that discriminate between failure modes:
         #   node-join diagnostics reads
-        #   worker CPU throttling counters
         #   worker network counters
         #   serial-console family (~5m50s at worst, ~3m30s at the pool's minimum)
+        #   worker CPU usage and throttling counters, two samples
+        #   sandbox node CPU time, two samples
+        #     (those two alternate rather than run to completion in turn: both
+        #     take their first reading, one wait passes, both take their second)
         #   guest Talos capture
         #   ghcr-mirror state, access log and warm-up Job
         #   talos-image-cache diagnosis

--- a/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
@@ -26,9 +26,12 @@ spec:
         # so that a budget running out drops the collectors that cost minutes rather
         # than the reads that discriminate between failure modes:
         #   node-join diagnostics reads
-        #   worker CPU throttling counters
         #   worker network counters
         #   serial-console family (~5m50s at worst, ~3m30s at the pool's minimum)
+        #   worker CPU usage and throttling counters, two samples
+        #   sandbox node CPU time, two samples
+        #     (those two alternate rather than run to completion in turn: both
+        #     take their first reading, one wait passes, both take their second)
         #   guest Talos capture
         #   ghcr-mirror state, access log and warm-up Job
         #   talos-image-cache diagnosis

--- a/hack/run-kubernetes-cpu-throttle_test.bats
+++ b/hack/run-kubernetes-cpu-throttle_test.bats
@@ -21,11 +21,15 @@ kubectl_raw_rc=0
 kubectl_raw_stderr=
 # Two of the fixtures in this file claim to be wire shapes, and the rest do not.
 # This one and the uncapped test's single line are the two cAdvisor can actually
-# produce -- all five families for a capped container, the period alone for one
-# with no limit, the two sides of the same Quota != 0 gate. Every other fixture
+# produce -- every family for a capped container, the period alone for one
+# with no limit, the two sides of the same Quota != 0 gate. Usage sits outside
+# that gate and is published for any container at all, so it belongs in both
+# shapes; the uncapped fixture stages only the line its own assertion needs, as
+# the rest of this file does. Every other fixture
 # below stages only the lines its own assertion needs, so a missing sibling
 # series there means "not relevant here" rather than "absent on the wire".
-kubectl_raw_output='container_cpu_cfs_periods_total{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 51200
+kubectl_raw_output='container_cpu_usage_seconds_total{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 118.4
+container_cpu_cfs_periods_total{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 51200
 container_cpu_cfs_throttled_periods_total{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 4211
 container_cpu_cfs_throttled_seconds_total{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 12.5
 container_spec_cpu_quota{container="compute",namespace="tenant-test",pod="virt-launcher-a"} 100000
@@ -142,7 +146,7 @@ assert_file_lacks_pattern() {
 # tracer. Call through this wrapper so the sinks hold what production writes.
 run_capture() {
   local _rc=0
-  ( set +x; cozy_capture_tenant_worker_cpu_throttle ) || _rc=$?
+  ( set +x; cozy_capture_tenant_worker_cpu_throttle 1 ) || _rc=$?
   return "${_rc}"
 }
 
@@ -231,7 +235,7 @@ run_capture() {
   # name has to come from the Pod. Reading a fixed node, or the wrong one,
   # returns a healthy stranger's counters.
   assert_file_contains 'get --raw /api/v1/nodes/srv1/proxy/metrics/cadvisor' "$kubectl_calls"
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'container_cpu_cfs_throttled_periods_total' "$capture"
   # One assertion per alternative in the filter's regex, because a typo in an
   # alternative no test drives through drops that family silently while every
@@ -246,7 +250,7 @@ run_capture() {
   # inverted, and it fires on every healthy run rather than on the rare one.
   assert_file_lacks_pattern 'incomplete' "$capture"
   assert_file_lacks_pattern 'unknown' "$capture"
-  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle"
+  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1"
   [ ! -f "$dir/srv1.read-error.log" ]
   [ ! -f "$dir/READ-WARNINGS.txt" ]
   [ ! -f "$dir/COLLECTION-FAILED.txt" ]
@@ -255,6 +259,29 @@ run_capture() {
   # the stream to TMPDIR; this one only says the fallback leaves nothing behind
   # either, and it would go green on a run that never took the fallback.
   [ ! -f "$dir/srv1.stream.tmp" ]
+  rm -rf "$tmp"
+}
+
+@test "what the workers consumed is captured beside what they were denied" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="srv1"
+  COZY_REPORT_DIR="$tmp/report"
+  COZY_SNAPSHOT_NAME=throttle-smoke
+
+  run_capture
+
+  # The throttled counters say the container met its ceiling. They cannot say
+  # how much CPU it got, and the two are different quantities: a guest held at a
+  # one-core ceiling and a guest scheduled onto a physical CPU for a tenth of
+  # that ceiling both report throttled periods, and the ratio alone does not
+  # separate them. The consumed seconds are what does, and cAdvisor publishes
+  # them on the same stream this capture already reads, so the answer costs a
+  # wider filter rather than another read.
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
+  assert_file_contains 'container_cpu_usage_seconds_total' "$capture"
   rm -rf "$tmp"
 }
 
@@ -285,7 +312,61 @@ run_capture() {
   # below exists for.
   assert_file_contains '--request-timeout=20s' "$kubectl_calls"
   assert_file_contains '[capture exit code: 0]' \
-    "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+    "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
+  rm -rf "$tmp"
+}
+
+@test "the sample number decides which reading a file belongs to" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="srv1"
+  COZY_REPORT_DIR="$tmp/report"
+  COZY_SNAPSHOT_NAME=throttle-smoke
+
+  ( set +x; cozy_capture_tenant_worker_cpu_throttle 2 )
+
+  # Every counter here is cumulative since the container started, so one reading
+  # is an average over an uptime and the pair is what gives a rate over the
+  # window the deadline covered. A second reading written over the first leaves
+  # one file and no interval -- collected, and unable to answer the question it
+  # was collected for.
+  assert_file_contains 'container_cpu_usage_seconds_total' \
+    "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-2/srv1.txt"
+  [ ! -d "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1" ]
+  rm -rf "$tmp"
+}
+
+@test "each reading records when it was taken" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="srv1"
+  COZY_REPORT_DIR="$tmp/report"
+  COZY_SNAPSHOT_NAME=throttle-smoke
+
+  run_capture
+
+  # The knob names how long the block WAITS between its two passes, which is not
+  # the interval a subject's two readings span: the other subject's pass falls
+  # between them, and on the run this collector exists for that pass is the slow
+  # part. A reader who divides by the advertised number is then wrong by
+  # whatever that pass cost, in the direction that understates a rate. The stamp
+  # is what makes the real interval readable off the pair.
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
+  assert_file_contains 'read attempted from' "$capture"
+  # Both ends, not one. A single stamp leaves the sampling instant somewhere
+  # inside a read whose duration is what goes wrong on the run this collector
+  # exists for, so the interval a reader divides by would be off by up to the
+  # read bound with nothing in the artifact saying so.
+  stamp=$(sed -n 's/.*read attempted from \([0-9][0-9]*\) to \([0-9][0-9]*\) epoch seconds.*/\1 \2/p' "$capture")
+  if [ -z "$stamp" ]; then
+    echo "expected a bare epoch stamp in $capture" >&2
+    cat "$capture" >&2
+    return 1
+  fi
   rm -rf "$tmp"
 }
 
@@ -383,7 +464,7 @@ run_capture() {
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains '[capture exit code: 0]' "$capture"
   assert_file_contains 'the kubelet answered' "$capture"
   assert_file_lacks_pattern 'the kubelet was not read' "$capture"
@@ -405,7 +486,7 @@ run_capture() {
   # One throttled worker answers the question, but only if the walk survives
   # the node that did not answer -- and the wedged one is as likely as not to
   # be first, since the node list is sorted.
-  dir="$COZY_REPORT_DIR/snapshots/throttle-partial/tenant-cpu-throttle"
+  dir="$COZY_REPORT_DIR/snapshots/throttle-partial/tenant-cpu-throttle/sample-1"
   assert_file_contains '[capture exit code: 124]' "$dir/srv1.txt"
   assert_file_contains '[capture exit code: 0]' "$dir/srv2.txt"
   rm -rf "$tmp"
@@ -428,7 +509,7 @@ run_capture() {
   # decided by the status rather than by something having been written. Filed
   # as a collection failure, a healthy listing reads as a collector that never
   # ran at all.
-  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle"
+  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1"
   assert_file_contains 'ComponentStatus is deprecated' "$dir/READ-WARNINGS.txt"
   [ ! -f "$dir/COLLECTION-FAILED.txt" ]
   assert_file_contains 'container_cpu_cfs_throttled_periods_total' "$dir/srv1.txt"
@@ -446,7 +527,7 @@ run_capture() {
 
   run_capture
 
-  [ ! -f "$COZY_REPORT_DIR/snapshots/throttle-uncapped/tenant-cpu-throttle/COLLECTION-TRUNCATED.txt" ]
+  [ ! -f "$COZY_REPORT_DIR/snapshots/throttle-uncapped/tenant-cpu-throttle/sample-1/COLLECTION-TRUNCATED.txt" ]
   rm -rf "$tmp"
 }
 
@@ -558,14 +639,25 @@ run_capture() {
   for f in hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml \
            hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml; do
     reads=$(grep -n 'node-join diagnostics reads' "$f" | head -n 1 | cut -d: -f1)
-    cgroup=$(grep -n 'worker CPU throttling counters' "$f" | head -n 1 | cut -d: -f1)
+    cgroup=$(grep -n 'worker CPU usage and throttling counters' "$f" | head -n 1 | cut -d: -f1)
     console=$(grep -n 'serial-console family' "$f" | head -n 1 | cut -d: -f1)
-    if [ -z "$reads" ] || [ -z "$cgroup" ] || [ -z "$console" ]; then
-      echo "expected $f to list the reads, the throttling capture and the console family" >&2
+    talos=$(grep -n 'guest Talos capture' "$f" | head -n 1 | cut -d: -f1)
+    if [ -z "$reads" ] || [ -z "$cgroup" ] || [ -z "$console" ] || [ -z "$talos" ]; then
+      echo "expected $f to list the reads, the counter capture, the console family and the guest Talos capture" >&2
       return 1
     fi
-    if [ "$cgroup" -le "$reads" ] || [ "$cgroup" -ge "$console" ]; then
-      echo "in $f the throttling capture must sit between the reads and the console family" >&2
+    # Below the console, not above it. This capture is read twice and can spend
+    # most of the phase budget, and admission gates only when a collector may
+    # start, so above the console it would bound what the console gets -- and
+    # the console is the only surface that survives a worker which never reached
+    # apid. Above the guest Talos capture, which needs the apid that failure
+    # never reached and is the more expensive of the two.
+    if [ "$cgroup" -le "$console" ] || [ "$cgroup" -ge "$talos" ]; then
+      echo "in $f the counter capture must sit between the console family and the guest Talos capture" >&2
+      return 1
+    fi
+    if [ "$console" -le "$reads" ]; then
+      echo "in $f the console family must sit after the node-join reads" >&2
       return 1
     fi
   done
@@ -576,36 +668,43 @@ run_capture() {
   # declined the cheaper reads around it -- which is the failure the phase
   # budget exists to prevent, reintroduced by the newest caller.
   lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
-  gate=$(grep -n "^ *if cozy_diag_phase_has_time '(d) tenant worker CPU throttling'; then$" \
+  gate=$(grep -n "^ *if cozy_diag_phase_has_time '(d) tenant worker CPU counters and sandbox node CPU time'; then$" \
     "$lib" | head -n 1 | cut -d: -f1)
-  call=$(grep -n '^ *cozy_capture_tenant_worker_cpu_throttle || true$' "$lib" | head -n 1 | cut -d: -f1)
+  call=$(grep -n '^ *cozy_capture_tenant_worker_cpu_throttle "${_sample}" || true$' "$lib" | head -n 1 | cut -d: -f1)
   if [ -z "$gate" ] || [ -z "$call" ]; then
     echo "expected the capture to sit behind a cozy_diag_phase_has_time gate" >&2
     return 1
   fi
-  # Adjacency, not just order: a gate anywhere above the call would satisfy a
-  # line comparison while guarding something else entirely.
-  if [ "$call" -ne $((gate + 2)) ]; then
-    echo "the gate (line $gate) must guard the capture (line $call) directly" >&2
+  # THIS gate, not just some gate above the call. A line comparison alone is
+  # satisfied by any earlier gate in the block, which would leave the capture
+  # guarded by a decision taken about something else. The call now sits inside
+  # the sampling loop rather than on the line after the gate, so adjacency is no
+  # longer the way to say it: what says it is that no other gate opens in
+  # between.
+  next=$(awk -v g="$gate" 'NR > g && /cozy_diag_phase_has_time/ { print NR; exit }' "$lib")
+  if [ -z "$next" ]; then
+    echo "expected another phase gate after line $gate, so this test could bound the section" >&2
+    return 1
+  fi
+  if [ "$call" -le "$gate" ] || [ "$call" -ge "$next" ]; then
+    echo "the capture (line $call) must sit between its gate ($gate) and the next one ($next)" >&2
     return 1
   fi
 }
 
-@test "the capture runs ahead of the collectors that cost more" {
+@test "the capture runs ahead of the collectors that cost more, and behind the one it could starve" {
   lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
-  call=$(grep -n '^ *cozy_capture_tenant_worker_cpu_throttle || true$' "$lib" | head -n 1 | cut -d: -f1)
+  call=$(grep -n '^ *cozy_capture_tenant_worker_cpu_throttle "${_sample}" || true$' "$lib" | head -n 1 | cut -d: -f1)
   if [ -z "$call" ]; then
     echo "expected the failure path to call the throttling capture" >&2
     return 1
   fi
   # What runs last is what the budget declines, so position is what decides
-  # whether this collector is ever taken on a tight run. It is cheaper than
-  # every leg below and the only one whose question nothing else in this tree
-  # answers, so it precedes all of them. Stated without a count on purpose: the
-  # loop below is the enumeration, and a sentence that also counted would go
-  # stale the first time a leg is added to it.
-  for leg in 'cozy_capture_tenant_serial_console || true' \
-             'cozy_capture_tenant_talos "${test_name}" || true' \
+  # whether this collector is ever taken on a tight run. Its question has no
+  # other answer in this tree, so it precedes the legs below. Stated without a
+  # count on purpose: the loop below is the enumeration, and a sentence that
+  # also counted would go stale the first time a leg is added to it.
+  for leg in 'cozy_capture_tenant_talos "${test_name}" || true' \
              'ghcr_mirror_diagnose || true' \
              'talos_image_cache_diagnose || true'; do
     line=$(grep -n -F -x "    ${leg}" "$lib" | head -n 1 | cut -d: -f1)
@@ -618,6 +717,22 @@ run_capture() {
       return 1
     fi
   done
+  # And behind the console. Reading the counters twice costs the walk twice
+  # plus the interval, which is most of the phase budget at the read bound and
+  # the node cap, and admission gates only when a collector may START. Ahead of
+  # the console, a run that hits those bounds would leave the console never
+  # started rather than cut short -- and the console is the only capture that
+  # survives a worker which never reached apid, the shape this failure usually
+  # takes. Cost, not worth, is what puts it here.
+  console=$(grep -n 'cozy_capture_tenant_serial_console || true' "$lib" | head -n 1 | cut -d: -f1)
+  if [ -z "$console" ]; then
+    echo "expected the failure block to still capture the guest serial console" >&2
+    return 1
+  fi
+  if [ "$call" -le "$console" ]; then
+    echo "the throttling capture (line $call) must run after the console capture (line $console)" >&2
+    return 1
+  fi
 }
 
 @test "the ceiling is captured beside the counters" {
@@ -631,7 +746,7 @@ run_capture() {
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   # The throttled counters on their own say a container hit some ceiling, not
   # which one. Without the quota beside them the reader cannot tell a VM capped
   # at one core from one capped at eight, which is the whole question.
@@ -640,6 +755,52 @@ run_capture() {
   # 100000us of quota is one core against a 100000us period and a tenth of one
   # against a 1000000us period.
   assert_file_contains 'container_spec_cpu_period' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the capture tells the reader how to pair it with its sibling sample" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="srv1"
+  COZY_REPORT_DIR="$tmp/report"
+  COZY_SNAPSHOT_NAME=throttle-smoke
+
+  run_capture
+
+  # The instruction lives with the subject that has a sibling rather than in the
+  # walk both subjects share, because the other caller of that walk takes one
+  # sample and would otherwise carry an instruction pointing at a directory that
+  # is never created.
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
+  assert_file_contains 'subtract this node file from its sibling under the other sample directory' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a read that did not finish is not told to pair with a sibling" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="srv1"
+  COZY_REPORT_DIR="$tmp/report"
+  COZY_SNAPSHOT_NAME=throttle-smoke
+  # Series arrived and the read still failed, which is a stream cut off part way
+  # through.
+  kubectl_raw_rc=124
+
+  run_capture
+
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
+  assert_file_contains 'these counters are incomplete' "$capture"
+  # Telling a reader to subtract two files asserts that both hold a whole
+  # reading. This one is already marked incomplete, and a difference taken
+  # against it understates the counter by whatever the read did not return --
+  # in the direction that makes a starved worker look busier than it was. The
+  # sandbox capture withholds its column legend from a short read for the same
+  # reason, so the pair answers this the same way on both sides.
+  assert_file_lacks_pattern 'subtract this node file from its sibling' "$capture"
   rm -rf "$tmp"
 }
 
@@ -662,7 +823,7 @@ run_capture() {
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'container_spec_cpu_period' "$capture"
   assert_file_lacks_pattern 'unknown' "$capture"
   assert_file_lacks_pattern 'incomplete' "$capture"
@@ -696,7 +857,7 @@ run_capture() {
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_lacks_pattern 'running uncapped' "$capture"
   unset -f grep
   rm -rf "$tmp"
@@ -713,8 +874,8 @@ run_capture() {
 
   run_capture
 
-  # The default fixture is the capped shape: all five families, quota included.
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  # The default fixture is the capped shape: every family, quota included.
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'container_spec_cpu_quota' "$capture"
   assert_file_lacks_pattern 'running uncapped' "$capture"
   rm -rf "$tmp"
@@ -736,7 +897,7 @@ run_capture() {
   # had to be killed, by whatever did it. Naming every way a read comes up
   # short is this collector's whole argument,
   # so the one status that means "killed, not finished" cannot be the exception.
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'exit 137' "$capture"
   assert_file_lacks_pattern 'exit 124' "$capture"
   rm -rf "$tmp"
@@ -756,7 +917,7 @@ run_capture() {
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   # This is the failure this collector exists to prevent, inverted: an empty
   # file here reads as a container that never hit its ceiling, which is the
   # exact conclusion the capture was added to stop people reaching by default.
@@ -768,8 +929,14 @@ run_capture() {
   assert_file_contains 'the kubelet was not read' "$capture"
   # And that it points at the log rather than leaving the reader to find it.
   assert_file_contains 'see read-error.log' "$capture"
+  # The stamp claims only when the read was attempted. This arm has just said
+  # nothing was read, so a line asserting the counters were sampled inside the
+  # bracket contradicts the line above it -- the same two-lines-disagreeing
+  # failure the pairing note and the legend are both gated against.
+  assert_file_lacks_pattern 'counters were sampled' "$capture"
+  assert_file_contains 'read attempted from' "$capture"
   assert_file_contains 'error: unable to connect to the server' \
-    "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.read-error.log"
+    "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.read-error.log"
   rm -rf "$tmp"
 }
 
@@ -790,7 +957,7 @@ run_capture() {
 
   run_capture
 
-  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle"
+  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1"
   assert_file_contains 'the kubelet was not read' "$dir/srv1.txt"
   assert_file_contains 'nodes/proxy' "$dir/srv1.read-error.log"
   assert_file_contains 'Forbidden' "$dir/srv1.read-error.log"
@@ -815,7 +982,7 @@ run_capture() {
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'the kubelet was not read' "$capture"
   # The half that makes it a defect rather than a wording preference: the
   # artifact must not state the opposite of what happened.
@@ -824,7 +991,7 @@ run_capture() {
   # after evidence that was never written.
   assert_file_lacks_pattern 'see read-error.log' "$capture"
   assert_file_contains 'without a word' "$capture"
-  [ ! -f "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.read-error.log" ]
+  [ ! -f "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.read-error.log" ]
   rm -rf "$tmp"
 }
 
@@ -846,7 +1013,7 @@ run_capture() {
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'incomplete' "$capture"
   assert_file_lacks_pattern 'see read-error.log' "$capture"
   rm -rf "$tmp"
@@ -869,7 +1036,7 @@ run_capture() {
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'could not be read back on this runner' "$capture"
   assert_file_lacks_pattern 'the kubelet answered' "$capture"
   assert_file_lacks_pattern 'the kubelet was not read' "$capture"
@@ -898,7 +1065,7 @@ run_capture() {
 
   run_capture
 
-  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle"
+  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1"
   assert_file_contains 'could not be read back on this runner' "$dir/srv1.txt"
   assert_file_contains 'see filter-error.log' "$dir/srv1.txt"
   assert_file_lacks_pattern 'the filter said nothing about why' "$dir/srv1.txt"
@@ -922,7 +1089,7 @@ run_capture() {
 
   run_capture
 
-  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle"
+  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1"
   assert_file_contains 'the filter said nothing about why' "$dir/srv1.txt"
   assert_file_lacks_pattern 'see filter-error.log' "$dir/srv1.txt"
   [ ! -f "$dir/srv1.filter-error.log" ]
@@ -946,7 +1113,7 @@ run_capture() {
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'could not be read back on this runner' "$capture"
   assert_file_lacks_pattern 'the kubelet answered' "$capture"
   assert_file_lacks_pattern 'the kubelet was not read' "$capture"
@@ -970,7 +1137,7 @@ run_capture() {
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'could not be read back on this runner' "$capture"
   assert_file_lacks_pattern 'the kubelet answered' "$capture"
   assert_file_lacks_pattern 'the kubelet was not read' "$capture"
@@ -1004,7 +1171,7 @@ run_capture() {
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'incomplete' "$capture"
   assert_file_contains 'see filter-error.log' "$capture"
   # The read itself was fine, so nothing here may blame it.
@@ -1031,7 +1198,7 @@ run_capture() {
 
   run_capture
 
-  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle"
+  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1"
   assert_file_contains 'incomplete' "$dir/srv1.txt"
   assert_file_contains 'the filter said nothing about why' "$dir/srv1.txt"
   assert_file_lacks_pattern 'see filter-error.log' "$dir/srv1.txt"
@@ -1059,7 +1226,7 @@ container_cpu_cfs_throttled_periods_total{container="compute",namespace="tenant-
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'unknown' "$capture"
   assert_file_contains 'none of them from a worker Pod' "$capture"
   assert_file_lacks_pattern 'reported no CPU series' "$capture"
@@ -1083,7 +1250,7 @@ container_cpu_cfs_throttled_periods_total{container="compute",namespace="tenant-
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   # Distinct from the kubelet that never answered: this one did, and an
   # artifact that blames the read would send an operator after RBAC and
   # networking when the actual finding is that no worker container was there.
@@ -1113,7 +1280,7 @@ container_cpu_cfs_throttled_periods_total{container="compute",namespace="tenant-
   mkdir -p "$tmp/bin"
   # Everything the collector shells out to, minus `timeout` itself. Missing one
   # would fail this test for the wrong reason and read as the arm being broken.
-  for c in mkdir sort grep mv rm mktemp wc tr cat; do
+  for c in mkdir sort grep mv rm mktemp wc tr cat date; do
     for d in /bin /usr/bin /usr/local/bin /opt/homebrew/bin; do
       if [ -x "$d/$c" ]; then
         ln -sf "$d/$c" "$tmp/bin/$c"
@@ -1121,7 +1288,7 @@ container_cpu_cfs_throttled_periods_total{container="compute",namespace="tenant-
       fi
     done
   done
-  for c in mkdir sort grep mv rm mktemp wc tr; do
+  for c in mkdir sort grep mv rm mktemp wc tr date; do
     if [ ! -x "$tmp/bin/$c" ]; then
       echo "FAIL: could not stage $c in the stripped PATH; the check below would be vacuous" >&2
       return 1
@@ -1155,7 +1322,7 @@ container_cpu_cfs_throttled_periods_total{container="compute",namespace="tenant-
     COZY_REPORT_DIR='"$tmp"'/report
     COZY_SNAPSHOT_NAME=fallback
     PATH='"$tmp"'/bin
-    cozy_capture_tenant_worker_cpu_throttle
+    cozy_capture_tenant_worker_cpu_throttle 1
   ' 2>&1) || true
   printf '%s\n' "$out" >"$tmp/out"
 
@@ -1166,14 +1333,14 @@ container_cpu_cfs_throttled_periods_total{container="compute",namespace="tenant-
   assert_file_contains '--request-timeout=20s' "$tmp/calls"
   # And produced counters rather than an "unknown" label.
   assert_file_contains 'container_cpu_cfs_throttled_periods_total' \
-    "$tmp/report/snapshots/fallback/tenant-cpu-throttle/srv1.txt"
+    "$tmp/report/snapshots/fallback/tenant-cpu-throttle/sample-1/srv1.txt"
   rm -rf "$tmp"
 }
 
 @test "a killed read is not written up as a grace period that never ran" {
   tmp=$(mktemp -d)
   mkdir -p "$tmp/bin"
-  for c in mkdir sort grep mv rm mktemp wc tr cat; do
+  for c in mkdir sort grep mv rm mktemp wc tr cat date; do
     for d in /bin /usr/bin /usr/local/bin /opt/homebrew/bin; do
       if [ -x "$d/$c" ]; then
         ln -sf "$d/$c" "$tmp/bin/$c"
@@ -1202,11 +1369,11 @@ container_cpu_cfs_throttled_periods_total{container="compute",namespace="tenant-
     COZY_REPORT_DIR='"$tmp"'/report
     COZY_SNAPSHOT_NAME=killed
     PATH='"$tmp"'/bin
-    cozy_capture_tenant_worker_cpu_throttle
+    cozy_capture_tenant_worker_cpu_throttle 1
   ' 2>&1) || true
   printf '%s\n' "$out" >"$tmp/out"
 
-  capture="$tmp/report/snapshots/killed/tenant-cpu-throttle/srv1.txt"
+  capture="$tmp/report/snapshots/killed/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'exit 137' "$capture"
   assert_file_lacks_pattern 'grace period' "$capture"
   rm -rf "$tmp"
@@ -1232,7 +1399,7 @@ container_cpu_cfs_throttled_periods_total{container="compute",namespace="tenant-
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'virt-launcher-worker-a-11111' "$capture"
   assert_file_lacks_pattern 'kube-apiserver' "$capture"
   rm -rf "$tmp"
@@ -1257,7 +1424,7 @@ container_cpu_cfs_throttled_periods_total{container="compute",namespace="tenant-
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_contains 'virt-launcher-worker-a-11111' "$capture"
   assert_file_lacks_pattern 'tenant-other' "$capture"
   assert_file_lacks_pattern 'virt-launcher-elsewhere' "$capture"
@@ -1283,7 +1450,7 @@ recorded_container_spec_cpu_quota{namespace="tenant-test",pod="virt-launcher-wor
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   assert_file_lacks_pattern 'xcontainer' "$capture"
   assert_file_lacks_pattern 'recorded_container' "$capture"
   assert_file_contains 'the kubelet answered' "$capture"
@@ -1303,7 +1470,7 @@ recorded_container_spec_cpu_quota{namespace="tenant-test",pod="virt-launcher-wor
 
   run_capture
 
-  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/srv1.txt"
+  capture="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/srv1.txt"
   # `timeout` reports 124 on expiry and passes the command's own status through
   # otherwise, so a 124 here is either this collector's deadline or the read
   # exiting 124 by itself, and nothing separates them. The file states that
@@ -1328,13 +1495,13 @@ recorded_container_spec_cpu_quota{namespace="tenant-test",pod="virt-launcher-wor
   # This runs inside a failure path that already spends minutes on other
   # collectors under one chainsaw op timeout. A short listing otherwise reads
   # as a small cluster rather than a cut walk.
-  truncated="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/COLLECTION-TRUNCATED.txt"
+  truncated="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/COLLECTION-TRUNCATED.txt"
   assert_file_contains '6 carried a worker in total' "$truncated"
   # n4, not n6: the cap's VALUE is the claim, and the two chainsaw Test files
   # order the failure path on it. Asserting some later node is absent leaves a
   # larger cap green, which would silently overspend the budget.
-  [ -f "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/n3.txt" ]
-  [ ! -f "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/n4.txt" ]
+  [ -f "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/n3.txt" ]
+  [ ! -f "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/n4.txt" ]
   rm -rf "$tmp"
 }
 
@@ -1355,7 +1522,7 @@ recorded_container_spec_cpu_quota{namespace="tenant-test",pod="virt-launcher-wor
 
   run_capture
 
-  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle"
+  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1"
   capture="$dir/srv1.txt"
   assert_file_contains 'incomplete' "$capture"
   assert_file_contains 'see read-error.log' "$capture"
@@ -1378,7 +1545,7 @@ recorded_container_spec_cpu_quota{namespace="tenant-test",pod="virt-launcher-wor
   # An unscheduled virt-launcher has no node, so there is no kubelet to ask --
   # which is itself a finding about the failure, not a gap in the collector.
   assert_file_contains 'no virt-launcher Pod with a node assigned' \
-    "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/COLLECTION-FAILED.txt"
+    "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/COLLECTION-FAILED.txt"
   rm -rf "$tmp"
 }
 
@@ -1395,7 +1562,7 @@ recorded_container_spec_cpu_quota{namespace="tenant-test",pod="virt-launcher-wor
 
   run_capture
 
-  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle"
+  dir="$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1"
   # kubectl writes deprecation and partial-result warnings on stderr with a
   # zero exit, so the exit status decides the filename, not the fact that
   # something was written. Filed as an error, a healthy read would look failed.
@@ -1422,9 +1589,9 @@ recorded_container_spec_cpu_quota{namespace="tenant-test",pod="virt-launcher-wor
   # status it is judged on has to be kubectl's rather than that of whatever
   # post-processing follows it.
   assert_file_contains 'Unable to connect to the server' \
-    "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/COLLECTION-FAILED.txt"
+    "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/COLLECTION-FAILED.txt"
   assert_file_contains 'failed to list' \
-    "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/COLLECTION-FAILED.txt"
+    "$COZY_REPORT_DIR/snapshots/throttle-smoke/tenant-cpu-throttle/sample-1/COLLECTION-FAILED.txt"
   rm -rf "$tmp"
 }
 
@@ -1440,7 +1607,7 @@ recorded_container_spec_cpu_quota{namespace="tenant-test",pod="virt-launcher-wor
     return 1
   fi
   tail=$(awk -v h="$head" 'NR > h && $0 == "}" { print NR; exit }' "$lib")
-  call=$(grep -n '^ *cozy_capture_tenant_worker_cpu_throttle || true$' "$lib" | head -n 1 | cut -d: -f1)
+  call=$(grep -n '^ *cozy_capture_tenant_worker_cpu_throttle "${_sample}" || true$' "$lib" | head -n 1 | cut -d: -f1)
   if [ -z "$call" ] || [ -z "$tail" ]; then
     echo "expected the node-join failure path to capture worker CPU throttling" >&2
     return 1

--- a/hack/run-kubernetes-network-counters_test.bats
+++ b/hack/run-kubernetes-network-counters_test.bats
@@ -187,6 +187,35 @@ run_capture() {
   return "${_rc}"
 }
 
+@test "the capture does not send a reader after a sibling sample it never takes" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_series "$worker_labels")"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-network-counters/node-a.txt"
+  # This capture is read once. Its sibling under the same shared walk is read
+  # twice, and the walk is where a stamp would naturally be written for both --
+  # which is how a file could end up carrying, on consecutive lines, this
+  # capture's own note that no second reading exists and an instruction to
+  # subtract one. Two lines of the same artifact contradicting each other is the
+  # reading failure this tree is written against, and it costs a reader the time
+  # it takes to go looking for a directory that was never created.
+  assert_file_contains 'a second capture of the same stream is what turns them into one' "$out"
+  assert_file_lacks_pattern 'sibling' "$out"
+  assert_file_lacks_pattern 'other sample directory' "$out"
+  # The stamp itself stays: when the read happened is true of every caller, and
+  # it is what makes a rate computable at all if a second capture is ever added.
+  assert_file_contains 'read attempted from' "$out"
+  rm -rf "$tmp"
+}
+
 @test "a negative assertion fails when its own matcher cannot evaluate" {
   # The helper under every "must not appear" claim in this file. What rides on
   # it is the collector's contract stated negatively: that an unread kubelet was

--- a/hack/run-kubernetes-node-join_test.bats
+++ b/hack/run-kubernetes-node-join_test.bats
@@ -77,6 +77,13 @@ kubectl() {
       printf 'srv1\n'
       return 0
       ;;
+    *"get nodes"*"InternalIP"*)
+      # Name and address, the shape the sandbox CPU time capture asks for. One
+      # node, so the walk proceeds past its listing into the per-node Talos
+      # read -- the read the audit above is the only instrument for.
+      printf 'srv1|192.0.2.11\n'
+      return 0
+      ;;
     *"get pods -o name"*)
       [ -z "${importer_pod_names}" ] || printf '%s\n' ${importer_pod_names}
       return 0
@@ -89,6 +96,31 @@ kubectl() {
       ;;
   esac
   return 0
+}
+
+# The sandbox nodes are read over the Talos API rather than through the
+# apiserver, so a mock for kubectl alone leaves those reads outside the audit
+# above: an unbounded talosctl call would hold the op exactly as an unbounded
+# kubectl one does. Recorded through the same in_bound pair for that reason.
+talosctl_calls=/dev/null
+talosctl() {
+  printf '%s\n' "$*" >>"${talosctl_calls}"
+  if [ "${in_bound}" != 1 ]; then
+    printf '%s\n' "$*" >>"${unbounded_calls}"
+  fi
+  # A plausible /proc/stat first line. The collector files a note when the read
+  # returns nothing, so a mock that printed nothing would drive every test here
+  # down that arm instead of the one being exercised.
+  printf 'cpu  10 0 5 900 1 0 0 7 4000 0\n'
+}
+
+# The sampling interval is a real wait in production and a recorded call here.
+# Without the mock every test that drives the block would pay it in wall clock;
+# with it, the log is also what pins the interval being taken ONCE for both
+# collectors rather than once each.
+sleep_calls=/dev/null
+sleep() {
+  printf '%s\n' "$*" >>"${sleep_calls}"
 }
 
 date() {
@@ -152,6 +184,21 @@ use_temp_report_dir() {
   export COZY_REPORT_DIR="$1/report"
 }
 
+# The sandbox CPU time capture refuses to read anything without a talosconfig,
+# and says so rather than leaving an empty directory. Tests that are about the
+# reads have to get past that, and tests that are about the refusal have to be
+# sure the file is absent -- which is not the same as leaving TALOSCONFIG unset,
+# since the fallback path is repo-relative and a developer's tree can carry a
+# stale one from a local sandbox run. Both directions are therefore explicit.
+stage_sandbox_talosconfig() {
+  printf 'context: e2e\n' >"$1/talosconfig"
+  export TALOSCONFIG="$1/talosconfig"
+}
+
+no_sandbox_talosconfig() {
+  export TALOSCONFIG="$1/talosconfig-absent"
+}
+
 # The block calls seven collectors that have their own suites and their own
 # bounds. Four of them are stubbed here; the other three are stubbed only where
 # the test is about the budget rather than the reads, for the reason given
@@ -184,6 +231,7 @@ stub_collectors() {
 stub_gated_collectors() {
   cozy_capture_tenant_worker_cpu_throttle() { printf 'cpu-throttle-stub\n'; }
   cozy_capture_tenant_worker_network_counters() { printf 'network-counters-stub\n'; }
+  cozy_capture_sandbox_node_cpu_time() { printf 'sandbox-cpu-time-stub\n'; }
   ghcr_mirror_diagnose() { printf 'ghcr-mirror-stub\n'; }
 }
 
@@ -198,14 +246,47 @@ assert_file_contains() {
   return 1
 }
 
+# The sibling suites' three-way split, and here for the same reason. A bare
+# `! grep -q` succeeds on a file that does not exist, which is
+# indistinguishable from the file existing without the pattern; and awk exits 1
+# for "no line matched" and 2 for "I could not evaluate this", so folding those
+# together lets a broken matcher satisfy a negative assertion. A positive
+# assertion fails loudly when its matcher breaks and gets fixed; this one would
+# go green and stay green.
+assert_file_lacks_pattern() {
+  local pattern="$1"
+  local file="$2"
+  local _rc=0
+
+  if [ ! -f "${file}" ]; then
+    printf 'expected %s to exist so it could be checked for: %s\n' "${file}" "${pattern}" >&2
+    return 1
+  fi
+  awk -v pattern="${pattern}" '$0 ~ pattern { found = 1 } END { exit found ? 0 : 1 }' "${file}" || _rc=$?
+  case "${_rc}" in
+    0)
+      printf 'expected %s not to match: %s\n' "${file}" "${pattern}" >&2
+      return 1
+      ;;
+    1) return 0 ;;
+    *)
+      printf 'awk could not evaluate pattern %s against %s\n' "${pattern}" "${file}" >&2
+      return 1
+      ;;
+  esac
+}
+
 @test "no node join diagnostic read escapes a wall clock bound" {
   . hack/e2e-chainsaw/_lib/run-kubernetes.sh
   stub_collectors
   tmp=$(mktemp -d)
   use_temp_report_dir "$tmp"
+  stage_sandbox_talosconfig "$tmp"
   kubectl_calls="$tmp/kubectl.calls"
   unbounded_calls="$tmp/unbounded.calls"
   timeout_calls="$tmp/timeout.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  sleep_calls="$tmp/sleep.calls"
   : >"$unbounded_calls"
   importer_pod_names='pod/importer-md0-a pod/importer-md0-b'
 
@@ -244,7 +325,7 @@ assert_file_contains() {
   # empty one is exactly what a capture that issued no read leaves behind -- and
   # that is the state this pin has to reject, since a capture missing from the
   # audit is a capture whose reads nobody bounded.
-  for subdir in tenant-cpu-throttle tenant-network-counters; do
+  for subdir in tenant-cpu-throttle tenant-network-counters sandbox-host-cpu-time; do
     dir="$COZY_REPORT_DIR/snapshots/kubernetes/$subdir"
     if [ -z "$(find "$dir" -type f 2>/dev/null | head -n 1)" ]; then
       echo "FAIL: $subdir produced no file, so that capture issued no read and its reads were not audited" >&2
@@ -252,6 +333,102 @@ assert_file_contains() {
       false
     fi
   done
+  rm -rf "$tmp"
+}
+
+@test "the counters are read twice, one interval apart, and the interval is paid once" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  stub_collectors
+  tmp=$(mktemp -d)
+  use_temp_report_dir "$tmp"
+  stage_sandbox_talosconfig "$tmp"
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  sleep_calls="$tmp/sleep.calls"
+  : >"$sleep_calls"
+  COZY_DIAG_RATE_INTERVAL=7
+
+  ( set +x; cozy_report_node_join_failure test-latest-version ) >"$tmp/out" 2>&1
+
+  # A single reading of either subject is an average over an uptime: every
+  # counter on both sides is cumulative, so one file says what the container has
+  # used since it started and nothing about the window the deadline covered. The
+  # pair is the instrument, and a second reading that never happened leaves a
+  # directory that looks collected.
+  for subject in tenant-cpu-throttle sandbox-host-cpu-time; do
+    for sample in 1 2; do
+      dir="$COZY_REPORT_DIR/snapshots/kubernetes/$subject/sample-$sample"
+      if [ -z "$(find "$dir" -type f 2>/dev/null | head -n 1)" ]; then
+        echo "expected $subject to leave a reading under sample-$sample" >&2
+        ls -R "$COZY_REPORT_DIR/snapshots/kubernetes" >&2 || true
+        return 1
+      fi
+    done
+  done
+  # Once, not once per subject. Both subjects answer the same question about the
+  # same window, so they are read on either side of one wait; paid per subject
+  # the wait would be the larger half of what this pair adds to a failing run,
+  # and the two windows would no longer line up.
+  waits=$(grep -c . "$sleep_calls" || true)
+  if [ "$waits" -ne 1 ]; then
+    echo "expected exactly one interval between the two readings; got $waits" >&2
+    cat "$sleep_calls" >&2
+    return 1
+  fi
+  assert_file_contains '7' "$sleep_calls"
+  rm -rf "$tmp"
+}
+
+@test "an interval that would put both readings at the same instant is refused" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  stub_collectors
+  stub_gated_collectors
+  tmp=$(mktemp -d)
+  use_temp_report_dir "$tmp"
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  sleep_calls="$tmp/sleep.calls"
+  : >"$sleep_calls"
+  # Zero is all digits and passes every check the other knobs make, and it is
+  # the one value that leaves this pair collected and meaningless: two readings
+  # at the same instant subtract to nothing. Unlike the read bounds, where zero
+  # removes a ceiling, here it removes the measurement while leaving the files.
+  COZY_DIAG_RATE_INTERVAL=0
+
+  ( set +x; cozy_report_node_join_failure test-latest-version ) >"$tmp/out" 2>&1
+
+  assert_file_contains 'ignoring COZY_DIAG_RATE_INTERVAL' "$tmp/out"
+  # The reason, not just the refusal. The shared helper's default parenthetical
+  # says zero disables a bound, which is true of every other knob it guards and
+  # false of this one: zero here removes no ceiling, it puts both readings at
+  # the same instant. A warning that names the wrong reason sends the reader to
+  # look for a ceiling that was never involved.
+  assert_file_contains 'both readings at the same instant' "$tmp/out"
+  assert_file_lacks_pattern 'COZY_DIAG_RATE_INTERVAL.*disables the bound' "$tmp/out"
+  # The default, not the rejected value: a warning that named the fallback and
+  # then used the value anyway would be worse than no warning.
+  assert_file_contains "$COZY_DIAG_RATE_INTERVAL_DEFAULT" "$sleep_calls"
+  rm -rf "$tmp"
+}
+
+@test "a sandbox with no talosconfig is recorded rather than left as an empty directory" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  stub_collectors
+  tmp=$(mktemp -d)
+  use_temp_report_dir "$tmp"
+  no_sandbox_talosconfig "$tmp"
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  sleep_calls="$tmp/sleep.calls"
+
+  ( set +x; cozy_report_node_join_failure test-latest-version ) >"$tmp/out" 2>&1
+
+  # Steal is the quantity that separates a sandbox node oversubscribed from
+  # inside from one not given its turn by the machine under it. An empty
+  # directory here reads as the first, which is a conclusion nothing observed.
+  assert_file_contains 'no sandbox talosconfig at' \
+    "$COZY_REPORT_DIR/snapshots/kubernetes/sandbox-host-cpu-time/sample-1/COLLECTION-FAILED.txt"
   rm -rf "$tmp"
 }
 
@@ -534,7 +711,7 @@ assert_file_contains() {
   assert_file_contains '(b1) tenant worker guest serial console: not collected' "$tmp/out"
   assert_file_contains '(b) in-guest Talos dmesg + kubelet logs + service states + links: not collected' "$tmp/out"
   assert_file_contains 're-probe talos-image-cache ClusterIP + cacher debug bundle: not collected' "$tmp/out"
-  assert_file_contains '(d) tenant worker CPU throttling: not collected' "$tmp/out"
+  assert_file_contains '(d) tenant worker CPU counters and sandbox node CPU time: not collected' "$tmp/out"
   assert_file_contains '(d2) tenant worker network counters: not collected' "$tmp/out"
   assert_file_contains 'ghcr-mirror state, access log and warm-up Job: not collected' "$tmp/out"
   rm -rf "$tmp"
@@ -733,7 +910,7 @@ assert_file_contains() {
   # found`, and nothing else. That is not a scenario worth modelling either, because
   # `date +%s` is already required by the wait helpers this block sits after, so no
   # run reaches here without it.
-  for c in date grep awk sed cat mktemp rm tr wc head; do
+  for c in date grep awk sed cat mktemp rm tr wc head mkdir; do
     for d in /bin /usr/bin /usr/local/bin /opt/homebrew/bin; do
       if [ -x "$d/$c" ]; then
         ln -sf "$d/$c" "$tmp/bin/$c"
@@ -755,6 +932,7 @@ assert_file_contains() {
     cozy_capture_tenant_worker_cpu_throttle() { :; }
     cozy_capture_tenant_worker_network_counters() { :; }
     ghcr_mirror_diagnose() { :; }
+    cozy_capture_sandbox_node_cpu_time() { :; }
     kubectl() { printf "KUBECTL_RAN\n" >&2; }
     PATH='"$tmp"'/bin
     cozy_report_node_join_failure test-latest-version
@@ -767,6 +945,21 @@ assert_file_contains() {
     head -20 "$tmp/out" >&2
     false
   fi
+  # And the block ran to its end. The count above saturates before the last
+  # sections -- every collector past (d) is stubbed here, so it reads 11 whether
+  # the block finished or died half way -- which is how an unguarded external
+  # inside the sampling loop could land green. The final section's own header is
+  # the one line printed only if nothing unwound the function on the way there,
+  # and under `set -eu` a single `command not found` is enough to unwind it.
+  assert_file_contains 're-probe talos-image-cache ClusterIP' "$tmp/out"
+  assert_file_lacks_pattern 'command not found' "$tmp/out"
+  # `sleep` is deliberately NOT staged above. It is the one external this block
+  # calls outside a `|| true` and outside cozy_diag_read, so an unguarded call
+  # exits 127 under `set -eu` and unwinds the function -- taking the collectors
+  # after it, two of which the warning above promises keep collecting. Staging
+  # it would make this test pass against exactly that defect, which is how it
+  # went unnoticed once.
+  assert_file_contains 'sleep is not on PATH' "$tmp/out"
   # And it is announced as a missing local dependency, not implied by the notes.
   assert_file_contains 'timeout is not on PATH' "$tmp/out"
   # Matched as a read's note rather than as the bare status: the phase's own warning
@@ -937,28 +1130,25 @@ assert_file_contains() {
   # what runs last is what gets declined, and a collector's position is its
   # priority.
   #
-  # It goes with the cheap reads for the same two reasons the CPU counters
-  # beside it do. It costs four bounded reads rather than the minutes the
-  # console walk and the guest capture can spend between them, and its answer
-  # exists nowhere else in the artifact: the bytes that arrived at the Pod, set
-  # against the progress the guest reported, separate a pull that kept
+  # It is first of the gated collectors, and it is there because it is the
+  # cheapest of them: one listing and one read per node against the minutes the
+  # console walk, the guest capture and the CPU pair can each spend. Its answer
+  # exists nowhere else in the artifact either -- the bytes that arrived at the
+  # Pod, set against the progress the guest reported, separate a pull that kept
   # restarting from a slow link, and no other collector here separates those
   # two. Which of the Pod's four interfaces carries that number, and which one
   # is the dummy that reads zero, is stated where the collector is gated. Placed
   # after the guest captures it would be the first thing declined on exactly the
   # slow runs that produce this failure.
   #
-  # It goes AFTER the CPU counters rather than before them, and that ordering is
-  # the weaker of the two claims: both are four bounded reads of the same
-  # endpoint, so the pair could be swapped without changing what a tight run
-  # collects. What decides it is that the CPU capture's placement was argued on
-  # its own terms and this one has no argument for displacing it -- and "the
-  # last red run made the network question look more urgent" is not one, since
-  # the next red run picks a different subsystem and the order would follow it
-  # around.
-  cpu=$(grep -n 'cozy_capture_tenant_worker_cpu_throttle || true' "$lib" | head -n 1 | cut -d: -f1)
+  # It goes AHEAD of the CPU pair, which is a stronger claim than the one it
+  # replaces. The two used to be the same size, so the order between them was
+  # nearly arbitrary; the pair now walks twice and can spend most of the budget,
+  # so cost decides it rather than taste. The companion guard is the one that
+  # bounds what may sit ahead of the console at all.
   net=$(grep -n 'cozy_capture_tenant_worker_network_counters || true' "$lib" | head -n 1 | cut -d: -f1)
   console=$(grep -n 'cozy_capture_tenant_serial_console || true' "$lib" | head -n 1 | cut -d: -f1)
+  cpu=$(grep -n 'cozy_capture_tenant_worker_cpu_throttle "${_sample}" || true' "$lib" | head -n 1 | cut -d: -f1)
   talos=$(grep -n 'cozy_capture_tenant_talos "${test_name}" || true' "$lib" | head -n 1 | cut -d: -f1)
   mirror=$(grep -n 'ghcr_mirror_diagnose || true' "$lib" | head -n 1 | cut -d: -f1)
   cache=$(grep -n 'talos_image_cache_diagnose || true' "$lib" | head -n 1 | cut -d: -f1)
@@ -969,17 +1159,151 @@ assert_file_contains() {
       exit 1
     fi
   done
-  if [ "$cpu" -ge "$net" ]; then
-    echo "the CPU counters (line $cpu) keep their argued place ahead of the network counters ($net)" >&2
-    exit 1
-  fi
-  for later in console talos mirror cache; do
+  for later in console cpu talos mirror cache; do
     eval "n=\$$later"
     if [ "$net" -ge "$n" ]; then
       echo "the network counters (line $net) must precede $later (line $n), or a tight run declines them" >&2
       exit 1
     fi
   done
+}
+
+@test "nothing gated ahead of the console can spend the phase budget by itself" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # The budget guard below holds the phase against the op. This one holds the
+  # ORDER against the collector the phase exists to reach. Admission is "the
+  # budget is not spent yet", so whatever is gated ahead of the serial console
+  # bounds what the console can lose, and the console is documented as the only
+  # surface that survives a worker which never reached apid -- the dominant
+  # shape of this failure. A collector below it can only cost itself; one above
+  # it can cost the console.
+  #
+  # Two claims, because one of them is structural and the other is arithmetic
+  # and neither implies the other.
+  console=$(grep -n 'cozy_capture_tenant_serial_console || true' "$lib" | head -n 1 | cut -d: -f1)
+  if [ -z "$console" ]; then
+    echo "expected the failure path to capture the guest serial console" >&2
+    return 1
+  fi
+  # Structural: a collector read more than once costs its whole walk again, and
+  # the interval on top. That shape belongs below the console whatever its
+  # arithmetic says today, because the arithmetic is what changes when a node is
+  # added to the sandbox.
+  loop=$(grep -n '^ *for _sample in 1 2; do$' "$lib" | head -n 1 | cut -d: -f1)
+  if [ -z "$loop" ]; then
+    echo "expected the sampling loop to still exist in $lib" >&2
+    return 1
+  fi
+  if [ "$loop" -lt "$console" ]; then
+    echo "the sampling loop (line $loop) is gated ahead of the console (line $console); a collector that walks twice must not bound what the console gets" >&2
+    return 1
+  fi
+  # Arithmetic: what IS ahead of it must not be able to spend the whole budget
+  # on its own. This is deliberately not "ahead + console <= budget", which the
+  # tree has never satisfied and did not at the merge base either: the console's
+  # own worst case plus one four-read walk already exceeds the budget, so a
+  # tight run has always been able to cut the console short. What must not
+  # happen is a collector ahead of it that can spend the budget outright, which
+  # turns "cut short" into "never started".
+  budget=$(grep -oE '^COZY_DIAG_PHASE_BUDGET_DEFAULT=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  bound=$(grep -oE '^COZY_DIAG_READ_TIMEOUT_DEFAULT=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  grace=$(grep -oE '^COZY_DIAG_READ_GRACE_DEFAULT=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  for v in budget bound grace; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
+      return 1
+    fi
+  done
+  # Every walk's cap, not the first one. The two subjects declare their own
+  # `local max_nodes` and are equal today, so taking the first would be right by
+  # accident: raise one alone and the arithmetic below would keep using the
+  # other, under-counting the pair while reading as satisfied.
+  caps=$(grep -oE 'local max_nodes=[0-9]+' "$lib" | sed -E 's/.*=//')
+  # `|| true`: grep -c exits 1 on a count of zero, and under errexit that ends
+  # the test before the branch below can say what was missing -- the guard would
+  # still fail, with the diagnostic it was given replaced by silence.
+  ncaps=$(printf '%s\n' "$caps" | grep -c . || true)
+  if [ "$ncaps" -ne 2 ]; then
+    echo "expected two capped walks in $lib, found $ncaps; the pair arithmetic below is written for exactly the two subjects the sampling loop reads" >&2
+    return 1
+  fi
+  # A capped walk costs a listing plus one read per node, each at the read bound
+  # plus its kill grace. Taken from the shared cAdvisor body by name rather than
+  # as the first cap in the file: everything counted into `ahead` below runs
+  # through that body, and picking by position would be right only while it
+  # happens to be declared first.
+  cap=$(awk '/^_cozy_capture_worker_cadvisor\(\)/,/^}/' "$lib" \
+    | grep -oE 'local max_nodes=[0-9]+' | head -n 1 | sed -E 's/.*=//')
+  if [ -z "$cap" ]; then
+    echo "expected the shared cAdvisor walk to declare its own cap; without it this guard reports success for having lost its input" >&2
+    return 1
+  fi
+  walk=$(( (1 + cap) * (bound + grace) ))
+  ahead=0
+  gated=$(grep -nE '^ *(cozy_(capture|report)_[a-z_]+|[a-z_]+_diagnose) [^|]*\|\| true|^ *(cozy_(capture|report)_[a-z_]+|[a-z_]+_diagnose) \|\| true' "$lib" \
+    | sed -E 's/:[[:space:]]*/:/; s/(:[a-z_]+) .*/\1/; s/\|\|.*//')
+  # Checked for emptiness like every other input here, and this one matters
+  # most: the loop below fails on a collector gated ahead of the console that
+  # has no cost arm, which is what catches the next heavy collector being put
+  # there. With no input the loop runs zero times, `ahead` stays 0, and both
+  # arms pass while nothing has been looked at. The input is a grep over call
+  # spellings, and this branch changed one of those spellings.
+  if [ -z "$gated" ]; then
+    echo "found no gated collector at all, so this guard checked nothing" >&2
+    return 1
+  fi
+  for entry in $gated; do
+    line=${entry%%:*}
+    fn=${entry#*:}
+    [ "$line" -lt "$console" ] || continue
+    case "$fn" in
+      # Not behind the phase gate at all: it runs ahead of the headline so the
+      # console experiment's own failure is named before the wording that
+      # matches the bug it studies, and it is two bounded reads.
+      cozy_report_guest_console_wedge) continue ;;
+      cozy_capture_tenant_worker_network_counters) ahead=$((ahead + walk)) ;;
+      *)
+        echo "$fn is gated ahead of the console and this guard has no cost arm for it; add one, or move it below the console" >&2
+        return 1
+        ;;
+    esac
+  done
+  if [ "$ahead" -gt "$budget" ]; then
+    echo "the collectors gated ahead of the console can spend ${ahead}s against a ${budget}s budget, so the console can be declined rather than merely cut short" >&2
+    return 1
+  fi
+  # And the pair's own overshoot stays inside the term the budget was derived
+  # against. The phase is start-gated, so a collector admitted a moment before
+  # the deadline runs its whole cost afterwards; the derivation below covers
+  # exactly one such overshoot, sized from the heaviest collector. A pair
+  # heavier than that term would push the tenant snapshot past the op while the
+  # inequality still read as satisfied, because the inequality does not know
+  # which collector is heaviest. Read from the guard that owns it rather than
+  # restated, since two copies of a number are a scheduled divergence.
+  interval=$(grep -oE '^COZY_DIAG_RATE_INTERVAL_DEFAULT=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  # Named rather than taken from $0: cozytest.sh dot-sources a transformed copy
+  # of this file, so $0 is the runner there and the bats binary here, and the
+  # two runners would read different files.
+  largest=$(grep -oE '^  largest=[0-9]+' hack/run-kubernetes-node-join_test.bats | head -n 1 | sed -E 's/.*=//')
+  for v in interval largest; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to read $v; without it this half of the guard reports success for having lost its input" >&2
+      return 1
+    fi
+  done
+  # Two subjects, two samples each, one walk apiece at that subject's own cap,
+  # plus the single wait. Summed per subject rather than doubling one walk, so a
+  # cap raised on one side alone is counted where it lands.
+  pair=$interval
+  for c in $caps; do
+    pair=$(( pair + 2 * (1 + c) * (bound + grace) ))
+  done
+  if [ "$pair" -gt "$largest" ]; then
+    echo "the sampling pair can overshoot by ${pair}s against the ${largest}s the budget derivation allows for one late admission; the snapshot the phase exists to reach no longer fits behind it" >&2
+    return 1
+  fi
 }
 
 @test "every collector that survives a missing timeout is named in the warning that says so" {
@@ -1050,6 +1374,7 @@ assert_file_contains() {
   for entry in \
     'cozy_capture_tenant_worker_cpu_throttle:CPU throttling:_cozy_cadvisor_node_stream _cozy_cadvisor_worker_nodes' \
     'cozy_capture_tenant_worker_network_counters:network counter:_cozy_cadvisor_node_stream _cozy_cadvisor_worker_nodes' \
+    'cozy_capture_sandbox_node_cpu_time:sandbox node CPU time:cozy_capture_sandbox_node_cpu_time' \
     'ghcr_mirror_diagnose:ghcr-mirror:ghcr_mirror_diagnose _ghcr_mirror_bounded_read' \
     'talos_image_cache_diagnose:talos-image-cache:talos_image_cache_diagnose _talos_image_cache_bounded_read'; do
     fn=${entry%%:*}
@@ -1084,6 +1409,7 @@ ${carrier}
     case "$fn" in
       cozy_capture_tenant_worker_cpu_throttle) phrase='CPU throttling' ;;
       cozy_capture_tenant_worker_network_counters) phrase='network counter' ;;
+      cozy_capture_sandbox_node_cpu_time) phrase='sandbox node CPU time' ;;
       ghcr_mirror_diagnose) phrase='ghcr-mirror' ;;
       talos_image_cache_diagnose) phrase='talos-image-cache' ;;
       # The sentence enumerates the CAPTURES. Two other kinds of function guard
@@ -1145,7 +1471,8 @@ ${carrier}
   for entry in $gated; do
     fn=${entry#*:}
     case "$fn" in
-      cozy_capture_tenant_worker_cpu_throttle) phrase='worker CPU throttling counters' ;;
+      cozy_capture_tenant_worker_cpu_throttle) phrase='worker CPU usage and throttling counters' ;;
+      cozy_capture_sandbox_node_cpu_time) phrase='sandbox node CPU time' ;;
       cozy_capture_tenant_worker_network_counters) phrase='worker network counters' ;;
       cozy_capture_tenant_serial_console) phrase='serial-console family' ;;
       cozy_capture_tenant_talos) phrase='guest Talos capture' ;;

--- a/hack/run-kubernetes-sandbox-cpu-time_test.bats
+++ b/hack/run-kubernetes-sandbox-cpu-time_test.bats
@@ -1,0 +1,604 @@
+#!/usr/bin/env bats
+# Regression coverage for the sandbox node CPU time capture in
+# hack/e2e-chainsaw/_lib/run-kubernetes.sh. cozytest.sh ends an @test block at
+# the first bare closing brace, so command mocks stay at top level.
+#
+# What this capture answers, and why nothing beside it answers the same thing:
+# the worker captures describe a cgroup, so they can say what the tenant worker
+# was allowed and what it consumed, and they are blind to the layer under the
+# sandbox. A guest that is runnable and never scheduled looks from the cgroup
+# like a guest that asked for nothing. Whether the sandbox node itself was given
+# its turn is recorded in one place only -- the steal column of its own
+# /proc/stat -- and the kubelet endpoints this tree already reads do not carry
+# it. So the failure this suite guards against is not a wrong number; it is an
+# empty directory, which reads as a sandbox that lost no time while nothing was
+# ever asked.
+
+kubectl_calls=/dev/null
+kubectl_rows='srv1|192.0.2.11'
+kubectl_list_rc=0
+kubectl_list_stderr=
+talosctl_calls=/dev/null
+talosctl_rc=0
+talosctl_stderr=
+talosctl_output='cpu  10 0 5 900 1 0 0 7 4000 0
+cpu0 10 0 5 900 1 0 0 7 4000 0'
+timeout_calls=/dev/null
+timeout_fail_node=
+
+kubectl() {
+  printf '%s\n' "$*" >>"${kubectl_calls}"
+  [ -z "${kubectl_list_stderr}" ] || printf '%s\n' "${kubectl_list_stderr}" >&2
+  [ "${kubectl_list_rc}" -eq 0 ] || return "${kubectl_list_rc}"
+  # Quoted, or the mock decides the shape of the answer before the code under
+  # test sees it: jsonpath puts a dual-stack node's two addresses in one field,
+  # separated by a space, and an unquoted expansion splits that into two rows
+  # here -- which is exactly the input the walk has a branch for, and the branch
+  # would then be unreachable from this suite.
+  [ -z "${kubectl_rows}" ] || printf '%s\n' "${kubectl_rows}"
+  return 0
+}
+
+talosctl() {
+  printf '%s\n' "$*" >>"${talosctl_calls}"
+  [ -z "${talosctl_stderr}" ] || printf '%s\n' "${talosctl_stderr}" >&2
+  # Output before the status, because a read cut off part way has already
+  # written what it managed to read. A mock that returned first could only ever
+  # produce empty-plus-failure, leaving the arm that labels a partial capture
+  # unreachable in tests while being the likeliest one in production.
+  [ -z "${talosctl_output}" ] || printf '%s\n' "${talosctl_output}"
+  return "${talosctl_rc}"
+}
+
+timeout() {
+  local command_rc=0
+  printf '%s\n' "$*" >>"${timeout_calls}"
+  # Return 97 rather than running the command when the wrapper is not the
+  # bounded form: a read that lost its ceiling must not pass as a read.
+  [ "${1:-}" = -k ] || return 97
+  shift 3
+  "$@" || command_rc=$?
+  if [ -n "${timeout_fail_node}" ]; then
+    case " $* " in
+      *"${timeout_fail_node}"*) return 124 ;;
+    esac
+  fi
+  return "${command_rc}"
+}
+
+assert_file_contains() {
+  local needle="$1"
+  local file="$2"
+
+  if [ ! -f "${file}" ]; then
+    printf 'expected %s to exist so it could be checked for: %s\n' "${file}" "${needle}" >&2
+    return 1
+  fi
+  case "$(cat "${file}")" in
+    *"${needle}"*) return 0 ;;
+  esac
+  printf 'expected %s to contain: %s\n' "${file}" "${needle}" >&2
+  return 1
+}
+
+assert_file_lacks_pattern() {
+  local pattern="$1"
+  local file="$2"
+
+  # A missing file must fail rather than vacuously pass: a bare `! grep -q`
+  # succeeds on an unreadable path, which is indistinguishable from "the file
+  # exists and does not carry the label".
+  if [ ! -f "${file}" ]; then
+    printf 'expected %s to exist so it could be checked for: %s\n' "${file}" "${pattern}" >&2
+    return 1
+  fi
+  # Branched on awk's exact status. awk exits 1 for "no line matched" and 2 for
+  # "I could not evaluate this"; folded together, a negative assertion is
+  # satisfied by its own matcher giving up, which is the direction that goes
+  # green and stays green.
+  local _rc=0
+  awk -v pattern="${pattern}" '$0 ~ pattern { found = 1 } END { exit found ? 0 : 1 }' "${file}" || _rc=$?
+  case "${_rc}" in
+    0)
+      printf 'expected %s not to match: %s\n' "${file}" "${pattern}" >&2
+      return 1
+      ;;
+    1) return 0 ;;
+    *)
+      printf 'awk could not evaluate pattern %s against %s\n' "${pattern}" "${file}" >&2
+      return 1
+      ;;
+  esac
+}
+
+# The function under test redirects a command's stderr into a report file and
+# decides which artifact to write from it. cozytest.sh runs under `set -x`, so
+# the tracer's own line for that command lands on the very stderr being
+# redirected, and every assertion about those files would be reading the
+# tracer. Call through this wrapper so the sinks hold what production writes.
+run_capture() {
+  local _rc=0
+  ( set +x; cozy_capture_sandbox_node_cpu_time "${1:-1}" ) || _rc=$?
+  return "${_rc}"
+}
+
+stage() {
+  COZY_REPORT_DIR="$1/report"
+  COZY_SNAPSHOT_NAME=steal-smoke
+  printf 'context: e2e\n' >"$1/talosconfig"
+  export TALOSCONFIG="$1/talosconfig"
+}
+
+@test "the node's own CPU accounting is read over the Talos API" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_capture
+
+  # The endpoint and the node are both the address, because the e2e talosconfig
+  # carries no endpoints: one without the other reaches nothing at all.
+  assert_file_contains '-e 192.0.2.11 -n 192.0.2.11 read /proc/stat' "$talosctl_calls"
+  capture="$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/srv1.txt"
+  assert_file_contains 'cpu  10 0 5 900 1 0 0 7 4000 0' "$capture"
+  assert_file_lacks_pattern 'unknown' "$capture"
+  assert_file_lacks_pattern 'incomplete' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the column legend travels with the numbers" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_capture
+
+  # /proc/stat carries no header, and the two columns that matter here sit next
+  # to each other: steal is the eighth number after the label and guest is the
+  # ninth. Guest is large on a node running VMs and is already counted inside
+  # user, so reading the ninth as the eighth turns a fraction of a percent into
+  # twenty-odd -- which has already happened once against these nodes. The
+  # legend is what stops the next reader repeating it, and it is only useful
+  # where the numbers are.
+  capture="$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/srv1.txt"
+  assert_file_contains 'The eighth number is steal and the ninth is guest' "$capture"
+  # The pairing instruction rides with the legend, on the one arm that holds a
+  # whole reading, and so does the claim that counters were sampled inside the
+  # brackets -- the stamp itself only says when the read was attempted.
+  assert_file_contains 'subtracting this node file from its sibling' "$capture"
+  assert_file_contains 'counters were sampled somewhere inside each read' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "each reading records when it was taken" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_capture
+
+  # Here the stamp is the only timing there is. A cAdvisor row carries its own
+  # sample time; a /proc/stat row carries none, so without this the gap between
+  # two readings of a node is unrecoverable from the artifact and a steal rate
+  # would have to be computed from a number the block does not promise.
+  capture="$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/srv1.txt"
+  assert_file_contains 'read attempted from' "$capture"
+  # Both ends, for the reason the sibling suite states: one stamp hides the read
+  # duration inside the interval, and that duration is the variable this
+  # collector is deployed against.
+  stamp=$(sed -n 's/.*read attempted from \([0-9][0-9]*\) to \([0-9][0-9]*\) epoch seconds.*/\1 \2/p' "$capture")
+  if [ -z "$stamp" ]; then
+    echo "expected a bare epoch stamp in $capture" >&2
+    cat "$capture" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "each read is bounded and keeps its exit code" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_capture
+
+  # An unbounded read here would hold the whole diagnostics block against a node
+  # whose Talos API is up but wedged, and the phase budget bounds when a read
+  # may START, never how long one already running may take. Named by their verbs
+  # rather than by the bound, because both carry the same one and a bare check
+  # for it would be satisfied twice by whichever read survived.
+  assert_file_contains '-k 5 20 kubectl get nodes' "$timeout_calls"
+  assert_file_contains '-k 5 20 talosctl' "$timeout_calls"
+  assert_file_contains '--request-timeout=20s' "$kubectl_calls"
+  assert_file_contains '[capture exit code: 0]' \
+    "$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/srv1.txt"
+  rm -rf "$tmp"
+}
+
+@test "a lowered read budget moves both of this collector's bounds" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # Set after sourcing, which is how a caller and a test both set it. A value
+  # read only at assignment time would reach `timeout` unchecked here.
+  COZY_DIAG_READ_TIMEOUT=4
+
+  run_capture
+
+  assert_file_contains '-k 5 4 kubectl get nodes' "$timeout_calls"
+  assert_file_contains '-k 5 4 talosctl' "$timeout_calls"
+  assert_file_contains '--request-timeout=4s' "$kubectl_calls"
+  rm -rf "$tmp"
+}
+
+@test "a zero read budget is corrected rather than disabling the bound" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # `timeout -k 5 0` disables the timeout outright, so a zero assigned after
+  # sourcing would restore the unbounded read this bound exists to remove.
+  COZY_DIAG_READ_TIMEOUT=0
+
+  run_capture
+
+  assert_file_lacks_pattern '^-k 5 0 ' "$timeout_calls"
+  assert_file_contains "-k 5 $COZY_DIAG_READ_TIMEOUT_DEFAULT talosctl" "$timeout_calls"
+  rm -rf "$tmp"
+}
+
+@test "no talosctl on PATH is recorded rather than left as an empty directory" {
+  # A subprocess with a stripped PATH, because this file mocks `talosctl` as a
+  # shell function and `command -v` finds functions -- the arm cannot be reached
+  # from inside a test body. Same device the sibling suites use, and the PATH is
+  # staged rather than emptied: the collector shells out before it gets to the
+  # check, so an empty PATH would fail this for the wrong reason and read as the
+  # arm being broken.
+  tmp=$(mktemp -d)
+  mkdir -p "$tmp/bin"
+  for c in mkdir grep mv rm; do
+    for d in /bin /usr/bin /usr/local/bin /opt/homebrew/bin; do
+      if [ -x "$d/$c" ]; then
+        ln -sf "$d/$c" "$tmp/bin/$c"
+        break
+      fi
+    done
+    if [ ! -x "$tmp/bin/$c" ]; then
+      echo "FAIL: could not stage $c in the stripped PATH; the check below would be vacuous" >&2
+      return 1
+    fi
+  done
+  if [ -e "$tmp/bin/talosctl" ]; then
+    echo "FAIL: talosctl leaked into the stripped PATH; this test would prove nothing" >&2
+    return 1
+  fi
+  printf 'context: e2e\n' >"$tmp/talosconfig"
+  rc=0
+
+  # Assigned inside the subprocess rather than in front of it: bash resolves the
+  # command name with the PATH the assignment sets, so `PATH=... bash` cannot
+  # find bash itself.
+  out=$(bash -c '
+    set -eu
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    COZY_REPORT_DIR='"$tmp"'/report
+    COZY_SNAPSHOT_NAME=steal-smoke
+    TALOSCONFIG='"$tmp"'/talosconfig
+    PATH='"$tmp"'/bin
+    cozy_capture_sandbox_node_cpu_time 1
+  ' 2>&1) || rc=$?
+  printf '%s\n' "$out" >"$tmp/out"
+
+  [ "$rc" -ne 0 ]
+  marker="$tmp/report/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/COLLECTION-FAILED.txt"
+  assert_file_contains 'talosctl is not on PATH' "$marker"
+  # The distinction the marker exists for, spelled out in the artifact: a tool
+  # that was never run says nothing about the nodes, and the reading a missing
+  # file invites is that they lost no time.
+  assert_file_contains 'not a reading that they lost no time' "$marker"
+  rm -rf "$tmp"
+}
+
+@test "no talosconfig is recorded as a config that was missing, not as a node that refused" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  export TALOSCONFIG="$tmp/absent"
+  rc=0
+
+  run_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  assert_file_contains 'no sandbox talosconfig at' \
+    "$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/COLLECTION-FAILED.txt"
+  # And nothing was asked, so no per-node file may claim otherwise.
+  [ ! -f "$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/srv1.txt" ]
+  rm -rf "$tmp"
+}
+
+@test "a node listing that failed is not reported as a cluster with no nodes" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  kubectl_list_rc=1
+  kubectl_list_stderr='error: You must be logged in to the server (Unauthorized)'
+  rc=0
+
+  run_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  marker="$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/COLLECTION-FAILED.txt"
+  assert_file_contains 'failed to list sandbox nodes' "$marker"
+  # The status alone names none of the ways a listing fails -- Unauthorized, a
+  # refused connection and an unrecognised kind are all exit 1 -- so the stderr
+  # that says which is kept.
+  assert_file_contains 'Unauthorized' "$marker"
+  rm -rf "$tmp"
+}
+
+@test "a warning on a successful listing is kept apart from a failure" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # kubectl writes deprecation and partial-result warnings on stderr with a zero
+  # exit, so which file stderr lands in is decided by the status and not by
+  # something having been written.
+  kubectl_list_stderr='Warning: v1 Node is deprecated'
+  dir="$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1"
+
+  run_capture
+
+  assert_file_contains 'Warning: v1 Node is deprecated' "$dir/READ-WARNINGS.txt"
+  [ ! -f "$dir/COLLECTION-FAILED.txt" ]
+  rm -rf "$tmp"
+}
+
+@test "a node with no InternalIP says why it was not asked" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  kubectl_rows='srv1|'
+
+  run_capture
+
+  # An absent file would be the same artifact as a node that was never listed.
+  # The Talos API is reached on that address, so its absence is the reason this
+  # node carries no numbers, and the reason is what the file holds.
+  assert_file_contains 'reports no InternalIP' \
+    "$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/srv1.txt"
+  rm -rf "$tmp"
+}
+
+@test "a dual-stack node is one node, dialled on its first address" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # jsonpath emits every matching address into the same field, space separated,
+  # so a node with an IPv4 and an IPv6 InternalIP arrives as one row carrying
+  # two addresses. Both halves of that are wrong if taken literally: the pair
+  # concatenated is not an address to dial, and the second one is not a node.
+  kubectl_rows='srv1|192.0.2.11 2001:db8::11
+srv2|192.0.2.12 2001:db8::12
+srv3|192.0.2.13 2001:db8::13
+srv4|192.0.2.14 2001:db8::14'
+
+  run_capture
+
+  assert_file_contains '-e 192.0.2.11 -n 192.0.2.11 read /proc/stat' "$talosctl_calls"
+  assert_file_lacks_pattern '2001:db8' "$talosctl_calls"
+  # And the count in the truncation marker is nodes, not addresses. The marker
+  # exists to say a short listing was truncated rather than small, so a total
+  # that counts each node twice is the one number in it that must not be wrong.
+  assert_file_contains 'capture stopped after 3 nodes; 4 were listed in total' \
+    "$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/COLLECTION-TRUNCATED.txt"
+  rm -rf "$tmp"
+}
+
+@test "a node whose read timed out does not stop the next node" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  kubectl_rows='srv1|192.0.2.11
+srv2|192.0.2.12'
+  timeout_fail_node=192.0.2.11
+
+  run_capture
+
+  dir="$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1"
+  assert_file_contains '[capture exit code: 124]' "$dir/srv1.txt"
+  assert_file_contains 'cpu  10 0 5 900 1 0 0 7 4000 0' "$dir/srv2.txt"
+  rm -rf "$tmp"
+}
+
+@test "a read that never answered is recorded as unread, not as a node that lost nothing" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  talosctl_rc=1
+  talosctl_output=
+  talosctl_stderr='rpc error: code = Unavailable desc = connection error'
+
+  run_capture
+
+  capture="$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/srv1.txt"
+  assert_file_contains 'is unknown: the Talos API was not read' "$capture"
+  # This file holds no counters at all, so a reader following a pairing
+  # instruction here would subtract nothing from a healthy sibling and read that
+  # sibling's whole cumulative value as the delta -- steal inflated to the node's
+  # entire uptime, manufacturing the finding this collector looks for.
+  assert_file_lacks_pattern 'subtracting this node file from its sibling' "$capture"
+  # Nor may the stamp assert that anything was sampled between its two instants.
+  # When the read was attempted is true on every arm; that counters exist inside
+  # that bracket is exactly what this arm has just denied, and two consecutive
+  # lines contradicting each other is the reading failure this tree is written
+  # against.
+  assert_file_lacks_pattern 'counters were sampled' "$capture"
+  assert_file_contains 'read attempted from' "$capture"
+  # The note has to name a file that exists. There is no bare read-error.log in
+  # the directory -- each is named for its node, and the walk writes one per
+  # node -- so a note pointing at the bare name sends the reader after an
+  # artifact that was never written, which is the same harm as silence reported
+  # as an answer, one indirection out.
+  assert_file_contains 'beside this file, named for the same node' "$capture"
+  assert_file_contains 'connection error' \
+    "$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/srv1.read-error.log"
+  rm -rf "$tmp"
+}
+
+@test "a read killed without a word does not point at a file that was never written" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # `timeout` SIGKILLs its child, so the dominant failure arrives non-zero with
+  # nothing on either stream. A note naming an error log here sends the reader
+  # after evidence that does not exist.
+  talosctl_rc=1
+  talosctl_output=
+  talosctl_stderr=
+
+  run_capture
+
+  capture="$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/srv1.txt"
+  assert_file_contains 'died without a word on either stream' "$capture"
+  [ ! -f "$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/srv1.read-error.log" ]
+  rm -rf "$tmp"
+}
+
+@test "a read cut off part way is marked incomplete rather than presented whole" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # Output arrived and the read still failed, which is what a stream cut off
+  # part way through looks like. Read as complete, its numbers are a smaller
+  # total over the same interval -- a steal figure biased toward zero, in the
+  # direction that ends the investigation.
+  talosctl_rc=124
+
+  run_capture
+
+  capture="$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/srv1.txt"
+  assert_file_contains 'these counters are incomplete' "$capture"
+  # And the legend, which is a statement about a complete row, must not be
+  # attached to one that was truncated.
+  assert_file_lacks_pattern 'eighth number is steal' "$capture"
+  # Nor the instruction to pair it. A difference taken against a prefix
+  # understates the counter by whatever the read did not return, which for steal
+  # is the direction that says the node was given every turn it asked for.
+  assert_file_lacks_pattern 'subtracting this node file from its sibling' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a read that succeeded and returned nothing is not filed as a reading" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  talosctl_output=
+
+  run_capture
+
+  capture="$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/srv1.txt"
+  assert_file_contains 'the read succeeded and returned nothing' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the walk is capped and names both counts when it stops" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  kubectl_rows='srv1|192.0.2.11
+srv2|192.0.2.12
+srv3|192.0.2.13
+srv4|192.0.2.14'
+
+  run_capture
+
+  # A short listing otherwise reads as a small cluster rather than a truncated
+  # walk, so a cap that fired is recorded with both counts.
+  assert_file_contains 'capture stopped after 3 nodes; 4 were listed in total' \
+    "$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/COLLECTION-TRUNCATED.txt"
+  [ ! -f "$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/srv4.txt" ]
+  rm -rf "$tmp"
+}
+
+@test "a cluster within the cap leaves no truncation marker" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_capture
+
+  [ ! -f "$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1/COLLECTION-TRUNCATED.txt" ]
+  rm -rf "$tmp"
+}
+
+@test "the sample number decides which reading a file belongs to" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  kubectl_calls="$tmp/kubectl.calls"
+  talosctl_calls="$tmp/talosctl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_capture 2
+
+  # The pair is the instrument and the counters are cumulative, so a second
+  # reading written over the first leaves one file and no interval -- collected,
+  # and unable to answer the question it was collected for.
+  assert_file_contains 'cpu  10 0 5 900 1 0 0 7 4000 0' \
+    "$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-2/srv1.txt"
+  [ ! -d "$COZY_REPORT_DIR/snapshots/steal-smoke/sandbox-host-cpu-time/sample-1" ]
+  rm -rf "$tmp"
+}


### PR DESCRIPTION
## What this PR does

Two instruments for the tenant worker that misses the node-Ready deadline. They are instruments, not a fix: the failure they instrument is cozystack/cozystack#3513, and this PR does not close it. Neither changes what the suites assert.

The worker CPU capture now reads `container_cpu_usage_seconds_total` beside the CFS counters it already read, and it is read twice a fixed interval apart instead of once. The throttled counters say a container met its ceiling; they cannot say how much CPU it got, and the two failures behind a stalled worker are exactly those, a guest held at a one-core ceiling and a guest whose vCPU thread is rarely scheduled at all. Both leave throttled periods behind. Every counter involved is cumulative since the container started, so a single reading divides out to an average over the whole uptime and says nothing about the window the deadline covered, which matters here because the profile under investigation is a guest that freezes for tens of seconds and then runs flat out: the average comes out low, the instantaneous figure comes out at the cap, and only the second distinguishes it from a guest that is simply capped.

The second instrument is a new subject. The worker captures describe a cgroup, so they are blind to the layer under the sandbox, and a guest that is runnable and never scheduled looks from the cgroup like a guest that asked for nothing. Whether the sandbox node itself was given its turn is recorded only in the steal column of its own `/proc/stat`. No kubelet endpoint carries it, and crust-gather cannot reach it because PodSecurity refuses its node-shell Pod in this cluster, so the capture goes over the Talos API, which is already how the report reads those nodes for dmesg. It is captured verbatim with its column legend beside it rather than reduced to a percentage: `/proc/stat` has no header, steal and guest sit next to each other, and guest is large on a node running VMs and already counted inside user, so reading one as the other turns a fraction of a percent into twenty-odd.

Both subjects are read on either side of one shared wait, so the pair pays it once. That wait is guarded like every other external in the block: it is the one call there outside a `|| true`, and under `set -eu` a missing `sleep` would exit 127 and take the collectors after it, two of which the phase's own missing-`timeout` warning promises keep collecting. Without it the two readings are taken back to back and the block says so, which is honest here because the interval is read off the stamps rather than off the knob. The default is 12 seconds and that is the whole wall-clock cost this adds to a failing run. The wait is not the interval either subject's counters span, though: each pass walks its own nodes and the other subject's pass falls between a subject's two readings, and on the run these diagnostics exist for those passes are the slow part rather than the wait. Each capture therefore stamps both ends of its read, so the real interval is subtracted off the pair instead of assumed from the knob, and the width of those brackets is the uncertainty. This matters more on the sandbox side than on the worker side, since a cAdvisor row carries its own sample time and a `/proc/stat` row carries none. That wait is a measurement interval rather than a stand-in for a condition nobody wrote a wait for, so `docs/agents/e2e-testing.md` carves it out by name instead of leaving a reader to decide whether the `TODO(e2e-replace-fixed-timeouts):` marker applies to a gap between two readings of a cumulative counter.

The pair is gated below the serial console rather than above it, and its ceiling rather than its worth is the reason. Reading two collectors twice is sixteen bounded reads plus the interval, which at the read bound and the three-node cap is most of the phase budget, and admission gates only when a collector may start. Above the console, a run that hit those bounds would leave the console never started rather than merely cut short, and the console is the only capture that survives a worker which never reached apid, which is the shape this failure usually takes. That overrun is inside the term the budget derivation already allows for one collector admitted a moment before the deadline, and a guard in `hack/run-kubernetes-node-join_test.bats` holds the pair's ceiling against it. Two more guards there hold what may sit ahead of the console: nothing read more than once, and nothing whose ceiling could spend the budget on its own.

Failure marking follows the existing collectors rather than inventing a shape: no collector here may leave an empty directory, because an empty directory reads as a healthy node, so a missing binary, a missing talosconfig, a listing that never answered, a node with no address and a read that was cut off each land as a named note or a `COLLECTION-FAILED.txt`.

The phase budget is unchanged at 420s and the derivation guard still holds.

Covered by `hack/run-kubernetes-sandbox-cpu-time_test.bats` (new) plus additions to the cpu-throttle, node-join and network-counters suites. Each collector was checked against a deliberate break of its own guard: dropping the usage family, ignoring the sample number, removing the interval, accepting a zero interval, swallowing the missing-talosconfig marker, reading the wrong `/proc` file, taking a dual-stack node's second address for a node, counting addresses instead of nodes in the truncation marker, stamping only one end of a read, letting the stamp claim counters were sampled on an arm that read nothing, telling a capture with no counters to subtract a sibling, leaving the sampling wait unguarded, and starving the budget guard of its input. Every one is caught by a named test.

### Screenshots

Not applicable, no UI change.

### Downstream repositories

The diff touches `hack/e2e-chainsaw/_lib/run-kubernetes.sh`, two `chainsaw-test.yaml` files, four BATS files and one agent doc. Walking the trigger map: nothing under `hack/` is moved or renamed, `hack/package.mk` and `hack/common-envs.mk` are untouched, no make target changes what it does, no package is added or removed, no schema, default, enum, CRD or namespace moves. The one entry that mentions this area is the `ccp` rule about moving or renaming things under `hack/`, and no file is moved or renamed here.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
test(e2e): the node-join failure diagnostics now read the tenant worker CPU counters twice a fixed interval apart, so consumed CPU and throttling are both available as a rate over the same window instead of as an average over the container's uptime, and they add the sandbox node's own /proc/stat over the Talos API, which is the only place the steal time under the sandbox is recorded. Each reading carries the time it was taken, so the interval a rate divides by comes from the captures rather than from the configured wait.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Kubernetes diagnostics with paired, timestamped samples for worker CPU usage and throttling.
  - Added sandbox-node CPU steal-time diagnostics, including support for partial, unavailable, or timed-out captures.
  - Improved diagnostic reports with clearer capture status, rate-calculation context, and sample-specific artifacts.
  - Updated diagnostic sequencing and time budgets to accommodate the expanded metrics collection.

- **Documentation**
  - Clarified when measurement intervals are appropriate and updated the review checklist accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->