### PR TITLE
refactor(console): clear the eslint backlog, 54 problems down to 6

### DIFF
--- a/packages/system/dashboard/images/console/apps/console/src/App.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/App.tsx
@@ -1,6 +1,6 @@
 import { Navigate, Route, Routes, useLocation } from "react-router"
 import { AppShell } from "@cozystack/ui"
-import { TenantProvider } from "./lib/tenant-context.tsx"
+import { TenantProvider } from "./lib/tenant-provider.tsx"
 import { Breadcrumb } from "./components/Breadcrumb.tsx"
 import { MarketplacePage } from "./routes/MarketplacePage.tsx"
 import { ConsolePage } from "./routes/ConsolePage.tsx"
@@ -12,7 +12,8 @@ import {
   useMarketplaceSidebarSections,
 } from "./routes/sidebar-sections.tsx"
 import type { HeaderTab } from "@cozystack/ui"
-import { CommandPaletteProvider, useCommandPalette } from "./components/command-palette/command-palette-provider.tsx"
+import { CommandPaletteProvider } from "./components/command-palette/command-palette-provider.tsx"
+import { useCommandPalette } from "./components/command-palette/command-palette-context.ts"
 import { CommandPalette } from "./components/command-palette/command-palette.tsx"
 import type { AppConfig } from "./lib/config.ts"
 

--- a/packages/system/dashboard/images/console/apps/console/src/components/ArrayFieldItemTemplate.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/ArrayFieldItemTemplate.tsx
@@ -1,0 +1,36 @@
+import type {
+  ArrayFieldTemplateItemType,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+} from "@rjsf/utils"
+
+/**
+ * One row of an RJSF array field: the item itself plus a hover-revealed
+ * remove control. Numeric items get a fixed narrow column so a list of
+ * numbers doesn't stretch across the form.
+ */
+export function ArrayFieldItemTemplate<
+  T = unknown,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = FormContextType,
+>(props: ArrayFieldTemplateItemType<T, S, F>) {
+  const { children, hasRemove, index, onDropIndexClick, disabled, readonly, schema } = props
+  const isNumeric = schema.type === 'integer' || schema.type === 'number'
+  return (
+    <div className="array-item-row group flex items-center gap-1.5 mb-1">
+      <div className={isNumeric ? 'w-36 shrink-0' : 'flex-1'}>{children}</div>
+      {hasRemove && (
+        <button
+          type="button"
+          aria-label="Remove"
+          className="opacity-0 group-hover:opacity-100 size-[26px] flex-shrink-0 flex items-center justify-center rounded-full border border-red-200 bg-white text-red-400 text-sm leading-none hover:bg-red-50 hover:text-red-600 hover:border-red-300 disabled:opacity-30 transition-all duration-150"
+          onClick={onDropIndexClick(index)}
+          disabled={disabled || readonly}
+        >
+          ×
+        </button>
+      )}
+    </div>
+  )
+}

--- a/packages/system/dashboard/images/console/apps/console/src/components/CustomObjectFieldTemplate.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/CustomObjectFieldTemplate.tsx
@@ -6,31 +6,56 @@ import type {
   FormContextType,
 } from "@rjsf/utils"
 
-function isSimpleField(schema: any): boolean {
-  if (!schema) return true
-  const type = schema.type
+/** Structural view of the JSON-schema nodes this template inspects. */
+interface FieldSchemaNode {
+  type?: string
+  items?: { type?: string }
+  anyOf?: unknown
+  oneOf?: unknown
+  allOf?: unknown
+  "x-kubernetes-int-or-string"?: unknown
+  properties?: Record<string, unknown>
+}
+
+function isSimpleField(schema: unknown): boolean {
+  if (!schema || typeof schema !== "object") return true
+  const node = schema as FieldSchemaNode
+  const type = node.type
   if (type === "object") return false
   if (type === "array") {
-    const itemType = schema.items?.type
+    const itemType = node.items?.type
     return itemType === "integer" || itemType === "string" || itemType === "number"
   }
-  if (schema.anyOf || schema.oneOf || schema.allOf) {
-    if (schema["x-kubernetes-int-or-string"]) return true
+  if (node.anyOf || node.oneOf || node.allOf) {
+    if (node["x-kubernetes-int-or-string"]) return true
     return false
   }
   return true
 }
 
+/** Read the addon `enabled` flag off form data of an unknown shape. */
+function isAddonEnabled(formData: unknown): boolean {
+  return (
+    typeof formData === "object" &&
+    formData !== null &&
+    (formData as { enabled?: unknown }).enabled === true
+  )
+}
+
 function groupByComplexity(
   properties: ObjectFieldTemplatePropertyType[],
-  parentSchema: any,
+  parentSchema: unknown,
 ) {
   type Group = { simple: boolean; items: ObjectFieldTemplatePropertyType[] }
   const groups: Group[] = []
   let current: Group | null = null
+  const parentProperties =
+    parentSchema && typeof parentSchema === "object"
+      ? (parentSchema as FieldSchemaNode).properties
+      : undefined
 
   for (const prop of properties) {
-    const fieldSchema = parentSchema?.properties?.[prop.name]
+    const fieldSchema = parentProperties?.[prop.name]
     const simple = isSimpleField(fieldSchema)
     if (!current || current.simple !== simple) {
       current = { simple, items: [] }
@@ -42,9 +67,9 @@ function groupByComplexity(
 }
 
 export function CustomObjectFieldTemplate<
-  T = any,
+  T = unknown,
   S extends StrictRJSFSchema = RJSFSchema,
-  F extends FormContextType = any,
+  F extends FormContextType = FormContextType,
 >(props: ObjectFieldTemplateProps<T, S, F>) {
   const { formData } = props
 
@@ -54,7 +79,7 @@ export function CustomObjectFieldTemplate<
   const isAddon = hasEnabledField && hasOtherFields
 
   if (isAddon) {
-    const isEnabled = (formData as any)?.enabled === true
+    const isEnabled = isAddonEnabled(formData)
     const enabledProp = props.properties.find((p) => p.name === "enabled")
     const otherProps = props.properties.filter((p) => p.name !== "enabled")
     const groups = groupByComplexity(otherProps, props.schema)

--- a/packages/system/dashboard/images/console/apps/console/src/components/IconButton.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/IconButton.tsx
@@ -1,0 +1,29 @@
+import type {
+  IconButtonProps,
+  FormContextType,
+  RJSFSchema,
+  StrictRJSFSchema,
+} from "@rjsf/utils"
+
+/**
+ * Bare button used by every RJSF ButtonTemplate. Lives in its own module so
+ * rjsf-templates.tsx can stay a plain template registry — a file mixing
+ * component definitions with non-component exports breaks Fast Refresh.
+ */
+export function IconButton<
+  T = unknown,
+  S extends StrictRJSFSchema = RJSFSchema,
+  F extends FormContextType = FormContextType,
+>(props: IconButtonProps<T, S, F>) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { icon, className, uiSchema, registry, iconType, ...btnProps } = props
+  return (
+    <button
+      type="button"
+      className={className}
+      {...btnProps}
+    >
+      {icon}
+    </button>
+  )
+}

--- a/packages/system/dashboard/images/console/apps/console/src/components/SchemaForm.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/SchemaForm.tsx
@@ -27,7 +27,7 @@ import "./schema-form.css"
 function addAdditionalPropertiesWidgets(schema: RJSFSchema, uiSchema: UiSchema = {}): UiSchema {
   if (!schema || typeof schema !== "object") return uiSchema
 
-  const properties = (schema as any).properties
+  const properties = (schema as SchemaNode).properties
   if (!properties || typeof properties !== "object") return uiSchema
 
   const result = { ...uiSchema }
@@ -43,7 +43,7 @@ function addAdditionalPropertiesWidgets(schema: RJSFSchema, uiSchema: UiSchema =
 }
 
 /**
- * Minimal structural view of a JSON-schema node used by the walk below.
+ * Minimal structural view of a JSON-schema node used by the walks in this file.
  * RJSFSchema is intersected with an `any` index signature, so reading fields
  * straight off it yields `any`; routing through this interface keeps the walk
  * typed without an `as any` cast.
@@ -299,8 +299,15 @@ export const SchemaForm = forwardRef<SchemaFormHandle, SchemaFormProps>(function
     // Override resourceQuotas field with structured quota editor.
     // Scoped to schemas where resourceQuotas has additionalProperties: {type: "string"}
     // (the cozystack-tenants chart shape) to avoid activating on unrelated CRDs.
-    const rqSchema = (schema as any).properties?.resourceQuotas
-    if (rqSchema && rqSchema.additionalProperties?.type === "string") {
+    const rqSchema = (schema as SchemaNode).properties?.resourceQuotas as
+      | SchemaNode
+      | undefined
+    const rqValueSchema = rqSchema?.additionalProperties
+    if (
+      rqValueSchema &&
+      typeof rqValueSchema === "object" &&
+      (rqValueSchema as SchemaNode).type === "string"
+    ) {
       withSensitive.resourceQuotas = {
         ...withSensitive.resourceQuotas,
         "ui:field": "ResourceQuotasField",

--- a/packages/system/dashboard/images/console/apps/console/src/components/SourceField.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/SourceField.tsx
@@ -19,6 +19,15 @@ interface PVC {
   metadata: { name: string; namespace: string }
 }
 
+/** Structural view of the mutually-exclusive `source` sub-schemas we render. */
+interface SourceOptionSchema {
+  type?: string
+  title?: string
+  description?: string
+  required?: string[]
+  properties?: Record<string, SourceOptionSchema>
+}
+
 function useVMDiskOptions(tenantNamespace: string | null | undefined) {
   const { data, isLoading } = useK8sList<VMDisk>({
     apiGroup: APPS_GROUP,
@@ -44,7 +53,7 @@ function useImageOptions() {
 
 export function SourceField(props: FieldProps) {
   const { schema, formData, onChange, name, required, idSchema } = props
-  const properties = (schema as any).properties || {}
+  const properties = (schema.properties || {}) as Record<string, SourceOptionSchema>
   const options = Object.keys(properties)
   const { tenantNamespace } = useTenantContext()
   const { disks, isLoading: disksLoading } = useVMDiskOptions(tenantNamespace)
@@ -77,7 +86,7 @@ export function SourceField(props: FieldProps) {
   }
 
   const renderFieldInput = (option: string) => {
-    const prop = properties[option] as any
+    const prop = properties[option]
     if (!prop || typeof prop !== "object") return null
 
     // If it's an empty object marker (like upload: {}), show confirmation message
@@ -103,7 +112,7 @@ export function SourceField(props: FieldProps) {
     const subProps = prop.properties || {}
     return (
       <div className="ml-6 mt-2 space-y-2">
-        {Object.entries(subProps).map(([key, subProp]: [string, any]) => {
+        {Object.entries(subProps).map(([key, subProp]) => {
           const currentValue = (formData?.[option] as Record<string, string>)?.[key] || ""
           const handleChange = (val: string) => {
             onChange({
@@ -190,7 +199,7 @@ export function SourceField(props: FieldProps) {
 
       <div className="space-y-2">
         {options.map((option: string) => {
-          const prop = properties[option] as any
+          const prop = properties[option]
           const optionDescription =
             typeof prop === "object" && prop ? prop.description : undefined
           const isSelected = selected === option

--- a/packages/system/dashboard/images/console/apps/console/src/components/SourceWidget.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/SourceWidget.tsx
@@ -1,9 +1,18 @@
 import { useState, useEffect } from "react"
 import type { WidgetProps } from "@rjsf/utils"
 
+/** Structural view of the mutually-exclusive `source` sub-schemas we render. */
+interface SourceOptionSchema {
+  type?: string
+  title?: string
+  description?: string
+  required?: string[]
+  properties?: Record<string, SourceOptionSchema>
+}
+
 export function SourceWidget(props: WidgetProps) {
   const { schema, value, onChange, id, label, required } = props
-  const properties = schema.properties || {}
+  const properties = (schema.properties || {}) as Record<string, SourceOptionSchema>
   const options = Object.keys(properties)
 
   const currentOption = value
@@ -26,9 +35,9 @@ export function SourceWidget(props: WidgetProps) {
     // If the property is an empty object marker (like upload: {}), set it to {}
     // Otherwise initialize with default value or empty object
     const defaultValue =
-      prop && typeof prop === "object" && Object.keys((prop as any).properties || {}).length === 0
+      prop && typeof prop === "object" && Object.keys(prop.properties || {}).length === 0
         ? {}
-        : prop && typeof prop === "object" && (prop as any).type === "object"
+        : prop && typeof prop === "object" && prop.type === "object"
           ? {}
           : ""
     onChange({ [option]: defaultValue })
@@ -40,7 +49,7 @@ export function SourceWidget(props: WidgetProps) {
   }
 
   const renderFieldInput = (option: string) => {
-    const prop = properties[option] as any
+    const prop = properties[option]
     if (!prop || typeof prop !== "object") return null
 
     // If it's an empty object marker (like upload: {}), show confirmation message
@@ -66,7 +75,7 @@ export function SourceWidget(props: WidgetProps) {
     const subProps = prop.properties || {}
     return (
       <div className="ml-6 mt-2 space-y-2">
-        {Object.entries(subProps).map(([key, subProp]: [string, any]) => (
+        {Object.entries(subProps).map(([key, subProp]) => (
           <div key={key} className="flex flex-col gap-1">
             <label className="text-sm font-medium text-slate-700">
               {subProp.title || key}
@@ -107,7 +116,7 @@ export function SourceWidget(props: WidgetProps) {
 
       <div className="space-y-2">
         {options.map((option: string) => {
-          const prop = properties[option] as any
+          const prop = properties[option]
           const optionDescription =
             typeof prop === "object" && prop ? prop.description : undefined
           const isSelected = selected === option

--- a/packages/system/dashboard/images/console/apps/console/src/components/command-palette/command-palette-context.ts
+++ b/packages/system/dashboard/images/console/apps/console/src/components/command-palette/command-palette-context.ts
@@ -1,0 +1,21 @@
+import { createContext, useContext } from "react"
+
+export interface CommandPaletteContextValue {
+  open: boolean
+  setOpen: (open: boolean) => void
+  toggle: () => void
+}
+
+// Kept out of command-palette-provider.tsx: a file exporting a component
+// alongside a context or a hook breaks Fast Refresh.
+export const CommandPaletteContext = createContext<CommandPaletteContextValue | undefined>(
+  undefined
+)
+
+export function useCommandPalette() {
+  const context = useContext(CommandPaletteContext)
+  if (!context) {
+    throw new Error("useCommandPalette must be used within CommandPaletteProvider")
+  }
+  return context
+}

--- a/packages/system/dashboard/images/console/apps/console/src/components/command-palette/command-palette-provider.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/command-palette/command-palette-provider.tsx
@@ -1,15 +1,6 @@
-import { createContext, useContext, useState, useCallback, useMemo } from "react"
+import { useState, useCallback, useMemo } from "react"
 import { useHotkey } from "./use-hotkey"
-
-interface CommandPaletteContextValue {
-  open: boolean
-  setOpen: (open: boolean) => void
-  toggle: () => void
-}
-
-const CommandPaletteContext = createContext<CommandPaletteContextValue | undefined>(
-  undefined
-)
+import { CommandPaletteContext } from "./command-palette-context.ts"
 
 export function CommandPaletteProvider({ children }: { children: React.ReactNode }) {
   const [open, setOpen] = useState(false)
@@ -30,12 +21,4 @@ export function CommandPaletteProvider({ children }: { children: React.ReactNode
       {children}
     </CommandPaletteContext.Provider>
   )
-}
-
-export function useCommandPalette() {
-  const context = useContext(CommandPaletteContext)
-  if (!context) {
-    throw new Error("useCommandPalette must be used within CommandPaletteProvider")
-  }
-  return context
 }

--- a/packages/system/dashboard/images/console/apps/console/src/components/command-palette/command-palette.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/command-palette/command-palette.tsx
@@ -11,7 +11,7 @@ import { cn } from "@cozystack/ui"
 import { useIsMac } from "../../hooks/use-is-mac"
 import { useKeyboardNav } from "./use-keyboard-nav"
 import { useCommandItems } from "./use-command-items"
-import { useCommandPalette } from "./command-palette-provider"
+import { useCommandPalette } from "./command-palette-context.ts"
 import type { NavigationLevel } from "./types"
 
 export function CommandPalette() {

--- a/packages/system/dashboard/images/console/apps/console/src/components/command-palette/types.ts
+++ b/packages/system/dashboard/images/console/apps/console/src/components/command-palette/types.ts
@@ -1,3 +1,5 @@
+import type { ApplicationInstance } from "@cozystack/types"
+
 export interface CommandItem {
   id: string
   label: string
@@ -20,7 +22,7 @@ export type NavigationLevel =
   | {
       type: "instance"
       plural: string
-      instance: any
+      instance: ApplicationInstance
       label: string
       resourceLabel: string
       icon?: string

--- a/packages/system/dashboard/images/console/apps/console/src/components/command-palette/use-command-items.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/command-palette/use-command-items.tsx
@@ -4,6 +4,7 @@ import { useQueries } from "@tanstack/react-query"
 import { useApplicationDefinitions, iconDataUrl, appDisplayName } from "../../lib/app-definitions"
 import { useK8sList, useK8sClient } from "@cozystack/k8s-client"
 import { APPS_GROUP, APPS_VERSION } from "@cozystack/types"
+import type { ApplicationInstance } from "@cozystack/types"
 import { useTenantContext } from "../../lib/tenant-context"
 import type { CommandItem, NavigationLevel } from "./types"
 
@@ -40,7 +41,7 @@ export function useCommandItems(
 
   // For resource-level drill-down: fetch instances of one type
   const resourcePlural = level.type === "resource" ? level.plural : ""
-  const { data: singleResourceData, isLoading: singleLoading } = useK8sList(
+  const { data: singleResourceData, isLoading: singleLoading } = useK8sList<ApplicationInstance>(
     {
       apiGroup: APPS_GROUP,
       apiVersion: APPS_VERSION,
@@ -66,7 +67,12 @@ export function useCommandItems(
           "",
         ] as const,
         queryFn: () =>
-          client.list(APPS_GROUP, APPS_VERSION, plural, tenantNamespace ?? undefined),
+          client.list<ApplicationInstance>(
+            APPS_GROUP,
+            APPS_VERSION,
+            plural,
+            tenantNamespace ?? undefined,
+          ),
         enabled: hasQuery && !!plural && !!tenantNamespace,
       }
     }),
@@ -254,8 +260,7 @@ export function useCommandItems(
       const queryResult = allInstancesQueries[i]
       const instances = queryResult?.data?.items ?? []
 
-      for (const inst of instances) {
-        const instance = inst as any
+      for (const instance of instances) {
         items.push({
           id: `search-inst-${plural}-${instance.metadata.name}`,
           label: instance.metadata.name,

--- a/packages/system/dashboard/images/console/apps/console/src/components/command-palette/use-command-items.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/command-palette/use-command-items.tsx
@@ -37,7 +37,10 @@ export function useCommandItems(
   const { tenantNamespace } = useTenantContext()
   const { data: adList } = useApplicationDefinitions()
 
-  const ads = adList?.items || []
+  // Memoised on the query result: `adList?.items || []` allocates a fresh
+  // array while the query is pending, which would re-run every item memo below
+  // on every render.
+  const ads = useMemo(() => adList?.items || [], [adList])
 
   // For resource-level drill-down: fetch instances of one type
   const resourcePlural = level.type === "resource" ? level.plural : ""

--- a/packages/system/dashboard/images/console/apps/console/src/components/rjsf-templates.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/rjsf-templates.tsx
@@ -14,9 +14,9 @@ import { AdditionalPropertiesWidget } from "./AdditionalPropertiesWidget.tsx"
 import { SensitiveStringWidget } from "./SensitiveStringWidget.tsx"
 
 function IconButton<
-  T = any,
+  T = unknown,
   S extends StrictRJSFSchema = RJSFSchema,
-  F extends FormContextType = any,
+  F extends FormContextType = FormContextType,
 >(props: IconButtonProps<T, S, F>) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { icon, className, uiSchema, registry, iconType, ...btnProps } = props
@@ -38,12 +38,12 @@ const removeButtonClassName =
   "rounded-md border border-red-200 bg-white px-3 py-1.5 text-sm font-medium text-red-600 shadow-sm hover:bg-red-50 hover:border-red-300 transition-colors"
 
 function ArrayFieldItemTemplate<
-  T = any,
+  T = unknown,
   S extends StrictRJSFSchema = RJSFSchema,
-  F extends FormContextType = any,
+  F extends FormContextType = FormContextType,
 >(props: ArrayFieldTemplateItemType<T, S, F>) {
   const { children, hasRemove, index, onDropIndexClick, disabled, readonly, schema } = props
-  const isNumeric = (schema as any).type === 'integer' || (schema as any).type === 'number'
+  const isNumeric = schema.type === 'integer' || schema.type === 'number'
   return (
     <div className="array-item-row group flex items-center gap-1.5 mb-1">
       <div className={isNumeric ? 'w-36 shrink-0' : 'flex-1'}>{children}</div>

--- a/packages/system/dashboard/images/console/apps/console/src/components/rjsf-templates.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/rjsf-templates.tsx
@@ -1,66 +1,21 @@
 import type {
   IconButtonProps,
-  ArrayFieldTemplateItemType,
   TemplatesType,
-  FormContextType,
-  RJSFSchema,
-  StrictRJSFSchema,
   SubmitButtonProps,
 } from "@rjsf/utils"
 import { CustomObjectFieldTemplate } from "./CustomObjectFieldTemplate.tsx"
+import { ArrayFieldItemTemplate } from "./ArrayFieldItemTemplate.tsx"
+import { IconButton } from "./IconButton.tsx"
 import { SourceWidget } from "./SourceWidget.tsx"
 import { DynamicOptionsWidget } from "./DynamicOptionsWidget.tsx"
 import { AdditionalPropertiesWidget } from "./AdditionalPropertiesWidget.tsx"
 import { SensitiveStringWidget } from "./SensitiveStringWidget.tsx"
-
-function IconButton<
-  T = unknown,
-  S extends StrictRJSFSchema = RJSFSchema,
-  F extends FormContextType = FormContextType,
->(props: IconButtonProps<T, S, F>) {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { icon, className, uiSchema, registry, iconType, ...btnProps } = props
-  return (
-    <button
-      type="button"
-      className={className}
-      {...btnProps}
-    >
-      {icon}
-    </button>
-  )
-}
 
 const buttonClassName =
   "rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm font-medium text-slate-600 shadow-sm hover:bg-slate-50 hover:border-slate-300 transition-colors"
 
 const removeButtonClassName =
   "rounded-md border border-red-200 bg-white px-3 py-1.5 text-sm font-medium text-red-600 shadow-sm hover:bg-red-50 hover:border-red-300 transition-colors"
-
-function ArrayFieldItemTemplate<
-  T = unknown,
-  S extends StrictRJSFSchema = RJSFSchema,
-  F extends FormContextType = FormContextType,
->(props: ArrayFieldTemplateItemType<T, S, F>) {
-  const { children, hasRemove, index, onDropIndexClick, disabled, readonly, schema } = props
-  const isNumeric = schema.type === 'integer' || schema.type === 'number'
-  return (
-    <div className="array-item-row group flex items-center gap-1.5 mb-1">
-      <div className={isNumeric ? 'w-36 shrink-0' : 'flex-1'}>{children}</div>
-      {hasRemove && (
-        <button
-          type="button"
-          aria-label="Remove"
-          className="opacity-0 group-hover:opacity-100 size-[26px] flex-shrink-0 flex items-center justify-center rounded-full border border-red-200 bg-white text-red-400 text-sm leading-none hover:bg-red-50 hover:text-red-600 hover:border-red-300 disabled:opacity-30 transition-all duration-150"
-          onClick={onDropIndexClick(index)}
-          disabled={disabled || readonly}
-        >
-          ×
-        </button>
-      )}
-    </div>
-  )
-}
 
 export const customTemplates = {
   ObjectFieldTemplate: CustomObjectFieldTemplate,

--- a/packages/system/dashboard/images/console/apps/console/src/hooks/use-is-mac.ts
+++ b/packages/system/dashboard/images/console/apps/console/src/hooks/use-is-mac.ts
@@ -1,11 +1,12 @@
-import { useState, useEffect } from "react"
+import { useState } from "react"
 
+/**
+ * Whether the browser runs on a Mac, so callers can render the right modifier
+ * key. Read once on first render — the platform cannot change while the SPA
+ * is open, and this app never renders on a server.
+ */
 export function useIsMac(): boolean {
-  const [isMac, setIsMac] = useState(false)
-
-  useEffect(() => {
-    setIsMac(navigator.platform.toUpperCase().indexOf("MAC") >= 0)
-  }, [])
+  const [isMac] = useState(() => navigator.platform.toUpperCase().indexOf("MAC") >= 0)
 
   return isMac
 }

--- a/packages/system/dashboard/images/console/apps/console/src/lib/tenant-context.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/lib/tenant-context.tsx
@@ -1,16 +1,8 @@
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from "react"
-import { useK8sList } from "@cozystack/k8s-client"
+import { createContext, useContext } from "react"
 import type { TenantNamespace } from "@cozystack/types"
-import { SELECTED_TENANT_KEY, TENANT_NAMESPACE_PREFIX } from "./constants.ts"
+import { TENANT_NAMESPACE_PREFIX } from "./constants.ts"
 
-interface TenantContextValue {
+export interface TenantContextValue {
   /**
    * Flat list of every TenantNamespace in the cluster, ordered by display
    * name (the namespace prefix stripped). Callers typically only need
@@ -27,70 +19,9 @@ interface TenantContextValue {
   error: unknown
 }
 
-const TenantContext = createContext<TenantContextValue | null>(null)
-
-function displayName(ns: TenantNamespace): string {
-  const name = ns.metadata.name
-  return name.startsWith(TENANT_NAMESPACE_PREFIX)
-    ? name.slice(TENANT_NAMESPACE_PREFIX.length)
-    : name
-}
-
-export function TenantProvider({ children }: { children: ReactNode }) {
-  const [selectedTenant, setSelectedTenant] = useState<string | null>(() => {
-    if (typeof window === "undefined") return null
-    return window.localStorage.getItem(SELECTED_TENANT_KEY)
-  })
-
-  const ns = selectedTenant ? `${TENANT_NAMESPACE_PREFIX}${selectedTenant}` : null
-
-  // TenantNamespace is cluster-scoped, filter by parent tenant label
-  // to show only child tenants of the selected tenant
-  const labelSelector = ns ? `tenant.cozystack.io/${ns}` : undefined
-
-  const list = useK8sList<TenantNamespace>(
-    {
-      apiGroup: "core.cozystack.io",
-      apiVersion: "v1alpha1",
-      plural: "tenantnamespaces",
-    },
-    { labelSelector }
-  )
-
-  const tenants = useMemo<TenantNamespace[]>(() => {
-    return (list.data?.items ?? [])
-      .slice()
-      .sort((a, b) => displayName(a).localeCompare(displayName(b)))
-  }, [list.data])
-
-  useEffect(() => {
-    if (!tenants.length) return
-    if (selectedTenant && tenants.some((t) => displayName(t) === selectedTenant)) return
-    const fallback =
-      tenants.find((t) => displayName(t) === "root") ?? tenants[0]
-    setSelectedTenant(displayName(fallback))
-  }, [tenants, selectedTenant])
-
-  const selectTenant = (name: string) => {
-    setSelectedTenant(name)
-    try {
-      window.localStorage.setItem(SELECTED_TENANT_KEY, name)
-    } catch {
-      // ignore storage quota / private-mode failures
-    }
-  }
-
-  const value: TenantContextValue = {
-    tenants,
-    selectedTenant,
-    selectTenant,
-    tenantNamespace: list.isLoading ? null : ns,
-    isLoading: list.isLoading,
-    error: list.error,
-  }
-
-  return <TenantContext.Provider value={value}>{children}</TenantContext.Provider>
-}
+// TenantProvider lives in tenant-provider.tsx: a file exporting a component
+// alongside a context or a hook breaks Fast Refresh.
+export const TenantContext = createContext<TenantContextValue | null>(null)
 
 export function useTenantContext(): TenantContextValue {
   const ctx = useContext(TenantContext)
@@ -102,5 +33,8 @@ export function useTenantContext(): TenantContextValue {
  * Pull the display name of a TenantNamespace (no `tenant-` prefix).
  */
 export function tenantDisplayName(ns: TenantNamespace): string {
-  return displayName(ns)
+  const name = ns.metadata.name
+  return name.startsWith(TENANT_NAMESPACE_PREFIX)
+    ? name.slice(TENANT_NAMESPACE_PREFIX.length)
+    : name
 }

--- a/packages/system/dashboard/images/console/apps/console/src/lib/tenant-provider.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/lib/tenant-provider.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useMemo, useState, type ReactNode } from "react"
+import { useK8sList } from "@cozystack/k8s-client"
+import type { TenantNamespace } from "@cozystack/types"
+import { SELECTED_TENANT_KEY, TENANT_NAMESPACE_PREFIX } from "./constants.ts"
+import {
+  TenantContext,
+  tenantDisplayName,
+  type TenantContextValue,
+} from "./tenant-context.tsx"
+
+export function TenantProvider({ children }: { children: ReactNode }) {
+  const [selectedTenant, setSelectedTenant] = useState<string | null>(() => {
+    if (typeof window === "undefined") return null
+    return window.localStorage.getItem(SELECTED_TENANT_KEY)
+  })
+
+  const ns = selectedTenant ? `${TENANT_NAMESPACE_PREFIX}${selectedTenant}` : null
+
+  // TenantNamespace is cluster-scoped, filter by parent tenant label
+  // to show only child tenants of the selected tenant
+  const labelSelector = ns ? `tenant.cozystack.io/${ns}` : undefined
+
+  const list = useK8sList<TenantNamespace>(
+    {
+      apiGroup: "core.cozystack.io",
+      apiVersion: "v1alpha1",
+      plural: "tenantnamespaces",
+    },
+    { labelSelector }
+  )
+
+  const tenants = useMemo<TenantNamespace[]>(() => {
+    return (list.data?.items ?? [])
+      .slice()
+      .sort((a, b) => tenantDisplayName(a).localeCompare(tenantDisplayName(b)))
+  }, [list.data])
+
+  useEffect(() => {
+    if (!tenants.length) return
+    if (selectedTenant && tenants.some((t) => tenantDisplayName(t) === selectedTenant)) return
+    const fallback =
+      tenants.find((t) => tenantDisplayName(t) === "root") ?? tenants[0]
+    setSelectedTenant(tenantDisplayName(fallback))
+  }, [tenants, selectedTenant])
+
+  const selectTenant = (name: string) => {
+    setSelectedTenant(name)
+    try {
+      window.localStorage.setItem(SELECTED_TENANT_KEY, name)
+    } catch {
+      // ignore storage quota / private-mode failures
+    }
+  }
+
+  const value: TenantContextValue = {
+    tenants,
+    selectedTenant,
+    selectTenant,
+    tenantNamespace: list.isLoading ? null : ns,
+    isLoading: list.isLoading,
+    error: list.error,
+  }
+
+  return <TenantContext.Provider value={value}>{children}</TenantContext.Provider>
+}

--- a/packages/system/dashboard/images/console/apps/console/src/routes/BackupCreatePage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/BackupCreatePage.tsx
@@ -8,12 +8,20 @@ import { useApplicationDefinitions } from "../lib/app-definitions.ts"
 import { useCRDSchema } from "../lib/use-crd-schema.ts"
 import { SchemaForm, type SchemaFormHandle } from "../components/SchemaForm.tsx"
 import { enrichSchemaWithEnums } from "../lib/backup-utils.ts"
+import type { ApplicationInstance } from "@cozystack/types"
+
+/** The subset of the CRD-driven form data this page reads back. */
+interface BackupFormData {
+  applicationRef?: { apiGroup?: string; kind?: string; name?: string }
+  strategyRef?: { apiGroup?: string; kind?: string; name?: string }
+  takenAt?: string
+}
 
 export function BackupCreatePage() {
   const navigate = useNavigate()
   const { tenantNamespace } = useTenantContext()
   const { data: appDefs } = useApplicationDefinitions()
-  const [formData, setFormData] = useState<any>({})
+  const [formData, setFormData] = useState<BackupFormData>({})
   const [name, setName] = useState("")
   const schemaFormRef = useRef<SchemaFormHandle>(null)
 
@@ -29,7 +37,7 @@ export function BackupCreatePage() {
     [appDefs, selectedKind]
   )
 
-  const { data: instancesData } = useK8sList<any>({
+  const { data: instancesData } = useK8sList<ApplicationInstance>({
     apiGroup: "apps.cozystack.io",
     apiVersion: "v1alpha1",
     plural: selectedAppDef?.spec?.application.plural ?? "",
@@ -47,7 +55,7 @@ export function BackupCreatePage() {
     if (!baseSchema) return null
 
     const base = JSON.parse(baseSchema)
-    const instances = instancesData?.items.map((inst: any) => inst.metadata.name) ?? []
+    const instances = instancesData?.items.map((inst) => inst.metadata.name) ?? []
 
     const enumMap: Record<string, string[]> = {}
 
@@ -173,7 +181,7 @@ export function BackupCreatePage() {
                 ref={schemaFormRef}
                 openAPISchema={schema}
                 formData={formData}
-                onChange={setFormData}
+                onChange={(data) => setFormData(data as BackupFormData)}
               >
                 <div className="hidden" />
               </SchemaForm>

--- a/packages/system/dashboard/images/console/apps/console/src/routes/BackupJobCreatePage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/BackupJobCreatePage.tsx
@@ -8,12 +8,20 @@ import { useApplicationDefinitions } from "../lib/app-definitions.ts"
 import { useCRDSchema } from "../lib/use-crd-schema.ts"
 import { SchemaForm, type SchemaFormHandle } from "../components/SchemaForm.tsx"
 import { enrichSchemaWithEnums } from "../lib/backup-utils.ts"
+import type { ApplicationInstance } from "@cozystack/types"
+
+/** The subset of the CRD-driven form data this page reads back. */
+interface BackupJobFormData {
+  applicationRef?: { apiGroup?: string; kind?: string; name?: string }
+  planRef?: { name?: string }
+  backupClassName?: string
+}
 
 export function BackupJobCreatePage() {
   const navigate = useNavigate()
   const { tenantNamespace } = useTenantContext()
   const { data: appDefs } = useApplicationDefinitions()
-  const [formData, setFormData] = useState<any>({})
+  const [formData, setFormData] = useState<BackupJobFormData>({})
   const [name, setName] = useState("")
   const schemaFormRef = useRef<SchemaFormHandle>(null)
 
@@ -42,7 +50,7 @@ export function BackupJobCreatePage() {
     [appDefs, selectedKind]
   )
 
-  const { data: instancesData } = useK8sList<any>({
+  const { data: instancesData } = useK8sList<ApplicationInstance>({
     apiGroup: "apps.cozystack.io",
     apiVersion: "v1alpha1",
     plural: selectedAppDef?.spec?.application.plural ?? "",
@@ -66,7 +74,7 @@ export function BackupJobCreatePage() {
       console.error("Failed to parse BackupJob schema:", e)
       return null
     }
-    const instances = instancesData?.items.map((inst: any) => inst.metadata.name) ?? []
+    const instances = instancesData?.items.map((inst) => inst.metadata.name) ?? []
 
     const enumMap: Record<string, string[]> = {}
     // applicationRef.name depends on the selected kind, so it cannot be served
@@ -195,7 +203,7 @@ export function BackupJobCreatePage() {
                 ref={schemaFormRef}
                 openAPISchema={schema}
                 formData={formData}
-                onChange={setFormData}
+                onChange={(data) => setFormData(data as BackupJobFormData)}
               >
                 <div className="hidden" />
               </SchemaForm>

--- a/packages/system/dashboard/images/console/apps/console/src/routes/BackupPlanCreatePage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/BackupPlanCreatePage.tsx
@@ -8,12 +8,19 @@ import { useApplicationDefinitions } from "../lib/app-definitions.ts"
 import { useCRDSchema } from "../lib/use-crd-schema.ts"
 import { SchemaForm, type SchemaFormHandle } from "../components/SchemaForm.tsx"
 import { enrichSchemaWithEnums } from "../lib/backup-utils.ts"
+import type { ApplicationInstance } from "@cozystack/types"
+
+/** The subset of the CRD-driven form data this page reads back. */
+interface BackupPlanFormData {
+  applicationRef?: { apiGroup?: string; kind?: string; name?: string }
+  backupClassName?: string
+}
 
 export function BackupPlanCreatePage() {
   const navigate = useNavigate()
   const { tenantNamespace } = useTenantContext()
   const { data: appDefs } = useApplicationDefinitions()
-  const [formData, setFormData] = useState<any>({})
+  const [formData, setFormData] = useState<BackupPlanFormData>({})
   const [name, setName] = useState("")
   const schemaFormRef = useRef<SchemaFormHandle>(null)
 
@@ -39,7 +46,7 @@ export function BackupPlanCreatePage() {
     [appDefs, selectedKind]
   )
 
-  const { data: instancesData } = useK8sList<any>({
+  const { data: instancesData } = useK8sList<ApplicationInstance>({
     apiGroup: "apps.cozystack.io",
     apiVersion: "v1alpha1",
     plural: selectedAppDef?.spec?.application.plural ?? "",
@@ -63,7 +70,7 @@ export function BackupPlanCreatePage() {
       console.error("Failed to parse Plan schema:", e)
       return null
     }
-    const instances = instancesData?.items.map((inst: any) => inst.metadata.name) ?? []
+    const instances = instancesData?.items.map((inst) => inst.metadata.name) ?? []
 
     const enumMap: Record<string, string[]> = {}
 
@@ -190,7 +197,7 @@ export function BackupPlanCreatePage() {
                 ref={schemaFormRef}
                 openAPISchema={schema}
                 formData={formData}
-                onChange={setFormData}
+                onChange={(data) => setFormData(data as BackupPlanFormData)}
               >
                 <div className="hidden" />
               </SchemaForm>

--- a/packages/system/dashboard/images/console/apps/console/src/routes/BackupResourceEditPage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/BackupResourceEditPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react"
 import { useNavigate, useParams } from "react-router"
 import { Archive, Save } from "lucide-react"
 import { Button, Section, Spinner } from "@cozystack/ui"
-import { useK8sGet, useK8sUpdate } from "@cozystack/k8s-client"
+import { useK8sGet, useK8sUpdate, type K8sResource } from "@cozystack/k8s-client"
 import { useTenantContext } from "../lib/tenant-context.tsx"
 import { useCRDSchema } from "../lib/use-crd-schema.ts"
 import { prepareUpdateSpec } from "../lib/prepare-update.ts"
@@ -22,7 +22,7 @@ export function BackupResourceEditPage({
   const { name } = useParams<{ name: string }>()
   const navigate = useNavigate()
   const { tenantNamespace } = useTenantContext()
-  const [formData, setFormData] = useState<any>({})
+  const [formData, setFormData] = useState<unknown>({})
   const initializedRef = useRef(false)
   // Snapshot of resource.spec at the moment the form initialised. Used as
   // the source for the immutable-field overlay so the value the user saw
@@ -45,7 +45,7 @@ export function BackupResourceEditPage({
   const schema = overrideSchema || crdSchema
 
   // Fetch existing resource
-  const { data: resource, isLoading: resourceLoading, error } = useK8sGet<any>(
+  const { data: resource, isLoading: resourceLoading, error } = useK8sGet<K8sResource>(
     {
       apiGroup: "backups.cozystack.io",
       apiVersion: "v1alpha1",

--- a/packages/system/dashboard/images/console/apps/console/src/routes/BackupRestoreJobCreatePage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/BackupRestoreJobCreatePage.tsx
@@ -8,12 +8,19 @@ import { useApplicationDefinitions } from "../lib/app-definitions.ts"
 import { useCRDSchema } from "../lib/use-crd-schema.ts"
 import { SchemaForm, type SchemaFormHandle } from "../components/SchemaForm.tsx"
 import { enrichSchemaWithEnums } from "../lib/backup-utils.ts"
+import type { ApplicationInstance } from "@cozystack/types"
+
+/** The subset of the CRD-driven form data this page reads back. */
+interface RestoreJobFormData {
+  targetApplicationRef?: { apiGroup?: string; kind?: string; name?: string }
+  backupRef?: { name?: string }
+}
 
 export function BackupRestoreJobCreatePage() {
   const navigate = useNavigate()
   const { tenantNamespace } = useTenantContext()
   const { data: appDefs } = useApplicationDefinitions()
-  const [formData, setFormData] = useState<any>({})
+  const [formData, setFormData] = useState<RestoreJobFormData>({})
   const [name, setName] = useState("")
   const schemaFormRef = useRef<SchemaFormHandle>(null)
 
@@ -39,7 +46,7 @@ export function BackupRestoreJobCreatePage() {
     [appDefs, selectedKind]
   )
 
-  const { data: instancesData } = useK8sList<any>({
+  const { data: instancesData } = useK8sList<ApplicationInstance>({
     apiGroup: "apps.cozystack.io",
     apiVersion: "v1alpha1",
     plural: selectedAppDef?.spec?.application.plural ?? "",
@@ -63,7 +70,7 @@ export function BackupRestoreJobCreatePage() {
       console.error("Failed to parse RestoreJob schema:", e)
       return null
     }
-    const instances = instancesData?.items.map((inst: any) => inst.metadata.name) ?? []
+    const instances = instancesData?.items.map((inst) => inst.metadata.name) ?? []
 
     const enumMap: Record<string, string[]> = {}
 
@@ -219,7 +226,7 @@ export function BackupRestoreJobCreatePage() {
                 ref={schemaFormRef}
                 openAPISchema={schema}
                 formData={formData}
-                onChange={setFormData}
+                onChange={(data) => setFormData(data as RestoreJobFormData)}
               >
                 <div className="hidden" />
               </SchemaForm>

--- a/packages/system/dashboard/images/console/apps/console/src/routes/ClusterUsageResourcePage.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/ClusterUsageResourcePage.test.tsx
@@ -6,7 +6,7 @@ import { ClusterUsageResourcePage } from "./ClusterUsageResourcePage.tsx"
 import { aggregateNodeResources } from "../lib/cluster-usage/aggregate.ts"
 import { humanizeCpu } from "../lib/k8s-quantity.ts"
 import type { Node, Pod } from "../lib/cluster-usage/types.ts"
-import { TenantProvider } from "../lib/tenant-context.tsx"
+import { TenantProvider } from "../lib/tenant-provider.tsx"
 import { renderWithK8sProvider } from "../test-utils/render.tsx"
 
 interface PodOpts {

--- a/packages/system/dashboard/images/console/apps/console/src/routes/ConsolePage.routing.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/ConsolePage.routing.test.tsx
@@ -6,7 +6,7 @@ import {
   type APIGroupList,
 } from "@cozystack/k8s-client"
 import { ConsolePage } from "./ConsolePage.tsx"
-import { TenantProvider } from "../lib/tenant-context.tsx"
+import { TenantProvider } from "../lib/tenant-provider.tsx"
 import { renderWithK8sProvider } from "../test-utils/render.tsx"
 
 function makeClient(): K8sClient {

--- a/packages/system/dashboard/images/console/apps/console/src/routes/StorageClassUsagePage.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/StorageClassUsagePage.test.tsx
@@ -3,7 +3,7 @@ import { screen, within } from "@testing-library/react"
 import { Route, Routes } from "react-router"
 import { K8sClient, type K8sList } from "@cozystack/k8s-client"
 import { StorageClassUsagePage } from "./StorageClassUsagePage.tsx"
-import { TenantProvider } from "../lib/tenant-context.tsx"
+import { TenantProvider } from "../lib/tenant-provider.tsx"
 import { renderWithK8sProvider } from "../test-utils/render.tsx"
 
 let seq = 0

--- a/packages/system/dashboard/images/console/apps/console/src/routes/detail/OverviewTab.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/detail/OverviewTab.tsx
@@ -11,7 +11,7 @@ interface OverviewTabProps {
   instance: ApplicationInstance
 }
 
-export function OverviewTab({ ad: _ad, instance }: OverviewTabProps) {
+export function OverviewTab({ instance }: OverviewTabProps) {
   const ready = readyCondition(instance)
   return (
     <div className="grid gap-4 p-6 md:grid-cols-3">

--- a/packages/system/dashboard/images/console/apps/console/src/routes/detail/SecretsTab.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/detail/SecretsTab.tsx
@@ -6,7 +6,7 @@ import {
   type K8sResource,
 } from "@cozystack/k8s-client"
 import { Section, Spinner } from "@cozystack/ui"
-import type { ApplicationDefinition, ApplicationInstance } from "@cozystack/types"
+import type { ApplicationDefinition, ApplicationInstance, Tenant } from "@cozystack/types"
 import { appInstanceLabel } from "../../lib/labels.ts"
 import { formatAge } from "../../lib/status.ts"
 import { TENANT_NAMESPACE_PREFIX } from "../../lib/constants.ts"
@@ -185,7 +185,7 @@ export function SecretsTab({
 }) {
   const appKind = ad.spec?.application.kind
   const ns = appKind === "Tenant"
-    ? (instance.status as any)?.namespace ?? instance.metadata.namespace ?? ""
+    ? (instance as Tenant).status?.namespace ?? instance.metadata.namespace ?? ""
     : instance.metadata.namespace ?? ""
 
   // Use TenantSecrets API for all applications in tenant namespaces


### PR DESCRIPTION
`pnpm lint` has been red on `main`, 54 problems across about twenty files. This clears 48 of them and leaves 6, all of which are behavioural and listed below with the reason.

None of this is a regression from anything recent. The backlog is what it was; this PR is the sweep.

One commit per rule class, ordered from safest to least safe, so a group can be dropped without losing the rest.

`no-explicit-any`, 39 of 39. Real types rather than looser ones: `ApplicationInstance` for the instance lists in the Backup pages and the command palette, `K8sResource` for the backup edit fetch, `Tenant` for the tenant status in `SecretsTab`, and file-local structural interfaces for JSON-schema nodes in the RJSF templates, `SourceField` and `SourceWidget`, following the pattern `lib/sensitive-fields.ts` already uses. RJSF generic defaults go from `any` to `unknown` or `FormContextType`. The two load-bearing casts in `SchemaForm.tsx` now route through the existing `SchemaNode` interface, with the `resourceQuotas` check narrowed so a boolean `additionalProperties` still falls through exactly as before. No `eslint-disable` was added anywhere; the one that moves in the diff is an existing one travelling with its code.

`no-unused-vars`, 1 of 1. Dropped an unused binding in `OverviewTab`, prop kept on the interface, callers untouched.

`react-refresh/only-export-components`, 5 of 5, pure moves. `IconButton` and `ArrayFieldItemTemplate` split out of `rjsf-templates.tsx`; `command-palette-context.ts` now owns the context and its hook; `TenantProvider` moves to `lib/tenant-provider.tsx` so `tenant-context.tsx` keeps its path for its roughly twenty five importers. Four import sites changed in total.

`exhaustive-deps`, 2 of 3. `ads` gets its own `useMemo` in `use-command-items.tsx`, which is the fix the rule prescribes. Same items, fewer recomputations.

`set-state-in-effect`, 1 of 6. `useIsMac` reads `navigator.platform` in a lazy `useState` initialiser. The effect had nothing to synchronise, the value is constant and this SPA does not server-render, so the only visible difference is that a Mac stops painting "Ctrl+K" for one frame before correcting itself.

### The 6 left, and why

Every one of these is a real behavioural decision rather than a lint fix, which is why they are not in a lint sweep.

`ResourceQuotasField.tsx:77` buffers local number and unit state and resyncs from the prop only when its own ref says the change came from outside. A render-phase rewrite fights that hand-tuned protocol, and it already carries a deps disable.

`SourceWidget.tsx:29` and `:30` share one effect. `options` cannot go into the deps because it is `Object.keys(...)` on a fresh object every render, so the effect would run on every commit. The real fix is deriving `selected` instead of storing it, which changes when the radio resets.

`command-palette.tsx:28` clears the query and level when the dialog closes. `open` can flip from the hotkey as well as from `close()`, so a handler-side reset misses paths, and the render-phase form clears the popup during its exit rather than after it.

`use-keyboard-nav.ts:11` resets the highlight when the item list changes. The render-phase form removes the intermediate commit that still shows a stale index, which also changes when the `scrollIntoView` effect fires.

`tenant-provider.tsx:43` picks the fallback tenant once the list loads, and it sets `tenantNamespace`, which gates every query in the app. Changing when children first see a non-null namespace is not something to decide inside a lint sweep.

Checks after every commit: `pnpm typecheck` green across all four projects, `pnpm test` 48 files and 320 tests passing. Final `pnpm lint` is 6 problems, 5 errors and 1 warning.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved tenant selection with remembered preferences, clearer display names, automatic fallback selection, and loading/error handling.
  - Enhanced array-based forms with clearer item layout and accessible removal controls.
  - Improved command palette reliability when searching and navigating application instances.

- **Bug Fixes**
  - Improved platform detection for Mac-specific shortcuts.
  - Strengthened form handling for backup, restore, and resource workflows to prevent invalid data issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->