### PR TITLE
test(e2e): give tenant workers two vCPUs

### DIFF
--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -2651,7 +2651,7 @@ ${ouroboros_addon}
     md0:
       diskSize: 20Gi
       gpus: []
-      instanceType: u1.medium
+      instanceType: u1.large
       # The failure this suite keeps hitting is a worker that stalls in the
       # guest before Talos apid answers, which leaves nothing to read on the
       # management side and nothing for talosctl to connect to. Turning this on


### PR DESCRIPTION
## What this PR does

One line in the kubernetes e2e suite values: tenant workers move from `u1.medium` to `u1.large`, one vCPU to two.

The reason is measured, in two independent ways on cozystack/cozystack#3513. A single-scrape reading on a quiet branch run and the two-scrape instrument from #3836 on a loaded run with six parallel e2e workflows agree: the worker's compute container sits at 93 to 98 percent of its one-core ceiling for the whole node-Ready budget, the sandbox nodes under it show ~0.05 percent steal, and raising the CPU request changes nothing because the workers never lose a scheduling fight. The binding constraint is capacity: one vCPU has to boot Talos and unpack the kubelet image, and its quota also covers the QEMU emulator and IO threads.

This is an experiment as much as a fix: the suites run the same assertions, and the next waves of runs under parallel load measure whether the join flake documented in cozystack/cozystack#3513 disappears with the ceiling doubled. The diagnostics landed in #3804 and #3836 stay aboard, so the same instrument reports the new profile.

Memory math on the sandbox: two suites with two workers each move from 4Gi to 8Gi guests, and the virt-launcher pods spread across three 24Gi nodes, so the placement still fits.

### Screenshots

Not applicable, no UI change.

### Downstream repositories

The diff is one value inside `hack/e2e-chainsaw/_lib/run-kubernetes.sh`. Nothing under `hack/` is moved or renamed, no make target changes behaviour, no package, schema, default or CRD changes. Nothing in the trigger map is touched.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
test(e2e): tenant workers in the kubernetes e2e suites run with two vCPUs, since measurements showed the single-vCPU worker saturating its CPU ceiling for the entire node-join budget
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the tenant worker node configuration to use a larger instance type, improving available capacity for end-to-end Kubernetes testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->