### PR TITLE
chore(ci): namespace the backport labels without breaking the trigger

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
   - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
 - If it's a work in progress, consider creating this PR as a draft.
 - Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
-- Add the label `backport` if it's a bugfix that needs to be backported to a previous version.
+- Add the label `kind/backport` if it's a bugfix that needs to be backported to a previous version.
 -->
 
 ## What this PR does

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -78,6 +78,18 @@
   color: 'e11d21'
   description: Indicates the change introduces a breaking API or behaviour change
 
+# kind/backport-previous has no upstream Kubernetes equivalent (k8s has no
+# two-release-line model); it stays under kind/ per the file convention.
+- name: kind/backport
+  color: 'fbca04'
+  description: Categorizes issue or PR as requiring a backport to the current release line
+  aliases: ['backport']
+
+- name: kind/backport-previous
+  color: 'fbd876'
+  description: Categorizes issue or PR as requiring a backport to the previous release line
+  aliases: ['backport-previous']
+
 # ──────────────────────────────────────────────
 # priority/ — urgency
 # ──────────────────────────────────────────────
@@ -277,14 +289,6 @@
 - name: upstream-issue
   color: 'aaaaaa'
   description: Requires resolving an issue in an upstream project
-
-- name: backport
-  color: 'fbca04'
-  description: Should change be backported on previous release
-
-- name: backport-previous
-  color: 'fbd876'
-  description: Backport target — previous release line
 
 - name: release
   color: 'aaaaaa'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -78,6 +78,18 @@
   color: 'e11d21'
   description: Indicates the change introduces a breaking API or behaviour change
 
+# kind/backport-previous has no upstream Kubernetes equivalent (k8s has no
+# two-release-line model); it stays under kind/ per the file convention.
+- name: kind/backport
+  color: 'fbca04'
+  description: Categorizes issue or PR as requiring a backport to the current release line
+  aliases: ['backport']
+
+- name: kind/backport-previous
+  color: 'fbd876'
+  description: Categorizes issue or PR as requiring a backport to the previous release line
+  aliases: ['backport-previous']
+
 # ──────────────────────────────────────────────
 # priority/ — urgency
 # ──────────────────────────────────────────────
@@ -281,14 +293,6 @@
 - name: upstream-issue
   color: 'aaaaaa'
   description: Requires resolving an issue in an upstream project
-
-- name: backport
-  color: 'fbca04'
-  description: Should change be backported on previous release
-
-- name: backport-previous
-  color: 'fbd876'
-  description: Backport target — previous release line
 
 - name: release
   color: 'aaaaaa'

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -54,7 +54,7 @@ on:
 # surviving run rather than a hundred queued ones, and the feature only shipped
 # 2026-05-07, on a path that delivers fixes to release lines.
 concurrency:
-  group: backport-${{ github.workflow }}-${{ github.event.pull_request.number }}${{ (github.event.action == 'labeled' && github.event.label.name != 'backport' && github.event.label.name != 'backport-previous') && '-label' || '' }}
+  group: backport-${{ github.workflow }}-${{ github.event.pull_request.number }}${{ (github.event.action == 'labeled' && github.event.label.name != 'backport' && github.event.label.name != 'backport-previous' && github.event.label.name != 'kind/backport' && github.event.label.name != 'kind/backport-previous') && '-label' || '' }}
   # Stated positively, matching the group key above. `!= 'labeled'` is equivalent
   # only while `types:` holds exactly these two, and that form fails open: adding
   # `unlabeled` or `reopened` there would hand those events cancellation in the

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -144,10 +144,13 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const labels = pr.labels.map(l => l.name);
-            // Both spellings are accepted on purpose. The namespaced names are
-            // the convention this repo declares, but the org-level dosubot still
-            // applies the legacy ones and it is the dominant applier on real
-            // backports, so dropping them would silently stop the bot for those.
+            // TRANSITIONAL: both spellings are accepted so the rename can land
+            // in any order relative to the org-level dosubot, which still
+            // applies the legacy names and is today the dominant applier on
+            // real backports. Once dosubot's PR labelling is switched off and
+            // the in-repo labeler is the only applier, the legacy arms here,
+            // in the `if:` gate above and in the concurrency group can all be
+            // deleted in one pass.
             const isBackport = labels.includes('kind/backport') || labels.includes('backport');
             const isBackportPrevious = labels.includes('kind/backport-previous') || labels.includes('backport-previous');
             

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -95,8 +95,8 @@ jobs:
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
       (
-        (github.event.action == 'closed' && (contains(github.event.pull_request.labels.*.name, 'backport') || contains(github.event.pull_request.labels.*.name, 'backport-previous'))) ||
-        (github.event.action == 'labeled' && (github.event.label.name == 'backport' || github.event.label.name == 'backport-previous'))
+        (github.event.action == 'closed' && (contains(github.event.pull_request.labels.*.name, 'backport') || contains(github.event.pull_request.labels.*.name, 'backport-previous') || contains(github.event.pull_request.labels.*.name, 'kind/backport') || contains(github.event.pull_request.labels.*.name, 'kind/backport-previous'))) ||
+        (github.event.action == 'labeled' && (github.event.label.name == 'backport' || github.event.label.name == 'backport-previous' || github.event.label.name == 'kind/backport' || github.event.label.name == 'kind/backport-previous'))
       )
     # GitHub API calls only — no docker, no repo toolchain: GitHub-hosted.
     runs-on: ubuntu-latest
@@ -144,8 +144,12 @@ jobs:
           script: |
             const pr = context.payload.pull_request;
             const labels = pr.labels.map(l => l.name);
-            const isBackport = labels.includes('backport');
-            const isBackportPrevious = labels.includes('backport-previous');
+            // Both spellings are accepted on purpose. The namespaced names are
+            // the convention this repo declares, but the org-level dosubot still
+            // applies the legacy ones and it is the dominant applier on real
+            // backports, so dropping them would silently stop the bot for those.
+            const isBackport = labels.includes('kind/backport') || labels.includes('backport');
+            const isBackportPrevious = labels.includes('kind/backport-previous') || labels.includes('backport-previous');
             
             core.setOutput('backport', isBackport ? 'true' : 'false');
             core.setOutput('backport_previous', isBackportPrevious ? 'true' : 'false');

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -40,7 +40,7 @@ jobs:
             triage/accepted,kind/regression
           exempt-pr-labels: >-
             lifecycle/frozen,do-not-merge/hold,
-            backport,backport-previous
+            kind/backport,kind/backport-previous
           days-before-stale: 60
           days-before-close: 14
           operations-per-run: 100

--- a/docs/agents/contributing.md
+++ b/docs/agents/contributing.md
@@ -105,7 +105,7 @@ git commit --signoff -m "docs(contributing): add installation guide"
 
 **Special handling:**
 
-- `[Backport release-1.x]` prefix is stripped before parsing; `area/release` and `backport` labels are added.
+- `[Backport release-1.x]` prefix is stripped before parsing; the `area/release` label is added.
 - Composite scope (`feat(platform, system, apps): ...`) — each comma-separated part is mapped independently.
 - `!` after type or `BREAKING CHANGE:` footer in the body → `kind/breaking-change`.
 - Unmapped scope or non-conventional title → `area/uncategorized` (signals the PR needs manual area selection).

--- a/docs/agents/contributing.md
+++ b/docs/agents/contributing.md
@@ -106,7 +106,7 @@ git commit --signoff -m "docs(contributing): add installation guide"
 
 **Special handling:**
 
-- `[Backport release-1.x]` prefix is stripped before parsing; `area/release` and `backport` labels are added.
+- `[Backport release-1.x]` prefix is stripped before parsing; the `area/release` label is added.
 - Composite scope (`feat(platform, system, apps): ...`) — each comma-separated part is mapped independently.
 - `!` after type or `BREAKING CHANGE:` footer in the body → `kind/breaking-change`.
 - Unmapped scope or non-conventional title → `area/uncategorized` (signals the PR needs manual area selection).

--- a/docs/release.md
+++ b/docs/release.md
@@ -345,8 +345,8 @@ The matching Talos node image is `ghcr.io/cozystack/cozystack/cozystack-nocloud:
 
 | Label | Target branch |
 |-------|---------------|
-| `backport` | the newest existing `release-X.Y` branch |
-| `backport-previous` | the second-newest existing `release-X.Y` branch |
+| `kind/backport` | the newest existing `release-X.Y` branch |
+| `kind/backport-previous` | the second-newest existing `release-X.Y` branch |
 
 Resolution is dynamic at run time, and it reads the branches themselves: the job lists the repository's branches, keeps the ones matching `release-<major>.<minor>`, and sorts them numerically descending — so `release-1.10` ranks above `release-1.9`, which a lexicographic sort gets backwards. `backport` takes the first, `backport-previous` the second, so both name a branch that exists by construction; asking for `backport-previous` when only one line exists fails the job rather than inventing a target. Nothing is derived arithmetically — an earlier version computed the previous line as `Y-1`, which named a non-existent branch whenever a minor was skipped.
 
@@ -376,7 +376,7 @@ git push origin release-X.Y  # or push to a new branch and open a PR
 To find the bot's failed comments across a batch of PRs:
 
 ```bash
-for n in $(gh pr list --search "label:backport label:backport-previous merged:>=2026-01-01" --json number --jq '.[].number'); do
+for n in $(gh pr list --search "label:kind/backport label:kind/backport-previous merged:>=2026-01-01" --json number --jq '.[].number'); do
   echo "=== #$n ==="
   gh pr view $n --json comments --jq '.comments[] | select(.author.login == "github-actions" or (.author.login | contains("backport"))) | .body' | head -20
 done
@@ -388,8 +388,8 @@ A patch release includes bugfixes for code that shipped in the corresponding min
 
 ```bash
 # 1. Inventory PRs already labeled for backport (merged but not yet on release-X.Y)
-gh pr list --search "is:merged label:backport" --limit 100
-gh pr list --search "is:merged label:backport-previous" --limit 100
+gh pr list --search "is:merged label:kind/backport" --limit 100
+gh pr list --search "is:merged label:kind/backport-previous" --limit 100
 
 # 2. List commits on main since the release branch diverged that are NOT yet on release-X.Y
 git merge-base origin/main origin/release-X.Y

--- a/docs/release.md
+++ b/docs/release.md
@@ -340,8 +340,8 @@ The matching Talos node image is `ghcr.io/cozystack/cozystack/cozystack-nocloud:
 
 | Label | Target branch |
 |-------|---------------|
-| `backport` | the newest existing `release-X.Y` branch |
-| `backport-previous` | the second-newest existing `release-X.Y` branch |
+| `kind/backport` | the newest existing `release-X.Y` branch |
+| `kind/backport-previous` | the second-newest existing `release-X.Y` branch |
 
 Resolution is dynamic at run time, and it reads the branches themselves: the job lists the repository's branches, keeps the ones matching `release-<major>.<minor>`, and sorts them numerically descending — so `release-1.10` ranks above `release-1.9`, which a lexicographic sort gets backwards. `backport` takes the first, `backport-previous` the second, so both name a branch that exists by construction; asking for `backport-previous` when only one line exists fails the job rather than inventing a target. Nothing is derived arithmetically — an earlier version computed the previous line as `Y-1`, which named a non-existent branch whenever a minor was skipped.
 
@@ -371,7 +371,7 @@ git push origin release-X.Y  # or push to a new branch and open a PR
 To find the bot's failed comments across a batch of PRs:
 
 ```bash
-for n in $(gh pr list --search "label:backport label:backport-previous merged:>=2026-01-01" --json number --jq '.[].number'); do
+for n in $(gh pr list --search "label:kind/backport label:kind/backport-previous merged:>=2026-01-01" --json number --jq '.[].number'); do
   echo "=== #$n ==="
   gh pr view $n --json comments --jq '.comments[] | select(.author.login == "github-actions" or (.author.login | contains("backport"))) | .body' | head -20
 done
@@ -383,8 +383,8 @@ A patch release includes bugfixes for code that shipped in the corresponding min
 
 ```bash
 # 1. Inventory PRs already labeled for backport (merged but not yet on release-X.Y)
-gh pr list --search "is:merged label:backport" --limit 100
-gh pr list --search "is:merged label:backport-previous" --limit 100
+gh pr list --search "is:merged label:kind/backport" --limit 100
+gh pr list --search "is:merged label:kind/backport-previous" --limit 100
 
 # 2. List commits on main since the release branch diverged that are NOT yet on release-X.Y
 git merge-base origin/main origin/release-X.Y

--- a/hack/release-freeze-contract.bats
+++ b/hack/release-freeze-contract.bats
@@ -437,7 +437,7 @@ closed-merged=true"
   # holding the run they have to queue behind, and one request could then evict
   # the other.
   #
-  # Pinned as the literal pair, not as a count of `label.name != '`. That count
+  # Pinned as the literal names, not as a count of `label.name != '`. That count
   # measures the operator and says nothing about the operands, so renaming one
   # name here and not in `prepare` — the half-finished rename — left it at two
   # and stayed green, while a real `backport-previous` event took the `-label`
@@ -449,16 +449,25 @@ closed-merged=true"
   # EVERY event takes the suffix. A constant suffix is exactly as vacuous as no
   # split at all. Every operand here was pinned before this line existed; the
   # operator joining them was not.
-  printf '%s\n' "$line" | grep -qF "github.event.action == 'labeled' && github.event.label.name != 'backport' && github.event.label.name != 'backport-previous'"
+  #
+  # TRANSITIONAL: four names, not the original pair, because backport.yaml
+  # accepts both spellings while the org-level dosubot still applies the legacy
+  # ones. The namespaced names are genuine backport requests, so they belong on
+  # this side of the split exactly as the legacy ones do — routing them aside
+  # would hand a `kind/backport` event its own group and let it cherry-pick
+  # alongside the merge run, which is the failure the pin above describes. When
+  # dosubot's PR labelling is switched off and backport.yaml drops its legacy
+  # arms, this literal and the count below go back to the pair.
+  printf '%s\n' "$line" | grep -qF "github.event.action == 'labeled' && github.event.label.name != 'backport' && github.event.label.name != 'backport-previous' && github.event.label.name != 'kind/backport' && github.event.label.name != 'kind/backport-previous'"
 
-  # And exactly two of them. The literal above is a substring check, so appending
-  # a third exclusion satisfies it unchanged — and a third exclusion is not
+  # And exactly four of them. The literal above is a substring check, so appending
+  # a fifth exclusion satisfies it unchanged — and a fifth exclusion is not
   # cosmetic: the named label stops being routed aside, lands in the main group,
   # takes its single pending slot, skips in `prepare`, and evicts a genuine
   # backport request while delivering nothing. Same harm as widening `types:`.
   # Presence and count answer different questions; this test needs both.
   count="$(printf '%s\n' "$line" | grep -o "github\.event\.label\.name != '" | wc -l | tr -d ' ')"
-  [ "${count:-0}" -eq 2 ]
+  [ "${count:-0}" -eq 4 ]
 
   # The suffix the condition selects, not only the condition. Asserting the
   # operands alone leaves the whole split deletable — collapsing the tail to
@@ -542,21 +551,27 @@ closed-merged=true"
   # ungated it re-enters this job on every later unrelated label — an automated
   # size/* or kind/* — for a merged PR still carrying `backport`, redoing a
   # backport that has already been delivered.
-  printf '%s\n' "$block" | grep -qF "(github.event.action == 'closed' && (contains(github.event.pull_request.labels.*.name, 'backport') || contains(github.event.pull_request.labels.*.name, 'backport-previous')))"
+  #
+  # TRANSITIONAL: four reads, not the original pair. backport.yaml accepts the
+  # namespaced and the legacy spelling of each label while the org-level dosubot
+  # still applies the legacy ones; when its PR labelling is switched off and the
+  # legacy arms are dropped, this literal and the count below go back to two.
+  printf '%s\n' "$block" | grep -qF "(github.event.action == 'closed' && (contains(github.event.pull_request.labels.*.name, 'backport') || contains(github.event.pull_request.labels.*.name, 'backport-previous') || contains(github.event.pull_request.labels.*.name, 'kind/backport') || contains(github.event.pull_request.labels.*.name, 'kind/backport-previous')))"
 
-  # And the guard reads that set exactly twice, both of them inside the gated
+  # And the guard reads that set exactly four times, all of them inside the gated
   # disjunct above, so it cannot be joined by an ungated one that quietly
   # restores the old behaviour while the assertion above stays green.
   #
-  # Counted as OCCURRENCES, not lines. `grep -c` counts matching lines, and both
-  # reads live on one line here, so it answers 1 and keeps answering 1 when a
-  # third read is appended to that same line — which is exactly the restoration
+  # Counted as OCCURRENCES, not lines. `grep -c` counts matching lines, and all
+  # four reads live on one line here, so it answers 1 and keeps answering 1 when a
+  # fifth read is appended to that same line — which is exactly the restoration
   # this is meant to catch. Only an append on a NEW line would have moved it.
   count="$(printf '%s\n' "$block" | grep -o 'contains(github\.event\.pull_request\.labels' | wc -l | tr -d ' ')"
-  [ "${count:-0}" -eq 2 ]
+  [ "${count:-0}" -eq 4 ]
 
-  # A label event answers for the label it carries.
-  printf '%s\n' "$block" | grep -qF "(github.event.action == 'labeled' && (github.event.label.name == 'backport' || github.event.label.name == 'backport-previous'))"
+  # A label event answers for the label it carries. Both spellings of each name,
+  # for the transitional reason given above.
+  printf '%s\n' "$block" | grep -qF "(github.event.action == 'labeled' && (github.event.label.name == 'backport' || github.event.label.name == 'backport-previous' || github.event.label.name == 'kind/backport' || github.event.label.name == 'kind/backport-previous'))"
 
   # The two conjuncts the label logic hangs off, which the label assertions above
   # would not miss. `base.ref == 'main'` is what stops the bot backporting its own


### PR DESCRIPTION
Takes over #3433 and finishes it. Closes #2585.

The rename itself is IvanHunters' work, replayed here on current main with his commits intact. What was blocking it was my own review, and this fixes that plus one thing that appeared on main afterwards.

## What was blocking it

The gate in `backport.yaml` matched `kind/backport` only after the rename. The `aliases:` in `labels.yml` migrate labels already attached to issues and pull requests, but they do not change what an external applier does going forward, and the org-level dosubot still applies the legacy names. So the bot would have quietly stopped firing for the share of backports it labels.

Both spellings are now accepted, in the `if:` gate and in the JS step that reads them.

## What appeared afterwards

#3569 landed while #3433 sat, and it added a concurrency guard that appends `-label` to the group for any labeled event that is not a backport label, so a backport label never cancels a run already in flight. That guard enumerated the two legacy names, so once the labels are namespaced a `kind/backport` event takes the `-label` branch and the guard stops covering the case it exists for. Extended to the new names.

## The dual acceptance is transitional and says so

Accepting two spellings is a bridge, not a design. The plan is to switch dosubot's pull request labelling off and leave the in-repo labeler as the only applier, at which point the legacy arms can go. The comment in the workflow names all three deletion sites so that cleanup is mechanical: the `if:` gate, the JS step, and the concurrency group.

Landing this before or after dosubot is switched off both work, which is the point.

## Checks

`actionlint` clean on the workflow. There is no bats coverage for this gate on main; #3813 is what adds `hack/pr-labeler-contract.bats`, so the two are worth landing in that order.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Workflow Improvements**
  - Backport automation now supports standardized `kind/backport` and `kind/backport-previous` labels while maintaining compatibility with legacy labels during the transition.
  - Stale pull request handling and backport detection now follow the standardized labeling scheme.

- **Documentation**
  - Updated contribution and release documentation with the new labels, labeling requirements, and troubleshooting guidance.

- **Tests**
  - Expanded validation to cover both standardized and legacy backport labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->