### PR TITLE
fix(platform): make mongodb-application depend on its operator

### DIFF
--- a/packages/core/platform/sources/mongodb-application.yaml
+++ b/packages/core/platform/sources/mongodb-application.yaml
@@ -15,6 +15,15 @@ spec:
         - cozystack.networking
         # cozystack-engine ships the ApplicationDefinition CRD rendered by the *-rd component below.
         - cozystack.cozystack-engine
+        # The mongodb chart renders kind: PerconaServerMongoDB from
+        # psmdb.percona.com/v1, so the operator that serves that CRD is a
+        # prerequisite of offering the app at all. Without this edge the
+        # mongodb-rd HelmRelease registers the ApplicationDefinition as soon as
+        # the engine is up, a tenant can create a MongoDB before the operator
+        # exists, and its HelmRelease fails with `no matches for kind
+        # "PerconaServerMongoDB"`. Same shape as every other operator-backed app
+        # here (postgres, mariadb, kafka, redis, etcd).
+        - cozystack.mongodb-operator
       libraries:
         - name: cozy-lib
           path: library/cozy-lib

--- a/packages/core/platform/tests/sources_mongodb_application_dependson_test.yaml
+++ b/packages/core/platform/tests/sources_mongodb_application_dependson_test.yaml
@@ -1,0 +1,31 @@
+suite: mongodb-application waits for the operator that serves its CRD
+# The mongodb chart (apps/mongodb) renders kind: PerconaServerMongoDB from
+# psmdb.percona.com/v1, so cozystack.mongodb-operator is a genuine prerequisite
+# of offering the app rather than a test-selection hint. Without this edge the
+# mongodb-rd HelmRelease registers the ApplicationDefinition as soon as
+# cozystack-engine is up, a tenant can create a MongoDB before the operator
+# exists, and its HelmRelease fails with `no matches for kind
+# "PerconaServerMongoDB"`.
+# The edge is also what makes the mongodb Chainsaw suite reachable from the
+# operator's own package, so a change to the operator selects that suite instead
+# of the whole run — see hack/select-e2e.sh's src_to_suites().
+templates:
+  - templates/sources.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  - it: mongodb-application dependsOn mongodb-operator alongside its baseline edges
+    documentSelector:
+      path: metadata.name
+      value: cozystack.mongodb-application
+    asserts:
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.mongodb-operator
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.networking
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.cozystack-engine


### PR DESCRIPTION
The mongodb chart renders `kind: PerconaServerMongoDB` from `psmdb.percona.com/v1`, but `cozystack.mongodb-application` depended only on `cozystack.networking` and `cozystack.cozystack-engine`. So `mongodb-rd` registers the ApplicationDefinition as soon as the engine is up, a tenant can create a MongoDB before the operator exists, and its HelmRelease then fails with `no matches for kind "PerconaServerMongoDB"`.

Every other operator-backed application here already carries the edge. This is the same defect #3817 fixes for etcd, and it was found while reviewing that one.

It also closes a test-selection gap. Without the edge `cozystack.mongodb-operator` reaches no runnable suite, so every change to the operator escalates to the full 21-suite run instead of selecting `mongodb`. See `src_to_suites()` in `hack/select-e2e.sh`.

## Checks

`packages/core/platform/tests/sources_mongodb_application_dependson_test.yaml` pins the edge alongside the two baseline ones, mirroring the etcd guard. Mutation checked: removing the edge turns it red, restoring it turns it green.

`hack/select-install.sh --validate` reports the graph still has no cycle, 99 sources. Platform helm unit tests are 134 across 31 suites.

## The exposure this adds

An administrator who lists `cozystack.mongodb-operator` in `bundles.disabledPackages` while keeping the application now leaves it `DependenciesNotReady`. That is the same exposure postgres, mariadb, kafka, redis and etcd already carry, with `Package.spec.ignoreDependencies` as the escape hatch.

### Release note

```release-note
fix(platform): the mongodb application now waits for the mongodb operator, so a tenant can no longer create a MongoDB before the CRD that serves it exists
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the MongoDB operator is available before MongoDB application components are registered or deployed.
  * Preserved required dependencies on networking and the platform engine.

* **Tests**
  * Added coverage verifying the MongoDB application dependency configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->