### PR TITLE
fix(monitoring-agents): give kube-state-metrics a sized memory limit

### DIFF
--- a/packages/system/monitoring-agents/tests/kube_state_metrics_resources_test.yaml
+++ b/packages/system/monitoring-agents/tests/kube_state_metrics_resources_test.yaml
@@ -1,0 +1,26 @@
+suite: kube-state-metrics carries a memory limit sized above its measured peak
+# Without a memory limit the container sets no memory.max on its pod cgroup, and
+# the Talos userspace OOM handler only ever selects cgroups that lack one, so it
+# is an eviction candidate on every node regardless of what caused the pressure.
+# The numbers come from a measured 14d peak of 307Mi on the smallest cluster we
+# run; the limit carries headroom because this component scales with object
+# count. A CPU limit is deliberately absent: it does not affect the OOM ranking
+# and a binding ceiling turns into scrape timeouts.
+templates:
+  - charts/kube-state-metrics/templates/deployment.yaml
+tests:
+  - it: sets a memory limit above the measured peak and a request above the mean
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 2Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 192Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 50m
+  - it: sets no CPU limit
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resources.limits.cpu

--- a/packages/system/monitoring-agents/values.yaml
+++ b/packages/system/monitoring-agents/values.yaml
@@ -2,6 +2,28 @@ global:
   target: cozy-monitoring
 
 kube-state-metrics:
+  # Sized from a measured 14d peak of 307Mi working set on a 3-node cluster with
+  # 322 pods and roughly 25.6k series, which is the smallest cluster we run. The
+  # request sits above the 176Mi mean rather than at the peak, and the limit
+  # carries wide headroom on purpose: this component's memory scales with the
+  # number of objects in the cluster, and --metric-labels-allowlist below widens
+  # every pod and deployment series further, so a cluster larger than the one
+  # measured will land well above the peak seen here.
+  #
+  # A memory limit is what sets memory.max on the pod cgroup, and the Talos
+  # userspace OOM handler only ever selects cgroups that lack one, so running
+  # this without a limit leaves it an eviction candidate on every node. See
+  # docs/operations/system-memory-limits.md.
+  #
+  # No CPU limit: it is irrelevant to that OOM ranking, and a ceiling that binds
+  # only buys CFS throttling, which for a metrics scraper turns into scrape
+  # timeouts rather than backpressure.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 192Mi
+    limits:
+      memory: 2Gi
   extraArgs:
     - --metric-labels-allowlist=pods=[*],deployments=[*]
   rbac:

--- a/packages/system/monitoring-agents/values.yaml
+++ b/packages/system/monitoring-agents/values.yaml
@@ -9,6 +9,8 @@ kube-state-metrics:
   # number of objects in the cluster, and --metric-labels-allowlist below widens
   # every pod and deployment series further, so a cluster larger than the one
   # measured will land well above the peak seen here.
+  # 2Gi is 6.7x that peak, so scaling linearly with object count it stays a
+  # ceiling rather than a bound up to roughly 2100 pods and 170k series.
   #
   # A memory limit is what sets memory.max on the pod cgroup, and the Talos
   # userspace OOM handler only ever selects cgroups that lack one, so running


### PR DESCRIPTION
`kube-state-metrics` ran BestEffort with no resources at all: the subchart ships `resources: {}` and our wrapper never set any. So it put no `memory.max` on its pod cgroup, and the Talos userspace OOM handler only ever selects cgroups that lack one, which left it permanently in the victim set. Any tenant workload driving node memory pressure could evict the source of every kube-state metric we alert on. Background is in `docs/operations/system-memory-limits.md`.

## The numbers are measured

On a three node cluster with 322 pods and roughly 25.6k series, which is the smallest we run: 14 day peak working set 307Mi, peak RSS 280Mi, mean 176Mi.

So the request sits above the mean at 192Mi rather than at the peak, and the limit carries wide headroom at 2Gi. The headroom is deliberate: this component's memory scales with the number of objects in the cluster, and the `--metric-labels-allowlist=pods=[*],deployments=[*]` already in this file widens every pod and deployment series further, so a cluster larger than the one measured lands well above what was seen here. `2Gi` is 6.7x that peak, which read as linear in object count is roughly 2100 pods and 170k series, so the limit stays a ceiling rather than a bound well past the largest cluster this sizing was drawn from.

No CPU limit, following the node DaemonSet sizing in `c9ba7a3cc`, which set one zero times across nineteen files. CPU is irrelevant to the OOM ranking, and a ceiling that binds on a scraper turns into scrape timeouts rather than backpressure.

## This supersedes #2632

#2632 proposes 256Mi, which is below the 307Mi peak measured on the smallest cluster we have, so it would convert an eviction risk into a reliable OOM kill. It also adds a `cpu: 200m` limit, which is the half that buys nothing. The diagnosis there was right and it sat since May; the numbers are what needed replacing.

## Checks

`packages/system/monitoring-agents/tests/kube_state_metrics_resources_test.yaml` pins the limit, both requests, and the absence of a CPU limit. Mutation checked: dropping the limit to 256Mi turns it red. The chart's suites are 3 files and 6 tests, all green.

### Release note

```release-note
fix(monitoring-agents): kube-state-metrics now carries a memory request and limit sized from a measured peak, so it is no longer a permanent candidate for the node OOM handler
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resource settings for kube-state-metrics, including CPU and memory requests and a 2Gi memory limit.
  * Added validation to ensure the configured resource values are applied correctly and no CPU limit is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
