### PR TITLE
fix(kubernetes): delete orphaned resources in new post-delete job

### DIFF
--- a/packages/apps/kubernetes/templates/post-delete.yaml
+++ b/packages/apps/kubernetes/templates/post-delete.yaml
@@ -1,0 +1,158 @@
+{{- /*
+  Post-delete cleanup of objects that outlive `helm uninstall`.
+
+  Two classes of orphan, with two different causes:
+
+  1. <release>-talos-ca and <release>-talos-tls-cert Secrets.
+     cert-manager runs with --enable-certificate-owner-ref left at the upstream
+     default of false, so the Secrets it issues carry no ownerReference back to
+     the Certificate that produced them. Helm owns the two Certificates in
+     templates/talos/talos-pki.yaml but not their output, so an uninstall leaves
+     the Secrets behind, holding the Talos CA private key of a cluster that no
+     longer exists. Recreating a cluster with the same name in the same
+     namespace then makes cert-manager adopt the stale Secret instead of issuing
+     a fresh CA, so the new cluster silently inherits the old trust root.
+
+  2. <release>-oidc-bootstrap Job.
+     It is a post-install/post-upgrade hook (templates/oidc-rbac-job.yaml) whose
+     hook-delete-policy is before-hook-creation only. Hook resources are not part
+     of the release manifest, so uninstall never deletes them, and
+     before-hook-creation only fires when a later install recreates the hook —
+     which never happens after an uninstall. Its ServiceAccount, Role and
+     RoleBinding are release-owned and do go away, leaving a Job referencing a
+     ServiceAccount that no longer exists.
+
+  This runs as post-delete, not as another step in the pre-delete Job in
+  delete.yaml, and for the Secrets that distinction matters: pre-delete hooks run
+  while the release's objects are still present, and deleting a cert-manager
+  Secret whose Certificate still exists is the documented way to force a
+  re-issue. The Secret would come back within a second or two and be orphaned
+  again with a fresh key. By post-delete the Certificates are gone, so nothing
+  can recreate them.
+*/}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  name: {{ .Release.Name }}-post-cleanup
+spec:
+  template:
+    metadata:
+      labels:
+        policy.cozystack.io/allow-to-apiserver: "true"
+    spec:
+      serviceAccountName: {{ .Release.Name }}-post-cleanup
+      restartPolicy: Never
+      tolerations:
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: "NoSchedule"
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: kubectl
+          image: docker.io/clastix/kubectl:v1.32
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          env:
+            - name: HOME
+              value: /tmp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              echo "Deleting the Talos PKI Secrets orphaned by cert-manager"
+              kubectl -n {{ .Release.Namespace }} delete secret \
+                {{ .Release.Name }}-talos-ca {{ .Release.Name }}-talos-tls-cert \
+                --ignore-not-found=true
+
+              echo "Deleting the OIDC bootstrap hook Job orphaned by Helm"
+              kubectl -n {{ .Release.Namespace }} delete job \
+                {{ .Release.Name }}-oidc-bootstrap \
+                --ignore-not-found=true
+
+              echo "Cleanup completed successfully"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-post-cleanup
+  annotations:
+    helm.sh/hook: post-delete
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation,hook-failed
+    helm.sh/hook-weight: "0"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation,hook-failed
+    "helm.sh/hook-weight": "5"
+  name: {{ .Release.Name }}-post-cleanup
+rules:
+  # resourceNames pins both rules to exactly the objects this chart orphaned, so
+  # the Job can never reach any other Secret or Job in the tenant namespace.
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - {{ .Release.Name }}-talos-ca
+      - {{ .Release.Name }}-talos-tls-cert
+    verbs:
+      - get
+      - delete
+  - apiGroups:
+      - "batch"
+    resources:
+      - jobs
+    resourceNames:
+      - {{ .Release.Name }}-oidc-bootstrap
+    verbs:
+      - get
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation,hook-failed
+    "helm.sh/hook-weight": "5"
+  name: {{ .Release.Name }}-post-cleanup
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-post-cleanup
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-post-cleanup
+    namespace: {{ .Release.Namespace }}

--- a/packages/apps/kubernetes/tests/post_delete_cleanup_test.yaml
+++ b/packages/apps/kubernetes/tests/post_delete_cleanup_test.yaml
@@ -1,0 +1,83 @@
+suite: post-delete cleanup of uninstall orphans
+
+# Two objects outlive `helm uninstall` for different reasons: the
+# <release>-talos-ca / <release>-talos-tls-cert Secrets, which cert-manager
+# issues without an ownerReference back to their Certificate, and the
+# <release>-oidc-bootstrap Job, a Helm hook whose delete policy is
+# before-hook-creation only so nothing removes it at uninstall. These tests pin
+# the cleanup that removes both, and the post-delete placement that keeps
+# cert-manager from re-issuing the Secrets: in a pre-delete hook the
+# Certificates are still present, and deleting their Secret is the documented
+# way to force a re-issue.
+
+templates:
+  - templates/post-delete.yaml
+
+release:
+  name: test-k8s
+  namespace: tenant-test
+
+values:
+  - values-ci.yaml
+
+tests:
+  - it: cleanup runs as post-delete, after the Certificates are gone
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: post-delete
+
+  - it: post-delete Job deletes both Talos Secrets by name
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete secret \\\n\s+test-k8s-talos-ca test-k8s-talos-tls-cert'
+
+  - it: post-delete Job deletes the orphaned OIDC bootstrap Job
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'delete job \\\n\s+test-k8s-oidc-bootstrap'
+
+  - it: post-cleanup Role can delete only the orphans this chart created
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              resourceNames:
+                - test-k8s-talos-ca
+                - test-k8s-talos-tls-cert
+              verbs:
+                - get
+                - delete
+            - apiGroups:
+                - "batch"
+              resources:
+                - jobs
+              resourceNames:
+                - test-k8s-oidc-bootstrap
+              verbs:
+                - get
+                - delete
+
+  - it: post-delete Job runs under its own ServiceAccount
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: test-k8s-post-cleanup


### PR DESCRIPTION
## What this PR does
When tenant deletes the kubernetes cluster, 2 resources are orphaned and leftover in the tenant namespace.
- jobs/<name>-oidc-bootstrap
- secrets/<name>-talos-ca
- secrets/<name>-talos-tls-cert

This PR adds a new post-delete cleanup job and delete these resources manually.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(kubernetes): Fixed the `<name>-talos-ca` and `<name>-talos-tls-cert` Secrets and the `<name>-oidc-bootstrap` Job being left in the tenant namespace after a Kubernetes cluster is deleted.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup after application deletion.
  * Removes orphaned Talos PKI Secrets and the OIDC bootstrap Job.
  * Cleanup runs securely with restricted permissions and non-root execution.

* **Tests**
  * Added coverage verifying cleanup ordering, targeted resource deletion, permissions, and service account usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->