### PR TITLE
fix(e2e): drop the worker CPU limit until it can carry its own request

### DIFF
--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -3163,16 +3163,12 @@ ${ouroboros_addon}
       logSerialConsole: true
       maxReplicas: 10
       minReplicas: 2
-      # Headroom over the vCPU count, where KubeVirt would otherwise put the
-      # ceiling. Workers failing to join (cozystack/cozystack#3513) have been
-      # measured burning their vCPU threads flat out at a ceiling equal to
-      # their vCPU count while the guest kernel made no progress, which is what
-      # a vCPU spinning on a lock looks like when the vCPU holding that lock is
-      # the one preempted out of the quota they share. Whether the spare CPU
-      # lets the preempted one back in is what this value is here to answer:
-      # measured mechanism, predicted remedy. If the join failure rate does not
-      # move, the lever is elsewhere and this goes back to the vCPU count.
-      podCpuLimit: 3
+      # No podCpuLimit here for now: a limit with no request makes Kubernetes
+      # default the request to the limit, so the compute pod asks the scheduler
+      # for the whole ceiling and the workers sit Pending on Insufficient cpu
+      # before the guest exists. The headroom experiment for
+      # cozystack/cozystack#3513 returns once the chart can pair the limit with
+      # an explicit request.
       # Two vCPUs at the memory the workers had before. Sized by resources
       # rather than by instanceType: u1.large doubles memory along with the
       # vCPUs, and four 8Gi workers do not fit beside the rest of the suite,


### PR DESCRIPTION
## What this PR does

Removes the `podCpuLimit: 3` the e2e kubernetes suites set on their tenant workers, because as shipped it makes the workers unschedulable: a container with a CPU limit and no CPU request is given a request equal to the limit, so each worker asked the scheduler for its whole three-CPU ceiling, and on the first runs after it landed every kubernetes suite worker sat Pending with `0/3 nodes are available: 3 Insufficient cpu` before any guest booted. The failure diagnostics from those runs carry it directly: the virt-launcher Pods are `phase=Pending` with no start times, the console capture returns empty with the Pod state beside it, and the thread capture declines with a marker naming the absent compute container.

The limit itself was an experiment against the measured mechanism of cozystack/cozystack#3513 (both vCPU threads of a stuck worker burn flat out at a ceiling equal to the vCPU count while the guest kernel makes no progress). The experiment was never run: the request side spoiled it before the first guest started. It returns once the chart can pair the limit with an explicit request, which is a follow-up to #3859.

### Screenshots

Not applicable, no UI change.

### Downstream repositories

The diff is one values block inside `hack/e2e-chainsaw/_lib/run-kubernetes.sh`. Nothing in the trigger map is touched.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(e2e): tenant workers in the kubernetes e2e suites no longer set a CPU limit, since without a paired request it defaulted the scheduler request to the full ceiling and left the workers unschedulable
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the worker CPU limit to prevent worker nodes from becoming unschedulable.
  * Added documentation clarifying the current CPU resource configuration and its future considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->