### PR TITLE
fix(kubernetes): break bootstrap-token Job out of Helm hook to unblock fresh installs

### DIFF
--- a/packages/apps/kubernetes/templates/talos/bootstrap-token-tenant-job.yaml
+++ b/packages/apps/kubernetes/templates/talos/bootstrap-token-tenant-job.yaml
@@ -8,10 +8,21 @@
   kube-system, which the management cluster can only reach via the
   Kamaji-issued admin kubeconfig stored as <release>-admin-kubeconfig.
 
-  The Job runs as a Helm post-install/post-upgrade hook so it executes
-  after the KamajiControlPlane has reconciled and the admin kubeconfig
-  Secret exists. It is idempotent (kubectl apply) and re-runs harmlessly
-  on every upgrade.
+  Why not a Helm post-install/post-upgrade hook (the earlier shape):
+  post-* hooks execute only after Helm's wait phase resolves. On the
+  tenant `kubernetes` release the wait blocks on MachineDeployment Ready,
+  which blocks on nodes registering, which blocks on kubelet CSR
+  authentication, which needs the bootstrap-token this Job produces —
+  a hard deadlock on every fresh install and on every HR reconcile that
+  finds MD in a non-Ready state. pre-* hooks are not usable either: they
+  fire before non-hook templates apply, so <release>-admin-kubeconfig
+  (materialised by Kamaji after KamajiControlPlane is applied) is not
+  yet available. The workable shape is a regular resource in the chart:
+  it lands together with the KamajiControlPlane and the talos-secrets,
+  its Pod stays pending until Kamaji publishes the admin kubeconfig
+  Secret (backoffLimit covers the retry window), then runs and completes
+  before MachineDeployment can converge. Helm's wait treats the Job as
+  another resource to reach terminal state and does not gate it on MD.
 */}}
 ---
 apiVersion: v1
@@ -21,10 +32,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: batch/v1
 kind: Job
@@ -33,10 +40,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   # backoffLimit + restartPolicy: OnFailure gives the Job up to 11 attempts at
   # the tenant apiserver with exponential backoff (capped at 6 min between

--- a/packages/apps/kubernetes/tests/talos_templates_test.yaml
+++ b/packages/apps/kubernetes/tests/talos_templates_test.yaml
@@ -362,6 +362,21 @@ tests:
           path: metadata.name
           value: test-k8s-bootstrap-token-tenant
         documentIndex: 1
+      # Main-phase, not a hook: NONE of the bootstrap-token resources may
+      # carry helm.sh/hook. The Job must run at t0 alongside the tenant
+      # KamajiControlPlane so that the bootstrap-token-<id> Secret lands
+      # in the tenant kube-system before MachineDeployment starts
+      # scaling. post-install/post-upgrade hooks would gate this on
+      # Helm's wait phase, which itself waits on MachineDeployment
+      # Ready, which waits on nodes to register, which waits on the
+      # very token this Job produces — a deadlock. Pin the absence on
+      # both documents (0 SA, 1 Job).
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+        documentIndex: 0
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+        documentIndex: 1
 
   - it: talos-pki emits two cert-manager Certificates and two Issuers
     templates:


### PR DESCRIPTION
## What this PR does

Break the tenant `bootstrap-token-tenant` Job out of its `helm.sh/hook: post-install,post-upgrade` lifecycle and move it into the main install phase, so the `bootstrap-token-<id>` Secret lands in the tenant `kube-system` before `MachineDeployment` can converge.

### Why it deadlocks today

- Job wired as `post-install,post-upgrade` fires only after Helm's wait phase resolves
- Wait phase blocks on `MachineDeployment` Ready
- MD Ready blocks on nodes registering
- Node registration blocks on the kubelet CSR path, which needs the very `bootstrap-token-<id>` Secret this Job produces
- Result: any fresh install, or any HR reconcile that finds MD in a non-Ready state, sits in a deadlock; `HR.status.upgradeFailures` climbs without the post-upgrade hook ever getting its turn

`pre-install,pre-upgrade` is not a fix either — those fire before non-hook templates apply, so `<release>-admin-kubeconfig` (materialised by Kamaji after `KamajiControlPlane` is applied) is not yet available.

### The shape that works

Same shape `talos-reconcile` already uses in this chart: main-phase resources. Helm applies the SA and Job together with `KamajiControlPlane` and `talos-secrets`. Job's Pod stays pending until Kamaji publishes the admin kubeconfig Secret (`backoffLimit` covers the retry window). Job completes before MachineDeployment can converge. Helm's wait treats the Job as another resource to reach terminal state — it doesn't gate it on MD.

### Verification

- Reproduced the deadlock on two independent long-running tenant clusters (v1.6.x), documented in #3875
- Reproduced the manual unblock (creating the `bootstrap-token-<id>` Secret by hand in the tenant `kube-system`) on both — nodes register within seconds, MD converges within minutes, HR clears
- Extended `packages/apps/kubernetes/tests/talos_templates_test.yaml` to pin the absence of `helm.sh/hook` on both rendered documents; `helm unittest` passes 9/9

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md`. The diff touches `packages/apps/kubernetes/templates/talos/bootstrap-token-tenant-job.yaml` and its test — no app add/remove, no `values.schema.json`, no core/platform values, no `hack/`, no CRD, no `ApplicationDefinition`, no telemetry metric.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(kubernetes): tenant `bootstrap-token-<id>` Secret is now created in the main install phase instead of a post-install/post-upgrade hook, unblocking fresh installs and any HR reconcile that finds MachineDeployment in a non-Ready state.
```

Closes #3875
