### PR TITLE
test(e2e): capture the sandbox kernel KVM exit counters across the node-join wait

### DIFF
--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -1864,6 +1864,375 @@ ${rows}
 EOF
 }
 
+# The walk over a mounted debugfs that turns the kernel's KVM counters into
+# lines, taking the mount point as its first argument.
+#
+# A function emitting a program rather than a literal at the call site, for the
+# reason the thread walk beside it is written the same way: staging a subject
+# worth reading needs a hypervisor, and the outcomes this has to get right --
+# counters present, kvm directory absent, directory present and empty -- are
+# reachable against a tree of files and against nothing else.
+#
+# Nothing is computed here. Each counter goes out under the level it was read
+# at, because debugfs publishes the same names twice: once summed over every VM
+# the kernel hosts and once per VM. Folded together they answer neither
+# question.
+_cozy_kvm_stats_probe() {
+  cat <<'PROBE'
+kvm_root="${1}/kvm"
+globals=0
+vm_lines=0
+vms=0
+skipped=0
+if [ ! -d "${kvm_root}" ]; then
+  printf '%s\n' "NO-KVM-DIR: debugfs is mounted and holds no kvm directory, so this kernel has no KVM in use. The sandbox VMs are started with accel=kvm by hack/e2e-prepare-cluster.bats, so this is a statement about how they are being run rather than a capture that came up short"
+  exit 4
+fi
+printf '%s\n' '[counters follow, one per line, as: level name value; a file under these directories that is not a counter is named on a skipped line instead]'
+# A counter is one integer and nothing else, and that shape is what decides
+# whether a file here ends up in the numbers. It cannot decide whether the file
+# gets read, which is a separate job done by name above, because for a seq_file
+# the reading is the cost.
+#
+# `read` returning non-zero is not what decides whether a line arrived: it does
+# that on a last line with no newline while still setting the variable. The
+# kernel's own stat files do carry the newline, since it formats them through
+# "%llu\n", but this walks whatever the directory holds rather than a list of
+# names it was given.
+# The files that must not be OPENED, as opposed to the ones that must not be
+# emitted. Those are two different jobs and only one of them a shape test can
+# do: mmu_rmaps_stat is registered with single_open() and seq_read, so the walk
+# over every rmap head under the VM slots_lock and MMU write lock runs on the
+# first read() rather than at open, and a reader that opens the file to find out
+# what shape it is has already paid for it. Hence a name, checked before
+# anything is opened, even though a name is a property of the kernel version
+# where a shape is a property of the class. The shape test below stays as the
+# general net: it keeps an unknown non-counter out of the artifact, which is all
+# it can do, and this list keeps the one known expensive read from happening.
+is_known_non_counter() {
+  case "$1" in
+    mmu_rmaps_stat) return 0 ;;
+  esac
+  return 1
+}
+read_counter() {
+  counter_value=
+  # Status 2 keeps "could not be read" apart from "read, wrong shape", and one
+  # command carries both ways the first can happen: the open is refused in the
+  # instant a VM's debugfs entry is being removed, and a file that did open
+  # keeps refusing the read for the whole teardown once its entry is detached.
+  # A file that fails either way may well be a counter whose VM is going away,
+  # and saying "not a counter" about it would send the reader away from exactly
+  # the per-VM files the legend tells them to consult when a guest disappears.
+  _content=$(cat "$1" 2>/dev/null) || return 2
+  case "${_content}" in
+    '' | *[!0-9]*) return 1 ;;
+  esac
+  counter_value=${_content}
+}
+for stat_file in "${kvm_root}"/*; do
+  [ -f "${stat_file}" ] || continue
+  stat_name=${stat_file##*/}
+  if is_known_non_counter "${stat_name}"; then
+    skipped=$((skipped + 1))
+    printf '[skipped global] %s: not opened, it is a known non-counter and reading it costs the guest\n' "${stat_name}"
+  elif read_counter "${stat_file}"; then
+    globals=$((globals + 1))
+    printf '[global] %s %s\n' "${stat_name}" "${counter_value}"
+  else
+    case "$?" in
+      2) skip_why='could not be read, so nothing about its shape is known' ;;
+      *) skip_why='not a single integer, so not a counter' ;;
+    esac
+    skipped=$((skipped + 1))
+    printf '[skipped global] %s: %s\n' "${stat_name}" "${skip_why}"
+  fi
+done 2>/dev/null
+# On the loop as well as inside read_counter's own silencing: a counter that
+# disappears between the glob and the read is routine -- a VM directory goes
+# when its VM does -- and this probe's stderr is the collector's warning
+# artifact, which must not name something that did not affect the reading.
+for vm_dir in "${kvm_root}"/*/; do
+  [ -d "${vm_dir}" ] || continue
+  vm_name=${vm_dir%/}
+  vm_name=${vm_name##*/}
+  vms=$((vms + 1))
+  for stat_file in "${vm_dir}"*; do
+    [ -f "${stat_file}" ] || continue
+    stat_name=${stat_file##*/}
+    if is_known_non_counter "${stat_name}"; then
+      skipped=$((skipped + 1))
+      printf '[skipped vm %s] %s: not opened, it is a known non-counter and reading it costs the guest\n' "${vm_name}" "${stat_name}"
+    elif read_counter "${stat_file}"; then
+      vm_lines=$((vm_lines + 1))
+      printf '[vm %s] %s %s\n' "${vm_name}" "${stat_name}" "${counter_value}"
+    else
+      case "$?" in
+        2) skip_why='could not be read, so nothing about its shape is known' ;;
+        *) skip_why='not a single integer, so not a counter' ;;
+      esac
+      skipped=$((skipped + 1))
+      printf '[skipped vm %s] %s: %s\n' "${vm_name}" "${stat_name}" "${skip_why}"
+    fi
+  done
+done 2>/dev/null
+printf '[counters read: %s kernel-wide and %s per-VM, across %s per-VM director(ies); %s file(s) skipped, each with its reason beside it above]\n' \
+  "${globals}" "${vm_lines}" "${vms}" "${skipped}"
+# On counters rather than on directories. A VM that goes away under the walk
+# leaves a directory whose files cannot be read, which is indistinguishable on
+# disk from a VM that reported nothing -- and counted as a directory it would
+# satisfy this test while the capture holds no number at all, then carry the
+# legend telling a reader to difference it against its sibling.
+if [ "${globals}" -eq 0 ] && [ "${vm_lines}" -eq 0 ]; then
+  # A kvm directory that could be opened and held nothing readable. Without
+  # this the probe exits clean carrying only a heading, a heading is enough to
+  # make the capture non-empty, and the collector would pin a legend about
+  # taking differences onto a file with nothing to difference.
+  printf '%s\n' 'NO-COUNTER-FILES: the kvm directory was opened and not one counter under it could be read, so this says nothing about what the kernel paid'
+  exit 5
+fi
+PROBE
+}
+
+# The KVM exit counters of the kernel the sandbox VMs run on.
+#
+# This exists because every other CPU reading in this tree measures a subject
+# inside the sandbox and none of them can price a tick. The cgroup captures say
+# what a tenant worker was allowed and what it consumed; the per-thread split
+# says which QEMU thread consumed it; the node's own /proc/stat says whether the
+# sandbox node was given its turn. All of them can be healthy at once -- quota
+# untouched, steal at zero, the vCPU thread at its ceiling -- while the guest
+# does six to ten times less work per core than the same image does on a run
+# that passes. Ticks handed out and work not done is not a quantity any counter
+# inside the sandbox holds.
+#
+# It is held one layer down. A tenant worker is a guest of a sandbox node, which
+# is itself a guest of the runner, and the arrangement's cost is paid by the
+# runner's kernel: every exit a sandbox node takes, every nested page fault, and
+# every TLB flush that servicing its own guest provokes. That kernel publishes
+# the totals in debugfs, and the suite runs in a container sharing it, so this
+# is a local read rather than a walk over nodes -- which is also why it can be
+# afforded at all. The reading it does NOT give is the other half: a tenant
+# worker's exits into its sandbox node are counted by that node's kernel, and
+# reaching those costs a bounded read per node per sample, which the phase
+# budget in hack/run-kubernetes-node-join_test.bats does not have.
+#
+# Mounted in a mount namespace of this call's own rather than in the sandbox's.
+# The suite keeps running for the length of a node-join wait after this returns,
+# and a mount left behind would be a diagnostic editing the environment the rest
+# of the run measures. The namespace also removes the unmount: there is nothing
+# to clean up after a read the wrapper killed, which is the arm where a
+# collector that unmounts itself would leak.
+#
+# Takes the sample number it is writing, because it is called twice and the two
+# calls sit on either side of the node-join wait rather than inside one block.
+# A counter here accumulates over the life of the VM it belongs to, so a single
+# reading is an average over that life rather than a rate over anything; the
+# pair spans the window the guest was failing to boot in, and the stamps in each
+# file are what say how wide that window was. What the kernel-wide files add on
+# top of that is stated in the legend they ship with rather than here, because
+# it changes what a difference means rather than how wide the window is.
+cozy_capture_sandbox_kvm_exits() {
+  local sample="$1"
+  local report_dir="${COZY_REPORT_DIR:-/workspace/_out/cozyreport}/snapshots/${COZY_SNAPSHOT_NAME:-kubernetes}/sandbox-kvm-exits/sample-${sample}"
+  local raw="${report_dir}/kvm-stats.txt"
+  local err_log="${report_dir}/COLLECTION-FAILED.txt"
+  local read_log="${report_dir}/read-error.log"
+  local rc=0
+  local counters_present=0
+  local program read_at read_done
+  # The mount point, and the seam that lets the walk above be exercised against
+  # a tree of files instead of against a kernel. Production never sets it: the
+  # path is where debugfs belongs, and mounting there inside a private namespace
+  # is invisible outside this call.
+  local mount_point="${COZY_DIAG_KVM_DEBUGFS:-/sys/kernel/debug}"
+
+  # Checked, unlike its neighbours, because this is the one failure the markers
+  # below cannot describe: with no directory every write under it fails, the
+  # collector becomes a silent no-op, and the artifact carries the empty space
+  # this capture exists to refuse -- with nowhere to put a marker saying so.
+  if ! mkdir -p "${report_dir}"; then
+    echo "the report directory for the sandbox KVM counters could not be created, so nothing was read and nothing could be written to say so" >&2
+    return 1
+  fi
+  # Re-validated here for the reason every collector re-validates them: a value
+  # assigned after this file is sourced never passed the assignment-time check,
+  # and zero reaches `timeout` as no bound at all.
+  COZY_DIAG_READ_TIMEOUT=$(_cozy_diag_seconds "${COZY_DIAG_READ_TIMEOUT-}" "$COZY_DIAG_READ_TIMEOUT_DEFAULT" COZY_DIAG_READ_TIMEOUT positive)
+  COZY_DIAG_READ_GRACE=$(_cozy_diag_seconds "${COZY_DIAG_READ_GRACE-}" "$COZY_DIAG_READ_GRACE_DEFAULT" COZY_DIAG_READ_GRACE)
+
+  # Both preconditions are reported rather than returned into silence, and both
+  # say the same thing in their own words: nothing was asked, which is not a
+  # reading that the arrangement cost the kernel nothing.
+  if ! command -v unshare >/dev/null 2>&1; then
+    echo "unshare is not on PATH, so the sandbox kernel's KVM counters were not read" >&2
+    printf '%s\n' \
+      'unshare is not on PATH, so debugfs could not be mounted in a namespace of this capture own and the counters were never asked for; that is not a reading that nesting cost it nothing' \
+      >"${err_log}"
+    return 1
+  fi
+  if ! command -v mount >/dev/null 2>&1; then
+    echo "mount is not on PATH, so the sandbox kernel's KVM counters were not read" >&2
+    printf '%s\n' \
+      'mount is not on PATH, so debugfs was never mounted and the counters were never asked for; that is not a reading that nesting cost it nothing' \
+      >"${err_log}"
+    return 1
+  fi
+
+  program="if ! mount -t debugfs none \"\${1}\"; then exit 3; fi
+$(_cozy_kvm_stats_probe)"
+
+  echo "--- capturing the sandbox kernel's KVM exit counters (sample ${sample}) ---"
+  # Stamped around the read rather than inside it, and here the stamps are the
+  # only timing there is: a debugfs counter carries no sample time, and the two
+  # readings of this pair are separated by the node-join wait rather than by a
+  # knob, so without these the interval the pair spans is unrecoverable from the
+  # artifact.
+  read_at=$(date -u +%s)
+  # stdin closed explicitly for the reason the node walk above states: nothing
+  # here reads it today, and a program that started to would consume whatever
+  # the caller was iterating.
+  if command -v timeout >/dev/null 2>&1; then
+    timeout -k "${COZY_DIAG_READ_GRACE}" "${COZY_DIAG_READ_TIMEOUT}" \
+      unshare --mount --propagation private \
+      sh -c "${program}" cozy-kvm-exits "${mount_point}" \
+      >"${raw}" 2>"${read_log}" </dev/null || rc=$?
+  else
+    unshare --mount --propagation private \
+      sh -c "${program}" cozy-kvm-exits "${mount_point}" \
+      >"${raw}" 2>"${read_log}" </dev/null || rc=$?
+  fi
+  read_done=$(date -u +%s)
+
+  # Emptied rather than only removed, because the arms below decide what to tell
+  # the reader by whether there is an error log to send them to, and a variable
+  # still holding the path of a file that is gone points at nothing.
+  if [ ! -s "${read_log}" ]; then
+    rm -f "${read_log}"
+    read_log=
+  elif [ "${rc}" -eq 0 ] || [ "${rc}" -eq 4 ] || [ "${rc}" -eq 5 ]; then
+    # mount writes hints to stderr and exits zero, the way kubectl and talosctl
+    # do beside it. Which file the complaint lands in is decided by the status,
+    # not by whether stderr holds anything, so a healthy capture keeps its
+    # warning instead of shipping a failure marker next to a reading.
+    mv "${read_log}" "${report_dir}/READ-WARNINGS.txt" 2>/dev/null || true
+    read_log=
+  fi
+
+  # Whether a counter reached the file, which is a different question from
+  # whether the file has bytes in it. The probe writes its heading before it
+  # reads anything, so a walk killed on its first blocked read leaves a file
+  # that is not empty and holds no number; keyed on size, the arms below would
+  # call that a partial reading, and the caller would be told a pair was
+  # collected. Same distinction the probe makes one level down when it counts
+  # counters rather than the directories they sit in.
+  if grep -q -e '^\[global\] ' -e '^\[vm ' "${raw}" 2>/dev/null; then
+    counters_present=1
+  fi
+
+  # How to read the numbers goes on every capture that holds numbers, which is a
+  # wider set than the captures holding a whole reading. The naming trap and the
+  # anonymity of the per-VM split do not depend on the walk having finished, and
+  # a capture cut short is exactly where a reader needs them. Only the
+  # instruction to difference two files asserts completeness, and that one stays
+  # on the arm below that has it.
+  if [ "${counters_present}" -ne 0 ]; then
+    printf '%s\n' \
+      '[these counters belong to the kernel that hosts the sandbox VMs and not what runs inside them: this suite runs in a container sharing the runner kernel, which is the hypervisor for the Talos nodes hack/e2e-prepare-cluster.bats starts with accel=kvm. An exit counted here is a sandbox node leaving its guest mode, so the cost of running a tenant worker inside that node is paid here too -- while the worker own exits into its sandbox node are counted by that node kernel, which this file does not read]' \
+      '[what a difference between the two samples means depends on the level. A per-VM file is cumulative since that VM was created. A kernel-wide file is not an accumulator at all: the kernel answers it by summing the same counter over the VMs alive at the moment of the read, so a VM that went away between the samples takes its whole contribution with it. What the survivors accumulated in the meantime competes with that loss, so the difference is understated by a whole VM life while its sign proves nothing when positive. When it does come out negative, that is a finding about the sandbox -- a guest disappeared, since no per-vCPU counter ever decreases -- and not a rate; read the per-VM files beside it to see which one went]' \
+      '[and several of these are not counts at all, sitting in the same directory under the same kind of name: guest_mode and blocking are per-vCPU booleans that every file here sums, so a reading is the number of vCPUs in that state at that instant -- bounded by the vCPU count, not by 1 -- while pages_4k, pages_2m, pages_1g, mmu_unsync and nx_lpage_splits are instantaneous, and max_mmu_rmap_size and max_mmu_page_hash_collisions are running maxima. A difference of any of those is a number with no meaning. Which kind a counter is comes from the kernel own descriptor tables in arch/x86/kvm/x86.c and include/linux/kvm_host.h and from nothing visible here, so read this as the names present when it was written rather than as a closed set]' \
+      '[not every file in these directories is a counter, and the ones that are not are named on a skipped line above. Two different reasons appear there. mmu_rmaps_stat, which the kernel puts in every per-VM directory, is skipped by name and is never opened: it is a seq_file whose contents are computed on the first read, under that VM slots_lock and its MMU write lock, walking every rmap head -- so a reader that opened it to see what shape it was would already have stalled the guest page faults of the VM this capture exists to observe. Anything else that turns out not to hold exactly one integer is skipped after being read, which keeps it out of the numbers but cannot make its read free]' \
+      '[there is no ept_violation counter here to look for. The nested-paging faults are counted as pf_taken and pf_fixed, under those names on both vendors, so a reader who searches for the Intel spelling concludes the capture is missing what it holds]' \
+      '[a per-VM directory is named <pid>-<fd> with the pid in the kernel initial namespace, which this container cannot map to its own processes: /proc/<pid>/sched and NSpid both answer with the container-local number. So the split is per-VM and anonymous -- it says how evenly the sandbox VMs paid, not which sandbox node paid what]' \
+      >>"${raw}"
+  fi
+
+  case "${rc}" in
+    0)
+      # The pairing instruction is the one line that stays on this arm, for the
+      # reason the node CPU time capture withholds its own: telling a reader to
+      # subtract two files asserts that both hold a whole reading.
+      #
+      # Unconditional on this arm, and deliberately not also gated on
+      # counters_present. A zero status means the probe read counters, because
+      # the probe exits 4 or 5 when it did not -- so the second test would be
+      # unreachable, and an unreachable guard here is not free: it would absorb
+      # those exit codes, leaving nothing that notices if the probe ever stopped
+      # honouring them. The codes are pinned directly instead, by the two tests
+      # that read them out of the capture.
+      printf '%s\n' \
+        '[subtracting this file from its sibling under the other sample directory, and the stamps below from each other, gives a rate. The two readings are taken on either side of the node-join wait, so the interval is that window rather than a fixed knob, and it is exact to the width of the two brackets]' \
+        >>"${raw}"
+      ;;
+    3)
+      echo "debugfs could not be mounted, so the sandbox kernel's KVM counters were not read" >&2
+      # Branched on whether there is a message, because the sentence below
+      # points at one. mount almost always writes a reason and exits non-zero,
+      # but a refusal that says nothing leaves this marker holding a single line
+      # telling the reader to look above it at an empty file -- the same shape
+      # of promise-without-a-referent that the arms further down avoid.
+      if [ -n "${read_log}" ]; then
+        mv "${read_log}" "${err_log}" 2>/dev/null || true
+        read_log=
+        printf '%s\n' \
+          'debugfs could not be mounted, so the counters were never reached; the message above is what mount said. This is not a kernel that was asked and had nothing to report' \
+          >>"${err_log}"
+      else
+        printf '%s\n' \
+          'debugfs could not be mounted, so the counters were never reached, and mount refused without a word on either stream. This is not a kernel that was asked and had nothing to report' \
+          >>"${err_log}"
+      fi
+      printf '%s\n' \
+        'these counters are unavailable: debugfs could not be mounted, and the failure is recorded beside this file' \
+        >>"${raw}"
+      ;;
+    4 | 5) : ;;
+    *)
+      # Four arms rather than two, and the pair of questions they answer are
+      # independent: whether a counter reached the file, and whether the read
+      # left a message anywhere. Told only the first, a reader goes looking for
+      # an explanation in the job log of a run that may be days old; told only
+      # the second, they cannot tell a capture worth differencing from one that
+      # holds nothing.
+      if [ "${counters_present}" -ne 0 ] && [ -n "${read_log}" ]; then
+        printf '%s\n' \
+          'these counters are incomplete: the walk was cut short part way through the kvm directory, so a difference against the sibling sample understates every counter it did not reach; what the read said before it stopped is in the read-error.log beside this file' \
+          >>"${raw}"
+      elif [ "${counters_present}" -ne 0 ]; then
+        printf '%s\n' \
+          'these counters are incomplete: the walk was cut short part way through the kvm directory, so a difference against the sibling sample understates every counter it did not reach, and it stopped without a word on either stream' \
+          >>"${raw}"
+      elif [ -n "${read_log}" ]; then
+        printf '%s\n' \
+          'these counters are unavailable: the read produced no counter at all; what it said before it stopped is in the read-error.log beside this file' \
+          >>"${raw}"
+      else
+        printf '%s\n' \
+          'these counters are unavailable: the read produced no counter at all and stopped without a word on either stream, so what the kernel paid is not recorded here either way' \
+          >>"${raw}"
+      fi
+      ;;
+  esac
+  printf '[read attempted from %s to %s epoch seconds]\n' \
+    "${read_at}" "${read_done}" >>"${raw}"
+  printf '\n[capture exit code: %s]\n' "${rc}" >>"${raw}"
+  # Non-zero when the capture holds no counter, and only then -- whether that is
+  # a read that failed or a kernel that answered and had none. Both callers ask
+  # this function whether it collected something to pair with, and one of them
+  # runs on the passing path where the report is the artifact nobody downloads,
+  # so a capture holding no number has to answer out loud or the warning saying
+  # the pair is broken never prints. That covers the two findings as well by
+  # design: a kernel with no kvm directory at all is the most consequential
+  # thing this instrument can report, and reaching only the report would be the
+  # quietest possible place to put it. A capture cut short after it wrote
+  # counters is the case this does NOT cover: it left a usable reading, marked
+  # as partial, and telling the caller nothing was collected would contradict
+  # the file sitting beside it.
+  if [ "${rc}" -eq 3 ] || [ "${counters_present}" -eq 0 ]; then
+    return 1
+  fi
+}
+
 # The shell run inside a worker's compute container to list QEMU's threads.
 #
 # A function rather than a literal at the call site so it can be run against a
@@ -2518,17 +2887,17 @@ cozy_diag_phase_start() {
   # cozystack/cozystack#3666; the warning names both halves rather than promising the
   # better one for all of them.
   #
-  # The worker CPU throttling, worker network counter, sandbox node CPU time and
-  # worker per-thread CPU time captures belong to neither half: they call
-  # `timeout` directly AND carry the same fallback, so on a runner without the
-  # binary they run unbounded rather than exiting 127. That is the opposite
-  # failure from the one the sentence above would lead a reader to, and it is
-  # the half with the snapshot behind it, so they are named here rather than
-  # left to be inferred. The list is derived from the source by
-  # hack/run-kubernetes-node-join_test.bats, so a collector that joins this
-  # group without joining the sentence fails there.
+  # A third group belongs to neither half: those collectors call `timeout`
+  # directly AND carry the same fallback, so on a runner without the binary they
+  # run unbounded rather than exiting 127. That is the opposite failure from the
+  # one the sentence above would lead a reader to, and it is the half with the
+  # snapshot behind it, so the warning below names them one at a time. Only
+  # there: that list is derived from the source by
+  # hack/run-kubernetes-node-join_test.bats, and a second copy up here would be
+  # an unchecked list sitting beside a checked one, drifting from it at whatever
+  # rate collectors are added.
   command -v timeout >/dev/null 2>&1 || \
-    echo "» WARNING: timeout is not on PATH; the bounded reads below run UNBOUNDED, so one that hangs can still take the op and the tenant snapshot with it, and the collectors that call timeout directly (wedge check, serial console, guest Talos) exit 127 and collect nothing; the ones that guard the call with command -v -- the worker CPU throttling, worker network counter, sandbox node CPU time, worker per-thread CPU time, ghcr-mirror and talos-image-cache captures -- keep collecting instead, unbounded" >&2
+    echo "» WARNING: timeout is not on PATH; the bounded reads below run UNBOUNDED, so one that hangs can still take the op and the tenant snapshot with it, and the collectors that call timeout directly (wedge check, serial console, guest Talos) exit 127 and collect nothing; the ones that guard the call with command -v -- the worker CPU throttling, worker network counter, sandbox node CPU time, sandbox kernel KVM counters, worker per-thread CPU time, ghcr-mirror and talos-image-cache captures -- keep collecting instead, unbounded" >&2
   # Re-checked here, not only at assignment: a value set after this file is sourced
   # -- which is how a test sets it -- would otherwise reach the arithmetic below
   # unvalidated, and that is the one failure that costs the whole block.
@@ -2709,6 +3078,14 @@ cozy_report_node_join_failure() {
   # the instrumentation studies -- sends a triager to the known flake.
   echo "=== node-join failed: fewer than 2 tenant nodes Ready within 18m — diagnostics follow ==="
   cozy_report_guest_console_wedge || true
+  # The second KVM counter reading, pairing with the one taken before the wait.
+  # Ungated for the reason the wedge check above is, and for one of its own:
+  # the phase gate decides what may START, and a collector it declines loses
+  # only itself -- except this one, which would also retire a reading taken
+  # eighteen minutes earlier and leave it an orphan. Its cost is a single
+  # bounded read of a file on this machine, so it cannot meaningfully bound what
+  # comes after it.
+  cozy_capture_sandbox_kvm_exits 2 || true
   cozy_diag_read 'tenant node table' \
     kubectl --kubeconfig "${tenant_kc}" describe nodes "${request_timeout}"
   cozy_diag_read 'tenant HelmReleases' \
@@ -3309,6 +3686,22 @@ EOF
   # bring-up; 18m restores margin and still sits well inside the 50m step
   # timeout (the downstream LB/NFS/ouroboros checks add ~10-15m on the happy
   # path).
+  # The first of the two KVM counter readings, taken here rather than inside the
+  # failure block and taken on every run rather than on the failing ones. Both
+  # follow from what those counters are: running totals (per-VM since that VM
+  # was created, kernel-wide summed over the VMs alive at the read), so one
+  # reading is an average over a whole life and a rate needs two -- and the
+  # interval worth measuring is the window the guest is failing
+  # to boot in, which is the wait below. A pair taken a few seconds apart after
+  # the deadline has already expired would price the tail instead of the fault.
+  #
+  # Ungated and not fatal. It reads a file this kernel already keeps, so its
+  # cost is one bounded local read against a wait measured in minutes, and a run
+  # that could not take it must still be allowed to go on and fail for its own
+  # reasons.
+  if ! cozy_capture_sandbox_kvm_exits 1; then
+    echo "» WARNING: the sandbox kernel's KVM counters yielded no reading before the node-join wait, so the reading taken after it will have nothing to pair with; whether the read failed or the kernel had no counters to give is written into the capture itself, and any message the read left is in the log beside it" >&2
+  fi
   if ! timeout 18m bash -c '
     until [ "$(kubectl --kubeconfig tenantkubeconfig-'"${test_name}"' get nodes --no-headers 2>/dev/null | grep -cw Ready)" -ge 2 ]; do
       sleep 5
@@ -3321,6 +3714,21 @@ EOF
     # registered above), so it has to be reached.
     cozy_report_node_join_failure "${test_name}"
     exit 1
+  fi
+  # The second KVM counter reading on the path where the join succeeded, and it
+  # belongs here rather than beside the console baseline at the end of the run.
+  # The pair is only a measurement of the join window if both readings bracket
+  # it, and the tail below this point is another ten to fifteen minutes of a
+  # tenant cluster doing storage and LoadBalancer work: a sample taken after it
+  # would price a different window over a different workload while the legend in
+  # the capture says it priced the join. That would corrupt exactly the
+  # comparison these counters exist for, since the green run is what the red
+  # ones are read against. Placing it here also removes an orphan: a failure
+  # between the wait and the end of the suite would otherwise leave the first
+  # reading alone in the report, carrying an instruction to difference it
+  # against a sibling that was never written.
+  if ! cozy_capture_sandbox_kvm_exits 2; then
+    echo "» WARNING: the sandbox kernel's KVM counters yielded no reading after the node-join wait, so this report carries no green baseline for the exit rate; whether the read failed or the kernel had no counters to give is written into the capture itself, and any message the read left is in the log beside it" >&2
   fi
   kubectl --kubeconfig "tenantkubeconfig-${test_name}" get nodes -o wide
 

--- a/hack/run-kubernetes-kvm-exits_test.bats
+++ b/hack/run-kubernetes-kvm-exits_test.bats
@@ -1,0 +1,1016 @@
+#!/usr/bin/env bats
+# Regression coverage for the sandbox kernel's KVM exit counters in
+# hack/e2e-chainsaw/_lib/run-kubernetes.sh. cozytest.sh ends an @test block at
+# the first bare closing brace, so command mocks stay at top level.
+#
+# What this capture answers, and why nothing beside it answers the same thing:
+# every other CPU reading in this tree describes a subject inside the sandbox --
+# a cgroup, a thread, a node's own /proc/stat -- and each of them can say a guest
+# was given its ticks while the guest gets no work done. None of them can say
+# what a tick cost. The tenant worker is a guest of a sandbox node, which is
+# itself a guest of the runner, and the price of nesting is paid where the
+# runner's kernel serves the sandbox VMs: exits, nested page faults and TLB
+# flushes that no counter inside the sandbox can see. That kernel publishes them
+# in debugfs, and the sandbox container shares it, so this is a local read.
+#
+# So the failure this suite guards against is not a wrong number; it is an empty
+# directory, which reads as a kernel that paid nothing while nothing was ever
+# asked.
+
+timeout_calls=/dev/null
+timeout_rc_override=
+unshare_calls=/dev/null
+unshare_rc_override=
+mount_calls=/dev/null
+mount_rc=0
+mount_stderr=
+
+timeout() {
+  local command_rc=0
+  printf '%s\n' "$*" >>"${timeout_calls}"
+  # Return 97 rather than running the command when the wrapper is not the
+  # bounded form: a read that lost its ceiling must not pass as a read.
+  [ "${1:-}" = -k ] || return 97
+  shift 3
+  "$@" || command_rc=$?
+  [ -z "${timeout_rc_override}" ] || return "${timeout_rc_override}"
+  return "${command_rc}"
+}
+
+# Mocked as a function rather than staged as a binary because the collector
+# calls it in this shell. Its own flags are stripped and the rest is run, so the
+# program the collector composed is the program this suite exercises -- the
+# alternative, matching the program text here, would pass against a collector
+# that had stopped composing it.
+unshare() {
+  local command_rc=0
+  printf '%s\n' "$*" >>"${unshare_calls}"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --mount | --propagation) shift ;;
+      private) shift ;;
+      *) break ;;
+    esac
+  done
+  [ -z "${unshare_rc_override}" ] || return "${unshare_rc_override}"
+  # The status is captured and returned rather than left as the last command's,
+  # which is the same shape the wrapper above uses and not a matter of taste
+  # here: cozytest.sh rewrites every closing brace in the first column into
+  # `return 0` followed by the brace, so a mock ending on a bare command has its
+  # status replaced by zero under that runner and kept under bats. This mock
+  # exists to carry a non-zero mount refusal outward, so losing it turns the two
+  # tests about a refused mount green against a collector that never saw one.
+  "$@" || command_rc=$?
+  return "${command_rc}"
+}
+
+assert_file_contains() {
+  local needle="$1"
+  local file="$2"
+
+  if [ ! -f "${file}" ]; then
+    printf 'expected %s to exist so it could be checked for: %s\n' "${file}" "${needle}" >&2
+    return 1
+  fi
+  case "$(cat "${file}")" in
+    *"${needle}"*) return 0 ;;
+  esac
+  printf 'expected %s to contain: %s\n' "${file}" "${needle}" >&2
+  return 1
+}
+
+assert_file_lacks_pattern() {
+  local pattern="$1"
+  local file="$2"
+
+  # A missing file must fail rather than vacuously pass: a bare `! grep -q`
+  # succeeds on an unreadable path, which is indistinguishable from "the file
+  # exists and does not carry the label".
+  if [ ! -f "${file}" ]; then
+    printf 'expected %s to exist so it could be checked for: %s\n' "${file}" "${pattern}" >&2
+    return 1
+  fi
+  # Branched on awk's exact status. awk exits 1 for "no line matched" and 2 for
+  # "I could not evaluate this"; folded together, a negative assertion is
+  # satisfied by its own matcher giving up, which is the direction that goes
+  # green and stays green.
+  local _rc=0
+  awk -v pattern="${pattern}" '$0 ~ pattern { found = 1 } END { exit found ? 0 : 1 }' "${file}" || _rc=$?
+  case "${_rc}" in
+    0)
+      printf 'expected %s not to match: %s\n' "${file}" "${pattern}" >&2
+      return 1
+      ;;
+    1) return 0 ;;
+    *)
+      printf 'awk could not evaluate pattern %s against %s\n' "${pattern}" "${file}" >&2
+      return 1
+      ;;
+  esac
+}
+
+# The function under test redirects a command's stderr into a report file and
+# decides which artifact to write from it. cozytest.sh runs under `set -x`, so
+# the tracer's own line for that command lands on the very stderr being
+# redirected, and every assertion about those files would be reading the
+# tracer. Call through this wrapper so the sinks hold what production writes.
+run_capture() {
+  local _rc=0
+  ( set +x; cozy_capture_sandbox_kvm_exits "${1:-1}" ) || _rc=$?
+  return "${_rc}"
+}
+
+# `mount` is staged as an executable rather than mocked as a function: the
+# collector runs it inside `sh -c`, a subprocess this shell's functions do not
+# reach. A function here would be invisible exactly where the assertion needs
+# it, and the walk would run against a mount that never happened without the
+# suite noticing.
+stage_mount_stub() {
+  local dir="$1"
+  mkdir -p "${dir}/bin"
+  cat >"${dir}/bin/mount" <<STUB
+#!/bin/sh
+printf '%s\n' "\$*" >>"${dir}/mount.calls"
+[ -z "${mount_stderr}" ] || printf '%s\n' "${mount_stderr}" >&2
+exit ${mount_rc}
+STUB
+  chmod +x "${dir}/bin/mount"
+  mount_calls="${dir}/mount.calls"
+  PATH="${dir}/bin:${PATH}"
+}
+
+# A tree of files shaped like the kernel's, because staging a subject worth
+# reading needs a hypervisor. Two global counters and one per-VM directory is
+# enough to tell the two levels apart; the walk does not count them.
+stage_debugfs() {
+  local root="$1"
+  mkdir -p "${root}/kvm/4242-13"
+  printf '1200\n' >"${root}/kvm/exits"
+  printf '640\n' >"${root}/kvm/pf_taken"
+  printf '31\n' >"${root}/kvm/tlb_flush"
+  printf '800\n' >"${root}/kvm/4242-13/exits"
+  printf '17\n' >"${root}/kvm/4242-13/halt_exits"
+  # The shape the kernel actually puts in every per-VM directory beside the
+  # counters, reproduced rather than imagined: mmu_rmaps_stat is a seq_file
+  # printing a tab-separated histogram table. Without it in the fixture nothing
+  # here is shaped like the directory the walk meets in production, and both
+  # skip paths are unreachable from this suite.
+  {
+    printf 'Rmap_Count:\t0\t1\t2-3\t4-7\n'
+    printf 'Level=4K:\t6291000\t400\t50\t6\n'
+    printf 'Level=2M:\t12200\t88\t0\t0\n'
+    printf 'Level=1G:\t24\t0\t0\t0\n'
+  } >"${root}/kvm/4242-13/mmu_rmaps_stat"
+}
+
+stage() {
+  COZY_REPORT_DIR="$1/report"
+  COZY_SNAPSHOT_NAME=kvm-smoke
+  COZY_DIAG_KVM_DEBUGFS="$1/debugfs"
+  stage_debugfs "$1/debugfs"
+  stage_mount_stub "$1"
+}
+
+capture_path() {
+  printf '%s/snapshots/kvm-smoke/sandbox-kvm-exits/sample-%s/kvm-stats.txt' \
+    "${COZY_REPORT_DIR}" "${1:-1}"
+}
+
+marker_path() {
+  printf '%s/snapshots/kvm-smoke/sandbox-kvm-exits/sample-%s/COLLECTION-FAILED.txt' \
+    "${COZY_REPORT_DIR}" "${1:-1}"
+}
+
+@test "the kernel's own KVM counters are read through a debugfs of this capture's own" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+
+  run_capture
+
+  # The mount is what makes the counters reachable at all, and the namespace is
+  # what keeps it from being a change to the sandbox: the suite runs on for
+  # another twenty minutes after this, and a mount left behind would be this
+  # collector editing the environment the rest of the run measures.
+  assert_file_contains '--mount --propagation private' "$unshare_calls"
+  assert_file_contains '-t debugfs' "$mount_calls"
+  capture=$(capture_path)
+  assert_file_contains 'exits 1200' "$capture"
+  assert_file_contains 'tlb_flush 31' "$capture"
+  # What the walk found, counted at both levels and over the directories it
+  # opened. Three numbers rather than one because they answer different
+  # questions -- a kernel hosting no VM has counters and no directories, a VM
+  # that went away under the walk leaves a directory and no counters -- and
+  # without this the directory count and the guard that produces it are carried
+  # by nothing.
+  assert_file_contains 'counters read: 3 kernel-wide and 2 per-VM, across 1 per-VM director' "$capture"
+  assert_file_lacks_pattern 'unknown' "$capture"
+  assert_file_lacks_pattern 'incomplete' "$capture"
+  assert_file_lacks_pattern 'unavailable' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a file the kernel computes on read is skipped by name and never opened" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+
+  run_capture
+
+  # mmu_rmaps_stat is not a counter and, unlike every other file here, reading
+  # it is not free: it is registered with single_open and seq_read, so its
+  # contents are computed on the first read, under the VM slots_lock and MMU
+  # write lock, walking every rmap head. A shape test cannot save that -- to see
+  # the shape you must read it, and the read is the cost -- so it is skipped by
+  # name before anything opens it. The two skip reasons are worded differently
+  # on purpose: this assertion fails, rather than silently passing on the shape
+  # path, if the name check is ever dropped.
+  capture=$(capture_path)
+  assert_file_contains '[skipped vm 4242-13] mmu_rmaps_stat: not opened' "$capture"
+  assert_file_lacks_pattern 'Rmap_Count' "$capture"
+  assert_file_lacks_pattern 'Level=4K' "$capture"
+  # And it is not counted as a per-VM counter either.
+  assert_file_contains 'counters read: 3 kernel-wide and 2 per-VM' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a file that is not a counter at all is skipped by its shape" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # The general net behind the name list. A counter is one integer and nothing
+  # else; anything else in these directories would otherwise be emitted under a
+  # heading promising `level name value`, counted as a counter, and then offered
+  # to the reader as something to difference against its sibling.
+  {
+    printf 'header one two\n'
+    printf 'row 1 2\n'
+  } >"$tmp/debugfs/kvm/some_table"
+  printf 'not-a-number\n' >"$tmp/debugfs/kvm/some_text"
+  # A number followed by more of anything: the leading integer alone would
+  # pass, so this pins that the shape check reads the whole content rather than
+  # the first line. Without this fixture a check narrowed to the first line
+  # stays green, and a table whose first row happens to be a bare number would
+  # be filed as a counter.
+  {
+    printf '42\n'
+    printf 'and then some\n'
+  } >"$tmp/debugfs/kvm/some_prefixed_table"
+
+  run_capture
+
+  capture=$(capture_path)
+  assert_file_contains '[skipped global] some_table: not a single integer' "$capture"
+  assert_file_contains '[skipped global] some_text: not a single integer' "$capture"
+  assert_file_contains '[skipped global] some_prefixed_table: not a single integer' "$capture"
+  assert_file_lacks_pattern 'header one two' "$capture"
+  assert_file_lacks_pattern 'not-a-number' "$capture"
+  assert_file_lacks_pattern 'some_prefixed_table 42' "$capture"
+  # Still three kernel-wide counters: neither of the two joined them.
+  assert_file_contains 'counters read: 3 kernel-wide' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a file that cannot be read is skipped as unread, not called a non-counter" {
+  [ "$(id -u)" -ne 0 ] || skip "mode bits do not stop root from opening the file"
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # In production the failure is a live counter whose VM is being torn down:
+  # its entry is still listed while the kernel refuses the open, or refuses
+  # the read once the entry is detached. Neither state can be staged with a
+  # plain file, so an unreadable mode stands in; what the walk sees is the
+  # same, a listed file that yields no content.
+  printf '99\n' >"$tmp/debugfs/kvm/locked_out"
+  chmod 000 "$tmp/debugfs/kvm/locked_out"
+
+  run_capture
+
+  capture=$(capture_path)
+  assert_file_contains '[skipped global] locked_out: could not be read' "$capture"
+  assert_file_lacks_pattern 'locked_out: not a single integer' "$capture"
+  # Not read means not counted: still the three counters the fixture stages.
+  assert_file_contains 'counters read: 3 kernel-wide' "$capture"
+  chmod 700 "$tmp/debugfs/kvm/locked_out"
+  rm -rf "$tmp"
+}
+
+@test "the per-VM split is kept apart from the kernel-wide totals" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+
+  run_capture
+
+  # Both levels exist in debugfs and they answer different questions: the totals
+  # say what this kernel paid, the per-VM directories say whether the three
+  # sandbox VMs paid it evenly. Folded together, a single VM burning exits looks
+  # like a kernel under uniform load, which is the reading this split exists to
+  # refuse.
+  capture=$(capture_path)
+  assert_file_contains '[vm 4242-13] exits 800' "$capture"
+  assert_file_contains '[global] exits 1200' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the counter legend travels with the numbers" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+
+  run_capture
+
+  capture=$(capture_path)
+  # Which layer these numbers describe. The counters belong to the kernel
+  # hosting the sandbox VMs, so they price the sandbox's own execution and say
+  # nothing about what a tenant worker's guest did to its sandbox node -- and a
+  # reader who takes them for the second draws the opposite conclusion.
+  assert_file_contains 'the sandbox VMs and not what runs inside them' "$capture"
+  # Which of them a difference may be taken of. Subtracting an instantaneous
+  # gauge from its sibling reading yields a number with no meaning, and the
+  # names sit next to the cumulative ones in the same directory.
+  # Both of the vCPU-state gauges, not just the first. They sit in the same
+  # directory as everything else and under the same kind of name, and a list
+  # that names one of them reads as the closed set of things not to difference.
+  assert_file_contains 'guest_mode' "$capture"
+  assert_file_contains 'blocking' "$capture"
+  assert_file_contains 'cumulative' "$capture"
+  # The counter a reader will look for and not find, named where they look.
+  assert_file_contains 'no ept_violation counter' "$capture"
+  # Why the per-VM directories cannot be attributed to a sandbox node.
+  assert_file_contains 'cannot map' "$capture"
+  # The pairing instruction rides with the numbers on the one arm that holds a
+  # whole reading, as it does for the node CPU time capture beside it.
+  assert_file_contains 'subtracting this file from its sibling' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "each reading records when it was taken" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+
+  run_capture
+
+  # This pair is not taken inside one diagnostics block: the first reading is
+  # taken before the node-join wait and the second only when that wait has run
+  # out, so the interval between them is the whole join window rather than a
+  # knob. Nothing else in the artifact records it.
+  capture=$(capture_path)
+  assert_file_contains 'read attempted from' "$capture"
+  stamp=$(sed -n 's/.*read attempted from \([0-9][0-9]*\) to \([0-9][0-9]*\) epoch seconds.*/\1 \2/p' "$capture")
+  if [ -z "$stamp" ]; then
+    echo "expected a bare epoch stamp in $capture" >&2
+    cat "$capture" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "the read is bounded and keeps its exit code" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+
+  run_capture
+
+  # Local does not mean instant: a mount and a walk over debugfs both enter the
+  # kernel, and this one runs on the failure path of a host already wedged
+  # enough to lose a node join.
+  assert_file_contains '-k 5 20 unshare' "$timeout_calls"
+  assert_file_contains '[capture exit code: 0]' "$(capture_path)"
+  rm -rf "$tmp"
+}
+
+@test "a lowered read budget moves this collector's bound" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # Set after sourcing, which is how a caller and a test both set it. A value
+  # read only at assignment time would reach `timeout` unchecked here.
+  COZY_DIAG_READ_TIMEOUT=4
+
+  run_capture
+
+  assert_file_contains '-k 5 4 unshare' "$timeout_calls"
+  rm -rf "$tmp"
+}
+
+@test "a zero read budget is corrected rather than disabling the bound" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # `timeout -k 5 0` disables the timeout outright, so a zero assigned after
+  # sourcing would restore the unbounded read this bound exists to remove.
+  COZY_DIAG_READ_TIMEOUT=0
+
+  run_capture
+
+  assert_file_lacks_pattern '^-k 5 0 ' "$timeout_calls"
+  assert_file_contains "-k 5 $COZY_DIAG_READ_TIMEOUT_DEFAULT unshare" "$timeout_calls"
+  rm -rf "$tmp"
+}
+
+@test "no unshare on PATH is recorded rather than left as an empty directory" {
+  # A subprocess with a stripped PATH, because this file mocks `unshare` as a
+  # shell function and `command -v` finds functions -- the arm cannot be reached
+  # from inside a test body. The PATH is staged rather than emptied: the
+  # collector shells out before it gets to the check, so an empty PATH would
+  # fail this for the wrong reason and read as the arm being broken.
+  tmp=$(mktemp -d)
+  mkdir -p "$tmp/bin"
+  # /sbin and /usr/sbin are in the list because `mount` lives there on the host
+  # this suite is also run from, and a staging loop that cannot find it fails
+  # the test rather than quietly leaving the check to run against a PATH that
+  # is missing more than the one command it is about.
+  for c in mkdir grep rm mount date; do
+    for d in /bin /usr/bin /usr/local/bin /opt/homebrew/bin /sbin /usr/sbin; do
+      if [ -x "$d/$c" ]; then
+        ln -sf "$d/$c" "$tmp/bin/$c"
+        break
+      fi
+    done
+    if [ ! -x "$tmp/bin/$c" ]; then
+      echo "FAIL: could not stage $c in the stripped PATH; the check below would be vacuous" >&2
+      return 1
+    fi
+  done
+  if [ -e "$tmp/bin/unshare" ]; then
+    echo "FAIL: unshare leaked into the stripped PATH; this test would prove nothing" >&2
+    return 1
+  fi
+  rc=0
+
+  # Assigned inside the subprocess rather than in front of it: bash resolves the
+  # command name with the PATH the assignment sets, so `PATH=... bash` cannot
+  # find bash itself.
+  out=$(bash -c '
+    set -eu
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    COZY_REPORT_DIR='"$tmp"'/report
+    COZY_SNAPSHOT_NAME=kvm-smoke
+    PATH='"$tmp"'/bin
+    cozy_capture_sandbox_kvm_exits 1
+  ' 2>&1) || rc=$?
+  printf '%s\n' "$out" >"$tmp/out"
+
+  [ "$rc" -ne 0 ]
+  marker="$tmp/report/snapshots/kvm-smoke/sandbox-kvm-exits/sample-1/COLLECTION-FAILED.txt"
+  assert_file_contains 'unshare is not on PATH' "$marker"
+  # The distinction the marker exists for, spelled out in the artifact: a tool
+  # that was never run says nothing about the kernel, and the reading a missing
+  # file invites is that nesting cost it nothing.
+  assert_file_contains 'not a reading that nesting cost it nothing' "$marker"
+  rm -rf "$tmp"
+}
+
+@test "no mount on PATH is recorded rather than left as an empty directory" {
+  # The sibling of the unshare check above. Staged the same way and for the same
+  # reason, with one difference: `unshare` has to be present for the collector
+  # to reach the check this test is about, and the host running this suite may
+  # have no such binary, so a stub stands in. It is never executed -- the
+  # collector returns at the check below it.
+  tmp=$(mktemp -d)
+  mkdir -p "$tmp/bin"
+  for c in mkdir grep rm mv date; do
+    for d in /bin /usr/bin /usr/local/bin /opt/homebrew/bin /sbin /usr/sbin; do
+      if [ -x "$d/$c" ]; then
+        ln -sf "$d/$c" "$tmp/bin/$c"
+        break
+      fi
+    done
+    if [ ! -x "$tmp/bin/$c" ]; then
+      echo "FAIL: could not stage $c in the stripped PATH; the check below would be vacuous" >&2
+      return 1
+    fi
+  done
+  printf '#!/bin/sh\nexit 91\n' >"$tmp/bin/unshare"
+  chmod +x "$tmp/bin/unshare"
+  if [ -e "$tmp/bin/mount" ]; then
+    echo "FAIL: mount leaked into the stripped PATH; this test would prove nothing" >&2
+    return 1
+  fi
+  rc=0
+
+  out=$(bash -c '
+    set -eu
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    COZY_REPORT_DIR='"$tmp"'/report
+    COZY_SNAPSHOT_NAME=kvm-smoke
+    PATH='"$tmp"'/bin
+    cozy_capture_sandbox_kvm_exits 1
+  ' 2>&1) || rc=$?
+  printf '%s\n' "$out" >"$tmp/out"
+
+  [ "$rc" -ne 0 ]
+  marker="$tmp/report/snapshots/kvm-smoke/sandbox-kvm-exits/sample-1/COLLECTION-FAILED.txt"
+  assert_file_contains 'mount is not on PATH' "$marker"
+  assert_file_contains 'not a reading that nesting cost it nothing' "$marker"
+  rm -rf "$tmp"
+}
+
+@test "a mount that was refused is not reported as a kernel running no guests" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  mount_rc=32
+  mount_stderr='mount: /sys/kernel/debug: permission denied.'
+  stage "$tmp"
+  rc=0
+
+  run_capture || rc=$?
+
+  # The two readings this has to keep apart: a sandbox that would not let the
+  # capture at debugfs, and a kernel whose KVM is idle. Both leave no counters,
+  # and only the second is a statement about the run.
+  [ "$rc" -ne 0 ]
+  marker=$(marker_path)
+  assert_file_contains 'permission denied' "$marker"
+  assert_file_contains 'debugfs could not be mounted' "$marker"
+  assert_file_lacks_pattern 'no KVM' "$marker"
+  rm -rf "$tmp"
+}
+
+@test "a kernel with no kvm directory is a finding rather than an empty capture" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  # A hint on stderr beside the finding, so the arm that routes stderr by status
+  # is exercised for this code and not only for its sibling. The kernel answered
+  # here, so the complaint belongs in a file named as a warning; routed with the
+  # failures it would put read-error.log next to a capture that did not fail.
+  mount_stderr='mount: (hint) debugfs is already mounted here.'
+  stage "$tmp"
+  rm -rf "$tmp/debugfs/kvm"
+  rc=0
+
+  run_capture || rc=$?
+
+  # Answered to the caller and not only to the report, because one of the two
+  # callers runs on the passing path, whose report is the artifact nobody
+  # downloads, and this is the most consequential thing the instrument can say.
+  [ "$rc" -ne 0 ]
+  # Not a shortfall of the capture. The sandbox VMs are started with
+  # accel=kvm by hack/e2e-prepare-cluster.bats, so a kernel with no kvm
+  # directory under debugfs is a kernel that ran them some other way -- which
+  # would explain the slowness this whole line of measurement is chasing, and
+  # must not be filed as a collector that came up short.
+  capture=$(capture_path)
+  assert_file_contains 'NO-KVM-DIR' "$capture"
+  assert_file_contains 'accel=kvm' "$capture"
+  # And the legend must not ride on it. A file carrying a finding and no
+  # counters cannot be differenced against its sibling, and an instruction to do
+  # so would turn the sibling's whole cumulative total into a rate over the
+  # window -- the largest number this artifact could possibly produce, arrived
+  # at by following its own advice.
+  assert_file_lacks_pattern 'subtracting this file from its sibling' "$capture"
+  # And a finding is not also a truncated walk, nor a read that came back with
+  # nothing. All three sentences fit in this file and they contradict each
+  # other: one says the kernel answered and had no KVM, the second says the walk
+  # was cut off before it could tell, the third says the read never got that
+  # far. Only the first is true here, and the other two describe an instrument
+  # that failed rather than one that has something to report.
+  assert_file_lacks_pattern 'incomplete' "$capture"
+  assert_file_lacks_pattern 'unavailable' "$capture"
+  # The probe's own status, read out of the capture rather than inferred from
+  # what the legend did or did not say. The collector decides four things from
+  # this code -- which file stderr lands in, whether the legend rides, whether
+  # the pairing instruction rides, what it returns -- so a probe that stopped
+  # emitting it would change all four, and a test that only watches the effects
+  # can be made blind by any one guard added upstream of them.
+  assert_file_contains '[capture exit code: 4]' "$capture"
+  dir="$COZY_REPORT_DIR/snapshots/kvm-smoke/sandbox-kvm-exits/sample-1"
+  assert_file_contains 'debugfs is already mounted here' "$dir/READ-WARNINGS.txt"
+  [ ! -f "$dir/read-error.log" ]
+  rm -rf "$tmp"
+}
+
+@test "a kvm directory holding only per-VM counters is not reported as holding none" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # The kernel-wide files gone and one VM directory left. Both levels are
+  # optional in their own way -- a kernel hosting no VM has no per-VM
+  # directories -- so the emptiness test has to be about the two together. Read
+  # as either-or it reports a capture that holds counters as one that holds
+  # none, and the arm that says so is the one a reader trusts over the numbers
+  # printed above it.
+  rm -f "$tmp"/debugfs/kvm/exits "$tmp"/debugfs/kvm/pf_taken "$tmp"/debugfs/kvm/tlb_flush
+
+  run_capture
+
+  capture=$(capture_path)
+  assert_file_contains '[vm 4242-13] exits 800' "$capture"
+  assert_file_lacks_pattern 'NO-COUNTER-FILES' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a kvm directory holding no counter is not filed as a reading" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  rm -rf "$tmp/debugfs/kvm"
+  mkdir -p "$tmp/debugfs/kvm"
+  rc=0
+
+  run_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  capture=$(capture_path)
+  assert_file_contains 'NO-COUNTER-FILES' "$capture"
+  # And the legend must not ride on it: telling a reader to subtract two files
+  # asserts that both hold a whole reading, and this one holds none.
+  assert_file_lacks_pattern 'subtracting this file from its sibling' "$capture"
+  assert_file_lacks_pattern 'incomplete' "$capture"
+  assert_file_lacks_pattern 'unavailable' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a warning beside a finding is filed as a warning, not as a failed read" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  mount_stderr='mount: (hint) debugfs is already mounted here.'
+  stage "$tmp"
+  # A kernel that answered and had no counters, while mount also wrote a hint.
+  # The status decides which file the complaint lands in, and the two findings
+  # are on the side that succeeded: routing them with the failures would put a
+  # file named read-error.log next to a capture that reports what the kernel
+  # said, which is the failure-shaped name this routing exists to keep off a
+  # reading that did not fail.
+  rm -rf "$tmp/debugfs/kvm"
+  mkdir -p "$tmp/debugfs/kvm"
+  rc=0
+
+  run_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  dir="$COZY_REPORT_DIR/snapshots/kvm-smoke/sandbox-kvm-exits/sample-1"
+  assert_file_contains 'NO-COUNTER-FILES' "$dir/kvm-stats.txt"
+  assert_file_contains '[capture exit code: 5]' "$dir/kvm-stats.txt"
+  assert_file_contains 'debugfs is already mounted here' "$dir/READ-WARNINGS.txt"
+  [ ! -f "$dir/read-error.log" ]
+  rm -rf "$tmp"
+}
+
+@test "a capture holding no counter carries no legend about how to read counters" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # The legend rides on any capture that HOLDS numbers, which is wider than the
+  # captures that hold a whole reading -- and the widening has a floor. Every
+  # line of it describes numbers: which layer they belong to, which of them may
+  # be differenced, what the per-VM tag does and does not identify. On a file
+  # with no numbers the most consequential of those lines invites a reader to
+  # difference a counter that is not there, which is the sibling's entire
+  # cumulative total read as a rate over the window.
+  rm -rf "$tmp/debugfs/kvm"
+  mkdir -p "$tmp/debugfs/kvm"
+
+  run_capture || true
+
+  capture=$(capture_path)
+  assert_file_lacks_pattern 'a difference against the sibling sample' "$capture"
+  assert_file_lacks_pattern 'no ept_violation counter' "$capture"
+  assert_file_lacks_pattern 'per-VM and anonymous' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a kvm directory holding only kernel-wide counters is not reported as holding none" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # The mirror of the per-VM case beside this one, and the production shape
+  # whenever the sandbox VMs are down: the kernel keeps its own totals and hosts
+  # no VM, so there is no per-VM directory at all. The emptiness test is about
+  # the two levels together, and read as either-or this direction reports a
+  # capture holding three counters as one holding none.
+  rm -rf "$tmp/debugfs/kvm/4242-13"
+
+  run_capture
+
+  capture=$(capture_path)
+  assert_file_contains '[global] exits 1200' "$capture"
+  assert_file_lacks_pattern 'NO-COUNTER-FILES' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a counter written without a trailing newline is read rather than passed over" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # `read` returns non-zero on a last line with no newline while still setting
+  # the variable, so a walk that trusted its status would drop the value it had
+  # just read. The kernel formats its own stat files through "%llu\n" and so
+  # does not produce this shape, which is exactly why nothing else here would
+  # exercise the branch that handles it.
+  # One at each level, because the fallback is written twice -- once per walk --
+  # and a fixture at one level leaves the other's copy free to be deleted with
+  # the suite still green.
+  printf '7' >"$tmp/debugfs/kvm/nested_run"
+  printf '5' >"$tmp/debugfs/kvm/4242-13/irq_exits"
+
+  run_capture
+
+  assert_file_contains '[global] nested_run 7' "$(capture_path)"
+  assert_file_contains '[vm 4242-13] irq_exits 5' "$(capture_path)"
+  rm -rf "$tmp"
+}
+
+@test "a per-VM directory holding no readable counter is not filed as a reading" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # A VM directory whose counters cannot be read is the shape a VM going away
+  # under the walk produces, and it is indistinguishable on disk from a VM that
+  # reported nothing. Counting directories rather than counters lets it satisfy
+  # the emptiness test: the capture then holds no number and still carries the
+  # instruction to difference it against its sibling, which would turn that
+  # sibling's whole cumulative total into a rate over the window.
+  rm -rf "$tmp/debugfs/kvm"
+  mkdir -p "$tmp/debugfs/kvm/4242-13"
+  rc=0
+
+  run_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  capture=$(capture_path)
+  assert_file_contains 'NO-COUNTER-FILES' "$capture"
+  assert_file_lacks_pattern 'subtracting this file from its sibling' "$capture"
+  assert_file_lacks_pattern 'incomplete' "$capture"
+  assert_file_lacks_pattern 'unavailable' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a read killed before it reached a counter is not presented as a partial reading" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # The walk writes a heading before it reads anything, so a read killed on its
+  # first blocked file leaves a file that is not empty and holds no number. That
+  # shape is staged here by walking a kvm directory with nothing in it and
+  # forcing the wrapper's status, since what the arm has to get right is the
+  # file, not how it came to look that way. Keyed on file size rather than on a
+  # counter, the capture would be labelled partial and the caller told a pair
+  # was collected.
+  rm -rf "$tmp/debugfs/kvm"
+  mkdir -p "$tmp/debugfs/kvm"
+  timeout_rc_override=124
+  rc=0
+
+  run_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  capture=$(capture_path)
+  assert_file_contains 'no counter at all' "$capture"
+  assert_file_lacks_pattern 'incomplete' "$capture"
+  assert_file_lacks_pattern 'subtracting this file from its sibling' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a read that returned nothing is reported to the caller, not only to the report" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # Killed before it produced a byte: the dominant shape of a bounded read that
+  # ran out. Both callers ask this function whether it collected anything, and
+  # one of them runs on the passing path where the report is the artifact nobody
+  # downloads -- so a capture that got nothing has to answer non-zero or the
+  # warning that says the pair is broken never prints.
+  unshare_rc_override=124
+  rc=0
+
+  run_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  capture=$(capture_path)
+  assert_file_contains 'produced no counter at all' "$capture"
+  assert_file_lacks_pattern 'subtracting this file from its sibling' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a partial read is not reported to the caller as nothing collected" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # The other half of the pair above, and the reason the status is decided by
+  # what reached the file rather than by the exit code alone: a walk cut off
+  # after it wrote counters left a usable capture, and a caller told that
+  # nothing was collected would contradict the artifact sitting beside it.
+  timeout_rc_override=124
+  rc=0
+
+  run_capture || rc=$?
+
+  [ "$rc" -eq 0 ]
+  assert_file_contains 'incomplete' "$(capture_path)"
+  rm -rf "$tmp"
+}
+
+@test "a capture that failed points at the error log written beside it" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  mount_stderr='mount: (hint) debugfs is already mounted here.'
+  stage "$tmp"
+  # A read that was cut short while something was also written to stderr: the
+  # message belongs beside the capture rather than in the job log of a run that
+  # may be days old, and an arm that reports the shortfall without saying where
+  # the message went sends the reader looking there anyway. The node CPU time
+  # capture beside this one names its own error file for the same reason.
+  timeout_rc_override=124
+
+  run_capture || true
+
+  dir="$COZY_REPORT_DIR/snapshots/kvm-smoke/sandbox-kvm-exits/sample-1"
+  assert_file_contains 'read-error.log' "$dir/kvm-stats.txt"
+  assert_file_contains 'debugfs is already mounted here' "$dir/read-error.log"
+  rm -rf "$tmp"
+}
+
+@test "a read that returned no counter but left a message points at where it went" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  mount_stderr='mount: (hint) debugfs is already mounted here.'
+  stage "$tmp"
+  # The fourth corner of the pair of questions the arms answer: no counter
+  # reached the file, and something was written to stderr. The three other
+  # corners are staged elsewhere in this file, and without this one the arm that
+  # names the error log can be deleted with the suite still green -- leaving a
+  # reader told the capture is unavailable and not told that the reason is
+  # sitting in the file next to it.
+  rm -rf "$tmp/debugfs/kvm"
+  mkdir -p "$tmp/debugfs/kvm"
+  timeout_rc_override=124
+  rc=0
+
+  run_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  capture=$(capture_path)
+  assert_file_contains 'no counter at all' "$capture"
+  assert_file_contains 'read-error.log' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a mount that refused without a word does not point at a message that is not there" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  mount_rc=32
+  mount_stderr=
+  stage "$tmp"
+  rc=0
+
+  run_capture || rc=$?
+
+  # mount almost always writes a reason, which is why the marker was written to
+  # point at one. When it does not, the marker is a single line telling the
+  # reader to look above it at nothing, and a reader who follows that concludes
+  # the artifact lost the message rather than that there never was one.
+  [ "$rc" -ne 0 ]
+  marker=$(marker_path)
+  assert_file_contains 'without a word on either stream' "$marker"
+  assert_file_lacks_pattern 'the message above' "$marker"
+  rm -rf "$tmp"
+}
+
+@test "a read cut off part way is marked incomplete rather than presented whole" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # The walk wrote counters and then the wrapper killed it: the dominant shape
+  # of a bounded read that ran out, and the one where a whole-looking file is
+  # most misleading, since the difference against its sibling would understate
+  # every counter the walk never reached.
+  timeout_rc_override=124
+
+  run_capture || true
+
+  capture=$(capture_path)
+  assert_file_contains 'exits 1200' "$capture"
+  assert_file_contains 'incomplete' "$capture"
+  assert_file_lacks_pattern 'subtracting this file from its sibling' "$capture"
+  assert_file_contains '[capture exit code: 124]' "$capture"
+  # The lines that say how to read the numbers stay, because they do not depend
+  # on the walk having finished and this is exactly where a reader needs them:
+  # the counters above are real, and the naming trap and the anonymity of the
+  # per-VM split apply to them whether or not the walk reached the end. Only the
+  # instruction to difference two files asserts completeness.
+  assert_file_contains 'no ept_violation counter' "$capture"
+  assert_file_contains 'per-VM and anonymous' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a warning beside a healthy read is not filed as a failure" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  mount_stderr='mount: (hint) source is ignored for debugfs.'
+  stage "$tmp"
+
+  run_capture
+
+  # mount writes hints to stderr and exits zero, exactly as kubectl and talosctl
+  # do. Which file the complaint lands in is decided by the status, so a healthy
+  # capture keeps its warning instead of shipping a failure marker beside a
+  # reading that succeeded.
+  dir="$COZY_REPORT_DIR/snapshots/kvm-smoke/sandbox-kvm-exits/sample-1"
+  assert_file_contains 'source is ignored for debugfs' "$dir/READ-WARNINGS.txt"
+  [ ! -f "$dir/COLLECTION-FAILED.txt" ]
+  assert_file_contains 'exits 1200' "$dir/kvm-stats.txt"
+  rm -rf "$tmp"
+}
+
+@test "a report directory that cannot be created is said out loud" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+  # A file where the directory has to go. Every write below it then fails, and
+  # without a check the capture is a silent no-op -- the empty directory this
+  # whole suite exists to refuse, produced by the one cause the markers cannot
+  # describe, because there is nowhere to write a marker.
+  mkdir -p "$COZY_REPORT_DIR/snapshots/kvm-smoke"
+  printf 'not a directory\n' >"$COZY_REPORT_DIR/snapshots/kvm-smoke/sandbox-kvm-exits"
+  rc=0
+
+  out=$( ( set +x; cozy_capture_sandbox_kvm_exits 1 ) 2>&1 ) || rc=$?
+
+  [ "$rc" -ne 0 ]
+  case "$out" in
+    *"could not be created"*) ;;
+    *)
+      printf 'expected the collector to say the report directory could not be created, got: %s\n' "$out" >&2
+      return 1
+      ;;
+  esac
+  rm -rf "$tmp"
+}
+
+@test "the sample number decides which reading a file belongs to" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  unshare_calls="$tmp/unshare.calls"
+  stage "$tmp"
+
+  run_capture 2
+
+  # The pair is the instrument: one reading of a running total is an average
+  # over its whole life, not a rate over the failure. Two readings filed under
+  # the same name would leave the
+  # second overwriting the first and the artifact reading like a single sample.
+  assert_file_contains 'exits 1200' "$(capture_path 2)"
+  [ ! -f "$(capture_path 1)" ]
+  rm -rf "$tmp"
+}

--- a/hack/run-kubernetes-node-join_test.bats
+++ b/hack/run-kubernetes-node-join_test.bats
@@ -199,10 +199,10 @@ no_sandbox_talosconfig() {
   export TALOSCONFIG="$1/talosconfig-absent"
 }
 
-# The block calls seven collectors that have their own suites and their own
-# bounds. Four of them are stubbed here; the other three are stubbed only where
-# the test is about the budget rather than the reads, for the reason given
-# under stub_gated_collectors below. Stubbed after sourcing so these tests are
+# The block calls collectors that have their own suites and their own bounds.
+# The ones here are stubbed everywhere; the ones under stub_gated_collectors
+# below are stubbed only where the test is about the budget rather than the
+# reads, for the reason given there. Stubbed after sourcing so these tests are
 # about the block's own reads; left un-stubbed they would drag a Certificate, a
 # helper Pod and a cache probe into every case here.
 stub_collectors() {
@@ -210,6 +210,21 @@ stub_collectors() {
   cozy_capture_tenant_serial_console() { printf 'serial-console-stub\n'; }
   cozy_capture_tenant_talos() { printf 'talos-stub\n'; }
   talos_image_cache_diagnose() { printf 'image-cache-stub\n'; }
+  # Stubbed here rather than left to the gated set, and the audit below loses
+  # nothing by it: that audit works by letting real collector bodies reach the
+  # kubectl mock and failing on any read taken outside a `timeout` wrapper, and
+  # this one issues no kubectl read at all -- it shells out to `unshare` and
+  # `mount`. Un-stubbed it does that for real, so on Linux the unit suite
+  # attempts to mount debugfs with whatever privileges the host gives it -- this
+  # suite runs from `make unit-tests` on an ordinary VM rather than in the
+  # privileged sandbox container, so whether the attempt succeeds is the host's
+  # answer and not the code's -- while on macOS there is no `unshare` at all and
+  # the collector stops at its own precondition, so the path is never exercised.
+  # A unit test whose result is set by the machine rather than by the code is
+  # the property being removed, and the `timeout` mock in this file is a
+  # pass-through, so a `mount` that hung would hang the suite with no ceiling to
+  # stop it.
+  cozy_capture_sandbox_kvm_exits() { printf 'kvm-exits-stub\n'; }
 }
 
 # The collectors below are deliberately NOT in stub_collectors, and that is
@@ -866,6 +881,7 @@ assert_file_lacks_pattern() {
       talos_image_cache_diagnose() { :; }
       cozy_capture_tenant_worker_cpu_throttle() { :; }
       cozy_capture_tenant_worker_network_counters() { :; }
+      cozy_capture_sandbox_kvm_exits() { :; }
       ghcr_mirror_diagnose() { :; }
       kubectl() { :; }
       cozy_report_node_join_failure test-latest-version
@@ -932,6 +948,7 @@ assert_file_lacks_pattern() {
     talos_image_cache_diagnose() { :; }
     cozy_capture_tenant_worker_cpu_throttle() { :; }
     cozy_capture_tenant_worker_network_counters() { :; }
+    cozy_capture_sandbox_kvm_exits() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_capture_sandbox_node_cpu_time() { :; }
     cozy_capture_tenant_worker_thread_cpu() { :; }
@@ -1006,6 +1023,7 @@ assert_file_lacks_pattern() {
     talos_image_cache_diagnose() { :; }
     cozy_capture_tenant_worker_cpu_throttle() { :; }
     cozy_capture_tenant_worker_network_counters() { :; }
+    cozy_capture_sandbox_kvm_exits() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_report_node_join_failure test-latest-version
   ' 2>&1) || true
@@ -1038,6 +1056,7 @@ assert_file_lacks_pattern() {
     talos_image_cache_diagnose() { :; }
     cozy_capture_tenant_worker_cpu_throttle() { :; }
     cozy_capture_tenant_worker_network_counters() { :; }
+    cozy_capture_sandbox_kvm_exits() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_report_node_join_failure test-latest-version
   ' 2>&1) || true
@@ -1268,6 +1287,13 @@ assert_file_lacks_pattern() {
       # console experiment's own failure is named before the wording that
       # matches the bug it studies, and it is two bounded reads.
       cozy_report_guest_console_wedge) continue ;;
+      # Not behind the phase gate either, and for a reason of its own: it is the
+      # second half of a pair whose first reading was taken before the node-join
+      # wait, so declining it would not save a reading, it would orphan one
+      # already taken. Counted rather than skipped all the same -- it does sit
+      # ahead of the console in wall clock, and one bounded read is a cost this
+      # arm can state exactly, unlike a walk whose size follows the sandbox.
+      cozy_capture_sandbox_kvm_exits) ahead=$((ahead + bound + grace)) ;;
       cozy_capture_tenant_worker_network_counters) ahead=$((ahead + walk)) ;;
       *)
         echo "$fn is gated ahead of the console and this guard has no cost arm for it; add one, or move it below the console" >&2
@@ -1382,6 +1408,7 @@ assert_file_lacks_pattern() {
     'cozy_capture_tenant_worker_cpu_throttle:CPU throttling:_cozy_cadvisor_node_stream _cozy_virt_launcher_listing' \
     'cozy_capture_tenant_worker_network_counters:network counter:_cozy_cadvisor_node_stream _cozy_virt_launcher_listing' \
     'cozy_capture_sandbox_node_cpu_time:sandbox node CPU time:cozy_capture_sandbox_node_cpu_time' \
+    'cozy_capture_sandbox_kvm_exits:sandbox kernel KVM counters:cozy_capture_sandbox_kvm_exits' \
     'cozy_capture_tenant_worker_thread_cpu:worker per-thread CPU time:cozy_capture_tenant_worker_thread_cpu _cozy_virt_launcher_listing' \
     'ghcr_mirror_diagnose:ghcr-mirror:ghcr_mirror_diagnose _ghcr_mirror_bounded_read' \
     'talos_image_cache_diagnose:talos-image-cache:talos_image_cache_diagnose _talos_image_cache_bounded_read'; do
@@ -1418,6 +1445,7 @@ ${carrier}
       cozy_capture_tenant_worker_cpu_throttle) phrase='CPU throttling' ;;
       cozy_capture_tenant_worker_network_counters) phrase='network counter' ;;
       cozy_capture_sandbox_node_cpu_time) phrase='sandbox node CPU time' ;;
+      cozy_capture_sandbox_kvm_exits) phrase='sandbox kernel KVM counters' ;;
       cozy_capture_tenant_worker_thread_cpu) phrase='worker per-thread CPU time' ;;
       ghcr_mirror_diagnose) phrase='ghcr-mirror' ;;
       talos_image_cache_diagnose) phrase='talos-image-cache' ;;
@@ -1493,6 +1521,11 @@ ${carrier}
       # the wording that matches the bug it studies, and it is not part of what
       # the budget covers.
       cozy_report_guest_console_wedge) continue ;;
+      # Called the same way and also not behind the gate. Its first reading was
+      # taken before the node-join wait, so it is not something the budget hands
+      # out or withholds: declining it would leave that earlier reading with
+      # nothing to pair against rather than save the phase any time.
+      cozy_capture_sandbox_kvm_exits) continue ;;
       *)
         echo "$fn runs in the diagnostics block but this test has no phrase for it; add one here and to both chainsaw comments" >&2
         exit 1
@@ -1525,6 +1558,134 @@ EOF
       exit 1
     fi
   done
+}
+
+@test "the KVM counter readings sit on either side of the node-join wait on both paths" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # What this pair measures is decided by where its two calls sit, not by
+  # anything inside the collector: the counters carry running totals, so the
+  # interval a difference divides by is whatever runs between the readings.
+  #
+  # The failure path gets that for free -- the second reading is among the first
+  # things the failure block does, so the interval is the wait. The passing path
+  # does not. Everything from the kubelet-version check through the storage and
+  # LoadBalancer assertions runs after the wait, and the comment above the wait
+  # prices that tail at ten to fifteen minutes, so a second reading placed after
+  # it prices a different window over a different workload while the capture's
+  # own legend says it priced the join. Since the green run is what the red ones
+  # are read against, that does not merely widen the green number, it removes
+  # the comparison the collector exists for.
+  wait_line=$(grep -n '^  if ! timeout 18m bash -c' "$lib" | head -n 1 | cut -d: -f1)
+  first=$(grep -n 'cozy_capture_sandbox_kvm_exits 1' "$lib" | head -n 1 | cut -d: -f1)
+  # The green second reading, found as the one after the wait rather than by
+  # position in the file: the other call with the same argument is the failure
+  # block's, and picking by count would be right only while the two happen to be
+  # written in this order.
+  green=$(awk -v w="$wait_line" 'NR > w && /cozy_capture_sandbox_kvm_exits 2/ { print NR; exit }' "$lib")
+  # The first thing the happy path does with the tenant cluster once the wait
+  # returns. It stands in for the whole tail rather than for itself.
+  tail_line=$(grep -n '^  versions=\$(kubectl --kubeconfig' "$lib" | head -n 1 | cut -d: -f1)
+  for v in wait_line first green tail_line; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
+      return 1
+    fi
+  done
+  if [ "$first" -ge "$wait_line" ]; then
+    echo "the first KVM counter reading (line $first) is not taken before the node-join wait (line $wait_line), so the pair does not span it" >&2
+    return 1
+  fi
+  if [ "$green" -le "$wait_line" ]; then
+    echo "the passing path's second KVM counter reading (line $green) is not after the wait (line $wait_line)" >&2
+    return 1
+  fi
+  if [ "$green" -ge "$tail_line" ]; then
+    echo "the passing path's second KVM counter reading (line $green) is taken after the suite's happy-path tail begins (line $tail_line), so the green interval covers minutes of work the red one does not and the two are no longer comparable" >&2
+    return 1
+  fi
+  # And the same claim on the failing side, which is the half that has no
+  # equivalent of the tail to fail against and so would otherwise widen in
+  # silence. The failure block's own reads are bounded and small against an 18m
+  # wait, so this is not about today's arithmetic; it is that a collector
+  # inserted ahead of the reading later moves the red interval while the
+  # symmetric mistake on the green side fails loudly.
+  red=$(awk -v w="$wait_line" 'NR < w && /cozy_capture_sandbox_kvm_exits 2/ { line = NR } END { if (line) print line }' "$lib")
+  node_table=$(grep -n "cozy_diag_read 'tenant node table'" "$lib" | head -n 1 | cut -d: -f1)
+  for v in red node_table; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to read $v from $lib; without it this half of the guard reports success for having lost its input" >&2
+      return 1
+    fi
+  done
+  if [ "$red" -ge "$node_table" ]; then
+    echo "the failure path's second KVM counter reading (line $red) is taken after the diagnostics block has started reading the cluster (line $node_table), so the red interval is the wait plus whatever those reads cost" >&2
+    return 1
+  fi
+  # And what is allowed to run in front of it, by name. The check above bounds
+  # the reading against one later line; it does not notice a collector inserted
+  # between the block's first line and the reading, which is the way the red
+  # interval actually widens. One collector is there on purpose -- the wedge
+  # check, which has to name the console experiment's own failure before the
+  # headline whose wording matches the bug it studies -- and it is two bounded
+  # reads. Anything joining it has to be a decision rather than a diff nobody
+  # priced, so the set is pinned to that one name.
+  block=$(grep -n '^cozy_report_node_join_failure() {' "$lib" | head -n 1 | cut -d: -f1)
+  if [ -z "$block" ]; then
+    echo "expected the failure block to still be a function in $lib; without it this half of the guard reports success for having lost its input" >&2
+    return 1
+  fi
+  # Matched on the call, not on the `|| true` suffix the other guards key on.
+  # The suffix is what makes a call gated by the phase; it says nothing about
+  # what costs time, and the dominant idiom inside this block is `cozy_diag_read`
+  # with no suffix at all. Keyed on the suffix, this check would accept exactly
+  # the insertion it exists to refuse. `cozy_diag_phase_*` is out because it is
+  # bookkeeping rather than a read, and the trailing space or end-of-line keeps
+  # a function definition from matching its own call form.
+  ahead_of_red=$(grep -nE '^ *(cozy_capture_[a-z_]+|cozy_report_[a-z_]+|cozy_diag_read|[a-z_]+_diagnose)( |$)' "$lib" \
+    | sed -E 's/:[[:space:]]*/:/; s/(:[a-z_]+) .*/\1/' \
+    | awk -F: -v b="$block" -v r="$red" '$1 > b && $1 < r { print $2 }')
+  case "$(printf '%s\n' $ahead_of_red)" in
+    cozy_report_guest_console_wedge) ;;
+    '')
+      echo "found no collector at all ahead of the failure path's KVM reading; the wedge check belongs there, so this half of the guard checked nothing" >&2
+      return 1
+      ;;
+    *)
+      echo "more than the wedge check now runs between the failure block's start and its KVM counter reading, so the red interval is wider than the wait by whatever those collectors cost:" >&2
+      printf '%s\n' $ahead_of_red >&2
+      return 1
+      ;;
+  esac
+}
+
+@test "both KVM counter readings report a shortfall to the job log, not only to the report" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # The status exists to make a line print, and the reason is not symmetry with
+  # the collectors inside the diagnostics block, which are called `|| true` and
+  # whose whole record is the report. Both of these readings run outside that
+  # block -- one before the node-join wait, one after it on the passing path --
+  # and a passing run's report is the artifact nobody opens.
+  # docs/agents/e2e-testing.md requires what a passing-path collector could not
+  # collect at all to reach the job log. The guest console capture on the
+  # passing path is consumed the same way for the same reason, and its own suite
+  # pins that shape; this one had nothing pinning it, so rewriting both sites to
+  # `|| true` was invisible to every test in the tree.
+  #
+  # Derived from the source rather than restated, like the call-order checks
+  # above: what is pinned is the shape, one `if !` and one warning line per
+  # call site, not the wording of either.
+  calls=$(grep -c 'if ! cozy_capture_sandbox_kvm_exits [12]; then' "$lib")
+  warns=$(grep -c "» WARNING: the sandbox kernel's KVM counters yielded no reading" "$lib")
+  if [ "$calls" -ne 2 ]; then
+    echo "expected both KVM counter readings outside the diagnostics block to consume the collector's status with 'if !', found $calls" >&2
+    return 1
+  fi
+  if [ "$warns" -ne 2 ]; then
+    echo "expected each of those two call sites to put its shortfall in the job log, found $warns warning lines" >&2
+    return 1
+  fi
 }
 
 @test "the declined path leaves no shell error in the diagnostics log" {
@@ -1560,6 +1721,7 @@ EOF
     talos_image_cache_diagnose() { :; }
     cozy_capture_tenant_worker_cpu_throttle() { :; }
     cozy_capture_tenant_worker_network_counters() { :; }
+    cozy_capture_sandbox_kvm_exits() { :; }
     ghcr_mirror_diagnose() { :; }
     kubectl() { :; }
     COZY_DIAG_PHASE_BUDGET=0


### PR DESCRIPTION
## What this PR does

Every CPU reading this suite takes on a failing node-join describes a subject inside the sandbox: a cgroup, a QEMU thread, a sandbox node's own `/proc/stat`. All of them can report a guest that was handed its ticks while the guest gets no work done, and none of them can say what a tick cost. That is the state the node-join failures are in now, with quota untouched, throttling near zero, steal at zero and the sandbox host between a third and two thirds idle, while the guest does several times less work per core than the same image does on a run that passes.

The price is paid one layer down. A tenant worker is a guest of a sandbox node, which is itself a guest of the runner, and the runner's kernel absorbs the exits, nested page faults and TLB flushes that the arrangement provokes. That kernel publishes the totals in debugfs, and the suite runs in a container sharing it, so this is a local read rather than a walk over nodes.

Being local is what makes it affordable. The budget guard in `hack/run-kubernetes-node-join_test.bats` computes both sides of its own inequality, and on this tree the sampling pair can overshoot by 662s against the 680s the derivation allows, which leaves 18 seconds of room. A per-node reading costs two samples times three nodes times the read bound and its kill grace, or 150 seconds at today's knobs, and no transport changes that: the cost sits in the number of per-node calls rather than in the number of counters. Reading the layer the sandbox shares with the runner costs one bounded read instead, and takes nothing away from the collectors already there.

debugfs is mounted in a mount namespace belonging to the call. The suite runs for another twenty minutes after this returns, and a mount left behind would be a diagnostic editing the environment the rest of the run measures.

The pair is taken across the node-join wait rather than inside the diagnostics block. A counter here accumulates over the life of the VM it belongs to, so one reading is an average over that life rather than a rate over anything; taking the first before the wait and the second after it makes the interval a difference divides by the window the guest was failing to boot in, instead of a few seconds after the deadline had already expired. The kernel-wide files add a wrinkle the artifact states beside the numbers: the kernel answers them by summing over the VMs alive at the moment of the read, so a VM that went away between the samples takes its whole contribution with it while the survivors keep accumulating. The difference is then understated by a whole VM life and its sign proves nothing when positive; when it does come out negative, that is a finding about the sandbox rather than a rate.

The second reading is taken on the passing path too, so a green run leaves a baseline to read the failing ones against, and it is taken immediately after the wait rather than at the end of the run. That placement is the measurement: the happy-path tail is another ten to fifteen minutes of a tenant cluster doing storage and LoadBalancer work, so a reading taken after it would price a different window over a different workload while the capture's legend says it priced the join, and the green-versus-red comparison the collector exists for would be gone. A guard in `hack/run-kubernetes-node-join_test.bats` pins both calls to either side of the wait and fails if either drifts.

What the capture cannot answer is written into the artifact rather than left for a reader to assume. The counters price the sandbox VMs' own execution and not what runs inside them. A per-VM directory is named after a pid in the kernel's initial namespace, which the container cannot map to its own processes, so the split says how evenly the sandbox VMs paid and not which node paid what. Several counters sitting in that same directory are gauges or running maxima rather than cumulative, so a difference of those is a number with no meaning. And there is no `ept_violation` counter to look for: the nested-paging faults are counted as `pf_taken` and `pf_fixed`, under those names whichever vendor the runner turns out to be.

Every branch that can come up short is named where a reader will look for it: no `unshare` or no `mount` on PATH, a mount the sandbox refused, a kernel whose debugfs holds no `kvm` directory at all (which would be a finding about how the sandbox VMs are being run, not a collector that failed), a `kvm` directory holding nothing readable, a walk the wrapper cut short, and a report directory that could not be created. The pairing instruction rides only on the arm that holds a whole reading, so the artifact never invites a difference against a file that has no counters in it.

A capture holding no counter answers its caller non-zero, the two findings included, so the passing path writes the shortfall into the job log instead of leaving it in a report nobody downloads. A walk cut short after it wrote counters does not: it left a usable partial reading, marked as partial, and telling the caller nothing was collected would contradict the file sitting beside it. That distinction is decided by whether a counter reached the file rather than by whether the file has bytes in it, because the walk writes a heading before it reads anything.

Covered by `hack/run-kubernetes-kvm-exits_test.bats`, which runs under `make unit-tests`. The guards in `hack/run-kubernetes-node-join_test.bats` that enumerate the collectors were updated rather than worked around: the new capture gets a cost arm in the budget guard, an entry in the missing-timeout warning, and an explicit exemption from the spend-order list, because it is not behind the phase gate. It is not behind that gate deliberately: every other collector the phase declines loses only itself, while declining this one would orphan a reading already taken eighteen minutes earlier. Two guards there are new: one pins where the two readings sit rather than what they contain, the other pins that both call sites consume the collector's status, since this is the only collector in that file whose return value is read at all and it is read so a passing run's shortfall reaches the job log.

The collector is also stubbed in that suite, at the shared helper and at each of the five inline stub lists inside its `bash -c` bodies. Left out of them the node-join unit tests call it for real, which on Linux means the unit suite runs `unshare --mount` and `mount -t debugfs` with whatever privileges the host gives it, while on macOS the collector stops at its own `command -v unshare` precondition and the path is never exercised at all: a unit test whose result is set by the machine rather than by the code. Measured with a recording fake on `PATH`, the suite makes 21 real invocations with no stub, 9 with the shared helper alone, and none with every site covered. Stubbing costs the block-level read audit nothing, because that audit works by letting real collector bodies reach the kubectl mock and this collector issues no kubectl read.

Context for the measurement is cozystack/cozystack#3513.

### Screenshots

Not a UI change.

### Downstream repositories

I walked the trigger map in `docs/agents/contributing.md` against the diff. The diff adds one collector to `hack/e2e-chainsaw/_lib/run-kubernetes.sh`, adds one BATS suite under `hack/`, and edits guards in an existing BATS suite. Nothing under `hack/` is moved or renamed, no make target changes what it does, and `hack/e2e-prepare-cluster.bats` is not touched, so neither the `ccp` trigger on `hack/` layout nor the `ansible-cozystack` and `talm` triggers on node prerequisites fire.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
test(e2e): capture the runner kernel's KVM exit counters on either side of the tenant node-join wait, so a node-join failure can be told apart from a nested-virtualisation slowdown that no counter inside the sandbox can see
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added sandbox KVM-exit diagnostics during Kubernetes node-join operations.
  - Reports counter availability, interpretation, timestamps, warnings, and read status.
  - Captures readings before and after node-join waits, including failure scenarios.
  - Uses bounded collection and isolated debugfs access to limit diagnostic overhead.

- **Bug Fixes**
  - Improved timeout warnings with KVM diagnostic status and missing-reading details.

- **Tests**
  - Added extensive coverage for counter types, malformed or unavailable data, timeouts, failures, cleanup, and report generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->