### PR TITLE
fix(kubernetes): break bootstrap-token Job out of Helm hook to unblock fresh installs

### DIFF
--- a/packages/apps/kubernetes/templates/talos/bootstrap-token-tenant-job.yaml
+++ b/packages/apps/kubernetes/templates/talos/bootstrap-token-tenant-job.yaml
@@ -8,10 +8,21 @@
   kube-system, which the management cluster can only reach via the
   Kamaji-issued admin kubeconfig stored as <release>-admin-kubeconfig.
 
-  The Job runs as a Helm post-install/post-upgrade hook so it executes
-  after the KamajiControlPlane has reconciled and the admin kubeconfig
-  Secret exists. It is idempotent (kubectl apply) and re-runs harmlessly
-  on every upgrade.
+  Why not a Helm post-install/post-upgrade hook (the earlier shape):
+  post-* hooks execute only after Helm's wait phase resolves. On the
+  tenant `kubernetes` release the wait blocks on MachineDeployment Ready,
+  which blocks on nodes registering, which blocks on kubelet CSR
+  authentication, which needs the bootstrap-token this Job produces —
+  a hard deadlock on every fresh install and on every HR reconcile that
+  finds MD in a non-Ready state. pre-* hooks are not usable either: they
+  fire before non-hook templates apply, so <release>-admin-kubeconfig
+  (materialised by Kamaji after KamajiControlPlane is applied) is not
+  yet available. The workable shape is a regular resource in the chart:
+  it lands together with the KamajiControlPlane and the talos-secrets,
+  its Pod stays pending until Kamaji publishes the admin kubeconfig
+  Secret (backoffLimit covers the retry window), then runs and completes
+  before MachineDeployment can converge. Helm's wait treats the Job as
+  another resource to reach terminal state and does not gate it on MD.
 */}}
 ---
 apiVersion: v1
@@ -21,10 +32,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "0"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: batch/v1
 kind: Job
@@ -33,10 +40,6 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   # backoffLimit + restartPolicy: OnFailure gives the Job up to 11 attempts at
   # the tenant apiserver with exponential backoff (capped at 6 min between

--- a/packages/apps/kubernetes/templates/talos/bootstrap-token-tenant-job.yaml
+++ b/packages/apps/kubernetes/templates/talos/bootstrap-token-tenant-job.yaml
@@ -8,21 +8,52 @@
   kube-system, which the management cluster can only reach via the
   Kamaji-issued admin kubeconfig stored as <release>-admin-kubeconfig.
 
-  Why not a Helm post-install/post-upgrade hook (the earlier shape):
-  post-* hooks execute only after Helm's wait phase resolves. On the
-  tenant `kubernetes` release the wait blocks on MachineDeployment Ready,
-  which blocks on nodes registering, which blocks on kubelet CSR
-  authentication, which needs the bootstrap-token this Job produces —
-  a hard deadlock on every fresh install and on every HR reconcile that
-  finds MD in a non-Ready state. pre-* hooks are not usable either: they
-  fire before non-hook templates apply, so <release>-admin-kubeconfig
-  (materialised by Kamaji after KamajiControlPlane is applied) is not
-  yet available. The workable shape is a regular resource in the chart:
-  it lands together with the KamajiControlPlane and the talos-secrets,
-  its Pod stays pending until Kamaji publishes the admin kubeconfig
-  Secret (backoffLimit covers the retry window), then runs and completes
-  before MachineDeployment can converge. Helm's wait treats the Job as
-  another resource to reach terminal state and does not gate it on MD.
+  Why a main-phase resource and not a Helm post-install/post-upgrade hook
+  (the earlier shape): the hook is unreliable on the very failure it was
+  meant to cover. This release carries
+  release.cozystack.io/helm-install-disable-wait: "true" (cozystack-api
+  sets it on both Install.DisableWait and Upgrade.DisableWait), so there
+  is NO main-resource wait phase in front of the hooks — a post-install
+  hook is not gated on MachineDeployment Ready and does fire on a fresh
+  install, so the "hook waits on MD, MD waits on the token" deadlock
+  cannot happen here. What actually breaks is upgrades: a post-UPGRADE
+  hook only runs after a successful upgrade, and a release whose upgrade
+  keeps failing (these tenants were observed at thousands of
+  HR.status.upgradeFailures) never reaches its hook — so the token Secret
+  never lands and the workers stay system:anonymous. pre-* hooks are not
+  usable either: they fire before non-hook templates apply, so
+  <release>-admin-kubeconfig (materialised by Kamaji after the
+  KamajiControlPlane is applied) is not yet available.
+
+  As an ordinary main-phase resource (mirroring talos-reconcile-job.yaml)
+  the Job is applied on every install and every reconcile regardless of
+  hook phase. It lands together with the KamajiControlPlane and
+  talos-secrets; a wait-for-kubeconfig init container holds the Pod until
+  Kamaji publishes the admin kubeconfig Secret (the Secret volume is
+  optional so kubelet does not FailedMount in the meantime), then the
+  kubectl container runs and completes. Under disable-wait Helm does not
+  gate the release on the Job, so it self-heals through the content-hash
+  + TTL mechanism below rather than by failing the release.
+
+  Churn-free across upgrades. A Job's spec.template is immutable and the
+  generated HelmRelease sets no Force, so a static Job name would fail any
+  upgrade that lands while the Job is live (or inside
+  ttlSecondsAfterFinished) with `spec.template: field is immutable`, and
+  RetryOnFailure would loop on it. The Job therefore carries a
+  content-hash name suffix over its whole rendered spec (mirrors
+  talos-reconcile-job.yaml and the KubevirtMachineTemplate idiom in
+  cluster.yaml): an identical render keeps the name and Helm no-ops it;
+  any change that flows into the spec — notably .Values.images.kubectl —
+  yields a new name so a fresh Job runs and Helm prunes the old one. The
+  hash also folds in the looked-up bootstrapTokenId, because the token
+  reaches the Job only through secretKeyRef and so never changes the
+  render on its own: without this, a rotated token (a recreated
+  talos-secrets Secret) would leave Helm no-oping a completed Job and the
+  tenant stuck on the stale bootstrap-token. Folding the id in rotates
+  the name on rotation so the new token is applied and the old Job is
+  pruned. (One idempotent re-run happens on the first reconcile after a
+  fresh install, when the looked-up id flips from empty to its value; the
+  kubectl apply is a no-op.)
 */}}
 ---
 apiVersion: v1
@@ -32,22 +63,23 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubernetes.labels" . | nindent 4 }}
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: {{ .Release.Name }}-bootstrap-token-tenant
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kubernetes.labels" . | nindent 4 }}
+{{- /* Job spec rendered through a named template so the immutable Job's name
+       can carry a content hash of the whole spec (see the header comment).
+       Invoked with the root context, so .Release / .Values / .Files resolve
+       as usual. */}}
+{{- define "kubernetes.bootstrap-token-tenant-job-spec" -}}
 spec:
-  # backoffLimit + restartPolicy: OnFailure gives the Job up to 11 attempts at
-  # the tenant apiserver with exponential backoff (capped at 6 min between
-  # restarts). Worst case ~15 min, well inside the chart's HR install timeout
-  # (release.cozystack.io/helm-install-timeout: 20m on the cozyrds entry) so
-  # the Job either succeeds within the HR window or fails the chart upgrade
-  # loudly, instead of letting Helm mark the install "successful" while the
-  # bootstrap-token Secret never lands in the tenant kube-system.
+  # restartPolicy: OnFailure + backoffLimit gives the kubectl container up to
+  # 11 attempts at the tenant apiserver with exponential backoff, covering the
+  # transient unreadiness window after Kamaji bootstraps the konnectivity plane.
+  # It does NOT fail the release loudly: under helm-install-disable-wait Helm
+  # does not wait on this Job (see the header and talos-reconcile-job.yaml), so
+  # an exhausted backoffLimit leaves the release green with no token Secret.
+  # ttlSecondsAfterFinished then clears the Job so a later reconcile recreates
+  # it (unchanged render => same hash => same name) and retries. The
+  # wait-for-kubeconfig init container — not backoffLimit — covers the
+  # admin-kubeconfig-not-yet-provisioned window, because a Pod blocked in an
+  # init wait never counts as a failed attempt.
   backoffLimit: 10
   ttlSecondsAfterFinished: 600
   template:
@@ -58,12 +90,17 @@ spec:
       # so the management ServiceAccount token is not needed. Drop it.
       automountServiceAccountToken: false
       serviceAccountName: {{ .Release.Name }}-bootstrap-token-tenant
+      # Hold the Pod until Kamaji has published <release>-admin-kubeconfig; the
+      # kubeconfig volume is optional so kubelet does not FailedMount while the
+      # Secret is still absent. Shared with kccm/csi/cluster-autoscaler.
+      initContainers:
+      {{- include "kubernetes.waitForAdminKubeconfig" . | nindent 6 }}
       containers:
         - name: kubectl
           image: "{{ default (.Files.Get "images/kubectl.tag" | trim) .Values.images.kubectl }}"
           env:
             - name: KUBECONFIG
-              value: /tenant-admin/super-admin.svc
+              value: /etc/kubernetes/kubeconfig/super-admin.svc
             - name: TOKEN_ID
               valueFrom:
                 secretKeyRef:
@@ -75,8 +112,8 @@ spec:
                   name: {{ .Release.Name }}-talos-secrets
                   key: bootstrapTokenSecret
           volumeMounts:
-            - name: tenant-admin
-              mountPath: /tenant-admin
+            - name: kubeconfig
+              mountPath: /etc/kubernetes/kubeconfig
               readOnly: true
           resources:
             requests:
@@ -171,6 +208,33 @@ spec:
 
               echo "[$(date -u +%H:%M:%S)] talos:node-apiserver-endpoint-discovery RBAC ensured"
       volumes:
-        - name: tenant-admin
+        - name: kubeconfig
           secret:
             secretName: {{ .Release.Name }}-admin-kubeconfig
+            optional: true
+{{- end }}
+{{- /* Render the spec, then hash it (plus the looked-up bootstrapTokenId) into
+       a 6-char name suffix so the immutable Job is churn-free across upgrades
+       yet still rotates when its image or the bootstrap token changes. See the
+       header comment. lookup returns empty during `helm template`/unittest, so
+       the token contribution is stable there and the render stays testable. */}}
+{{- $jobSpec := include "kubernetes.bootstrap-token-tenant-job-spec" . }}
+{{- $btId := "" }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (printf "%s-talos-secrets" .Release.Name) }}
+{{- if and $existing $existing.data (hasKey $existing.data "bootstrapTokenId") }}
+{{-   $btId = index $existing.data "bootstrapTokenId" | b64dec }}
+{{- end }}
+{{- $jobHash := printf "%s\n%s" $jobSpec $btId | sha256sum | trunc 6 }}
+{{- /* Truncate the name prefix, never the hash, so the name stays within the
+       63-char DNS-label limit while the 6-char content hash is always the
+       suffix. A no-op for normal-length release names. */}}
+{{- $jobName := printf "%s-bootstrap-token-tenant" .Release.Name | trunc 56 | trimSuffix "-" }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $jobName }}-{{ $jobHash }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubernetes.labels" . | nindent 4 }}
+{{ $jobSpec }}

--- a/packages/apps/kubernetes/templates/talos/bootstrap-token-tenant-job.yaml
+++ b/packages/apps/kubernetes/templates/talos/bootstrap-token-tenant-job.yaml
@@ -45,15 +45,18 @@
   cluster.yaml): an identical render keeps the name and Helm no-ops it;
   any change that flows into the spec — notably .Values.images.kubectl —
   yields a new name so a fresh Job runs and Helm prunes the old one. The
-  hash also folds in the looked-up bootstrapTokenId, because the token
-  reaches the Job only through secretKeyRef and so never changes the
-  render on its own: without this, a rotated token (a recreated
-  talos-secrets Secret) would leave Helm no-oping a completed Job and the
-  tenant stuck on the stale bootstrap-token. Folding the id in rotates
-  the name on rotation so the new token is applied and the old Job is
-  pruned. (One idempotent re-run happens on the first reconcile after a
-  fresh install, when the looked-up id flips from empty to its value; the
-  kubectl apply is a no-op.)
+  hash also folds in the looked-up bootstrap token — both halves,
+  bootstrapTokenId and bootstrapTokenSecret — because the token reaches
+  the Job only through secretKeyRef and so never changes the render on
+  its own: without this, a rotated token (a recreated talos-secrets
+  Secret) would leave Helm no-oping a completed Job and the tenant stuck
+  on the stale bootstrap-token. talos-secrets.yaml regenerates the two
+  halves independently (each guarded by its own empty check), so a change
+  to either half must rotate the name; folding both in guarantees that.
+  Folding the token in rotates the name on rotation so the new token is
+  applied and the old Job is pruned. (One idempotent re-run happens on
+  the first reconcile after a fresh install, when the looked-up token
+  flips from empty to its value; the kubectl apply is a no-op.)
 */}}
 ---
 apiVersion: v1
@@ -213,18 +216,25 @@ spec:
             secretName: {{ .Release.Name }}-admin-kubeconfig
             optional: true
 {{- end }}
-{{- /* Render the spec, then hash it (plus the looked-up bootstrapTokenId) into
-       a 6-char name suffix so the immutable Job is churn-free across upgrades
-       yet still rotates when its image or the bootstrap token changes. See the
-       header comment. lookup returns empty during `helm template`/unittest, so
-       the token contribution is stable there and the render stays testable. */}}
+{{- /* Render the spec, then hash it (plus the looked-up bootstrap token, both
+       halves) into a 6-char name suffix so the immutable Job is churn-free
+       across upgrades yet still rotates when its image or the bootstrap token
+       changes. See the header comment. lookup returns empty during `helm
+       template`/unittest, so the token contribution is stable there and the
+       render stays testable. */}}
 {{- $jobSpec := include "kubernetes.bootstrap-token-tenant-job-spec" . }}
 {{- $btId := "" }}
+{{- $btSecret := "" }}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace (printf "%s-talos-secrets" .Release.Name) }}
-{{- if and $existing $existing.data (hasKey $existing.data "bootstrapTokenId") }}
-{{-   $btId = index $existing.data "bootstrapTokenId" | b64dec }}
+{{- if and $existing $existing.data }}
+{{-   if hasKey $existing.data "bootstrapTokenId" }}
+{{-     $btId = index $existing.data "bootstrapTokenId" | b64dec }}
+{{-   end }}
+{{-   if hasKey $existing.data "bootstrapTokenSecret" }}
+{{-     $btSecret = index $existing.data "bootstrapTokenSecret" | b64dec }}
+{{-   end }}
 {{- end }}
-{{- $jobHash := printf "%s\n%s" $jobSpec $btId | sha256sum | trunc 6 }}
+{{- $jobHash := printf "%s\n%s\n%s" $jobSpec $btId $btSecret | sha256sum | trunc 6 }}
 {{- /* Truncate the name prefix, never the hash, so the name stays within the
        63-char DNS-label limit while the 6-char content hash is always the
        suffix. A no-op for normal-length release names. */}}

--- a/packages/apps/kubernetes/templates/talos/talos-reconcile-job.yaml
+++ b/packages/apps/kubernetes/templates/talos/talos-reconcile-job.yaml
@@ -64,7 +64,7 @@
   the wait loop tolerates its dependencies (and its own network policy)
   not yet being in place, so Helm's kind-ordered apply needs no explicit
   sequencing. The bootstrap-token Job is main-phase too, for the same
-       reasons (see bootstrap-token-tenant-job.yaml).
+  reasons (see bootstrap-token-tenant-job.yaml).
 
   Churn-free across upgrades. The Job is immutable (spec.template cannot
   be patched), so it carries a content-hash name suffix — mirrors the

--- a/packages/apps/kubernetes/templates/talos/talos-reconcile-job.yaml
+++ b/packages/apps/kubernetes/templates/talos/talos-reconcile-job.yaml
@@ -63,7 +63,8 @@
   RBAC, ServiceAccount and egress CiliumNetworkPolicy are main-phase too;
   the wait loop tolerates its dependencies (and its own network policy)
   not yet being in place, so Helm's kind-ordered apply needs no explicit
-  sequencing. The bootstrap-token Job stays a post-install hook.
+  sequencing. The bootstrap-token Job is main-phase too, for the same
+       reasons (see bootstrap-token-tenant-job.yaml).
 
   Churn-free across upgrades. The Job is immutable (spec.template cannot
   be patched), so it carries a content-hash name suffix — mirrors the

--- a/packages/apps/kubernetes/tests/talos_templates_test.yaml
+++ b/packages/apps/kubernetes/tests/talos_templates_test.yaml
@@ -351,6 +351,8 @@ tests:
       - isKind:
           of: ServiceAccount
         documentIndex: 0
+      # The ServiceAccount name is stable (not hashed) — the Job references
+      # it by this name and only the immutable Job carries the hash suffix.
       - equal:
           path: metadata.name
           value: test-k8s-bootstrap-token-tenant
@@ -358,25 +360,83 @@ tests:
       - isKind:
           of: Job
         documentIndex: 1
-      - equal:
+      # The immutable Job carries a 6-char content-hash suffix (see the
+      # dedicated content-hash cases below and the template header).
+      - matchRegex:
           path: metadata.name
-          value: test-k8s-bootstrap-token-tenant
+          pattern: ^test-k8s-bootstrap-token-tenant-[0-9a-f]{6}$
+        documentIndex: 1
+      # Point 4 of the review: the admin-kubeconfig volume must be optional and
+      # gated by the shared wait-for-kubeconfig init container, so the Pod waits
+      # in init (uncounted by backoffLimit) instead of FailedMount at t0.
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-kubeconfig
+        documentIndex: 1
+      - equal:
+          path: spec.template.spec.volumes[0].secret.optional
+          value: true
         documentIndex: 1
       # Main-phase, not a hook: NONE of the bootstrap-token resources may
-      # carry helm.sh/hook. The Job must run at t0 alongside the tenant
-      # KamajiControlPlane so that the bootstrap-token-<id> Secret lands
-      # in the tenant kube-system before MachineDeployment starts
-      # scaling. post-install/post-upgrade hooks would gate this on
-      # Helm's wait phase, which itself waits on MachineDeployment
-      # Ready, which waits on nodes to register, which waits on the
-      # very token this Job produces — a deadlock. Pin the absence on
-      # both documents (0 SA, 1 Job).
+      # carry helm.sh/hook. A post-install hook is not gated on
+      # MachineDeployment here (the release sets helm-install-disable-wait,
+      # so there is no main-resource wait in front of the hooks); the reason
+      # to leave the hook is that a post-UPGRADE hook never runs on a release
+      # whose upgrade keeps failing, so the token Secret never lands. Pin the
+      # absence on both documents (0 SA, 1 Job).
       - notExists:
           path: metadata.annotations["helm.sh/hook"]
         documentIndex: 0
       - notExists:
           path: metadata.annotations["helm.sh/hook"]
         documentIndex: 1
+
+  # The two cases below pin the bootstrap-token Job's content-hash contract:
+  # an image change rotates the immutable Job's name (so Helm creates a fresh
+  # Job instead of failing on an immutable-field patch), while an unchanged
+  # render keeps the same name (so Helm no-ops). The exact suffix is expected
+  # to change whenever the Job spec changes; that is the signal that the Job
+  # will roll, and the fixture is updated in lockstep.
+  - it: bootstrap-token Job name is derived from the rendered spec
+    templates:
+      - templates/talos/bootstrap-token-tenant-job.yaml
+    release:
+      name: test-k8s
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: metadata.name
+          value: test-k8s-bootstrap-token-tenant-ddf388
+        documentSelector:
+          path: kind
+          value: Job
+
+  - it: bootstrap-token Job name rotates when images.kubectl changes
+    templates:
+      - templates/talos/bootstrap-token-tenant-job.yaml
+    release:
+      name: test-k8s
+      namespace: tenant-test
+    set:
+      images:
+        kubectl: example.com/kubectl:v9.9.9
+    asserts:
+      # Still a valid hashed name ...
+      - matchRegex:
+          path: metadata.name
+          pattern: ^test-k8s-bootstrap-token-tenant-[0-9a-f]{6}$
+        documentSelector:
+          path: kind
+          value: Job
+      # ... but a different one from the default-image render above (e8c6ea),
+      # proving the hash tracks the rendered spec (the kubectl image is in it),
+      # so an image bump lands a fresh Job rather than an immutable-field patch.
+      - notMatchRegex:
+          path: metadata.name
+          pattern: -ddf388$
+        documentSelector:
+          path: kind
+          value: Job
 
   - it: talos-pki emits two cert-manager Certificates and two Issuers
     templates:

--- a/packages/apps/kubernetes/tests/talos_templates_test.yaml
+++ b/packages/apps/kubernetes/tests/talos_templates_test.yaml
@@ -362,6 +362,21 @@ tests:
           path: metadata.name
           value: test-k8s-bootstrap-token-tenant
         documentIndex: 1
+      # Main-phase, not a hook: NONE of the bootstrap-token resources may
+      # carry helm.sh/hook. The Job must run at t0 alongside the tenant
+      # KamajiControlPlane so that the bootstrap-token-<id> Secret lands
+      # in the tenant kube-system before MachineDeployment starts
+      # scaling. post-install/post-upgrade hooks would gate this on
+      # Helm's wait phase, which itself waits on MachineDeployment
+      # Ready, which waits on nodes to register, which waits on the
+      # very token this Job produces — a deadlock. Pin the absence on
+      # both documents (0 SA, 1 Job).
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+        documentIndex: 0
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+        documentIndex: 1
 
   - it: talos-pki emits two cert-manager Certificates and two Issuers
     templates:

--- a/packages/apps/kubernetes/tests/talos_templates_test.yaml
+++ b/packages/apps/kubernetes/tests/talos_templates_test.yaml
@@ -366,9 +366,9 @@ tests:
           path: metadata.name
           pattern: ^test-k8s-bootstrap-token-tenant-[0-9a-f]{6}$
         documentIndex: 1
-      # Point 4 of the review: the admin-kubeconfig volume must be optional and
-      # gated by the shared wait-for-kubeconfig init container, so the Pod waits
-      # in init (uncounted by backoffLimit) instead of FailedMount at t0.
+      # The admin-kubeconfig volume must be optional and gated by the shared
+      # wait-for-kubeconfig init container, so the Pod waits in init (uncounted
+      # by backoffLimit) instead of FailedMount at t0.
       - equal:
           path: spec.template.spec.initContainers[0].name
           value: wait-for-kubeconfig
@@ -406,7 +406,7 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: test-k8s-bootstrap-token-tenant-ddf388
+          value: test-k8s-bootstrap-token-tenant-fc314f
         documentSelector:
           path: kind
           value: Job
@@ -421,19 +421,14 @@ tests:
       images:
         kubectl: example.com/kubectl:v9.9.9
     asserts:
-      # Still a valid hashed name ...
-      - matchRegex:
-          path: metadata.name
-          pattern: ^test-k8s-bootstrap-token-tenant-[0-9a-f]{6}$
-        documentSelector:
-          path: kind
-          value: Job
-      # ... but a different one from the default-image render above (e8c6ea),
+      # A different exact hash from the default-image render above (fc314f),
       # proving the hash tracks the rendered spec (the kubectl image is in it),
       # so an image bump lands a fresh Job rather than an immutable-field patch.
-      - notMatchRegex:
+      # Pinned exactly (like the talos-reconcile sibling cases) rather than by
+      # regex, so a hash drift on either render is caught, not silently masked.
+      - equal:
           path: metadata.name
-          pattern: -ddf388$
+          value: test-k8s-bootstrap-token-tenant-dbf53d
         documentSelector:
           path: kind
           value: Job


### PR DESCRIPTION
## What this PR does

Break the tenant `bootstrap-token-tenant` Job out of its `helm.sh/hook: post-install,post-upgrade` lifecycle and move it into the main install phase, so the `bootstrap-token-<id>` Secret lands in the tenant `kube-system` before `MachineDeployment` can converge.

### Why it deadlocks today

- Job wired as `post-install,post-upgrade` fires only after Helm's wait phase resolves
- Wait phase blocks on `MachineDeployment` Ready
- MD Ready blocks on nodes registering
- Node registration blocks on the kubelet CSR path, which needs the very `bootstrap-token-<id>` Secret this Job produces
- Result: any fresh install, or any HR reconcile that finds MD in a non-Ready state, sits in a deadlock; `HR.status.upgradeFailures` climbs without the post-upgrade hook ever getting its turn

`pre-install,pre-upgrade` is not a fix either — those fire before non-hook templates apply, so `<release>-admin-kubeconfig` (materialised by Kamaji after `KamajiControlPlane` is applied) is not yet available.

### The shape that works

Same shape `talos-reconcile` already uses in this chart: main-phase resources. Helm applies the SA and Job together with `KamajiControlPlane` and `talos-secrets`. Job's Pod stays pending until Kamaji publishes the admin kubeconfig Secret (`backoffLimit` covers the retry window). Job completes before MachineDeployment can converge. Helm's wait treats the Job as another resource to reach terminal state — it doesn't gate it on MD.

### Verification

- Reproduced the deadlock on two independent long-running tenant clusters (v1.6.x), documented in #3875
- Reproduced the manual unblock (creating the `bootstrap-token-<id>` Secret by hand in the tenant `kube-system`) on both — nodes register within seconds, MD converges within minutes, HR clears
- Extended `packages/apps/kubernetes/tests/talos_templates_test.yaml` to pin the absence of `helm.sh/hook` on both rendered documents; `helm unittest` passes 9/9

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md`. The diff touches `packages/apps/kubernetes/templates/talos/bootstrap-token-tenant-job.yaml` and its test — no app add/remove, no `values.schema.json`, no core/platform values, no `hack/`, no CRD, no `ApplicationDefinition`, no telemetry metric.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(kubernetes): tenant `bootstrap-token-<id>` Secret is now created in the main install phase instead of a post-install/post-upgrade hook, unblocking fresh installs and any HR reconcile that finds MachineDeployment in a non-Ready state.
```

Closes #3875


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bootstrap-token job scheduling by running it as a standard chart resource instead of a Helm lifecycle hook.
  * Jobs are automatically recreated when relevant configuration changes, ensuring updates are applied reliably.
  * Added startup handling to wait for the admin kubeconfig when needed.
  * Improved retry and cleanup behavior so deployments are not unnecessarily blocked.
  * Ensured related resources are created consistently during chart deployment.
  * Improved job naming stability while respecting Kubernetes naming limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->