### PR TITLE
test(e2e): capture worker block IO and volume state on node-join failure

### DIFF
--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -1123,13 +1123,13 @@ _cozy_cadvisor_node_stream() {
   # duration -- and it is declined for a reason that outlives any particular way
   # of sharing the read.
   #
-  # Sharing it means the two captures becoming one walk, and that is not done
-  # here for scope rather than for merit: one walk behind the first of the two
-  # gates would be cheaper AND collect more. The gate is a deadline checked with
-  # date, not a per-collector allowance, so the pair yields both, the first
-  # alone, or neither -- and a merged walk admitted at the first gate turns the
-  # first-alone case into both while leaving neither unchanged. Anyone weighing
-  # this should read that as an argument for merging, not against it.
+  # Sharing it means the captures of one node becoming one walk, and that is not
+  # done here for scope rather than for merit: one walk behind the earliest of
+  # their gates would be cheaper AND collect more. The gate is a deadline checked
+  # with date, not a per-collector allowance, so a run yields all of them, a
+  # prefix of them, or none -- and a merged walk admitted at the earliest gate
+  # turns every prefix into all of them while leaving none unchanged. Anyone
+  # weighing this should read that as an argument for merging, not against it.
   #
   # A cross-phase cache avoids the merge and was tried; it is not what stands
   # here, and the reason is not the cost above but that a cache publishes a
@@ -1154,7 +1154,7 @@ _cozy_cadvisor_node_stream() {
 
 # _cozy_capture_worker_cadvisor <subdir> <label> <subject> <series> <tmp-prefix> <tail-hook> <metric-re>
 #
-# The body both worker counter captures share. It was two near-identical copies
+# The body every worker counter capture shares. It was two near-identical copies
 # differing in a report subdirectory, a regex, a subject phrase and a trailing
 # note, and the copies cost more than duplication normally does: the block-level
 # bound audit pins each collector by something only it produces, and two
@@ -1411,12 +1411,12 @@ _cozy_capture_worker_cadvisor() {
     # hooks today end on an `if` that returns 0 when its condition is false, so
     # this changes nothing now and removes the requirement that they always will.
     "${tail_hook}" "${raw}" "${rc}" "${filter_rc}" "${had_series}" || true
-    # Sample-agnostic on purpose. This body is shared, and only one of its two
-    # callers takes a second sample: telling the reader of the other one to
-    # subtract a sibling would name a file that does not exist and contradict
-    # that capture's own tail note in the line above it. What is true for both
-    # is when the read happened, so that is what this says, and the instruction
-    # to pair it belongs to the capture that has a pair.
+    # Sample-agnostic on purpose. This body is shared, and only one of its
+    # callers takes a second sample: telling the reader of a caller that does not
+    # to subtract a sibling would name a file that does not exist and contradict
+    # that capture's own tail note in the line above it. What is true for every
+    # caller is when the read happened, so that is what this says, and the
+    # instruction to pair it belongs to the capture that has a pair.
     # The bracket only, with no claim about what was sampled inside it. When the
     # read was attempted is true on every arm, including the ones that just said
     # nothing was read; that counters exist between the two instants is not, and
@@ -2527,6 +2527,149 @@ cozy_capture_tenant_worker_network_counters() {
     '^container_network_(receive|transmit)_(bytes|packets|packets_dropped|errors)_total\{'
 }
 
+# How to read the device label, which is the one sentence here that holds on a
+# partial file as well as on a whole one. A function because more than one arm of
+# the note below prints it and a second copy is a scheduled divergence.
+_cozy_block_io_device_legend() {
+  printf '%s\n' \
+    '[the device labels here name HOST devices, and which of them backs the guest system disk is decided by the major rather than by the name: the kernel registers block major 147 for DRBD, so a container_blkio_device_usage_total row at that major with operation="Read" is the replicated volume the guest reads its image from]' \
+    >>"$1"
+}
+
+# Said in the file because which families arrive is decided by the kernel
+# interface under them, and a family's absence is not a reading about the disk.
+_cozy_block_io_tail_note() {
+  local raw="$1" rc="$2" filter_rc="$3" had_series="$4"
+  local start_rc=0 counter_rc=0
+
+  [ "${had_series}" -eq 1 ] || return 0
+  # Every sentence that reads the file AS A WHOLE reading is withheld from a read
+  # that did not finish, the way the CPU note withholds its pairing sentence and
+  # the sandbox capture withholds its column legend. On a truncated capture what
+  # is here is a prefix: a total over the container's age understates it by
+  # whatever never arrived, and a family missing from a prefix says nothing about
+  # the kernel interface that would explain its absence.
+  #
+  # The device legend is not one of those and stays: it explains how to read a
+  # label on the rows that did arrive, which is as true of a prefix as of a whole
+  # file, and a reader is most in need of it exactly when the file is short.
+  if [ "${rc}" -ne 0 ] || [ "${filter_rc}" -ge 2 ]; then
+    printf '%s\n' \
+      'these counters are cumulative since the container started, and this capture is marked incomplete above, so what is here may be a prefix of what the kubelet had: no averaging instruction and no reading of a missing family follows, because both would treat a prefix as the whole' \
+      >>"${raw}"
+    _cozy_block_io_device_legend "${raw}"
+    return 0
+  fi
+  # The divisor family is not a counter, and keeping it in the filter costs this
+  # sentence: the shared walk decides "the kubelet reported nothing for this
+  # subject" from whether ANY row survived, so a container cAdvisor knows about
+  # puts its start time in the file whether or not a single disk row arrived, and
+  # the walk's own "no series" arm can no longer fire. Without this the file would
+  # carry a start time, an instruction for dividing counters, and no counters --
+  # which is the reading this capture exists to make impossible. Decided on the
+  # subject families rather than on the row count, and on grep's exact status for
+  # the reason the arms below are.
+  grep -qE '^container_(blkio_device_usage_total|fs_|pressure_io_)' "${raw}" || counter_rc=$?
+  if [ "${counter_rc}" -eq 1 ]; then
+    printf '%s\n' \
+      'no block IO counter reached this file: what is above is a container start time, which cAdvisor publishes for any container it knows and which this capture keeps as the divisor for counters that did arrive. So the kubelet answered and reported no block IO for a tenant-test worker on this node -- not a worker that touched no disk' \
+      >>"${raw}"
+    return 0
+  fi
+  if [ "${counter_rc}" -ne 0 ]; then
+    printf '%s\n' \
+      'whether any block IO counter reached this file could not be checked: the search for the subject families failed on this runner rather than answering, so read the rows above before taking any sentence here as a statement about the disk' \
+      >>"${raw}"
+    _cozy_block_io_device_legend "${raw}"
+    return 0
+  fi
+  # Totals, and the note says so rather than calling them an average: an average
+  # needs a divisor, and the only reason this file can offer one is that the
+  # start-time row is kept in the filter.
+  #
+  # Two arms rather than the three the checks above take, because the check above
+  # already read this file: reaching here means grep returned 0 or 1 on it, so a
+  # third arm for "could not read it" would be unreachable by construction.
+  grep -q '^container_start_time_seconds{' "${raw}" || start_rc=$?
+  if [ "${start_rc}" -eq 0 ]; then
+    printf '%s\n' \
+      "these counters are cumulative since the container started and this is one reading of them, so what is above are totals and not a rate. container_start_time_seconds above is the divisor, one row per container rather than one per node, so take the row whose container and pod labels match the counters being divided: a worker Pod's container starts with the guest it carries and KubeVirt gives that Pod restartPolicy Never, so the container is never restarted under the guest, the read stamp below minus that start is the guest's own life, and a total over that span is the average across exactly the window the node-join deadline covers. A rate INSIDE that window needs a second capture of the same stream, which this collector does not take" \
+      >>"${raw}"
+  else
+    printf '%s\n' \
+      'these counters are cumulative since the container started and this is one reading of them, so what is above are totals and not a rate. The divisor is missing from this file: container_start_time_seconds carries it and no row of it survived here, so the container Started line in the virt-launcher describe dump is where the age has to come from' \
+      >>"${raw}"
+  fi
+  printf '%s\n' \
+    "[container_pressure_io_stalled_seconds_total and container_pressure_io_waiting_seconds_total, where they appear, answer this collector's question directly, since they count the time the group spent stalled on IO rather than the bytes it moved. Their absence is a setting rather than a quiet disk: cAdvisor publishes these families only when the kubelet turns its pressure metrics on, which sits behind a feature gate. The kernel is not the missing half on these nodes, since the sandbox kernel ships pressure accounting enabled]" \
+    >>"${raw}"
+  _cozy_block_io_device_legend "${raw}"
+  printf '%s\n' \
+    '[a missing service time or queue depth here is the kernel interface and not an idle disk: under cgroup v2 io.stat publishes transferred bytes and completed operations only, so container_fs_io_current and container_fs_io_time_seconds_total are either absent or carry the node filesystem counters cAdvisor falls back to, which are not this Pod]' \
+    >>"${raw}"
+}
+
+# Read how much each tenant worker moved through its block devices, from the
+# kubelet's cAdvisor endpoint on the node the worker runs on.
+#
+# This exists because a worker burning its whole vCPU while making no progress
+# has two mechanisms behind one appearance. It is computing and getting nowhere,
+# or it is waiting on blocks -- and a vCPU thread spinning in a wait on a nested
+# guest with no idle exit looks like a busy vCPU either way, at a quota with room
+# to spare and with the node under it half free. Nothing else in this tree counts
+# the worker's IO: the CPU counters beside it measure what the group was allowed
+# and what it got, the network counters measure what crossed into the Pod, and
+# both are blind to blocks by construction.
+#
+# The guest's own /proc/diskstats would answer it from inside, and cannot be
+# reached: the diagnostics credential minted for the guest carries the os:reader
+# role, which Talos does not allow to read file contents at all, and Talos
+# publishes no resource carrying disk statistics. The Pod's cgroup is the nearest
+# surface that exists, and it sits outside the guest, so a wedged guest does not
+# slow the reading down.
+#
+# Read once rather than twice, unlike its neighbours in the sampling loop, and
+# the counter's own origin is why: it accumulates from the container starting,
+# which for a worker Pod is when the guest was created. A single reading is
+# therefore an average over the guest's whole life, and the guest's whole life IS
+# the window the deadline covers on this failure. What one reading cannot give is
+# a rate inside that window, which is what would separate a guest reading slowly
+# throughout from one that read its image and then burned CPU; the file says so
+# where the rows are.
+cozy_capture_tenant_worker_block_io() {
+  # Anchored on the metric names, and the namespace is not a worker filter: the
+  # tenant-test namespace also carries the Kamaji control plane, whose apiserver
+  # and etcd have disks of their own, so the Pod name carries the second half of
+  # the filter as it does for the sibling captures.
+  #
+  # container_blkio_device_usage_total is the row that survives cgroup v2 with an
+  # operation and a device major on it, so it is the one that attributes reads to
+  # a volume; the fs_* families are kept beside it because a node that publishes
+  # the service-time ones must not produce an artifact identical to a node that
+  # cannot.
+  #
+  # container_start_time_seconds is in the filter for a different reason from
+  # every other family here: it is not a counter but the divisor these counters
+  # need. cAdvisor publishes it for any container it knows, outside the disk
+  # group, and keeping it is what lets one reading of a cumulative total be read
+  # as an average without leaving the file for a Started line in a describe dump.
+  #
+  # It costs two things, both paid rather than left implicit. The subject word
+  # below names it, because the shared walk builds its "reported no <subject>
+  # series" sentences from that word and a sentence naming only block IO would be
+  # false about a file holding a start time. And the tail note decides "no
+  # counter arrived" on the subject families rather than on the walk's row count,
+  # which this family would otherwise make always true.
+  _cozy_capture_worker_cadvisor \
+    tenant-block-io \
+    'block IO counters capture' \
+    'how much these workers moved through their disks' \
+    'block IO or container start-time' \
+    cozy-block-io \
+    _cozy_block_io_tail_note \
+    '^container_(blkio_device_usage_total|start_time_seconds|fs_((reads|writes)(_bytes)?_total|(read|write)_seconds_total|io_(current|time_seconds_total|time_weighted_seconds_total))|pressure_io_(stalled|waiting)_seconds_total)\{'
+}
+
 # Collect the guest-side evidence requested by issue #3513. This runs only after
 # the 18-minute Ready deadline has already failed. VMIs without a reported IP
 # are recorded before any Certificate or Pod is created; when at least one IP is
@@ -2676,7 +2819,7 @@ _cozy_diag_seconds() {
 # count rather than confidence: those bound a single read or a short walk, while the
 # block below issues a dozen back to back, so the same per-read bound would put the
 # block's own ceiling ahead of the tenant crust-gather snapshot it exists to reach.
-# The two worker counter captures are the exception and deliberately so: they
+# The worker counter captures are the exception and deliberately so: they
 # share one body that is a short walk by that measure, and it still takes this
 # knob rather than a higher literal, because a bound that does not follow the
 # knob is a bound nobody can lower. Read the sentence above as describing the
@@ -2745,23 +2888,34 @@ COZY_DIAG_RATE_INTERVAL_DEFAULT=12
 # re-probe has no substitute and is the collector this budget gives up first,
 # which was already true at 480.
 #
-# The second cost lands on the guest captures rather than on the tail. One
-# collector reads the node's metric stream ahead of the console: (d2) spends a
-# listing plus one read per node -- up to 100s at the read bound and the
-# three-node cap, a ceiling those numbers impose rather than a duration measured
-# on a live cluster. Between that and the sixty seconds off the budget, the
-# console and guest-Talos captures reach their gate with less left than before;
-# they are still ahead of the tail in the order, so they are not first to go,
-# but a run that was marginal for them is likelier to decline them now.
+# The second cost lands on the guest captures rather than on the tail. Two
+# collectors read the node's metric stream ahead of the console -- (d2) and (d3)
+# -- and each spends a listing plus one read per node, so up to 200s between them
+# at the read bound and the three-node cap, plus the single read at (a3), which
+# takes its 25s from the same budget: 225s, a ceiling those numbers impose rather
+# than a duration measured on a live cluster. Between that and the sixty seconds
+# off the budget, the console and guest-Talos captures reach their gate with less
+# left than before; they are still ahead of the tail in the order, so they are not
+# first to go, but a run that was marginal for them is likelier to decline them
+# now.
+#
+# Only part of that figure is held mechanically, and the boundary is worth naming
+# rather than leaving a reader to trust the whole of it: the guard in
+# hack/run-kubernetes-node-join_test.bats walks the CAPTURE-style collectors gated
+# ahead of the console -- the ones called as `cozy_capture_… || true` -- and fails
+# on any it has no cost arm for, so a walk added there is priced before the suite
+# goes green. A bounded read added ahead of the console, as (a3) is, is not in that
+# enumeration and its 25s are not summed there. That gap is recorded where the
+# other budget residuals are rather than fixed here.
 #
 # What is deliberately NOT ahead of the console is the two-sample CPU pair,
 # whose own ceiling is several times this one. What sits ahead of the console
 # bounds what the console can lose, so that figure is the one to keep small; the
 # ordering argument at the pair says the rest.
 #
-# That second read is not shared away in this change, and the reason is scope
-# rather than merit -- the note at the read says why, and says that merging
-# would improve both the cost and what a tight run collects.
+# Those reads are not shared away in this change, and the reason is scope rather
+# than merit -- the note at the read says why, and says that merging would
+# improve both the cost and what a tight run collects.
 COZY_DIAG_PHASE_BUDGET_DEFAULT=420
 
 # The operation both kubernetes-*/chainsaw-test.yaml give the script, and the
@@ -2897,7 +3051,7 @@ cozy_diag_phase_start() {
   # an unchecked list sitting beside a checked one, drifting from it at whatever
   # rate collectors are added.
   command -v timeout >/dev/null 2>&1 || \
-    echo "» WARNING: timeout is not on PATH; the bounded reads below run UNBOUNDED, so one that hangs can still take the op and the tenant snapshot with it, and the collectors that call timeout directly (wedge check, serial console, guest Talos) exit 127 and collect nothing; the ones that guard the call with command -v -- the worker CPU throttling, worker network counter, sandbox node CPU time, sandbox kernel KVM counters, worker per-thread CPU time, ghcr-mirror and talos-image-cache captures -- keep collecting instead, unbounded" >&2
+    echo "» WARNING: timeout is not on PATH; the bounded reads below run UNBOUNDED, so one that hangs can still take the op and the tenant snapshot with it, and the collectors that call timeout directly (wedge check, serial console, guest Talos) exit 127 and collect nothing; the ones that guard the call with command -v -- the worker CPU throttling, worker network counter, worker block IO counter, sandbox node CPU time, sandbox kernel KVM counters, worker per-thread CPU time, ghcr-mirror and talos-image-cache captures -- keep collecting instead, unbounded" >&2
   # Re-checked here, not only at assignment: a value set after this file is sourced
   # -- which is how a test sets it -- would otherwise reach the arithmetic below
   # unvalidated, and that is the one failure that costs the whole block.
@@ -3208,6 +3362,31 @@ cozy_report_node_join_failure() {
     kubectl -n tenant-test logs -l kamaji.clastix.io/name="kubernetes-${test_name}" \
     -c talos-csr-signer --tail=200 --prefix
 
+  # (a3) State of the replicated volumes behind the worker disks. Numbered with
+  # the import stage it belongs to and placed here instead, because position in
+  # this block is cost order rather than subject: it is one read, and moving it up
+  # would push the two reads at (c) a read further from the start of the budget.
+  #
+  # What it answers is a state rather than a rate, which is why one read settles
+  # it. A worker reads its system disk over DRBD, and a replica that is
+  # SyncTarget, Inconsistent or Diskless serves those reads from a peer over the
+  # network instead of locally, which is slow in a way no counter in this block
+  # attributes to storage. The state also disappears with the volume: the report
+  # collects the same tables after the suite, by which time cleanup has usually
+  # deleted the worker's volumes, so a red run leaves nothing about them there.
+  #
+  # Which rows are the worker's is decided through the PV name, which the (a2)
+  # dump above prints beside each PVC; resource names here are those PV names.
+  #
+  # No --request-timeout: this is an exec stream rather than an API request, so
+  # the wall clock around it is the whole bound. A controller that is absent and
+  # one that is wedged both arrive as a failed read, and kubectl's own message
+  # beside the note is what separates them.
+  echo "=== (a3) replicated volume state behind the worker disks (management cluster) ==="
+  cozy_diag_read 'LINSTOR resource state' \
+    kubectl -n cozy-linstor exec deploy/linstor-controller \
+    --container=linstor-controller -- linstor --no-color r l
+
   # Order below is load-bearing and the phase budget is why. The budget declines
   # whatever has not started when it runs out, so what runs last is what gets
   # declined -- and (c) is the discriminator for mode 2b, the failure this whole
@@ -3256,6 +3435,20 @@ cozy_report_node_join_failure() {
   if cozy_diag_phase_has_time '(d2) tenant worker network counters'; then
     echo "=== (d2) tenant worker network counters (management cluster, ns tenant-test) ==="
     cozy_capture_tenant_worker_network_counters || true
+  fi
+
+  # (d3) Worker block IO, and it sits here for the reason (d2) does: one listing
+  # and one read per node, read once, against the minutes the collectors below can
+  # spend between them. What it settles has no other answer in this artifact
+  # either. A worker whose vCPU thread runs at its physical maximum while nothing
+  # progresses is either computing without result or waiting on blocks, and every
+  # other counter here is blind to the second: the CPU families say what the group
+  # was allowed and what it got, (d2) says what crossed the network, and neither
+  # counts a read. Placed below the guest captures it would be declined on exactly
+  # the slow runs this failure comes from.
+  if cozy_diag_phase_has_time '(d3) tenant worker block IO counters'; then
+    echo "=== (d3) tenant worker block IO counters (management cluster, ns tenant-test) ==="
+    cozy_capture_tenant_worker_block_io || true
   fi
 
   # (b1) Guest serial console, read from the management cluster. First of the

--- a/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
@@ -33,6 +33,7 @@ spec:
         # than the reads that discriminate between failure modes:
         #   node-join diagnostics reads
         #   worker network counters
+        #   worker block IO counters
         #   serial-console family (~6m25s at worst, ~4m05s at the pool's minimum)
         #   worker CPU usage and throttling counters, two samples
         #   sandbox node CPU time, two samples

--- a/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
@@ -27,6 +27,7 @@ spec:
         # than the reads that discriminate between failure modes:
         #   node-join diagnostics reads
         #   worker network counters
+        #   worker block IO counters
         #   serial-console family (~6m25s at worst, ~4m05s at the pool's minimum)
         #   worker CPU usage and throttling counters, two samples
         #   sandbox node CPU time, two samples

--- a/hack/run-kubernetes-block-io_test.bats
+++ b/hack/run-kubernetes-block-io_test.bats
@@ -1,0 +1,569 @@
+#!/usr/bin/env bats
+# Regression coverage for the tenant-worker block IO capture in
+# hack/e2e-chainsaw/_lib/run-kubernetes.sh. cozytest.sh ends an @test block at
+# the first bare closing brace, so command mocks stay at top level.
+#
+# What this capture answers, and why neither the guest nor the other collectors
+# can. A worker that burns its whole vCPU while making no progress is either
+# computing and getting nowhere or waiting on blocks, and from outside the Pod
+# the two look identical: a busy vCPU thread with a clean cgroup quota. The
+# guest's own /proc/diskstats would settle it, and the diagnostics credential
+# minted for the guest is os:reader, which Talos does not allow to read file
+# contents at all. The kubelet's view of the Pod's cgroup is what remains, and it
+# is outside the guest entirely.
+#
+# The families are the subject of two tests here, because what arrives depends on
+# the cgroup version and the artifact has to stay readable either way. Under
+# cgroup v2 the kernel's io.stat carries transferred bytes and completed
+# operations and nothing else, so the queue-depth and service-time families
+# cAdvisor declares for this group are either absent or filled from the node
+# filesystem's own counters, which are not this Pod's. A zero read as an idle
+# disk is the wrong conclusion this suite pins against.
+
+kubectl_calls=/dev/null
+kubectl_node_names=
+kubectl_list_rc=0
+kubectl_list_stderr=
+kubectl_raw_rc=0
+kubectl_raw_stderr=
+
+# Row shapes and label sets are upstream cAdvisor's own golden exposition
+# (lib/metrics/testdata/prometheus_metrics) with the identifying labels rewritten
+# to a worker Pod's; the values are illustrative of direction rather than
+# measured. A virt-launcher Pod was not available to sample. Two properties are
+# load-bearing and both come from that golden file: the blkio family carries its
+# own operation label with Read as one value, and the device label on every one
+# of these families is a HOST device rather than anything the guest names.
+worker_pod='virt-launcher-kubernetes-test-latest-version-md0-abc12-xyz34'
+worker_labels='container="compute",device="/dev/drbd1000",id="/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod0000000a_0000_0000_0000_00000000000b.slice/cri-containerd-0000000000000000000000000000000000000000000000000000000000000001.scope",image="quay.io/kubevirt/virt-launcher:v1.8.4",name="0000000000000000000000000000000000000000000000000000000000000001",namespace="tenant-test",pod="'"${worker_pod}"'"'
+kubectl_raw_output=
+
+# The divisor on its own, because it is also a shape the wire produces on its
+# own: cAdvisor publishes it for any container it knows, so a worker whose disk
+# counters never arrived still puts this row in the file.
+worker_start_time_row() {
+  printf 'container_start_time_seconds{%s} 1.786656e+09 1786657157281\n' "${worker_labels}"
+}
+
+# The two shapes a cgroup v2 node puts on the wire for one worker: the byte and
+# operation counters, plus the blkio family split by operation. The start-time row
+# rides along because it is the divisor the counters need, and cAdvisor publishes
+# it for any container it knows rather than as part of the disk group. Built rather
+# than pasted so a family cannot drift by a typo in one copy.
+worker_v2_series() {
+  local read_bytes=8.8080384e+07
+  worker_start_time_row
+  printf 'container_fs_reads_bytes_total{%s} %s 1786657157281\n' "${worker_labels}" "${read_bytes}"
+  printf 'container_fs_reads_total{%s} 2148 1786657157281\n' "${worker_labels}"
+  printf 'container_fs_writes_bytes_total{%s} 1.048576e+06 1786657157281\n' "${worker_labels}"
+  printf 'container_fs_writes_total{%s} 64 1786657157281\n' "${worker_labels}"
+  printf 'container_blkio_device_usage_total{container="compute",device="/dev/drbd1000",major="147",minor="1000",namespace="tenant-test",operation="Read",pod="%s"} %s 1786657157281\n' "${worker_pod}" "${read_bytes}"
+  printf 'container_blkio_device_usage_total{container="compute",device="/dev/drbd1000",major="147",minor="1000",namespace="tenant-test",operation="Write",pod="%s"} 1.048576e+06 1786657157281\n' "${worker_pod}"
+}
+
+# The service-time and queue-depth families as a cgroup v1 node would carry them.
+# Kept as a fixture of its own because their absence is what the note in the
+# artifact explains, and a suite that only ever stages them present would leave
+# that explanation unexercised.
+worker_v1_extra_series() {
+  printf 'container_fs_read_seconds_total{%s} 33.9 1786657157281\n' "${worker_labels}"
+  printf 'container_fs_write_seconds_total{%s} 4.1 1786657157281\n' "${worker_labels}"
+  printf 'container_fs_io_current{%s} 3 1786657157281\n' "${worker_labels}"
+  printf 'container_fs_io_time_seconds_total{%s} 41.2 1786657157281\n' "${worker_labels}"
+  printf 'container_fs_io_time_weighted_seconds_total{%s} 118.7 1786657157281\n' "${worker_labels}"
+}
+
+# The IO pressure families as the kubelet publishes them when its pressure gate
+# is on. PSI is accounted per cgroup rather than per device, so these rows carry
+# the worker's identifying labels with no device label; derived from the shared
+# label set rather than pasted so the identity cannot drift between fixtures.
+worker_psi_series() {
+  local psi_labels
+  psi_labels=$(printf '%s' "${worker_labels}" | sed 's|device="[^"]*",||')
+  printf 'container_pressure_io_stalled_seconds_total{%s} 12.4 1786657157281\n' "${psi_labels}"
+  printf 'container_pressure_io_waiting_seconds_total{%s} 15.9 1786657157281\n' "${psi_labels}"
+}
+
+# Two rows that must not reach a file headed "worker": the node's own filesystem,
+# which arrives with both selector labels empty, and the Kamaji apiserver, which
+# shares the namespace and has a disk of its own.
+non_worker_series() {
+  printf 'container_fs_reads_bytes_total{container="",device="/dev/sda1",id="/",image="",name="",namespace="",pod=""} 4.294967296e+09 1786657157281\n'
+  printf 'container_fs_reads_bytes_total{container="kube-apiserver",device="/dev/sda1",id="/kubepods.slice/x.scope",image="registry.k8s.io/kube-apiserver:v1.33.0",name="x",namespace="tenant-test",pod="kubernetes-test-latest-version-7d9f8b6c5d-abcde"} 5.24288e+08 1786657157281\n'
+}
+
+timeout_calls=/dev/null
+timeout_fail_node=
+
+kubectl() {
+  printf '%s\n' "$*" >>"${kubectl_calls}"
+
+  if [ "${3:-}" = get ] && [ "${4:-}" = pods ]; then
+    [ -z "${kubectl_list_stderr}" ] || printf '%s\n' "${kubectl_list_stderr}" >&2
+    [ "${kubectl_list_rc}" -eq 0 ] || return "${kubectl_list_rc}"
+    [ -z "${kubectl_node_names}" ] || printf '%s\n' ${kubectl_node_names}
+    return 0
+  fi
+
+  if [ "${1:-}" = get ] && [ "${2:-}" = --raw ]; then
+    [ -z "${kubectl_raw_stderr}" ] || printf '%s\n' "${kubectl_raw_stderr}" >&2
+    # Output before status: a read cut off part way has already written what it
+    # managed to read, and a stub that returns first makes the branch labelling a
+    # partial capture unreachable in tests while it stays the likeliest one in
+    # production.
+    [ -z "${kubectl_raw_output}" ] || printf '%s\n' "${kubectl_raw_output}"
+    return "${kubectl_raw_rc}"
+  fi
+
+  return 0
+}
+
+timeout() {
+  local command_rc=0
+  printf '%s\n' "$*" >>"${timeout_calls}"
+  # Return 97 rather than running the command when the wrapper is not the bounded
+  # form: a read that lost its ceiling must not pass as a read.
+  [ "${1:-}" = -k ] || return 97
+  shift 3
+  "$@" || command_rc=$?
+  if [ -n "${timeout_fail_node}" ]; then
+    case " $* " in
+      *"${timeout_fail_node}"*) return 124 ;;
+    esac
+  fi
+  return "${command_rc}"
+}
+
+assert_file_contains() {
+  local needle="$1"
+  local file="$2"
+
+  if [ ! -f "${file}" ]; then
+    printf 'expected %s to exist so it could be checked for: %s\n' "${file}" "${needle}" >&2
+    return 1
+  fi
+  case "$(cat "${file}")" in
+    *"${needle}"*) return 0 ;;
+  esac
+  printf 'expected %s to contain: %s\n' "${file}" "${needle}" >&2
+  return 1
+}
+
+assert_file_lacks_pattern() {
+  local pattern="$1"
+  local file="$2"
+
+  # A missing file must fail rather than vacuously pass: a bare `! grep -q`
+  # succeeds on an unreadable path, which is indistinguishable from "the file
+  # exists and does not carry the label".
+  if [ ! -f "${file}" ]; then
+    printf 'expected %s to exist so it could be checked for: %s\n' "${file}" "${pattern}" >&2
+    return 1
+  fi
+  # Branched on awk's exact status. awk exits 1 for "no line matched" and 2 for
+  # "I could not evaluate this"; folded into an `if`, both land in the passing
+  # branch and the assertion "this is absent" is satisfied by the matcher giving
+  # up. Every negative claim in this file rests on the three-way split.
+  local _rc=0
+  awk -v pattern="${pattern}" '$0 ~ pattern { found = 1 } END { exit found ? 0 : 1 }' "${file}" || _rc=$?
+  case "${_rc}" in
+    0)
+      printf 'expected %s not to match: %s\n' "${file}" "${pattern}" >&2
+      return 1
+      ;;
+    1) return 0 ;;
+    *)
+      printf 'awk could not evaluate pattern %s against %s\n' "${pattern}" "${file}" >&2
+      return 1
+      ;;
+  esac
+}
+
+# The function under test redirects a command's stderr into a report file and
+# decides which artifact to write from it. cozytest.sh runs under `set -x`, so
+# the tracer's own line for that command lands on the very stderr being
+# redirected, and every assertion about those files would be reading the tracer.
+# Call through this wrapper so the sinks hold what production writes.
+run_capture() {
+  local _rc=0
+  ( set +x; cozy_capture_tenant_worker_block_io ) || _rc=$?
+  return "${_rc}"
+}
+
+@test "a negative assertion fails when its own matcher cannot evaluate" {
+  # The helper under every "must not appear" claim here. What rides on it is this
+  # collector's contract stated negatively: that an unread kubelet was not
+  # written up as an idle disk, and that the node's own filesystem did not land
+  # under a worker heading. A matcher that fails open turns each of those into a
+  # sentence nobody checked.
+  tmp=$(mktemp -d)
+  printf 'anything\n' >"$tmp/subject"
+
+  if assert_file_lacks_pattern '*(' "$tmp/subject" 2>/dev/null; then
+    echo "FAIL: an unparseable pattern was reported as absent" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+  assert_file_lacks_pattern 'absent-string' "$tmp/subject"
+  if assert_file_lacks_pattern 'anything' "$tmp/subject" 2>/dev/null; then
+    echo "FAIL: a present pattern was reported as absent" >&2
+    rm -rf "$tmp"
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "the byte, operation and blkio families of a worker Pod are captured" {
+  # The positive control every negative claim below is measured against. Families
+  # are named one by one rather than counted, because a count passes while one is
+  # silently missing from the filter -- and the blkio family is the one a filter
+  # written from the fs_* names alone loses, while it is the only one carrying the
+  # device major that identifies which volume the reads went to.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_v2_series)"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-block-io/node-a.txt"
+  assert_file_contains 'container_fs_reads_bytes_total{' "$out"
+  assert_file_contains 'container_fs_reads_total{' "$out"
+  assert_file_contains 'container_fs_writes_bytes_total{' "$out"
+  assert_file_contains 'container_fs_writes_total{' "$out"
+  assert_file_contains 'container_blkio_device_usage_total{' "$out"
+  assert_file_contains 'operation="Read"' "$out"
+  # The divisor, kept for a different reason from the rest and therefore the one
+  # a later edit to the filter is most likely to drop: without it the totals in
+  # this file cannot be read as an average at all.
+  assert_file_contains 'container_start_time_seconds{' "$out"
+  rm -rf "$tmp"
+}
+
+@test "one reading is called a total, with the row that turns it into an average" {
+  # The claim the file may not make is that a single cumulative reading IS a rate,
+  # and the claim it may only make when the row is present is how to divide. Both
+  # directions are pinned here, because the note is the only thing standing between
+  # a total and an invented throughput figure.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_v2_series)"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-block-io/node-a.txt"
+  assert_file_contains 'totals and not a rate' "$out"
+  assert_file_contains 'container_start_time_seconds above is the divisor' "$out"
+  rm -rf "$tmp"
+}
+
+@test "a capture with no start time row does not tell the reader to divide by it" {
+  # The same note with its divisor gone. A kubelet can answer with the disk
+  # families and no start time -- a filter narrowed later is the likeliest way --
+  # and an instruction to subtract a row that is not in the file sends the reader
+  # after something that does not exist, which is the failure the note exists to
+  # prevent rather than to cause.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_v2_series | grep -v '^container_start_time_seconds')"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-block-io/node-a.txt"
+  assert_file_contains 'The divisor is missing from this file' "$out"
+  assert_file_lacks_pattern 'above is the divisor' "$out"
+  rm -rf "$tmp"
+}
+
+@test "a truncated capture gets no averaging instruction and no missing-family reading" {
+  # Rows arrived and the read was then cut off, which is the shape a wedged
+  # kubelet produces: the file holds a prefix. Dividing a prefix by the
+  # container's age understates it, and a family absent from a prefix says nothing
+  # about the kernel interface, so both readings are withheld -- the same rule the
+  # CPU note follows for its pairing sentence and the sandbox capture for its
+  # column legend.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_v2_series)"
+  timeout_fail_node=node-a
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-block-io/node-a.txt"
+  assert_file_contains 'may be a prefix of what the kubelet had' "$out"
+  assert_file_lacks_pattern 'above is the divisor' "$out"
+  assert_file_lacks_pattern 'io.stat' "$out"
+  assert_file_lacks_pattern 'is a setting rather than a quiet disk' "$out"
+  # The device legend is the exception and stays: it explains a label on the rows
+  # that did arrive, which is as true of a prefix as of a whole file, and a short
+  # file is where a reader needs it most.
+  assert_file_contains 'block major 147 for DRBD' "$out"
+  timeout_fail_node=
+  rm -rf "$tmp"
+}
+
+@test "a counter check that could not run claims nothing about the disk" {
+  # grep exits 1 for "read it, no match" and 2 for "could not read it", and every
+  # sentence past that check is a statement about what the kubelet reported, which
+  # a check that never answered cannot support. Driven by handing the hook a path
+  # that does not exist, which is the cheapest way to reach a status the walk does
+  # not produce on purpose.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+
+  ( set +x; _cozy_block_io_tail_note "$tmp/absent.txt" 0 0 1 )
+
+  assert_file_contains 'could not be checked' "$tmp/absent.txt"
+  # The device legend still follows: it explains a label on rows, not the file
+  # as a whole, and the arm's own sentence sends the reader to the rows above.
+  assert_file_contains 'block major 147 for DRBD' "$tmp/absent.txt"
+  assert_file_lacks_pattern 'above is the divisor' "$tmp/absent.txt"
+  assert_file_lacks_pattern 'divisor is missing' "$tmp/absent.txt"
+  assert_file_lacks_pattern 'no block IO counter reached' "$tmp/absent.txt"
+  rm -rf "$tmp"
+}
+
+@test "the IO pressure families survive the filter where the kubelet publishes them" {
+  # Asserted on rows rather than on the note text: the note names these families
+  # on every capture, so only a brace after the family name proves a row of the
+  # family itself came through the filter.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_v2_series; worker_psi_series)"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-block-io/node-a.txt"
+  assert_file_contains 'container_pressure_io_stalled_seconds_total{' "$out"
+  assert_file_contains 'container_pressure_io_waiting_seconds_total{' "$out"
+  rm -rf "$tmp"
+}
+
+@test "the queue depth and service time families are captured where they exist" {
+  # The cgroup v1 shape. The filter has to keep them, or a node that does publish
+  # them produces an artifact identical to one that cannot -- and the difference
+  # is the whole reason the note beside the rows explains which families the
+  # cgroup version costs.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_v2_series; worker_v1_extra_series)"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-block-io/node-a.txt"
+  assert_file_contains 'container_fs_read_seconds_total{' "$out"
+  assert_file_contains 'container_fs_write_seconds_total{' "$out"
+  assert_file_contains 'container_fs_io_current{' "$out"
+  assert_file_contains 'container_fs_io_time_seconds_total{' "$out"
+  assert_file_contains 'container_fs_io_time_weighted_seconds_total{' "$out"
+  rm -rf "$tmp"
+}
+
+@test "a capture with no service time family says what the cgroup version costs" {
+  # The reading this collector is most likely to be misread on, and the one a row
+  # cannot state for itself: under cgroup v2 io.stat carries bytes and operations
+  # only, so a missing service time is the kernel interface rather than a disk
+  # that was never touched. Asserted on the cgroup v2 fixture, which is the shape
+  # the sandbox actually produces.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_v2_series)"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-block-io/node-a.txt"
+  assert_file_contains 'io.stat' "$out"
+  # And the row that carries the attribution, because a reader looking for the
+  # guest's system disk has several devices to choose between and the major is
+  # what decides.
+  assert_file_contains 'block major 147 for DRBD' "$out"
+  # The families that would answer the question outright if the kubelet published
+  # them. Their absence is a setting rather than a quiet disk, and a reader with
+  # no sentence for that reads the silence as the answer.
+  assert_file_contains 'container_pressure_io_stalled_seconds_total' "$out"
+  rm -rf "$tmp"
+}
+
+@test "the capture does not send a reader after a sibling sample it never takes" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_v2_series)"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-block-io/node-a.txt"
+  # This capture is read once, and it shares its walk with a capture that is read
+  # twice. A file telling the reader to subtract a sibling that was never written
+  # costs them the time it takes to go looking for a directory that does not
+  # exist, so the instruction here has to be the opposite one.
+  assert_file_contains 'a second capture of the same stream' "$out"
+  assert_file_lacks_pattern 'other sample directory' "$out"
+  assert_file_contains 'read attempted from' "$out"
+  rm -rf "$tmp"
+}
+
+@test "the node filesystem and the tenant control plane stay out of a worker heading" {
+  # Both rows are what the wire actually carries. The node's own filesystem
+  # arrives in the same families with both selector labels empty, and the Kamaji
+  # apiserver shares the namespace with the workers and has a disk of its own --
+  # under a heading that says worker, either one answers the question with the
+  # wrong subject.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(non_worker_series; worker_v2_series)"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-block-io/node-a.txt"
+  assert_file_contains "pod=\"${worker_pod}\"" "$out"
+  assert_file_lacks_pattern 'kube-apiserver' "$out"
+  assert_file_lacks_pattern 'pod=""' "$out"
+  rm -rf "$tmp"
+}
+
+@test "a start time with no counter beside it is not written up as an idle disk" {
+  # The shape the divisor row makes possible, and the reason it is not free: the
+  # walk decides "the kubelet reported nothing for this subject" from whether any
+  # row survived, and this family survives for any container cAdvisor knows. So a
+  # worker whose disk counters never arrived leaves a file that is not empty, the
+  # walk's own "no series" sentence cannot fire, and without the note below the
+  # artifact would carry a start time, an instruction for dividing counters, and
+  # no counters.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_start_time_row)"
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-block-io/node-a.txt"
+  assert_file_contains 'no block IO counter reached this file' "$out"
+  assert_file_lacks_pattern 'above is the divisor' "$out"
+  assert_file_lacks_pattern 'io.stat' "$out"
+  rm -rf "$tmp"
+}
+
+@test "a kubelet that knows nothing about the container is not written up as an idle disk" {
+  # The other empty direction, and the one the walk does answer: cAdvisor
+  # contributes none of these families for a container it does not know, so the
+  # file is empty and the walk says which of its own arms fired. An empty file
+  # reads as a worker that touched no disk, which is the conclusion the whole
+  # capture was added to test.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output='container_cpu_usage_seconds_total{container="compute",namespace="tenant-test",pod="'"${worker_pod}"'"} 412.5 1786657157281'
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-block-io/node-a.txt"
+  # The walk builds this sentence from the subject word the capture passes, and
+  # that word names the divisor family too, because the file can hold the divisor
+  # with no counter beside it and a sentence naming only block IO would be false
+  # about such a file.
+  assert_file_contains 'no block IO or container start-time series' "$out"
+  rm -rf "$tmp"
+}
+
+@test "a kubelet that never answered is not written up as an idle disk either" {
+  # The other half of the same claim, and the one the status decides rather than
+  # the output: timeout kills its child without a word, so this arrives non-zero
+  # with an empty error log, and a collector keyed on stderr would land in the arm
+  # that says the kubelet answered.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output=
+  timeout_fail_node=node-a
+
+  run_capture
+
+  out="$tmp/snapshots/kubernetes-latest/tenant-block-io/node-a.txt"
+  assert_file_contains 'is unknown' "$out"
+  assert_file_contains '[capture exit code: 124]' "$out"
+  assert_file_lacks_pattern 'io.stat' "$out"
+  timeout_fail_node=
+  rm -rf "$tmp"
+}
+
+@test "every read this capture makes carries a wall clock bound" {
+  # The property that keeps this collector from costing the artifacts behind it.
+  # It runs on the failure path, where the apiserver and the kubelet are the two
+  # components least likely to answer, and an unbounded read here holds the
+  # chainsaw op until the op is killed -- which loses the tenant snapshot rather
+  # than truncating it. The mock refuses any call that is not the bounded form, so
+  # a read that lost its ceiling exits 97 and the file says so.
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  export COZY_REPORT_DIR="$tmp"
+  COZY_SNAPSHOT_NAME=kubernetes-latest
+  kubectl_calls="$tmp/kubectl.calls"
+  timeout_calls="$tmp/timeout.calls"
+  kubectl_node_names="node-a"
+  kubectl_raw_output="$(worker_v2_series)"
+
+  run_capture
+
+  # Two reads: the virt-launcher listing and the node's metric stream. Both go
+  # through the wrapper, and the count is asserted so a read added later without
+  # one fails here rather than in a timed-out run.
+  [ "$(grep -c 'kubectl' "$timeout_calls")" -eq 2 ]
+  assert_file_lacks_pattern 'exit code: 97' "$tmp/snapshots/kubernetes-latest/tenant-block-io/node-a.txt"
+  rm -rf "$tmp"
+}

--- a/hack/run-kubernetes-node-join_test.bats
+++ b/hack/run-kubernetes-node-join_test.bats
@@ -235,7 +235,7 @@ stub_collectors() {
 # make that test pass more easily; it removes the collector from the audit
 # entirely, and the test stays green because there is nothing left to audit.
 # Each of them carries reads the audit is the only instrument that sees:
-# ghcr_mirror_diagnose issues five, and the two cadvisor captures issue a Pod
+# ghcr_mirror_diagnose issues five, and every cadvisor capture issues a Pod
 # listing and a node read apiece. Their own suites substitute a grep over the
 # source, which by construction cannot see a read that was added without a
 # bound.
@@ -246,6 +246,7 @@ stub_collectors() {
 stub_gated_collectors() {
   cozy_capture_tenant_worker_cpu_throttle() { printf 'cpu-throttle-stub\n'; }
   cozy_capture_tenant_worker_network_counters() { printf 'network-counters-stub\n'; }
+  cozy_capture_tenant_worker_block_io() { printf 'block-io-stub\n'; }
   cozy_capture_sandbox_node_cpu_time() { printf 'sandbox-cpu-time-stub\n'; }
   cozy_capture_tenant_worker_thread_cpu() { printf 'thread-cpu-stub\n'; }
   ghcr_mirror_diagnose() { printf 'ghcr-mirror-stub\n'; }
@@ -327,7 +328,7 @@ assert_file_lacks_pattern() {
   # -- so each collector is pinned individually.
   #
   # Pinned by the report directory each capture writes, not by a read only it
-  # issues. The two cAdvisor captures run one shared body, so their Pod listing
+  # issues. The cAdvisor captures run one shared body, so their Pod listing
   # and node read are byte-identical and neither has a read of its own: a
   # listing-keyed pin is satisfied by whichever of them ran, and stays green
   # with the other absent from the audit entirely. The directory is the one
@@ -341,7 +342,7 @@ assert_file_lacks_pattern() {
   # empty one is exactly what a capture that issued no read leaves behind -- and
   # that is the state this pin has to reject, since a capture missing from the
   # audit is a capture whose reads nobody bounded.
-  for subdir in tenant-cpu-throttle tenant-network-counters sandbox-host-cpu-time; do
+  for subdir in tenant-cpu-throttle tenant-network-counters tenant-block-io sandbox-host-cpu-time; do
     dir="$COZY_REPORT_DIR/snapshots/kubernetes/$subdir"
     if [ -z "$(find "$dir" -type f 2>/dev/null | head -n 1)" ]; then
       echo "FAIL: $subdir produced no file, so that capture issued no read and its reads were not audited" >&2
@@ -700,14 +701,14 @@ assert_file_lacks_pattern() {
     cat "$kubectl_calls" >&2
     false
   fi
-  # The six gates whose collectors are stubbed here are the mechanism, not a
+  # The gates whose collectors are stubbed here are the mechanism, not a
   # detail: declining the heaviest guest-Talos capture is what the budget
   # derivation is for, and a stub issues no kubectl, so the check above cannot
-  # see it run. That is the whole reason the count is over the stubbed ones and
+  # see it run. That is the whole reason the walk is over the stubbed ones and
   # not over every gate in the block -- the importer listing is gated too, and
   # it reads for real, so the check above already covers it. Each stub prints a
-  # marker; none of the six may appear, and each must have said why. The count
-  # is load-bearing rather than descriptive -- a stubbed gate added without a
+  # marker; none of them may appear, and each must have said why. The list is
+  # load-bearing rather than descriptive -- a stubbed gate added without a
   # line here is a collector that may run past the deadline while this test
   # stays green, which is exactly what the empty-kubectl_calls check above
   # cannot catch for a collector that issues no reads of its own.
@@ -718,7 +719,8 @@ assert_file_lacks_pattern() {
   # A rule written for additions does not catch a removal, so both directions
   # are named here.
   for marker in serial-console-stub talos-stub image-cache-stub cpu-throttle-stub \
-    network-counters-stub sandbox-cpu-time-stub thread-cpu-stub ghcr-mirror-stub; do
+    network-counters-stub block-io-stub sandbox-cpu-time-stub thread-cpu-stub \
+    ghcr-mirror-stub; do
     if grep -q "$marker" "$tmp/out"; then
       echo "FAIL: $marker ran after the phase ran out of budget" >&2
       false
@@ -729,6 +731,7 @@ assert_file_lacks_pattern() {
   assert_file_contains 're-probe talos-image-cache ClusterIP + cacher debug bundle: not collected' "$tmp/out"
   assert_file_contains '(d) tenant worker CPU counters, sandbox node CPU time and worker per-thread CPU time: not collected' "$tmp/out"
   assert_file_contains '(d2) tenant worker network counters: not collected' "$tmp/out"
+  assert_file_contains '(d3) tenant worker block IO counters: not collected' "$tmp/out"
   assert_file_contains 'ghcr-mirror state, access log and warm-up Job: not collected' "$tmp/out"
   rm -rf "$tmp"
 }
@@ -949,6 +952,7 @@ assert_file_lacks_pattern() {
     cozy_capture_tenant_worker_cpu_throttle() { :; }
     cozy_capture_tenant_worker_network_counters() { :; }
     cozy_capture_sandbox_kvm_exits() { :; }
+    cozy_capture_tenant_worker_block_io() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_capture_sandbox_node_cpu_time() { :; }
     cozy_capture_tenant_worker_thread_cpu() { :; }
@@ -1024,6 +1028,7 @@ assert_file_lacks_pattern() {
     cozy_capture_tenant_worker_cpu_throttle() { :; }
     cozy_capture_tenant_worker_network_counters() { :; }
     cozy_capture_sandbox_kvm_exits() { :; }
+    cozy_capture_tenant_worker_block_io() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_report_node_join_failure test-latest-version
   ' 2>&1) || true
@@ -1057,6 +1062,7 @@ assert_file_lacks_pattern() {
     cozy_capture_tenant_worker_cpu_throttle() { :; }
     cozy_capture_tenant_worker_network_counters() { :; }
     cozy_capture_sandbox_kvm_exits() { :; }
+    cozy_capture_tenant_worker_block_io() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_report_node_join_failure test-latest-version
   ' 2>&1) || true
@@ -1142,6 +1148,68 @@ assert_file_lacks_pattern() {
     echo "the CSR reads (line $csr) must precede the serial console ($console) and the Talos capture ($talos)" >&2
     exit 1
   fi
+}
+
+@test "the replicated volume state is read before anything that can spend the budget" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # One read, and it answers a question with no other source once the suite ends:
+  # the report collects the same tables after cleanup has deleted the worker's
+  # volumes, so a red run leaves nothing about their state behind. A DRBD replica
+  # serving the worker's system disk from a peer rather than locally is slow in a
+  # way every counter in this block attributes to something else, so a budget that
+  # declines this read keeps every symptom and drops the cause.
+  volumes=$(grep -n "cozy_diag_read 'LINSTOR resource state'" "$lib" | head -n 1 | cut -d: -f1)
+  console=$(grep -n "cozy_capture_tenant_serial_console 'node-join failed" "$lib" | head -n 1 | cut -d: -f1)
+  cpu=$(grep -n 'cozy_capture_tenant_worker_cpu_throttle "${_sample}" || true' "$lib" | head -n 1 | cut -d: -f1)
+  talos=$(grep -n 'cozy_capture_tenant_talos "${test_name}" || true' "$lib" | head -n 1 | cut -d: -f1)
+  mirror=$(grep -n 'ghcr_mirror_diagnose || true' "$lib" | head -n 1 | cut -d: -f1)
+  cache=$(grep -n 'talos_image_cache_diagnose || true' "$lib" | head -n 1 | cut -d: -f1)
+  for v in volumes console cpu talos mirror cache; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to locate $v in $lib" >&2
+      exit 1
+    fi
+  done
+  for later in console cpu talos mirror cache; do
+    eval "n=\$$later"
+    if [ "$volumes" -ge "$n" ]; then
+      echo "the volume state read (line $volumes) must precede $later (line $n), or a tight run declines it" >&2
+      exit 1
+    fi
+  done
+}
+
+@test "the block IO counters run with the cheap reads, ahead of everything that costs minutes" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # Same decision as the network counters beside it and the same shape: one
+  # listing and one read per node, read once, against collectors that can spend
+  # minutes each. What makes it worth a position rather than a place is that
+  # nothing else here counts a read at all -- the CPU families say what the group
+  # was allowed and what it got, the byte counters say what crossed the network,
+  # and a guest waiting on blocks looks exactly like a guest computing without
+  # result in both. Below the guest captures it would be declined on the slow runs
+  # this failure comes from, which are the only runs it exists for.
+  block=$(grep -n 'cozy_capture_tenant_worker_block_io || true' "$lib" | head -n 1 | cut -d: -f1)
+  console=$(grep -n "cozy_capture_tenant_serial_console 'node-join failed" "$lib" | head -n 1 | cut -d: -f1)
+  cpu=$(grep -n 'cozy_capture_tenant_worker_cpu_throttle "${_sample}" || true' "$lib" | head -n 1 | cut -d: -f1)
+  talos=$(grep -n 'cozy_capture_tenant_talos "${test_name}" || true' "$lib" | head -n 1 | cut -d: -f1)
+  mirror=$(grep -n 'ghcr_mirror_diagnose || true' "$lib" | head -n 1 | cut -d: -f1)
+  cache=$(grep -n 'talos_image_cache_diagnose || true' "$lib" | head -n 1 | cut -d: -f1)
+  for v in block console cpu talos mirror cache; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to locate $v in $lib" >&2
+      exit 1
+    fi
+  done
+  for later in console cpu talos mirror cache; do
+    eval "n=\$$later"
+    if [ "$block" -ge "$n" ]; then
+      echo "the block IO counters (line $block) must precede $later (line $n), or a tight run declines them" >&2
+      exit 1
+    fi
+  done
 }
 
 @test "the byte-path counters run with the cheap reads, ahead of everything that costs minutes" {
@@ -1295,6 +1363,11 @@ assert_file_lacks_pattern() {
       # arm can state exactly, unlike a walk whose size follows the sandbox.
       cozy_capture_sandbox_kvm_exits) ahead=$((ahead + bound + grace)) ;;
       cozy_capture_tenant_worker_network_counters) ahead=$((ahead + walk)) ;;
+      # One walk apiece and read once, so each costs what the expression above
+      # prices a capped walk at. Both sit ahead of the console on the same
+      # ground: their answers exist nowhere else in the artifact, and a walk read
+      # once cannot cost the console more than a walk's worth.
+      cozy_capture_tenant_worker_block_io) ahead=$((ahead + walk)) ;;
       *)
         echo "$fn is gated ahead of the console and this guard has no cost arm for it; add one, or move it below the console" >&2
         return 1
@@ -1399,7 +1472,7 @@ assert_file_lacks_pattern() {
     exit 1
   fi
   # Direction one: for each capture the sentence names, the functions whose
-  # guard is what makes that sentence true of it. The two cAdvisor captures do
+  # guard is what makes that sentence true of it. The cAdvisor captures do
   # not carry the guard themselves -- it lives in the body they share -- and
   # naming that body here is what the closure was trying and failing to derive.
   # A helper renamed or a guard removed drops it out of `guarded`, and this
@@ -1407,6 +1480,7 @@ assert_file_lacks_pattern() {
   for entry in \
     'cozy_capture_tenant_worker_cpu_throttle:CPU throttling:_cozy_cadvisor_node_stream _cozy_virt_launcher_listing' \
     'cozy_capture_tenant_worker_network_counters:network counter:_cozy_cadvisor_node_stream _cozy_virt_launcher_listing' \
+    'cozy_capture_tenant_worker_block_io:block IO counter:_cozy_cadvisor_node_stream _cozy_virt_launcher_listing' \
     'cozy_capture_sandbox_node_cpu_time:sandbox node CPU time:cozy_capture_sandbox_node_cpu_time' \
     'cozy_capture_sandbox_kvm_exits:sandbox kernel KVM counters:cozy_capture_sandbox_kvm_exits' \
     'cozy_capture_tenant_worker_thread_cpu:worker per-thread CPU time:cozy_capture_tenant_worker_thread_cpu _cozy_virt_launcher_listing' \
@@ -1512,6 +1586,7 @@ ${carrier}
       cozy_capture_sandbox_node_cpu_time) phrase='sandbox node CPU time' ;;
       cozy_capture_tenant_worker_thread_cpu) phrase='worker per-thread CPU time' ;;
       cozy_capture_tenant_worker_network_counters) phrase='worker network counters' ;;
+      cozy_capture_tenant_worker_block_io) phrase='worker block IO counters' ;;
       cozy_capture_tenant_serial_console) phrase='serial-console family' ;;
       cozy_capture_tenant_talos) phrase='guest Talos capture' ;;
       ghcr_mirror_diagnose) phrase='ghcr-mirror state' ;;
@@ -1722,6 +1797,7 @@ EOF
     cozy_capture_tenant_worker_cpu_throttle() { :; }
     cozy_capture_tenant_worker_network_counters() { :; }
     cozy_capture_sandbox_kvm_exits() { :; }
+    cozy_capture_tenant_worker_block_io() { :; }
     ghcr_mirror_diagnose() { :; }
     kubectl() { :; }
     COZY_DIAG_PHASE_BUDGET=0
@@ -1761,9 +1837,12 @@ EOF
   # So this catches a budget raised past what today's collectors leave room for, and
   # nothing else. It does not cover the guest-Talos walk growing with the pool, which
   # carries no cap; nor the collector gated last, whose image-cache re-probe has no
-  # wall-clock bound at all; nor a new collector heavier than the literal, since
-  # nothing makes one move it. Those are the residuals, and the first two exist
-  # today rather than hypothetically. All are tracked in cozystack/cozystack#3666.
+  # wall-clock bound at all; nor a bounded read gated ahead of the console outside
+  # the CAPTURE-style call form this walk enumerates, as the LINSTOR resource state
+  # read is, whose cost is therefore not summed here; nor a new collector heavier
+  # than the literal, since nothing makes one move it. Those are the residuals, and
+  # the first three exist today rather than hypothetically. All are tracked in
+  # cozystack/cozystack#3666.
   bringup=1500
   # 620 was this figure while the guest-Talos walk ran two commands per worker.
   # It now runs four: the service list and the link table were added at a 10s


### PR DESCRIPTION
## What this PR does

The node-join failure path already records what a stuck tenant worker was allowed and what it got. It records nothing about disk, and that gap now decides an open question: on one-vCPU workers the vCPU thread sits at its physical maximum with the quota untouched, throttling near zero, steal near zero and the sandbox node half idle, while unpacking the same initrd takes six to ten times longer than on a run that passes. Cycles are being handed out and no work comes back. A guest spinning in a wait for blocks on nested virtio looks exactly like a guest computing without result, and every counter on this path is blind to the difference: the CPU families measure the cgroup ceiling and what met it, the byte counters measure what crossed the network, and neither counts a read.

Two reads close that.

The first is the Pod's block IO, taken from the same kubelet cAdvisor endpoint the CPU counters come from, so it needs no new transport and no access into the guest. It is read once rather than twice, unlike its neighbours in the sampling loop: these counters accumulate from the container starting, a worker container starts with the guest it carries, and KubeVirt gives that Pod restartPolicy Never, so one reading spans exactly the window the deadline covers. Totals are not a rate, though, so the filter also keeps `container_start_time_seconds`: it is the divisor, it costs no extra read, and with it in the same file a reader can turn a total into an average without going to a describe dump for the container's age. What one reading still cannot give is a rate inside the window, and the capture says so where the rows are rather than leaving a reader to assume otherwise.

The second is the state of the replicated volumes behind the worker disks. A replica that is SyncTarget, Inconsistent or Diskless serves the guest's system disk from a peer over the network rather than locally, which is slow in a way no counter here attributes to storage. That is a state rather than a rate, so one read settles it, and it has to be read now: the report collects the same tables after the suite, by which time cleanup has usually deleted the volumes a red run would need them for.

Both sit with the cheap reads ahead of the collectors that cost minutes, for the reason the phase budget makes structural: admission gates when a collector may start, so what runs last is what gets declined, and a collector below the guest captures is one that disappears on exactly the slow runs it exists for. Neither changes the budget, the read bound, the sampling interval or any cap, so the two inequalities the guards hold the phase against are untouched.

### What this does not do

**The guest's own `/proc/diskstats` is out of reach, and stays out of reach.** The diagnostics credential minted for the guest carries the `os:reader` role, which Talos documents as granting the safe methods, "for example, that includes the ability to list files, but does not include the ability to read files content"; only the admin and operator roles read file contents, and `features.rbac: true` is set in the worker machine config. No Talos resource carries disk statistics either, so `read` is the only door. Getting through it means minting a credential that also carries reboot and reset rights on the tenant workers, and that is not a trade a diagnostic makes: the point of the existing `os:reader` credential is precisely that it cannot do those things, and a collector is the worst place to reverse that, because the next one gets written from it.

**The one guest source that is readable carries no substitute, and that was measured rather than assumed.** A guest blocked on IO would normally leave a hung-task warning in its own dmesg, which this path already captures. The Talos kernel is built with `CONFIG_DETECT_HUNG_TASK` unset (`kernel/build/config-amd64` in the kernel package tree, on trunk and on the pinned series alike), so that line is never printed however long a task waits, and `blk_update_request` covers IO *errors* rather than slowness. So there is no cheap grep over existing artifacts to run first. The same file settles a related question: the kernel ships `CONFIG_PSI=y` with PSI enabled by default, so when the io-pressure families are missing from the kubelet's output, the kubelet feature gate is the reason and not the kernel.

**The per-device host view is parked, with its arithmetic, rather than pursued here.** Sandbox-node `/proc/diskstats` would add the service time and queue depth that cgroup v2 does not publish, and its transport already exists in this file. It costs one more read per node in each of the two passes the existing walk makes: six reads at the read bound, 150s, against a sampling pair that already stands at 662s of the 680s the budget derivation allows for one late admission, over a derivation sitting 10s under the window the op leaves after the bringup and the snapshot. Paying for it means raising the op ceiling, and that is worse than it looks: the E2E job is capped at 180 minutes, a run that hits that cap is cancelled with the report and the job log both lost, and two suites at five more minutes each spend exactly that headroom on the runs where every instrument is already at risk. So the ceiling stays, and this is the step to take if the two reads above do not answer, with the result in hand rather than guessed.

The families this capture keeps are the ones cAdvisor declares for the disk IO group, verified against the upstream exposition rather than written from the metric names. Under cgroup v2 the kernel's `io.stat` carries transferred bytes and completed operations only, so the service time and queue depth families are either absent or filled from the node filesystem's own counters. That is stated beside the rows, because a missing service time read as an idle disk is the opposite of what was measured.

### Validity, stated in the artifact

Every outcome that is not a reading gets a sentence in the file rather than an empty directory: a kubelet that never answered, a kubelet that answered and carried nothing for a worker on that node, a namespace whose containers are none of them workers, a filter that could not read its own input back, and a read cut short part way through. Empty bytes read as a healthy worker, which is the conclusion this capture was added to test, so no path is allowed to leave them.

Keeping the divisor in the filter costs one more of those, and it is paid rather than left implicit. The start-time family is published for any container cAdvisor knows, so a file can hold it with no counter beside it, and then "nothing survived the filter" no longer means "no disk counter arrived". The note therefore decides that on the subject families themselves and says so in the file: a start time with no counter under it reads as the kubelet reporting no block IO for this worker, never as a worker that touched no disk. On a capture already marked incomplete, every sentence that treats the rows as a whole reading is withheld, since a total over a prefix understates it and a family missing from a prefix says nothing about the kernel interface. The device legend stays there, because it explains a label on the rows that did arrive.

Context: cozystack/cozystack#3513.

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

No UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff, file by file. The diff touches `hack/e2e-chainsaw/_lib/run-kubernetes.sh`, the two kubernetes suites' comment blocks, one new unit suite under `hack/`, and the node-join guard suite. It adds no package, changes no `values.schema.json`, no `values.yaml`, no ApplicationDefinition, no CRD, no namespace, no make target, and no node prerequisite in `hack/e2e-prepare-cluster.bats`. Nothing under `hack/` is moved or renamed. That leaves no trigger matched.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tenant-worker block I/O counters to Kubernetes node-join diagnostics.
  * Included device labels, cumulative-counter interpretation, missing-data handling, and read-status notes.
  * Documented block I/O collection in Kubernetes diagnostic sequences.

* **Bug Fixes**
  * Improved diagnostic output for incomplete, unavailable, timed-out, or partially readable metric data.

* **Tests**
  * Added comprehensive coverage for block I/O capture, filtering, counter handling, timeout behavior, and diagnostic budgeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->