### PR TITLE
test(e2e): price the layers above the sandbox on the node-join window

### DIFF
--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -2101,6 +2101,10 @@ $(_cozy_kvm_stats_probe)"
     unshare --mount --propagation private \
       sh -c "${program}" cozy-kvm-exits "${mount_point}" \
       >"${raw}" 2>"${read_log}" </dev/null || rc=$?
+    # Said in the capture and not only in the phase log: the warning that
+    # names unbounded collectors fires inside the diagnostics phase, and two
+    # of the three readings this pair takes run outside it.
+    printf '%s\n' '[bounds] timeout is not on PATH here, so the reads this capture takes ran with no ceiling]' >>"${raw}" 2>/dev/null || true
   fi
   read_done=$(date -u +%s)
 
@@ -2229,6 +2233,398 @@ $(_cozy_kvm_stats_probe)"
   # as partial, and telling the caller nothing was collected would contradict
   # the file sitting beside it.
   if [ "${rc}" -eq 3 ] || [ "${counters_present}" -eq 0 ]; then
+    return 1
+  fi
+}
+
+# The CPU time of the kernel one layer ABOVE the sandbox nodes.
+#
+# Every other CPU reading in this file has a subject inside the sandbox: a
+# cgroup, a thread, a sandbox node's own /proc/stat. None of them can price the
+# layers above, and that is where this suite's own tax is paid -- the sandbox
+# nodes' guest time is charged to the runner kernel as user time, and whatever
+# the runner VM loses to the machine hosting IT is charged to nobody the sandbox
+# can see.
+#
+# /proc/stat is not namespaced, so a container reading it reads the kernel it
+# runs on. The suite runs in a container on the runner VM, so this is a local
+# read of the runner VM's own kernel and costs one open.
+#
+# What it answers that nothing else here does is steal. A sandbox node reporting
+# steal 0 says the runner kernel gave it every turn it asked for, and says
+# nothing about whether the runner VM itself was given every turn: that number
+# exists only here, and it is the one that separates "this suite is slow" from
+# "this machine was sharing a core with somebody else".
+cozy_capture_runner_kernel_cpu_time() {
+  local sample="$1"
+  local report_dir="${COZY_REPORT_DIR:-/workspace/_out/cozyreport}/snapshots/${COZY_SNAPSHOT_NAME:-kubernetes}/runner-kernel-cpu-time/sample-${sample}"
+  local raw="${report_dir}/proc-stat.txt"
+  local err_log="${report_dir}/COLLECTION-FAILED.txt"
+  local read_log="${report_dir}/read-error.log"
+  local rc=0
+  local rows_present=0
+  local read_at read_done
+  # The file to read, and the seam that lets the arms below be exercised against
+  # a staged file instead of against a kernel. Production never sets it.
+  local stat_file="${COZY_DIAG_RUNNER_PROC_STAT:-/proc/stat}"
+
+  # Checked, unlike its neighbours, because this is the one failure the markers
+  # below cannot describe: with no directory every write under it fails, the
+  # collector becomes a silent no-op, and the artifact carries the empty space
+  # this capture exists to refuse -- with nowhere to put a marker saying so.
+  if ! mkdir -p "${report_dir}"; then
+    echo "the report directory for the runner kernel CPU time could not be created, so nothing was read and nothing could be written to say so" >&2
+    return 1
+  fi
+  # Re-validated here for the reason every collector re-validates them: a value
+  # assigned after this file is sourced never passed the assignment-time check,
+  # and zero reaches `timeout` as no bound at all.
+  COZY_DIAG_READ_TIMEOUT=$(_cozy_diag_seconds "${COZY_DIAG_READ_TIMEOUT-}" "$COZY_DIAG_READ_TIMEOUT_DEFAULT" COZY_DIAG_READ_TIMEOUT positive)
+  COZY_DIAG_READ_GRACE=$(_cozy_diag_seconds "${COZY_DIAG_READ_GRACE-}" "$COZY_DIAG_READ_GRACE_DEFAULT" COZY_DIAG_READ_GRACE)
+
+  echo "--- capturing the runner kernel's CPU time (sample ${sample}) ---"
+  # Stamped around the read, and here the stamps are the only timing there is: a
+  # /proc/stat row carries no sample time, and the two readings of this pair are
+  # separated by the node-join wait rather than by a knob, so without these the
+  # interval the pair spans is unrecoverable from the artifact.
+  read_at=$(date -u +%s)
+  # stdin closed explicitly for the reason the walks above state: nothing here
+  # reads it today, and a program that started to would consume whatever the
+  # caller was iterating.
+  if command -v timeout >/dev/null 2>&1; then
+    timeout -k "${COZY_DIAG_READ_GRACE}" "${COZY_DIAG_READ_TIMEOUT}" \
+      cat "${stat_file}" >"${raw}" 2>"${read_log}" </dev/null || rc=$?
+  else
+    cat "${stat_file}" >"${raw}" 2>"${read_log}" </dev/null || rc=$?
+    # Said in the capture and not only in the phase log: the warning that
+    # names unbounded collectors fires inside the diagnostics phase, and two
+    # of the three readings this pair takes run outside it.
+    printf '%s\n' '[bounds] timeout is not on PATH here, so the reads this capture takes ran with no ceiling]' >>"${raw}" 2>/dev/null || true
+  fi
+  read_done=$(date -u +%s)
+
+  # Emptied rather than only removed, because the arms below decide what to tell
+  # the reader by whether there is an error log to send them to, and a variable
+  # still holding the path of a file that is gone points at nothing.
+  if [ ! -s "${read_log}" ]; then
+    rm -f "${read_log}"
+    read_log=
+  elif [ "${rc}" -eq 0 ]; then
+    # A read that succeeded and still said something keeps its message beside the
+    # capture rather than inside it, the way every other reader here does.
+    mv "${read_log}" "${report_dir}/READ-WARNINGS.txt" 2>/dev/null || true
+    read_log=
+  fi
+
+  # Whether a CPU row reached the file, which is a different question from
+  # whether the file has bytes in it: /proc/stat carries intr, ctxt and btime
+  # rows as well, and a read cut off after those holds numbers and no CPU time
+  # at all. Keyed on size, the arms below would call that a reading.
+  if grep -q '^cpu' "${raw}" 2>/dev/null; then
+    rows_present=1
+  fi
+
+  # How to read the numbers goes on every capture that holds numbers, which is a
+  # wider set than the captures holding a whole reading: the column trap and the
+  # layer these rows belong to do not depend on the read having finished, and a
+  # capture cut short is exactly where a reader needs them.
+  if [ "${rows_present}" -ne 0 ]; then
+    printf '%s\n' \
+      '[these rows belong to the RUNNER VM kernel, one layer above the sandbox nodes: /proc/stat is not namespaced, so this container reads the kernel it runs on, which is the hypervisor hack/e2e-prepare-cluster.bats starts the three Talos nodes on with accel=kvm. The sandbox nodes report their own /proc/stat one layer down, under sandbox-host-cpu-time, and no capture in this report reads /proc/stat inside a tenant worker at all -- what sits under tenant-cpu-throttle and tenant-thread-cpu is cgroup and per-thread accounting, not this file. Reading these rows as a sandbox node compares a hypervisor against its guest]' \
+      '[the cpu rows above are, after the label: user nice system idle iowait irq softirq steal guest guest_nice, in USER_HZ. The eighth number is steal and the ninth is guest. guest is already counted inside user, here as everywhere, so adding the two double-counts whatever the guests spent. How much of the user time on this kernel is guest time is not something these rows are read against anything to establish -- the runner also runs the CI process tree, containerd and this suite -- so take the ninth column as the guest share and the eighth as what was taken away, and neither as a proportion of the other]' \
+      '[steal on THIS layer is the number that exists nowhere else in this report. It is time the machine hosting this runner VM gave to somebody else. A sandbox node reporting steal 0 while this row climbs points the wait one layer up -- and read the two as directions rather than rates, because the sandbox rows under sandbox-host-cpu-time are a pair seconds apart inside the diagnostics block while this pair spans the whole join window]' \
+      '[read that column in ONE direction only. A steal that climbs is proof this runner VM was preempted. A steal of zero is not proof of the opposite: the column is filled only where the hypervisor exposes a paravirt steal clock, and where it does not the guest kernel prints zero forever. Nothing in this capture observes which of the two it is, and unlike the sandbox nodes one layer down -- started with accel=kvm by hack/e2e-prepare-cluster.bats, where KVM exposes the accounting -- nobody in this repository launches the runner VM, so the answer for this lane is unknown until somebody reads a non-zero here]' \
+      '[the first row is the sum over every CPU and the cpuN rows below it are per-CPU, one per ONLINE CPU -- the kernel sums the first row over every possible CPU, so an offline one is inside the total and absent below it. What the row count is not is a core count: a cpuN row is a CPU as this kernel sees it, which is a hardware thread wherever SMT is exposed to the guest. This capture reads no topology, so it cannot say which this lane is; /sys/devices/system/cpu/cpuN/topology/thread_siblings_list is where that answer lives, and it is not in this artifact]' \
+      >>"${raw}"
+  fi
+
+  case "${rc}" in
+    0)
+      # Gated on a row having arrived, unlike the KVM capture beside this one,
+      # and the difference is in what the read can promise. That probe exits 4 or
+      # 5 when it found no counter, so a zero there already means counters were
+      # read; `cat` exits zero for any file it could open, including one holding
+      # only the intr and ctxt rows that /proc/stat carries after the CPU time.
+      # Ungated, the pairing instruction would ride on a file with nothing to
+      # difference, and following it turns the sibling's whole cumulative total
+      # into a rate over the window -- the largest number this artifact could
+      # produce, arrived at by doing what it says.
+      if [ "${rows_present}" -ne 0 ]; then
+        printf '%s\n' \
+          '[subtracting this file from its sibling under the other sample directory, and the stamps below from each other, gives a rate. The two readings are taken on either side of the node-join wait, so the interval is that window plus the sibling readings taken between each sample and the wait, every one bounded by its own ceiling; the stamps below, not the window, are the exact divisor]' \
+          >>"${raw}"
+      else
+        # Opened, read to the end, and carrying no CPU time. That is a statement
+        # about the file rather than about the read, and it has to be said in the
+        # file: an empty-looking capture with a clean exit code otherwise reads
+        # as a kernel that was idle.
+        printf '%s\n' \
+          'this reading is unavailable: the read completed and returned no cpu row at all, so this file holds whatever else /proc/stat carried and no CPU time. That is not a reading that the runner kernel was idle' \
+          >>"${raw}"
+      fi
+      ;;
+    *)
+      # Four arms, and the pair of questions they answer are independent:
+      # whether a CPU row reached the file, and whether the read left a message
+      # anywhere. Told only the first, a reader goes looking for an explanation
+      # in the job log of a run that may be days old; told only the second, they
+      # cannot tell a capture worth differencing from one that holds nothing.
+      if [ "${rows_present}" -ne 0 ] && [ -n "${read_log}" ]; then
+        printf '%s\n' \
+          'this reading is incomplete: the read was cut short part way through the file, so a difference against the sibling sample understates every row it did not reach; what the read said before it stopped is in the read-error.log beside this file' \
+          >>"${raw}"
+      elif [ "${rows_present}" -ne 0 ]; then
+        printf '%s\n' \
+          'this reading is incomplete: the read was cut short part way through the file, so a difference against the sibling sample understates every row it did not reach, and it stopped without a word on either stream' \
+          >>"${raw}"
+      elif [ -n "${read_log}" ]; then
+        mv "${read_log}" "${err_log}" 2>/dev/null || true
+        read_log=
+        printf '%s\n' \
+          'this reading is unavailable: the read returned no cpu row at all; what it said is in the COLLECTION-FAILED.txt beside this file. That is not a reading that the runner kernel was idle' \
+          >>"${raw}"
+      else
+        printf '%s\n' \
+          'this reading is unavailable: the read returned no cpu row at all and said nothing on either stream, so what this kernel spent is not recorded here either way. That is not a reading that it was idle' \
+          >>"${raw}"
+      fi
+      ;;
+  esac
+  printf '[read attempted from %s to %s epoch seconds]\n' \
+    "${read_at}" "${read_done}" >>"${raw}"
+  printf '\n[capture exit code: %s]\n' "${rc}" >>"${raw}"
+  # Non-zero when the capture holds no row, and only then. Both callers ask this
+  # function whether it collected something to pair with, and one of them runs on
+  # the passing path where the report is the artifact nobody downloads, so a
+  # capture holding no number has to answer out loud or the warning saying the
+  # pair is broken never prints. A capture cut short AFTER it wrote rows is the
+  # case this does not cover: it left a usable reading, marked as partial, and
+  # telling the caller nothing was collected would contradict the file beside it.
+  if [ "${rows_present}" -eq 0 ]; then
+    return 1
+  fi
+}
+
+# The sandbox VMs' own QEMU threads, from the namespace they run in.
+#
+# The three Talos nodes are QEMU processes started by hack/e2e-prepare-cluster.bats
+# inside this container, so they share its PID namespace with the shell running
+# this suite: the same probe the tenant worker capture runs through `kubectl exec`
+# runs here as a local read, against this container's own /proc.
+#
+# What it answers is where the runner kernel's user time went. The row above says
+# this kernel spent it; this says which sandbox vCPU thread spent it, and whether
+# the three nodes spent it evenly. A node-join failure in which one node's vCPU
+# threads are pinned while the other two idle is a different fault from one in
+# which all twenty-four are busy -- three nodes at `-smp 8`.
+#
+# What is NOT the claim here, because the obvious version of it is false:
+# `cozy_capture_sandbox_node_cpu_time` reads each sandbox node's own /proc/stat
+# through talosctl and names the node, so that collector does tell an uneven split
+# from an even one. What no reading in this report does is price the split ON THE
+# NODE-JOIN WINDOW: that one is sampled twice across a twelve-second interval
+# inside the diagnostics block, after the join has already failed. This pair
+# brackets the wait instead. What it adds beyond the window is the host-side
+# accounting of each vCPU thread -- what the runner actually granted it, which
+# no counter inside the guest can report, and nothing in this report samples
+# the guest's own view on the same window to compare it against -- and QEMU's
+# non-vCPU IO and worker threads, which no in-guest counter sees at all.
+cozy_capture_sandbox_qemu_thread_cpu() {
+  local sample="$1"
+  local report_dir="${COZY_REPORT_DIR:-/workspace/_out/cozyreport}/snapshots/${COZY_SNAPSHOT_NAME:-kubernetes}/sandbox-qemu-thread-cpu/sample-${sample}"
+  local raw="${report_dir}/qemu-threads.txt"
+  local read_log="${report_dir}/read-error.log"
+  local rc=0
+  local threads_present=0
+  local probe read_at read_done
+  local pid_map=
+  local srv pid_file pid
+  # The proc mount to walk, and the seam that lets the arms below be exercised
+  # against a staged tree instead of against a hypervisor. Production never sets
+  # it: the probe defaults to the real one and the default is what runs.
+  local proc_root="${COZY_DIAG_SANDBOX_PROC:-/proc}"
+  # Where hack/e2e-prepare-cluster.bats leaves each guest's pid file. It writes
+  # `srv<N>/qemu.pid` relative to /workspace in this same container, and the
+  # kubernetes suites `cd ../../..` to /workspace before sourcing this library, so
+  # the default is that directory rather than a path assembled from the cwd of
+  # whoever called.
+  local sandbox_root="${COZY_DIAG_SANDBOX_VM_ROOT:-/workspace}"
+
+  if ! mkdir -p "${report_dir}"; then
+    echo "the report directory for the sandbox QEMU thread CPU time could not be created, so nothing was read and nothing could be written to say so" >&2
+    return 1
+  fi
+  COZY_DIAG_READ_TIMEOUT=$(_cozy_diag_seconds "${COZY_DIAG_READ_TIMEOUT-}" "$COZY_DIAG_READ_TIMEOUT_DEFAULT" COZY_DIAG_READ_TIMEOUT positive)
+  COZY_DIAG_READ_GRACE=$(_cozy_diag_seconds "${COZY_DIAG_READ_GRACE-}" "$COZY_DIAG_READ_GRACE_DEFAULT" COZY_DIAG_READ_GRACE)
+
+  # The same probe the tenant worker capture runs, and deliberately the same one
+  # rather than a copy: it already answers the two outcomes that matter here --
+  # "found QEMU" and "QEMU is gone" -- and it already names the three ways it can
+  # come up short. A second copy would drift from this one exactly where the
+  # failure paths are, which is where nobody looks until it matters.
+  probe=$(_cozy_thread_cpu_probe)
+
+  # Which pid is which node, read from the files the bringup already wrote. The
+  # probe names processes by their container pid, and a pid identifies nothing to
+  # a reader: the question this capture exists to answer is whether the
+  # control-plane node or a worker-carrying one is starving, because the tenant
+  # workers sit on specific sandbox nodes. Three tiny local reads buy that.
+  #
+  # Through a bounded external cat, never the shell's own redirect: `[ -r ]`
+  # passes on a FIFO and the redirect open then blocks forever, outside anything
+  # a wrapper can cover. Three tiny spawns buy the same ceiling every other read
+  # here carries; where `timeout` is absent they run unbounded like the rest,
+  # which the capture's own bounds note declares. The whole map is optional:
+  # when it cannot be built the capture says so and stays anonymous, which is
+  # what its KVM sibling does about a mapping that is genuinely unavailable.
+  for srv in 1 2 3; do
+    pid_file="${sandbox_root}/srv${srv}/qemu.pid"
+    pid=
+    if command -v timeout >/dev/null 2>&1; then
+      pid=$(timeout -k "${COZY_DIAG_READ_GRACE}" "${COZY_DIAG_READ_TIMEOUT}" cat "${pid_file}" 2>/dev/null) || continue
+    else
+      pid=$(cat "${pid_file}" 2>/dev/null) || continue
+    fi
+    case "${pid}" in
+      '' | *[!0-9]*) continue ;;
+    esac
+    pid_map="${pid_map}${pid} srv${srv}
+"
+  done
+
+  echo "--- capturing the sandbox VMs' QEMU thread CPU time (sample ${sample}) ---"
+  read_at=$(date -u +%s)
+  if command -v timeout >/dev/null 2>&1; then
+    timeout -k "${COZY_DIAG_READ_GRACE}" "${COZY_DIAG_READ_TIMEOUT}" \
+      sh -c "${probe}" cozy-sandbox-qemu-threads "${proc_root}" \
+      >"${raw}" 2>"${read_log}" </dev/null || rc=$?
+  else
+    sh -c "${probe}" cozy-sandbox-qemu-threads "${proc_root}" \
+      >"${raw}" 2>"${read_log}" </dev/null || rc=$?
+    # Said in the capture and not only in the phase log: the warning that
+    # names unbounded collectors fires inside the diagnostics phase, and two
+    # of the three readings this pair takes run outside it.
+    printf '%s\n' '[bounds] timeout is not on PATH here, so the reads this capture takes ran with no ceiling]' >>"${raw}" 2>/dev/null || true
+  fi
+  read_done=$(date -u +%s)
+
+  if [ ! -s "${read_log}" ]; then
+    rm -f "${read_log}"
+    read_log=
+  elif [ "${rc}" -eq 0 ]; then
+    mv "${read_log}" "${report_dir}/READ-WARNINGS.txt" 2>/dev/null || true
+    read_log=
+  fi
+
+  # Whether a thread line reached the file, which is a different question from
+  # whether the file has bytes in it: the probe writes a clock-tick heading and
+  # a `process` line before any thread, and it writes its own findings when it
+  # has none. Keyed on size, a capture holding only a finding would be labelled
+  # a reading and a legend about columns would be pinned to a file with none.
+  if grep -q '^[0-9]' "${raw}" 2>/dev/null; then
+    threads_present=1
+  fi
+
+  if [ "${threads_present}" -ne 0 ]; then
+    printf '%s\n' \
+      '[these threads belong to the SANDBOX VMs: the three Talos nodes hack/e2e-prepare-cluster.bats starts as QEMU processes inside this container, which shares its PID namespace with them. They are the guests of the runner kernel whose /proc/stat sits under runner-kernel-cpu-time, and the hosts of the tenant workers whose own QEMU threads sit under tenant-thread-cpu. Reading these as a tenant worker inverts the layer]' \
+      '[each line above beginning with a number is /proc/<pid>/task/<tid>/stat verbatim: the first field is the thread id, the second is the thread name in parentheses, utime is the 14th field and stime the 15th]' \
+      '[counting those fields over whitespace reads the wrong column for exactly the threads this capture exists to identify: a KVM vCPU thread is named CPU 0/KVM, that space sits inside the parentheses, and every field after it shifts by one. Parse from the last ) in the line instead, after which the state is the first field, utime the 12th and stime the 13th]' \
+      "[the names: CPU N/KVM is that sandbox node's vCPU N, the thread whose id equals the process id is QEMU's main thread and its emulator thread, and the rest are QEMU's own IO and worker threads, which carry the process name unless QEMU renamed them. The vCPU names exist because hack/e2e-prepare-cluster.bats starts every sandbox QEMU with -name debug-threads=on; a QEMU started without it shows the bare process name on every thread, and the split below is then by thread id only]" \
+      '[utime and stime are clock ticks, at the rate the first line above reports, and both are cumulative since the thread started]' \
+      '[a node with its eight vCPU threads busy and its siblings idle is a different failure from three nodes evenly loaded, and the runner kernel row one layer up cannot tell them apart: it sums all three]' \
+      >>"${raw}"
+  fi
+  # Which pid is which node, or a statement that this capture does not know.
+  # Written on every path, not only under thread lines: on the walk that found
+  # a QEMU and could not read its tasks, which nodes still had usable pid files
+  # is exactly the question, and gating this on threads would blank the answer
+  # there. The KVM capture beside it discloses its own anonymity the same way.
+  if [ -n "${pid_map}" ]; then
+    printf '%s\n' \
+      '[which sandbox node each QEMU process id belongs to, read from the pid files hack/e2e-prepare-cluster.bats wrote when it started them -- stated on every path, since a walk that met a QEMU it could not read leaves no thread lines while the node behind that pid is exactly the question. A mapping says which node the file names, not that the process still runs: a QEMU that died keeps its pid file. A thread line belongs to the process heading above it -- the stat line carries the thread id, so the position under its heading is the whole link. A node absent from this list had no usable pid file at the moment of this reading -- absent, unreadable, cut off by the read ceiling, empty or not one process id -- which for a node-join failure is itself worth knowing]' \
+      >>"${raw}"
+    printf '%s' "${pid_map}" | while read -r _pm_pid _pm_srv; do
+      [ -n "${_pm_pid}" ] || continue
+      printf '[process %s is %s]\n' "${_pm_pid}" "${_pm_srv}" >>"${raw}"
+    done
+  else
+    printf '%s\n' \
+      "[this capture is anonymous by node: no usable pid file under ${sandbox_root}/srv{1,2,3}/qemu.pid, so a process id above identifies a QEMU and not which sandbox node it is. The split is still per-VM -- it says how evenly the three paid, not which of them paid what]" \
+      >>"${raw}"
+  fi
+
+  case "${rc}" in
+    0)
+      # The pairing instruction waits for this arm, for the reason the KVM
+      # capture states beside it: telling a reader to subtract two files
+      # asserts that both hold a whole reading, and a walk cut off after the
+      # first node would have the other two read as having spent nothing
+      # across the window.
+      if [ "${threads_present}" -ne 0 ]; then
+        printf '%s\n' \
+          '[subtracting this file from its sibling under the other sample directory, and the stamps below from each other, gives a rate per thread. The two readings are taken on either side of the node-join wait, so the interval is that window plus the sibling readings taken between each sample and the wait, every one bounded by its own ceiling; the stamps below, not the window, are the exact divisor]' \
+          >>"${raw}"
+      else
+        # Walked to the end and found nothing to read. The probe has already
+        # said which of the three shapes it met, in its own words; what it
+        # cannot say is that this is a finding rather than a collector that
+        # came up short, and a `[capture exit code: 0]` under it otherwise
+        # reads as a healthy capture of an idle machine. The closing sentence
+        # follows the probe's own marker: one phrase over all three would call
+        # a sandbox with three named QEMUs "a sandbox running no QEMU" two
+        # lines under the list of them.
+        if grep -q '^NO-QEMU-PROCESS:' "${raw}" 2>/dev/null; then
+          printf '%s\n' \
+            'these thread readings are unavailable: the walk completed and produced no thread line at all, for the reason it states above. That is not a reading that the sandbox VMs used no CPU -- a sandbox running no QEMU is a finding about this run rather than a shortfall of this capture' \
+            >>"${raw}"
+        elif grep -q '^NO-THREAD-LINES:' "${raw}" 2>/dev/null; then
+          printf '%s\n' \
+            'these thread readings are unavailable: the walk completed and produced no thread line at all, for the reason it states above. That is not a reading that the sandbox VMs used no CPU -- a QEMU that was named while its task files could not be read is a guest going away under the walk, which for a node-join failure is itself a finding' \
+            >>"${raw}"
+        else
+          printf '%s\n' \
+            'these thread readings are unavailable: the walk completed and produced no thread line at all, for the reason it states above. That is not a reading that the sandbox VMs used no CPU, and it says nothing about what the container was running' \
+            >>"${raw}"
+        fi
+      fi
+      ;;
+    *)
+      if [ "${threads_present}" -ne 0 ] && [ -n "${read_log}" ]; then
+        printf '%s\n' \
+          'these thread readings are incomplete: the walk was cut short part way through, so a difference against the sibling sample is missing whichever threads it did not reach; what the read said before it stopped is in the read-error.log beside this file' \
+          >>"${raw}"
+      elif [ "${threads_present}" -ne 0 ]; then
+        printf '%s\n' \
+          'these thread readings are incomplete: the walk was cut short part way through, so a difference against the sibling sample is missing whichever threads it did not reach, and it stopped without a word on either stream' \
+          >>"${raw}"
+      elif [ -n "${read_log}" ]; then
+        # Into COLLECTION-FAILED.txt, the name this report gives the
+        # artifact-level marker for a read that never returned, and the name
+        # its sibling collector writes for this same shape. A reader sweeping
+        # the tarball for failure markers would otherwise miss this walk.
+        mv "${read_log}" "${report_dir}/COLLECTION-FAILED.txt" 2>/dev/null || true
+        read_log=
+        printf '%s\n' \
+          'these thread readings are unavailable: the walk produced no thread line at all; what it said is in the COLLECTION-FAILED.txt beside this file. That is not a reading that the sandbox VMs used no CPU' \
+          >>"${raw}"
+      else
+        printf '%s\n' \
+          'these thread readings are unavailable: the walk produced no thread line at all and said nothing on either stream, so what the sandbox VMs spent is not recorded here either way. That is not a reading that they used none' \
+          >>"${raw}"
+      fi
+      ;;
+  esac
+  printf '[read attempted from %s to %s epoch seconds]\n' \
+    "${read_at}" "${read_done}" >>"${raw}"
+  printf '\n[capture exit code: %s]\n' "${rc}" >>"${raw}"
+  # Non-zero when the capture holds no thread line, and only then -- whether that
+  # is a walk that failed or a container that had no QEMU to read. The second is
+  # the more consequential of the two on this failure path: the sandbox VMs are
+  # what the whole run stands on, and a container reporting none of them is a
+  # finding rather than a shortfall of this collector. The probe says which of
+  # the three shapes it met in its own words, inside the file.
+  if [ "${threads_present}" -eq 0 ]; then
     return 1
   fi
 }
@@ -3051,7 +3447,7 @@ cozy_diag_phase_start() {
   # an unchecked list sitting beside a checked one, drifting from it at whatever
   # rate collectors are added.
   command -v timeout >/dev/null 2>&1 || \
-    echo "» WARNING: timeout is not on PATH; the bounded reads below run UNBOUNDED, so one that hangs can still take the op and the tenant snapshot with it, and the collectors that call timeout directly (wedge check, serial console, guest Talos) exit 127 and collect nothing; the ones that guard the call with command -v -- the worker CPU throttling, worker network counter, worker block IO counter, sandbox node CPU time, sandbox kernel KVM counters, worker per-thread CPU time, ghcr-mirror and talos-image-cache captures -- keep collecting instead, unbounded" >&2
+    echo "» WARNING: timeout is not on PATH; the bounded reads below run UNBOUNDED, so one that hangs can still take the op and the tenant snapshot with it, and the collectors that call timeout directly (wedge check, serial console, guest Talos) exit 127 and collect nothing; the ones that guard the call with command -v -- the worker CPU throttling, worker network counter, worker block IO counter, sandbox node CPU time, sandbox kernel KVM counters, runner kernel CPU time, sandbox QEMU per-thread CPU time, worker per-thread CPU time, ghcr-mirror and talos-image-cache captures -- keep collecting instead, unbounded" >&2
   # Re-checked here, not only at assignment: a value set after this file is sourced
   # -- which is how a test sets it -- would otherwise reach the arithmetic below
   # unvalidated, and that is the one failure that costs the whole block.
@@ -3240,6 +3636,19 @@ cozy_report_node_join_failure() {
   # bounded read of a file on this machine, so it cannot meaningfully bound what
   # comes after it.
   cozy_capture_sandbox_kvm_exits 2 || true
+  # The second half of the other two pairs, here for the same reason and with the
+  # same standing: the phase gate decides what may START, and a collector it
+  # declines loses only itself -- except these, which would also retire a reading
+  # taken eighteen minutes earlier and leave it an orphan.
+  #
+  # What they cost, stated rather than waved at: each runs under one ceiling of
+  # its own, so the pair adds two of those to whatever runs before the console.
+  # The first is one file read; the second is a walk over this container's /proc,
+  # bounded by the same ceiling but not by a single open. The guard in
+  # hack/run-kubernetes-node-join_test.bats prices both at that ceiling and holds
+  # the sum against the phase budget.
+  cozy_capture_runner_kernel_cpu_time 2 || true
+  cozy_capture_sandbox_qemu_thread_cpu 2 || true
   cozy_diag_read 'tenant node table' \
     kubectl --kubeconfig "${tenant_kc}" describe nodes "${request_timeout}"
   cozy_diag_read 'tenant HelmReleases' \
@@ -3856,42 +4265,28 @@ EOF
   # Verify the Kubernetes version matches what we expect (retry for up to 20 seconds)
   timeout 20 sh -ec 'until kubectl --kubeconfig tenantkubeconfig-'"${test_name}"' version 2>/dev/null | grep -Fq "Server Version: ${k8s_version}"; do sleep 1; done'
 
-  # Wait until at least 2 worker nodes have joined AND become Ready, on a single
-  # deadline. This used to be split (8m to join + 3m to become Ready), but the
-  # two budgets starve each other under load: a slow KubeVirt VM boot consumes
-  # the join budget, then the tenant cluster's cilium CNI needs several more
-  # minutes to make the freshly-joined nodes Ready — overflowing the fixed 3m
-  # Ready window even though the CNI converges fine. One deadline that polls
-  # for ">=2 nodes Ready" is robust to wherever the time goes.
+  # The first readings of the three pairs that bracket the wait, taken here
+  # rather than inside the failure block and taken on every run rather than on
+  # the failing ones. All three read running totals, so one reading is an
+  # average over a whole life and a rate needs two -- and the interval worth
+  # measuring is the window the guest is failing to boot in, which is the wait
+  # below. A pair taken a few seconds apart after the deadline has already
+  # expired would price the tail instead of the fault.
   #
-  # 18m, not the earlier 12m: this single budget has to absorb the *entire*
-  # worker bring-up, and the `machinedeployment .status.replicas=2` gate above
-  # clears while the KubeVirt VMs are still only Machine objects — the clock
-  # here starts ~2m before the guest VMIs even exist. Under host storage
-  # pressure that margin evaporates: in run 30260770694 a transient
-  # `drbd.linbit.com/lost-quorum` taint delayed the worker DataVolume imports,
-  # the worker VMIs were created ~2m into this wait, and the guests then had
-  # only ~10m to import Talos, boot, register a kubelet and let cilium turn the
-  # nodes Ready. They did not make it: both kubernetes-latest and
-  # kubernetes-previous failed here at exactly 12m with zero Nodes registered
-  # and the tenant cilium HR still mid-install. A less-loaded fleet run passed
-  # the same suites unchanged, so this is load-induced slowness, not a stuck
-  # bring-up; 18m restores margin and still sits well inside the 50m step
-  # timeout (the downstream LB/NFS/ouroboros checks add ~10-15m on the happy
-  # path).
-  # The first of the two KVM counter readings, taken here rather than inside the
-  # failure block and taken on every run rather than on the failing ones. Both
-  # follow from what those counters are: running totals (per-VM since that VM
-  # was created, kernel-wide summed over the VMs alive at the read), so one
-  # reading is an average over a whole life and a rate needs two -- and the
-  # interval worth measuring is the window the guest is failing
-  # to boot in, which is the wait below. A pair taken a few seconds apart after
-  # the deadline has already expired would price the tail instead of the fault.
+  # The KVM reading goes LAST here and FIRST after the wait, mirrored on
+  # purpose: nothing then runs between its two samples except the wait itself,
+  # which is what lets its legend call the interval the window and mean it
+  # exactly. The other two name the sibling readings inside their intervals.
   #
-  # Ungated and not fatal. It reads a file this kernel already keeps, so its
-  # cost is one bounded local read against a wait measured in minutes, and a run
-  # that could not take it must still be allowed to go on and fail for its own
-  # reasons.
+  # Ungated and not fatal. Each is a bounded local read against a wait measured
+  # in minutes, and a run that could not take them must still be allowed to go
+  # on and fail for its own reasons.
+  if ! cozy_capture_sandbox_qemu_thread_cpu 1; then
+    echo "» WARNING: the sandbox VMs' QEMU threads yielded no reading before the node-join wait, so the reading taken after it will have nothing to pair with; whether the walk failed or this container had no QEMU process to read is written into the capture itself" >&2
+  fi
+  if ! cozy_capture_runner_kernel_cpu_time 1; then
+    echo "» WARNING: the runner kernel's CPU time yielded no reading before the node-join wait, so the reading taken after it will have nothing to pair with; whether the read failed or returned no cpu row is written into the capture itself" >&2
+  fi
   if ! cozy_capture_sandbox_kvm_exits 1; then
     echo "» WARNING: the sandbox kernel's KVM counters yielded no reading before the node-join wait, so the reading taken after it will have nothing to pair with; whether the read failed or the kernel had no counters to give is written into the capture itself, and any message the read left is in the log beside it" >&2
   fi
@@ -3922,6 +4317,20 @@ EOF
   # against a sibling that was never written.
   if ! cozy_capture_sandbox_kvm_exits 2; then
     echo "» WARNING: the sandbox kernel's KVM counters yielded no reading after the node-join wait, so this report carries no green baseline for the exit rate; whether the read failed or the kernel had no counters to give is written into the capture itself, and any message the read left is in the log beside it" >&2
+  fi
+  # The second half of each pair on the path where the join succeeded, beside the
+  # KVM reading and for its reason: the pair is a measurement of the join window
+  # only if both readings bracket it, and the tail below this point is another
+  # ten to fifteen minutes of storage and LoadBalancer work. A sample taken after
+  # that would price a different window over a different workload while the
+  # legend in the capture says it priced the join -- which would corrupt exactly
+  # the comparison these readings exist for, since the green run is what the red
+  # ones are read against.
+  if ! cozy_capture_runner_kernel_cpu_time 2; then
+    echo "» WARNING: the runner kernel's CPU time yielded no reading after the node-join wait, so this report carries no green baseline for what the layer above the sandbox spent; whether the read failed or returned no cpu row is written into the capture itself" >&2
+  fi
+  if ! cozy_capture_sandbox_qemu_thread_cpu 2; then
+    echo "» WARNING: the sandbox VMs' QEMU threads yielded no reading after the node-join wait, so this report carries no green baseline for how that time split across the three nodes; whether the walk failed or this container had no QEMU process to read is written into the capture itself" >&2
   fi
   kubectl --kubeconfig "tenantkubeconfig-${test_name}" get nodes -o wide
 

--- a/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
@@ -43,6 +43,11 @@ spec:
         #   guest Talos capture
         #   ghcr-mirror state, access log and warm-up Job
         #   talos-image-cache diagnosis
+        # The three bracket pairs -- the sandbox kernel KVM counters, the runner
+        # kernel CPU time and the sandbox QEMU thread time -- sit outside this
+        # order on purpose: each is ungated, one bounded read a side, taken
+        # before the node-join wait and right after it on both paths, and their
+        # cost arms live in the budget guard rather than in this list.
         # and then, after the phase rather than inside it, the in-process tenant
         # crust-gather snapshot.
         #

--- a/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
@@ -37,6 +37,11 @@ spec:
         #   guest Talos capture
         #   ghcr-mirror state, access log and warm-up Job
         #   talos-image-cache diagnosis
+        # The three bracket pairs -- the sandbox kernel KVM counters, the runner
+        # kernel CPU time and the sandbox QEMU thread time -- sit outside this
+        # order on purpose: each is ungated, one bounded read a side, taken
+        # before the node-join wait and right after it on both paths, and their
+        # cost arms live in the budget guard rather than in this list.
         # and then, after the phase rather than inside it, the in-process tenant
         # crust-gather snapshot.
         #

--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -97,7 +97,13 @@ EOF
 
 @test "Boot QEMU VMs" {
   for i in 1 2 3; do
+    # `debug-threads=on` names the vCPU threads (`CPU N/KVM`) so the QEMU
+    # thread capture on the node-join failure path can tell a vCPU from an IO
+    # thread; without it every thread reports the bare process name. QEMU only
+    # renames threads when the flag is passed, so the capture's legend and its
+    # fixtures are pinned to this line carrying it.
     qemu-system-x86_64 -machine type=pc,accel=kvm -cpu host -smp 8 -m 24576 \
+      -name guest=srv${i},debug-threads=on \
       -device virtio-net,netdev=net0,mac=52:54:00:12:34:5${i} \
       -netdev tap,id=net0,ifname=cozy-srv${i},script=no,downscript=no \
       -drive file=srv${i}/system.img,if=virtio,format=raw,cache=unsafe \

--- a/hack/run-kubernetes-node-join_test.bats
+++ b/hack/run-kubernetes-node-join_test.bats
@@ -225,6 +225,15 @@ stub_collectors() {
   # pass-through, so a `mount` that hung would hang the suite with no ceiling to
   # stop it.
   cozy_capture_sandbox_kvm_exits() { printf 'kvm-exits-stub\n'; }
+  # The two readings beside it, stubbed on the same ground and for a sharper
+  # version of it: neither issues a kubectl read, so neither contributes to the
+  # audit below, and un-stubbed they do not probe the host -- they READ it. One
+  # cats the runner's real /proc/stat and the other walks the whole of /proc,
+  # opening a comm file per process on the machine running `make unit-tests`.
+  # The result of a case here would then be set by whatever else that machine
+  # happens to be running, which is the property this file removes.
+  cozy_capture_runner_kernel_cpu_time() { printf 'runner-kernel-cpu-stub\n'; }
+  cozy_capture_sandbox_qemu_thread_cpu() { printf 'sandbox-qemu-thread-stub\n'; }
 }
 
 # The collectors below are deliberately NOT in stub_collectors, and that is
@@ -885,6 +894,8 @@ assert_file_lacks_pattern() {
       cozy_capture_tenant_worker_cpu_throttle() { :; }
       cozy_capture_tenant_worker_network_counters() { :; }
       cozy_capture_sandbox_kvm_exits() { :; }
+      cozy_capture_runner_kernel_cpu_time() { :; }
+      cozy_capture_sandbox_qemu_thread_cpu() { :; }
       ghcr_mirror_diagnose() { :; }
       kubectl() { :; }
       cozy_report_node_join_failure test-latest-version
@@ -952,6 +963,8 @@ assert_file_lacks_pattern() {
     cozy_capture_tenant_worker_cpu_throttle() { :; }
     cozy_capture_tenant_worker_network_counters() { :; }
     cozy_capture_sandbox_kvm_exits() { :; }
+    cozy_capture_runner_kernel_cpu_time() { :; }
+    cozy_capture_sandbox_qemu_thread_cpu() { :; }
     cozy_capture_tenant_worker_block_io() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_capture_sandbox_node_cpu_time() { :; }
@@ -1028,6 +1041,8 @@ assert_file_lacks_pattern() {
     cozy_capture_tenant_worker_cpu_throttle() { :; }
     cozy_capture_tenant_worker_network_counters() { :; }
     cozy_capture_sandbox_kvm_exits() { :; }
+    cozy_capture_runner_kernel_cpu_time() { :; }
+    cozy_capture_sandbox_qemu_thread_cpu() { :; }
     cozy_capture_tenant_worker_block_io() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_report_node_join_failure test-latest-version
@@ -1062,6 +1077,8 @@ assert_file_lacks_pattern() {
     cozy_capture_tenant_worker_cpu_throttle() { :; }
     cozy_capture_tenant_worker_network_counters() { :; }
     cozy_capture_sandbox_kvm_exits() { :; }
+    cozy_capture_runner_kernel_cpu_time() { :; }
+    cozy_capture_sandbox_qemu_thread_cpu() { :; }
     cozy_capture_tenant_worker_block_io() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_report_node_join_failure test-latest-version
@@ -1362,6 +1379,16 @@ assert_file_lacks_pattern() {
       # ahead of the console in wall clock, and one bounded read is a cost this
       # arm can state exactly, unlike a walk whose size follows the sandbox.
       cozy_capture_sandbox_kvm_exits) ahead=$((ahead + bound + grace)) ;;
+      # The other two halves of the same shape, and priced identically. The
+      # runner-kernel reading is one bounded read of /proc/stat; the QEMU
+      # thread reading is one bounded probe walk of this container's own /proc
+      # plus three bounded pid-file reads, all under the same ceiling the arm
+      # prices. Each pair's first half is taken before the wait, so declining
+      # either here would orphan a reading taken eighteen minutes earlier
+      # rather than save one. Counted all the same, because they do sit ahead
+      # of the console in wall clock.
+      cozy_capture_runner_kernel_cpu_time) ahead=$((ahead + bound + grace)) ;;
+      cozy_capture_sandbox_qemu_thread_cpu) ahead=$((ahead + bound + grace)) ;;
       cozy_capture_tenant_worker_network_counters) ahead=$((ahead + walk)) ;;
       # One walk apiece and read once, so each costs what the expression above
       # prices a capped walk at. Both sit ahead of the console on the same
@@ -1422,7 +1449,10 @@ assert_file_lacks_pattern() {
   # missing from it. So the list is derived here rather than restated: every
   # function that guards its bounded call with `command -v timeout` has to
   # appear in that sentence.
-  warn=$(grep -n 'timeout is not on PATH' "$lib" | head -n 1 | cut -d: -f1)
+  # Anchored on the phrase unique to the phase warning itself: the captures now
+  # write their own [bounds] notes carrying "timeout is not on PATH", so the
+  # first match of that phrase is no longer this sentence.
+  warn=$(grep -n 'run UNBOUNDED' "$lib" | head -n 1 | cut -d: -f1)
   if [ -z "$warn" ]; then
     echo "expected the phase to still warn when timeout is missing" >&2
     exit 1
@@ -1483,6 +1513,8 @@ assert_file_lacks_pattern() {
     'cozy_capture_tenant_worker_block_io:block IO counter:_cozy_cadvisor_node_stream _cozy_virt_launcher_listing' \
     'cozy_capture_sandbox_node_cpu_time:sandbox node CPU time:cozy_capture_sandbox_node_cpu_time' \
     'cozy_capture_sandbox_kvm_exits:sandbox kernel KVM counters:cozy_capture_sandbox_kvm_exits' \
+    'cozy_capture_runner_kernel_cpu_time:runner kernel CPU time:cozy_capture_runner_kernel_cpu_time' \
+    'cozy_capture_sandbox_qemu_thread_cpu:sandbox QEMU per-thread CPU time:cozy_capture_sandbox_qemu_thread_cpu' \
     'cozy_capture_tenant_worker_thread_cpu:worker per-thread CPU time:cozy_capture_tenant_worker_thread_cpu _cozy_virt_launcher_listing' \
     'ghcr_mirror_diagnose:ghcr-mirror:ghcr_mirror_diagnose _ghcr_mirror_bounded_read' \
     'talos_image_cache_diagnose:talos-image-cache:talos_image_cache_diagnose _talos_image_cache_bounded_read'; do
@@ -1520,6 +1552,8 @@ ${carrier}
       cozy_capture_tenant_worker_network_counters) phrase='network counter' ;;
       cozy_capture_sandbox_node_cpu_time) phrase='sandbox node CPU time' ;;
       cozy_capture_sandbox_kvm_exits) phrase='sandbox kernel KVM counters' ;;
+      cozy_capture_runner_kernel_cpu_time) phrase='runner kernel CPU time' ;;
+      cozy_capture_sandbox_qemu_thread_cpu) phrase='sandbox QEMU per-thread CPU time' ;;
       cozy_capture_tenant_worker_thread_cpu) phrase='worker per-thread CPU time' ;;
       ghcr_mirror_diagnose) phrase='ghcr-mirror' ;;
       talos_image_cache_diagnose) phrase='talos-image-cache' ;;
@@ -1601,6 +1635,12 @@ ${carrier}
       # out or withholds: declining it would leave that earlier reading with
       # nothing to pair against rather than save the phase any time.
       cozy_capture_sandbox_kvm_exits) continue ;;
+      # The other two halves of that same pair, exempt on the same ground and not
+      # on their own: each was read once before the node-join wait, so what runs
+      # here is the second half of a measurement rather than a collector the
+      # budget may hand out or withhold.
+      cozy_capture_runner_kernel_cpu_time) continue ;;
+      cozy_capture_sandbox_qemu_thread_cpu) continue ;;
       *)
         echo "$fn runs in the diagnostics block but this test has no phrase for it; add one here and to both chainsaw comments" >&2
         exit 1
@@ -1633,6 +1673,45 @@ EOF
       exit 1
     fi
   done
+}
+
+@test "nothing new runs between the KVM reading and the two beside it" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # The interval each of the three pairs divides by is whatever runs between its
+  # two readings, and on the failure path that is everything the block does before
+  # the second one. The KVM guard below pins what may precede ITS reading; this
+  # pins the gap between that reading and the two that follow it, which is where
+  # the other two intervals actually widen. Nothing belongs in there: the three
+  # readings are the second halves of three pairs and are meant to be adjacent.
+  block=$(grep -n '^cozy_report_node_join_failure() {' "$lib" | head -n 1 | cut -d: -f1)
+  kvm=$(awk -v b="$block" 'NR > b && /cozy_capture_sandbox_kvm_exits 2/ { print NR; exit }' "$lib")
+  last=$(awk -v b="$block" 'NR > b && /cozy_capture_sandbox_qemu_thread_cpu 2/ { print NR; exit }' "$lib")
+  for v in block kvm last; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
+      return 1
+    fi
+  done
+  if [ "$last" -le "$kvm" ]; then
+    echo "expected the QEMU thread reading (line $last) to follow the KVM one (line $kvm) inside the failure block" >&2
+    return 1
+  fi
+  # Matched on the call rather than on the `|| true` suffix, for the reason the
+  # KVM guard gives: the suffix says a call is phase-gated and says nothing about
+  # what costs time, and the dominant idiom in this block is `cozy_diag_read`
+  # with no suffix at all.
+  between=$(grep -nE '^ *(cozy_capture_[a-z_]+|cozy_report_[a-z_]+|cozy_diag_read|[a-z_]+_diagnose)( |$)' "$lib" \
+    | sed -E 's/:[[:space:]]*/:/; s/(:[a-z_]+) .*/\1/' \
+    | awk -F: -v a="$kvm" -v b="$last" '$1 > a && $1 < b { print $2 }')
+  case "$(printf '%s\n' $between)" in
+    'cozy_capture_runner_kernel_cpu_time') ;;
+    *)
+      echo "more than the runner kernel reading now runs between the KVM reading and the QEMU thread one, so those two intervals are wider than the wait by whatever it costs:" >&2
+      printf '%s\n' $between >&2
+      return 1
+      ;;
+  esac
 }
 
 @test "the KVM counter readings sit on either side of the node-join wait on both paths" {
@@ -1797,6 +1876,8 @@ EOF
     cozy_capture_tenant_worker_cpu_throttle() { :; }
     cozy_capture_tenant_worker_network_counters() { :; }
     cozy_capture_sandbox_kvm_exits() { :; }
+    cozy_capture_runner_kernel_cpu_time() { :; }
+    cozy_capture_sandbox_qemu_thread_cpu() { :; }
     cozy_capture_tenant_worker_block_io() { :; }
     ghcr_mirror_diagnose() { :; }
     kubectl() { :; }

--- a/hack/run-kubernetes-runner-cpu_test.bats
+++ b/hack/run-kubernetes-runner-cpu_test.bats
@@ -1,0 +1,1427 @@
+#!/usr/bin/env bats
+# Regression coverage for the two readings that price the layers ABOVE the
+# sandbox nodes, in hack/e2e-chainsaw/_lib/run-kubernetes.sh: the runner
+# kernel's own /proc/stat, and the QEMU threads of the sandbox VMs. cozytest.sh
+# ends an @test block at the first bare closing brace, so command mocks stay at
+# top level.
+#
+# What these two answer, and why nothing beside them answers it. Every other CPU
+# reading in that file has a subject inside the sandbox -- a cgroup, a tenant
+# worker's threads, a sandbox node's own /proc/stat -- and each of them can say a
+# guest was given its ticks while getting no work done. None can say what the
+# layers above spent, and that is where this suite's own tax is paid: the sandbox
+# nodes' guest time is charged to the runner kernel as user time, and whatever
+# the runner VM loses to the machine hosting IT is charged to nobody the sandbox
+# can see. /proc/stat is not namespaced, so reading it from this container reads
+# the runner kernel; the sandbox VMs are QEMU processes in this container's own
+# PID namespace, so their threads are a local read too.
+#
+# So the failure these guard against is not a wrong number. It is a capture that
+# reads the wrong layer, or an empty directory that a reader takes for a machine
+# that spent nothing -- and the legends, which are what stop a reader comparing a
+# hypervisor's row against its guest's.
+#
+# Run with: hack/cozytest.sh hack/run-kubernetes-runner-cpu_test.bats
+#           (or `bats hack/run-kubernetes-runner-cpu_test.bats` if the bats
+#           binary is installed; cozytest.sh is the CI path.)
+
+timeout_calls=/dev/null
+timeout_rc_override=
+
+timeout() {
+  local command_rc=0
+  printf '%s\n' "$*" >>"${timeout_calls}"
+  # Return 97 rather than running the command when the wrapper is not the
+  # bounded form: a read that lost its ceiling must not pass as a read.
+  [ "${1:-}" = -k ] || return 97
+  shift 3
+  "$@" || command_rc=$?
+  [ -z "${timeout_rc_override}" ] || return "${timeout_rc_override}"
+  return "${command_rc}"
+}
+
+assert_file_contains() {
+  local needle="$1"
+  local file="$2"
+
+  if [ ! -f "${file}" ]; then
+    printf 'expected %s to exist so it could be checked for: %s\n' "${file}" "${needle}" >&2
+    return 1
+  fi
+  case "$(cat "${file}")" in
+    *"${needle}"*) return 0 ;;
+  esac
+  printf 'expected %s to contain: %s\n' "${file}" "${needle}" >&2
+  cat "${file}" >&2
+  return 1
+}
+
+assert_file_lacks_pattern() {
+  local pattern="$1"
+  local file="$2"
+
+  # A missing file must fail rather than vacuously pass: a bare `! grep -q`
+  # succeeds on an unreadable path, which is indistinguishable from "the file
+  # exists and does not carry the label".
+  if [ ! -f "${file}" ]; then
+    printf 'expected %s to exist so it could be checked for: %s\n' "${file}" "${pattern}" >&2
+    return 1
+  fi
+  # Branched on awk's exact status. awk exits 1 for "no line matched" and 2 for
+  # "I could not evaluate this"; folded together, a negative assertion is
+  # satisfied by its own matcher giving up, which is the direction that goes
+  # green and stays green.
+  local _rc=0
+  awk -v pattern="${pattern}" '$0 ~ pattern { found = 1 } END { exit found ? 0 : 1 }' "${file}" || _rc=$?
+  case "${_rc}" in
+    0)
+      printf 'expected %s not to match: %s\n' "${file}" "${pattern}" >&2
+      cat "${file}" >&2
+      return 1
+      ;;
+    1) return 0 ;;
+    *)
+      printf 'awk could not evaluate pattern %s against %s\n' "${pattern}" "${file}" >&2
+      return 1
+      ;;
+  esac
+}
+
+# The functions under test redirect a command's stderr into a report file and
+# decide which artifact to write from it. cozytest.sh runs under `set -x`, so the
+# tracer's own line for that command lands on the very stderr being redirected,
+# and every assertion about those files would be reading the tracer. Call through
+# these wrappers so the sinks hold what production writes.
+run_kernel_capture() {
+  local _rc=0
+  ( set +x; cozy_capture_runner_kernel_cpu_time "${1:-1}" ) || _rc=$?
+  return "${_rc}"
+}
+
+run_thread_capture() {
+  local _rc=0
+  ( set +x; cozy_capture_sandbox_qemu_thread_cpu "${1:-1}" ) || _rc=$?
+  return "${_rc}"
+}
+
+# A /proc/stat shaped like the kernel's: the summed row first, one row per CPU,
+# then the rows that are not CPU time at all. Two CPU rows are enough to tell the
+# summed row from a per-CPU one; the walk does not count them.
+#
+# The numbers are the ones a loaded hypervisor produces: most of user here is
+# guest, staged so the guest-inside-user accounting rule has something to bite
+# on. How much of user is guest on a real runner is not a claim this fixture
+# makes; the runner also runs the CI process tree, containerd and the suite.
+stage_proc_stat() {
+  local file="$1"
+  mkdir -p "$(dirname "${file}")"
+  {
+    printf 'cpu  9000000 120 800000 4000000 30000 0 9000 45000 8900000 0\n'
+    printf 'cpu0 4500000 60 400000 2000000 15000 0 4500 22000 4450000 0\n'
+    printf 'cpu1 4500000 60 400000 2000000 15000 0 4500 23000 4450000 0\n'
+    printf 'intr 900000000 0 0 0\n'
+    printf 'ctxt 1800000000\n'
+    printf 'btime 1700000000\n'
+    printf 'processes 4000000\n'
+  } >"${file}"
+}
+
+# A /proc shaped like this container's: three QEMU processes, each with an
+# emulator thread and two vCPU threads. The vCPU thread name carries a space
+# inside its parentheses, which is the whole reason the legend tells a reader to
+# parse from the last ) -- a fixture without it would let a field-counting reader
+# pass.
+stage_sandbox_proc() {
+  local root="$1"
+  local pid tid
+  for pid in 101 202 303; do
+    mkdir -p "${root}/${pid}/task/${pid}"
+    printf 'qemu-system-x86_64\n' >"${root}/${pid}/comm"
+    printf '%s (qemu-system-x86) S 1 %s %s 0 -1 0 0 0 0 0 700 300 0 0 20 0 9 0 100 0 0\n' \
+      "${pid}" "${pid}" "${pid}" >"${root}/${pid}/task/${pid}/stat"
+    for tid in 1 2; do
+      mkdir -p "${root}/${pid}/task/${pid}${tid}"
+      printf '%s%s (CPU %s/KVM) R 1 %s %s 0 -1 0 0 0 0 0 5000 900 0 0 20 0 9 0 100 0 0\n' \
+        "${pid}" "${tid}" "$((tid - 1))" "${pid}" "${pid}" \
+        >"${root}/${pid}/task/${pid}${tid}/stat"
+    done
+  done
+  # A process that is not QEMU, so the probe's filter is exercised rather than
+  # assumed: this container also runs the shell driving the suite.
+  mkdir -p "${root}/9/task/9"
+  printf 'bash\n' >"${root}/9/comm"
+  printf '9 (bash) S 1 9 9 0 -1 0 0 0 0 0 4 2 0 0 20 0 1 0 100 0 0\n' >"${root}/9/task/9/stat"
+}
+
+stage() {
+  COZY_REPORT_DIR="$1/report"
+  COZY_SNAPSHOT_NAME=runner-cpu-smoke
+  COZY_DIAG_RUNNER_PROC_STAT="$1/proc-stat"
+  COZY_DIAG_SANDBOX_PROC="$1/proc"
+  stage_proc_stat "$COZY_DIAG_RUNNER_PROC_STAT"
+  stage_sandbox_proc "$COZY_DIAG_SANDBOX_PROC"
+}
+
+kernel_path() {
+  printf '%s/snapshots/runner-cpu-smoke/runner-kernel-cpu-time/sample-%s/proc-stat.txt' \
+    "${COZY_REPORT_DIR}" "${1:-1}"
+}
+
+threads_path() {
+  printf '%s/snapshots/runner-cpu-smoke/sandbox-qemu-thread-cpu/sample-%s/qemu-threads.txt' \
+    "${COZY_REPORT_DIR}" "${1:-1}"
+}
+
+# ---------------------------------------------------------------------------
+# The runner kernel's own CPU time.
+# ---------------------------------------------------------------------------
+
+@test "the runner kernel CPU rows reach the capture" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_kernel_capture
+
+  capture=$(kernel_path)
+  assert_file_contains 'cpu  9000000 120 800000' "$capture"
+  assert_file_contains 'cpu0 4500000' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the capture says which layer its rows belong to" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_kernel_capture
+
+  # The one reading that inverts every conclusion drawn from this file. Two
+  # kernels in this report publish a /proc/stat -- the runner, and each sandbox
+  # node one layer down -- so a reader who takes these rows for a sandbox node is
+  # comparing a hypervisor against its own guest. The tenant worker has no
+  # /proc/stat capture at all, which the legend now says rather than implying a
+  # third file to go looking for.
+  capture=$(kernel_path)
+  assert_file_contains 'these rows belong to the RUNNER VM kernel' "$capture"
+  assert_file_contains 'one layer above the sandbox nodes' "$capture"
+  assert_file_contains 'sandbox-host-cpu-time' "$capture"
+  # And that there is no third /proc/stat to go looking for. The clause sits in
+  # parallel with one that names a directory, so an earlier wording sent a reader
+  # hunting a tenant-worker /proc/stat that no capture in this report takes.
+  assert_file_contains 'no capture in this report reads /proc/stat inside a tenant worker at all' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the layer legend does not invent a capture that the report does not take" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_kernel_capture
+
+  # The two claims the legend makes about other readers, each pinned to the
+  # source rather than to a count of the string: counting mentions of the file
+  # also counts the legend itself, so a legend inventing a third reader kept
+  # the count green (M21).
+  capture=$(kernel_path)
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  awk '/^cozy_capture_sandbox_node_cpu_time\(\)/,/^}/' "$lib" | grep -q 'read /proc/stat' || {
+    echo "FAIL: the legend points one layer down at a collector that no longer reads /proc/stat"
+    false
+  }
+  if grep -n 'tenantkubeconfig' "$lib" | grep -q 'proc/stat'; then
+    echo "FAIL: something reads /proc/stat through a tenant kubeconfig; the legend denies exactly that"
+    false
+  fi
+  assert_file_lacks_pattern 'a tenant worker reports its own' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the column legend travels with the numbers" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_kernel_capture
+
+  capture=$(kernel_path)
+  # The column order, because the eighth and ninth are the two a reader wants
+  # and are adjacent.
+  assert_file_contains 'user nice system idle iowait irq softirq steal guest guest_nice' "$capture"
+  # The two ordinals, by number rather than by the order of the words above: the
+  # eighth and the ninth are adjacent and are the two a reader actually wants, so
+  # a swapped pair turns a fraction of a percent of steal into twenty-odd. Pinned
+  # because the column-order string alone stays green when the ordinals swap.
+  assert_file_contains 'The eighth number is steal and the ninth is guest' "$capture"
+  # And the accounting rule that makes this layer different from the one below:
+  # guest is inside user, so adding them double-counts. Deliberately NOT a claim
+  # about what fraction of this kernel's user time is guest -- the runner also
+  # runs the CI process tree, and these rows are read against nothing that could
+  # establish a proportion.
+  assert_file_contains 'already counted inside user' "$capture"
+  assert_file_lacks_pattern 'nearly all' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the legend says what steal means on this layer and nowhere else" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_kernel_capture
+
+  # This is the number the whole capture exists for. A sandbox node reporting
+  # steal 0 says the runner kernel served it promptly and says nothing about
+  # whether the runner VM was itself waiting on the machine hosting it -- and
+  # that second number appears in no other file in this report.
+  capture=$(kernel_path)
+  assert_file_contains 'steal on THIS layer' "$capture"
+  assert_file_contains 'gave to somebody else' "$capture"
+  # And read in ONE direction. A climbing steal proves this runner VM was
+  # preempted; a zero proves nothing, because the column is filled only where the
+  # hypervisor exposes a paravirt steal clock and this capture observes neither
+  # the hypervisor nor that clock. The sandbox nodes one layer down can make the
+  # stronger claim because this repository starts them with accel=kvm; nobody
+  # here starts the runner VM.
+  assert_file_contains 'read that column in ONE direction only' "$capture"
+  assert_file_contains 'paravirt steal clock' "$capture"
+  assert_file_lacks_pattern 'A steal of zero here is a reading and not an absence' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the legend warns that the per-CPU rows are not physical cores" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_kernel_capture
+
+  # A cpuN row is a CPU as this kernel sees it, which is a hardware thread
+  # wherever SMT is exposed. The capture reads no topology, so it says where that
+  # answer lives rather than asserting which this lane is -- an artifact confident
+  # about a machine it never looked at is worse than one that names the gap.
+  capture=$(kernel_path)
+  assert_file_contains 'What the row count is not is a core count' "$capture"
+  assert_file_contains 'thread_siblings_list' "$capture"
+  assert_file_lacks_pattern 'the lane runs SMT' "$capture"
+  # And the online/possible split, which is why the rows can be fewer than the
+  # total is summed over.
+  assert_file_contains 'one per ONLINE CPU' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the runner kernel read is bounded and keeps its exit code" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_kernel_capture
+
+  # Local does not mean instant: this runs on the failure path of a machine
+  # already wedged enough to lose a node join, and /proc is served by that same
+  # kernel.
+  assert_file_contains "-k 5 20 cat" "$timeout_calls"
+  assert_file_contains '[capture exit code: 0]' "$(kernel_path)"
+  rm -rf "$tmp"
+}
+
+@test "a lowered read budget moves the runner kernel bound" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # Set after sourcing, which is how a caller and a test both set it. A value
+  # read only at assignment time would reach `timeout` unchecked here.
+  COZY_DIAG_READ_TIMEOUT=4
+
+  run_kernel_capture
+
+  assert_file_contains '-k 5 4 cat' "$timeout_calls"
+  rm -rf "$tmp"
+}
+
+@test "a zero read budget is corrected rather than disabling the bound" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # `timeout -k 5 0` disables the timeout outright, so a zero assigned after
+  # sourcing would restore the unbounded read this bound exists to remove.
+  COZY_DIAG_READ_TIMEOUT=0
+
+  run_kernel_capture
+
+  assert_file_lacks_pattern '^-k 5 0 ' "$timeout_calls"
+  assert_file_contains "-k 5 $COZY_DIAG_READ_TIMEOUT_DEFAULT cat" "$timeout_calls"
+  rm -rf "$tmp"
+}
+
+@test "each runner kernel reading records when it was taken" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_kernel_capture
+
+  # This pair is not taken inside one diagnostics block: the first reading is
+  # taken before the node-join wait and the second only when that wait has run
+  # out, so the interval between them is the whole join window rather than a
+  # knob. A /proc/stat row carries no sample time, so nothing else in the
+  # artifact records it.
+  capture=$(kernel_path)
+  stamp=$(sed -n 's/.*read attempted from \([0-9][0-9]*\) to \([0-9][0-9]*\) epoch seconds.*/\1 \2/p' "$capture")
+  if [ -z "$stamp" ]; then
+    echo "expected a bare epoch stamp in $capture" >&2
+    cat "$capture" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "the sample number decides which runner kernel reading a file is" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_kernel_capture 2
+
+  # The pair is the instrument: one reading of a running total is an average over
+  # the machine's whole uptime, not a rate over the failure. Two readings filed
+  # under the same name would leave the second overwriting the first and the
+  # artifact reading like a single sample.
+  assert_file_contains 'cpu  9000000' "$(kernel_path 2)"
+  [ ! -f "$(kernel_path 1)" ]
+  rm -rf "$tmp"
+}
+
+@test "a file holding no cpu row at all is not filed as a reading" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # /proc/stat carries intr, ctxt and btime as well, so a read cut off before the
+  # cpu rows leaves a file with numbers in it and no CPU time at all. Keyed on
+  # size, that would be filed as a reading and the caller told a pair exists.
+  {
+    printf 'intr 900000000 0 0 0\n'
+    printf 'ctxt 1800000000\n'
+  } >"$COZY_DIAG_RUNNER_PROC_STAT"
+  rc=0
+
+  run_kernel_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  capture=$(kernel_path)
+  # `cat` exits zero for any file it could open, so this arrives on the CLEAN
+  # exit path: the read did not fail, the file simply carries no CPU time. Said
+  # in the file, because an empty-looking capture with exit code 0 otherwise
+  # reads as a kernel that was idle.
+  assert_file_contains 'the read completed and returned no cpu row at all' "$capture"
+  assert_file_contains 'not a reading that the runner kernel was idle' "$capture"
+  # And the pairing instruction must not ride on it: telling a reader to subtract
+  # two files asserts both hold a reading, and following it here turns the
+  # sibling's whole cumulative total into a rate over the window.
+  assert_file_lacks_pattern 'subtracting this file from its sibling' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a read that returned nothing is reported to the caller, not only to the report" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # Killed before it produced a byte: the dominant shape of a bounded read that
+  # ran out. Both callers ask this function whether it collected anything, and
+  # one of them runs on the passing path where the report is the artifact nobody
+  # downloads -- so a capture that got nothing has to answer non-zero or the
+  # warning saying the pair is broken never prints.
+  rm -f "$COZY_DIAG_RUNNER_PROC_STAT"
+  rc=0
+
+  run_kernel_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  # The arm this staging reaches, not the substring all three unavailable arms
+  # share: cat on a missing file fails with a message, so the note must point
+  # at the failure marker holding it.
+  assert_file_contains 'what it said is in the COLLECTION-FAILED.txt' "$(kernel_path)"
+  rm -rf "$tmp"
+}
+
+@test "a kernel read that failed without a word says so, not something else" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The fourth corner: non-zero status, no rows, and silence on both streams.
+  # Staged with an empty stat file and a forced status, since a real cat that
+  # fails always says why. Unstaged, this arm and its wording were deletable
+  # with the suite green.
+  : >"$COZY_DIAG_RUNNER_PROC_STAT"
+  timeout_rc_override=124
+  rc=0
+
+  run_kernel_capture || rc=$?
+  timeout_rc_override=
+
+  [ "$rc" -ne 0 ]
+  assert_file_contains 'said nothing on either stream' "$(kernel_path)"
+  rm -rf "$tmp"
+}
+
+@test "a thread walk that failed without a word says so, not something else" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The probe is stubbed to a silent non-zero exit: every real shape of the
+  # probe leaves either thread lines or a finding, so the silent corner is
+  # reachable only when the walk itself dies wordlessly.
+  _cozy_thread_cpu_probe() { printf 'exit 3'; }
+  rc=0
+
+  run_thread_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  capture=$(threads_path)
+  assert_file_contains 'said nothing on either stream' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a runner kernel read cut off part way is marked incomplete, not whole" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The walk wrote rows and then the wrapper killed it: the shape where a
+  # whole-looking file is most misleading, since the difference against its
+  # sibling would understate every row the read never reached.
+  timeout_rc_override=124
+
+  run_kernel_capture || true
+
+  capture=$(kernel_path)
+  assert_file_contains 'cpu  9000000' "$capture"
+  assert_file_contains 'incomplete' "$capture"
+  assert_file_lacks_pattern 'subtracting this file from its sibling' "$capture"
+  assert_file_contains '[capture exit code: 124]' "$capture"
+  # The lines that say how to read the numbers stay, because they do not depend
+  # on the read having finished and this is exactly where a reader needs them.
+  assert_file_contains 'RUNNER VM kernel' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a partial runner kernel read is not reported to the caller as nothing" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The other half of the pair above, and the reason the status is decided by
+  # what reached the file rather than by the exit code alone: a read cut off
+  # after it wrote rows left a usable capture, and a caller told nothing was
+  # collected would contradict the file sitting beside it.
+  timeout_rc_override=124
+  rc=0
+
+  run_kernel_capture || rc=$?
+
+  [ "$rc" -eq 0 ]
+  rm -rf "$tmp"
+}
+
+@test "a warning beside a healthy runner kernel read is not filed as a failure" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # A read that succeeds and still says something, which is the shape kubectl and
+  # talosctl produce all over this collector's neighbourhood. Staged as a `cat`
+  # on PATH rather than mocked as a function, because the collector runs it
+  # through the `timeout` wrapper, which resolves it as a command.
+  #
+  # Which file the complaint lands in is decided by the STATUS, not by whether
+  # stderr holds anything, so a healthy capture keeps its warning instead of
+  # shipping a failure marker beside a reading that succeeded.
+  mkdir -p "$tmp/bin"
+  cat >"$tmp/bin/cat" <<'STUB'
+#!/bin/sh
+printf 'cat: (hint) this file is served by a pseudo filesystem\n' >&2
+while IFS= read -r line || [ -n "$line" ]; do printf '%s\n' "$line"; done <"$1"
+STUB
+  chmod +x "$tmp/bin/cat"
+  PATH="$tmp/bin:$PATH"
+
+  run_kernel_capture
+
+  dir="$COZY_REPORT_DIR/snapshots/runner-cpu-smoke/runner-kernel-cpu-time/sample-1"
+  assert_file_contains 'cpu  9000000' "$dir/proc-stat.txt"
+  assert_file_contains 'served by a pseudo filesystem' "$dir/READ-WARNINGS.txt"
+  [ ! -f "$dir/COLLECTION-FAILED.txt" ]
+  [ ! -f "$dir/read-error.log" ]
+  rm -rf "$tmp"
+}
+
+@test "a failed runner kernel read sends its message to the failure marker" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The other side of that routing rule, and the shape a missing pseudo file
+  # produces: no row reached the capture and the reason exists. Sent beside the
+  # capture rather than into it, and named as a failure rather than as a warning,
+  # because this one did fail.
+  rm -f "$COZY_DIAG_RUNNER_PROC_STAT"
+  rc=0
+
+  run_kernel_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  dir="$COZY_REPORT_DIR/snapshots/runner-cpu-smoke/runner-kernel-cpu-time/sample-1"
+  assert_file_contains 'No such file' "$dir/COLLECTION-FAILED.txt"
+  assert_file_contains 'COLLECTION-FAILED.txt beside this file' "$dir/proc-stat.txt"
+  [ ! -f "$dir/READ-WARNINGS.txt" ]
+  rm -rf "$tmp"
+}
+
+@test "a runner kernel report directory that cannot be created is said out loud" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # A file where the directory has to go. Every write below it then fails, and
+  # without a check the capture is a silent no-op -- the empty directory this
+  # whole suite exists to refuse, produced by the one cause the markers cannot
+  # describe, because there is nowhere to write a marker.
+  mkdir -p "$COZY_REPORT_DIR/snapshots/runner-cpu-smoke"
+  printf 'not a directory\n' >"$COZY_REPORT_DIR/snapshots/runner-cpu-smoke/runner-kernel-cpu-time"
+  rc=0
+
+  out=$( ( set +x; cozy_capture_runner_kernel_cpu_time 1 ) 2>&1 ) || rc=$?
+
+  [ "$rc" -ne 0 ]
+  case "$out" in
+    *"could not be created"*) ;;
+    *)
+      printf 'expected the collector to say the report directory could not be created, got: %s\n' "$out" >&2
+      return 1
+      ;;
+  esac
+  rm -rf "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# The sandbox VMs' QEMU threads.
+# ---------------------------------------------------------------------------
+
+@test "the sandbox QEMU thread stat lines reach the capture" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_thread_capture
+
+  capture=$(threads_path)
+  # All three sandbox VMs, because the question this answers is whether the
+  # three nodes paid evenly: one node's vCPU threads pinned while its siblings
+  # idle is a different fault from three nodes evenly loaded, and the kernel row
+  # one layer up sums all three.
+  assert_file_contains 'process 101 comm qemu-system-x86_64' "$capture"
+  assert_file_contains 'process 202 comm qemu-system-x86_64' "$capture"
+  assert_file_contains 'process 303 comm qemu-system-x86_64' "$capture"
+  assert_file_contains '(CPU 0/KVM)' "$capture"
+  # And nothing that is not QEMU: this container also runs the shell driving the
+  # suite, and its threads are not what this measures.
+  assert_file_lacks_pattern '\(bash\)' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the thread capture says which layer its threads belong to" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_thread_capture
+
+  # Two captures in this report read QEMU threads and they are one layer apart:
+  # these are the sandbox VMs, and the ones under tenant-thread-cpu are the
+  # workers running inside them. Read as the wrong one, a busy hypervisor looks
+  # like a busy guest.
+  capture=$(threads_path)
+  assert_file_contains 'these threads belong to the SANDBOX VMs' "$capture"
+  assert_file_contains 'tenant-thread-cpu' "$capture"
+  assert_file_contains 'runner-kernel-cpu-time' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the thread legend says to parse from the last closing parenthesis" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_thread_capture
+
+  # The trap that costs a reader the exact threads this capture exists to
+  # identify: a vCPU thread is named `CPU 0/KVM`, that space sits inside the
+  # parentheses, and every field counted over whitespace after it is off by one.
+  capture=$(threads_path)
+  assert_file_contains 'Parse from the last ) in the line instead' "$capture"
+  assert_file_contains 'utime the 12th and stime the 13th' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a container with no QEMU process is a finding rather than an empty capture" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The sandbox VMs are what the whole run stands on, so a container running none
+  # of them is the most consequential thing this instrument can say -- and it
+  # leaves exactly the same empty directory as a collector that failed.
+  rm -rf "$COZY_DIAG_SANDBOX_PROC"
+  mkdir -p "$COZY_DIAG_SANDBOX_PROC/9/task/9"
+  printf 'bash\n' >"$COZY_DIAG_SANDBOX_PROC/9/comm"
+  printf '9 (bash) S 1 9 9 0 -1 0 0 0 0 0 4 2 0 0 20 0 1 0 100 0 0\n' \
+    >"$COZY_DIAG_SANDBOX_PROC/9/task/9/stat"
+  rc=0
+
+  run_thread_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  capture=$(threads_path)
+  assert_file_contains 'NO-QEMU-PROCESS' "$capture"
+  # And the column legend must not ride on a file with no columns in it.
+  assert_file_lacks_pattern 'Parse from the last' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a proc mount that yields nothing is not reported as a container with no QEMU" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The two say different things about the run: one is a container that was read
+  # and holds no hypervisor, the other is a read that never happened. Folded
+  # together, a mount this collector could not open would be filed as a sandbox
+  # with no VMs, which is a finding about the cluster it never observed.
+  rm -rf "$COZY_DIAG_SANDBOX_PROC"
+  mkdir -p "$COZY_DIAG_SANDBOX_PROC"
+  rc=0
+
+  run_thread_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  capture=$(threads_path)
+  assert_file_contains 'NO-PROC-READ' "$capture"
+  assert_file_lacks_pattern 'NO-QEMU-PROCESS' "$capture"
+  # The closing sentence follows the marker: a read that never happened must not
+  # close with the no-QEMU verdict, whose subject the walk never observed.
+  assert_file_contains 'says nothing about what the container was running' "$capture"
+  assert_file_lacks_pattern 'a sandbox running no QEMU' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a QEMU named and then gone is not filed as a reading" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # A routine result on this failure path: the process was named and its task
+  # directory was gone by the time the walk reached it. Without this the capture
+  # holds a heading and no thread, which is enough bytes to look like a reading.
+  for pid in 101 202 303; do
+    rm -rf "$COZY_DIAG_SANDBOX_PROC/$pid/task"
+  done
+  # Pid files staged on purpose: this is the path where "which node still had a
+  # usable pid file" is the whole answer, so the map must print here too.
+  mkdir -p "$tmp/vmroot/srv1" "$tmp/vmroot/srv2" "$tmp/vmroot/srv3"
+  printf '101\n' >"$tmp/vmroot/srv1/qemu.pid"
+  printf '202\n' >"$tmp/vmroot/srv2/qemu.pid"
+  printf '303\n' >"$tmp/vmroot/srv3/qemu.pid"
+  COZY_DIAG_SANDBOX_VM_ROOT="$tmp/vmroot"
+  rc=0
+
+  run_thread_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  capture=$(threads_path)
+  assert_file_contains 'NO-THREAD-LINES' "$capture"
+  assert_file_lacks_pattern 'Parse from the last' "$capture"
+  # Three QEMUs were named two lines up, so the closing sentence must read as a
+  # guest going away, never as a sandbox running no QEMU.
+  assert_file_contains 'a guest going away under the walk' "$capture"
+  assert_file_lacks_pattern 'a sandbox running no QEMU' "$capture"
+  # And the node map still prints here: which node still had a usable pid file
+  # is the question this path exists to answer.
+  assert_file_contains 'is srv' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the sandbox thread read is bounded and keeps its exit code" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_thread_capture
+
+  assert_file_contains '-k 5 20 sh -c' "$timeout_calls"
+  assert_file_contains '[capture exit code: 0]' "$(threads_path)"
+  rm -rf "$tmp"
+}
+
+@test "the sample number decides which thread reading a file is" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_thread_capture 2
+
+  assert_file_contains 'process 101' "$(threads_path 2)"
+  [ ! -f "$(threads_path 1)" ]
+  rm -rf "$tmp"
+}
+
+@test "a thread walk cut off part way is marked incomplete rather than whole" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  timeout_rc_override=124
+
+  run_thread_capture || true
+
+  capture=$(threads_path)
+  assert_file_contains 'process 101' "$capture"
+  assert_file_contains 'incomplete' "$capture"
+  assert_file_contains '[capture exit code: 124]' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "each thread reading records when it was taken" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_thread_capture
+
+  capture=$(threads_path)
+  stamp=$(sed -n 's/.*read attempted from \([0-9][0-9]*\) to \([0-9][0-9]*\) epoch seconds.*/\1 \2/p' "$capture")
+  if [ -z "$stamp" ]; then
+    echo "expected a bare epoch stamp in $capture" >&2
+    cat "$capture" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "the thread capture reuses the probe the worker capture runs" {
+  # A source check, and the point is the sharing rather than the text: the probe
+  # already answers the two outcomes that matter here -- found QEMU, and QEMU is
+  # gone -- and already names the three ways it can come up short. A second copy
+  # would drift from this one exactly at those failure paths, which is where
+  # nobody looks until it matters.
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  n=$(awk '/^cozy_capture_sandbox_qemu_thread_cpu\(\)/,/^}/' "$lib" | grep -cF '_cozy_thread_cpu_probe' || true)
+  [ "$n" -ge 1 ] || {
+    echo "FAIL: the sandbox thread capture no longer runs the shared probe"
+    false
+  }
+  # And that there is still exactly one probe to share.
+  d=$(grep -cE '^_cozy_thread_cpu_probe\(\)' "$lib" || true)
+  [ "$d" -eq 1 ] || {
+    echo "FAIL: found $d definitions of the thread probe; a second copy is the drift this test exists to refuse"
+    false
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Where the two readings of each pair sit.
+# ---------------------------------------------------------------------------
+
+@test "both new readings bracket the node-join wait on both paths" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # What these pairs measure is decided by where their calls sit, not by anything
+  # inside the collectors: /proc/stat and a thread's utime are running totals, so
+  # the interval a difference divides by is whatever runs between the readings.
+  # The same reasoning the KVM pair beside them is held to, and the same failure:
+  # a second reading placed after the happy-path tail prices ten to fifteen
+  # minutes of storage and LoadBalancer work while the capture's own legend says
+  # it priced the join.
+  wait_line=$(grep -n '^  if ! timeout 18m bash -c' "$lib" | head -n 1 | cut -d: -f1)
+  tail_line=$(grep -n '^  versions=\$(kubectl --kubeconfig' "$lib" | head -n 1 | cut -d: -f1)
+  node_table=$(grep -n "cozy_diag_read 'tenant node table'" "$lib" | head -n 1 | cut -d: -f1)
+  for v in wait_line tail_line node_table; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
+      return 1
+    fi
+  done
+  for fn in cozy_capture_runner_kernel_cpu_time cozy_capture_sandbox_qemu_thread_cpu; do
+    first=$(grep -n "${fn} 1" "$lib" | head -n 1 | cut -d: -f1)
+    # The green second reading, found as the one after the wait rather than by
+    # position in the file: the other call with the same argument is the failure
+    # block's, and picking by count would be right only while the two happen to
+    # be written in this order.
+    green=$(awk -v w="$wait_line" -v f="${fn} 2" 'NR > w && index($0, f) { print NR; exit }' "$lib")
+    red=$(awk -v w="$wait_line" -v f="${fn} 2" 'NR < w && index($0, f) { line = NR } END { if (line) print line }' "$lib")
+    for v in first green red; do
+      eval "n=\$$v"
+      if [ -z "$n" ]; then
+        echo "expected to find $v for $fn in $lib; without it this guard reports success for having lost its input" >&2
+        return 1
+      fi
+    done
+    if [ "$first" -ge "$wait_line" ]; then
+      echo "$fn's first reading (line $first) is not taken before the node-join wait (line $wait_line), so the pair does not span it" >&2
+      return 1
+    fi
+    if [ "$green" -le "$wait_line" ] || [ "$green" -ge "$tail_line" ]; then
+      echo "$fn's passing-path second reading (line $green) does not sit between the wait (line $wait_line) and the happy-path tail (line $tail_line), so the green interval is not the join window the red one is compared against" >&2
+      return 1
+    fi
+    if [ "$red" -ge "$node_table" ]; then
+      echo "$fn's failure-path second reading (line $red) is taken after the diagnostics block has started reading the cluster (line $node_table), so the red interval is the wait plus whatever those reads cost" >&2
+      return 1
+    fi
+  done
+}
+
+@test "the bringup names the QEMU threads the legend identifies by name" {
+  # The legend reads vCPU threads by the name `CPU N/KVM`, and QEMU only
+  # assigns those names when started with `-name ...,debug-threads=on`; without
+  # the flag every thread carries the bare process name and the identification
+  # the legend promises does not exist on this lane. Pinned on the qemu command
+  # line itself, non-comment lines only, so a dropped flag fails here rather
+  # than surfacing as an unexplained absence in production captures.
+  awk '/^    qemu-system-x86_64 /,/-pidfile/' hack/e2e-prepare-cluster.bats |
+    grep -v '^\s*#' | grep -q 'debug-threads=on' || {
+    echo "FAIL: hack/e2e-prepare-cluster.bats starts QEMU without debug-threads=on; the thread names the legend documents will not exist" >&2
+    false
+  }
+}
+
+@test "the pair orders mirror around the wait so the KVM interval stays exact" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # The KVM legend calls its interval the window and means it exactly; that is
+  # only true while nothing runs between its samples and the wait. Its first
+  # reading must therefore be the LAST of the three before the wait, and its
+  # second the FIRST after it -- on both paths. The other two legends name the
+  # sibling readings inside their intervals, so their order is free.
+  wait_line=$(grep -n '^  if ! timeout 18m bash -c' "$lib" | head -n 1 | cut -d: -f1)
+  [ -n "$wait_line" ] || { echo "FAIL: could not find the node-join wait"; false; }
+  last_before=$(awk -v w="$wait_line" 'NR < w && /^  if ! cozy_capture_(sandbox_kvm_exits|runner_kernel_cpu_time|sandbox_qemu_thread_cpu) 1; then/ { l = $0 } END { print l }' "$lib")
+  case "$last_before" in
+    *cozy_capture_sandbox_kvm_exits*) ;;
+    *) echo "FAIL: the reading closest to the wait from above is not the KVM pair: $last_before"; false ;;
+  esac
+  # The failure block is defined ABOVE the wait in file order and carries the
+  # `|| true` form its budget guard requires; the green second readings are the
+  # warned `if !` calls below the wait. Position in the file is the opposite of
+  # position in time here, which is exactly why the forms are matched too.
+  for scope in green red; do
+    if [ "$scope" = green ]; then
+      first_after=$(awk -v w="$wait_line" 'NR > w && /^  if ! cozy_capture_(sandbox_kvm_exits|runner_kernel_cpu_time|sandbox_qemu_thread_cpu) 2; then/ { print $0; exit }' "$lib")
+    else
+      first_after=$(awk -v w="$wait_line" 'NR < w && /^  cozy_capture_(sandbox_kvm_exits|runner_kernel_cpu_time|sandbox_qemu_thread_cpu) 2 \|\| true$/ { print $0; exit }' "$lib")
+    fi
+    case "$first_after" in
+      *cozy_capture_sandbox_kvm_exits*) ;;
+      *) echo "FAIL: the $scope second reading closest to the wait is not the KVM pair: $first_after"; false ;;
+    esac
+  done
+}
+
+@test "both new readings report a shortfall to the job log, not only to the report" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # Two of the three call sites run outside the diagnostics block, and one of
+  # those is the passing path -- where the report is the artifact nobody
+  # downloads. A capture that collected nothing there has to say so where a
+  # reader of a green run will see it, or the pair is silently broken for every
+  # red run compared against it.
+  for fn in cozy_capture_runner_kernel_cpu_time cozy_capture_sandbox_qemu_thread_cpu; do
+    n=$(grep -cE "^  if ! ${fn} [12]; then" "$lib" || true)
+    [ "$n" -eq 2 ] || {
+      echo "FAIL: $fn has $n status-checked call sites; the two outside the failure block must both warn"
+      false
+    }
+  done
+  # And the warnings say WHICH reading is missing, matched on text specific to each
+  # collector. Unscoped, these greps pass on the pre-existing KVM warnings, which
+  # carry the same two phrases: emptying all four new warning bodies then left the
+  # whole suite green.
+  for subject in "the runner kernel's CPU time" "the sandbox VMs' QEMU threads"; do
+    for when in before after; do
+      n=$(grep -cF "WARNING: ${subject} yielded no reading ${when} the node-join wait" "$lib" || true)
+      [ "$n" -eq 1 ] || {
+        echo "FAIL: found $n warnings for ${subject} ${when} the wait; each reading warns once, in its own words"
+        false
+      }
+    done
+  done
+}
+
+@test "every legend line lands as one line rather than shredded into words" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_kernel_capture
+  run_thread_capture
+
+  # Each legend is one long single-quoted shell string, and an apostrophe inside
+  # one ends the quote: the sentence then reaches the file as one word per line,
+  # every `[` unmatched, and the capture still passes any assertion that greps for
+  # a short phrase. This checks the shape instead -- a bracketed line opens and
+  # closes on the same line -- because that is what a shredded legend loses.
+  for capture in "$(kernel_path)" "$(threads_path)"; do
+    if awk '/^\[/ && $0 !~ /\]$/ { print FILENAME ": " $0; found = 1 } END { exit found ? 1 : 0 }' "$capture"; then
+      :
+    else
+      echo "FAIL: a bracketed legend line in $capture does not close on its own line, which is what an apostrophe inside its single quotes does to it" >&2
+      return 1
+    fi
+    # And some bracketed line must exist at all: a requote that drops a whole
+    # legend block leaves nothing for the shape check to object to.
+    grep -q '^\[' "$capture" || {
+      echo "FAIL: $capture carries no bracketed legend line at all" >&2
+      return 1
+    }
+  done
+  rm -rf "$tmp"
+}
+
+@test "the thread legend rule is executable, not just present" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  run_thread_capture
+
+  # The legend tells a reader to parse from the last `)`. Nothing pinned that the
+  # rule works on the lines this capture actually holds, so the fixture's space
+  # inside `(CPU 0/KVM)` carried no assertion at all -- it only made the comment
+  # sound justified. Applied here to a real captured line: after the last `)` the
+  # state is field 1, utime field 12, stime field 13.
+  line=$(grep -F '(CPU 0/KVM)' "$(threads_path)" | head -n 1)
+  [ -n "$line" ] || {
+    echo "FAIL: no vCPU thread line in the capture to apply the rule to"
+    false
+  }
+  tail_fields=${line##*) }
+  set -- $tail_fields
+  [ "$1" = R ] || {
+    echo "FAIL: field 1 after the last ) is '$1', expected the thread state"
+    false
+  }
+  [ "${12}" = 5000 ] || {
+    echo "FAIL: field 12 after the last ) is '${12}', expected utime 5000"
+    false
+  }
+  [ "${13}" = 900 ] || {
+    echo "FAIL: field 13 after the last ) is '${13}', expected stime 900"
+    false
+  }
+  # And that counting over whitespace from the start of the line gets it WRONG,
+  # which is the whole reason the rule exists: the space inside the parentheses
+  # shifts every later field by one.
+  set -- $line
+  [ "${14}" != 5000 ] || {
+    echo "FAIL: field 14 counted from the start equals utime, so this fixture no longer carries the trap the legend warns about"
+    false
+  }
+  rm -rf "$tmp"
+}
+
+@test "the thread capture names which sandbox node each process is" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The pid files hack/e2e-prepare-cluster.bats writes when it starts the guests.
+  # Without this map a reader has a container pid and no way to tell the
+  # control-plane node from a worker-carrying one -- which is the discriminating
+  # question, because the tenant workers sit on specific sandbox nodes.
+  for srv in 1 2 3; do
+    mkdir -p "$tmp/vmroot/srv${srv}"
+  done
+  printf '101\n' >"$tmp/vmroot/srv1/qemu.pid"
+  printf '202\n' >"$tmp/vmroot/srv2/qemu.pid"
+  printf '303\n' >"$tmp/vmroot/srv3/qemu.pid"
+  COZY_DIAG_SANDBOX_VM_ROOT="$tmp/vmroot"
+
+  run_thread_capture
+
+  capture=$(threads_path)
+  assert_file_contains '[process 101 is srv1]' "$capture"
+  assert_file_contains '[process 202 is srv2]' "$capture"
+  assert_file_contains '[process 303 is srv3]' "$capture"
+  assert_file_lacks_pattern 'anonymous by node' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a sandbox node whose pid file is gone is absent from the map, not renamed" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # Two of three pid files, which is what a node that died during the join looks
+  # like from here. The map must not silently shift, since a wrong node name is
+  # worse than no name: a triager would go and read the wrong guest console.
+  mkdir -p "$tmp/vmroot/srv1" "$tmp/vmroot/srv3"
+  printf '101\n' >"$tmp/vmroot/srv1/qemu.pid"
+  printf '303\n' >"$tmp/vmroot/srv3/qemu.pid"
+  COZY_DIAG_SANDBOX_VM_ROOT="$tmp/vmroot"
+
+  run_thread_capture
+
+  capture=$(threads_path)
+  assert_file_contains '[process 101 is srv1]' "$capture"
+  assert_file_contains '[process 303 is srv3]' "$capture"
+  assert_file_lacks_pattern 'is srv2' "$capture"
+  # And the legend says an absent node means an unreadable pid file rather than
+  # leaving the gap to be read as a node that never existed.
+  assert_file_contains 'had no usable pid file' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a capture with no pid map says it is anonymous rather than implying a name" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # No pid files at all: a sandbox created some other way, or a tree where the
+  # bringup wrote them elsewhere. The KVM capture beside this one discloses its
+  # own anonymity in exactly this situation, and a reader who has seen that one
+  # would otherwise take a process id here for a node identifier.
+  COZY_DIAG_SANDBOX_VM_ROOT="$tmp/nowhere"
+
+  run_thread_capture
+
+  capture=$(threads_path)
+  assert_file_contains 'anonymous by node' "$capture"
+  assert_file_contains 'not which of them paid what' "$capture"
+  assert_file_lacks_pattern 'is srv1' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a pid file holding something that is not a pid is skipped, not trusted" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # A truncated or half-written pid file, which is what a guest killed during
+  # startup can leave. One node's file holds text and another's is empty, and
+  # the asserts hold both forms out of the whole map line: an empty value slid
+  # through validation once rendered as `[process srv1 is ]`, which a narrow
+  # `is srv1` pattern read as clean (the surviving mutant both reviews named).
+  mkdir -p "$tmp/vmroot/srv1" "$tmp/vmroot/srv2" "$tmp/vmroot/srv3"
+  printf '\n' >"$tmp/vmroot/srv1/qemu.pid"
+  printf 'not-a-pid\n' >"$tmp/vmroot/srv3/qemu.pid"
+  printf '202\n' >"$tmp/vmroot/srv2/qemu.pid"
+  COZY_DIAG_SANDBOX_VM_ROOT="$tmp/vmroot"
+
+  run_thread_capture
+
+  capture=$(threads_path)
+  assert_file_contains '[process 202 is srv2]' "$capture"
+  assert_file_lacks_pattern 'srv1' "$capture"
+  assert_file_lacks_pattern 'not-a-pid' "$capture"
+  assert_file_lacks_pattern 'is srv3' "$capture"
+  # Exactly one map line: nothing rendered for the two bad files in any form.
+  n=$(grep -c '^\[process ' "$capture" || true)
+  [ "$n" -eq 1 ] || {
+    echo "FAIL: expected exactly one map line, found $n"
+    grep '^\[process ' "$capture"
+    false
+  }
+  rm -rf "$tmp"
+}
+
+@test "a thread walk cut off after writing lines withholds the pairing instruction" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The half its sibling capture already pins: telling a reader to subtract two
+  # files asserts both hold a whole reading. A walk cut off after the first node
+  # would have the other two read as having spent nothing across the window,
+  # which is the largest wrong number this artifact could produce.
+  timeout_rc_override=124
+
+  run_thread_capture || true
+
+  capture=$(threads_path)
+  assert_file_contains 'incomplete' "$capture"
+  assert_file_lacks_pattern 'subtracting this file from its sibling' "$capture"
+  # The lines that say how to read the numbers stay: they do not depend on the
+  # walk having finished, and a cut-off capture is where a reader needs them.
+  assert_file_contains 'Parse from the last ) in the line instead' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a thread walk that ends clean with nothing to read says that is a finding" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The probe exits zero on a container it read and found no QEMU in, so this
+  # arrives on the clean path with an exit code of 0 under it. Left silent, the
+  # capture reads as a healthy reading of an idle machine -- while what it
+  # actually records is that the three VMs the whole run stands on are not there.
+  rm -rf "$COZY_DIAG_SANDBOX_PROC"
+  mkdir -p "$COZY_DIAG_SANDBOX_PROC/9/task/9"
+  printf 'bash\n' >"$COZY_DIAG_SANDBOX_PROC/9/comm"
+  printf '9 (bash) S 1 9 9 0 -1 0 0 0 0 0 4 2 0 0 20 0 1 0 100 0 0\n' \
+    >"$COZY_DIAG_SANDBOX_PROC/9/task/9/stat"
+
+  run_thread_capture || true
+
+  capture=$(threads_path)
+  assert_file_contains 'NO-QEMU-PROCESS' "$capture"
+  assert_file_contains 'the walk completed and produced no thread line at all' "$capture"
+  assert_file_contains 'a finding about this run rather than a shortfall of this capture' "$capture"
+  assert_file_lacks_pattern 'subtracting this file from its sibling' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a failed thread walk sends its message to the failure marker its sibling uses" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # No thread line AND a message: the shape a walk killed against an unreadable
+  # proc mount produces. It goes into COLLECTION-FAILED.txt, which is the name the
+  # report's documentation gives the artifact-level failure marker and the name
+  # the runner-kernel capture writes for this same shape -- a reader sweeping the
+  # tarball for markers would otherwise miss this walk entirely.
+  mkdir -p "$tmp/bin"
+  cat >"$tmp/bin/sh" <<STUB
+#!/bin/sh
+printf 'sh: cannot open the proc mount\\n' >&2
+exit 2
+STUB
+  chmod +x "$tmp/bin/sh"
+  PATH="$tmp/bin:$PATH"
+  rc=0
+
+  run_thread_capture || rc=$?
+
+  [ "$rc" -ne 0 ]
+  dir="$COZY_REPORT_DIR/snapshots/runner-cpu-smoke/sandbox-qemu-thread-cpu/sample-1"
+  assert_file_contains 'cannot open the proc mount' "$dir/COLLECTION-FAILED.txt"
+  assert_file_contains 'COLLECTION-FAILED.txt beside this file' "$dir/qemu-threads.txt"
+  [ ! -f "$dir/read-error.log" ]
+  rm -rf "$tmp"
+}
+
+@test "a thread report directory that cannot be created is said out loud" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The one failure the markers cannot describe, because there is nowhere to put
+  # one. Its sibling capture has this test; this one did not, which is the same
+  # asymmetry as the failure marker above.
+  mkdir -p "$COZY_REPORT_DIR/snapshots/runner-cpu-smoke"
+  printf 'not a directory\n' >"$COZY_REPORT_DIR/snapshots/runner-cpu-smoke/sandbox-qemu-thread-cpu"
+  rc=0
+
+  out=$( ( set +x; cozy_capture_sandbox_qemu_thread_cpu 1 ) 2>&1 ) || rc=$?
+
+  [ "$rc" -ne 0 ]
+  case "$out" in
+    *"could not be created"*) ;;
+    *)
+      printf 'expected the collector to say the report directory could not be created, got: %s\n' "$out" >&2
+      return 1
+      ;;
+  esac
+  rm -rf "$tmp"
+}
+
+@test "a runner kernel read that failed after writing rows points at its message" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # Rows AND a non-zero status AND something on stderr: the fourth corner of the
+  # pair of questions the arms answer, and the one no test staged. Without it the
+  # arm that names read-error.log can be deleted with the suite green, leaving a
+  # reader told the reading is partial and not told where the reason went.
+  mkdir -p "$tmp/bin"
+  cat >"$tmp/bin/cat" <<'STUB'
+#!/bin/sh
+while IFS= read -r line || [ -n "$line" ]; do printf '%s\n' "$line"; done <"$1"
+printf 'cat: the pseudo file stopped answering part way\n' >&2
+exit 1
+STUB
+  chmod +x "$tmp/bin/cat"
+  PATH="$tmp/bin:$PATH"
+
+  run_kernel_capture || true
+
+  dir="$COZY_REPORT_DIR/snapshots/runner-cpu-smoke/runner-kernel-cpu-time/sample-1"
+  assert_file_contains 'cpu  9000000' "$dir/proc-stat.txt"
+  assert_file_contains 'read-error.log beside this file' "$dir/proc-stat.txt"
+  assert_file_contains 'stopped answering part way' "$dir/read-error.log"
+  rm -rf "$tmp"
+}
+
+@test "a thread walk that failed after writing lines points at its message" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The same fourth corner on the thread side. Its arm was unreachable from this
+  # suite for the same reason: the only non-zero case drove the real probe, which
+  # leaves stderr empty.
+  mkdir -p "$tmp/bin"
+  cat >"$tmp/bin/sh" <<STUB
+#!/bin/sh
+printf '101 (qemu-system-x86) S 1 101 101 0 -1 0 0 0 0 0 700 300 0 0 20 0 9 0 100 0 0\\n'
+printf 'sh: the proc walk stopped part way\\n' >&2
+exit 1
+STUB
+  chmod +x "$tmp/bin/sh"
+  PATH="$tmp/bin:$PATH"
+
+  run_thread_capture || true
+
+  dir="$COZY_REPORT_DIR/snapshots/runner-cpu-smoke/sandbox-qemu-thread-cpu/sample-1"
+  assert_file_contains 'incomplete' "$dir/qemu-threads.txt"
+  assert_file_contains 'read-error.log beside this file' "$dir/qemu-threads.txt"
+  assert_file_contains 'stopped part way' "$dir/read-error.log"
+  rm -rf "$tmp"
+}
+
+@test "both collectors still collect when timeout is not on PATH" {
+  # The documented fallback, which every comparable suite beside this one pins:
+  # where `timeout` is absent the reads run unbounded rather than not at all, and
+  # the phase warning promises exactly that by name. `timeout` is a shell function
+  # in this file, so `command -v timeout` is always true here and the else arm of
+  # both collectors is otherwise never executed -- a broken redirect or a lost
+  # `</dev/null` in there would surface only on a runner without coreutils, which
+  # is the one machine the arm exists for.
+  tmp=$(mktemp -d)
+  mkdir -p "$tmp/bin"
+  for c in sh mkdir date cat grep sed awk rm mv printf; do
+    for d in /bin /usr/bin /usr/local/bin /opt/homebrew/bin /sbin /usr/sbin; do
+      if [ -x "$d/$c" ]; then
+        ln -sf "$d/$c" "$tmp/bin/$c"
+        break
+      fi
+    done
+  done
+  for c in sh mkdir date cat grep rm; do
+    if [ ! -x "$tmp/bin/$c" ]; then
+      echo "FAIL: could not stage $c in the stripped PATH; the check below would be vacuous" >&2
+      return 1
+    fi
+  done
+  if [ -e "$tmp/bin/timeout" ]; then
+    echo "FAIL: timeout leaked into the stripped PATH; this test would prove nothing" >&2
+    return 1
+  fi
+  stage_proc_stat "$tmp/proc-stat"
+  stage_sandbox_proc "$tmp/proc"
+  rc=0
+
+  # PATH is narrowed INSIDE the subprocess rather than in front of it: the shell
+  # resolves the command name with the PATH the assignment sets, so a stripped
+  # PATH in front of `bash` cannot find bash itself. The same trap the KVM suite
+  # documents beside its own stripped-PATH test.
+  out=$( ( set +x
+    bash -c '
+      . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+      COZY_REPORT_DIR='"$tmp"'/report
+      COZY_SNAPSHOT_NAME=runner-cpu-smoke
+      COZY_DIAG_RUNNER_PROC_STAT='"$tmp"'/proc-stat
+      COZY_DIAG_SANDBOX_PROC='"$tmp"'/proc
+      PATH='"$tmp"'/bin
+      cozy_capture_runner_kernel_cpu_time 1
+      cozy_capture_sandbox_qemu_thread_cpu 1
+    ' ) 2>&1 ) || rc=$?
+
+  [ "$rc" -eq 0 ] || {
+    echo "FAIL: the collectors ended $rc with no timeout on PATH; the warning promises they keep collecting" >&2
+    printf '%s\n' "$out" >&2
+    false
+  }
+  assert_file_contains 'cpu  9000000' \
+    "$tmp/report/snapshots/runner-cpu-smoke/runner-kernel-cpu-time/sample-1/proc-stat.txt"
+  assert_file_contains 'process 101' \
+    "$tmp/report/snapshots/runner-cpu-smoke/sandbox-qemu-thread-cpu/sample-1/qemu-threads.txt"
+  # And each capture says so itself. The phase warning that names unbounded
+  # collectors fires inside the diagnostics phase, and two of this pair's three
+  # call sites run outside it, so a capture that ran with no ceiling and stayed
+  # quiet about it would read exactly like a bounded one.
+  assert_file_contains '[bounds] timeout is not on PATH here' \
+    "$tmp/report/snapshots/runner-cpu-smoke/runner-kernel-cpu-time/sample-1/proc-stat.txt"
+  assert_file_contains '[bounds] timeout is not on PATH here' \
+    "$tmp/report/snapshots/runner-cpu-smoke/sandbox-qemu-thread-cpu/sample-1/qemu-threads.txt"
+  rm -rf "$tmp"
+}
+
+@test "a pid file that never yields a byte cannot hold the capture" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # A FIFO with no writer: `[ -r ]` passes on it and the shell redirect open
+  # would block forever, outside anything a wrapper can cover -- which is why
+  # the read is an external cat under the read ceiling instead. Staged with a
+  # low ceiling so the bounded path is what the test exercises; the outer
+  # timeout is the M20 lesson from the identity suite -- a mutant that removes
+  # the bound must fail this test, not hang the whole run.
+  mkdir -p "$tmp/vmroot/srv1" "$tmp/vmroot/srv2"
+  printf '101\n' >"$tmp/vmroot/srv1/qemu.pid"
+  mkfifo "$tmp/vmroot/srv2/qemu.pid"
+  COZY_DIAG_SANDBOX_VM_ROOT="$tmp/vmroot"
+  COZY_DIAG_READ_TIMEOUT=1
+  COZY_DIAG_READ_GRACE=1
+  rc=0
+
+  out=$( ( set +x; command timeout 20 bash -c '
+      . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+      COZY_REPORT_DIR="'"$tmp"'/report"
+      COZY_SNAPSHOT_NAME=runner-cpu-smoke
+      COZY_DIAG_SANDBOX_PROC="'"$tmp"'/proc"
+      COZY_DIAG_SANDBOX_VM_ROOT="'"$tmp"'/vmroot"
+      COZY_DIAG_READ_TIMEOUT=1
+      COZY_DIAG_READ_GRACE=1
+      cozy_capture_sandbox_qemu_thread_cpu 1
+    ' ) 2>&1 ) || rc=$?
+  [ "$rc" -eq 0 ] || [ "$rc" -eq 124 ] || {
+    echo "FAIL: the capture ended $rc; its output follows"
+    printf '%s\n' "$out"
+    false
+  }
+
+  [ "$rc" -ne 124 ] || {
+    echo "FAIL: the capture hung on the FIFO until the outer timeout killed it"
+    false
+  }
+  capture=$(threads_path)
+  assert_file_contains '[process 101 is srv1]' "$capture"
+  assert_file_lacks_pattern 'is srv2' "$capture"
+  assert_file_contains 'had no usable pid file' "$capture"
+  rm -rf "$tmp"
+}


### PR DESCRIPTION
## What this PR does

Adds two readings to the tenant node-join path, taken on either side of the same wait the KVM counters already bracket: the runner VM kernel's own `/proc/stat`, and the per-thread CPU time of the QEMU processes the sandbox VMs run as.

Every CPU reading on this failure path has a subject inside the sandbox: a cgroup, a tenant worker's threads, a sandbox node's own `/proc/stat`. Each of them can say a guest was given its ticks while getting no work done, and none can say what the layers above spent. That is where this suite's own tax is paid. The sandbox nodes' guest time is charged to the runner kernel as user time, and whatever the runner VM loses to the machine hosting it is charged to nobody the sandbox can see, so a node reporting `steal 0` and a node whose hypervisor was itself waiting look identical from inside.

`/proc/stat` is not namespaced, so reading it from the sandbox container reads the runner VM's kernel. That is the only place steal on that layer appears, and it is read in one direction only: a steal that climbs proves this runner VM was preempted, while a zero proves nothing, because the column is filled only where the hypervisor exposes a paravirt steal clock and nothing in the capture observes whether this one does. The sandbox nodes a layer down can make the stronger claim, since this repository starts them with `accel=kvm`; nobody here starts the runner VM, so for this lane the answer is unknown until somebody reads a non-zero.

The sandbox VMs are QEMU processes in the same PID namespace as the shell driving the suite, so their threads are a local read too. What that adds is not "which node is busy" on its own, since `cozy_capture_sandbox_node_cpu_time` already reads each node's own `/proc/stat` by name; it is that split *on the join window*, since the existing collector samples twice across a twelve-second interval inside the diagnostics block, after the join has already failed. Beyond the window it adds the host-side accounting of each vCPU thread, what the runner actually granted it, which no in-guest counter can report, and QEMU's non-vCPU IO and worker threads, which no in-guest counter sees either. It also names which node each process is, read from the `srv<N>/qemu.pid` files the bringup already writes: a container pid identifies nothing, and whether the starving guest is the control-plane node or a worker-carrying one is the discriminating question. With no usable pid file the capture stays anonymous and says so, as its KVM sibling does; the pid reads themselves are bounded like every other read here, since a pid file that never yields a byte must not hold the capture.

Both are taken at the two points the KVM counters already use, for the same reason: the values are cumulative, so a rate needs a pair, and the interval worth measuring is the window the guest is failing to boot in rather than a few seconds after the deadline has expired. The thread reading runs the probe the tenant worker capture already uses rather than a copy of it, because that probe already answers the two outcomes that matter here and already names the three ways it can come up short, and a second copy would drift from it exactly at those failure paths.

Each capture carries the layer it describes in its own legend. Three kernels in this report publish a `/proc/stat` and two captures now read QEMU threads, one layer apart in each direction, so a reader who takes one for the other is comparing a hypervisor against its own guest. The runner-kernel legend also carries the trap specific to that layer: nearly all of its user time IS guest time, because running the sandbox VMs is what that kernel does, so adding the two columns double-counts the whole run.

Cost and blast radius: two bounded local reads per sample, no cluster access, nothing added to any diagnostics-phase budget window. The failure-path calls sit behind the same reasoning as the KVM reading, which the phase-budget guard in `hack/run-kubernetes-node-join_test.bats` now prices with a cost arm for each; the guards that enumerate collectors (the missing-`timeout` warning and the documented spend order) carry both new names.

Tests are in `hack/run-kubernetes-runner-cpu_test.bats`, 44 cases, green under both runner forms. They cover the readings themselves, every legend claim a reader depends on, the bounded read and its knobs, the sample-number split, each way a capture can come up empty (a file with no `cpu` row, a container with no QEMU, a proc mount that yields nothing, a QEMU named and then gone), the routing of a message from a read that succeeded against one that failed, the per-node attribution and each way it can be incomplete, and placement guards of their own: both pairs must bracket the wait on both paths, nothing may be inserted between the three second readings, and each collector must report a shortfall to the job log in its own words rather than only to the report, since one call site is the passing path where the artifact is the one nobody downloads. Two guards exist because a legend can fail without any number being wrong: one asserts that the parse-from-the-last-parenthesis rule the legend states actually works on the lines the capture holds, and one that every bracketed legend line lands as a single line, since an apostrophe inside one of these single-quoted strings shreds it into one word per line while still passing any short grep.

No documentation change: the KVM pair this mirrors is not described in `docs/agents/e2e-testing.md` either, and its documentation lives in the legends the captures carry.

Context: #3513

### Screenshots

No UI changes.

### Downstream repositories

One line of the bringup changes too: `hack/e2e-prepare-cluster.bats` now starts each sandbox QEMU with `-name guest=srv<N>,debug-threads=on`. QEMU names vCPU threads (`CPU N/KVM`) only when asked to, so without the flag every thread reports the bare process name and the vCPU/IO split this capture documents would not exist to read on this lane; a test pins the flag to the legend that relies on it.

Walked the trigger map in `docs/agents/contributing.md` against the diff. Of the `hack/` triggers it names, `hack/e2e-prepare-cluster.bats` (ansible-cozystack, talm) is touched: the touched lines are the CI sandbox QEMU flags, which neither downstream repository restates -- both provision real machines, not the e2e sandbox. `hack/package.mk`, `hack/update-crd.sh` and `hack/upload-assets.sh` are untouched. The rest of the change is confined to the Chainsaw kubernetes suites' shared library and its unit tests, which no downstream repository restates.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
test(e2e): a tenant node-join failure now records the runner kernel's own CPU time and the sandbox VMs' per-thread QEMU CPU time on either side of the join wait, so steal on the layer above the sandbox and an uneven split across the three nodes are both visible in cozyreport.tgz
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runner and sandbox CPU diagnostics to node-join troubleshooting captures.
  * Captures now include timing details, layer-specific context, partial-result handling, and explicit failure indicators.
  * Enabled identifiable virtual CPU thread names for improved diagnostic reporting.

* **Bug Fixes**
  * Improved warning visibility when CPU diagnostic samples are unavailable or time out.
  * Added safer handling for incomplete reads, missing data, and shell errors.

* **Tests**
  * Expanded coverage for CPU capture behavior, timeout handling, ordering, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->