### PR TITLE
chore(e2e): ignore the artifacts the sandbox bringup writes to the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,24 @@ packages/core/platform/images/migrations/etcd-operator-crds/
 # (validator, agent instructions) is current even when the checked-out rc tag
 # predates it. Never committed.
 .release-tooling
+
+# Machine credentials and boot artifacts hack/e2e-prepare-cluster.bats writes
+# to the repository root when the e2e sandbox is brought up outside CI: the
+# Talos secrets bundle and rendered machine configs, the kubeconfigs, the boot
+# image and the per-VM directories. secrets.yaml holds the cluster's private
+# keys, and before this block nothing here matched any of them -- leaving
+# `git add -A` in a tree that once ran the bringup one keystroke from
+# committing a credentials bundle.
+/secrets.yaml
+/talosconfig
+/kubeconfig
+/tenantkubeconfig*
+/controlplane.yaml
+/worker.yaml
+/patch.yaml
+/patch-controlplane.yaml
+/nocloud-amd64.raw
+/nocloud-amd64.raw.xz
+/srv1/
+/srv2/
+/srv3/


### PR DESCRIPTION
## What this PR does

Adds a .gitignore block for the files `hack/e2e-prepare-cluster.bats` writes to the repository root when the e2e sandbox is brought up outside CI: the Talos secrets bundle, the rendered machine configs, the kubeconfigs, the boot image and the per-VM `srv1..3/` directories.

None of these was matched by anything in .gitignore (`git check-ignore` answers "not ignored" for every one), so in a tree that once ran the bringup a broad `git add` stages a credentials bundle -- `secrets.yaml` holds the cluster's private keys. This came one pre-push check away from landing in a PR once, which is what moved it from a hypothetical to a standing trap worth closing.

All patterns are anchored to the repository root, so files with the same names elsewhere in the tree stay visible to git.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added ignore rules for sensitive Talos cluster files, kubeconfig files, generated machine configurations, boot images, and temporary VM directories.
  * Prevents generated deployment and test artifacts from being accidentally included in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->