### PR TITLE
fix(migrations): pin KubeadmConfigTemplate on the 1.5 slot 45 migration and in the chart

### DIFF
--- a/hack/migration-seaweedfs-db-adopt.bats
+++ b/hack/migration-seaweedfs-db-adopt.bats
@@ -1,7 +1,20 @@
 #!/usr/bin/env bats
 # -----------------------------------------------------------------------------
-# Unit tests for the SeaweedFS db-split hand-over shared by platform migrations
-# 43 (original) and 45 (repair) — lib/seaweedfs-db-adopt.sh.
+# Unit tests for the platform migrations in slots 43 and 45 — driven end-to-end
+# against a fake kubectl, so what is under test is the migration scripts rather
+# than their helpers in isolation.
+#
+# Slot 45 does TWO independent jobs on release-1.5, and both are covered here
+# because they run in one script and share one version stamp:
+#
+#   1. lib/seaweedfs-db-adopt.sh — the SeaweedFS db-split hand-over, shared with
+#      migration 43. Sections 1-3 below.
+#   2. lib/kubeadm-keep-pin.sh — the helm.sh/resource-policy=keep pin on the CAPI
+#      kubeadm bootstrap objects, which is 1.6's own migration 45 folded into this
+#      slot because a v1.5.4 cluster is stamped 46 and its later 1.6 upgrade runs
+#      `seq 46 53`, skipping 1.6's slot 45 entirely. Section 4 below.
+#
+# --- 1-3: the SeaweedFS hand-over ---
 #
 # The 1.5.0 split (PR #2601) moved Cluster/seaweedfs-db out of the <name>-system
 # release into a new <name>-db release. The hand-over must, before <name>-system
@@ -97,6 +110,11 @@ run_migration() {
     -e FAKE_LIST_FAIL="${FAKE_LIST_FAIL-}" \
     -e FAKE_GET_FAIL="${FAKE_GET_FAIL-}" \
     -e FAKE_ANNOTATE_FAIL="${FAKE_ANNOTATE_FAIL-}" \
+    -e FAKE_KCTS="${FAKE_KCTS-}" \
+    -e FAKE_KCS="${FAKE_KCS-}" \
+    -e FAKE_KUBEADM_LIST_FAIL="${FAKE_KUBEADM_LIST_FAIL-}" \
+    -e FAKE_KUBEADM_ANNOTATE_FAIL="${FAKE_KUBEADM_ANNOTATE_FAIL-}" \
+    -e FAKE_KUBEADM_ANNOTATE_FAIL_NS="${FAKE_KUBEADM_ANNOTATE_FAIL_NS-}" \
     "$ALPINE" "/migrations/$1" || _run_migration_rc=$?
   return "$_run_migration_rc"
 }
@@ -116,7 +134,11 @@ prep() {
   : > "$FAKE_CMDLOG"
   export NAMESPACE=cozy-system
   export FAKE_CLUSTERS=""
+  export FAKE_KCTS=""
+  export FAKE_KCS=""
   unset FAKE_LIST_FAIL FAKE_GET_FAIL FAKE_ANNOTATE_FAIL || true
+  unset FAKE_KUBEADM_LIST_FAIL FAKE_KUBEADM_ANNOTATE_FAIL \
+        FAKE_KUBEADM_ANNOTATE_FAIL_NS || true
 }
 
 # --- 1. instance name -------------------------------------------------------
@@ -217,7 +239,7 @@ tenant-named foo-db keep"
   run_migration 45 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
-  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  [ "$(grep -c 'ANNOTATE' "$FAKE_CMDLOG")" -eq 0 ]
   grep -qF -- "STAMP 46" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }
@@ -231,7 +253,7 @@ tenant-named foo-db keep"
   run_migration 45 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
-  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  [ "$(grep -c 'ANNOTATE' "$FAKE_CMDLOG")" -eq 0 ]
   grep -qF -- "carries no meta.helm.sh/release-name" "$WORK/out"
   rm -rf "$WORK"
 }
@@ -243,7 +265,7 @@ tenant-named foo-db keep"
   run_migration 45 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
-  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  [ "$(grep -c 'ANNOTATE' "$FAKE_CMDLOG")" -eq 0 ]
   grep -qF -- "owned by unrelated release" "$WORK/out"
   rm -rf "$WORK"
 }
@@ -258,7 +280,7 @@ tenant-named foo-db keep"
   run_migration 45 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
-  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  [ "$(grep -c 'ANNOTATE' "$FAKE_CMDLOG")" -eq 0 ]
   grep -qF -- "no instance name" "$WORK/out"
   rm -rf "$WORK"
 }
@@ -275,7 +297,7 @@ tenant-named foo-db keep"
   # Must propagate: the Job retries rather than advancing the version.
   [ "$rc" -ne 0 ]
   grep -qF -- "refusing to stamp past an unverified fleet" "$WORK/out"
-  ! grep -q 'STAMP' "$FAKE_CMDLOG"
+  [ "$(grep -c 'STAMP' "$FAKE_CMDLOG")" -eq 0 ]
   rm -rf "$WORK"
 }
 
@@ -288,7 +310,7 @@ tenant-named foo-db keep"
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -ne 0 ]
   grep -qF -- "cannot read the Helm owner" "$WORK/out"
-  ! grep -q 'STAMP' "$FAKE_CMDLOG"
+  [ "$(grep -c 'STAMP' "$FAKE_CMDLOG")" -eq 0 ]
   rm -rf "$WORK"
 }
 
@@ -300,7 +322,7 @@ tenant-named foo-db keep"
   run_migration 45 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -ne 0 ]
-  ! grep -q 'STAMP' "$FAKE_CMDLOG"
+  [ "$(grep -c 'STAMP' "$FAKE_CMDLOG")" -eq 0 ]
   rm -rf "$WORK"
 }
 
@@ -315,7 +337,7 @@ tenant-named foo-db keep"
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
   grep -qF -- "resource type is not served" "$WORK/out"
-  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  [ "$(grep -c 'ANNOTATE' "$FAKE_CMDLOG")" -eq 0 ]
   grep -qF -- "STAMP 46" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }
@@ -327,7 +349,261 @@ tenant-named foo-db keep"
   run_migration 45 >"$WORK/out" 2>&1 || rc=$?
   cat "$WORK/out"; cat "$FAKE_CMDLOG"
   [ "$rc" -eq 0 ]
-  ! grep -q 'ANNOTATE' "$FAKE_CMDLOG"
+  [ "$(grep -c 'ANNOTATE' "$FAKE_CMDLOG")" -eq 0 ]
   grep -qF -- "STAMP 46" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+# --- 4. kubeadm bootstrap keep-pin -----------------------------------------
+#
+# THE THREAT. 1.6 drops KubeadmConfigTemplate from the tenant `kubernetes` chart
+# (workers move to TalosConfigTemplate), so its upgrade sees the resource in the
+# previous release manifest and absent from the new one and deletes it — while the
+# kubeadm-backed MachineSet is still around mid-rollover with its
+# bootstrap.configRef pointing at it. 1.6 guards that with its own migration 45.
+# A v1.5.4 cluster is stamped 46 and runs `seq 46 53`, so it never executes that
+# slot; the pin has to already be on the objects, which is what this half of
+# release-1.5's slot 45 does.
+#
+# So the property under test is the ANNOTATION LANDING ON THE OBJECT, not a
+# function being callable. Every assertion below reads the PIN records the fake
+# kubectl wrote, and the fake models the label selector rather than ignoring it:
+# selecting on meta.helm.sh/release-name (an annotation, and therefore never a
+# valid selector) returns no rows, so the classic silent-no-op shape of this bug
+# fails these tests instead of passing them.
+#
+# PIN, not ANNOTATE, is the fake's verb for this half — the SeaweedFS assertions
+# above count ANNOTATE lines, and a shared verb would couple the two halves'
+# tests to each other.
+#
+# "DID NOT HAPPEN" IS ASSERTED AS `[ "$(grep -c ...)" -eq 0 ]`, NEVER `! grep -q`.
+# POSIX and bash both exempt a !-negated pipeline from errexit — "the -e setting
+# shall be ignored ... if the command's return value is being inverted with !" —
+# so `! grep -q X file` cannot fail a cozytest test no matter what the file
+# contains. It reads like an assertion and is a no-op. Measured, not assumed: with
+# the two halves of slot 45 deliberately swapped, a `! grep -q 'PIN '` test stayed
+# green while the cmdlog plainly contained the PIN line. The counting form puts the
+# result in `[`, whose non-zero status does trip errexit.
+
+@test "pins an unannotated Helm-managed KubeadmConfigTemplate, and stamps 46" {
+  prep
+  export FAKE_KCTS="tenant-root kubernetes-md0 - Helm"
+  rc=0
+  run_migration 45 >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  grep -qF -- "PIN kubeadmconfigtemplate tenant-root/kubernetes-md0 resource-policy=keep" "$FAKE_CMDLOG"
+  grep -qF -- "STAMP 46" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "pins every Helm-managed KubeadmConfigTemplate, each in its own namespace" {
+  prep
+  export FAKE_KCTS="tenant-root kubernetes-md0 - Helm
+tenant-root kubernetes-gpu-md1 - Helm
+tenant-a other-cluster-md0 - Helm"
+  rc=0
+  run_migration 45 >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  grep -qF -- "PIN kubeadmconfigtemplate tenant-root/kubernetes-md0 resource-policy=keep" "$FAKE_CMDLOG"
+  grep -qF -- "PIN kubeadmconfigtemplate tenant-root/kubernetes-gpu-md1 resource-policy=keep" "$FAKE_CMDLOG"
+  grep -qF -- "PIN kubeadmconfigtemplate tenant-a/other-cluster-md0 resource-policy=keep" "$FAKE_CMDLOG"
+  [ "$(grep -c 'PIN ' "$FAKE_CMDLOG")" -eq 3 ]
+  rm -rf "$WORK"
+}
+
+# Re-running must not write. The pin reads helm.sh/resource-policy first and skips
+# on "keep", so an already-pinned fleet produces no annotate call at all — an
+# unconditional `kubectl annotate --overwrite` would still be correct on the
+# cluster but would make "no-op" unobservable, and this is the assertion that
+# keeps it observable.
+@test "idempotent: an already-pinned KubeadmConfigTemplate is skipped without a write" {
+  prep
+  export FAKE_KCTS="tenant-root kubernetes-md0 keep Helm"
+  rc=0
+  run_migration 45 >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  [ "$(grep -c 'PIN ' "$FAKE_CMDLOG")" -eq 0 ]
+  grep -qF -- "already carries helm.sh/resource-policy=keep" "$WORK/out"
+  grep -qF -- "already-pinned=1" "$WORK/out"
+  grep -qF -- "STAMP 46" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+# A cluster with no tenant Kubernetes clusters at all. Zero matching objects is a
+# clean run, not a failure: the CRDs are served (CAPI is installed platform-wide)
+# and the selector simply matches nothing.
+@test "zero Helm-managed kubeadm objects is success, not failure" {
+  prep
+  export FAKE_KCTS=""
+  export FAKE_KCS=""
+  rc=0
+  run_migration 45 >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  [ "$(grep -c 'PIN ' "$FAKE_CMDLOG")" -eq 0 ]
+  grep -qF -- "pinned=0 already-pinned=0 failures=0" "$WORK/out"
+  grep -qF -- "STAMP 46" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+# The KubeadmConfig children CAPI spawns from the template are owned by their
+# Machine, not by Helm: no app.kubernetes.io/managed-by label, so Helm never
+# prunes them and the pin must not touch them. Pinning one would leave keep on an
+# object whose lifecycle belongs to CAPI. Verified against a live v1.5 stand,
+# where the spawned KubeadmConfig carries no managed-by at all.
+@test "leaves a CAPI-spawned KubeadmConfig alone: it is not Helm-managed" {
+  prep
+  export FAKE_KCS="tenant-root kubernetes-md0-lw46d-z2wqn - -"
+  rc=0
+  run_migration 45 >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  [ "$(grep -c 'PIN ' "$FAKE_CMDLOG")" -eq 0 ]
+  grep -qF -- "STAMP 46" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+# The fail-open that IS load-bearing, mirroring the CNPG case above: a cluster
+# without the CAPI bootstrap provider has nothing to pin and must not be blocked
+# from upgrading.
+@test "a cluster with no kubeadm bootstrap provider stamps cleanly without pinning" {
+  prep
+  export FAKE_KUBEADM_LIST_FAIL="error: the server doesn't have a resource type \"kubeadmconfigtemplates\" in group \"bootstrap.cluster.x-k8s.io\""
+  rc=0
+  run_migration 45 >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  grep -qF -- "is not served on this cluster" "$WORK/out"
+  [ "$(grep -c 'PIN ' "$FAKE_CMDLOG")" -eq 0 ]
+  grep -qF -- "STAMP 46" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "a failing kubeadm fleet scan aborts instead of stamping past it" {
+  prep
+  export FAKE_KCTS="tenant-root kubernetes-md0 - Helm"
+  export FAKE_KUBEADM_LIST_FAIL="Error from server (Timeout): the server was unable to return a response in the time allotted"
+  rc=0
+  run_migration 45 >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  # Must propagate: the Job retries rather than advancing the version, because
+  # nothing later will pin what this pass could not see.
+  [ "$rc" -ne 0 ]
+  grep -qF -- "refusing to stamp past an unverified fleet" "$WORK/out"
+  [ "$(grep -c 'STAMP' "$FAKE_CMDLOG")" -eq 0 ]
+  rm -rf "$WORK"
+}
+
+# The one per-object failure that is NOT a failure: an app deleted concurrently
+# with this hook takes its KubeadmConfigTemplate away between the fleet scan and
+# the annotate. Helm cannot prune what no longer exists, so nothing is at risk, and
+# failing the pre-upgrade hook over it would block the platform upgrade on an
+# object nobody needs. "not found" is accepted HERE and deliberately not for the
+# fleet scan, where a list never answers NotFound and accepting it would let a real
+# failure read as an empty fleet.
+@test "an object that disappears between the scan and the pin is skipped, not fatal" {
+  prep
+  export FAKE_KCTS="tenant-doomed kubernetes-md0 - Helm"
+  export FAKE_KUBEADM_ANNOTATE_FAIL="Error from server (NotFound): kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io \"kubernetes-md0\" not found"
+  rc=0
+  run_migration 45 >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  grep -qF -- "disappeared between the scan and the pin" "$WORK/out"
+  grep -qF -- "pinned=0 already-pinned=1 failures=0" "$WORK/out"
+  grep -qF -- "STAMP 46" "$FAKE_CMDLOG"
+  rm -rf "$WORK"
+}
+
+@test "a failed pin aborts rather than stamping a half-pinned fleet" {
+  prep
+  export FAKE_KCTS="tenant-root kubernetes-md0 - Helm"
+  export FAKE_KUBEADM_ANNOTATE_FAIL="Error from server (Conflict): the object has been modified"
+  rc=0
+  run_migration 45 >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -ne 0 ]
+  grep -qF -- "could not be pinned" "$WORK/out"
+  [ "$(grep -c 'STAMP' "$FAKE_CMDLOG")" -eq 0 ]
+  rm -rf "$WORK"
+}
+
+# Aggregation, and the reason it is worth having: one unpinnable object must not
+# stop the others from being pinned, because the version is not stamped either way
+# and the next attempt starts from the same place. The failing namespace is listed
+# FIRST so a loop that aborted on the first failure would leave tenant-b unpinned
+# and fail this test.
+@test "a partial pin failure still pins the rest, then aborts without stamping" {
+  prep
+  export FAKE_KCTS="tenant-a broken-md0 - Helm
+tenant-b healthy-md0 - Helm"
+  export FAKE_KUBEADM_ANNOTATE_FAIL="Error from server (Forbidden): kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io is forbidden"
+  export FAKE_KUBEADM_ANNOTATE_FAIL_NS="tenant-a"
+  rc=0
+  run_migration 45 >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -ne 0 ]
+  grep -qF -- "PIN kubeadmconfigtemplate tenant-b/healthy-md0 resource-policy=keep" "$FAKE_CMDLOG"
+  [ "$(grep -cF -- "tenant-a/broken-md0 resource-policy=keep" "$FAKE_CMDLOG")" -eq 0 ]
+  grep -qF -- "pinned=1 already-pinned=0 failures=1" "$WORK/out"
+  [ "$(grep -c 'STAMP' "$FAKE_CMDLOG")" -eq 0 ]
+  rm -rf "$WORK"
+}
+
+# --- 5. the two halves, in one slot ----------------------------------------
+
+@test "runs both halves in one pass: SeaweedFS hand-over first, then the pin" {
+  prep
+  export FAKE_CLUSTERS="tenant-named foo-system -"
+  export FAKE_KCTS="tenant-root kubernetes-md0 - Helm"
+  rc=0
+  run_migration 45 >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  grep -qF -- "ANNOTATE tenant-named release-name=foo-db resource-policy=keep" "$FAKE_CMDLOG"
+  grep -qF -- "PIN kubeadmconfigtemplate tenant-root/kubernetes-md0 resource-policy=keep" "$FAKE_CMDLOG"
+  grep -qF -- "STAMP 46" "$FAKE_CMDLOG"
+  # Order is deliberate, not incidental: a missed hand-over loses a tenant's filer
+  # metadata, a missed pin gives a recoverable broken worker rollover. On a pass
+  # where only one half gets to run, it must be the irreversible one.
+  sw_line=$(grep -n 'ANNOTATE tenant-named' "$FAKE_CMDLOG" | head -1 | cut -d: -f1)
+  pin_line=$(grep -n 'PIN kubeadmconfigtemplate' "$FAKE_CMDLOG" | head -1 | cut -d: -f1)
+  [ "$sw_line" -lt "$pin_line" ]
+  rm -rf "$WORK"
+}
+
+# The other side of that order: the SeaweedFS half failing must abort before the
+# pin is attempted at all, and must not stamp.
+@test "a SeaweedFS failure aborts before the pin half runs" {
+  prep
+  export FAKE_CLUSTERS="tenant-named foo-system -"
+  export FAKE_KCTS="tenant-root kubernetes-md0 - Helm"
+  export FAKE_LIST_FAIL="Error from server (Timeout): the server was unable to return a response in the time allotted"
+  rc=0
+  run_migration 45 >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -ne 0 ]
+  [ "$(grep -c 'PIN ' "$FAKE_CMDLOG")" -eq 0 ]
+  [ "$(grep -c 'STAMP' "$FAKE_CMDLOG")" -eq 0 ]
+  rm -rf "$WORK"
+}
+
+# Migration 43 sources ONLY lib/seaweedfs-db-adopt.sh. The pin must not leak into
+# it: a cluster running 43 is mid-upgrade to 44 and 1.6's slot 45 will still run
+# for it, and the two libs must stay independently sourceable (neither may call
+# the other's private helpers).
+@test "migration 43 does not pin: the keep-pin belongs to slot 45 alone" {
+  prep
+  export FAKE_CLUSTERS="tenant-root seaweedfs-system -"
+  export FAKE_KCTS="tenant-root kubernetes-md0 - Helm"
+  rc=0
+  run_migration 43 >"$WORK/out" 2>&1 || rc=$?
+  cat "$WORK/out"; cat "$FAKE_CMDLOG"
+  [ "$rc" -eq 0 ]
+  [ "$(grep -c 'PIN ' "$FAKE_CMDLOG")" -eq 0 ]
+  grep -qF -- "STAMP 44" "$FAKE_CMDLOG"
   rm -rf "$WORK"
 }

--- a/hack/seaweedfs-guard-parity.bats
+++ b/hack/seaweedfs-guard-parity.bats
@@ -37,6 +37,16 @@ detection_block() {
   sed -n '/\$renamedVol := include/,/\$systemGen := or/p' "$1"
 }
 
+# strip_tpl_comments <file> -- the file with every {{/* ... */}} block removed, so
+# an assertion can be made about the template LOGIC without the prose around it
+# matching. Every comment opener in both files starts its own line, so dropping
+# whole lines cannot take code with it. Written as a single awk program: cozytest.sh
+# rewrites any bare `}` in column 0 into `return 0` + `}`, which would corrupt a
+# multi-line awk body.
+strip_tpl_comments() {
+  awk '/\{\{-? *\/\*/{c=1} !c{print} /\*\/ *-?\}\}/{c=0}' "$1"
+}
+
 @test "both charts detect naming generations with byte-identical logic" {
   a=$(mktemp); b=$(mktemp)
   detection_block "$SYS"   > "$a"
@@ -103,11 +113,26 @@ detection_block() {
   # old classification pointed at deletes the claim Step 2 just re-bound.
   # readyReplicas is likewise only a snapshot, not proof a duplicate never
   # served. Neither may come back as a discriminator.
+  #
+  # Counted rather than written as `! grep -qF ...`: POSIX and bash both exempt a
+  # !-negated pipeline from errexit — "the -e setting shall be ignored ... if the
+  # command's return value is being inverted with !" — so the negated form runs,
+  # returns 1, and the test carries on reporting success no matter what the file
+  # contains. These four assertions were the entire body of this test, so it
+  # asserted nothing at all. Putting the count inside `[` gives it a status errexit
+  # acts on.
+  #
+  # Matched against the TEMPLATE LOGIC ONLY, with {{/* */}} comment blocks stripped.
+  # All four names legitimately appear in the prose of both files — in the passages
+  # that explain why they were rejected as discriminators — so grepping the raw file
+  # would fail on the very documentation that records the decision this test exists
+  # to enforce. What must not come back is a live reference.
   for f in "$SYS" "$EXTRA"; do
-    ! grep -qF -- 'creationTimestamp' "$f"
-    ! grep -qF -- 'readyReplicas' "$f"
-    ! grep -qF -- '$systemOldest' "$f"
-    ! grep -qF -- '$legacyOldest' "$f"
+    logic=$(strip_tpl_comments "$f")
+    [ "$(printf '%s\n' "$logic" | grep -cF -- 'creationTimestamp')" -eq 0 ]
+    [ "$(printf '%s\n' "$logic" | grep -cF -- 'readyReplicas')" -eq 0 ]
+    [ "$(printf '%s\n' "$logic" | grep -cF -- '$systemOldest')" -eq 0 ]
+    [ "$(printf '%s\n' "$logic" | grep -cF -- '$legacyOldest')" -eq 0 ]
   done
 }
 

--- a/hack/testdata/migration-seaweedfs-db/kubectl
+++ b/hack/testdata/migration-seaweedfs-db/kubectl
@@ -1,8 +1,9 @@
 #!/bin/sh
 # Fake kubectl for hack/migration-seaweedfs-db-adopt.bats. It serves only the
-# calls lib/seaweedfs-db-adopt.sh makes; behaviour is driven by FAKE_* env and
-# every invocation is appended to $FAKE_CMDLOG so the test can assert on which
-# namespaces were acted on and with which annotations.
+# calls the two halves of migration 45 make — lib/seaweedfs-db-adopt.sh and
+# lib/kubeadm-keep-pin.sh; behaviour is driven by FAKE_* env and every invocation
+# is appended to $FAKE_CMDLOG so the test can assert on which objects were acted
+# on and with which annotations.
 #
 #   FAKE_CMDLOG    file to append a one-line record of each call to
 #   FAKE_CLUSTERS  newline list of "<ns> <release-name> <resource-policy>" — one
@@ -12,6 +13,24 @@
 #   FAKE_LIST_FAIL      non-empty => the -A fleet scan exits 1 with this as stderr
 #   FAKE_GET_FAIL       non-empty => the per-namespace get exits 1 with this stderr
 #   FAKE_ANNOTATE_FAIL  non-empty => `annotate` exits 1 (a failed hand-over)
+#
+# For the keep-pin half:
+#
+#   FAKE_KCTS  newline list of "<ns> <name> <resource-policy> <managed-by>" — one
+#              per KubeadmConfigTemplate. "-" models the annotation/label being
+#              ABSENT; managed-by is "Helm" for a chart-rendered object.
+#   FAKE_KCS   the same, for KubeadmConfig. A CAPI-spawned child is modelled with
+#              managed-by "-": it is owned by its Machine, Helm never prunes it,
+#              and the pin must leave it alone.
+#   FAKE_KUBEADM_LIST_FAIL         non-empty => the fleet scan for either kubeadm
+#                                  kind exits 1 with this as stderr
+#   FAKE_KUBEADM_ANNOTATE_FAIL     non-empty => `annotate` on a kubeadm object
+#                                  exits 1 with this as stderr
+#   FAKE_KUBEADM_ANNOTATE_FAIL_NS  restrict the above to one namespace, so a
+#                                  partial failure can be told apart from a total
+#                                  one — that is what proves the pin keeps going
+#                                  and reports every failure at the end rather
+#                                  than aborting on the first.
 #
 # The failure knobs exist because the point of the helper is that a kubectl error
 # must ABORT the migration rather than let it stamp the version and never run
@@ -37,6 +56,24 @@ field() {
       break
     fi
   done
+}
+
+# kubeadm_rows <args> -- echo the row list for whichever kubeadm kind <args> names.
+# "kubeadmconfigs" is not a substring of "kubeadmconfigtemplates", so the two
+# patterns cannot both match; templates is tried first regardless.
+kubeadm_rows() {
+  case "$1" in
+    *kubeadmconfigtemplates*) printf '%s\n' "${FAKE_KCTS:-}" ;;
+    *kubeadmconfigs*)         printf '%s\n' "${FAKE_KCS:-}" ;;
+  esac
+}
+
+# kubeadm_short <args> -- singular kind name for the PIN log line.
+kubeadm_short() {
+  case "$1" in
+    *kubeadmconfigtemplates*) printf 'kubeadmconfigtemplate' ;;
+    *kubeadmconfigs*)         printf 'kubeadmconfig' ;;
+  esac
 }
 
 case "$args" in
@@ -93,6 +130,73 @@ case "$args" in
       esac
     done
     log "ANNOTATE $ns release-name=${rel:-<unset>} resource-policy=${keep:-<unset>}"
+    exit 0
+    ;;
+
+  # --- kubeadm bootstrap objects: migration 45's keep-pin half --------------
+  # Fleet scan for one kubeadm kind.
+  #
+  # THE LABEL SELECTOR IS MODELLED, NOT IGNORED. The pin selects on
+  # app.kubernetes.io/managed-by=Helm, which Helm injects as a LABEL into every
+  # resource it applies. meta.helm.sh/release-name is an ANNOTATION and can never
+  # be a selector: passing it matches nothing, the pin silently applies to nothing,
+  # and the run looks clean. A fake that answered every selector identically could
+  # not tell that apart from a working pin, so a row is returned only when the
+  # selector actually names its managed-by value.
+  *"get kubeadmconfig"*" --all-namespaces"*)
+    if [ -n "${FAKE_KUBEADM_LIST_FAIL:-}" ]; then
+      printf '%s\n' "$FAKE_KUBEADM_LIST_FAIL" >&2
+      exit 1
+    fi
+    sel=$(arg_after --selector "$@")
+    kubeadm_rows "$args" | while read -r ns name policy mgr; do
+      [ -n "${ns:-}" ] || continue
+      # NO --selector LISTS EVERYTHING, exactly as kubectl does. Modelling an
+      # absent selector as "matches nothing" would be backwards and would hide the
+      # over-pinning bug: dropping the selector would then read as a quiet no-op
+      # instead of as the pin stamping keep on Machine-owned objects whose
+      # lifecycle belongs to CAPI.
+      if [ -n "$sel" ]; then
+        [ "app.kubernetes.io/managed-by=${mgr:--}" = "$sel" ] || continue
+      fi
+      printf '%s/%s\n' "$ns" "$name"
+    done
+    exit 0
+    ;;
+
+  # Per-object read of helm.sh/resource-policy, which is what makes the pin skip
+  # an already-pinned object without a write.
+  *"get kubeadmconfig"*)
+    ns=$(arg_after --namespace "$@")
+    name=$(arg_after "$ns" "$@")
+    kubeadm_rows "$args" | while read -r n nm policy mgr; do
+      if [ "$n" = "$ns" ] && [ "$nm" = "$name" ]; then
+        [ "${policy:--}" = "-" ] || printf '%s' "$policy"
+        break
+      fi
+    done
+    exit 0
+    ;;
+
+  # The pin itself. Logged as PIN rather than ANNOTATE on purpose: the SeaweedFS
+  # assertions above count ANNOTATE lines, and reusing the verb would make them
+  # pass or fail for the other half's reasons.
+  *"annotate kubeadmconfig"*)
+    ns=$(arg_after --namespace "$@")
+    name=$(arg_after "$ns" "$@")
+    if [ -n "${FAKE_KUBEADM_ANNOTATE_FAIL:-}" ] &&
+       { [ -z "${FAKE_KUBEADM_ANNOTATE_FAIL_NS:-}" ] ||
+         [ "$ns" = "${FAKE_KUBEADM_ANNOTATE_FAIL_NS:-}" ]; }; then
+      printf '%s\n' "$FAKE_KUBEADM_ANNOTATE_FAIL" >&2
+      exit 1
+    fi
+    keep=""
+    for a in "$@"; do
+      case "$a" in
+        helm.sh/resource-policy=*) keep="${a#helm.sh/resource-policy=}" ;;
+      esac
+    done
+    log "PIN $(kubeadm_short "$args") $ns/$name resource-policy=${keep:-<unset>}"
     exit 0
     ;;
 esac

--- a/packages/apps/kubernetes/templates/cluster.yaml
+++ b/packages/apps/kubernetes/templates/cluster.yaml
@@ -432,6 +432,33 @@ kind: KubeadmConfigTemplate
 metadata:
   name: {{ $.Release.Name }}-{{ $groupName }}
   namespace: {{ $.Release.Namespace }}
+  annotations:
+    {{- /* 1.6 drops this object from the chart entirely — workers move to
+           TalosConfigTemplate. On that upgrade Helm sees it in the previous
+           release manifest and absent from the new one and deletes it, while the
+           kubeadm-backed MachineSet is still mid-rollover with its
+           bootstrap.configRef pointing here: controller-manager floods with
+           reconcile errors and workers can hang pending with nothing to bootstrap
+           from. Being born with keep means the object is already protected no
+           matter which migration path a cluster takes to 1.6 — platform migration
+           45 pins the templates that already exist, and this covers every one
+           created after that migration has run.
+
+           Safe on the uninstall path, which is the only thing keep changes here:
+           CAPI stamps an ownerReference to the Cluster on this object (verified on
+           a live v1.5 stand, alongside MachineDeployment and
+           KubevirtMachineTemplate), and the Cluster itself is Helm-managed with no
+           keep. So `helm uninstall` deletes the Cluster and Kubernetes garbage
+           collection reclaims this template through that ownerReference. keep only
+           suppresses Helm's own delete; it has no bearing on owner-driven GC.
+
+           The name is deterministic — <release>-<nodeGroup>, not content-hashed
+           like KubevirtMachineTemplate above — so keep cannot accumulate a copy
+           per upgrade. The one residue is a removed nodeGroup, whose template
+           Helm no longer prunes; it is inert (nothing references it), it is
+           re-adopted in place if that nodeGroup comes back, and GC reclaims it
+           with the Cluster. */}}
+    helm.sh/resource-policy: keep
 spec:
   template:
     spec:

--- a/packages/apps/kubernetes/tests/cluster_test.yaml
+++ b/packages/apps/kubernetes/tests/cluster_test.yaml
@@ -389,6 +389,105 @@ tests:
           errorMessage: 'nodeGroup "md0": ephemeralStorage is no longer supported and should have been automatically migrated to diskSize by platform migration 41. If you see this error after upgrading, the migration did not run — check the cozystack-migration-hook Job logs in cozy-system.'
 
   ###############################################
+  # KubeadmConfigTemplate — Helm prune guard    #
+  ###############################################
+
+  # THE THREAT. 1.6 drops KubeadmConfigTemplate from this chart entirely —
+  # workers move to TalosConfigTemplate. On that upgrade Helm sees the object in
+  # the previous release manifest and absent from the new one and deletes it,
+  # while the kubeadm-backed MachineSet is still mid-rollover with its
+  # bootstrap.configRef pointing at it: controller-manager floods with reconcile
+  # errors and workers can hang pending with nothing to bootstrap from.
+  #
+  # Platform migration 45 pins the templates that already exist when a cluster
+  # upgrades. This annotation covers the ones created AFTERWARDS — a new tenant
+  # Kubernetes cluster, or a nodeGroup added on 1.5.4 — which that migration has
+  # already run past and which 1.6's own slot 45 will skip, because a 1.5.4
+  # cluster is stamped 46 and runs `seq 46 53`.
+  #
+  # Safe on uninstall, the only path keep changes: CAPI stamps an ownerReference
+  # to the Cluster on this object, and the Cluster is Helm-managed with no keep,
+  # so `helm uninstall` deletes the Cluster and garbage collection reclaims this
+  # template through that reference. keep suppresses only Helm's own delete.
+
+  - it: is born with helm.sh/resource-policy=keep so the 1.6 upgrade cannot prune it
+    release:
+      name: test-k8s
+      namespace: tenant-test
+    asserts:
+      - isKind:
+          of: KubeadmConfigTemplate
+        documentIndex: 4
+      - equal:
+          path: metadata.name
+          value: test-k8s-md0
+        documentIndex: 4
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+        documentIndex: 4
+
+  # The annotation must sit inside the per-nodeGroup range, not on one template by
+  # accident. With two groups every KubeadmConfigTemplate has to carry it, or the
+  # groups added later are exactly the ones left prunable.
+  - it: pins the KubeadmConfigTemplate of every node group, not just the first
+    release:
+      name: test-k8s
+      namespace: tenant-test
+    set:
+      _namespace:
+        etcd: etcd
+        ingress: nginx
+        host: example.com
+      _cluster:
+        cluster-domain: cozy.local
+      nodeGroups:
+        md0:
+          minReplicas: 0
+          maxReplicas: 10
+          instanceType: ""
+          diskSize: 20Gi
+          roles:
+            - worker
+          resources: {}
+        md1:
+          minReplicas: 1
+          maxReplicas: 5
+          instanceType: ""
+          diskSize: 40Gi
+          roles:
+            - worker
+          resources:
+            memory: "8Gi"
+            cpu: 4
+    asserts:
+      # md0 at documentIndex 4; md1 at documentIndex 9, since each nodeGroup emits
+      # 5 documents (KubeadmConfigTemplate, KubevirtMachineTemplate,
+      # MachineDeployment, MachineHealthCheck, WorkloadMonitor).
+      - isKind:
+          of: KubeadmConfigTemplate
+        documentIndex: 4
+      - equal:
+          path: metadata.name
+          value: test-k8s-md0
+        documentIndex: 4
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+        documentIndex: 4
+      - isKind:
+          of: KubeadmConfigTemplate
+        documentIndex: 9
+      - equal:
+          path: metadata.name
+          value: test-k8s-md1
+        documentIndex: 9
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+        documentIndex: 9
+
+  ###############################################
   # KubeadmConfigTemplate — files block         #
   ###############################################
 

--- a/packages/core/platform/images/migrations/migrations/45
+++ b/packages/core/platform/images/migrations/migrations/45
@@ -1,7 +1,26 @@
 #!/bin/sh
 # Migration 45 --> 46
-# Repair the 1.5.0 db-split hand-over for SeaweedFS instances whose name is not
-# the default `seaweedfs`.
+# This slot does TWO independent jobs. Both are protective, both are idempotent,
+# and neither may be reached by way of the other failing.
+#
+#   1. Repair the 1.5.0 db-split hand-over for SeaweedFS instances whose name is
+#      not the default `seaweedfs` (the original contents of this slot, below).
+#   2. Pin the CAPI kubeadm bootstrap objects with helm.sh/resource-policy=keep,
+#      which is 1.6's OWN migration 45 folded in here — see
+#      lib/kubeadm-keep-pin.sh for why it has to be, and ORDER below for why it
+#      runs second.
+#
+# ORDER. The SeaweedFS repair runs first and the keep-pin second, because the two
+# failure modes are not equally bad: a missed SeaweedFS hand-over loses a tenant's
+# filer metadata, hence all of its S3, while a missed keep-pin gives a noisy
+# broken tenant-Kubernetes worker rollover that is recoverable by hand. Both halves
+# fail closed ahead of the version stamp at the bottom and the Job retries the
+# whole slot, so a half-completed attempt is safe either way — but on an attempt
+# where only one half gets to run, it should be the one whose failure is
+# irreversible. Running the pin first would mean a pin failure stops the SeaweedFS
+# repair from being attempted at all on that pass, which is strictly worse.
+#
+# --- 1. SeaweedFS db-split repair -------------------------------------------
 #
 # Migration 43 performs the hand-over of Cluster/seaweedfs-db from the
 # <name>-system release to the <name>-db release introduced by the split (PR
@@ -42,8 +61,15 @@ set -euo pipefail
 
 # shellcheck source=lib/seaweedfs-db-adopt.sh
 . "$(dirname "$0")/lib/seaweedfs-db-adopt.sh"
+# shellcheck source=lib/kubeadm-keep-pin.sh
+. "$(dirname "$0")/lib/kubeadm-keep-pin.sh"
 
+# Called bare, so a non-zero return trips errexit and aborts before the stamp
+# below. Both helpers report their own reason on stderr first.
 adopt_seaweedfs_db_clusters
+
+# --- 2. kubeadm bootstrap keep-pin ------------------------------------------
+pin_kubeadm_bootstrap_objects
 
 # Stamp version.
 # Mirror migration 42's labeled manifest. A label-less apply by the same field

--- a/packages/core/platform/images/migrations/migrations/lib/kubeadm-keep-pin.sh
+++ b/packages/core/platform/images/migrations/migrations/lib/kubeadm-keep-pin.sh
@@ -1,0 +1,199 @@
+# shellcheck shell=sh
+# Shared helper for pinning the CAPI kubeadm bootstrap objects with
+# helm.sh/resource-policy=keep, so the 1.6 Talos worker migration cannot let Helm
+# prune them while CAPI still references them.
+#
+# 1.6 drops KubeadmConfigTemplate from the tenant `kubernetes` app chart
+# entirely — workers move to TalosConfigTemplate. On that upgrade Helm sees the
+# resource present in the previous release manifest and absent from the new one,
+# and issues a delete. The kubeadm-backed MachineSet is still around until CAPI
+# finishes rolling workers onto Talos, so its bootstrap.configRef then points at
+# a missing object: controller-manager floods with reconcile errors, and where the
+# Talos image fetch from factory.talos.dev is slow or a MachineHealthCheck
+# remediates, workers can hang pending with nothing to bootstrap from. Tenant
+# Kubernetes only, and a noisy broken upgrade rather than data loss — but it is
+# not self-healing.
+#
+# WHY THIS LIVES ON release-1.5 AT ALL. 1.6 ships the same pin as its own
+# migration 45, and every released 1.5 (v1.5.0 through v1.5.3, all stamped
+# targetVersion 45) reaches it on the way to 1.6. What breaks that is v1.5.4: the
+# #3370 backport put the SeaweedFS db-split repair in release-1.5's slot 45 and
+# bumped targetVersion to 46, so a v1.5.4 cluster is stamped 46 and its later 1.6
+# upgrade runs `seq 46 53` — skipping 1.6's slot 45, and with it the pin. Folding
+# the pin into the slot that IS run leaves the annotation already in place by the
+# time 1.6 skips it. Renumbering release-1.5's repair to 1.6's slot 53 instead is
+# not an option: run-migrations.sh hard-fails on a missing slot file, so it would
+# need no-op stubs for 46-52, and a cluster stamped 54 would then run `seq 54 53`
+# and skip every real 1.6 migration.
+#
+# WHY THE managed-by SELECTOR, AND WHY A LABEL. Helm injects the
+# app.kubernetes.io/managed-by=Helm LABEL into every resource it applies.
+# meta.helm.sh/release-name is an ANNOTATION and cannot be used as a --selector:
+# doing so silently matches nothing and the pin is applied to nothing at all,
+# which looks exactly like a clean run. Verified on a live v1.5 stand stamped 45:
+# the chart's KubeadmConfigTemplate carries managed-by=Helm and no
+# resource-policy, while the KubeadmConfig children CAPI spawns from the template
+# carry no managed-by at all — they are owned by their Machine, Helm never prunes
+# them, and this selector correctly leaves them alone.
+#
+# FAILS CLOSED, AND AGGREGATES. Every object that can be pinned is pinned before a
+# non-zero return aborts the migration ahead of its version stamp, so the Job
+# retries the whole slot and reports all failures at once instead of one per
+# attempt. Best-effort (returning 0 on partial failure) is not an option:
+# migrations never re-run, and any KubeadmConfigTemplate left un-pinned is one
+# Helm prune away from breaking a live MachineSet's bootstrap.configRef
+# mid-rollover, which is recovered only by recreating the template by hand with
+# the right Helm ownership metadata.
+#
+# Idempotent: an object already carrying keep is skipped WITHOUT a write, so
+# re-running is a no-op on a cluster that has already been pinned.
+#
+# COST OF A KEEP THAT WAS NOT NEEDED, since `keep` is stamped on every
+# Helm-managed template rather than only on those a 1.6 upgrade would prune:
+# within 1.5 the chart still renders these objects and `keep` only suppresses
+# DELETION, so updates are unaffected. What it does leave behind is an orphan
+# where a nodeGroup is removed or the whole `kubernetes` app is deleted while its
+# namespace survives. That orphan keeps its Helm ownership annotations, so a
+# same-named app is adopted rather than blocked on re-install, and the asymmetry
+# is the same one the SeaweedFS hand-over accepts: an orphan is cleaned up by
+# hand, a pruned bootstrap reference breaks a live worker rollover.
+#
+# Sourced, not executed:
+#   . "$(dirname "$0")/lib/kubeadm-keep-pin.sh"
+
+_KKP_KEEP_ANNOTATION="helm.sh/resource-policy=keep"
+_KKP_HELM_MANAGED_SELECTOR="app.kubernetes.io/managed-by=Helm"
+
+# Fully qualified so a same-named CRD in another API group can never be matched
+# instead. KubeadmConfig is included for parity with 1.6's slot 45: the 1.5 chart
+# renders only the template, and the managed-by selector leaves the Machine-owned
+# children alone, so this is a no-op on a stock cluster and covers a Helm-managed
+# KubeadmConfig if one is ever rendered.
+_KKP_KINDS="kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io
+kubeadmconfigs.bootstrap.cluster.x-k8s.io"
+
+# _kkp_is_absent_err <file>
+# True when a kubectl error means the resource type simply is not served, as
+# opposed to the API being unreachable, forbidden, throttled, or not yet
+# established: a cluster with no CAPI bootstrap provider has nothing to pin.
+# Deliberately narrow — anything unrecognised is fatal — and deliberately NOT
+# shared with lib/seaweedfs-db-adopt.sh, because migration 43 sources that lib
+# alone and neither may depend on the other having been loaded.
+_kkp_is_absent_err() {
+  grep -qiE "server doesn't have a resource type|server could not find the requested resource|could not find the requested resource|no matches for kind" "$1"
+}
+
+# _kkp_is_gone_err <file>
+# True when a PER-OBJECT kubectl error means that one object is no longer there:
+# an app being deleted concurrently with this hook can take its
+# KubeadmConfigTemplate away between the fleet scan and the annotate. Nothing is at
+# risk in that case — Helm cannot prune an object that does not exist — so it is a
+# skip, not a failure, and must not fail a pre-upgrade hook and block the platform
+# upgrade over an object nobody needs any more.
+#
+# Separate from _kkp_is_absent_err, and wider than it by exactly one phrase,
+# because "not found" must NOT be accepted for the fleet SCAN: a list never
+# answers NotFound, so accepting it there would let some genuine failure read as
+# an empty fleet and leave every template un-pinned.
+_kkp_is_gone_err() {
+  _kkp_is_absent_err "$1" || grep -qiE "not found" "$1"
+}
+
+# _kkp_pin_one <kind> <namespace> <name>
+# Stamp keep on one object, counting the outcome. Always returns 0: a failure is
+# recorded in _kkp_failures and reported by the caller once the whole fleet has
+# been walked, so one bad object cannot abort the loop before the rest are pinned.
+_kkp_pin_one() {
+  _kkp_p_kind="$1"
+  _kkp_p_ns="$2"
+  _kkp_p_name="$3"
+
+  # An unreadable current value is deliberately NOT fatal here: the annotate below
+  # is the operation that has to succeed and it IS checked, so a failed read costs
+  # only a redundant write. There is no fail-open hiding in this `|| true`.
+  _kkp_p_current=$(kubectl get "$_kkp_p_kind" --namespace "$_kkp_p_ns" "$_kkp_p_name" \
+    --output 'jsonpath={.metadata.annotations.helm\.sh/resource-policy}' 2>/dev/null) \
+    || _kkp_p_current=""
+
+  if [ "$_kkp_p_current" = "keep" ]; then
+    echo "$_kkp_p_kind $_kkp_p_ns/$_kkp_p_name already carries $_KKP_KEEP_ANNOTATION — nothing to do"
+    _kkp_skipped=$((_kkp_skipped + 1))
+    return 0
+  fi
+
+  if kubectl annotate "$_kkp_p_kind" --namespace "$_kkp_p_ns" "$_kkp_p_name" \
+       "$_KKP_KEEP_ANNOTATION" --overwrite >/dev/null 2>"$_kkp_err"; then
+    echo "Pinned $_kkp_p_kind $_kkp_p_ns/$_kkp_p_name with $_KKP_KEEP_ANNOTATION"
+    _kkp_patched=$((_kkp_patched + 1))
+  elif _kkp_is_gone_err "$_kkp_err"; then
+    echo "$_kkp_p_kind $_kkp_p_ns/$_kkp_p_name disappeared between the scan and the pin — skipping"
+    _kkp_skipped=$((_kkp_skipped + 1))
+  else
+    echo "WARNING: failed to pin $_kkp_p_kind $_kkp_p_ns/$_kkp_p_name:" >&2
+    cat "$_kkp_err" >&2
+    _kkp_failures=$((_kkp_failures + 1))
+  fi
+  return 0
+}
+
+# pin_kubeadm_bootstrap_objects
+# Stamp helm.sh/resource-policy=keep on every Helm-managed kubeadm bootstrap
+# object. Returns non-zero (aborting the migration before its version stamp) on
+# any error that is not "this resource type is not served".
+pin_kubeadm_bootstrap_objects() {
+  _kkp_err=$(mktemp)
+  _kkp_items=$(mktemp)
+  _kkp_patched=0
+  _kkp_skipped=0
+  _kkp_failures=0
+
+  for _kkp_kind in $_KKP_KINDS; do
+    echo "==> Pinning Helm-managed $_kkp_kind with $_KKP_KEEP_ANNOTATION"
+
+    # Redirecting to a file inside `if !` keeps errexit from firing so the exit
+    # status can be inspected. `for x in $(kubectl ...)` would not trip errexit
+    # either: on failure it iterates zero times and lets the caller stamp the
+    # version regardless, which is the fail-open this guard exists for.
+    if ! kubectl get "$_kkp_kind" --all-namespaces \
+          --selector "$_KKP_HELM_MANAGED_SELECTOR" \
+          --output 'jsonpath={range .items[*]}{.metadata.namespace}{"/"}{.metadata.name}{"\n"}{end}' \
+          >"$_kkp_items" 2>"$_kkp_err"; then
+      if _kkp_is_absent_err "$_kkp_err"; then
+        echo "$_kkp_kind is not served on this cluster — nothing to pin"
+        continue
+      fi
+      echo "FATAL: cannot list $_kkp_kind across namespaces; refusing to stamp past an unverified fleet:" >&2
+      cat "$_kkp_err" >&2
+      rm -f "$_kkp_err" "$_kkp_items"
+      return 1
+    fi
+
+    # Read from a file, not a pipe: `kubectl ... | while read` runs the loop body
+    # in a subshell, so the counters would be discarded on exit and a failed pin
+    # would be reported as a clean run. A namespace and an object name are both
+    # DNS labels and cannot contain "/", so the separator is unambiguous.
+    while IFS= read -r _kkp_item; do
+      [ -n "$_kkp_item" ] || continue
+      _kkp_ns="${_kkp_item%%/*}"
+      _kkp_name="${_kkp_item#*/}"
+      if [ -z "$_kkp_ns" ] || [ -z "$_kkp_name" ] || [ "$_kkp_ns" = "$_kkp_item" ]; then
+        echo "WARNING: cannot parse '$_kkp_item' as <namespace>/<name> for $_kkp_kind — refusing to guess" >&2
+        _kkp_failures=$((_kkp_failures + 1))
+        continue
+      fi
+      _kkp_pin_one "$_kkp_kind" "$_kkp_ns" "$_kkp_name"
+    done <"$_kkp_items"
+  done
+
+  rm -f "$_kkp_err" "$_kkp_items"
+
+  echo "==> kubeadm keep-pin summary: pinned=$_kkp_patched already-pinned=$_kkp_skipped failures=$_kkp_failures"
+
+  if [ "$_kkp_failures" -gt 0 ]; then
+    echo "ERROR: $_kkp_failures kubeadm bootstrap object(s) could not be pinned; refusing to stamp the version so this migration retries on the next platform upgrade." >&2
+    echo "ERROR: an un-pinned KubeadmConfigTemplate can be pruned by the 1.6 kubernetes chart upgrade, breaking the bootstrap.configRef of the kubeadm-backed MachineSet that is still rolling workers over to Talos." >&2
+    return 1
+  fi
+
+  return 0
+}


### PR DESCRIPTION
Migration slot 45 holds a different migration here than on main and release-1.6. On this branch it is the seaweedfs db-split repair, added after v1.5.3 by `33611dfe7` (the #3370 backport), which in the same commit bumped `migrations.targetVersion` from 45 to 46. On main and 1.6 slot 45 is the `helm.sh/resource-policy=keep` pin on `KubeadmConfigTemplate`, and the seaweedfs repair sits at slot 53 instead.

Nothing is broken today. v1.5.0 through v1.5.3 all ship `targetVersion: 45`, so no released cluster is stamped past it and every one of them still runs 1.6's slot 45 on the way up. Cutting v1.5.4 is what first ships 46. After that a 1.5.4 to 1.6 upgrade runs `seq 46 53` and never executes 1.6's slot 45, so helm prunes `KubeadmConfigTemplate` while the live kubeadm-backed MachineSet still references it, `bootstrap.configRef` dangles and controller-manager floods through the talos worker rollover. Tenant kubernetes only, noisy broken upgrade rather than data loss.

This folds the keep-pin into release-1.5's slot 45 so it does both jobs, and puts the annotation on the rendered template in `packages/apps/kubernetes/templates/cluster.yaml` so templates created after the upgrade are born pinned. `targetVersion` stays 46.

### Why uninstall does not leak

`keep` suppresses only helm's own delete. CAPI stamps an `ownerReference` to the `Cluster` on this object, which the chart does not render (checked on a live v1.5 stand, and `MachineDeployment` and `KubevirtMachineTemplate` carry the same reference). The `Cluster` itself is helm-managed with no `keep`, so `helm uninstall` deletes it and GC reclaims the template through that reference.

Template name is deterministic rather than content-hashed, so `keep` cannot accumulate a copy per upgrade. One residue is the template of a removed nodeGroup, which helm no longer prunes. It is inert, re-adopted in place if the group comes back, and GC takes it with the `Cluster`.

### Tests

Mutation-proven rather than revert-tested. The one worth naming: swapping the selector to the `meta.helm.sh/release-name` annotation makes the migration exit 0 reporting `pinned=0 failures=0`, which looks like a clean run, and the test catches it because the annotation never reached the object.

Also converts four pre-existing negated-grep assertions in `hack/seaweedfs-guard-parity.bats`. `! grep -q X f` cannot fail, posix and bash both exempt a `!`-negated pipeline from errexit, so those were comments that look like assertions. All of them hold once they are real.
