### PR TITLE
ci(release): complete the candidate-aware promotion pipeline on release-1.6

### DIFF
--- a/.github/workflows/e2e-tag.yaml
+++ b/.github/workflows/e2e-tag.yaml
@@ -1,0 +1,374 @@
+name: E2E Release Tag
+
+# Validate the installable release closure for an existing version tag.
+#
+# Every RC must pass this lane after tags.yaml has published the prerelease and
+# pushed its release-X.Y.Z-rc.N digest-pinned staging branch — tags.yaml's
+# rc-e2e job calls this workflow as that mandatory post-cut check. The
+# workflow_dispatch trigger is the manual validation button for published
+# alpha, beta, RC, and stable releases.
+#
+# This lane validates published tags only; draft and promote-time validation are
+# explicitly out of scope because release checks run at RC publication time.
+# Prerelease tags use the matching digest-pinned staging branch, while stable
+# tags use their pinned merge tree directly. In both cases the nocloud disk
+# comes from the published release identified by the same tag.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to validate, e.g. v1.7.0-rc.1"
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to validate, e.g. v1.7.0-rc.1"
+        required: true
+        type: string
+      debug:
+        description: "Open a maintainer SSH breakpoint if E2E fails"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: e2e-tag-${{ inputs.tag }}
+  cancel-in-progress: false
+
+# Listing published releases, reading Git refs, downloading a release asset, and
+# checking out the pinned tree require only repository contents read access.
+# Draft releases are not part of this lane's contract. The public GHCR images
+# referenced by that tree need no package token.
+#
+# CALLERS MUST GRANT `contents: read` AND `checks: write`. A caller's permissions
+# are the ceiling for every job here, and GitHub validates that ceiling when it
+# creates the run, before any `if:` is evaluated — so the `checks: write` the e2e
+# job below declares for its dispatch-only breakpoint has to be granted even by a
+# caller whose invocation can never reach that step. Granting less does not
+# degrade the breakpoint; it fails the caller's entire workflow run at startup.
+permissions:
+  contents: read
+
+jobs:
+  resolve:
+    name: Resolve release assets and tree
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      disk_id: ${{ steps.resolve.outputs.disk_id }}
+      tree_ref: ${{ steps.resolve.outputs.tree_ref }}
+    steps:
+      - name: Validate tag and resolve release
+        id: resolve
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          TAG: ${{ inputs.tag }}
+        with:
+          script: |
+            const tag = process.env.TAG;
+            const pattern = /^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/;
+            if (!pattern.test(tag)) {
+              core.setFailed(`Tag '${tag}' must match vX.Y.Z, vX.Y.Z-alpha.N, vX.Y.Z-beta.N, or vX.Y.Z-rc.N`);
+              return;
+            }
+
+            const isPrerelease = /-(alpha|beta|rc)\.[0-9]+$/.test(tag);
+            const releases = await github.paginate(github.rest.repos.listReleases, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100
+            });
+            const release = releases.find(candidate => candidate.tag_name === tag);
+            if (!release) {
+              core.setFailed(`GitHub release '${tag}' not found`);
+              return;
+            }
+
+            if (release.draft) {
+              core.setFailed(`Release for tag '${tag}' is still a draft — this lane validates published tags only; RC validation runs after tags.yaml publishes the prerelease`);
+              return;
+            } else if (isPrerelease && !release.prerelease) {
+              core.setFailed(`Release '${tag}' must be published as a prerelease`);
+              return;
+            } else if (!isPrerelease && release.prerelease) {
+              core.setFailed(`Release '${tag}' must be published as a stable release`);
+              return;
+            }
+
+            const disk = release.assets.find(asset => asset.name === 'nocloud-amd64.raw.xz');
+            if (!disk) {
+              core.setFailed(`Required asset 'nocloud-amd64.raw.xz' is missing from release '${tag}'`);
+              return;
+            }
+
+            const treeRef = isPrerelease ? `release-${tag.slice(1)}` : tag;
+            const gitRef = isPrerelease ? `heads/${treeRef}` : `tags/${treeRef}`;
+            try {
+              await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: gitRef
+              });
+            } catch (error) {
+              if (error.status === 404 && isPrerelease) {
+                core.setFailed(`Expected staging branch '${treeRef}' for prerelease tag '${tag}' was not found`);
+                return;
+              }
+              if (error.status === 404) {
+                core.setFailed(`Expected stable tag ref '${tag}' was not found`);
+                return;
+              }
+              throw error;
+            }
+
+            core.setOutput('disk_id', String(disk.id));
+            core.setOutput('tree_ref', treeRef);
+            core.info(`Resolved ${tag}: tree '${treeRef}', disk asset ${disk.id}`);
+
+  e2e:
+    name: E2E ${{ inputs.tag }} (full suite)
+    needs: resolve
+    # The sandbox boots three 8-vCPU / 24-GiB QEMU guests. This runner leaves
+    # enough host headroom for QEMU, networking, containerd, and the runner
+    # agent while the full platform installs across all three guests.
+    runs-on: oracle-vm-32cpu-128gb-x86-64
+    timeout-minutes: 180
+    permissions:
+      contents: read
+      checks: write # Breakpoint action updates its dedicated "Breakpoint Open" Check Run.
+    steps:
+      # The resolved ref is the digest-pinned staging branch for a prerelease,
+      # or the stable tag's pinned merge tree.
+      - name: Checkout resolved release tree
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ needs.resolve.outputs.tree_ref }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download disk asset from release
+        env:
+          DISK_ID: ${{ needs.resolve.outputs.disk_id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p _out/assets
+          curl --fail-with-body --silent --show-error --location \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/octet-stream" \
+            -o _out/assets/nocloud-amd64.raw.xz \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/assets/${DISK_ID}"
+
+      - name: Set sandbox ID
+        env:
+          TAG: ${{ inputs.tag }}
+        run: echo "SANDBOX_NAME=cozy-e2e-sandbox-$(echo "${GITHUB_REPOSITORY}:${GITHUB_WORKFLOW}:${TAG}" | sha256sum | cut -c1-10)" >> "$GITHUB_ENV"
+
+      - name: Prepare workspace
+        run: |
+          rm -rf "/tmp/$SANDBOX_NAME"
+          cp -r "${{ github.workspace }}" "/tmp/$SANDBOX_NAME"
+
+      # This is the only retried stage: Talos image unpacking, QEMU startup, and
+      # sandbox networking are pure runner infrastructure, not product logic.
+      - name: Prepare environment
+        run: |
+          cd "/tmp/$SANDBOX_NAME"
+          attempt=0
+          until make SANDBOX_NAME=$SANDBOX_NAME prepare-env; do
+            attempt=$((attempt + 1))
+            if [ $attempt -ge 3 ]; then
+              echo "Attempt $attempt failed, exiting..."
+              exit 1
+            fi
+            echo "Attempt $attempt failed, retrying..."
+          done
+          echo "Prepare environment completed after $((attempt + 1)) attempts"
+
+      - name: Install Cozystack into sandbox
+        run: |
+          cd "/tmp/$SANDBOX_NAME"
+          if ! make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME install-cozystack; then
+            echo "❌ Install failed (no retry — see diagnostics below)"
+            echo "::group::Diagnostics: HelmRelease status"
+            docker exec "$SANDBOX_NAME" sh -c 'kubectl get hr -A -o wide 2>&1 | tail -100' || true
+            echo "::endgroup::"
+            echo "::group::Diagnostics: not-Ready HelmReleases (describe)"
+            docker exec "$SANDBOX_NAME" sh -c 'kubectl get hr -A --no-headers 2>/dev/null | awk "\$4 != \"True\" {print \$1\" \"\$2}"' \
+              | while read -r ns name; do
+                  echo "--- $ns/$name ---"
+                  docker exec "$SANDBOX_NAME" sh -c "kubectl describe hr '$name' -n '$ns' 2>&1 | tail -50" || true
+                done
+            echo "::endgroup::"
+            echo "::group::Diagnostics: recent events"
+            docker exec "$SANDBOX_NAME" sh -c 'kubectl get events -A --sort-by=.lastTimestamp 2>&1 | tail -50' || true
+            echo "::endgroup::"
+            exit 1
+          fi
+
+      - name: Run OpenAPI tests
+        run: |
+          cd "/tmp/$SANDBOX_NAME"
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME test-openapi
+
+      # A tag has no PR diff to scope with Test Impact Analysis. Empty
+      # CHAINSAW_SUITES is the testing Makefile's full-suite mode.
+      - name: Run E2E tests (full suite)
+        id: e2e_tests
+        run: |
+          cd "/tmp/$SANDBOX_NAME"
+          if ! make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME test-chainsaw CHAINSAW_SUITES=""; then
+            echo "❌ Chainsaw E2E failed (see the assertion diffs above and diagnostics below)"
+            echo "::group::Diagnostics: HelmRelease status"
+            docker exec "$SANDBOX_NAME" sh -c 'kubectl get hr -A -o wide 2>&1 | tail -50' || true
+            echo "::endgroup::"
+            echo "::group::Diagnostics: recent events"
+            docker exec "$SANDBOX_NAME" sh -c 'kubectl get events -A --sort-by=.lastTimestamp 2>&1 | tail -30' || true
+            echo "::endgroup::"
+            # COSI CRDs have no printer columns, so capture readiness fields at
+            # failure time before tests and report collection can move state.
+            echo "::group::Diagnostics: COSI bucket state"
+            docker exec "$SANDBOX_NAME" sh -c '
+              kubectl get bucketclaims.objectstorage.k8s.io -A -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name,READY:.status.bucketReady,BUCKET:.status.bucketName" 2>&1
+              kubectl get buckets.objectstorage.k8s.io -o custom-columns="NAME:.metadata.name,READY:.status.bucketReady,ID:.status.bucketID,CLAIMNS:.spec.bucketClaim.namespace" 2>&1
+              kubectl get bucketaccesses.objectstorage.k8s.io -A -o custom-columns="NAMESPACE:.metadata.namespace,NAME:.metadata.name,GRANTED:.status.accessGranted,CLAIM:.spec.bucketClaimName" 2>&1
+            ' || true
+            echo "::endgroup::"
+            exit 1
+          fi
+          echo "✅ All E2E tests passed"
+
+      - name: Collect chainsaw report
+        if: always()
+        run: |
+          cd "/tmp/$SANDBOX_NAME"
+          mkdir -p _out
+          docker cp "$SANDBOX_NAME":/workspace/hack/e2e-chainsaw/chainsaw-report.xml \
+            _out/chainsaw-report.xml || true
+
+      - name: Upload chainsaw report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: chainsaw-report-${{ inputs.tag }}
+          path: /tmp/${{ env.SANDBOX_NAME }}/_out/chainsaw-report.xml
+          if-no-files-found: ignore
+
+      # collect-report packages cozyreport plus per-failed-test crust-gather
+      # snapshots captured before Chainsaw cleanup.
+      #
+      # A ceiling of its own, not the job's 180 minutes. `Upload cozyreport.tgz`
+      # is the next step and the collector writes its tarball at the very end of
+      # its run, so a read that never returns spends what is left of the job
+      # budget, the job is cancelled, and the upload never runs -- the artifact
+      # is lost rather than truncated. 30 minutes is measured against the step:
+      # it takes 3-42s across sampled runs, failed e2e jobs included.
+      # `continue-on-error` because the ceiling must not change what the job
+      # reports: `|| true` says collecting diagnostics is never fatal, and a step
+      # killed at its ceiling never reaches it.
+      - name: Collect report
+        id: collect_report
+        if: always()
+        timeout-minutes: 30
+        continue-on-error: true
+        run: |
+          cd "/tmp/$SANDBOX_NAME"
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME collect-report || true
+
+      # `continue-on-error` keeps the overrun out of the job's result, which also
+      # keeps it out of everyone's view: a step that ended at its ceiling renders
+      # green and the only trace is in the raw log. This branch's own standard is
+      # that a bound which fires is recorded, and that has to hold for the outer
+      # bound too.
+      #
+      # The wording says what `outcome` establishes and no more. A step can end
+      # non-zero without any ceiling firing -- in e2e-tag.yaml the body opens with
+      # a `cd` into a sandbox tree an earlier step may never have created, and the
+      # default shell is `bash -e` -- so naming the timeout as the cause would be
+      # the same false-mechanism claim the collector refuses to make for a 137.
+      - name: Report collection overran its ceiling
+        if: always() && steps.collect_report.outcome == 'failure'
+        run: |
+          echo "::warning title=cozyreport::Collect report ended non-zero -- its timeout-minutes fired, or the step failed before the collector ran; cozyreport.tgz is missing or partial for this run"
+
+      - name: Upload cozyreport.tgz
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: cozyreport-${{ inputs.tag }}
+          path: /tmp/${{ env.SANDBOX_NAME }}/_out/cozyreport.tgz
+
+      - name: Collect images list
+        if: always()
+        run: |
+          cd "/tmp/$SANDBOX_NAME"
+          make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME collect-images || true
+
+      - name: Upload image list
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: image-list-${{ inputs.tag }}
+          path: /tmp/${{ env.SANDBOX_NAME }}/_out/images.txt
+
+      # ▸ Open an SSH breakpoint to the failing sandbox so maintainers can attach,
+      #   inspect Talos/Cozystack state and resume with `breakpoint resume`.
+      #
+      #   Gated by the workflow_dispatch `debug` boolean and the configured
+      #   BREAKPOINT_ENDPOINT repository variable. workflow_call runs never get
+      #   a breakpoint. authorized-users is kept as a second defense layer at
+      #   the breakpoint level.
+      #
+      #   Uses cozystack/breakpoint-action (fork of namespacelabs/breakpoint-action)
+      #   pinned by SHA. The fork adds: pause-idle mode (initial grace period for
+      #   the first SSH connection, idle-aware exit afterwards), endpoint output
+      #   and ::notice:: annotation, and a dedicated Check Run "Breakpoint Open"
+      #   that carries the SSH endpoint in output.summary while the breakpoint is
+      #   paused (conclusion=failure → standard ✗ in checks; updated to
+      #   conclusion=success when the breakpoint exits).
+      - name: Breakpoint on E2E failure
+        if: |
+          failure() &&
+          github.event_name == 'workflow_dispatch' &&
+          inputs.debug == true &&
+          vars.BREAKPOINT_ENDPOINT != ''
+        # cozystack/breakpoint-action v2-cozy.1
+        # mode: pause-idle defaults: grace-period=20m, idle-timeout=10m
+        uses: cozystack/breakpoint-action@a6f3a6f87be398ad63b6577351e3398e53f578e4
+        with:
+          mode: pause-idle
+          endpoint: ${{ vars.BREAKPOINT_ENDPOINT }}
+          authorized-users: androndo, Arsolitt, IvanHunters, kvaps, lexfrei, lllamnyp, mattia-eleuteri, matthieu-robin, myasnikovdaniil, sircthulhu, tym83
+          check-run-name: "Breakpoint Open"
+          github-token: ${{ github.token }}
+          check-run-summary-template: |
+            ## 🔴 SSH breakpoint open — paused for debug
+
+            ```
+            {endpoint}
+            ```
+
+            Enter the e2e sandbox after SSH:
+            ```
+            docker exec -ti $(docker ps --filter name=cozy-e2e-sandbox -q | head -1) bash
+            export KUBECONFIG=/workspace/kubeconfig
+            ```
+
+            Resume from inside: `breakpoint resume`. Otherwise the breakpoint
+            exits 10 minutes after the last SSH session disconnects.
+
+      - name: Tear down sandbox
+        if: always()
+        run: make -C packages/core/testing SANDBOX_NAME=$SANDBOX_NAME delete || true
+
+      - name: Remove workspace
+        if: always()
+        run: rm -rf "/tmp/$SANDBOX_NAME"
+
+      - name: Summarize outcome
+        if: always()
+        env:
+          OUTCOME: ${{ job.status }}
+          TAG: ${{ inputs.tag }}
+        run: printf '| E2E tag `%s` | %s |\n' "$TAG" "$OUTCOME" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pull-requests-release.yaml
+++ b/.github/workflows/pull-requests-release.yaml
@@ -91,6 +91,90 @@ jobs:
           # app token authenticates, matching how promote-rc.yaml already pushes.
           persist-credentials: false
 
+      # Use the trusted pre-merge base version of the verifier, while its root
+      # argument remains the merged packages tree checked out above. This keeps
+      # the final guard independent of the release PR's executable contents.
+      - name: Checkout release tooling from base
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .release-tooling
+          sparse-checkout: hack
+          persist-credentials: false
+
+      # Resolve and verify the candidate before creating any write-once stable
+      # git or registry name. The candidate was serialized at promote time from
+      # the tag-rewritten tree; this guard pulls it by the committed digest and
+      # proves it still matches the merge commit (apart from its impossible
+      # self-reference) and still pins the rc-tested container digests.
+      #
+      # This step block runs HERE, ahead of the tag creation, the draft-release
+      # publish and the retag, rather than in its old position after the publish:
+      # a guard that runs after the write-once names exist cannot refuse them.
+      # It absorbs the former "Set up toolchain (skopeo, yq, helm)" and "Login to
+      # registry (GHCR)" steps, which is why neither appears later in this job
+      # any more — the tools and the logins are set up once, before the first
+      # irreversible action, and stay in scope for the retag and chart publish.
+      #
+      # flux and yq are version-pinned: they are what this job verifies the
+      # candidate with and what stamps the stable chart, so `latest/download`
+      # would make an irreversible step depend on whatever mikefarah shipped
+      # this morning. The version tracks
+      # packages/core/testing/images/e2e-sandbox/Dockerfile. yq is additionally
+      # pinned by content — it stamps the chart's platformVersion, and this step
+      # is the last one before write-once names exist. The Flux installer is not,
+      # because it checksums the binary it fetches and the mutable part is its
+      # own bootstrap script.
+      - name: Set up promotion toolchain (flux, skopeo, yq, helm)
+        if: ${{ !contains(steps.get_tag.outputs.tag, '-') }}
+        env:
+          FLUX_VERSION: "2.8.6"
+          YQ_VERSION: "4.53.3"
+          YQ_SHA256: "fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
+        run: |
+          if ! flux version --client 2>/dev/null | grep -qx "flux: v${FLUX_VERSION}"; then
+            install_script="$(mktemp)"
+            curl -fsSL https://fluxcd.io/install.sh -o "$install_script"
+            sudo env "FLUX_VERSION=$FLUX_VERSION" bash "$install_script"
+            rm -f "$install_script"
+          fi
+          if ! yq --version 2>/dev/null | grep -q "mikefarah.* version v${YQ_VERSION}\$"; then
+            yq_bin="$(mktemp)"
+            curl -fsSL -o "$yq_bin" \
+              "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+            printf '%s  %s\n' "$YQ_SHA256" "$yq_bin" | sha256sum -c -
+            sudo install -m 0755 "$yq_bin" /usr/local/bin/yq
+            rm -f "$yq_bin"
+          fi
+          command -v skopeo >/dev/null \
+            || { sudo apt-get update -qq && sudo apt-get install -y -qq skopeo; }
+          command -v helm >/dev/null \
+            || curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+          # Not installed here, only required: `flux pull artifact` reads its
+          # registry credentials from ~/.docker/config.json, which is why the
+          # login step below runs `docker login` as well as skopeo's and helm's.
+          # This job's runner class is not one of the docker-using build ones, so
+          # say what is missing here rather than letting the login step fail with
+          # a bare "command not found" in the middle of the release path.
+          command -v docker >/dev/null \
+            || { echo "::error::docker is required on this runner: flux reads registry credentials from ~/.docker/config.json"; exit 1; }
+
+      - name: Login to registry (GHCR)
+        if: ${{ !contains(steps.get_tag.outputs.tag, '-') }}
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "$GHCR_TOKEN" | docker login "${REGISTRY%%/*}" -u "$GHCR_USER" --password-stdin
+          echo "$GHCR_TOKEN" | skopeo login "${REGISTRY%%/*}" -u "$GHCR_USER" --password-stdin
+          echo "$GHCR_TOKEN" | helm registry login "${REGISTRY%%/*}" -u "$GHCR_USER" --password-stdin
+
+      - name: Verify stable packages candidate
+        if: ${{ !contains(steps.get_tag.outputs.tag, '-') }}
+        env:
+          TAG: ${{ steps.get_tag.outputs.tag }}
+        run: .release-tooling/hack/verify-promoted-packages.sh "${TAG#v}"
+
       # Create the release tag at the merge commit — write-once.
       #
       # The tag is attached to the PR merge commit, which did not exist before
@@ -393,24 +477,12 @@ jobs:
       #    The checked-out merge commit is the promoted stable tree: the rc's
       #    digests with the tag string rewritten to stable. skopeo retags those
       #    digests to the stable image tag; helm packages+pushes the stable chart.
-      - name: Set up toolchain (skopeo, yq, helm)
-        if: ${{ !contains(steps.get_tag.outputs.tag, '-') }}
-        run: |
-          command -v yq >/dev/null \
-            || { sudo curl -sSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 && sudo chmod +x /usr/local/bin/yq; }
-          command -v skopeo >/dev/null \
-            || { sudo apt-get update -qq && sudo apt-get install -y -qq skopeo; }
-          command -v helm >/dev/null \
-            || curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-
-      - name: Login to registry (GHCR)
-        if: ${{ !contains(steps.get_tag.outputs.tag, '-') }}
-        env:
-          GHCR_USER:  ${{ github.actor }}
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "$GHCR_TOKEN" | skopeo login "${REGISTRY%%/*}" -u "$GHCR_USER" --password-stdin
-          echo "$GHCR_TOKEN" | helm registry login "${REGISTRY%%/*}" -u "$GHCR_USER" --password-stdin
+      #
+      #    The toolchain and the GHCR logins these two steps need are established
+      #    earlier in this job, by "Set up promotion toolchain (flux, skopeo, yq,
+      #    helm)" and "Login to registry (GHCR)" — both moved ahead of the tag
+      #    creation so the candidate verification can refuse a release before any
+      #    write-once name exists. Same job, so both are still in scope here.
 
       # Retag every rc image/digest to the stable tag. No rebuild — bit-for-bit
       # the e2e-tested rc. :latest moves only when this stable is the newest

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -83,6 +83,106 @@ jobs:
             echo "any=true" >> "$GITHUB_OUTPUT"
           fi
 
+  # Verify GitHub's prospective merge tree here, so a `packages/` edit pushed to
+  # this PR fails this check before it can merge.
+  #
+  # Checking the MERGE tree rather than the head is what makes base drift
+  # visible when this job runs — but nothing re-runs it when the base moves:
+  # GitHub does not fire `pull_request` on the base branch advancing, it only
+  # recomputes refs/pull/N/merge. So a `packages/` change landing on the base
+  # after this went green is never re-verified here, and the PR stays mergeable
+  # on the stale result. Finalize repeats the check against the real merge
+  # commit before creating the write-once stable tag, which is where that case
+  # is actually caught — loudly, and before any stable name exists.
+  #
+  # The trigger predicate is the promote PR's author plus its head-branch shape,
+  # NOT the `release` label main keys on. This branch's `on.pull_request.types`
+  # has no `labeled` event, and `gh pr create --label release` applies the label
+  # in a separate call one second after the PR opens (observed on the v1.6.1
+  # promote PR), so the `opened` payload carries no labels at all and a
+  # label-keyed guard would never fire here. Every `cozystack-ci[bot]` PR whose
+  # head starts with `release-` is a promote PR, so this is if anything the
+  # narrower predicate — and it re-runs on `synchronize`, which is what makes a
+  # `packages/` edit pushed to the PR visible. A prerelease staging head
+  # (release-X.Y.Z-rc.N) never gets a PR under the checks-at-rc flow; if one ever
+  # did, the verifier's own X.Y.Z assertion fails it closed rather than passing.
+  verify-release-candidate:
+    name: Verify release packages candidate
+    runs-on: ubuntu-latest
+    # Matching `checks` and `finalize`. Without a ceiling the job inherits the
+    # 6-hour default, and a stalled `flux pull artifact` would hold this check
+    # pending for all of it.
+    timeout-minutes: 30
+    if: |
+      github.event.pull_request.user.login == 'cozystack-ci[bot]'
+      && startsWith(github.head_ref, 'release-')
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      # The default pull_request checkout is GitHub's prospective merge commit,
+      # not just the head branch. That makes base-branch package drift visible.
+      - name: Checkout prospective merge
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      # Execute the verifier from the trusted base SHA. An older rc-derived head
+      # may not contain it, and a PR must not be able to weaken its own guard.
+      - name: Checkout release tooling from base
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: .release-tooling
+          sparse-checkout: hack
+          persist-credentials: false
+
+      # Both tools are version-pinned. This job decides whether a stable release
+      # may be created, so what it runs has to be a fixed input: `latest/download`
+      # resolves to whatever mikefarah shipped this morning, and a yq that changed
+      # how it emits or compares a value turns a release gate into a moving one.
+      # The version tracks packages/core/testing/images/e2e-sandbox/Dockerfile.
+      # yq is additionally pinned by content; the Flux installer is not, because
+      # it checksums the binary it fetches and the mutable part is its own
+      # bootstrap script.
+      - name: Set up promotion toolchain (flux, yq)
+        env:
+          FLUX_VERSION: "2.8.6"
+          YQ_VERSION: "4.53.3"
+          YQ_SHA256: "fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
+        run: |
+          if ! flux version --client 2>/dev/null | grep -qx "flux: v${FLUX_VERSION}"; then
+            install_script="$(mktemp)"
+            curl -fsSL https://fluxcd.io/install.sh -o "$install_script"
+            sudo env "FLUX_VERSION=$FLUX_VERSION" bash "$install_script"
+            rm -f "$install_script"
+          fi
+          if ! yq --version 2>/dev/null | grep -q "mikefarah.* version v${YQ_VERSION}\$"; then
+            yq_bin="$(mktemp)"
+            curl -fsSL -o "$yq_bin" \
+              "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64"
+            printf '%s  %s\n' "$YQ_SHA256" "$yq_bin" | sha256sum -c -
+            sudo install -m 0755 "$yq_bin" /usr/local/bin/yq
+            rm -f "$yq_bin"
+          fi
+
+      - name: Login to registry (GHCR)
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
+
+      - name: Verify stable packages candidate
+        env:
+          DOCKER_CONFIG: ${{ runner.temp }}/.docker
+          HEAD_BRANCH: ${{ github.head_ref }}
+        run: |
+          STABLE_VERSION="${HEAD_BRANCH#release-}"
+          .release-tooling/hack/verify-promoted-packages.sh "$STABLE_VERSION"
+
   # Helm-unittest + Go controller tests. Decoupled from the image build and from
   # e2e so they give fast, independent signal; they gate the PR as their own
   # required check rather than blocking e2e from starting.

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -311,6 +311,35 @@ jobs:
       # not exists" step was gated on `is_stable && release_exists==false` —
       # unreachable now that a hand-pushed stable tag is rejected above.
 
+  # Mandatory only for vX.Y.Z-rc.N tags. Alpha/beta tags deliberately skip this
+  # job and use e2e-tag.yaml's manual dispatch when validation is wanted.
+  #
+  # Deliberately not gated on release_exists: validating an already-published rc
+  # again is an idempotent re-tag-run check, while prepare-release still provides
+  # the ordering guarantee for a fresh rc. Its "Publish rc release" and "Create
+  # release branch" steps finish before this reusable workflow can start.
+  rc-e2e:
+    name: E2E Release Candidate
+    needs: prepare-release
+    if: needs.prepare-release.result == 'success' && contains(github.ref_name, '-rc.')
+    # A caller's permissions are the ceiling for every job in the called
+    # workflow, and GitHub validates that ceiling STATICALLY, when it creates the
+    # run — before this job's `if:` is evaluated, let alone before a step runs.
+    # e2e-tag.yaml's e2e job declares `checks: write` for its
+    # workflow_dispatch-only breakpoint, so even though workflow_call can never
+    # take that branch, omitting the grant here fails the whole tags.yaml run with
+    # "requesting 'checks: write', but is only allowed 'checks: none'". Not just
+    # rc cuts: the `if:` cannot gate a startup failure, so EVERY tag push — rc and
+    # stable, including the one finalize pushes to publish a release — would build
+    # nothing at all. hack/promote-gate-contract.bats pins the pair, because no CI
+    # lane exercises this file (it runs only on tag pushes).
+    permissions:
+      contents: read
+      checks: write
+    uses: ./.github/workflows/e2e-tag.yaml
+    with:
+      tag: ${{ github.ref_name }}
+
   generate-changelog:
     name: Generate Changelog
     # git + node + copilot CLI only — no docker, no repo toolchain: GitHub-hosted.

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -409,11 +409,22 @@ jobs:
           fetch-tags: true
           token: ${{ steps.app-token.outputs.token }}
 
-      # Check whether the changelog already exists on origin/main.
-      # The previous step checked out the tag commit, which never has the
-      # changelog (the changelog PR merges to main AFTER the tag is cut).
-      # Looking at origin/main is what the gate is supposed to do — skip
-      # generation on workflow reruns when the changelog has already merged.
+      # Two independent questions, and the answers select between three paths.
+      #
+      # `exists` — is the changelog already on origin/main? Then this whole job
+      # is a no-op. On a maintenance line that is the EXCEPTION: the promote PR
+      # merges into release-1.6, so the file it carried never touched main, and
+      # this is true only if something else put it there.
+      #
+      # `at_tag` — is it present in THIS checkout (the tag commit)? Under the
+      # promote flow it normally is, because the promote PR carried it onto
+      # release-1.6 and the stable tag sits on that merge commit. So this is the
+      # usual state on arrival: `exists` false, `at_tag` true, a reviewed and
+      # already-published changelog sitting right here — port it rather than
+      # regenerate.
+      #
+      # Only when both are false is there genuinely no changelog to publish, and
+      # only then does the AI run.
       - name: Check if changelog already exists
         id: check_changelog
         env:
@@ -428,19 +439,36 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
             echo "Changelog file $CHANGELOG_FILE does not exist on origin/main"
           fi
+          # Is the changelog present at the TAG (this checkout)? Under the promote
+          # flow it normally is: promote-rc.yaml commits it onto release-X.Y.Z and
+          # it reaches the tag via the merge commit. That PR targets the maintenance
+          # line, so the file lands on release-1.6 and never reaches main —
+          # `exists` above is false even though a reviewed, already-PUBLISHED
+          # changelog exists right here.
+          #
+          # Regenerating in that case would spend a second AI run and, once the
+          # backstop PR merged, update-releasenotes.yaml would overwrite the
+          # published release body with text nobody approved. Port the reviewed
+          # file verbatim instead; the AI is only for the genuinely-absent case.
+          if [ -s "$CHANGELOG_FILE" ]; then
+            echo "at_tag=true" >> $GITHUB_OUTPUT
+            echo "Changelog present at the tag — will port it to main verbatim, no regeneration."
+          else
+            echo "at_tag=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Setup Node.js
-        if: steps.check_changelog.outputs.exists == 'false'
+        if: steps.check_changelog.outputs.exists == 'false' && steps.check_changelog.outputs.at_tag == 'false'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
       - name: Install GitHub Copilot CLI
-        if: steps.check_changelog.outputs.exists == 'false'
+        if: steps.check_changelog.outputs.exists == 'false' && steps.check_changelog.outputs.at_tag == 'false'
         run: npm i -g @github/copilot
 
       - name: Generate changelog using AI
-        if: steps.check_changelog.outputs.exists == 'false'
+        if: steps.check_changelog.outputs.exists == 'false' && steps.check_changelog.outputs.at_tag == 'false'
         timeout-minutes: 30
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
@@ -462,12 +490,19 @@ jobs:
           CHANGELOG_FILE="docs/changelogs/v${VERSION}.md"
           CHANGELOG_BRANCH="changelog-v${VERSION}"
 
+          # Two ways the file can be here: ported verbatim from the tag commit
+          # (at_tag=true — the reviewed, already-published changelog reaching main
+          # for the first time), or freshly generated above. Either is valid.
           if [ ! -f "$CHANGELOG_FILE" ]; then
-            echo "::error::Changelog file $CHANGELOG_FILE was not produced by the Generate changelog using AI step"
+            echo "::error::Changelog file $CHANGELOG_FILE is absent — it was neither present at the tag nor produced by the Generate changelog using AI step"
             exit 1
           fi
-          if [ ! -s "$CHANGELOG_FILE" ]; then
-            echo "::error::Changelog file $CHANGELOG_FILE is empty"
+          # A ported file came from the tag and a generated one from a step allowed
+          # to fail, so neither has been checked here. update-releasenotes.yaml
+          # will push whatever this PR merges into the published release body, so a
+          # fragment must not get that far.
+          if ! REASON="$(hack/validate-changelog.sh "$CHANGELOG_FILE" "${VERSION}" 2>&1)"; then
+            echo "::error::Changelog file $CHANGELOG_FILE is not usable: ${REASON}"
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,8 @@ examples/backups/*/.bucket-info.env
 examples/backups/*/.sentinel.env
 examples/backups/*/.backup-name.env
 packages/core/platform/images/migrations/etcd-operator-crds/
+
+# CI scratch: the candidate-verification jobs check the trusted base ref here so
+# release tooling (the packages verifier and its library) is the pre-merge
+# version even when the checked-out tree predates it. Never committed.
+.release-tooling

--- a/hack/lib/promoted-packages.sh
+++ b/hack/lib/promoted-packages.sh
@@ -1,0 +1,25 @@
+# shellcheck shell=sh
+# Shared definitions for the stable-candidate packages artifact.
+#
+# Sourced by hack/promote-packages-artifact.sh, which publishes the candidate,
+# and hack/verify-promoted-packages.sh, which proves it. The publisher's whole
+# reason to inspect the pin at all is to make the verifier's refusal land at
+# dispatch time, before a registry write, two commits and a draft release exist
+# — so the two have to be testing the same thing. Copied constants would drift
+# apart silently and turn that dispatch-time refusal back into the late failure
+# it was added to remove; they live here instead.
+#
+# Not a general library: promotion is the only caller, and both halves run from
+# a `hack`-only sparse checkout of a trusted ref, so this file has to stay
+# inside hack/ next to them.
+
+# The one OCI repository a packages candidate may ever be published to or read
+# back from. Overridable only so the behavioural suites can point both halves
+# at a fixture registry; production never sets it.
+EXPECTED_PACKAGES_REPOSITORY="${EXPECTED_PACKAGES_REPOSITORY:-oci://ghcr.io/cozystack/cozystack/cozystack-packages}"
+
+# An immutable Flux OCI source pin, `digest=sha256:<64 lowercase hex>`. The
+# tag form Flux also accepts is exactly what promotion must neither publish nor
+# accept: a stable installer pinned by tag resolves to whatever that tag points
+# at later, which is how a stable install ends up serving rc content (#3477).
+PACKAGES_DIGEST_REF_PATTERN='^digest=sha256:[0-9a-f]{64}$'

--- a/hack/promote-gate-contract.bats
+++ b/hack/promote-gate-contract.bats
@@ -1,0 +1,269 @@
+#!/usr/bin/env bats
+
+# Contract for the halves of the rc-E2E promotion gate that live on THIS branch.
+# These tests intentionally pin executable/structural workflow lines, not prose:
+# a commented-out gate, job, or step must never satisfy the contract.
+#
+# Scope, and why it is narrower than main's copy of this file.
+#
+# The gate itself is not here. `Promote RC` is a workflow_dispatch, so it runs
+# from the ref the maintainer dispatches — main — and it is main's promote-rc.yaml
+# that composes the expected job name, walks the Actions API for evidence, and
+# refuses to promote without it. This branch's promote-rc.yaml predates all of
+# that and is deliberately left alone: porting it would drag in a `parse` job, a
+# `skip_e2e_gate` input, promote-time changelog and website-docs jobs, and the
+# `labeled` pull_request trigger those depend on. main's copy of this file pins
+# exactly those things, which is why it cannot be used verbatim here.
+#
+# What release-1.6 owns is the PRODUCER side of the same contract, and that is
+# what these tests pin:
+#
+#   * a tag push must actually run the full suite, under a job name whose
+#     rendered form is what the gate on main searches for. Workflows run from the
+#     ref they fire on, so only this file's tags.yaml can do that for an rc cut
+#     on this line;
+#   * the target base must carry the five files promote-rc.yaml's preflight
+#     demands before its first registry write, or the dispatch fails closed with
+#     "Target base 'release-1.6' lacks '<path>'";
+#   * the candidate verification in finalize must run before anything
+#     irreversible, because a guard that runs after the write-once stable tag
+#     exists cannot refuse it.
+#
+# No CI lane exercises tags.yaml (it runs only on tag pushes) and no lane
+# exercises finalize's ordering, which is why these are pinned mechanically here.
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
+PULL_REQUESTS="$REPO_ROOT/.github/workflows/pull-requests.yaml"
+TAGS="$REPO_ROOT/.github/workflows/tags.yaml"
+FINALIZE="$REPO_ROOT/.github/workflows/pull-requests-release.yaml"
+E2E_TAG="$REPO_ROOT/.github/workflows/e2e-tag.yaml"
+
+job_block() {
+  awk -v job="  $1:" '
+    $0 == job { inside = 1; next }
+    /^  [a-z0-9_-]+:$/ { inside = 0 }
+    inside' "$2"
+}
+
+# Comment-stripping filter for the pins below. POSIX `grep` only: the unit-test
+# runner has no ripgrep, and a missing filter used to be swallowed by `|| true`,
+# silently reducing every pin to "0 matches" instead of failing on the real
+# cause. grep exits 1 when nothing is selected (legitimate for an empty block)
+# and 2 on an actual error. Do not read the `rc` check below as what catches
+# that: code_lines is never the last stage of a pipeline in this file, so
+# ordinary (non-pipefail) pipe semantics discard whatever it itself returns,
+# and `hack/cozytest.sh`'s translator appends `return 0` to every line that is
+# exactly `}`, code_lines' closing brace included, making its own exit status
+# even less trustworthy as a signal. What catches a real grep error is the
+# OUTPUT, and only for one class of pin: the error empties code_lines' stream,
+# so a pin that requires something to be present in that stream fails on it. A
+# pin demanding an absence stays blind, because an exact count of zero is what
+# an emptied stream produces anyway, and what the pin was written to assert.
+code_lines() {
+  local rc=0
+  grep -v '^[[:space:]]*#' || rc=$?
+  [ "$rc" -le 1 ]
+}
+
+# First line number of a named step inside an already-extracted job block, in
+# code_lines' comment-stripped view. Top-level rather than nested inside a test
+# so its closing brace is the only one the runner's translator has to rewrite.
+step_line() {
+  printf '%s\n' "$2" | code_lines | grep -nF "      - name: $1" \
+    | awk -F: 'NR == 1 { print $1 }'
+}
+
+# ── the producer half of the rc-E2E gate ─────────────────────────────────────
+
+@test "an rc tag push calls the full-suite e2e workflow" {
+  [ -f "$E2E_TAG" ]
+
+  rc_e2e="$(job_block rc-e2e "$TAGS")"
+  [ -n "$rc_e2e" ]
+
+  printf '%s\n' "$rc_e2e" | code_lines | grep -qF 'uses: ./.github/workflows/e2e-tag.yaml'
+
+  # The tag under test must be the pushed ref. The gate correlates evidence by a
+  # job name that embeds the exact tag, so passing anything else here would
+  # produce a green run that no promotion can ever match to its rc.
+  printf '%s\n' "$rc_e2e" | code_lines | grep -qF 'tag: ${{ github.ref_name }}'
+
+  # rc tags only. A stable tag push must not re-run the suite, and alpha/beta use
+  # e2e-tag.yaml's manual dispatch.
+  printf '%s\n' "$rc_e2e" | code_lines | grep -qF "contains(github.ref_name, '-rc.')"
+}
+
+@test "rc-e2e grants the ceiling e2e-tag.yaml's jobs declare" {
+  rc_e2e="$(job_block rc-e2e "$TAGS")"
+  [ -n "$rc_e2e" ]
+
+  # Every permission any job in the called workflow declares must be granted by
+  # the caller. GitHub validates that ceiling STATICALLY, when it creates the run,
+  # before this job's `if:` is evaluated — so a missing grant does not skip the
+  # rc lane, it fails the whole tags.yaml run for EVERY tag push, rc and stable
+  # alike, building nothing at all. Assert the pair in both files, so removing
+  # either side surfaces here instead of at the next release.
+  e2e_job="$(job_block e2e "$E2E_TAG")"
+  [ -n "$e2e_job" ]
+  printf '%s\n' "$e2e_job" | code_lines | grep -qF 'checks: write'
+
+  printf '%s\n' "$rc_e2e" | code_lines | grep -qF 'contents: read'
+  printf '%s\n' "$rc_e2e" | code_lines | grep -qF 'checks: write'
+}
+
+@test "the e2e job name is the exact string the promote gate searches for" {
+  # main's promote-rc.yaml builds `E2E ${rcTag} (full suite)` and matches a job
+  # whose name either equals it or ends in " / " plus it (the second form is how
+  # GitHub renders a called workflow's job: "<caller job> / <called job>"). This
+  # branch supplies the called half, so the literal below is the contract — a
+  # rename on either side makes the gate fail closed and blocks promotion until
+  # someone notices. Cheap to pin, expensive to debug.
+  #
+  # -F is not optional: the pattern contains `${{`, and as a basic regular
+  # expression that silently matches nothing rather than erroring, which would
+  # turn this pin into a test that passes by finding its own subject absent.
+  count="$(code_lines < "$E2E_TAG" | grep -cF 'name: E2E ${{ inputs.tag }} (full suite)' || true)"
+  [ "${count:-0}" -eq 1 ]
+}
+
+@test "the tag-push e2e lane runs the full chainsaw suite it claims to" {
+  e2e_job="$(job_block e2e "$E2E_TAG")"
+  [ -n "$e2e_job" ]
+
+  # Empty CHAINSAW_SUITES is the testing Makefile's full-suite mode. A tag has no
+  # PR diff to scope with Test Impact Analysis, so a narrowed suite here would
+  # make the gate's evidence weaker than its name advertises.
+  printf '%s\n' "$e2e_job" | code_lines | grep -qF 'test-chainsaw CHAINSAW_SUITES=""'
+
+  # The target and the sandbox binary the step above depends on.
+  grep -qE '^test-chainsaw' "$REPO_ROOT/packages/core/testing/Makefile"
+  grep -qF 'CHAINSAW_VERSION' "$REPO_ROOT/packages/core/testing/images/e2e-sandbox/Dockerfile"
+}
+
+# ── the candidate-aware promotion pipeline this base must carry ──────────────
+
+@test "the base carries every file promote-rc.yaml's preflight demands" {
+  # promote-rc.yaml resolves the target base (release-X.Y when it exists) and
+  # reads each path below off it, refusing to promote unless the content contains
+  # the paired marker. It fails closed BEFORE the first registry write, so a base
+  # missing any of these cannot be promoted at all — which is exactly the state
+  # this branch was in. Keep the list in lockstep with the requiredBaseFiles array
+  # in main's promote-rc.yaml.
+  grep -qF 'verify-release-candidate:' "$PULL_REQUESTS"
+  grep -qF 'Verify stable packages candidate' "$FINALIZE"
+  grep -qF 'EXPECTED_PACKAGES_REPOSITORY' "$REPO_ROOT/hack/verify-promoted-packages.sh"
+  grep -qF 'collect_image_refs()' "$REPO_ROOT/hack/lib/image-refs.sh"
+  grep -qF 'PACKAGES_DIGEST_REF_PATTERN' "$REPO_ROOT/hack/lib/promoted-packages.sh"
+
+  # The verifier sources both libraries by path relative to itself. A base
+  # carrying the script without them fails at the PR gate and again at finalize,
+  # after the candidate, the staging branch and the draft release already exist.
+  [ -x "$REPO_ROOT/hack/verify-promoted-packages.sh" ]
+  [ -f "$REPO_ROOT/hack/lib/promoted-packages.sh" ]
+  [ -f "$REPO_ROOT/hack/lib/image-refs.sh" ]
+}
+
+@test "verify-release-candidate fires on the promote PR without needing a label" {
+  block="$(job_block verify-release-candidate "$PULL_REQUESTS")"
+  [ -n "$block" ]
+
+  # This branch's on.pull_request.types has no `labeled` event, and the promote
+  # PR's `release` label is applied a moment AFTER the PR opens, so the `opened`
+  # payload carries no labels at all. A label-keyed guard would therefore never
+  # fire here. Pin the author + head-branch predicate that does, and pin the
+  # absence of the label dependency so nobody "restores" it from main and
+  # silently switches the job off.
+  printf '%s\n' "$block" | code_lines | grep -qF "github.event.pull_request.user.login == 'cozystack-ci[bot]'"
+  printf '%s\n' "$block" | code_lines | grep -qF "startsWith(github.head_ref, 'release-')"
+
+  count="$(printf '%s\n' "$block" | code_lines | grep -cF "contains(github.event.pull_request.labels.*.name, 'release')" || true)"
+  [ "${count:-0}" -eq 0 ]
+
+  # The verifier must come from the trusted base, not from the PR's own tree: a
+  # promote PR must not be able to weaken the guard that judges it.
+  printf '%s\n' "$block" | code_lines | grep -qF 'ref: ${{ github.event.pull_request.base.sha }}'
+  printf '%s\n' "$block" | code_lines | grep -qF '.release-tooling/hack/verify-promoted-packages.sh'
+}
+
+@test "the candidate verification runs before every irreversible finalize step" {
+  block="$(job_block finalize "$FINALIZE")"
+  [ -n "$block" ]
+
+  verify="$(step_line 'Verify stable packages candidate' "$block")"
+  [ -n "$verify" ]
+
+  # Each of these creates or moves a name that cannot be taken back: the
+  # write-once stable git tag, the API submodule tag, the published release, the
+  # stable image tags (and :latest), and the stable installer chart. The
+  # verification is only a gate if it precedes all of them.
+  tag_step="$(step_line 'Create tag on merge commit (write-once)' "$block")"
+  [ -n "$tag_step" ]
+  [ "$verify" -lt "$tag_step" ]
+
+  submodule_step="$(step_line 'Tag API submodule (write-once)' "$block")"
+  [ -n "$submodule_step" ]
+  [ "$verify" -lt "$submodule_step" ]
+
+  publish_step="$(step_line 'Publish draft release' "$block")"
+  [ -n "$publish_step" ]
+  [ "$verify" -lt "$publish_step" ]
+
+  retag_step="$(step_line 'Retag rc images to stable' "$block")"
+  [ -n "$retag_step" ]
+  [ "$verify" -lt "$retag_step" ]
+
+  chart_step="$(step_line 'Publish stable cozy-installer chart' "$block")"
+  [ -n "$chart_step" ]
+  [ "$verify" -lt "$chart_step" ]
+
+  # The toolchain and the registry login the verification needs must precede it
+  # too. They used to sit after "Publish draft release"; moving the verification
+  # up without them would make it fail on a missing `flux` instead of verifying.
+  toolchain_step="$(step_line 'Set up promotion toolchain (flux, skopeo, yq, helm)' "$block")"
+  [ -n "$toolchain_step" ]
+  [ "$toolchain_step" -lt "$verify" ]
+
+  login_step="$(step_line 'Login to registry (GHCR)' "$block")"
+  [ -n "$login_step" ]
+  [ "$login_step" -lt "$verify" ]
+
+  tooling_step="$(step_line 'Checkout release tooling from base' "$block")"
+  [ -n "$tooling_step" ]
+  [ "$tooling_step" -lt "$verify" ]
+}
+
+@test "finalize checkout does not persist credentials so the app-token tag push triggers tags.yaml" {
+  block="$(job_block finalize "$FINALIZE")"
+  [ -n "$block" ]
+  checkout="$(printf '%s\n' "$block" | awk '
+    /^      - name: Checkout repo$/ { inside = 1; next }
+    /^      - name: / { inside = 0 }
+    inside')"
+  [ -n "$checkout" ]
+
+  # The one-line root-cause fix. Without persist-credentials:false the checkout
+  # persists GITHUB_TOKEN as http.extraheader, which silently defeats the app token
+  # each later `git remote set-url` injects onto the tag pushes — and a
+  # GITHUB_TOKEN-authenticated push creates no workflow run (anti-recursion), so
+  # tags.yaml's stable-tag backstops never fire (v1.6.0's tag never triggered it).
+  count="$(printf '%s\n' "$checkout" | code_lines | grep -cF 'persist-credentials: false' || true)"
+  [ "${count:-0}" -eq 1 ]
+}
+
+# ── the tag-time changelog backstop ──────────────────────────────────────────
+
+@test "the tag-time changelog is validated and ported rather than regenerated" {
+  block="$(job_block generate-changelog "$TAGS")"
+  [ -n "$block" ]
+
+  # The promote PR merges into release-1.6, so its reviewed changelog never
+  # reaches main and `exists` alone reads as "absent". at_tag is what stops a
+  # second AI run from overwriting an already-published release body.
+  printf '%s\n' "$block" | code_lines | grep -qF 'at_tag=true'
+  printf '%s\n' "$block" | code_lines | grep -qF "steps.check_changelog.outputs.at_tag == 'false'"
+
+  # Neither a ported nor a generated file has been checked at this point, and the
+  # generating step is allowed to fail, so a truncated fragment must not pass.
+  printf '%s\n' "$block" | code_lines | grep -qF 'hack/validate-changelog.sh'
+  [ -x "$REPO_ROOT/hack/validate-changelog.sh" ]
+}

--- a/hack/validate-changelog.sh
+++ b/hack/validate-changelog.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Usage: hack/validate-changelog.sh <changelog-file> <version-without-v>
+#
+# Decides whether a changelog file is publishable as a GitHub Release body.
+#
+# promote-rc.yaml lets the AI generation step fail (a Copilot outage must never
+# block a release), which means a run can die mid-stream and leave a fragment
+# behind. Without this check that fragment would be committed, advertised as a
+# valid changelog in the promote PR body, and published verbatim by finalize as
+# the release notes — worse than having no changelog, because nobody is told.
+#
+# The assertions are deliberately narrow: only invariants every shipped changelog
+# in docs/changelogs/ actually satisfies. Two forms exist and both are valid —
+# minor releases use `# Cozystack vX.Y.Z`, patch releases use `# vX.Y.Z (date)` —
+# so the header check accepts either. There is deliberately NO line-count floor:
+# v1.5.1 is a complete, shipped, 19-line patch changelog, and a floor set above
+# it would reject good output and mislabel it as a generation failure.
+#
+# The version is checked into the header, the release-link comment and the
+# compare link, so a changelog generated for the wrong version (an rc string, or
+# a stale version carried over from a retry) is caught rather than published.
+#
+# Exit 0 = publishable. Exit 1 = not publishable, with the reason on stderr.
+
+set -eu
+
+CL="${1:?usage: validate-changelog.sh <file> <version>}"
+VERSION="${2:?usage: validate-changelog.sh <file> <version>}"
+
+fail() {
+  echo "$1" >&2
+  exit 1
+}
+
+[ -f "$CL" ] || fail "file absent: $CL"
+[ -s "$CL" ] || fail "file empty: $CL"
+grep -q '[^[:space:]]' "$CL" || fail "file is only whitespace: $CL"
+
+# Both header conventions. \b is not portable in POSIX grep -E, so anchor on
+# "end of line or a non-version character" instead: that keeps v1.5.1 from
+# satisfying a check for v1.5.11.
+grep -qE "^# (Cozystack )?v${VERSION}([^0-9.]|\$)" "$CL" \
+  || fail "missing an H1 for v${VERSION}: expected '# Cozystack v${VERSION}' (minor) or '# v${VERSION} (<date>)' (patch)"
+
+# Leading HTML comment pointing at the release. Present in every shipped
+# changelog and the first thing a truncated write would still have, so on its
+# own it is weak — it is the version check here that earns its keep.
+grep -qF "releases/tag/v${VERSION}" "$CL" \
+  || fail "missing the release-link comment for v${VERSION}"
+
+# A truncated stream loses the tail, so assert something that only exists at the
+# end. The compare link must also name this version, catching a changelog
+# generated against the rc tag or a stale version.
+grep -qE "compare/.*\.\.\.v${VERSION}([^0-9.]|\$)" "$CL" \
+  || fail "missing the 'Full Changelog' compare link ending in v${VERSION} (likely truncated, or generated for the wrong version)"
+
+# At least one section. Distinguishes a real changelog from a header plus a
+# stub line, without assuming which sections a given release happens to have.
+grep -qE '^## ' "$CL" \
+  || fail "no '## ' sections — not a complete changelog"
+
+echo "OK: $CL is publishable as the v${VERSION} release body ($(wc -l < "$CL" | tr -d ' ') lines)"

--- a/hack/verify-promoted-packages.sh
+++ b/hack/verify-promoted-packages.sh
@@ -1,0 +1,230 @@
+#!/bin/sh
+# Verify that the packages artifact pinned by a stable promotion is exactly the
+# packages tree in the merge commit, apart from the artifact's impossible
+# self-reference. This runs before finalize creates any stable git/release tag.
+#
+# Usage: hack/verify-promoted-packages.sh <stable-version> [root]
+#   <stable-version>  X.Y.Z (without a leading v)
+#   [root]            release packages tree; defaults to packages
+#
+# Environment:
+#   EXPECTED_PACKAGES_REPOSITORY  exact trusted OCI repository; defaults to
+#                                 the public Cozystack release repository
+#   VERIFY_PACKAGES_WORKDIR       caller-owned work directory; when set, the
+#                                 verifier neither creates nor removes it
+set -eu
+
+STABLE_VERSION="${1:?usage: verify-promoted-packages.sh <stable-version> [root]}"
+ROOT="${2:-packages}"
+
+# EXPECTED_PACKAGES_REPOSITORY and PACKAGES_DIGEST_REF_PATTERN, shared with the
+# publisher so its dispatch-time preflight cannot drift from this guard.
+# shellcheck source=hack/lib/promoted-packages.sh
+. "$(dirname "$0")/lib/promoted-packages.sh"
+
+printf '%s\n' "$STABLE_VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  || { echo "stable-version '$STABLE_VERSION' must match X.Y.Z" >&2; exit 1; }
+[ -d "$ROOT" ] || { echo "root '$ROOT' is not a directory" >&2; exit 1; }
+VALUES="$ROOT/core/installer/values.yaml"
+[ -f "$VALUES" ] || { echo "root '$ROOT' has no core/installer/values.yaml" >&2; exit 1; }
+
+command -v flux >/dev/null || { echo "flux is required" >&2; exit 1; }
+command -v yq >/dev/null   || { echo "yq (mikefarah) is required" >&2; exit 1; }
+yq --version 2>&1 | grep -q mikefarah \
+  || { echo "yq (mikefarah) is required" >&2; exit 1; }
+
+source_url="$(yq -e -r '.cozystackOperator.platformSourceUrl' "$VALUES")"
+source_ref="$(yq -e -r '.cozystackOperator.platformSourceRef' "$VALUES")"
+[ "$source_url" = "$EXPECTED_PACKAGES_REPOSITORY" ] \
+  || { echo "platformSourceUrl '$source_url' must equal trusted repository '$EXPECTED_PACKAGES_REPOSITORY'" >&2; exit 1; }
+printf '%s\n' "$source_ref" | grep -Eq "$PACKAGES_DIGEST_REF_PATTERN" \
+  || { echo "platformSourceRef '$source_ref' is not an immutable digest" >&2; exit 1; }
+
+if [ -n "${VERIFY_PACKAGES_WORKDIR:-}" ]; then
+  tmp="$VERIFY_PACKAGES_WORKDIR"
+  [ ! -e "$tmp" ] || { echo "VERIFY_PACKAGES_WORKDIR '$tmp' already exists" >&2; exit 1; }
+  mkdir -p "$tmp"
+else
+  tmp="$(mktemp -d)"
+  cleanup() {
+    case "$tmp" in
+      "${TMPDIR:-/tmp}"/*) rm -r -- "$tmp" ;;
+      *) echo "refusing to clean unexpected work directory '$tmp'" >&2 ;;
+    esac
+  }
+  trap cleanup EXIT HUP INT TERM
+fi
+artifact="$tmp/artifact"
+mkdir -p "$artifact"
+flux pull artifact "${source_url}@${source_ref#digest=}" --output "$artifact"
+
+ARTIFACT_VALUES="$artifact/core/installer/values.yaml"
+[ -f "$ARTIFACT_VALUES" ] \
+  || { echo "promoted artifact has no core/installer/values.yaml" >&2; exit 1; }
+
+# The candidate was pushed before its own digest was written into installer
+# values, so its embedded platformSourceRef is the immutable rc artifact it was
+# derived from. Pull that baseline now; comparing its normalized refs below is
+# what proves promotion changed tag strings rather than container bytes.
+rc_source_url="$(yq -e -r '.cozystackOperator.platformSourceUrl' "$ARTIFACT_VALUES")"
+rc_source_ref="$(yq -e -r '.cozystackOperator.platformSourceRef' "$ARTIFACT_VALUES")"
+[ "$rc_source_url" = "$EXPECTED_PACKAGES_REPOSITORY" ] \
+  || { echo "candidate's original platformSourceUrl '$rc_source_url' must equal trusted repository '$EXPECTED_PACKAGES_REPOSITORY'" >&2; exit 1; }
+printf '%s\n' "$rc_source_ref" | grep -Eq "$PACKAGES_DIGEST_REF_PATTERN" \
+  || { echo "candidate's original platformSourceRef '$rc_source_ref' is not an immutable digest" >&2; exit 1; }
+
+# Promotion must have rewritten every version-line image tag in the artifact,
+# not merely in git. Keep the match scoped to image-reference positions so an
+# unrelated dependency version or historical prose cannot abort a release.
+stable_esc="$(printf '%s' "$STABLE_VERSION" | sed 's/\./\\./g')"
+scan_err="$tmp/rc-scan-err"
+leftovers="$(find "$artifact" -type f ! -path '*/charts/*' ! -name '*.md' \
+  -exec grep -lE -- \
+  "(image|repository|tag)[\"']?:[^#]*${stable_esc}-rc\.[0-9]+|${stable_esc}-rc\.[0-9]+@sha256:" \
+  {} + 2>"$scan_err" || true)"
+# An unreadable file is NOT "a file with no match" — the silent-skip shape
+# hack/promote-rewrite-tags.sh refuses by name, and the `|| true` here has to
+# stay because `-exec … +` reports the legitimate "nothing matched" as failure
+# too. That leaves grep's own diagnostics as the only signal that a file went
+# unscanned, so treat any of them as a failed scan. Defence in depth: the
+# per-file `cmp` below would catch a leftover rc string anyway, since the
+# release tree has none. Cheap enough to not depend on that.
+if [ -s "$scan_err" ]; then
+  echo "::error::could not scan the promoted artifact for rc image references:" >&2
+  cat "$scan_err" >&2
+  exit 1
+fi
+if [ -n "$leftovers" ]; then
+  echo "::error::promoted packages artifact still carries rc image references:" >&2
+  printf '%s\n' "$leftovers" >&2
+  exit 1
+fi
+
+# Flux's default archive excludes these file classes and omits symlinks rather
+# than following or storing them. Match that established RC artifact view here;
+# changing it would be a separate packages-format migration. .build-revision is
+# an ignored build nonce generated only by the rc image-packages target; it is
+# not consumed at runtime. The installer values are compared separately below
+# after normalizing the one impossible self-reference.
+#
+# This list is a RESTATEMENT of flux's built-in `excludeOCI` set, not a
+# derivation of it — the CLI does not expose it — so it is coupled to a flux
+# version. That version is pinned as FLUX_VERSION (2.8.6) in all three workflow
+# steps that install the toolchain, and the promote-packages contract test pins
+# that they agree. If flux ever changes the set, the symptom is a "contain
+# different files" failure naming the newly included or excluded class, which
+# is loud and lands before any stable name exists; the fix is to update this
+# list and FLUX_VERSION together, in that order.
+artifact_entries() {
+  (
+    cd "$1"
+    find . -type f \
+      ! -name '.gitignore' \
+      ! -name '.gitmodules' \
+      ! -name '.gitattributes' \
+      ! -name '*.jpg' \
+      ! -name '*.jpeg' \
+      ! -name '*.gif' \
+      ! -name '*.png' \
+      ! -name '*.wmv' \
+      ! -name '*.flv' \
+      ! -name '*.tar.gz' \
+      ! -name '*.zip' \
+      ! -name '.build-revision' \
+      ! -path './core/installer/values.yaml' \
+      | LC_ALL=C sort
+  )
+}
+
+artifact_entries "$artifact" > "$tmp/artifact-files"
+artifact_entries "$ROOT" > "$tmp/release-files"
+if ! cmp -s "$tmp/artifact-files" "$tmp/release-files"; then
+  echo "::error::promoted artifact and release tree contain different files:" >&2
+  diff -u "$tmp/artifact-files" "$tmp/release-files" >&2 || true
+  exit 1
+fi
+
+while IFS= read -r rel; do
+  rel="${rel#./}"
+  artifact_file="$artifact/$rel"
+  release_file="$ROOT/$rel"
+  if ! cmp -s "$artifact_file" "$release_file"; then
+    echo "::error::promoted artifact file differs from release tree: $rel" >&2
+    exit 1
+  fi
+  # Resolve each side to a value first. Written as one `&&`/`||` chain this
+  # reads like a symmetric difference and is not one: POSIX gives the two
+  # operators equal precedence and left associativity, so `A && B || C && D`
+  # groups as `((A && B) || C) && D` and the candidate-executable direction —
+  # the one that makes content executable inside the artifact the operator
+  # installs — is accepted silently.
+  if [ -x "$artifact_file" ]; then artifact_exec=1; else artifact_exec=0; fi
+  if [ -x "$release_file" ]; then release_exec=1; else release_exec=0; fi
+  if [ "$artifact_exec" -ne "$release_exec" ]; then
+    echo "::error::promoted artifact executable bit differs from release tree: $rel" >&2
+    exit 1
+  fi
+done < "$tmp/artifact-files"
+
+normalize_installer() {
+  sed -E 's|^([[:space:]]*platformSourceRef:[[:space:]]*).*$|\1digest=sha256:SELF|' "$1"
+}
+normalize_installer "$ARTIFACT_VALUES" > "$tmp/artifact-installer"
+normalize_installer "$VALUES" > "$tmp/release-installer"
+if ! cmp -s "$tmp/artifact-installer" "$tmp/release-installer"; then
+  echo "::error::promoted artifact installer values differ beyond their self-reference" >&2
+  diff -u "$tmp/artifact-installer" "$tmp/release-installer" >&2 || true
+  exit 1
+fi
+
+# Compare normalized repo@digest sets against the rc artifact as an explicit
+# proof that promotion did not change any container bytes. The packages
+# artifact's own digest is omitted because that is the intentional declarative
+# content change this verification is proving.
+# shellcheck source=hack/lib/image-refs.sh
+. "$(dirname "$0")/lib/image-refs.sh"
+normalized_refs() {
+  # Collect into a file rather than piping straight into the loop. As the head
+  # of a pipeline the collector's exit status is thrown away — the pipeline
+  # reports `sort -u`'s, POSIX sh has no `pipefail` and this script has to stay
+  # POSIX — so `set -e` never sees it and a failed or truncated collection
+  # becomes a smaller set that the comparison below happily matches. Same
+  # fail-open class as the rc-reference scan above, on the one guard that is
+  # supposed to prove the container bytes did not move across promotion.
+  _nr_raw="$tmp/refs-raw"
+  collect_image_refs "$1" > "$_nr_raw"
+  # A collection that comes back empty is that same failure wearing a zero exit
+  # status: two empty sets compare equal, so the proof passes having examined
+  # nothing at all. Every packages tree carries image references — none means
+  # the collector understood nothing it was given, not that there was nothing
+  # to find.
+  [ -s "$_nr_raw" ] \
+    || { echo "::error::collected no image references from '$1'; cannot prove the container digests are unchanged" >&2; exit 1; }
+  while IFS= read -r raw; do
+    [ -n "$raw" ] || continue
+    without_digest="${raw%@*}"
+    digest="${raw##*@}"
+    image="${without_digest##*/}"
+    if [ "$without_digest" = "$image" ]; then
+      repo="${image%:*}"
+    else
+      repo="${without_digest%/*}/${image%:*}"
+    fi
+    case "$repo" in
+      */cozystack-packages) continue ;;
+    esac
+    printf '%s@%s\n' "$repo" "$digest"
+  done < "$_nr_raw" | LC_ALL=C sort -u
+}
+rc_artifact="$tmp/rc-artifact"
+mkdir -p "$rc_artifact"
+flux pull artifact "${rc_source_url}@${rc_source_ref#digest=}" --output "$rc_artifact"
+normalized_refs "$rc_artifact" > "$tmp/rc-refs"
+normalized_refs "$artifact" > "$tmp/artifact-refs"
+if ! cmp -s "$tmp/rc-refs" "$tmp/artifact-refs"; then
+  echo "::error::promotion changed the container repository/digest set" >&2
+  diff -u "$tmp/rc-refs" "$tmp/artifact-refs" >&2 || true
+  exit 1
+fi
+
+echo "Verified ${source_url}@${source_ref#digest=}: stable tags, identical package tree, and the rc artifact's container digests."

--- a/hack/verify-promoted-packages_test.bats
+++ b/hack/verify-promoted-packages_test.bats
@@ -1,0 +1,367 @@
+#!/usr/bin/env bats
+# Behavioural tests for the pre-publication packages artifact verification.
+# Run with: hack/cozytest.sh hack/verify-promoted-packages_test.bats
+
+_test_workspace() {
+  if [ -n "${BATS_TEST_TMPDIR:-}" ]; then
+    printf '%s\n' "$BATS_TEST_TMPDIR"
+  else
+    printf '%s\n' "${tmp:?cozytest workspace is missing}"
+  fi
+}
+
+_make_verify_fixture() {
+  t="$1"
+  mkdir -p "$t/bin" "$t/release/core/installer" "$t/release/system/dashboard"
+  mkdir -p "$t/artifact/core/installer" "$t/artifact/system/dashboard"
+  mkdir -p "$t/rc-artifact/core/installer" "$t/rc-artifact/system/dashboard"
+  cat > "$t/bin/flux" <<'EOF'
+#!/bin/sh
+set -eu
+[ "$1" = "pull" ]
+[ "$2" = "artifact" ]
+shift 2
+ref="$1"
+printf '%s\n' "$@" >> "$MOCK_FLUX_LOG"
+out=""
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "--output" ]; then
+    out="$2"
+    shift 2
+  else
+    shift
+  fi
+done
+[ -n "$out" ]
+case "$ref" in
+  *@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb)
+    src="$MOCK_ARTIFACT"
+    ;;
+  *@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+    src="$MOCK_RC_ARTIFACT"
+    ;;
+  *)
+    echo "unexpected artifact ref: $ref" >&2
+    exit 1
+    ;;
+esac
+cp -R "$src"/. "$out"/
+EOF
+  chmod +x "$t/bin/flux"
+  cat > "$t/release/core/installer/values.yaml" <<'EOF'
+cozystackOperator:
+  platformSourceUrl: oci://ghcr.io/cozystack/cozystack/cozystack-packages
+  platformSourceRef: digest=sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+EOF
+  cat > "$t/artifact/core/installer/values.yaml" <<'EOF'
+cozystackOperator:
+  platformSourceUrl: oci://ghcr.io/cozystack/cozystack/cozystack-packages
+  platformSourceRef: digest=sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+EOF
+  image='ghcr.io/cozystack/cozystack/cozystack-ui:v9.9.9@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc'
+  printf 'console:\n  image: %s\n' "$image" > "$t/release/system/dashboard/values.yaml"
+  printf 'console:\n  image: %s\n' "$image" > "$t/artifact/system/dashboard/values.yaml"
+  cp "$t/artifact/core/installer/values.yaml" "$t/rc-artifact/core/installer/values.yaml"
+  printf 'console:\n  image: %s\n' \
+    'ghcr.io/cozystack/cozystack/cozystack-ui:v9.9.9-rc.3@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc' \
+    > "$t/rc-artifact/system/dashboard/values.yaml"
+  # Flux's established packages archive omits symlinks. The verifier must
+  # compare against that archive view rather than demanding this node back.
+  ln -s values.yaml "$t/release/system/dashboard/values-link.yaml"
+}
+
+@test "accepts an identical candidate with only the self-reference changed" {
+  tmp="$(_test_workspace)/fixture"
+  _make_verify_fixture "$tmp"
+
+  rc=0
+  MOCK_ARTIFACT="$tmp/artifact" MOCK_RC_ARTIFACT="$tmp/rc-artifact" MOCK_FLUX_LOG="$tmp/flux.log" \
+    VERIFY_PACKAGES_WORKDIR="$tmp/work" \
+    PATH="$tmp/bin:$PATH" \
+    hack/verify-promoted-packages.sh 9.9.9 "$tmp/release" \
+    > "$tmp/out" 2> "$tmp/err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "verification exited $rc" >&2
+    cat "$tmp/err" >&2
+    return "$rc"
+  fi
+
+  grep -qx 'oci://ghcr.io/cozystack/cozystack/cozystack-packages@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' "$tmp/flux.log"
+  grep -q "stable tags, identical package tree, and the rc artifact's container digests" "$tmp/out"
+}
+
+@test "rejects an rc image reference inside the candidate" {
+  tmp="$(_test_workspace)/fixture"
+  _make_verify_fixture "$tmp"
+  sed 's/:v9.9.9@/:v9.9.9-rc.3@/' "$tmp/artifact/system/dashboard/values.yaml" \
+    > "$tmp/rc-values.yaml"
+  mv "$tmp/rc-values.yaml" "$tmp/artifact/system/dashboard/values.yaml"
+
+  rc=0
+  MOCK_ARTIFACT="$tmp/artifact" MOCK_RC_ARTIFACT="$tmp/rc-artifact" MOCK_FLUX_LOG="$tmp/flux.log" \
+    VERIFY_PACKAGES_WORKDIR="$tmp/work" \
+    PATH="$tmp/bin:$PATH" \
+    hack/verify-promoted-packages.sh 9.9.9 "$tmp/release" \
+    > "$tmp/out" 2> "$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q 'still carries rc image references' "$tmp/err"
+}
+
+# The scan's `|| true` is not optional — `find … -exec … +` reports the
+# legitimate "nothing matched" as a failure too — which leaves grep's own
+# diagnostics as the only remaining signal that a file went unscanned. Produce
+# that signal the way an unreadable file produces it, without depending on the
+# runner's uid: root reads a chmod 000 fixture anyway, so a permissions-based
+# test would quietly stop testing anything wherever the suite runs as root.
+# A grep on PATH answering the scan's invocation the way the real one answers a
+# file it cannot open is the same injection idiom as _tooling_with_collector
+# below, one dependency further out.
+_grep_failing_the_rc_scan() {
+  real_grep="$(command -v grep)"
+  cat > "$1/grep" <<EOF
+#!/bin/sh
+# Only the scan, which find invokes as: grep -lE -- <pattern> <files...>. Every
+# other grep in the verifier, and in the collector it sources, must behave.
+if [ "\$1" = "-lE" ]; then
+  for _a in "\$@"; do _last="\$_a"; done
+  echo "grep: \$_last: Permission denied" >&2
+  exit 2
+fi
+exec $real_grep "\$@"
+EOF
+  chmod +x "$1/grep"
+}
+
+@test "refuses when the rc-reference scan could not read a file" {
+  tmp="$(_test_workspace)/fixture"
+  _make_verify_fixture "$tmp"
+  _grep_failing_the_rc_scan "$tmp/bin"
+
+  rc=0
+  MOCK_ARTIFACT="$tmp/artifact" MOCK_RC_ARTIFACT="$tmp/rc-artifact" MOCK_FLUX_LOG="$tmp/flux.log" \
+    VERIFY_PACKAGES_WORKDIR="$tmp/work" \
+    PATH="$tmp/bin:$PATH" \
+    hack/verify-promoted-packages.sh 9.9.9 "$tmp/release" \
+    > "$tmp/out" 2> "$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q 'could not scan the promoted artifact for rc image references' "$tmp/err"
+  # The diagnostic itself has to reach the log, or the failure names no file and
+  # nobody can tell which one went unscanned.
+  grep -q 'Permission denied' "$tmp/err"
+  # …and the verifier did not go on to report a proof it skipped part of.
+  # Counted rather than negated with `!`, which suppresses errexit and would
+  # pass regardless.
+  count="$(grep -c 'identical package tree' "$tmp/out" || true)"
+  [ "${count:-0}" -eq 0 ]
+}
+
+# The threat this whole job exists for: someone edits packages/ on the release
+# PR after promotion published the candidate, so the artifact the installer
+# resolves is no longer the tree that was reviewed and tagged. A file present on
+# BOTH sides with different bytes is the shape that takes, and only the per-file
+# comparison catches it — the file-set compare sees the same names, the installer
+# compare reads one file, and the rc-refs compare never looks at the release tree
+# at all. The edit here is deliberately not an image reference, so no other leg
+# can fire and claim the credit.
+@test "rejects a file whose content changed on only one side" {
+  tmp="$(_test_workspace)/fixture"
+  _make_verify_fixture "$tmp"
+  printf '  replicas: 3\n' >> "$tmp/release/system/dashboard/values.yaml"
+
+  rc=0
+  MOCK_ARTIFACT="$tmp/artifact" MOCK_RC_ARTIFACT="$tmp/rc-artifact" MOCK_FLUX_LOG="$tmp/flux.log" \
+    VERIFY_PACKAGES_WORKDIR="$tmp/work" \
+    PATH="$tmp/bin:$PATH" \
+    hack/verify-promoted-packages.sh 9.9.9 "$tmp/release" \
+    > "$tmp/out" 2> "$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q 'promoted artifact file differs from release tree: system/dashboard/values.yaml' "$tmp/err"
+}
+
+@test "rejects package content changed after the candidate was published" {
+  tmp="$(_test_workspace)/fixture"
+  _make_verify_fixture "$tmp"
+  printf 'changed: true\n' > "$tmp/release/system/dashboard/extra.yaml"
+
+  rc=0
+  MOCK_ARTIFACT="$tmp/artifact" MOCK_RC_ARTIFACT="$tmp/rc-artifact" MOCK_FLUX_LOG="$tmp/flux.log" \
+    VERIFY_PACKAGES_WORKDIR="$tmp/work" \
+    PATH="$tmp/bin:$PATH" \
+    hack/verify-promoted-packages.sh 9.9.9 "$tmp/release" \
+    > "$tmp/out" 2> "$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q 'contain different files' "$tmp/err"
+}
+
+@test "rejects a candidate outside the trusted release repository" {
+  tmp="$(_test_workspace)/fixture"
+  _make_verify_fixture "$tmp"
+  sed 's#oci://ghcr.io/cozystack/cozystack/cozystack-packages#oci://example.invalid/cozystack-packages#' \
+    "$tmp/release/core/installer/values.yaml" > "$tmp/untrusted-values.yaml"
+  mv "$tmp/untrusted-values.yaml" "$tmp/release/core/installer/values.yaml"
+
+  rc=0
+  MOCK_ARTIFACT="$tmp/artifact" MOCK_RC_ARTIFACT="$tmp/rc-artifact" MOCK_FLUX_LOG="$tmp/flux.log" \
+    VERIFY_PACKAGES_WORKDIR="$tmp/work" \
+    PATH="$tmp/bin:$PATH" \
+    hack/verify-promoted-packages.sh 9.9.9 "$tmp/release" \
+    > "$tmp/out" 2> "$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q 'must equal trusted repository' "$tmp/err"
+  [ ! -s "$tmp/flux.log" ]
+}
+
+@test "rejects an embedded rc baseline outside the trusted release repository" {
+  tmp="$(_test_workspace)/fixture"
+  _make_verify_fixture "$tmp"
+  sed 's#oci://ghcr.io/cozystack/cozystack/cozystack-packages#oci://example.invalid/cozystack-packages#' \
+    "$tmp/artifact/core/installer/values.yaml" > "$tmp/untrusted-values.yaml"
+  mv "$tmp/untrusted-values.yaml" "$tmp/artifact/core/installer/values.yaml"
+
+  rc=0
+  MOCK_ARTIFACT="$tmp/artifact" MOCK_RC_ARTIFACT="$tmp/rc-artifact" MOCK_FLUX_LOG="$tmp/flux.log" \
+    VERIFY_PACKAGES_WORKDIR="$tmp/work" \
+    PATH="$tmp/bin:$PATH" \
+    hack/verify-promoted-packages.sh 9.9.9 "$tmp/release" \
+    > "$tmp/out" 2> "$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q "candidate's original platformSourceUrl.*must equal trusted repository" "$tmp/err"
+}
+
+# The mode check has to catch BOTH directions, and only one of them is the
+# dangerous one. A candidate whose file is executable where the release tree's
+# is not is content the merge reviewer never saw made runnable inside the
+# artifact the operator installs — cmp(1) compares bytes and says nothing about
+# it. The mirror case is the benign one, and it was the only one an earlier
+# `&&`/`||` chain actually rejected: POSIX gives the two operators equal
+# precedence and left associativity, so the guard grouped as
+# `((A && B) || C) && D` and quietly accepted a candidate-only executable bit.
+@test "rejects an executable bit set only in the candidate" {
+  tmp="$(_test_workspace)/fixture"
+  _make_verify_fixture "$tmp"
+  chmod +x "$tmp/artifact/system/dashboard/values.yaml"
+
+  rc=0
+  MOCK_ARTIFACT="$tmp/artifact" MOCK_RC_ARTIFACT="$tmp/rc-artifact" MOCK_FLUX_LOG="$tmp/flux.log" \
+    VERIFY_PACKAGES_WORKDIR="$tmp/work" \
+    PATH="$tmp/bin:$PATH" \
+    hack/verify-promoted-packages.sh 9.9.9 "$tmp/release" \
+    > "$tmp/out" 2> "$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q 'executable bit differs from release tree' "$tmp/err"
+}
+
+@test "rejects an executable bit set only in the release tree" {
+  tmp="$(_test_workspace)/fixture"
+  _make_verify_fixture "$tmp"
+  chmod +x "$tmp/release/system/dashboard/values.yaml"
+
+  rc=0
+  MOCK_ARTIFACT="$tmp/artifact" MOCK_RC_ARTIFACT="$tmp/rc-artifact" MOCK_FLUX_LOG="$tmp/flux.log" \
+    VERIFY_PACKAGES_WORKDIR="$tmp/work" \
+    PATH="$tmp/bin:$PATH" \
+    hack/verify-promoted-packages.sh 9.9.9 "$tmp/release" \
+    > "$tmp/out" 2> "$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q 'executable bit differs from release tree' "$tmp/err"
+}
+
+@test "rejects installer drift beyond the self-reference" {
+  tmp="$(_test_workspace)/fixture"
+  _make_verify_fixture "$tmp"
+  printf '  platformSourceSecret: changed-after-push\n' \
+    >> "$tmp/release/core/installer/values.yaml"
+
+  rc=0
+  MOCK_ARTIFACT="$tmp/artifact" MOCK_RC_ARTIFACT="$tmp/rc-artifact" MOCK_FLUX_LOG="$tmp/flux.log" \
+    VERIFY_PACKAGES_WORKDIR="$tmp/work" \
+    PATH="$tmp/bin:$PATH" \
+    hack/verify-promoted-packages.sh 9.9.9 "$tmp/release" \
+    > "$tmp/out" 2> "$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q 'installer values differ beyond their self-reference' "$tmp/err"
+}
+
+# Run the verifier from a copy whose sibling lib/ is ours. That is already how
+# the workflows invoke it — `.release-tooling/hack/verify-promoted-packages.sh`,
+# with its libraries resolved next to the script — so replacing one library is
+# the faithful way to reach a failure inside it rather than a contrived one.
+_tooling_with_collector() {
+  mkdir -p "$1/lib"
+  cp hack/verify-promoted-packages.sh "$1/"
+  cp hack/lib/promoted-packages.sh "$1/lib/"
+  cat > "$1/lib/image-refs.sh" <<EOF
+collect_image_refs() {
+$2
+}
+EOF
+}
+
+# The digest-set comparison is the only thing standing behind "no container
+# bytes changed". Both tests below make it compare two empty sets, which
+# succeeds, so without the fix the verifier reports that proof as passed having
+# examined nothing.
+@test "refuses when image-reference collection fails" {
+  tmp="$(_test_workspace)/fixture"
+  _make_verify_fixture "$tmp"
+  _tooling_with_collector "$tmp/tooling" '  echo "collector exploded" >&2
+  return 3'
+
+  rc=0
+  MOCK_ARTIFACT="$tmp/artifact" MOCK_RC_ARTIFACT="$tmp/rc-artifact" MOCK_FLUX_LOG="$tmp/flux.log" \
+    VERIFY_PACKAGES_WORKDIR="$tmp/work" \
+    PATH="$tmp/bin:$PATH" \
+    "$tmp/tooling/verify-promoted-packages.sh" 9.9.9 "$tmp/release" \
+    > "$tmp/out" 2> "$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q 'collector exploded' "$tmp/err"
+  # …and it did not also claim the proof it never completed. Counted rather
+  # than negated with `!`, which suppresses errexit and would pass regardless.
+  count="$(grep -c 'identical package tree' "$tmp/out" || true)"
+  [ "${count:-0}" -eq 0 ]
+}
+
+@test "refuses when the collector reports no image references at all" {
+  tmp="$(_test_workspace)/fixture"
+  _make_verify_fixture "$tmp"
+  _tooling_with_collector "$tmp/tooling" '  return 0'
+
+  rc=0
+  MOCK_ARTIFACT="$tmp/artifact" MOCK_RC_ARTIFACT="$tmp/rc-artifact" MOCK_FLUX_LOG="$tmp/flux.log" \
+    VERIFY_PACKAGES_WORKDIR="$tmp/work" \
+    PATH="$tmp/bin:$PATH" \
+    "$tmp/tooling/verify-promoted-packages.sh" 9.9.9 "$tmp/release" \
+    > "$tmp/out" 2> "$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q 'collected no image references' "$tmp/err"
+}
+
+@test "rejects a changed container digest even when candidate and merge tree match" {
+  tmp="$(_test_workspace)/fixture"
+  _make_verify_fixture "$tmp"
+  sed 's/cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc/dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd/' \
+    "$tmp/artifact/system/dashboard/values.yaml" > "$tmp/changed-values.yaml"
+  mv "$tmp/changed-values.yaml" "$tmp/artifact/system/dashboard/values.yaml"
+  cp "$tmp/artifact/system/dashboard/values.yaml" "$tmp/release/system/dashboard/values.yaml"
+
+  rc=0
+  MOCK_ARTIFACT="$tmp/artifact" MOCK_RC_ARTIFACT="$tmp/rc-artifact" MOCK_FLUX_LOG="$tmp/flux.log" \
+    VERIFY_PACKAGES_WORKDIR="$tmp/work" \
+    PATH="$tmp/bin:$PATH" \
+    hack/verify-promoted-packages.sh 9.9.9 "$tmp/release" \
+    > "$tmp/out" 2> "$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  grep -q 'promotion changed the container repository/digest set' "$tmp/err"
+}


### PR DESCRIPTION
v1.6.1 was promoted with the rc e2e gate bypassed, and its promote PR body says so verbatim. The reason is mechanical rather than anyone's judgement call: workflows run from the ref they fire on, release-1.6's `tags.yaml` has no `rc-e2e` job and this branch has no `e2e-tag.yaml` at all, so when `v1.6.1-rc.1` was pushed there was nothing to produce evidence the gate could find. Bypass was the only outcome available.

This closes that. Adds `e2e-tag.yaml` verbatim from main, which works as written here because `hack/e2e-chainsaw/` and the `test-chainsaw` target already exist on this branch. Splices main's `rc-e2e` job into `tags.yaml`. Adds the `verify-release-candidate` job to `pull-requests.yaml`, and the candidate-verification step to `pull-requests-release.yaml` positioned before tag creation, publish and retag. Plus `hack/verify-promoted-packages.sh`, `hack/lib/promoted-packages.sh`, `hack/validate-changelog.sh` and two bats suites.

All five files `promote-rc.yaml`'s preflight demands are present now with their markers, where this branch previously satisfied one of five. The e2e job name is kept byte-identical because promote-rc matches on exactly that string, and `hack/promote-gate-contract.bats` now pins the pair so the next drift gets a red test instead of a silent bypass.

One deviation worth knowing about. The verify job is keyed on author plus a `release-` head branch, not on the presence of the `release` label. On #3550 the PR was created at 09:35:31Z and the label arrived as a separate `labeled` event at 09:35:32Z, and this branch's `on.pull_request.types` has no `labeled`, so a label-keyed job would satisfy the preflight marker and then never fire. Adding `labeled` was the other option but on main it is interlocked with a concurrency split, a `plan` guard complement and `e2e-fork.yaml`, so keying on the author is the narrower change. Checked against every release-labelled bot PR back to v1.0.7, the bot's other release PRs use `changelog-v*` heads so they do not collide.
