### PR TITLE
fix(release): preserve tag prefixes when retagging promoted images

### DIFF
--- a/hack/promote-retag.sh
+++ b/hack/promote-retag.sh
@@ -28,6 +28,16 @@
 #
 # The repo/tag split (ref_repo below) strips the :tag from the last path
 # component only, so registry hosts that carry a :port are preserved.
+#
+# A source tag is not always just the version. Some images are one-per-something
+# within a single repository — ubuntu-container-disk is one per Kubernetes minor,
+# six digests under one repo tagged v1.30-vX.Y.Z … v1.35-vX.Y.Z — and there the
+# part before the version is the only thing telling them apart. Composing the
+# destination from the release version alone aimed all six at
+# ubuntu-container-disk:vX.Y.Z: the first was written and the second hit the
+# write-once guard, mid-finalize, after the stable git tag and the GitHub release
+# were already public. ref_tag_prefix below carries that part through, so the
+# destination is <prefix><stable> and each source keeps its own tag.
 set -eu
 
 STABLE="${1:?usage: promote-retag.sh <stable-version> [--dry-run]}"
@@ -82,6 +92,67 @@ ref_repo() {
 }
 ref_digest() { printf '%s' "${1##*@}"; }               # sha256:...
 
+# ref_tag <ref> — the :tag of a "<repo>[:<tag>]@<digest>" ref, or nothing when it
+# carries none. Splits on the LAST path component exactly as ref_repo does, so
+# the two always agree on where the repo ends and the tag begins.
+#
+# Only refs collected from an images/*.tag file or a textually scraped extra
+# file still carry a tag by the time they reach here; every yq shape in
+# hack/lib/image-refs.sh rebuilds the ref as "<repo>@<digest>" and drops it. That
+# is fine for the images that need a prefix today (ubuntu-container-disk is a
+# .tag file) but it does bound this fix: a prefixed image vendored through one of
+# the yq shapes would arrive tagless and get the bare stable tag. Widening the
+# library's output is a change to every consumer of it and is not attempted here.
+ref_tag() {
+  r="${1%@*}"            # strip @digest
+  img="${r##*/}"         # last path component (may carry :tag)
+  case "$img" in
+    *:*) printf '%s' "${img#*:}" ;;
+  esac
+}
+
+# _is_version <string> — true when <string> is a whole cozystack version: a
+# three-component core with an optional prerelease/build suffix. v1.5.4 and
+# v1.6.0-rc.1 are versions; v1.30, latest and rc.1 are not.
+_is_version() {
+  printf '%s\n' "$1" | grep -qE '^v?[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z][0-9A-Za-z.-]*)?$'
+}
+
+# ref_tag_prefix <tag> — the leading "<something>-" of a source tag that
+# qualifies WHICH image in a repository the ref is, as opposed to which version
+# of it. Empty when the tag is version-only, or when no split yields a version.
+#
+# The rule: split at each "-" left to right and stop at the first split whose
+# REMAINDER is a whole version; everything consumed so far is the prefix.
+# Anchoring on the remainder rather than on the head is what keeps a plain
+# prerelease intact — v1.6.0-rc.1 leaves "rc.1", which is not a version, so the
+# tag has no prefix and is replaced whole. A last-hyphen split would instead read
+# it as "v1.6.0-" + "rc.1" and mis-tag every ref in a real promotion, since an rc
+# version string is exactly what a promoted tree's refs carry. Conversely
+# v1.30-v1.5.2 leaves "v1.5.2", a version, so "v1.30-" is a prefix.
+#
+# When nothing matches — "latest", "dev", a git-describe like v1.5.2-3-gabc1234 —
+# the prefix is empty and the whole tag is replaced, which is what this script did
+# for every ref before prefixes were handled. The fallback is deliberately the
+# old behaviour: an unrecognized tag shape cannot start mis-mapping, it can only
+# keep doing what it already did.
+ref_tag_prefix() {
+  _t="$1"
+  _p=""
+  while :; do
+    case "$_t" in
+      *-*) ;;
+      *) return 0 ;;     # no split left to try; no prefix
+    esac
+    _p="${_p}${_t%%-*}-"
+    _t="${_t#*-}"
+    if _is_version "$_t"; then
+      printf '%s' "$_p"
+      return 0
+    fi
+  done
+}
+
 # manifest_digest <ref> — the digest of <ref>'s raw manifest, or empty output if
 # the tag is PROVEN not to exist. Anything else is indeterminate and returns
 # non-zero, which under `set -e` aborts the promotion before it writes.
@@ -134,9 +205,16 @@ copy() {
   skopeo copy --multi-arch all "docker://$_src" "docker://$_dst"
 }
 
-# Normalize every collected ref to the canonical "<repo>@<digest>" form (drops
-# the cosmetic :tag from shape 1) so the dedup is on the real identity — the
-# same image vendored in two shapes is retagged once, not twice.
+# Normalize every collected ref to the canonical "<repo>@<digest>|<prefix>" form
+# so the dedup is on the real identity — the same image vendored in two shapes is
+# retagged once, not twice. The cosmetic version part of the source :tag is
+# dropped; only the prefix that identifies which image in the repo this is
+# survives, because that is the part the destination tag has to reproduce.
+#
+# "|" is the field separator because no registry host, repository path, tag or
+# digest may contain one, so both halves are recoverable with a plain parameter
+# expansion, and an absent prefix is an unambiguous empty trailing field rather
+# than a missing one.
 refs=""
 for raw in $(collect_refs); do
   [ -n "$raw" ] || continue
@@ -159,17 +237,22 @@ for raw in $(collect_refs); do
     "${REGISTRY}/"*) ;;
     *) continue ;;
   esac
-  refs="${refs}${_repo}@$(ref_digest "$raw")
+  refs="${refs}${_repo}@$(ref_digest "$raw")|$(ref_tag_prefix "$(ref_tag "$raw")")
 "
 done
 refs="$(printf '%s' "$refs" | sort -u)"
 [ -n "$refs" ] || { echo "No cozystack-owned digest-pinned image refs found under ${REGISTRY}/ — is this the rc's baked tree?" >&2; exit 1; }
 
-echo "$refs" | while IFS= read -r ref; do
-  [ -n "$ref" ] || continue
+echo "$refs" | while IFS= read -r record; do
+  [ -n "$record" ] || continue
+  ref="${record%|*}"
+  prefix="${record##*|}"
   repo="${ref%@*}"
   digest="${ref##*@}"
-  echo "▸ ${repo}  ${digest}"
+  # <prefix><stable> is the destination tag throughout: the stable tag, the
+  # write-once probe, the post-copy verify and :latest must all name the same one.
+  stable_tag="${prefix}${STABLE}"
+  echo "▸ ${repo}:${stable_tag}  ${digest}"
   # The stable tag is write-once at the image level: resolve the destination's
   # raw manifest digest before copying. No-op if it already points at this rc
   # digest (idempotent re-run), fail if it points elsewhere (a partial run or
@@ -177,25 +260,29 @@ echo "$refs" | while IFS= read -r ref; do
   # bytes. :latest is intentionally mutable and (re)pointed below only when
   # MOVE_LATEST=1.
   if [ "$DRY_RUN" -eq 0 ]; then
-    cur="$(manifest_digest "${repo}:${STABLE}")"
+    cur="$(manifest_digest "${repo}:${stable_tag}")"
     if [ -n "$cur" ] && [ "$cur" != "$digest" ]; then
-      echo "::error::${repo}:${STABLE} already exists at '${cur}'; refusing to move it to '${digest}' (stable image tags are write-once)" >&2
+      echo "::error::${repo}:${stable_tag} already exists at '${cur}'; refusing to move it to '${digest}' (stable image tags are write-once)" >&2
       exit 1
     fi
     if [ "$cur" = "$digest" ]; then
-      echo "  = ${repo}:${STABLE} already at ${digest}; skipping stable copy"
+      echo "  = ${repo}:${stable_tag} already at ${digest}; skipping stable copy"
     else
-      copy "$ref" "${repo}:${STABLE}"
+      copy "$ref" "${repo}:${stable_tag}"
     fi
   else
-    copy "$ref" "${repo}:${STABLE}"
+    copy "$ref" "${repo}:${stable_tag}"
   fi
-  [ "$MOVE_LATEST" = "1" ] && copy "$ref" "${repo}:latest"
+  # The floating tag is prefixed for the same reason the stable one is: without
+  # it, every per-Kubernetes-minor disk copies to <repo>:latest and the tag ends
+  # up on whichever digest the sort put last — a floating tag that names one
+  # minor's image while reading as if it named the repository's.
+  [ "$MOVE_LATEST" = "1" ] && copy "$ref" "${repo}:${prefix}latest"
   # Verify the stable tag now resolves to the exact rc digest (skip in dry-run).
   if [ "$DRY_RUN" -eq 0 ]; then
-    got="$(manifest_digest "${repo}:${STABLE}")"
+    got="$(manifest_digest "${repo}:${stable_tag}")"
     if [ "$got" != "$digest" ]; then
-      echo "::error::${repo}:${STABLE} resolved to '${got}', expected '${digest}'" >&2
+      echo "::error::${repo}:${stable_tag} resolved to '${got}', expected '${digest}'" >&2
       exit 1
     fi
   fi

--- a/hack/promote-retag_test.bats
+++ b/hack/promote-retag_test.bats
@@ -94,6 +94,50 @@ EOF
   chmod +x "$t/bin/yq" "$t/bin/skopeo" "$t/bin/sha256sum"
 }
 
+# _make_ref_tree <dir> <ref>... — build a throwaway package tree under <dir>
+# whose only refs are the ones given, one images/*.tag file each, so a test can
+# drive the destination-tag composition with ref shapes the committed tree does
+# not contain. Run promote-retag.sh with <dir> as its CWD to pick it up:
+# collect_image_refs is rooted at the relative path "packages", while the script
+# sources hack/lib/image-refs.sh from its own $0.
+#
+# images/*.tag is the deliberate choice of storage shape. It is what
+# ubuntu-container-disk actually uses, and it is the only shape whose collected
+# ref still carries the source :tag — every yq shape in hack/lib/image-refs.sh
+# rebuilds the ref as "<repo>@<digest>" and drops the tag — so it is the shape
+# from which a prefix can be recovered at all.
+_make_ref_tree() {
+  t="$1"; shift
+  n=0
+  mkdir -p "$t/packages/apps/fake/images"
+  for r in "$@"; do
+    n=$((n + 1))
+    printf '%s\n' "$r" >"$t/packages/apps/fake/images/ref-$n.tag"
+  done
+}
+
+# _plan_destinations <plan-file> <out-file> — the destination ref of every copy
+# in a --dry-run plan, one per line, sorted. The destination is the last field of
+# a "DRY-RUN skopeo copy --multi-arch all docker://<src> docker://<dst>" line.
+_plan_destinations() {
+  awk '/^DRY-RUN skopeo copy /{print $NF}' "$1" | sed 's|^docker://||' | sort >"$2"
+}
+
+# _refute_duplicate_destinations <dst-file> — fail, loudly, if any destination
+# ref appears twice. Two copies aimed at one tag mean the second trips the
+# write-once guard mid-finalize, after the stable git tag and the GitHub release
+# are already public. Written as an explicit non-empty test rather than
+# `! uniq -d ... | grep -q .`: a `!`-negated pipeline is exempt from errexit, so
+# that form cannot fail the test.
+_refute_duplicate_destinations() {
+  dup="$(uniq -d <"$1")"
+  if [ -n "$dup" ]; then
+    echo "duplicate destination refs in the promotion plan:" >&2
+    printf '%s\n' "$dup" >&2
+    return 1
+  fi
+}
+
 @test "dry-run over the real tree retags only cozystack-owned refs" {
   tmp=$(mktemp -d)
 
@@ -385,5 +429,207 @@ EOF
   grep -q 'cannot be treated as unpublished' "$tmp/err"
   grep -q '429' "$tmp/err"
   ! grep -q '^copy ' "$tmp/skopeo.log"
+  rm -rf "$tmp"
+}
+
+@test "the destination tag keeps a source tag's prefix and nothing else" {
+  root=$(pwd -P)
+  tmp=$(mktemp -d)
+  reg=ghcr.io/cozystack/cozystack
+  d1=1111111111111111111111111111111111111111111111111111111111111111
+  d2=2222222222222222222222222222222222222222222222222222222222222222
+  d3=3333333333333333333333333333333333333333333333333333333333333333
+  d4=4444444444444444444444444444444444444444444444444444444444444444
+  d5=5555555555555555555555555555555555555555555555555555555555555555
+
+  # One ref per source-tag shape a promoted tree carries, or plausibly will. The
+  # version component is the part promotion replaces; whatever precedes it says
+  # WHICH image in the repository the ref is, and has to survive the retag.
+  _make_ref_tree "$tmp" \
+    "$reg/plain:v1.5.2@sha256:$d1" \
+    "$reg/prefixed:v1.30-v1.5.2@sha256:$d2" \
+    "$reg/floating:latest@sha256:$d3" \
+    "$reg/prerelease:v1.6.0-rc.1@sha256:$d4"
+
+  # ...plus a ref with no tag at all, the form every yq shape in
+  # hack/lib/image-refs.sh emits. Nothing to preserve, and nothing to invent.
+  mkdir -p "$tmp/packages/system/fake-values"
+  cat >"$tmp/packages/system/fake-values/values.yaml" <<EOF
+image:
+  repository: $reg/tagless
+  digest: sha256:$d5
+EOF
+
+  rc=0
+  ( cd "$tmp" && env -u REGISTRY "$root/hack/promote-retag.sh" v1.5.4 --dry-run ) \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "promote-retag.sh exited $rc" >&2
+    echo "--- script stderr ---" >&2; cat "$tmp/err" >&2
+    echo "--- script stdout ---" >&2; cat "$tmp/out" >&2
+    return "$rc"
+  fi
+
+  _plan_destinations "$tmp/out" "$tmp/dst"
+
+  # v1.30- is a prefix: the tail of the tag parses as a version, so the head
+  # cannot be one.
+  [ "$(grep -cFx "$reg/prefixed:v1.30-v1.5.4" "$tmp/dst")" -eq 1 ]
+  # A version-only tag has no prefix. This is the regression guard that matters
+  # most — all but six of the branch's refs are this shape.
+  [ "$(grep -cFx "$reg/plain:v1.5.4" "$tmp/dst")" -eq 1 ]
+  # "latest" is not a version, so it is not a prefix either: a tag that does not
+  # END in a version contributes nothing and is replaced whole. Reading it as a
+  # prefix would invent floating:latest-v1.5.4, a tag nothing references.
+  [ "$(grep -cFx "$reg/floating:v1.5.4" "$tmp/dst")" -eq 1 ]
+  # v1.6.0-rc.1 is ONE version, not "v1.6.0-" + "rc.1". Splitting on the last
+  # hyphen instead would emit prerelease:v1.6.0-v1.5.4 and mis-tag every ref in a
+  # real promotion, because an rc version string is exactly what the promoted
+  # tree's refs carry.
+  [ "$(grep -cFx "$reg/prerelease:v1.5.4" "$tmp/dst")" -eq 1 ]
+  # A ref that reached the script tagless gets the bare stable tag.
+  [ "$(grep -cFx "$reg/tagless:v1.5.4" "$tmp/dst")" -eq 1 ]
+
+  [ "$(awk 'END{print NR}' "$tmp/dst")" -eq 5 ]
+  _refute_duplicate_destinations "$tmp/dst"
+  rm -rf "$tmp"
+}
+
+@test "several prefixed refs in one repository get distinct destinations" {
+  root=$(pwd -P)
+  tmp=$(mktemp -d)
+  reg=ghcr.io/cozystack/cozystack
+
+  # The 1.5-line ubuntu-container-disk refs, verbatim: one image per Kubernetes
+  # minor, six distinct digests sharing one repository and told apart only by the
+  # tag prefix. Composing the destination tag from the release version alone aims
+  # all six at ubuntu-container-disk:v1.5.4 — the sort-first one is written and
+  # the next trips the write-once guard, inside finalize, after the stable git tag
+  # and the GitHub release are already public.
+  _make_ref_tree "$tmp" \
+    "$reg/ubuntu-container-disk:v1.30-v1.5.2@sha256:dc2e4794e75b861bf087e93037a2522fec398ffd8ac2b69591c4b0a50260f431" \
+    "$reg/ubuntu-container-disk:v1.31-v1.5.2@sha256:4e3479b4f469581d87574c72246995d1df6262be42e60022084aca658ead8755" \
+    "$reg/ubuntu-container-disk:v1.32-v1.5.2@sha256:79df2a0da2b1c13eee44f32793e4ca726bf4987935cecc34d204898d58cbbce1" \
+    "$reg/ubuntu-container-disk:v1.33-v1.5.2@sha256:200d41bfb8108d43e1e938df47175dd4dbaae23d48e6d1c20ae6c6432213eeee" \
+    "$reg/ubuntu-container-disk:v1.34-v1.5.2@sha256:21c0112abe14caba7a001b542d587ec1dab477e5f0fe65dba4383cac331c206c" \
+    "$reg/ubuntu-container-disk:v1.35-v1.5.2@sha256:f90a024f2e2b4ef1b3ea653f5f47699218114e41bbd9b7c46e7c0ed00558aebb"
+
+  rc=0
+  ( cd "$tmp" && env -u REGISTRY "$root/hack/promote-retag.sh" v1.5.4 --dry-run ) \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "promote-retag.sh exited $rc" >&2
+    echo "--- script stderr ---" >&2; cat "$tmp/err" >&2
+    return "$rc"
+  fi
+
+  _plan_destinations "$tmp/out" "$tmp/dst"
+  _refute_duplicate_destinations "$tmp/dst"
+  [ "$(awk 'END{print NR}' "$tmp/dst")" -eq 6 ]
+  for minor in v1.30 v1.31 v1.32 v1.33 v1.34 v1.35; do
+    [ "$(grep -cFx "$reg/ubuntu-container-disk:${minor}-v1.5.4" "$tmp/dst")" -eq 1 ]
+  done
+  rm -rf "$tmp"
+}
+
+@test "MOVE_LATEST keeps the prefix so each prefix gets its own floating tag" {
+  root=$(pwd -P)
+  tmp=$(mktemp -d)
+  reg=ghcr.io/cozystack/cozystack
+  d1=1111111111111111111111111111111111111111111111111111111111111111
+  d2=2222222222222222222222222222222222222222222222222222222222222222
+
+  # :latest is prefixed for the same reason the stable tag is. Without it, both
+  # refs below copy to disk:latest and the tag ends up pointing at whichever
+  # digest the sort happened to put last — a floating tag that names one
+  # Kubernetes minor's disk and reads as if it named all of them.
+  _make_ref_tree "$tmp" \
+    "$reg/disk:v1.30-v1.5.2@sha256:$d1" \
+    "$reg/disk:v1.31-v1.5.2@sha256:$d2"
+
+  rc=0
+  ( cd "$tmp" && env -u REGISTRY MOVE_LATEST=1 \
+      "$root/hack/promote-retag.sh" v1.5.4 --dry-run ) \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "promote-retag.sh exited $rc" >&2
+    echo "--- script stderr ---" >&2; cat "$tmp/err" >&2
+    return "$rc"
+  fi
+
+  _plan_destinations "$tmp/out" "$tmp/dst"
+  _refute_duplicate_destinations "$tmp/dst"
+  [ "$(awk 'END{print NR}' "$tmp/dst")" -eq 4 ]
+  [ "$(grep -cFx "$reg/disk:v1.30-latest" "$tmp/dst")" -eq 1 ]
+  [ "$(grep -cFx "$reg/disk:v1.31-latest" "$tmp/dst")" -eq 1 ]
+  # The unprefixed floating tag is left alone: it belongs to no minor.
+  [ "$(grep -cFx "$reg/disk:latest" "$tmp/dst")" -eq 0 ]
+  rm -rf "$tmp"
+}
+
+@test "two digests behind one prefixed destination still trip the write-once guard" {
+  root=$(pwd -P)
+  tmp=$(mktemp -d)
+  _make_registry_mocks "$tmp"
+  reg=example.com/cozystack
+
+  # Preserving the prefix must not become a way around the write-once guard. Two
+  # digests that still land on the SAME destination tag have to be refused, not
+  # silently overwritten — and same-repo/same-prefix is that case routed through
+  # the new composition rather than the old path.
+  published='{"schemaVersion":2,"config":{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"sha256:5555555555555555555555555555555555555555555555555555555555555555"},"layers":[]}'
+  first="sha256:$(printf '%s' "$published" | sha256sum | cut -d' ' -f1)"
+  # All-f is the largest hex digest, so the ref carrying $first is the one the
+  # sorted plan copies first and the one the post-copy verify then matches. That
+  # keeps the failure the write-once refusal rather than a verify mismatch.
+  second=sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+
+  _make_ref_tree "$tmp" \
+    "$reg/disk:v1.30-v1.5.2@$first" \
+    "$reg/disk:v1.30-v1.5.2@$second"
+
+  rc=0
+  ( cd "$tmp" && env REGISTRY="$reg" MOCK_REF="" MOCK_MANIFEST="$published" \
+      MOCK_MISSING_ONCE=1 MOCK_STATE="$tmp/state" MOCK_SKOPEO_LOG="$tmp/skopeo.log" \
+      PATH="$tmp/bin:/usr/bin:/bin" "$root/hack/promote-retag.sh" v1.5.4 ) \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+
+  [ "$rc" -ne 0 ]
+  # The message names the PREFIXED destination, which is also what proves the
+  # composition reached the guard.
+  grep -q "disk:v1.30-v1.5.4 already exists at '${first}'; refusing to move it to '${second}'" "$tmp/err"
+  # Exactly one copy: the first ref's, before the refusal. Counted rather than
+  # negated, so the assertion can actually fail.
+  [ "$(grep -c '^copy --multi-arch all ' "$tmp/skopeo.log")" -eq 1 ]
+  rm -rf "$tmp"
+}
+
+@test "the real tree's promotion plan has no duplicate destination" {
+  tmp=$(mktemp -d)
+
+  # The check that would have caught the ubuntu-container-disk collision before a
+  # release reached finalize. A duplicate destination in the plan is a promotion
+  # that fails halfway through the irreversible step, so it is worth pinning
+  # against the committed tree permanently rather than against fixtures alone.
+  rc=0
+  env -u REGISTRY hack/promote-retag.sh v1.5.4 --dry-run \
+    >"$tmp/out" 2>"$tmp/err" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "promote-retag.sh exited $rc" >&2
+    echo "--- script stderr ---" >&2; cat "$tmp/err" >&2
+    return "$rc"
+  fi
+
+  _plan_destinations "$tmp/out" "$tmp/dst"
+  _refute_duplicate_destinations "$tmp/dst"
+
+  # And the per-Kubernetes-minor disks each get their own destination: one per
+  # images/ubuntu-container-disk-*.tag file in the tree, derived from the tree so
+  # adding or dropping a minor does not need this number edited. Branches that
+  # ship no such image (main, release-1.6) assert 0 == 0 and stay green.
+  minors=$(find packages/apps/kubernetes/images -name 'ubuntu-container-disk-*.tag' \
+             2>/dev/null | awk 'END{print NR}')
+  [ "$(grep -c '^ghcr\.io/cozystack/cozystack/ubuntu-container-disk:' "$tmp/dst")" \
+    -eq "$minors" ]
   rm -rf "$tmp"
 }

--- a/hack/promote-retag_test.bats
+++ b/hack/promote-retag_test.bats
@@ -17,6 +17,13 @@
 # so the harness's `set -e` does not abort first. mikefarah yq is assumed
 # present (provided by the test toolchain, like the other yq-using bats here).
 #
+# A negative expectation must be COUNTED — `[ "$(grep -c X f)" -eq 0 ]` — never
+# written as `! grep -q X f`. POSIX and bash both exempt a `!`-negated pipeline
+# from errexit, so the `!` form cannot fail a test: it is a comment that looks
+# like an assertion. Six of them lived here, each proven inert by mutating the
+# script under test (an unconditional copy before the write-once probe, and a
+# MOVE_LATEST default of 1, both of which the `!` form waved through).
+#
 # Run with: hack/cozytest.sh hack/promote-retag_test.bats
 #           (or `bats hack/promote-retag_test.bats` if the bats binary is
 #           installed; cozytest.sh is the CI path.)
@@ -214,7 +221,7 @@ _refute_duplicate_destinations() {
   # The stable tag is in the copy plan...
   grep -qE 'docker://ghcr\.io/cozystack/cozystack/[^ ]*:v9\.9\.9' "$tmp/out"
   # ...but nothing moves :latest.
-  ! grep -qE 'docker://[^ ]+:latest' "$tmp/out"
+  [ "$(grep -cE 'docker://[^ ]+:latest' "$tmp/out")" -eq 0 ]
   rm -rf "$tmp"
 }
 
@@ -300,7 +307,7 @@ _refute_duplicate_destinations() {
 
   grep -q "already at ${digest}; skipping stable copy" "$tmp/out"
   [ "$(grep -c '^inspect --raw ' "$tmp/skopeo.log")" -eq 2 ]
-  ! grep -q '^copy ' "$tmp/skopeo.log"
+  [ "$(grep -c '^copy ' "$tmp/skopeo.log")" -eq 0 ]
   rm -rf "$tmp"
 }
 
@@ -373,7 +380,7 @@ _refute_duplicate_destinations() {
   [ "$rc" -ne 0 ]
   grep -q "already exists at '${published_digest}'; refusing to move it to '${rc_digest}'" "$tmp/err"
   # The refusal must happen BEFORE any write.
-  ! grep -q '^copy ' "$tmp/skopeo.log"
+  [ "$(grep -c '^copy ' "$tmp/skopeo.log")" -eq 0 ]
   [ "$(grep -c '^inspect --raw ' "$tmp/skopeo.log")" -eq 1 ]
   rm -rf "$tmp"
 }
@@ -399,10 +406,10 @@ _refute_duplicate_destinations() {
   # an overwrite of a published stable tag.
   [ "$rc" -ne 0 ]
   grep -q 'returned no manifest bytes' "$tmp/err"
-  ! grep -q '^copy ' "$tmp/skopeo.log"
+  [ "$(grep -c '^copy ' "$tmp/skopeo.log")" -eq 0 ]
   [ "$(grep -c '^inspect --raw ' "$tmp/skopeo.log")" -eq 1 ]
   # The empty-input hash must never appear: that is the guard being absent.
-  ! grep -q 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' "$tmp/err"
+  [ "$(grep -c 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' "$tmp/err")" -eq 0 ]
   rm -rf "$tmp"
 }
 
@@ -428,7 +435,7 @@ _refute_duplicate_destinations() {
   [ "$rc" -ne 0 ]
   grep -q 'cannot be treated as unpublished' "$tmp/err"
   grep -q '429' "$tmp/err"
-  ! grep -q '^copy ' "$tmp/skopeo.log"
+  [ "$(grep -c '^copy ' "$tmp/skopeo.log")" -eq 0 ]
   rm -rf "$tmp"
 }
 


### PR DESCRIPTION
Merge after the release-machinery port PR, this is stacked on it because release-1.5 has no `hack/promote-retag.sh` until that lands.

`ubuntu-container-disk` on the 1.5 line is one image per kubernetes minor, six digests under a single repository distinguished only by a tag prefix, `v1.30-v1.5.2` through `v1.35-v1.5.2`. The retag composes its destination from the release version alone, so all six aim at `ubuntu-container-disk:v1.5.4`. The sort-first one is written and the second fails the write-once guard, and that happens in finalize, after the stable tag and the github release are already public.

Three separate things hid this. The tag is discarded at collection, `ref_repo()` strips it and refs are carried as `<repo>@<digest>`. The guard detects collisions by manifest digest rather than by planning, so `--dry-run` skips the probe entirely and six copies aimed at one tag print as a clean plan. And the `sort -u` dedup operates on `<repo>@<digest>`, which six distinct digests pass without complaint.

Fix splits the source tag at each `-` left to right and treats as prefix everything before the first remainder that is a whole version. Anchoring on the remainder is the load-bearing part: `v1.6.0-rc.1` leaves `rc.1`, which is not a version, so that tag stays whole, and an rc string is exactly what a promoted tree carries since `tags.yaml` stamps `IMAGE_TAG: github.ref_name`. Left to right also gets `v1.30.0-v1.5.2` right where a longest-suffix rule would collapse it. No match means empty prefix and exactly the old behaviour.

A/B of the full copy plan against the base is byte-identical for all 40 unprefixed refs in both `MOVE_LATEST` modes, and gives 46 of 46 unique destinations where the base gave 46 to 41. Also a no-op on main (42/42) and release-1.6 (43/43), neither of which carries prefixed refs, so this is safe to cherry-pick upstream unchanged.

The red phase reports `duplicate destination refs in the promotion plan: ghcr.io/cozystack/cozystack/ubuntu-container-disk:v1.5.4`, and there is a permanent assertion that a v1.5.4 plan contains no duplicate destination, since that is the check that would have caught this in the first place.

Separate commit converts six pre-existing negated-grep assertions in the same file, each proven inert before conversion by mutating the thing it claimed to check. All six hold once they are real, so no guard was actually broken, they were just decorative.

main needs the identical change as a straight cherry-pick, `promote-retag.sh` and `promote-retag_test.bats` are byte-identical there. One known limitation: a `<prefix>-<non-semver>` tag like `v1.30-dev` from a local build gets no prefix and collapses as it does today. Not reachable in promotion, `tags.yaml` is the only workflow that commits image refs back.
