### PR TITLE
ci(backport): open backport PRs with the cozystack-ci App token

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -277,13 +277,33 @@ jobs:
         if: steps.target.outcome == 'success' && steps.guard.outputs.already_merged != 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      # 4. Create the back‑port pull request
+      # 4. Mint the cozystack-ci App token.
+      #
+      # Not interchangeable with GITHUB_TOKEN. This repository sets
+      # actions/permissions/fork-pr-contributor-approval to
+      # "all_external_contributors", and github-actions[bot] is external under
+      # that policy, so every run triggered by a PR it authors lands in
+      # action_required and waits for a maintainer to click "Approve and run
+      # workflows" — even though the branch is same-repo. Backports then sit
+      # silently ungated; nine were parked that way on 2026-08-18. An
+      # org-installed App is not an external contributor, so nothing extra
+      # gates its PRs.
+      - name: Generate GitHub App token
+        id: app-token
+        if: steps.target.outcome == 'success' && steps.guard.outputs.already_merged != 'true'
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.COZYSTACK_CI_APP_ID }}
+          private-key: ${{ secrets.COZYSTACK_CI_PRIVATE_KEY }}
+          owner: cozystack
+
+      # 5. Create the back‑port pull request
       - name: Create back‑port PR
         id: backport
         if: steps.target.outcome == 'success' && steps.guard.outputs.already_merged != 'true'
         uses: korthout/backport-action@0193454f0c5947491d348f33a275c119f30eb736 # v3.2.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           label_pattern: '' # don't read labels for targets
           target_branches: ${{ steps.target.outputs.branch }}
           merge_commits: skip

--- a/hack/release-freeze-contract.bats
+++ b/hack/release-freeze-contract.bats
@@ -310,15 +310,17 @@ step_line() {
   printf '%s\n' "$block" | script_lines | grep -qF 'p.merged_at !== null'
 }
 
-@test "both the checkout and the backport-action step are gated on the guard" {
+@test "the checkout, app-token and backport-action steps are all gated on the guard" {
   block="$(job_block backport "$BACKPORT")"
   [ -n "$block" ]
 
-  # Losing the gate on either step still runs the action against a target that
-  # already has the change, reproducing the false comment the guard exists to
-  # prevent.
+  # Losing the gate on any of these still runs work against a target that
+  # already has the change: checkout and the action reproduce the false comment
+  # the guard exists to prevent, and the token step mints an App credential for
+  # a backport that was already decided against. Count, not names, so that a
+  # step renamed but left ungated cannot pass.
   count="$(printf '%s\n' "$block" | code_lines | grep -cF "steps.guard.outputs.already_merged != 'true'" || true)"
-  [ "${count:-0}" -eq 2 ]
+  [ "${count:-0}" -eq 3 ]
 }
 
 @test "the guard runs before the checkout and the backport-action step" {


### PR DESCRIPTION
Backport PRs opened by bot wait for maintainer to click "Approve and run workflows" before any check starts. Nine of them were parked like that today and nothing surfaces them, so backports carrying fixes to release lines are exactly the ones sitting still.

Reason is not in this workflow but in repo policy:

```
GET /repos/cozystack/cozystack/actions/permissions/fork-pr-contributor-approval
{"approval_policy":"all_external_contributors"}
```

github-actions[bot] is external under that policy, so every run triggered by PR it authors lands in action_required, even when branch is same-repo. Org installed App is not external contributor. #3550 was opened by cozystack-ci[bot] with this same App token and got full check set without any approval, including 54 minutes e2e job.

So this PR mints App token and passes it to backport-action, same as retention, cut-prerelease, promote-rc, tags, pull-requests and pull-requests-release already do. Same action pin and same `owner: cozystack` as other ten call sites.

This moves only PR authorship. backport-action documents `github_token` as "used to create and label pull requests and to comment", git push still uses credentials that actions/checkout persists, so backport carrying `.github/workflows/` change is still rejected. That needs `workflows: write` on the App and I don't ask for it here, App able to rewrite CI can reach every secret, and hand-porting those is rare (#3893, #3894).

Token step gated on same already_merged guard as two steps around it, so backport that guard already rejected mints no credential. That makes three gated steps where contract test counted exactly two, so count updated to three. It still fails if any single gate dropped.

#3844 edits same file and is open, whichever lands second needs rebase.
