### PR TITLE
test(e2e): anchor the phase-warning guard on its own unique phrase

### DIFF
--- a/hack/run-kubernetes-cpu-throttle_test.bats
+++ b/hack/run-kubernetes-cpu-throttle_test.bats
@@ -159,7 +159,10 @@ run_capture() {
   # sentence sends the reader to the opposite conclusion about the one collector
   # whose behaviour differs, and a comment in the source does not reach them.
   lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
-  warn=$(grep -n 'timeout is not on PATH' "$lib" | head -n 1 | cut -d: -f1)
+  # Anchored on the phrase unique to the phase warning itself: the bracket-pair
+  # captures write their own [bounds] notes carrying "timeout is not on PATH",
+  # so the first match of that phrase is no longer this sentence.
+  warn=$(grep -n 'run UNBOUNDED' "$lib" | head -n 1 | cut -d: -f1)
   if [ -z "$warn" ]; then
     echo "expected the phase to still warn when timeout is missing" >&2
     return 1


### PR DESCRIPTION
The guard in the CPU throttle suite finds the missing-timeout phase warning by the first match of a phrase that stopped being unique when the bracket-pair captures started writing their own [bounds] notes with the same words. The first match is now a note, the guard reads it as the warning, and the unit gate fails on every run, blocking all PRs. Same fix the node-join copy of this guard already carries: anchor on the phrase unique to the warning itself. All fifteen suites that read the shared library as text pass locally with the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved warning-location test matching by targeting the specific phase warning message.
  * Preserved validation of warning status and collector identification while avoiding unrelated capture-note matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->