### PR TITLE
chore(kubernetes): drop the force-delete flag that blocks partial cleanup

### DIFF
--- a/packages/apps/kubernetes/templates/cluster-autoscaler/deployment.yaml
+++ b/packages/apps/kubernetes/templates/cluster-autoscaler/deployment.yaml
@@ -55,7 +55,6 @@ spec:
         - --ignore-mirror-pods-utilization=true
         - --scale-down-unneeded-time=30s
         - --scan-interval=25s
-        - --force-delete-unregistered-nodes=true
         - --kubeconfig=/etc/kubernetes/kubeconfig/super-admin.svc
         - --clusterapi-cloud-config-authoritative
         - --node-group-auto-discovery=clusterapi:namespace={{ .Release.Namespace }},clusterName={{ .Release.Name }}

--- a/packages/apps/kubernetes/tests/cluster_autoscaler_args_test.yaml
+++ b/packages/apps/kubernetes/tests/cluster_autoscaler_args_test.yaml
@@ -1,0 +1,38 @@
+suite: cluster-autoscaler arguments
+
+# `--force-delete-unregistered-nodes` reads as a safety override that lets the
+# autoscaler remove a long-unregistered machine below the group's min size. On
+# the clusterapi provider it grants nothing of the sort: the provider does not
+# implement force deletion, the call falls back to the ordinary delete path,
+# and that path refuses to take a group below its min size. What the flag does
+# do is skip the step that trims the delete batch down to the group's headroom,
+# so a batch larger than the headroom is refused whole instead of trimmed and
+# partly executed. The flag is therefore absent by intent rather than by
+# oversight, which is what this asserts.
+#
+# The positive assertion is not decoration: an absence assertion against a path
+# that does not resolve passes for the wrong reason, so the args list is proven
+# live first.
+
+templates:
+  - templates/cluster-autoscaler/deployment.yaml
+
+values:
+  - values/common.yaml
+
+release:
+  name: test-k8s
+  namespace: tenant-test
+
+tests:
+  - it: runs against the clusterapi provider without the force-delete override
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --cloud-provider=clusterapi
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --force-delete-unregistered-nodes=true


### PR DESCRIPTION
## What this PR does

Removes `--force-delete-unregistered-nodes=true` from the tenant cluster-autoscaler Deployment. On the clusterapi provider the flag cannot do what its name promises: the provider's `ForceDeleteNodes` returns `cloudprovider.ErrNotImplemented`, the autoscaler falls back to the ordinary `DeleteNodes` path, and that path enforces the node group's minimum size. The one behavior the flag does change is harmful here: it skips the step that trims a long-unregistered delete batch down to the group's headroom above min size, so a batch larger than the headroom is refused whole where the default would trim it and delete what fits. Context: #3513.

A regression test renders the Deployment, proves the args list is live with a positive anchor on `--cloud-provider=clusterapi`, and asserts the flag is absent, so reintroducing it fails the suite.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
chore(kubernetes): drop the cluster-autoscaler force-delete-unregistered-nodes flag; the clusterapi provider does not implement force deletion, and the flag only made batch removal of long-unregistered machines all-or-nothing
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cluster autoscaling behavior to avoid forcibly deleting nodes that are no longer registered.
  * Continued using the Cluster API provider for autoscaling.

* **Tests**
  * Added validation to ensure the autoscaler configuration uses the expected provider and excludes the removed deletion override.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->