### PR TITLE
ci(release): move the v1.5.4 release path off the decommissioned runner pool

### DIFF
--- a/.github/workflows/pull-requests-release.yaml
+++ b/.github/workflows/pull-requests-release.yaml
@@ -14,7 +14,11 @@ concurrency:
 jobs:
   finalize:
     name: Finalize Release
-    runs-on: [self-hosted]
+    # Was [self-hosted], the decommissioned cozy-runner-1 (#2937), which nothing
+    # answers -- this job would sit in Queued and never publish the release. It
+    # is git plus GitHub API calls only, so the small ephemeral shape is ample;
+    # it is also the one both live branches use for this job.
+    runs-on: [oracle-vm-4cpu-16gb-x86-64]
     permissions:
       contents: write
 

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   prepare-release:
     name: Prepare Release
-    runs-on: [self-hosted]
+    runs-on: oracle-vm-24cpu-96gb-x86-64
     outputs:
       skip: ${{ steps.check_release.outputs.skip }}
     permissions:
@@ -245,7 +245,7 @@ jobs:
 
   generate-changelog:
     name: Generate Changelog
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     needs: [prepare-release]
     permissions:
       contents: write
@@ -450,7 +450,7 @@ jobs:
 
   update-website-docs:
     name: Update Website Docs
-    runs-on: [self-hosted]
+    runs-on: ubuntu-latest
     needs: [generate-changelog, prepare-release]
     # generate-changelog is non-blocking — run as long as prepare-release succeeded.
     # `always()` is needed so this job runs even if generate-changelog failed/skipped.

--- a/.github/workflows/tags.yaml
+++ b/.github/workflows/tags.yaml
@@ -102,6 +102,14 @@ jobs:
           fetch-depth: 0
           fetch-tags:  true
 
+      # Ephemeral runners lack the flux CLI the installer's image-packages step
+      # shells out to; install if absent (idempotent).
+      - name: Set up build toolchain
+        if: steps.check_release.outputs.skip == 'false'
+        run: |
+          command -v flux >/dev/null \
+            || curl -fsSL https://fluxcd.io/install.sh | sudo bash
+
       - name: Login to GHCR
         if: steps.check_release.outputs.skip == 'false'
         uses: docker/login-action@v3


### PR DESCRIPTION
v1.5.4 is cut from this branch, and every job on the release path is pinned to `[self-hosted]`, a pool that no longer exists. `gh api repos/cozystack/cozystack/actions/runners` returns `total_count: 0` and the last confirmed execution anywhere was 2026-07-07. A job pinned to a label nothing answers does not fail, it sits in `Queued` with no logs, so the release would appear to hang with nothing red to point at.

Three commits.

`tags.yaml`, three jobs, to what `release-1.6` uses for the same job names: `prepare-release` to `oracle-vm-24cpu-96gb-x86-64`, `generate-changelog` and `update-website-docs` to `ubuntu-latest`.

`pull-requests-release.yaml` `finalize` to `[oracle-vm-4cpu-16gb-x86-64]`, which both live branches agree on. This one matters more than it looks. This branch still carries the `Create pull request if not exists` step that 1.6 deleted, so the cut opens a `release`-labelled PR whose merge fires `finalize`, and `finalize` is what runs `Publish draft release`. Left queued, v1.5.4 builds, drafts, and then sits unpublished.

`prepare-release` gets the `Set up build toolchain` step, `run:` body byte-identical to the one on `main` and `release-1.6`, because `make build` ends at `packages/core/installer image-packages` calling `flux push artifact` and flux is not on the ephemeral image. Only the `if:` differs and it has to: this branch's guard sets `skip` where 1.6 renamed the output `release_exists`.

Gate, stated as a ceiling rather than a pass. Both files parse, plus a parsed-yaml assertion that the new step lands between `Checkout code` and `Login to GHCR`. `pre-commit` cannot pass in a linked worktree in this repo at all, the `run-make-generate` hook does `flock -x .git/pre-commit.lock` and `.git` is a file there, exit 66, reproduced against an untouched file. zizmor does not exist on this branch, no hook and no config, so it was run by hand instead and reports no new findings.

Deliberately not fixed: `release-e2e.yaml` is on the same dead pool and will silently queue rather than go red. It gates nothing by its own header, and both live branches replaced it with `e2e-tag.yaml`.
