### PR TITLE
chore(ci): add area/cilium label and map the cilium PR scope to it

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -196,7 +196,11 @@
 
 - name: area/networking
   color: 'bfd4f2'
-  description: Issues or PRs related to networking (ingress, gateway, vpn, metallb, cilium, kube-ovn)
+  description: Issues or PRs related to networking (ingress, gateway, vpn, metallb, kube-ovn)
+
+- name: area/cilium
+  color: 'bfd4f2'
+  description: Issues or PRs related to Cilium (agent, operator, Gateway API, network policy, LB-IPAM)
 
 - name: area/platform
   color: 'bfd4f2'

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -98,11 +98,13 @@ jobs:
               'gateway':             'area/networking',
               'vpn':                 'area/networking',
               'metallb':             'area/networking',
-              'cilium':              'area/networking',
               'kube-ovn':            'area/networking',
               'tcp-balancer':        'area/networking',
               'securitygroups':      'area/networking',
               'cozy-proxy':          'area/networking',
+
+              // area/cilium
+              'cilium':              'area/cilium',
 
               // area/platform
               'platform':            'area/platform',

--- a/docs/agents/contributing.md
+++ b/docs/agents/contributing.md
@@ -91,12 +91,13 @@ git commit --signoff -m "docs(contributing): add installation guide"
 | api, cozystack-api | area/api |
 | build | area/build |
 | ci | area/ci |
+| cilium | area/cilium |
 | dashboard | area/dashboard |
 | postgres, mariadb, redis, etcd, kafka, clickhouse, postgres-operator, mariadb-operator | area/database |
 | extra | area/extra |
 | kubernetes | area/kubernetes |
 | monitoring, vlogs, vmstack, grafana, workloadmonitor | area/monitoring |
-| ingress, gateway, vpn, metallb, cilium, kube-ovn, cozy-proxy, ... | area/networking |
+| ingress, gateway, vpn, metallb, kube-ovn, cozy-proxy, ... | area/networking |
 | platform, bundle, flux, fluxcd, cluster-api, talos, installer, cozyctl, cozystack-engine, cozy-lib | area/platform |
 | backport, release | area/release |
 | seaweedfs, bucket, linstor, velero, harbor, backups | area/storage |


### PR DESCRIPTION
## What this PR does

Adds an `area/cilium` label and routes the `cilium` PR scope to it. Cilium has more than 20 open issues of its own right now (the pinned version and its bumps, the Gateway API implementation, network policy, IPAM next to kube-ovn, LB-IPAM), and `area/networking` no longer narrows a search. #3913 is the tracking issue that uses the label.

The label already exists in the repository, created by hand so the open issues could be labelled before this lands. The sync workflow runs with `delete-other-labels: false`, so nothing is at risk in between; this PR makes `labels.yml` the owner of it and updates the scope table in `docs/agents/contributing.md`.

The `cilium` scope moves from `area/networking` to `area/cilium`, following the `kamaji` and `keycloak` precedent where the dedicated area replaces the broad one rather than stacking on it.

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a dedicated `area/cilium` label for Cilium-related issues and pull requests.
  * Updated automated labeling and contribution guidance so Cilium changes are categorized separately from general networking work.
  * Refined the networking label description to exclude Cilium-related items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->