### PR TITLE
test(e2e): add a runner-layer fixed-work canary around the node-join wait

### DIFF
--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -2629,6 +2629,454 @@ cozy_capture_sandbox_qemu_thread_cpu() {
   fi
 }
 
+# How much work one canary arm does, and how long it may take doing it.
+#
+# Constants rather than knobs, and assigned unconditionally so they stay that
+# way: the legend states an expected duration against exactly these figures, so
+# a run that quietly used other ones would publish a range that was never true
+# of it.
+#
+# Sized so each arm takes about a second on a fast core: short enough that the
+# pair costs a few seconds of one core there, long enough that the 10ms clock
+# below is about a percent of the figure. Slower cores take proportionally
+# longer, up to the ceiling below, and the expected ranges the legend states are
+# where that is written down.
+COZY_CANARY_CPU_ITERATIONS=30000000
+# Declared in MiB and passed to dd in bytes. A suffix would be read differently
+# by the dd of the machine that happens to run this -- the sandbox image ships
+# the GNU one, where M is 1048576 while MB is a million, and dds elsewhere
+# disagree about which spellings they accept at all -- so the multiplication
+# happens here, where the unit the rate is reported in is the unit the constant
+# is written in.
+COZY_CANARY_MEM_BLOCK_MIB=64
+COZY_CANARY_MEM_BLOCKS=128
+# The rate below which an arm is pathological rather than merely slow, in the
+# unit that arm's rate is printed in. The legend prints both figures from these
+# two constants, so the number a reader is given is the number the collector
+# compares against. The sentences around them describe how each floor sits
+# against its band in words, and those are written rather than derived, so they
+# are the part that can go stale when a constant moves.
+#
+# Both sit under the healthy band rather than at its edge, and how far under is
+# what the ceiling limits. A floor an arm cannot reach before the ceiling stops
+# it never fires: the arm is cut off before its rate can fall that far, so every
+# alert arrives as the ceiling and carries a bound instead of the slowdown the
+# floor was meant to name. The memory arm crosses 500 MiB/s at 16.4s against the
+# 20s ceiling, under that band's own bottom of 8192 MiB in about eight seconds
+# rather than at it, so a core sitting at the bottom reads slow and raises
+# nothing where a floor placed at the bottom would have called that core
+# pathological on a green run. The compute arm has room for the full decade: a
+# tenth of a healthy mawk needs 10s, which is half the ceiling. Both
+# floors are set downwards on purpose -- the rate is printed in the capture
+# either way, so an alert this collector fails to raise costs less than one it
+# manufactures on a healthy machine. hack/run-kubernetes-runner-canary_test.bats
+# derives both crossings from these constants and fails when either leaves that
+# window.
+COZY_CANARY_CPU_MIN_RATE=3000000
+COZY_CANARY_MEM_MIN_RATE=500
+# The canary is work rather than a read, so it takes a ceiling of its own
+# instead of COZY_DIAG_READ_TIMEOUT. That bound is sized for an apiserver that
+# answers in under a second and lowering it is what the knob is for, which would
+# kill a canary meant to take seconds -- and unlike a read, a slow run here is
+# the finding rather than a lost one. This number is therefore the largest
+# slowdown the capture can still put a figure on: at the sizes above it stops an
+# arm an order of magnitude or more past the expected duration, past the factor
+# being hunted and short of spending the diagnostics budget on it.
+COZY_CANARY_RUN_BOUND_DEFAULT=20
+
+# The canary clock: /proc/uptime, in centiseconds, into _COZY_CANARY_CS.
+#
+# A global rather than a printed value, because the alternative is a command
+# substitution and that is a fork inside the interval being measured, at both
+# ends of every arm.
+#
+# /proc/uptime rather than `date`, and not for portability: the field is a
+# monotonic count no clock adjustment moves, and `read` is a builtin, so taking
+# the stamp costs no process. What it costs is resolution -- the kernel prints
+# hundredths -- which is why every duration here is quantised to 10ms and why
+# the legend says so.
+_cozy_canary_stamp() {
+  local raw='' rest='' secs='' frac=''
+
+  # The suppression goes ahead of the redirect rather than after it: applied in
+  # order, a missing file would otherwise put the shell error on the real stderr
+  # before the suppression took effect, and this function reports its own
+  # failures by returning rather than by printing.
+  read -r raw rest 2>/dev/null <"${COZY_DIAG_RUNNER_PROC_UPTIME:-/proc/uptime}" || return 1
+  # Refused unless the shape is exactly the one the arithmetic below is written
+  # for. A field with no decimal point is what this catches, and the only shape
+  # it catches: `${raw#*.}` hands back the whole string when there is no `.`, so
+  # a two-digit whole-second uptime passes the hundredths guard below as its own
+  # hundredths and ten seconds reads as 1010 centiseconds -- a duration off by a
+  # percent, manufactured by the one clock every figure here divides by. A field
+  # carrying three decimals never reaches the arithmetic at all: it is refused
+  # by that hundredths guard rather than by this one.
+  case "${raw}" in
+    *.*) ;;
+    *) return 1 ;;
+  esac
+  secs="${raw%%.*}"
+  frac="${raw#*.}"
+  case "${secs}" in
+    0 | [1-9]*) ;;
+    *) return 1 ;;
+  esac
+  case "${secs}" in
+    *[!0-9]*) return 1 ;;
+  esac
+  case "${frac}" in
+    [0-9][0-9]) ;;
+    *) return 1 ;;
+  esac
+  # A leading zero is octal to `$(( ))`, and 09 is not a number there at all, so
+  # the hundredths lose theirs before they are added.
+  frac="${frac#0}"
+  _COZY_CANARY_CS=$(( secs * 100 + frac ))
+}
+
+# One arm: run a fixed amount of work under a wall-clock ceiling and time it.
+#
+# The ceiling and its kill grace are read from the globals the collector
+# re-validates, the way the shared cAdvisor stream reads the pair its own caller
+# validates. Both also take a pass at source time, so this function finds them
+# set however it is reached; what the collector's pass adds is a value assigned
+# after sourcing, which is how a test sets one.
+#
+# Sets _COZY_CANARY_MS to the elapsed milliseconds and _COZY_CANARY_RC to the
+# status the shell waited on: the work's own whenever the work ended by itself,
+# which is what a healthy run does under a ceiling as much as without one, and
+# timeout's when the ceiling ended it instead. Which of the two a number came
+# from is not readable from the number, which is why the clock decides it below.
+# Returns 1 when the clock could not be read at both ends and 2 when it read but
+# went backwards, which the caller reports as different things -- neither is a
+# duration, but the first is silence about this machine and the second is a
+# broken instrument. Both are different again from work that failed, which is a
+# statement about the machine.
+_cozy_canary_run_arm() {
+  local capture="$1"
+  shift
+  local start=0 end=0
+
+  _COZY_CANARY_CS=0
+  _COZY_CANARY_MS=0
+  _COZY_CANARY_RC=0
+  # Whether a ceiling was in play at all, for the reporter to read beside the
+  # exit status: 124 and 137 are what the ceiling produces, and they are also
+  # what a work command exiting on its own or an outside SIGKILL produces, so
+  # the status alone cannot say the ceiling fired.
+  _COZY_CANARY_BOUNDED=0
+
+  _cozy_canary_stamp || return 1
+  start="${_COZY_CANARY_CS}"
+  # stdin closed for the reason every walk in this file closes it: nothing here
+  # reads it, and a program that started to would consume whatever the caller
+  # was iterating. stdout is discarded because an arm exists for its duration
+  # and its exit status already says whether the work ran to the end; stderr is
+  # kept, since that is where dd reports and where timeout names a command it
+  # could not start. A ceiling that fires says nothing there -- without
+  # --verbose, which this call does not pass, timeout is silent about it -- and
+  # that silence is why the status below is read against the clock rather than
+  # on its own.
+  if command -v timeout >/dev/null 2>&1; then
+    _COZY_CANARY_BOUNDED=1
+    timeout -k "${COZY_DIAG_READ_GRACE}" "${COZY_CANARY_RUN_BOUND}" \
+      "$@" >/dev/null 2>>"${capture}" </dev/null || _COZY_CANARY_RC=$?
+  else
+    "$@" >/dev/null 2>>"${capture}" </dev/null || _COZY_CANARY_RC=$?
+  fi
+  _cozy_canary_stamp || return 1
+  end="${_COZY_CANARY_CS}"
+
+  # A clock that went backwards is refused rather than published as a negative
+  # duration. Every figure this capture prints is derived from it, and a wrong
+  # duration produces a rate that reads exactly like a real one.
+  [ "${end}" -ge "${start}" ] || return 2
+  _COZY_CANARY_MS=$(( (end - start) * 10 ))
+}
+
+# One arm reported into the capture: what it ran, whatever it said on stderr,
+# how long it took, and what that divides to. <quantity> is the work expressed
+# in <unit>s, so the rate is <unit>s per second, and <floor> is the rate in that
+# unit below which the legend calls the machine pathological rather than slow.
+#
+# Returns non-zero when the arm could not be measured at all, so the caller can
+# tell a capture worth reading from one that holds nothing. An arm that finished
+# inside one tick was measured: it carries the note instead of a rate and still
+# returns zero. Sets _COZY_CANARY_ALERT when the figure it did produce is below
+# <floor> or was cut off by the ceiling. The status cannot carry that: an arm
+# that measured a starved machine produced a reading and returns zero like any
+# arm that finished.
+_cozy_canary_report_arm() {
+  local capture="$1" label="$2" quantity="$3" unit="$4" floor="$5"
+  shift 5
+  local timed=0 ms=0 rate=0 bound_rate=0
+
+  printf '\n=== arm: %s ===\n' "${label}" >>"${capture}"
+  printf 'command: %s\n' "$*" >>"${capture}"
+  # The work this arm was asked for, written down before it is divided by
+  # anything. Every other figure here is derived, so a reader who doubts one of
+  # them has the two inputs in front of them rather than in the source of the
+  # release that produced the artifact.
+  printf 'work: %s %s\n' "${quantity}" "${unit}" >>"${capture}"
+  _cozy_canary_run_arm "${capture}" "$@" || timed=$?
+  if [ "${timed}" -eq 2 ]; then
+    printf '%s\n' \
+      'this arm produced no reading: the canary clock read at both ends and the second stamp was the earlier one, so the instrument is wrong rather than the machine slow. Nothing is derived from it here' \
+      >>"${capture}"
+    return 1
+  fi
+  if [ "${timed}" -ne 0 ]; then
+    printf '%s\n' \
+      'this arm produced no reading: the canary clock could not be read at both ends, so how long the work took is not recorded here. That is silence about this machine rather than a finding about it' \
+      >>"${capture}"
+    return 1
+  fi
+  ms="${_COZY_CANARY_MS}"
+  printf 'elapsed: %s ms\n' "${ms}" >>"${capture}"
+
+  # Whether 124 or 137 means the ceiling is decided by the clock rather than by
+  # the status: timeout exits 124 when its term signal ends the work and the
+  # work exits 137 when a kill does, and an outside kill -- the OOM killer
+  # taking the 64 MiB buffer dd allocates is the realistic one -- produces the
+  # same 137 with the ceiling never involved. An arm that ended in either status
+  # before the ceiling could have fired was ended by something else, and
+  # reporting that as the ceiling manufactures the too-slow-to-finish finding
+  # this collector exists to detect. No tolerance is given for the truncation,
+  # because a ceiling that fired cannot read short: both stamps truncate
+  # hundredths off the one clock and the bound is a whole number of seconds, so
+  # the difference of the two floors is at least the bound whatever fraction the
+  # first stamp landed on. A duration under it was produced by something else.
+  local at_ceiling=0 ceiling_note=''
+  case "${_COZY_CANARY_RC}" in
+    124 | 137)
+      if [ "${_COZY_CANARY_BOUNDED}" -eq 1 ] && [ "${ms}" -ge $(( COZY_CANARY_RUN_BOUND * 1000 )) ]; then
+        at_ceiling=1
+      fi
+      ;;
+  esac
+  # Named apart the way the sibling collectors name a kill apart from a
+  # deadline: 137 says a kill ended the arm where 124 says the term signal did,
+  # and that is a different observation even though the status does not say
+  # whose kill it was. Timeout's own follow-up and a kill from outside are the
+  # same 137 here, the way they are before the ceiling above.
+  if [ "${at_ceiling}" -eq 1 ] && [ "${_COZY_CANARY_RC}" -eq 137 ]; then
+    ceiling_note=', on a status that says a kill ended the arm without saying whose'
+  fi
+  # The work's own failure is settled before its duration is, and the order is
+  # the whole of it: a command this machine does not have fails in well under
+  # one tick, so a duration-first reading would report the one arm that never
+  # ran as the one arm too fast to measure.
+  case "${_COZY_CANARY_RC}" in
+    0) ;;
+    124 | 137)
+      if [ "${at_ceiling}" -ne 1 ]; then
+        if [ "${_COZY_CANARY_BOUNDED}" -eq 1 ]; then
+          printf 'this arm produced no reading: the work ended with status %s after %s ms, before the %ss ceiling could have fired, so something other than the canary bound ended it and the duration above is how long it survived rather than how long the work takes here\n' \
+            "${_COZY_CANARY_RC}" "${ms}" "${COZY_CANARY_RUN_BOUND}" >>"${capture}"
+        else
+          printf 'this arm produced no reading: the work ended with status %s with no ceiling in play, so something on this machine ended it and the duration above is how long it survived rather than how long the work takes here\n' \
+            "${_COZY_CANARY_RC}" >>"${capture}"
+        fi
+        return 1
+      fi
+      ;;
+    *)
+      # The exit status goes in the line rather than only in the stderr above
+      # it: a 127 is a binary missing from this machine and a non-zero from the
+      # work itself is something else, and the number is what tells them apart.
+      printf 'this arm produced no reading: it ended %s, so the duration above is how long it took to fail rather than how long the work takes here\n' \
+        "${_COZY_CANARY_RC}" >>"${capture}"
+      return 1
+      ;;
+  esac
+  # And a zero duration before anything divides by it. It is not a fast machine
+  # reported badly, it is a duration this clock cannot express, and dividing by
+  # it ends the shell. Only a finished arm can reach this with a zero: the
+  # ceiling needs the whole bound on the clock, and a kill ahead of the ceiling
+  # was returned above.
+  if [ "${ms}" -eq 0 ]; then
+    printf '%s\n' \
+      'no rate: the arm finished inside one tick of the 10ms clock, so its duration is under the resolution rather than measured. At the sizes this canary runs, that is itself unexpected' \
+      >>"${capture}"
+    return 0
+  fi
+  # Integer division, so a rate under one unit per second lands on zero -- and a
+  # capture saying `rate: 0` reads as a machine that did nothing rather than as
+  # arithmetic that ran out of places.
+  rate=$(( quantity * 1000 / ms ))
+  # The figure the ceiling sentence prints is rounded up where the rate line is
+  # truncated, because the two are different kinds of number: a rate is measured
+  # and rounds toward what was seen, while this is an upper bound on work that
+  # never finished, and truncating a bound downwards prints a strict inequality
+  # the arm itself can sit inside.
+  bound_rate=$(( (quantity * 1000 + ms - 1) / ms ))
+  # The alert every call site turns into a job-log line: the two outside the
+  # diagnostics block and the one inside it. Raised here because this is the one
+  # place the figure and the floor it is read against are both in scope. An arm
+  # the ceiling stopped and an arm that finished under the floor are the same
+  # answer to the question this collector exists to ask -- the machine is not
+  # getting the work done -- and what differs is whether the figure is labelled a
+  # bound or a reading. An arm that finished inside one tick returned above and
+  # raises nothing: too fast to measure is not slow.
+  if [ "${at_ceiling}" -eq 1 ] || [ "${rate}" -lt "${floor}" ]; then
+    _COZY_CANARY_ALERT=1
+  fi
+  if [ "${at_ceiling}" -eq 1 ]; then
+    # The ceiling firing is the strongest reading this arm can produce, so it
+    # is recorded as a bound rather than dropped: the work did not finish in
+    # that many seconds, which is already a multiple of what it should take.
+    # Not recorded as a rate, because a rate would average over work that did
+    # not all happen. One sentence rather than two: rounding up makes the bound
+    # at least one in the printed unit for any quantity of at least one, and the
+    # sizes declared above are never zero, so there is no zero case left for a
+    # second sentence to carry.
+    printf 'this arm did not finish: it was stopped at the %ss ceiling%s, so its rate is BELOW %s %s per second and that figure is a bound rather than a reading\n' \
+      "${COZY_CANARY_RUN_BOUND}" "${ceiling_note}" "${bound_rate}" "${unit}" >>"${capture}"
+  else
+    if [ "${rate}" -eq 0 ]; then
+      printf 'rate: under one %s per second, which the work and elapsed lines above give exactly\n' \
+        "${unit}" >>"${capture}"
+    else
+      printf 'rate: %s %s per second\n' "${rate}" "${unit}" >>"${capture}"
+    fi
+  fi
+}
+
+# The runner layer fixed-work canary.
+#
+# The counters this report already carries are read in whatever unit their
+# source publishes -- time in the /proc/stat rows and the per-thread ticks,
+# events in the KVM exits, throttled periods beside throttled seconds in the
+# cgroup rows, and instantaneous values and running maxima in the files sitting
+# beside those exits -- and none of them is a fixed quantity of work.
+# So a machine that spent every tick and got a fraction of the work done reads
+# as healthy in all of them. That is the shape the node-join failures on this
+# lane have: the counters at every layer look normal while the work does not
+# get done. This collector carries its own unit of work instead, which gives its
+# reading a scale of its own and makes the pathology visible in a single red run
+# with no green one beside it.
+#
+# Two arms, because the candidates the time counters cannot separate act on
+# different resources: interference on the shared cache and the memory
+# controller from whatever else the host is running, and a core doing less per
+# cycle. The two arms differ in how much of each they feel rather than in being
+# deaf to one: the compute arm's working set is small enough that pressure on
+# the shared cache and the memory controller moves it little, while the memory
+# arm is dominated by it. A large asymmetric shift between them therefore points
+# at one of the two, to the factor of ten these figures resolve and no finer.
+#
+# What this is NOT is a measurement of the tenant workers. It runs at the runner
+# layer, where the sandbox nodes are hosted. Two layers down, the same
+# fixed-work question is already answered by how long the tenant workers take to
+# unpack their initramfs, which the serial console capture records. One layer
+# down no capture times it: the QEMU line that boots the sandbox nodes passes no
+# serial backend (hack/e2e-prepare-cluster.bats), so nothing carries their
+# console anywhere for a capture to read. What those nodes do put in this report
+# is their kernel ring buffer, which hack/cozyreport.sh pulls over the Talos API
+# into sandbox-host/talos-<node>-dmesg.txt -- read there for what their kernels
+# said, and a canary here would still be measuring the layer above them.
+cozy_capture_runner_canary() {
+  local sample="$1"
+  local report_dir="${COZY_REPORT_DIR:-/workspace/_out/cozyreport}/snapshots/${COZY_SNAPSHOT_NAME:-kubernetes}/runner-canary/sample-${sample}"
+  local capture="${report_dir}/fixed-work.txt"
+  local readings=0 mem_mib=0 cpu_program='' read_at='' read_done=''
+
+  # Cleared before anything below can return, so a call site reads it after
+  # every exit from here rather than only after the ones that reached an arm.
+  _COZY_CANARY_ALERT=0
+  # Checked, unlike most of what follows: with no directory every write below
+  # fails, the collector becomes a silent no-op, and the artifact carries the
+  # empty space this capture exists to refuse -- with nowhere to put a marker
+  # saying so.
+  if ! mkdir -p "${report_dir}"; then
+    echo "the report directory for the runner canary could not be created, so nothing was measured and nothing could be written to say so" >&2
+    return 1
+  fi
+  # Truncated once here and appended to from then on, the way every raw file
+  # beside this one is written: the arms and the legend are written in pieces,
+  # and a file left over from an earlier call would otherwise carry two runs of
+  # one sample with nothing between them to say where the first ended. Opened
+  # with `true` rather than `:` and checked: `:` is a POSIX special built-in,
+  # so a redirection that fails on it exits a non-interactive shell -- dash,
+  # which is /bin/sh in the sandbox image, honours that -- and on the failure
+  # path that exit ends the whole diagnostics block, straight past the call
+  # site's `|| true`. The tenant snapshot survives it -- it is an EXIT trap,
+  # armed before this block runs -- so what the exit costs is the rest of the
+  # diagnostics, not the snapshot behind them. A capture that cannot be opened
+  # is the mkdir case again: nothing can be measured, and the report has nowhere
+  # to say so.
+  if ! true >"${capture}"; then
+    echo "the capture file for the runner canary could not be opened for writing, so nothing was measured and nothing could be written to say so" >&2
+    return 1
+  fi
+  # Re-validated here for the reason every collector re-validates: a value
+  # assigned after this file is sourced never passed the assignment-time check,
+  # and zero reaches `timeout` as no bound at all.
+  COZY_CANARY_RUN_BOUND=$(_cozy_diag_seconds "${COZY_CANARY_RUN_BOUND-}" "$COZY_CANARY_RUN_BOUND_DEFAULT" COZY_CANARY_RUN_BOUND positive "zero is no ceiling at all, and an arm that never returns costs the phase whatever is gated behind it")
+  COZY_DIAG_READ_GRACE=$(_cozy_diag_seconds "${COZY_DIAG_READ_GRACE-}" "$COZY_DIAG_READ_GRACE_DEFAULT" COZY_DIAG_READ_GRACE)
+
+  mem_mib=$(( COZY_CANARY_MEM_BLOCK_MIB * COZY_CANARY_MEM_BLOCKS ))
+  # `print s` is kept and its output discarded: the sum is not wanted, but an
+  # awk able to see that the loop has no effect would be free to skip it, and a
+  # canary optimised away reports a healthy machine at any speed.
+  cpu_program="BEGIN { s = 0; for (i = 0; i < ${COZY_CANARY_CPU_ITERATIONS}; i++) s = (s + i) % 1000003; print s }"
+
+  echo "--- running the runner fixed-work canary (sample ${sample}) ---"
+  # Stamped around the pair for the reason the readings beside this one are
+  # stamped: the capture carries no sample time of its own, and the two samples
+  # are separated by the node-join wait rather than by a knob.
+  read_at=$(date -u +%s)
+  if _cozy_canary_report_arm "${capture}" \
+    "compute, a loop over a handful of integer-valued scalars" \
+    "${COZY_CANARY_CPU_ITERATIONS}" iterations "${COZY_CANARY_CPU_MIN_RATE}" \
+    awk "${cpu_program}"; then
+    readings=$(( readings + 1 ))
+  fi
+  if _cozy_canary_report_arm "${capture}" \
+    "memory, a store stream over blocks sized against one core's cache" \
+    "${mem_mib}" MiB "${COZY_CANARY_MEM_MIN_RATE}" \
+    dd if=/dev/zero of=/dev/null "bs=$(( COZY_CANARY_MEM_BLOCK_MIB * 1048576 ))" "count=${COZY_CANARY_MEM_BLOCKS}"; then
+    readings=$(( readings + 1 ))
+  fi
+  read_done=$(date -u +%s)
+
+  if ! command -v timeout >/dev/null 2>&1; then
+    # Said in the capture and not only in the phase log, for the reason the
+    # readings beside this one say it there: the warning naming the unbounded
+    # collectors fires inside the diagnostics phase, and one of this pair of
+    # samples is taken outside that phase on every run.
+    printf '\n%s\n' '[bounds] timeout is not on PATH here, so the arms above ran with no ceiling; each of them terminates on its own, so what was lost is the ceiling rather than the reading -- but on the slow machine this canary exists to catch, fixed work with no ceiling can take minutes rather than seconds, and everything that prices this collector at two bounded arms no longer holds]' \
+      >>"${capture}"
+  fi
+
+  printf '\n' >>"${capture}"
+  printf '%s\n' \
+    '[this canary runs on the RUNNER VM, inside the sandbox container: one layer above the three Talos nodes and two above the tenant workers. It is the only reading in this report that carries its own unit of work at this layer; two layers down the serial console capture records the tenant workers unpacking their initramfs, and one layer down no capture times it, because the QEMU line that boots the sandbox nodes passes no serial backend for a capture to read; what those nodes put here instead is their kernel ring buffer, under sandbox-host/talos-<node>-dmesg.txt. The counters beside it are read in the units their sources publish -- time in the CPU rows, events in the KVM exits, instantaneous values and running maxima in the files beside those -- and a counter with no unit of work in it cannot see a machine that spent its ticks and got less done with them, which is the shape this lane keeps failing in]' \
+    >>"${capture}"
+  printf '[two arms, and what makes them answer the same interference differently is the working set, not the amount of work each does. The compute arm loops over a handful of scalars, which live in registers and the nearest cache, so pressure on the shared cache or the memory controller moves it little rather than not at all. The memory arm streams blocks: a read of /dev/zero zeroes the buffer the caller supplied and a write to /dev/null never looks at it, so each block is one pass of stores over the whole block. The block size is both the working set and the reuse distance -- %s MiB here, against the 32 MiB of last-level cache an EPYC core can allocate into on the parts this lane has run on -- and a block that exceeds that cache leaves no byte still cached by the time it is written again, so the traffic lands on the memory controller. Which part this run got is recorded in sandbox-host/runner-identity.txt at the root of this report, and that is what tells a reader of this artifact which case it is looking at: on a part whose per-core cache exceeds the block size this arm stops being memory-bound and reads high. On a machine in front of you the dd line above can be rerun with a block size that fits the cache, and the figure rises several times over]\n' \
+    "${COZY_CANARY_MEM_BLOCK_MIB}" >>"${capture}"
+  printf '[expected ranges, and what they are worth. These are what the construction can do on a healthy server core, not figures measured on this lane, and they are stated to the precision they have: a factor of ten is what they resolve and a factor of two is not. Memory arm: one core sustains single-digit to low-double-digit GB per second of streaming stores, because the ceiling is how many misses one core keeps outstanding rather than how many memory channels the socket has, so the %s MiB it writes land in about a second on a fast core and in about eight at the bottom of that band, while anything under %s in the MiB-per-second unit the rate lines above are printed in, about half a gigabyte a second, is pathological rather than merely slow. Compute arm: the rate depends on the awk implementation as much as on the core, and that implementation is a property of the sandbox image rather than of the run, pinned by digest in packages/core/testing/images/e2e-sandbox/Dockerfile, so on the mawk that image ships a simple loop over integer-valued scalars runs at tens of millions of iterations a second and the %s of them here land in about a second, so anything under %s iterations a second, one factor of ten below that, is pathological rather than merely slow]\n' \
+    "${mem_mib}" "${COZY_CANARY_MEM_MIN_RATE}" "${COZY_CANARY_CPU_ITERATIONS}" "${COZY_CANARY_CPU_MIN_RATE}" >>"${capture}"
+  printf '%s\n' \
+    '[what this canary does NOT separate. It reads wall clock only, so an arm that took ten times as long could be a core doing less per cycle or a container that was not on a core at all. Where to look for the second is runner-kernel-cpu-time beside this capture and sandbox-host-cpu-time one layer down, and their steal columns do not read the same way. On the runner row a climb is proof this VM was preempted and a zero proves nothing, because nobody here launches that VM and the column is filled only where the hypervisor exposes the clock. One layer down the sandbox nodes are started with accel=kvm, which hands the guest that accounting, so a zero there means the node got every turn it asked for. Which is what makes the pair worth reading together: a sandbox zero under a climbing runner row puts the wait a layer above them. Read those first when an arm here is slow, and read each for what it covers: the runner-kernel rows are a pair bracketing the node-join wait, so they describe the whole join window next to these seconds rather than these seconds themselves, while the sandbox-host rows are a pair seconds apart inside the on-failure diagnostics block, taken minutes after the wait already failed and absent from a green run altogether]' \
+    '[the two samples. Sample 1 is taken before the node-join wait and sample 2 after it, on the failing and the passing path alike, on the same binaries in the same container. A difference between them puts the change inside the interval the pair brackets, which is the wait together with the readings taken on either side of it; two equally slow samples say it was already there going into that interval, which is the case the expected ranges above are the only instrument for -- the pair speaks for the interval between its own readings and for nothing before them]' \
+    '[this collector perturbs what it measures, which is why it is placed where it is. It occupies one core for the duration of each arm, twice per run. Sample 1 runs before the first reading of all three pairs that bracket the node-join wait, and sample 2 after the last of their second readings, so neither burn falls inside any interval those pairs divide by]' \
+    '[durations here are read from /proc/uptime, which the kernel prints in hundredths of a second, so every figure is quantised to 10ms. Against arms sized to take about a second that is about a percent, and it is why an arm finishing inside one tick is reported as being under the resolution rather than as a rate]' \
+    >>"${capture}"
+  printf '[read attempted from %s to %s epoch seconds]\n' \
+    "${read_at}" "${read_done}" >>"${capture}"
+
+  # Non-zero when no arm reported at all, and only then. An arm that finished
+  # inside one tick counts as having reported, so a capture holding that note
+  # instead of a rate still returns zero. Both call sites outside the
+  # diagnostics block consume this status to put a shortfall in the job log, and
+  # both of them run on the passing path, where the report is the artifact
+  # nobody downloads.
+  if [ "${readings}" -eq 0 ]; then
+    return 1
+  fi
+}
+
 # The shell run inside a worker's compute container to list QEMU's threads.
 #
 # A function rather than a literal at the call site so it can be run against a
@@ -3363,6 +3811,13 @@ COZY_DIAG_MAX_IMPORTERS=$(_cozy_diag_seconds "${COZY_DIAG_MAX_IMPORTERS:-$COZY_D
 # not a disabled bound but two readings taken at the same instant, which divide
 # to nothing and leave a pair that looks collected and answers no question.
 COZY_DIAG_RATE_INTERVAL=$(_cozy_diag_seconds "${COZY_DIAG_RATE_INTERVAL:-$COZY_DIAG_RATE_INTERVAL_DEFAULT}" "$COZY_DIAG_RATE_INTERVAL_DEFAULT" COZY_DIAG_RATE_INTERVAL positive "zero puts both readings at the same instant, so the pair divides to nothing")
+# The canary ceiling takes the same source-time pass as its neighbours, and not
+# only for symmetry: the collector re-validates with `${COZY_CANARY_RUN_BOUND-}`,
+# so without this line a run that never set the knob hands the validator an
+# empty string, and the job log opens with a warning about ignoring a value
+# nobody supplied. Rejected as `positive` because zero reaches `timeout` as no
+# bound at all.
+COZY_CANARY_RUN_BOUND=$(_cozy_diag_seconds "${COZY_CANARY_RUN_BOUND:-$COZY_CANARY_RUN_BOUND_DEFAULT}" "$COZY_CANARY_RUN_BOUND_DEFAULT" COZY_CANARY_RUN_BOUND positive "zero is no ceiling at all, and an arm that never returns costs the phase whatever is gated behind it")
 
 # Wall-clock budget for the on-failure diagnostics phase as a whole, on top of the
 # per-read bounds above, because the two buy different things. A per-read bound
@@ -3447,7 +3902,7 @@ cozy_diag_phase_start() {
   # an unchecked list sitting beside a checked one, drifting from it at whatever
   # rate collectors are added.
   command -v timeout >/dev/null 2>&1 || \
-    echo "» WARNING: timeout is not on PATH; the bounded reads below run UNBOUNDED, so one that hangs can still take the op and the tenant snapshot with it, and the collectors that call timeout directly (wedge check, serial console, guest Talos) exit 127 and collect nothing; the ones that guard the call with command -v -- the worker CPU throttling, worker network counter, worker block IO counter, sandbox node CPU time, sandbox kernel KVM counters, runner kernel CPU time, sandbox QEMU per-thread CPU time, worker per-thread CPU time, ghcr-mirror and talos-image-cache captures -- keep collecting instead, unbounded" >&2
+    echo "» WARNING: timeout is not on PATH; the bounded reads below run UNBOUNDED, so one that hangs can still take the op and the tenant snapshot with it, and the collectors that call timeout directly (wedge check, serial console, guest Talos) exit 127 and collect nothing; the ones that guard the call with command -v -- the worker CPU throttling, worker network counter, worker block IO counter, sandbox node CPU time, sandbox kernel KVM counters, runner kernel CPU time, sandbox QEMU per-thread CPU time, runner fixed-work canary, worker per-thread CPU time, ghcr-mirror and talos-image-cache captures -- keep collecting instead, unbounded" >&2
   # Re-checked here, not only at assignment: a value set after this file is sourced
   # -- which is how a test sets it -- would otherwise reach the arithmetic below
   # unvalidated, and that is the one failure that costs the whole block.
@@ -3649,6 +4104,31 @@ cozy_report_node_join_failure() {
   # the sum against the phase budget.
   cozy_capture_runner_kernel_cpu_time 2 || true
   cozy_capture_sandbox_qemu_thread_cpu 2 || true
+  # The canary's second sample, last of the four that bracket the wait. Last
+  # rather than beside them because it is the only one of the four that costs a
+  # core rather than a read -- ahead of them, its burn would sit inside the
+  # interval each of those pairs divides by.
+  #
+  # Here rather than further down the block, and ungated, for a reason of its
+  # own: unlike the three beside it this sample is an absolute reading
+  # and would still be a reading taken minutes later. What it would stop being
+  # is comparable. The passing path takes its own sample within seconds of the
+  # wait returning, and the whole use of the expected ranges is that a red
+  # figure and a green figure describe the same moment in the run; a red sample
+  # that drifted behind the diagnostics reads a machine several minutes past the
+  # failure it is meant to characterise.
+  #
+  # What it costs, stated rather than waved at: two arms, each under a ceiling
+  # of its own. The guard in hack/run-kubernetes-node-join_test.bats prices both
+  # at that ceiling and holds the sum against the phase budget.
+  cozy_capture_runner_canary 2 || true
+  # The alert reaches the job log here as well, and for a sharper version of the
+  # reason the two samples outside this block report theirs: this is the run a
+  # triager opens, the tail of it is where they start, and sample 1's warning is
+  # eighteen minutes and thousands of lines above.
+  if [ "${_COZY_CANARY_ALERT:-0}" -eq 1 ]; then
+    echo "» WARNING: the runner fixed-work canary did not read inside the range its own legend calls healthy on the failing run, so what follows was collected on a machine that was not getting the work done; which arm it was and what figure it gave is written into the capture" >&2
+  fi
   cozy_diag_read 'tenant node table' \
     kubectl --kubeconfig "${tenant_kc}" describe nodes "${request_timeout}"
   cozy_diag_read 'tenant HelmReleases' \
@@ -4265,6 +4745,27 @@ EOF
   # Verify the Kubernetes version matches what we expect (retry for up to 20 seconds)
   timeout 20 sh -ec 'until kubectl --kubeconfig tenantkubeconfig-'"${test_name}"' version 2>/dev/null | grep -Fq "Server Version: ${k8s_version}"; do sleep 1; done'
 
+  # The canary goes first, outside the three counter pairs below rather than
+  # among them, and it is a different kind of instrument from all three: it does
+  # not read a running total twice, it runs a fixed amount of work and times it,
+  # so each sample stands on its own and there is no interval for anything to
+  # widen. What it does have is a cost, since it occupies a core for a couple of
+  # seconds. That is why it sits out here. Taken between any of those first
+  # readings and the wait, its burn would land inside the interval that pair
+  # divides by: runner-kernel CPU time the pair would then charge to the join
+  # window, and for the two counting the guests, a core taken away from what
+  # they count; ahead of all three, it lands on neither side of any of them, and
+  # the second sample sits behind all three second readings for the same reason.
+  #
+  # Both outcomes reach the job log rather than only the capture, and the second
+  # for the same reason as the first: a run that took a reading the legend calls
+  # pathological is the loudest thing this collector can say, and on the passing
+  # path the report holding it is the artifact nobody downloads.
+  if ! cozy_capture_runner_canary 1; then
+    echo "» WARNING: the runner fixed-work canary produced no reading before the node-join wait, so this run has no measure of what one core got done at this layer going into it; if a capture was written it says whether the clock could not be read or the work itself failed, and if it could not be written the line above this one says so" >&2
+  elif [ "${_COZY_CANARY_ALERT:-0}" -eq 1 ]; then
+    echo "» WARNING: the runner fixed-work canary did not read inside the range its own legend calls healthy before the node-join wait, so this run went into the wait on a machine that was already not getting the work done; which arm it was and what figure it gave is written into the capture" >&2
+  fi
   # The first readings of the three pairs that bracket the wait, taken here
   # rather than inside the failure block and taken on every run rather than on
   # the failing ones. All three read running totals, so one reading is an
@@ -4331,6 +4832,22 @@ EOF
   fi
   if ! cozy_capture_sandbox_qemu_thread_cpu 2; then
     echo "» WARNING: the sandbox VMs' QEMU threads yielded no reading after the node-join wait, so this report carries no green baseline for how that time split across the three nodes; whether the walk failed or this container had no QEMU process to read is written into the capture itself" >&2
+  fi
+  # The canary's second sample, last on this path as it was first before the
+  # wait. Behind all three second readings deliberately: it burns a core, and
+  # taken ahead of any of them that burn would sit inside the interval the pair
+  # divides by. It is also the half of the pair with the green figure in it --
+  # the expected ranges the capture states are what a red run is read against
+  # when there is no green run to compare it with, and a green run that records
+  # its own numbers is what says whether those ranges describe this lane.
+  #
+  # Ungated, unlike the console capture further down this path, and the reason is
+  # not that the rule there does not apply. That rule is for a collector costing
+  # minutes; both arms here sit under one ceiling apiece and the pair is seconds.
+  if ! cozy_capture_runner_canary 2; then
+    echo "» WARNING: the runner fixed-work canary produced no reading after the node-join wait, so this report carries no green figure for what one core gets done at this layer; if a capture was written it says whether the clock could not be read or the work itself failed, and if it could not be written the line above this one says so" >&2
+  elif [ "${_COZY_CANARY_ALERT:-0}" -eq 1 ]; then
+    echo "» WARNING: the runner fixed-work canary did not read inside the range its own legend calls healthy after the node-join wait, so this run passed on a machine that was not getting the work done at this layer; which arm it was and what figure it gave is written into the capture" >&2
   fi
   kubectl --kubeconfig "tenantkubeconfig-${test_name}" get nodes -o wide
 

--- a/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
@@ -43,11 +43,18 @@ spec:
         #   guest Talos capture
         #   ghcr-mirror state, access log and warm-up Job
         #   talos-image-cache diagnosis
-        # The three bracket pairs -- the sandbox kernel KVM counters, the runner
-        # kernel CPU time and the sandbox QEMU thread time -- sit outside this
-        # order on purpose: each is ungated, one bounded read a side, taken
-        # before the node-join wait and right after it on both paths, and their
-        # cost arms live in the budget guard rather than in this list.
+        # The four collectors that bracket the node-join wait -- the sandbox
+        # kernel KVM counters, the runner kernel CPU time, the sandbox QEMU
+        # thread time and the runner fixed-work canary -- sit outside this order
+        # on purpose: each is ungated and taken before the wait and right after
+        # it on both paths, and their cost arms live in the budget guard rather
+        # than in this list. Three of the four are reads: the KVM counters and
+        # the runner kernel CPU time are one bounded read a side, and the QEMU
+        # thread time is a bounded probe walk plus a bounded read of each
+        # sandbox pid file. The canary is two arms of fixed work under a ceiling
+        # of its own apiece, and it is the one of the four that costs a core
+        # rather than a read, which is why it runs outside the brackets of the
+        # other three rather than among them.
         # and then, after the phase rather than inside it, the in-process tenant
         # crust-gather snapshot.
         #
@@ -56,7 +63,9 @@ spec:
         # phase rather than this ceiling raised. None of it is a worst case and none is
         # claimed: several of those collectors carry no wall-clock bound at all, and
         # the bringup's own waits already exceed this op on ceilings before a single
-        # diagnostic runs. Those residuals are tracked in cozystack/cozystack#3666.
+        # diagnostic runs, and the pre-wait halves of the four readings above spend
+        # inside that bringup rather than inside this phase. Those residuals are
+        # tracked in cozystack/cozystack#3666.
         timeout: 50m
         # Co-locate the tenant crust-gather snapshot (captured by
         # run-kubernetes.sh on failure) under the same snapshots/<test>/ dir as

--- a/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
@@ -37,11 +37,18 @@ spec:
         #   guest Talos capture
         #   ghcr-mirror state, access log and warm-up Job
         #   talos-image-cache diagnosis
-        # The three bracket pairs -- the sandbox kernel KVM counters, the runner
-        # kernel CPU time and the sandbox QEMU thread time -- sit outside this
-        # order on purpose: each is ungated, one bounded read a side, taken
-        # before the node-join wait and right after it on both paths, and their
-        # cost arms live in the budget guard rather than in this list.
+        # The four collectors that bracket the node-join wait -- the sandbox
+        # kernel KVM counters, the runner kernel CPU time, the sandbox QEMU
+        # thread time and the runner fixed-work canary -- sit outside this order
+        # on purpose: each is ungated and taken before the wait and right after
+        # it on both paths, and their cost arms live in the budget guard rather
+        # than in this list. Three of the four are reads: the KVM counters and
+        # the runner kernel CPU time are one bounded read a side, and the QEMU
+        # thread time is a bounded probe walk plus a bounded read of each
+        # sandbox pid file. The canary is two arms of fixed work under a ceiling
+        # of its own apiece, and it is the one of the four that costs a core
+        # rather than a read, which is why it runs outside the brackets of the
+        # other three rather than among them.
         # and then, after the phase rather than inside it, the in-process tenant
         # crust-gather snapshot.
         #
@@ -50,7 +57,9 @@ spec:
         # phase rather than this ceiling raised. None of it is a worst case and none is
         # claimed: several of those collectors carry no wall-clock bound at all, and
         # the bringup's own waits already exceed this op on ceilings before a single
-        # diagnostic runs. Those residuals are tracked in cozystack/cozystack#3666.
+        # diagnostic runs, and the pre-wait halves of the four readings above spend
+        # inside that bringup rather than inside this phase. Those residuals are
+        # tracked in cozystack/cozystack#3666.
         timeout: 50m
         # Co-locate the tenant crust-gather snapshot (captured by
         # run-kubernetes.sh on failure) under the same snapshots/<test>/ dir as

--- a/hack/run-kubernetes-node-join_test.bats
+++ b/hack/run-kubernetes-node-join_test.bats
@@ -234,6 +234,13 @@ stub_collectors() {
   # happens to be running, which is the property this file removes.
   cozy_capture_runner_kernel_cpu_time() { printf 'runner-kernel-cpu-stub\n'; }
   cozy_capture_sandbox_qemu_thread_cpu() { printf 'sandbox-qemu-thread-stub\n'; }
+  # Stubbed on the same ground and for a sharper version of it again: the canary
+  # issues no kubectl read either, so it contributes nothing to the audit below,
+  # and un-stubbed it does not read this machine -- it LOADS it, occupying a
+  # core for a couple of seconds on every case that drives the block. What it
+  # would then record is set by whatever else is running on the machine, which
+  # is the property this file removes.
+  cozy_capture_runner_canary() { printf 'runner-canary-stub\n'; }
 }
 
 # The collectors below are deliberately NOT in stub_collectors, and that is
@@ -896,6 +903,7 @@ assert_file_lacks_pattern() {
       cozy_capture_sandbox_kvm_exits() { :; }
       cozy_capture_runner_kernel_cpu_time() { :; }
       cozy_capture_sandbox_qemu_thread_cpu() { :; }
+      cozy_capture_runner_canary() { :; }
       ghcr_mirror_diagnose() { :; }
       kubectl() { :; }
       cozy_report_node_join_failure test-latest-version
@@ -965,6 +973,7 @@ assert_file_lacks_pattern() {
     cozy_capture_sandbox_kvm_exits() { :; }
     cozy_capture_runner_kernel_cpu_time() { :; }
     cozy_capture_sandbox_qemu_thread_cpu() { :; }
+    cozy_capture_runner_canary() { :; }
     cozy_capture_tenant_worker_block_io() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_capture_sandbox_node_cpu_time() { :; }
@@ -1043,6 +1052,7 @@ assert_file_lacks_pattern() {
     cozy_capture_sandbox_kvm_exits() { :; }
     cozy_capture_runner_kernel_cpu_time() { :; }
     cozy_capture_sandbox_qemu_thread_cpu() { :; }
+    cozy_capture_runner_canary() { :; }
     cozy_capture_tenant_worker_block_io() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_report_node_join_failure test-latest-version
@@ -1079,6 +1089,7 @@ assert_file_lacks_pattern() {
     cozy_capture_sandbox_kvm_exits() { :; }
     cozy_capture_runner_kernel_cpu_time() { :; }
     cozy_capture_sandbox_qemu_thread_cpu() { :; }
+    cozy_capture_runner_canary() { :; }
     cozy_capture_tenant_worker_block_io() { :; }
     ghcr_mirror_diagnose() { :; }
     cozy_report_node_join_failure test-latest-version
@@ -1314,7 +1325,13 @@ assert_file_lacks_pattern() {
   budget=$(grep -oE '^COZY_DIAG_PHASE_BUDGET_DEFAULT=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
   bound=$(grep -oE '^COZY_DIAG_READ_TIMEOUT_DEFAULT=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
   grace=$(grep -oE '^COZY_DIAG_READ_GRACE_DEFAULT=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
-  for v in budget bound grace; do
+  # The canary declares a ceiling of its own rather than taking the read bound,
+  # so its arm below is priced from that number and not from `bound`. Read from
+  # the source for the reason every other input to this guard is: a ceiling
+  # raised there and left alone here would be summed at the old figure while the
+  # guard went on reading as satisfied.
+  canary=$(grep -oE '^COZY_CANARY_RUN_BOUND_DEFAULT=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  for v in budget bound grace canary; do
     eval "n=\$$v"
     if [ -z "$n" ]; then
       echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
@@ -1389,6 +1406,15 @@ assert_file_lacks_pattern() {
       # of the console in wall clock.
       cozy_capture_runner_kernel_cpu_time) ahead=$((ahead + bound + grace)) ;;
       cozy_capture_sandbox_qemu_thread_cpu) ahead=$((ahead + bound + grace)) ;;
+      # The fourth reading that brackets the wait, and the only one of them that
+      # is not a read: two arms of fixed work, each under the canary ceiling, so
+      # it is priced at two of those rather than at the read bound the three
+      # above it share. Exempt on a ground of its own rather than theirs: its
+      # samples stand alone, so nothing is orphaned by declining this one, but
+      # the figure is only worth what its nearness to the failure makes it, and
+      # the gate can only decline or defer. Counted all the same, because it
+      # does sit ahead of the console in wall clock.
+      cozy_capture_runner_canary) ahead=$((ahead + 2 * (canary + grace))) ;;
       cozy_capture_tenant_worker_network_counters) ahead=$((ahead + walk)) ;;
       # One walk apiece and read once, so each costs what the expression above
       # prices a capped walk at. Both sit ahead of the console on the same
@@ -1515,6 +1541,7 @@ assert_file_lacks_pattern() {
     'cozy_capture_sandbox_kvm_exits:sandbox kernel KVM counters:cozy_capture_sandbox_kvm_exits' \
     'cozy_capture_runner_kernel_cpu_time:runner kernel CPU time:cozy_capture_runner_kernel_cpu_time' \
     'cozy_capture_sandbox_qemu_thread_cpu:sandbox QEMU per-thread CPU time:cozy_capture_sandbox_qemu_thread_cpu' \
+    'cozy_capture_runner_canary:runner fixed-work canary:_cozy_canary_run_arm' \
     'cozy_capture_tenant_worker_thread_cpu:worker per-thread CPU time:cozy_capture_tenant_worker_thread_cpu _cozy_virt_launcher_listing' \
     'ghcr_mirror_diagnose:ghcr-mirror:ghcr_mirror_diagnose _ghcr_mirror_bounded_read' \
     'talos_image_cache_diagnose:talos-image-cache:talos_image_cache_diagnose _talos_image_cache_bounded_read'; do
@@ -1554,6 +1581,12 @@ ${carrier}
       cozy_capture_sandbox_kvm_exits) phrase='sandbox kernel KVM counters' ;;
       cozy_capture_runner_kernel_cpu_time) phrase='runner kernel CPU time' ;;
       cozy_capture_sandbox_qemu_thread_cpu) phrase='sandbox QEMU per-thread CPU time' ;;
+      # In `guarded` twice over: the body that runs one arm guards the ceiling
+      # it puts around the work, and the capture guards a second check of its
+      # own to decide whether to write the [bounds] note. Both belong to the one
+      # collector the sentence names, so the phrase here answers for the pair
+      # and the arm body is exempted below rather than given a phrase of its own.
+      cozy_capture_runner_canary) phrase='runner fixed-work canary' ;;
       cozy_capture_tenant_worker_thread_cpu) phrase='worker per-thread CPU time' ;;
       ghcr_mirror_diagnose) phrase='ghcr-mirror' ;;
       talos_image_cache_diagnose) phrase='talos-image-cache' ;;
@@ -1567,6 +1600,10 @@ ${carrier}
       # this a list of exemptions rather than a list of everything.
       cozy_diag_read | _ghcr_mirror_bounded_read | _talos_image_cache_bounded_read) continue ;;
       _cozy_cadvisor_node_stream | _cozy_virt_launcher_listing) continue ;;
+      # The canary carries its guard in the body that runs one arm, the way the
+      # cAdvisor captures carry theirs in the stream they share, so the sentence
+      # names the capture and the table above names what makes it true of it.
+      _cozy_canary_run_arm) continue ;;
       cozy_report_node_join_failure | _talos_image_cache_deploy_state) continue ;;
       *)
         echo "$fn guards its call with command -v but this test has no phrase for it; add one here and to the warning" >&2
@@ -1641,6 +1678,8 @@ ${carrier}
       # budget may hand out or withhold.
       cozy_capture_runner_kernel_cpu_time) continue ;;
       cozy_capture_sandbox_qemu_thread_cpu) continue ;;
+      # The fourth bracket half, and also not behind the gate.
+      cozy_capture_runner_canary) continue ;;
       *)
         echo "$fn runs in the diagnostics block but this test has no phrase for it; add one here and to both chainsaw comments" >&2
         exit 1
@@ -1878,6 +1917,7 @@ EOF
     cozy_capture_sandbox_kvm_exits() { :; }
     cozy_capture_runner_kernel_cpu_time() { :; }
     cozy_capture_sandbox_qemu_thread_cpu() { :; }
+    cozy_capture_runner_canary() { :; }
     cozy_capture_tenant_worker_block_io() { :; }
     ghcr_mirror_diagnose() { :; }
     kubectl() { :; }
@@ -1908,7 +1948,10 @@ EOF
   # `bringup` is what the chainsaw comments give for reaching the failure. That is an
   # observed figure and not a ceiling, deliberately: the bringup's own waits already
   # exceed the whole op on ceilings, so a guard written against those would assert a
-  # worst case nobody can state.
+  # worst case nobody can state. The pre-wait halves of the readings that bracket
+  # the node-join wait spend inside it -- the canary's first sample alone is bounded
+  # at two arms of (canary + grace) -- so a collector added before the wait moves
+  # the real figure while this literal sits still.
   #
   # `largest` is the heaviest collector's cost at the pool's MINIMUM size, so it is a
   # floor rather than a ceiling. It is here because admission gates when a collector
@@ -1921,9 +1964,11 @@ EOF
   # wall-clock bound at all; nor a bounded read gated ahead of the console outside
   # the CAPTURE-style call form this walk enumerates, as the LINSTOR resource state
   # read is, whose cost is therefore not summed here; nor a new collector heavier
-  # than the literal, since nothing makes one move it. Those are the residuals, and
-  # the first three exist today rather than hypothetically. All are tracked in
-  # cozystack/cozystack#3666.
+  # than the literal, since nothing makes one move it; nor the pre-wait halves of the four
+  # readings that bracket the wait, which spend inside the bringup term this literal fixes
+  # rather than inside the budget, and which the canary's first sample alone can carry to
+  # two arms of (canary + grace). Those are the residuals, and the first three exist today
+  # rather than hypothetically. All are tracked in cozystack/cozystack#3666.
   bringup=1500
   # 620 was this figure while the guest-Talos walk ran two commands per worker.
   # It now runs four: the service list and the link table were added at a 10s

--- a/hack/run-kubernetes-runner-canary_test.bats
+++ b/hack/run-kubernetes-runner-canary_test.bats
@@ -1,0 +1,2185 @@
+#!/usr/bin/env bats
+# Regression coverage for the runner fixed-work canary in
+# hack/e2e-chainsaw/_lib/run-kubernetes.sh. cozytest.sh ends an @test block at
+# the first bare closing brace, so command mocks stay at top level.
+#
+# What this collector is for, and why its failure modes are worth pinning. No
+# counter that file already reads carries a unit of work of its own, whatever
+# unit it is read in; this one runs a fixed amount of work and times it, which
+# is what gives its reading a scale of its own and lets it call a single red run
+# pathological with no green run beside it. That scale is exactly what a wrong
+# duration destroys, and a wrong duration is cheap to produce: a clock field
+# parsed with the wrong number of decimals is off by a factor of ten, which is
+# the size of the effect being hunted, and a capture reporting it would read like
+# a finding rather than like a bug.
+#
+# So most of what follows is about the arithmetic and about the difference
+# between silence and a reading. An arm nobody could time, an arm stopped at its
+# ceiling and an arm that ran to the end are three different things, and only
+# the last of them is a rate.
+#
+# Run with: hack/cozytest.sh hack/run-kubernetes-runner-canary_test.bats
+#
+# cozytest.sh is the canonical runner and the CI path: it runs this file under
+# `sh` with `set -eu`, and in CI that `sh` is dash, which is what the collector
+# meets in the sandbox image. `bats` runs the same file under bash without those
+# flags, so it is a convenience rather than an equal alternative: the guards
+# here that exist for dash semantics do not fire under it. Spelling the capture
+# truncation `: >` again -- the regression the guard below is written for --
+# leaves bats green, and leaves cozytest green too wherever /bin/sh is not dash,
+# which includes macOS, where it is bash in POSIX mode. Run `dash
+# hack/cozytest.sh` to exercise those guards off CI.
+
+timeout_calls=/dev/null
+timeout_rc_override=
+timeout_rc_match=
+timeout_skip_command=
+
+timeout() {
+  local command_rc=0
+  printf '%s\n' "$*" >>"${timeout_calls}"
+  # Return 97 rather than running the command when the wrapper is not the
+  # bounded form: work that lost its ceiling must not pass as work that had one.
+  [ "${1:-}" = -k ] || return 97
+  shift 3
+  if [ -z "${timeout_skip_command}" ]; then
+    "$@" || command_rc=$?
+  fi
+  case "$*" in
+    *"${timeout_rc_match}"*)
+      [ -z "${timeout_rc_override}" ] || return "${timeout_rc_override}"
+      ;;
+  esac
+  return "${command_rc}"
+}
+
+assert_file_contains() {
+  local needle="$1"
+  local file="$2"
+
+  if [ ! -f "${file}" ]; then
+    printf 'expected %s to exist so it could be checked for: %s\n' "${file}" "${needle}" >&2
+    return 1
+  fi
+  case "$(cat "${file}")" in
+    *"${needle}"*) return 0 ;;
+  esac
+  printf 'expected %s to contain: %s\n' "${file}" "${needle}" >&2
+  cat "${file}" >&2
+  return 1
+}
+
+assert_file_lacks_pattern() {
+  local pattern="$1"
+  local file="$2"
+
+  # A missing file must fail rather than vacuously pass: a bare `! grep -q`
+  # succeeds on an unreadable path, which is indistinguishable from "the file
+  # exists and does not carry the label".
+  if [ ! -f "${file}" ]; then
+    printf 'expected %s to exist so it could be checked for: %s\n' "${file}" "${pattern}" >&2
+    return 1
+  fi
+  # Branched on awk's exact status. awk exits 1 for "no line matched" and 2 for
+  # "I could not evaluate this"; folded together, a negative assertion is
+  # satisfied by its own matcher giving up, which is the direction that goes
+  # green and stays green.
+  local _rc=0
+  awk -v pattern="${pattern}" '$0 ~ pattern { found = 1 } END { exit found ? 0 : 1 }' "${file}" || _rc=$?
+  case "${_rc}" in
+    0)
+      printf 'expected %s not to match: %s\n' "${file}" "${pattern}" >&2
+      cat "${file}" >&2
+      return 1
+      ;;
+    1) return 0 ;;
+    *)
+      printf 'awk could not evaluate pattern %s against %s\n' "${pattern}" "${file}" >&2
+      return 1
+      ;;
+  esac
+}
+
+# The clock the arms are timed by, replaced by a scripted sequence.
+#
+# Real durations are the one thing this suite must not depend on: they are set
+# by whatever else is running on the machine, and every rate below is derived
+# from them. The stub hands out one centisecond stamp per call in the order the
+# collector takes them -- arm one start, arm one end, arm two start, arm two end
+# -- so the arithmetic the capture prints is decided by the test rather than by
+# the host.
+#
+# Installed by a function called after the library is sourced, because sourcing
+# would otherwise replace it with the real one.
+stamp_values=
+stamp_index=0
+stamp_fail_at=
+
+stub_stamp() {
+  _cozy_canary_stamp() {
+    stamp_index=$(( stamp_index + 1 ))
+    if [ "${stamp_index}" = "${stamp_fail_at}" ]; then
+      return 1
+    fi
+    _COZY_CANARY_CS=$(printf '%s\n' ${stamp_values} | sed -n "${stamp_index}p")
+    [ -n "${_COZY_CANARY_CS}" ] || return 1
+  }
+}
+
+# The same collector run in this shell rather than in a subshell, for the cases
+# that read a variable it leaves behind rather than a file: the alert the call
+# sites branch on would go with the subshell.
+run_canary_here() {
+  local _rc=0
+  set +x
+  cozy_capture_runner_canary "${1:-1}" || _rc=$?
+  return "${_rc}"
+}
+
+# The collector writes into files it decides from a command's stderr, and
+# cozytest.sh runs under `set -x`, so the tracer's own lines would land on the
+# very stderr being redirected. Call through this so the sinks hold what
+# production writes.
+run_canary() {
+  local _rc=0
+  ( set +x; cozy_capture_runner_canary "${1:-1}" ) || _rc=$?
+  return "${_rc}"
+}
+
+stage() {
+  COZY_REPORT_DIR="$1/report"
+  COZY_SNAPSHOT_NAME=canary-smoke
+  COZY_DIAG_RUNNER_PROC_UPTIME="$1/uptime"
+  printf '70062.90 774208.84\n' >"${COZY_DIAG_RUNNER_PROC_UPTIME}"
+}
+
+capture_path() {
+  printf '%s/snapshots/canary-smoke/runner-canary/sample-%s/fixed-work.txt' \
+    "${COZY_REPORT_DIR}" "${1:-1}"
+}
+
+# ---------------------------------------------------------------------------
+# The clock.
+# ---------------------------------------------------------------------------
+
+@test "the clock reads the kernel hundredths into centiseconds" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  stage "$tmp"
+
+  _cozy_canary_stamp
+  [ "$_COZY_CANARY_CS" = 7006290 ] || {
+    echo "FAIL: 70062.90 read as $_COZY_CANARY_CS centiseconds" >&2
+    return 1
+  }
+  rm -rf "$tmp"
+}
+
+@test "a clock field the arithmetic is not written for is refused rather than parsed" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  stage "$tmp"
+
+  # None of these is a shape the arithmetic below is written for, and they fail
+  # in three different ways once the checks are gone: a fraction of the wrong
+  # width divides by ten or multiplies by it, which is the size of the effect
+  # being hunted; a field with no point at all reads its own digits as
+  # hundredths and skews by a percent; a non-digit ends the shell mid-arm. A
+  # refused clock is silence; a mis-scaled one is a finding nobody made.
+  for field in '70062.900' '70062.9' '70062' '70' 'x.90' '70062.9x' '070062.90' '7x.90'; do
+    printf '%s 774208.84\n' "$field" >"$COZY_DIAG_RUNNER_PROC_UPTIME"
+    _COZY_CANARY_CS=unset
+    if _cozy_canary_stamp; then
+      echo "FAIL: the clock accepted the field $field and read it as $_COZY_CANARY_CS" >&2
+      return 1
+    fi
+  done
+  rm -rf "$tmp"
+}
+
+@test "a leading zero in the hundredths is not read as octal" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  stage "$tmp"
+
+  # 08 and 09 are not numbers to `$(( ))` at all, so an unstripped fraction ends
+  # the shell on one uptime in fifty rather than returning a wrong figure. There
+  # is no third kind to exercise: the field is two digits, so a leading zero can
+  # only make 00 through 09, and every one of those that parses at all parses as
+  # the value it reads as -- 07 is seven in both shells with the strip and
+  # without it. So the rows are the two that are errors, and each pins the
+  # figure the strip has to leave behind as well as the error it avoids.
+  for pair in '70062.09 7006209' '70062.08 7006208'; do
+    field=${pair% *}
+    want=${pair#* }
+    printf '%s 774208.84\n' "$field" >"$COZY_DIAG_RUNNER_PROC_UPTIME"
+    _cozy_canary_stamp
+    [ "$_COZY_CANARY_CS" = "$want" ] || {
+      echo "FAIL: $field read as $_COZY_CANARY_CS, expected $want" >&2
+      return 1
+    }
+  done
+  rm -rf "$tmp"
+}
+
+@test "an unreadable clock is refused without putting a shell error on stderr" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  stage "$tmp"
+  COZY_DIAG_RUNNER_PROC_UPTIME="$tmp/absent"
+
+  rc=0
+  # The redirect goes INSIDE the subshell, after the tracer is off. cozytest.sh
+  # runs under `set -x`, and a sink attached to the subshell itself collects the
+  # tracer's own line for `set +x` before it takes effect -- so the assertion
+  # below would be reading the runner rather than the function.
+  ( set +x; _cozy_canary_stamp 2>"$tmp/err" ) || rc=$?
+  [ "$rc" -ne 0 ] || {
+    echo "FAIL: a missing clock file was accepted as a stamp" >&2
+    return 1
+  }
+  # The function reports by returning. A shell error here reaches the job log of
+  # a run whose every other line is written to mean something exact, which is
+  # what teaches the next reader to skim.
+  [ ! -s "$tmp/err" ] || {
+    echo "FAIL: the missing clock file put this on stderr:" >&2
+    cat "$tmp/err" >&2
+    return 1
+  }
+  rm -rf "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# The ceiling around each arm.
+# ---------------------------------------------------------------------------
+
+@test "each arm runs under the canary ceiling rather than under the read bound" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='100 150 150 250'
+  # Set apart on purpose. The canary is work rather than a read, and a read
+  # bound lowered to speed the diagnostics up would kill an arm that is meant to
+  # take seconds; taking the wrong one of these two is invisible until that
+  # happens.
+  COZY_CANARY_RUN_BOUND=11
+  COZY_DIAG_READ_TIMEOUT=7
+  COZY_DIAG_READ_GRACE=3
+
+  run_canary
+
+  assert_file_contains '-k 3 11 awk' "$timeout_calls"
+  assert_file_contains '-k 3 11 dd' "$timeout_calls"
+  assert_file_lacks_pattern '-k 3 7 ' "$timeout_calls"
+  rm -rf "$tmp"
+}
+
+@test "a zero canary ceiling is rejected because zero is no ceiling at all" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='100 150 150 250'
+  COZY_CANARY_RUN_BOUND=0
+  COZY_DIAG_READ_GRACE=3
+
+  ( set +x; run_canary 2>"$tmp/err" )
+
+  # The default, not the rejected value: a warning that named the fallback and
+  # then used the number anyway would be worse than no warning.
+  assert_file_contains "COZY_CANARY_RUN_BOUND='0'" "$tmp/err"
+  assert_file_contains "-k 3 ${COZY_CANARY_RUN_BOUND_DEFAULT} awk" "$timeout_calls"
+  rm -rf "$tmp"
+}
+
+@test "a run that never set the canary ceiling is not warned about ignoring one" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+
+  # Re-sourced inside the subshell with the knob unset, because that is the
+  # state of every real run: nobody sets COZY_CANARY_RUN_BOUND, the source-time
+  # assignment settles it to the default, and the collector's re-validation
+  # must then find a value rather than an empty string. Without the assignment
+  # the validator warns about ignoring a value nobody supplied, on the
+  # » WARNING: prefix CI readers grep for, on every run including green ones.
+  ( set +x
+    unset COZY_CANARY_RUN_BOUND
+    . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+    COZY_CANARY_CPU_ITERATIONS=1000
+    COZY_CANARY_MEM_BLOCK_MIB=1
+    COZY_CANARY_MEM_BLOCKS=1
+    cozy_capture_runner_canary 1
+  ) >"$tmp/out" 2>"$tmp/err"
+
+  assert_file_lacks_pattern 'ignoring COZY_CANARY_RUN_BOUND' "$tmp/err"
+  # And the default reached the arms as a real ceiling, so the silence above is
+  # the knob settling rather than the warning merely going missing.
+  assert_file_contains "-k 5 ${COZY_CANARY_RUN_BOUND_DEFAULT} awk" "$timeout_calls"
+  rm -rf "$tmp"
+}
+
+@test "the arms still run when timeout is not on PATH, and the capture says so" {
+  # The documented fallback: where `timeout` is absent the work runs unbounded
+  # rather than not at all, and the phase warning promises exactly that by name.
+  # `timeout` is a shell function in this file, so `command -v timeout` is always
+  # true here and the else arm is otherwise never executed -- which is the arm
+  # that runs on a machine without coreutils, the one machine it exists for.
+  tmp=$(mktemp -d)
+  mkdir -p "$tmp/bin"
+  for c in sh mkdir date cat grep sed awk dd rm mv printf; do
+    for d in /bin /usr/bin /usr/local/bin /opt/homebrew/bin /sbin /usr/sbin; do
+      if [ -x "$d/$c" ]; then
+        ln -sf "$d/$c" "$tmp/bin/$c"
+        break
+      fi
+    done
+  done
+  for c in sh mkdir date cat awk dd rm; do
+    if [ ! -x "$tmp/bin/$c" ]; then
+      echo "FAIL: could not stage $c in the stripped PATH; the check below would be vacuous" >&2
+      return 1
+    fi
+  done
+  if [ -e "$tmp/bin/timeout" ]; then
+    echo "FAIL: timeout leaked into the stripped PATH; this test would prove nothing" >&2
+    return 1
+  fi
+  printf '70062.90 774208.84\n' >"$tmp/uptime"
+  # The clock here is a file, because /proc/uptime is not on every machine this
+  # suite runs on. A file does not advance on its own, so both stamps of an arm
+  # would read one value, every arm would take the sub-tick branch, and the
+  # division this case exists to exercise would never run. So awk and dd are
+  # wrapped: the wrapper advances the clock by a fixed step and then execs the
+  # real binary, which keeps the work real while the duration each arm reports
+  # is decided here rather than by whatever machine this is. Removed before
+  # writing rather than written over: these are symlinks, and a redirect would
+  # land in the binary they point at.
+  real_awk=$(readlink "$tmp/bin/awk")
+  real_dd=$(readlink "$tmp/bin/dd")
+  rm -f "$tmp/bin/awk" "$tmp/bin/dd"
+  cat >"$tmp/bin/awk" <<EOF
+#!/bin/sh
+printf '70063.90 774208.84\n' >"$tmp/uptime"
+exec "$real_awk" "\$@"
+EOF
+  cat >"$tmp/bin/dd" <<EOF
+#!/bin/sh
+printf '70064.90 774208.84\n' >"$tmp/uptime"
+exec "$real_dd" "\$@"
+EOF
+  chmod +x "$tmp/bin/awk" "$tmp/bin/dd"
+  rc=0
+
+  # PATH is narrowed INSIDE the subprocess rather than in front of it: the shell
+  # resolves the command name with the PATH the assignment sets, so a stripped
+  # PATH in front of `bash` cannot find bash itself.
+  out=$( ( set +x
+    bash -c '
+      . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+      COZY_REPORT_DIR='"$tmp"'/report
+      COZY_SNAPSHOT_NAME=canary-smoke
+      COZY_DIAG_RUNNER_PROC_UPTIME='"$tmp"'/uptime
+      COZY_CANARY_CPU_ITERATIONS=1000
+      COZY_CANARY_MEM_BLOCK_MIB=1
+      COZY_CANARY_MEM_BLOCKS=1
+      PATH='"$tmp"'/bin
+      cozy_capture_runner_canary 1
+    ' ) 2>&1 ) || rc=$?
+
+  [ "$rc" -eq 0 ] || {
+    echo "FAIL: the canary ended $rc with no timeout on PATH; the warning promises it keeps collecting" >&2
+    printf '%s\n' "$out" >&2
+    false
+  }
+  capture="$tmp/report/snapshots/canary-smoke/runner-canary/sample-1/fixed-work.txt"
+  # Both arms ran the real binaries, and the wrapped clock gives each of them a
+  # second, so each reports a duration and divides by it: 1000 iterations and
+  # 1 MiB, each in one second. That is what makes this the case that exercises
+  # the unbounded arm end to end rather than only reaching it.
+  assert_file_contains 'arm: compute' "$capture"
+  assert_file_contains 'arm: memory' "$capture"
+  assert_file_contains 'elapsed: 1000 ms' "$capture"
+  assert_file_contains 'rate: 1000 iterations per second' "$capture"
+  assert_file_contains 'rate: 1 MiB per second' "$capture"
+  assert_file_lacks_pattern 'produced no reading' "$capture"
+  assert_file_lacks_pattern 'finished inside one tick' "$capture"
+  # And the capture says it ran without a ceiling. The phase warning that names
+  # unbounded collectors fires inside the diagnostics phase, and one of this
+  # pair of samples is taken outside it on every run, so a capture that ran
+  # unbounded and stayed quiet about it would read exactly like a bounded one.
+  assert_file_contains '[bounds] timeout is not on PATH here' "$capture"
+  rm -rf "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# What a duration divides to.
+# ---------------------------------------------------------------------------
+
+@test "an arm that ran with no ceiling is not reported as having hit one" {
+  # The else arm of the `command -v timeout` branch, driven to a status the
+  # ceiling also produces. Nothing bounded this arm, so its elapsed time cannot
+  # be attributed to a bound: on a machine without coreutils an outside kill
+  # landing past the bound would otherwise be published as the
+  # too-slow-to-finish finding this collector exists to detect.
+  tmp=$(mktemp -d)
+  mkdir -p "$tmp/bin"
+  for c in sh mkdir date cat grep sed rm dd printf; do
+    for d in /bin /usr/bin /usr/local/bin /opt/homebrew/bin /sbin /usr/sbin; do
+      if [ -x "$d/$c" ]; then
+        ln -sf "$d/$c" "$tmp/bin/$c"
+        break
+      fi
+    done
+  done
+  for c in sh mkdir date rm dd; do
+    if [ ! -x "$tmp/bin/$c" ]; then
+      echo "FAIL: could not stage $c in the stripped PATH; the check below would be vacuous" >&2
+      return 1
+    fi
+  done
+  if [ -e "$tmp/bin/timeout" ]; then
+    echo "FAIL: timeout leaked into the stripped PATH; this test would prove nothing" >&2
+    return 1
+  fi
+  printf '70062.90 774208.84\n' >"$tmp/uptime"
+  # The compute arm's own command, replaced by one that moves the clock 21
+  # seconds past the start stamp -- one second past the twenty-second bound the
+  # collector would have applied had there been a timeout to apply it with --
+  # and then dies the way an outside kill does.
+  cat >"$tmp/bin/awk" <<STUB
+#!/bin/sh
+printf '70083.90 774208.84\n' >"$tmp/uptime"
+exit 137
+STUB
+  chmod +x "$tmp/bin/awk"
+  rc=0
+
+  out=$( ( set +x
+    bash -c '
+      . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+      COZY_REPORT_DIR='"$tmp"'/report
+      COZY_SNAPSHOT_NAME=canary-smoke
+      COZY_DIAG_RUNNER_PROC_UPTIME='"$tmp"'/uptime
+      COZY_CANARY_MEM_BLOCK_MIB=1
+      COZY_CANARY_MEM_BLOCKS=1
+      COZY_CANARY_RUN_BOUND=20
+      PATH='"$tmp"'/bin
+      cozy_capture_runner_canary 1
+    ' ) 2>&1 ) || rc=$?
+
+  # The memory arm beside it returned without failing, so the collector still
+  # reports success: an arm that died is not the collector failing. That arm
+  # takes both its stamps after the stub moved the clock, so what it contributes
+  # is the sub-tick note rather than a rate.
+  [ "$rc" -eq 0 ] || {
+    echo "FAIL: the canary ended $rc with one arm killed and the other returning cleanly; the call sites read that status as no reading at all" >&2
+    printf '%s\n' "$out" >&2
+    false
+  }
+  capture="$tmp/report/snapshots/canary-smoke/runner-canary/sample-1/fixed-work.txt"
+  assert_file_contains 'ended with status 137 with no ceiling in play' "$capture"
+  # The whole point of the sentence above: the bound was never in play, so the
+  # elapsed time cannot be read as the bound firing.
+  assert_file_lacks_pattern 'stopped at the' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "an unbounded arm ending at a ceiling status survives the flags production runs under" {
+  # `_COZY_CANARY_BOUNDED` is read where a 124 or 137 is classified, and the
+  # suites source this library under `set -eu`. It is initialised at the top of
+  # every arm rather than only on the branch that sets it to 1, so the read on
+  # the unbounded path finds a value; without that initialisation this path dies
+  # on an unset variable instead of reporting, and on the failing path the death
+  # takes the rest of the diagnostics block with it. The case above drives the
+  # same path without the flags, so it cannot see this.
+  tmp=$(mktemp -d)
+  mkdir -p "$tmp/bin"
+  for c in sh mkdir date cat grep sed rm dd printf; do
+    for d in /bin /usr/bin /usr/local/bin /opt/homebrew/bin /sbin /usr/sbin; do
+      if [ -x "$d/$c" ]; then
+        ln -sf "$d/$c" "$tmp/bin/$c"
+        break
+      fi
+    done
+  done
+  for c in sh mkdir date rm dd; do
+    if [ ! -x "$tmp/bin/$c" ]; then
+      echo "FAIL: could not stage $c in the stripped PATH; the check below would be vacuous" >&2
+      return 1
+    fi
+  done
+  if [ -e "$tmp/bin/timeout" ]; then
+    echo "FAIL: timeout leaked into the stripped PATH; this test would prove nothing" >&2
+    return 1
+  fi
+  printf '70062.90 774208.84\n' >"$tmp/uptime"
+  # Exits with the status the ceiling also produces, which is the only status
+  # that reaches the read this case exists for.
+  cat >"$tmp/bin/awk" <<STUB
+#!/bin/sh
+printf '70083.90 774208.84\n' >"$tmp/uptime"
+exit 137
+STUB
+  chmod +x "$tmp/bin/awk"
+  rc=0
+
+  out=$( ( set +x
+    bash -c '
+      set -eu
+      . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+      COZY_REPORT_DIR='"$tmp"'/report
+      COZY_SNAPSHOT_NAME=canary-smoke
+      COZY_DIAG_RUNNER_PROC_UPTIME='"$tmp"'/uptime
+      COZY_CANARY_MEM_BLOCK_MIB=1
+      COZY_CANARY_MEM_BLOCKS=1
+      COZY_CANARY_RUN_BOUND=20
+      PATH='"$tmp"'/bin
+      cozy_capture_runner_canary 1
+    ' ) 2>&1 ) || rc=$?
+
+  [ "$rc" -eq 0 ] || {
+    echo "FAIL: under set -eu the canary ended $rc on the unbounded path; an unset read here aborts the collector instead of reporting" >&2
+    printf '%s\n' "$out" >&2
+    false
+  }
+  case "$out" in
+    *'_COZY_CANARY_BOUNDED'*)
+      echo "FAIL: the unbounded path named _COZY_CANARY_BOUNDED on stderr, which is what an unset read looks like under set -u" >&2
+      printf '%s\n' "$out" >&2
+      return 1
+      ;;
+  esac
+  capture="$tmp/report/snapshots/canary-smoke/runner-canary/sample-1/fixed-work.txt"
+  assert_file_contains 'ended with status 137 with no ceiling in play' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the note about a missing ceiling is written only when the ceiling was missing" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+  COZY_CANARY_CPU_ITERATIONS=1000000
+  COZY_CANARY_MEM_BLOCK_MIB=2048
+  COZY_CANARY_MEM_BLOCKS=4
+
+  run_canary
+
+  capture=$(capture_path)
+  # `timeout` is a shell function in this file, so both arms here ran under a
+  # ceiling. A note saying they did not would tell a reader the figures above it
+  # were taken with no bound -- on every run, which is how a note that is not
+  # conditional reads.
+  assert_file_lacks_pattern 'timeout is not on PATH here' "$capture"
+  assert_file_contains 'rate: 2000000 iterations per second' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a completed arm reports its duration and the rate that duration divides to" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  # 50 centiseconds for the compute arm, 200 for the memory one.
+  stamp_values='1000 1050 1050 1250'
+  COZY_CANARY_CPU_ITERATIONS=1000000
+  COZY_CANARY_MEM_BLOCK_MIB=2
+  COZY_CANARY_MEM_BLOCKS=4
+
+  run_canary
+
+  capture=$(capture_path)
+  assert_file_contains 'elapsed: 500 ms' "$capture"
+  assert_file_contains 'rate: 2000000 iterations per second' "$capture"
+  assert_file_contains 'elapsed: 2000 ms' "$capture"
+  # The memory rate is per MiB of the work actually done, so it follows both
+  # sizes rather than the block size alone: 2 MiB four times over in 2s.
+  assert_file_contains 'rate: 4 MiB per second' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the memory arm streams the block size the capture reports it in" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+  COZY_CANARY_MEM_BLOCK_MIB=2
+  COZY_CANARY_MEM_BLOCKS=4
+
+  run_canary
+
+  # Bytes rather than a suffix, and the conversion is what makes the reported
+  # MiB the MiB that were written: a `2M` here would be two million bytes to one
+  # dd, two mebibytes to another and an error to a third, and the rate above
+  # would be wrong by that ratio in the first case with nothing to show for it.
+  assert_file_contains 'bs=2097152 count=4' "$timeout_calls"
+  rm -rf "$tmp"
+}
+
+@test "an arm stopped at its ceiling is recorded as a bound rather than as a rate" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  timeout_rc_match=dd
+  timeout_rc_override=124
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 3050'
+  COZY_CANARY_MEM_BLOCK_MIB=100
+  COZY_CANARY_MEM_BLOCKS=8
+  COZY_CANARY_RUN_BOUND=20
+
+  run_canary
+
+  capture=$(capture_path)
+  assert_file_contains 'work: 800 MiB' "$capture"
+  # The ceiling firing is the strongest reading this arm produces, so it is kept
+  # and labelled rather than dropped: the work did not finish inside that many
+  # seconds, which is already a multiple of what it should take. Reported as a
+  # rate it would be an average over work that did not all happen.
+  assert_file_contains 'this arm did not finish: it was stopped at the 20s ceiling' "$capture"
+  assert_file_contains 'BELOW 40 MiB per second' "$capture"
+  assert_file_lacks_pattern '^rate: [0-9]+ MiB' "$capture"
+  # And the compute arm beside it, which did finish, still reports a rate: a
+  # collector that gave up on both arms because one hit its ceiling would lose
+  # the half that discriminates.
+  assert_file_contains 'iterations per second' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a kill before the ceiling is not reported as the ceiling" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  timeout_rc_match=dd
+  timeout_rc_override=137
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+  COZY_CANARY_RUN_BOUND=20
+
+  run_canary
+
+  capture=$(capture_path)
+  # 137 is what the ceiling's follow-up kill produces and also what the OOM
+  # killer produces, and the elapsed line is the only thing that separates
+  # them: an arm that ended two seconds into a twenty-second bound was not
+  # stopped by the bound. Read by status alone, this was published as the
+  # too-slow-to-finish finding the instrument exists to detect, manufactured
+  # by whatever sent the kill.
+  assert_file_contains 'ended with status 137 after 2000 ms, before the 20s ceiling could have fired' "$capture"
+  assert_file_lacks_pattern 'stopped at the' "$capture"
+  assert_file_lacks_pattern 'BELOW' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a kill that landed at the ceiling is recorded as the ceiling and named as a kill" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  timeout_rc_match=dd
+  timeout_rc_override=137
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 3050'
+  COZY_CANARY_MEM_BLOCK_MIB=100
+  COZY_CANARY_MEM_BLOCKS=8
+  COZY_CANARY_RUN_BOUND=20
+
+  run_canary
+
+  capture=$(capture_path)
+  # A status of 137 says a kill ended the arm where 124 says the term signal
+  # did, which is a different observation the way the sibling collectors name a
+  # kill apart from a deadline -- and it is still the ceiling, because the whole
+  # bound was on the clock when the kill landed. Whose kill it was is not in the
+  # status, so the sentence does not name one.
+  assert_file_contains 'it was stopped at the 20s ceiling, on a status that says a kill ended the arm without saying whose' "$capture"
+  assert_file_contains 'BELOW 40 MiB per second' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "both arms stopped at the ceiling raise the alert rather than a shortfall" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  timeout_rc_match=
+  timeout_rc_override=124
+  stage "$tmp"
+  stub_stamp
+  # Both arms on the clock for the whole bound, which is the pathology this
+  # collector exists to detect at its loudest. A ceiling-stopped arm carries a
+  # bound rather than a rate, but it is still a reading: counted as nothing, the
+  # sample would report a shortfall and the call sites would print that they got
+  # no reading, which is the vaguest thing they can say about the one machine
+  # state worth naming exactly.
+  stamp_values='1000 3000 3000 5000'
+  COZY_CANARY_MEM_BLOCK_MIB=100
+  COZY_CANARY_MEM_BLOCKS=8
+  COZY_CANARY_RUN_BOUND=20
+  rc=0
+
+  run_canary_here || rc=$?
+
+  capture=$(capture_path)
+  [ "$rc" -eq 0 ] || {
+    echo "FAIL: two arms stopped at their ceiling reported a shortfall ($rc); the call sites would say no reading was taken for the loudest reading this collector produces" >&2
+    cat "$capture" >&2
+    return 1
+  }
+  if [ "${_COZY_CANARY_ALERT:-unset}" != 1 ]; then
+    echo "expected two arms stopped at their ceiling to raise the alert, found ${_COZY_CANARY_ALERT:-unset}" >&2
+    cat "$capture" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "an arm stopped one tick short of its ceiling is not the ceiling" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  timeout_rc_match=dd
+  timeout_rc_override=124
+  stage "$tmp"
+  stub_stamp
+  # 1099 centiseconds, so 10990 ms against an 11000 ms bound. The bound is not
+  # the 20 the default carries: this is the only case that reaches the sentence
+  # naming the ceiling it did not reach, so it is the only one that can tell
+  # that sentence reading the knob from it reading the compiled-in figure.
+  stamp_values='1000 1050 1050 2149'
+  COZY_CANARY_MEM_BLOCK_MIB=100
+  COZY_CANARY_MEM_BLOCKS=8
+  COZY_CANARY_RUN_BOUND=11
+
+  run_canary
+
+  capture=$(capture_path)
+  # A ceiling that fired cannot read short of its bound: both stamps truncate
+  # hundredths off the one clock and the bound is whole seconds, so the two
+  # floors differ by at least the bound. A duration under it was produced by
+  # something else, and filing that as the ceiling manufactures the very finding
+  # this collector exists to detect.
+  assert_file_lacks_pattern 'it was stopped at the 11s ceiling' "$capture"
+  assert_file_contains 'before the 11s ceiling could have fired' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "an arm stopped exactly at its ceiling is the ceiling" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  timeout_rc_match=dd
+  timeout_rc_override=124
+  stage "$tmp"
+  stub_stamp
+  # 1100 centiseconds, so 11000 ms against an 11000 ms bound: the shortest
+  # duration a fired ceiling can produce. This case and the one above it hold
+  # the comparison exactly where it belongs -- at the bound it is the ceiling,
+  # one tick under it is not -- so both a reintroduced tolerance and a
+  # comparison tightened to greater-than fail one of the pair. The bound here is
+  # deliberately not the 20 the default carries: every other ceiling case sets
+  # it to exactly that default, so their assertions would hold just as well if
+  # the comparison read the compiled-in figure instead of the knob the caller
+  # set. Reading the default here classifies a fired ceiling as something else.
+  stamp_values='1000 1050 1050 2150'
+  COZY_CANARY_MEM_BLOCK_MIB=100
+  COZY_CANARY_MEM_BLOCKS=8
+  COZY_CANARY_RUN_BOUND=11
+
+  run_canary
+
+  capture=$(capture_path)
+  # The bound on the clock exactly, which is what a ceiling that fired produces
+  # at its shortest. Filing this as something else ending the work early would
+  # lose the strongest reading the collector takes, so the comparison has to
+  # admit the bound itself and nothing under it.
+  assert_file_contains 'it was stopped at the 11s ceiling' "$capture"
+  assert_file_contains 'BELOW 73 MiB per second' "$capture"
+  assert_file_lacks_pattern 'before the 11s ceiling could have fired' "$capture"
+  # The kill note belongs to 124's sibling status and must not appear here. The
+  # case that pins the note pins only its presence, and every case that reaches
+  # this sentence on a 124 asserts it by two substrings the note sits between,
+  # so without this line the note could be attached to every ceiling report and
+  # nothing would notice -- telling a triager a kill ended an arm the term
+  # signal ended, which is the attribution this collector is built to refuse.
+  assert_file_lacks_pattern 'a kill ended the arm' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "an arm that failed on its own account produces no reading and names its exit status" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  timeout_rc_match=dd
+  timeout_rc_override=127
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+
+  run_canary
+
+  capture=$(capture_path)
+  # 127 is a binary missing from this machine and a non-zero from the work
+  # itself is something else. The number is what tells them apart, so it goes in
+  # the line rather than only into the stderr above it. Said as what the arm
+  # ended on rather than as what the work returned, because a ceiling that fires
+  # ends the arm with timeout's status while work that ends by itself keeps its
+  # own, and the number does not say which happened.
+  assert_file_contains 'it ended 127' "$capture"
+  # The sentence says "the duration above", which is a claim about order rather
+  # than about presence: every no-reading sentence points back at the elapsed
+  # line instead of repeating the figure, so the line has to be written before
+  # the status is classified. Asserting only that it exists somewhere would hold
+  # just as well with it printed underneath.
+  elapsed_at=$(grep -n '^elapsed: ' "$capture" | head -n 1 | cut -d: -f1)
+  ended_at=$(grep -n 'it ended 127' "$capture" | head -n 1 | cut -d: -f1)
+  for v in elapsed_at ended_at; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to read $v from the capture; without it this check reports success for having lost its input" >&2
+      cat "$capture" >&2
+      return 1
+    fi
+  done
+  if [ "$elapsed_at" -ge "$ended_at" ]; then
+    echo "the no-reading sentence (capture line $ended_at) says the duration is above it, but the elapsed line is at $elapsed_at" >&2
+    cat "$capture" >&2
+    return 1
+  fi
+  # And not as a rate: a duration measured on a command that never ran is how
+  # long it took to fail.
+  assert_file_lacks_pattern 'MiB per second' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "an arm that failed instantly is named as failed rather than as too fast to measure" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  timeout_rc_match=dd
+  timeout_rc_override=127
+  stage "$tmp"
+  stub_stamp
+  # Both stamps of the memory arm land on the same tick, which is what a command
+  # this machine does not have actually produces: it fails in well under 10ms.
+  stamp_values='1000 1050 1050 1050'
+
+  run_canary
+
+  capture=$(capture_path)
+  # Read in the other order, the one arm that never ran is reported as the one
+  # arm too fast to measure -- and on a machine missing dd that is every run,
+  # with the capture claiming the memory arm was instantaneous.
+  assert_file_contains 'it ended 127' "$capture"
+  assert_file_lacks_pattern 'finished inside one tick' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "an arm nobody could time is reported as silence rather than as a duration" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+  # The clock fails on the memory arm's closing stamp.
+  stamp_fail_at=4
+
+  run_canary
+
+  capture=$(capture_path)
+  assert_file_contains 'the canary clock could not be read at both ends' "$capture"
+  # Silence about this machine rather than a finding about it. A missing
+  # duration written as a zero, or as the arm having been fast, is the one way
+  # this capture could manufacture the conclusion it exists to test for.
+  assert_file_lacks_pattern 'MiB per second' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "an arm whose opening stamp fails reports nothing rather than the machine's uptime" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  # The clock fails on the compute arm's OPENING stamp, which the case beside
+  # this one never reaches: it fails the closing stamp of the second arm, so
+  # indices 1 to 3 go unexercised. The opening stamp is the one that matters,
+  # because the start it would have set is initialised to zero: unchecked, the
+  # closing stamp turns the machine's whole uptime into the arm's duration, and
+  # a duration that large divides to a rate under any floor. The collector would
+  # then raise the alert every call site turns into a job-log line -- a
+  # pathological finding manufactured on a healthy machine, which is the one
+  # outcome this collector must never produce.
+  stamp_fail_at=1
+  stamp_values='1000 1050 1150 1250'
+  COZY_CANARY_CPU_ITERATIONS=6000000
+  COZY_CANARY_MEM_BLOCK_MIB=1000
+  COZY_CANARY_MEM_BLOCKS=1
+
+  run_canary_here
+
+  capture=$(capture_path)
+  assert_file_contains 'the canary clock could not be read at both ends' "$capture"
+  # The arm beside it was timed and carries the run's only figure.
+  assert_file_contains 'rate: 1000 MiB per second' "$capture"
+  if [ "${_COZY_CANARY_ALERT:-unset}" != 0 ]; then
+    echo "expected an arm whose opening stamp failed to raise no alert; an alert here is a pathology manufactured out of an unread clock" >&2
+    cat "$capture" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "an arm faster than one tick reports no rate rather than dividing by zero" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1000 1000 1000'
+  rc=0
+
+  run_canary || rc=$?
+
+  # Dividing by it ends the shell: in dash an arithmetic division by zero is
+  # fatal on its own account rather than through errexit, so it fires even
+  # inside the `if` condition these call sites use, and on this path that takes
+  # the whole diagnostics block with it. The duration is under the resolution
+  # rather than measured, and at the sizes this canary runs that is itself a
+  # finding.
+  [ "$rc" -eq 0 ] || {
+    echo "FAIL: a sub-tick duration ended the collector with $rc" >&2
+    return 1
+  }
+  capture=$(capture_path)
+  assert_file_contains 'no rate: the arm finished inside one tick' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a kill inside one tick is named as a kill rather than as the ceiling or a finish" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  timeout_rc_match=dd
+  timeout_rc_override=124
+  stage "$tmp"
+  stub_stamp
+  # The memory arm ends with a ceiling-shaped status while both of its stamps
+  # land on the same tick, which a real ceiling cannot produce: the ceiling
+  # needs the whole bound on the clock. Read by status alone this was reported
+  # as the ceiling with no duration, which is a finding about the machine
+  # manufactured by whatever actually killed the work.
+  stamp_values='1000 1050 1050 1050'
+  COZY_CANARY_RUN_BOUND=20
+  rc=0
+
+  run_canary || rc=$?
+
+  capture=$(capture_path)
+  assert_file_contains 'before the 20s ceiling could have fired' "$capture"
+  assert_file_lacks_pattern 'finished inside one tick' "$capture"
+  assert_file_lacks_pattern 'stopped at the' "$capture"
+  # And the shell survives it: on the failure path an exit here takes the rest
+  # of the diagnostics block with it, straight past the call site's guard. The
+  # tenant snapshot is armed as an EXIT trap before the block, so it still runs.
+  [ "$rc" -eq 0 ] || {
+    echo "FAIL: a killed arm beside a healthy one ended the collector with $rc" >&2
+    return 1
+  }
+  rm -rf "$tmp"
+}
+
+@test "a clock that could not be read yields no reading rather than a silent success" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  # No stamp at all resolves, so every arm fails at its clock rather than at its
+  # work. The backwards-clock case below pins the same contract for the other
+  # way a duration can be refused; this one is the half that was reported only
+  # in the capture. A sample that measured nothing has to say so through its
+  # status too, because the status is what the two call sites outside the
+  # diagnostics block turn into a job-log line -- report it as success and a run
+  # that timed nothing at all passes in silence.
+  stamp_values=''
+  rc=0
+
+  run_canary || rc=$?
+
+  [ "$rc" -ne 0 ] || {
+    echo "FAIL: a sample whose clock could not be read at either end reported success" >&2
+    return 1
+  }
+  capture=$(capture_path)
+  assert_file_contains 'the canary clock could not be read at both ends' "$capture"
+  # The legend states units of its own, so the absence is asserted on the rate
+  # line rather than on the words.
+  assert_file_lacks_pattern '^rate: ' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a clock that went backwards yields no reading rather than a negative duration" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 900 900 800'
+  rc=0
+
+  run_canary || rc=$?
+
+  # Neither arm yields a figure, so the collector reports a shortfall -- which
+  # is what the two call sites outside the diagnostics block turn into a line in
+  # the job log.
+  [ "$rc" -ne 0 ] || {
+    echo "FAIL: a capture holding no figure at all reported success" >&2
+    return 1
+  }
+  capture=$(capture_path)
+  # Named as the instrument being wrong rather than as the clock being
+  # unreadable: those send a reader to different places, and one of them is a
+  # machine that has nothing wrong with it. Every figure here is derived from
+  # the duration, so a negative one produces a negative rate that reads exactly
+  # like a real number with a sign in front.
+  assert_file_contains 'the second stamp was the earlier one' "$capture"
+  assert_file_lacks_pattern 'elapsed: -' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a rate under one unit per second is said in words rather than rounded to nothing" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  # 8 MiB in twenty seconds is under half a MiB per second, which integer
+  # division reports as none at all.
+  stamp_values='1000 1050 1050 3050'
+  COZY_CANARY_MEM_BLOCK_MIB=2
+  COZY_CANARY_MEM_BLOCKS=4
+
+  run_canary
+
+  capture=$(capture_path)
+  # `rate: 0` is the reading this capture must never produce: it is the shape of
+  # a machine that did nothing, and here it would mean arithmetic that ran out
+  # of places on a machine that was merely very slow -- which is the finding, so
+  # rounding it away loses exactly the run this collector exists for.
+  assert_file_lacks_pattern 'rate: 0 ' "$capture"
+  assert_file_contains 'under one MiB per second' "$capture"
+  # And the inputs are in the file, so the reader can divide them themselves.
+  assert_file_contains 'work: 8 MiB' "$capture"
+  assert_file_contains 'elapsed: 20000 ms' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "what the work said on stderr lands beside the figure it explains" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050'
+  # The arm reads the ceiling and its grace from globals the library settles at
+  # source time, so driving it on its own needs no setup; they are restated here
+  # to pin the two numbers this case's assertions are written against.
+  COZY_CANARY_RUN_BOUND=20
+  COZY_DIAG_READ_GRACE=5
+
+  # Driven through one arm with a command of the test's own, rather than through
+  # the collector: what is pinned is that an arm keeps its stderr, and dd is the
+  # arm that relies on it -- it reports there by design, and a `timeout` giving
+  # up says so there too.
+  capture="$tmp/one-arm.txt"
+  ( set +x; _cozy_canary_report_arm "$capture" 'synthetic' 100 units 1 \
+    sh -c 'echo "$((6*7))-complained" >&2' )
+
+  # The marker is computed by the work rather than written into its command
+  # line, and that is the whole of the case: the reporter echoes the command
+  # before running it, so a needle that appears in both is satisfied by the echo
+  # and says nothing about where the arm's stderr went.
+  assert_file_contains '42-complained' "$capture"
+  assert_file_lacks_pattern 'command: .*42-complained' "$capture"
+  assert_file_contains 'command: sh -c echo "$((6*7))-complained" >&2' "$capture"
+  rm -rf "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# What the collector tells its caller.
+# ---------------------------------------------------------------------------
+
+@test "the collector reports a shortfall only when the capture holds no figure at all" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+  rc=0
+
+  run_canary || rc=$?
+  [ "$rc" -eq 0 ] || {
+    echo "FAIL: a capture holding two rates reported a shortfall ($rc)" >&2
+    return 1
+  }
+
+  # One arm failing is not a shortfall: the other still carries a figure, and
+  # both call sites outside the diagnostics block turn a non-zero into a warning
+  # line saying nothing was measured.
+  timeout_rc_match=dd
+  timeout_rc_override=127
+  stamp_index=0
+  rc=0
+  run_canary 2 || rc=$?
+  [ "$rc" -eq 0 ] || {
+    echo "FAIL: one failed arm out of two reported a shortfall ($rc)" >&2
+    return 1
+  }
+
+  # Both failing is.
+  timeout_rc_match=
+  stamp_index=0
+  rc=0
+  run_canary 3 || rc=$?
+  [ "$rc" -ne 0 ] || {
+    echo "FAIL: a capture holding no figure at all reported success" >&2
+    return 1
+  }
+
+  # And so is both being killed before the ceiling, which reaches the shortfall
+  # by a different branch: a status the ceiling also produces, refused as the
+  # ceiling because the clock says the bound had not run out. Three of the four
+  # ways an arm can yield no reading are pinned for status elsewhere -- the
+  # clock unreadable, the clock backwards, the work failing on its own account
+  # -- and this is the fourth. Left unpinned, two arms killed from outside,
+  # which is the OOM case the ceiling attribution is written for, would report
+  # success with nothing measured and both call sites would stay quiet.
+  timeout_rc_override=137
+  stamp_values='1000 1200 1200 1400'
+  COZY_CANARY_RUN_BOUND=20
+  stamp_index=0
+  rc=0
+  run_canary 4 || rc=$?
+  [ "$rc" -ne 0 ] || {
+    echo "FAIL: two arms killed before their ceiling reported success with no figure in the capture" >&2
+    return 1
+  }
+  rm -rf "$tmp"
+}
+
+@test "no path that measured nothing raises the alert" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  # The alert is what all three reporting sites turn into a job-log line saying
+  # the machine was not getting the work done. Raised on a path that took no
+  # reading, it is a pathology manufactured out of nothing -- the one outcome
+  # this collector must never produce. The clock-failure path is pinned against
+  # it by the case that drives an unreadable stamp; these are the other three
+  # ways an arm can end without a figure, each of which reaches a different
+  # branch of the reporter.
+  COZY_CANARY_RUN_BOUND=20
+
+  # The work failed on its own account.
+  timeout_rc_match=
+  timeout_rc_override=127
+  stamp_values='1000 1200 1200 1400'
+  stamp_index=0
+  run_canary_here || true
+  [ "${_COZY_CANARY_ALERT:-unset}" = 0 ] || {
+    echo "expected two arms that failed on their own account to raise no alert, found ${_COZY_CANARY_ALERT:-unset}" >&2
+    return 1
+  }
+
+  # Killed before the ceiling could have fired.
+  timeout_rc_override=137
+  stamp_index=0
+  run_canary_here 2 || true
+  [ "${_COZY_CANARY_ALERT:-unset}" = 0 ] || {
+    echo "expected two arms killed before their ceiling to raise no alert, found ${_COZY_CANARY_ALERT:-unset}" >&2
+    return 1
+  }
+
+  # Finished inside one tick, which is too fast to measure rather than slow.
+  timeout_rc_override=
+  stamp_values='1000 1000 1000 1000'
+  stamp_index=0
+  run_canary_here 3 || true
+  [ "${_COZY_CANARY_ALERT:-unset}" = 0 ] || {
+    echo "expected two arms finishing inside one tick to raise no alert, found ${_COZY_CANARY_ALERT:-unset}" >&2
+    return 1
+  }
+  rm -rf "$tmp"
+}
+
+@test "each sample announces itself and its number in the job log" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+
+  out=$(run_canary 2)
+
+  # The line is the only trace of the canary a reader of the job log gets on a
+  # green run before the report is downloaded, and the sample number is what
+  # ties it to the side of the wait it was taken on.
+  case "$out" in
+    *'--- running the runner fixed-work canary (sample 2) ---'*) ;;
+    *)
+      echo "FAIL: the job log does not announce the canary sample; it said: $out" >&2
+      return 1
+      ;;
+  esac
+  rm -rf "$tmp"
+}
+
+@test "the sample number decides which directory a reading lands in" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+
+  run_canary 2
+
+  # Sample 1 is the pre-wait reading and sample 2 the post-wait one; a
+  # collector that folded them into one directory would overwrite the before
+  # with the after, and the pair would compare a reading against itself.
+  [ -f "$(capture_path 2)" ] || {
+    echo "FAIL: sample 2 did not land in its own directory" >&2
+    return 1
+  }
+  [ ! -e "$(capture_path 1)" ] || {
+    echo "FAIL: sample 2 wrote into the sample-1 directory" >&2
+    return 1
+  }
+  rm -rf "$tmp"
+}
+
+@test "a capture left by an earlier run is truncated rather than appended to" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+  # The report directory outlives a run, so the same sample number can find a
+  # file already there. Appended to, the capture would carry two runs of one
+  # sample with nothing between them to say where the first ended, and every
+  # figure a reader took from it could belong to either. The neighbouring case
+  # covers the other half of this line -- that a failed open returns rather than
+  # ending the shell -- and cannot see the truncation, because a failed append
+  # fails the same way.
+  capture=$(capture_path)
+  mkdir -p "$(dirname "$capture")"
+  printf 'STALE-FROM-AN-EARLIER-RUN\n' >"$capture"
+
+  run_canary
+
+  assert_file_lacks_pattern 'STALE-FROM-AN-EARLIER-RUN' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "a capture file that cannot be opened reaches the job log rather than ending the shell" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The capture path is made a directory, so the open fails while the mkdir -p
+  # above it succeeds -- the one shape where the truncation is the first write
+  # to notice, and one that fails for root and non-root alike. It must fail by
+  # returning: this truncation used to be spelled `: >`, and `:` is a POSIX
+  # special built-in, whose redirection failure exits a non-interactive shell
+  # -- dash, the /bin/sh of the sandbox image -- taking the rest of the
+  # diagnostics block with it, straight past the call site's `|| true`. The
+  # tenant snapshot behind it is an EXIT trap and runs either way; what the exit
+  # costs is everything the block had left to collect.
+  mkdir -p "$(capture_path)"
+  rc=0
+
+  ( set +x; cozy_capture_runner_canary 1 >"$tmp/out" 2>&1 ) || rc=$?
+
+  [ "$rc" -ne 0 ] || {
+    echo "FAIL: a collector that could write nothing reported success" >&2
+    return 1
+  }
+  assert_file_contains 'could not be opened for writing' "$tmp/out"
+  rm -rf "$tmp"
+}
+
+@test "an alert from the sample before does not survive a sample that returned early" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # The flag is cleared at the top of the collector rather than beside the arms,
+  # so that it is cleared on the paths that return before any arm runs too. The
+  # case that pins it beside the arms cannot see this one: it drives a sample
+  # that reaches its work, and the early returns are exactly the paths that do
+  # not. Left standing, sample 1's alert is read back after a sample 2 that
+  # measured nothing, and the call site prints a pathology naming a sample that
+  # took no reading.
+  _COZY_CANARY_ALERT=1
+  printf 'not a directory\n' >"$tmp/blocked"
+  COZY_REPORT_DIR="$tmp/blocked"
+  rc=0
+
+  # Run in this shell rather than a subshell: the flag the call sites branch on
+  # would go with the subshell.
+  set +x
+  cozy_capture_runner_canary 2 >"$tmp/out" 2>&1 || rc=$?
+
+  [ "${_COZY_CANARY_ALERT:-unset}" = 0 ] || {
+    echo "expected a sample that returned before its arms to clear the alert, found ${_COZY_CANARY_ALERT:-unset}; the flag would be read back as a pathology for a sample that measured nothing" >&2
+    return 1
+  }
+  rm -rf "$tmp"
+}
+
+@test "a report directory that cannot be created reaches the job log" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  stage "$tmp"
+  # A file where the directory tree has to go, so mkdir -p cannot succeed.
+  printf 'not a directory\n' >"$tmp/blocked"
+  COZY_REPORT_DIR="$tmp/blocked"
+  rc=0
+
+  ( set +x; cozy_capture_runner_canary 1 >"$tmp/out" 2>&1 ) || rc=$?
+
+  # With no directory every write below it fails, the collector becomes a silent
+  # no-op, and the artifact carries exactly the empty space it exists to refuse
+  # -- with nowhere to put a marker saying so, which is why this one goes to the
+  # log and not to the report.
+  [ "$rc" -ne 0 ] || {
+    echo "FAIL: a collector that could write nothing reported success" >&2
+    return 1
+  }
+  assert_file_contains 'could not be created' "$tmp/out"
+  rm -rf "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# The legends, which are what let a single red run be read at all.
+# ---------------------------------------------------------------------------
+
+@test "every legend line lands as one line rather than shredded into words" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+
+  run_canary
+
+  # Each legend is one long single-quoted shell string, and an apostrophe inside
+  # one ends the quote: the sentence then reaches the file as one word per line,
+  # every `[` unmatched, and the capture still passes any assertion that greps
+  # for a short phrase. This checks the shape instead -- a bracketed line opens
+  # and closes on the same line -- because that is what a shredded legend loses.
+  capture=$(capture_path)
+  if awk '/^\[/ && $0 !~ /\]$/ { print FILENAME ": " $0; found = 1 } END { exit found ? 1 : 0 }' "$capture"; then
+    :
+  else
+    echo "FAIL: a bracketed legend line does not close on its own line, which is what an apostrophe inside its single quotes does to it" >&2
+    return 1
+  fi
+  grep -q '^\[' "$capture" || {
+    echo "FAIL: the capture carries no bracketed legend line at all" >&2
+    return 1
+  }
+  rm -rf "$tmp"
+}
+
+@test "the expected ranges quote the sizes this run actually used" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+  COZY_CANARY_CPU_ITERATIONS=777
+  # The floors are overridden away from their defaults for the reason the
+  # ceiling case sets a bound of 11: the legend interpolates them, so a fixture
+  # left on the default cannot tell a templated figure from one written into the
+  # sentence.
+  COZY_CANARY_MEM_MIN_RATE=17
+  COZY_CANARY_CPU_MIN_RATE=19
+  COZY_CANARY_MEM_BLOCK_MIB=3
+  COZY_CANARY_MEM_BLOCKS=5
+
+  run_canary
+
+  # The whole worth of this capture is that its number can be called
+  # pathological with no green run beside it, and that rests on the stated range
+  # describing the work that was actually done. Restated rather than derived,
+  # the range survives a change to the sizes and then describes a different
+  # experiment, which is worse than no range at all.
+  capture=$(capture_path)
+  assert_file_contains 'the 15 MiB it writes' "$capture"
+  assert_file_contains 'the 777 of them here' "$capture"
+  # The sizes are data and the cache figure is context: the sentence must not
+  # assert which of the two is larger, because the relation is a property of
+  # the constants at their declaration, not of this template.
+  assert_file_contains '3 MiB here, against the 32 MiB' "$capture"
+  # The floors the alert compares against are printed from the same constants
+  # rather than written into the sentence, so what a reader is told and what the
+  # collector decides on cannot drift apart.
+  assert_file_contains "anything under ${COZY_CANARY_MEM_MIN_RATE} in the MiB-per-second unit" "$capture"
+  assert_file_contains "anything under ${COZY_CANARY_CPU_MIN_RATE} iterations a second" "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the capture names what it cannot separate and where that answer lives" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+
+  run_canary
+
+  # A slow arm has two readings, and only one of them is this collector's. A
+  # capture that stated the interesting one and stayed quiet about the dull one
+  # would be read as proof of the interesting one, which is the failure this
+  # whole investigation keeps producing.
+  capture=$(capture_path)
+  assert_file_contains 'It reads wall clock only' "$capture"
+  assert_file_contains 'runner-kernel-cpu-time' "$capture"
+  assert_file_contains 'sandbox-host-cpu-time' "$capture"
+  # And it describes what each of those two actually covers, because the two
+  # are nothing alike: the runner-kernel rows bracket the wait on both paths,
+  # while the sandbox-host rows are taken inside the on-failure diagnostics
+  # block, seconds apart, minutes after the wait failed. A legend equating them
+  # sends a reader to interpret a 12-second post-mortem pair as the whole join
+  # window, which is why the legend states the window each of them covers
+  # instead of naming the two side by side.
+  assert_file_contains 'a pair bracketing the node-join wait' "$capture"
+  assert_file_contains 'a pair seconds apart inside the on-failure diagnostics block' "$capture"
+  # The legends below are the standalone-readability deliverable, and a reader of
+  # a red run with no green one beside it needs each: which layer the reading
+  # describes and where the answers a layer down are kept, what a difference
+  # between the samples means, that the collector's own burn sits outside the
+  # intervals the sibling pairs divide by, and the resolution every figure here
+  # is quantised to.
+  assert_file_contains 'this canary runs on the RUNNER VM, inside the sandbox container' "$capture"
+  assert_file_contains 'sandbox-host/talos-' "$capture"
+  assert_file_contains 'A difference between them puts the change inside the interval the pair brackets' "$capture"
+  assert_file_contains 'neither burn falls inside any interval those pairs divide by' "$capture"
+  assert_file_contains 'quantised to 10ms' "$capture"
+  # The working set is what makes the two answer the same interference
+  # differently; they differ in plenty else, including how much work each does,
+  # so the sentence claims the one property the two-arm design rests on rather
+  # than a separation the arms do not have.
+  assert_file_contains 'what makes them answer the same interference differently is the working set' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the capture records the wall-clock window its arms ran in" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+
+  run_canary
+
+  # The durations inside the capture are read from a monotonic clock that
+  # says nothing about when, and the two samples sit the whole node-join wait
+  # apart; without this window a reader cannot put either sample beside the
+  # console capture or anything else stamped in the report.
+  capture=$(capture_path)
+  grep -Eq '\[read attempted from [0-9]+ to [0-9]+ epoch seconds\]' "$capture" || {
+    echo "FAIL: the capture does not record when its arms were attempted" >&2
+    cat "$capture" >&2
+    return 1
+  }
+  rm -rf "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# Where the two samples sit, which is what decides what they mean.
+# ---------------------------------------------------------------------------
+
+@test "the canary samples sit outside the three counter pairs on every path" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # The three pairs beside it read running totals, so each divides by whatever
+  # runs between its two readings. The canary is the one collector here that
+  # occupies a core rather than reading a file, so a sample taken inside any of
+  # those brackets inflates the numerator of a rate the pair reports as the
+  # node-join window. Outside all three on both sides, it cannot.
+  wait_line=$(grep -n '^  if ! timeout 18m bash -c' "$lib" | head -n 1 | cut -d: -f1)
+  first=$(grep -n 'cozy_capture_runner_canary 1' "$lib" | head -n 1 | cut -d: -f1)
+  green=$(awk -v w="$wait_line" 'NR > w && /cozy_capture_runner_canary 2/ { print NR; exit }' "$lib")
+  tail_line=$(grep -n '^  versions=\$(kubectl --kubeconfig' "$lib" | head -n 1 | cut -d: -f1)
+  console_line=$(grep -n "cozy_capture_tenant_serial_console 'node-join failed" "$lib" | head -n 1 | cut -d: -f1)
+  # The signal is a separate word from the keyword, the way the fixtures in
+  # hack/bats-no-exit-trap.bats assemble theirs: that guard matches the pair
+  # lexically, so a pattern naming both would be counted here as an installed
+  # trap this file would then have to declare as debt.
+  armed_sig=EXIT
+  armed_line=$(grep -n "^  trap '_tenant_snapshot_on_fail' ${armed_sig}" "$lib" | head -n 1 | cut -d: -f1)
+  red=$(awk -v w="$wait_line" 'NR < w && /cozy_capture_runner_canary 2/ { line = NR } END { if (line) print line }' "$lib")
+  pairs_first=''
+  pairs_green=''
+  pairs_red=''
+  # Derived across all three pairs rather than anchored on one of them. Which
+  # sibling sits outermost is not a property anything holds -- it is today's
+  # source order -- so a guard that compared against one name would keep passing
+  # once the three were reordered around it, while the canary's burn sat inside
+  # whichever pair moved. What has to hold is the extremes: earlier than the
+  # earliest first reading, later than the latest second one, on both paths.
+  for fn in cozy_capture_sandbox_kvm_exits cozy_capture_runner_kernel_cpu_time \
+    cozy_capture_sandbox_qemu_thread_cpu; do
+    sib_first=$(grep -n "${fn} 1" "$lib" | head -n 1 | cut -d: -f1)
+    sib_green=$(awk -v w="$wait_line" -v f="${fn} 2" 'NR > w && index($0, f) { print NR; exit }' "$lib")
+    sib_red=$(awk -v w="$wait_line" -v f="${fn} 2" 'NR < w && index($0, f) { line = NR } END { if (line) print line }' "$lib")
+    for v in sib_first sib_green sib_red; do
+      eval "n=\$$v"
+      if [ -z "$n" ]; then
+        echo "expected to read $v for $fn from $lib; without it this guard reports success for having lost its input" >&2
+        return 1
+      fi
+    done
+    if [ -z "$pairs_first" ] || [ "$sib_first" -lt "$pairs_first" ]; then
+      pairs_first="$sib_first"
+    fi
+    if [ -z "$pairs_green" ] || [ "$sib_green" -gt "$pairs_green" ]; then
+      pairs_green="$sib_green"
+    fi
+    if [ -z "$pairs_red" ] || [ "$sib_red" -gt "$pairs_red" ]; then
+      pairs_red="$sib_red"
+    fi
+  done
+  for v in wait_line first green tail_line red console_line armed_line \
+    pairs_first pairs_green pairs_red; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
+      return 1
+    fi
+  done
+  if [ "$first" -ge "$pairs_first" ]; then
+    echo "the canary sample before the wait (line $first) is taken after the earliest of the three counter readings (line $pairs_first), so its burn falls inside the interval that pair divides by" >&2
+    return 1
+  fi
+  if [ "$green" -le "$pairs_green" ]; then
+    echo "the passing path takes its canary sample (line $green) before the latest of the three second readings (line $pairs_green), so its burn falls inside the interval that pair divides by" >&2
+    return 1
+  fi
+  if [ "$green" -ge "$tail_line" ]; then
+    echo "the passing path's canary sample (line $green) is taken after the suite's happy-path tail begins (line $tail_line), so the green figure describes a different window than the red one" >&2
+    return 1
+  fi
+  if [ "$red" -le "$pairs_red" ]; then
+    echo "the failure path takes its canary sample (line $red) before the latest of the three second readings (line $pairs_red), so its burn falls inside the interval that pair divides by" >&2
+    return 1
+  fi
+  # And the failure path's sample is bounded from above as well, the way the
+  # passing path's already is. The two bounds are not the same requirement: the
+  # lower one keeps the burn out of a pair's interval, this one keeps the figure
+  # comparable. Everything from the console down can spend the whole diagnostics
+  # phase, so a sample that drifted behind it describes a machine minutes past
+  # the failure, against a green figure taken seconds after the wait -- and the
+  # budget guard prices only what sits above the console, so the drift would
+  # also drop this collector out of that sum while it still runs.
+  if [ "$red" -ge "$console_line" ]; then
+    echo "the failure path takes its canary sample (line $red) at or after the serial console capture (line $console_line), so the red figure describes a machine minutes past the failure and the budget guard stops pricing it" >&2
+    return 1
+  fi
+  # The pre-wait sample is bounded from below for the same reason the others are
+  # bounded at all: the legend tells a reader the pair brackets the wait and the
+  # readings on either side of it. Taken before the tenant is even up, it would
+  # bracket the whole test instead, and the sentence would be false about the
+  # artifact it is printed into.
+  if [ "$first" -le "$armed_line" ]; then
+    echo "the canary sample before the wait (line $first) is taken at or before the tenant snapshot trap is armed (line $armed_line), so it describes the run before the cluster it is meant to characterise exists" >&2
+    return 1
+  fi
+}
+
+@test "both call sites outside the diagnostics block report a shortfall on their own side of the wait" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # docs/agents/e2e-testing.md requires what a passing-path collector could not
+  # collect at all to reach the job log, and one of these two runs on exactly
+  # that path, where the report is the artifact nobody downloads. Each side is
+  # counted through the clause that names it rather than through the shared
+  # prefix: which side of the wait a shortfall fell on is the whole product of a
+  # pair, and two lines matched by one prefix could be swapped between the sites
+  # with the count unchanged.
+  # `|| true`: grep -c exits 1 on a count of zero, and under errexit that ends
+  # the test before the branch below can say what was missing -- the guard would
+  # still fail, with its diagnostic replaced by silence, on exactly the
+  # regression it exists to name.
+  calls=$(grep -c 'if ! cozy_capture_runner_canary [12]; then' "$lib" || true)
+  if [ "$calls" -ne 2 ]; then
+    echo "expected both canary samples outside the diagnostics block to consume the collector's status with 'if !', found $calls" >&2
+    return 1
+  fi
+  # Each clause is located rather than counted. A count of one apiece is
+  # satisfied by the two lines swapped between the sites, and a shortfall
+  # reported on the wrong side of the wait is worse than none: the pair exists to
+  # say which side moved.
+  wait_line=$(grep -n '^  if ! timeout 18m bash -c' "$lib" | head -n 1 | cut -d: -f1)
+  before=$(grep -n 'produced no reading before the node-join wait' "$lib" | head -n 1 | cut -d: -f1)
+  after=$(grep -n 'produced no reading after the node-join wait' "$lib" | head -n 1 | cut -d: -f1)
+  tail_line=$(grep -n '^  versions=\$(kubectl --kubeconfig' "$lib" | head -n 1 | cut -d: -f1)
+  for v in wait_line tail_line before after; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
+      return 1
+    fi
+  done
+  if [ "$before" -ge "$wait_line" ]; then
+    echo "the shortfall line naming the pre-wait sample sits at line $before, at or after the wait at $wait_line" >&2
+    return 1
+  fi
+  if [ "$after" -le "$wait_line" ] || [ "$after" -ge "$tail_line" ]; then
+    echo "the shortfall line naming the post-wait sample sits at line $after, outside the stretch between the wait at $wait_line and the suite's happy-path tail at $tail_line" >&2
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# What a pathological reading does, which is what makes the collector worth
+# taking on the passing path.
+# ---------------------------------------------------------------------------
+
+@test "a memory rate under the floor the legend states raises the alert" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+  # 8 MiB in two seconds: 4 MiB per second, against a floor of 500. The compute
+  # arm is sized to 12,000,000 iterations a second, above its own floor, so this
+  # arm is the only one that can raise the alert asserted below. The alert is
+  # one flag for the sample rather than one per arm, so a compute arm left under
+  # its own floor here would satisfy the assertion before this arm ran at all,
+  # and the memory floor could then be disconnected entirely with this case
+  # still green.
+  COZY_CANARY_CPU_ITERATIONS=6000000
+  COZY_CANARY_MEM_BLOCK_MIB=2
+  COZY_CANARY_MEM_BLOCKS=4
+
+  run_canary_here
+
+  capture=$(capture_path)
+  assert_file_contains 'rate: 4 MiB per second' "$capture"
+  if [ "${_COZY_CANARY_ALERT:-unset}" != 1 ]; then
+    echo "expected a memory rate of 4 MiB per second, against the ${COZY_CANARY_MEM_MIN_RATE} the legend calls the floor, to raise the alert the call sites turn into a job-log line" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "a core at the bottom of the healthy band raises no alert" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1150'
+  # 953 MiB in one second, a gigabyte a second expressed in the unit the rate
+  # line is printed in. The floor sits well under that, so this core is slow and
+  # nothing more. A floor at the near-1000 MiB/s the legend gives for that
+  # bottom would raise the warning here -- on a green run, about a machine its
+  # own legend calls healthy. At this rate exactly it would not: the comparison
+  # is strict.
+  COZY_CANARY_CPU_ITERATIONS=6000000
+  COZY_CANARY_MEM_BLOCK_MIB=953
+  COZY_CANARY_MEM_BLOCKS=1
+
+  run_canary_here
+
+  capture=$(capture_path)
+  assert_file_contains 'rate: 953 MiB per second' "$capture"
+  if [ "${_COZY_CANARY_ALERT:-unset}" != 0 ]; then
+    echo "expected a memory rate of 953 MiB per second to raise no alert against the ${COZY_CANARY_MEM_MIN_RATE} floor" >&2
+    cat "$capture" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "a memory rate exactly at the floor raises no alert" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+  # A rate landing on the floor rather than above or below it, which is the one
+  # case that tells `-lt` from `-le`. The neighbours put a rate on either side
+  # and both stay correct under either operator, so without this case the
+  # comparison the alert turns on is unconstrained. The block size is derived
+  # from the floor rather than written next to it: two seconds of a block twice
+  # the floor divides to the floor exactly, whatever the floor is later set to.
+  # The compute arm is sized well above its own floor, so the flag read below
+  # can only have come from the memory arm.
+  COZY_CANARY_CPU_ITERATIONS=6000000
+  COZY_CANARY_MEM_BLOCK_MIB=$(( COZY_CANARY_MEM_MIN_RATE * 2 ))
+  COZY_CANARY_MEM_BLOCKS=1
+
+  run_canary_here
+
+  capture=$(capture_path)
+  assert_file_contains "rate: ${COZY_CANARY_MEM_MIN_RATE} MiB per second" "$capture"
+  if [ "${_COZY_CANARY_ALERT:-unset}" != 0 ]; then
+    echo "expected a memory rate of exactly the ${COZY_CANARY_MEM_MIN_RATE} floor to raise no alert: the comparison is strict, and an alert here means it has stopped being" >&2
+    cat "$capture" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "a memory rate just under the floor raises the alert, not only one far under it" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1150'
+  # 400 MiB in one second, just under the floor rather than an order of
+  # magnitude beneath it. The case above pins where the alert stays quiet and
+  # this one pins where it starts, so between them the floor is the number that
+  # decides -- a floor moved down far enough to be unreachable leaves the first
+  # case green and fails here.
+  COZY_CANARY_CPU_ITERATIONS=6000000
+  COZY_CANARY_MEM_BLOCK_MIB=400
+  COZY_CANARY_MEM_BLOCKS=1
+
+  run_canary_here
+
+  capture=$(capture_path)
+  assert_file_contains 'rate: 400 MiB per second' "$capture"
+  if [ "${_COZY_CANARY_ALERT:-unset}" != 1 ]; then
+    echo "expected a memory rate of 400 MiB per second, under the ${COZY_CANARY_MEM_MIN_RATE} floor, to raise the alert the call sites turn into a job-log line" >&2
+    cat "$capture" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "a compute rate under the floor the legend states raises the alert" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+  # 1000 iterations in half a second: 2000 a second against a floor of three
+  # million. The memory arm beside it is above its own, so each arm's floor is
+  # pinned by the case where only that arm is under it -- one floor left at zero
+  # would otherwise be covered by the other one firing.
+  COZY_CANARY_CPU_ITERATIONS=1000
+  COZY_CANARY_MEM_BLOCK_MIB=2048
+  COZY_CANARY_MEM_BLOCKS=4
+
+  run_canary_here
+
+  capture=$(capture_path)
+  assert_file_contains 'rate: 2000 iterations per second' "$capture"
+  assert_file_contains 'rate: 4096 MiB per second' "$capture"
+  if [ "${_COZY_CANARY_ALERT:-unset}" != 1 ]; then
+    echo "expected a compute rate of 2000 iterations per second, against the ${COZY_CANARY_CPU_MIN_RATE} the legend calls the floor, to raise the alert the call sites turn into a job-log line" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "an arm stopped at its ceiling raises the alert without a rate to compare" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  timeout_rc_match=dd
+  timeout_rc_override=124
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 3050'
+  # Sized so the bound rounds up to 1639 MiB per second, above the floor, and
+  # the compute arm beside it is above its own: the ceiling has to raise the
+  # alert on its own account or nothing here does. An arm the bound stopped got
+  # less work done than the figure printed for it, which is why that figure is a
+  # bound rather than a rate -- and why a machine whose ceiling is reached at a
+  # size the floor would have passed must not read as healthy.
+  COZY_CANARY_CPU_ITERATIONS=6000000
+  COZY_CANARY_MEM_BLOCK_MIB=2048
+  COZY_CANARY_MEM_BLOCKS=16
+  COZY_CANARY_RUN_BOUND=20
+
+  run_canary_here
+
+  capture=$(capture_path)
+  assert_file_contains 'it was stopped at the 20s ceiling' "$capture"
+  # Stated so the case cannot quietly stop being about the ceiling: a size whose
+  # bound falls under the floor would satisfy the assertion below through the
+  # floor instead, and the ceiling could then be dropped from the alert with
+  # every test here still green.
+  assert_file_contains 'BELOW 1639 MiB per second' "$capture"
+  if [ "${_COZY_CANARY_ALERT:-unset}" != 1 ]; then
+    echo "expected an arm stopped at its ceiling, at a size whose bound sits above the floor, to raise the alert the call sites turn into a job-log line" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "an alert raised before the wait does not stand as the reading taken after it" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  # Eight stamps: four for each sample, because run_kubernetes_test takes both
+  # from one shell and the alert is one variable for the pair.
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1500'
+  COZY_CANARY_CPU_ITERATIONS=1000
+  COZY_CANARY_MEM_BLOCK_MIB=2048
+  COZY_CANARY_MEM_BLOCKS=4
+
+  run_canary_here 1
+  first="${_COZY_CANARY_ALERT:-unset}"
+  COZY_CANARY_CPU_ITERATIONS=6000000
+  run_canary_here 2
+  second="${_COZY_CANARY_ALERT:-unset}"
+
+  if [ "$first" != 1 ]; then
+    echo "expected sample 1, whose compute arm ran at 2000 iterations a second, to raise the alert; got $first" >&2
+    return 1
+  fi
+  # The whole product of the pair is which side of the wait a change fell on. An
+  # alert left standing from the sample before it would be published as the
+  # reading taken after it, so a run that went into the wait slow and came out
+  # healthy would be reported as one that never recovered -- a warning on a green
+  # run, which is the kind a reader learns to skip.
+  if [ "$second" != 0 ]; then
+    echo "expected sample 2, with both arms above their floors, to leave no alert standing from sample 1; got $second" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "a reading inside the range the legend states raises nothing" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+  # Both arms above their floors. Without this case an alert wired to fire
+  # always would satisfy every assertion above it, and the job log would carry
+  # the warning on every green run until a reader learned to skip it.
+  COZY_CANARY_CPU_ITERATIONS=6000000
+  COZY_CANARY_MEM_BLOCK_MIB=2048
+  COZY_CANARY_MEM_BLOCKS=4
+
+  run_canary_here
+
+  if [ "${_COZY_CANARY_ALERT:-unset}" != 0 ]; then
+    echo "expected a compute rate of 12000000 and a memory rate of 4096, both above their floors, to raise no alert" >&2
+    cat "$(capture_path)" >&2
+    return 1
+  fi
+  rm -rf "$tmp"
+}
+
+@test "the source keeps an alert branch at every reporting site, each naming where it was taken" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # A reading the legend calls pathological is the loudest thing this collector
+  # produces, and the report holding it is the artifact nobody downloads on the
+  # passing path and the one a triager opens last on the failing one. So all
+  # three reporting sites put it in the job log, each naming where it was taken:
+  # two outside the diagnostics block, on either side of the wait, and the third
+  # inside it, where sample 1's line is eighteen minutes above.
+  #
+  # Counted through those clauses rather than through the shared prefix, for the
+  # reason the shortfall guard above gives: three lines matched by one prefix
+  # could be swapped between the sites with the count unchanged.
+  # `|| true` on each count: grep -c exits 1 on a count of zero, and under
+  # errexit that ends the test before the branch below can say what was
+  # missing -- the guard would still fail, with its diagnostic replaced by
+  # silence, on exactly the regression it exists to name.
+  branches=$(grep -cF 'elif [ "${_COZY_CANARY_ALERT:-0}" -eq 1 ]; then' "$lib" || true)
+  # Two leading spaces, so an `elif` line does not answer for the plain `if`
+  # this counts: the shorter needle is a substring of every one of them.
+  in_block=$(grep -cF '  if [ "${_COZY_CANARY_ALERT:-0}" -eq 1 ]; then' "$lib" || true)
+  if [ "$branches" -ne 2 ]; then
+    echo "expected both samples outside the diagnostics block to branch on the alert with elif, found $branches" >&2
+    return 1
+  fi
+  if [ "$in_block" -ne 1 ]; then
+    echo "expected the sample inside the diagnostics block to branch on the alert on its own, found $in_block" >&2
+    return 1
+  fi
+  # Located rather than counted, for the reason the shortfall guard above gives:
+  # one line apiece is satisfied by the three of them swapped around.
+  fail_fn=$(grep -n '^cozy_report_node_join_failure() {' "$lib" | head -n 1 | cut -d: -f1)
+  test_fn=$(grep -n '^run_kubernetes_test() {' "$lib" | head -n 1 | cut -d: -f1)
+  wait_line=$(grep -n '^  if ! timeout 18m bash -c' "$lib" | head -n 1 | cut -d: -f1)
+  before=$(grep -n '» WARNING: the runner fixed-work canary did not read inside the range its own legend calls healthy before the node-join wait' "$lib" | head -n 1 | cut -d: -f1)
+  after=$(grep -n '» WARNING: the runner fixed-work canary did not read inside the range its own legend calls healthy after the node-join wait' "$lib" | head -n 1 | cut -d: -f1)
+  failing=$(grep -n '» WARNING: the runner fixed-work canary did not read inside the range its own legend calls healthy on the failing run' "$lib" | head -n 1 | cut -d: -f1)
+  tail_line=$(grep -n '^  versions=\$(kubectl --kubeconfig' "$lib" | head -n 1 | cut -d: -f1)
+  for v in fail_fn test_fn wait_line tail_line before after failing; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
+      return 1
+    fi
+  done
+  if [ "$failing" -le "$fail_fn" ] || [ "$failing" -ge "$test_fn" ]; then
+    echo "the alert line naming the failing run sits at line $failing, outside the diagnostics block between $fail_fn and $test_fn" >&2
+    return 1
+  fi
+  if [ "$before" -le "$test_fn" ] || [ "$before" -ge "$wait_line" ]; then
+    echo "the alert line naming the pre-wait sample sits at line $before, not between the test body at $test_fn and the wait at $wait_line" >&2
+    return 1
+  fi
+  if [ "$after" -le "$wait_line" ] || [ "$after" -ge "$tail_line" ]; then
+    echo "the alert line naming the post-wait sample sits at line $after, outside the stretch between the wait at $wait_line and the suite's happy-path tail at $tail_line" >&2
+    return 1
+  fi
+}
+
+@test "each arm's floor sits inside the window a bounded arm can reach" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # A floor the ceiling gets to first never fires. The arm is cut off before its
+  # rate can fall that far, so every alert arrives as the ceiling and carries a
+  # bound rather than the slowdown the floor was meant to name -- the collector
+  # goes quiet on exactly the effect it was sized for while its legend states a
+  # figure that decides nothing. A floor crossed in the first few ticks is the
+  # other end of the same failure: it fires on a duration this clock barely
+  # resolves. Derived from the constants because the size, the floor and the
+  # ceiling are three numbers in three places, and moving any one of them moves
+  # this window.
+  iters=$(grep -oE '^COZY_CANARY_CPU_ITERATIONS=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  cpu_floor=$(grep -oE '^COZY_CANARY_CPU_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  blk=$(grep -oE '^COZY_CANARY_MEM_BLOCK_MIB=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  blocks=$(grep -oE '^COZY_CANARY_MEM_BLOCKS=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  mem_floor=$(grep -oE '^COZY_CANARY_MEM_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  bound=$(grep -oE '^COZY_CANARY_RUN_BOUND_DEFAULT=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  for v in iters cpu_floor blk blocks mem_floor bound; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
+      return 1
+    fi
+  done
+  # Checked before dividing, for the reason the emptiness check above is
+  # checked: a floor read out as zero makes the shell die on the division rather
+  # than reach the branch below, and the failure then arrives as a raw
+  # arithmetic error rather than as a sentence naming the floor and the file it
+  # was read from.
+  for v in cpu_floor mem_floor; do
+    eval "n=\$$v"
+    if [ "$n" -eq 0 ]; then
+      echo "read $v as zero from $lib; a floor of zero has no window to sit inside and this guard cannot divide by it" >&2
+      return 1
+    fi
+  done
+  for arm in "compute:$(( iters * 1000 / cpu_floor ))" \
+    "memory:$(( blk * blocks * 1000 / mem_floor ))"; do
+    name=${arm%%:*}
+    ms=${arm#*:}
+    if [ "$ms" -ge $(( bound * 1000 )) ]; then
+      echo "the $name arm crosses its floor at ${ms}ms, at or past the ${bound}s ceiling, so the ceiling stops it first and the floor can never fire" >&2
+      return 1
+    fi
+    if [ "$ms" -lt 1000 ]; then
+      echo "the $name arm crosses its floor at ${ms}ms, under a hundred ticks of the 10ms clock, so the floor fires on a duration barely above the resolution" >&2
+      return 1
+    fi
+  done
+}
+
+@test "the memory block is larger than the cache figure its legend states" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # The memory arm measures the memory controller only while its block exceeds
+  # what one core can keep cached; a block that fits reads cache bandwidth
+  # instead, several times higher, and the two arms stop telling the causes
+  # apart. The window guard beside this one divides by the product of the block
+  # size and the block count, so the split between them is invisible to it: 8
+  # MiB across 1024 blocks writes the same 8192 MiB and passes there. Both
+  # numbers are read from the source rather than written here, so the legend and
+  # the constant it describes cannot drift apart.
+  blk=$(grep -oE '^COZY_CANARY_MEM_BLOCK_MIB=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  cache=$(grep -oE 'against the [0-9]+ MiB of last-level cache' "$lib" | head -n 1 | grep -oE '[0-9]+')
+  for v in blk cache; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
+      return 1
+    fi
+  done
+  if [ "$blk" -le "$cache" ]; then
+    echo "the memory block is ${blk} MiB against the ${cache} MiB of cache the legend states, so the arm fits in cache and stops measuring the memory controller" >&2
+    return 1
+  fi
+  # Bounded above as well: the block is one buffer dd allocates, and the source
+  # names the OOM killer taking that buffer as the realistic outside kill. A
+  # block large enough to be that buffer would pass the window guard beside this
+  # one, which only ever divides by the product of the size and the count.
+  if [ "$blk" -gt $(( cache * 8 )) ]; then
+    echo "the memory block is ${blk} MiB, more than eight times the ${cache} MiB of cache the legend states, so the arm asks dd for a buffer large enough to be the OOM the ceiling attribution is written for" >&2
+    return 1
+  fi
+}
+
+@test "each arm is sized to the duration its own legend states" {
+  lib=hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  # The sizes are chosen so each arm takes about a second, which is what makes
+  # the 10ms clock about a percent of the figure rather than a tenth of it. The
+  # window guard beside this one divides the quantity by the floor, so it holds a
+  # RATIO and moves with the floor: it admits a compute arm a tenth of this size,
+  # whose legend would then print "land in about a second" about a run that took
+  # a hundred milliseconds. What has to hold is the absolute duration, and both
+  # arms carry an anchor for it in the legend already: the compute floor is
+  # stated as a factor of ten under a healthy rate, and the memory arm is stated
+  # to take about eight seconds at the bottom of its band. Derived rather than
+  # timed, because a duration asserted against the clock of whatever machine
+  # runs this would be a flake rather than a guard.
+  iters=$(grep -oE '^COZY_CANARY_CPU_ITERATIONS=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  cpu_floor=$(grep -oE '^COZY_CANARY_CPU_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  blk=$(grep -oE '^COZY_CANARY_MEM_BLOCK_MIB=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  blocks=$(grep -oE '^COZY_CANARY_MEM_BLOCKS=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  mem_floor=$(grep -oE '^COZY_CANARY_MEM_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  for v in iters cpu_floor blk blocks mem_floor; do
+    eval "n=\$$v"
+    if [ -z "$n" ]; then
+      echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
+      return 1
+    fi
+  done
+  # Compute: a healthy rate is the floor times the decade the legend states, so
+  # the arm's own duration at that rate is what the sentence promises.
+  compute_ms=$(( iters * 1000 / ( cpu_floor * 10 ) ))
+  if [ "$compute_ms" -lt 500 ] || [ "$compute_ms" -gt 2000 ]; then
+    echo "the compute arm runs ${compute_ms}ms at the healthy rate its own legend states, not the about-a-second the sizing comment promises, so the 10ms clock is no longer about a percent of the figure" >&2
+    return 1
+  fi
+  # Memory: the bottom of the band is the size over the eight seconds the legend
+  # gives it, and that bottom has to stay above the floor -- below it, a core at
+  # the bottom of the healthy band would read as pathological.
+  mem_mib=$(( blk * blocks ))
+  if [ $(( mem_mib / 8 )) -le "$mem_floor" ]; then
+    echo "the memory arm is ${mem_mib} MiB, so the bottom of the band its legend describes is $(( mem_mib / 8 )) MiB per second, at or under the ${mem_floor} floor: a core at the bottom of the healthy band would read as pathological" >&2
+    return 1
+  fi
+}
+
+@test "each arm runs the work its rate is a rate of" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250'
+
+  run_canary
+
+  capture=$(capture_path)
+  # Every figure in this capture is a rate of THIS work, and nothing else here
+  # reads the commands. An awk program with its loop gone and a dd reading a
+  # file that yields nothing still take a duration and still divide to a rate,
+  # and that rate is process startup reported as the speed of a machine.
+  assert_file_contains "for (i = 0; i < ${COZY_CANARY_CPU_ITERATIONS}; i++)" "$capture"
+  # Kept for the reason the source states beside it: an awk able to see that the
+  # loop has no effect is free to skip it.
+  assert_file_contains 'print s }' "$capture"
+  # The zero device rather than any readable file: dd's read is what fills the
+  # buffer this arm is timing the stores of.
+  assert_file_contains 'dd if=/dev/zero of=/dev/null' "$capture"
+  rm -rf "$tmp"
+}
+
+@test "both kubernetes suites describe the collectors that bracket the wait" {
+  # The node-join guard's own failure message sends a reader to both suite files,
+  # and the guard that orders those files against the library covers the gated
+  # list only -- these four are exempt from it, so nothing else checks the
+  # paragraph that names them. A paragraph that went back to describing three
+  # collectors would be false in two files and green everywhere.
+  for suite in hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml \
+    hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml; do
+  # `|| true` on each count: grep -c exits 1 on a count of zero, and under
+  # errexit that ends the test before the branch below can say what was
+  # missing -- the guard would still fail, with its diagnostic replaced by
+  # silence, on exactly the regression it exists to name.
+    # Counted inside the enumeration rather than anywhere in the file: the
+    # paragraph is what names all four, so a canary dropped from it and
+    # mentioned elsewhere would satisfy a file-wide count while the sentence
+    # stopped identifying the collectors it claims to.
+    named=$(sed -n '/The four collectors that bracket the node-join wait/,/sit outside this order/p' "$suite" | grep -cF 'runner fixed-work canary' || true)
+    counted=$(grep -cF 'The four collectors that bracket the node-join wait' "$suite" || true)
+    if [ "$named" -lt 1 ]; then
+      echo "expected $suite to name the runner fixed-work canary among the collectors that bracket the wait, found $named" >&2
+      return 1
+    fi
+    if [ "$counted" -ne 1 ]; then
+      echo "expected $suite to describe four collectors bracketing the wait, found $counted" >&2
+      return 1
+    fi
+  done
+}


### PR DESCRIPTION
## What this PR does

The diagnostics around the node-join wait already carry counter pairs that report time in the CPU rows, events in the KVM exits, and instantaneous values and running maxima in the files beside those. None of them is a fixed quantity of work, so none can separate a machine that was given fewer turns from a machine that took its turns and got less done with them.

This adds a collector that runs two fixed amounts of work on the runner VM and times them: an integer loop and a streaming write, each under a ceiling of its own. It takes one sample before the node-join wait and one after it, on the failing and the passing path alike. Each sample is an absolute reading rather than half a difference, so one alone is still readable against the expected ranges the capture prints, and the pair says whether a slowdown began inside the interval it brackets or was already there going into it.

The collector sits outside the three counter pairs that bracket the same wait rather than among them, because it occupies a core while it runs, and a burn placed inside one of those intervals would be charged to the join window it is supposed to measure.

A new bats suite of 57 tests covers the collector. The existing node-join guards were extended to price it against the phase budget and to keep the spend order documented in both kubernetes suites in step with the order the block actually runs.

On the budget: the sample taken before the wait is bounded at two arms of the canary ceiling plus grace, so it can add up to fifty seconds ahead of the wait, and the guard prices it at exactly that, while the guard's total stays below an honest worst case because collectors it already priced can spend more than the figures it prices them at.

This branch was reviewed extensively before it was opened, and what is known to be incomplete is written down rather than left implied: the words describing how each floor sits against its healthy band are marked in the code as written rather than derived, so they are the part that can go stale when a constant moves, and the phase budget residuals are tracked in the issue the comments beside them cite.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff, file by file. The diff is five files: the e2e diagnostics collector library, its two new and extended bats suites, and the two chainsaw suite definitions that document the spend order.

The closest call is `cozystack/ccp`, whose skills gate on `hack/package.mk` and `hack/common-envs.mk` and drive `make generate`. Neither file is touched, nothing under `hack/` is moved or renamed, and no make target changes what it does: the new suite is picked up because `BATS_UNIT_FILES` already globs `hack/*.bats`, so the file list grows and the target's contract does not.

Nothing else matches. No package is added, renamed or removed, so the website app lists are unaffected. No `values.schema.json`, version enum, default or `ApplicationDefinition` changes, so the Terraform provider is unaffected. `hack/e2e-prepare-cluster.bats` is untouched, so the node prerequisites that `ansible-cozystack` and `talm` restate are unchanged. `hack/update-crd.sh`, the `release.labels` convention and the chart source kinds are untouched, so `external-apps-example` and `cozyhr` are unaffected. No label, annotation or metric name changes, so `cozy-proxy` and `cozystack-telemetry-server` are unaffected. Minimum node and network requirements are unchanged, so `examples` is unaffected.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
test(e2e): the node-join diagnostics now time two fixed amounts of work on the runner before and after the wait, so a run that spent its wall clock without completing work is visible in the report. No user-facing change.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a runner fixed-work canary to Kubernetes diagnostics, measuring compute and memory throughput around node-join operations.
  - Reports execution rates, timeout conditions, and alerts when performance falls below healthy thresholds.
  - Includes diagnostic output explaining expected ranges, sampling behavior, and measurement overhead.

- **Documentation**
  - Updated Kubernetes test documentation to describe the additional canary and diagnostic timing.

- **Tests**
  - Added comprehensive coverage for canary execution, reporting, thresholds, timeout behavior, and integration with diagnostic collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->