### PR TITLE
fix(cdi): update CDI to v1.66.1

### DIFF
--- a/packages/system/kubevirt-cdi-operator/Makefile
+++ b/packages/system/kubevirt-cdi-operator/Makefile
@@ -10,4 +10,5 @@ update:
 	wget https://github.com/kubevirt/containerized-data-importer/releases/download/$$VERSION/cdi-operator.yaml -O templates/cdi-operator.yaml
 	sed -i 's/namespace: cdi/namespace: cozy-kubevirt-cdi/g' templates/cdi-operator.yaml
 	awk -i inplace -v RS="---" '!/kind: Namespace/{printf "%s", $$0 RS}' templates/cdi-operator.yaml
-	patch --no-backup-if-mismatch -p1 < patches/startupProbe.diff
+	patch --no-backup-if-mismatch -p4 < patches/startupProbe.diff
+	patch --no-backup-if-mismatch -p4 < patches/tolerations.diff

--- a/packages/system/kubevirt-cdi-operator/patches/tolerations.diff
+++ b/packages/system/kubevirt-cdi-operator/patches/tolerations.diff
@@ -1,0 +1,17 @@
+--- a/packages/system/kubevirt-cdi-operator/templates/cdi-operator.yaml
++++ b/packages/system/kubevirt-cdi-operator/templates/cdi-operator.yaml
+@@ -5807,4 +5807,13 @@
+       securityContext:
+         runAsNonRoot: true
+       serviceAccountName: cdi-operator
++      tolerations:
++      - key: CriticalAddonsOnly
++        operator: Exists
++      - effect: NoSchedule
++        key: node-role.kubernetes.io/control-plane
++        operator: Exists
++      - effect: NoSchedule
++        key: node-role.kubernetes.io/master
++        operator: Exists
+ ---
+\ No newline at end of file

--- a/packages/system/kubevirt-cdi-operator/templates/cdi-operator.yaml
+++ b/packages/system/kubevirt-cdi-operator/templates/cdi-operator.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: cdis.cdi.kubevirt.io
 spec:
   group: cdi.kubevirt.io
@@ -159,9 +159,7 @@ spec:
                             This field is effectively required, but due to backwards compatibility is
                             allowed to be empty. Instances of this type with an empty value here are
                             almost certainly wrong.
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -191,7 +189,7 @@ spec:
                           is consumed by the DataImportCron controller for creating
                           cronjobs, and by the import controller referring a copy
                           of the ConfigMap in the import namespace.\nHere is an example
-                          of the ConfigMap (in yaml):\n\n\napiVersion: v1\nkind: ConfigMap\nmetadata:\n
+                          of the ConfigMap (in yaml):\n\napiVersion: v1\nkind: ConfigMap\nmetadata:\n
                           \ name: my-ca-proxy-cm\n  namespace: cozy-kubevirt-cdi\ndata:\n  ca.pem:
                           |\n    -----BEGIN CERTIFICATE-----\n\t   ... <base64 encoded
                           cert> ...\n\t   -----END CERTIFICATE-----"
@@ -216,10 +214,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -230,6 +226,12 @@ spec:
                                 Name must match the name of one entry in pod.spec.resourceClaims of
                                 the Pod where this field is used. It makes that resource available
                                 inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -286,7 +288,6 @@ spec:
                           profile as invalid configurations can be catastrophic. An example custom profile
                           looks like this:
 
-
                             ciphers:
                               - ECDHE-ECDSA-CHACHA20-POLY1305
                               - ECDHE-RSA-CHACHA20-POLY1305
@@ -301,7 +302,6 @@ spec:
                               during the TLS handshake.  Operators may remove entries their operands
                               do not support.  For example, to use DES-CBC3-SHA  (yaml):
 
-
                                 ciphers:
                                   - DES-CBC3-SHA
                             items:
@@ -313,9 +313,7 @@ spec:
                               that is negotiated during the TLS handshake. For example, to use TLS
                               versions 1.1, 1.2 and 1.3 (yaml):
 
-
                                 minTLSVersion: VersionTLS11
-
 
                               NOTE: currently the highest minTLSVersion allowed is VersionTLS12
                             enum:
@@ -332,12 +330,9 @@ spec:
                         description: |-
                           intermediate is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
 
-
                           and looks like this (yaml):
-
 
                             ciphers:
                               - TLS_AES_128_GCM_SHA256
@@ -358,19 +353,15 @@ spec:
                         description: |-
                           modern is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
 
-
                           and looks like this (yaml):
-
 
                             ciphers:
                               - TLS_AES_128_GCM_SHA256
                               - TLS_AES_256_GCM_SHA384
                               - TLS_CHACHA20_POLY1305_SHA256
                             minTLSVersion: VersionTLS13
-
 
                           NOTE: Currently unsupported.
                         nullable: true
@@ -379,12 +370,9 @@ spec:
                         description: |-
                           old is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
 
-
                           and looks like this (yaml):
-
 
                             ciphers:
                               - TLS_AES_128_GCM_SHA256
@@ -425,14 +413,11 @@ spec:
                           the ability to specify individual TLS security profile parameters.
                           Old, Intermediate and Modern are TLS security profiles based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
-
 
                           The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers
                           are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be
                           reduced.
-
 
                           Note that the Modern profile is currently not supported because it is not
                           yet well adopted by common software libraries.
@@ -445,6 +430,12 @@ spec:
                     type: object
                   uploadProxyURLOverride:
                     description: Override the URL used when uploading to a DataVolume
+                    type: string
+                  webhookPvcRendering:
+                    description: |-
+                      WebhookPvcRendering controls whether the PVC mutating webhook that completes
+                      PVC specs from StorageProfiles is enabled or disabled
+                      Allowed values are "Enabled" (default) and "Disabled"
                     type: string
                 type: object
               customizeComponents:
@@ -795,7 +786,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -810,7 +801,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -977,7 +968,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -992,7 +983,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1157,7 +1148,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -1172,7 +1163,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -1339,7 +1330,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1354,7 +1345,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1804,7 +1795,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -1819,7 +1810,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -1986,7 +1977,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2001,7 +1992,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2166,7 +2157,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -2181,7 +2172,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -2348,7 +2339,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2363,7 +2354,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2691,9 +2682,7 @@ spec:
                             This field is effectively required, but due to backwards compatibility is
                             allowed to be empty. Instances of this type with an empty value here are
                             almost certainly wrong.
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -2723,7 +2712,7 @@ spec:
                           is consumed by the DataImportCron controller for creating
                           cronjobs, and by the import controller referring a copy
                           of the ConfigMap in the import namespace.\nHere is an example
-                          of the ConfigMap (in yaml):\n\n\napiVersion: v1\nkind: ConfigMap\nmetadata:\n
+                          of the ConfigMap (in yaml):\n\napiVersion: v1\nkind: ConfigMap\nmetadata:\n
                           \ name: my-ca-proxy-cm\n  namespace: cozy-kubevirt-cdi\ndata:\n  ca.pem:
                           |\n    -----BEGIN CERTIFICATE-----\n\t   ... <base64 encoded
                           cert> ...\n\t   -----END CERTIFICATE-----"
@@ -2748,10 +2737,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -2762,6 +2749,12 @@ spec:
                                 Name must match the name of one entry in pod.spec.resourceClaims of
                                 the Pod where this field is used. It makes that resource available
                                 inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -2818,7 +2811,6 @@ spec:
                           profile as invalid configurations can be catastrophic. An example custom profile
                           looks like this:
 
-
                             ciphers:
                               - ECDHE-ECDSA-CHACHA20-POLY1305
                               - ECDHE-RSA-CHACHA20-POLY1305
@@ -2833,7 +2825,6 @@ spec:
                               during the TLS handshake.  Operators may remove entries their operands
                               do not support.  For example, to use DES-CBC3-SHA  (yaml):
 
-
                                 ciphers:
                                   - DES-CBC3-SHA
                             items:
@@ -2845,9 +2836,7 @@ spec:
                               that is negotiated during the TLS handshake. For example, to use TLS
                               versions 1.1, 1.2 and 1.3 (yaml):
 
-
                                 minTLSVersion: VersionTLS11
-
 
                               NOTE: currently the highest minTLSVersion allowed is VersionTLS12
                             enum:
@@ -2864,12 +2853,9 @@ spec:
                         description: |-
                           intermediate is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
 
-
                           and looks like this (yaml):
-
 
                             ciphers:
                               - TLS_AES_128_GCM_SHA256
@@ -2890,19 +2876,15 @@ spec:
                         description: |-
                           modern is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
 
-
                           and looks like this (yaml):
-
 
                             ciphers:
                               - TLS_AES_128_GCM_SHA256
                               - TLS_AES_256_GCM_SHA384
                               - TLS_CHACHA20_POLY1305_SHA256
                             minTLSVersion: VersionTLS13
-
 
                           NOTE: Currently unsupported.
                         nullable: true
@@ -2911,12 +2893,9 @@ spec:
                         description: |-
                           old is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
 
-
                           and looks like this (yaml):
-
 
                             ciphers:
                               - TLS_AES_128_GCM_SHA256
@@ -2957,14 +2936,11 @@ spec:
                           the ability to specify individual TLS security profile parameters.
                           Old, Intermediate and Modern are TLS security profiles based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
-
 
                           The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers
                           are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be
                           reduced.
-
 
                           Note that the Modern profile is currently not supported because it is not
                           yet well adopted by common software libraries.
@@ -2977,6 +2953,12 @@ spec:
                     type: object
                   uploadProxyURLOverride:
                     description: Override the URL used when uploading to a DataVolume
+                    type: string
+                  webhookPvcRendering:
+                    description: |-
+                      WebhookPvcRendering controls whether the PVC mutating webhook that completes
+                      PVC specs from StorageProfiles is enabled or disabled
+                      Allowed values are "Enabled" (default) and "Disabled"
                     type: string
                 type: object
               customizeComponents:
@@ -3327,7 +3309,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -3342,7 +3324,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -3509,7 +3491,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -3524,7 +3506,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -3689,7 +3671,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -3704,7 +3686,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -3871,7 +3853,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -3886,7 +3868,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -4336,7 +4318,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -4351,7 +4333,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -4518,7 +4500,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -4533,7 +4515,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -4698,7 +4680,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -4713,7 +4695,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -4880,7 +4862,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -4895,7 +4877,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -5449,6 +5431,12 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
   - authorization.k8s.io
   resources:
   - subjectaccessreviews
@@ -5468,6 +5456,16 @@ rules:
   - get
   - list
   - update
+  - patch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+- nonResourceURLs:
+  - /debug/pprof
+  - /debug/pprof/*
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -5738,27 +5736,27 @@ spec:
         - name: DEPLOY_CLUSTER_RESOURCES
           value: "true"
         - name: OPERATOR_VERSION
-          value: v1.64.0
+          value: v1.66.0
         - name: CONTROLLER_IMAGE
-          value: quay.io/kubevirt/cdi-controller:v1.64.0
+          value: quay.io/kubevirt/cdi-controller:v1.66.0
         - name: IMPORTER_IMAGE
-          value: quay.io/kubevirt/cdi-importer:v1.64.0
+          value: quay.io/kubevirt/cdi-importer:v1.66.0
         - name: CLONER_IMAGE
-          value: quay.io/kubevirt/cdi-cloner:v1.64.0
+          value: quay.io/kubevirt/cdi-cloner:v1.66.0
         - name: OVIRT_POPULATOR_IMAGE
-          value: quay.io/kubevirt/cdi-importer:v1.64.0
+          value: quay.io/kubevirt/cdi-importer:v1.66.0
         - name: APISERVER_IMAGE
-          value: quay.io/kubevirt/cdi-apiserver:v1.64.0
+          value: quay.io/kubevirt/cdi-apiserver:v1.66.0
         - name: UPLOAD_SERVER_IMAGE
-          value: quay.io/kubevirt/cdi-uploadserver:v1.64.0
+          value: quay.io/kubevirt/cdi-uploadserver:v1.66.0
         - name: UPLOAD_PROXY_IMAGE
-          value: quay.io/kubevirt/cdi-uploadproxy:v1.64.0
+          value: quay.io/kubevirt/cdi-uploadproxy:v1.66.0
         - name: VERBOSITY
           value: "1"
         - name: PULL_POLICY
           value: IfNotPresent
         - name: MONITORING_NAMESPACE
-        image: quay.io/kubevirt/cdi-operator:v1.64.0
+        image: quay.io/kubevirt/cdi-operator:v1.66.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -5810,12 +5808,12 @@ spec:
         runAsNonRoot: true
       serviceAccountName: cdi-operator
       tolerations:
-       - key: CriticalAddonsOnly
-         operator: Exists
-       - effect: NoSchedule
-         key: node-role.kubernetes.io/control-plane
-         operator: Exists
-       - effect: NoSchedule
-         key: node-role.kubernetes.io/master
-         operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
 ---

--- a/packages/system/kubevirt-cdi-operator/templates/cdi-operator.yaml
+++ b/packages/system/kubevirt-cdi-operator/templates/cdi-operator.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: cdis.cdi.kubevirt.io
 spec:
   group: cdi.kubevirt.io
@@ -159,9 +159,7 @@ spec:
                             This field is effectively required, but due to backwards compatibility is
                             allowed to be empty. Instances of this type with an empty value here are
                             almost certainly wrong.
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -191,7 +189,7 @@ spec:
                           is consumed by the DataImportCron controller for creating
                           cronjobs, and by the import controller referring a copy
                           of the ConfigMap in the import namespace.\nHere is an example
-                          of the ConfigMap (in yaml):\n\n\napiVersion: v1\nkind: ConfigMap\nmetadata:\n
+                          of the ConfigMap (in yaml):\n\napiVersion: v1\nkind: ConfigMap\nmetadata:\n
                           \ name: my-ca-proxy-cm\n  namespace: cozy-kubevirt-cdi\ndata:\n  ca.pem:
                           |\n    -----BEGIN CERTIFICATE-----\n\t   ... <base64 encoded
                           cert> ...\n\t   -----END CERTIFICATE-----"
@@ -216,10 +214,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -230,6 +226,12 @@ spec:
                                 Name must match the name of one entry in pod.spec.resourceClaims of
                                 the Pod where this field is used. It makes that resource available
                                 inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -286,7 +288,6 @@ spec:
                           profile as invalid configurations can be catastrophic. An example custom profile
                           looks like this:
 
-
                             ciphers:
                               - ECDHE-ECDSA-CHACHA20-POLY1305
                               - ECDHE-RSA-CHACHA20-POLY1305
@@ -301,7 +302,6 @@ spec:
                               during the TLS handshake.  Operators may remove entries their operands
                               do not support.  For example, to use DES-CBC3-SHA  (yaml):
 
-
                                 ciphers:
                                   - DES-CBC3-SHA
                             items:
@@ -313,9 +313,7 @@ spec:
                               that is negotiated during the TLS handshake. For example, to use TLS
                               versions 1.1, 1.2 and 1.3 (yaml):
 
-
                                 minTLSVersion: VersionTLS11
-
 
                               NOTE: currently the highest minTLSVersion allowed is VersionTLS12
                             enum:
@@ -332,12 +330,9 @@ spec:
                         description: |-
                           intermediate is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
 
-
                           and looks like this (yaml):
-
 
                             ciphers:
                               - TLS_AES_128_GCM_SHA256
@@ -358,19 +353,15 @@ spec:
                         description: |-
                           modern is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
 
-
                           and looks like this (yaml):
-
 
                             ciphers:
                               - TLS_AES_128_GCM_SHA256
                               - TLS_AES_256_GCM_SHA384
                               - TLS_CHACHA20_POLY1305_SHA256
                             minTLSVersion: VersionTLS13
-
 
                           NOTE: Currently unsupported.
                         nullable: true
@@ -379,12 +370,9 @@ spec:
                         description: |-
                           old is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
 
-
                           and looks like this (yaml):
-
 
                             ciphers:
                               - TLS_AES_128_GCM_SHA256
@@ -425,14 +413,11 @@ spec:
                           the ability to specify individual TLS security profile parameters.
                           Old, Intermediate and Modern are TLS security profiles based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
-
 
                           The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers
                           are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be
                           reduced.
-
 
                           Note that the Modern profile is currently not supported because it is not
                           yet well adopted by common software libraries.
@@ -445,6 +430,12 @@ spec:
                     type: object
                   uploadProxyURLOverride:
                     description: Override the URL used when uploading to a DataVolume
+                    type: string
+                  webhookPvcRendering:
+                    description: |-
+                      WebhookPvcRendering controls whether the PVC mutating webhook that completes
+                      PVC specs from StorageProfiles is enabled or disabled
+                      Allowed values are "Enabled" (default) and "Disabled"
                     type: string
                 type: object
               customizeComponents:
@@ -795,7 +786,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -810,7 +801,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -977,7 +968,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -992,7 +983,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1157,7 +1148,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -1172,7 +1163,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -1339,7 +1330,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1354,7 +1345,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1804,7 +1795,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -1819,7 +1810,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -1986,7 +1977,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2001,7 +1992,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2166,7 +2157,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -2181,7 +2172,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -2348,7 +2339,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2363,7 +2354,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -2691,9 +2682,7 @@ spec:
                             This field is effectively required, but due to backwards compatibility is
                             allowed to be empty. Instances of this type with an empty value here are
                             almost certainly wrong.
-                            TODO: Add other useful fields. apiVersion, kind, uid?
                             More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
@@ -2723,7 +2712,7 @@ spec:
                           is consumed by the DataImportCron controller for creating
                           cronjobs, and by the import controller referring a copy
                           of the ConfigMap in the import namespace.\nHere is an example
-                          of the ConfigMap (in yaml):\n\n\napiVersion: v1\nkind: ConfigMap\nmetadata:\n
+                          of the ConfigMap (in yaml):\n\napiVersion: v1\nkind: ConfigMap\nmetadata:\n
                           \ name: my-ca-proxy-cm\n  namespace: cozy-kubevirt-cdi\ndata:\n  ca.pem:
                           |\n    -----BEGIN CERTIFICATE-----\n\t   ... <base64 encoded
                           cert> ...\n\t   -----END CERTIFICATE-----"
@@ -2748,10 +2737,8 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-
 
                           This field is immutable. It can only be set for containers.
                         items:
@@ -2762,6 +2749,12 @@ spec:
                                 Name must match the name of one entry in pod.spec.resourceClaims of
                                 the Pod where this field is used. It makes that resource available
                                 inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
                               type: string
                           required:
                           - name
@@ -2818,7 +2811,6 @@ spec:
                           profile as invalid configurations can be catastrophic. An example custom profile
                           looks like this:
 
-
                             ciphers:
                               - ECDHE-ECDSA-CHACHA20-POLY1305
                               - ECDHE-RSA-CHACHA20-POLY1305
@@ -2833,7 +2825,6 @@ spec:
                               during the TLS handshake.  Operators may remove entries their operands
                               do not support.  For example, to use DES-CBC3-SHA  (yaml):
 
-
                                 ciphers:
                                   - DES-CBC3-SHA
                             items:
@@ -2845,9 +2836,7 @@ spec:
                               that is negotiated during the TLS handshake. For example, to use TLS
                               versions 1.1, 1.2 and 1.3 (yaml):
 
-
                                 minTLSVersion: VersionTLS11
-
 
                               NOTE: currently the highest minTLSVersion allowed is VersionTLS12
                             enum:
@@ -2864,12 +2853,9 @@ spec:
                         description: |-
                           intermediate is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
 
-
                           and looks like this (yaml):
-
 
                             ciphers:
                               - TLS_AES_128_GCM_SHA256
@@ -2890,19 +2876,15 @@ spec:
                         description: |-
                           modern is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility
 
-
                           and looks like this (yaml):
-
 
                             ciphers:
                               - TLS_AES_128_GCM_SHA256
                               - TLS_AES_256_GCM_SHA384
                               - TLS_CHACHA20_POLY1305_SHA256
                             minTLSVersion: VersionTLS13
-
 
                           NOTE: Currently unsupported.
                         nullable: true
@@ -2911,12 +2893,9 @@ spec:
                         description: |-
                           old is a TLS security profile based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
 
-
                           and looks like this (yaml):
-
 
                             ciphers:
                               - TLS_AES_128_GCM_SHA256
@@ -2957,14 +2936,11 @@ spec:
                           the ability to specify individual TLS security profile parameters.
                           Old, Intermediate and Modern are TLS security profiles based on:
 
-
                           https://wiki.mozilla.org/Security/Server_Side_TLS#Recommended_configurations
-
 
                           The profiles are intent based, so they may change over time as new ciphers are developed and existing ciphers
                           are found to be insecure.  Depending on precisely which ciphers are available to a process, the list may be
                           reduced.
-
 
                           Note that the Modern profile is currently not supported because it is not
                           yet well adopted by common software libraries.
@@ -2977,6 +2953,12 @@ spec:
                     type: object
                   uploadProxyURLOverride:
                     description: Override the URL used when uploading to a DataVolume
+                    type: string
+                  webhookPvcRendering:
+                    description: |-
+                      WebhookPvcRendering controls whether the PVC mutating webhook that completes
+                      PVC specs from StorageProfiles is enabled or disabled
+                      Allowed values are "Enabled" (default) and "Disabled"
                     type: string
                 type: object
               customizeComponents:
@@ -3327,7 +3309,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -3342,7 +3324,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -3509,7 +3491,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -3524,7 +3506,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -3689,7 +3671,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -3704,7 +3686,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -3871,7 +3853,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -3886,7 +3868,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -4336,7 +4318,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -4351,7 +4333,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -4518,7 +4500,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -4533,7 +4515,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -4698,7 +4680,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -4713,7 +4695,7 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -4880,7 +4862,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -4895,7 +4877,7 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -5449,6 +5431,12 @@ rules:
   verbs:
   - update
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
   - authorization.k8s.io
   resources:
   - subjectaccessreviews
@@ -5468,6 +5456,16 @@ rules:
   - get
   - list
   - update
+  - patch
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+- nonResourceURLs:
+  - /debug/pprof
+  - /debug/pprof/*
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -5738,27 +5736,27 @@ spec:
         - name: DEPLOY_CLUSTER_RESOURCES
           value: "true"
         - name: OPERATOR_VERSION
-          value: v1.64.0
+          value: v1.66.1
         - name: CONTROLLER_IMAGE
-          value: quay.io/kubevirt/cdi-controller:v1.64.0
+          value: quay.io/kubevirt/cdi-controller:v1.66.1
         - name: IMPORTER_IMAGE
-          value: quay.io/kubevirt/cdi-importer:v1.64.0
+          value: quay.io/kubevirt/cdi-importer:v1.66.1
         - name: CLONER_IMAGE
-          value: quay.io/kubevirt/cdi-cloner:v1.64.0
+          value: quay.io/kubevirt/cdi-cloner:v1.66.1
         - name: OVIRT_POPULATOR_IMAGE
-          value: quay.io/kubevirt/cdi-importer:v1.64.0
+          value: quay.io/kubevirt/cdi-importer:v1.66.1
         - name: APISERVER_IMAGE
-          value: quay.io/kubevirt/cdi-apiserver:v1.64.0
+          value: quay.io/kubevirt/cdi-apiserver:v1.66.1
         - name: UPLOAD_SERVER_IMAGE
-          value: quay.io/kubevirt/cdi-uploadserver:v1.64.0
+          value: quay.io/kubevirt/cdi-uploadserver:v1.66.1
         - name: UPLOAD_PROXY_IMAGE
-          value: quay.io/kubevirt/cdi-uploadproxy:v1.64.0
+          value: quay.io/kubevirt/cdi-uploadproxy:v1.66.1
         - name: VERBOSITY
           value: "1"
         - name: PULL_POLICY
           value: IfNotPresent
         - name: MONITORING_NAMESPACE
-        image: quay.io/kubevirt/cdi-operator:v1.64.0
+        image: quay.io/kubevirt/cdi-operator:v1.66.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -5810,12 +5808,12 @@ spec:
         runAsNonRoot: true
       serviceAccountName: cdi-operator
       tolerations:
-       - key: CriticalAddonsOnly
-         operator: Exists
-       - effect: NoSchedule
-         key: node-role.kubernetes.io/control-plane
-         operator: Exists
-       - effect: NoSchedule
-         key: node-role.kubernetes.io/master
-         operator: Exists
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
 ---


### PR DESCRIPTION
## What this PR does

CDI v1.64.0 -> v1.66.1, operator manifest refetched with `make update`.

The bump was stuck since v1.65.0: its bundled qemu-img broke HTTP imports to block volumes on 4Kn devices (DRBD/LINSTOR). This PR first targeted v1.66.0 on the assumption that kubevirt/containerized-data-importer#4179 had closed it, and that was wrong: the qemu-img in the v1.66.0 importer is 10.1.0-21.el9, which does not carry the first-sector fix, and the E2E run on that head failed exactly there. The fix is in 10.1.0-24.el9, which reached the release branch through kubevirt/containerized-data-importer#4274 and shipped in v1.66.1. Verified by running the released image: `cdi-importer:v1.66.1` reports `qemu-img version 10.1.0 (qemu-kvm-10.1.0-24.el9)`.

The other v1.64.0 symptom is a resourceVersion storm on the prime PVC during WFFC imports, which makes the scheduler retry FailedScheduling dozens of times per import; it was reported by a production user importing golden images on a local StorageClass. That one is fixed by commit e547586e9, a one-line guard in `updatePvcFromPod` that clears the bound-condition annotations only when they came from scratch-space creation. It is in v1.66.0 and later. The commit is squashed under a title about kubevirtci lanes, so it appears in no release note and searching for it by symptom finds nothing.

Two local edits to the vendored manifest survive refetches now. The startupProbe patch gets the correct -p4 strip level, as written it never applied from the package directory. The control-plane tolerations were hand-edited into the manifest with no patch behind them, so any refetch silently dropped them; they live in patches/tolerations.diff now. `make update` round-trips to a byte-identical file.

Behavior changes checked against this repo: /metrics on CDI components now requires a bearer token, nothing here scrapes it. Scratch PVCs inherit the target StorageClass instead of the cluster default (since v1.65.0). The PVC-rendering webhook is always registered now, but only matches PVCs labeled cdi.kubevirt.io/applyStorageProfile=true, which nothing here sets.

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(cdi): update CDI to v1.66.1. Fixes HTTP imports to block volumes on 4Kn devices (DRBD/LINSTOR) with the repaired qemu-img, and the resourceVersion storm on prime PVCs during WaitForFirstConsumer imports.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes tolerations for critical add-on and control-plane nodes.
  * Added resource claim requests and webhook PVC rendering configuration to CDI custom resources.
  * Added permissions for token reviews, metrics, and profiling endpoints.
  * Updated affinity feature-gate documentation to beta status.

* **Improvements**
  * Updated CDI operator and operand images to version 1.66.1.
  * Refreshed Kubernetes schema metadata and deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

