### PR TITLE
fix(ci): resolve fork PRs by open-PR head SHA, not commit association

### DIFF
--- a/.github/workflows/e2e-fork.yaml
+++ b/.github/workflows/e2e-fork.yaml
@@ -192,18 +192,34 @@ jobs:
               return;
             }
 
-            // Resolve the PR number for this commit (workflow_run.pull_requests
-            // is empty for forks). Only OPEN PRs count — never fall back to a
-            // closed/merged association, which a fork could point at a stale
-            // commit to smuggle a green through.
-            // Paginated, like every other lookup in this script: the check
-            // below counts open associations, so reading only the first page
-            // would miss the second PR in exactly the case it exists to catch.
-            const assoc = await github.paginate(
-              github.rest.repos.listPullRequestsAssociatedWithCommit,
-              { owner, repo, commit_sha: HEAD_SHA, per_page: 100 },
+            // Resolve the PR number for this commit. Neither obvious lookup
+            // works for a fork: `workflow_run.pull_requests` is empty for a
+            // cross-repository run, and the association endpoint this used to
+            // call, `listPullRequestsAssociatedWithCommit`, returns nothing
+            // either — a fork PR head reaches the base repo only as
+            // `refs/pull/<n>/head`, and that association index does not walk
+            // `refs/pull/*`. It resolves same-repo heads fine, which is exactly
+            // why the hole stayed invisible: every fork PR fail-closed right
+            // here on `found 0` and no fork run ever reached publish or e2e,
+            // while same-repo PRs get "E2E Tests" from pull-requests.yaml and
+            // never enter this workflow at all.
+            //
+            // So enumerate the base repo's OPEN pull requests and match on the
+            // head SHA. Same trust properties as the call it replaces — plain
+            // base-repo API data, nothing the fork can forge — and asking for
+            // `state: 'open'` at the source keeps the old rule that a closed or
+            // merged PR never counts, so a fork cannot point a stale commit at
+            // a green.
+            // Paginated, like every other lookup in this script. Here it is
+            // load-bearing twice over: the PR being looked for is frequently
+            // not on the first page at all, and the check below counts matches,
+            // so a single page would also miss the second PR in exactly the
+            // case that count exists to catch.
+            const openPrs = await github.paginate(
+              github.rest.pulls.list,
+              { owner, repo, state: 'open', per_page: 100 },
             );
-            // Exactly one PR AT this head, not the first association. A single
+            // Exactly one PR AT this head, not the first match. A single
             // branch may have several open PRs against different base branches,
             // and every decision below is taken from whichever PR this picks:
             // the merge-ref checkout, the docs-only verdict, the TIA file list,
@@ -213,16 +229,15 @@ jobs:
             // code. The HEAD^2 == head_sha assert downstream cannot catch that:
             // it holds for every PR sitting on the commit.
             //
-            // The head_sha filter is what keeps the guard as narrow as its
-            // reason. This endpoint returns PRs ASSOCIATED with the commit,
-            // which per the API docs means any open PR whose branch contains
-            // it, not only those pointing at it. Without the filter, stacking
-            // one branch on another and opening both PRs counts as two, and
-            // the lower PR fails closed on a state its author cannot clear by
+            // Matching head.sha, rather than any notion of reachability, is
+            // what keeps the guard as narrow as its reason. Stack one branch on
+            // another and open both PRs, and the lower PR's head is merely
+            // CONTAINED in the upper branch; counting that as two would fail
+            // the lower PR closed on a state its author cannot clear by
             // pushing. That is the same unfixable red this workflow refuses to
             // inflict elsewhere. Two PRs genuinely at the same head still fail
             // closed, which is the case the guard exists for.
-            const open = assoc.filter(p => p.state === 'open' && p.head && p.head.sha === HEAD_SHA);
+            const open = openPrs.filter(p => p.head && p.head.sha === HEAD_SHA);
             if (open.length !== 1) {
               await decide('failure', `expected exactly one open PR for ${HEAD_SHA}, found ${open.length}`);
               return;


### PR DESCRIPTION
Fork PR e2e lane never ran. `resolve` looks up PR for head sha with `listPullRequestsAssociatedWithCommit` on base repo, and this endpoint returns nothing for fork PR head, because fork commit reaches base repo only as `refs/pull/<n>/head` and association index doesn't walk `refs/pull/*`. So every fork PR failed closed on `expected exactly one open PR for <sha>, found 0`, got red required `E2E Tests` that its author cant clear by pushing, and `publish`, `e2e`, `report` skipped.

Endpoint works fine for same-repo heads, that is why nobody saw it - same-repo PRs get `E2E Tests` from `pull-requests.yaml` and never enter this workflow at all. Of 935 runs of `E2E (fork)` 930 skipped as designed, and all 5 that reached `resolve` stopped right there (three on `found 0`, one on genuinely failed fork build). One of those reds was later overwritten by mirrored same-repo run, so symptom got hidden second time.

Checked on live api: on base repo that endpoint returns 0 for head sha of all 5 currently open fork PRs and 1 for same-repo PRs, on fork repo it returns 1 for same commit. Listing open PRs of base repo and matching head sha returns 1.

### Fix

```js
const openPrs = await github.paginate(
  github.rest.pulls.list,
  { owner, repo, state: 'open', per_page: 100 },
);
const open = openPrs.filter(p => p.head && p.head.sha === HEAD_SHA);
```

Same trust properties as call it replaces, this is plain base-repo api data that fork cannot forge, and asking `state: 'open'` at source keeps old rule that closed or merged PR never counts. Exactly-one guard and head sha match are not changed, so stacked lower PR whose head is only contained in upper branch still passes, and two PRs really sitting at same head still fail closed. Pagination becomes load bearing here, repo has 180 open PRs and fork PR that surfaced this sits on page two.

Most of diff is the comment block, rewritten so association call doesn't come back later as an optimization.

Simulated new logic on live api, failing head resolves to exactly one open PR and `labels` are present in list payload, so `full-e2e` override still reads. actionlint, zizmor, `node --check` on extracted script and pre-commit pass.

### What is not verified

`publish`, `e2e` and `report` never executed in this workflow, so first fork PR going through the gate will exercise them for the first time. I would watch digest push from OCI archives and `HEAD^2 == head_sha` assert. Also there is no test harness for inline `resolve` script and this PR doesn't add one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fork pull request detection by matching the exact triggering commit.
  * Prevented stacked or unrelated pull requests containing the same commit from being incorrectly selected.
  * Ensured the workflow proceeds only when exactly one matching open pull request is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->