### PR TITLE
fix(postgres): run init-job in main phase and wait for the superuser secret

### DIFF
--- a/examples/backups/postgres/00-helpers.sh
+++ b/examples/backups/postgres/00-helpers.sh
@@ -99,6 +99,34 @@ wait_for_field() {
     done
 }
 
+# Wait until a Job matched by a label selector reports .status.succeeded >= 1.
+# The chart's init Job name carries a content-hash suffix (it is a main-phase
+# immutable Job), so it cannot be waited on by a fixed name — it is found by its
+# stable selector labels instead.
+wait_for_job_succeeded_by_label() {
+    local selector="$1"
+    local namespace="$2"
+    local timeout="${3:-300}"
+
+    log_substep "Waiting for Job matching '$selector' to succeed..."
+    local elapsed=0
+    while true; do
+        local succeeded
+        succeeded=$(kubectl -n "$namespace" get jobs -l "$selector" \
+            -o jsonpath='{.items[?(@.status.succeeded>=1)].metadata.name}' 2>/dev/null || true)
+        if [[ -n "$succeeded" ]]; then
+            log_success "Job $succeeded succeeded"
+            return 0
+        fi
+        if [[ $elapsed -ge $timeout ]]; then
+            log_error "Timeout waiting for Job matching '$selector'"
+            return 1
+        fi
+        sleep 5
+        elapsed=$((elapsed + 5))
+    done
+}
+
 # Wait for a HelmRelease to become Ready, with an existence backstop (the
 # apps controller creates the HR asynchronously, so a bare `kubectl wait`
 # right after `kubectl apply` races it) and a fail-fast on Stalled=True —

--- a/examples/backups/postgres/run-all.sh
+++ b/examples/backups/postgres/run-all.sh
@@ -123,9 +123,11 @@ wait_hr_ready "postgres-${PG_SRC_NAME}" 360
 wait_for_field clusters.postgresql.cnpg.io "$PG_SRC_CLUSTER" \
     '{.status.phase}' 'Cluster in healthy state' "$NAMESPACE" 360
 # The 'demo' database and 'app' user are created by the chart's init Job, not
-# by cluster readiness — wait for it before writing into demo.
-wait_for_field jobs.batch "postgres-${PG_SRC_NAME}-init-job" \
-    '{.status.succeeded}' 1 "$NAMESPACE" 180
+# by cluster readiness — wait for it before writing into demo. The Job name
+# carries a content-hash suffix, so it is matched by its stable labels.
+wait_for_job_succeeded_by_label \
+    "app.kubernetes.io/instance=postgres-${PG_SRC_NAME},app.kubernetes.io/component=init-job" \
+    "$NAMESPACE" 180
 
 print_header "Step 05c: Write a sentinel row so the backup has something to prove"
 SENTINEL_TOKEN="e2e-$(date +%s)-$$"

--- a/hack/e2e-chainsaw/postgres/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/postgres/chainsaw-test.yaml
@@ -42,13 +42,17 @@ spec:
 
   - name: wait-init-job-complete
     try:
+    # The init Job's name carries a content-hash suffix (it is a main-phase
+    # immutable Job), so it is matched by its stable selector labels, not by name.
     - assert:
         timeout: 2m
         resource:
           apiVersion: batch/v1
           kind: Job
           metadata:
-            name: postgres-test-init-job
+            labels:
+              app.kubernetes.io/instance: postgres-test
+              app.kubernetes.io/component: init-job
           status:
             (conditions[?type == 'Complete']):
             - status: "True"
@@ -123,7 +127,9 @@ spec:
         ref:
           apiVersion: batch/v1
           kind: Job
-          name: postgres-test-init-job
+          labels:
+            app.kubernetes.io/instance: postgres-test
+            app.kubernetes.io/component: init-job
 
   # The trust anchor a client verifies against, checked against the live
   # operator rather than against our own beliefs about it.

--- a/packages/apps/postgres/templates/init-job.yaml
+++ b/packages/apps/postgres/templates/init-job.yaml
@@ -1,82 +1,130 @@
 {{/*
-  Skip the post-install/post-upgrade init Job entirely while the chart
-  renders bootstrap.recovery. Helm waits up to 5m for hooks to succeed,
-  but the Job's pg_isready loop can't drain that budget while CNPG is
-  still streaming the restore from S3 - the hook then times out and
-  Helm rolls the upgrade back to the previous bootstrap.initdb spec,
-  which makes every subsequent recovery pod panic in CNPG's
-  InitInfo.loadBackup (Recovery == nil after the rollback).
-  Recovered postgres carries source's roles/databases at the on-disk
-  level, so the chart's role/db management can re-converge on the next
-  user-driven helm upgrade after recovery completes.
+  The init Job reconciles users/databases/roles once per release revision.
+  It reads the CNPG-managed superuser Secret (<release>-superuser), which the
+  operator creates asynchronously after the Cluster is applied. The Job is a
+  main-phase resource, not a Helm hook, for two reasons:
+
+    1. A post-install/post-upgrade hook never runs while the release is stuck
+       in UpgradeFailed, so role/database convergence would silently stop until
+       the release recovered.
+    2. The superuser Secret does not exist at t0. As a hook the Pod raced the
+       operator and hit FailedMount / CreateContainerConfigError. Here the
+       secret volume is optional and an init container blocks the Pod until the
+       Secret is published, so the wait happens in the init phase instead of a
+       mount failure.
+
+  Because the Job template is immutable and the HelmRelease is applied without
+  Force, the name carries a content-hash suffix so a changed spec (e.g. a new
+  init script) produces a new Job instead of failing to patch the old one.
+
+  Still skipped while bootstrap.recovery is in effect: CNPG streams the restore
+  from S3, the Job's psql loop cannot run against it, and recovered postgres
+  already carries the source's roles/databases at the on-disk level. Role/db
+  management re-converges on the next user-driven upgrade after recovery.
 */}}
+{{- define "postgres.initJobSpec" -}}
+ttlSecondsAfterFinished: 3600
+template:
+  metadata:
+    name: {{ .Release.Name }}-init-job
+    annotations:
+      checksum/config: {{ include (print $.Template.BasePath "/init-script.yaml") . | sha256sum }}
+  spec:
+    restartPolicy: Never
+    initContainers:
+    # Hold the Pod until CNPG has published the <release>-superuser Secret. The
+    # secret volume is optional so kubelet does not FailedMount at t0; the deadline
+    # sits below the HelmRelease install timeout so a stuck bootstrap surfaces as a
+    # CrashLoopBackOff here rather than a silent hang.
+    - name: wait-for-superuser
+      image: ghcr.io/cloudnative-pg/postgresql:{{ include "postgres.versionMap" $ | trimPrefix "v" }}
+      command:
+      - sh
+      - -c
+      - |
+        set -eu
+        deadline=$(( $(date +%s) + 300 ))
+        until [ -s /etc/secret/username ] && [ -s /etc/secret/password ]; do
+          if [ "$(date +%s)" -ge "$deadline" ]; then
+            echo "CNPG superuser secret was not provisioned within 5m; exiting so the pod goes CrashLoopBackOff and surfaces in dashboards" >&2
+            exit 1
+          fi
+          echo "waiting for CNPG-managed superuser secret (<release>-superuser)..."
+          sleep 5
+        done
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+      volumeMounts:
+      - mountPath: /etc/secret
+        name: secret
+        readOnly: true
+    containers:
+    - name: postgres
+      image: ghcr.io/cloudnative-pg/postgresql:{{ include "postgres.versionMap" $ | trimPrefix "v" }}
+      command:
+      - bash
+      - /scripts/init.sh
+      env:
+      - name: PGUSER
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Release.Name }}-superuser
+            key: username
+      - name: PGPASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: {{ .Release.Name }}-superuser
+            key: password
+      - name: PGHOST
+        value: {{ .Release.Name }}-rw
+      - name: PGPORT
+        value: "5432"
+      - name: PGDATABASE
+        value: postgres
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+      volumeMounts:
+      - mountPath: /etc/secret
+        name: secret
+      - mountPath: /scripts
+        name: scripts
+      {{- include "postgresjobs.resources" . | nindent 6 }}
+    securityContext:
+      fsGroup: 26
+      runAsGroup: 26
+      runAsNonRoot: true
+      runAsUser: 26
+      seccompProfile:
+        type: RuntimeDefault
+    volumes:
+    - name: secret
+      secret:
+        secretName: {{ .Release.Name }}-superuser
+        optional: true
+    - name: scripts
+      secret:
+        secretName: {{ .Release.Name }}-init-script
+{{- end }}
 {{- if not .Values.bootstrap.enabled }}
+{{- $jobSpec := include "postgres.initJobSpec" . }}
+{{- $jobHash := $jobSpec | sha256sum | trunc 6 }}
+{{- $jobName := printf "%s-init-job" .Release.Name | trunc 56 | trimSuffix "-" }}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-init-job
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation
+  name: {{ $jobName }}-{{ $jobHash }}
 spec:
-  ttlSecondsAfterFinished: 3600
-  template:
-    metadata:
-      name: {{ .Release.Name }}-init-job
-      annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/init-script.yaml") . | sha256sum }}
-    spec:
-      restartPolicy: Never
-      containers:
-      - name: postgres
-        image: ghcr.io/cloudnative-pg/postgresql:{{ include "postgres.versionMap" $ | trimPrefix "v" }}
-        command:
-        - bash
-        - /scripts/init.sh
-        env:
-        - name: PGUSER
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-superuser
-              key: username
-        - name: PGPASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-superuser
-              key: password
-        - name: PGHOST
-          value: {{ .Release.Name }}-rw
-        - name: PGPORT
-          value: "5432"
-        - name: PGDATABASE
-          value: postgres
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-          privileged: false
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-        volumeMounts:
-        - mountPath: /etc/secret
-          name: secret
-        - mountPath: /scripts
-          name: scripts
-        {{- include "postgresjobs.resources" . | nindent 8 }}
-      securityContext:
-        fsGroup: 26
-        runAsGroup: 26
-        runAsNonRoot: true
-        runAsUser: 26
-        seccompProfile:
-          type: RuntimeDefault
-      volumes:
-      - name: secret
-        secret:
-          secretName: {{ .Release.Name }}-superuser
-      - name: scripts
-        secret:
-          secretName: {{ .Release.Name }}-init-script
+{{ $jobSpec | indent 2 }}
 {{- end }}

--- a/packages/apps/postgres/templates/init-job.yaml
+++ b/packages/apps/postgres/templates/init-job.yaml
@@ -125,6 +125,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ $jobName }}-{{ $jobHash }}
+  # Stable selector labels: the name carries a content hash, so consumers
+  # (E2E asserts, the backup example) must find this Job by label, not by name.
+  labels:
+    app.kubernetes.io/name: postgres.apps.cozystack.io
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: init-job
 spec:
 {{ $jobSpec | indent 2 }}
 {{- end }}

--- a/packages/apps/postgres/tests/init_job_cleanup_test.yaml
+++ b/packages/apps/postgres/tests/init_job_cleanup_test.yaml
@@ -54,6 +54,14 @@ tests:
       - matchRegex:
           path: metadata.name
           pattern: ^pg-test-init-job-[0-9a-f]{6}$
+      # Stable selector labels: because the name is hashed, consumers (E2E
+      # asserts, the backup example) find the Job by these labels, not by name.
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: init-job
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: pg-test
 
   - it: "init-job waits for the superuser Secret behind an optional volume"
     template: templates/init-job.yaml

--- a/packages/apps/postgres/tests/init_job_cleanup_test.yaml
+++ b/packages/apps/postgres/tests/init_job_cleanup_test.yaml
@@ -1,13 +1,17 @@
-suite: init-job is garbage-collected after completion
+suite: init-job is a main-phase reconciler, garbage-collected after completion
 
-# Locks in cozystack/cozystack#3055: the post-install/post-upgrade init Job
-# is a one-shot reconciler of users/databases/roles. Without a TTL it lingers
-# in the namespace forever after the Postgres CR is deleted (its hook-delete-policy
-# is 'before-hook-creation' only, which never fires on uninstall). A native
-# ttlSecondsAfterFinished lets the Kubernetes TTL controller GC the Job and its
-# Pod ~1 hour after it completes, regardless of Helm hook lifecycle — without
-# touching the hook-timeout semantics the recovery flow depends on. 1h leaves a
+# Locks in cozystack/cozystack#3055: the init Job is a one-shot reconciler of
+# users/databases/roles. Without a TTL it lingers in the namespace forever after
+# the Postgres CR is deleted. A native ttlSecondsAfterFinished lets the Kubernetes
+# TTL controller GC the Job and its Pod ~1 hour after it completes. 1h leaves a
 # debugging window for a failed init Job before it is collected.
+#
+# Locks in cozystack/cozystack#3921: the Job is a main-phase resource (no
+# helm.sh/hook), so it also runs while the release is UpgradeFailed, and it waits
+# for the CNPG-managed superuser Secret in an init container behind an optional
+# volume instead of racing the operator with a FailedMount at t0. Because the Job
+# template is immutable and the HelmRelease is applied without Force, the name
+# carries a content-hash suffix so a changed spec produces a new Job.
 
 # Both templates are loaded so the Job's checksum/config annotation can resolve
 # its `include ".../init-script.yaml"`. Each test then pins assertions to a
@@ -36,11 +40,58 @@ tests:
       - isKind:
           of: Job
       - equal:
-          path: metadata.name
-          value: pg-test-init-job
-      - equal:
           path: spec.ttlSecondsAfterFinished
           value: 3600
+
+  - it: "init-job is a main-phase resource, not a Helm hook"
+    template: templates/init-job.yaml
+    asserts:
+      # Main-phase, not a hook: the Job must not carry any helm.sh/hook
+      # annotation, otherwise it stops reconciling on an UpgradeFailed release.
+      - notExists:
+          path: metadata.annotations["helm.sh/hook"]
+      # Immutable Job carries a 6-char content-hash suffix (see pinned cases below).
+      - matchRegex:
+          path: metadata.name
+          pattern: ^pg-test-init-job-[0-9a-f]{6}$
+
+  - it: "init-job waits for the superuser Secret behind an optional volume"
+    template: templates/init-job.yaml
+    asserts:
+      # The wait-for-superuser init container gates the Pod so it blocks in the
+      # init phase until CNPG publishes the Secret, instead of a FailedMount at t0.
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-superuser
+      # The superuser volume is the first volume and must be optional so kubelet
+      # does not FailedMount while the Secret is still absent.
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: secret
+      - equal:
+          path: spec.template.spec.volumes[0].secret.optional
+          value: true
+
+  - it: "init-job name is derived from the rendered spec"
+    template: templates/init-job.yaml
+    asserts:
+      # Pinned exactly (not by regex) so a hash drift is caught, not masked.
+      - equal:
+          path: metadata.name
+          value: pg-test-init-job-04a639
+
+  - it: "init-job name rotates when the rendered spec changes"
+    template: templates/init-job.yaml
+    set:
+      users:
+        app:
+          password: secret
+        reader:
+          password: secret
+    asserts:
+      - equal:
+          path: metadata.name
+          value: pg-test-init-job-560a99
 
   - it: "init-job is skipped entirely under bootstrap recovery"
     template: templates/init-job.yaml


### PR DESCRIPTION
## What this PR does

Fixes #3921.

The postgres chart's `<release>-init-job` (the users/databases/roles reconciler) mounted the CNPG-managed `<release>-superuser` secret as a `post-install,post-upgrade` Helm hook. That secret is created asynchronously by the operator, which caused two problems:

- On a fresh install the hook Pod raced the operator and hit `FailedMount` / `CreateContainerConfigError`, and Helm blocks on hook completion, so a slow CNPG bootstrap could burn the hook timeout and roll the release back.
- As a `post-upgrade` hook the Job never ran while the release was `UpgradeFailed`, so role/database convergence silently stopped until the release recovered.

This is the same anti-pattern already addressed in `apps/kubernetes` (talos-reconcile #3145, bootstrap-token #3875 / #3887), tracked by the umbrella #2497.

### Change

- Move the Job out of the Helm hook lifecycle into a main-phase resource.
- Gate it with a `wait-for-superuser` init container behind an `optional: true` secret volume, so the Pod waits in the init phase until the operator publishes the secret instead of failing the mount. The init container polls the mounted file (no API access, no RBAC), with a deadline below the HelmRelease install timeout so a stuck bootstrap surfaces as CrashLoopBackOff.
- Give the Job a content-hash name suffix, because a main-phase immutable Job cannot be patched in place across revisions.
- Preserve the `bootstrap.recovery` skip and the `ttlSecondsAfterFinished` GC.

Out of scope: this PR does not add `helm-install-disable-wait` to the postgres AppDef, so a main-phase Job still gates release readiness the same way the hook did. Changing readiness semantics is a broader decision left to a separate discussion.

### Existing installs

An upgrade replaces the old hook Job (`<release>-init-job`) with a new main-phase Job (`<release>-init-job-<hash>`). The old hook Job is no longer managed by the release, but it self-collects via its existing `ttlSecondsAfterFinished` once finished.

### Downstream repositories

- [x] No downstream repository is affected by this change

The diff only touches the chart's Job template and its unit test; `values.yaml`, the values schema, and CRDs are unchanged, so no downstream repository tracks it.

### Release note

```release-note
fix(postgres): the init-job now runs as a main-phase Job that waits for the CNPG superuser secret, fixing a fresh-install race and ensuring role/database reconciliation continues on an UpgradeFailed release
```
