### PR TITLE
test(e2e): capture CertificateSigningRequests in cozyreport

### DIFF
--- a/hack/cozyreport.bats
+++ b/hack/cozyreport.bats
@@ -105,6 +105,66 @@ fold_source() {
   esac
 }
 
+@test "CSR capture lists and reads every request on the host cluster and each tenant kubeconfig on disk" {
+  host=$(fold_source "$SCRIPT" | awk '/^echo "Collecting CertificateSigningRequests/,/^echo "Collecting tenant kubernetes CertificateSigningRequests/')
+  [ -n "$host" ] || { echo "FAIL: could not locate the host CSR walk"; false; }
+  printf '%s\n' "$host" | grep -q '^cozyreport_read_object "\$REPORT_DIR/kubernetes/csr.txt" kubectl get csr -o wide$' || {
+    echo "FAIL: the host CSR listing is not a bounded read of every request"; false; }
+  printf '%s\n' "$host" | grep -q '^cozyreport_select_objects "csr" kubectl get csr --no-headers |$' || {
+    echo "FAIL: the host CSR walk does not select through the bounded selector"; false; }
+  printf '%s\n' "$host" | grep -q '^    cozyreport_read_object "\$DIR/csr.yaml" kubectl get csr "\$NAME" -o yaml$' || {
+    echo "FAIL: the host CSR walk does not read each request's yaml through the bounded reader"; false; }
+
+  tenant=$(fold_source "$SCRIPT" | awk '/^echo "Collecting tenant kubernetes CertificateSigningRequests/,/^done$/')
+  [ -n "$tenant" ] || { echo "FAIL: could not locate the tenant CSR walk"; false; }
+  printf '%s\n' "$tenant" | grep -q '^for TENANT_KC in tenantkubeconfig-\*; do$' || {
+    echo "FAIL: the tenant CSR walk does not glob every leftover tenant kubeconfig"; false; }
+  printf '%s\n' "$tenant" | grep -q '^  \[ -f "\$TENANT_KC" \] || continue$' || {
+    echo "FAIL: the tenant CSR walk does not skip a glob match with no matching file"; false; }
+  printf '%s\n' "$tenant" | grep -q '^  cozyreport_read_object "\$DIR/csr.txt" kubectl --kubeconfig "\$TENANT_KC" get csr -o wide$' || {
+    echo "FAIL: the tenant CSR listing is not a bounded read of every request"; false; }
+  printf '%s\n' "$tenant" | grep -q '^  cozyreport_select_objects "tenant csr (\$TENANT_NAME)" kubectl --kubeconfig "\$TENANT_KC" get csr --no-headers |$' || {
+    echo "FAIL: the tenant CSR walk does not select through the bounded selector"; false; }
+  printf '%s\n' "$tenant" | grep -q '^      cozyreport_read_object "\$DIR/\$NAME.yaml" kubectl --kubeconfig "\$TENANT_KC" get csr "\$NAME" -o yaml$' || {
+    echo "FAIL: the tenant CSR walk does not read each request's yaml through the bounded reader"; false; }
+}
+
+@test "no tenant kubeconfig on disk means no tenant CSR read is attempted" {
+  # tenantkubeconfig-<test> only exists while a kubernetes-* Chainsaw test is
+  # running or failed before its own cleanup (hack/e2e-chainsaw/_lib/run-
+  # kubernetes.sh). Every other suite, and a kubernetes suite that passed,
+  # leaves cwd with no such file, and the glob must not turn that absence into
+  # a literal `--kubeconfig tenantkubeconfig-*` read.
+  tmp=$(mktemp -d)
+  mkdir -p "$tmp/bin" "$tmp/work"
+  cat > "$tmp/bin/kubectl" <<'STUB'
+#!/bin/sh
+echo "kubectl $*" >> "$KUBECTL_CALL_LOG"
+exit 0
+STUB
+  chmod +x "$tmp/bin/kubectl"
+
+  body=$(fold_source "$SCRIPT" | awk '/^for TENANT_KC in tenantkubeconfig-\*; do$/,/^done$/')
+  [ -n "$body" ] || { echo "FAIL: could not locate the tenant CSR walk"; false; }
+
+  KUBECTL_CALL_LOG="$tmp/calls.txt"
+  : > "$KUBECTL_CALL_LOG"
+  REPORT_DIR="$tmp/report"
+  export KUBECTL_CALL_LOG REPORT_DIR
+  ( cd "$tmp/work" && PATH="$tmp/bin:$PATH" eval "$body" )
+
+  [ ! -s "$KUBECTL_CALL_LOG" ] || {
+    echo "FAIL: kubectl was invoked with no tenant kubeconfig present on disk"
+    cat "$KUBECTL_CALL_LOG"
+    false
+  }
+  [ ! -e "$REPORT_DIR" ] || {
+    echo "FAIL: a report directory was created with nothing to walk"
+    false
+  }
+  rm -rf "$tmp"
+}
+
 @test "every Deployment this script names by hand is one somebody chose to name" {
   # Pinning the two gates above only guards the two lines that were looked at.
   # The same defect sat in the cozystack module the whole time: the image read

--- a/hack/cozyreport.sh
+++ b/hack/cozyreport.sh
@@ -1735,6 +1735,35 @@ cozyreport_select_objects "nodes" kubectl get nodes --no-headers | awk '$2 != "R
     cozyreport_read_object "$DIR/describe.txt" kubectl describe node "$NAME"
   done
 
+echo "Collecting CertificateSigningRequests..."
+# Node bootstrap goes through this on the HOST cluster too: a Node stuck
+# before Ready with a Pending or missing CSR here is blocked on approval
+# rather than on kubelet startup, which the walk above already covers.
+cozyreport_read_object "$REPORT_DIR/kubernetes/csr.txt" kubectl get csr -o wide
+cozyreport_select_objects "csr" kubectl get csr --no-headers |
+  while read NAME _; do
+    DIR=$REPORT_DIR/kubernetes/csr/$NAME
+    mkdir -p $DIR
+    cozyreport_read_object "$DIR/csr.yaml" kubectl get csr "$NAME" -o yaml
+  done
+
+echo "Collecting tenant kubernetes CertificateSigningRequests..."
+# A Kamaji-fronted tenant cluster is a second apiserver this script has no
+# route to except through the kubeconfig hack/e2e-chainsaw/_lib/run-
+# kubernetes.sh leaves at tenantkubeconfig-<test> when a kubernetes-* test
+# fails before reaching its own success-path cleanup; no file, nothing to walk.
+for TENANT_KC in tenantkubeconfig-*; do
+  [ -f "$TENANT_KC" ] || continue
+  TENANT_NAME=${TENANT_KC#tenantkubeconfig-}
+  DIR=$REPORT_DIR/kubernetes/tenant-csr/$TENANT_NAME
+  mkdir -p $DIR
+  cozyreport_read_object "$DIR/csr.txt" kubectl --kubeconfig "$TENANT_KC" get csr -o wide
+  cozyreport_select_objects "tenant csr ($TENANT_NAME)" kubectl --kubeconfig "$TENANT_KC" get csr --no-headers |
+    while read NAME _; do
+      cozyreport_read_object "$DIR/$NAME.yaml" kubectl --kubeconfig "$TENANT_KC" get csr "$NAME" -o yaml
+    done
+done
+
 echo "Collecting namespaces..."
 cozyreport_read_object "$REPORT_DIR/kubernetes/namespaces.txt" kubectl get ns -o wide
 cozyreport_select_objects "namespaces" kubectl get ns --no-headers | awk '$2 != "Active"' |


### PR DESCRIPTION
## What this PR does

hack/cozyreport.sh never captured CertificateSigningRequests, so the hypothesis that a node join hangs on kubelet certificate issuance (bootstrap token, CSR, approval) had no artifact to check it against. This adds a bounded CSR list and a per object yaml capture for the host cluster, next to the existing node walk, plus the same capture for every tenant Kubernetes cluster whose kubeconfig a failed kubernetes-* Chainsaw test left on disk under tenantkubeconfig-<test>.

Both captures reuse the existing bounded read helpers (cozyreport_read_object, cozyreport_select_objects), so a cut off or refused read leaves the same truncation and failure markers every other capture in the file already produces, and an empty CSR list is not treated as an error. The tenant walk globs tenantkubeconfig-* and skips silently when nothing matches, which is the ordinary case for every suite that is not kubernetes-* and for a kubernetes-* run that passed and cleaned up after itself.

Neither walk carries a count cap or an object time budget, unlike the VM/VMI/service walks in the same section: this follows the file's own documented convention that an uncapped per-object walk is acceptable when the collection step's own ceiling is the backstop, and CSR count on a freshly provisioned e2e cluster is bounded by node count and kubelet retry frequency rather than by workload scale; if a real collected report ever shows the CSR walk taking a meaningful share of collection time, add the existing count-cap-plus-time-budget pattern here and update the header's BUDGETS arithmetic to match.

A bats test pins the shape of both walks against the script source, and a second test proves the tenant walk never invokes kubectl when no tenant kubeconfig is present on disk.

### Screenshots

Not applicable, this changes an e2e diagnostic collector script, not the UI.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collection of cluster-wide CertificateSigningRequests, including summary listings and individual request details.
  * Added collection of tenant-cluster CertificateSigningRequests from available tenant configurations.
* **Tests**
  * Added coverage for bounded listings, request selection, YAML export, tenant configuration matching, missing files, and environments without tenant configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->