### PR TITLE
ci(workflows): make the E2E breakpoint fully label opt-in

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -1121,15 +1121,10 @@ jobs:
       # ▸ Open an SSH breakpoint to the failing sandbox so maintainers can attach,
       #   inspect Talos/Cozystack state and resume with `breakpoint resume`.
       #
-      #   Opens when the E2E job fails AND any of: the `debug` label, the
-      #   `release` label (release PRs are bot-created, so their presence
-      #   implies maintainer authorship), or the PR author is a maintainer
-      #   (author_association is OWNER/MEMBER/COLLABORATOR). The maintainer-
-      #   authorship path needs no label and does NOT move the jobs onto
-      #   self-hosted runners — only the `debug` label flips `runs-on`, so a
-      #   maintainer PR opens the breakpoint on the default oracle-vm runner the
-      #   job already uses and simply holds that ephemeral runner. authorized-users
-      #   is kept as a second defense layer controlling who may actually SSH in.
+      #   Opens when the E2E job fails AND the PR carries the `debug` label or
+      #   the `release` label (release PRs are bot-created, so the label
+      #   implies maintainer authorship). authorized-users is kept as a second
+      #   defense layer controlling who may actually SSH in.
       #
       #   Uses cozystack/breakpoint-action (fork of namespacelabs/breakpoint-action)
       #   pinned by SHA. The fork adds: pause-idle mode (initial grace period for
@@ -1147,8 +1142,7 @@ jobs:
           failure() &&
           vars.BREAKPOINT_ENDPOINT != '' &&
           (contains(github.event.pull_request.labels.*.name, 'debug')
-            || contains(github.event.pull_request.labels.*.name, 'release')
-            || contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
+            || contains(github.event.pull_request.labels.*.name, 'release'))
         # cozystack/breakpoint-action v2-cozy.1
         # mode: pause-idle defaults: grace-period=20m, idle-timeout=10m
         uses: cozystack/breakpoint-action@a6f3a6f87be398ad63b6577351e3398e53f578e4


### PR DESCRIPTION
## What this PR does

The SSH debug breakpoint that opens on a failed end-to-end run used to open automatically for pull requests authored by any project maintainer, even when nobody intended to use it, in addition to opening for pull requests carrying an explicit label. Every red end-to-end run on such a pull request held an ephemeral CI runner open for up to twenty minutes for a breakpoint nobody attached to, which adds up across an ordinary day of pull requests. This change makes the breakpoint strictly opt-in: it now opens only when the pull request carries the debug label or the release label. A maintainer who wants to attach adds the debug label before or after the run fails. The step's explanatory comment is trimmed to match: the paragraph describing the removed authorship path, including a claim about runner selection that no longer applied to the current workflow, is removed rather than rewritten.

### Screenshots


Not applicable: this is a CI workflow text change with no user interface.

### Downstream repositories


- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note


```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * E2E debugging sessions now open only for failed E2E jobs with the `debug` or `release` label.
  * Removed the fallback based on maintainer-author association.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->