### PR TITLE
fix(platform tests): make negated containsDocument assertions load-bearing with any: true

### DIFF
--- a/packages/core/platform/tests/bundles_proxy_protocol_lookup_nil_test.yaml
+++ b/packages/core/platform/tests/bundles_proxy_protocol_lookup_nil_test.yaml
@@ -28,8 +28,8 @@ tests:
           apiVersion: cozystack.io/v1alpha1
           kind: Package
           name: cozystack.ouroboros
+          any: true
         not: true
-        documentIndex: -1
 
   - it: renders cleanly with proxyProtocol true on a fresh cluster (lookup-nil happy path also irrelevant — render does not invoke lookup when proxyProtocol=true)
     set:

--- a/packages/core/platform/tests/bundles_proxy_protocol_lookup_test.yaml
+++ b/packages/core/platform/tests/bundles_proxy_protocol_lookup_test.yaml
@@ -56,8 +56,8 @@ tests:
           apiVersion: cozystack.io/v1alpha1
           kind: Package
           name: cozystack.ouroboros
+          any: true
         not: true
-        documentIndex: -1
 
   - it: renders cleanly with proxyProtocol true when the Package CR exists (steady state)
     set:

--- a/packages/core/platform/tests/bundles_proxy_protocol_test.yaml
+++ b/packages/core/platform/tests/bundles_proxy_protocol_test.yaml
@@ -18,8 +18,8 @@ tests:
           apiVersion: cozystack.io/v1alpha1
           kind: Package
           name: cozystack.ouroboros
+          any: true
         not: true
-        documentIndex: -1
 
   - it: leaves cozystack.ingress-application as the bare default Package when proxyProtocol is false
     set:
@@ -150,8 +150,8 @@ tests:
           apiVersion: cozystack.io/v1alpha1
           kind: Package
           name: cozystack.ouroboros
+          any: true
         not: true
-        documentIndex: -1
 
   - it: renders cleanly with proxyProtocol=false and proxyProtocolAcknowledgeUnclean=true (operator acknowledged cleanup)
     set:

--- a/packages/core/platform/tests/bundles_velero_default_test.yaml
+++ b/packages/core/platform/tests/bundles_velero_default_test.yaml
@@ -37,9 +37,11 @@ tests:
           apiVersion: cozystack.io/v1alpha1
           kind: Package
           name: cozystack.velero
+          any: true
         not: true
       - containsDocument:
           apiVersion: cozystack.io/v1alpha1
           kind: Package
           name: cozystack.backupstrategy-controller
+          any: true
         not: true


### PR DESCRIPTION
## Summary

Fixes #3864. Seven platform-chart `helm-unittest` cases used a negated `containsDocument` without `any: true`. In that form the assertion negates "every document matches", which any multi-document render satisfies, so the cases stayed green regardless of what the template emitted — the guards were inert.

Changes (matching the correct form already in the tree at `bundles_isp_hosted_dependency_closure_test.yaml:132`):
- add `any: true` to the `containsDocument` map at the 7 sites listed in #3864
- drop the redundant `documentIndex: -1` (it restated the broken all-documents form)

Files:
- `packages/core/platform/tests/bundles_velero_default_test.yaml` (velero + backupstrategy-controller)
- `packages/core/platform/tests/bundles_proxy_protocol_test.yaml` (3 ouroboros sites)
- `packages/core/platform/tests/bundles_proxy_protocol_lookup_test.yaml`
- `packages/core/platform/tests/bundles_proxy_protocol_lookup_nil_test.yaml`

## Verification

`helm unittest` on `packages/core/platform`: **139 passed** before and after the fix (templates are currently correct, so the corrected guards still pass).

Proven load-bearing by mutation (then reverted):
- suppressing the `cozystack.velero` emit made the velero-absent guard **fail** (was inert)
- force-emitting `cozystack.ouroboros` made the proxyProtocol-absent guard **fail** (was inert)

Without the `any: true` fix a converted assertion is indistinguishable from a still-broken one; the mutation runs above are the distinguishing proof.

## Suggested follow-up (not in this PR)

A lint over `packages/**/tests/*.yaml` rejecting a `containsDocument` with `not: true` but no `any: true` would stop the shape returning (26 `containsDocument` uses tree-wide, 18 already correct).

Signed-off-by: Mehrdad Biukian Naeini <mehrdadbiukian@gmail.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of rendered document checks by matching documents regardless of their position.
  * Updated negative assertions to reliably confirm that unwanted package and controller documents are absent.
  * Strengthened Velero opt-out test coverage for related configuration documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->