### PR TITLE
fix(tests): support skipped tests in cozytest

### DIFF
--- a/hack/cozytest-skip.bats
+++ b/hack/cozytest-skip.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+# Behavioral coverage for Bats-compatible skip handling in hack/cozytest.sh.
+
+HACK_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")" && pwd)"
+RUNNER="$HACK_DIR/cozytest.sh"
+
+@test "skip stops the current test and keeps the suite green" {
+  dir=$(mktemp -d)
+  fixture="$dir/fixture.bats"
+  printf '%s\n' \
+    '@test "skipped fixture" {' \
+    '  skip "not applicable"' \
+    '  echo SHOULD_NOT_RUN' \
+    '  false' \
+    '}' \
+    '@test "following fixture" {' \
+    '  true' \
+    '}' >"$fixture"
+
+  if ! "$RUNNER" "$fixture" >"$dir/out" 2>&1; then
+    echo "runner failed a suite containing a skipped test" >&2
+    cat "$dir/out" >&2
+    exit 1
+  fi
+
+  grep -qF 'Test skipped: skipped fixture (not applicable)' "$dir/out"
+  if grep -qF 'SHOULD_NOT_RUN' "$dir/out"; then
+    echo "runner continued executing the skipped test body" >&2
+    cat "$dir/out" >&2
+    exit 1
+  fi
+  grep -qF 'Test OK: following fixture' "$dir/out"
+  rm -rf "$dir"
+}

--- a/hack/cozytest.sh
+++ b/hack/cozytest.sh
@@ -9,6 +9,14 @@ TEST_FILE=${1:?Usage: ./cozytest.sh <file.bats> [pattern]}
 PATTERN=${2:-*}
 LINE='----------------------------------------------------------------'
 
+# Bats' skip stops the current test without failing the suite. Each test runs
+# in its own subshell below, so exiting here leaves the runner itself alive to
+# report the skip and continue with the next test.
+skip() {
+  printf '%s\n' "$*" > "$skip_file"
+  exit 0
+}
+
 cols() { stty size 2>/dev/null | awk '{print $2}' || echo 80; }
 if [ -t 1 ]; then
   MAXW=$(( $(cols) - 12 )); [ "$MAXW" -lt 40 ] && MAXW=70
@@ -25,6 +33,7 @@ run_one() {
   fn=$1 title=$2
   tmp=$(mktemp -d) || { echo "Failed to create temp directory" >&2; exit 1; }
   log="$tmp/log"
+  skip_file="$tmp/skip"
 
   echo "╭ » Run test: $title"
   START=$(date +%s)
@@ -57,7 +66,14 @@ run_one() {
   [ -z "$rc" ] && rc=1
   now=$(( $(date +%s) - START ))
 
-  if [ "$rc" -eq 0 ]; then
+  if [ "$rc" -eq 0 ] && [ -f "$skip_file" ]; then
+    skip_reason=$(cat "$skip_file")
+    if [ -n "$skip_reason" ]; then
+      printf '╰[%02d:%02d] ⏭️ Test skipped: %s (%s)\n' $((now/60)) $((now%60)) "$title" "$skip_reason"
+    else
+      printf '╰[%02d:%02d] ⏭️ Test skipped: %s\n' $((now/60)) $((now%60)) "$title"
+    fi
+  elif [ "$rc" -eq 0 ]; then
     printf '╰[%02d:%02d] ✅ Test OK: %s\n' $((now/60)) $((now%60)) "$title"
   else
     printf '╰[%02d:%02d] ❌ Test failed: %s (exit %s)\n' \


### PR DESCRIPTION
## What this PR does

`cozytest.sh` currently treats Bats `skip` as a missing command. Root runs hit this in `run-kubernetes-kvm-exits_test.bats` and fail instead of skipping. Repro on `main`:

```bash
sudo env PATH="$PATH" ./hack/cozytest.sh hack/run-kubernetes-kvm-exits_test.bats 'a file that cannot be read is skipped as unread'

hack/cozytest.sh: skip: not found
```

This adds proper skip handling, reports the reason, and continues with the next test. 
A small end to end test covers it too
Fixes #3827

### Screenshots

Not a UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
NONE
```
