### PR TITLE
fix(kubernetes): pin KubeVirt CSI sidecars to SIG Storage releases

### DIFF
--- a/packages/apps/kubernetes/templates/csi/deploy.yaml
+++ b/packages/apps/kubernetes/templates/csi/deploy.yaml
@@ -79,7 +79,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: csi-provisioner
-          image: quay.io/openshift/origin-csi-external-provisioner:latest
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.1.0
           resources:
             limits:
               cpu: 512m
@@ -109,7 +109,7 @@ spec:
               mountPath: /etc/kubernetes/kubeconfig
               readOnly: true
         - name: csi-attacher
-          image: quay.io/openshift/origin-csi-external-attacher:latest
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubeconfig=/etc/kubernetes/kubeconfig/super-admin.svc"
@@ -138,7 +138,7 @@ spec:
               - ALL
             readOnlyRootFilesystem: true
         - name: csi-liveness-probe
-          image: quay.io/openshift/origin-csi-livenessprobe:latest
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
           args:
             - "--csi-address=/csi/csi.sock"
             - "--probe-timeout=3s"

--- a/packages/apps/kubernetes/tests/kcsi_sidecar_images_test.yaml
+++ b/packages/apps/kubernetes/tests/kcsi_sidecar_images_test.yaml
@@ -1,0 +1,36 @@
+suite: KubeVirt CSI sidecar images
+
+templates:
+  - templates/csi/deploy.yaml
+
+values:
+  - values/common.yaml
+
+release:
+  name: test-k8s
+  namespace: tenant-test
+
+tests:
+  - it: uses versioned upstream sig-storage sidecars
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].name
+          value: csi-provisioner
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: registry.k8s.io/sig-storage/csi-provisioner:v6.1.0
+      - equal:
+          path: spec.template.spec.containers[2].name
+          value: csi-attacher
+      - equal:
+          path: spec.template.spec.containers[2].image
+          value: registry.k8s.io/sig-storage/csi-attacher:v4.10.0
+      - equal:
+          path: spec.template.spec.containers[3].name
+          value: csi-liveness-probe
+      - equal:
+          path: spec.template.spec.containers[3].image
+          value: registry.k8s.io/sig-storage/livenessprobe:v2.17.0

--- a/packages/system/kubevirt-csi-node/templates/deploy.yaml
+++ b/packages/system/kubevirt-csi-node/templates/deploy.yaml
@@ -208,7 +208,7 @@ spec:
             limits:
               memory: 512Mi
         - name: csi-node-driver-registrar
-          image: quay.io/openshift/origin-csi-node-driver-registrar:latest
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -234,7 +234,7 @@ spec:
             limits:
               memory: 128Mi
         - name: csi-liveness-probe
-          image: quay.io/openshift/origin-csi-livenessprobe:latest
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.17.0
           args:
             - "--csi-address=/csi/csi.sock"
             - "--probe-timeout=3s"

--- a/packages/system/kubevirt-csi-node/tests/sidecar_images_test.yaml
+++ b/packages/system/kubevirt-csi-node/tests/sidecar_images_test.yaml
@@ -1,0 +1,17 @@
+suite: csi-node sidecar images
+
+templates:
+  - templates/deploy.yaml
+
+tests:
+  - it: pins upstream CSI sidecars to versioned release tags
+    documentSelector:
+      path: kind
+      value: DaemonSet
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="csi-node-driver-registrar")].image
+          value: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
+      - equal:
+          path: spec.template.spec.containers[?(@.name=="csi-liveness-probe")].image
+          value: registry.k8s.io/sig-storage/livenessprobe:v2.17.0


### PR DESCRIPTION
## What this PR does

Replaces five mutable OpenShift `latest` image references (four unique sidecar images) in the KubeVirt CSI controller and tenant-node DaemonSet with versioned Kubernetes SIG Storage releases. This addresses the affected references from #3578 without claiming the other references in that issue.

The selected controller versions match the sidecars already used by Cozystack's LINSTOR CSI deployment. Render tests pin every changed container name and image so a mutable tag cannot return silently.

Validation:

- `helm unittest packages/apps/kubernetes`: 247/247 passed.
- `helm unittest packages/system/kubevirt-csi-node`: 6/6 passed.
- Live MSK-prod guest-cluster canaries on 2026-08-20 and 2026-08-21 reproduced the failure with the stock chart: the `latest` sidecars exited on the old CPU with the x86-64-v3 glibc error and the controller stayed in CrashLoopBackOff. A disposable guest cluster with the pinned images reached a 7/7 Ready controller on 2026-08-19 and was removed after the check.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map against the four changed template/test files. No package, schema, API, default, CRD, tooling contract, or downstream hardcoded value changes.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(kubernetes): pin KubeVirt CSI sidecars to versioned SIG Storage images that run on pre-x86-64-v3 CPUs
```

