### PR TITLE
test(e2e): measure disk latency, host page backing and memory-miss latency

### DIFF
--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -2673,6 +2673,22 @@ COZY_CANARY_MEM_BLOCKS=128
 # unit this constant is written in.
 COZY_CANARY_DISK_BLOCK_BYTES=4096
 COZY_CANARY_DISK_BLOCKS=4096
+# The cache arm's working set, in array slots, and how many reads it takes of
+# it. The slot count is the load-bearing one: mawk holds this array in about 40
+# MiB, against the 32 MiB of last-level cache the parts this lane runs on
+# report, so no slot is still cached by the time the walk returns to it and
+# every read is a miss that goes to memory. Drop it under that and the arm
+# measures cache bandwidth instead, which is a different quantity and a much
+# larger number.
+#
+# The walk order is a linear congruential step rather than a fixed stride,
+# because a fixed stride is exactly what a hardware prefetcher is built to
+# follow: it would fetch the next slot before the arm asked for it and the
+# figure would stop being a latency. The multiplier and the modulus keep every
+# intermediate inside the range a double represents exactly, so the sequence is
+# the same on every machine that runs it.
+COZY_CANARY_CACHE_SLOTS=1048576
+COZY_CANARY_CACHE_ACCESSES=1000000
 # The rate below which an arm is pathological rather than merely slow, in the
 # unit that arm's rate is printed in. The legend prints both figures from these
 # two constants, so the number a reader is given is the number the collector
@@ -2706,6 +2722,11 @@ COZY_CANARY_MEM_MIN_RATE=500
 # merely slow -- a network-attached volume answers in hundreds of microseconds
 # and a local one in tens.
 COZY_CANARY_DISK_MIN_RATE=300
+# The cache arm's floor, in reads per second. A healthy core resolves these at
+# around a million a second -- measured at 1.14M in the sandbox image -- so this
+# sits the same decade below that as the compute floor sits below its own band,
+# and crosses at 10s inside the ceiling.
+COZY_CANARY_CACHE_MIN_RATE=100000
 # The canary is work rather than a read, so it takes a ceiling of its own
 # instead of COZY_DIAG_READ_TIMEOUT. That bound is sized for an apiserver that
 # answers in under a second and lowering it is what the knob is for, which would
@@ -2714,7 +2735,16 @@ COZY_CANARY_DISK_MIN_RATE=300
 # slowdown the capture can still put a figure on: at the sizes above it stops an
 # arm an order of magnitude or more past the expected duration, past the factor
 # being hunted and short of spending the diagnostics budget on it.
-COZY_CANARY_RUN_BOUND_DEFAULT=20
+#
+# Lowered from 20 when the fourth arm was added, and the reason is arithmetic
+# rather than taste: the phase budget guard prices this collector at one ceiling
+# per arm, and four at 20s plus grace put the collectors gated ahead of the
+# serial console at 485s against a 480s budget. At 18s they come to 477s. Every
+# arm's floor still crosses inside it -- compute at 10.0s, disk at 13.7s, cache
+# at 10.0s, memory at 16.4s -- which is what the window guard checks, so what
+# the reduction costs is the top of the range this capture can still put a
+# figure on rather than any arm's ability to report a shortfall.
+COZY_CANARY_RUN_BOUND_DEFAULT=18
 
 # The canary clock: /proc/uptime, in centiseconds, into _COZY_CANARY_CS.
 #
@@ -2999,7 +3029,7 @@ _cozy_canary_report_arm() {
 # those two therefore points at one of those two candidates, to the factor of
 # ten these figures resolve and no finer.
 #
-# The disk arm is not a third shade of the same thing, it is a different
+# The last two arms are not further shades of the same thing, they are different
 # question, and it is here because nothing in this report has ever asked it. The
 # block-IO capture beside it counts bytes, and a byte count says a transfer
 # happened without saying what it cost. The one field already in this report
@@ -3026,7 +3056,7 @@ cozy_capture_runner_canary() {
   local report_dir="${COZY_REPORT_DIR:-/workspace/_out/cozyreport}/snapshots/${COZY_SNAPSHOT_NAME:-kubernetes}/runner-canary/sample-${sample}"
   local capture="${report_dir}/fixed-work.txt"
   local readings=0 mem_mib=0 cpu_program='' read_at='' read_done=''
-  local disk_probe=''
+  local disk_probe='' cache_program=''
 
   # Cleared before anything below can return, so a call site reads it after
   # every exit from here rather than only after the ones that reached an arm.
@@ -3067,6 +3097,10 @@ cozy_capture_runner_canary() {
   # awk able to see that the loop has no effect would be free to skip it, and a
   # canary optimised away reports a healthy machine at any speed.
   cpu_program="BEGIN { s = 0; for (i = 0; i < ${COZY_CANARY_CPU_ITERATIONS}; i++) s = (s + i) % 1000003; print s }"
+  # `print s` kept here for the reason it is kept above: the sum is not wanted,
+  # but an interpreter free to see that the loop has no effect could skip the
+  # walk, and an arm optimised away reports a healthy machine at any latency.
+  cache_program="BEGIN { n = ${COZY_CANARY_CACHE_SLOTS}; for (i = 0; i < n; i++) a[i] = i; x = 1; s = 0; for (k = 0; k < ${COZY_CANARY_CACHE_ACCESSES}; k++) { x = (1103515245 * x + 12345) % n; s += a[x] } print s }"
 
   echo "--- running the runner fixed-work canary (sample ${sample}) ---"
   # Stamped around the pair for the reason the readings beside this one are
@@ -3109,6 +3143,20 @@ cozy_capture_runner_canary() {
   # job, and a collector that failed the diagnostics block over its own
   # housekeeping would cost the report the arms it just took.
   rm -f "${disk_probe}" 2>/dev/null || true
+  # The latency counterpart to the memory arm's bandwidth. That arm streams, so
+  # the prefetchers hide every miss and it reports how fast this core can pull
+  # sequential bytes; this one walks a working set larger than the last-level
+  # cache in an order no prefetcher can follow, so what it reports is how long a
+  # miss takes to come back. The two move independently, and the pair that
+  # matters for a nested guest is this one: a page walk under nesting is up to
+  # twenty-five dependent memory references, so its cost is set by miss latency
+  # rather than by bandwidth, and nothing in this report has measured that.
+  if _cozy_canary_report_arm "${capture}" \
+    "cache, a dependent walk over a working set larger than last-level cache" \
+    "${COZY_CANARY_CACHE_ACCESSES}" "random reads" "${COZY_CANARY_CACHE_MIN_RATE}" \
+    awk "${cache_program}"; then
+    readings=$(( readings + 1 ))
+  fi
   read_done=$(date -u +%s)
 
   if ! command -v timeout >/dev/null 2>&1; then
@@ -3124,10 +3172,10 @@ cozy_capture_runner_canary() {
   printf '%s\n' \
     '[this canary runs on the RUNNER VM, inside the sandbox container: one layer above the three Talos nodes and two above the tenant workers. It is the only reading in this report that carries its own unit of work at this layer; two layers down the serial console capture records the tenant workers unpacking their initramfs, and one layer down no capture times it, because the QEMU line that boots the sandbox nodes passes no serial backend for a capture to read; what those nodes put here instead is their kernel ring buffer, under sandbox-host/talos-<node>-dmesg.txt. The counters beside it are read in the units their sources publish -- time in the CPU rows, events in the KVM exits, instantaneous values and running maxima in the files beside those -- and a counter with no unit of work in it cannot see a machine that spent its ticks and got less done with them, which is the shape this lane keeps failing in]' \
     >>"${capture}"
-  printf '[three arms. What makes the first two answer the same interference differently is the working set, not the amount of work each does. The compute arm loops over a handful of scalars, which live in registers and the nearest cache, so pressure on the shared cache or the memory controller moves it little rather than not at all. The memory arm streams blocks: a read of /dev/zero zeroes the buffer the caller supplied and a write to /dev/null never looks at it, so each block is one pass of stores over the whole block. The block size is both the working set and the reuse distance -- %s MiB here, against the 32 MiB of last-level cache an EPYC core can allocate into on the parts this lane has run on -- and a block that exceeds that cache leaves no byte still cached by the time it is written again, so the traffic lands on the memory controller. Which part this run got is recorded in sandbox-host/runner-identity.txt at the root of this report, and that is what tells a reader of this artifact which case it is looking at: on a part whose per-core cache exceeds the block size this arm stops being memory-bound and reads high. On a machine in front of you the dd line above can be rerun with a block size that fits the cache, and the figure rises several times over. The disk arm shares neither property: its working set is one 4 KiB block, and what it waits on is the device answering rather than a cache or a controller. It is the one arm here whose figure can move while the other two hold steady, which is the whole reason it exists -- a runner whose compute and memory read healthy and whose storage does not is a case the first two arms report as a healthy machine]\n' \
-    "${COZY_CANARY_MEM_BLOCK_MIB}" >>"${capture}"
-  printf '[expected ranges, and what they are worth. These are what the construction can do on a healthy server core, not figures measured on this lane, and they are stated to the precision they have: a factor of ten is what they resolve and a factor of two is not. Memory arm: one core sustains single-digit to low-double-digit GB per second of streaming stores, because the ceiling is how many misses one core keeps outstanding rather than how many memory channels the socket has, so the %s MiB it writes land in about a second on a fast core and in about eight at the bottom of that band, while anything under %s in the MiB-per-second unit the rate lines above are printed in, about half a gigabyte a second, is pathological rather than merely slow. Compute arm: the rate depends on the awk implementation as much as on the core, and that implementation is a property of the sandbox image rather than of the run, pinned by digest in packages/core/testing/images/e2e-sandbox/Dockerfile, so on the mawk that image ships a simple loop over integer-valued scalars runs at tens of millions of iterations a second and the %s of them here land in about a second, so anything under %s iterations a second, one factor of ten below that, is pathological rather than merely slow. Disk arm: the rate is operations a second at queue depth one, so its reciprocal is how long one 4 KiB write took to reach the volume, and that is the figure to read rather than the rate itself. A local NVMe answers in tens of microseconds and a network-attached volume in hundreds, so a healthy reading here is thousands of operations a second and the %s of them land in about a second; anything under %s a second, a decade below the low end of that, is 3.3ms for one write and is pathological for any device rather than merely slow. Storage fast enough to finish well inside a second is the one case this arm reports coarsely rather than precisely: the clock quantises to 10ms, so a run of tens of milliseconds carries a resolution of some percent instead of the one percent the arms are sized for, and two such readings differ by noise. That direction is not the one this arm exists to catch, and a figure in it is already the answer. This arm reports no rate at all where the filesystem refuses O_DIRECT, which is the likely reading of a low non-zero exit status on this arm and not a statement about the storage]\n' \
-    "${mem_mib}" "${COZY_CANARY_MEM_MIN_RATE}" "${COZY_CANARY_CPU_ITERATIONS}" "${COZY_CANARY_CPU_MIN_RATE}" "${COZY_CANARY_DISK_BLOCKS}" "${COZY_CANARY_DISK_MIN_RATE}" >>"${capture}"
+  printf '[four arms. What makes the first two answer the same interference differently is the working set, not the amount of work each does. The compute arm loops over a handful of scalars, which live in registers and the nearest cache, so pressure on the shared cache or the memory controller moves it little rather than not at all. The memory arm streams blocks: a read of /dev/zero zeroes the buffer the caller supplied and a write to /dev/null never looks at it, so each block is one pass of stores over the whole block. The block size is both the working set and the reuse distance -- %s MiB here, against the 32 MiB of last-level cache an EPYC core can allocate into on the parts this lane has run on -- and a block that exceeds that cache leaves no byte still cached by the time it is written again, so the traffic lands on the memory controller. Which part this run got is recorded in sandbox-host/runner-identity.txt at the root of this report, and that is what tells a reader of this artifact which case it is looking at: on a part whose per-core cache exceeds the block size this arm stops being memory-bound and reads high. On a machine in front of you the dd line above can be rerun with a block size that fits the cache, and the figure rises several times over. The disk arm shares neither property: its working set is one 4 KiB block, and what it waits on is the device answering rather than a cache or a controller. It is the one arm here whose figure can move while the other two hold steady, which is the whole reason it exists -- a runner whose compute and memory read healthy and whose storage does not is a case the first two arms report as a healthy machine. The cache arm shares its subject with the memory arm and not its question: same DRAM, but a dependent walk over %s slots -- about 40 MiB in mawk, past the 32 MiB of last-level cache -- in an order no prefetcher can follow, so it reports how long one miss takes to come back rather than how many bytes a second stream sustains. Those two move independently, and for a nested guest it is this one that prices the work: a page walk under nesting is up to twenty-five dependent memory references, so a translation costs miss latency rather than bandwidth]\n' \
+    "${COZY_CANARY_MEM_BLOCK_MIB}" "${COZY_CANARY_CACHE_SLOTS}" >>"${capture}"
+  printf '[expected ranges, and what they are worth. These are what the construction can do on a healthy server core, not figures measured on this lane, and they are stated to the precision they have: a factor of ten is what they resolve and a factor of two is not. Memory arm: one core sustains single-digit to low-double-digit GB per second of streaming stores, because the ceiling is how many misses one core keeps outstanding rather than how many memory channels the socket has, so the %s MiB it writes land in about a second on a fast core and in about eight at the bottom of that band, while anything under %s in the MiB-per-second unit the rate lines above are printed in, about half a gigabyte a second, is pathological rather than merely slow. Compute arm: the rate depends on the awk implementation as much as on the core, and that implementation is a property of the sandbox image rather than of the run, pinned by digest in packages/core/testing/images/e2e-sandbox/Dockerfile, so on the mawk that image ships a simple loop over integer-valued scalars runs at tens of millions of iterations a second and the %s of them here land in about a second, so anything under %s iterations a second, one factor of ten below that, is pathological rather than merely slow. Disk arm: the rate is operations a second at queue depth one, so its reciprocal is how long one 4 KiB write took to reach the volume, and that is the figure to read rather than the rate itself. A local NVMe answers in tens of microseconds and a network-attached volume in hundreds, so a healthy reading here is thousands of operations a second and the %s of them land in about a second; anything under %s a second, a decade below the low end of that, is 3.3ms for one write and is pathological for any device rather than merely slow. Storage fast enough to finish well inside a second is the one case this arm reports coarsely rather than precisely: the clock quantises to 10ms, so a run of tens of milliseconds carries a resolution of some percent instead of the one percent the arms are sized for, and two such readings differ by noise. That direction is not the one this arm exists to catch, and a figure in it is already the answer. This arm reports no rate at all where the filesystem refuses O_DIRECT, which is the likely reading of a low non-zero exit status on this arm and not a statement about the storage. Cache arm: a healthy core resolves these dependent reads at around a million a second -- 1.14M measured in the sandbox image -- so the %s of them land in about a second, and anything under %s a second, a decade below that, is a core waiting on memory rather than computing. Read this one against the memory arm above it: both cross the same DRAM, so bandwidth healthy while this reads low is contention for the cache and the memory controller rather than a shortage of either]\n' \
+    "${mem_mib}" "${COZY_CANARY_MEM_MIN_RATE}" "${COZY_CANARY_CPU_ITERATIONS}" "${COZY_CANARY_CPU_MIN_RATE}" "${COZY_CANARY_DISK_BLOCKS}" "${COZY_CANARY_DISK_MIN_RATE}" "${COZY_CANARY_CACHE_ACCESSES}" "${COZY_CANARY_CACHE_MIN_RATE}" >>"${capture}"
   printf '%s\n' \
     '[what this canary does NOT separate. It reads wall clock only, so an arm that took ten times as long could be a core doing less per cycle or a container that was not on a core at all. Where to look for the second is runner-kernel-cpu-time beside this capture and sandbox-host-cpu-time one layer down, and their steal columns do not read the same way. On the runner row a climb is proof this VM was preempted and a zero proves nothing, because nobody here launches that VM and the column is filled only where the hypervisor exposes the clock. One layer down the sandbox nodes are started with accel=kvm, which hands the guest that accounting, so a zero there means the node got every turn it asked for. Which is what makes the pair worth reading together: a sandbox zero under a climbing runner row puts the wait a layer above them. That pair covers the two CPU arms; neither column says anything about the disk arm, whose wait is on a device rather than on a turn at a core, and no counter in this report covers that one at all -- which is why its figure stands alone. Read those first when a CPU arm here is slow, and read each for what it covers: the runner-kernel rows are a pair bracketing the node-join wait, so they describe the whole join window next to these seconds rather than these seconds themselves, while the sandbox-host rows are a pair seconds apart inside the on-failure diagnostics block, taken minutes after the wait already failed and absent from a green run altogether]' \
     '[the two samples. Sample 1 is taken before the node-join wait and sample 2 after it, on the failing and the passing path alike, on the same binaries in the same container. A difference between them puts the change inside the interval the pair brackets, which is the wait together with the readings taken on either side of it; two equally slow samples say it was already there going into that interval, which is the case the expected ranges above are the only instrument for -- the pair speaks for the interval between its own readings and for nothing before them]' \
@@ -3187,6 +3235,28 @@ for comm_file in "${proc_root}"/[0-9]*/comm; do
   pid_dir=${comm_file%/comm}
   found=1
   printf 'process %s comm %s\n' "${pid_dir##*/}" "${comm}"
+  # How this process's memory is backed by the HOST, which decides what a nested
+  # page walk costs. A guest whose anonymous memory sits on 2 MiB pages walks a
+  # shorter table and covers far more per TLB entry than the same guest on 4 KiB
+  # pages, and QEMU allocates lazily, so which one it gets is decided as the
+  # guest touches pages rather than when it starts -- minutes into a job, on a
+  # host that has been churning containers and image imports the whole time.
+  # AnonHugePages against Rss is that fraction. Read here rather than in a
+  # collector of its own because this walk already has the process open and its
+  # ceiling already paid; a separate reader would cost another bounded call per
+  # process, and the budget guard prices those.
+  rollup_seen=0
+  while read -r _sm_key _sm_val _sm_rest; do
+    case "${_sm_key}" in
+      Rss: | Pss: | AnonHugePages: | ShmemPmdMapped: | FilePmdMapped: | Private_Hugetlb: | Shared_Hugetlb:)
+        printf 'mem %s %s kB\n' "${_sm_key%:}" "${_sm_val}"
+        rollup_seen=1
+        ;;
+    esac
+  done 2>/dev/null <"${pid_dir}/smaps_rollup"
+  if [ "${rollup_seen}" -eq 0 ]; then
+    printf '%s\n' 'mem NO-ROLLUP: smaps_rollup could not be read for this process, so how its memory is backed is not recorded here'
+  fi
   # One line per file, because that is all /proc/<pid>/task/<tid>/stat is, and
   # `read` returns non-zero on a last line with no newline while still setting
   # the variable -- so the status is not what decides whether anything arrived.
@@ -3207,6 +3277,24 @@ for comm_file in "${proc_root}"/[0-9]*/comm; do
 # affect the reading. On the loop the redirect is in place before the body runs,
 # which is also the only spelling that holds in every shell.
 done 2>/dev/null
+# The machine-wide side of the same question, once rather than per process: the
+# policy in force, and how much of this host's memory is on huge pages at all. A
+# per-process fraction of zero means something different depending on whether
+# the policy is `never`, in which case it is the setting rather than the host
+# having run out of contiguous memory to give.
+thp_enabled=''
+read -r thp_enabled 2>/dev/null </sys/kernel/mm/transparent_hugepage/enabled || thp_enabled='unreadable'
+printf 'thp policy: %s\n' "${thp_enabled:-unreadable}"
+thp_defrag=''
+read -r thp_defrag 2>/dev/null </sys/kernel/mm/transparent_hugepage/defrag || thp_defrag='unreadable'
+printf 'thp defrag: %s\n' "${thp_defrag:-unreadable}"
+while read -r _mi_key _mi_val _mi_rest; do
+  case "${_mi_key}" in
+    AnonHugePages: | ShmemHugePages: | Hugetlb: | HugePages_Total: | HugePages_Free: | MemTotal: | MemFree: | MemAvailable:)
+      printf 'meminfo %s %s\n' "${_mi_key%:}" "${_mi_val}"
+      ;;
+  esac
+done 2>/dev/null <"${proc_root}/meminfo"
 if [ "${seen}" -eq 0 ]; then
   printf '%s\n' 'NO-PROC-READ: not one process could be read under the proc mount, so this says nothing about what the container was running'
 elif [ "${found}" -eq 0 ]; then

--- a/hack/e2e-chainsaw/_lib/run-kubernetes.sh
+++ b/hack/e2e-chainsaw/_lib/run-kubernetes.sh
@@ -2658,6 +2658,21 @@ COZY_CANARY_CPU_ITERATIONS=30000000
 # is written in.
 COZY_CANARY_MEM_BLOCK_MIB=64
 COZY_CANARY_MEM_BLOCKS=128
+# The disk arm's work, as a block size and a count. 4 KiB is the unit a block
+# device is specified in and the unit an allocating write lands on, and the arm
+# issues them one at a time under O_DIRECT, so the rate this divides to is
+# operations per second at queue depth one and its reciprocal is how long one
+# write took to reach the volume. That reciprocal is the reading: nothing else
+# in this report measures how long the storage takes to answer, and every disk
+# hypothesis this lane has closed was closed on byte counts, which say a
+# transfer happened and say nothing about what it cost.
+#
+# Declared in bytes rather than as a dd suffix for the reason the memory block
+# above is: the dds of different machines disagree about which spellings they
+# accept and about whether M is a mebibyte, and the rate here is printed in the
+# unit this constant is written in.
+COZY_CANARY_DISK_BLOCK_BYTES=4096
+COZY_CANARY_DISK_BLOCKS=4096
 # The rate below which an arm is pathological rather than merely slow, in the
 # unit that arm's rate is printed in. The legend prints both figures from these
 # two constants, so the number a reader is given is the number the collector
@@ -2682,6 +2697,15 @@ COZY_CANARY_MEM_BLOCKS=128
 # window.
 COZY_CANARY_CPU_MIN_RATE=3000000
 COZY_CANARY_MEM_MIN_RATE=500
+# The disk arm's floor, in the operations-per-second unit its rate is printed
+# in. It crosses at 13.7s against the 20s ceiling, inside that ceiling for the
+# same reason the memory floor is: a floor the ceiling reaches first never
+# fires, and every alert then arrives as a bound instead of as the slowdown the
+# floor was meant to name. 300 operations a second at queue depth one is 3.3ms
+# for one 4 KiB write, which is pathological for any block device rather than
+# merely slow -- a network-attached volume answers in hundreds of microseconds
+# and a local one in tens.
+COZY_CANARY_DISK_MIN_RATE=300
 # The canary is work rather than a read, so it takes a ceiling of its own
 # instead of COZY_DIAG_READ_TIMEOUT. That bound is sized for an apiserver that
 # answers in under a second and lowering it is what the knob is for, which would
@@ -2964,14 +2988,28 @@ _cozy_canary_report_arm() {
 # reading a scale of its own and makes the pathology visible in a single red run
 # with no green one beside it.
 #
-# Two arms, because the candidates the time counters cannot separate act on
+# Three arms, because the candidates the time counters cannot separate act on
 # different resources: interference on the shared cache and the memory
-# controller from whatever else the host is running, and a core doing less per
-# cycle. The two arms differ in how much of each they feel rather than in being
-# deaf to one: the compute arm's working set is small enough that pressure on
-# the shared cache and the memory controller moves it little, while the memory
-# arm is dominated by it. A large asymmetric shift between them therefore points
-# at one of the two, to the factor of ten these figures resolve and no finer.
+# controller from whatever else the host is running, a core doing less per
+# cycle, and storage that takes longer to answer. The compute and memory arms
+# split the first two of those: they differ in how much of each they feel rather
+# than in being deaf to one, since the compute arm's working set is small enough
+# that pressure on the shared cache and the memory controller moves it little,
+# while the memory arm is dominated by it. A large asymmetric shift between
+# those two therefore points at one of those two candidates, to the factor of
+# ten these figures resolve and no finer.
+#
+# The disk arm is not a third shade of the same thing, it is a different
+# question, and it is here because nothing in this report has ever asked it. The
+# block-IO capture beside it counts bytes, and a byte count says a transfer
+# happened without saying what it cost. The one field already in this report
+# that would say -- delayacct_blkio_ticks, carried verbatim in every per-thread
+# stat line the QEMU thread capture writes -- reads zero on all 225 threads of
+# both samples of a green run and of a red one, which is what it reads on any
+# kernel booted without `delayacct` and therefore silence rather than a finding.
+# This arm times the storage directly,
+# under O_DIRECT so the page cache cannot answer for the device, one operation
+# at a time so the figure is a latency rather than a queue depth.
 #
 # What this is NOT is a measurement of the tenant workers. It runs at the runner
 # layer, where the sandbox nodes are hosted. Two layers down, the same
@@ -2988,6 +3026,7 @@ cozy_capture_runner_canary() {
   local report_dir="${COZY_REPORT_DIR:-/workspace/_out/cozyreport}/snapshots/${COZY_SNAPSHOT_NAME:-kubernetes}/runner-canary/sample-${sample}"
   local capture="${report_dir}/fixed-work.txt"
   local readings=0 mem_mib=0 cpu_program='' read_at='' read_done=''
+  local disk_probe=''
 
   # Cleared before anything below can return, so a call site reads it after
   # every exit from here rather than only after the ones that reached an arm.
@@ -3046,6 +3085,30 @@ cozy_capture_runner_canary() {
     dd if=/dev/zero of=/dev/null "bs=$(( COZY_CANARY_MEM_BLOCK_MIB * 1048576 ))" "count=${COZY_CANARY_MEM_BLOCKS}"; then
     readings=$(( readings + 1 ))
   fi
+  # Written outside the report directory, never inside it. An arm the ceiling
+  # stops leaves its file behind, and a file left inside the report ships in the
+  # artifact; a scratch path cannot, whatever happens to the removal below. The
+  # same reasoning kept the sandbox bringup's Talos secret bundle out of the
+  # tree it was writing into.
+  #
+  # The container's own filesystem rather than a mount of the runner's: the
+  # sandbox is started with no volume for /workspace, so the QEMU disk images
+  # the three Talos nodes boot from live on this same overlay. Timing it is
+  # timing the path their IO takes.
+  disk_probe="${TMPDIR:-/tmp}/cozy-canary-disk.$$"
+  if _cozy_canary_report_arm "${capture}" \
+    "disk, single 4KiB direct writes to the filesystem the sandbox runs on" \
+    "${COZY_CANARY_DISK_BLOCKS}" "4KiB direct writes" "${COZY_CANARY_DISK_MIN_RATE}" \
+    dd if=/dev/zero "of=${disk_probe}" "bs=${COZY_CANARY_DISK_BLOCK_BYTES}" \
+    "count=${COZY_CANARY_DISK_BLOCKS}" oflag=direct; then
+    readings=$(( readings + 1 ))
+  fi
+  # On every path, including the one where the arm was stopped at its ceiling
+  # with the file half written. Unchecked on purpose: a scratch file that
+  # outlives this is 16 MiB in a container that is torn down at the end of the
+  # job, and a collector that failed the diagnostics block over its own
+  # housekeeping would cost the report the arms it just took.
+  rm -f "${disk_probe}" 2>/dev/null || true
   read_done=$(date -u +%s)
 
   if ! command -v timeout >/dev/null 2>&1; then
@@ -3061,14 +3124,14 @@ cozy_capture_runner_canary() {
   printf '%s\n' \
     '[this canary runs on the RUNNER VM, inside the sandbox container: one layer above the three Talos nodes and two above the tenant workers. It is the only reading in this report that carries its own unit of work at this layer; two layers down the serial console capture records the tenant workers unpacking their initramfs, and one layer down no capture times it, because the QEMU line that boots the sandbox nodes passes no serial backend for a capture to read; what those nodes put here instead is their kernel ring buffer, under sandbox-host/talos-<node>-dmesg.txt. The counters beside it are read in the units their sources publish -- time in the CPU rows, events in the KVM exits, instantaneous values and running maxima in the files beside those -- and a counter with no unit of work in it cannot see a machine that spent its ticks and got less done with them, which is the shape this lane keeps failing in]' \
     >>"${capture}"
-  printf '[two arms, and what makes them answer the same interference differently is the working set, not the amount of work each does. The compute arm loops over a handful of scalars, which live in registers and the nearest cache, so pressure on the shared cache or the memory controller moves it little rather than not at all. The memory arm streams blocks: a read of /dev/zero zeroes the buffer the caller supplied and a write to /dev/null never looks at it, so each block is one pass of stores over the whole block. The block size is both the working set and the reuse distance -- %s MiB here, against the 32 MiB of last-level cache an EPYC core can allocate into on the parts this lane has run on -- and a block that exceeds that cache leaves no byte still cached by the time it is written again, so the traffic lands on the memory controller. Which part this run got is recorded in sandbox-host/runner-identity.txt at the root of this report, and that is what tells a reader of this artifact which case it is looking at: on a part whose per-core cache exceeds the block size this arm stops being memory-bound and reads high. On a machine in front of you the dd line above can be rerun with a block size that fits the cache, and the figure rises several times over]\n' \
+  printf '[three arms. What makes the first two answer the same interference differently is the working set, not the amount of work each does. The compute arm loops over a handful of scalars, which live in registers and the nearest cache, so pressure on the shared cache or the memory controller moves it little rather than not at all. The memory arm streams blocks: a read of /dev/zero zeroes the buffer the caller supplied and a write to /dev/null never looks at it, so each block is one pass of stores over the whole block. The block size is both the working set and the reuse distance -- %s MiB here, against the 32 MiB of last-level cache an EPYC core can allocate into on the parts this lane has run on -- and a block that exceeds that cache leaves no byte still cached by the time it is written again, so the traffic lands on the memory controller. Which part this run got is recorded in sandbox-host/runner-identity.txt at the root of this report, and that is what tells a reader of this artifact which case it is looking at: on a part whose per-core cache exceeds the block size this arm stops being memory-bound and reads high. On a machine in front of you the dd line above can be rerun with a block size that fits the cache, and the figure rises several times over. The disk arm shares neither property: its working set is one 4 KiB block, and what it waits on is the device answering rather than a cache or a controller. It is the one arm here whose figure can move while the other two hold steady, which is the whole reason it exists -- a runner whose compute and memory read healthy and whose storage does not is a case the first two arms report as a healthy machine]\n' \
     "${COZY_CANARY_MEM_BLOCK_MIB}" >>"${capture}"
-  printf '[expected ranges, and what they are worth. These are what the construction can do on a healthy server core, not figures measured on this lane, and they are stated to the precision they have: a factor of ten is what they resolve and a factor of two is not. Memory arm: one core sustains single-digit to low-double-digit GB per second of streaming stores, because the ceiling is how many misses one core keeps outstanding rather than how many memory channels the socket has, so the %s MiB it writes land in about a second on a fast core and in about eight at the bottom of that band, while anything under %s in the MiB-per-second unit the rate lines above are printed in, about half a gigabyte a second, is pathological rather than merely slow. Compute arm: the rate depends on the awk implementation as much as on the core, and that implementation is a property of the sandbox image rather than of the run, pinned by digest in packages/core/testing/images/e2e-sandbox/Dockerfile, so on the mawk that image ships a simple loop over integer-valued scalars runs at tens of millions of iterations a second and the %s of them here land in about a second, so anything under %s iterations a second, one factor of ten below that, is pathological rather than merely slow]\n' \
-    "${mem_mib}" "${COZY_CANARY_MEM_MIN_RATE}" "${COZY_CANARY_CPU_ITERATIONS}" "${COZY_CANARY_CPU_MIN_RATE}" >>"${capture}"
+  printf '[expected ranges, and what they are worth. These are what the construction can do on a healthy server core, not figures measured on this lane, and they are stated to the precision they have: a factor of ten is what they resolve and a factor of two is not. Memory arm: one core sustains single-digit to low-double-digit GB per second of streaming stores, because the ceiling is how many misses one core keeps outstanding rather than how many memory channels the socket has, so the %s MiB it writes land in about a second on a fast core and in about eight at the bottom of that band, while anything under %s in the MiB-per-second unit the rate lines above are printed in, about half a gigabyte a second, is pathological rather than merely slow. Compute arm: the rate depends on the awk implementation as much as on the core, and that implementation is a property of the sandbox image rather than of the run, pinned by digest in packages/core/testing/images/e2e-sandbox/Dockerfile, so on the mawk that image ships a simple loop over integer-valued scalars runs at tens of millions of iterations a second and the %s of them here land in about a second, so anything under %s iterations a second, one factor of ten below that, is pathological rather than merely slow. Disk arm: the rate is operations a second at queue depth one, so its reciprocal is how long one 4 KiB write took to reach the volume, and that is the figure to read rather than the rate itself. A local NVMe answers in tens of microseconds and a network-attached volume in hundreds, so a healthy reading here is thousands of operations a second and the %s of them land in about a second; anything under %s a second, a decade below the low end of that, is 3.3ms for one write and is pathological for any device rather than merely slow. Storage fast enough to finish well inside a second is the one case this arm reports coarsely rather than precisely: the clock quantises to 10ms, so a run of tens of milliseconds carries a resolution of some percent instead of the one percent the arms are sized for, and two such readings differ by noise. That direction is not the one this arm exists to catch, and a figure in it is already the answer. This arm reports no rate at all where the filesystem refuses O_DIRECT, which is the likely reading of a low non-zero exit status on this arm and not a statement about the storage]\n' \
+    "${mem_mib}" "${COZY_CANARY_MEM_MIN_RATE}" "${COZY_CANARY_CPU_ITERATIONS}" "${COZY_CANARY_CPU_MIN_RATE}" "${COZY_CANARY_DISK_BLOCKS}" "${COZY_CANARY_DISK_MIN_RATE}" >>"${capture}"
   printf '%s\n' \
-    '[what this canary does NOT separate. It reads wall clock only, so an arm that took ten times as long could be a core doing less per cycle or a container that was not on a core at all. Where to look for the second is runner-kernel-cpu-time beside this capture and sandbox-host-cpu-time one layer down, and their steal columns do not read the same way. On the runner row a climb is proof this VM was preempted and a zero proves nothing, because nobody here launches that VM and the column is filled only where the hypervisor exposes the clock. One layer down the sandbox nodes are started with accel=kvm, which hands the guest that accounting, so a zero there means the node got every turn it asked for. Which is what makes the pair worth reading together: a sandbox zero under a climbing runner row puts the wait a layer above them. Read those first when an arm here is slow, and read each for what it covers: the runner-kernel rows are a pair bracketing the node-join wait, so they describe the whole join window next to these seconds rather than these seconds themselves, while the sandbox-host rows are a pair seconds apart inside the on-failure diagnostics block, taken minutes after the wait already failed and absent from a green run altogether]' \
+    '[what this canary does NOT separate. It reads wall clock only, so an arm that took ten times as long could be a core doing less per cycle or a container that was not on a core at all. Where to look for the second is runner-kernel-cpu-time beside this capture and sandbox-host-cpu-time one layer down, and their steal columns do not read the same way. On the runner row a climb is proof this VM was preempted and a zero proves nothing, because nobody here launches that VM and the column is filled only where the hypervisor exposes the clock. One layer down the sandbox nodes are started with accel=kvm, which hands the guest that accounting, so a zero there means the node got every turn it asked for. Which is what makes the pair worth reading together: a sandbox zero under a climbing runner row puts the wait a layer above them. That pair covers the two CPU arms; neither column says anything about the disk arm, whose wait is on a device rather than on a turn at a core, and no counter in this report covers that one at all -- which is why its figure stands alone. Read those first when a CPU arm here is slow, and read each for what it covers: the runner-kernel rows are a pair bracketing the node-join wait, so they describe the whole join window next to these seconds rather than these seconds themselves, while the sandbox-host rows are a pair seconds apart inside the on-failure diagnostics block, taken minutes after the wait already failed and absent from a green run altogether]' \
     '[the two samples. Sample 1 is taken before the node-join wait and sample 2 after it, on the failing and the passing path alike, on the same binaries in the same container. A difference between them puts the change inside the interval the pair brackets, which is the wait together with the readings taken on either side of it; two equally slow samples say it was already there going into that interval, which is the case the expected ranges above are the only instrument for -- the pair speaks for the interval between its own readings and for nothing before them]' \
-    '[this collector perturbs what it measures, which is why it is placed where it is. It occupies one core for the duration of each arm, twice per run. Sample 1 runs before the first reading of all three pairs that bracket the node-join wait, and sample 2 after the last of their second readings, so neither burn falls inside any interval those pairs divide by]' \
+    '[this collector perturbs what it measures, which is why it is placed where it is. It occupies one core for the duration of each CPU arm and writes 16 MiB to the sandbox filesystem in the disk arm, twice per run; the file is removed as soon as the arm returns, so what it leaves on the volume is the write itself rather than the space. Sample 1 runs before the first reading of all three pairs that bracket the node-join wait, and sample 2 after the last of their second readings, so neither burn falls inside any interval those pairs divide by]' \
     '[durations here are read from /proc/uptime, which the kernel prints in hundredths of a second, so every figure is quantised to 10ms. Against arms sized to take about a second that is about a percent, and it is why an arm finishing inside one tick is reported as being under the resolution rather than as a rate]' \
     >>"${capture}"
   printf '[read attempted from %s to %s epoch seconds]\n' \

--- a/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-latest/chainsaw-test.yaml
@@ -58,10 +58,15 @@ spec:
         # than in this list. Three of the four are reads: the KVM counters and
         # the runner kernel CPU time are one bounded read a side, and the QEMU
         # thread time is a bounded probe walk plus a bounded read of each
-        # sandbox pid file. The canary is two arms of fixed work under a ceiling
-        # of its own apiece, and it is the one of the four that costs a core
-        # rather than a read, which is why it runs outside the brackets of the
-        # other three rather than among them.
+        # sandbox pid file. The canary is three arms of fixed work under a
+        # ceiling of its own apiece, and it is the one of the four that does
+        # work rather than take a read, which is why it runs outside the
+        # brackets of the other three rather than among them. Two of its arms
+        # cost a core; the third writes 16 MiB to this container's filesystem
+        # with O_DIRECT and removes it, and its rate is operations a second at
+        # queue depth one, so what it reports is how long the storage took to
+        # answer -- the one question about this lane that no counter in the
+        # report has ever asked.
         # and then, after the phase rather than inside it, the in-process tenant
         # crust-gather snapshot.
         #

--- a/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/kubernetes-previous/chainsaw-test.yaml
@@ -45,10 +45,15 @@ spec:
         # than in this list. Three of the four are reads: the KVM counters and
         # the runner kernel CPU time are one bounded read a side, and the QEMU
         # thread time is a bounded probe walk plus a bounded read of each
-        # sandbox pid file. The canary is two arms of fixed work under a ceiling
-        # of its own apiece, and it is the one of the four that costs a core
-        # rather than a read, which is why it runs outside the brackets of the
-        # other three rather than among them.
+        # sandbox pid file. The canary is three arms of fixed work under a
+        # ceiling of its own apiece, and it is the one of the four that does
+        # work rather than take a read, which is why it runs outside the
+        # brackets of the other three rather than among them. Two of its arms
+        # cost a core; the third writes 16 MiB to this container's filesystem
+        # with O_DIRECT and removes it, and its rate is operations a second at
+        # queue depth one, so what it reports is how long the storage took to
+        # answer -- the one question about this lane that no counter in the
+        # report has ever asked.
         # and then, after the phase rather than inside it, the in-process tenant
         # crust-gather snapshot.
         #

--- a/hack/run-kubernetes-runner-canary_test.bats
+++ b/hack/run-kubernetes-runner-canary_test.bats
@@ -260,7 +260,7 @@ capture_path() {
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='100 150 150 250 250 300'
+  stamp_values='100 150 150 250 250 300 300 350'
   # Set apart on purpose. The canary is work rather than a read, and a read
   # bound lowered to speed the diagnostics up would kill an arm that is meant to
   # take seconds; taking the wrong one of these two is invisible until that
@@ -284,7 +284,7 @@ capture_path() {
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='100 150 150 250 250 300'
+  stamp_values='100 150 150 250 250 300 300 350'
   COZY_CANARY_RUN_BOUND=0
   COZY_DIAG_READ_GRACE=3
 
@@ -592,7 +592,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
   COZY_CANARY_CPU_ITERATIONS=1000000
   COZY_CANARY_MEM_BLOCK_MIB=2048
   COZY_CANARY_MEM_BLOCKS=4
@@ -617,7 +617,7 @@ STUB
   stage "$tmp"
   stub_stamp
   # 50 centiseconds for the compute arm, 200 for the memory one.
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
   COZY_CANARY_CPU_ITERATIONS=1000000
   COZY_CANARY_MEM_BLOCK_MIB=2
   COZY_CANARY_MEM_BLOCKS=4
@@ -641,7 +641,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
   COZY_CANARY_MEM_BLOCK_MIB=2
   COZY_CANARY_MEM_BLOCKS=4
 
@@ -664,7 +664,7 @@ STUB
   timeout_rc_override=124
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 3050 3050 3100'
+  stamp_values='1000 1050 1050 3050 3050 3100 3100 3150'
   COZY_CANARY_MEM_BLOCK_MIB=100
   COZY_CANARY_MEM_BLOCKS=8
   COZY_CANARY_RUN_BOUND=20
@@ -696,7 +696,7 @@ STUB
   timeout_rc_override=137
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
   COZY_CANARY_RUN_BOUND=20
 
   run_canary
@@ -723,7 +723,7 @@ STUB
   timeout_rc_override=137
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 3050 3050 3100'
+  stamp_values='1000 1050 1050 3050 3050 3100 3100 3150'
   COZY_CANARY_MEM_BLOCK_MIB=100
   COZY_CANARY_MEM_BLOCKS=8
   COZY_CANARY_RUN_BOUND=20
@@ -756,7 +756,7 @@ STUB
   # sample would report a shortfall and the call sites would print that they got
   # no reading, which is the vaguest thing they can say about the one machine
   # state worth naming exactly.
-  stamp_values='1000 3000 3000 5000 5000 5050'
+  stamp_values='1000 3000 3000 5000 5000 5050 5050 5100'
   COZY_CANARY_MEM_BLOCK_MIB=100
   COZY_CANARY_MEM_BLOCKS=8
   COZY_CANARY_RUN_BOUND=20
@@ -791,7 +791,7 @@ STUB
   # the 20 the default carries: this is the only case that reaches the sentence
   # naming the ceiling it did not reach, so it is the only one that can tell
   # that sentence reading the knob from it reading the compiled-in figure.
-  stamp_values='1000 1050 1050 2149 2149 2199'
+  stamp_values='1000 1050 1050 2149 2149 2199 2199 2249'
   COZY_CANARY_MEM_BLOCK_MIB=100
   COZY_CANARY_MEM_BLOCKS=8
   COZY_CANARY_RUN_BOUND=11
@@ -827,7 +827,7 @@ STUB
   # it to exactly that default, so their assertions would hold just as well if
   # the comparison read the compiled-in figure instead of the knob the caller
   # set. Reading the default here classifies a fired ceiling as something else.
-  stamp_values='1000 1050 1050 2150 2150 2200'
+  stamp_values='1000 1050 1050 2150 2150 2200 2200 2250'
   COZY_CANARY_MEM_BLOCK_MIB=100
   COZY_CANARY_MEM_BLOCKS=8
   COZY_CANARY_RUN_BOUND=11
@@ -861,7 +861,7 @@ STUB
   timeout_rc_override=127
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
 
   run_canary
 
@@ -910,7 +910,7 @@ STUB
   stub_stamp
   # Both stamps of the memory arm land on the same tick, which is what a command
   # this machine does not have actually produces: it fails in well under 10ms.
-  stamp_values='1000 1050 1050 1050 1050 1100'
+  stamp_values='1000 1050 1050 1050 1050 1100 1100 1150'
 
   run_canary
 
@@ -930,7 +930,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
   # The clock fails on the memory arm's closing stamp.
   stamp_fail_at=4
 
@@ -962,7 +962,7 @@ STUB
   # pathological finding manufactured on a healthy machine, which is the one
   # outcome this collector must never produce.
   stamp_fail_at=1
-  stamp_values='1000 1050 1150 1250 1250 1300'
+  stamp_values='1000 1050 1150 1250 1250 1300 1300 1350'
   COZY_CANARY_CPU_ITERATIONS=6000000
   COZY_CANARY_MEM_BLOCK_MIB=1000
   COZY_CANARY_MEM_BLOCKS=1
@@ -988,7 +988,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1000 1000 1000 1000 1050'
+  stamp_values='1000 1000 1000 1000 1000 1050 1050 1100'
   rc=0
 
   run_canary || rc=$?
@@ -1022,7 +1022,7 @@ STUB
   # needs the whole bound on the clock. Read by status alone this was reported
   # as the ceiling with no duration, which is a finding about the machine
   # manufactured by whatever actually killed the work.
-  stamp_values='1000 1050 1050 1050 1050 1100'
+  stamp_values='1000 1050 1050 1050 1050 1100 1100 1150'
   COZY_CANARY_RUN_BOUND=20
   rc=0
 
@@ -1080,7 +1080,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 900 900 800 800 750'
+  stamp_values='1000 900 900 800 800 750 750 700'
   rc=0
 
   run_canary || rc=$?
@@ -1112,7 +1112,7 @@ STUB
   stub_stamp
   # 8 MiB in twenty seconds is under half a MiB per second, which integer
   # division reports as none at all.
-  stamp_values='1000 1050 1050 3050 3050 3100'
+  stamp_values='1000 1050 1050 3050 3050 3100 3100 3150'
   COZY_CANARY_MEM_BLOCK_MIB=2
   COZY_CANARY_MEM_BLOCKS=4
 
@@ -1173,7 +1173,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
   rc=0
 
   run_canary || rc=$?
@@ -1214,7 +1214,7 @@ STUB
   # which is the OOM case the ceiling attribution is written for, would report
   # success with nothing measured and both call sites would stay quiet.
   timeout_rc_override=137
-  stamp_values='1000 1200 1200 1400 1400 1450'
+  stamp_values='1000 1200 1200 1400 1400 1450 1450 1500'
   COZY_CANARY_RUN_BOUND=20
   stamp_index=0
   rc=0
@@ -1245,7 +1245,7 @@ STUB
   # The work failed on its own account.
   timeout_rc_match=
   timeout_rc_override=127
-  stamp_values='1000 1200 1200 1400 1400 1450'
+  stamp_values='1000 1200 1200 1400 1400 1450 1450 1500'
   stamp_index=0
   run_canary_here || true
   [ "${_COZY_CANARY_ALERT:-unset}" = 0 ] || {
@@ -1264,7 +1264,7 @@ STUB
 
   # Finished inside one tick, which is too fast to measure rather than slow.
   timeout_rc_override=
-  stamp_values='1000 1000 1000 1000 1000 1050'
+  stamp_values='1000 1000 1000 1000 1000 1050 1050 1100'
   stamp_index=0
   run_canary_here 3 || true
   [ "${_COZY_CANARY_ALERT:-unset}" = 0 ] || {
@@ -1281,7 +1281,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
 
   out=$(run_canary 2)
 
@@ -1305,7 +1305,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
 
   run_canary 2
 
@@ -1330,7 +1330,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
   # The report directory outlives a run, so the same sample number can find a
   # file already there. Appended to, the capture would carry two runs of one
   # sample with nothing between them to say where the first ended, and every
@@ -1439,7 +1439,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
 
   run_canary
 
@@ -1469,7 +1469,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
   COZY_CANARY_CPU_ITERATIONS=777
   # The floors are overridden away from their defaults for the reason the
   # ceiling case sets a bound of 11: the legend interpolates them, so a fixture
@@ -1509,7 +1509,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
 
   run_canary
 
@@ -1565,7 +1565,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
 
   run_canary
 
@@ -1744,7 +1744,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
   # 8 MiB in two seconds: 4 MiB per second, against a floor of 500. The compute
   # arm is sized to 12,000,000 iterations a second, above its own floor, so this
   # arm is the only one that can raise the alert asserted below. The alert is
@@ -1774,7 +1774,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1150 1150 1200'
+  stamp_values='1000 1050 1050 1150 1150 1200 1200 1250'
   # 953 MiB in one second, a gigabyte a second expressed in the unit the rate
   # line is printed in. The floor sits well under that, so this core is slow and
   # nothing more. A floor at the near-1000 MiB/s the legend gives for that
@@ -1804,7 +1804,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
   # A rate landing on the floor rather than above or below it, which is the one
   # case that tells `-lt` from `-le`. The neighbours put a rate on either side
   # and both stay correct under either operator, so without this case the
@@ -1836,7 +1836,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1150 1150 1200'
+  stamp_values='1000 1050 1050 1150 1150 1200 1200 1250'
   # 400 MiB in one second, just under the floor rather than an order of
   # magnitude beneath it. The case above pins where the alert stays quiet and
   # this one pins where it starts, so between them the floor is the number that
@@ -1865,7 +1865,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
   # 1000 iterations in half a second: 2000 a second against a floor of three
   # million. The memory arm beside it is above its own, so each arm's floor is
   # pinned by the case where only that arm is under it -- one floor left at zero
@@ -1895,7 +1895,7 @@ STUB
   timeout_rc_override=124
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 3050 3050 3100'
+  stamp_values='1000 1050 1050 3050 3050 3100 3100 3150'
   # Sized so the bound rounds up to 1639 MiB per second, above the floor, and
   # the compute arm beside it is above its own: the ceiling has to raise the
   # alert on its own account or nothing here does. An arm the bound stopped got
@@ -1930,10 +1930,10 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  # Twelve stamps: six for each sample, one pair per arm, because
+  # Sixteen stamps: eight for each sample, one pair per arm, because
   # run_kubernetes_test takes both samples from one shell and the alert is one
   # variable for the pair.
-  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350 1350 1550 1550 1600'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350 1350 1400 1400 1600 1600 1650 1650 1700'
   COZY_CANARY_CPU_ITERATIONS=1000
   COZY_CANARY_MEM_BLOCK_MIB=2048
   COZY_CANARY_MEM_BLOCKS=4
@@ -1967,7 +1967,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
   # Both arms above their floors. Without this case an alert wired to fire
   # always would satisfy every assertion above it, and the job log would carry
   # the warning on every green run until a reader learned to skip it.
@@ -2064,8 +2064,10 @@ STUB
   mem_floor=$(grep -oE '^COZY_CANARY_MEM_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
   dblocks=$(grep -oE '^COZY_CANARY_DISK_BLOCKS=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
   disk_floor=$(grep -oE '^COZY_CANARY_DISK_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  cacc=$(grep -oE '^COZY_CANARY_CACHE_ACCESSES=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  cache_floor=$(grep -oE '^COZY_CANARY_CACHE_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
   bound=$(grep -oE '^COZY_CANARY_RUN_BOUND_DEFAULT=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
-  for v in iters cpu_floor blk blocks mem_floor dblocks disk_floor bound; do
+  for v in iters cpu_floor blk blocks mem_floor dblocks disk_floor cacc cache_floor bound; do
     eval "n=\$$v"
     if [ -z "$n" ]; then
       echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
@@ -2077,7 +2079,7 @@ STUB
   # than reach the branch below, and the failure then arrives as a raw
   # arithmetic error rather than as a sentence naming the floor and the file it
   # was read from.
-  for v in cpu_floor mem_floor disk_floor; do
+  for v in cpu_floor mem_floor disk_floor cache_floor; do
     eval "n=\$$v"
     if [ "$n" -eq 0 ]; then
       echo "read $v as zero from $lib; a floor of zero has no window to sit inside and this guard cannot divide by it" >&2
@@ -2090,7 +2092,8 @@ STUB
   # window derived from the byte total would be wrong by the block size.
   for arm in "compute:$(( iters * 1000 / cpu_floor ))" \
     "memory:$(( blk * blocks * 1000 / mem_floor ))" \
-    "disk:$(( dblocks * 1000 / disk_floor ))"; do
+    "disk:$(( dblocks * 1000 / disk_floor ))" \
+    "cache:$(( cacc * 1000 / cache_floor ))"; do
     name=${arm%%:*}
     ms=${arm#*:}
     if [ "$ms" -ge $(( bound * 1000 )) ]; then
@@ -2157,7 +2160,9 @@ STUB
   mem_floor=$(grep -oE '^COZY_CANARY_MEM_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
   dblocks=$(grep -oE '^COZY_CANARY_DISK_BLOCKS=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
   disk_floor=$(grep -oE '^COZY_CANARY_DISK_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
-  for v in iters cpu_floor blk blocks mem_floor dblocks disk_floor; do
+  cacc=$(grep -oE '^COZY_CANARY_CACHE_ACCESSES=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  cache_floor=$(grep -oE '^COZY_CANARY_CACHE_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  for v in iters cpu_floor blk blocks mem_floor dblocks disk_floor cacc cache_floor; do
     eval "n=\$$v"
     if [ -z "$n" ]; then
       echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
@@ -2191,6 +2196,15 @@ STUB
     echo "the disk arm runs ${disk_ms}ms at the healthy rate its own legend states, not the about-a-second the sizing comment promises, so the 10ms clock is no longer about a percent of the figure" >&2
     return 1
   fi
+  # Cache: same anchor again, its legend stating the floor a decade under the
+  # million reads a second a healthy core resolves. This arm is the one whose
+  # figure is read as a latency, so a duration near the clock's resolution is a
+  # latency near it too.
+  cache_ms=$(( cacc * 1000 / ( cache_floor * 10 ) ))
+  if [ "$cache_ms" -lt 500 ] || [ "$cache_ms" -gt 2000 ]; then
+    echo "the cache arm runs ${cache_ms}ms at the healthy rate its own legend states, not the about-a-second the sizing comment promises, so the 10ms clock is no longer about a percent of the figure" >&2
+    return 1
+  fi
 }
 
 @test "each arm runs the work its rate is a rate of" {
@@ -2200,7 +2214,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
 
   run_canary
 
@@ -2225,6 +2239,15 @@ STUB
   # only a 4 KiB one while dd is asked for 4 KiB.
   assert_file_contains 'oflag=direct' "$capture"
   assert_file_contains "bs=${COZY_CANARY_DISK_BLOCK_BYTES} count=${COZY_CANARY_DISK_BLOCKS}" "$capture"
+  # And the cache arm walks a working set of the size its legend prices, in the
+  # order that makes the figure a latency. A fixed stride here is what a
+  # hardware prefetcher follows, so it would report bandwidth wearing a latency
+  # label; the congruential step is the whole reason the number means what the
+  # legend says. The slot count is pinned with it, because the arm only exceeds
+  # last-level cache while the array is that large.
+  assert_file_contains "n = ${COZY_CANARY_CACHE_SLOTS};" "$capture"
+  assert_file_contains '(1103515245 * x + 12345) % n' "$capture"
+  assert_file_contains "k < ${COZY_CANARY_CACHE_ACCESSES}" "$capture"
   rm -rf "$tmp"
 }
 
@@ -2235,7 +2258,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250 1250 1300'
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350'
 
   run_canary
 

--- a/hack/run-kubernetes-runner-canary_test.bats
+++ b/hack/run-kubernetes-runner-canary_test.bats
@@ -260,7 +260,7 @@ capture_path() {
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='100 150 150 250'
+  stamp_values='100 150 150 250 250 300'
   # Set apart on purpose. The canary is work rather than a read, and a read
   # bound lowered to speed the diagnostics up would kill an arm that is meant to
   # take seconds; taking the wrong one of these two is invisible until that
@@ -284,7 +284,7 @@ capture_path() {
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='100 150 150 250'
+  stamp_values='100 150 150 250 250 300'
   COZY_CANARY_RUN_BOUND=0
   COZY_DIAG_READ_GRACE=3
 
@@ -364,15 +364,35 @@ capture_path() {
   real_awk=$(readlink "$tmp/bin/awk")
   real_dd=$(readlink "$tmp/bin/dd")
   rm -f "$tmp/bin/awk" "$tmp/bin/dd"
+  # A step of one second rather than a value each wrapper writes: dd is now the
+  # binary of two arms rather than one, and a wrapper that stamps a constant
+  # gives the second of them a start and an end on the same hundredth. That
+  # reads as an arm too fast to measure, which is the one outcome this case
+  # asserts against, on the arm it is not even about.
   cat >"$tmp/bin/awk" <<EOF
 #!/bin/sh
-printf '70063.90 774208.84\n' >"$tmp/uptime"
+"$real_awk" '{ printf "%.2f 774208.84\n", \$1 + 1 }' "$tmp/uptime" >"$tmp/uptime.next"
+mv "$tmp/uptime.next" "$tmp/uptime"
 exec "$real_awk" "\$@"
 EOF
   cat >"$tmp/bin/dd" <<EOF
 #!/bin/sh
-printf '70064.90 774208.84\n' >"$tmp/uptime"
-exec "$real_dd" "\$@"
+"$real_awk" '{ printf "%.2f 774208.84\n", \$1 + 1 }' "$tmp/uptime" >"$tmp/uptime.next"
+mv "$tmp/uptime.next" "$tmp/uptime"
+# The disk arm asks for O_DIRECT, and whether the filesystem under whoever runs
+# this suite honours it is not what this case is about -- tmpfs refuses it
+# outright, and a refusal here would be read as the unbounded fallback having
+# failed. The flag is dropped so the arm still runs its real dd; that the
+# sandbox image's overlay does honour it is a property of the sandbox, checked
+# where the arm runs rather than here.
+kept=
+for a in "\$@"; do
+  case "\$a" in
+    oflag=direct) continue ;;
+  esac
+  kept="\$kept \$a"
+done
+exec "$real_dd" \$kept
 EOF
   chmod +x "$tmp/bin/awk" "$tmp/bin/dd"
   rc=0
@@ -389,6 +409,7 @@ EOF
       COZY_CANARY_CPU_ITERATIONS=1000
       COZY_CANARY_MEM_BLOCK_MIB=1
       COZY_CANARY_MEM_BLOCKS=1
+      COZY_CANARY_DISK_BLOCKS=1
       PATH='"$tmp"'/bin
       cozy_capture_runner_canary 1
     ' ) 2>&1 ) || rc=$?
@@ -399,15 +420,18 @@ EOF
     false
   }
   capture="$tmp/report/snapshots/canary-smoke/runner-canary/sample-1/fixed-work.txt"
-  # Both arms ran the real binaries, and the wrapped clock gives each of them a
-  # second, so each reports a duration and divides by it: 1000 iterations and
-  # 1 MiB, each in one second. That is what makes this the case that exercises
-  # the unbounded arm end to end rather than only reaching it.
+  # All three arms ran the real binaries, and the wrapped clock gives each of
+  # them a second, so each reports a duration and divides by it: 1000
+  # iterations, 1 MiB and one direct write, each in one second. That is what
+  # makes this the case that exercises the unbounded arm end to end rather than
+  # only reaching it.
   assert_file_contains 'arm: compute' "$capture"
   assert_file_contains 'arm: memory' "$capture"
+  assert_file_contains 'arm: disk' "$capture"
   assert_file_contains 'elapsed: 1000 ms' "$capture"
   assert_file_contains 'rate: 1000 iterations per second' "$capture"
   assert_file_contains 'rate: 1 MiB per second' "$capture"
+  assert_file_contains 'rate: 1 4KiB direct writes per second' "$capture"
   assert_file_lacks_pattern 'produced no reading' "$capture"
   assert_file_lacks_pattern 'finished inside one tick' "$capture"
   # And the capture says it ran without a ceiling. The phase warning that names
@@ -568,7 +592,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
   COZY_CANARY_CPU_ITERATIONS=1000000
   COZY_CANARY_MEM_BLOCK_MIB=2048
   COZY_CANARY_MEM_BLOCKS=4
@@ -593,7 +617,7 @@ STUB
   stage "$tmp"
   stub_stamp
   # 50 centiseconds for the compute arm, 200 for the memory one.
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
   COZY_CANARY_CPU_ITERATIONS=1000000
   COZY_CANARY_MEM_BLOCK_MIB=2
   COZY_CANARY_MEM_BLOCKS=4
@@ -617,7 +641,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
   COZY_CANARY_MEM_BLOCK_MIB=2
   COZY_CANARY_MEM_BLOCKS=4
 
@@ -636,11 +660,11 @@ STUB
   tmp=$(mktemp -d)
   timeout_calls="$tmp/timeout.calls"
   timeout_skip_command=1
-  timeout_rc_match=dd
+  timeout_rc_match=of=/dev/null
   timeout_rc_override=124
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 3050'
+  stamp_values='1000 1050 1050 3050 3050 3100'
   COZY_CANARY_MEM_BLOCK_MIB=100
   COZY_CANARY_MEM_BLOCKS=8
   COZY_CANARY_RUN_BOUND=20
@@ -668,11 +692,11 @@ STUB
   tmp=$(mktemp -d)
   timeout_calls="$tmp/timeout.calls"
   timeout_skip_command=1
-  timeout_rc_match=dd
+  timeout_rc_match=of=/dev/null
   timeout_rc_override=137
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
   COZY_CANARY_RUN_BOUND=20
 
   run_canary
@@ -695,11 +719,11 @@ STUB
   tmp=$(mktemp -d)
   timeout_calls="$tmp/timeout.calls"
   timeout_skip_command=1
-  timeout_rc_match=dd
+  timeout_rc_match=of=/dev/null
   timeout_rc_override=137
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 3050'
+  stamp_values='1000 1050 1050 3050 3050 3100'
   COZY_CANARY_MEM_BLOCK_MIB=100
   COZY_CANARY_MEM_BLOCKS=8
   COZY_CANARY_RUN_BOUND=20
@@ -732,7 +756,7 @@ STUB
   # sample would report a shortfall and the call sites would print that they got
   # no reading, which is the vaguest thing they can say about the one machine
   # state worth naming exactly.
-  stamp_values='1000 3000 3000 5000'
+  stamp_values='1000 3000 3000 5000 5000 5050'
   COZY_CANARY_MEM_BLOCK_MIB=100
   COZY_CANARY_MEM_BLOCKS=8
   COZY_CANARY_RUN_BOUND=20
@@ -759,7 +783,7 @@ STUB
   tmp=$(mktemp -d)
   timeout_calls="$tmp/timeout.calls"
   timeout_skip_command=1
-  timeout_rc_match=dd
+  timeout_rc_match=of=/dev/null
   timeout_rc_override=124
   stage "$tmp"
   stub_stamp
@@ -767,7 +791,7 @@ STUB
   # the 20 the default carries: this is the only case that reaches the sentence
   # naming the ceiling it did not reach, so it is the only one that can tell
   # that sentence reading the knob from it reading the compiled-in figure.
-  stamp_values='1000 1050 1050 2149'
+  stamp_values='1000 1050 1050 2149 2149 2199'
   COZY_CANARY_MEM_BLOCK_MIB=100
   COZY_CANARY_MEM_BLOCKS=8
   COZY_CANARY_RUN_BOUND=11
@@ -790,7 +814,7 @@ STUB
   tmp=$(mktemp -d)
   timeout_calls="$tmp/timeout.calls"
   timeout_skip_command=1
-  timeout_rc_match=dd
+  timeout_rc_match=of=/dev/null
   timeout_rc_override=124
   stage "$tmp"
   stub_stamp
@@ -803,7 +827,7 @@ STUB
   # it to exactly that default, so their assertions would hold just as well if
   # the comparison read the compiled-in figure instead of the knob the caller
   # set. Reading the default here classifies a fired ceiling as something else.
-  stamp_values='1000 1050 1050 2150'
+  stamp_values='1000 1050 1050 2150 2150 2200'
   COZY_CANARY_MEM_BLOCK_MIB=100
   COZY_CANARY_MEM_BLOCKS=8
   COZY_CANARY_RUN_BOUND=11
@@ -833,11 +857,11 @@ STUB
   tmp=$(mktemp -d)
   timeout_calls="$tmp/timeout.calls"
   timeout_skip_command=1
-  timeout_rc_match=dd
+  timeout_rc_match=of=/dev/null
   timeout_rc_override=127
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
 
   run_canary
 
@@ -880,13 +904,13 @@ STUB
   tmp=$(mktemp -d)
   timeout_calls="$tmp/timeout.calls"
   timeout_skip_command=1
-  timeout_rc_match=dd
+  timeout_rc_match=of=/dev/null
   timeout_rc_override=127
   stage "$tmp"
   stub_stamp
   # Both stamps of the memory arm land on the same tick, which is what a command
   # this machine does not have actually produces: it fails in well under 10ms.
-  stamp_values='1000 1050 1050 1050'
+  stamp_values='1000 1050 1050 1050 1050 1100'
 
   run_canary
 
@@ -906,7 +930,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
   # The clock fails on the memory arm's closing stamp.
   stamp_fail_at=4
 
@@ -938,7 +962,7 @@ STUB
   # pathological finding manufactured on a healthy machine, which is the one
   # outcome this collector must never produce.
   stamp_fail_at=1
-  stamp_values='1000 1050 1150 1250'
+  stamp_values='1000 1050 1150 1250 1250 1300'
   COZY_CANARY_CPU_ITERATIONS=6000000
   COZY_CANARY_MEM_BLOCK_MIB=1000
   COZY_CANARY_MEM_BLOCKS=1
@@ -964,7 +988,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1000 1000 1000'
+  stamp_values='1000 1000 1000 1000 1000 1050'
   rc=0
 
   run_canary || rc=$?
@@ -989,7 +1013,7 @@ STUB
   tmp=$(mktemp -d)
   timeout_calls="$tmp/timeout.calls"
   timeout_skip_command=1
-  timeout_rc_match=dd
+  timeout_rc_match=of=/dev/null
   timeout_rc_override=124
   stage "$tmp"
   stub_stamp
@@ -998,7 +1022,7 @@ STUB
   # needs the whole bound on the clock. Read by status alone this was reported
   # as the ceiling with no duration, which is a finding about the machine
   # manufactured by whatever actually killed the work.
-  stamp_values='1000 1050 1050 1050'
+  stamp_values='1000 1050 1050 1050 1050 1100'
   COZY_CANARY_RUN_BOUND=20
   rc=0
 
@@ -1056,12 +1080,12 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 900 900 800'
+  stamp_values='1000 900 900 800 800 750'
   rc=0
 
   run_canary || rc=$?
 
-  # Neither arm yields a figure, so the collector reports a shortfall -- which
+  # No arm yields a figure, so the collector reports a shortfall -- which
   # is what the two call sites outside the diagnostics block turn into a line in
   # the job log.
   [ "$rc" -ne 0 ] || {
@@ -1088,7 +1112,7 @@ STUB
   stub_stamp
   # 8 MiB in twenty seconds is under half a MiB per second, which integer
   # division reports as none at all.
-  stamp_values='1000 1050 1050 3050'
+  stamp_values='1000 1050 1050 3050 3050 3100'
   COZY_CANARY_MEM_BLOCK_MIB=2
   COZY_CANARY_MEM_BLOCKS=4
 
@@ -1149,7 +1173,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
   rc=0
 
   run_canary || rc=$?
@@ -1161,7 +1185,7 @@ STUB
   # One arm failing is not a shortfall: the other still carries a figure, and
   # both call sites outside the diagnostics block turn a non-zero into a warning
   # line saying nothing was measured.
-  timeout_rc_match=dd
+  timeout_rc_match=of=/dev/null
   timeout_rc_override=127
   stamp_index=0
   rc=0
@@ -1190,7 +1214,7 @@ STUB
   # which is the OOM case the ceiling attribution is written for, would report
   # success with nothing measured and both call sites would stay quiet.
   timeout_rc_override=137
-  stamp_values='1000 1200 1200 1400'
+  stamp_values='1000 1200 1200 1400 1400 1450'
   COZY_CANARY_RUN_BOUND=20
   stamp_index=0
   rc=0
@@ -1221,7 +1245,7 @@ STUB
   # The work failed on its own account.
   timeout_rc_match=
   timeout_rc_override=127
-  stamp_values='1000 1200 1200 1400'
+  stamp_values='1000 1200 1200 1400 1400 1450'
   stamp_index=0
   run_canary_here || true
   [ "${_COZY_CANARY_ALERT:-unset}" = 0 ] || {
@@ -1240,7 +1264,7 @@ STUB
 
   # Finished inside one tick, which is too fast to measure rather than slow.
   timeout_rc_override=
-  stamp_values='1000 1000 1000 1000'
+  stamp_values='1000 1000 1000 1000 1000 1050'
   stamp_index=0
   run_canary_here 3 || true
   [ "${_COZY_CANARY_ALERT:-unset}" = 0 ] || {
@@ -1257,7 +1281,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
 
   out=$(run_canary 2)
 
@@ -1281,7 +1305,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
 
   run_canary 2
 
@@ -1306,7 +1330,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
   # The report directory outlives a run, so the same sample number can find a
   # file already there. Appended to, the capture would carry two runs of one
   # sample with nothing between them to say where the first ended, and every
@@ -1415,7 +1439,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
 
   run_canary
 
@@ -1445,7 +1469,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
   COZY_CANARY_CPU_ITERATIONS=777
   # The floors are overridden away from their defaults for the reason the
   # ceiling case sets a bound of 11: the legend interpolates them, so a fixture
@@ -1485,7 +1509,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
 
   run_canary
 
@@ -1517,11 +1541,20 @@ STUB
   assert_file_contains 'A difference between them puts the change inside the interval the pair brackets' "$capture"
   assert_file_contains 'neither burn falls inside any interval those pairs divide by' "$capture"
   assert_file_contains 'quantised to 10ms' "$capture"
-  # The working set is what makes the two answer the same interference
+  # The working set is what makes the two CPU arms answer the same interference
   # differently; they differ in plenty else, including how much work each does,
-  # so the sentence claims the one property the two-arm design rests on rather
-  # than a separation the arms do not have.
-  assert_file_contains 'what makes them answer the same interference differently is the working set' "$capture"
+  # so the sentence claims the one property their pairing rests on rather than a
+  # separation the arms do not have. It is scoped to those two on purpose: the
+  # disk arm does not sit on that axis at all, and a sentence that swept it in
+  # would describe the collector as three shades of one measurement.
+  assert_file_contains 'What makes the first two answer the same interference differently is the working set' "$capture"
+  # And the disk arm says what it is for and what it is not. Its figure is a
+  # latency in disguise, and a reader who takes the rate at face value has the
+  # wrong end of it; the counters this report already carries are named as not
+  # covering it, so the arm is not read as a duplicate of one of them.
+  assert_file_contains 'what it waits on is the device answering' "$capture"
+  assert_file_contains 'its reciprocal is how long one 4 KiB write took to reach the volume' "$capture"
+  assert_file_contains 'no counter in this report covers that one at all' "$capture"
   rm -rf "$tmp"
 }
 
@@ -1532,7 +1565,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
 
   run_canary
 
@@ -1711,7 +1744,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
   # 8 MiB in two seconds: 4 MiB per second, against a floor of 500. The compute
   # arm is sized to 12,000,000 iterations a second, above its own floor, so this
   # arm is the only one that can raise the alert asserted below. The alert is
@@ -1741,7 +1774,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1150'
+  stamp_values='1000 1050 1050 1150 1150 1200'
   # 953 MiB in one second, a gigabyte a second expressed in the unit the rate
   # line is printed in. The floor sits well under that, so this core is slow and
   # nothing more. A floor at the near-1000 MiB/s the legend gives for that
@@ -1771,7 +1804,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
   # A rate landing on the floor rather than above or below it, which is the one
   # case that tells `-lt` from `-le`. The neighbours put a rate on either side
   # and both stay correct under either operator, so without this case the
@@ -1803,7 +1836,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1150'
+  stamp_values='1000 1050 1050 1150 1150 1200'
   # 400 MiB in one second, just under the floor rather than an order of
   # magnitude beneath it. The case above pins where the alert stays quiet and
   # this one pins where it starts, so between them the floor is the number that
@@ -1832,7 +1865,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
   # 1000 iterations in half a second: 2000 a second against a floor of three
   # million. The memory arm beside it is above its own, so each arm's floor is
   # pinned by the case where only that arm is under it -- one floor left at zero
@@ -1858,11 +1891,11 @@ STUB
   tmp=$(mktemp -d)
   timeout_calls="$tmp/timeout.calls"
   timeout_skip_command=1
-  timeout_rc_match=dd
+  timeout_rc_match=of=/dev/null
   timeout_rc_override=124
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 3050'
+  stamp_values='1000 1050 1050 3050 3050 3100'
   # Sized so the bound rounds up to 1639 MiB per second, above the floor, and
   # the compute arm beside it is above its own: the ceiling has to raise the
   # alert on its own account or nothing here does. An arm the bound stopped got
@@ -1897,9 +1930,10 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  # Eight stamps: four for each sample, because run_kubernetes_test takes both
-  # from one shell and the alert is one variable for the pair.
-  stamp_values='1000 1050 1050 1250 1250 1300 1300 1500'
+  # Twelve stamps: six for each sample, one pair per arm, because
+  # run_kubernetes_test takes both samples from one shell and the alert is one
+  # variable for the pair.
+  stamp_values='1000 1050 1050 1250 1250 1300 1300 1350 1350 1550 1550 1600'
   COZY_CANARY_CPU_ITERATIONS=1000
   COZY_CANARY_MEM_BLOCK_MIB=2048
   COZY_CANARY_MEM_BLOCKS=4
@@ -1933,7 +1967,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
   # Both arms above their floors. Without this case an alert wired to fire
   # always would satisfy every assertion above it, and the job log would carry
   # the warning on every green run until a reader learned to skip it.
@@ -2028,8 +2062,10 @@ STUB
   blk=$(grep -oE '^COZY_CANARY_MEM_BLOCK_MIB=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
   blocks=$(grep -oE '^COZY_CANARY_MEM_BLOCKS=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
   mem_floor=$(grep -oE '^COZY_CANARY_MEM_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  dblocks=$(grep -oE '^COZY_CANARY_DISK_BLOCKS=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  disk_floor=$(grep -oE '^COZY_CANARY_DISK_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
   bound=$(grep -oE '^COZY_CANARY_RUN_BOUND_DEFAULT=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
-  for v in iters cpu_floor blk blocks mem_floor bound; do
+  for v in iters cpu_floor blk blocks mem_floor dblocks disk_floor bound; do
     eval "n=\$$v"
     if [ -z "$n" ]; then
       echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
@@ -2041,15 +2077,20 @@ STUB
   # than reach the branch below, and the failure then arrives as a raw
   # arithmetic error rather than as a sentence naming the floor and the file it
   # was read from.
-  for v in cpu_floor mem_floor; do
+  for v in cpu_floor mem_floor disk_floor; do
     eval "n=\$$v"
     if [ "$n" -eq 0 ]; then
       echo "read $v as zero from $lib; a floor of zero has no window to sit inside and this guard cannot divide by it" >&2
       return 1
     fi
   done
+  # The disk arm's quantity is its block COUNT rather than the bytes it writes,
+  # because that is the unit its rate is printed in: operations a second at
+  # queue depth one, whose reciprocal is the latency the arm exists to read. A
+  # window derived from the byte total would be wrong by the block size.
   for arm in "compute:$(( iters * 1000 / cpu_floor ))" \
-    "memory:$(( blk * blocks * 1000 / mem_floor ))"; do
+    "memory:$(( blk * blocks * 1000 / mem_floor ))" \
+    "disk:$(( dblocks * 1000 / disk_floor ))"; do
     name=${arm%%:*}
     ms=${arm#*:}
     if [ "$ms" -ge $(( bound * 1000 )) ]; then
@@ -2114,7 +2155,9 @@ STUB
   blk=$(grep -oE '^COZY_CANARY_MEM_BLOCK_MIB=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
   blocks=$(grep -oE '^COZY_CANARY_MEM_BLOCKS=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
   mem_floor=$(grep -oE '^COZY_CANARY_MEM_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
-  for v in iters cpu_floor blk blocks mem_floor; do
+  dblocks=$(grep -oE '^COZY_CANARY_DISK_BLOCKS=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  disk_floor=$(grep -oE '^COZY_CANARY_DISK_MIN_RATE=[0-9]+' "$lib" | head -n 1 | sed -E 's/.*=//')
+  for v in iters cpu_floor blk blocks mem_floor dblocks disk_floor; do
     eval "n=\$$v"
     if [ -z "$n" ]; then
       echo "expected to read $v from $lib; without it this guard reports success for having lost its input" >&2
@@ -2136,6 +2179,18 @@ STUB
     echo "the memory arm is ${mem_mib} MiB, so the bottom of the band its legend describes is $(( mem_mib / 8 )) MiB per second, at or under the ${mem_floor} floor: a core at the bottom of the healthy band would read as pathological" >&2
     return 1
   fi
+  # Disk: the same shape as compute, because its legend carries the same anchor
+  # -- the floor is stated as a decade under the low end of a healthy rate, so
+  # the arm's duration at that low end is what the sentence promises. An arm
+  # sized much shorter would print "land in about a second" over a run of a
+  # hundred milliseconds, on the one arm here whose figure is read as its
+  # reciprocal, where a duration near the clock's resolution is a latency near
+  # it too.
+  disk_ms=$(( dblocks * 1000 / ( disk_floor * 10 ) ))
+  if [ "$disk_ms" -lt 500 ] || [ "$disk_ms" -gt 2000 ]; then
+    echo "the disk arm runs ${disk_ms}ms at the healthy rate its own legend states, not the about-a-second the sizing comment promises, so the 10ms clock is no longer about a percent of the figure" >&2
+    return 1
+  fi
 }
 
 @test "each arm runs the work its rate is a rate of" {
@@ -2145,7 +2200,7 @@ STUB
   timeout_skip_command=1
   stage "$tmp"
   stub_stamp
-  stamp_values='1000 1050 1050 1250'
+  stamp_values='1000 1050 1050 1250 1250 1300'
 
   run_canary
 
@@ -2161,6 +2216,55 @@ STUB
   # The zero device rather than any readable file: dd's read is what fills the
   # buffer this arm is timing the stores of.
   assert_file_contains 'dd if=/dev/zero of=/dev/null' "$capture"
+  # And the disk arm asks the kernel for the device rather than for the page
+  # cache. Without O_DIRECT the write lands in memory and returns, and the arm
+  # reports a healthy volume at any storage speed -- the one failure this
+  # collector cannot be allowed to have, since it exists to be the reading that
+  # stands alone on a red run with no green one beside it. The block size is
+  # pinned with it, because the rate is operations a second and an operation is
+  # only a 4 KiB one while dd is asked for 4 KiB.
+  assert_file_contains 'oflag=direct' "$capture"
+  assert_file_contains "bs=${COZY_CANARY_DISK_BLOCK_BYTES} count=${COZY_CANARY_DISK_BLOCKS}" "$capture"
+  rm -rf "$tmp"
+}
+
+@test "the disk arm writes outside the report it is written into" {
+  . hack/e2e-chainsaw/_lib/run-kubernetes.sh
+  tmp=$(mktemp -d)
+  timeout_calls="$tmp/timeout.calls"
+  timeout_skip_command=1
+  stage "$tmp"
+  stub_stamp
+  stamp_values='1000 1050 1050 1250 1250 1300'
+
+  run_canary
+
+  # An arm the ceiling stops leaves its file behind, and a file left inside the
+  # report ships in the artifact -- 16 MiB of zeroes in an archive read by
+  # people looking for a reason a run failed. A scratch path cannot, whatever
+  # happens to the removal, which is why the invariant is the path rather than
+  # the cleanup. The sandbox bringup shipped a Talos secret bundle into the
+  # tree it was writing to for the want of exactly this check.
+  capture=$(capture_path)
+  target=$(grep -oE 'of=[^ ]*cozy-canary-disk[^ ]*' "$capture" | head -n 1)
+  if [ -z "$target" ]; then
+    echo "FAIL: the capture does not record where the disk arm wrote; without it this guard checks nothing" >&2
+    cat "$capture" >&2
+    return 1
+  fi
+  case "${target#of=}" in
+    "$COZY_REPORT_DIR"*)
+      echo "FAIL: the disk arm writes to ${target#of=}, inside the report directory $COZY_REPORT_DIR; an arm stopped at its ceiling would ship its probe file in the artifact" >&2
+      return 1
+      ;;
+  esac
+  # And nothing is left behind on the path it did use. The stub skips the dd, so
+  # what this pins is the removal running at all rather than the size it
+  # reclaimed.
+  if [ -e "${target#of=}" ]; then
+    echo "FAIL: ${target#of=} survived the collector; the probe file is removed as soon as the arm returns" >&2
+    return 1
+  fi
   rm -rf "$tmp"
 }
 


### PR DESCRIPTION
This PR adds three readings to the runner fixed-work canary to collect data for #3513. Not for merge yet, I want an e2e run with these instruments on both green and red path first.

Every disk hypothesis on node-join was closed on byte counts, and a byte count says the transfer happened but not what it cost. Memory is the same story from the other side: the canary streams `dd` and reports bandwidth, which reads 12.6-14.4 GB/s on a green run and on a red one alike, while nothing anywhere measures latency. A page walk under nesting is up to 25 dependent memory references, so it is paid in miss latency and not in bandwidth.

Three arms:

- disk, 4096 single 4KiB writes with `oflag=direct`, so the rate is IOPS at queue depth one and its reciprocal is how long one write took to reach the volume. Without O_DIRECT the write lands in page cache and the arm would report a healthy volume at any storage speed.
- cache, a dependent walk over a working set larger than last level cache, in congruential order so the prefetcher can't follow it. The same walk over an L2 resident array runs 12.6x faster, so the arm is dominated by miss latency and not by mawk. A fixed stride is what a prefetcher is built to follow and would report bandwidth wearing a latency label, so the step and the slot count are both pinned by tests.
- host page backing, AnonHugePages against Rss per qemu process from `smaps_rollup`, plus thp policy and machine wide totals. It rides in the existing qemu thread probe because that walk already has each process open and its ceiling paid. qemu allocates lazily so a guest's backing is settled when it touches memory, minutes into a job, and defrag reads `madvise` in the sandbox image, which means plain anonymous memory gets huge pages only when they are already there.

All three sit in the canary rather than in a failure path collector because that is the only instrument that runs on the passing path too. Twelve of the seventeen captures a red report carries are failure path only, so they have no green side to be read against.

Canary ceiling goes 20s to 18s, and that is arithmetic. The phase budget guard prices this collector at one ceiling per arm, four arms at 20s put the collectors gated ahead of the serial console at 485s against a 480s budget, at 18s they come to 477s. Every floor still crosses inside it (compute 10.0s, cache 10.0s, disk 13.7s, memory 16.4s), and putting the ceiling back to 20 now fails that guard instead of silently overspending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded runner canary diagnostics to cover CPU, memory, disk latency, and cache performance.
  * Added configurable thresholds and workload sizing for storage and cache checks.
  * Enhanced diagnostic reports with storage, cache, process-memory, and host memory insights.
* **Bug Fixes**
  * Improved detection and reporting of disk-performance failures.
  * Ensured temporary disk test files are cleaned up and excluded from reports.
* **Tests**
  * Added comprehensive coverage for the new canary arms, thresholds, timeouts, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->