### PR TITLE
test(e2e): discriminator arm, same lean lane at 1.5x CPU oversubscription [DO NOT MERGE]

### DIFF
--- a/hack/e2e-prepare-cluster.bats
+++ b/hack/e2e-prepare-cluster.bats
@@ -102,7 +102,7 @@ EOF
     # thread; without it every thread reports the bare process name. QEMU only
     # renames threads when the flag is passed, so the capture's legend and its
     # fixtures are pinned to this line carrying it.
-    qemu-system-x86_64 -machine type=pc,accel=kvm -cpu host -smp 4 -m 24576 \
+    qemu-system-x86_64 -machine type=pc,accel=kvm -cpu host -smp 8 -m 24576 \
       -name guest=srv${i},debug-threads=on \
       -device virtio-net,netdev=net0,mac=52:54:00:12:34:5${i} \
       -netdev tap,id=net0,ifname=cozy-srv${i},script=no,downscript=no \


### PR DESCRIPTION
**Throwaway experiment. Not for merge.** Stacked on #3942; the diff against it is one character.

## Why this exists

#3942 changed two things at once and so cannot separate them. It cut oversubscription from 1.5x to 0.75x (`-smp 8` to `-smp 4`, so 24 vCPU threads to 12 against the runner's 16 physical cores) **and** it cut pod CPU requests from 16810m to 7310m by trimming the platform down to what the tenant-Kubernetes suites actually use.

On that branch all four tenant workers reached `Ready=True`:

| suite | worker | created | Ready | time to Ready |
|---|---|---|---|---|
| latest | m45xx | 18:23:01 | 18:25:37 | 2m36s |
| latest | bbfvw | 18:23:48 | 18:25:57 | 2m09s |
| previous | tcnfv | 18:50:04 | 18:50:54 | 50s |
| previous | 4zb5q | 18:50:00 | 18:51:41 | 1m41s |

against a 29 minute deadline, where in failing runs no worker reached Ready at all. Both changes reduce contention, so that result supports the capacity hypothesis without saying which half carried it.

## What this arm does

Holds the workload trim fixed and restores only the oversubscription, back to `-smp 8`.

- **Workers fail to join** means oversubscription is the cause. The fix is then a larger runner or fewer sandbox vCPUs, and this becomes the evidence for that ask rather than an assertion.
- **Workers join** means the workload was the cause. The fix is then the trim itself, which is ours to make and needs nobody's approval.

Either outcome is actionable, which is the point of running it.

## Notes for whoever reads the logs

The capacity preflight should read about 61% on this branch too, unchanged from #3942: allocatable triples while requests stay put. That is expected and is not a bug in the preflight. It guards against `Insufficient cpu`, which is a scheduler verdict on requests versus allocatable, and that is independent of how many host cores back those vCPUs.

`hack/sandbox-runner-headroom.bats` parses the `-smp` value out of `hack/e2e-prepare-cluster.bats`; it passes at 8, 13 assertions.

The suites are still expected to go red after node-join, on the tenant Kubernetes HelmRelease, because the `oidc-bootstrap` Job force-cleans chart-owned Keycloak objects even at `oidc.mode: None` and the Keycloak CRDs are absent while the platform OIDC feature is off. That failure is downstream of the measurement and does not affect it: the tenant Node objects carry their own `Ready` transition timestamps, which is where the table above comes from.

Refs #3513
