### PR TITLE
test(e2e): attribution arm, monitoring back on at 1.5x oversubscription [DO NOT MERGE]

### DIFF
--- a/hack/e2e-install-cozystack.bats
+++ b/hack/e2e-install-cozystack.bats
@@ -278,7 +278,6 @@ spec:
           # it closes the chain.
           disabledPackages:
             - cozystack.velero
-            - cozystack.monitoring-agents
             - cozystack.goldpinger
             - cozystack.backup-controller
             - cozystack.backupstrategy-controller
@@ -342,7 +341,16 @@ EOF
 }
 
 @test "Configure Tenant and wait for applications" {
-  # Capacity experiment (throwaway branch): monitoring and seaweedfs are off.
+  # Attribution arm (throwaway branch): monitoring is back ON, seaweedfs stays
+  # off, and -smp stays at 8. This is the only difference from the smp8 branch
+  # this one is stacked on, so whatever it changes is attributable to the
+  # monitoring stack: the VictoriaMetrics and VictoriaLogs clusters, Grafana
+  # and its CNPG database, Alerta, plus cozystack.monitoring-agents, which is
+  # re-enabled below because the per-node scrapers are the continuously-busy
+  # half of that load and the part most likely to matter to a booting guest.
+  #
+  # Original comment, still true of everything else:
+  # monitoring and seaweedfs are off.
   # Those flags are what created most of the ~5.3 CPU of tenant-root workload
   # (the VictoriaMetrics/VictoriaLogs clusters, Grafana plus its CNPG database,
   # Alerta and the SeaweedFS chain) that the tenant-Kubernetes suites never
@@ -361,16 +369,16 @@ EOF
   # would wedge the Tenant CR itself. Turning the instances off via the Tenant
   # spec is the lever that costs nothing.
   timeout 120 sh -ec 'until kubectl get tenants.apps.cozystack.io root -n tenant-root >/dev/null 2>&1; do sleep 2; done'
-  kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":false,"etcd":true,"isolated":true, "seaweedfs": false}}'
+  kubectl patch tenants/root -n tenant-root --type merge -p '{"spec":{"host":"example.org","ingress":true,"monitoring":true,"etcd":true,"isolated":true, "seaweedfs": false}}'
 
-  timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress tenant-root >/dev/null 2>&1; do sleep 1; done'
+  timeout 60 sh -ec 'until kubectl get hr -n tenant-root etcd ingress monitoring tenant-root >/dev/null 2>&1; do sleep 1; done'
   # tenant-root parent HR only flips Ready after every child HR is Ready, so
   # listing the one remaining top-level child plus the parent gives precise
   # failure messages without redundant separate waits. The 20m budget is kept
   # from the full-fat lane rather than tightened: it costs nothing in the happy
   # path, and a shorter timeout here would turn "slower than expected" into a
   # different failure than the one this branch exists to measure.
-  kubectl wait hr/etcd hr/ingress hr/tenant-root \
+  kubectl wait hr/etcd hr/ingress hr/monitoring hr/tenant-root \
     -n tenant-root --timeout=20m --for=condition=ready
 
   # etcd cluster. The v1alpha2 operator manages member Pods directly and creates

--- a/packages/core/platform/tests/capacity_experiment_system_test.yaml
+++ b/packages/core/platform/tests/capacity_experiment_system_test.yaml
@@ -10,7 +10,6 @@ set:
     naas: {enabled: false}
     disabledPackages:
       - cozystack.velero
-      - cozystack.monitoring-agents
       - cozystack.goldpinger
       - cozystack.backup-controller
       - cozystack.backupstrategy-controller
@@ -25,8 +24,6 @@ tests:
         not: true
       - containsDocument: {apiVersion: cozystack.io/v1alpha1, kind: Package, name: cozystack.goldpinger, any: true}
         not: true
-      - containsDocument: {apiVersion: cozystack.io/v1alpha1, kind: Package, name: cozystack.monitoring-agents, any: true}
-        not: true
       - containsDocument: {apiVersion: cozystack.io/v1alpha1, kind: Package, name: cozystack.backup-controller, any: true}
         not: true
       # dependsOn velero AND backup-controller; leaving it enabled while either
@@ -35,6 +32,9 @@ tests:
         not: true
   - it: keeps the dependsOn blockers and the tenant path
     asserts:
+      # re-enabled on this arm: the per-node scrapers are the subject of the
+      # attribution test, and they dependsOn vertical-pod-autoscaler, which stays
+      - containsDocument: {apiVersion: cozystack.io/v1alpha1, kind: Package, name: cozystack.monitoring-agents, any: true}
       - containsDocument: {apiVersion: cozystack.io/v1alpha1, kind: Package, name: cozystack.etcd-operator, any: true}
       - containsDocument: {apiVersion: cozystack.io/v1alpha1, kind: Package, name: cozystack.vertical-pod-autoscaler, any: true}
       - containsDocument: {apiVersion: cozystack.io/v1alpha1, kind: Package, name: cozystack.tenant-application, any: true}


### PR DESCRIPTION
**Throwaway experiment. Not for merge.** Stacked on #3943 so the diff is one variable.

## What changed against #3943

The root Tenant gets `monitoring: true`, and `cozystack.monitoring-agents` comes off the disabled list. Everything else is identical: seaweedfs off, `paas` and `naas` off, velero / goldpinger / backup-controller / backupstrategy-controller disabled, `-smp 8`. Whatever this arm changes is attributable to the monitoring stack alone.

## Why

Both earlier arms had all four tenant workers reach Ready well inside the 29 minute deadline:

| arm | oversubscription | time to Ready |
|---|---|---|
| #3942, `-smp 4` | 0.75x | 2m36s, 2m09s, 50s, 1m41s |
| #3943, `-smp 8` | 1.5x | 63s, 57s, 2m35s, 2m45s |

So vCPU oversubscription is **not** the discriminator. 1.5x is fine. What fixed node-join was the workload trim, not the `-smp` change. But the trim removed roughly 9.5 CPU of requests in one go, so it cannot say which part mattered.

The monitoring stack is the largest single block of that, at 2980m across the VictoriaMetrics and VictoriaLogs clusters, before Grafana with its CNPG database and Alerta. It is also the only block that is continuously busy rather than idle: `monitoring-agents` scrapes every pod on every node on an interval, and the storage side compresses and indexes that stream, so it burns cycles during exactly the seconds a tenant worker is trying to boot. An idle operator costs a reservation; an ingest pipeline costs the machine.

## Reading the result

Read it off the **tenant Node objects** in the report, not off the run conclusion.

- workers fail to join, then the monitoring stack is the cause and trimming it from this lane is the whole fix
- workers join, then monitoring is exonerated and the cost is spread across seaweedfs, the paas operators and the rest

Neither this arm nor #3943 carries the fix for the `oidc-bootstrap` Job failing on the absent `keycloakclient` CRD, so both suites can go red on that regardless of what node-join does. Leaving it unfixed is deliberate: it keeps this a one-variable change against the branch it is stacked on.

## Caveat that bounds all three arms

The pre-trim baseline was **intermittently** green, not reliably red. So no single arm settles anything; these are samples, and the reruns on #3942 and #3943 exist to accumulate more.

## Verification

Platform helm-unittest 36 suites / 144 tests pass, with the system-bundle suite updated to expect `monitoring-agents` present. Dependency closure over every PackageSource against the disable set is clean: the two remaining `keycloak` edges live only on `oidc` variants and OIDC is off here.
