### PR TITLE
test(kubernetes): vGIF host-draw lane 3 [DO NOT MERGE]

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -942,6 +942,39 @@ jobs:
           done
           echo "Prepare environment completed after $((attempt + 1)) attempts"
 
+      # DRAW GATE -- present only on the vGIF hunt lanes, never on main.
+      #
+      # Virtual GIF is exposed to roughly one host in eleven in this pool, and no
+      # run without it has passed a tenant-Kubernetes suite. Finding a host that
+      # has one means drawing repeatedly, and a draw that is only readable once
+      # the job ends costs a full run: install plus the 29 minute node-join wait
+      # before the miss is even visible. GitHub serves no log for a job still in
+      # progress, so the reading cannot be taken from outside either.
+      #
+      # So the draw is decided here instead, seconds after `prepare-env` wrote the
+      # record, and a miss ends the job rather than the run continuing to a
+      # failure already measured 62 times. A hit falls through and everything
+      # after this point is main's code, unmodified, which is the run that matters.
+      - name: Require Virtual GIF on this host (draw gate)
+        run: |
+          record=_out/runner-identity.txt
+          if [ ! -f "$record" ]; then
+            echo "::error title=draw gate::$record is missing, so the draw cannot be read"
+            exit 1
+          fi
+          features=$(sed -n 's/^svm features: //p' "$record")
+          echo "svm features: ${features:-<line absent>}"
+          # Whole-word match: `vgif` must not be read out of some longer flag.
+          case " $features " in
+            *' vgif '*)
+              echo "::notice title=draw gate::HIT -- this host exposes Virtual GIF, continuing"
+              ;;
+            *)
+              echo "::error title=draw gate::MISS -- no Virtual GIF on this host; ending the job here rather than spending an install and a 29m node-join wait on a failure already measured"
+              exit 1
+              ;;
+          esac
+
       # ▸ Install Cozystack
       - name: Install Cozystack into sandbox
         run: |

--- a/packages/apps/kubernetes/tests/oidc_test.yaml
+++ b/packages/apps/kubernetes/tests/oidc_test.yaml
@@ -570,3 +570,6 @@ tests:
     asserts:
       - failedTemplate:
           errorMessage: "spec.oidc.customConfig: set exactly one of `config` (inline) or `secretRef.name` — they are mutually exclusive."
+# vGIF host-draw lane 3. Inert comment: this file is chosen only because
+# hack/select-e2e.sh maps this path to the tenant-Kubernetes suites, so the e2e
+# runs unmodified main code and reports which host it landed on.


### PR DESCRIPTION
**Not for merge.** Comment only, appended to a helm-unittest file. Nothing in this diff changes behaviour.

The point is to open a pull request whose e2e runs unmodified `main` code, so the runner identity record it prints says which host the lane drew. `hack/select-e2e.sh` maps this path to the tenant-Kubernetes suites, which is why this file rather than a README: a docs-only change selects nothing and never reaches a runner.

Virtual GIF is exposed to roughly one Oracle host in eleven, and no run without it has passed a tenant-Kubernetes suite (0 of 62, against 11 of 12 with it). The exit-rate comparison that would turn that correlation into a mechanism needs one run that lands on a host which has it, and the instrument that would show it postdates every archived green run. So this draws for one.

The reading arrives in the `Prepare environment` step, where #3945's capture prints `svm features:` before the sandbox starts. A lane that drew a host without `vgif` gets an empty commit pushed to it, which cancels the run and redraws; a lane that drew one with it is left to finish.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added informational comments identifying the OIDC test suite’s role in end-to-end test host selection.
  * No test behavior, assertions, or application functionality changed.

* **Chores**
  * Added a validation gate to ensure eligible environments are selected before installation and end-to-end test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->