### PR TITLE
fix(kubeovn-webhook): restrict the webhook port to the API server

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -99,6 +99,7 @@ jobs:
               'vpn':                 'area/networking',
               'metallb':             'area/networking',
               'kube-ovn':            'area/networking',
+              'kubeovn-webhook':     'area/networking',
               'tcp-balancer':        'area/networking',
               'securitygroups':      'area/networking',
               'cozy-proxy':          'area/networking',

--- a/packages/system/kubeovn-webhook/templates/_helpers.tpl
+++ b/packages/system/kubeovn-webhook/templates/_helpers.tpl
@@ -5,3 +5,14 @@ kube-ovn-webhook
 {{- define "namespace-annotation-webhook.fullname" -}}
 kube-ovn-webhook
 {{- end }}
+
+{{/*
+The port the webhook serves on. Defined once and consumed by the container
+port, the Service targetPort and the CiliumNetworkPolicy, because those three
+must agree: the policy has default-deny disabled, so a policy pointed at a port
+nothing serves denies nothing while the real port stays open -- a drift that
+removes the control silently rather than breaking anything visibly.
+*/}}
+{{- define "namespace-annotation-webhook.port" -}}
+8443
+{{- end }}

--- a/packages/system/kubeovn-webhook/templates/deployment.yaml
+++ b/packages/system/kubeovn-webhook/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
               cpu: 100m
               memory: 128Mi
           ports:
-            - containerPort: 8443
+            - containerPort: {{ include "namespace-annotation-webhook.port" . }}
               name: https
           volumeMounts:
             - name: webhook-certs

--- a/packages/system/kubeovn-webhook/templates/networkpolicy.yaml
+++ b/packages/system/kubeovn-webhook/templates/networkpolicy.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.webhookPolicy.enabled }}
+---
+# The /mutate-pods handler answers whoever asks it with namespace-derived
+# annotations, and only the API server has any business calling it
+# (GHSA-g883-q79m-8225). Client-certificate verification cannot close this on
+# its own: enabling --client-ca-file requires the API server to *present* a
+# certificate, which it does only when its AdmissionConfiguration names a
+# kubeConfigFile for the webhook plugins. A stock Cozystack control plane ships
+# a PodSecurity plugin block and nothing else, so no certificate is offered and
+# RequireAndVerifyClientCert would reject the API server itself -- with
+# failurePolicy: Fail that stops pod creation cluster-wide. Until that changes,
+# the network is the only place the caller can actually be constrained.
+#
+# This is a CiliumNetworkPolicy, not a core NetworkPolicy, and the distinction
+# is the whole reason it works: packages/system/kubeovn/values.yaml sets
+# ENABLE_NP: false, so kube-ovn programs no ACLs and a core NetworkPolicy would
+# be created and never enforced. Cilium enforces its own policies regardless,
+# which is why the platform already relies on them elsewhere.
+#
+# Deny-only, with default-deny explicitly disabled. A Cilium rule carrying an
+# ingress section puts the selected endpoints behind a default-deny, which here
+# would mean enumerating every port these pods serve and silently breaking
+# traffic on the first one forgotten. Subtracting one port leaves everything
+# else exactly as it was.
+#
+# The API server needs no carve-out: it runs on the host network, so it is not
+# a Cilium endpoint and fromEndpoints never matches it. Unlike the ingress-nginx
+# admission webhook, this component exists only on the management cluster, so
+# there is no konnectivity-tunnelled caller to exempt either.
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: {{ include "namespace-annotation-webhook.name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "namespace-annotation-webhook.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  enableDefaultDeny:
+    ingress: false
+    egress: false
+  ingressDeny:
+  # Every pod in the cluster. The namespace key is matched with Exists so the
+  # rule spans all namespaces: a plain fromEndpoints in a namespaced
+  # CiliumNetworkPolicy would only ever select pods sharing this policy's
+  # namespace, which would leave the webhook open to every other one.
+  - fromEndpoints:
+    - matchExpressions:
+      - key: k8s:io.kubernetes.pod.namespace
+        operator: Exists
+    toPorts:
+    - ports:
+      - port: {{ .Values.webhookPolicy.port | quote }}
+        protocol: TCP
+  - fromEntities:
+    - world
+    toPorts:
+    - ports:
+      - port: {{ .Values.webhookPolicy.port | quote }}
+        protocol: TCP
+{{- end }}

--- a/packages/system/kubeovn-webhook/templates/networkpolicy.yaml
+++ b/packages/system/kubeovn-webhook/templates/networkpolicy.yaml
@@ -1,32 +1,44 @@
 {{- if .Values.webhookPolicy.enabled }}
 ---
-# The /mutate-pods handler answers whoever asks it with namespace-derived
-# annotations, and only the API server has any business calling it
-# (GHSA-g883-q79m-8225). Client-certificate verification cannot close this on
-# its own: enabling --client-ca-file requires the API server to *present* a
-# certificate, which it does only when its AdmissionConfiguration names a
-# kubeConfigFile for the webhook plugins. A stock Cozystack control plane ships
-# a PodSecurity plugin block and nothing else, so no certificate is offered and
-# RequireAndVerifyClientCert would reject the API server itself -- with
-# failurePolicy: Fail that stops pod creation cluster-wide. Until that changes,
-# the network is the only place the caller can actually be constrained.
-#
-# This is a CiliumNetworkPolicy, not a core NetworkPolicy, and the distinction
-# is the whole reason it works: packages/system/kubeovn/values.yaml sets
-# ENABLE_NP: false, so kube-ovn programs no ACLs and a core NetworkPolicy would
-# be created and never enforced. Cilium enforces its own policies regardless,
-# which is why the platform already relies on them elsewhere.
-#
-# Deny-only, with default-deny explicitly disabled. A Cilium rule carrying an
-# ingress section puts the selected endpoints behind a default-deny, which here
-# would mean enumerating every port these pods serve and silently breaking
-# traffic on the first one forgotten. Subtracting one port leaves everything
-# else exactly as it was.
-#
-# The API server needs no carve-out: it runs on the host network, so it is not
-# a Cilium endpoint and fromEndpoints never matches it. Unlike the ingress-nginx
-# admission webhook, this component exists only on the management cluster, so
-# there is no konnectivity-tunnelled caller to exempt either.
+{{/*
+The /mutate-pods handler answers whoever asks it with namespace-derived
+annotations, and only the API server has any business calling it
+(GHSA-g883-q79m-8225). Client-certificate verification cannot close this on
+its own: enabling --client-ca-file requires the API server to *present* a
+certificate, which it does only when its AdmissionConfiguration names a
+kubeConfigFile for the webhook plugins. A stock Cozystack control plane ships
+a PodSecurity plugin block and nothing else, so no certificate is offered and
+RequireAndVerifyClientCert would reject the API server itself -- with
+failurePolicy: Fail that stops pod creation cluster-wide. Until that changes,
+the network is the only place the caller can actually be constrained.
+
+This is a CiliumNetworkPolicy, not a core NetworkPolicy, and the distinction
+is the whole reason it works: packages/system/kubeovn/values.yaml sets
+ENABLE_NP: false, so kube-ovn programs no ACLs and a core NetworkPolicy would
+be created and never enforced. Cilium enforces its own policies regardless,
+which is why the platform already relies on them elsewhere.
+
+Deny-only, with default-deny explicitly disabled. A Cilium rule carrying an
+ingress section puts the selected endpoints behind a default-deny, which here
+would mean enumerating every port these pods serve and silently breaking
+traffic on the first one forgotten. Subtracting one port leaves everything
+else exactly as it was.
+
+The API server needs no carve-out, and this was confirmed on a live kube-ovn
+cluster rather than reasoned about: cilium monitor on the webhook's endpoint
+shows the API server's connection arriving from the node InternalIP with
+identity "host" when it originates on the same node and "kube-apiserver" when
+it originates on another, never from the kube-ovn join subnet and never as
+"world". Neither identity is a Cilium endpoint, so fromEndpoints cannot match
+it and the world deny does not apply to it. Unlike the ingress-nginx admission
+webhook, this component exists only on the management cluster, so there is no
+konnectivity-tunnelled caller to exempt either.
+
+Note the scope this actually has: it removes in-cluster pods and external
+traffic, not every possible caller. Any host-network workload on the
+management cluster carries the same host / remote-node identity that exempts
+the API server and keeps its reach.
+*/}}
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -39,24 +51,25 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   enableDefaultDeny:
     ingress: false
-    egress: false
   ingressDeny:
-  # Every pod in the cluster. The namespace key is matched with Exists so the
-  # rule spans all namespaces: a plain fromEndpoints in a namespaced
-  # CiliumNetworkPolicy would only ever select pods sharing this policy's
-  # namespace, which would leave the webhook open to every other one.
+{{- /*
+Every pod in the cluster. The namespace key is matched with Exists so the rule
+spans all namespaces: a plain fromEndpoints in a namespaced
+CiliumNetworkPolicy would only ever select pods sharing this policy's
+namespace, which would leave the webhook open to every other one.
+*/}}
   - fromEndpoints:
     - matchExpressions:
       - key: k8s:io.kubernetes.pod.namespace
         operator: Exists
     toPorts:
     - ports:
-      - port: {{ .Values.webhookPolicy.port | quote }}
+      - port: {{ include "namespace-annotation-webhook.port" . | quote }}
         protocol: TCP
   - fromEntities:
     - world
     toPorts:
     - ports:
-      - port: {{ .Values.webhookPolicy.port | quote }}
+      - port: {{ include "namespace-annotation-webhook.port" . | quote }}
         protocol: TCP
 {{- end }}

--- a/packages/system/kubeovn-webhook/templates/service.yaml
+++ b/packages/system/kubeovn-webhook/templates/service.yaml
@@ -9,7 +9,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 443
-      targetPort: 8443
+      targetPort: {{ include "namespace-annotation-webhook.port" . }}
       protocol: TCP
       name: https
   selector:

--- a/packages/system/kubeovn-webhook/tests/networkpolicy_test.yaml
+++ b/packages/system/kubeovn-webhook/tests/networkpolicy_test.yaml
@@ -1,0 +1,88 @@
+suite: kubeovn-webhook exposure
+release:
+  name: kubeovn-webhook
+  namespace: cozy-kubeovn
+templates:
+  - templates/networkpolicy.yaml
+tests:
+  - it: denies pod traffic to the webhook port
+    # The /mutate-pods handler returns namespace-derived annotations to any
+    # caller that reaches it (GHSA-g883-q79m-8225), so closing the port to pods
+    # is the whole point of the object.
+    asserts:
+      - equal:
+          path: spec.ingressDeny[0].toPorts[0].ports[0].port
+          value: "8443"
+      - equal:
+          path: spec.ingressDeny[0].toPorts[0].ports[0].protocol
+          value: TCP
+
+  - it: spans every namespace rather than only the release namespace
+    # A bare fromEndpoints in a namespaced CiliumNetworkPolicy selects only pods
+    # in the policy's own namespace, which would leave the webhook reachable
+    # from every other one — the exact gap being closed.
+    asserts:
+      - contains:
+          path: spec.ingressDeny[0].fromEndpoints[0].matchExpressions
+          content:
+            key: k8s:io.kubernetes.pod.namespace
+            operator: Exists
+
+  - it: carries no label-based exemption
+    # There is no caller to carve out: the API server runs on the host network
+    # and is therefore not a Cilium endpoint, so fromEndpoints never matches it.
+    # A label exemption would be both unnecessary and forgeable — any workload
+    # can set a pod label on itself, and with default-deny disabled, falling out
+    # of the deny is the entire access decision.
+    asserts:
+      - lengthEqual:
+          path: spec.ingressDeny[0].fromEndpoints[0].matchExpressions
+          count: 1
+      - lengthEqual:
+          path: spec.ingressDeny[0].fromEndpoints
+          count: 1
+
+  - it: denies world traffic to the webhook port
+    asserts:
+      - contains:
+          path: spec.ingressDeny[1].fromEntities
+          content: world
+      - equal:
+          path: spec.ingressDeny[1].toPorts[0].ports[0].port
+          value: "8443"
+
+  - it: does not put the webhook behind a default deny
+    # Enabling default-deny would require enumerating every port these pods
+    # serve and would break traffic on the first one omitted.
+    asserts:
+      - equal:
+          path: spec.enableDefaultDeny.ingress
+          value: false
+      - equal:
+          path: spec.enableDefaultDeny.egress
+          value: false
+      - isNull:
+          path: spec.ingress
+
+  - it: is a CiliumNetworkPolicy rather than a core NetworkPolicy
+    # kube-ovn runs with ENABLE_NP: false, so a core NetworkPolicy would be
+    # created and never enforced. Cilium enforces its own policies regardless.
+    asserts:
+      - isKind:
+          of: CiliumNetworkPolicy
+      - equal:
+          path: apiVersion
+          value: cilium.io/v2
+
+  - it: selects only the webhook pods
+    asserts:
+      - equal:
+          path: spec.endpointSelector.matchLabels["app.kubernetes.io/instance"]
+          value: kubeovn-webhook
+
+  - it: can be disabled where no Cilium is present to enforce it
+    set:
+      webhookPolicy.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/packages/system/kubeovn-webhook/tests/networkpolicy_test.yaml
+++ b/packages/system/kubeovn-webhook/tests/networkpolicy_test.yaml
@@ -58,9 +58,6 @@ tests:
       - equal:
           path: spec.enableDefaultDeny.ingress
           value: false
-      - equal:
-          path: spec.enableDefaultDeny.egress
-          value: false
       - isNull:
           path: spec.ingress
 

--- a/packages/system/kubeovn-webhook/tests/port_agreement_test.yaml
+++ b/packages/system/kubeovn-webhook/tests/port_agreement_test.yaml
@@ -1,0 +1,32 @@
+suite: kubeovn-webhook port agreement
+release:
+  name: kubeovn-webhook
+  namespace: cozy-kubeovn
+templates:
+  - templates/networkpolicy.yaml
+  - templates/deployment.yaml
+  - templates/service.yaml
+tests:
+  - it: protects exactly the port the webhook serves and the Service routes to
+    # The regression guard for the one drift that fails open. The policy runs
+    # with default-deny disabled, so a policy port that disagrees with the
+    # container port denies a port nothing serves and leaves the real one
+    # reachable -- the control disappears without anything breaking visibly.
+    # All three render from namespace-annotation-webhook.port for that reason.
+    asserts:
+      - equal:
+          path: spec.ingressDeny[0].toPorts[0].ports[0].port
+          value: "8443"
+        template: templates/networkpolicy.yaml
+      - equal:
+          path: spec.ingressDeny[1].toPorts[0].ports[0].port
+          value: "8443"
+        template: templates/networkpolicy.yaml
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8443
+        template: templates/deployment.yaml
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 8443
+        template: templates/service.yaml

--- a/packages/system/kubeovn-webhook/values.yaml
+++ b/packages/system/kubeovn-webhook/values.yaml
@@ -43,7 +43,11 @@ image: ghcr.io/cozystack/cozystack/kubeovn-webhook:v1.6.0@sha256:593c324a38db594
 # ENABLE_NP: false, so a core NetworkPolicy object would be created and never
 # enforced. Set enabled: false on a cluster whose networking variant ships no
 # Cilium, where the object would have no controller to act on it.
+# The port is deliberately not configurable here. It has to agree with the
+# container port and the Service targetPort, and because the policy runs with
+# default-deny disabled, a disagreement fails open: the policy would deny a port
+# nothing serves while the real one stayed reachable, removing this control
+# without breaking anything visible. All three read one definition instead --
+# see namespace-annotation-webhook.port in templates/_helpers.tpl.
 webhookPolicy:
   enabled: true
-  # Container port the webhook serves on; matches the deployment's containerPort.
-  port: 8443

--- a/packages/system/kubeovn-webhook/values.yaml
+++ b/packages/system/kubeovn-webhook/values.yaml
@@ -4,10 +4,12 @@ routes: ""
 #
 # The handler returns namespace-derived annotations to whoever asks it, so the
 # only thing that keeps it from answering an arbitrary in-cluster pod is
-# authenticating the caller (GHSA-g883-q79m-8225). NetworkPolicy is not an
-# option here: packages/system/kubeovn/values.yaml sets ENABLE_NP: false, so
-# kube-ovn-controller programs no ACLs and a NetworkPolicy object would be
-# created and never enforced.
+# authenticating the caller (GHSA-g883-q79m-8225), or constraining who can
+# reach it at all -- see webhookPolicy below, which does the latter. A *core*
+# NetworkPolicy is not an option here: packages/system/kubeovn/values.yaml sets
+# ENABLE_NP: false, so kube-ovn-controller programs no ACLs and the object would
+# be created and never enforced. A CiliumNetworkPolicy is enforced by Cilium
+# regardless, which is the path webhookPolicy takes.
 #
 # Empty (the default) = certificates are requested and logged, never required.
 # Nothing is rejected, so this cannot break admission. Read the webhook log:
@@ -27,3 +29,21 @@ routes: ""
 # observation above can run, not so it can be switched on.
 clientCAFile: ""
 image: ghcr.io/cozystack/cozystack/kubeovn-webhook:v1.6.0@sha256:593c324a38db59495497c5b68b90cad25dfe6753c73b7a287b3280e26f70a15f
+
+# Restrict who may reach the webhook's serving port.
+#
+# The handler returns namespace-derived annotations to any caller, and only the
+# API server should be calling it. clientCAFile above cannot enforce that on a
+# stock control plane -- the API server presents no client certificate unless
+# its AdmissionConfiguration names a kubeConfigFile for the webhook plugins,
+# and a stock Cozystack control plane ships only a PodSecurity block. Until
+# that changes, this policy is the enforcement.
+#
+# Rendered as a CiliumNetworkPolicy on purpose: kube-ovn runs with
+# ENABLE_NP: false, so a core NetworkPolicy object would be created and never
+# enforced. Set enabled: false on a cluster whose networking variant ships no
+# Cilium, where the object would have no controller to act on it.
+webhookPolicy:
+  enabled: true
+  # Container port the webhook serves on; matches the deployment's containerPort.
+  port: 8443


### PR DESCRIPTION
## What this PR does

Closes the exposure behind GHSA-g883-q79m-8225 by constraining who can reach the kube-ovn webhook's serving port. The `/mutate-pods` handler returns namespace-derived annotations to any caller that reaches it, and until now nothing stopped an arbitrary in-cluster pod from being that caller.

### Why the client-certificate path does not close it

cozystack/cozystack#2698 added `--client-ca-file`, deliberately off by default, as observation mode. Turning it on requires the API server to **present** a certificate, which it does only when its `AdmissionConfiguration` names a `kubeConfigFile` for the webhook plugins.

Checked against a running Cozystack control plane rather than assumed: the `AdmissionConfiguration` there carries a `PodSecurity` plugin block and nothing else, so no client certificate is offered to admission webhooks at all. Flipping to `RequireAndVerifyClientCert` on such a cluster would reject the API server itself, and with `failurePolicy: Fail` that stops pod creation cluster-wide.

This matters for how the remaining work was scoped: the plan had been to observe issuer logs for a day and then pin a CA. No amount of observation changes the outcome, because the absence is a property of the control plane's configuration, not of the traffic. Making `--client-ca-file` usable is a separate, larger change to how the platform configures the API server, and it is not a prerequisite for closing the exposure.

### What the policy does

Denies pod traffic and world traffic to the serving port, and needs no carve-out for the legitimate caller: the API server runs on the host network, so it is not a Cilium endpoint and `fromEndpoints` never matches it. Unlike the ingress-nginx admission webhook this component exists only on the management cluster, so there is no konnectivity-tunnelled caller to exempt either — and consequently no forgeable pod label anywhere in the selector.

It is a `CiliumNetworkPolicy` rather than a core `NetworkPolicy`, and that distinction is the reason it works at all: `packages/system/kubeovn/values.yaml` sets `ENABLE_NP: false`, so kube-ovn programs no ACLs and a core NetworkPolicy would be created and never enforced. The values comment that claimed NetworkPolicy was simply not an option is corrected — it was true only of the core kind. `webhookPolicy.enabled` lets a cluster whose networking variant ships no Cilium turn the object off.

Deny-only with default-deny explicitly disabled, matching the ingress-nginx admission policy: putting these pods behind a default-deny would mean enumerating every port they serve and breaking traffic on the first one forgotten.

### Verification

Eight helm-unittest cases cover the port, the all-namespaces span, the absence of any label-based exemption, the world deny, the disabled default-deny, the Cilium kind, the selector and the off switch. The rendered object was additionally accepted by a live API server via `kubectl apply --dry-run=server`, so the CRD validates it as written.

Not verified: that a denied pod actually fails to reach the port at runtime. That needs a live negative test against the policy, which is the same gap the ingress-nginx admission policy carries.

### Screenshots

Not applicable — no UI change.

### Downstream repositories

Walked the trigger map against the diff. Nothing is reached: the change is one chart template, its values and its tests under `packages/system/`, with no package added or removed under `packages/apps/` or `packages/extra/`, no `packages/core/platform/values.yaml` key, no platform variant or bundle change, nothing under `hack/`, and no node prerequisite.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(kubeovn-webhook): the kube-ovn webhook's serving port is now closed to in-cluster pods and external traffic by a CiliumNetworkPolicy. It previously answered any in-cluster pod with namespace-derived annotations (GHSA-g883-q79m-8225). Disable with webhookPolicy.enabled=false on clusters whose networking variant ships no Cilium.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Cilium network policy to protect the namespace-annotation webhook.
  * The policy is enabled by default and restricts access to the webhook port, blocking unauthorized in-cluster and external traffic.
  * Standardized the webhook port across its deployment, service, and network policy configuration.

* **Bug Fixes**
  * Improved webhook network isolation when standard Kubernetes NetworkPolicy enforcement is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
