### PR TITLE
fix(api): repair an empty required field instead of failing the release

### DIFF
--- a/pkg/registry/apps/application/rest.go
+++ b/pkg/registry/apps/application/rest.go
@@ -202,6 +202,20 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		return nil, apierrors.NewBadRequest(err.Error())
 	}
 
+	// An empty key in the spec (`registryMirrors:` with nothing under it)
+	// arrives here as a JSON null, and Helm's coalescing deletes it together
+	// with the chart default underneath it - which fails the render outright
+	// for a field the schema requires. Repair those before admission, storage
+	// and the emitted HelmRelease see the object; a null on a field the schema
+	// allows to be absent keeps the meaning it has today.
+	emptied, err := r.normalizeSpecNulls(app)
+	if err != nil {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("failed to normalize spec: %v", err))
+	}
+	if len(emptied) > 0 {
+		warning.AddWarning(ctx, "", emptyFieldsWarning(emptied))
+	}
+
 	r.warnLegacyPresets(app)
 	r.warnRemovedKubernetesFields(ctx, app)
 
@@ -539,6 +553,16 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 	// Validate that values don't contain reserved keys (starting with "_")
 	if err := validateNoInternalKeys(app.Spec); err != nil {
 		return nil, false, apierrors.NewBadRequest(err.Error())
+	}
+
+	// Same normalization as on create: an empty key on a required field means
+	// the field was left unset, not that the chart default should be deleted.
+	emptied, err := r.normalizeSpecNulls(app)
+	if err != nil {
+		return nil, false, apierrors.NewBadRequest(fmt.Sprintf("failed to normalize spec: %v", err))
+	}
+	if len(emptied) > 0 {
+		warning.AddWarning(ctx, "", emptyFieldsWarning(emptied))
 	}
 
 	// Enforce hierarchical quota allocation on quota changes too: raising a

--- a/pkg/registry/apps/application/rest.go
+++ b/pkg/registry/apps/application/rest.go
@@ -171,6 +171,8 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		return nil, fmt.Errorf("expected *appsv1alpha1.Application object, got %T", obj)
 	}
 
+	app = app.DeepCopy()
+
 	// Validate Application name format (DNS-1035 plus any kind-specific rules)
 	if errs := r.validateNameFormat(app.Name); len(errs) > 0 {
 		return nil, apierrors.NewInvalid(r.gvk.GroupKind(), app.Name, errs)
@@ -202,12 +204,8 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		return nil, apierrors.NewBadRequest(err.Error())
 	}
 
-	// An empty key in the spec (`registryMirrors:` with nothing under it)
-	// arrives here as a JSON null, and Helm's coalescing deletes it together
-	// with the chart default underneath it - which fails the render outright
-	// for a field the schema requires. Repair those before admission, storage
-	// and the emitted HelmRelease see the object; a null on a field the schema
-	// allows to be absent keeps the meaning it has today.
+	// Omission permits a chart default; explicit null suppresses it in Helm.
+	// Normalize only repairable fields before admission and persistence.
 	emptied, err := r.normalizeSpecNulls(app)
 	if err != nil {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("failed to normalize spec: %v", err))
@@ -228,7 +226,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	// this hook explicitly — unlike genericregistry.Store, which
 	// wires it automatically.
 	if createValidation != nil {
-		if err := createValidation(ctx, obj); err != nil {
+		if err := createValidation(ctx, app); err != nil {
 			return nil, err
 		}
 	}
@@ -531,20 +529,14 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 		return nil, false, err
 	}
 
-	// Validate the update if a validation function is provided
-	if updateValidation != nil {
-		if err := updateValidation(ctx, newObj, oldObj); err != nil {
-			klog.Errorf("Update validation failed for Application %s: %v", name, err)
-			return nil, false, err
-		}
-	}
-
 	// Assert the new object is of type Application
 	app, ok := newObj.(*appsv1alpha1.Application)
 	if !ok {
 		klog.Errorf("expected *appsv1alpha1.Application object, got %T", newObj)
 		return nil, false, fmt.Errorf("expected *appsv1alpha1.Application object, got %T", newObj)
 	}
+
+	app = app.DeepCopy()
 
 	// Note: name validation (DNS-1035 format + length) is intentionally skipped on
 	// Update because Kubernetes names are immutable. Validating here would block
@@ -555,14 +547,21 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 		return nil, false, apierrors.NewBadRequest(err.Error())
 	}
 
-	// Same normalization as on create: an empty key on a required field means
-	// the field was left unset, not that the chart default should be deleted.
+	// Admission must validate the same normalized values that will be stored.
 	emptied, err := r.normalizeSpecNulls(app)
 	if err != nil {
 		return nil, false, apierrors.NewBadRequest(fmt.Sprintf("failed to normalize spec: %v", err))
 	}
 	if len(emptied) > 0 {
 		warning.AddWarning(ctx, "", emptyFieldsWarning(emptied))
+	}
+
+	// Validate the update if a validation function is provided
+	if updateValidation != nil {
+		if err := updateValidation(ctx, app, oldObj); err != nil {
+			klog.Errorf("Update validation failed for Application %s: %v", name, err)
+			return nil, false, err
+		}
 	}
 
 	// Enforce hierarchical quota allocation on quota changes too: raising a

--- a/pkg/registry/apps/application/rest_nullstrip.go
+++ b/pkg/registry/apps/application/rest_nullstrip.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	appsv1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+)
+
+// maxWarnedNullPaths bounds the number of field paths named in the warning
+// handed back to the client, so a spec that nulls out dozens of fields does not
+// turn into a multi-kilobyte response header.
+const maxWarnedNullPaths = 8
+
+// normalizeSpecNulls repairs a JSON null on a field the schema marks required,
+// by removing the key so the chart's own default applies to it.
+//
+// The spec reaches flux verbatim as HelmRelease .spec.values (see
+// convertApplicationToHelmRelease), and Helm's value coalescing deletes a
+// null-valued key together with the chart default underneath it, before the
+// result is validated against values.schema.json. A required field written with
+// nothing under it is therefore rejected for being absent - "at '/talos':
+// missing property 'registryMirrors'", naming a property the spec does contain -
+// and the whole release fails to render. Nothing reaches the user that would
+// point at the empty key they actually typed.
+//
+// Only required properties are repaired, and that boundary is the point. A
+// required property's null cannot be load-bearing for anyone, because today it
+// fails the render outright; resolving it to the chart default is pure repair.
+// Where the schema permits the field to be absent, a null keeps the meaning it
+// has today - the chart default is suppressed and the key does not reach the
+// template - and that meaning is worth keeping: 167 optional fields across the
+// catalogue carry a non-trivial default, placeholders such as "<password>" and
+// example S3 buckets among them, so resolving a user's null to one of those
+// would be worse than leaving the key out.
+//
+// Filling in the schema default instead of removing the key would also pin
+// today's value into the stored HelmRelease and freeze the application on it,
+// so a later bump of that default in the chart would never reach an application
+// that had once been created with an empty key.
+//
+// Free-form subtrees are left alone, as is a null map entry whose key the user
+// chose (a node group, a registry host): there the null may be the payload, and
+// dropping the entry would drop the user's intent along with it. Array elements
+// keep their positions for the same reason.
+//
+// Returns the dotted paths that were removed, sorted, so the caller can tell
+// the user what happened to them.
+func (r *REST) normalizeSpecNulls(app *appsv1alpha1.Application) ([]string, error) {
+	if r.specSchema == nil || app == nil || app.Spec == nil || len(app.Spec.Raw) == 0 {
+		return nil, nil
+	}
+	var spec map[string]any
+	if err := json.Unmarshal(app.Spec.Raw, &spec); err != nil {
+		return nil, err
+	}
+	if spec == nil {
+		return nil, nil
+	}
+
+	var stripped []string
+	stripDeclaredNulls(spec, r.specSchema, "", &stripped)
+	if len(stripped) == 0 {
+		return nil, nil
+	}
+
+	raw, err := json.Marshal(spec)
+	if err != nil {
+		return nil, err
+	}
+	app.Spec = &apiextv1.JSON{Raw: raw}
+	sort.Strings(stripped)
+	return stripped, nil
+}
+
+// stripDeclaredNulls walks a value alongside its structural schema, deleting
+// every null whose key the schema declares as a property *and* lists as
+// required. Dispatch is on the shape of the value rather than on schema.Type,
+// which is empty for a schema that carries only properties or only items.
+func stripDeclaredNulls(v any, s *structuralschema.Structural, path string, stripped *[]string) {
+	if s == nil || v == nil {
+		return
+	}
+
+	switch value := v.(type) {
+	case map[string]any:
+		required := requiredNames(s)
+		// Keys are collected up front: the loop deletes from the map it walks,
+		// and a sorted walk keeps the reported paths stable across calls.
+		for _, name := range sortedKeys(value) {
+			child := value[name]
+			if prop, declared := s.Properties[name]; declared {
+				if child == nil {
+					if _, mustBeSet := required[name]; mustBeSet {
+						delete(value, name)
+						*stripped = append(*stripped, joinFieldPath(path, name))
+					}
+					continue
+				}
+				stripDeclaredNulls(child, &prop, joinFieldPath(path, name), stripped)
+				continue
+			}
+			if s.AdditionalProperties != nil && s.AdditionalProperties.Structural != nil {
+				stripDeclaredNulls(child, s.AdditionalProperties.Structural, joinFieldPath(path, name), stripped)
+			}
+		}
+	case []any:
+		if s.Items == nil {
+			return
+		}
+		for i := range value {
+			stripDeclaredNulls(value[i], s.Items, fmt.Sprintf("%s[%d]", path, i), stripped)
+		}
+	}
+}
+
+// requiredNames returns the property names the schema marks required. The
+// validation half of a structural schema is an optional pointer, absent for
+// every schema that constrains nothing.
+func requiredNames(s *structuralschema.Structural) map[string]struct{} {
+	if s.ValueValidation == nil || len(s.ValueValidation.Required) == 0 {
+		return nil
+	}
+	names := make(map[string]struct{}, len(s.ValueValidation.Required))
+	for _, name := range s.ValueValidation.Required {
+		names[name] = struct{}{}
+	}
+	return names
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func joinFieldPath(path, name string) string {
+	if path == "" {
+		return name
+	}
+	return path + "." + name
+}
+
+// emptyFieldsWarning renders the client-facing warning for stripped nulls. The
+// normalization is deliberately visible: an empty key is a typo often enough
+// that silently resolving it would trade one confusing outcome for another.
+func emptyFieldsWarning(paths []string) string {
+	shown := paths
+	suffix := ""
+	if len(shown) > maxWarnedNullPaths {
+		shown = shown[:maxWarnedNullPaths]
+		suffix = fmt.Sprintf(" (and %d more)", len(paths)-maxWarnedNullPaths)
+	}
+	return fmt.Sprintf("spec: %s left empty%s; treated as unset, the chart default applies", strings.Join(shown, ", "), suffix)
+}

--- a/pkg/registry/apps/application/rest_nullstrip.go
+++ b/pkg/registry/apps/application/rest_nullstrip.go
@@ -17,8 +17,10 @@ limitations under the License.
 package application
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 
@@ -32,47 +34,24 @@ import (
 // turn into a multi-kilobyte response header.
 const maxWarnedNullPaths = 8
 
-// normalizeSpecNulls repairs a JSON null on a field the schema marks required,
-// by removing the key so the chart's own default applies to it.
-//
-// The spec reaches flux verbatim as HelmRelease .spec.values (see
-// convertApplicationToHelmRelease), and Helm's value coalescing deletes a
-// null-valued key together with the chart default underneath it, before the
-// result is validated against values.schema.json. A required field written with
-// nothing under it is therefore rejected for being absent - "at '/talos':
-// missing property 'registryMirrors'", naming a property the spec does contain -
-// and the whole release fails to render. Nothing reaches the user that would
-// point at the empty key they actually typed.
-//
-// Only required properties are repaired, and that boundary is the point. A
-// required property's null cannot be load-bearing for anyone, because today it
-// fails the render outright; resolving it to the chart default is pure repair.
-// Where the schema permits the field to be absent, a null keeps the meaning it
-// has today - the chart default is suppressed and the key does not reach the
-// template - and that meaning is worth keeping: 167 optional fields across the
-// catalogue carry a non-trivial default, placeholders such as "<password>" and
-// example S3 buckets among them, so resolving a user's null to one of those
-// would be worse than leaving the key out.
-//
-// Filling in the schema default instead of removing the key would also pin
-// today's value into the stored HelmRelease and freeze the application on it,
-// so a later bump of that default in the chart would never reach an application
-// that had once been created with an empty key.
-//
-// Free-form subtrees are left alone, as is a null map entry whose key the user
-// chose (a node group, a registry host): there the null may be the payload, and
-// dropping the entry would drop the user's intent along with it. Array elements
-// keep their positions for the same reason.
-//
-// Returns the dotted paths that were removed, sorted, so the caller can tell
-// the user what happened to them.
+// normalizeSpecNulls removes required null properties whose schema supplies a
+// non-null default. Helm deletes explicit nulls before validating values, whereas
+// omission lets the chart default apply without persisting its current value.
+// Optional/nullable properties retain their explicit-null meaning. User-keyed
+// maps and array elements do not imply a matching Helm values-default path,
+// so defaults in their item schemas alone cannot justify a repair.
 func (r *REST) normalizeSpecNulls(app *appsv1alpha1.Application) ([]string, error) {
 	if r.specSchema == nil || app == nil || app.Spec == nil || len(app.Spec.Raw) == 0 {
 		return nil, nil
 	}
 	var spec map[string]any
-	if err := json.Unmarshal(app.Spec.Raw, &spec); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(app.Spec.Raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&spec); err != nil {
 		return nil, err
+	}
+	if decoder.Decode(new(any)) != io.EOF {
+		return nil, fmt.Errorf("spec must contain a single JSON object")
 	}
 	if spec == nil {
 		return nil, nil
@@ -93,10 +72,9 @@ func (r *REST) normalizeSpecNulls(app *appsv1alpha1.Application) ([]string, erro
 	return stripped, nil
 }
 
-// stripDeclaredNulls walks a value alongside its structural schema, deleting
-// every null whose key the schema declares as a property *and* lists as
-// required. Dispatch is on the shape of the value rather than on schema.Type,
-// which is empty for a schema that carries only properties or only items.
+// Only declared property paths identify defaults independently of user keys.
+// In particular, a schema default inside an array item is not a
+// default for an element of a user-supplied replacement array.
 func stripDeclaredNulls(v any, s *structuralschema.Structural, path string, stripped *[]string) {
 	if s == nil || v == nil {
 		return
@@ -111,7 +89,7 @@ func stripDeclaredNulls(v any, s *structuralschema.Structural, path string, stri
 			child := value[name]
 			if prop, declared := s.Properties[name]; declared {
 				if child == nil {
-					if _, mustBeSet := required[name]; mustBeSet {
+					if _, mustBeSet := required[name]; mustBeSet && prop.Default.Object != nil && !prop.Nullable {
 						delete(value, name)
 						*stripped = append(*stripped, joinFieldPath(path, name))
 					}
@@ -120,16 +98,6 @@ func stripDeclaredNulls(v any, s *structuralschema.Structural, path string, stri
 				stripDeclaredNulls(child, &prop, joinFieldPath(path, name), stripped)
 				continue
 			}
-			if s.AdditionalProperties != nil && s.AdditionalProperties.Structural != nil {
-				stripDeclaredNulls(child, s.AdditionalProperties.Structural, joinFieldPath(path, name), stripped)
-			}
-		}
-	case []any:
-		if s.Items == nil {
-			return
-		}
-		for i := range value {
-			stripDeclaredNulls(value[i], s.Items, fmt.Sprintf("%s[%d]", path, i), stripped)
 		}
 	}
 }

--- a/pkg/registry/apps/application/rest_nullstrip_admission_test.go
+++ b/pkg/registry/apps/application/rest_nullstrip_admission_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	appsv1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/warning"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type nullChartCase struct {
+	name, chart, rd, input, want string
+	schema, values               string
+	paths                        []string
+}
+
+var nullChartCases = []nullChartCase{
+	{name: "nullable schema default", schema: `{"type":"object","required":["name"],"properties":{"name":{"type":"string","nullable":true,"default":"example"}}}`, values: `{"name":"example"}`, input: `{"name":null}`},
+	{name: "item schema defaults", schema: `{"type":"object","properties":{"entries":{"type":"object","additionalProperties":{"type":"object","required":["name"],"properties":{"name":{"type":"string","default":"example"}}}},"items":{"type":"array","items":{"type":"object","required":["name"],"properties":{"name":{"type":"string","default":"example"}}}}}}`, values: `{"entries":{},"items":[{"name":"chart-default"}]}`, input: `{"entries":{"mine":{"name":null}},"items":[{"name":null}]}`},
+
+	{name: "nested defaults", chart: "apps/kubernetes", rd: "kubernetes", input: `{"talos":{"registryMirrors":null,"version":null},"controlPlane":{"replicas":null,"apiServer":{"resourcesPreset":null}},"nodeGroups":{"legacy":{"instanceType":null}}}`, want: `{"talos":{},"controlPlane":{"apiServer":{}},"nodeGroups":{"legacy":{"instanceType":null}}}`, paths: []string{"controlPlane.apiServer.resourcesPreset", "controlPlane.replicas", "talos.registryMirrors", "talos.version"}},
+	{name: "mariadb users", chart: "apps/mariadb", rd: "mariadb", input: `{"users":{"alice":{"password":null,"maxUserConnections":null},"blank":null}}`},
+	{name: "rabbitmq vhosts", chart: "apps/rabbitmq", rd: "rabbitmq", input: `{"vhosts":{"vh1":{"roles":null},"blank":null}}`},
+	{name: "seaweedfs pools", chart: "extra/seaweedfs", rd: "seaweedfs", input: `{"volume":{"pools":{"ssd":{"diskType":null},"blank":null}}}`},
+	{name: "vm source http", chart: "apps/vm-disk", rd: "vm-disk", input: `{"source":{"http":{"url":null}}}`},
+	{name: "vm source disk", chart: "apps/vm-disk", rd: "vm-disk", input: `{"source":{"disk":{"name":null}}}`},
+	{name: "vm source image", chart: "apps/vm-disk", rd: "vm-disk", input: `{"source":{"image":{"name":null}}}`},
+	{name: "optional section", chart: "apps/kubernetes", rd: "kubernetes", input: `{"talos":null,"storageClass":null}`},
+}
+
+func chartSpecSchema(t *testing.T, rd string) *structuralschema.Structural {
+	t.Helper()
+	raw := readEmbeddedOpenAPISchema(t, "../../../../packages/system/"+rd+"-rd/cozyrds/"+rd+".yaml")
+	s, err := buildSpecSchema(raw)
+	if err != nil || s == nil {
+		t.Fatalf("build %s schema: %v", rd, err)
+	}
+	return s
+}
+
+func nullCaseSchema(t *testing.T, tt nullChartCase) *structuralschema.Structural {
+	t.Helper()
+	if tt.schema == "" {
+		return chartSpecSchema(t, tt.rd)
+	}
+	schema, err := buildSpecSchema(tt.schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return schema
+}
+
+func jsonValue(t *testing.T, raw []byte) any {
+	t.Helper()
+	var v any
+	decoder := json.NewDecoder(strings.NewReader(string(raw)))
+	decoder.UseNumber()
+	if err := decoder.Decode(&v); err != nil {
+		t.Fatal(err)
+	}
+	return v
+}
+
+func TestNullNormalizationAdmissionAndStorage(t *testing.T) {
+	for _, tt := range nullChartCases {
+		for _, verb := range []string{"create", "update", "upsert"} {
+			for _, reject := range []bool{false, true} {
+				t.Run(tt.name+"/"+verb+"/reject="+map[bool]string{true: "true", false: "false"}[reject], func(t *testing.T) {
+					existing := &helmv2.HelmRelease{ObjectMeta: metav1.ObjectMeta{Name: "kubernetes-good-name", Namespace: "tenant-foo", Labels: map[string]string{
+						ApplicationKindLabel: kubernetesKind, ApplicationGroupLabel: appsv1alpha1.GroupName, ApplicationNameLabel: "good-name",
+					}}, Spec: helmv2.HelmReleaseSpec{Values: &apiextv1.JSON{Raw: []byte(`{"unchanged":"old"}`)}}}
+					r := newKubernetesWarnREST(t)
+					if verb == "update" {
+						r = newKubernetesWarnREST(t, existing)
+					}
+					r.specSchema = nullCaseSchema(t, tt)
+					app := &appsv1alpha1.Application{TypeMeta: metav1.TypeMeta{Kind: kubernetesKind, APIVersion: "apps.cozystack.io/v1alpha1"}, ObjectMeta: metav1.ObjectMeta{Name: "good-name", Namespace: "tenant-foo"}, Spec: &apiextv1.JSON{Raw: []byte(tt.input)}}
+					original := app.DeepCopy()
+					want := tt.want
+					if want == "" {
+						want = tt.input
+					}
+					expected := jsonValue(t, []byte(want))
+					rec := &fakeWarningRecorder{}
+					ctx := warning.WithWarningRecorder(request.WithNamespace(context.Background(), app.Namespace), rec)
+					called := 0
+					sentinel := errors.New("admission rejected the normalized object")
+					validate := func(_ context.Context, obj runtime.Object) error {
+						called++
+						got, ok := obj.(*appsv1alpha1.Application)
+						if !ok {
+							t.Fatalf("admission got %T", obj)
+						}
+						if !reflect.DeepEqual(jsonValue(t, got.Spec.Raw), expected) {
+							t.Errorf("admission saw %s; want %s", got.Spec.Raw, want)
+						}
+						if reject {
+							return sentinel
+						}
+						return nil
+					}
+					updateValidate := func(ctx context.Context, obj, old runtime.Object) error {
+						oldApp, ok := old.(*appsv1alpha1.Application)
+						if !ok {
+							t.Fatalf("old object %T", old)
+						}
+						if !strings.Contains(string(oldApp.Spec.Raw), `"unchanged":"old"`) {
+							t.Errorf("old object changed: %s", oldApp.Spec.Raw)
+						}
+						return validate(ctx, obj)
+					}
+					var err error
+					if verb == "create" {
+						_, err = r.Create(ctx, app, validate, &metav1.CreateOptions{})
+					} else {
+						_, created, e := r.Update(ctx, app.Name, newDefaultUpdatedObjectInfo(app), validate, updateValidate, verb == "upsert", &metav1.UpdateOptions{})
+						err = e
+						if err == nil && created != (verb == "upsert") {
+							t.Errorf("created=%t for %s", created, verb)
+						}
+					}
+					if called != 1 {
+						t.Errorf("admission calls=%d; want 1", called)
+					}
+					if reject {
+						if !errors.Is(err, sentinel) {
+							t.Errorf("rejection lost: %v", err)
+						}
+					} else if err != nil {
+						t.Fatal(err)
+					}
+					if !reflect.DeepEqual(app, original) {
+						t.Error("caller input was mutated")
+					}
+					got := &helmv2.HelmRelease{}
+					getErr := r.c.Get(ctx, client.ObjectKeyFromObject(existing), got)
+					if reject && verb != "update" {
+						all := &helmv2.HelmReleaseList{}
+						if err := r.c.List(ctx, all); err != nil {
+							t.Fatal(err)
+						}
+						if len(all.Items) != 0 {
+							t.Error("rejected admission wrote a HelmRelease")
+						}
+					} else {
+						if getErr != nil {
+							t.Fatal(getErr)
+						}
+						storedWant := expected
+						if reject {
+							storedWant = jsonValue(t, existing.Spec.Values.Raw)
+						}
+						if !reflect.DeepEqual(jsonValue(t, got.Spec.Values.Raw), storedWant) {
+							t.Errorf("stored values=%s; want %v", got.Spec.Values.Raw, storedWant)
+						}
+					}
+					var nullWarnings []string
+					for _, w := range rec.warnings {
+						if strings.HasPrefix(w, "spec:") {
+							nullWarnings = append(nullWarnings, w)
+						}
+					}
+					if len(tt.paths) == 0 {
+						if len(nullWarnings) != 0 {
+							t.Errorf("false repair warning: %v", nullWarnings)
+						}
+					} else if !reflect.DeepEqual(nullWarnings, []string{emptyFieldsWarning(tt.paths)}) {
+						t.Errorf("warnings=%v for removed paths=%v", nullWarnings, tt.paths)
+					}
+				})
+			}
+		}
+	}
+}

--- a/pkg/registry/apps/application/rest_nullstrip_helm_test.go
+++ b/pkg/registry/apps/application/rest_nullstrip_helm_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"sigs.k8s.io/yaml"
+)
+
+// Schema defaults describe API reads; Helm coalesces values.yaml instead. Check
+// their effective values independently so drift cannot turn repair into omission.
+func TestRequiredNullDefaultsMatchChartValues(t *testing.T) {
+	for _, tt := range nullChartCases {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.chart == "" {
+				return
+			}
+			s := chartSpecSchema(t, tt.rd)
+			raw, err := os.ReadFile("../../../../packages/" + tt.chart + "/values.yaml")
+			if err != nil {
+				t.Fatal(err)
+			}
+			var values map[string]any
+			if err := yaml.Unmarshal(raw, &values); err != nil {
+				t.Fatal(err)
+			}
+			var visit func(*structuralschema.Structural, map[string]any, string)
+			visit = func(schema *structuralschema.Structural, defaults map[string]any, path string) {
+				for key, prop := range schema.Properties {
+					value, present := defaults[key]
+					if _, required := requiredNames(schema)[key]; required && prop.Default.Object != nil && !prop.Nullable {
+						if !present {
+							t.Errorf("%s%s schema default has no chart value", path, key)
+							continue
+						}
+						// Expand nested defaults using the existing API read path, without the
+						// null normalizer, then compare semantically to the shipped chart value.
+						raw, err := json.Marshal(map[string]any{key: prop.Default.Object})
+						if err != nil {
+							t.Fatal(err)
+						}
+						app := &appsv1alpha1.Application{Spec: &apiextv1.JSON{Raw: raw}}
+						if err := (&REST{specSchema: schema}).applySpecDefaults(app); err != nil {
+							t.Fatal(err)
+						}
+						expanded := jsonValue(t, app.Spec.Raw).(map[string]any)[key]
+						rawValue, err := json.Marshal(value)
+						if err != nil {
+							t.Fatal(err)
+						}
+						if !reflect.DeepEqual(expanded, jsonValue(t, rawValue)) {
+							t.Errorf("%s%s effective schema default differs from chart: %v != %v", path, key, expanded, value)
+						}
+					}
+					if child, ok := value.(map[string]any); ok {
+						visit(&prop, child, path+key+".")
+					}
+				}
+			}
+			visit(s, values, "")
+		})
+	}
+}
+
+// A minimal rendering template exposes Helm's real coalesced values while the
+// values and validation schema remain the shipped files, without chart-specific
+// cluster lookups or templates obscuring defaulting failures.
+func TestRequiredNullHelmCoalescing(t *testing.T) {
+	helm, err := exec.LookPath("helm")
+	if err != nil {
+		t.Skip("Helm executable required for the coalescing integration test")
+	}
+	for _, tt := range nullChartCases {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.Mkdir(filepath.Join(dir, "templates"), 0755); err != nil {
+				t.Fatal(err)
+			}
+			for _, file := range []string{"values.yaml", "values.schema.json"} {
+				var data []byte
+				if tt.chart != "" {
+					var err error
+					data, err = os.ReadFile("../../../../packages/" + tt.chart + "/" + file)
+					if err != nil {
+						t.Fatal(err)
+					}
+				} else if file == "values.yaml" {
+					data = []byte(tt.values)
+				} else {
+					data = []byte(tt.schema)
+				}
+				if err := os.WriteFile(filepath.Join(dir, file), data, 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for file, body := range map[string]string{"Chart.yaml": "apiVersion: v2\nname: null-contract\nversion: 0.0.0\n", "templates/values.yaml": "{{ .Values | toJson }}\n"} {
+				if err := os.WriteFile(filepath.Join(dir, file), []byte(body), 0600); err != nil {
+					t.Fatal(err)
+				}
+			}
+			render := func(input []byte) ([]byte, error) {
+				values := filepath.Join(dir, "input.json")
+				if err := os.WriteFile(values, input, 0600); err != nil {
+					t.Fatal(err)
+				}
+				ctx, cancel := context.WithTimeout(t.Context(), 20*time.Second)
+				defer cancel()
+				return exec.CommandContext(ctx, helm, "template", "null-contract", dir, "-f", values).CombinedOutput()
+			}
+			app := &appsv1alpha1.Application{Spec: &apiextv1.JSON{Raw: []byte(tt.input)}}
+			paths, err := (&REST{specSchema: nullCaseSchema(t, tt)}).normalizeSpecNulls(app)
+			if err != nil {
+				t.Fatal(err)
+			}
+			before, beforeErr := render([]byte(tt.input))
+			after, afterErr := render(app.Spec.Raw)
+			if len(tt.paths) == 0 {
+				if len(paths) != 0 || string(app.Spec.Raw) != tt.input {
+					t.Fatalf("nonrepairable input changed: %s", app.Spec.Raw)
+				}
+				if (beforeErr == nil) != (afterErr == nil) {
+					t.Fatalf("normalization changed validation outcome: %s / %s", before, after)
+				}
+				if tt.name != "optional section" && beforeErr == nil {
+					t.Fatalf("required null unexpectedly accepted: %s", before)
+				}
+				return
+			}
+			if beforeErr == nil {
+				t.Fatalf("required-null input unexpectedly accepted by Helm: %s", before)
+			}
+			if afterErr != nil {
+				t.Fatalf("normalized input failed Helm: %v\n%s", afterErr, after)
+			}
+			var rendered map[string]any
+			if err := yaml.Unmarshal(after, &rendered); err != nil {
+				t.Fatal(err)
+			}
+			chartValues, err := os.ReadFile(filepath.Join(dir, "values.yaml"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var defaults map[string]any
+			if err := yaml.Unmarshal(chartValues, &defaults); err != nil {
+				t.Fatal(err)
+			}
+			at := func(v map[string]any, path string) any {
+				var value any = v
+				for _, key := range strings.Split(path, ".") {
+					value = value.(map[string]any)[key]
+				}
+				return value
+			}
+			for _, path := range tt.paths {
+				if !reflect.DeepEqual(at(rendered, path), at(defaults, path)) {
+					t.Errorf("Helm failed to restore %s", path)
+				}
+			}
+		})
+	}
+}

--- a/pkg/registry/apps/application/rest_nullstrip_test.go
+++ b/pkg/registry/apps/application/rest_nullstrip_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	appsv1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+)
+
+// kubernetesSpecSchema builds the REST spec schema from the Kubernetes
+// Application's shipped cozyrd. The real schema is the fixture on purpose: the
+// bug this file pins came from the interaction between a declared-and-defaulted
+// field, a free-form passthrough field and a user-keyed map, and a synthetic
+// schema can be made to agree with any behaviour.
+func kubernetesSpecSchema(t *testing.T) *structuralschema.Structural {
+	t.Helper()
+	raw := readEmbeddedOpenAPISchema(t,
+		"../../../../packages/system/kubernetes-rd/cozyrds/kubernetes.yaml")
+	s, err := buildSpecSchema(raw)
+	if err != nil {
+		t.Fatalf("buildSpecSchema: %v", err)
+	}
+	if s == nil {
+		t.Fatal("buildSpecSchema returned nil for the shipped Kubernetes schema")
+	}
+	return s
+}
+
+func normalize(t *testing.T, s *structuralschema.Structural, spec string) ([]string, map[string]any) {
+	t.Helper()
+	r := &REST{specSchema: s}
+	app := &appsv1alpha1.Application{Spec: &apiextv1.JSON{Raw: []byte(spec)}}
+	paths, err := r.normalizeSpecNulls(app)
+	if err != nil {
+		t.Fatalf("normalizeSpecNulls(%s): %v", spec, err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(app.Spec.Raw, &got); err != nil {
+		t.Fatalf("unmarshal normalized spec: %v", err)
+	}
+	return paths, got
+}
+
+// TestNormalizeSpecNulls_RequiredFields pins the fix: a required field written
+// with nothing under it is dropped, so the chart default applies to it instead
+// of being deleted along with the null by Helm's value coalescing. Before this,
+// `registryMirrors:` failed the whole HelmRelease with "at '/talos': missing
+// property 'registryMirrors'" - a property the user had in fact written.
+func TestNormalizeSpecNulls_RequiredFields(t *testing.T) {
+	s := kubernetesSpecSchema(t)
+
+	paths, got := normalize(t, s, `{"host":"k8s","talos":{"registryMirrors":null,"version":null,"imageFactoryURL":"https://factory.example.invalid"}}`)
+
+	want := []string{"talos.registryMirrors", "talos.version"}
+	if !reflect.DeepEqual(paths, want) {
+		t.Errorf("stripped paths = %v, want %v", paths, want)
+	}
+	wantSpec := map[string]any{
+		"host":  "k8s",
+		"talos": map[string]any{"imageFactoryURL": "https://factory.example.invalid"},
+	}
+	if !reflect.DeepEqual(got, wantSpec) {
+		t.Errorf("normalized spec = %v, want %v", got, wantSpec)
+	}
+}
+
+// TestNormalizeSpecNulls_OptionalFieldsUntouched is the guard on the boundary:
+// where the schema permits a field to be absent, a null keeps the meaning it has
+// today - the chart default is suppressed and the key never reaches the template.
+// Repairing these too would change what a running application renders: 167
+// optional fields across the catalogue carry a non-trivial default, placeholder
+// credentials and example S3 buckets among them.
+func TestNormalizeSpecNulls_OptionalFieldsUntouched(t *testing.T) {
+	s := kubernetesSpecSchema(t)
+
+	paths, got := normalize(t, s, `{"talos":null,"storageClass":null,"nodeGroups":null,"version":null}`)
+
+	if len(paths) != 0 {
+		t.Errorf("stripped paths = %v, want none: the Kubernetes schema requires none of these at the root", paths)
+	}
+	for _, key := range []string{"talos", "storageClass", "nodeGroups", "version"} {
+		v, ok := got[key]
+		if !ok || v != nil {
+			t.Errorf("%s = %v (present=%v), want a preserved null", key, v, ok)
+		}
+	}
+}
+
+// TestNormalizeSpecNulls_FreeFormSubtreeUntouched pins the boundary: inside
+// registryMirrors the keys are registry hostnames the user invents, and the
+// schema declares nothing there. A null in that position may be the payload, so
+// it is left exactly as written rather than guessed at.
+func TestNormalizeSpecNulls_FreeFormSubtreeUntouched(t *testing.T) {
+	s := kubernetesSpecSchema(t)
+
+	paths, got := normalize(t, s, `{"talos":{"registryMirrors":{"ghcr.io":null}}}`)
+
+	if len(paths) != 0 {
+		t.Errorf("stripped paths = %v, want none", paths)
+	}
+	mirrors := got["talos"].(map[string]any)["registryMirrors"].(map[string]any)
+	if _, ok := mirrors["ghcr.io"]; !ok {
+		t.Errorf("free-form key ghcr.io was dropped: %v", mirrors)
+	}
+}
+
+// TestNormalizeSpecNulls_UserKeyedMapEntry covers both halves of a map whose
+// keys the user chooses: the entry itself stays (dropping it would drop a node
+// group the user asked for), while a declared field inside it is normalized the
+// same way as anywhere else.
+func TestNormalizeSpecNulls_UserKeyedMapEntry(t *testing.T) {
+	s := kubernetesSpecSchema(t)
+
+	paths, got := normalize(t, s, `{"nodeGroups":{"md0":null,"md1":{"instanceType":null,"storageClass":null,"minReplicas":2}}}`)
+
+	if !reflect.DeepEqual(paths, []string{"nodeGroups.md1.instanceType"}) {
+		t.Errorf("stripped paths = %v, want [nodeGroups.md1.instanceType]", paths)
+	}
+	groups := got["nodeGroups"].(map[string]any)
+	if v, ok := groups["md0"]; !ok || v != nil {
+		t.Errorf("md0 = %v (present=%v), want a preserved null", v, ok)
+	}
+	md1 := groups["md1"].(map[string]any)
+	if _, ok := md1["instanceType"]; ok {
+		t.Errorf("md1.instanceType is required by the schema and survived: %v", md1)
+	}
+	if v, ok := md1["storageClass"]; !ok || v != nil {
+		t.Errorf("md1.storageClass = %v (present=%v), want a preserved null: the schema allows it to be absent", v, ok)
+	}
+	if md1["minReplicas"] != float64(2) {
+		t.Errorf("md1.minReplicas = %v, want 2", md1["minReplicas"])
+	}
+}
+
+// TestStripDeclaredNulls_ArrayPositionsKept pins that array elements are never
+// removed - an index is part of the address of every element after it - while a
+// declared field inside an element is still normalized.
+func TestStripDeclaredNulls_ArrayPositionsKept(t *testing.T) {
+	s := &structuralschema.Structural{
+		Generic: structuralschema.Generic{Type: "object"},
+		Properties: map[string]structuralschema.Structural{
+			"items": {
+				Generic: structuralschema.Generic{Type: "array"},
+				Items: &structuralschema.Structural{
+					Generic: structuralschema.Generic{Type: "object"},
+					Properties: map[string]structuralschema.Structural{
+						"name": {Generic: structuralschema.Generic{Type: "string"}},
+					},
+					ValueValidation: &structuralschema.ValueValidation{
+						Required: []string{"name"},
+					},
+				},
+			},
+		},
+	}
+
+	spec := map[string]any{"items": []any{map[string]any{"name": nil}, nil}}
+	var stripped []string
+	stripDeclaredNulls(spec, s, "", &stripped)
+
+	if !reflect.DeepEqual(stripped, []string{"items[0].name"}) {
+		t.Errorf("stripped = %v, want [items[0].name]", stripped)
+	}
+	list := spec["items"].([]any)
+	if len(list) != 2 {
+		t.Fatalf("array length = %d, want 2 (elements must keep their positions)", len(list))
+	}
+	if len(list[0].(map[string]any)) != 0 {
+		t.Errorf("items[0] = %v, want {}", list[0])
+	}
+	if list[1] != nil {
+		t.Errorf("items[1] = %v, want the null left in place", list[1])
+	}
+}
+
+// TestNormalizeSpecNulls_NoSchemaOrNoNulls pins the no-op paths: a kind whose
+// ApplicationDefinition ships no schema must pass its spec through untouched,
+// and a spec without nulls must not be re-serialized (re-marshalling reorders
+// keys, which would show up as spurious HelmRelease churn).
+func TestNormalizeSpecNulls_NoSchemaOrNoNulls(t *testing.T) {
+	const spec = `{"b":1,"a":{"c":2}}`
+
+	noSchema := &REST{}
+	app := &appsv1alpha1.Application{Spec: &apiextv1.JSON{Raw: []byte(spec)}}
+	paths, err := noSchema.normalizeSpecNulls(app)
+	if err != nil || paths != nil {
+		t.Errorf("no schema: paths=%v err=%v, want no-op", paths, err)
+	}
+	if string(app.Spec.Raw) != spec {
+		t.Errorf("no schema: spec rewritten to %s", app.Spec.Raw)
+	}
+
+	withSchema := &REST{specSchema: kubernetesSpecSchema(t)}
+	clean := &appsv1alpha1.Application{Spec: &apiextv1.JSON{Raw: []byte(`{"host":"k8s"}`)}}
+	paths, err = withSchema.normalizeSpecNulls(clean)
+	if err != nil || paths != nil {
+		t.Errorf("clean spec: paths=%v err=%v, want no-op", paths, err)
+	}
+	if string(clean.Spec.Raw) != `{"host":"k8s"}` {
+		t.Errorf("clean spec rewritten to %s", clean.Spec.Raw)
+	}
+}
+
+func TestEmptyFieldsWarning(t *testing.T) {
+	short := emptyFieldsWarning([]string{"talos.version", "talos.registryMirrors"})
+	if !strings.Contains(short, "talos.version, talos.registryMirrors") ||
+		!strings.Contains(short, "the chart default applies") {
+		t.Errorf("unexpected warning: %q", short)
+	}
+
+	many := make([]string, maxWarnedNullPaths+3)
+	for i := range many {
+		many[i] = "f"
+	}
+	long := emptyFieldsWarning(many)
+	if !strings.Contains(long, "(and 3 more)") {
+		t.Errorf("long warning not truncated: %q", long)
+	}
+}

--- a/pkg/registry/apps/application/rest_nullstrip_test.go
+++ b/pkg/registry/apps/application/rest_nullstrip_test.go
@@ -61,11 +61,6 @@ func normalize(t *testing.T, s *structuralschema.Structural, spec string) ([]str
 	return paths, got
 }
 
-// TestNormalizeSpecNulls_RequiredFields pins the fix: a required field written
-// with nothing under it is dropped, so the chart default applies to it instead
-// of being deleted along with the null by Helm's value coalescing. Before this,
-// `registryMirrors:` failed the whole HelmRelease with "at '/talos': missing
-// property 'registryMirrors'" - a property the user had in fact written.
 func TestNormalizeSpecNulls_RequiredFields(t *testing.T) {
 	s := kubernetesSpecSchema(t)
 
@@ -84,12 +79,6 @@ func TestNormalizeSpecNulls_RequiredFields(t *testing.T) {
 	}
 }
 
-// TestNormalizeSpecNulls_OptionalFieldsUntouched is the guard on the boundary:
-// where the schema permits a field to be absent, a null keeps the meaning it has
-// today - the chart default is suppressed and the key never reaches the template.
-// Repairing these too would change what a running application renders: 167
-// optional fields across the catalogue carry a non-trivial default, placeholder
-// credentials and example S3 buckets among them.
 func TestNormalizeSpecNulls_OptionalFieldsUntouched(t *testing.T) {
 	s := kubernetesSpecSchema(t)
 
@@ -124,72 +113,43 @@ func TestNormalizeSpecNulls_FreeFormSubtreeUntouched(t *testing.T) {
 	}
 }
 
-// TestNormalizeSpecNulls_UserKeyedMapEntry covers both halves of a map whose
-// keys the user chooses: the entry itself stays (dropping it would drop a node
-// group the user asked for), while a declared field inside it is normalized the
-// same way as anywhere else.
-func TestNormalizeSpecNulls_UserKeyedMapEntry(t *testing.T) {
-	s := kubernetesSpecSchema(t)
-
-	paths, got := normalize(t, s, `{"nodeGroups":{"md0":null,"md1":{"instanceType":null,"storageClass":null,"minReplicas":2}}}`)
-
-	if !reflect.DeepEqual(paths, []string{"nodeGroups.md1.instanceType"}) {
-		t.Errorf("stripped paths = %v, want [nodeGroups.md1.instanceType]", paths)
+func TestNormalizeSpecNulls_NoDefaultOrUserCollection(t *testing.T) {
+	// Even an item schema default is not a Helm default for a user-created entry.
+	s, err := buildSpecSchema(`{"type":"object","required":["missing","nullDefault","nullable","zero","false","empty"],"properties":{
+  "missing":{"type":"string"},"nullDefault":{"type":"string","default":null},
+  "nullable":{"type":"string","nullable":true,"default":"keep-null"},
+  "zero":{"type":"integer","default":0},"false":{"type":"boolean","default":false},"empty":{"type":"string","default":""},
+  "entries":{"type":"object","additionalProperties":{"type":"object","required":["name"],"properties":{"name":{"type":"string","default":"example"}}}},
+  "items":{"type":"array","items":{"type":"object","required":["name"],"properties":{"name":{"type":"string","default":"example"}}}}
+ }}`)
+	if err != nil {
+		t.Fatal(err)
 	}
-	groups := got["nodeGroups"].(map[string]any)
-	if v, ok := groups["md0"]; !ok || v != nil {
-		t.Errorf("md0 = %v (present=%v), want a preserved null", v, ok)
+	paths, got := normalize(t, s, `{"missing":null,"nullDefault":null,"nullable":null,"zero":null,"false":null,"empty":null,"entries":{"mine":{"name":null},"blank":null},"items":[{"name":null},null]}`)
+	if !reflect.DeepEqual(paths, []string{"empty", "false", "zero"}) {
+		t.Fatalf("removed paths=%v", paths)
 	}
-	md1 := groups["md1"].(map[string]any)
-	if _, ok := md1["instanceType"]; ok {
-		t.Errorf("md1.instanceType is required by the schema and survived: %v", md1)
+	for _, key := range []string{"missing", "nullDefault", "nullable"} {
+		if value, ok := got[key]; !ok || value != nil {
+			t.Errorf("%s null changed", key)
+		}
 	}
-	if v, ok := md1["storageClass"]; !ok || v != nil {
-		t.Errorf("md1.storageClass = %v (present=%v), want a preserved null: the schema allows it to be absent", v, ok)
+	if !reflect.DeepEqual(got["entries"], map[string]any{"mine": map[string]any{"name": nil}, "blank": nil}) {
+		t.Error("user map entries changed")
 	}
-	if md1["minReplicas"] != float64(2) {
-		t.Errorf("md1.minReplicas = %v, want 2", md1["minReplicas"])
+	if !reflect.DeepEqual(got["items"], []any{map[string]any{"name": nil}, nil}) {
+		t.Error("user array changed")
 	}
 }
 
-// TestStripDeclaredNulls_ArrayPositionsKept pins that array elements are never
-// removed - an index is part of the address of every element after it - while a
-// declared field inside an element is still normalized.
-func TestStripDeclaredNulls_ArrayPositionsKept(t *testing.T) {
-	s := &structuralschema.Structural{
-		Generic: structuralschema.Generic{Type: "object"},
-		Properties: map[string]structuralschema.Structural{
-			"items": {
-				Generic: structuralschema.Generic{Type: "array"},
-				Items: &structuralschema.Structural{
-					Generic: structuralschema.Generic{Type: "object"},
-					Properties: map[string]structuralschema.Structural{
-						"name": {Generic: structuralschema.Generic{Type: "string"}},
-					},
-					ValueValidation: &structuralschema.ValueValidation{
-						Required: []string{"name"},
-					},
-				},
-			},
-		},
+func TestNormalizeSpecNulls_PreservesOtherValuesExactly(t *testing.T) {
+	app := &appsv1alpha1.Application{Spec: &apiextv1.JSON{Raw: []byte(`{"talos":{"registryMirrors":null},"large":9007199254740993,"negative":-9007199254740993,"text":"null","bool":false,"empty":[],"object":{}}`)}}
+	r := &REST{specSchema: kubernetesSpecSchema(t)}
+	if _, err := r.normalizeSpecNulls(app); err != nil {
+		t.Fatal(err)
 	}
-
-	spec := map[string]any{"items": []any{map[string]any{"name": nil}, nil}}
-	var stripped []string
-	stripDeclaredNulls(spec, s, "", &stripped)
-
-	if !reflect.DeepEqual(stripped, []string{"items[0].name"}) {
-		t.Errorf("stripped = %v, want [items[0].name]", stripped)
-	}
-	list := spec["items"].([]any)
-	if len(list) != 2 {
-		t.Fatalf("array length = %d, want 2 (elements must keep their positions)", len(list))
-	}
-	if len(list[0].(map[string]any)) != 0 {
-		t.Errorf("items[0] = %v, want {}", list[0])
-	}
-	if list[1] != nil {
-		t.Errorf("items[1] = %v, want the null left in place", list[1])
+	if string(app.Spec.Raw) != `{"bool":false,"empty":[],"large":9007199254740993,"negative":-9007199254740993,"object":{},"talos":{},"text":"null"}` {
+		t.Fatalf("unrelated values changed: %s", app.Spec.Raw)
 	}
 }
 


### PR DESCRIPTION
## What this PR does

Application spec goes to flux as HelmRelease `.spec.values` as is, and helm value coalescing deletes null key together with chart default under it, before values are validated against `values.schema.json`. So a field that was written but left empty:

```yaml
apiVersion: apps.cozystack.io/v1alpha1
kind: Kubernetes
spec:
  talos:
    registryMirrors:
```

fails whole release with `at '/talos': missing property 'registryMirrors'`, naming property that spec does contain, and application never installs. Writing `registryMirrors: {}` works, and nothing in the error points at difference between the two.

Such null is now removed on write path (`Create` and `Update` in cozystack-api), so chart default applies to it, and client gets a warning naming every field that was dropped. Writing schema default into the spec instead would pin current value into stored HelmRelease and freeze application on it, so a later bump of that default in the chart would never reach it.

Only fields that schema marks required are repaired. For those null cant be load-bearing, because today it fails render entirely. Where schema allows field to be absent, null keeps meaning it has now (chart default suppressed, key never reaches template), and that one is worth keeping: 167 optional fields in catalogue carry non-trivial default, placeholder credentials and example s3 buckets among them, so resolving user null to those is worse than leaving key out. Free-form subtrees, null map entries under user chosen key (node group, registry host) and array elements are left as written too, there null may be the payload.

Not covered by this PR: `talos:` with whole section left empty. Root schema of kubernetes app has no required fields at all, so it still dies at render with `nil pointer evaluating interface {}.version`. That one is loud and visible in HelmRelease status, and it belongs to templates.

Tests are on the real shipped schema from `packages/system/kubernetes-rd/cozyrds/kubernetes.yaml`, and cover both sides of the boundary: required field repaired, optional field left alone.

### Related

Same class as #3705, where `tls:` written empty deletes the chart default and panics the render in four charts. This PR covers the half where schema marks the field required, so validation fails instead of a nil deref. Template half of #3705 (guard the map, not the value) is not here, and that one also covers `talos:` with whole section left empty.

#3046 was the same failure through the typed CR, closed by dropping `required` from one field in #3121, and #3949 was a second attempt of the same per field approach. That loop is what this PR is meant to end.

### Downstream repositories

Walked the trigger map against the diff. Go code in api layer only, no package touched, no values.yaml, no schema field, no default, no version enum, no `kind` or `plural`, README unchanged. terraform-provider models spec fields itself and none of them changed here.

- [x] No downstream repository is affected by this change

### Release note

```release-note
fix(api): a field written with no value in an application spec (`registryMirrors:` with nothing under it) no longer fails the whole HelmRelease when the schema marks that field required. It is treated as unset, so the chart default applies to it.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Application specifications with null required fields are normalized so chart defaults apply correctly.
  * Admission validation now evaluates the normalized specification.
  * Invalid specification normalization requests return a clear bad-request response.
  * Application creation and updates provide warnings when null fields are automatically repaired.
  * Optional fields, free-form data, user-defined map entries, and array positions retain their existing null values.
  * Incoming application objects remain unchanged during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->