### PR TITLE
fix(etcd-operator): gate VMServiceScrape on VictoriaMetrics operator CRD

### DIFF
--- a/packages/system/etcd-operator/templates/metrics.yaml
+++ b/packages/system/etcd-operator/templates/metrics.yaml
@@ -15,6 +15,7 @@ spec:
     targetPort: metrics
     protocol: TCP
 ---
+{{- if .Capabilities.APIVersions.Has "operator.victoriametrics.com/v1beta1" }}
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape
 metadata:
@@ -27,3 +28,4 @@ spec:
   endpoints:
   - port: metrics
     scheme: http
+{{- end }}

--- a/packages/system/etcd-operator/tests/metrics_test.yaml
+++ b/packages/system/etcd-operator/tests/metrics_test.yaml
@@ -1,0 +1,40 @@
+suite: metrics — Service is unconditional, VMServiceScrape is gated on the vmoperator CRD
+
+templates:
+  - templates/metrics.yaml
+
+release:
+  name: etcd-operator
+  namespace: cozy-etcd-operator
+
+capabilities:
+  apiVersions: []
+
+tests:
+  - it: the metrics Service renders even when the VictoriaMetrics operator CRDs are absent
+    asserts:
+      - hasDocuments:
+          count: 1
+      - containsDocument:
+          apiVersion: v1
+          kind: Service
+          name: etcd-operator-metrics
+          any: true
+
+  - it: the VMServiceScrape renders alongside the Service when the VictoriaMetrics operator CRD is present
+    capabilities:
+      apiVersions:
+        - operator.victoriametrics.com/v1beta1
+    asserts:
+      - hasDocuments:
+          count: 2
+      - containsDocument:
+          apiVersion: v1
+          kind: Service
+          name: etcd-operator-metrics
+          any: true
+      - containsDocument:
+          apiVersion: operator.victoriametrics.com/v1beta1
+          kind: VMServiceScrape
+          name: etcd-operator
+          any: true


### PR DESCRIPTION
## What this PR does

`packages/system/etcd-operator/templates/metrics.yaml` rendered a `VMServiceScrape` (`operator.victoriametrics.com/v1beta1`) unconditionally, so the `cozy-etcd-operator/etcd-operator` HelmRelease fails to install on any cluster that does not have the VictoriaMetrics operator CRDs, with `no matches for kind "VMServiceScrape" in version "operator.victoriametrics.com/v1beta1"`. That made the VictoriaMetrics operator a hard dependency of etcd-operator, which it should not be.

This wraps only the `VMServiceScrape` document in a `.Capabilities.APIVersions.Has "operator.victoriametrics.com/v1beta1"` gate, following the precedent already established in `packages/system/linstor/templates/podscrape.yaml`. The `etcd-operator-metrics` Service keeps rendering unconditionally, so any scraper — a `VMServiceScrape` when the CRD is present, or something else entirely — can still target the `metrics` port.

Note: this is a Cozystack-packaging-only issue. The upstream etcd-operator repo's own chart is unaffected — it already gates its scrape object.

Added `packages/system/etcd-operator/tests/metrics_test.yaml` (`helm unittest`) pinning the new behavior: the Service always renders, and the `VMServiceScrape` renders only when the capability is injected.

Kept this minimal — a pure capabilities gate with no new values key, matching linstor's style, rather than adding a values toggle.

Follow-up (out of scope for this PR): `packages/extra/etcd/templates/podscrape.yaml` (a `VMPodScrape`) is unconditional the same way and would hit the same install failure on a cluster without the VictoriaMetrics operator. `packages/system/monitoring-agents` also ships several unconditional `VMServiceScrape`/`VMPodScrape` objects, though that package may already assume the VictoriaMetrics operator is present as part of the monitoring stack it belongs to.

### Screenshots

Not applicable — no UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change

### Release note

```release-note
fix(etcd-operator): stop requiring the VictoriaMetrics operator to install etcd-operator; the VMServiceScrape now only renders when the operator's CRD is present
```
