### PR TITLE
fix(backupstrategy-controller): gate the default MongoDB Strategy on its CRD

### DIFF
--- a/packages/system/backupstrategy-controller/templates/_helpers.tpl
+++ b/packages/system/backupstrategy-controller/templates/_helpers.tpl
@@ -122,3 +122,66 @@
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+  Answer, for one CRD this chart ships as a template, whether the apiserver
+  already serves its kind.
+
+  Why a default Strategy needs this on top of the bucket-name gate. This chart
+  ships its strategy.backups.cozystack.io CRDs as ordinary templates
+  (templates/crds.yaml globs definitions/*.yaml), and Helm resolves EVERY
+  document in a release manifest through the cluster's RESTMapper in Build()
+  before it applies any of them. A Strategy CR whose CRD is not served yet
+  therefore fails Build(), and the release applies ZERO objects — including the
+  CRDs that would have made the mapping resolve. Every retry renders the same
+  manifest, so the failure is permanent rather than a race.
+
+  The bucket-name gate covers the FIRST INSTALL of a new cluster, where nothing
+  is resolvable yet and no Strategy renders at all. It cannot cover the case
+  this helper exists for: adding a NEW strategy kind to a chart that is already
+  installed. There the bucket name resolved long ago, so the first upgraded
+  revision renders the new CRD and the new Strategy CR together and wedges the
+  release exactly as above. That is not hypothetical — it is how the MongoDB
+  driver reached main, and the upgrade E2E lane caught it on the v1.6.2 → main
+  path with `no matches for kind "MongoDB"`.
+
+  Asking about the CRD OBJECT rather than listing the custom kind is
+  deliberate. `lookup` on a kind the apiserver does not serve is not an empty
+  result — it is a render ERROR ("unable to get apiresource"), which would trade
+  the wedge for a different permanent failure. apiextensions.k8s.io/v1 is always
+  served, so this lookup can only answer yes or no. Established=True rather than
+  mere existence, because a CRD is only in the RESTMapper once it is; a
+  not-yet-established CRD costs one retried revision here instead of a failed
+  one, and Flux retries.
+
+  Convergence after a skip is the same mechanism the bucket gate relies on and
+  is NOT the HelmRelease interval (see the bucketName helper): once the CRD is
+  served, the controller's DefaultObjectsGate sees the kind mapped and the CR
+  absent and forces a real Helm upgrade, whose render then includes it. The gate
+  skips kinds that do not map at all (meta.IsNoMatchError), which is what keeps
+  it from forcing upgrades against a render that cannot yet produce the object.
+
+  bucketNameOverride short-circuits the lookup for the same reason it does in
+  bucketName: it marks an offline render — `helm template`, a CI diff, a
+  helm-unittest case — where there is no apiserver to ask and the operator has
+  declared that cluster-derived state should be treated as resolved. Live
+  deploys go through Flux and never set it.
+
+  Every default Strategy added from here on should gate on this helper as well
+  as on the bucket name. The siblings that predate it are not wedged today only
+  because their CRDs already shipped in an earlier release.
+*/}}
+{{- define "backupstrategy-controller.crdEstablished" -}}
+{{- if .root.Values.backupStorage.bucketNameOverride -}}
+true
+{{- else -}}
+{{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" .crd -}}
+{{- if and $crd $crd.status -}}
+{{- range $c := (default (list) $crd.status.conditions) -}}
+{{- if and (eq $c.type "Established") (eq (toString $c.status) "True") -}}
+true
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/packages/system/backupstrategy-controller/templates/strategy-mongodb-default.yaml
+++ b/packages/system/backupstrategy-controller/templates/strategy-mongodb-default.yaml
@@ -6,24 +6,36 @@
   lives on the MongoDB application (declared by the chart as "s3-storage" when
   backup.enabled=true), not here.
 
-  It is gated on $bucketName all the same, and NOT because it needs the value.
-  The gate is what keeps this chart installable on a fresh cluster. This chart
+  It is gated all the same, and NOT because it needs a bucket value. This chart
   ships its own strategy.backups.cozystack.io CRDs as ordinary templates
   (templates/crds.yaml globs definitions/*.yaml), and Helm resolves every
   document in a release manifest through the cluster's RESTMapper in Build()
   BEFORE it applies any of them. An ungated Strategy CR therefore has no
-  mapping on the first install, Build() fails with "no matches for kind", and
-  the release applies ZERO objects — including the CRDs that would have made
-  the mapping resolve. Nothing recovers from that: every retry renders the same
-  manifest, so the failure is permanent rather than a race, and Helm's kind
-  sorter cannot help because it orders the apply, not the Build.
+  mapping while its CRD is still absent, Build() fails with "no matches for
+  kind", and the release applies ZERO objects — including the CRDs that would
+  have made the mapping resolve. Nothing recovers from that: every retry
+  renders the same manifest, so the failure is permanent rather than a race,
+  and Helm's kind sorter cannot help because it orders the apply, not the
+  Build.
 
-  So every default Strategy in this chart must be absent from the first render.
-  $bucketName is empty until the COSI BucketClaim status is reconciled (see
-  templates/_helpers.tpl), which is exactly the window where the CRDs are being
-  applied; by the time DefaultObjectsGate forces a second revision the CRDs
-  exist and the mapping resolves. The seven sibling strategies got this for
-  free by needing the bucket name. This one has to ask for it.
+  So this Strategy must be absent from any render whose cluster cannot yet map
+  it, and there are TWO such renders, not one.
+
+  A fresh install is the first. $bucketName is empty until the COSI BucketClaim
+  status is reconciled (see templates/_helpers.tpl), which is exactly the window
+  where the CRDs are being applied; by the time DefaultObjectsGate forces a
+  second revision the CRDs exist and the mapping resolves. The seven sibling
+  strategies get that for free by needing the bucket name.
+
+  Adding this kind to an ALREADY-INSTALLED chart is the second, and the bucket
+  gate is no help there: the bucket name resolved releases ago, so the first
+  upgraded revision renders the new CRD and this CR together and wedges the
+  release. That is not a hypothetical — this Strategy shipped to main that way,
+  and the upgrade E2E lane caught it on the v1.6.2 → main path. Hence the
+  explicit CRD gate below, which asks whether the apiserver serves the kind and
+  answers for both renders; see the crdEstablished helper for why it asks about
+  the CRD object rather than listing the kind, and for how the release converges
+  afterwards.
 
   Precondition (surfaced by the driver as a clear Ready=False, not a silent
   hang): the MongoDB application must be deployed with backup.enabled=true so
@@ -31,7 +43,8 @@
   docs/operations/backup-classes.md.
 */}}
 {{- $bucketName := include "backupstrategy-controller.bucketName" . -}}
-{{- if $bucketName -}}
+{{- $crdEstablished := include "backupstrategy-controller.crdEstablished" (dict "root" . "crd" "mongodbs.strategy.backups.cozystack.io") -}}
+{{- if and $bucketName $crdEstablished -}}
 apiVersion: strategy.backups.cozystack.io/v1alpha1
 kind: MongoDB
 metadata:

--- a/packages/system/backupstrategy-controller/tests/rendering_test.yaml
+++ b/packages/system/backupstrategy-controller/tests/rendering_test.yaml
@@ -90,6 +90,10 @@ tests:
         template: templates/backupclass-default.yaml
 
   - it: "all Strategy CRs and the Velero BSL render once a bucket name resolves"
+    # bucketNameOverride marks an offline render, and the MongoDB count below is
+    # what pins that the CRD gate honours it: without that short-circuit no
+    # `helm template` or CI diff could ever produce this Strategy, since neither
+    # has an apiserver to ask about the CRD.
     set:
       backupStorage.bucketNameOverride: test-bucket
     asserts:
@@ -149,6 +153,30 @@ tests:
           path: spec.template.storage.s3.bucket
           value: ext-bucket
         template: templates/strategy-mariadb-default.yaml
+
+  - it: "MongoDB Strategy gates on its CRD too, so shipping the kind to an installed chart cannot wedge the release"
+    # provisionBucket=false is what makes this case load-bearing: it resolves
+    # $bucketName WITHOUT the offline bucketNameOverride, which is the shape of a
+    # cluster that has been running for releases — bucket gate open, and only the
+    # CRD gate still able to hold the CR back. helm-unittest renders with no
+    # apiserver, so the CRD lookup answers "absent", which is the same answer a
+    # real cluster gives on the upgrade that first ships that CRD. Rendering the
+    # CR there fails Build() for the WHOLE release ("no matches for kind
+    # MongoDB") and applies zero objects, including the CRD that would have
+    # fixed it, so a count of 1 here is that wedge, green.
+    set:
+      backupStorage.provisionBucket: false
+      backupStorage.bucketName: ext-bucket
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/strategy-mongodb-default.yaml
+      # A sibling whose CRD shipped in an earlier release keeps rendering, which
+      # is what makes the count above an assertion about the MongoDB gate rather
+      # than about a chart-wide render failure.
+      - hasDocuments:
+          count: 1
+        template: templates/strategy-cnpg-default.yaml
 
   - it: "velero.bslEnabled=false: Velero strategies and BSL drop out while other strategies keep rendering"
     set:


### PR DESCRIPTION
## What breaks today

Upgrading any existing cluster to a build that carries the new MongoDB backup driver wedges the `backupstrategy-controller` HelmRelease permanently, with `resource mapping not found for name: "cozy-default-mongodb" ... no matches for kind "MongoDB" in version "strategy.backups.cozystack.io/v1alpha1"; ensure CRDs are installed first`.

This chart ships its `strategy.backups.cozystack.io` CRDs as ordinary templates, and Helm resolves every document in a release manifest through the cluster's RESTMapper in `Build()` **before** it applies any of them. A Strategy CR whose CRD is not served yet therefore fails `Build()`, so the release applies **zero** objects — including the CRD that would have made the mapping resolve — and every retry renders the same manifest. Nothing recovers on its own.

## Why the gate that exists does not cover it

The chart already knows this trap: it is why every default Strategy gates on the bucket name. That gate covers the **first install** of a fresh cluster, where nothing is resolvable yet and no Strategy renders at all. It cannot cover shipping a **new kind** to a chart that is already installed — there the bucket name resolved releases ago, so the first upgraded revision renders the new CRD and the new Strategy CR together and wedges.

## The fix

Gate the CR on its CRD actually being served, through a `crdEstablished` helper. The helper asks about the **CRD object** rather than listing the custom kind, because `lookup` on a kind the apiserver does not serve is a render *error*, not an empty result, which would trade this wedge for a different permanent failure; `apiextensions.k8s.io/v1` is always served, so that lookup can only answer yes or no. It requires `Established=True` rather than mere existence, because that is when the kind enters the RESTMapper.

Convergence afterwards is the mechanism the bucket gate already relies on, and is **not** the HelmRelease interval: once the CRD is served, the controller's `DefaultObjectsGate` sees the kind mapped and the CR absent and forces a real Helm upgrade whose render includes it. Kinds that do not map at all are skipped there (`meta.IsNoMatchError`), which is what stops the gate forcing upgrades against a render that cannot yet produce the object.

`bucketNameOverride` short-circuits the CRD lookup for the same reason it short-circuits the bucket lookup: it marks an offline render — `helm template`, a CI diff, a unit test — where there is no apiserver to ask. Live deploys go through Flux and never set it.

## How it was found

The release upgrade E2E lane in #3276, on the `v1.6.2 → main` path. `mongodbs.strategy.backups.cozystack.io` is the only definition added to this chart since the tag, so this is reachable only by upgrading an existing install — no install-only suite can see it.

## Verification

Reproduced and fixed against a live cluster that happens to be in exactly the pre-upgrade state (the seven older strategy CRDs present, `mongodbs` absent). `helm template --dry-run=server` of main's chart fails with the error above and produces zero documents; the same render with this change succeeds with 21 documents and the Strategy correctly withheld. The helper's two branches were probed the same way against that cluster: a served CRD answers `true`, an absent one answers empty.

The new unit case pins the gate offline through the external-S3 path, where the bucket name resolves without the offline override so that only the CRD gate can hold the CR back. Removing the gate turns exactly that case red; the suite is 19/19 green with it.

```release-note
Fixed a permanent failure of the backupstrategy-controller release when upgrading a cluster to a version that adds a new backup-strategy kind: the default MongoDB Strategy is now withheld until its CRD is served, instead of failing the whole release with "no matches for kind".
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup strategy rendering during upgrades by waiting until the required MongoDB resource definition is available.
  * Preserved offline rendering when an explicit bucket name is provided.
  * Prevented invalid default strategies from being generated when the required resource definition is unavailable.

* **Tests**
  * Added coverage for offline rendering and unavailable resource-definition scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->