### PR TITLE
feat(kubevirt): expose vmStateStorageClass on the KubeVirt CR

### DIFF
--- a/packages/core/platform/templates/bundles/iaas.yaml
+++ b/packages/core/platform/templates/bundles/iaas.yaml
@@ -14,6 +14,9 @@
 {{- if .Values.resources.cpuAllocationRatio -}}
 {{- $_ := set $kubevirtValues "cpuAllocationRatio" (.Values.resources.cpuAllocationRatio | int) -}}
 {{- end -}}
+{{- if .Values.vmStateStorageClass -}}
+{{- $_ := set $kubevirtValues "vmStateStorageClass" .Values.vmStateStorageClass -}}
+{{- end -}}
 {{- /*
   When cozystack.gpu-operator is enabled the platform mirrors the variant
   into the KubeVirt CR: the HostDevices feature gate plus a starter

--- a/packages/core/platform/tests/bundles_gpu_kubevirt_wiring_test.yaml
+++ b/packages/core/platform/tests/bundles_gpu_kubevirt_wiring_test.yaml
@@ -27,6 +27,8 @@ tests:
           path: spec.components.kubevirt.values.permittedHostDevices
       - notExists:
           path: spec.components.kubevirt.values.mediatedDevicesConfiguration
+      - notExists:
+          path: spec.components.kubevirt.values.vmStateStorageClass
 
   - it: emits gpu-operator Package at default variant when only the package is enabled (no explicit variant override)
     set:
@@ -385,6 +387,24 @@ tests:
       - equal:
           path: spec.components.kubevirt.values.cpuAllocationRatio
           value: 7
+
+  - it: propagates vmStateStorageClass into the kubevirt component values so persistent EFI/TPM state can land on an RWX-Filesystem class
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+        iaas:
+          enabled: true
+        enabledPackages: []
+      vmStateStorageClass: nfs-csi
+    documentSelector:
+      path: metadata.name
+      value: cozystack.kubevirt
+    asserts:
+      - equal:
+          path: spec.components.kubevirt.values.vmStateStorageClass
+          value: nfs-csi
 
   - it: appends user-supplied pciHostDevices in vgpu mode so post-kubevirt#16890 SR-IOV vGPU VFs can be advertised alongside the platform mediated defaults
     set:

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -603,6 +603,18 @@ resources:
   cpuAllocationRatio: 10
   memoryAllocationRatio: 1
   ephemeralStorageAllocationRatio: 40
+# StorageClass for the persistent EFI vars and TPM state of VirtualMachine
+# workloads — KubeVirt's backend-storage PVC, persistent-state-for-<vm>.
+# Forwarded to the KubeVirt CR's spec.configuration.vmStateStorageClass.
+#
+# Empty by default: KubeVirt then reads the CDI StorageProfile of the
+# cluster-default StorageClass, and the linstor classes shipped by cozystack
+# advertise ReadWriteMany for volumeMode Block only. The backend PVC is then
+# created ReadWriteOnce, which pins the VM to its node — every VM using a
+# windows.* preference (persistent TPM/EFI) can neither be live-migrated nor
+# drained. Point this at a class that advertises ReadWriteMany for volumeMode
+# Filesystem to restore live-migration for those VMs (#3005).
+vmStateStorageClass: ""
 # GPU host-device wiring for VirtualMachine workloads. Auto-injected into the
 # KubeVirt CR's permittedHostDevices when bundles.enabledPackages contains
 # cozystack.gpu-operator. Without it the admission webhook rejects any VM

--- a/packages/system/kubevirt/Makefile
+++ b/packages/system/kubevirt/Makefile
@@ -27,7 +27,7 @@ CR_FILE ?= templates/kubevirt-cr.yaml
 #   1. Operator inspects the new upstream release notes for spec changes
 #      that affect the cozystack-managed fields listed above.
 #   2. Operator hand-merges the new fields into templates/kubevirt-cr.yaml.
-#   3. Operator runs `make update` to re-apply the five cozystack
+#   3. Operator runs `make update` to re-apply the six cozystack
 #      parameterization sed patches in case they were lost during the
 #      hand-merge.
 #
@@ -46,6 +46,9 @@ update:
 	@# sanity-check tail below.
 	grep -q '{{- with .Values.permittedHostDevices }}' $(CR_FILE) || sed -i '/^    evictionStrategy:/i\    {{- with .Values.permittedHostDevices }}\n    permittedHostDevices:\n      {{- toYaml . | nindent 6 }}\n    {{- end }}' $(CR_FILE)
 	grep -q '{{- with .Values.mediatedDevicesConfiguration }}' $(CR_FILE) || sed -i '/^    evictionStrategy:/i\    {{- with .Values.mediatedDevicesConfiguration }}\n    mediatedDevicesConfiguration:\n      {{- toYaml . | nindent 6 }}\n    {{- end }}' $(CR_FILE)
+	@# vmStateStorageClass keys off the same evictionStrategy: anchor and is
+	@# guarded on its own for the same reason as the two blocks above.
+	grep -q '{{- with .Values.vmStateStorageClass }}' $(CR_FILE) || sed -i '/^    evictionStrategy:/i\    {{- with .Values.vmStateStorageClass }}\n    vmStateStorageClass: {{ . | quote }}\n    {{- end }}' $(CR_FILE)
 	@# Sanity-check: every cozystack patch MUST end up in the file. If the
 	@# hand-merge step moved or renamed an anchor (developerConfiguration:,
 	@# - VMExport, evictionStrategy:) the sed silently no-ops and the chart
@@ -56,3 +59,4 @@ update:
 	@grep -q '{{- range .Values.extraFeatureGates }}' $(CR_FILE) || { echo "ERROR: directive '{{- range .Values.extraFeatureGates }}' not inserted — restore the '- VMExport' anchor in $(CR_FILE) and re-run" >&2; exit 1; }
 	@grep -q '{{- with .Values.permittedHostDevices }}' $(CR_FILE) || { echo "ERROR: directive '{{- with .Values.permittedHostDevices }}' not inserted — restore the 'evictionStrategy:' anchor in $(CR_FILE) and re-run" >&2; exit 1; }
 	@grep -q '{{- with .Values.mediatedDevicesConfiguration }}' $(CR_FILE) || { echo "ERROR: directive '{{- with .Values.mediatedDevicesConfiguration }}' not inserted — restore the 'evictionStrategy:' anchor in $(CR_FILE) and re-run" >&2; exit 1; }
+	@grep -q '{{- with .Values.vmStateStorageClass }}' $(CR_FILE) || { echo "ERROR: directive '{{- with .Values.vmStateStorageClass }}' not inserted — restore the 'evictionStrategy:' anchor in $(CR_FILE) and re-run" >&2; exit 1; }

--- a/packages/system/kubevirt/templates/kubevirt-cr.yaml
+++ b/packages/system/kubevirt/templates/kubevirt-cr.yaml
@@ -32,6 +32,9 @@ spec:
     mediatedDevicesConfiguration:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.vmStateStorageClass }}
+    vmStateStorageClass: {{ . | quote }}
+    {{- end }}
     evictionStrategy: LiveMigrate
     virtualMachineOptions:
       disableSerialConsoleLog: {}

--- a/packages/system/kubevirt/tests/kubevirt_cr_test.yaml
+++ b/packages/system/kubevirt/tests/kubevirt_cr_test.yaml
@@ -23,6 +23,8 @@ tests:
           path: spec.configuration.permittedHostDevices
       - notExists:
           path: spec.configuration.mediatedDevicesConfiguration
+      - notExists:
+          path: spec.configuration.vmStateStorageClass
 
   - it: emits cpuAllocationRatio under developerConfiguration when set
     set:
@@ -116,3 +118,11 @@ tests:
       - matchRegex:
           path: spec.customizeComponents.patches[0].patch
           pattern: '"requests":\{"cpu":"100m","memory":"128Mi"\}'
+
+  - it: emits vmStateStorageClass when set so persistent EFI/TPM state can land on an RWX-Filesystem class
+    set:
+      vmStateStorageClass: nfs-csi
+    asserts:
+      - equal:
+          path: spec.configuration.vmStateStorageClass
+          value: nfs-csi

--- a/packages/system/kubevirt/tests/update_idempotency_test.sh
+++ b/packages/system/kubevirt/tests/update_idempotency_test.sh
@@ -55,6 +55,7 @@ trap 'rm -rf "$tmpdir"' EXIT
 
 PHD='{{- with .Values.permittedHostDevices }}'
 MDC='{{- with .Values.mediatedDevicesConfiguration }}'
+VMS='{{- with .Values.vmStateStorageClass }}'
 
 # --- case 1: a hand-merge dropped ONLY the mediatedDevicesConfiguration block.
 # `make update` must reinsert it without duplicating permittedHostDevices.
@@ -80,7 +81,22 @@ fi
 assert_present "$PHD" "$missing_phd"
 assert_count 1 "$MDC" "$missing_phd"
 
-# --- case 3: an already-parameterized template is a no-op (idempotent).
+# --- case 3: a hand-merge dropped ONLY the vmStateStorageClass block. It keys
+# off the same evictionStrategy: anchor as the two blocks above, so a guard
+# shared with either of them would skip this insert while they are present.
+missing_vms="$tmpdir/missing-vms.yaml"
+sed '/{{- with .Values.vmStateStorageClass }}/,/{{- end }}/d' "$src" >"$missing_vms"
+assert_absent "$VMS" "$missing_vms"
+assert_present "$PHD" "$missing_vms"
+assert_present "$MDC" "$missing_vms"
+if ! run_update "$missing_vms"; then
+	fail "make update exited non-zero on a template missing only vmStateStorageClass"
+fi
+assert_present "$VMS" "$missing_vms"
+assert_count 1 "$PHD" "$missing_vms"
+assert_count 1 "$MDC" "$missing_vms"
+
+# --- case 4: an already-parameterized template is a no-op (idempotent).
 full="$tmpdir/full.yaml"
 cp "$src" "$full"
 if ! run_update "$full"; then
@@ -90,13 +106,14 @@ if ! diff -u "$src" "$full" >/dev/null; then
 	fail "make update mutated an already-parameterized template"
 fi
 
-# --- case 4: repeated runs never duplicate a guard directive.
+# --- case 5: repeated runs never duplicate a guard directive.
 run_update "$missing_mdev"
 for guard in \
 	'{{- if .Values.cpuAllocationRatio }}' \
 	'{{- range .Values.extraFeatureGates }}' \
 	"$PHD" \
-	"$MDC"; do
+	"$MDC" \
+	"$VMS"; do
 	assert_count 1 "$guard" "$missing_mdev"
 done
 

--- a/packages/system/kubevirt/values.yaml
+++ b/packages/system/kubevirt/values.yaml
@@ -46,3 +46,18 @@ permittedHostDevices: {}
 #     mediatedDeviceTypes:
 #     - nvidia-740
 mediatedDevicesConfiguration: {}
+
+# StorageClass for the backend-storage PVC that carries a VM's persistent EFI
+# vars and TPM state (persistent-state-for-<vm>). Empty by default, which
+# leaves the CR field unset: KubeVirt then reads the CDI StorageProfile of the
+# cluster-default StorageClass. Driven by .Values.vmStateStorageClass at the
+# platform level.
+#
+# The class MUST advertise ReadWriteMany for volumeMode Filesystem.
+# backend-storage only asks for RWX when the StorageProfile offers it for
+# Filesystem, and an RWO backend PVC pins the VM to its node — a VM whose
+# preference sets preferredTPM.persistent / preferredEfi.persistent, which
+# every windows.* preference in kubevirt-instancetypes does, can then neither
+# be live-migrated nor drained. The linstor `replicated` classes advertise RWX
+# for Block only, so on a stock install those VMs are non-migratable (#3005).
+vmStateStorageClass: ""


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `kind/backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Adds `vmStateStorageClass` to the `kubevirt` chart and forwards it from the
platform's iaas bundle, so `spec.configuration.vmStateStorageClass` on the
KubeVirt CR becomes settable. This is the first direction #3005 lists for the
live-migration regression it reports, and today that field is unreachable from
any values file.

### The problem, as #3005 states it

With persistent firmware state restored by #3154 (after #3006 had stripped it),
KubeVirt creates a `persistent-state-for-<vm>` PVC for every VM whose preference
sets `preferredTPM.persistent` / `preferredEfi.persistent` — which is every
`windows.11`, `windows.2k22` and `windows.2k25` preference shipped in
`kubevirt-instancetypes`. `backend-storage.getAccessMode` reads the CDI
StorageProfile of the cluster-default StorageClass, and the linstor classes
advertise `ReadWriteMany` for `volumeMode: Block` only, so the backend PVC is
created `ReadWriteOnce`. An RWO backend PVC pins the VM to its node: those VMs
can neither be live-migrated nor drained, while the CR asks for
`evictionStrategy: LiveMigrate` and `workloadUpdateMethods: [LiveMigrate,
Evict]`, so node drains and cluster upgrades can wedge on them.

Reproduced on a v1.6.1 cluster (KubeVirt v1.8.4, three nodes):

```
$ kubectl -n tenant-… get pvc persistent-state-for-vm-instance-<vm>
…  Bound  10Mi  RWO  local

$ kubectl -n tenant-… get vmi vm-instance-<vm> -o yaml   # .status.conditions
LiveMigratable=False  NoTSCFrequencyNotLiveMigratable
RestartRequired=True  memory updated in template spec. Memory-hotplug is only available for migratable VMs
```

The second condition is the user-visible cost beyond drains: because the VM is
not migratable, `vmRolloutStrategy: LiveUpdate` cannot hotplug CPU or memory
either. Resizing a Windows VM's instancetype is accepted, staged in the template,
and silently never applied until the VM is stopped and started.

### What this changes

- `packages/system/kubevirt`: `vmStateStorageClass` value, rendered as
  `spec.configuration.vmStateStorageClass` only when non-empty. Default `""`
  keeps the field omitted, so behaviour is unchanged on upgrade.
- `packages/core/platform`: same value forwarded onto `$kubevirtValues` in the
  iaas bundle when non-empty, mirroring `resources.cpuAllocationRatio`. Without
  this the chart value has no path: the cluster values Secret carries only the
  `_cluster` block.
- `make update`: a sixth sed patch with its own grep guard and its own
  sanity-check line. The insert keys off the same `evictionStrategy:` anchor as
  `permittedHostDevices` and `mediatedDevicesConfiguration`, and a guard shared
  with either of them would skip this insert whenever that neighbour is still
  present — the exact trap `tests/update_idempotency_test.sh` exists to pin, so
  that suite gains the matching case.

### What it deliberately does not do

It does not provision an RWX-Filesystem class, and it does not change the
default. Defaulting to `replicated` would not help: its `ReadWriteMany` is
Block-only, and the Block-mode backend volume is still a draft
(kubevirt/kubevirt#18215). So this PR delivers the lever #3005 asks for and
leaves the operator to point it at a class that advertises `ReadWriteMany` for
`volumeMode: Filesystem` — the NFS-export path the issue mentions, or any other.
Whether cozystack should ship such a class by default, and default this value to
it, looks like a separate decision and a separate PR.

### Testing

- `make -C packages/system/kubevirt test` — `helm unittest` 7/7, and
  `tests/update_idempotency_test.sh` PASS including the new case.
- `helm unittest packages/core/platform` — 33 suites, 140 tests, all pass.
- `helm template` on the chart: field absent by default, `vmStateStorageClass:
  "nfs-csi"` rendered above `evictionStrategy` when set.

### Screenshots

<!-- REQUIRED for UI changes: attach screenshots or screen recordings demonstrating
the visual impact of your changes. PRs with UI changes without screenshots will not be merged. -->

N/A — no UI change.

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [ ] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

**Downstream: not ticked, one open question for a human.** Walked the trigger
map file by file against the diff:

- `cozystack/website` — the diff touches `packages/core/platform/values.yaml`,
  which the map maps to the hand-written table in
  `content/en/docs/next/operations/configuration/platform-package.md`. That
  table has no section for the platform's top-level virtualization keys today —
  `gpu.*` is absent from it as well — so the follow-up is a new section rather
  than a row, and which shape the docs owners want is not my call. Happy to open
  either the docs PR or an issue there, whichever you prefer; say which and it
  is done before this leaves draft.
- `terraform-provider-cozystack` — no app `values.schema.json`, `kind`/`plural`,
  version enum, release prefix or CRD field is touched. No trigger.
- `ansible-cozystack` — the role sets `networking.*` and `publishing.*` keys
  only; this adds a key it does not pass, and touches no installer values,
  namespace, variant or waited-on object. No trigger.
- `ccp`, `talm`, `external-apps-example`, `cozyhr`, `cozy-proxy`, `examples`,
  `cozystack-telemetry-server` — nothing under `hack/`, no package layout,
  namespace, CRD, node prerequisite or release-prep change. No trigger.

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
feat(kubevirt): the KubeVirt CR's `vmStateStorageClass` is now settable, as `spec.components.platform.values.vmStateStorageClass` on the platform package and as `vmStateStorageClass` on the kubevirt component. Point it at a StorageClass that advertises `ReadWriteMany` for `volumeMode: Filesystem` to keep the persistent EFI/TPM backend PVC out of ReadWriteOnce, which otherwise makes every Windows VM (persistent TPM/EFI) non-migratable and undrainable, and blocks CPU/memory hotplug on it. Empty by default: no change on upgrade.
```
