### PR TITLE
fix(e2e): include gateway suite for ingress changes

### DIFF
--- a/hack/select-e2e.sh
+++ b/hack/select-e2e.sh
@@ -235,6 +235,7 @@ src_to_suites() {
     # not exist, is dropped by intersect_suites(), and a CDI change reaches
     # nothing runnable through it.
     vm-disk-application) echo vminstance ;;
+    ingress-application|ingress-nginx) echo gateway ;;
     kubernetes-application) echo "kubernetes-latest kubernetes-previous kubernetes-oidc-system kubernetes-oidc-customconfig" ;;
     securitygroup-controller) echo securitygroup ;;
     *-application) echo "${1%-application}" ;;

--- a/hack/select-e2e_test.bats
+++ b/hack/select-e2e_test.bats
@@ -208,6 +208,19 @@ assert_full_suite() {
     echo "$output" | grep -q "kubernetes-oidc-customconfig"
 }
 
+@test "suite coverage from every owner is unioned and deduplicated" {
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    mkdir -p "$tmp/sources"
+    for source in ingress-application ingress-nginx kubernetes-application; do
+        printf 'metadata:\n  name: cozystack.%s\nspec:\n  variants:\n    - components:\n        - path: system/shared-ingress\n' "$source" > "$tmp/sources/$source.yaml"
+    done
+    echo "packages/system/shared-ingress/values.yaml" > "$tmp/diff"
+    output=$(hack/select-e2e.sh "$tmp/diff" "$tmp/sources")
+    assert_selection "every suite covering the shared package must be selected once" \
+        "$output" "gateway kubernetes-latest kubernetes-oidc-customconfig kubernetes-oidc-system kubernetes-previous"
+}
+
 @test "dashboards-only diff selects nothing (path is plural)" {
     tmp=$(mktemp -d)
     trap 'rm -rf "$tmp"' EXIT


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `kind/backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

Fixes #3985.

Maps both ingress PackageSources to the `gateway` suite, which contains the legacy Ingress coverage, while retaining the four suites selected through `kubernetes-application`. A synthetic PackageSource fixture verifies that coverage contributed by every owner is unioned and that duplicate `gateway` entries are emitted only once.

Tests:

- `hack/cozytest.sh hack/select-e2e_test.bats`
- `hack/cozytest.sh hack/select-e2e_test.bats "suite coverage from every owner is unioned and deduplicated"`
- `hack/select-e2e.sh` with `packages/system/ingress-nginx/values.yaml` as the changed path

### Screenshots

N/A — no UI change.

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

<!--  Write a release note:
- Explain what has changed internally and for users.
- Start with the same `type(scope):` prefix as in the PR title
- Follow the guidelines at https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md.
-->

```release-note
fix(e2e): select the gateway suite when ingress packages change, so ingress coverage is not silently omitted from targeted runs.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected end-to-end test suite selection for ingress-related package sources so they run against the appropriate gateway suite.
  * Ensured changes shared by multiple package owners select the complete set of relevant suites without duplicates.

* **Tests**
  * Added coverage validating that selected suites are correctly combined, deduplicated, and sorted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->