### PR TITLE
fix(dashboard): link a tenant row to its detail page

### DIFF
--- a/packages/system/dashboard/images/console/CLAUDE.md
+++ b/packages/system/dashboard/images/console/CLAUDE.md
@@ -77,9 +77,7 @@ same paths to `kubernetes.default.svc` using the pod's service-account token.
    to a chunked-encoding WATCH against the same `resourceVersion`. Don't
    poll. Don't add `refetchInterval`. If you need a one-shot, pass
    `{ watch: false }`.
-4. **Tenant scoping.** Most resources live in `tenant-<name>` namespaces.
-   Pull the active tenant from `useTenantContext()` — never read the
-   namespace from a URL param or guess it.
+4. **Tenant scoping.** Most resources live in `tenant-<name>` namespaces. Pull the active tenant from `useTenantContext()` — never read the namespace from a URL param or guess it. A link that crosses tenants is the one exception, and it still does not read the namespace: it names the tenant in `?tenant=`, which `useTenantFromUrl` feeds into the context on each navigation. Without it a real `<a href>` opened by middle click or in a new tab runs no `onClick`, and a relative CR name resolves against whichever tenant was selected last — a different tenant's resource, behind a Delete confirm that shows only that name.
 5. **Auth.** In production the SPA sits behind oauth2-proxy. The client
    relies on cookies forwarded by nginx, and `/oauth2/userinfo` returns the
    logged-in user. There is no token handling in the SPA itself.

--- a/packages/system/dashboard/images/console/apps/console/src/App.routing.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/App.routing.test.tsx
@@ -6,6 +6,7 @@ import {
   type APIGroupList,
 } from "@cozystack/k8s-client"
 import App from "./App.tsx"
+import { SELECTED_TENANT_KEY } from "./lib/constants.ts"
 import { renderWithK8sProvider } from "./test-utils/render.tsx"
 
 function makeClient(): K8sClient {
@@ -69,5 +70,25 @@ describe("default landing", () => {
     expect(
       await screen.findByRole("heading", { name: "Marketplace", level: 1 }),
     ).toBeTruthy()
+  })
+})
+
+describe("tenant in the URL", () => {
+  // The shell has to call useTenantFromUrl for a cross-tenant link to survive
+  // a middle click or a pasted URL; the hook's own tests cannot see whether it
+  // is wired in, so pin it against the real App.
+  it("adopts the tenant named in the query string", async () => {
+    const client = makeClient()
+    localStorage.setItem(SELECTED_TENANT_KEY, "globex")
+
+    // Any route will do — the shell adopts the param regardless of which page
+    // renders under it; the tenant list just gives a stable marker to await.
+    renderWithK8sProvider(<App />, {
+      client,
+      initialRoute: "/admin/tenants?tenant=acme",
+    })
+
+    await screen.findByRole("heading", { name: "Tenants" })
+    expect(localStorage.getItem(SELECTED_TENANT_KEY)).toBe("acme")
   })
 })

--- a/packages/system/dashboard/images/console/apps/console/src/App.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/App.tsx
@@ -1,6 +1,6 @@
 import { Navigate, Route, Routes, useLocation } from "react-router"
 import { AppShell } from "@cozystack/ui"
-import { TenantProvider } from "./lib/tenant-context.tsx"
+import { TenantProvider, useTenantFromUrl } from "./lib/tenant-context.tsx"
 import { Breadcrumb } from "./components/Breadcrumb.tsx"
 import { MarketplacePage } from "./routes/MarketplacePage.tsx"
 import { ConsolePage } from "./routes/ConsolePage.tsx"
@@ -24,6 +24,7 @@ interface ShellProps {
 
 function Shell({ config, username }: ShellProps) {
   const { pathname } = useLocation()
+  useTenantFromUrl()
   const inMarketplace = pathname.startsWith("/marketplace")
   const inAdmin = pathname.startsWith("/admin")
   const marketplaceSections = useMarketplaceSidebarSections()

--- a/packages/system/dashboard/images/console/apps/console/src/components/WorkloadCell.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/WorkloadCell.tsx
@@ -34,7 +34,13 @@ export function WorkloadCell({ namespace, kind, name }: WorkloadCellProps) {
   const tenant = namespace.startsWith(TENANT_NAMESPACE_PREFIX)
     ? namespace.slice(TENANT_NAMESPACE_PREFIX.length)
     : null
-  const href = plural && tenant ? `/console/${plural}/${name}/workloads` : null
+  // These drill-downs list workloads from every namespace, so the tenant has to
+  // travel in the URL: onClick alone leaves middle click and open-in-new-tab
+  // resolving the name against the previously selected tenant.
+  const href =
+    plural && tenant
+      ? `/console/${plural}/${name}/workloads?tenant=${encodeURIComponent(tenant)}`
+      : null
 
   return (
     <>

--- a/packages/system/dashboard/images/console/apps/console/src/components/WorkloadCell.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/components/WorkloadCell.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router"
 import { useApplicationDefinitions } from "../lib/app-definitions.ts"
 import { useTenantContext } from "../lib/tenant-context.tsx"
 import { TENANT_NAMESPACE_PREFIX } from "../lib/constants.ts"
+import { navigatesThisTab } from "../lib/links.ts"
 
 interface WorkloadCellProps {
   /** Namespace the workload lives in (tenant-<name> for tenant workloads). */
@@ -17,8 +18,9 @@ interface WorkloadCellProps {
  * Renders a consuming workload (the owning application) as a deep-link to its
  * Console Workloads tab, with the kind shown as a subtitle. The link is only active for
  * real app instances: the kind must resolve to a plural via ApplicationDefinitions
- * and the workload must live in a tenant namespace (so the Console tenant
- * context can be switched on click). Shared by every per-resource drill-down.
+ * and the workload must live in a tenant namespace, since the link has to name
+ * that tenant for the Console to resolve the instance. Shared by every
+ * per-resource drill-down.
  */
 export function WorkloadCell({ namespace, kind, name }: WorkloadCellProps) {
   const { data: appDefs } = useApplicationDefinitions()
@@ -47,7 +49,10 @@ export function WorkloadCell({ namespace, kind, name }: WorkloadCellProps) {
       {href ? (
         <Link
           to={href}
-          onClick={() => tenant && selectTenant(tenant)}
+          onClick={(e) => {
+            if (!navigatesThisTab(e) || !tenant) return
+            selectTenant(tenant)
+          }}
           className="font-medium text-blue-700 hover:text-blue-800 hover:underline"
         >
           {name}

--- a/packages/system/dashboard/images/console/apps/console/src/lib/links.test.ts
+++ b/packages/system/dashboard/images/console/apps/console/src/lib/links.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest"
+import type { MouseEvent } from "react"
+import { navigatesThisTab } from "./links.ts"
+
+function click(overrides: Partial<MouseEvent> = {}): MouseEvent {
+  return {
+    button: 0,
+    metaKey: false,
+    altKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    ...overrides,
+  } as MouseEvent
+}
+
+describe("navigatesThisTab", () => {
+  it("accepts a plain primary click", () => {
+    expect(navigatesThisTab(click())).toBe(true)
+  })
+
+  // Each of these hands the navigation to a new tab or window, so the tab the
+  // click happened in keeps whatever tenant it was showing.
+  it.each(["metaKey", "ctrlKey", "shiftKey", "altKey"] as const)(
+    "refuses a click modified with %s",
+    (modifier) => {
+      expect(navigatesThisTab(click({ [modifier]: true }))).toBe(false)
+    },
+  )
+
+  it("refuses a non-primary button", () => {
+    expect(navigatesThisTab(click({ button: 1 }))).toBe(false)
+  })
+})

--- a/packages/system/dashboard/images/console/apps/console/src/lib/links.ts
+++ b/packages/system/dashboard/images/console/apps/console/src/lib/links.ts
@@ -1,0 +1,13 @@
+import type { MouseEvent } from "react"
+
+/**
+ * Whether a click on an anchor will navigate the tab it happened in, rather
+ * than open a new tab or window. React runs `onClick` either way, and a
+ * cross-tenant link's handler aligns the tenant context of the tab it is
+ * leaving — which is wrong when that tab is staying where it is. Same button
+ * and modifier test react-router's own `Link` applies before it intercepts a
+ * click, minus the `target` check these links have no attribute for.
+ */
+export function navigatesThisTab(e: MouseEvent): boolean {
+  return e.button === 0 && !e.metaKey && !e.altKey && !e.ctrlKey && !e.shiftKey
+}

--- a/packages/system/dashboard/images/console/apps/console/src/lib/tenant-context.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/lib/tenant-context.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useNavigate } from "react-router"
+import { K8sClient, type K8sList } from "@cozystack/k8s-client"
+import { TenantProvider, useTenantContext, useTenantFromUrl } from "./tenant-context.tsx"
+import { SELECTED_TENANT_KEY } from "./constants.ts"
+import { renderWithK8sProvider } from "../test-utils/render.tsx"
+
+function tn(name: string) {
+  return {
+    apiVersion: "core.cozystack.io/v1alpha1",
+    kind: "TenantNamespace",
+    metadata: { name, labels: {} },
+  }
+}
+
+function makeClient(): K8sClient {
+  const client = new K8sClient()
+  vi.spyOn(client, "list").mockImplementation(async (_g, _v, plural) => {
+    const items =
+      plural === "tenantnamespaces"
+        ? [tn("tenant-acme"), tn("tenant-globex")]
+        : []
+    return {
+      apiVersion: "v1",
+      kind: `${plural}List`,
+      metadata: {},
+      items,
+    } as K8sList<unknown>
+  })
+  return client
+}
+
+function Probe() {
+  useTenantFromUrl()
+  const { tenantNamespace, selectTenant } = useTenantContext()
+  const navigate = useNavigate()
+  return (
+    <>
+      <output>{tenantNamespace ?? "none"}</output>
+      <button type="button" onClick={() => selectTenant("globex")}>
+        pick globex
+      </button>
+      <button type="button" onClick={() => navigate("/console")}>
+        leave
+      </button>
+      <button type="button" onClick={() => navigate(-1)}>
+        back
+      </button>
+    </>
+  )
+}
+
+function renderAt(route: string) {
+  return renderWithK8sProvider(
+    <TenantProvider>
+      <Probe />
+    </TenantProvider>,
+    { client: makeClient(), initialRoute: route },
+  )
+}
+
+describe("useTenantFromUrl", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  // The detail routes take the resource name from the URL and the namespace
+  // from the tenant context, so a cross-tenant link has to name its tenant in
+  // the URL. Middle click and open-in-new-tab never run onClick, which is the
+  // only other thing that aligns the context.
+  it("selects the tenant named in the query string with no click", async () => {
+    window.localStorage.setItem(SELECTED_TENANT_KEY, "globex")
+
+    renderAt("/admin/tenants/x?tenant=acme")
+
+    expect(await screen.findByText("tenant-acme")).toBeInTheDocument()
+  })
+
+  it("persists the tenant from the URL so the rest of the session agrees", async () => {
+    window.localStorage.setItem(SELECTED_TENANT_KEY, "globex")
+
+    renderAt("/admin/tenants/x?tenant=acme")
+
+    await screen.findByText("tenant-acme")
+    expect(window.localStorage.getItem(SELECTED_TENANT_KEY)).toBe("acme")
+  })
+
+  // The picker switches tenant without leaving the page, so re-applying the
+  // param on every render would drag the user back to it.
+  it("does not drag the picker back to the tenant in the URL", async () => {
+    renderAt("/console/vminstances/demo?tenant=acme")
+    await screen.findByText("tenant-acme")
+
+    await userEvent.click(screen.getByRole("button", { name: "pick globex" }))
+
+    expect(await screen.findByText("tenant-globex")).toBeInTheDocument()
+  })
+
+  it("asserts the URL tenant again when the entry is revisited", async () => {
+    renderAt("/console/vminstances/demo?tenant=acme")
+    await screen.findByText("tenant-acme")
+    await userEvent.click(screen.getByRole("button", { name: "pick globex" }))
+    await screen.findByText("tenant-globex")
+
+    await userEvent.click(screen.getByRole("button", { name: "leave" }))
+    await userEvent.click(screen.getByRole("button", { name: "back" }))
+
+    expect(await screen.findByText("tenant-acme")).toBeInTheDocument()
+  })
+
+  it("leaves the stored tenant alone when the URL names none", async () => {
+    window.localStorage.setItem(SELECTED_TENANT_KEY, "globex")
+
+    renderAt("/admin/tenants/x")
+
+    expect(await screen.findByText("tenant-globex")).toBeInTheDocument()
+  })
+})

--- a/packages/system/dashboard/images/console/apps/console/src/lib/tenant-context.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/lib/tenant-context.test.tsx
@@ -110,6 +110,21 @@ describe("useTenantFromUrl", () => {
     expect(await screen.findByText("tenant-acme")).toBeInTheDocument()
   })
 
+  // A pasted or shared URL can name a tenant this user cannot see. The
+  // provider already refuses to select it; the point here is that the refusal
+  // reaches storage too, so the next load does not open on it and correct
+  // itself again.
+  it("does not leave an unreachable tenant from the URL in storage", async () => {
+    window.localStorage.setItem(SELECTED_TENANT_KEY, "acme")
+
+    renderAt("/admin/tenants/x?tenant=initech")
+
+    // "acme" is the first tenant in the list and there is no "root" here, so
+    // the fallback lands on it — the assertion is about storage, not the pick.
+    expect(await screen.findByText("tenant-acme")).toBeInTheDocument()
+    expect(window.localStorage.getItem(SELECTED_TENANT_KEY)).toBe("acme")
+  })
+
   it("leaves the stored tenant alone when the URL names none", async () => {
     window.localStorage.setItem(SELECTED_TENANT_KEY, "globex")
 

--- a/packages/system/dashboard/images/console/apps/console/src/lib/tenant-context.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/lib/tenant-context.tsx
@@ -117,7 +117,7 @@ export function useTenantContext(): TenantContextValue {
  * tenants under different parents can share a relative CR name, so the name
  * alone would resolve against whichever tenant happened to be selected last.
  * Applied once per navigation rather than on every render, so the tenant picker
- * -- which switches the tenant without leaving the page -- is not dragged back
+ * — which switches the tenant without leaving the page — is not dragged back
  * to the URL under the user, while returning to the entry through history
  * asserts it again. The provider's own fallback stays free to reject a tenant
  * the user cannot see.

--- a/packages/system/dashboard/images/console/apps/console/src/lib/tenant-context.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/lib/tenant-context.tsx
@@ -31,6 +31,14 @@ interface TenantContextValue {
 
 const TenantContext = createContext<TenantContextValue | null>(null)
 
+function persistTenant(name: string) {
+  try {
+    window.localStorage.setItem(SELECTED_TENANT_KEY, name)
+  } catch {
+    // ignore storage quota / private-mode failures
+  }
+}
+
 function displayName(ns: TenantNamespace): string {
   const name = ns.metadata.name
   return name.startsWith(TENANT_NAMESPACE_PREFIX)
@@ -70,16 +78,17 @@ export function TenantProvider({ children }: { children: ReactNode }) {
     if (selectedTenant && tenants.some((t) => displayName(t) === selectedTenant)) return
     const fallback =
       tenants.find((t) => displayName(t) === "root") ?? tenants[0]
+    // Write the override through to storage, not just to state. Whatever the
+    // stored name was, it is one the user cannot see — a revoked grant, or a
+    // `?tenant=` naming someone else's tenant — and leaving it there makes
+    // every later load open on it and correct itself again.
+    persistTenant(displayName(fallback))
     setSelectedTenant(displayName(fallback))
   }, [tenants, selectedTenant])
 
   const selectTenant = (name: string) => {
     setSelectedTenant(name)
-    try {
-      window.localStorage.setItem(SELECTED_TENANT_KEY, name)
-    } catch {
-      // ignore storage quota / private-mode failures
-    }
+    persistTenant(name)
   }
 
   const value: TenantContextValue = {

--- a/packages/system/dashboard/images/console/apps/console/src/lib/tenant-context.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/lib/tenant-context.tsx
@@ -3,9 +3,11 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react"
+import { useLocation, useSearchParams } from "react-router"
 import { useK8sList } from "@cozystack/k8s-client"
 import type { TenantNamespace } from "@cozystack/types"
 import { SELECTED_TENANT_KEY, TENANT_NAMESPACE_PREFIX } from "./constants.ts"
@@ -96,6 +98,34 @@ export function useTenantContext(): TenantContextValue {
   const ctx = useContext(TenantContext)
   if (!ctx) throw new Error("useTenantContext must be used inside TenantProvider")
   return ctx
+}
+
+/**
+ * The detail routes take the resource name from the URL and the namespace from
+ * this context, so a link that crosses tenants has to name its tenant in the
+ * URL: the browser-native paths a real anchor enables — middle click, open in
+ * new tab, a bookmarked or pasted URL — never run React's onClick, and two
+ * tenants under different parents can share a relative CR name, so the name
+ * alone would resolve against whichever tenant happened to be selected last.
+ * Applied once per navigation rather than on every render, so the tenant picker
+ * -- which switches the tenant without leaving the page -- is not dragged back
+ * to the URL under the user, while returning to the entry through history
+ * asserts it again. The provider's own fallback stays free to reject a tenant
+ * the user cannot see.
+ */
+export function useTenantFromUrl() {
+  const { key } = useLocation()
+  const [params] = useSearchParams()
+  const wanted = params.get("tenant")
+  const { selectTenant } = useTenantContext()
+  const navigated = useRef<string | null>(null)
+
+  useEffect(() => {
+    const previous = navigated.current
+    navigated.current = key
+    if (!wanted || previous === key) return
+    selectTenant(wanted)
+  }, [key, wanted, selectTenant])
 }
 
 /**

--- a/packages/system/dashboard/images/console/apps/console/src/lib/tenant-tree.test.ts
+++ b/packages/system/dashboard/images/console/apps/console/src/lib/tenant-tree.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest"
+import type { TenantNamespace } from "@cozystack/types"
+import { realParentNamespace } from "./tenant-tree.ts"
+
+function tn(name: string, ancestors: string[]): TenantNamespace {
+  const labels: Record<string, string> = {}
+  for (const a of [...ancestors, name]) labels[`tenant.cozystack.io/${a}`] = ""
+  return {
+    apiVersion: "core.cozystack.io/v1alpha1",
+    kind: "TenantNamespace",
+    metadata: { name, labels },
+  } as TenantNamespace
+}
+
+describe("realParentNamespace", () => {
+  it("takes the deepest ancestor that prefixes the namespace", () => {
+    // The full chain is on the labels; only the longest prefix is the parent.
+    expect(
+      realParentNamespace(
+        tn("tenant-acme-eu-dev", ["tenant-root", "tenant-acme", "tenant-acme-eu"]),
+      ),
+    ).toBe("tenant-acme-eu")
+  })
+
+  it("names an inaccessible parent, which is the point of asking", () => {
+    // Visibility is the caller's problem: the CR of a bridged row lives in a
+    // namespace the user may not read, and the caller has to be able to tell.
+    expect(
+      realParentNamespace(tn("tenant-acme-eu", ["tenant-root", "tenant-acme"])),
+    ).toBe("tenant-acme")
+  })
+
+  it("resolves a tenant ordered directly in the root", () => {
+    // A tenant `acme` created in `tenant-root` owns `tenant-acme`, not
+    // `tenant-root-acme`, so the prefix rule alone leaves every top-level
+    // tenant — most tenants on a normal cluster — looking parentless.
+    expect(realParentNamespace(tn("tenant-acme", ["tenant-root"]))).toBe(
+      "tenant-root",
+    )
+  })
+
+  it("does not mistake a root-level name that starts with root", () => {
+    // `tenant-root-x` is the tenant `root-x` ordered in the root, and the
+    // prefix branch answers with the same parent the label does.
+    expect(realParentNamespace(tn("tenant-root-x", ["tenant-root"]))).toBe(
+      "tenant-root",
+    )
+  })
+
+  it("has no parent for the hierarchy root", () => {
+    expect(realParentNamespace(tn("tenant-root", []))).toBeUndefined()
+  })
+
+  it("has no parent when the ancestor labels are gone", () => {
+    // A TenantNamespace carrying only its own label is either the root or
+    // mislabelled; either way there is no CR namespace to derive.
+    expect(realParentNamespace(tn("tenant-acme", []))).toBeUndefined()
+  })
+})

--- a/packages/system/dashboard/images/console/apps/console/src/lib/tenant-tree.ts
+++ b/packages/system/dashboard/images/console/apps/console/src/lib/tenant-tree.ts
@@ -1,4 +1,5 @@
 import type { TenantNamespace } from "@cozystack/types"
+import { ROOT_TENANT_NAMESPACE } from "./constants.ts"
 import { tenantDisplayName } from "./tenant-context.tsx"
 
 const ANCESTOR_LABEL_PREFIX = "tenant.cozystack.io/"
@@ -76,11 +77,18 @@ export function flattenTenantForest(
 /**
  * Row label relative to the visible parent: `tenant-whmcs-crpjxhwm` under
  * `tenant-whmcs` shows as `crpjxhwm`. Forest roots keep their full display
- * name — there is no parent on screen to be relative to.
+ * name — there is no parent on screen to be relative to, and neither do the
+ * root's own children, whose namespace never carries the parent's name: under
+ * `tenant-root` the tenant `root-x` owns `tenant-root-x`, and stripping the
+ * prefix there would label it `x` while its CR is `root-x`.
  */
 export function relativeTenantName(node: TenantTreeNode): string {
   const ns = node.tn.metadata.name
-  if (node.parentNs && ns.startsWith(`${node.parentNs}-`)) {
+  if (
+    node.parentNs &&
+    node.parentNs !== ROOT_TENANT_NAMESPACE &&
+    ns.startsWith(`${node.parentNs}-`)
+  ) {
     return ns.slice(node.parentNs.length + 1)
   }
   return tenantDisplayName(node.tn)
@@ -96,7 +104,16 @@ export function relativeTenantName(node: TenantTreeNode): string {
  */
 export function realParentNamespace(tn: TenantNamespace): string | undefined {
   const ns = tn.metadata.name
-  return ancestorNamespaces(tn)
+  const ancestors = ancestorNamespaces(tn)
+  const nested = ancestors
     .filter((ancestor) => ns.startsWith(`${ancestor}-`))
     .sort((a, b) => b.length - a.length)[0]
+  if (nested) return nested
+  // The root is the one level the naming rule skips: a tenant `x` ordered in
+  // `tenant-root` owns `tenant-x`, not `tenant-root-x`, so the prefix test
+  // never matches and every top-level tenant — most tenants on a normal
+  // cluster — looked parentless. The ancestor labels still say otherwise.
+  return ancestors.includes(ROOT_TENANT_NAMESPACE)
+    ? ROOT_TENANT_NAMESPACE
+    : undefined
 }

--- a/packages/system/dashboard/images/console/apps/console/src/routes/ClusterUsageResourcePage.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/ClusterUsageResourcePage.test.tsx
@@ -165,7 +165,12 @@ describe("ClusterUsageResourcePage", () => {
     renderResource(client, GPU)
 
     const link = await screen.findByRole("link", { name: "demo-vm" })
-    expect(link).toHaveAttribute("href", "/console/vminstances/demo-vm/workloads")
+    // The tenant travels in the URL: this table lists workloads from every
+    // namespace, and a middle click never runs the link's onClick.
+    expect(link).toHaveAttribute(
+      "href",
+      "/console/vminstances/demo-vm/workloads?tenant=root",
+    )
   })
 
   it("does not link a consumer whose kind is not a known application", async () => {

--- a/packages/system/dashboard/images/console/apps/console/src/routes/StorageClassUsagePage.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/StorageClassUsagePage.test.tsx
@@ -107,7 +107,12 @@ describe("StorageClassUsagePage", () => {
     )
     renderPage(client, "replicated")
     const link = await screen.findByRole("link", { name: "demo-vm" })
-    expect(link).toHaveAttribute("href", "/console/vminstances/demo-vm/workloads")
+    // Same cross-namespace listing as the cluster drill-down, same need to
+    // carry the tenant rather than rely on the click handler.
+    expect(link).toHaveAttribute(
+      "href",
+      "/console/vminstances/demo-vm/workloads?tenant=root",
+    )
   })
 
   it("shows an empty state when nothing uses the class", async () => {

--- a/packages/system/dashboard/images/console/apps/console/src/routes/TenantsPage.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/TenantsPage.test.tsx
@@ -89,6 +89,17 @@ describe("TenantsPage tree", () => {
     expect(editButtons).toHaveLength(1)
     expect(screen.getByTitle("Edit tenant whmcs-x")).toBeInTheDocument()
     expect(screen.queryByTitle("Edit tenant whmcs-a-b")).not.toBeInTheDocument()
+
+    // A reachable Tenant CR links directly to its detail page, where Delete is
+    // available. A bridged row with an unreadable real parent stays plain text.
+    // The CR name is relative to the parent, so the link has to name the tenant
+    // too: middle click and open-in-new-tab never run onClick, and the detail
+    // page would otherwise resolve "x" against the previously selected tenant.
+    expect(screen.getByRole("link", { name: "x" })).toHaveAttribute(
+      "href",
+      "/admin/tenants/x?tenant=whmcs",
+    )
+    expect(screen.queryByRole("link", { name: "a-b" })).toBeNull()
   })
 
   it("collapses a subtree via the row toggle", async () => {

--- a/packages/system/dashboard/images/console/apps/console/src/routes/TenantsPage.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/TenantsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll } from "vitest"
-import { screen } from "@testing-library/react"
+import { fireEvent, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import {
   K8sClient,
@@ -181,6 +181,35 @@ describe("TenantsPage under a visible root", () => {
 // other row, and deriving the CR name must not subtract the node's own name
 // from itself and leave nothing.
 const SELF_ROOT = [tn("tenant-whmcs", [])]
+
+describe("TenantsPage cross-tenant link", () => {
+  // The href carries the tenant, so the tab that opens resolves on its own.
+  // The click handler exists only to spare the tab that navigates a render
+  // against the previous tenant — a ctrl-click is not that tab.
+  it("does not switch the current tenant on a ctrl-click", async () => {
+    localStorage.setItem(SELECTED_TENANT_KEY, "root")
+
+    renderWithK8sProvider(
+      <TenantProvider>
+        <TenantsPage />
+      </TenantProvider>,
+      { client: makeClient(ROOT_VISIBLE), initialRoute: "/admin/tenants" },
+    )
+
+    // "eu" hangs under acme, so a plain click here would move the selection
+    // off root and the assertion below could not tell the two apart.
+    const link = await screen.findByRole("link", { name: "eu" })
+    // jsdom cannot follow an href, and a ctrl-click is exactly the case
+    // react-router leaves to the browser. Swallow the default so the run does
+    // not carry a "navigation to another Document" line; the handler under
+    // test has already run by then, since React's own listener sits on the
+    // container and this one is on the anchor.
+    link.addEventListener("click", (e) => e.preventDefault())
+    fireEvent.click(link, { ctrlKey: true })
+
+    expect(localStorage.getItem(SELECTED_TENANT_KEY)).toBe("root")
+  })
+})
 
 describe("TenantsPage self-referential root", () => {
   it("names the CR of a root that is not tenant-root", async () => {

--- a/packages/system/dashboard/images/console/apps/console/src/routes/TenantsPage.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/TenantsPage.test.tsx
@@ -30,10 +30,10 @@ const VISIBLE = [
   tn("tenant-whmcs-a-b", ["tenant-root", "tenant-whmcs", "tenant-whmcs-a"]),
 ]
 
-function makeClient(): K8sClient {
+function makeClient(tenants: unknown[] = VISIBLE): K8sClient {
   const client = new K8sClient()
   vi.spyOn(client, "list").mockImplementation(async (_g, _v, plural) => {
-    const items = plural === "tenantnamespaces" ? VISIBLE : []
+    const items = plural === "tenantnamespaces" ? tenants : []
     return {
       apiVersion: "v1",
       kind: `${plural}List`,
@@ -118,5 +118,84 @@ describe("TenantsPage tree", () => {
     expect(screen.queryByText("a-b")).not.toBeInTheDocument()
     await user.click(screen.getByTitle("Expand"))
     expect(await screen.findByText("x")).toBeInTheDocument()
+  })
+})
+
+// Tenants ordered directly in the root are the common case on a normal
+// cluster, and they are the one level the hierarchical namespace naming skips:
+// `acme` created in `tenant-root` owns `tenant-acme`, not `tenant-root-acme`.
+const ROOT_VISIBLE = [
+  tn("tenant-root", []),
+  tn("tenant-acme", ["tenant-root"]),
+  tn("tenant-acme-eu", ["tenant-root", "tenant-acme"]),
+  // A root-level tenant whose own name starts with `root`, which is the case
+  // that makes "strip the parent's prefix" the wrong rule rather than merely
+  // an incomplete one.
+  tn("tenant-root-x", ["tenant-root"]),
+]
+
+describe("TenantsPage under a visible root", () => {
+  it("reaches the Tenant CR of a tenant ordered directly in the root", async () => {
+    // Start on the tenant this fixture actually contains: landing on one it
+    // does not makes the provider fall back and refetch, and the page blinks
+    // back through its spinner mid-assertion.
+    localStorage.setItem(SELECTED_TENANT_KEY, "root")
+    renderWithK8sProvider(
+      <TenantProvider>
+        <TenantsPage />
+      </TenantProvider>,
+      { client: makeClient(ROOT_VISIBLE), initialRoute: "/admin/tenants" },
+    )
+
+    // The root's CR is self-referential: `root` inside its own namespace.
+    expect(await screen.findByRole("link", { name: "root" })).toHaveAttribute(
+      "href",
+      "/admin/tenants/root?tenant=root",
+    )
+
+    // The row that the prefix-only parent rule used to leave as plain text.
+    expect(screen.getByRole("link", { name: "acme" })).toHaveAttribute(
+      "href",
+      "/admin/tenants/acme?tenant=root",
+    )
+    expect(screen.getByTitle("Edit tenant acme")).toBeInTheDocument()
+
+    // A level down the rule applies as before, and the link names the parent
+    // rather than the root.
+    expect(screen.getByRole("link", { name: "eu" })).toHaveAttribute(
+      "href",
+      "/admin/tenants/eu?tenant=acme",
+    )
+
+    // `tenant-root-x` is the tenant `root-x`, not the tenant `x` — the row
+    // label and the CR in the link have to agree on that.
+    expect(screen.getByRole("link", { name: "root-x" })).toHaveAttribute(
+      "href",
+      "/admin/tenants/root-x?tenant=root",
+    )
+  })
+})
+
+// A forest root that carries no ancestor labels is self-referential: its CR
+// lives in its own namespace. The list reaches it the same way it reaches any
+// other row, and deriving the CR name must not subtract the node's own name
+// from itself and leave nothing.
+const SELF_ROOT = [tn("tenant-whmcs", [])]
+
+describe("TenantsPage self-referential root", () => {
+  it("names the CR of a root that is not tenant-root", async () => {
+    localStorage.setItem(SELECTED_TENANT_KEY, "whmcs")
+
+    renderWithK8sProvider(
+      <TenantProvider>
+        <TenantsPage />
+      </TenantProvider>,
+      { client: makeClient(SELF_ROOT), initialRoute: "/admin/tenants" },
+    )
+
+    expect(await screen.findByRole("link", { name: "whmcs" })).toHaveAttribute(
+      "href",
+      "/admin/tenants/whmcs?tenant=whmcs",
+    )
   })
 })

--- a/packages/system/dashboard/images/console/apps/console/src/routes/TenantsPage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/TenantsPage.tsx
@@ -14,6 +14,7 @@ import {
   type TenantTreeNode,
 } from "../lib/tenant-tree.ts"
 import { ROOT_TENANT_NAMESPACE, TENANT_NAMESPACE_PREFIX } from "../lib/constants.ts"
+import { navigatesThisTab } from "../lib/links.ts"
 import { formatAge } from "../lib/status.ts"
 import { TenantQuotaCompact } from "../components/QuotaDisplay.tsx"
 import type { ResourceQuota } from "../components/QuotaDisplay.tsx"
@@ -233,7 +234,15 @@ export function TenantsPage() {
                           {route ? (
                             <Link
                               to={route.href}
-                              onClick={() => selectTenant(route.parentTenant)}
+                              // The href alone would leave the detail page's
+                              // first render on the previous tenant, flashing
+                              // a not-found before the URL is adopted. Aligning
+                              // the context here is for the tab that navigates
+                              // — a ctrl-click leaves this one where it is.
+                              onClick={(e) => {
+                                if (!navigatesThisTab(e)) return
+                                selectTenant(route.parentTenant)
+                              }}
                               className="block truncate text-sm font-medium text-slate-900 hover:underline"
                             >
                               {relativeTenantName(node)}

--- a/packages/system/dashboard/images/console/apps/console/src/routes/TenantsPage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/TenantsPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react"
-import { useNavigate } from "react-router"
+import { Link, useNavigate } from "react-router"
 import { Plus, Edit, Info, ChevronDown, ChevronRight, CornerDownRight } from "lucide-react"
 import { Spinner, Section, Button } from "@cozystack/ui"
 import { useK8sList } from "@cozystack/k8s-client"
@@ -125,8 +125,8 @@ export function TenantsPage() {
   // A node's Tenant CR lives in its REAL parent's namespace, which is not
   // necessarily the parent it hangs under: a node whose real parent is
   // inaccessible is bridged onto the nearest visible ancestor. Deriving the CR
-  // from that bridged ancestor names a CR that does not exist, so the edit
-  // target comes from realParentNamespace instead — and is offered only when
+  // from that bridged ancestor names a CR that does not exist, so Tenant CR
+  // routes come from realParentNamespace instead — and are offered only when
   // that namespace is actually readable, since otherwise there is no CR the
   // user could open. The hierarchy root (no ancestor labels at all) is
   // self-referential: its CR (`root`) lives in its own namespace.
@@ -137,12 +137,28 @@ export function TenantsPage() {
     const real = realParentNamespace(node.tn)
     return real && visibleNs.has(real) ? real : undefined
   }
-  const canEdit = (node: TreeNode) => !!editParentNs(node)
-  const editNode = (node: TreeNode) => {
+  const tenantRoute = (node: TreeNode) => {
     const parentNs = editParentNs(node)
-    if (!parentNs) return
-    selectTenant(parentNs.slice(TENANT_NAMESPACE_PREFIX.length))
-    navigate(`${basePath}/tenants/${tenantCrName(node.tn.metadata.name, parentNs)}/edit`)
+    if (!parentNs) return undefined
+    const parentTenant = parentNs.slice(TENANT_NAMESPACE_PREFIX.length)
+    const path = `${basePath}/tenants/${tenantCrName(node.tn.metadata.name, parentNs)}`
+    return {
+      parentTenant,
+      path,
+      // The CR name is relative to the parent, so two tenants under different
+      // parents share one path; the detail page reads the namespace from the
+      // tenant context, which only the query param can set on a new tab.
+      href: `${path}?tenant=${encodeURIComponent(parentTenant)}`,
+    }
+  }
+  const canEdit = (node: TreeNode) => !!tenantRoute(node)
+  const editNode = (node: TreeNode) => {
+    const route = tenantRoute(node)
+    if (!route) return
+    selectTenant(route.parentTenant)
+    navigate(
+      `${route.path}/edit?tenant=${encodeURIComponent(route.parentTenant)}`,
+    )
   }
 
   return (
@@ -183,6 +199,7 @@ export function TenantsPage() {
                 const modules = modulesByNamespace.get(ns) ?? []
                 const tenantQuotas = quotasByNamespace.get(ns) ?? []
                 const host = node.tn.metadata.labels?.[HOST_LABEL]
+                const route = tenantRoute(node)
                 return (
                   <tr key={ns} className="hover:bg-slate-50">
                     <td className="px-4 py-3">
@@ -207,9 +224,19 @@ export function TenantsPage() {
                           <CornerDownRight className="size-3.5 shrink-0 text-slate-300" />
                         ) : null}
                         <div className="min-w-0">
-                          <p className="truncate text-sm font-medium text-slate-900">
-                            {relativeTenantName(node)}
-                          </p>
+                          {route ? (
+                            <Link
+                              to={route.href}
+                              onClick={() => selectTenant(route.parentTenant)}
+                              className="block truncate text-sm font-medium text-slate-900 hover:underline"
+                            >
+                              {relativeTenantName(node)}
+                            </Link>
+                          ) : (
+                            <p className="truncate text-sm font-medium text-slate-900">
+                              {relativeTenantName(node)}
+                            </p>
+                          )}
                           <p className="truncate font-mono text-[11px] text-slate-400">
                             {ns}
                           </p>

--- a/packages/system/dashboard/images/console/apps/console/src/routes/TenantsPage.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/TenantsPage.tsx
@@ -13,7 +13,7 @@ import {
   relativeTenantName,
   type TenantTreeNode,
 } from "../lib/tenant-tree.ts"
-import { TENANT_NAMESPACE_PREFIX } from "../lib/constants.ts"
+import { ROOT_TENANT_NAMESPACE, TENANT_NAMESPACE_PREFIX } from "../lib/constants.ts"
 import { formatAge } from "../lib/status.ts"
 import { TenantQuotaCompact } from "../components/QuotaDisplay.tsx"
 import type { ResourceQuota } from "../components/QuotaDisplay.tsx"
@@ -34,11 +34,17 @@ type TreeNode = TenantTreeNode
 /**
  * The Tenant CR of a namespace lives in its parent's namespace under the
  * short name: `tenant-whmcs-jzmnbwum` under `tenant-whmcs` is CR `jzmnbwum`.
- * Root-level children (`tenant-kvaps` under `tenant-root`) collapse to the
- * same rule via the plain `tenant-` prefix strip.
+ * Under the root the naming rule drops a level — a tenant `kvaps` ordered in
+ * `tenant-root` owns `tenant-kvaps` — so there the CR name is the plain
+ * prefix strip, which also names the root's own self-referential CR (`root`).
+ * Excluding the root from the prefix branch rather than dropping the branch
+ * keeps two things right at once: a root-level tenant called `root-x`
+ * resolves to the CR `root-x` and not `x`, and a self-referential node whose
+ * namespace is not `tenant-root` still names itself instead of the empty
+ * string that subtracting its own name would leave.
  */
 function tenantCrName(ns: string, parentNs: string): string {
-  return ns.startsWith(`${parentNs}-`)
+  return parentNs !== ROOT_TENANT_NAMESPACE && ns.startsWith(`${parentNs}-`)
     ? ns.slice(parentNs.length + 1)
     : ns.slice(TENANT_NAMESPACE_PREFIX.length)
 }


### PR DESCRIPTION
Fixes #3822

Tenant list showed name as plain text and the only link in a row was Edit button, so detail page with its tabs and Delete action was reachable only by opening edit form and cancelling out of it. Name cell is a link now.

Link carries its tenant in `?tenant=`. CR name in the path is relative to parent, so two tenants under different parents share one path, and detail page takes name from url but namespace from tenant context. Middle click, open in new tab and pasted url never run onClick, so without the parameter they resolve against whichever tenant was selected last, behind a Delete confirm that shows only relative name. New `useTenantFromUrl` applies it once per navigation and not per render, so tenant picker still can switch tenant on a page whose url names another one. `WorkloadCell` had same onClick-only pattern and is fixed with it.

Second commit is why that link was mostly useless. Console recovers a tenant's parent from namespace name (`tenant-a-b` sits under `tenant-a`), but root is the one level that naming skips: tenant `acme` ordered in `tenant-root` owns `tenant-acme`, not `tenant-root-acme`. So `realParentNamespace` returned undefined for every top level tenant, which is most tenants on a normal cluster, and Edit button has been missing there for as long as it exists. Ancestor labels carry the parent that the name does not.

Third one is ctrl-click. Click handler aligns the context so opened page renders against right tenant from first frame instead of flashing not-found while url is adopted, but React runs it for ctrl and cmd click too, which browser turns into a new tab, so the tab you left behind moved as well. Now it runs only for the click that navigates its own tab.

### Notes

A row links, and offers Edit, exactly when namespace holding its Tenant CR is one the apiserver returns to this user. It returns a tenant namespace only if the user is subject of a RoleBinding in it, so sub-tenant admin that cant act in `tenant-root` sees no link there.

`?tenant=` grants nothing by itself, every call still goes with the user's own credentials, and a parameter naming unreachable tenant is refused by the provider's existing fallback. That refusal now reaches localStorage too, so pasted link doesn't leave a name behind that every later load opens on and corrects again.

No row level Delete button. Issue allows either that or a route to detail page, I took the route so confirm and mutation stay in one place. Detail page tabs still drop the parameter as you move between them, that is pre-existing and matters only for a tab url opened cold.

Covered by tests: top level tenant, nested one, root level tenant named `root-x`, forest root without ancestor labels, bridged row whose real parent is invisible, `?tenant=` naming a tenant the user cant see, ctrl-click, picker switching on a page whose url names another. Every source change here fails a test when reverted.

#3837 touches some of the same files (`App.tsx`, console `CLAUDE.md`, two capacity drill-down tests), so whichever lands second needs a small rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tenant-specific links now include tenant information in the URL, ensuring resources open in the correct tenant when opened in a new tab or via middle-click.
  * The Console automatically adopts and remembers the tenant specified in a URL.
  * Reachable tenants in hierarchy views are now clickable and navigate directly to their details.

* **Bug Fixes**
  * Improved tenant hierarchy and root-level tenant resolution.
  * Prevented modified-click navigation from unexpectedly changing the active tenant.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->