### PR TITLE
test(clickhouse): move the backup API contract from e2e into unit tests

### DIFF
--- a/packages/apps/clickhouse/tests/backup_api_contract_test.yaml
+++ b/packages/apps/clickhouse/tests/backup_api_contract_test.yaml
@@ -1,0 +1,99 @@
+suite: clickhouse-backup sidecar API contract (port and credential wiring)
+
+# The contract between the chart and the cozy-default-altinity backup strategy:
+# the strategy Pod reaches the in-Pod clickhouse-backup HTTP API on the named
+# port ch-backup-api, authenticating with the credentials in the chart-emitted
+# <release>-backup-api-auth Secret. A chart bump that renames the container,
+# moves the port, or repoints either secretKeyRef breaks every ClickHouse
+# BackupJob, and surfaces only as 401s or a connection refused at backup time.
+#
+# The e2e suite also checks this wiring on the operator-created Pod and admitted
+# Secret. These render assertions add an earlier, chart-owned failure signal on
+# every pull request; they do not replace the live operator/API integration.
+#
+# The e2e Test keeps its own reason to exist: it proves a backup-enabled
+# ClickHouse actually reaches a ready replica, which no amount of rendering can.
+
+templates:
+  - templates/clickhouse.yaml
+  - templates/backup-api-auth-secret.yaml
+
+release:
+  name: ch-test
+  namespace: tenant-test
+
+set:
+  _cluster: {}
+
+tests:
+  - it: "sidecar exposes the API on the named port the strategy dials"
+    template: templates/clickhouse.yaml
+    documentSelector:
+      path: kind
+      value: ClickHouseInstallation
+    set:
+      backup:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.templates.podTemplates[0].spec.containers[?(@.name=='clickhouse-backup')].ports
+          content:
+            name: ch-backup-api
+            containerPort: 7171
+            protocol: TCP
+
+  - it: "sidecar authenticates from the chart-emitted auth Secret"
+    template: templates/clickhouse.yaml
+    documentSelector:
+      path: kind
+      value: ClickHouseInstallation
+    set:
+      backup:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.templates.podTemplates[0].spec.containers[?(@.name=='clickhouse-backup')].env
+          content:
+            name: API_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: ch-test-backup-api-auth
+                key: username
+      - contains:
+          path: spec.templates.podTemplates[0].spec.containers[?(@.name=='clickhouse-backup')].env
+          content:
+            name: API_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: ch-test-backup-api-auth
+                key: password
+
+  - it: "the auth Secret carries both keys the sidecar reads"
+    template: templates/backup-api-auth-secret.yaml
+    set:
+      backup:
+        enabled: true
+    asserts:
+      - isKind:
+          of: Secret
+      - equal:
+          path: metadata.name
+          value: ch-test-backup-api-auth
+      # stringData, not data: the apiserver converts one to the other on
+      # admission, so the live object the e2e suite inspects has `data` while
+      # the rendered manifest has `stringData`. Asserting the rendered shape is
+      # the point of testing here rather than there.
+      - equal:
+          path: stringData.username
+          value: backup
+      - isNotNullOrEmpty:
+          path: stringData.password
+
+  - it: "no auth Secret when backups are off"
+    template: templates/backup-api-auth-secret.yaml
+    set:
+      backup:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
## What this PR does

Two related moves, both from the same question: can a change to this repository make this assertion fail?

### The clickhouse-backup API contract moves into unit tests

The contract between the chart and the `cozy-default-altinity` strategy is the named port the strategy Pod dials and the two `secretKeyRef`s it authenticates with. It lived only in `hack/e2e-chainsaw/clickhouse`, Test `clickhouse-1-backup-contracts`, where reaching it costs a live ClickHouse plus Keeper and roughly a hundred seconds, and where it runs only when test-impact analysis happens to select that suite.

Every property it asserts is a property of the rendered chart: the port and both env entries are literals in `templates/clickhouse.yaml`, and the Altinity operator copies the podTemplate through unchanged. So they now run in helm-unittest, in milliseconds, on every pull request rather than on the subset that selects clickhouse.

The e2e Test is untouched and keeps its own reason to exist: it proves a backup-enabled ClickHouse actually reaches a ready replica, which no amount of rendering can.

One difference the move made visible: the Secret is rendered with `stringData` and the apiserver converts it, so the live object the e2e suite inspects has `data` while the manifest has `stringData`. The unit test asserts the rendered shape, which is precisely why it belongs here.

### Assertions on other projects' constants are dropped

`postgres` asserted 5432 on `postgres-test-{r,ro,rw}`; `mariadb` asserted 3306 and 9104. None of those Services is ours: `packages/apps/postgres/templates/` renders exactly one Service (`external-svc.yaml`, none of the three) and `packages/apps/mariadb/templates/` renders none outside a cleanup hook. They are created by CNPG and mariadb-operator, their ports are constants in those projects' sources, and they are covered by those projects' own tests. No change to this repository could make those asserts fail, so they spent suite time on a result that cannot vary with the code under test.

The `Endpoints` asserts on the same objects are kept and are strictly stronger: an address appears only once the Service exists **and** a replica has passed its readiness probe, which is a statement about this deployment rather than about an upstream constant.

### Why this is worth doing beyond the seconds

The time saved is negligible and is not the point. The point is where the checks run. As e2e assertions they fire only when TIA selects that suite; as unit tests they fire on every pull request. The dropped ones fired everywhere and proved nothing.

This is three suites out of twenty-one, from an assertion audit that covered postgres, clickhouse and mariadb. The same pass over the rest is a follow-up.

### Downstream repositories

- [x] No downstream repository is affected by this change

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added contract coverage for ClickHouse backup configuration in Helm deployments.
  * Verified backup sidecar port configuration and authentication credentials.
  * Added checks for release-specific Secret metadata and credential references.
  * Confirmed the authentication Secret is omitted when backups are disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->