### PR TITLE
fix(ingress-nginx): re-pin to the segfault-free v1.11.5 rebuild

### DIFF
--- a/packages/system/ingress-nginx/values.yaml
+++ b/packages/system/ingress-nginx/values.yaml
@@ -6,7 +6,7 @@ ingress-nginx:
       registry: ghcr.io
       image: cozystack/ingress-nginx-with-protobuf-exporter/controller
       tag: v1.11.5
-      digest: sha256:09ff83ca891683b23e782873257af2285837d5923965ef5c462be7503bbe991b
+      digest: sha256:f51c7ee0968ad542d4b77854fc57f68e17b2f6e498bcd168cd5f42b409bf54e6
     allowSnippetAnnotations: true
     replicaCount: 2
     admissionWebhooks:
@@ -16,7 +16,7 @@ ingress-nginx:
       enabled: true
     extraContainers:
     - name: protobuf-exporter
-      image: ghcr.io/cozystack/ingress-nginx-with-protobuf-exporter/protobuf-exporter:v1.11.5@sha256:cd4a5b7f35afe53baf82da8877417b09b5d77e879846633d42b5820999fe4a14
+      image: ghcr.io/cozystack/ingress-nginx-with-protobuf-exporter/protobuf-exporter:v1.11.5@sha256:0f981014415e00cfee3bf38f7ca084e6774150d6a57774e73da04acd8b346335
       args:
       - --server.telemetry-address=0.0.0.0:9090
       - --server.exporter-address=0.0.0.0:9091


### PR DESCRIPTION
Re-pins the ingress controller to the rebuilt `v1.11.5`. The digest pinned before this segfaults.

`pb.c` in lua-protobuf violates strict aliasing and gcc 14 at `-O2` acts on it, so `pb.so` in the previously pinned build makes nginx `cache manager` and `cache loader` children segfault continuously, tens per second and it never stops. Workers are untouched, so the pod stays `Ready` with `restarts=0` and nothing surfaces until master itself dies, which is how it got here unnoticed. Fixed in cozystack/ingress-nginx-with-protobuf-exporter#7, tag `v1.11.5` re-pointed at that merge and both images rebuilt.

Verified against the published image, not a local build:

* `luajit -e 'require "protoc"'` exits 0, was 139.
* 25 second nginx run on a real generated config: 0 `signal 11`, was 105. 0 emerg, all four lua modules load.
* `luarocks` and `gcc` are gone from the runtime image now, so `apk` no longer upgrades musl underneath the nginx the base image already built.

The exporter is re-pinned too, because one tag builds both images and the rebuild published a new exporter digest. Its source did not change.

`release-1.5` and `release-1.6` pin v1.11.2 and were never affected, so nothing to backport.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image versions for the ingress controller and protobuf exporter to newer verified builds.
  * Existing image tags and configuration remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->