### PR TITLE
fix(virtual-machine): guard Kube-OVN IP lookup

### DIFF
--- a/packages/apps/vm-instance/templates/vm.yaml
+++ b/packages/apps/vm-instance/templates/vm.yaml
@@ -35,11 +35,13 @@ spec:
     metadata:
       annotations:
         kubevirt.io/allow-pod-bridge-network-live-migration: "true"
+        {{- if .Capabilities.APIVersions.Has "kubeovn.io/v1/IP" }}
         {{- $ovnIPName := printf "%s.%s" (include "virtual-machine.fullname" .) .Release.Namespace }}
         {{- $ovnIP := lookup "kubeovn.io/v1" "IP" "" $ovnIPName }}
         {{- if $ovnIP }}
         ovn.kubernetes.io/mac_address: {{ $ovnIP.spec.macAddress | quote }}
         ovn.kubernetes.io/ip_address: {{ $ovnIP.spec.ipAddress | quote }}
+        {{- end }}
         {{- end }}
       labels:
         {{- include "virtual-machine.labels" . | nindent 8 }}

--- a/packages/apps/vm-instance/tests/kubeovn_capability_test.yaml
+++ b/packages/apps/vm-instance/tests/kubeovn_capability_test.yaml
@@ -1,0 +1,61 @@
+suite: vm-instance Kube-OVN IP pinning follows API discovery
+
+# On a live cluster Helm's `lookup` propagates the discovery error when the
+# requested API group is not served, so the chart could not render at all
+# without the Kube-OVN CRDs. helm-unittest's fake lookup never errors: it just
+# returns nothing for an unserved kind, so an IP object is mocked here to pin
+# both sides. With the API advertised the annotations must carry the mocked
+# values; with the API absent they must be missing even though the object
+# exists, which is the branch the discovery guard adds.
+release:
+  name: test-vm
+  namespace: tenant-test
+templates:
+  - templates/vm.yaml
+set:
+  fullnameOverride: test-vm
+  instanceType: ""
+  instanceProfile: ""
+  resources:
+    cpu: 1
+    sockets: 1
+    memory: 1Gi
+  _cluster:
+    scheduling:
+      dedicatedNodesForWindowsVMs: "false"
+kubernetesProvider:
+  scheme:
+    "kubeovn.io/v1/IP":
+      gvr:
+        group: kubeovn.io
+        version: v1
+        resource: ips
+      namespaced: false
+  objects:
+    - apiVersion: kubeovn.io/v1
+      kind: IP
+      metadata:
+        name: test-vm.tenant-test
+      spec:
+        macAddress: "00:00:5E:00:53:01"
+        ipAddress: "192.0.2.10"
+tests:
+  - it: pins the Kube-OVN IP and MAC when the IP API is served
+    capabilities:
+      apiVersions:
+        - kubeovn.io/v1/IP
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/mac_address"]
+          value: "00:00:5E:00:53:01"
+      - equal:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/ip_address"]
+          value: "192.0.2.10"
+  - it: skips the lookup when the IP API is not served, even if an IP object exists
+    capabilities:
+      apiVersions: []
+    asserts:
+      - notExists:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/mac_address"]
+      - notExists:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/ip_address"]


### PR DESCRIPTION
## What this PR does

Guards the Kube-OVN `IP` lookup behind API discovery. The `vm-instance` chart now renders on clusters using another CNI instead of trying to query a CRD that is not installed.

The Helm regression suite mocks the IP object through `kubernetesProvider` and pins both sides: with `kubeovn.io/v1/IP` advertised the annotations carry the mocked MAC and IP, without it they are absent even though the object exists, which is the branch the guard adds. helm-unittest's fake lookup never errors on an unserved kind, so only the second case distinguishes the guard; it fails on main and passes here.

Open PRs #3991, #3978, #3931, and #3900 touch the same template. Their current hunks do not alter this lookup; #3900 adds secondary-interface annotations immediately after it, so it is the only nearby merge hunk to watch.

### Screenshots

Not applicable; there is no UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(virtual-machine): render VM instances on clusters where the Kube-OVN IP API is not installed.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * VM instances now render correctly in environments without the Kube-OVN IP capability.
  * OVN IP lookups and MAC/IP annotations are only generated when the required Kube-OVN API is available.
  * MAC/IP annotations are omitted when the capability is unavailable, even if an IP object exists.

* **Tests**
  * Added coverage for both supported and unsupported Kube-OVN IP discovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->