### PR TITLE
test(hack): add a render smoke check over every app chart

### DIFF
--- a/hack/check-render-matrix.bats
+++ b/hack/check-render-matrix.bats
@@ -56,19 +56,30 @@
     rm -rf "$tmp"
 }
 
-# Every skipped chart has to carry a reason, so a skip cannot quietly become the
-# way a chart avoids the check.
-@test "every skip names a reason" {
-    output=$(hack/check-render-matrix.sh)
-    printf '%s\n' "$output" | grep '^SKIP' > /tmp/render-skips.$$ || true
-    while read -r line; do
-        [ -n "$line" ] || continue
-        case "$line" in
-            *"("*")"*) ;;
-            *) echo "skip without a reason: $line" >&2; rm -f /tmp/render-skips.$$; exit 1 ;;
-        esac
-    done < /tmp/render-skips.$$
-    rm -f /tmp/render-skips.$$
+# A skip that has stopped being necessary is worse than no skip: it silently
+# drops a chart from the sweep forever. This renders each skipped chart directly
+# and requires it to STILL fail, so a chart that becomes renderable shows up as a
+# red test rather than as permanent invisible exclusion.
+#
+# Replaces an earlier test that asserted every SKIP line contains parentheses.
+# The only line that emits one is `echo "SKIP $name ($reason)"` guarded on a
+# non-empty reason, so that assertion was unreachable by construction: it could
+# not fail for the property it named.
+@test "every skipped chart still genuinely fails to render" {
+    # mktemp, not $BATS_TMPDIR: cozytest.sh is not real bats and defines none of
+    # bats's variables, so under `set -u` that name aborts the suite.
+    skips=$(mktemp)
+    hack/check-render-matrix.sh | grep '^SKIP' | sed 's/^SKIP \([^ ]*\) .*/\1/' > "$skips" || true
+    while read -r name; do
+        [ -n "$name" ] || continue
+        if helm template "$name-render-check" "packages/apps/$name" -n tenant-test \
+             -f hack/testdata/render-fixtures/fresh.yaml >/dev/null 2>&1; then
+            echo "chart '$name' is on the skip list but renders fine now — remove the skip" >&2
+            rm -f "$skips"
+            exit 1
+        fi
+    done < "$skips"
+    rm -f "$skips"
 }
 
 # The sweep must cover the charts that exist rather than a number frozen when
@@ -92,21 +103,31 @@
 # `eq $x "true"`, so a real YAML bool makes helm fail on incompatible types.
 @test "fixtures carry the platform's string-typed values" {
     for f in hack/testdata/render-fixtures/*.yaml; do
-        python3 -c 'import sys,yaml; d=yaml.safe_load(open(sys.argv[1])) or {}; c=d.get("_cluster") or {}; bad=[k for k,v in c.items() if isinstance(v,bool)]; sys.exit(f"{sys.argv[1]}: _cluster keys are YAML booleans, the platform injects strings: {bad}") if bad else None; sys.exit(f"{sys.argv[1]}: no _cluster map") if not c else None' "$f"
+        python3 -c 'import sys,yaml;d=yaml.safe_load(open(sys.argv[1])) or {};bad=[];[bad.append(f"{sec}.{k}") for sec in ("_cluster","_namespace") for k,v in (d.get(sec) or {}).items() if isinstance(v,(bool,int,float)) or v is None];sys.exit(f"{sys.argv[1]}: scalars must be strings, the platform quotes them: {bad}") if bad else None;sys.exit(f"{sys.argv[1]}: no _cluster map") if not (d.get("_cluster") or {}) else None' "$f"
     done
 }
 
-# Each fixture is one cluster state and they must actually differ, or the sweep
-# renders the same shape three times and reports triple the coverage it has.
-@test "the fixtures represent different cluster states" {
-    count=$(find hack/testdata/render-fixtures -name '*.yaml' | wc -l | tr -d ' ')
+# Each fixture is one cluster state, and what matters is that they produce
+# DIFFERENT RENDERS -- otherwise the sweep runs helm three times over the same
+# shape and reports triple the coverage it has.
+#
+# An earlier version compared the fixture FILES on three key names. That passed
+# while the sweep was in fact rendering 19 of 21 charts identically across all
+# three states, which is the exact condition it claimed to prevent. Comparing
+# output is the only form of this test that can fail for the right reason.
+@test "the fixtures produce different renders for at least one chart" {
+    count=$(find hack/testdata/render-fixtures -maxdepth 1 -name '*.yaml' | wc -l | tr -d ' ')
     [ "$count" -ge 2 ]
-    distinct=$(for f in hack/testdata/render-fixtures/*.yaml; do
-        grep -E '^  (oidc-enabled|solver|wildcard-issue):' "$f" | tr -d ' ' | sort | tr '\n' ','
-        echo
-    done | sort -u | wc -l | tr -d ' ')
-    if [ "$distinct" -lt "$count" ]; then
-        echo "fixtures do not differ on the keys charts branch on ($distinct distinct of $count files)" >&2
+
+    # packages/apps/kubernetes is the chart that branches most on these values
+    # (the _namespace.<service> flags gate ~15 manifests). If a future fixture
+    # change stops moving even this one, the states have collapsed.
+    a=$(helm template kubernetes-render-check packages/apps/kubernetes -n tenant-test \
+          -f hack/testdata/render-fixtures/fresh.yaml 2>/dev/null | grep -c '^kind:')
+    b=$(helm template kubernetes-render-check packages/apps/kubernetes -n tenant-test \
+          -f hack/testdata/render-fixtures/configured.yaml 2>/dev/null | grep -c '^kind:')
+    if [ "$a" = "$b" ]; then
+        echo "fresh and configured render the same number of documents ($a) for packages/apps/kubernetes — the fixtures no longer represent different cluster states" >&2
         exit 1
     fi
 }

--- a/hack/check-render-matrix.bats
+++ b/hack/check-render-matrix.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+
+# Contract for hack/check-render-matrix.sh. The point of these is that the check
+# FAILS on a broken chart: a smoke check that cannot go red is worse than none,
+# because it reports a number that looks like coverage.
+#
+# Written for cozytest.sh, which is not real bats: no `run`, no `$status`, no
+# setup()/teardown(). Each test calls the script directly and inspects its exit
+# with `if`, the way the other hack/*.bats here do.
+
+@test "render matrix passes on the tree as it stands" {
+    output=$(hack/check-render-matrix.sh)
+    case "$output" in
+        *"rendered,"*" skipped"*) ;;
+        *) echo "expected a summary line, got: $output" >&2; exit 1 ;;
+    esac
+}
+
+@test "render matrix fails on a chart whose template is broken" {
+    tmp=$(mktemp -d)
+    mkdir -p "$tmp/broken/templates"
+    printf 'apiVersion: v2\nname: broken\nversion: 0.0.0\n' > "$tmp/broken/Chart.yaml"
+    # `required` with no value is the cheapest deterministic render failure.
+    printf '{{ required "deliberately broken" .Values.nope }}\n' > "$tmp/broken/templates/boom.yaml"
+
+    if out=$(hack/check-render-matrix.sh "$tmp/broken" 2>&1); then
+        echo "expected a non-zero exit for a broken chart, got success: $out" >&2
+        rm -rf "$tmp"
+        exit 1
+    fi
+    case "$out" in
+        *"FAIL broken"*) ;;
+        *) echo "expected 'FAIL broken', got: $out" >&2; rm -rf "$tmp"; exit 1 ;;
+    esac
+    rm -rf "$tmp"
+}
+
+# helm's own parser is what catches this, which is why the script carries no
+# separate YAML pass. Pinned so that stays true: if a future helm accepted it,
+# the check would silently start passing malformed manifests.
+@test "render matrix fails on a template that is not valid YAML" {
+    tmp=$(mktemp -d)
+    mkdir -p "$tmp/badyaml/templates"
+    printf 'apiVersion: v2\nname: badyaml\nversion: 0.0.0\n' > "$tmp/badyaml/Chart.yaml"
+    printf 'a: b\n  c: d\n' > "$tmp/badyaml/templates/boom.yaml"
+
+    if out=$(hack/check-render-matrix.sh "$tmp/badyaml" 2>&1); then
+        echo "expected a non-zero exit for invalid YAML, got success: $out" >&2
+        rm -rf "$tmp"
+        exit 1
+    fi
+    case "$out" in
+        *"FAIL badyaml"*) ;;
+        *) echo "expected 'FAIL badyaml', got: $out" >&2; rm -rf "$tmp"; exit 1 ;;
+    esac
+    rm -rf "$tmp"
+}
+
+# Every skipped chart has to carry a reason, so a skip cannot quietly become the
+# way a chart avoids the check.
+@test "every skip names a reason" {
+    output=$(hack/check-render-matrix.sh)
+    printf '%s\n' "$output" | grep '^SKIP' > /tmp/render-skips.$$ || true
+    while read -r line; do
+        [ -n "$line" ] || continue
+        case "$line" in
+            *"("*")"*) ;;
+            *) echo "skip without a reason: $line" >&2; rm -f /tmp/render-skips.$$; exit 1 ;;
+        esac
+    done < /tmp/render-skips.$$
+    rm -f /tmp/render-skips.$$
+}
+
+# The sweep must cover the charts that exist rather than a number frozen when
+# this was written: a chart added to packages/apps must land in the check or in
+# the skip list, and the two together have to account for all of them.
+@test "rendered plus skipped accounts for every app chart" {
+    total=$(find packages/apps -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
+    output=$(hack/check-render-matrix.sh)
+    summary=$(printf '%s\n' "$output" | grep '^check-render-matrix:')
+    rendered=$(printf '%s\n' "$summary" | sed 's/.*: \([0-9]*\) rendered.*/\1/')
+    skipped=$(printf '%s\n' "$summary" | sed 's/.*, \([0-9]*\) skipped.*/\1/')
+    sum=$((rendered + skipped))
+    if [ "$sum" -ne "$total" ]; then
+        echo "sweep covered $sum charts ($rendered rendered, $skipped skipped) but packages/apps holds $total" >&2
+        exit 1
+    fi
+}
+
+# A fixture that does not reproduce the platform's types tests a shape the
+# platform never produces. The booleans are the trap: charts compare them with
+# `eq $x "true"`, so a real YAML bool makes helm fail on incompatible types.
+@test "fixtures carry the platform's string-typed values" {
+    for f in hack/testdata/render-fixtures/*.yaml; do
+        python3 -c 'import sys,yaml; d=yaml.safe_load(open(sys.argv[1])) or {}; c=d.get("_cluster") or {}; bad=[k for k,v in c.items() if isinstance(v,bool)]; sys.exit(f"{sys.argv[1]}: _cluster keys are YAML booleans, the platform injects strings: {bad}") if bad else None; sys.exit(f"{sys.argv[1]}: no _cluster map") if not c else None' "$f"
+    done
+}
+
+# Each fixture is one cluster state and they must actually differ, or the sweep
+# renders the same shape three times and reports triple the coverage it has.
+@test "the fixtures represent different cluster states" {
+    count=$(find hack/testdata/render-fixtures -name '*.yaml' | wc -l | tr -d ' ')
+    [ "$count" -ge 2 ]
+    distinct=$(for f in hack/testdata/render-fixtures/*.yaml; do
+        grep -E '^  (oidc-enabled|solver|wildcard-issue):' "$f" | tr -d ' ' | sort | tr '\n' ','
+        echo
+    done | sort -u | wc -l | tr -d ' ')
+    if [ "$distinct" -lt "$count" ]; then
+        echo "fixtures do not differ on the keys charts branch on ($distinct distinct of $count files)" >&2
+        exit 1
+    fi
+}

--- a/hack/check-render-matrix.bats
+++ b/hack/check-render-matrix.bats
@@ -1,133 +1,161 @@
 #!/usr/bin/env bats
 
-# Contract for hack/check-render-matrix.sh. The point of these is that the check
-# FAILS on a broken chart: a smoke check that cannot go red is worse than none,
-# because it reports a number that looks like coverage.
-#
-# Written for cozytest.sh, which is not real bats: no `run`, no `$status`, no
-# setup()/teardown(). Each test calls the script directly and inspects its exit
-# with `if`, the way the other hack/*.bats here do.
+# Shared by bats and cozytest.sh: inspect exit codes directly, without bats-only
+# helpers. Scratch directories stay available if an assertion fails.
 
-@test "render matrix passes on the tree as it stands" {
-    output=$(hack/check-render-matrix.sh)
-    case "$output" in
-        *"rendered,"*" skipped"*) ;;
-        *) echo "expected a summary line, got: $output" >&2; exit 1 ;;
-    esac
+make_render_chart() {
+    mkdir -p "$1/templates"
+    printf 'apiVersion: v2\nname: render-test\nversion: 0.0.0\n' > "$1/Chart.yaml"
+    printf 'apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: render-test\n' > "$1/templates/object.yaml"
 }
 
-@test "render matrix fails on a chart whose template is broken" {
-    tmp=$(mktemp -d)
-    mkdir -p "$tmp/broken/templates"
-    printf 'apiVersion: v2\nname: broken\nversion: 0.0.0\n' > "$tmp/broken/Chart.yaml"
-    # `required` with no value is the cheapest deterministic render failure.
-    printf '{{ required "deliberately broken" .Values.nope }}\n' > "$tmp/broken/templates/boom.yaml"
-
-    if out=$(hack/check-render-matrix.sh "$tmp/broken" 2>&1); then
-        echo "expected a non-zero exit for a broken chart, got success: $out" >&2
-        rm -rf "$tmp"
-        exit 1
+expect_render_failure() {
+    if output=$(dash hack/check-render-matrix.sh "$@" 2>&1); then
+        echo "expected render failure, got: $output" >&2
+        return 1
     fi
-    case "$out" in
-        *"FAIL broken"*) ;;
-        *) echo "expected 'FAIL broken', got: $out" >&2; rm -rf "$tmp"; exit 1 ;;
-    esac
-    rm -rf "$tmp"
+    printf '%s\n' "$output"
 }
 
-# helm's own parser is what catches this, which is why the script carries no
-# separate YAML pass. Pinned so that stays true: if a future helm accepted it,
-# the check would silently start passing malformed manifests.
-@test "render matrix fails on a template that is not valid YAML" {
-    tmp=$(mktemp -d)
-    mkdir -p "$tmp/badyaml/templates"
-    printf 'apiVersion: v2\nname: badyaml\nversion: 0.0.0\n' > "$tmp/badyaml/Chart.yaml"
-    printf 'a: b\n  c: d\n' > "$tmp/badyaml/templates/boom.yaml"
-
-    if out=$(hack/check-render-matrix.sh "$tmp/badyaml" 2>&1); then
-        echo "expected a non-zero exit for invalid YAML, got success: $out" >&2
-        rm -rf "$tmp"
-        exit 1
-    fi
-    case "$out" in
-        *"FAIL badyaml"*) ;;
-        *) echo "expected 'FAIL badyaml', got: $out" >&2; rm -rf "$tmp"; exit 1 ;;
-    esac
-    rm -rf "$tmp"
-}
-
-# A skip that has stopped being necessary is worse than no skip: it silently
-# drops a chart from the sweep forever. This renders each skipped chart directly
-# and requires it to STILL fail, so a chart that becomes renderable shows up as a
-# red test rather than as permanent invisible exclusion.
-#
-# Replaces an earlier test that asserted every SKIP line contains parentheses.
-# The only line that emits one is `echo "SKIP $name ($reason)"` guarded on a
-# non-empty reason, so that assertion was unreachable by construction: it could
-# not fail for the property it named.
-@test "every skipped chart still genuinely fails to render" {
-    # mktemp, not $BATS_TMPDIR: cozytest.sh is not real bats and defines none of
-    # bats's variables, so under `set -u` that name aborts the suite.
-    skips=$(mktemp)
-    hack/check-render-matrix.sh | grep '^SKIP' | sed 's/^SKIP \([^ ]*\) .*/\1/' > "$skips" || true
-    while read -r name; do
-        [ -n "$name" ] || continue
-        if helm template "$name-render-check" "packages/apps/$name" -n tenant-test \
-             -f hack/testdata/render-fixtures/fresh.yaml >/dev/null 2>&1; then
-            echo "chart '$name' is on the skip list but renders fine now — remove the skip" >&2
-            rm -f "$skips"
-            exit 1
-        fi
-    done < "$skips"
-    rm -f "$skips"
-}
-
-# The sweep must cover the charts that exist rather than a number frozen when
-# this was written: a chart added to packages/apps must land in the check or in
-# the skip list, and the two together have to account for all of them.
 @test "rendered plus skipped accounts for every app chart" {
     total=$(find packages/apps -mindepth 1 -maxdepth 1 -type d | wc -l | tr -d ' ')
-    output=$(hack/check-render-matrix.sh)
+    output=$(dash hack/check-render-matrix.sh)
     summary=$(printf '%s\n' "$output" | grep '^check-render-matrix:')
     rendered=$(printf '%s\n' "$summary" | sed 's/.*: \([0-9]*\) rendered.*/\1/')
     skipped=$(printf '%s\n' "$summary" | sed 's/.*, \([0-9]*\) skipped.*/\1/')
-    sum=$((rendered + skipped))
-    if [ "$sum" -ne "$total" ]; then
-        echo "sweep covered $sum charts ($rendered rendered, $skipped skipped) but packages/apps holds $total" >&2
-        exit 1
-    fi
+    [ "$rendered" -gt 0 ]
+    [ "$((rendered + skipped))" -eq "$total" ]
 }
 
-# A fixture that does not reproduce the platform's types tests a shape the
-# platform never produces. The booleans are the trap: charts compare them with
-# `eq $x "true"`, so a real YAML bool makes helm fail on incompatible types.
-@test "fixtures carry the platform's string-typed values" {
-    for f in hack/testdata/render-fixtures/*.yaml; do
-        python3 -c 'import sys,yaml;d=yaml.safe_load(open(sys.argv[1])) or {};bad=[];[bad.append(f"{sec}.{k}") for sec in ("_cluster","_namespace") for k,v in (d.get(sec) or {}).items() if isinstance(v,(bool,int,float)) or v is None];sys.exit(f"{sys.argv[1]}: scalars must be strings, the platform quotes them: {bad}") if bad else None;sys.exit(f"{sys.argv[1]}: no _cluster map") if not (d.get("_cluster") or {}) else None' "$f"
+@test "render matrix preserves multiple chart paths containing spaces" {
+    tmp=$(mktemp -d)
+    make_render_chart "$tmp/space in parent/first"
+    make_render_chart "$tmp/space in parent/second"
+    output=$(dash hack/check-render-matrix.sh "$tmp/space in parent/first/" "$tmp/space in parent/second")
+    printf '%s\n' "$output" | grep -Fx 'check-render-matrix: 2 rendered, 0 skipped'
+    rm -rf "$tmp"
+}
+
+@test "render matrix reports a broken chart and still checks the next chart" {
+    tmp=$(mktemp -d)
+    make_render_chart "$tmp/broken"
+    make_render_chart "$tmp/valid"
+    printf '{{ required "deliberately broken" .Values.nope }}\n' > "$tmp/broken/templates/object.yaml"
+    output=$(expect_render_failure "$tmp/broken" "$tmp/valid")
+    for fixture in hack/testdata/render-fixtures/*.yaml; do
+        state=$(basename "$fixture" .yaml)
+        printf '%s\n' "$output" | grep -Fx "FAIL broken ($state)"
+    done
+    printf '%s\n' "$output" | grep -F 'deliberately broken'
+    printf '%s\n' "$output" | grep -Fx 'check-render-matrix: 1 rendered, 0 skipped'
+    rm -rf "$tmp"
+}
+
+@test "render matrix fails on malformed YAML" {
+    tmp=$(mktemp -d)
+    make_render_chart "$tmp/badyaml"
+    printf 'a: b\n  c: d\n' > "$tmp/badyaml/templates/object.yaml"
+    output=$(expect_render_failure "$tmp/badyaml")
+    printf '%s\n' "$output" | grep -F 'FAIL badyaml'
+    printf '%s\n' "$output" | grep -F 'YAML parse error'
+    rm -rf "$tmp"
+}
+
+@test "render matrix does not count a nonexistent chart as rendered" {
+    tmp=$(mktemp -d)
+    output=$(expect_render_failure "$tmp/missing")
+    printf '%s\n' "$output" | grep -F 'FAIL missing'
+    printf '%s\n' "$output" | grep -Fx 'check-render-matrix: 0 rendered, 0 skipped'
+    rm -rf "$tmp"
+}
+
+@test "render matrix rejects skips that now render or fail for another reason" {
+    tmp=$(mktemp -d)
+    for name in vm-instance kubernetes-nodes; do
+        make_render_chart "$tmp/$name"
+        output=$(expect_render_failure "$tmp/$name")
+        printf '%s\n' "$output" | grep -F 'chart now renders; remove its skip'
+        printf '{{ fail "unrelated render failure" }}\n' > "$tmp/$name/templates/object.yaml"
+        output=$(expect_render_failure "$tmp/$name")
+        printf '%s\n' "$output" | grep -F 'unrelated render failure'
+        printf '%s\n' "$output" | grep -Fx 'check-render-matrix: 0 rendered, 0 skipped'
+    done
+    rm -rf "$tmp"
+}
+
+@test "fixtures match the injected value types" {
+    for fixture in hack/testdata/render-fixtures/*.yaml; do
+        helm template fixture-check hack/testdata/render-fixtures/validator \
+            --set-file "fixture=$fixture"
     done
 }
 
-# Each fixture is one cluster state, and what matters is that they produce
-# DIFFERENT RENDERS -- otherwise the sweep runs helm three times over the same
-# shape and reports triple the coverage it has.
-#
-# An earlier version compared the fixture FILES on three key names. That passed
-# while the sweep was in fact rendering 19 of 21 charts identically across all
-# three states, which is the exact condition it claimed to prevent. Comparing
-# output is the only form of this test that can fail for the right reason.
-@test "the fixtures produce different renders for at least one chart" {
-    count=$(find hack/testdata/render-fixtures -maxdepth 1 -name '*.yaml' | wc -l | tr -d ' ')
-    [ "$count" -ge 2 ]
+@test "fixture validation rejects wrong scalar and scheduling types" {
+    tmp=$(mktemp -d)
+    for value in true 12 null '[]' '{}'; do
+        printf '_cluster:\n  oidc-enabled: %s\n_namespace: {host: "example.org"}\n' "$value" > "$tmp/value.yaml"
+        if output=$(helm template fixture-check hack/testdata/render-fixtures/validator \
+            --set-file "fixture=$tmp/value.yaml" 2>&1); then
+            echo "accepted non-string oidc-enabled: $value" >&2
+            exit 1
+        fi
+        printf '%s\n' "$output" | grep -F '_cluster.oidc-enabled must be a string'
+    done
+    for value in true 12 null '[]' '{}'; do
+        printf '_cluster:\n  scheduling:\n    globalAppTopologySpreadConstraints: %s\n    dedicatedNodesForWindowsVMs: "false"\n_namespace: {host: "example.org"}\n' "$value" > "$tmp/value.yaml"
+        if output=$(helm template fixture-check hack/testdata/render-fixtures/validator \
+            --set-file "fixture=$tmp/value.yaml" 2>&1); then
+            echo "accepted non-string scheduling constraint: $value" >&2
+            exit 1
+        fi
+        printf '%s\n' "$output" | grep -F '_cluster.scheduling.globalAppTopologySpreadConstraints must be a string'
+    done
+    rm -rf "$tmp"
+}
 
-    # packages/apps/kubernetes is the chart that branches most on these values
-    # (the _namespace.<service> flags gate ~15 manifests). If a future fixture
-    # change stops moving even this one, the states have collapsed.
-    a=$(helm template kubernetes-render-check packages/apps/kubernetes -n tenant-test \
-          -f hack/testdata/render-fixtures/fresh.yaml 2>/dev/null | grep -c '^kind:')
-    b=$(helm template kubernetes-render-check packages/apps/kubernetes -n tenant-test \
-          -f hack/testdata/render-fixtures/configured.yaml 2>/dev/null | grep -c '^kind:')
-    if [ "$a" = "$b" ]; then
-        echo "fresh and configured render the same number of documents ($a) for packages/apps/kubernetes — the fixtures no longer represent different cluster states" >&2
+@test "configured scheduling reaches the postgres manifest" {
+    tmp=$(mktemp -d)
+    for state in fresh configured wildcard; do
+        helm template postgres-render-check packages/apps/postgres -n tenant-test \
+            -f "hack/testdata/render-fixtures/$state.yaml" > "$tmp/$state.yaml"
+    done
+    if grep -q '^  topologySpreadConstraints:' "$tmp/fresh.yaml"; then
+        echo 'fresh unexpectedly enables topology spread' >&2
         exit 1
     fi
+    for state in configured wildcard; do
+        grep -A 7 '^  topologySpreadConstraints:' "$tmp/$state.yaml" > "$tmp/constraints"
+        grep -F 'maxSkew: 1' "$tmp/constraints"
+        grep -F 'topologyKey: topology.kubernetes.io/zone' "$tmp/constraints"
+        grep -F 'cnpg.io/cluster: postgres-render-check' "$tmp/constraints"
+    done
+    rm -rf "$tmp"
+}
+
+@test "every pair of fixture states produces different deterministic manifests" {
+    tmp=$(mktemp -d)
+    count=0
+    for fixture in hack/testdata/render-fixtures/*.yaml; do
+        state=$(basename "$fixture" .yaml)
+        count=$((count + 1))
+        # Tenant exercises OIDC and certificate modes without random Secrets.
+        # Render twice so randomness cannot masquerade as state coverage.
+        for run in first second; do
+            helm template tenant-check packages/apps/tenant -n tenant-test \
+                -f "$fixture" > "$tmp/$state-$run.yaml"
+        done
+        cmp "$tmp/$state-first.yaml" "$tmp/$state-second.yaml"
+        cp "$tmp/$state-first.yaml" "$tmp/$state.manifests"
+    done
+    [ "$count" -ge 3 ]
+    for a in "$tmp"/*.manifests; do
+        for b in "$tmp"/*.manifests; do
+            [ "$a" != "$b" ] || continue
+            if cmp -s "$a" "$b"; then
+                echo "fixture states produce identical manifests: $a and $b" >&2
+                exit 1
+            fi
+        done
+    done
+    rm -rf "$tmp"
 }

--- a/hack/check-render-matrix.bats
+++ b/hack/check-render-matrix.bats
@@ -132,17 +132,74 @@ expect_render_failure() {
     rm -rf "$tmp"
 }
 
+@test "render matrix reaches capability-gated OIDC templates" {
+    tmp=$(mktemp -d)
+    make_render_chart "$tmp/tenant"
+    cat > "$tmp/tenant/templates/object.yaml" <<'EOF'
+{{- if and (eq (index .Values._cluster "oidc-enabled") "true") (.Capabilities.APIVersions.Has "v1.edp.epam.com/v1") }}
+{{- fail "OIDC branch rendered" }}
+{{- end }}
+EOF
+    output=$(expect_render_failure "$tmp/tenant")
+    printf '%s\n' "$output" | grep -Fx 'FAIL tenant (configured)'
+    printf '%s\n' "$output" | grep -Fx 'FAIL tenant (wildcard)'
+    printf '%s\n' "$output" | grep -F 'OIDC branch rendered'
+    if printf '%s\n' "$output" | grep -Fq 'FAIL tenant (fresh)'; then
+        echo 'OIDC branch enabled for fresh fixture' >&2
+        exit 1
+    fi
+    rm -rf "$tmp"
+}
+
+@test "fixture states enable OIDC groups and shared-service resources" {
+    tmp=$(mktemp -d)
+    for state in fresh configured wildcard; do
+        helm template tenant-check packages/apps/tenant -n tenant-test \
+            --api-versions v1.edp.epam.com/v1 \
+            -f "hack/testdata/render-fixtures/$state.yaml" > "$tmp/tenant.yaml"
+        helm template kubernetes-check packages/apps/kubernetes -n tenant-test \
+            -f "hack/testdata/render-fixtures/$state.yaml" > "$tmp/kubernetes.yaml"
+        groups=$(awk '/^kind: KeycloakRealmGroup$/ {n++} END {print n+0}' "$tmp/tenant.yaml")
+        metrics=$(awk '/^  name: kubernetes-check-metrics-server$/ {n++} END {print n+0}' "$tmp/kubernetes.yaml")
+        case "$state" in
+            fresh) [ "$groups" -eq 0 ]; [ "$metrics" -eq 0 ] ;;
+            *) [ "$groups" -eq 4 ]; [ "$metrics" -eq 1 ] ;;
+        esac
+    done
+    rm -rf "$tmp"
+}
+
+@test "certificate fixtures exercise per-host ACME and wildcard ingress" {
+    tmp=$(mktemp -d)
+    for state in configured wildcard; do
+        helm template harbor-check packages/apps/harbor -n tenant-test \
+            -f "hack/testdata/render-fixtures/$state.yaml" \
+            --show-only templates/ingress.yaml > "$tmp/$state.yaml"
+        grep -Fx 'kind: Ingress' "$tmp/$state.yaml"
+        grep -F 'harbor-check.example.org' "$tmp/$state.yaml"
+    done
+    grep -F 'acme.cert-manager.io/http01-ingress-ingressclassname: tenant-test' "$tmp/configured.yaml"
+    grep -F 'cert-manager.io/cluster-issuer: letsencrypt-prod' "$tmp/configured.yaml"
+    grep -F 'secretName: harbor-check-ingress-tls' "$tmp/configured.yaml"
+    grep -Fx '  tls:' "$tmp/wildcard.yaml"
+    if grep -Eq '^[[:space:]]+(acme.cert-manager.io/|cert-manager.io/cluster-issuer:|secretName:)' "$tmp/wildcard.yaml"; then
+        echo 'wildcard ingress unexpectedly requests a per-host certificate' >&2
+        exit 1
+    fi
+    rm -rf "$tmp"
+}
+
 @test "every pair of fixture states produces different deterministic manifests" {
     tmp=$(mktemp -d)
     count=0
     for fixture in hack/testdata/render-fixtures/*.yaml; do
         state=$(basename "$fixture" .yaml)
         count=$((count + 1))
-        # Tenant exercises OIDC and certificate modes without random Secrets.
+        # This compares whole states; the tests above assert specific branches.
         # Render twice so randomness cannot masquerade as state coverage.
         for run in first second; do
             helm template tenant-check packages/apps/tenant -n tenant-test \
-                -f "$fixture" > "$tmp/$state-$run.yaml"
+                --api-versions v1.edp.epam.com/v1 -f "$fixture" > "$tmp/$state-$run.yaml"
         done
         cmp "$tmp/$state-first.yaml" "$tmp/$state-second.yaml"
         cp "$tmp/$state-first.yaml" "$tmp/$state.manifests"

--- a/hack/check-render-matrix.sh
+++ b/hack/check-render-matrix.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+# Render every app chart and fail if one does not produce valid YAML.
+#
+# The gap this closes: helm-unittest covers roughly a fifth of the packages, so
+# for most charts nothing outside the E2E suite ever renders them. A template
+# that breaks on its own defaults is then found by a 176-minute lane, or by a
+# release, rather than by a check that costs a second.
+#
+# What it does NOT cover, so the number is not read as more than it is.
+#
+# `lookup` returns nothing here. Without a cluster helm gives an empty result and
+# charts carry on -- which is why this works at all -- but 46 of the 55 lookup
+# call sites in packages/apps/*/templates/ sit inside a conditional on that
+# result, so this renders one side of each of them and never the other. The
+# unrendered side is where a whole class of real bugs has lived: the
+# lookup-preserve pattern that keeps an immutable PVC storageClass across
+# reconciles, and adopt-in-place migrations. Covering those needs a cluster
+# holding the objects, which is a different lane. Do not read a green sweep as
+# "these charts render correctly", only as "they render".
+#
+# Values outside `_cluster`/`_namespace` are chart defaults. Presets, replica
+# counts and feature toggles are not swept; assertions about what the output
+# CONTAINS belong in helm-unittest, per package, where they can be specific.
+#
+# Usage: hack/check-render-matrix.sh [chart-dir ...]
+#        defaults to packages/apps/*/
+set -eu
+
+# Cluster states to render each chart under. Each file reproduces the `_cluster`
+# map the platform injects, taken from packages/core/platform/templates/apps.yaml
+# rather than guessed -- including that every value is a STRING, because charts
+# compare them with `eq $oidcEnabled "true"` and a real bool makes helm fail on
+# incompatible types. hack/testdata/render-fixtures/README.md carries the detail.
+#
+# More than one, and that is the difference between a check and a formality:
+# charts branch on these values, so a single state renders one side of each
+# branch and passes a chart whose other side is broken.
+FIXTURE_DIR="hack/testdata/render-fixtures"
+
+# Charts needing one more value of their own. Kept as a table rather than folded
+# into FIXTURE so each entry names a chart-specific requirement instead of
+# widening what every chart is rendered with.
+# Empty today. Kept because the next chart that needs one value of its own
+# should get it here rather than by widening FIXTURE for all of them.
+extra_values() {
+  case "$1" in
+    *) echo "" ;;
+  esac
+}
+
+# Charts that cannot be rendered without a live cluster, with the reason. A
+# chart lands here only when the blocker is a lookup whose empty result the
+# template turns into a hard failure -- not merely because it uses lookup, which
+# most charts do and survive (helm returns an empty result and they carry on).
+#
+#   vm-instance, kubernetes-nodes
+#                both resolve an instance type through a lookup of
+#                VirtualMachineClusterInstancetype and fail when it finds
+#                nothing ("specified instanceType u1.medium not found in
+#                cluster"). That check is the point of those templates in
+#                production, so the charts are skipped here rather than weakened
+#                for a test. Covering them needs a cluster holding the
+#                instancetype CRs, which is a different lane, not a fixture.
+#
+# Every skip costs coverage, so keep the list short and say why.
+skip_reason() {
+  case "$1" in
+    vm-instance|kubernetes-nodes) echo "looks up VirtualMachineClusterInstancetype and hard-fails on an empty result" ;;
+    *) echo "" ;;
+  esac
+}
+
+# The release name matters to more than cosmetics: tenant's own template refuses
+# a name that is not `tenant-<something>`, so a fixed name would fail it for a
+# reason that has nothing to do with rendering health.
+release_name() {
+  case "$1" in
+    tenant) echo "tenant-sub" ;;
+    *) echo "$1-render-check" ;;
+  esac
+}
+
+charts="$*"
+if [ -z "$charts" ]; then
+  charts=$(find packages/apps -mindepth 1 -maxdepth 1 -type d | sort)
+fi
+if [ -z "$charts" ]; then
+  echo "check-render-matrix: found no charts under packages/apps — refusing to report success from an empty sweep" >&2
+  exit 1
+fi
+
+if [ -z "$(find "$FIXTURE_DIR" -name '*.yaml' 2>/dev/null)" ]; then
+  echo "check-render-matrix: no fixtures under $FIXTURE_DIR — every chart would render under nothing and the sweep would report success having checked no state" >&2
+  exit 1
+fi
+
+rc=0
+rendered=0
+skipped=0
+for dir in $charts; do
+  name=$(basename "$dir")
+
+  reason=$(skip_reason "$name")
+  if [ -n "$reason" ]; then
+    echo "SKIP $name ($reason)"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  chart_failed=0
+  for fixture in "$FIXTURE_DIR"/*.yaml; do
+    state=$(basename "$fixture" .yaml)
+    out=$(mktemp)
+    # shellcheck disable=SC2086  # extra_values is an argument list
+    if ! helm template "$(release_name "$name")" "$dir" -n tenant-test \
+        -f "$fixture" $(extra_values "$name") >"$out" 2>"$out.err"; then
+      echo "FAIL $name ($state)"
+      grep -v 'level=INFO' "$out.err" | sed 's/^/    /' | head -12
+      rc=1
+      chart_failed=1
+    fi
+    rm -f "$out" "$out.err"
+  done
+  if [ "$chart_failed" -ne 0 ]; then
+    continue
+  fi
+
+  rendered=$((rendered + 1))
+  rm -f "$out" "$out.err"
+done
+
+echo "check-render-matrix: $rendered rendered, $skipped skipped"
+exit "$rc"

--- a/hack/check-render-matrix.sh
+++ b/hack/check-render-matrix.sh
@@ -11,12 +11,21 @@
 # `lookup` returns nothing here. Without a cluster helm gives an empty result and
 # charts carry on -- which is why this works at all -- but 46 of the 55 lookup
 # call sites in packages/apps/*/templates/ sit inside a conditional on that
-# result, so this renders one side of each of them and never the other. The
-# unrendered side is where a whole class of real bugs has lived: the
+# result, so this sweep renders one side of each of them and never the other.
+# The unrendered side is where a whole class of real bugs has lived: the
 # lookup-preserve pattern that keeps an immutable PVC storageClass across
-# reconciles, and adopt-in-place migrations. Covering those needs a cluster
-# holding the objects, which is a different lane. Do not read a green sweep as
-# "these charts render correctly", only as "they render".
+# reconciles, and adopt-in-place migrations.
+#
+# That side is NOT out of reach, and it does not need a cluster: helm-unittest
+# can fake the API a chart looks up, via `kubernetesProvider` in a test suite.
+# packages/apps/clickhouse/tests/backup_api_password_persistence_test.yaml is
+# the worked example -- it covers both the mint and the preserve branch of the
+# backup API password, in milliseconds. So lookup branches belong there, per
+# chart, where the fake can be specific about what exists; this sweep stays what
+# it is, a check that every chart still renders at all.
+#
+# Do not read a green sweep as "these charts render correctly", only as "they
+# render, under these cluster states, on the empty-lookup path".
 #
 # Values outside `_cluster`/`_namespace` are chart defaults. Presets, replica
 # counts and feature toggles are not swept; assertions about what the output

--- a/hack/check-render-matrix.sh
+++ b/hack/check-render-matrix.sh
@@ -9,9 +9,11 @@
 # What it does NOT cover, so the number is not read as more than it is.
 #
 # `lookup` returns nothing here. Without a cluster helm gives an empty result and
-# charts carry on -- which is why this works at all -- but 46 of the 55 lookup
-# call sites in packages/apps/*/templates/ sit inside a conditional on that
-# result, so this sweep renders one side of each of them and never the other.
+# charts carry on -- which is why this works at all -- but the sweep then renders
+# only the empty-result side. There are 40 template lookup calls under
+# packages/apps/*/templates/ (`grep -rho 'lookup "'`; a plain `grep -c 'lookup '`
+# returns 55 by counting prose in comments), and 13 of them sit inside a
+# conditional on the result, so those 13 branches have a side this never renders.
 # The unrendered side is where a whole class of real bugs has lived: the
 # lookup-preserve pattern that keeps an immutable PVC storageClass across
 # reconciles, and adopt-in-place migrations.
@@ -37,9 +39,11 @@ set -eu
 
 # Cluster states to render each chart under. Each file reproduces the `_cluster`
 # map the platform injects, taken from packages/core/platform/templates/apps.yaml
-# rather than guessed -- including that every value is a STRING, because charts
-# compare them with `eq $oidcEnabled "true"` and a real bool makes helm fail on
-# incompatible types. hack/testdata/render-fixtures/README.md carries the detail.
+# rather than guessed. Every SCALAR there goes through `| quote`, so the booleans
+# arrive as the strings "true"/"false" -- tenant compares one with
+# `eq $oidcEnabled "true"` and a real bool makes helm fail on incompatible types.
+# `scheduling` and `branding` are the exceptions: the platform emits those as
+# maps. hack/testdata/render-fixtures/README.md carries the detail.
 #
 # More than one, and that is the difference between a check and a formality:
 # charts branch on these values, so a single state renders one side of each
@@ -67,9 +71,18 @@ extra_values() {
 #                VirtualMachineClusterInstancetype and fail when it finds
 #                nothing ("specified instanceType u1.medium not found in
 #                cluster"). That check is the point of those templates in
-#                production, so the charts are skipped here rather than weakened
-#                for a test. Covering them needs a cluster holding the
-#                instancetype CRs, which is a different lane, not a fixture.
+#                production, so the charts are skipped rather than weakened.
+#
+#                Worth being precise, because an earlier version of this comment
+#                was not: for kubernetes-nodes that lookup is the THIRD blocker,
+#                not the first. It also needs `--set cluster=<name>` and a
+#                release name starting with `kubernetes-nodes-<cluster>-`, and
+#                both of those are ordinary fixture work that extra_values() and
+#                release_name() below exist for. Only after supplying them does
+#                the chart reach the lookup. vm-instance likewise renders with
+#                explicit resources.* values; the lookup is what stops it on
+#                defaults. So "these need a cluster" is true of the last blocker
+#                in each, not of the charts as a whole.
 #
 # Every skip costs coverage, so keep the list short and say why.
 skip_reason() {
@@ -98,7 +111,10 @@ if [ -z "$charts" ]; then
   exit 1
 fi
 
-if [ -z "$(find "$FIXTURE_DIR" -name '*.yaml' 2>/dev/null)" ]; then
+# -maxdepth 1 so the guard tests exactly what the loop below globs; a recursive
+# find here would pass on a fixture in a subdirectory the glob never reaches, and
+# every chart would then fail on the literal `*.yaml`.
+if [ -z "$(find "$FIXTURE_DIR" -maxdepth 1 -name '*.yaml' 2>/dev/null)" ]; then
   echo "check-render-matrix: no fixtures under $FIXTURE_DIR — every chart would render under nothing and the sweep would report success having checked no state" >&2
   exit 1
 fi
@@ -135,7 +151,6 @@ for dir in $charts; do
   fi
 
   rendered=$((rendered + 1))
-  rm -f "$out" "$out.err"
 done
 
 echo "check-render-matrix: $rendered rendered, $skipped skipped"

--- a/hack/check-render-matrix.sh
+++ b/hack/check-render-matrix.sh
@@ -22,7 +22,7 @@ render_chart() {
   chart=$1 fixture=$2
   name=$(basename "$chart")
   case "$name" in
-    tenant) set -- tenant-sub ;;
+    tenant) set -- tenant-sub --api-versions v1.edp.epam.com/v1 ;;
     # Satisfy the parent-cluster and release-name contract before the lookup.
     kubernetes-nodes) set -- kubernetes-nodes-render-check --set-string cluster=render ;;
     *) set -- "$name-render-check" ;;

--- a/hack/check-render-matrix.sh
+++ b/hack/check-render-matrix.sh
@@ -1,156 +1,86 @@
 #!/bin/sh
-# Render every app chart and fail if one does not produce valid YAML.
-#
-# The gap this closes: helm-unittest covers roughly a fifth of the packages, so
-# for most charts nothing outside the E2E suite ever renders them. A template
-# that breaks on its own defaults is then found by a 176-minute lane, or by a
-# release, rather than by a check that costs a second.
-#
-# What it does NOT cover, so the number is not read as more than it is.
-#
-# `lookup` returns nothing here. Without a cluster helm gives an empty result and
-# charts carry on -- which is why this works at all -- but the sweep then renders
-# only the empty-result side. There are 40 template lookup calls under
-# packages/apps/*/templates/ (`grep -rho 'lookup "'`; a plain `grep -c 'lookup '`
-# returns 55 by counting prose in comments), and 13 of them sit inside a
-# conditional on the result, so those 13 branches have a side this never renders.
-# The unrendered side is where a whole class of real bugs has lived: the
-# lookup-preserve pattern that keeps an immutable PVC storageClass across
-# reconciles, and adopt-in-place migrations.
-#
-# That side is NOT out of reach, and it does not need a cluster: helm-unittest
-# can fake the API a chart looks up, via `kubernetesProvider` in a test suite.
-# packages/apps/clickhouse/tests/backup_api_password_persistence_test.yaml is
-# the worked example -- it covers both the mint and the preserve branch of the
-# backup API password, in milliseconds. So lookup branches belong there, per
-# chart, where the fake can be specific about what exists; this sweep stays what
-# it is, a check that every chart still renders at all.
-#
-# Do not read a green sweep as "these charts render correctly", only as "they
-# render, under these cluster states, on the empty-lookup path".
-#
-# Values outside `_cluster`/`_namespace` are chart defaults. Presets, replica
-# counts and feature toggles are not swept; assertions about what the output
-# CONTAINS belong in helm-unittest, per package, where they can be specific.
-#
-# Usage: hack/check-render-matrix.sh [chart-dir ...]
-#        defaults to packages/apps/*/
+# Render app charts on their defaults plus injected cluster/namespace values.
+# helm-unittest renders only templates selected by a suite; this smoke check
+# also reaches templates with no assertions. It checks rendering, not Kubernetes
+# schema validity or runtime behavior. See testdata/render-fixtures/README.md.
+# Usage (from the repository root): hack/check-render-matrix.sh [chart-dir ...]
 set -eu
 
-# Cluster states to render each chart under. Each file reproduces the `_cluster`
-# map the platform injects, taken from packages/core/platform/templates/apps.yaml
-# rather than guessed. Every SCALAR there goes through `| quote`, so the booleans
-# arrive as the strings "true"/"false" -- tenant compares one with
-# `eq $oidcEnabled "true"` and a real bool makes helm fail on incompatible types.
-# `scheduling` and `branding` are the exceptions: the platform emits those as
-# maps. hack/testdata/render-fixtures/README.md carries the detail.
-#
-# More than one, and that is the difference between a check and a formality:
-# charts branch on these values, so a single state renders one side of each
-# branch and passes a chart whose other side is broken.
 FIXTURE_DIR="hack/testdata/render-fixtures"
 
-# Charts needing one more value of their own. Kept as a table rather than folded
-# into FIXTURE so each entry names a chart-specific requirement instead of
-# widening what every chart is rendered with.
-# Empty today. Kept because the next chart that needs one value of its own
-# should get it here rather than by widening FIXTURE for all of them.
-extra_values() {
-  case "$1" in
-    *) echo "" ;;
-  esac
-}
-
-# Charts that cannot be rendered without a live cluster, with the reason. A
-# chart lands here only when the blocker is a lookup whose empty result the
-# template turns into a hard failure -- not merely because it uses lookup, which
-# most charts do and survive (helm returns an empty result and they carry on).
-#
-#   vm-instance, kubernetes-nodes
-#                both resolve an instance type through a lookup of
-#                VirtualMachineClusterInstancetype and fail when it finds
-#                nothing ("specified instanceType u1.medium not found in
-#                cluster"). That check is the point of those templates in
-#                production, so the charts are skipped rather than weakened.
-#
-#                Worth being precise, because an earlier version of this comment
-#                was not: for kubernetes-nodes that lookup is the THIRD blocker,
-#                not the first. It also needs `--set cluster=<name>` and a
-#                release name starting with `kubernetes-nodes-<cluster>-`, and
-#                both of those are ordinary fixture work that extra_values() and
-#                release_name() below exist for. Only after supplying them does
-#                the chart reach the lookup. vm-instance likewise renders with
-#                explicit resources.* values; the lookup is what stops it on
-#                defaults. So "these need a cluster" is true of the last blocker
-#                in each, not of the charts as a whole.
-#
-# Every skip costs coverage, so keep the list short and say why.
+# Empty lookup results are the only accepted reason to skip a chart. Match the
+# actual diagnostic, so another error cannot keep an obsolete skip alive.
 skip_reason() {
   case "$1" in
-    vm-instance|kubernetes-nodes) echo "looks up VirtualMachineClusterInstancetype and hard-fails on an empty result" ;;
+    vm-instance) echo 'Specified instanceType does not exist in the cluster: u1.medium' ;;
+    kubernetes-nodes) echo 'specified instanceType "u1.medium" not found in cluster' ;;
     *) echo "" ;;
   esac
 }
 
-# The release name matters to more than cosmetics: tenant's own template refuses
-# a name that is not `tenant-<something>`, so a fixed name would fail it for a
-# reason that has nothing to do with rendering health.
-release_name() {
-  case "$1" in
-    tenant) echo "tenant-sub" ;;
-    *) echo "$1-render-check" ;;
+render_chart() {
+  chart=$1 fixture=$2
+  name=$(basename "$chart")
+  case "$name" in
+    tenant) set -- tenant-sub ;;
+    # Satisfy the parent-cluster and release-name contract before the lookup.
+    kubernetes-nodes) set -- kubernetes-nodes-render-check --set-string cluster=render ;;
+    *) set -- "$name-render-check" ;;
   esac
+  helm template "$@" "$chart" -n tenant-test -f "$fixture"
 }
 
-charts="$*"
-if [ -z "$charts" ]; then
-  charts=$(find packages/apps -mindepth 1 -maxdepth 1 -type d | sort)
+if [ "$#" -eq 0 ]; then
+  set -- packages/apps/*/
+  if [ ! -d "$1" ]; then
+    echo "check-render-matrix: found no charts under packages/apps" >&2
+    exit 1
+  fi
 fi
-if [ -z "$charts" ]; then
-  echo "check-render-matrix: found no charts under packages/apps — refusing to report success from an empty sweep" >&2
+
+# Check exactly the files the render loop will consume, not nested fixtures.
+fixtures=0
+for fixture in "$FIXTURE_DIR"/*.yaml; do
+  [ -f "$fixture" ] || continue
+  fixtures=$((fixtures + 1))
+done
+if [ "$fixtures" -eq 0 ]; then
+  echo "check-render-matrix: no fixtures under $FIXTURE_DIR" >&2
   exit 1
 fi
 
-# -maxdepth 1 so the guard tests exactly what the loop below globs; a recursive
-# find here would pass on a fixture in a subdirectory the glob never reaches, and
-# every chart would then fail on the literal `*.yaml`.
-if [ -z "$(find "$FIXTURE_DIR" -maxdepth 1 -name '*.yaml' 2>/dev/null)" ]; then
-  echo "check-render-matrix: no fixtures under $FIXTURE_DIR — every chart would render under nothing and the sweep would report success having checked no state" >&2
-  exit 1
-fi
-
-rc=0
-rendered=0
-skipped=0
-for dir in $charts; do
+errors=$(mktemp)
+trap 'rm -f "$errors"' EXIT
+rc=0 rendered=0 skipped=0
+for dir in "$@"; do
   name=$(basename "$dir")
-
   reason=$(skip_reason "$name")
+  chart_failed=0
+  for fixture in "$FIXTURE_DIR"/*.yaml; do
+    [ -f "$fixture" ] || continue
+    state=$(basename "$fixture" .yaml)
+    if render_chart "$dir" "$fixture" >/dev/null 2>"$errors"; then
+      if [ -z "$reason" ]; then
+        continue
+      fi
+      echo "FAIL $name ($state): chart now renders; remove its skip"
+    else
+      if [ -n "$reason" ] && grep -Fq "$reason" "$errors"; then
+        continue
+      fi
+      echo "FAIL $name ($state)"
+      sed -n '/^level=INFO/d; s/^/    /; p' "$errors"
+    fi
+    rc=1
+    chart_failed=1
+  done
+  [ "$chart_failed" -eq 0 ] || continue
   if [ -n "$reason" ]; then
     echo "SKIP $name ($reason)"
     skipped=$((skipped + 1))
-    continue
+  else
+    rendered=$((rendered + 1))
   fi
-
-  chart_failed=0
-  for fixture in "$FIXTURE_DIR"/*.yaml; do
-    state=$(basename "$fixture" .yaml)
-    out=$(mktemp)
-    # shellcheck disable=SC2086  # extra_values is an argument list
-    if ! helm template "$(release_name "$name")" "$dir" -n tenant-test \
-        -f "$fixture" $(extra_values "$name") >"$out" 2>"$out.err"; then
-      echo "FAIL $name ($state)"
-      grep -v 'level=INFO' "$out.err" | sed 's/^/    /' | head -12
-      rc=1
-      chart_failed=1
-    fi
-    rm -f "$out" "$out.err"
-  done
-  if [ "$chart_failed" -ne 0 ]; then
-    continue
-  fi
-
-  rendered=$((rendered + 1))
 done
 
 echo "check-render-matrix: $rendered rendered, $skipped skipped"

--- a/hack/testdata/render-fixtures/README.md
+++ b/hack/testdata/render-fixtures/README.md
@@ -4,13 +4,24 @@ Values the platform injects into every app chart at install time, reproduced
 here so `hack/check-render-matrix.sh` can render a chart the way it is actually
 rendered in a cluster.
 
-The authority is `packages/core/platform/templates/apps.yaml`, which builds the
-`_cluster` map into the `cozystack-values` Secret, plus
-`templates/bundles/system.yaml` for `oidc-enabled`. **Every value there goes
-through `| quote`, so every value here is a string** — including the booleans.
-That is not cosmetic: charts compare them with `eq $oidcEnabled "true"`, and a
-real bool makes helm fail with "incompatible types for comparison". A fixture
-that guesses the type tests a shape the platform never produces.
+The authority is `packages/core/platform/templates/apps.yaml`, which builds the `_cluster` map
+into the `cozystack-values` Secret, plus `templates/bundles/system.yaml` for
+`oidc-enabled`. `_namespace` comes from
+`packages/apps/tenant/templates/namespace.yaml`.
+
+**Every scalar there goes through `| quote`, so every scalar here is a string** —
+including the booleans. That is not cosmetic: `tenant` compares one with
+`eq $oidcEnabled "true"`, and a real bool makes helm fail with "incompatible
+types for comparison". `scheduling` and `branding` are the exceptions: the
+platform emits those as maps.
+
+`_namespace.<service>` is not a boolean at all, which is easy to get wrong: the
+value is the NAMESPACE providing that service, or an empty string when the tenant
+has none (`$etcd = $tenantName` in namespace.yaml). Charts test it with a bare
+`{{- if .Values._namespace.etcd }}`, so `""` is the off side and any name is the
+on side. Omitting the key entirely renders the off side, which is a state the
+platform does produce — but then nothing renders the on side, and in
+`packages/apps/kubernetes` that is 15 manifests.
 
 Each file is one cluster state, and a chart is rendered under all of them. The
 states exist because charts branch on these values, so a single fixture renders
@@ -27,5 +38,12 @@ three. A key absent from every fixture is a branch nothing renders, and it fails
 silently by passing. To list what the charts read:
 
 ```sh
-grep -rhoE '_cluster "[a-z-]*"|_cluster\.[a-zA-Z-]*' packages/apps/*/templates/
+grep -rn '_cluster' packages/apps/*/templates/
 ```
+
+Grep for the bare word rather than a shape: the reads are written four different
+ways (`.Values._cluster.foo`, `index .Values._cluster "foo"`, `dig "foo" ...`,
+and `(.Values._cluster | default dict)`), so any pattern narrow enough to look
+tidy misses some of them. A key absent from every fixture is a branch nothing
+renders, and it fails silently by passing, so a false negative here is the
+expensive kind.

--- a/hack/testdata/render-fixtures/README.md
+++ b/hack/testdata/render-fixtures/README.md
@@ -1,0 +1,31 @@
+# Render fixtures
+
+Values the platform injects into every app chart at install time, reproduced
+here so `hack/check-render-matrix.sh` can render a chart the way it is actually
+rendered in a cluster.
+
+The authority is `packages/core/platform/templates/apps.yaml`, which builds the
+`_cluster` map into the `cozystack-values` Secret, plus
+`templates/bundles/system.yaml` for `oidc-enabled`. **Every value there goes
+through `| quote`, so every value here is a string** — including the booleans.
+That is not cosmetic: charts compare them with `eq $oidcEnabled "true"`, and a
+real bool makes helm fail with "incompatible types for comparison". A fixture
+that guesses the type tests a shape the platform never produces.
+
+Each file is one cluster state, and a chart is rendered under all of them. The
+states exist because charts branch on these values, so a single fixture renders
+one side of each branch and passes a chart whose other side is broken.
+
+| file | state it represents |
+|---|---|
+| `fresh.yaml` | a new install: nothing configured, OIDC off, no certificates |
+| `configured.yaml` | OIDC on, per-host ACME via http01, services exposed |
+| `wildcard.yaml` | dns01 with a platform-issued wildcard certificate |
+
+When a chart starts reading a `_cluster` key none of these set, add it to all
+three. A key absent from every fixture is a branch nothing renders, and it fails
+silently by passing. To list what the charts read:
+
+```sh
+grep -rhoE '_cluster "[a-z-]*"|_cluster\.[a-zA-Z-]*' packages/apps/*/templates/
+```

--- a/hack/testdata/render-fixtures/README.md
+++ b/hack/testdata/render-fixtures/README.md
@@ -1,49 +1,27 @@
 # Render fixtures
 
-Values the platform injects into every app chart at install time, reproduced
-here so `hack/check-render-matrix.sh` can render a chart the way it is actually
-rendered in a cluster.
+`hack/check-render-matrix.sh` renders every app chart with its defaults plus these injected values. helm-unittest renders the templates selected by each suite, so a chart with passing unit tests can still have an untested template that fails to render. This sweep checks that Helm accepts the rendered YAML; it does not validate Kubernetes schemas or runtime behavior.
 
-The authority is `packages/core/platform/templates/apps.yaml`, which builds the `_cluster` map
-into the `cozystack-values` Secret, plus `templates/bundles/system.yaml` for
-`oidc-enabled`. `_namespace` comes from
-`packages/apps/tenant/templates/namespace.yaml`.
+The source of `_cluster` is `packages/core/platform/templates/apps.yaml`; `_namespace` comes from `packages/apps/tenant/templates/namespace.yaml`. These fixtures model selected install states, not a complete copy of every platform setting. Top-level scalar values in these maps are strings, including booleans. Charts such as tenant compare `oidc-enabled` with `"true"`, so a YAML boolean has the wrong type.
 
-**Every scalar there goes through `| quote`, so every scalar here is a string** —
-including the booleans. That is not cosmetic: `tenant` compares one with
-`eq $oidcEnabled "true"`, and a real bool makes helm fail with "incompatible
-types for comparison". `scheduling` and `branding` are the exceptions: the
-platform emits those as maps.
+`scheduling` and `branding` are maps copied with `toYaml`, which preserves their nested types. The scheduling keys read by app charts have a more specific contract: `globalAppTopologySpreadConstraints` is a string containing YAML (or an empty string), and `dedicatedNodesForWindowsVMs` is compared with the string `"true"`. The configured and wildcard fixtures supply a topology constraint; fresh leaves it empty. The embedded YAML retains numeric fields such as `maxSkew`.
 
-`_namespace.<service>` is not a boolean at all, which is easy to get wrong: the
-value is the NAMESPACE providing that service, or an empty string when the tenant
-has none (`$etcd = $tenantName` in namespace.yaml). Charts test it with a bare
-`{{- if .Values._namespace.etcd }}`, so `""` is the off side and any name is the
-on side. Omitting the key entirely renders the off side, which is a state the
-platform does produce — but then nothing renders the on side, and in
-`packages/apps/kubernetes` that is 15 manifests.
+`_namespace.<service>` contains the namespace providing the shared service, or an empty string when unavailable. A non-empty value enables the service-dependent templates in the Kubernetes chart.
 
-Each file is one cluster state, and a chart is rendered under all of them. The
-states exist because charts branch on these values, so a single fixture renders
-one side of each branch and passes a chart whose other side is broken.
-
-| file | state it represents |
+| File | State |
 |---|---|
-| `fresh.yaml` | a new install: nothing configured, OIDC off, no certificates |
-| `configured.yaml` | OIDC on, per-host ACME via http01, services exposed |
-| `wildcard.yaml` | dns01 with a platform-issued wildcard certificate |
+| `fresh.yaml` | OIDC off, no certificates or shared services, no topology constraint |
+| `configured.yaml` | OIDC on, per-host ACME via http01, shared services and topology constraint |
+| `wildcard.yaml` | OIDC on, dns01 with a platform-issued wildcard certificate, shared services and topology constraint |
 
-When a chart starts reading a `_cluster` key none of these set, add it to all
-three. A key absent from every fixture is a branch nothing renders, and it fails
-silently by passing. To list what the charts read:
+Each chart is attempted under every fixture. `vm-instance` and `kubernetes-nodes` require a `VirtualMachineClusterInstancetype` lookup on their defaults. The sweep accepts their skip only while every fixture fails with the recorded lookup diagnostic; a successful render or a different error fails the sweep. For kubernetes-nodes it supplies a parent cluster and matching release name first.
+
+`lookup` returns an empty result during this check. Tests for existing objects belong in chart-specific helm-unittest suites using `kubernetesProvider`; `packages/apps/clickhouse/tests/backup_api_password_persistence_test.yaml` covers both password generation and preservation that way. Presets, replica counts and other app feature toggles are outside this sweep.
+
+The BATS suite checks fixture types with the small Helm chart in `validator/`, using `--set-file` so explicit nulls are not removed by Helm's values merge. It also verifies scheduling reaches the PostgreSQL manifest and compares complete tenant renders for every pair of fixture states. Tenant exercises OIDC and certificate modes without generating random Secrets; rendering each state twice verifies that the comparison is deterministic. Identical output from other charts is expected.
+
+When adding an injected value read by an app, update the relevant states and add an assertion for the branch it exercises. Review all read forms, including `index`, `get` and `dig`, before deciding a value is unused:
 
 ```sh
-grep -rn '_cluster' packages/apps/*/templates/
+grep -rn '_cluster\|_namespace' packages/apps/*/templates/
 ```
-
-Grep for the bare word rather than a shape: the reads are written four different
-ways (`.Values._cluster.foo`, `index .Values._cluster "foo"`, `dig "foo" ...`,
-and `(.Values._cluster | default dict)`), so any pattern narrow enough to look
-tidy misses some of them. A key absent from every fixture is a branch nothing
-renders, and it fails silently by passing, so a false negative here is the
-expensive kind.

--- a/hack/testdata/render-fixtures/README.md
+++ b/hack/testdata/render-fixtures/README.md
@@ -6,7 +6,7 @@ The source of `_cluster` is `packages/core/platform/templates/apps.yaml`; `_name
 
 `scheduling` and `branding` are maps copied with `toYaml`, which preserves their nested types. The scheduling keys read by app charts have a more specific contract: `globalAppTopologySpreadConstraints` is a string containing YAML (or an empty string), and `dedicatedNodesForWindowsVMs` is compared with the string `"true"`. The configured and wildcard fixtures supply a topology constraint; fresh leaves it empty. The embedded YAML retains numeric fields such as `maxSkew`.
 
-`_namespace.<service>` contains the namespace providing the shared service, or an empty string when unavailable. A non-empty value enables the service-dependent templates in the Kubernetes chart.
+`_namespace.<service>` contains the namespace providing the shared service, or an empty string when unavailable. A non-empty value enables the service-dependent templates in the Kubernetes chart. These states use ingress rather than Gateway API, so `gateway` stays empty: a non-empty gateway would disable Harbor Ingress and leave the certificate modes untested.
 
 | File | State |
 |---|---|
@@ -14,14 +14,14 @@ The source of `_cluster` is `packages/core/platform/templates/apps.yaml`; `_name
 | `configured.yaml` | OIDC on, per-host ACME via http01, shared services and topology constraint |
 | `wildcard.yaml` | OIDC on, dns01 with a platform-issued wildcard certificate, shared services and topology constraint |
 
-Each chart is attempted under every fixture. `vm-instance` and `kubernetes-nodes` require a `VirtualMachineClusterInstancetype` lookup on their defaults. The sweep accepts their skip only while every fixture fails with the recorded lookup diagnostic; a successful render or a different error fails the sweep. For kubernetes-nodes it supplies a parent cluster and matching release name first.
+Each chart is attempted under every fixture. `vm-instance` and `kubernetes-nodes` require a `VirtualMachineClusterInstancetype` lookup on their defaults. The sweep accepts their skip only while every fixture fails with the recorded lookup diagnostic; a successful render or a different error fails the sweep. For kubernetes-nodes it supplies a parent cluster and matching release name first. For tenant it declares the Keycloak API with `--api-versions v1.edp.epam.com/v1`, allowing OIDC-enabled fixtures to render the realm groups.
 
 `lookup` returns an empty result during this check. Tests for existing objects belong in chart-specific helm-unittest suites using `kubernetesProvider`; `packages/apps/clickhouse/tests/backup_api_password_persistence_test.yaml` covers both password generation and preservation that way. Presets, replica counts and other app feature toggles are outside this sweep.
 
-The BATS suite checks fixture types with the small Helm chart in `validator/`, using `--set-file` so explicit nulls are not removed by Helm's values merge. It also verifies scheduling reaches the PostgreSQL manifest and compares complete tenant renders for every pair of fixture states. Tenant exercises OIDC and certificate modes without generating random Secrets; rendering each state twice verifies that the comparison is deterministic. Identical output from other charts is expected.
+The BATS suite checks fixture types with the small Helm chart in `validator/`, using `--set-file` so explicit nulls are not removed by Helm's values merge. Separate assertions check PostgreSQL topology constraints, tenant OIDC groups, the Kubernetes metrics-server HelmRelease and Harbor per-host ACME versus wildcard TLS. Pairwise comparison of complete tenant renders detects duplicate fixture states, and a second render of each state checks that randomness cannot satisfy that comparison. The branch assertions are needed because tenant also copies injected values into a Secret, so different output alone does not prove a conditional resource was rendered.
 
 When adding an injected value read by an app, update the relevant states and add an assertion for the branch it exercises. Review all read forms, including `index`, `get` and `dig`, before deciding a value is unused:
 
 ```sh
-grep -rn '_cluster\|_namespace' packages/apps/*/templates/
+grep -rn -e '_cluster' -e '_namespace' packages/apps/*/templates/
 ```

--- a/hack/testdata/render-fixtures/configured.yaml
+++ b/hack/testdata/render-fixtures/configured.yaml
@@ -17,5 +17,14 @@ _cluster:
   scheduling:
     nodeSelector: {}
     tolerations: []
+# The value is the NAMESPACE providing the service, not a boolean: tenant's
+# namespace.yaml sets `$etcd = $tenantName`. A non-empty value is the on side of
+# the nine `{{- if .Values._namespace.<svc> }}` branches, and it renders 15
+# manifests in packages/apps/kubernetes that the off side does not.
 _namespace:
+  etcd: "tenant-test"
+  ingress: "tenant-test"
+  gateway: "tenant-test"
+  monitoring: "tenant-test"
+  seaweedfs: "tenant-test"
   host: "example.org"

--- a/hack/testdata/render-fixtures/configured.yaml
+++ b/hack/testdata/render-fixtures/configured.yaml
@@ -1,0 +1,21 @@
+# OIDC on, per-host ACME through http01, services exposed. The other side of the
+# branches fresh.yaml leaves off.
+_cluster:
+  root-host: "example.org"
+  bundle-name: "paas-full"
+  solver: "http01"
+  issuer-name: "letsencrypt-prod"
+  wildcard-secret-name: ""
+  wildcard-issue: "false"
+  oidc-enabled: "true"
+  oidc-insecure-skip-verify: "false"
+  keycloak-internal-url: "https://keycloak.cozy-keycloak.svc.cluster.local"
+  extra-keycloak-redirect-uri-for-dashboard: ""
+  expose-ingress: "tenant-root"
+  expose-services: "tenant-root"
+  cluster-domain: "cluster.local"
+  scheduling:
+    nodeSelector: {}
+    tolerations: []
+_namespace:
+  host: "example.org"

--- a/hack/testdata/render-fixtures/configured.yaml
+++ b/hack/testdata/render-fixtures/configured.yaml
@@ -24,7 +24,7 @@ _cluster:
 _namespace:
   etcd: "tenant-test"
   ingress: "tenant-test"
-  gateway: "tenant-test"
+  gateway: ""
   monitoring: "tenant-test"
   seaweedfs: "tenant-test"
   host: "example.org"

--- a/hack/testdata/render-fixtures/configured.yaml
+++ b/hack/testdata/render-fixtures/configured.yaml
@@ -15,12 +15,12 @@ _cluster:
   expose-services: "tenant-root"
   cluster-domain: "cluster.local"
   scheduling:
-    nodeSelector: {}
-    tolerations: []
-# The value is the NAMESPACE providing the service, not a boolean: tenant's
-# namespace.yaml sets `$etcd = $tenantName`. A non-empty value is the on side of
-# the nine `{{- if .Values._namespace.<svc> }}` branches, and it renders 15
-# manifests in packages/apps/kubernetes that the off side does not.
+    dedicatedNodesForWindowsVMs: "false"
+    globalAppTopologySpreadConstraints: |
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
 _namespace:
   etcd: "tenant-test"
   ingress: "tenant-test"

--- a/hack/testdata/render-fixtures/fresh.yaml
+++ b/hack/testdata/render-fixtures/fresh.yaml
@@ -1,0 +1,17 @@
+# A cluster right after install: nothing configured yet.
+_cluster:
+  root-host: "example.org"
+  bundle-name: "paas-full"
+  solver: ""
+  issuer-name: ""
+  wildcard-secret-name: ""
+  wildcard-issue: "false"
+  oidc-enabled: "false"
+  oidc-insecure-skip-verify: "false"
+  keycloak-internal-url: ""
+  extra-keycloak-redirect-uri-for-dashboard: ""
+  expose-ingress: ""
+  expose-services: ""
+  cluster-domain: "cluster.local"
+_namespace:
+  host: "example.org"

--- a/hack/testdata/render-fixtures/fresh.yaml
+++ b/hack/testdata/render-fixtures/fresh.yaml
@@ -13,5 +13,13 @@ _cluster:
   expose-ingress: ""
   expose-services: ""
   cluster-domain: "cluster.local"
+# Empty string means "this tenant has no such shared service"; the charts test it
+# with a bare `{{- if .Values._namespace.etcd }}`, and "" is false. This is the
+# off side of nine such branches.
 _namespace:
+  etcd: ""
+  ingress: ""
+  gateway: ""
+  monitoring: ""
+  seaweedfs: ""
   host: "example.org"

--- a/hack/testdata/render-fixtures/fresh.yaml
+++ b/hack/testdata/render-fixtures/fresh.yaml
@@ -13,9 +13,9 @@ _cluster:
   expose-ingress: ""
   expose-services: ""
   cluster-domain: "cluster.local"
-# Empty string means "this tenant has no such shared service"; the charts test it
-# with a bare `{{- if .Values._namespace.etcd }}`, and "" is false. This is the
-# off side of nine such branches.
+  scheduling:
+    dedicatedNodesForWindowsVMs: "false"
+    globalAppTopologySpreadConstraints: ""
 _namespace:
   etcd: ""
   ingress: ""

--- a/hack/testdata/render-fixtures/validator/Chart.yaml
+++ b/hack/testdata/render-fixtures/validator/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: render-fixture-validator
+version: 0.0.0
+type: application

--- a/hack/testdata/render-fixtures/validator/templates/check.yaml
+++ b/hack/testdata/render-fixtures/validator/templates/check.yaml
@@ -1,0 +1,32 @@
+{{- /* Parse raw fixture YAML: merging values would silently remove null keys. */ -}}
+{{- $fixture := .Values.fixture | fromYaml -}}
+{{- if hasKey $fixture "Error" -}}
+  {{- fail (get $fixture "Error") -}}
+{{- end -}}
+{{- range $section := list "_cluster" "_namespace" -}}
+  {{- $values := get $fixture $section -}}
+  {{- if or (not (kindIs "map" $values)) (empty $values) -}}
+    {{- fail (printf "%s must be a non-empty map" $section) -}}
+  {{- end -}}
+  {{- range $key, $value := $values -}}
+    {{- if and (eq $section "_cluster") (has $key (list "scheduling" "branding")) -}}
+      {{- if not (kindIs "map" $value) -}}
+        {{- fail (printf "%s.%s must be a map" $section $key) -}}
+      {{- end -}}
+    {{- else if not (kindIs "string" $value) -}}
+      {{- fail (printf "%s.%s must be a string" $section $key) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $scheduling := get $fixture._cluster "scheduling" -}}
+{{- if not (kindIs "map" $scheduling) -}}
+  {{- fail "_cluster.scheduling must be a map" -}}
+{{- end -}}
+{{- range $key := list "globalAppTopologySpreadConstraints" "dedicatedNodesForWindowsVMs" -}}
+  {{- if not (hasKey $scheduling $key) -}}
+    {{- fail (printf "_cluster.scheduling.%s is missing" $key) -}}
+  {{- end -}}
+  {{- if not (kindIs "string" (get $scheduling $key)) -}}
+    {{- fail (printf "_cluster.scheduling.%s must be a string" $key) -}}
+  {{- end -}}
+{{- end -}}

--- a/hack/testdata/render-fixtures/wildcard.yaml
+++ b/hack/testdata/render-fixtures/wildcard.yaml
@@ -1,0 +1,18 @@
+# dns01 with a platform-issued wildcard certificate: the path where charts stop
+# doing per-host ACME and point at a shared Secret instead.
+_cluster:
+  root-host: "example.org"
+  bundle-name: "paas-full"
+  solver: "dns01"
+  issuer-name: "letsencrypt-prod"
+  wildcard-secret-name: "wildcard-tls"
+  wildcard-issue: "true"
+  oidc-enabled: "true"
+  oidc-insecure-skip-verify: "false"
+  keycloak-internal-url: "https://keycloak.cozy-keycloak.svc.cluster.local"
+  extra-keycloak-redirect-uri-for-dashboard: ""
+  expose-ingress: "tenant-root"
+  expose-services: "tenant-root"
+  cluster-domain: "cluster.local"
+_namespace:
+  host: "example.org"

--- a/hack/testdata/render-fixtures/wildcard.yaml
+++ b/hack/testdata/render-fixtures/wildcard.yaml
@@ -14,5 +14,14 @@ _cluster:
   expose-ingress: "tenant-root"
   expose-services: "tenant-root"
   cluster-domain: "cluster.local"
+# The value is the NAMESPACE providing the service, not a boolean: tenant's
+# namespace.yaml sets `$etcd = $tenantName`. A non-empty value is the on side of
+# the nine `{{- if .Values._namespace.<svc> }}` branches, and it renders 15
+# manifests in packages/apps/kubernetes that the off side does not.
 _namespace:
+  etcd: "tenant-test"
+  ingress: "tenant-test"
+  gateway: "tenant-test"
+  monitoring: "tenant-test"
+  seaweedfs: "tenant-test"
   host: "example.org"

--- a/hack/testdata/render-fixtures/wildcard.yaml
+++ b/hack/testdata/render-fixtures/wildcard.yaml
@@ -1,5 +1,5 @@
 # dns01 with a platform-issued wildcard certificate: the path where charts stop
-# doing per-host ACME and point at a shared Secret instead.
+# doing per-host ACME and use the ingress controller default certificate.
 _cluster:
   root-host: "example.org"
   bundle-name: "paas-full"
@@ -24,7 +24,7 @@ _cluster:
 _namespace:
   etcd: "tenant-test"
   ingress: "tenant-test"
-  gateway: "tenant-test"
+  gateway: ""
   monitoring: "tenant-test"
   seaweedfs: "tenant-test"
   host: "example.org"

--- a/hack/testdata/render-fixtures/wildcard.yaml
+++ b/hack/testdata/render-fixtures/wildcard.yaml
@@ -14,10 +14,13 @@ _cluster:
   expose-ingress: "tenant-root"
   expose-services: "tenant-root"
   cluster-domain: "cluster.local"
-# The value is the NAMESPACE providing the service, not a boolean: tenant's
-# namespace.yaml sets `$etcd = $tenantName`. A non-empty value is the on side of
-# the nine `{{- if .Values._namespace.<svc> }}` branches, and it renders 15
-# manifests in packages/apps/kubernetes that the off side does not.
+  scheduling:
+    dedicatedNodesForWindowsVMs: "false"
+    globalAppTopologySpreadConstraints: |
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
 _namespace:
   etcd: "tenant-test"
   ingress: "tenant-test"

--- a/packages/apps/clickhouse/tests/backup_api_password_persistence_test.yaml
+++ b/packages/apps/clickhouse/tests/backup_api_password_persistence_test.yaml
@@ -1,0 +1,68 @@
+suite: clickhouse-backup API password persistence across reconciles
+
+# The chart mints the backup API password once and then preserves it, by looking
+# up its own previously-rendered Secret. Both halves matter and they are
+# different code paths:
+#   - no existing Secret  -> generate a fresh password;
+#   - existing Secret     -> reuse it, because rotating on every re-render leaves
+#                            a window where the sidecar and the strategy Pod
+#                            disagree and every backup 401s.
+#
+# The second path is reachable here only because helm-unittest can fake the API
+# the chart looks up (kubernetesProvider). Without that, `lookup` returns nothing
+# outside a cluster, only the generate path renders, and the preserve path -- the
+# one with the failure mode -- is covered by nothing short of a live upgrade.
+#
+# This is the pattern, not the exception: the same lookup-preserve shape guards
+# an immutable PVC storageClass in harbor and the adopt-in-place migrations in
+# seaweedfs. Anywhere a chart reads existing cluster state to decide what to
+# render, this is how the other branch gets tested.
+
+templates:
+  - templates/backup-api-auth-secret.yaml
+
+release:
+  name: ch-test
+  namespace: tenant-test
+
+set:
+  _cluster: {}
+  backup:
+    enabled: true
+
+tests:
+  - it: "mints a password when none exists yet"
+    asserts:
+      - equal:
+          path: stringData.username
+          value: backup
+      - exists:
+          path: stringData.password
+      # Not asserting the value: it is random by design. Asserting its length
+      # would pin randAlphaNum's argument, which is not the contract.
+      - notEqual:
+          path: stringData.password
+          value: ""
+
+  - it: "preserves the existing password rather than rotating it"
+    kubernetesProvider:
+      scheme:
+        "v1/Secret":
+          gvr:
+            version: "v1"
+            resource: "secrets"
+          namespaced: true
+      objects:
+        - kind: Secret
+          apiVersion: v1
+          metadata:
+            name: ch-test-backup-api-auth
+            namespace: tenant-test
+          data:
+            # base64 of "backup" and "preserved-password"
+            username: YmFja3Vw
+            password: cHJlc2VydmVkLXBhc3N3b3Jk
+    asserts:
+      - equal:
+          path: stringData.password
+          value: preserved-password


### PR DESCRIPTION
## What this PR does

helm-unittest covers roughly a fifth of the packages, so for most charts nothing outside the E2E suite ever renders them. A template that breaks on its own defaults is found by a 176-minute lane, or by a release, rather than by a check costing seconds.

`hack/check-render-matrix.sh` renders every chart in `packages/apps/` under three cluster states and fails if any render fails. Today: 21 rendered, 2 skipped with their reason recorded. `hack/*.bats` is picked up by `BATS_UNIT_FILES` automatically, so it runs in `make unit-tests` with no Makefile change.

### The fixtures are taken from the injector, not guessed

`helm template` on these charts is not a supported mode on its own. They read values the platform injects at install time, and without them most charts nil-pointer rather than failing a check: with no fixture at all, 11 of 23 render.

The fixtures reproduce what `packages/core/platform/templates/apps.yaml` puts in the `cozystack-values` Secret, plus `_namespace` from `packages/apps/tenant/templates/namespace.yaml`. Two things there are easy to get wrong and both cost a rewrite of this PR:

Every scalar goes through `| quote`, so the booleans arrive as the strings `"true"`/`"false"`. `tenant` compares one with `eq $oidcEnabled "true"`, and a real YAML bool makes helm fail on incompatible types. `scheduling` and `branding` are the exceptions, they are maps.

`_namespace.<service>` is not a boolean at all: the value is the namespace providing that service, empty when the tenant has none. Charts gate on it with a bare `if`, so an omitted key renders the off side of nine branches. That is a real state, but nothing then renders the on side, and in `packages/apps/kubernetes` that is 15 manifests.

### What this does not cover, stated plainly

`lookup` returns nothing here, so the sweep renders only the empty-result side. There are 40 template lookup calls under `packages/apps/*/templates/` and 13 sit inside a conditional on the result, so those 13 have a side this never renders.

That side is reachable without a cluster, which I had wrongly recorded as impossible: helm-unittest can fake the API a chart looks up, through `kubernetesProvider`. The second commit is the worked example, covering both the mint and the preserve branch of the clickhouse backup API password in milliseconds. The preserve branch is where the failure mode lives, since rotating on every re-render leaves a window where the sidecar and the strategy Pod disagree and every backup 401s, and it was covered by nothing. The same shape guards an immutable PVC storageClass in harbor and the adopt-in-place migrations in seaweedfs.

So lookup branches belong in helm-unittest per chart, where the fake can be specific. This sweep stays what it is: a check that every chart still renders at all.

Three states rather than one because charts branch on these values. Measured honestly: across the 21 swept charts exactly one, `packages/apps/kubernetes`, renders differently between `fresh` and `configured` (30 documents against 45). That is worth the three seconds, but it is not broad branch coverage and the code no longer claims it is.

### Skips

`vm-instance` and `kubernetes-nodes` both resolve an instance type through a lookup of `VirtualMachineClusterInstancetype` and fail on an empty result. That check is the point of those templates in production, so they are skipped rather than weakened. For `kubernetes-nodes` that lookup is the third blocker, not the first: it also needs a `cluster` value and a matching release name, and both are ordinary fixture work.

A test renders each skipped chart directly and requires it to still fail, so a skip that stops being necessary goes red instead of excluding a chart forever.

### What an independent review changed

The `_namespace` gap above, the three factual claims that were wrong (the lookup counts, "every value is a string", the `kubernetes-nodes` skip reason), an invented `scheduling` shape that no chart reads, and two tests that could not fail for the property they named. The third commit carries the detail.

### Downstream repositories

- [x] No downstream repository is affected by this change

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added automated validation that all application Helm charts render successfully across fresh, configured, and wildcard cluster scenarios.
  - Added coverage for invalid templates, malformed YAML, skipped charts, fixture completeness, and differing rendered output.
  - Added tests confirming ClickHouse backup API passwords are created when needed and preserved when an existing Secret is present.

- **Documentation**
  - Documented render-test fixtures, supported cluster states, value formats, and maintenance guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->