### PR TITLE
fix(virtual-machine): guard Kube-OVN lookup by API availability

### DIFF
--- a/packages/apps/vm-instance/templates/vm.yaml
+++ b/packages/apps/vm-instance/templates/vm.yaml
@@ -35,11 +35,13 @@ spec:
     metadata:
       annotations:
         kubevirt.io/allow-pod-bridge-network-live-migration: "true"
+        {{- if .Capabilities.APIVersions.Has "kubeovn.io/v1/IP" }}
         {{- $ovnIPName := printf "%s.%s" (include "virtual-machine.fullname" .) .Release.Namespace }}
         {{- $ovnIP := lookup "kubeovn.io/v1" "IP" "" $ovnIPName }}
         {{- if $ovnIP }}
         ovn.kubernetes.io/mac_address: {{ $ovnIP.spec.macAddress | quote }}
         ovn.kubernetes.io/ip_address: {{ $ovnIP.spec.ipAddress | quote }}
+        {{- end }}
         {{- end }}
       labels:
         {{- include "virtual-machine.labels" . | nindent 8 }}

--- a/packages/apps/vm-instance/tests/network_backend_test.yaml
+++ b/packages/apps/vm-instance/tests/network_backend_test.yaml
@@ -1,0 +1,118 @@
+suite: vm-instance network backend detection
+
+release:
+  name: test-vm
+  namespace: tenant-test
+templates:
+  - templates/vm.yaml
+set:
+  fullnameOverride: test-vm
+  instanceType: ""
+  instanceProfile: ""
+  resources:
+    cpu: 1
+    sockets: 1
+    memory: 1Gi
+  _cluster:
+    scheduling: {}
+
+tests:
+  - it: renders without Kube-OVN APIs on Cozyplane
+    capabilities:
+      apiVersions:
+        - sdn.cozystack.io/v1alpha1
+        - sdn.cozystack.io/v1alpha1/Port
+    # Keep a Kube-OVN object as a regression trap: it must not be looked up
+    # unless the corresponding API kind is advertised by the cluster.
+    kubernetesProvider:
+      scheme:
+        "kubeovn.io/v1/IP":
+          gvr:
+            group: kubeovn.io
+            version: v1
+            resource: ips
+          namespaced: false
+      objects:
+        - apiVersion: kubeovn.io/v1
+          kind: IP
+          metadata:
+            name: test-vm.tenant-test
+          spec:
+            macAddress: "02:00:00:00:00:03"
+            ipAddress: "10.0.0.12"
+    asserts:
+      - isKind:
+          of: VirtualMachine
+      - notExists:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/mac_address"]
+      - notExists:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/ip_address"]
+
+  - it: renders without backend-specific APIs
+    asserts:
+      - isKind:
+          of: VirtualMachine
+      - notExists:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/mac_address"]
+      - notExists:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/ip_address"]
+
+  - it: preserves Kube-OVN annotations when its IP API is available
+    capabilities:
+      apiVersions:
+        - kubeovn.io/v1
+        - kubeovn.io/v1/IP
+    kubernetesProvider:
+      scheme:
+        "kubeovn.io/v1/IP":
+          gvr:
+            group: kubeovn.io
+            version: v1
+            resource: ips
+          namespaced: false
+      objects:
+        - apiVersion: kubeovn.io/v1
+          kind: IP
+          metadata:
+            name: test-vm.tenant-test
+          spec:
+            macAddress: "02:00:00:00:00:01"
+            ipAddress: "10.0.0.10"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/mac_address"]
+          value: "02:00:00:00:00:01"
+      - equal:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/ip_address"]
+          value: "10.0.0.10"
+
+  - it: gives Kube-OVN priority when both backends are available
+    capabilities:
+      apiVersions:
+        - kubeovn.io/v1
+        - kubeovn.io/v1/IP
+        - sdn.cozystack.io/v1alpha1
+        - sdn.cozystack.io/v1alpha1/Port
+    kubernetesProvider:
+      scheme:
+        "kubeovn.io/v1/IP":
+          gvr:
+            group: kubeovn.io
+            version: v1
+            resource: ips
+          namespaced: false
+      objects:
+        - apiVersion: kubeovn.io/v1
+          kind: IP
+          metadata:
+            name: test-vm.tenant-test
+          spec:
+            macAddress: "02:00:00:00:00:02"
+            ipAddress: "10.0.0.11"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/mac_address"]
+          value: "02:00:00:00:00:02"
+      - equal:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/ip_address"]
+          value: "10.0.0.11"

--- a/packages/apps/vm-instance/tests/network_backend_test.yaml
+++ b/packages/apps/vm-instance/tests/network_backend_test.yaml
@@ -57,6 +57,37 @@ tests:
       - notExists:
           path: spec.template.metadata.annotations["ovn.kubernetes.io/ip_address"]
 
+  - it: ignores a Kube-OVN IP object when only the group version is advertised
+    # A guard keyed on the bare "kubeovn.io/v1" group version would pass every
+    # other case in this suite. The lookup must key on the exact IP kind, so a
+    # cluster advertising the group without that kind renders no OVN annotation.
+    capabilities:
+      apiVersions:
+        - kubeovn.io/v1
+    kubernetesProvider:
+      scheme:
+        "kubeovn.io/v1/IP":
+          gvr:
+            group: kubeovn.io
+            version: v1
+            resource: ips
+          namespaced: false
+      objects:
+        - apiVersion: kubeovn.io/v1
+          kind: IP
+          metadata:
+            name: test-vm.tenant-test
+          spec:
+            macAddress: "02:00:00:00:00:04"
+            ipAddress: "10.0.0.13"
+    asserts:
+      - isKind:
+          of: VirtualMachine
+      - notExists:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/mac_address"]
+      - notExists:
+          path: spec.template.metadata.annotations["ovn.kubernetes.io/ip_address"]
+
   - it: preserves Kube-OVN annotations when its IP API is available
     capabilities:
       apiVersions:


### PR DESCRIPTION
## What this PR does

This change guards the Kube-OVN `IP` lookup with the exact `kubeovn.io/v1/IP` API capability. Clusters that expose this API keep the existing lookup and OVN MAC/IP annotations unchanged, including hybrid clusters where Kube-OVN must take priority. Clusters without it, including Cozyplane-only installations, skip the backend-specific lookup and render the VM normally.

The regression suite covers Cozyplane-only, no backend-specific API, Kube-OVN-only, and hybrid discovery. The Cozyplane case deliberately exposes a fake Kube-OVN object without advertising its API, proving that the lookup is not executed merely because an object could be returned.

Validation completed with `helm unittest .` (5 tests) and on a Cozyplane-only lab where the Kube-OVN `IP` API is absent. Both Helm releases reconciled successfully, the canary VM and VMI reached `Running`, and Cozyplane allocated the automatic IP and MAC through a `Port`. The rendered VM contained no OVN annotations. The disposable canary resources were removed after validation.

### Screenshots

Not applicable; this change has no UI impact.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(virtual-machine): Avoid VM chart rendering failures on clusters without the Kube-OVN IP API while preserving Kube-OVN annotations when it is available.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved virtual machine networking compatibility by applying Kube-OVN IP and MAC address annotations only when the required Kube-OVN IP API is available.
  - Prevented unnecessary Kube-OVN resource lookups in clusters using other networking backends.
  - Preserved Kube-OVN annotations when the required API is available, including environments with multiple supported backends.

- **Tests**
  - Added coverage for network backend detection and annotation behavior across supported cluster configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->