### PR TITLE
[Backport release-1.6] fix(kubernetes): retry the tenant CNI install instead of uninstalling it

### DIFF
--- a/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
@@ -45,11 +45,30 @@ spec:
   storageNamespace: cozy-cilium
   interval: 5m
   timeout: 10m
+  {{- /* Flux's default install strategy remediates a failed install by
+         uninstalling the release, which takes the tenant's only CNI away
+         between attempts. RetryOnFailure drops that teardown: the manifests
+         stay applied and the failed install is retried as an upgrade. Both
+         actions carry the strategy because that retry runs as an upgrade and
+         would otherwise fall back to upgrade remediation. The cost is that a
+         genuine upgrade failure no longer rolls back either, which is forced,
+         since the controller cannot tell a retried install from a real one,
+         and what it replaces was an unbounded rollback-and-retry flap. This
+         removes an amplifier, not a cause: an install that outruns its budget
+         because no node has registered yet stays a problem. The remediation
+         blocks cover the branches no strategy reaches, an absent release for
+         install and an out-of-sync one for upgrade, so retries: -1 stays. */}}
   install:
     createNamespace: true
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 30s
     remediation:
       retries: -1
   upgrade:
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 30s
     remediation:
       retries: -1
   values:

--- a/packages/apps/kubernetes/tests/cilium_install_retry_test.yaml
+++ b/packages/apps/kubernetes/tests/cilium_install_retry_test.yaml
@@ -1,0 +1,42 @@
+suite: Cilium install retry strategy tests
+templates:
+  - templates/helmreleases/cilium.yaml
+values:
+  - values-ci.yaml
+tests:
+  # Flux's default strategy remediates a failed install by uninstalling the
+  # release, so a missed install budget on the tenant CNI takes the cluster's
+  # only CNI away for the window until the next install applies the manifests
+  # again, once per cycle for as long as retries allows. RetryOnFailure drops
+  # the teardown and retries as an upgrade instead.
+  - it: retries a failed install instead of uninstalling the CNI
+    asserts:
+      - equal:
+          path: spec.install.strategy.name
+          value: RetryOnFailure
+      - equal:
+          path: spec.install.strategy.retryInterval
+          value: 30s
+
+  # The retry of a failed install runs as an upgrade, so without a strategy on
+  # the upgrade action the second attempt falls back to upgrade remediation.
+  - it: keeps retrying on the upgrade action the install retry runs as
+    asserts:
+      - equal:
+          path: spec.upgrade.strategy.name
+          value: RetryOnFailure
+      - equal:
+          path: spec.upgrade.strategy.retryInterval
+          value: 30s
+
+  # The strategy governs a failed release. Two other branches consult the retry
+  # count instead and refuse to act once it is exhausted: an absent release,
+  # which reads the install block, and an out-of-sync one, which reads upgrade.
+  - it: keeps unlimited retries for the branches no strategy reaches
+    asserts:
+      - equal:
+          path: spec.install.remediation.retries
+          value: -1
+      - equal:
+          path: spec.upgrade.remediation.retries
+          value: -1


### PR DESCRIPTION
Backport of #3552 to `release-1.6`.

Tenant cilium HelmRelease on this branch sets `install.remediation.retries: -1` with no `strategy:`, so helm-controller uses its default install remediation, which is uninstall. Cilium is the tenant cluster's only CNI, so a tenant whose install misses its budget gets the CNI torn down and reinstalled once per cycle, and `-1` lets that repeat without end. `RetryOnFailure` keeps applied manifests in place and retries the failed install as an upgrade instead. Strategy is set on both actions because the retry of a failed install runs as an upgrade.

Shipped broken in v1.6.0, v1.6.1 and v1.6.2. `RetryOnFailure` appears in none of the 19 helmrelease templates on this branch, and the Flux CRD release-1.6 already ships accepts it - enum at `spec.install.strategy.name` and `spec.upgrade.strategy.name`, with the `retryInterval` CEL guard.

Cost is carried over from the original PR: a genuine upgrade failure now retries on failed manifests instead of rolling back. Controller can't tell a retried install from a real upgrade, and what it replaces was an unbounded rollback-and-retry flap.

Auto backport did not apply here, and it was not a conflict. Bot picked four commits from the PR branch, three of them empty `ci: re-run` commits, and `git cherry-pick` exits non-zero on an empty pick with no unmerged paths, which the action reads as a conflict. Picking `80a209044` alone is the whole backport and applies with a line offset only. Resulting tree matches the bot's four-SHA-with-three-skips recipe byte for byte.

### Testing

- `make test` in `packages/apps/kubernetes` - 18 suites, 186 tests green.
- New suite is mutation-proven rather than revert-proven: setting `install.strategy.name` to `Rollback` reds exactly the install test, removing the `upgrade.strategy` block reds exactly the upgrade test, other 185 unaffected both times.
- `make unit-tests` and `make test-controllers` green, `make generate` leaves no drift.
- No migration touched, `targetVersion` still 54.

```release-note
fix(kubernetes): retry the tenant CNI install instead of uninstalling it
```
