### PR TITLE
fix(vpc): render Cozyplane objects when Kube-OVN is absent

### DIFF
--- a/packages/apps/vpc/Makefile
+++ b/packages/apps/vpc/Makefile
@@ -1,5 +1,8 @@
 include ../../../hack/package.mk
 
+test:
+	helm unittest .
+
 generate:
 	cozyvalues-gen -m 'vpc' -v values.yaml -s values.schema.json -g ../../../api/apps/v1alpha1/vpc/types.go
 	../../../hack/update-crd.sh

--- a/packages/apps/vpc/README.md
+++ b/packages/apps/vpc/README.md
@@ -5,9 +5,23 @@ As the service evolves, it will provide more ways to isolate your workloads.
 
 ## Service details
 
-To function, the service requires kube-ovn and multus CNI to be present, so by default it will only work on `paas-full` bundle.
+To function, the service requires multus CNI and one of the two supported network backends, so by default it will only work on `paas-full` bundle.
 Kube-ovn provides VPC and Subnet resources and performs isolation and networking maintenance such as DHCP. Under the hood it uses ovn virtual routers and virtual switches.
 Multus enables a multi-nic capability, so a pod or a VM could have two or more network interfaces.
+
+### Network backend
+
+The chart picks the backend from the APIs the cluster serves; there is no value to set.
+
+| Cluster serves | Backend used |
+|---|---|
+| `kubeovn.io/v1` `Vpc` (with or without Cozyplane) | Kube-OVN, the historical rendering |
+| `sdn.cozystack.io/v1alpha1` `VPC` only | Cozyplane |
+| neither | Kube-OVN rendering (unchanged offline `helm template` output) |
+
+Kube-OVN keeps priority on a cluster that serves both APIs, so an installation that migrates to Cozyplane switches backends only once the Kube-OVN CRDs are gone.
+
+On Cozyplane each subnet becomes a `VPC` of its own carrying that subnet's CIDR (a Cozyplane VPC allocates from its first CIDR only), plus a `VPCBinding` authorizing attachment from the tenant namespace and the `NetworkAttachmentDefinition` under the same `subnet-<id>` name as with Kube-OVN. Subnets of one VirtualPrivateCloud are connected through `VPCPeering` halves, one per ordered pair of subnets, and `peers` produce one half per (local subnet, remote subnet) once the remote tenant's release exists; the remote release renders its own halves, as with Kube-OVN. `routes` have no Cozyplane equivalent and are refused explicitly.
 
 Currently every workload will have a connection to a default management network which will also have a default gateway, and the majority of traffic will go through it.
 VPC subnets are for now an additional dedicated networking spaces.

--- a/packages/apps/vpc/templates/vpc.yaml
+++ b/packages/apps/vpc/templates/vpc.yaml
@@ -54,7 +54,7 @@ metadata:
   name: {{ $subnetId }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    cozystack.io/subnetName: {{ .name }}
+    cozystack.io/subnetName: {{ .name | quote }}
     cozystack.io/vpcId: {{ $vpcId }}
     cozystack.io/vpcName: {{ $.Release.Name }}
     cozystack.io/tenantName: {{ $.Release.Namespace }}
@@ -68,7 +68,7 @@ metadata:
   name: {{ $subnetId }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    cozystack.io/subnetName: {{ .name }}
+    cozystack.io/subnetName: {{ .name | quote }}
     cozystack.io/vpcId: {{ $vpcId }}
     cozystack.io/vpcName: {{ $.Release.Name }}
     cozystack.io/tenantName: {{ $.Release.Namespace }}
@@ -83,7 +83,7 @@ metadata:
   name: {{ $subnetId }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    cozystack.io/subnetName: {{ .name }}
+    cozystack.io/subnetName: {{ .name | quote }}
     cozystack.io/vpcId: {{ $vpcId }}
     cozystack.io/vpcName: {{ $.Release.Name }}
     cozystack.io/tenantName: {{ $.Release.Namespace }}

--- a/packages/apps/vpc/templates/vpc.yaml
+++ b/packages/apps/vpc/templates/vpc.yaml
@@ -3,6 +3,148 @@
 
 {{ $vpcId := print "vpc-" (print .Release.Namespace "/" .Release.Name | sha256sum | trunc 6) }}
 
+{{- /*
+Network backend selection.
+
+Kube-OVN keeps priority: whenever the cluster serves kubeovn.io/v1 Vpc, the
+historical rendering is used unchanged, also on a hybrid cluster that serves
+both APIs. Cozyplane is used only when Kube-OVN is absent AND the cluster serves
+sdn.cozystack.io/v1alpha1 VPC. A cluster serving neither keeps the historical
+rendering, so offline `helm template` output is unchanged.
+
+Detection goes through .Capabilities (API discovery), never through `lookup`:
+a lookup against an API the cluster does not serve fails the whole render.
+*/}}
+{{- $hasKubeOVN := .Capabilities.APIVersions.Has "kubeovn.io/v1/Vpc" }}
+{{- $hasCozyplane := .Capabilities.APIVersions.Has "sdn.cozystack.io/v1alpha1/VPC" }}
+{{- $useCozyplane := and (not $hasKubeOVN) $hasCozyplane }}
+
+{{- if $useCozyplane }}
+{{- /*
+Cozyplane rendering.
+
+A Cozyplane VPC allocates addresses from its first CIDR only, so each subnet
+becomes a VPC of its own carrying that single CIDR. The VPC is named after the
+subnet ID, so the NetworkAttachmentDefinition keeps the historical name: that
+name is the contract vm-instance and the <release>-subnets ConfigMap rely on.
+
+Attachment is default-deny in Cozyplane: a VPCBinding in the tenant namespace
+authorizes it. The NetworkAttachmentDefinition is rendered here with the same
+content Cozyplane's controller writes for a binding, so both agree on one
+object, and rendering it keeps the cozystack.io/* labels consumers select on.
+
+Subnets of one VPC are routed to each other under Kube-OVN. Cozyplane connects
+two VPCs through a symmetric VPCPeering, one half per side, so every ordered
+pair of subnets gets a half here. Cross-tenant peers follow the same rule: the
+remote tenant's subnet VPCs are discovered by their cozystack.io/vpcId label
+and one half is rendered per (local subnet, remote subnet); the remote side
+renders its own halves from its own peers declaration, as with Kube-OVN.
+Static routes have no Cozyplane equivalent and are refused explicitly rather
+than dropped.
+*/}}
+{{- if .Values.routes }}
+{{- fail "virtualprivatecloud: static routes are not supported on the Cozyplane network backend" }}
+{{- end }}
+{{- range .Values.subnets }}
+{{- $subnetId := print "subnet-" (print $.Release.Namespace "/" $vpcId "/" .name | sha256sum | trunc 8) }}
+---
+apiVersion: sdn.cozystack.io/v1alpha1
+kind: VPC
+metadata:
+  name: {{ $subnetId }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    cozystack.io/subnetName: {{ .name }}
+    cozystack.io/vpcId: {{ $vpcId }}
+    cozystack.io/vpcName: {{ $.Release.Name }}
+    cozystack.io/tenantName: {{ $.Release.Namespace }}
+spec:
+  cidrs:
+    - {{ .cidr | quote }}
+---
+apiVersion: sdn.cozystack.io/v1alpha1
+kind: VPCBinding
+metadata:
+  name: {{ $subnetId }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    cozystack.io/subnetName: {{ .name }}
+    cozystack.io/vpcId: {{ $vpcId }}
+    cozystack.io/vpcName: {{ $.Release.Name }}
+    cozystack.io/tenantName: {{ $.Release.Namespace }}
+spec:
+  vpcRef:
+    namespace: {{ $.Release.Namespace }}
+    name: {{ $subnetId }}
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: {{ $subnetId }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    cozystack.io/subnetName: {{ .name }}
+    cozystack.io/vpcId: {{ $vpcId }}
+    cozystack.io/vpcName: {{ $.Release.Name }}
+    cozystack.io/tenantName: {{ $.Release.Namespace }}
+spec:
+  config: '{"cniVersion":"1.0.0","name":"{{ $subnetId }}","type":"cozyplane","vpc":"{{ $.Release.Namespace }}/{{ $subnetId }}"}'
+{{- end }}
+{{- range $i, $local := .Values.subnets }}
+{{- $localId := print "subnet-" (print $.Release.Namespace "/" $vpcId "/" $local.name | sha256sum | trunc 8) }}
+{{- range $j, $other := $.Values.subnets }}
+{{- if ne $i $j }}
+{{- $otherId := print "subnet-" (print $.Release.Namespace "/" $vpcId "/" $other.name | sha256sum | trunc 8) }}
+---
+apiVersion: sdn.cozystack.io/v1alpha1
+kind: VPCPeering
+metadata:
+  name: {{ $localId }}-{{ $otherId }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    cozystack.io/vpcId: {{ $vpcId }}
+    cozystack.io/vpcName: {{ $.Release.Name }}
+    cozystack.io/tenantName: {{ $.Release.Namespace }}
+spec:
+  vpcRef:
+    name: {{ $localId }}
+  peerRef:
+    namespace: {{ $.Release.Namespace }}
+    name: {{ $otherId }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- range .Values.peers }}
+{{- $remoteNamespace := .tenantNamespace }}
+{{- $remoteRelease := printf "virtualprivatecloud-%s" .vpcName }}
+{{- $remoteVpcId := printf "vpc-%s" (printf "%s/%s" $remoteNamespace $remoteRelease | sha256sum | trunc 6) }}
+{{- $remoteVPCs := lookup "sdn.cozystack.io/v1alpha1" "VPC" $remoteNamespace "" }}
+{{- range $local := $.Values.subnets }}
+{{- $localId := print "subnet-" (print $.Release.Namespace "/" $vpcId "/" $local.name | sha256sum | trunc 8) }}
+{{- range $remote := $remoteVPCs.items }}
+{{- if eq (dig "metadata" "labels" "cozystack.io/vpcId" "" $remote) $remoteVpcId }}
+---
+apiVersion: sdn.cozystack.io/v1alpha1
+kind: VPCPeering
+metadata:
+  name: {{ $localId }}-{{ $remote.metadata.name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    cozystack.io/vpcId: {{ $vpcId }}
+    cozystack.io/vpcName: {{ $.Release.Name }}
+    cozystack.io/tenantName: {{ $.Release.Namespace }}
+    cozystack.io/peerVpcId: {{ $remoteVpcId }}
+spec:
+  vpcRef:
+    name: {{ $localId }}
+  peerRef:
+    namespace: {{ $remoteNamespace }}
+    name: {{ $remote.metadata.name }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- else }}
 ---
 apiVersion: kubeovn.io/v1
 kind: Vpc
@@ -81,6 +223,7 @@ spec:
   protocol: IPv4
   enableLb: false
   private: true
+{{- end }}
 {{- end }}
 ---
 apiVersion: v1

--- a/packages/apps/vpc/tests/network_backend_test.yaml
+++ b/packages/apps/vpc/tests/network_backend_test.yaml
@@ -1,0 +1,315 @@
+suite: virtualprivatecloud network backend detection
+
+# The chart serves two network backends and must pick one from API discovery,
+# never from a `lookup`: a lookup against an API the cluster does not serve
+# fails the whole render. Kube-OVN keeps priority whenever kubeovn.io/v1 Vpc is
+# served; Cozyplane is used only when Kube-OVN is absent and
+# sdn.cozystack.io/v1alpha1 VPC is served; a cluster serving neither keeps the
+# historical Kube-OVN rendering, so offline `helm template` is unchanged.
+#
+# helm-unittest's fake `lookup` returns nothing for an unserved kind and never
+# errors the way a live cluster does, so the failure this chart guards against
+# cannot be reproduced here. Every Cozyplane case is instead pinned by the
+# objects it renders and, for `peers`, by remote VPC objects mocked through
+# kubernetesProvider: each of those cases is red on the Kube-OVN-only template.
+#
+# Identifiers below are the chart's own derivations for this release:
+#   vpcId            = "vpc-"    + sha256("tenant-test/virtualprivatecloud-test")[:6]
+#   subnet a / b     = "subnet-" + sha256("tenant-test/<vpcId>/<name>")[:8]
+#   remote vpcId     = "vpc-"    + sha256("tenant-other/virtualprivatecloud-other")[:6]
+#   remote subnet c  = "subnet-" + sha256("tenant-other/<remote vpcId>/c")[:8]
+#
+# Document order follows the template. Kube-OVN: Vpc, then NAD + Subnet per
+# subnet, then ConfigMap, RoleBinding, Role. Cozyplane: VPC + VPCBinding + NAD
+# per subnet, then the intra-VPC peering halves, then the cross-tenant halves,
+# then ConfigMap, RoleBinding, Role.
+
+release:
+  name: virtualprivatecloud-test
+  namespace: tenant-test
+templates:
+  - templates/vpc.yaml
+set:
+  subnets:
+    - name: a
+      cidr: 172.16.0.0/24
+    - name: b
+      cidr: 172.16.1.0/24
+
+tests:
+  - it: keeps the historical Kube-OVN rendering when neither backend API is served
+    asserts:
+      - containsDocument:
+          apiVersion: kubeovn.io/v1
+          kind: Vpc
+          name: vpc-2e37d4
+          any: true
+      - containsDocument:
+          apiVersion: kubeovn.io/v1
+          kind: Subnet
+          name: subnet-1f7afcd0
+          any: true
+      - containsDocument:
+          apiVersion: kubeovn.io/v1
+          kind: Subnet
+          name: subnet-408db55d
+          any: true
+      - matchRegex:
+          path: spec.config
+          pattern: '"type": "kube-ovn"'
+        documentIndex: 1
+      # Vpc + 2 x (NAD + Subnet) + ConfigMap + RoleBinding + Role.
+      - hasDocuments:
+          count: 8
+
+  - it: renders Kube-OVN objects when its Vpc API is served
+    capabilities:
+      apiVersions:
+        - kubeovn.io/v1
+        - kubeovn.io/v1/Vpc
+        - kubeovn.io/v1/Subnet
+    asserts:
+      - containsDocument:
+          apiVersion: kubeovn.io/v1
+          kind: Vpc
+          name: vpc-2e37d4
+          any: true
+      - hasDocuments:
+          count: 8
+
+  - it: gives Kube-OVN priority when both backends are served
+    capabilities:
+      apiVersions:
+        - kubeovn.io/v1
+        - kubeovn.io/v1/Vpc
+        - sdn.cozystack.io/v1alpha1
+        - sdn.cozystack.io/v1alpha1/VPC
+    asserts:
+      - containsDocument:
+          apiVersion: kubeovn.io/v1
+          kind: Vpc
+          name: vpc-2e37d4
+          any: true
+      - containsDocument:
+          apiVersion: kubeovn.io/v1
+          kind: Subnet
+          name: subnet-1f7afcd0
+          any: true
+      - hasDocuments:
+          count: 8
+
+  - it: renders Cozyplane objects when Kube-OVN is absent
+    capabilities:
+      apiVersions:
+        - sdn.cozystack.io/v1alpha1
+        - sdn.cozystack.io/v1alpha1/VPC
+    asserts:
+      # One VPC per subnet, named after the subnet so the NAD keeps its name.
+      - containsDocument:
+          apiVersion: sdn.cozystack.io/v1alpha1
+          kind: VPC
+          name: subnet-1f7afcd0
+          namespace: tenant-test
+          any: true
+      - containsDocument:
+          apiVersion: sdn.cozystack.io/v1alpha1
+          kind: VPC
+          name: subnet-408db55d
+          namespace: tenant-test
+          any: true
+      - equal:
+          path: spec.cidrs
+          value:
+            - 172.16.0.0/24
+        documentIndex: 0
+      - equal:
+          path: metadata.labels["cozystack.io/subnetName"]
+          value: a
+        documentIndex: 0
+      # The binding authorizes attachment from the tenant namespace.
+      - containsDocument:
+          apiVersion: sdn.cozystack.io/v1alpha1
+          kind: VPCBinding
+          name: subnet-1f7afcd0
+          namespace: tenant-test
+          any: true
+      - equal:
+          path: spec.vpcRef
+          value:
+            namespace: tenant-test
+            name: subnet-1f7afcd0
+        documentIndex: 1
+      # The NAD carries the cozyplane CNI config, the same content the
+      # cozyplane controller writes for the binding.
+      - isKind:
+          of: NetworkAttachmentDefinition
+        documentIndex: 2
+      - equal:
+          path: spec.config
+          value: '{"cniVersion":"1.0.0","name":"subnet-1f7afcd0","type":"cozyplane","vpc":"tenant-test/subnet-1f7afcd0"}'
+        documentIndex: 2
+      # Both intra-VPC peering halves, so the two subnets route to each other.
+      - containsDocument:
+          apiVersion: sdn.cozystack.io/v1alpha1
+          kind: VPCPeering
+          name: subnet-1f7afcd0-subnet-408db55d
+          namespace: tenant-test
+          any: true
+      - containsDocument:
+          apiVersion: sdn.cozystack.io/v1alpha1
+          kind: VPCPeering
+          name: subnet-408db55d-subnet-1f7afcd0
+          namespace: tenant-test
+          any: true
+      - equal:
+          path: spec
+          value:
+            vpcRef:
+              name: subnet-1f7afcd0
+            peerRef:
+              namespace: tenant-test
+              name: subnet-408db55d
+        documentSelector:
+          path: metadata.name
+          value: subnet-1f7afcd0-subnet-408db55d
+      # The tenant-facing ConfigMap contract is unchanged.
+      - equal:
+          path: data["a.ID"]
+          value: subnet-1f7afcd0
+        documentSelector:
+          path: kind
+          value: ConfigMap
+      # No Kube-OVN object at all: 2 VPC + 2 VPCBinding + 2 NAD + 2 peering
+      # halves + ConfigMap + RoleBinding + Role.
+      - hasDocuments:
+          count: 11
+
+  - it: renders one cross-tenant peering half per discovered remote subnet on Cozyplane
+    set:
+      peers:
+        - vpcName: other
+          tenantNamespace: tenant-other
+    capabilities:
+      apiVersions:
+        - sdn.cozystack.io/v1alpha1
+        - sdn.cozystack.io/v1alpha1/VPC
+    kubernetesProvider:
+      scheme:
+        "sdn.cozystack.io/v1alpha1/VPC":
+          gvr:
+            group: sdn.cozystack.io
+            version: v1alpha1
+            resource: vpcs
+          namespaced: true
+      objects:
+        # The remote release's subnet, found by its vpcId label.
+        - apiVersion: sdn.cozystack.io/v1alpha1
+          kind: VPC
+          metadata:
+            name: subnet-c02920b2
+            namespace: tenant-other
+            labels:
+              cozystack.io/vpcId: vpc-37739d
+              cozystack.io/subnetName: c
+          spec:
+            cidrs: ["172.16.9.0/24"]
+        # Another VPC of the remote tenant, not part of the peered release.
+        - apiVersion: sdn.cozystack.io/v1alpha1
+          kind: VPC
+          metadata:
+            name: unrelated
+            namespace: tenant-other
+          spec:
+            cidrs: ["10.0.0.0/24"]
+    asserts:
+      - containsDocument:
+          apiVersion: sdn.cozystack.io/v1alpha1
+          kind: VPCPeering
+          name: subnet-1f7afcd0-subnet-c02920b2
+          namespace: tenant-test
+          any: true
+      - containsDocument:
+          apiVersion: sdn.cozystack.io/v1alpha1
+          kind: VPCPeering
+          name: subnet-408db55d-subnet-c02920b2
+          namespace: tenant-test
+          any: true
+      - equal:
+          path: spec
+          value:
+            vpcRef:
+              name: subnet-408db55d
+            peerRef:
+              namespace: tenant-other
+              name: subnet-c02920b2
+        documentSelector:
+          path: metadata.name
+          value: subnet-408db55d-subnet-c02920b2
+      - equal:
+          path: metadata.labels["cozystack.io/peerVpcId"]
+          value: vpc-37739d
+        documentSelector:
+          path: metadata.name
+          value: subnet-408db55d-subnet-c02920b2
+      # 11 objects of the previous case + 2 cross-tenant halves; the unrelated
+      # remote VPC produced nothing.
+      - hasDocuments:
+          count: 13
+      - equal:
+          path: data["peer.tenant-other.other.vpcId"]
+          value: vpc-37739d
+        documentSelector:
+          path: kind
+          value: ConfigMap
+
+  - it: renders no cross-tenant half before the remote release exists on Cozyplane
+    set:
+      peers:
+        - vpcName: other
+          tenantNamespace: tenant-other
+    capabilities:
+      apiVersions:
+        - sdn.cozystack.io/v1alpha1
+        - sdn.cozystack.io/v1alpha1/VPC
+    kubernetesProvider:
+      scheme:
+        "sdn.cozystack.io/v1alpha1/VPC":
+          gvr:
+            group: sdn.cozystack.io
+            version: v1alpha1
+            resource: vpcs
+          namespaced: true
+      objects: []
+    asserts:
+      - hasDocuments:
+          count: 11
+
+  - it: refuses static routes on Cozyplane
+    set:
+      routes:
+        - cidr: 10.9.0.0/24
+          nextHopIP: 172.16.0.1
+    capabilities:
+      apiVersions:
+        - sdn.cozystack.io/v1alpha1
+        - sdn.cozystack.io/v1alpha1/VPC
+    asserts:
+      - failedTemplate:
+          errorPattern: static routes are not supported on the Cozyplane network backend
+
+  - it: keeps static routes on Kube-OVN
+    set:
+      routes:
+        - cidr: 10.9.0.0/24
+          nextHopIP: 172.16.0.1
+    capabilities:
+      apiVersions:
+        - kubeovn.io/v1
+        - kubeovn.io/v1/Vpc
+    asserts:
+      - equal:
+          path: spec.staticRoutes
+          value:
+            - cidr: 10.9.0.0/24
+              nextHopIP: 172.16.0.1
+        documentIndex: 0


### PR DESCRIPTION
## What this PR does

`packages/apps/vpc` rendered `kubeovn.io/v1` `Vpc` and `Subnet` objects and a `kube-ovn` NetworkAttachmentDefinition unconditionally, so a `VirtualPrivateCloud` could not be installed on a cluster whose network backend is Cozyplane (no `kubeovn.io` API served):

```
Helm install failed ... no matches for kind "Vpc" in version "kubeovn.io/v1"
```

The chart now picks its backend from API discovery, with Kube-OVN keeping priority:

| Cluster serves | Rendering |
|---|---|
| `kubeovn.io/v1` `Vpc` (with or without Cozyplane) | Kube-OVN, unchanged |
| `sdn.cozystack.io/v1alpha1` `VPC` only | Cozyplane |
| neither | Kube-OVN, unchanged (offline `helm template` output is byte-identical) |

Detection goes through `.Capabilities.APIVersions.Has`, never through `lookup`: a lookup against an API the cluster does not serve fails the whole render (the vm-instance counterpart is #4013). A hybrid cluster keeps rendering Kube-OVN, so an installation migrating to Cozyplane switches backends only once the Kube-OVN CRDs are gone.

### Cozyplane rendering

- **One Cozyplane `VPC` per subnet**, carrying that subnet's CIDR. Cozyplane allocates from `spec.cidrs[0]` only, so a single VPC with all CIDRs would leave every subnet but the first unusable.
- The VPC is named `subnet-<id>`, so the `NetworkAttachmentDefinition` keeps its historical name: the contract `vm-instance` (`networks[].name`) and the `<release>-subnets` ConfigMap rely on is unchanged.
- A `VPCBinding` in the tenant namespace authorizes attachment (Cozyplane is default-deny), and the NetworkAttachmentDefinition is rendered with the same content Cozyplane's controller writes for a binding, so both agree on one object and the `cozystack.io/*` labels consumers select on stay present.
- Subnets of one VirtualPrivateCloud are connected through symmetric `VPCPeering` halves, one per ordered pair of subnets (Kube-OVN routes the subnets of a Vpc to each other).
- `peers` render one half per (local subnet, remote subnet); the remote tenant's subnet VPCs are discovered by their `cozystack.io/vpcId` label. The remote release renders its own halves from its own `peers`, as with Kube-OVN, so the peering goes `Ready` once both releases have reconciled.
- `routes` have no Cozyplane equivalent and fail the render explicitly instead of being dropped.

No `values.yaml`, `values.schema.json` or ApplicationDefinition change, so nothing to regenerate.

### Tests

`packages/apps/vpc/tests/network_backend_test.yaml` (new `make test` target, 8 cases): Kube-OVN only, both backends served (Kube-OVN wins), neither served, Cozyplane only, cross-tenant peers with mocked remote VPCs, peers before the remote release exists, static routes refused on Cozyplane, static routes kept on Kube-OVN.

helm-unittest's fake `lookup` never errors for an unserved kind, so every Cozyplane case is pinned by the objects it renders and, for `peers`, by remote VPC objects mocked through `kubernetesProvider`. Run against the `main` template: **4 failed, 4 passed** (the four Cozyplane cases are red without the fix, the four Kube-OVN cases are the regression guard). `helm template` with default values and with `subnets` + `peers` + `routes`: output identical to `main`.

### Validation on a Cozyplane-only cluster (Cozystack v1.6.1, Kube-OVN CRDs absent)

Two `VirtualPrivateCloud` in two tenants, each declaring the other as a peer:

- Both HelmReleases `Ready`; 3 Cozyplane `VPC` `Ready` with a VNI each, 3 `VPCBinding`, 3 `subnet-<id>` NetworkAttachmentDefinitions, 6 `VPCPeering` halves all `Ready` (2 intra-VPC, 4 cross-tenant).
- Pods on the VPCs: TCP between the two subnets of one VirtualPrivateCloud, TCP across the tenant peering, no reachability towards an unrelated tenant's VPC.
- `VMInstance` with `networks: [{name: subnet-<id>}]`: `Running`, Cozyplane `Port` allocated with IP and MAC, no OVN annotation, SSH banner reachable from a pod on the same subnet.
- `<release>-subnets` ConfigMap: `<name>.ID` still resolves to the attachable NetworkAttachmentDefinition.

Attaching a VM through the NetworkAttachmentDefinition requires Cozyplane's Multus delegate mode (lllamnyp/cozyplane#27); the objects this chart renders are the same either way.

### Screenshots

Not applicable; there is no UI change.

### Downstream repositories

The diff touches `packages/apps/vpc/templates/vpc.yaml`, a new test suite, the package `Makefile` (`test` target, the pattern the other apps use) and the hand-written part of the package `README.md`. No package is added, renamed or removed; no `values.yaml`, `values.schema.json`, ApplicationDefinition, platform value, variant or `hack/` file changes. The website's `content/en/docs/next/networking/vpc.md` is autogenerated from this `README.md` (`vpc` is in the website `Makefile` `NETWORKING` list), so the updated backend paragraph reaches the site through the existing generator on the next stable tag.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(vpc): render Cozyplane VPC, VPCBinding, NetworkAttachmentDefinition and VPCPeering objects when the cluster does not serve kubeovn.io; Kube-OVN clusters, including hybrid ones, keep the existing rendering.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic network backend selection for VPC deployments.
  * Added support for Cozyplane networking, including subnet connectivity and cross-tenant peering.
  * Preserved existing Kube-OVN behavior and priority when available.
  * Static routes are not supported with Cozyplane.
  * Added documentation describing supported network backends and selection behavior.

* **Tests**
  * Added comprehensive coverage for backend detection, rendering, peering, routing, and fallback scenarios.
  * Added a test command for running the Helm chart test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->