### PR TITLE
feat(dashboard): show a connection hostname for LoadBalancer services

### DIFF
--- a/packages/core/platform/templates/apps.yaml
+++ b/packages/core/platform/templates/apps.yaml
@@ -139,6 +139,9 @@ stringData:
       monitoring-enabled: {{ dig "rootEnabled" true (.Values.monitoring | default dict) | quote }}
       cluster-domain: {{ .Values.networking.clusterDomain | quote }}
       api-server-endpoint: {{ .Values.publishing.apiServerEndpoint | quote }}
+      {{- /* Display-only DNS suffix for the dashboard's Services tab
+             (<service>.<suffix>). Empty -> the console shows no hostname. */}}
+      service-domain: {{ .Values.publishing.serviceDomain | default "" | toString | trimAll "." | quote }}
       {{- with .Values.branding }}
       branding:
         {{- . | toYaml | nindent 8 }}

--- a/packages/core/platform/tests/apps_service_domain_wiring_test.yaml
+++ b/packages/core/platform/tests/apps_service_domain_wiring_test.yaml
@@ -1,0 +1,52 @@
+suite: apps.yaml publishing.serviceDomain → _cluster wiring
+templates:
+  - templates/apps.yaml
+
+release:
+  name: cozy-platform
+  namespace: cozy-system
+
+# publishing.serviceDomain is the DNS suffix the dashboard appends to a
+# LoadBalancer Service name on the application Services tab. It reaches the
+# dashboard chart through _cluster.service-domain in the cozystack-values
+# Secret (the same path cluster-domain and branding travel). Pin both
+# directions: the empty default, which the console turns into "show no
+# hostname", and a configured value landing verbatim. Without these a refactor
+# of the values map could drop the key and the dashboard would silently stop
+# showing hostnames on every cluster that configured one.
+
+tests:
+  - it: writes an empty service-domain by default
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: '(?m)^\s*service-domain:\s*""'
+
+  - it: writes the service-domain when publishing.serviceDomain is set
+    set:
+      publishing.serviceDomain: svc.example.org
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: '(?m)^\s*service-domain:\s*"svc\.example\.org"'
+
+  # The console joins "<service>.<suffix>" verbatim, so a leading or trailing
+  # dot from the operator would render "demo..svc.example.org." — strip them
+  # here, the single place every consumer reads from.
+  - it: strips leading and trailing dots from publishing.serviceDomain
+    set:
+      publishing.serviceDomain: .svc.example.org.
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: '(?m)^\s*service-domain:\s*"svc\.example\.org"'
+
+  # An unquoted scalar in the operator's values arrives as a number, and
+  # trimAll on a float64 aborts the whole platform render. Coerce first.
+  - it: renders an unquoted numeric publishing.serviceDomain instead of failing
+    set:
+      publishing.serviceDomain: 123
+    asserts:
+      - matchRegex:
+          path: stringData["values.yaml"]
+          pattern: '(?m)^\s*service-domain:\s*"123"'

--- a/packages/core/platform/values.yaml
+++ b/packages/core/platform/values.yaml
@@ -169,6 +169,20 @@ publishing:
   # value requires recreating that Service once (the chart fails early with the
   # exact command).
   loadBalancerClass: ""
+  # DNS suffix the dashboard appends to the name of a LoadBalancer Service on
+  # the application Services tab, shown under the external IP as
+  # `<service-name>.<serviceDomain>` (e.g. demo-external-write.svc.example.org
+  # for a postgres release named demo). Display-only: nothing in the platform
+  # creates DNS records for it. Set it only when your DNS already resolves
+  # exactly that name to the Service's LoadBalancer IP, e.g. external-dns with
+  # a matching fqdn template. A CoreDNS k8s_external zone does not fit: it
+  # answers <service>.<namespace>.<zone>, which this suffix cannot express.
+  # This is not the `<release>.<tenant host>` name the app charts put into
+  # their certificates, so a TLS client may see a SAN mismatch unless DNS and
+  # certificates are aligned by the operator. The suffix is cluster-wide, so
+  # two tenants with a release of the same name get the same hostname.
+  # Empty (the default) shows no hostname.
+  serviceDomain: ""
   # Enable PROXY-protocol on the host ingress-nginx and auto-deploy
   # ouroboros (system/ouroboros) to fix the resulting hairpin-NAT
   # problem (intra-cluster traffic to the cluster's own public hostnames

--- a/packages/system/dashboard/images/console/apps/console/src/App.routing.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/App.routing.test.tsx
@@ -71,3 +71,18 @@ describe("default landing", () => {
     ).toBeTruthy()
   })
 })
+
+describe("runtime config", () => {
+  it("reaches the tree through AppConfigContext", async () => {
+    const client = makeClient()
+    renderWithK8sProvider(<App config={{ version: "v0.0.0-test" }} />, {
+      client,
+      initialRoute: "/",
+    })
+
+    // The header prints config.version verbatim, so it is the cheapest proof
+    // that the loaded config is published to the whole tree (routes read the
+    // same context for serviceDomain).
+    expect(await screen.findByText("v0.0.0-test")).toBeTruthy()
+  })
+})

--- a/packages/system/dashboard/images/console/apps/console/src/App.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/App.tsx
@@ -14,15 +14,11 @@ import {
 import type { HeaderTab } from "@cozystack/ui"
 import { CommandPaletteProvider, useCommandPalette } from "./components/command-palette/command-palette-provider.tsx"
 import { CommandPalette } from "./components/command-palette/command-palette.tsx"
-import type { AppConfig } from "./lib/config.ts"
+import { AppConfigContext, useAppConfig, type AppConfig } from "./lib/config.ts"
 import { DEFAULT_LANDING_PATH } from "./lib/portal.ts"
 
-interface ShellProps {
-  config: AppConfig
-  username?: string
-}
-
-function Shell({ config, username }: ShellProps) {
+function Shell({ username }: { username?: string }) {
+  const config = useAppConfig()
   const { pathname } = useLocation()
   const inMarketplace = pathname.startsWith("/marketplace")
   const inAdmin = pathname.startsWith("/admin")
@@ -72,10 +68,12 @@ export interface AppProps {
 
 export default function App({ config = {}, username }: AppProps) {
   return (
-    <TenantProvider>
-      <CommandPaletteProvider>
-        <Shell config={config} username={username} />
-      </CommandPaletteProvider>
-    </TenantProvider>
+    <AppConfigContext.Provider value={config}>
+      <TenantProvider>
+        <CommandPaletteProvider>
+          <Shell username={username} />
+        </CommandPaletteProvider>
+      </TenantProvider>
+    </AppConfigContext.Provider>
   )
 }

--- a/packages/system/dashboard/images/console/apps/console/src/lib/config.ts
+++ b/packages/system/dashboard/images/console/apps/console/src/lib/config.ts
@@ -1,3 +1,5 @@
+import { createContext, useContext } from "react"
+
 export interface AppConfig {
   titleText?: string
   footerText?: string
@@ -9,6 +11,16 @@ export interface AppConfig {
   // than the rc version baked into the bundle at build. Falls back to the
   // build-time VITE_APP_VERSION when absent.
   version?: string
+  // DNS suffix shown after a LoadBalancer Service name on the Services tab.
+  // Absent when the platform leaves publishing.serviceDomain empty; the tab
+  // then shows no hostname.
+  serviceDomain?: string
+}
+
+export const AppConfigContext = createContext<AppConfig>({})
+
+export function useAppConfig(): AppConfig {
+  return useContext(AppConfigContext)
 }
 
 const CONFIG_NAMESPACE = "cozy-dashboard"

--- a/packages/system/dashboard/images/console/apps/console/src/routes/detail/ServicesTab.test.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/detail/ServicesTab.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterEach } from "vitest"
 import { screen, waitFor, cleanup } from "@testing-library/react"
 import { K8sClient } from "@cozystack/k8s-client"
 import { renderWithK8sProvider } from "../../test-utils/render.tsx"
+import { AppConfigContext } from "../../lib/config.ts"
 import { ServicesTab } from "./ServicesTab.tsx"
 import type { ApplicationDefinition, ApplicationInstance } from "@cozystack/types"
 
@@ -90,5 +91,55 @@ describe("ServicesTab external IP", () => {
     expect(screen.queryByText("Pending")).not.toBeInTheDocument()
     // The External IP cell renders an em dash for non-LoadBalancer services.
     expect(screen.getAllByText("—").length).toBeGreaterThan(0)
+  })
+})
+
+describe("ServicesTab connection hostname", () => {
+  const lbService = {
+    metadata: { name: "demo", namespace: "tenant-root" },
+    spec: { type: "LoadBalancer", clusterIP: "10.96.1.2", ports: [{ port: 5432 }] },
+    status: { loadBalancer: { ingress: [{ ip: "192.0.2.50" }] } },
+  }
+
+  it("renders <service>.<serviceDomain> for a LoadBalancer, even while the IP is pending", async () => {
+    const client = makeClient([lbService, { ...lbService, metadata: { name: "late" }, status: {} }])
+    renderWithK8sProvider(
+      <AppConfigContext.Provider value={{ serviceDomain: "svc.example.org" }}>
+        <ServicesTab ad={ad} instance={instance} />
+      </AppConfigContext.Provider>,
+      { client },
+    )
+
+    await waitFor(() => expect(screen.getByText("demo.svc.example.org")).toBeInTheDocument())
+    expect(screen.getByText("late.svc.example.org")).toBeInTheDocument()
+    expect(screen.getByText("Pending")).toBeInTheDocument()
+  })
+
+  it("renders no hostname when the platform configured no serviceDomain", async () => {
+    // Nothing in the platform publishes DNS for a guessed name, so the tab
+    // must not invent one: neither "demo." nor a tenant-derived suffix.
+    const client = makeClient([lbService])
+    renderWithK8sProvider(<ServicesTab ad={ad} instance={instance} />, { client })
+
+    await waitFor(() => expect(screen.getByText("192.0.2.50")).toBeInTheDocument())
+    expect(screen.queryByText(/^demo\./)).not.toBeInTheDocument()
+  })
+
+  it("renders no hostname for a ClusterIP service", async () => {
+    const client = makeClient([
+      {
+        metadata: { name: "internal", namespace: "tenant-root" },
+        spec: { type: "ClusterIP", clusterIP: "10.96.1.5", ports: [{ port: 8080 }] },
+      },
+    ])
+    renderWithK8sProvider(
+      <AppConfigContext.Provider value={{ serviceDomain: "svc.example.org" }}>
+        <ServicesTab ad={ad} instance={instance} />
+      </AppConfigContext.Provider>,
+      { client },
+    )
+
+    await waitFor(() => expect(screen.getByText("internal")).toBeInTheDocument())
+    expect(screen.queryByText(/^internal\./)).not.toBeInTheDocument()
   })
 })

--- a/packages/system/dashboard/images/console/apps/console/src/routes/detail/ServicesTab.tsx
+++ b/packages/system/dashboard/images/console/apps/console/src/routes/detail/ServicesTab.tsx
@@ -3,6 +3,7 @@ import { Section, Spinner } from "@cozystack/ui"
 import type { ApplicationDefinition, ApplicationInstance } from "@cozystack/types"
 import { appInstanceLabel } from "../../lib/labels.ts"
 import { formatAge } from "../../lib/status.ts"
+import { useAppConfig } from "../../lib/config.ts"
 
 interface ServiceSpec {
   type?: string
@@ -29,6 +30,7 @@ export function ServicesTab({
     { labelSelector: appInstanceLabel(ad, instance) },
   )
   const items = data?.items ?? []
+  const { serviceDomain } = useAppConfig()
 
   return (
     <div className="p-6">
@@ -53,11 +55,17 @@ export function ServicesTab({
             </thead>
             <tbody className="divide-y divide-slate-100">
               {items.map((svc) => {
+                const isLoadBalancer = svc.spec?.type === "LoadBalancer"
                 const lb = svc.status?.loadBalancer?.ingress?.[0]
-                const external =
-                  svc.spec?.type === "LoadBalancer"
-                    ? (lb?.ip ?? lb?.hostname ?? "Pending")
-                    : "—"
+                const external = isLoadBalancer
+                  ? (lb?.ip ?? lb?.hostname ?? "Pending")
+                  : "—"
+                // Only when the operator configured a suffix: nothing in the
+                // platform publishes DNS for these names, so no fallback.
+                const hostname =
+                  isLoadBalancer && serviceDomain
+                    ? `${svc.metadata.name}.${serviceDomain}`
+                    : undefined
                 return (
                   <tr key={svc.metadata.name} className="hover:bg-slate-50">
                     <td className="px-4 py-3 font-mono text-xs text-slate-800">
@@ -70,7 +78,8 @@ export function ServicesTab({
                       {svc.spec?.clusterIP ?? "—"}
                     </td>
                     <td className="px-4 py-3 font-mono text-xs text-slate-700">
-                      {external}
+                      <div>{external}</div>
+                      {hostname && <div className="text-slate-500">{hostname}</div>}
                     </td>
                     <td className="px-4 py-3 text-slate-700">
                       {svc.spec?.ports

--- a/packages/system/dashboard/templates/configmap.yaml
+++ b/packages/system/dashboard/templates/configmap.yaml
@@ -13,6 +13,11 @@
        and the vX.Y.Z release tags, rather than stripping the leading v. */}}
 {{- $_ := set $config "version" $tag }}
 {{- end }}
+{{- /* Omitted when empty: the console treats a missing key as "show no
+       hostname", so an empty string must not reach config.json. */}}
+{{- with index .Values._cluster "service-domain" }}
+{{- $_ := set $config "serviceDomain" . }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/packages/system/dashboard/tests/configmap_service_domain_test.yaml
+++ b/packages/system/dashboard/tests/configmap_service_domain_test.yaml
@@ -1,0 +1,44 @@
+suite: console config.json service-domain wiring
+templates:
+  - templates/configmap.yaml
+
+release:
+  name: dashboard
+  namespace: cozy-dashboard
+
+# The console reads config.json once at startup and treats a missing
+# serviceDomain as "show no hostname". The chart therefore omits
+# the key when _cluster.service-domain is unset or empty, and copies the value
+# verbatim when set. Pin all three, next to the existing branding merge, so a
+# refactor of the $config assembly cannot drop the key or start shipping an
+# empty string the console would have to special-case.
+
+tests:
+  - it: omits serviceDomain when service-domain is unset
+    set:
+      _cluster:
+        root-host: example.org
+    asserts:
+      - notMatchRegex:
+          path: data["config.json"]
+          pattern: serviceDomain
+
+  - it: omits serviceDomain when service-domain is empty
+    set:
+      _cluster:
+        root-host: example.org
+        service-domain: ""
+    asserts:
+      - notMatchRegex:
+          path: data["config.json"]
+          pattern: serviceDomain
+
+  - it: writes serviceDomain when service-domain is set
+    set:
+      _cluster:
+        root-host: example.org
+        service-domain: svc.example.org
+    asserts:
+      - matchRegex:
+          path: data["config.json"]
+          pattern: '"serviceDomain":"svc\.example\.org"'


### PR DESCRIPTION
## What this PR does

The Services tab on the application page shows a connection hostname under the External IP of every LoadBalancer Service, as `<service-name>.<suffix>`, also while the IP is still Pending. ClusterIP Services get nothing.

The suffix is a new platform value, `publishing.serviceDomain`. It travels the same path as `cluster-domain` and `branding`: `_cluster.service-domain` in the cozystack-values Secret (leading and trailing dots stripped there), then `serviceDomain` in the dashboard's `config.json`, written only when non-empty.

Empty by default, and with it empty the tab shows no hostname. There is deliberately no fallback to a tenant-derived name: the app charts certify `<release>.<tenant host>` while the LoadBalancer Services are named `<release>-external-write` and similar, so a name built from the tenant apex would match neither DNS nor the certificate. Showing nothing beats showing a name nobody publishes.

The value is display-only. Nothing in the platform creates DNS records for it. Set it when your DNS already resolves `<service-name>.<serviceDomain>` to that Service's LoadBalancer IP, external-dns with a matching fqdn template for example. A CoreDNS `k8s_external` zone does not fit, it answers `<service>.<namespace>.<zone>`. The shown name is not the one in the app certificates, so a TLS client may see a SAN mismatch unless DNS and certificates are aligned by the operator, and two tenants with a release of the same name get the same hostname. The values comment says all of this.

Left for follow-ups: reading `external-dns.alpha.kubernetes.io/hostname` from the Service as the first source (only the opensearch chart stamps it today), and a per-Service override annotation. Parked from review, not blocking: the Admin External IPs page does not show the hostname yet, the column header still says "External IP", and surrounding whitespace in the value is not trimmed.

Closes #3112

### Screenshots

<img width="1200" height="360" alt="services-tab" src="https://github.com/user-attachments/assets/01e1f3e0-836e-41cc-b916-f675b62580cd" />

### Downstream repositories

`packages/core/platform/values.yaml` gains a key, so the hand-written table in `content/en/docs/next/operations/configuration/platform-package.md` on cozystack/website needs a row; that is cozystack/website#679, which also drops the stale `exposureClass` rows and adds the missing `loadBalancerClass` one, and should merge after this PR. No other repository restates this key: ansible-cozystack passes a fixed list of `publishing.*` keys that does not include it, and the terraform provider models app schemas, not platform values.

- [ ] No downstream repository is affected by this change
- [x] [cozystack/website](https://github.com/cozystack/website) - follow-up: https://github.com/cozystack/website/pull/679
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
feat(dashboard): the application Services tab shows `<service>.<suffix>` under the external IP of LoadBalancer services when the new platform value `publishing.serviceDomain` is set
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional service domain setting for displaying LoadBalancer service hostnames in the dashboard.
  - When configured, services display hostnames in the format `<service-name>.<service-domain>` alongside external IP information.
  - Hostnames are shown only for LoadBalancer services and remain hidden when no service domain is configured.
  - Dashboard configuration now receives the service domain setting automatically, including support for custom domain formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
