### PR TITLE
fix(cert-manager): enable the Gateway API solver in the host cert-manager

### DIFF
--- a/packages/core/platform/templates/bundles/system.yaml
+++ b/packages/core/platform/templates/bundles/system.yaml
@@ -173,7 +173,24 @@
 
 # Common Packages
 {{include "cozystack.platform.package.default" (list "cozystack.gateway-api-crds" $) }}
-{{include "cozystack.platform.package.default" (list "cozystack.cert-manager" $) }}
+{{- /* The ClusterIssuers of cert-manager-issuers and the per-tenant Issuers
+       rendered for TenantGateway both use an http01.gatewayHTTPRoute solver
+       when the Gateway is enabled, and the controller refuses that solver
+       unless Gateway API support is switched on: every such challenge fails
+       with "gateway api is not enabled" and no certificate is issued. Safe to
+       switch on for every host variant because cozystack.gateway-api-crds is
+       emitted above unconditionally and the cert-manager source depends on
+       it. Threaded here rather than set as a default of system/cert-manager:
+       the same chart is installed into tenant clusters, where the CRDs are an
+       opt-in addon and a controller started with enableGatewayAPI and no
+       CRDs exits at startup. */ -}}
+{{- $certManagerConfig := dict
+  "apiVersion" "controller.config.cert-manager.io/v1alpha1"
+  "kind" "ControllerConfiguration"
+  "enableGatewayAPI" true -}}
+{{- $certManagerValues := dict "cert-manager" (dict "config" $certManagerConfig) -}}
+{{- $certManagerComponents := dict "cert-manager" (dict "values" $certManagerValues) -}}
+{{include "cozystack.platform.package" (list "cozystack.cert-manager" "default" $ $certManagerComponents) }}
 {{- /* Disable hazard guard. The vendored cozy-ouroboros chart (0.8.0)
        ships a pre-delete Helm hook that sed-strips the BEGIN/END
        block from kube-system/coredns Corefile when the chart is

--- a/packages/core/platform/tests/bundles_cert_manager_gateway_api_test.yaml
+++ b/packages/core/platform/tests/bundles_cert_manager_gateway_api_test.yaml
@@ -1,0 +1,78 @@
+suite: cert-manager Gateway API solver bundle wiring
+templates:
+  - templates/bundles/system.yaml
+  - templates/sources.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  # With the Gateway enabled, the platform's ClusterIssuers and the per-tenant
+  # Issuers both carry an http01.gatewayHTTPRoute solver, and the controller
+  # refuses it unless Gateway API support is on: every challenge fails with
+  # "gateway api is not enabled". The flag rides on the Package's component
+  # values, not on a default of system/cert-manager, because that chart is also
+  # installed into tenant clusters without the CRDs, where the same flag makes
+  # the controller exit at startup. These tests pin the host side of that split.
+  - it: enables the Gateway API solver on the host cert-manager (isp-full)
+    template: templates/bundles/system.yaml
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-full
+    documentSelector:
+      path: metadata.name
+      value: cozystack.cert-manager
+    asserts:
+      - equal:
+          path: spec.components.cert-manager.values.cert-manager.config
+          value:
+            apiVersion: controller.config.cert-manager.io/v1alpha1
+            kind: ControllerConfiguration
+            enableGatewayAPI: true
+
+  - it: enables it on the hosted variant too (isp-hosted)
+    template: templates/bundles/system.yaml
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-hosted
+        iaas:
+          enabled: false
+    documentSelector:
+      path: metadata.name
+      value: cozystack.cert-manager
+    asserts:
+      - equal:
+          path: spec.components.cert-manager.values.cert-manager.config.enableGatewayAPI
+          value: true
+
+  # What makes the flag safe on the host: the CRDs ship on every variant and
+  # cert-manager is ordered after them. Losing either turns the flag into the
+  # tenant failure mode described above.
+  - it: ships the Gateway API CRDs on the hosted variant as well (isp-hosted)
+    template: templates/bundles/system.yaml
+    set:
+      bundles:
+        system:
+          enabled: true
+          variant: isp-hosted
+        iaas:
+          enabled: false
+    asserts:
+      - containsDocument:
+          apiVersion: cozystack.io/v1alpha1
+          kind: Package
+          name: cozystack.gateway-api-crds
+          any: true
+
+  - it: orders cert-manager after the Gateway API CRDs
+    template: templates/sources.yaml
+    documentSelector:
+      path: metadata.name
+      value: cozystack.cert-manager
+    asserts:
+      - contains:
+          path: spec.variants[0].dependsOn
+          content: cozystack.gateway-api-crds

--- a/packages/system/cert-manager/tests/controller_gateway_api_test.yaml
+++ b/packages/system/cert-manager/tests/controller_gateway_api_test.yaml
@@ -1,0 +1,82 @@
+suite: cert-manager controller config wiring
+
+# The host enables the Gateway API solver by passing a ControllerConfiguration
+# through this chart's `config` value from the platform bundle. It is not a
+# default of this package on purpose: the same chart is installed into tenant
+# clusters, where the Gateway API CRDs are an opt-in addon, and a controller
+# started with enableGatewayAPI and no CRDs exits at startup and crashloops.
+#
+# The first two tests pin the chart side of that contract with the exact
+# payload the host passes: a re-vendored chart that stops rendering `config`
+# into the ConfigMap, or stops mounting it and naming it in --config, would
+# turn the host flag into a silent no-op. The third pins the neutral default,
+# which is what keeps tenant clusters without the CRDs alive.
+
+templates:
+  - charts/cert-manager/templates/controller-config.yaml
+  - charts/cert-manager/templates/deployment.yaml
+
+release:
+  name: cert-manager
+  namespace: cozy-cert-manager
+
+tests:
+  - it: renders a ControllerConfiguration passed through config into the controller ConfigMap
+    template: charts/cert-manager/templates/controller-config.yaml
+    set:
+      cert-manager:
+        config:
+          apiVersion: controller.config.cert-manager.io/v1alpha1
+          kind: ControllerConfiguration
+          enableGatewayAPI: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: cert-manager
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?m)^apiVersion: controller\.config\.cert-manager\.io/v1alpha1$'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?m)^kind: ControllerConfiguration$'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: '(?m)^enableGatewayAPI: true$'
+
+  - it: mounts that ConfigMap into the controller and names it in --config
+    template: charts/cert-manager/templates/deployment.yaml
+    set:
+      cert-manager:
+        config:
+          apiVersion: controller.config.cert-manager.io/v1alpha1
+          kind: ControllerConfiguration
+          enableGatewayAPI: true
+    asserts:
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --config=/var/cert-manager/config/config.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: config
+            mountPath: /var/cert-manager/config
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: cert-manager
+
+  - it: ships no controller config by default, so the Gateway API solver stays off unless the installer asks
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: charts/cert-manager/templates/controller-config.yaml
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --config=/var/cert-manager/config/config.yaml
+        template: charts/cert-manager/templates/deployment.yaml


### PR DESCRIPTION
## What this PR does

With the platform Gateway enabled, the ClusterIssuers in `cert-manager-issuers` and the per-tenant Issuers rendered for `TenantGateway` carry an `http01.gatewayHTTPRoute` solver, but the controller refuses it: the vendored chart never turns Gateway API support on, so every HTTP-01 challenge behind the Gateway fails with `gateway api is not enabled` and no certificate is issued.

This passes a `ControllerConfiguration` with `enableGatewayAPI: true` to the host cert-manager through the component values of its platform Package. The host ships the Gateway API CRDs on every variant and orders cert-manager after them, so the flag is safe there.

It is deliberately not a default of the `system/cert-manager` chart. The same chart is installed into tenant Kubernetes clusters, where the CRDs are an opt-in addon, and cert-manager v1.20 exits at startup when Gateway API support is on and the CRDs are missing. The tenant HelmRelease in `packages/apps/kubernetes` already passes the same `ControllerConfiguration` when its `gatewayAPI` addon is enabled, so both clusters now opt in from the layer that knows whether the CRDs are there, and the chart itself stays neutral.

The new tests pin both halves: the host Package carries the flag and the preconditions that make it safe, and the chart wires `config` through to the controller while shipping none by default.

Closes #3725

### Screenshots

Not applicable, no UI changes.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(cert-manager): enable the Gateway API solver in the host cert-manager, so ACME HTTP-01 challenges succeed when the platform Gateway is enabled
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled cert-manager to use Gateway API HTTPRoute solvers in supported system bundles.
  - Added the required Gateway API CRDs to hosted deployments and ensured they are installed before cert-manager.
  - Gateway API support remains opt-in for environments that do not provide the required CRDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->