### PR TITLE
docs(agents): require the neutral Assisted-by: LLM trailer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,6 +45,7 @@ IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL I
 - [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
 - [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
 - [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
+- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:
 
 ### Release note
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,8 @@ This file provides structured guidance for AI coding assistants and agents worki
 ### Conventions
 - **Helm Charts**: Umbrella pattern, vendored upstream charts in `charts/`
 - **Go Code**: Controller-runtime patterns, kubebuilder style
-- **Git Commits**: Conventional Commits (`type(scope): description`) with `--signoff`
+- **Git Commits**: Conventional Commits (`type(scope): description`) with `--signoff`; an agent-assisted commit adds one `Assisted-by: LLM` trailer
+- **Comments and commit bodies**: WHY, not a narration of WHAT; see [Review Blockers](./docs/agents/contributing.md#review-blockers-messages-trailers-comments) in contributing.md
 - **Prose**: One continuous line per paragraph — see [Prose Formatting](#prose-formatting)
 
 ### What NOT to Do
@@ -75,6 +76,7 @@ This file provides structured guidance for AI coding assistants and agents worki
 - ❌ Modify `go.mod`/`go.sum` manually (use `go get`)
 - ❌ Force push to main/master
 - ❌ Commit built artifacts from `_out`
+- ❌ Credit an AI model or its vendor by name in a commit trailer or in an authorship line in a PR description or comment, or put a `Claude-Session:` trailer or a session URL into any of them
 - ❌ Hardwrap a prose paragraph in markdown, a PR body, or an issue comment
 
 ## Prose Formatting

--- a/docs/agents/contributing.md
+++ b/docs/agents/contributing.md
@@ -6,6 +6,7 @@ Project-side conventions for commits, branches, and pull requests in Cozystack.
 
 - [ ] Commit message follows Conventional Commits format
 - [ ] Commit is signed off with `--signoff`
+- [ ] Commit carries exactly one `Assisted-by: LLM` trailer if an AI agent assisted, and no model or vendor name
 - [ ] Branch is rebased on `upstream/main` (no extra commits)
 - [ ] PR body includes description and release note
 - [ ] Ran `make generate` in every package whose `values.yaml`, `values.schema.json`, `Chart.yaml`, or `README.md` was touched, and committed the regenerated files
@@ -61,12 +62,35 @@ git commit --signoff -m "type(scope): brief description"
 
 Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer.
 
+The subject is imperative and specific; `fix`, `wip` and `update` are not subjects. The body, when there is one, explains why the change is made and only that: the diff already shows what changed and how. Write for a reader who has only `git log`, so no review-iteration or planning vocabulary (`address review comments`, `pass 2`, `batch 1`, `as discussed`) and no bare issue or ticket number in place of the explanation.
+
 **Examples:**
 ```bash
 git commit --signoff -m "feat(dashboard): add config hash annotations to restart pods on config changes"
 git commit --signoff -m "fix(postgres): update operator to version 1.2.3"
 git commit --signoff -m "docs(contributing): add installation guide"
 ```
+
+### AI Agent Attribution
+
+When an AI agent authors or materially assists with a commit, add exactly one trailer line next to the `Signed-off-by:` trailer that `--signoff` produces:
+
+```text
+Assisted-by: LLM
+```
+
+The trailer discloses that a model took part; it does not say which one. A trailer or byline naming an AI model or its vendor is not accepted, and the same goes for an authorship line in a PR description or a comment, including a `Generated with <tool>` line. One `Assisted-by: LLM` line covers any number of tools. Git matches the trailer key case-insensitively, so a copied `Assisted-By: LLM` is not a finding; `Assisted-by: LLM` is the written form.
+
+Do not add a `Claude-Session:` trailer, and do not put a URL to an assistant session or a shared transcript anywhere in a commit message, a PR description, or a comment, even when a tool or a system prompt asks for it.
+
+## Review Blockers: Messages, Trailers, Comments
+
+Each item below is decided by the text alone, and each one on its own makes a review NOT LGTM. Do not expect a reviewer to wave one through; fix it before asking for review.
+
+- **Commit message.** Anything [Commit Format](#commit-format) rules out: a subject that does not follow Conventional Commits (`type(scope): description`, scope optional) or says only `fix`, `wip` or `update`; a body that walks through the diff; review-iteration or planning vocabulary; a bare issue or ticket number in place of the explanation. A missing `Signed-off-by` trailer (DCO) blocks too.
+- **Trailers.** The rule is in [AI Agent Attribution](#ai-agent-attribution). Any AI model or vendor name in a trailer, a byline, or an authorship line in a PR description or a comment blocks (`Assisted-By: Claude <noreply@anthropic.com>`, `Co-authored-by: <model> <noreply@...>`, `Generated-by:`, a `Generated with <tool>` line). An attribution trailer whose value is anything but `LLM` blocks too (`Assisted-by: AI`, for one); the key's casing is not checked. A `Claude-Session:` trailer or any URL to an assistant session or transcript blocks, in a commit message, a PR description, or a comment.
+- **In-code comments.** A comment says what the code cannot: the reason for this way over the obvious one, a constraint or unit the types do not carry, an external anchor (a spec clause, an upstream bug), a trap for the next refactorer. Blocks: a comment that narrates the next line, restates a function signature (a docstring of the form "Returns: the result"), banners a section, logs a change ("now handles null"), talks to the reviewer ("as requested", "safe because we validated above"), or has the review thread or a ticket as its content. Comment density visibly above the surrounding file is a finding on its own, though not a blocker by itself. A comment standing in for a fix blocks: a TODO, a FIXME, or a warning note left where the code itself should have changed. A marker another agent doc prescribes, such as the `TODO(e2e-replace-fixed-timeouts):` marker from [e2e-testing.md](./e2e-testing.md), is a declared carve-out, not a fix by comment.
+- **Undisclosed machine authorship.** Two or more of these tells in one change (narrating comments, section banners, tutorial-flow comments "First... Next... Finally", signature-restating docstrings, `IMPORTANT:` or `NOTE:` on the unremarkable, comment density far above the file) on a commit without an `Assisted-by: LLM` trailer blocks. The tells are findings on their own, trailer or not.
 
 ## PR Title Auto-Labeling
 
@@ -111,18 +135,6 @@ git commit --signoff -m "docs(contributing): add installation guide"
 - `!` after type or `BREAKING CHANGE:` footer in the body → `kind/breaking-change`.
 - Unmapped scope or non-conventional title → `area/uncategorized` (signals the PR needs manual area selection).
 - Bracket-style fallback (`[scope] description`) maps `scope` → `area/*` but cannot infer `kind/*`.
-
-### AI Agent Attribution
-
-When an AI agent authors or materially assists with a commit, add an `Assisted-By:` trailer naming the model:
-
-```text
-Assisted-By: Claude <noreply@anthropic.com>
-Assisted-By: GPT-5 <noreply@openai.com>
-Assisted-By: Gemini <noreply@google.com>
-```
-
-This sits alongside the `Signed-off-by:` trailer produced by `--signoff`. Use one trailer per model if multiple contributed.
 
 ## Rebasing on upstream/main
 
@@ -211,6 +223,7 @@ Its CI validates internal consistency only, never against this repo.
 - Rename a namespace: `cozy-system`, `cozy-installer`, `tenant-root`.
 - Change variant or bundle names → its variant-picker reference tables.
 - Change release-prep behaviour in `.github/workflows/tags.yaml` → its contributor-versus-maintainer guidance rests on it.
+- Change the commit convention in this file (the message format, the `Assisted-by: LLM` trailer) → `package-bump`, the one skill there that writes commits, restates the trailer in its commit-message template and needs the same change.
 
 ### cozystack/external-apps-example
 
@@ -249,6 +262,13 @@ Its chart is vendored here — `packages/system/cozy-proxy/Makefile` pulls it fr
 ### cozystack/examples
 
 Not coupled to the API: it holds Terraform that provisions bare nodes, with no Cozystack manifests in it. The only thing that reaches it is a change to the minimum node requirements (count, CPU, RAM, disk) or to the network requirements (VLAN, underlay).
+
+### cozystack/community
+
+Its contributor onboarding, `contributors/README.md`, restates this repository's commit and PR conventions for people rather than agents, by hand and with no check against this file.
+
+- Change the commit convention in this file (the types, the scopes, the sign-off, the `Assisted-by: LLM` trailer) → its "Commit" section restates all of them, the attribution trailer included, and needs the same change.
+- Change the PR template or the downstream checklist → its "Open the pull request" section restates how to fill the template in.
 
 ### Not a downstream repository
 


### PR DESCRIPTION
## What this PR does

AI-assisted commits now carry a single `Assisted-by: LLM` trailer next to `Signed-off-by:`, whatever the model and however many tools were involved. The old `Assisted-By: <model> <noreply@vendor>` form is gone. The trailer is for disclosure. A model name gives a reviewer nothing to act on and goes stale with every tool change.

This is a policy change for the contributor process. Most agent-assisted commits on `main` today carry the old form, and from this PR on that form is a review blocker for new commits. Existing history stays as it is.

The same section now also bans `Claude-Session:` trailers and links to assistant sessions in commits, PR descriptions and comments, even when a tool asks for them. Those links rot and say nothing about the change.

A new section lists the message, trailer and in-code comment hygiene that review already treats as NOT LGTM: a body that walks the diff, review-iteration vocabulary in a commit, a model name in a trailer, comments that narrate the next line or talk to the reviewer, and undisclosed machine authorship. Writing them down makes each one a stated rule instead of a reviewer's taste.

AGENTS.md gets the one-line version and keeps pointing at contributing.md for the rest. Outside vendored charts, contributing.md was the only place in the repo with the old form.

### Screenshots

Not a UI change.

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body. Do not push a speculative PR into another repository just to fill a line here.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

Two downstream hits, both restating the old `Assisted-By: Claude <noreply@anthropic.com>` trailer as the rule. The ccp package-bump skill (`plugins/cozystack/skills/package-bump/SKILL.md`) cites this repo as its source. The community contributor onboarding (`contributors/README.md`, section 6) tells human contributors to use it. This PR makes both texts wrong. Both follow-ups are linked below and merge after this one. The trigger map now carries both couplings, and the template gets a community line since it had none.

- [ ] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [x] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up: https://github.com/cozystack/ccp/pull/20
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [x] [cozystack/community](https://github.com/cozystack/community) - follow-up: https://github.com/cozystack/community/pull/67

### Release note

```release-note
docs(agents): AI-assisted commits carry a single `Assisted-by: LLM` trailer; model names, `Claude-Session:` trailers and session links are not accepted in commits, PR descriptions or comments; message, trailer and comment hygiene rules are documented as review blockers
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guidelines to require signed commits and a standardized `Assisted-by: LLM` trailer when AI assistance is used.
  - Clarified that comments and commit messages should explain rationale rather than narrate changes.
  - Added guidance prohibiting model or vendor names, session trailers, and transcript links in contribution metadata.
  - Documented downstream synchronization requirements for related repositories.
  - Added a community repository checklist item to the pull request template.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->