### PR TITLE
test(e2e): raise the chainsaw cleanup budget clear of the teardown floor

### DIFF
--- a/hack/chainsaw-cleanup-budget.bats
+++ b/hack/chainsaw-cleanup-budget.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+# Asserts that the Chainsaw cleanup budget clears the floor the kubernetes
+# chart's pre-delete hooks impose on it.
+#
+# The kubernetes e2e suites apply their Kubernetes CR declaratively, so the
+# tenant cluster is torn down by Chainsaw's auto-cleanup rather than by an
+# explicit delete op — which means `timeouts.cleanup` is what bounds a teardown
+# that runs the chart's pre-delete hooks. Those hooks are sequential and
+# blocking: packages/apps/kubernetes/templates/delete.yaml waits on the child
+# HelmReleases and then on the TenantControlPlane, each with its own
+# `--wait=true --timeout=`, and both are spent in full exactly when the tenant
+# has no working nodes — the teardown case that file's own comments call
+# expected. Their sum is a hard floor no cleanup can beat.
+#
+# A budget at or below that floor fails suites that have already passed every
+# assertion they make. That is not hypothetical: on the run for
+# cozystack/cozystack#4033 the budget was 300s against a 240s floor, and
+# kubernetes-oidc-system passed every assertion and then failed CLEANUP at
+# 303.72s, with Kamaji recording the TenantControlPlane gone 0.45s after
+# Chainsaw gave up. Its structural twin kubernetes-oidc-customconfig finished
+# the same teardown in 243.8s and passed, so the two bracketed one floor with
+# 4s and 64s of variance above it against 60s of headroom.
+#
+# The margin below is what separates this from a guard that only restates the
+# current number. Above the floor sit the `<release>-oidc-cleanup` hook Job
+# (rendered whenever oidc.mode != None, bounded at 30s per attempt with
+# backoffLimit 1 allowing a second, so 60s worst) and one cold start per hook
+# Job (~30s each on a loaded runner) — 120s of variable cost that the floor
+# itself does not account for. Requiring floor + 120s is therefore the
+# inequality that has to hold for the budget to be reachable at all, and it is
+# derived from both files rather than hardcoded, so adding a third blocking
+# wait to the chart moves the floor and this test with it.
+#
+# Harness note: the CI path is hack/cozytest.sh, NOT real bats. There is no
+# `run`, `$status`, `$output`, `skip`, or setup()/teardown(); each test runs as
+# a shell function under `set -eu -x`, so a non-zero exit is the failure.
+# Paths are repo-root-relative: BATS_TEST_DIRNAME is unset and would abort the
+# whole suite under `set -u`.
+#
+# Run with: hack/cozytest.sh hack/chainsaw-cleanup-budget.bats
+
+# Minimum slack the budget must carry above the chart's blocking-wait floor,
+# covering the oidc-cleanup hook Job's retry budget plus a cold start per Job.
+CHAINSAW_CLEANUP_MIN_SLACK=120
+
+# Convert a Chainsaw/Go duration that uses whole minutes or seconds into
+# seconds. Deliberately narrow: the timeouts block only ever holds Nm or Ns,
+# and a form this cannot read must fail loudly rather than silently score 0.
+_duration_seconds() {
+  _d=$1
+  case "$_d" in
+    *m) printf '%s\n' $(( ${_d%m} * 60 )) ;;
+    *s) printf '%s\n' "${_d%s}" ;;
+    *)
+      echo "unrecognised duration '${_d}': expected Nm or Ns" >&2
+      return 1
+      ;;
+  esac
+}
+
+@test "chainsaw cleanup budget clears the kubernetes pre-delete hook floor" {
+  cfg=hack/e2e-chainsaw/.chainsaw.yaml
+  hooks=packages/apps/kubernetes/templates/delete.yaml
+
+  for f in "$cfg" "$hooks"; do
+    if [ ! -f "$f" ]; then
+      echo "missing $f; this guard reads both files and cannot be evaluated without them" >&2
+      return 1
+    fi
+  done
+
+  cleanup_raw=$(yq '.spec.timeouts.cleanup' "$cfg")
+  if [ -z "$cleanup_raw" ] || [ "$cleanup_raw" = "null" ]; then
+    echo "no .spec.timeouts.cleanup in $cfg; Chainsaw would fall back to its own default and this floor would be unguarded" >&2
+    return 1
+  fi
+  cleanup_s=$(_duration_seconds "$cleanup_raw")
+
+  # Sum the blocking pre-delete waits. A line counts only when it carries both
+  # --wait=true (it blocks) and --timeout= (it is bounded); the prose comments
+  # in that file mention --wait=true without either, and a commented-out flag
+  # must not be scored as a live one.
+  floor_s=0
+  waits=0
+  for t in $(grep -- '--wait=true' "$hooks" \
+    | grep -v '^[[:space:]]*#' \
+    | grep -oE -- '--timeout=[0-9]+s' \
+    | grep -oE '[0-9]+'); do
+    floor_s=$(( floor_s + t ))
+    waits=$(( waits + 1 ))
+  done
+
+  if [ "$waits" -eq 0 ]; then
+    echo "found no bounded blocking waits in $hooks; either the hooks stopped blocking (in which case this guard is obsolete) or the flags were reshaped and this extraction silently scored nothing" >&2
+    return 1
+  fi
+
+  required=$(( floor_s + CHAINSAW_CLEANUP_MIN_SLACK ))
+  echo "cleanup budget ${cleanup_raw} = ${cleanup_s}s; ${waits} blocking waits floor = ${floor_s}s; required >= ${required}s"
+
+  if [ "$cleanup_s" -lt "$required" ]; then
+    echo "timeouts.cleanup is ${cleanup_raw} (${cleanup_s}s) but the ${waits} blocking pre-delete waits in ${hooks} floor teardown at ${floor_s}s, and the oidc-cleanup hook Job plus per-Job cold starts add up to ${CHAINSAW_CLEANUP_MIN_SLACK}s more" >&2
+    echo "a suite can then pass every assertion it makes and still fail CLEANUP, which is what cozystack/cozystack#4033 hit at 303.72s against a 300s budget" >&2
+    echo "raise timeouts.cleanup to at least ${required}s, or shorten the blocking waits in the chart if teardown no longer needs them" >&2
+    return 1
+  fi
+}

--- a/hack/e2e-chainsaw/.chainsaw.yaml
+++ b/hack/e2e-chainsaw/.chainsaw.yaml
@@ -20,7 +20,48 @@ spec:
     # Tenant child namespaces) can take minutes to fully reclaim their backing
     # resources, and Chainsaw waits for the delete to complete during cleanup.
     delete: 5m
-    cleanup: 5m
+    # cleanup sits above delete because the kubernetes suites apply their
+    # Kubernetes CR declaratively, so it is Chainsaw's auto-cleanup — not an
+    # explicit delete op — that tears the tenant cluster down, and that teardown
+    # runs the chart's pre-delete hooks. Those hooks impose a floor this budget
+    # has to clear rather than land on.
+    #
+    # The floor is structural. packages/apps/kubernetes/templates/delete.yaml
+    # runs its hooks in hook-weight order and Helm waits for each Job to finish
+    # before the next weight, so a suite with OIDC enabled pays them in series:
+    #   weight 5   <release>-oidc-cleanup Job, rendered only when
+    #              oidc.mode != None. Bounded by --request-timeout=30s and
+    #              --timeout=30s, and backoffLimit 1 with restartPolicy
+    #              OnFailure allows a second attempt --> 60s worst.
+    #   weight 10  <release>-pre-cleanup Job, whose two blocking deletes are
+    #              --wait=true --timeout=120s for the child HelmReleases and
+    #              --wait=true --timeout=120s for the TenantControlPlane
+    #              --> a 240s hard floor, and both are spent in full exactly
+    #              when the tenant has no working nodes, which is the teardown
+    #              case that file's own comments call expected.
+    # plus one cold start per Job: scheduling and container start, ~30s each on
+    # a loaded runner.
+    #
+    # So the derived worst case is 240 + 60 + 60 = 360s, and the 300s this was
+    # set to sat below it. Both measured samples confirm the shape: on the run
+    # for cozystack/cozystack#4033, kubernetes-oidc-customconfig completed the
+    # same teardown in 243.8s and passed, while kubernetes-oidc-system passed
+    # every assertion and then failed CLEANUP at 303.72s — Kamaji recorded the
+    # TenantControlPlane gone 0.45s after Chainsaw gave up. Two suites on one
+    # 240s floor, one landing 4s above it and one 64s above it, against 60s of
+    # headroom.
+    #
+    # 8m = the 240s floor plus twice the 120s derived variable worst case above
+    # it, so the variable part has to double from that worst case before the
+    # cliff returns. Raising the ceiling rather than shortening those two 120s
+    # waits is deliberate: delete.yaml is shipped product, and a shorter wait
+    # there would reach its finalizer-forcing backstop sooner on real clusters,
+    # trading a correct uninstall for a faster one to fit a CI budget. The cost
+    # of the wider ceiling is paid only by a cleanup that genuinely wedges,
+    # since the timeout is a ceiling and a healthy cleanup returns as soon as it
+    # is done — whereas the old value was failing suites that had already
+    # passed every assertion they make.
+    cleanup: 8m
     error: 5m
     exec: 5m
   cleanup:


### PR DESCRIPTION
Raises the chainsaw `cleanup` budget from 5m to 8m and adds a guard that derives the required floor from the chart instead of pinning a number.

The old 300s sat **below** the teardown's own worst case, so suites were failing after passing every assertion. On [#4033's run](https://github.com/cozystack/cozystack/actions/runs/33651478586), `kubernetes-oidc-system` passed all of its assertions and then failed CLEANUP at 303.72s. Kamaji observed the TenantControlPlane gone at 17:31:45, which is 0.45s after chainsaw gave up. The structurally identical `kubernetes-oidc-customconfig` did the same teardown in 243.8s and passed, so two suites sit on one floor, one landing at 244s and one at 300.5s.

Where the floor comes from: `packages/apps/kubernetes/templates/delete.yaml` imposes two `--wait=true --timeout=120s` pre-delete hook deletes, which is a 240s structural floor, plus the `oidc-cleanup` hook Job that renders only when `oidc.mode != None` (30s per attempt with `backoffLimit: 1`) and roughly 30s of cold start per hook Job. Derived worst case is 360s. 480s means the variable part has to double before the cliff comes back, rather than moving it a few seconds out.

Raising the harness ceiling rather than shortening the chart's waits is deliberate. `delete.yaml` is shipped product, and a shorter wait there reaches its finalizer-forcing backstop sooner on real clusters, which trades a correct uninstall for a faster one to fit a CI budget. The raise is global in `timeouts` rather than four per-suite overrides, because a timeout is a ceiling and not a sleep — a healthy cleanup returns as soon as it is done, so the only cost is that a genuinely wedged cleanup in an unrelated suite now takes 8m instead of 5m, and four overrides would be four places to drift.

`main` carries the same `cleanup: 5m` against the same 240s floor, so **this fix is needed there too** and should follow as its own change.

### Testing

- `hack/chainsaw-cleanup-budget.bats` derives the floor from `delete.yaml` and asserts the budget clears it, so it follows the chart rather than freezing today's arithmetic.
- Red phase executed in three directions rather than reasoned about: budget back to 5m goes red at 300s against 360s required; raising the chart waits to 240s each moves the derived floor to 480s and goes red; and turning `--wait=true` into `--wait=false` makes the guard **refuse** with "found no bounded blocking waits" instead of passing vacuously.
- `chainsaw test --config` reports `CleanupTimeout 8m0s`, so the value reaches the real consumer rather than merely parsing.
- `make unit-tests` and `make test-controllers` green, `make generate` leaves no drift, POSIX sh gate clean on both files.

### Not verified

The behavioural claim, that `kubernetes-oidc-system` now completes teardown inside the budget, needs a cluster and a full suite run. This change is justified by the measured arithmetic above, not by a green run.

```release-note
NONE
```
