### PR TITLE
fix(networking): harden webhook policy assumptions

### DIFF
--- a/hack/e2e-chainsaw/gateway/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/gateway/chainsaw-test.yaml
@@ -1657,18 +1657,48 @@ spec:
 
           svcs=$(kubectl -n "$ns" get svc -l "$sel" \
             -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
-          adm=$(printf '%s\n' "$svcs" | grep -- '-admission$' | head -1 || true)
+          adm_candidates=$(printf '%s\n' "$svcs" | grep -- '-admission$' || true)
           # -metrics is excluded explicitly rather than relying on
-          # ingress-nginx-controller sorting before ingress-nginx-controller-metrics
-          # under head -1: the positive control has to be the Service that
-          # actually exposes the controller's https port.
-          ctl=$(printf '%s\n' "$svcs" | grep -v -- '-admission$' | grep -v -- '-metrics$' | grep . | head -1 || true)
-          [ -n "$adm" ] || { echo "SETUP FAILURE: no ingress-nginx admission Service in $ns" >&2; exit 1; }
-          [ -n "$ctl" ] || { echo "SETUP FAILURE: no ingress-nginx controller Service in $ns" >&2; exit 1; }
+          # ingress-nginx-controller sorting before a metrics Service: the
+          # positive control has to be the one unambiguous controller Service.
+          ctl_candidates=$(printf '%s\n' "$svcs" | grep -v -- '-admission$' | grep -v -- '-metrics$' | grep . || true)
+          adm_count=$(printf '%s\n' "$adm_candidates" | grep -c . || true)
+          ctl_count=$(printf '%s\n' "$ctl_candidates" | grep -c . || true)
+          [ "$adm_count" -eq 1 ] || {
+            echo "SETUP FAILURE: expected one ingress-nginx admission Service in $ns, found $adm_count" >&2
+            printf '  candidates: %s\n' "${adm_candidates:-<none>}" >&2
+            exit 1
+          }
+          [ "$ctl_count" -eq 1 ] || {
+            echo "SETUP FAILURE: expected one ingress-nginx controller Service in $ns, found $ctl_count" >&2
+            printf '  candidates: %s\n' "${ctl_candidates:-<none>}" >&2
+            exit 1
+          }
+          adm=$adm_candidates
+          ctl=$ctl_candidates
 
-          adm_port=$(kubectl -n "$ns" get svc "$adm" -o jsonpath='{.spec.ports[0].port}')
-          ctl_port=$(kubectl -n "$ns" get svc "$ctl" -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
-          [ -n "$ctl_port" ] || { echo "SETUP FAILURE: $ctl exposes no https port" >&2; exit 1; }
+          service_port() {
+            kubectl -n "$ns" get svc "$1" -o json | jq -r --arg port_name "$2" '
+              [.spec.ports[]?
+               | select(.name == $port_name)
+               | select((.protocol // "TCP") == "TCP")
+               | .port
+               | select(type == "number")]
+              | if length == 1 then .[0] else empty end
+            '
+          }
+          adm_port=$(service_port "$adm" https-webhook)
+          ctl_port=$(service_port "$ctl" https)
+          [ -n "$adm_port" ] || {
+            echo "SETUP FAILURE: $adm must expose exactly one TCP https-webhook port" >&2
+            kubectl -n "$ns" get svc "$adm" -o yaml >&2 2>&1 || true
+            exit 1
+          }
+          [ -n "$ctl_port" ] || {
+            echo "SETUP FAILURE: $ctl must expose exactly one TCP https port" >&2
+            kubectl -n "$ns" get svc "$ctl" -o yaml >&2 2>&1 || true
+            exit 1
+          }
 
           # Ready endpoint addresses behind a Service, from EndpointSlice rather
           # than from pod readiness: this is the state the API server and the
@@ -1681,13 +1711,36 @@ spec:
             echo "$n"
           }
 
+          # Exact ready admission coordinates. The IP and backend port come
+          # from the same EndpointSlice as the ready condition; selecting them
+          # independently from .items[0] could probe an unready replica while a
+          # different replica kept the aggregate Service readiness above zero.
+          ready_admission_backends() {
+            kubectl -n "$ns" get endpointslice -l "kubernetes.io/service-name=$adm" -o json | jq -r '
+              .items[]? as $slice
+              | $slice.ports[]? as $port
+              | select($port.name == "https-webhook")
+              | select(($port.protocol // "TCP") == "TCP")
+              | select(($port.port | type) == "number")
+              | $slice.endpoints[]?
+              | select(.conditions.ready == true)
+              | select(.targetRef.kind == "Pod")
+              | select((.targetRef.name // "") != "")
+              | .targetRef.name as $pod
+              | .addresses[]?
+              | select(type == "string" and length > 0)
+              | [$pod, ., ($port.port | tostring)]
+              | @tsv
+            ' | sort -u
+          }
+
           # Pod identity plus restart count, as one string. Compared for
           # equality across the probe window, so a restart AND a replacement
           # both show up -- a crash-looping controller can satisfy a readiness
           # check at both ends of a window it spent dying in the middle of.
           controller_generation() {
             kubectl -n "$ns" get pod -l "$sel" \
-              -o jsonpath='{range .items[*]}{.metadata.name}={.status.containerStatuses[0].restartCount}{" "}{end}'
+              -o jsonpath='{range .items[*]}{.metadata.name}/{.metadata.uid}={range .status.containerStatuses[*]}{.name}:{.restartCount},{end}{"\n"}{end}' | sort
           }
 
           # Precondition. Both Services are backed by the same controller pods,
@@ -1696,7 +1749,7 @@ spec:
           # backend to answer.
           deadline=$(( $(date +%s) + 120 ))
           while :; do
-            adm_ready=$(ready_backends "$adm")
+            adm_ready=$(ready_admission_backends | grep -c . || true)
             ctl_ready=$(ready_backends "$ctl")
             if [ "$adm_ready" -gt 0 ] && [ "$ctl_ready" -gt 0 ]; then break; fi
             [ "$(date +%s)" -lt "$deadline" ] || {
@@ -1711,6 +1764,37 @@ spec:
             sleep 5
           done
 
+          backend=$(ready_admission_backends | head -1)
+          [ -n "$backend" ] || { echo "SETUP FAILURE: $adm has no complete ready Pod/IP/port coordinate" >&2; exit 1; }
+          tab=$(printf '\t')
+          backend_fields=$(printf '%s\n' "$backend" | awk -F "$tab" '{ print NF }')
+          [ "$backend_fields" -eq 3 ] || { echo "SETUP FAILURE: malformed ready backend coordinate: $backend" >&2; exit 1; }
+          pod_name=$(printf '%s\n' "$backend" | cut -f1)
+          pod_ip=$(printf '%s\n' "$backend" | cut -f2)
+          hook_port=$(printf '%s\n' "$backend" | cut -f3)
+          [ -n "$pod_name" ] && [ -n "$pod_ip" ] && [ -n "$hook_port" ] || {
+            echo "SETUP FAILURE: incomplete ready backend coordinate: $backend" >&2
+            exit 1
+          }
+
+          selected_backend_ready() {
+            ready_admission_backends | awk -F "$tab" \
+              -v pod="$pod_name" -v ip="$pod_ip" -v port="$hook_port" '
+                $1 == pod && $2 == ip && $3 == port { found = 1 }
+                END { exit !found }
+              '
+          }
+
+          require_selected_backend() {
+            selected_backend_ready && return 0
+            echo "SETUP FAILURE: selected admission backend $pod_name ($pod_ip:$hook_port) was not ready $1" >&2
+            kubectl -n "$ns" get endpointslice -l "kubernetes.io/service-name=$adm" -o yaml >&2 2>&1 || true
+            kubectl -n "$ns" get pod "$pod_name" -o wide >&2 2>&1 || true
+            exit 1
+          }
+
+          require_selected_backend "before the stability window"
+
           # Stability: the same evidence held across a window, not at one
           # instant. Six samples over 30s, all of which must be live and show no
           # restart or replacement.
@@ -1719,9 +1803,10 @@ spec:
           while [ "$i" -lt 6 ]; do
             sleep 5
             i=$(( i + 1 ))
-            n=$(ready_backends "$adm")
+            require_selected_backend "during the stability window (sample $i)"
+            n=$(ready_backends "$ctl")
             [ "$n" -gt 0 ] || {
-              echo "SETUP FAILURE: $adm lost its ready backend during the stability window (sample $i)" >&2
+              echo "SETUP FAILURE: $ctl lost its ready backend during the stability window (sample $i)" >&2
               kubectl -n "$ns" get pod -l "$sel" -o wide >&2 2>&1 || true
               exit 1
             }
@@ -1735,14 +1820,7 @@ spec:
             exit 1
           }
 
-          pod_ip=$(kubectl -n "$ns" get pod -l "$sel" \
-            -o jsonpath='{.items[0].status.podIP}')
-          hook_port=$(kubectl -n "$ns" get pod -l "$sel" \
-            -o jsonpath='{.items[0].spec.containers[0].ports[?(@.name=="webhook")].containerPort}')
-          [ -n "$pod_ip" ] || { echo "SETUP FAILURE: no controller Pod IP in $ns" >&2; exit 1; }
-          [ -n "$hook_port" ] || { echo "SETUP FAILURE: controller declares no webhook port" >&2; exit 1; }
-
-          echo "probing from $ns: expect reachable ${ctl}:${ctl_port}, denied ${adm}:${adm_port}, denied ${pod_ip}:${hook_port}"
+          echo "probing from $ns: expect reachable ${ctl}:${ctl_port}, denied ${adm}:${adm_port}, denied ${pod_name}@${pod_ip}:${hook_port}"
 
           kubectl -n "$ns" delete pod "$probe" --ignore-not-found --wait=true --timeout=60s
           # busybox:musl is staged onto every node by hack/e2e-prepull-images.sh,
@@ -1812,9 +1890,10 @@ spec:
           deadline=$(( $(date +%s) + 180 ))
           phase=""
           while [ "$(date +%s)" -lt "$deadline" ]; do
-            n=$(ready_backends "$adm")
+            require_selected_backend "while the probe was running"
+            n=$(ready_backends "$ctl")
             [ "$n" -gt 0 ] || {
-              echo "SETUP FAILURE: $adm lost its ready backend while the probe was running, so an unreachable webhook proves nothing" >&2
+              echo "SETUP FAILURE: $ctl lost its ready backend while the probe was running, so an unreachable positive control proves nothing" >&2
               kubectl -n "$ns" get pod -l "$sel" -o wide >&2 2>&1 || true
               kubectl -n "$ns" logs "$probe" >&2 2>&1 || true
               exit 1
@@ -1841,9 +1920,10 @@ spec:
             kubectl -n "$ns" get pod -l "$sel" -o wide >&2 2>&1 || true
             exit 1
           }
-          n=$(ready_backends "$adm")
+          require_selected_backend "after the probe"
+          n=$(ready_backends "$ctl")
           [ "$n" -gt 0 ] || {
-            echo "SETUP FAILURE: $adm has no ready backend after the probe, so its unreachability proves nothing" >&2
+            echo "SETUP FAILURE: $ctl has no ready backend after the probe, so its unreachability proves nothing" >&2
             exit 1
           }
 
@@ -1858,9 +1938,9 @@ spec:
             }
           done
 
-          # From here every branch is a real verdict: the destination had a live
-          # backend before, throughout and after, on pods that neither restarted
-          # nor were replaced.
+          # From here every branch is a real verdict: the exact direct
+          # destination stayed ready before, throughout and after, and the
+          # controller pods neither restarted nor were replaced.
           rc=0
           if [ "$ctl_seen" = reachable ]; then
             echo "OK   unrelated 443 egress works (${ctl}:${ctl_port})"

--- a/hack/e2e-chainsaw/gateway/chainsaw-test.yaml
+++ b/hack/e2e-chainsaw/gateway/chainsaw-test.yaml
@@ -1689,6 +1689,12 @@ spec:
           }
           adm_port=$(service_port "$adm" https-webhook)
           ctl_port=$(service_port "$ctl" https)
+          adm_cluster_ip=$(kubectl -n "$ns" get svc "$adm" -o jsonpath='{.spec.clusterIP}')
+          [ -n "$adm_cluster_ip" ] && [ "$adm_cluster_ip" != None ] || {
+            echo "SETUP FAILURE: $adm must have a real ClusterIP, found ${adm_cluster_ip:-<empty>}" >&2
+            kubectl -n "$ns" get svc "$adm" -o yaml >&2 2>&1 || true
+            exit 1
+          }
           [ -n "$adm_port" ] || {
             echo "SETUP FAILURE: $adm must expose exactly one TCP https-webhook port" >&2
             kubectl -n "$ns" get svc "$adm" -o yaml >&2 2>&1 || true
@@ -1711,10 +1717,11 @@ spec:
             echo "$n"
           }
 
-          # Exact ready admission coordinates. The IP and backend port come
-          # from the same EndpointSlice as the ready condition; selecting them
-          # independently from .items[0] could probe an unready replica while a
-          # different replica kept the aggregate Service readiness above zero.
+          # Exact ready admission coordinates. The Pod identity, IP and backend
+          # port come from the same EndpointSlice as the ready condition;
+          # selecting them independently from .items[0] could probe an unready
+          # replica while a different replica kept aggregate readiness above
+          # zero.
           ready_admission_backends() {
             kubectl -n "$ns" get endpointslice -l "kubernetes.io/service-name=$adm" -o json | jq -r '
               .items[]? as $slice
@@ -1726,21 +1733,32 @@ spec:
               | select(.conditions.ready == true)
               | select(.targetRef.kind == "Pod")
               | select((.targetRef.name // "") != "")
+              | select((.targetRef.uid // "") != "")
               | .targetRef.name as $pod
+              | .targetRef.uid as $uid
               | .addresses[]?
               | select(type == "string" and length > 0)
-              | [$pod, ., ($port.port | tostring)]
+              | [$pod, $uid, ., ($port.port | tostring)]
               | @tsv
             ' | sort -u
           }
 
-          # Pod identity plus restart count, as one string. Compared for
-          # equality across the probe window, so a restart AND a replacement
-          # both show up -- a crash-looping controller can satisfy a readiness
-          # check at both ends of a window it spent dying in the middle of.
+          # Pod identity, IP and every container restart count, as one string.
+          # Compared for equality across the probe window, so a restart AND a
+          # replacement both show up -- a crash-looping controller can satisfy
+          # a readiness check at both ends of a window it spent dying in the
+          # middle of.
           controller_generation() {
-            kubectl -n "$ns" get pod -l "$sel" \
-              -o jsonpath='{range .items[*]}{.metadata.name}/{.metadata.uid}={range .status.containerStatuses[*]}{.name}:{.restartCount},{end}{"\n"}{end}' | sort
+            generation=$(kubectl -n "$ns" get pod -l "$sel" \
+              -o jsonpath='{range .items[*]}{.metadata.name}/{.metadata.uid}/{.status.podIP}={range .status.containerStatuses[*]}{.name}:{.restartCount},{end}{"\n"}{end}') || {
+              echo "SETUP FAILURE: unable to read ingress-nginx controller generation" >&2
+              return 1
+            }
+            [ -n "$generation" ] || {
+              echo "SETUP FAILURE: ingress-nginx controller generation is empty" >&2
+              return 1
+            }
+            printf '%s\n' "$generation" | sort
           }
 
           # Precondition. Both Services are backed by the same controller pods,
@@ -1765,29 +1783,30 @@ spec:
           done
 
           backend=$(ready_admission_backends | head -1)
-          [ -n "$backend" ] || { echo "SETUP FAILURE: $adm has no complete ready Pod/IP/port coordinate" >&2; exit 1; }
+          [ -n "$backend" ] || { echo "SETUP FAILURE: $adm has no complete ready Pod/UID/IP/port coordinate" >&2; exit 1; }
           tab=$(printf '\t')
           backend_fields=$(printf '%s\n' "$backend" | awk -F "$tab" '{ print NF }')
-          [ "$backend_fields" -eq 3 ] || { echo "SETUP FAILURE: malformed ready backend coordinate: $backend" >&2; exit 1; }
+          [ "$backend_fields" -eq 4 ] || { echo "SETUP FAILURE: malformed ready backend coordinate: $backend" >&2; exit 1; }
           pod_name=$(printf '%s\n' "$backend" | cut -f1)
-          pod_ip=$(printf '%s\n' "$backend" | cut -f2)
-          hook_port=$(printf '%s\n' "$backend" | cut -f3)
-          [ -n "$pod_name" ] && [ -n "$pod_ip" ] && [ -n "$hook_port" ] || {
+          pod_uid=$(printf '%s\n' "$backend" | cut -f2)
+          pod_ip=$(printf '%s\n' "$backend" | cut -f3)
+          hook_port=$(printf '%s\n' "$backend" | cut -f4)
+          [ -n "$pod_name" ] && [ -n "$pod_uid" ] && [ -n "$pod_ip" ] && [ -n "$hook_port" ] || {
             echo "SETUP FAILURE: incomplete ready backend coordinate: $backend" >&2
             exit 1
           }
 
           selected_backend_ready() {
             ready_admission_backends | awk -F "$tab" \
-              -v pod="$pod_name" -v ip="$pod_ip" -v port="$hook_port" '
-                $1 == pod && $2 == ip && $3 == port { found = 1 }
+              -v pod="$pod_name" -v uid="$pod_uid" -v ip="$pod_ip" -v port="$hook_port" '
+                $1 == pod && $2 == uid && $3 == ip && $4 == port { found = 1 }
                 END { exit !found }
               '
           }
 
           require_selected_backend() {
             selected_backend_ready && return 0
-            echo "SETUP FAILURE: selected admission backend $pod_name ($pod_ip:$hook_port) was not ready $1" >&2
+            echo "SETUP FAILURE: selected admission backend $pod_name/$pod_uid ($pod_ip:$hook_port) was not ready $1" >&2
             kubectl -n "$ns" get endpointslice -l "kubernetes.io/service-name=$adm" -o yaml >&2 2>&1 || true
             kubectl -n "$ns" get pod "$pod_name" -o wide >&2 2>&1 || true
             exit 1
@@ -1799,6 +1818,14 @@ spec:
           # instant. Six samples over 30s, all of which must be live and show no
           # restart or replacement.
           gen_before=$(controller_generation)
+          printf '%s\n' "$gen_before" | awk \
+            -v prefix="${pod_name}/${pod_uid}/${pod_ip}=" '
+              index($0, prefix) == 1 { found = 1 }
+              END { exit !found }
+            ' || {
+              echo "SETUP FAILURE: selected admission backend is not a current controller Pod: $backend" >&2
+              exit 1
+            }
           i=0
           while [ "$i" -lt 6 ]; do
             sleep 5
@@ -1820,7 +1847,7 @@ spec:
             exit 1
           }
 
-          echo "probing from $ns: expect reachable ${ctl}:${ctl_port}, denied ${adm}:${adm_port}, denied ${pod_name}@${pod_ip}:${hook_port}"
+          echo "probing from $ns: expect reachable ${ctl}:${ctl_port}, denied ${adm}@${adm_cluster_ip}:${adm_port}, denied ${pod_name}/${pod_uid}@${pod_ip}:${hook_port}"
 
           kubectl -n "$ns" delete pod "$probe" --ignore-not-found --wait=true --timeout=60s
           # busybox:musl is staged onto every node by hack/e2e-prepull-images.sh,
@@ -1854,7 +1881,7 @@ spec:
               - name: CTL_PORT
                 value: "${ctl_port}"
               - name: ADM_HOST
-                value: "${adm}.${ns}.svc"
+                value: "${adm_cluster_ip}"
               - name: ADM_PORT
                 value: "${adm_port}"
               - name: POD_IP

--- a/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
+++ b/packages/apps/kubernetes/templates/helmreleases/cilium.yaml
@@ -88,21 +88,19 @@ spec:
 
 {{- /*
 addons.cilium.valuesOverride is x-kubernetes-preserve-unknown-fields, so a
-tenant can set cilium.kubeProxyReplacement: false for its own cluster. That is
-the one path by which the value reaches a live cluster without a cozystack
-commit, and it is the path the guest cluster's own ingress-nginx admission deny
-depends on: that policy names the webhook backend port only, which covers a pod
-dialling the ClusterIP solely because Cilium performs the service DNAT ahead of
-its own egress hook. Override it and pods inside the guest cluster regain the
-ClusterIP path to the admission webhook while the backend deny keeps working --
-no failure, no log line, and the rendered policy unchanged.
+tenant can set cilium.kubeProxyReplacement: false for its own cluster. Cozystack
+does not support that value or supply an alternative service load balancer for
+it; guest ClusterIP connectivity can fail. The guest ingress-nginx policy's
+source-side deny also loses the pre-DNAT match, but its target-side ingressDeny
+continues to deny pods after any translation, so the override does not imply
+that the admission webhook becomes reachable.
 
 The mismatch is detectable here rather than in the guest cluster, because this
 HelmRelease's values are assembled on the management cluster, so the beacon is
 emitted next to the release that carries the override. Same mechanism and same
 reasoning as the -awaiting-etcd beacon in ../cluster.yaml: a ConfigMap an
-operator and an alert can both see, not a fail() that would take the tenant's
-only CNI down over a weakened defence-in-depth control.
+operator and an alert can both see. It is a diagnostic for an unsupported
+override, not an alternative compatibility mode.
 
 Absence is not a warning: the value is unset in both the override and
 cozystack.defaultCiliumValues on every supported path, and the cilium chart's
@@ -129,14 +127,15 @@ data:
     addons.cilium.valuesOverride sets cilium.kubeProxyReplacement to
     {{ toString $kpr | quote }} for cluster {{ .Release.Name }}.
 
-    Cilium in that guest cluster will not perform the ClusterIP DNAT ahead of
-    its own egress hook, so the admission-webhook deny the guest cluster's
-    ingress-nginx ships no longer covers traffic addressed to the webhook
-    Service ClusterIP. Pods in the guest cluster can reach
-    <webhook>.<namespace>.svc:443; the webhook's backend port stays denied.
+    Cozystack supports guest cluster networking only when
+    cilium.kubeProxyReplacement is "true". No supported alternative service load
+    balancer is supplied for this override, so ClusterIP connectivity may fail.
 
-    This is a deliberate override, so it is reported rather than refused. Clear
-    it to restore the control, or set the guest ingress-nginx addon's
-    admissionWebhookPolicy.enabled explicitly so the posture is recorded.
+    The guest ingress-nginx policy's source-side deny also loses its pre-DNAT
+    match, but its target-side ingressDeny remains. This override does not imply
+    that the admission webhook is reachable through its Service.
+
+    Clear the override or set cilium.kubeProxyReplacement back to true. Disabling
+    the webhook policy does not make this networking configuration supported.
 {{- end }}
 {{- end }}

--- a/packages/apps/kubernetes/tests/cilium_kube_proxy_replacement_test.yaml
+++ b/packages/apps/kubernetes/tests/cilium_kube_proxy_replacement_test.yaml
@@ -1,17 +1,16 @@
 suite: tenant cilium kube-proxy-replacement override beacon
 # addons.cilium.valuesOverride is x-kubernetes-preserve-unknown-fields, so a
 # tenant can set cilium.kubeProxyReplacement: false for its own cluster. That is
-# the one path by which the value reaches a live cluster without a cozystack
-# commit, and it silently reopens the ClusterIP path to the guest cluster's own
-# ingress-nginx admission webhook -- the source-side deny there names the
-# backend port only, which covers the ClusterIP solely because Cilium performs
-# the service DNAT ahead of its own egress hook.
+# the one path by which the unsupported value reaches a live cluster without a
+# cozystack commit. It can break ClusterIP routing and removes the ingress-nginx
+# policy's source-side pre-DNAT match, but the target-side ingressDeny remains;
+# the override does not imply that the webhook becomes reachable.
 #
 # The override is assembled on the MANAGEMENT cluster, in this chart, which is
 # why the mismatch is detectable here at all. Same beacon mechanism as the
 # -awaiting-etcd ConfigMap in templates/cluster.yaml: something an operator and
-# an alert can both see, rather than a fail() that would take the tenant's only
-# CNI down over a weakened defence-in-depth control.
+# an alert can both see. It diagnoses an unsupported override rather than
+# defining an alternative compatibility mode.
 templates:
   - templates/helmreleases/cilium.yaml
 values:
@@ -61,7 +60,7 @@ tests:
           value: ConfigMap
       - matchRegex:
           path: data.message
-          pattern: "will not perform the ClusterIP DNAT ahead of"
+          pattern: "supports guest cluster networking only when"
         documentSelector:
           path: kind
           value: ConfigMap

--- a/packages/system/cilium/templates/kube-proxy-replacement-beacon.yaml
+++ b/packages/system/cilium/templates/kube-proxy-replacement-beacon.yaml
@@ -1,32 +1,30 @@
 {{- /*
-Render-time signal for the one value in this chart that two other packages
-depend on and that fails OPEN when it is lost.
+Render-time signal for a required Cozystack networking invariant.
 
-packages/system/ingress-nginx and packages/system/kubeovn-webhook each deny pod
-egress to their admission webhook by naming the webhook's BACKEND port only.
-That covers a pod dialling the Service ClusterIP because Cilium translates a
-service to its backends before it enforces egress policy -- which is true only
-while Cilium is the thing performing the DNAT, and only kubeProxyReplacement
-makes it so. Turn it off and the ClusterIP path to both webhooks reopens while
-the backend deny keeps working: nothing fails, nothing is logged, and the
-rendered policies look exactly as they did.
+Cozystack supports this chart only with kubeProxyReplacement: true. The
+platform does not supply a supported alternative owner for ClusterIP
+translation when it is false; in the kube-ovn management topology kube-proxy
+is absent and packages/system/kubeovn/values.yaml explicitly disables the OVN
+service load balancer. A false value can therefore break Service connectivity.
 
-A ConfigMap rather than `fail`, deliberately. Whether Cilium without
-kube-proxy replacement is a supported cozystack configuration is a platform
-decision, and refusing to render the CNI is not ours to make -- it would take
-the cluster's networking down over a weakened defence-in-depth control. This
-follows the user-visible status beacon the kubernetes chart already uses for
-the same reason (packages/apps/kubernetes/templates/cluster.yaml, the
-`-awaiting-etcd` ConfigMap): emit something an operator and an alert can both
-see, and let the install proceed.
+It also removes the pre-policy translation that the source-side webhook denies
+in packages/system/ingress-nginx and packages/system/kubeovn-webhook rely on.
+That does not make either webhook fail open: both policies also carry a
+target-side ingressDeny evaluated after any translation. Even a second,
+unsupported change that introduced another service load balancer would still
+meet that deny.
+
+A ConfigMap rather than `fail`, deliberately. A field override may already be
+running, and this guard keeps the unsupported state visible without turning
+every reconciliation into a render failure. The beacon is diagnostic, not an
+opt-in compatibility mode; the repair is always to restore the required value.
 
 `.Values.cilium.kubeProxyReplacement` reads the coalesced value, so this fires
 both on an explicit flip to false and on the umbrella key being deleted, which
 falls back to the vendored chart's own "false" default.
 
 tests/kube_proxy_replacement_test.yaml pins the value itself and carries the
-full argument, including why a target-side ingressDeny is not available as a
-fallback for the two policies.
+full service-routing and policy argument.
 */}}
 {{- $cilium := index .Values "cilium" | default dict }}
 {{- $kpr := dig "kubeProxyReplacement" "" $cilium }}
@@ -47,20 +45,15 @@ data:
   message: |
     cilium.kubeProxyReplacement is {{ toString $kpr | quote }}, not "true".
 
-    Cilium no longer performs the ClusterIP DNAT ahead of its own egress hook,
-    so the admission-webhook deny policies shipped by
-    packages/system/ingress-nginx and packages/system/kubeovn-webhook no longer
-    cover traffic addressed to the webhook Service ClusterIP. Both policies name
-    the webhook backend port only and run with default-deny disabled, so a pod
-    dialling <webhook>.<namespace>.svc:443 falls out of the deny and is allowed.
-    Direct access to the backend port stays denied.
+    Cozystack supports this chart only when cilium.kubeProxyReplacement is "true".
+    The current platform topology has no supported replacement for Cilium's
+    ClusterIP translation; on kube-ovn, kube-proxy is absent and the OVN service
+    load balancer is disabled. Service connectivity may fail in this state.
 
-    Nothing else reports this: the policies still render, still install, and
-    still deny what they name.
+    The source-side admission-webhook denies also lose their pre-DNAT match, but
+    both policies retain a target-side ingressDeny. This override does not imply
+    that either webhook is reachable through its Service.
 
-    Either set cilium.kubeProxyReplacement back to true, or accept that pods can
-    reach both admission webhooks through their Services and remove this beacon
-    by setting the policies' own values explicitly
-    (ingress-nginx admissionWebhookPolicy.enabled, kubeovn-webhook
-    webhookPolicy.enabled), so the posture is recorded rather than assumed.
+    Restore cilium.kubeProxyReplacement to true. Disabling the webhook policies
+    does not make this networking configuration supported.
 {{- end }}

--- a/packages/system/cilium/tests/kube_proxy_replacement_test.yaml
+++ b/packages/system/cilium/tests/kube_proxy_replacement_test.yaml
@@ -1,7 +1,6 @@
 suite: cilium owns service load-balancing
 
-# This pins one value, and it is pinned because two other packages depend on it
-# in a way that fails OPEN if it is lost. Read this before changing
+# This pins a required service-routing value. Read this before changing
 # kubeProxyReplacement in values.yaml or in any variant values file.
 #
 # packages/system/ingress-nginx and packages/system/kubeovn-webhook each ship a
@@ -21,23 +20,21 @@ suite: cilium owns service load-balancing
 # the backend pod on 8443, which is what the rules match.
 #
 # That ordering exists only while Cilium is the thing doing the DNAT, and the
-# only reason it is today is the value asserted below: kubeProxyReplacement,
-# "true" here against an upstream chart default of "false". Set it false and the
-# ClusterIP DNAT moves downstream of Cilium's egress hook (kube-proxy in the
-# host netns, or kube-ovn's OVN load balancer). The packet then reaches
-# policy_can_egress4 with dst = ClusterIP, which resolves to no endpoint
-# identity and cannot match toEndpoints; both policies run with
-# enableDefaultDeny: false, so falling out of the deny IS the access decision
-# and the packet is allowed. Every pod regains <webhook>.<ns>.svc:443 while the
-# backend-port deny keeps working and nothing reports a change.
+# value asserted below is what makes it so: kubeProxyReplacement, true here
+# against an upstream chart default of "false". Cozystack supplies no supported
+# alternative service load balancer for false; on the kube-ovn management
+# topology kube-proxy is absent and ENABLE_LB is also false. Turning this value
+# off therefore leaves ClusterIP routing without a supported owner and can break
+# Service connectivity. It does not by itself make either webhook reachable.
 #
 # Both policies also carry a target-side ingressDeny on their own webhook pods
 # for the same port, and that half does NOT depend on this value: it is
 # evaluated on the destination's ingress path, after whatever DNAT already
-# happened, so it enforces whoever performs the translation. Losing
-# kubeProxyReplacement therefore degrades the source-side rules and leaves the
-# target-side ones standing. That is defence in depth, not a reason to relax
-# this pin: the source-side form is what still denies while the webhook
+# happened, so it enforces whoever performs the translation. If a second
+# unsupported configuration change supplied a different translator,
+# kubeProxyReplacement=false would remove the source-side match before DNAT but
+# leave the target-side rules standing. That is defence in depth, not a reason
+# to relax this pin: the source-side form is what still denies while the webhook
 # endpoint's own policy is being recomputed or has overflowed its map, and the
 # target-side form is what survives a different service-LB implementation.
 # Neither subsumes the other, each carries its own cost, and both are argued in
@@ -139,10 +136,9 @@ tests:
   # The beacon is the only half of this guard that can fire in the field. The
   # pin above catches a cozystack commit changing the default; nothing in this
   # repo observes a live cluster's values, so an operator override reaches a
-  # running cluster unobserved. A ConfigMap rather than fail(), because whether
-  # Cilium without kube-proxy replacement is supported at all is a platform
-  # decision, and refusing to render the CNI over a weakened defence-in-depth
-  # control is not this chart's call to make.
+  # running cluster unobserved. The ConfigMap keeps that unsupported state
+  # visible without making each reconciliation fail to render; it is not an
+  # alternative supported mode.
   - it: emits no beacon while Cilium owns service load-balancing
     template: templates/kube-proxy-replacement-beacon.yaml
     asserts:
@@ -166,7 +162,7 @@ tests:
           value: "false"
       - matchRegex:
           path: data.message
-          pattern: "cover traffic addressed to the webhook Service ClusterIP"
+          pattern: "supports this chart only when"
 
   # The string form is what the upstream chart's own default uses, and the
   # subchart's value coalesces into the parent, so this is also the shape a

--- a/packages/system/cilium/values.yaml
+++ b/packages/system/cilium/values.yaml
@@ -1,24 +1,22 @@
 cilium:
-  # Load-bearing beyond service routing, and pinned for that reason. The
-  # admission-webhook deny policies in packages/system/ingress-nginx and
-  # packages/system/kubeovn-webhook name only their webhook's backend port, which
-  # covers a pod dialling the ClusterIP only while Cilium is the thing that
-  # performs the service DNAT -- and only this value makes it so, against an
-  # upstream chart default of "false". Setting it false does not break those
-  # policies visibly; it reopens the ClusterIP path to both webhooks while the
-  # backend deny keeps working. tests/kube_proxy_replacement_test.yaml asserts
-  # the rendered value across the defaults and every variant valuesFiles
-  # combination, and carries the whole argument. Both policies also carry a
-  # target-side rule that does not depend on this value, so losing it degrades
-  # the source-side half rather than removing enforcement outright.
+  # Required for the supported service-routing topology. Cozystack does not
+  # provide a supported alternative owner for ClusterIP translation when this
+  # is false; on kube-ovn, kube-proxy is absent and the OVN service load balancer
+  # is explicitly disabled. A false value can therefore break Service
+  # connectivity. tests/kube_proxy_replacement_test.yaml asserts the rendered
+  # value across the defaults and every variant valuesFiles combination.
+  #
+  # The source-side admission-webhook denies in packages/system/ingress-nginx
+  # and packages/system/kubeovn-webhook also rely on Cilium translating the
+  # Service before egress policy. Both policies retain a target-side ingressDeny,
+  # so even a second unsupported change that introduced another translator would
+  # not make the webhooks fail open.
   #
   # No test here can observe a live cluster's values, so an operator override in
   # the field is caught only by templates/kube-proxy-replacement-beacon.yaml,
-  # which renders a status ConfigMap whenever this is not true. It is a beacon
-  # and not a fail() on purpose: whether Cilium without kube-proxy replacement
-  # is a supported cozystack configuration is a platform decision, and refusing
-  # to render the CNI over a weakened defence-in-depth control is not this
-  # chart's call.
+  # which renders a status ConfigMap whenever this is not true. The beacon keeps
+  # a live unsupported override visible; it is not an alternative supported
+  # mode, and the required remediation is to restore true.
   kubeProxyReplacement: true
   # Upstream cilium with hostFirewall enabled and the IPv6 datapath disabled
   # (ipv6.enabled=false, the default here) drops ALL node IPv6 before any

--- a/packages/system/ingress-nginx/templates/admission-webhook-egress-policy.yaml
+++ b/packages/system/ingress-nginx/templates/admission-webhook-egress-policy.yaml
@@ -1,11 +1,10 @@
 {{- $policy := .Values.admissionWebhookPolicy | default dict -}}
-{{- $inc := index .Values "ingress-nginx" | default dict -}}
 {{- $ingress := index .Subcharts "ingress-nginx" -}}
-{{- $admissionWebhooks := dig "controller" "admissionWebhooks" dict $inc | default dict -}}
+{{- $admissionWebhooks := $ingress.Values.controller.admissionWebhooks | default dict -}}
 {{- if and (dig "enabled" true $policy) (dig "enabled" true $admissionWebhooks) (.Capabilities.APIVersions.Has "cilium.io/v2/CiliumClusterwideNetworkPolicy") }}
 {{- $controllerName := include "ingress-nginx.name" $ingress -}}
 {{- $controllerNamespace := include "ingress-nginx.namespace" $ingress -}}
-{{- $webhookPort := dig "port" 8443 $admissionWebhooks -}}
+{{- $webhookPort := required "ingress-nginx.controller.admissionWebhooks.port must be set while admissionWebhookPolicy is enabled" $admissionWebhooks.port -}}
 {{- $policyHash := printf "%s/%s" $controllerNamespace .Release.Name | sha256sum | trunc 12 -}}
 ---
 {{/*
@@ -64,27 +63,28 @@ destination on that port for every selected endpoint -- a cluster-wide
 egress outage, not a tighter deny.
 
 That ordering is Cilium's own, and it is conditional: it holds while Cilium owns
-service load-balancing, which on every cozystack variant it does because
-packages/system/cilium/values.yaml sets kubeProxyReplacement: true against an
-upstream chart default of "false". Set that false and the ClusterIP DNAT moves
-downstream of Cilium's egress hook (kube-proxy in the host netns, or kube-ovn's
-OVN load balancer): the packet reaches policy_can_egress4 with dst = ClusterIP,
-matches no endpoint identity, and -- default-deny being off -- is allowed. Pods
-regain <admission>.<ns>.svc:443 while the backend deny below keeps working, and
-nothing reports the change.
+service load-balancing. Cozystack supports this chart only with
+kubeProxyReplacement: true and does not provide a supported fallback service
+load balancer for a false value. On the kube-ovn management topology this is
+explicit: packages/system/kubeovn/values.yaml also sets ENABLE_LB: false. A
+false value therefore leaves ClusterIP routing without a supported owner and
+can break Service connectivity; it does not by itself make this webhook
+reachable.
 
-Three things keep that from happening quietly.
-packages/system/cilium/tests/kube_proxy_replacement_test.yaml pins the value
-across the chart defaults and all five variant valuesFiles combinations, so
-flipping it reddens the cilium package's own suite, and
-packages/system/cilium/templates/kube-proxy-replacement-beacon.yaml renders a
-status ConfigMap whenever it is not true -- the only signal an operator
-override in the field can produce, since no test in this repo observes a live
-cluster's values. The deny-still-enforced case in
-hack/e2e-chainsaw/gateway/chainsaw-test.yaml connects to the admission
-ClusterIP from a pod and requires that connect to fail, so the effect is
-asserted against a live cluster rather than only reasoned about here. And the
-third spec below keeps enforcing whoever performs the DNAT.
+If a second unsupported configuration change supplied another service DNAT,
+the source-side rules would no longer cover packets before that translation:
+they would reach Cilium's egress hook with dst = ClusterIP and match no endpoint
+identity. The third spec below remains target-side and is evaluated after any
+translation, so pod traffic still does not fail open. The source-side rules are
+still worth pinning because they carry the deny while the webhook endpoint's
+own policy is degraded.
+
+packages/system/cilium/tests/kube_proxy_replacement_test.yaml pins the supported
+value across the chart defaults and all five variant valuesFiles combinations,
+and packages/system/cilium/templates/kube-proxy-replacement-beacon.yaml reports
+an unsupported live override that repository tests cannot observe. The
+deny-still-enforced case in hack/e2e-chainsaw/gateway/chainsaw-test.yaml verifies
+both Service and direct-backend paths on a live supported cluster.
 
 The first rule covers every workload outside kube-system. The second covers
 kube-system except the konnectivity-agent ServiceAccount: a Kamaji-hosted

--- a/packages/system/ingress-nginx/templates/admission-webhook-egress-policy.yaml
+++ b/packages/system/ingress-nginx/templates/admission-webhook-egress-policy.yaml
@@ -19,9 +19,9 @@ a direction the other does not.
 
 The source-side specs (the first two) are an egressDeny evaluated on the
 caller's own endpoint, so they hold while the webhook endpoint's policy is
-being recomputed or has overflowed its own policy map. What they cannot do is
-survive a datapath where Cilium is not the service load balancer, because they
-name the webhook's backend port and rely on the DNAT happening first.
+being recomputed or has overflowed its own policy map. What they cannot cover is
+a Service translated by another component after Cilium's egress hook, because
+they name the webhook's backend port and rely on the DNAT happening first.
 
 The target-side spec (the third) is an ingressDeny on the webhook endpoint,
 evaluated after whatever DNAT already happened, so it is independent of the
@@ -36,8 +36,8 @@ namespace-churn map writes on that endpoint. It makes them non-load-bearing:
 whichever end is degraded, the other still denies, and the writes are writes
 rather than an outage (see the cost paragraph on the third spec). Removing the
 coupling outright would mean dropping the target-side rule and accepting a
-silent fail-open wherever Cilium does not own the DNAT, which is the worse
-trade.
+silent fail-open if another component performs DNAT only after Cilium's egress
+hook, which is the worse trade.
 
 Stated precisely, because #3983 was reported as a hard outage rather than a
 flap: the coupling above is real, but it was not reproduced in isolation as the
@@ -102,9 +102,10 @@ denies kept for different reasons.
 
 Its pod deny is deliberate belt and braces, not a leftover from the shape this
 change replaced. Being on the destination's ingress path it is evaluated after
-whatever DNAT has already happened, so it holds even where Cilium is not the
-service load balancer -- exactly the exposure the paragraphs above describe. It
-cannot catch the API server: for a clusterwide policy Cilium rewrites every
+whatever DNAT has already happened, so it still holds if another component
+translates the Service after source-side egress policy -- exactly the exposure
+the paragraphs above describe. It cannot catch the API server: for a
+clusterwide policy Cilium rewrites every
 fromEndpoints selector to also require k8s:io.kubernetes.pod.namespace to
 Exist, plus the cluster label (Cilium v1.19.5,
 pkg/k8s/apis/cilium.io/utils/utils.go:120-154 getEndpointSelector, whose own

--- a/packages/system/ingress-nginx/tests/admission_webhook_egress_policy_test.yaml
+++ b/packages/system/ingress-nginx/tests/admission_webhook_egress_policy_test.yaml
@@ -235,6 +235,13 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: fails closed when the effective subchart values have no webhook port
+    set:
+      ingress-nginx.controller.admissionWebhooks.port: null
+    asserts:
+      - failedTemplate:
+          errorMessage: ingress-nginx.controller.admissionWebhooks.port must be set while admissionWebhookPolicy is enabled
+
   - it: defaults to enabled when a backport has no policy values
     set:
       admissionWebhookPolicy: null

--- a/packages/system/ingress-nginx/values.yaml
+++ b/packages/system/ingress-nginx/values.yaml
@@ -116,22 +116,20 @@ ingress-nginx:
 #
 # The policy denies the webhook's backend port only, which covers a pod dialling
 # the Service ClusterIP because Cilium translates a service to its backends
-# before it enforces egress policy. That depends on Cilium owning service
-# load-balancing -- packages/system/cilium/values.yaml kubeProxyReplacement,
-# true there against an upstream default of "false". It is pinned by
-# packages/system/cilium/tests/kube_proxy_replacement_test.yaml, which carries
-# the argument; flip it and the ClusterIP path to this webhook reopens while the
-# backend deny keeps working. The target-side rule in the same policy does not
-# depend on that value at all -- it is evaluated on the webhook's own ingress
-# path, after whatever DNAT already happened -- so the two together degrade
-# rather than fail open.
+# before it enforces egress policy. Cozystack supports this only with
+# packages/system/cilium/values.yaml kubeProxyReplacement set to true and does
+# not provide a supported fallback service load balancer for false. Such an
+# override can break ClusterIP routing; it does not by itself make the webhook
+# reachable. If another unsupported change supplied a different translator, the
+# source-side rule would lose the pre-DNAT path but the target-side rule would
+# still deny pods after translation.
 #
 # Residual risk worth stating: no test in this repo can observe a live cluster's
 # Cilium values, so an operator setting kubeProxyReplacement: false in the field
 # is caught only by the status ConfigMap that
 # packages/system/cilium/templates/kube-proxy-replacement-beacon.yaml renders,
 # and inside a tenant Kubernetes cluster only by the equivalent beacon in
-# packages/apps/kubernetes. Whether that configuration is supported at all is a
-# platform question this chart does not answer.
+# packages/apps/kubernetes. Those beacons identify an unsupported networking
+# configuration; disabling this policy does not make it supported.
 admissionWebhookPolicy:
   enabled: true

--- a/packages/system/kubeovn-webhook/Makefile
+++ b/packages/system/kubeovn-webhook/Makefile
@@ -18,8 +18,6 @@ image:
 # and SKIPS any package that has no such target. This package carried three
 # suites under tests/ that consequently never ran in CI -- including the port
 # agreement guard, whose whole purpose is to catch a drift that fails open.
-# --with-subchart=false matches the other packages: run only our own suites.
-#
 # Declared phony because hack/package.mk's .PHONY line does not carry `test`:
 # without this a path named `test` next to the Makefile would make the target
 # up to date and skip the recipe, which is the same fail-open shape the port
@@ -27,4 +25,4 @@ image:
 # fact; this prevents it here.
 .PHONY: test
 test:
-	helm unittest --with-subchart=false .
+	helm unittest .

--- a/packages/system/kubeovn-webhook/templates/_helpers.tpl
+++ b/packages/system/kubeovn-webhook/templates/_helpers.tpl
@@ -16,9 +16,9 @@ removes the control silently rather than breaking anything visibly.
 The Service frontend port is deliberately NOT defined here. The policy denies
 the backend port only, which already covers ClusterIP-addressed traffic because
 Cilium translates a service to its backends before enforcing egress policy, so
-there is no second value that has to stay in agreement. That translation order
-is itself a pinned assumption -- see
-packages/system/cilium/tests/kube_proxy_replacement_test.yaml.
+there is no second value that has to stay in agreement. Cozystack supports that
+path only with kubeProxyReplacement enabled; the platform invariant is pinned
+in packages/system/cilium/tests/kube_proxy_replacement_test.yaml.
 */}}
 {{- define "namespace-annotation-webhook.port" -}}
 8443

--- a/packages/system/kubeovn-webhook/templates/networkpolicy.yaml
+++ b/packages/system/kubeovn-webhook/templates/networkpolicy.yaml
@@ -51,17 +51,20 @@ denies EVERY destination on that port for every selected endpoint -- a
 cluster-wide egress outage rather than a tighter deny.
 
 That ordering is Cilium's own and it is conditional: it holds while Cilium owns
-service load-balancing, which on every cozystack variant it does because
-packages/system/cilium/values.yaml sets kubeProxyReplacement: true against an
-upstream chart default of "false". Set that false and the ClusterIP DNAT moves
-downstream of Cilium's egress hook, the packet reaches policy_can_egress4 with
-dst = ClusterIP, matches no endpoint identity, and -- default-deny being off --
-is allowed, restoring pod access to /mutate-pods with nothing to look at.
-packages/system/cilium/tests/kube_proxy_replacement_test.yaml pins that value
-and packages/system/cilium/templates/kube-proxy-replacement-beacon.yaml renders
-a status ConfigMap whenever it is not true, which is the only signal an operator
-override in the field can produce. The second spec below then keeps enforcing
-whoever performs the DNAT.
+service load-balancing. This kube-ovn topology sets ENABLE_LB: false in
+packages/system/kubeovn/values.yaml, does not run kube-proxy, and supports
+ClusterIP routing only with packages/system/cilium/values.yaml
+kubeProxyReplacement set to true. Turning it false leaves no supported service
+translator, so Service traffic fails as a routing error rather than bypassing
+this policy.
+
+If a second unsupported change enabled another translator, the source-side
+rule would see dst = ClusterIP before DNAT and no longer match an endpoint
+identity. The second spec below is evaluated on the destination after whatever
+translation occurred and still denies pod traffic. The Cilium package pins the
+supported value in tests/kube_proxy_replacement_test.yaml and renders
+templates/kube-proxy-replacement-beacon.yaml for a live override that repository
+tests cannot observe.
 
 The API server and host-network workloads are not selected: a rule carrying an
 endpointSelector can never match the host endpoint, because Cilium routes host

--- a/packages/system/kubeovn-webhook/templates/networkpolicy.yaml
+++ b/packages/system/kubeovn-webhook/templates/networkpolicy.yaml
@@ -28,8 +28,8 @@ back. Shipping both does not eliminate the namespace-churn map writes here; it
 makes them non-load-bearing, because whichever end is degraded the other still
 denies, and the writes are writes rather than an outage (see the cost paragraph
 on the second spec). The alternative -- dropping the target-side rule -- buys
-the coupling back at the price of a silent fail-open wherever Cilium does not
-own the DNAT.
+the coupling back at the price of a silent fail-open if another component
+performs DNAT only after Cilium's egress hook.
 
 That coupling was not reproduced in isolation as the trigger of #3983, and the
 errno the issue reports cannot come from a policy denial; see the PR
@@ -76,10 +76,11 @@ The second spec is target-side, on the webhook endpoint, and carries two denies
 kept for different reasons.
 
 Its pod deny is deliberate belt and braces. Being on the destination's ingress
-path it is evaluated after whatever DNAT has already happened, so it holds even
-where Cilium is not the service load balancer -- exactly the exposure the
-paragraph above describes. It cannot catch the API server: for a clusterwide
-policy Cilium rewrites every fromEndpoints selector to also require
+path it is evaluated after whatever DNAT has already happened, so it still
+holds if another component translates the Service after source-side egress
+policy -- exactly the exposure the paragraph above describes. It cannot catch
+the API server: for a clusterwide policy Cilium rewrites every fromEndpoints
+selector to also require
 k8s:io.kubernetes.pod.namespace to Exist, plus the cluster label (Cilium
 v1.19.5, pkg/k8s/apis/cilium.io/utils/utils.go:120-154 getEndpointSelector,
 whose own comment at :141 says that even a wildcard must not become a truly

--- a/packages/system/kubeovn-webhook/values.yaml
+++ b/packages/system/kubeovn-webhook/values.yaml
@@ -51,22 +51,19 @@ image: ghcr.io/cozystack/cozystack/kubeovn-webhook:v1.6.0@sha256:593c324a38db594
 # target-side world deny both read that one definition -- see
 # namespace-annotation-webhook.port in templates/_helpers.tpl. Only the backend
 # port is denied; Cilium translates a service to its backends before enforcing
-# egress policy, so ClusterIP-addressed traffic is matched there too. That last
-# step depends on Cilium owning service load-balancing --
-# packages/system/cilium/values.yaml kubeProxyReplacement, true there against an
-# upstream default of "false", pinned by
-# packages/system/cilium/tests/kube_proxy_replacement_test.yaml, which carries
-# the argument. Flip it and the ClusterIP path to /mutate-pods reopens while the
-# backend deny keeps working -- except that the policy's target-side rule does
-# not depend on that value at all, being evaluated on the webhook's own ingress
-# path after whatever DNAT already happened, so the two together degrade rather
-# than fail open.
+# egress policy, so ClusterIP-addressed traffic is matched there too. Cozystack
+# supports this topology only with packages/system/cilium/values.yaml
+# kubeProxyReplacement set to true: kube-ovn has ENABLE_LB: false and kube-proxy
+# is absent. Turning it false leaves no supported Service translator and breaks
+# ClusterIP routing rather than reopening /mutate-pods. If another unsupported
+# change supplied a translator, the target-side rule would still deny pod
+# traffic after DNAT even though the source-side rule lost that path.
 #
 # Residual risk worth stating: no test in this repo can observe a live cluster's
 # Cilium values, so an operator setting kubeProxyReplacement: false in the field
 # is caught only by the status ConfigMap that
 # packages/system/cilium/templates/kube-proxy-replacement-beacon.yaml renders.
-# Whether that configuration is supported at all is a platform question this
-# chart does not answer.
+# The beacon identifies an unsupported networking configuration; disabling this
+# policy does not make it supported.
 webhookPolicy:
   enabled: true


### PR DESCRIPTION
## What this PR does

This is follow-up for [#3997](https://github.com/cozystack/cozystack/pull/3997). It reads ingress-nginx admission port from effective subchart values and refuses empty value, and fixes `kubeProxyReplacement=false` status because cozystack has no supported Service translator in that state. Gateway test now requires one real ClusterIP and keeps same ready Pod UID, IP and port for whole probe, so stale EndpointSlice, replaced Pod or wrong Service can't report deny. Policy selectors and two-ended deny from [#3997](https://github.com/cozystack/cozystack/pull/3997) stay unchanged, and this does not claim root cause for [#3983](https://github.com/cozystack/cozystack/issues/3983).

### Screenshots

Not applicable.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
fix(networking): use effective ingress admission port, report unsupported Cilium service routing correctly, and reject stale backend evidence in gateway tests
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Admission webhook connectivity checks now validate the exact Service and backend endpoint throughout probing, improving failure detection and diagnostics.
  - Admission webhook policies now fail closed when the webhook port is not explicitly configured.

- **Documentation**
  - Clarified that supported service routing requires `kubeProxyReplacement: true`.
  - Updated guidance to explain that disabling this setting or webhook policies does not provide a supported fallback.

- **Tests**
  - Added coverage for missing webhook port configuration and strengthened networking stability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->