### PR TITLE
fix(api): report AlreadyExists, NotFound and Conflict on Application writes

### DIFF
--- a/pkg/registry/apps/application/rest.go
+++ b/pkg/registry/apps/application/rest.go
@@ -19,6 +19,7 @@ package application
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -61,6 +62,40 @@ import (
 	// Importing API errors package to construct appropriate error responses
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
+
+// applicationStatusError restates an error from the underlying HelmRelease client on the aggregated
+// Application resource, preserving the Kubernetes API error semantics callers rely on.
+//
+// Wrapping such an error with fmt.Errorf discards its metav1.Status: the apiserver machinery can no
+// longer map it to an HTTP status and renders a generic 500 carrying only a message. Creating an
+// Application whose HelmRelease already exists therefore returned
+//
+//	{"kind":"Status","apiVersion":"v1","status":"Failure","code":500,
+//	 "message":"failed to create HelmRelease: helmreleases.helm.toolkit.fluxcd.io \"tenant-x\" already exists"}
+//
+// with no reason field. apierrors.IsAlreadyExists keys on the reason, so every client-go caller — every
+// controller included — sees a retryable server error instead of a conflict, and cannot make its create
+// idempotent. The same applied to Update and Delete.
+//
+// The error is restated on the Application, not on the HelmRelease: the HelmRelease is an implementation
+// detail of this registry that the caller never named. Any other typed status (Forbidden, Invalid,
+// TooManyRequests…) is passed through unchanged so that its code survives; only an untyped error keeps
+// the wrapping, since it carries no semantics the API contract defines.
+func (r *REST) applicationStatusError(verb string, name string, err error) error {
+	switch {
+	case apierrors.IsAlreadyExists(err):
+		return apierrors.NewAlreadyExists(r.gvr.GroupResource(), name)
+	case apierrors.IsNotFound(err):
+		return apierrors.NewNotFound(r.gvr.GroupResource(), name)
+	case apierrors.IsConflict(err):
+		return apierrors.NewConflict(r.gvr.GroupResource(), name, err)
+	}
+	var status apierrors.APIStatus
+	if errors.As(err, &status) {
+		return err
+	}
+	return fmt.Errorf("failed to %s HelmRelease: %v", verb, err)
+}
 
 // Ensure REST implements necessary interfaces
 var (
@@ -245,7 +280,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	err = r.c.Create(ctx, helmRelease, &client.CreateOptions{Raw: options})
 	if err != nil {
 		klog.Errorf("Failed to create HelmRelease %s: %v", helmRelease.Name, err)
-		return nil, fmt.Errorf("failed to create HelmRelease: %v", err)
+		return nil, r.applicationStatusError("create", app.Name, err)
 	}
 
 	// Convert the created HelmRelease back to Application
@@ -618,7 +653,7 @@ func (r *REST) Update(ctx context.Context, name string, objInfo rest.UpdatedObje
 	})
 	if err != nil {
 		klog.Errorf("Failed to update HelmRelease %s: %v", helmRelease.Name, err)
-		return nil, false, fmt.Errorf("failed to update HelmRelease: %v", err)
+		return nil, false, r.applicationStatusError("update", name, err)
 	}
 
 	// Convert the updated HelmRelease back to Application
@@ -691,7 +726,7 @@ func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.Va
 	err = r.c.Delete(ctx, helmRelease, &client.DeleteOptions{Raw: options})
 	if err != nil {
 		klog.Errorf("Failed to delete HelmRelease %s: %v", helmReleaseName, err)
-		return nil, false, fmt.Errorf("failed to delete HelmRelease: %v", err)
+		return nil, false, r.applicationStatusError("delete", name, err)
 	}
 
 	klog.V(6).Infof("Successfully deleted HelmRelease %s", helmReleaseName)

--- a/pkg/registry/apps/application/rest_status_error_test.go
+++ b/pkg/registry/apps/application/rest_status_error_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2026 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package application
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	appsv1alpha1 "github.com/cozystack/cozystack/pkg/apis/apps/v1alpha1"
+	"github.com/cozystack/cozystack/pkg/config"
+)
+
+// These tests pin the API error semantics of the aggregated Application resource.
+//
+// The registry stores an Application as a HelmRelease. Errors from that write used to be flattened with
+// fmt.Errorf, which discards the metav1.Status they carry: the apiserver machinery could no longer map
+// them to an HTTP status and answered a generic 500 whose body held only a message, with no reason.
+//
+// Creating an Application that already exists therefore returned
+//
+//	{"kind":"Status","apiVersion":"v1","status":"Failure","code":500,
+//	 "message":"failed to create HelmRelease: helmreleases.helm.toolkit.fluxcd.io \"tenant-x\" already exists"}
+//
+// apierrors.IsAlreadyExists keys on the reason, so no client could tell a conflict from a retryable
+// server failure — which makes an idempotent create impossible for every controller and every client-go
+// caller. kubectl reported it as `Error from server` rather than `AlreadyExists`.
+
+func statusErrorREST(t *testing.T, objects []client.Object, funcs interceptor.Funcs) *REST {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := helmv2.AddToScheme(scheme); err != nil {
+		t.Fatalf("register helmv2 scheme: %v", err)
+	}
+	resourceCfg := &config.ResourceConfig{
+		Resources: []config.Resource{
+			{Application: config.ApplicationConfig{Kind: "MySQL"}},
+		},
+	}
+	if err := appsv1alpha1.RegisterDynamicTypes(scheme, resourceCfg); err != nil {
+		t.Fatalf("register dynamic types: %v", err)
+	}
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	if len(objects) > 0 {
+		builder = builder.WithObjects(objects...)
+	}
+	return &REST{
+		c: builder.WithInterceptorFuncs(funcs).Build(),
+		gvr: schema.GroupVersionResource{
+			Group:    appsv1alpha1.GroupName,
+			Version:  "v1alpha1",
+			Resource: "mysqls",
+		},
+		gvk: schema.GroupVersionKind{
+			Group:   appsv1alpha1.GroupName,
+			Version: "v1alpha1",
+			Kind:    "MySQL",
+		},
+		kindName: "MySQL",
+		releaseConfig: config.ReleaseConfig{
+			Prefix: "mysql-",
+		},
+	}
+}
+
+func statusErrorApp() *appsv1alpha1.Application {
+	return &appsv1alpha1.Application{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps.cozystack.io/v1alpha1",
+			Kind:       "MySQL",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "good-name",
+			Namespace: "tenant-foo",
+		},
+	}
+}
+
+func existingHelmRelease() *helmv2.HelmRelease {
+	return &helmv2.HelmRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mysql-good-name",
+			Namespace: "tenant-foo",
+			Labels: map[string]string{
+				ApplicationKindLabel:  "MySQL",
+				ApplicationGroupLabel: appsv1alpha1.GroupName,
+				ApplicationNameLabel:  "good-name",
+			},
+		},
+	}
+}
+
+// TestCreate_ReportsAlreadyExists is the regression this file exists for.
+func TestCreate_ReportsAlreadyExists(t *testing.T) {
+	r := statusErrorREST(t, []client.Object{existingHelmRelease()}, interceptor.Funcs{})
+	ctx := request.WithNamespace(context.Background(), "tenant-foo")
+
+	_, err := r.Create(ctx, statusErrorApp(), nil, &metav1.CreateOptions{})
+	if err == nil {
+		t.Fatal("creating an Application whose HelmRelease already exists returned no error")
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("error is not AlreadyExists: %v", err)
+	}
+
+	// The conflict is reported on the resource the caller named, not on the HelmRelease backing it: a
+	// client that sees `helmreleases.helm.toolkit.fluxcd.io` cannot match it against what it asked for.
+	status, ok := err.(apierrors.APIStatus)
+	if !ok {
+		t.Fatalf("error carries no Status: %v", err)
+	}
+	details := status.Status().Details
+	if details == nil {
+		t.Fatalf("status carries no details: %v", status.Status())
+	}
+	if details.Kind != "mysqls" || details.Group != appsv1alpha1.GroupName {
+		t.Errorf("conflict reported on %s.%s, want mysqls.%s", details.Kind, details.Group,
+			appsv1alpha1.GroupName)
+	}
+	if details.Name != "good-name" {
+		t.Errorf("conflict reported on name %q, want good-name", details.Name)
+	}
+	if code := status.Status().Code; code != 409 {
+		t.Errorf("status code %d, want 409", code)
+	}
+}
+
+// TestDelete_ReportsNotFoundLostRace covers the HelmRelease disappearing between the registry's read and
+// its delete. Flattening the error turned that race into a 500, so a caller retrying a delete — the
+// normal way to converge — could not recognise that the object was already gone.
+func TestDelete_ReportsNotFoundLostRace(t *testing.T) {
+	r := statusErrorREST(t, []client.Object{existingHelmRelease()}, interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if _, ok := obj.(*helmv2.HelmRelease); ok {
+				return apierrors.NewNotFound(
+					schema.GroupResource{Group: "helm.toolkit.fluxcd.io", Resource: "helmreleases"},
+					obj.GetName(),
+				)
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+	})
+	ctx := request.WithNamespace(context.Background(), "tenant-foo")
+
+	_, _, err := r.Delete(ctx, "good-name", nil, &metav1.DeleteOptions{})
+	if err == nil {
+		t.Fatal("deleting an Application whose HelmRelease vanished returned no error")
+	}
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("error is not NotFound: %v", err)
+	}
+}
+
+// TestCreate_KeepsWrappingUntypedErrors is the negative control: only errors that carry an API status
+// are restated. An arbitrary failure has no semantics the API contract defines, and turning it into a
+// conflict would be worse than reporting it as a server error.
+func TestCreate_KeepsWrappingUntypedErrors(t *testing.T) {
+	r := statusErrorREST(t, nil, interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*helmv2.HelmRelease); ok {
+				return errors.New("dial tcp: connection refused")
+			}
+			return c.Create(ctx, obj, opts...)
+		},
+	})
+	ctx := request.WithNamespace(context.Background(), "tenant-foo")
+
+	_, err := r.Create(ctx, statusErrorApp(), nil, &metav1.CreateOptions{})
+	if err == nil {
+		t.Fatal("an untyped client failure returned no error")
+	}
+	if apierrors.IsAlreadyExists(err) || apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
+		t.Fatalf("an untyped failure was restated as an API conflict: %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to create HelmRelease") {
+		t.Errorf("error lost its context: %v", err)
+	}
+}


### PR DESCRIPTION
## What this PR does

`REST.Create`, `REST.Update` and `REST.Delete` in `pkg/registry/apps/application` store an Application as
a HelmRelease, and flattened the errors of that write with `fmt.Errorf("…: %v", err)`. That discards the
`metav1.Status` the error carries, so the apiserver machinery can no longer map it to an HTTP status and
answers a generic **500** whose body holds a message and **no `reason`**.

Creating an Application that already exists therefore returns, on v1.6.1:

```json
{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure",
 "message":"failed to create HelmRelease: helmreleases.helm.toolkit.fluxcd.io \"tenant-x\" already exists",
 "code":500}
```

`apierrors.IsAlreadyExists` keys on the reason, so no client can tell a conflict from a retryable server
failure. The consequence is concrete: the ordinary idempotent create — *create, tolerate AlreadyExists* —
is impossible for every controller and every client-go caller, and `kubectl create` on an existing
Application reports `Error from server` instead of `AlreadyExists`. `Update` and `Delete` lost `NotFound`
and `Conflict` the same way, which also turns a HelmRelease that vanished under a delete into a 500 rather
than the `NotFound` a converging caller expects.

This adds one helper, `applicationStatusError`, and uses it at those three sites:

- `AlreadyExists`, `NotFound` and `Conflict` are **restated on the aggregated Application**, which is the
  resource the caller named — a client that receives `helmreleases.helm.toolkit.fluxcd.io` cannot match it
  against what it asked for. This follows what the file already does elsewhere: `Get` and `Update` map a
  missing HelmRelease with `apierrors.NewNotFound(r.gvr.GroupResource(), name)`. The `Create` path was the
  outlier.
- any **other typed status** (Forbidden, Invalid, TooManyRequests…) is passed through unchanged, so its
  code survives instead of becoming a 500;
- an **untyped** error keeps the existing wrapping: it carries no semantics the API contract defines.

No status is ever inferred from an error message.

### Tests

`rest_status_error_test.go` adds three tests using the existing fake-client + interceptor harness:

| Test | Without this change | With it |
| --- | --- | --- |
| `TestCreate_ReportsAlreadyExists` | **fails**: `error is not AlreadyExists: failed to create HelmRelease: … already exists` | passes; code 409, details on `mysqls.apps.cozystack.io`, name `good-name` |
| `TestDelete_ReportsNotFoundLostRace` | **fails**: `error is not NotFound` | passes |
| `TestCreate_KeepsWrappingUntypedErrors` (negative control) | passes | passes |

Verified on `go 1.26.4`: `gofmt` clean, `go build ./pkg/...`, `go vet`, the whole
`pkg/registry/apps/application` package green, and `make generate` re-run with **no diff** outside the two
files above. No test anywhere depended on the flattened message.

This is a behaviour change in the status codes the API returns, not a schema change: no API group, no
resource and no field is added or altered.

### Screenshots

Not applicable: no UI change.

### Downstream repositories

I walked the trigger map in `docs/agents/contributing.md` against the diff, file by file. The diff is two
files under `pkg/registry/apps/application/`, and **no listed trigger matches**: every trigger concerns
`packages/apps|extra`, `packages/core/platform/values.yaml`, platform variants or components, release
asset names, `ApplicationDefinition` semantics, the Talos pin, developer tooling, `values.schema.json`
fields, version enums, `values.yaml` defaults, `kind`/`plural`, `release.prefix`, or a hand-typed CRD.

Two couplings are not in the map and I could not verify them, so I am **leaving every box empty** rather
than claiming work I have not done — following point 4 of the template's own guidance:

- **`website`** — the "make a documented workaround obsolete" trigger. If any page tells users to work
  around the 500 on creating an existing Application, it should go. I have not audited the site.
- **`terraform-provider-cozystack`** — it consumes this API and could carry error handling keyed on the
  message rather than on the reason. The change should only help it (a real 409 instead of a 500), but a
  maintainer of that repo is better placed to confirm.

Happy to open the follow-ups if you point me at either.

- [ ] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

This is a bugfix and would be worth the `kind/backport` label for the 1.6 line, where it was observed;
I cannot set labels on this repository.

### Release note

```release-note
fix(api): writes to an Application now return the proper Kubernetes status — AlreadyExists, NotFound or Conflict — instead of a generic 500 carrying only a message. Clients can once again make an Application create idempotent by tolerating AlreadyExists, and a delete that loses the race with a vanishing HelmRelease reports NotFound.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFkSpJkDLBehAE2y15eaXw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Application create, update, and delete operations now return accurate API errors for conflicts, duplicate resources, and missing resources.
  * Underlying connection and other untyped failures retain their original context instead of being misreported as API conflicts.
  * Error responses now include the correct resource and caller details where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->