### PR TITLE
fix(postgres): point the trust-anchor comment at the published projection

### DIFF
--- a/packages/apps/postgres/templates/db.yaml
+++ b/packages/apps/postgres/templates/db.yaml
@@ -17,9 +17,12 @@ spec:
   # admission webhook, which is why the chart no longer renders a cert-manager
   # chain — the operator owns the chain end-to-end.
   #
-  # Trust anchor for clients: the ca.crt key present in every user-credentials
-  # Secret CNPG creates (e.g. <release>-credentials). Mount that key into
-  # client pods to verify TLS.
+  # Trust anchor for clients: the key-free "<release>.tenant-ca" Secret the CA
+  # extraction controller publishes, as declared by the sentinel in
+  # templates/tenant-projection.yaml. Tenants read that Secret through the
+  # core.cozystack.io tenantsecrets API. It is neither <release>-credentials,
+  # which is chart-rendered and holds user passwords only, nor CNPG's
+  # <release>-ca, which holds the CA private key next to ca.crt.
   certificates:
     serverAltDNSNames:
       - {{ printf "%s.%s" .Release.Name .Values._namespace.host }}


### PR DESCRIPTION
## What this PR does

The TLS comment in `db.yaml` told operators to take `ca.crt` from `<release>-credentials`. That key is not there. The chart renders that Secret from `.Values.users`, so it holds passwords and nothing else.

The anchor a tenant can reach is `<release>.tenant-ca`, which the CA-extraction controller publishes from the sentinel this chart already renders in `templates/tenant-projection.yaml`, and which tenants read through `tenantsecrets`. The comment points there now. It also names the two Secrets it is not, because CNPG's own `<release>-ca` is one dash away and holds the CA private key next to `ca.crt`.

Comment only. `README.md` already documented the projection correctly and needed no change, and `helm unittest packages/apps/postgres` is green.

### Screenshots

Not a UI change.

### Downstream repositories

A comment inside one chart template. `values.yaml`, `values.schema.json`, `Chart.yaml` and `README.md` are untouched, so the generated reference page does not move, and no schema field, default, version enum, release prefix or Secret name changes.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated TLS trust-anchor comments to clarify that the CA extraction controller publishes the key-free `<release>.tenant-ca` Secret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->