### PR TITLE
fix(cacert): make the comments match the reconciler

### DIFF
--- a/internal/controller/cacert/reconciler.go
+++ b/internal/controller/cacert/reconciler.go
@@ -114,10 +114,11 @@ const (
 	// per-release name templating.
 	TenantCALabel = "internal.cozystack.io/tenant-ca"
 
-	// ManagedLabel marks a projection as controller-created. The reconciler
-	// only ever writes over a Secret bearing this label, so a Secret that
-	// merely shares the name — an engine's own key-bearing CA, for one — is
-	// never clobbered.
+	// ManagedLabel marks a projection as controller-created. It is part of the
+	// drift check, so stripping it produces a write that puts it back, but no
+	// decision keys on it beyond that: whether a Secret at the canonical name may
+	// be overwritten is isOurProjection's call, and it does not look at this
+	// label.
 	ManagedLabel = "internal.cozystack.io/ca-cert-copy"
 
 	// SourceRefAnnotation records the "<namespace>/<name>" of the source on the
@@ -165,7 +166,9 @@ const (
 	SelectorsDigestAnnotation = "internal.cozystack.io/ca-cert-selectors"
 
 	// managedByCozystackLabel is stamped by the lineage admission webhook. The
-	// reconciler never writes it; it only takes care not to strip it.
+	// reconciler removes it on exactly one occasion — a change to the selectors
+	// digest, which is what hands the projection back for re-admission (see
+	// upsertProjection) — and preserves it on every other write.
 	managedByCozystackLabel = "internal.cozystack.io/managed-by-cozystack"
 
 	// helmNameLabel is the Helm ownership label Flux stamps on every rendered
@@ -185,12 +188,18 @@ const (
 
 	// projectionSuffix completes the canonical name "<release>.tenant-ca".
 	//
-	// The DOT is load-bearing. Engine CA Secrets are named <prefix><app><suffix>,
-	// and app names are validated as DNS-1035 labels, which cannot contain a dot
-	// (pkg/apis/apps/validation); Secret names are DNS-1123 subdomains, which can.
-	// So no engine can generate this name for any application, and the projection
-	// cannot collide with an operator-owned object — in either direction, and both
-	// are unrecoverable. Do not "tidy" the dot into a dash.
+	// The DOT is what separates the projection from engine CA Secrets, named
+	// <prefix><app><suffix>; Secret names are DNS-1123 subdomains, so a dot in one
+	// is legal. A release the apps API created carries none: application names are
+	// DNS-1035 labels (pkg/apis/apps/validation) and release.prefix is restricted
+	// to ^[a-z0-9-]*$ (api/v1alpha1). That guarantee stops at the API, because the
+	// release here comes from the helm.toolkit.fluxcd.io/name LABEL and a label
+	// value may carry a dot, so a hand-written HelmRelease is outside it. On the
+	// validated path the dot can only come from the <suffix> an operator or chart
+	// appends, which nothing validates at all, and a canonical name ends in
+	// ".tenant-ca" carrying that one dot, so only a suffix ending in ".tenant-ca"
+	// reaches one. A Secret there this controller does not recognise as its own is
+	// never overwritten; see isOurProjection. Do not "tidy" the dot into a dash.
 	projectionSuffix = ".tenant-ca"
 
 	// appsGroup is the API group of the aggregated application kinds, as it
@@ -598,9 +607,13 @@ func (r *Reconciler) anotherSentinelForRelease(ctx context.Context, tp *internal
 // over itself.
 //
 // The canonical name is chosen so that no operator the platform ships claims
-// it, so this is not reachable through any of them today; it is reachable
-// through a misconfiguration (a sentinel pointing sourceSecretName at
-// "<release>.tenant-ca" itself), and the answer depends entirely on content.
+// it, so this is not reachable through any of them today. One way in is a
+// misconfiguration: a sentinel pointing sourceSecretName at
+// "<release>.tenant-ca" itself. The other is legitimate, and is why the
+// key-free branch below is a success rather than a refusal: an operator whose
+// own CA Secret is named with an appended ".tenant-ca", declared as the source
+// by its chart. Nothing validates that suffix; see projectionSuffix. The answer
+// depends entirely on content.
 //
 // A key-FREE Secret there is already the trust anchor the tenant needs: there
 // is nothing to extract, it is not the controller's to adopt, and that is a

--- a/internal/controller/cacert/reconciler_test.go
+++ b/internal/controller/cacert/reconciler_test.go
@@ -1488,10 +1488,14 @@ func TestOwnedSolelyBy(t *testing.T) {
 	}
 }
 
-// TestProjectionNameCannotCollideWithAnEngineCASecret pins the property the
-// canonical name exists to have: no engine CA Secret, for any release, can ever
-// produce the dotted "<release>.tenant-ca" name.
-func TestProjectionNameCannotCollideWithAnEngineCASecret(t *testing.T) {
+// TestProjectionNameCannotCollideWithADotFreeEngineSuffix pins the property the
+// canonical name exists to have, over the dot-free engine suffixes it samples:
+// no engine CA Secret takes the dotted "<release>.tenant-ca" name. Validation
+// elsewhere generalises this over the releases the apps API created and no
+// further, a hand-written HelmRelease being free to carry a dot in its name;
+// over suffixes nothing validates anything, so there the fixtures are the whole
+// coverage. See projectionSuffix.
+func TestProjectionNameCannotCollideWithADotFreeEngineSuffix(t *testing.T) {
 	engineSuffixes := []string{"-ca", "-ca-cert", "-cluster-ca-cert", "-clients-ca-cert", "-ssl", "-tls"}
 	prefixes := []string{"", "postgres-", "kafka-", "clickhouse-", "http-cache-"}
 	appNames := []string{
@@ -1500,8 +1504,8 @@ func TestProjectionNameCannotCollideWithAnEngineCASecret(t *testing.T) {
 	}
 
 	if !strings.HasPrefix(projectionSuffix, ".") {
-		t.Fatalf("the canonical suffix must start with a dot; it is what makes the name "+
-			"unreachable by any engine. Got %q", projectionSuffix)
+		t.Fatalf("the canonical suffix must start with a dot; it is what keeps the name "+
+			"out of reach of a dot-free engine suffix. Got %q", projectionSuffix)
 	}
 
 	for _, prefix := range prefixes {


### PR DESCRIPTION
## What this PR does

Comments in the CA-extraction package claim guards the code does not have. No behaviour change; one test is renamed to match the property it pins.

- `ManagedLabel` said the reconciler only ever writes over a Secret carrying that label. It does not. `isOurProjection` decides that from the Secret type and the owner reference, and never looks at the label, which any writer in the namespace can strip.
- `managedByCozystackLabel` said the reconciler never writes it. It deletes it whenever the selectors digest changes, which is what gets the projection re-admitted by the lineage webhook.
- `projectionSuffix` said the dotted canonical name cannot collide with an operator-owned object. A release the apps API created cannot carry a dot, since application names are DNS-1035 labels and `release.prefix` is restricted to `^[a-z0-9-]*$`. The guarantee stops there: the controller reads the release from the `helm.toolkit.fluxcd.io/name` label, where a dot is legal, so a hand-written HelmRelease sits outside it. On the validated path the dot can only come from the suffix an operator or chart appends, which nothing validates at all, and since a canonical name ends in `.tenant-ca` and carries that one dot, a suffix ending in `.tenant-ca` is the only one that reaches a canonical name. The comment says all of that now.
- The test pinning that name claimed the property for any engine suffix, in its doc and in its own name, while its loop samples only dot-free ones. It is now `TestProjectionNameCannotCollideWithADotFreeEngineSuffix`, and its doc says what the loop covers.

### Screenshots

Not a UI change.

### Downstream repositories

Comments and one test name in two Go files. No package, values key, schema field, CRD, metric, release asset or `hack/` target changes, so nothing in the trigger map fires.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified certificate reconciliation behavior, including label handling, projection naming, and source certificate scenarios.
  * Documented naming guarantees and their API boundaries more precisely.

* **Tests**
  * Updated test descriptions and failure messaging to clarify coverage for dot-free engine suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->