### PR TITLE
chore(seaweedfs): bump chart to 4.45

### DIFF
--- a/packages/system/seaweedfs/Makefile
+++ b/packages/system/seaweedfs/Makefile
@@ -29,6 +29,7 @@ update:
 	patch --no-backup-if-mismatch -p4 < patches/resize-api-server-annotation.diff
 	patch --no-backup-if-mismatch -p4 < patches/disable-ca-key-rotation.patch
 	patch --no-backup-if-mismatch -p4 < patches/s3-tls-main-port.patch
+	patch --no-backup-if-mismatch -p4 < patches/s3-iceberg-port-explicit.patch
 	patch --no-backup-if-mismatch -p4 < patches/cosi-provisioner-sa-name.patch
 	patch --no-backup-if-mismatch -p4 < patches/cosi-bucket-class-lock-readonly.patch
 	patch --no-backup-if-mismatch -p4 < patches/s3-service-name.patch

--- a/packages/system/seaweedfs/Makefile
+++ b/packages/system/seaweedfs/Makefile
@@ -27,6 +27,7 @@ update:
 	curl -sSL https://github.com/seaweedfs/seaweedfs/archive/refs/tags/$${version}.tar.gz | \
 	tar xzvf - --strip 3 -C charts seaweedfs-$${version}/k8s/charts/seaweedfs
 	patch --no-backup-if-mismatch -p4 < patches/resize-api-server-annotation.diff
+	patch --no-backup-if-mismatch -p4 < patches/volume-resize-quantity.diff
 	patch --no-backup-if-mismatch -p4 < patches/disable-ca-key-rotation.patch
 	patch --no-backup-if-mismatch -p4 < patches/s3-tls-main-port.patch
 	patch --no-backup-if-mismatch -p4 < patches/s3-iceberg-port-explicit.patch

--- a/packages/system/seaweedfs/charts/seaweedfs/Chart.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: SeaweedFS
 name: seaweedfs
-appVersion: "4.31"
+appVersion: "4.45"
 # Dev note: Trigger a helm chart release by `git tag -a helm-<version>`
-version: 4.31.0
+version: 4.45.0

--- a/packages/system/seaweedfs/charts/seaweedfs/README.md
+++ b/packages/system/seaweedfs/charts/seaweedfs/README.md
@@ -22,8 +22,8 @@ helm install --values=values.yaml seaweedfs seaweedfs/seaweedfs
 ## Info:
 * master/filer/volume are stateful sets with anti-affinity on the hostname,
 so your deployment will be spread/HA.
-* chart is using memsql(mysql) as the filer backend to enable HA (multiple filer instances) and backup/HA memsql can provide.
-* mysql user/password are created in a k8s secret (default: `<release>-seaweedfs-db-secret`) and injected to the filer with ENV.
+* leveldb2 is the default filer backend; a mysql-compatible database (memsql, ...) enables HA (multiple filer instances) and the backup/HA it can provide.
+* with `filer.extraEnvironmentVars.WEED_MYSQL_ENABLED` set to `"true"`, mysql user/password are created in a k8s secret (default: `<release>-seaweedfs-db-secret`) and injected to the filer with ENV. On any other store neither the secret nor the `WEED_MYSQL_*` env, plain or secret-backed, is rendered.
 * cert config exists and can be enabled, but not been tested, requires cert-manager to be installed.
 
 ## Prerequisites
@@ -107,6 +107,120 @@ https://github.com/rancher/local-path-provisioner
 you can use ANY storage class you like, just update the correct storage-class
 for your deployment.
 
+### Master data: hostPath vs a claim
+
+The master's `-mdir` holds its Raft log and snapshots, and with them the
+cluster's identity (its topology UUID). `master.data.type` defaults to
+`hostPath`, which does not follow a pod to another node: a master that is
+rescheduled comes back with an empty data directory and a brand new cluster
+UUID. With the chart's default of a single master replica there is no peer to
+recover the identity from either.
+
+Putting the master's data on a claim avoids that:
+
+```yaml
+master:
+  data:
+    type: "persistentVolumeClaim"
+    size: "1Gi"
+    storageClass: ""   # empty uses the cluster's default StorageClass
+```
+
+Raft state is small, so a modest claim is enough — sizing matters far more for
+volume and filer.
+
+The default is left at `hostPath` for backward compatibility:
+`volumeClaimTemplates` is immutable on a StatefulSet, so flipping the type on a
+release that already exists fails, whether the chart changes the default or you
+change it yourself:
+
+```text
+StatefulSet.apps "<release>-seaweedfs-master" is invalid: spec: Forbidden:
+updates to statefulset spec for fields other than 'replicas', ... are forbidden
+```
+
+New installs can set the claim from the start. To move an **existing** release
+onto a claim without losing the cluster UUID, use the migration below. The
+claim has to be seeded while the master is stopped: a running master rewrites
+its Raft state, so copying into a live pod is silently undone by the next
+restart.
+
+The steps below are for the chart's default of a single master
+(`master.replicas: 1`). With several master replicas, repeat steps 1, 3 and 4
+for every ordinal, or migrate one at a time and let the remaining quorum
+re-replicate.
+
+Take the names from the cluster rather than assembling them — the release
+name, `nameOverride` and `fullnameOverride` all feed the chart's fullname
+helper, so `<release>-seaweedfs` is not always right:
+
+```bash
+NS=<namespace>; REL=<release>
+# scope by instance as well as component: several releases can share a namespace
+STS=$(kubectl -n $NS get sts \
+        -l app.kubernetes.io/instance=$REL,app.kubernetes.io/component=master \
+        -o jsonpath='{.items[0].metadata.name}')
+POD=$STS-0
+# a StatefulSet names its claims <template>-<statefulset>-<ordinal>, and this
+# chart's template is data-<namespace>
+PVC=data-$NS-$STS-0
+
+# 1. back up the master data directory
+kubectl -n $NS cp $POD:/data ./master-backup
+
+# 2. stop the master, leaving the rest of the release running
+kubectl -n $NS delete sts $STS --cascade=orphan
+kubectl -n $NS delete pod $POD
+
+# 3. create the claim the new StatefulSet will adopt, and seed it through a
+#    pod that actually mounts it
+kubectl -n $NS apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: $PVC
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 1Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: seed
+spec:
+  containers:
+    - name: seed
+      image: alpine:3.20
+      command: ["sleep", "600"]
+      volumeMounts:
+        - name: d
+          mountPath: /data
+  volumes:
+    - name: d
+      persistentVolumeClaim:
+        claimName: $PVC
+EOF
+kubectl -n $NS wait --for=condition=Ready pod/seed --timeout=120s
+kubectl -n $NS cp ./master-backup/m9333 seed:/data/
+kubectl -n $NS exec seed -- ls /data/m9333    # conf, log, snapshot, state
+kubectl -n $NS delete pod seed
+
+# 4. upgrade; the StatefulSet adopts the claim you created
+helm upgrade $REL seaweedfs/seaweedfs -n $NS -f values.yaml
+```
+
+Confirm the UUID survived — it must match what the cluster reported before the
+migration:
+
+```bash
+kubectl -n $NS exec $POD -- curl -s localhost:9333/license/status
+```
+
+**Or accept a new cluster UUID** and, if you run the enterprise edition, have
+the license re-issued against it.
+
 ## current instances config (AIO):
 
 1 instance for each type (master/filer+s3/volume)
@@ -174,6 +288,32 @@ stringData:
   # this key must be an inline json config file
   seaweedfs_s3_config: '{"identities":[{"name":"anvAdmin","credentials":[{"accessKey":"snu8yoP6QAlY0ne4","secretKey":"PNzBcmeLNEdR0oviwm04NQAicOrDH1Km"}],"actions":["Admin","Read","Write"]},{"name":"anvReadOnly","credentials":[{"accessKey":"SCigFee6c5lbi04A","secretKey":"kgFhbT38R8WUYVtiFQ1OiSVOrYr3NKku"}],"actions":["Read"]}]}'
 ```
+
+#### Source S3 credentials from an existing Secret
+
+To keep the keys out of `values.yaml` while still letting the chart generate the
+identities file, point an identity at an existing Secret:
+
+```yaml
+s3:
+  enabled: true
+  enableAuth: true
+  credentials:
+    admin:
+      existingSecret: minio-root
+      accessKeyKey: root-user
+      secretKeyKey: root-password
+```
+
+`accessKeyKey` and `secretKeyKey` default to the chart's own key names
+(`admin_access_key_id`, `admin_secret_access_key`, and the `read_` pair). The
+generated `seaweedfs_s3_config` references the keys as `${SEAWEEDFS_S3_ADMIN_ACCESS_KEY_ID}`
+and the gateway resolves them from the environment, which the chart wires up
+from the Secret. Nothing is read from the cluster at render time, so
+`helm template`, `--dry-run` and an Argo CD diff all render what an install
+applies. Rotating a key in the Secret takes effect on the next pod restart, as
+with any other environment variable. The COSI driver parses the config itself
+and does not resolve these references.
 
 ## Admin Component
 
@@ -365,6 +505,47 @@ helm install seaweedfs-worker-vacuum seaweedfs/seaweedfs -f values-worker-vacuum
 helm install seaweedfs-worker-balance seaweedfs/seaweedfs -f values-worker-balance.yaml
 ```
 
+## Network Policies
+
+In a namespace with a default-deny policy the install hangs: the components cannot resolve each other, and the post-install bucket hook waits on the master and filer until it gives up. `networkPolicy.enabled` renders one `NetworkPolicy` per component, selecting its pods by the standard `app.kubernetes.io/{name,instance,component}` labels and admitting traffic from the other pods of the release on the ports that component listens on.
+
+```bash
+helm install seaweedfs seaweedfs/seaweedfs --set networkPolicy.enabled=true
+```
+
+That alone leaves outbound traffic untouched, which is enough when the namespace's default-deny only restricts ingress. If it lists `Egress` in its `policyTypes` too - the usual baseline - the components still cannot resolve DNS, and you need the second opt-in below as well.
+
+Egress is separate because the chart knows where its own components live but not where your filer store, notification sink or remote tier does, and because in a namespace with no default-deny at all, adding egress rules would narrow the components from "may reach anything" to "may reach these peers":
+
+```yaml
+networkPolicy:
+  enabled: true
+  egress:
+    enabled: true
+    kubeApiServer:
+      # the endpoint behind the kubernetes service, not its ClusterIP
+      cidrs: ["172.18.0.2/32"]
+    extraEgress:
+      - to:
+          - podSelector:
+              matchLabels:
+                app.kubernetes.io/name: postgresql
+        ports:
+          - protocol: TCP
+            port: 5432
+```
+
+`kubeApiServer.cidrs` is only demanded when something in the release actually needs the API server, which is the COSI sidecar and, on an upgrade that grows a volume PVC, the resize hook. No seaweedfs component itself speaks to it.
+
+Anything reaching the release from outside - an ingress controller, a Prometheus in another namespace - goes into `networkPolicy.extraIngress`, or into `networkPolicy.components.<component>.extraIngress` for a single component. See the `networkPolicy` block in `values.yaml` for the full set.
+
+Two things worth knowing before you turn this on:
+
+- **Monitoring stops.** The metrics ports are admitted from release pods like every other port, so with `global.seaweedfs.monitoring.enabled` the ServiceMonitors keep scraping targets a Prometheus in another namespace can no longer reach. Nothing reports it; add the scraper's namespace to `extraIngress`.
+- **The resize hook's policy is a Helm hook.** Its Job runs before the release manifest is applied, so the policy has to be a `pre-install` hook too. Helm does not garbage-collect hook resources, so on an upgrade that grows a volume PVC the policy is created and then left behind on uninstall - delete `<release>-seaweedfs-volume-resize-hook` by hand if it bothers you.
+
+The DNS selectors default to CoreDNS as kubeadm, kind and the managed offerings from AWS, Google and Azure install it. On OpenShift, override `egress.dnsNamespaceSelector` and `egress.dnsPodSelector` to match `openshift-dns`; see the comment in `values.yaml`.
+
 ## OpenShift Support
 
 SeaweedFS can be deployed on OpenShift or any cluster enforcing the Kubernetes "restricted" Pod Security Standard. By default, OpenShift blocks containers that run as root or use `hostPath` volumes.
@@ -385,3 +566,38 @@ helm install seaweedfs seaweedfs/seaweedfs \
 
 For enterprise users, please visit [seaweedfs.com](https://seaweedfs.com) for the SeaweedFS Enterprise Edition, 
 which has advanced features, including data recovery, self-healing storage, customizable erasure coding, EC vacuum and repair, etc.
+
+To run it, set the image and point the chart at a Secret holding the license
+file:
+
+```bash
+kubectl create secret generic seaweedfs-license -n <namespace> \
+  --from-file=seaweed-license.json=/path/to/seaweed-license.json
+```
+
+```yaml
+global:
+  seaweedfs:
+    image:
+      name: chrislusf/seaweedfs-enterprise
+    license:
+      existingSecret: seaweedfs-license
+      # secretKey: seaweed-license.json     # key within the Secret
+      # mountPath: /etc/seaweedfs/license   # directory it is mounted at
+```
+
+Set the image globally rather than per component: a per-component
+`imageOverride` wins, and a cluster that mixes editions comes up looking
+healthy with enterprise features quietly off.
+
+Only the master reads the license, so the Secret is mounted read-only there
+and on all-in-one (which runs `weed server -master`). It is mounted as a
+directory, not a `subPath`, so a renewed Secret reaches the running master —
+which re-reads the file periodically — without a restart.
+
+The license is tied to the cluster UUID kept in the master's Raft state, so put
+`master.data` on a claim — a master that restarts onto an empty data directory
+generates a new UUID and the license stops matching. See
+[Master data](#master-data-hostpath-vs-a-claim). Check the binding with
+`kubectl exec <master-pod> -- curl -s localhost:9333/license/status`
+(`cluster_uuid` must equal `license_uuid`).

--- a/packages/system/seaweedfs/charts/seaweedfs/ci/default-values.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Default configuration, kept so chart-testing still installs the chart as-is.

--- a/packages/system/seaweedfs/charts/seaweedfs/ci/sftp-values.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/ci/sftp-values.yaml
@@ -1,0 +1,5 @@
+# SFTP install: the pod only becomes ready if the server loads a host key
+# from the generated sftp-ssh-secret, so this exercises the whole path.
+sftp:
+  enabled: true
+  enableAuth: true

--- a/packages/system/seaweedfs/charts/seaweedfs/dashboards/seaweedfs-grafana-dashboard.json
+++ b/packages/system/seaweedfs/charts/seaweedfs/dashboards/seaweedfs-grafana-dashboard.json
@@ -3666,6 +3666,291 @@
       ],
       "title": "S3 Bucket Object Count",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 130
+      },
+      "id": 92,
+      "panels": [],
+      "title": "Filer Object Size Distribution",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rate of new objects created, split by size range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "objects/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 4,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short",
+          "unitScale": true
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 131
+      },
+      "id": 93,
+      "links": [],
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "8.1.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1024\",namespace=\"$NAMESPACE\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "< 1KB",
+          "refId": "A",
+          "step": 60
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"102400\",namespace=\"$NAMESPACE\"}[$__rate_interval])) - sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1024\",namespace=\"$NAMESPACE\"}[$__rate_interval])), 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "1KB - 100KB",
+          "refId": "B",
+          "step": 60
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+06\",namespace=\"$NAMESPACE\"}[$__rate_interval])) - sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"102400\",namespace=\"$NAMESPACE\"}[$__rate_interval])), 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "100KB - 1MB",
+          "refId": "C",
+          "step": 60
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+08\",namespace=\"$NAMESPACE\"}[$__rate_interval])) - sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+06\",namespace=\"$NAMESPACE\"}[$__rate_interval])), 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "1MB - 100MB",
+          "refId": "D",
+          "step": 60
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.073741824e+09\",namespace=\"$NAMESPACE\"}[$__rate_interval])) - sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+08\",namespace=\"$NAMESPACE\"}[$__rate_interval])), 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "100MB - 1GB",
+          "refId": "E",
+          "step": 60
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(rate(SeaweedFS_filer_object_size_bytes_count{namespace=\"$NAMESPACE\"}[$__rate_interval])) - sum(rate(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.073741824e+09\",namespace=\"$NAMESPACE\"}[$__rate_interval])), 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "> 1GB",
+          "refId": "F",
+          "step": 60
+        }
+      ],
+      "title": "Filer Object Write Rate by Size Range",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Objects created per size range over the selected time window.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 131
+      },
+      "id": 94,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "valueMode": "color"
+      },
+      "pluginVersion": "8.1.2",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1024\",namespace=\"$NAMESPACE\"}[$__range]))",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "< 1KB",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"102400\",namespace=\"$NAMESPACE\"}[$__range])) - sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1024\",namespace=\"$NAMESPACE\"}[$__range])), 0)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "1KB - 100KB",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+06\",namespace=\"$NAMESPACE\"}[$__range])) - sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"102400\",namespace=\"$NAMESPACE\"}[$__range])), 0)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "100KB - 1MB",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+08\",namespace=\"$NAMESPACE\"}[$__range])) - sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+06\",namespace=\"$NAMESPACE\"}[$__range])), 0)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "1MB - 100MB",
+          "refId": "D"
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.073741824e+09\",namespace=\"$NAMESPACE\"}[$__range])) - sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.048576e+08\",namespace=\"$NAMESPACE\"}[$__range])), 0)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "100MB - 1GB",
+          "refId": "E"
+        },
+        {
+          "exemplar": true,
+          "expr": "clamp_min(sum(increase(SeaweedFS_filer_object_size_bytes_count{namespace=\"$NAMESPACE\"}[$__range])) - sum(increase(SeaweedFS_filer_object_size_bytes_bucket{le=\"1.073741824e+09\",namespace=\"$NAMESPACE\"}[$__range])), 0)",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "> 1GB",
+          "refId": "F"
+        }
+      ],
+      "title": "Filer Object Size Distribution",
+      "type": "bargauge"
     }
   ],
   "refresh": "",

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/admin/admin-service.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/admin/admin-service.yaml
@@ -15,15 +15,27 @@ metadata:
     {{- toYaml .Values.admin.service.annotations | nindent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.admin.service.type }}
+  {{- $serviceType := .Values.admin.service.type }}
+  {{- $nodePorts := dict }}
+  {{- if or (eq $serviceType "NodePort") (eq $serviceType "LoadBalancer") }}
+  {{- $nodePorts = .Values.admin.service.nodePorts | default dict }}
+  {{- end }}
+  type: {{ $serviceType }}
+  {{- include "seaweedfs.service.loadBalancerFields" .Values.admin.service }}
   ports:
   - name: "http"
     port: {{ .Values.admin.port }}
     targetPort: {{ .Values.admin.port }}
+    {{- if $nodePorts.http }}
+    nodePort: {{ $nodePorts.http }}
+    {{- end }}
     protocol: TCP
   - name: "grpc"
     port: {{ .Values.admin.grpcPort }}
     targetPort: {{ .Values.admin.grpcPort }}
+    {{- if $nodePorts.grpc }}
+    nodePort: {{ $nodePorts.grpc }}
+    {{- end }}
     protocol: TCP
   selector:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/admin/admin-statefulset.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/admin/admin-statefulset.yaml
@@ -69,6 +69,9 @@ spec:
       {{- if .Values.admin.priorityClassName }}
       priorityClassName: {{ .Values.admin.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.admin.schedulerName }}
+      schedulerName: {{ .Values.admin.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       {{- if .Values.admin.serviceAccountName }}
       serviceAccountName: {{ .Values.admin.serviceAccountName | quote }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/all-in-one/all-in-one-deployment.yaml
@@ -64,6 +64,9 @@ spec:
       {{- if .Values.allInOne.priorityClassName }}
       priorityClassName: {{ .Values.allInOne.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.allInOne.schedulerName }}
+      schedulerName: {{ .Values.allInOne.schedulerName | quote }}
+      {{- end }}
       {{- if .Values.allInOne.serviceAccountName }}
       serviceAccountName: {{ .Values.allInOne.serviceAccountName | quote }}
       {{- end }}
@@ -80,9 +83,14 @@ spec:
           image: {{ template "seaweedfs.master.image" . }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
           env:
+            {{- include "seaweedfs.licenseEnv" . | nindent 12 }}
+            {{- if and .Values.allInOne.s3.enabled (or .Values.allInOne.s3.enableAuth .Values.s3.enableAuth .Values.filer.s3.enableAuth) }}
+            {{- include "seaweedfs.s3.credentialEnv" . | nindent 12 }}
+            {{- end }}
             {{- /* Determine default cluster alias and the corresponding env var keys to avoid conflicts */}}
-            {{- $envMerged := merge (.Values.global.seaweedfs.extraEnvironmentVars | default dict) (.Values.allInOne.extraEnvironmentVars | default dict) }}
-            {{- $clusterDefault := default "sw" (index $envMerged "WEED_CLUSTER_DEFAULT") }}
+            {{- $mergedExtraEnvironmentVars := dict }}
+            {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.allInOne "target" $mergedExtraEnvironmentVars) }}
+            {{- $clusterDefault := default "sw" (index $mergedExtraEnvironmentVars "WEED_CLUSTER_DEFAULT") }}
             {{- $clusterUpper := upper $clusterDefault }}
             {{- $clusterMasterKey := printf "WEED_CLUSTER_%s_MASTER" $clusterUpper }}
             {{- $clusterFilerKey := printf "WEED_CLUSTER_%s_FILER" $clusterUpper }}
@@ -100,8 +108,8 @@ spec:
                   fieldPath: metadata.namespace
             - name: SEAWEEDFS_FULLNAME
               value: "{{ include "seaweedfs.fullname" . }}"
-            {{- if .Values.allInOne.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.allInOne.extraEnvironmentVars }}
+            {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
+            {{- $value := index $mergedExtraEnvironmentVars $key }}
             {{- if and (ne $key $clusterMasterKey) (ne $key $clusterFilerKey) }}
             - name: {{ $key }}
               {{- if kindIs "string" $value }}
@@ -110,20 +118,6 @@ spec:
               valueFrom:
                 {{ toYaml $value | nindent 16 }}
               {{- end }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
-            {{- if .Values.global.seaweedfs.extraEnvironmentVars }}
-            {{- range $key, $value := .Values.global.seaweedfs.extraEnvironmentVars }}
-            {{- if and (ne $key $clusterMasterKey) (ne $key $clusterFilerKey) }}
-            - name: {{ $key }}
-              {{- if kindIs "string" $value }}
-              value: {{ tpl $value $ | quote }}
-              {{- else }}
-              valueFrom:
-                {{ toYaml $value | nindent 16 }}
-              {{- end }}
-            {{- end }}
             {{- end }}
             {{- end }}
             # Inject computed cluster endpoints for the default cluster
@@ -133,9 +127,11 @@ spec:
               value: {{ include "seaweedfs.cluster.filerAddress" . | quote }}
             {{- if .Values.allInOne.secretExtraEnvironmentVars }}
             {{- range $key, $value := .Values.allInOne.secretExtraEnvironmentVars }}
+            {{- if not (and $key (eq $key "SEAWEED_LICENSE") (include "seaweedfs.licenseEnabled" $)) }}
             - name: {{ $key }}
               valueFrom:
                 {{ toYaml $value | nindent 16 }}
+            {{- end }}
             {{- end }}
             {{- end }}
           command:
@@ -272,6 +268,9 @@ spec:
               {{- $authMethods := .Values.allInOne.sftp.authMethods | default .Values.sftp.authMethods }}
               {{- if $authMethods }}
               -sftp.authMethods={{ $authMethods }} \
+              {{- if contains "certificate" $authMethods }}
+              -sftp.trustedUserCAKeysFile=/etc/sw/sftp_ca/ca_user.pub \
+              {{- end }}
               {{- end }}
               {{- $maxAuthTries := .Values.allInOne.sftp.maxAuthTries | default .Values.sftp.maxAuthTries }}
               {{- if $maxAuthTries }}
@@ -312,11 +311,17 @@ spec:
             {{- end }}
             {{- if .Values.allInOne.sftp.enabled }}
             - name: config-ssh
-              mountPath: /etc/sw/ssh
+              mountPath: {{ .Values.allInOne.sftp.hostKeysFolder | default .Values.sftp.hostKeysFolder | default "/etc/sw/ssh" }}
               readOnly: true
             {{- if or .Values.allInOne.sftp.enableAuth .Values.sftp.enableAuth }}
             - mountPath: /etc/sw/sftp
               name: config-users
+              readOnly: true
+            {{- end }}
+            {{- $aioAuthMethods := .Values.allInOne.sftp.authMethods | default .Values.sftp.authMethods }}
+            {{- if and $aioAuthMethods (contains "certificate" $aioAuthMethods) }}
+            - mountPath: /etc/sw/sftp_ca
+              name: config-sftp-ca
               readOnly: true
             {{- end }}
             {{- end }}
@@ -356,6 +361,7 @@ spec:
             {{- include "seaweedfs.s3.tlsVolumeMount" . | nindent 12 }}
             {{- end }}
             {{- end }}
+            {{- include "seaweedfs.licenseVolumeMount" . | nindent 12 }}
             {{ tpl .Values.allInOne.extraVolumeMounts . | nindent 12 }}
           ports:
             - containerPort: {{ .Values.master.port }}
@@ -423,6 +429,7 @@ spec:
       {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.allInOne.sidecars "context" $) | nindent 8 }}
       {{- end }}
       volumes:
+        {{- include "seaweedfs.licenseVolume" . | nindent 8 }}
         - name: data
           {{- if eq .Values.allInOne.data.type "hostPath" }}
           hostPath:
@@ -453,6 +460,18 @@ spec:
           secret:
             defaultMode: 420
             secretName: {{ default (printf "%s-sftp-secret" (include "seaweedfs.fullname" .)) (or .Values.allInOne.sftp.existingConfigSecret .Values.sftp.existingConfigSecret) }}
+        {{- end }}
+        {{- $aioAuthMethodsVol := .Values.allInOne.sftp.authMethods | default .Values.sftp.authMethods }}
+        {{- if and $aioAuthMethodsVol (contains "certificate" $aioAuthMethodsVol) }}
+        {{- $aioCASecret := or .Values.allInOne.sftp.existingCAKeysSecret .Values.sftp.existingCAKeysSecret }}
+        {{- $aioCAKeys := or .Values.allInOne.sftp.trustedUserCAKeys .Values.sftp.trustedUserCAKeys }}
+        {{- if and (not $aioCASecret) (not $aioCAKeys) }}
+        {{- fail "allInOne.sftp.authMethods includes \"certificate\" but neither trustedUserCAKeys nor existingCAKeysSecret is set" }}
+        {{- end }}
+        - name: config-sftp-ca
+          secret:
+            defaultMode: 420
+            secretName: {{ default (printf "%s-sftp-ca-secret" (include "seaweedfs.fullname" .)) $aioCASecret }}
         {{- end }}
         {{- end }}
         {{- if .Values.filer.notificationConfig }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/all-in-one/all-in-one-service.yml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/all-in-one/all-in-one-service.yml
@@ -15,7 +15,13 @@ metadata:
     {{- toYaml .Values.allInOne.service.annotations | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.allInOne.service.type | default "ClusterIP" }}
+  {{- $serviceType := .Values.allInOne.service.type | default "ClusterIP" }}
+  {{- $nodePorts := dict }}
+  {{- if or (eq $serviceType "NodePort") (eq $serviceType "LoadBalancer") }}
+  {{- $nodePorts = .Values.allInOne.service.nodePorts | default dict }}
+  {{- end }}
+  type: {{ $serviceType }}
+  {{- include "seaweedfs.service.loadBalancerFields" .Values.allInOne.service }}
   internalTrafficPolicy: {{ .Values.allInOne.service.internalTrafficPolicy | default "Cluster" }}
   {{- if and (semverCompare ">=1.31-0" .Capabilities.KubeVersion.GitVersion) .Values.allInOne.s3.trafficDistribution }}
   trafficDistribution: {{ include "seaweedfs.trafficDistribution" (dict "value" .Values.allInOne.s3.trafficDistribution "Capabilities" .Capabilities) }}
@@ -25,30 +31,48 @@ spec:
   - name: "swfs-master"
     port: {{ .Values.master.port }}
     targetPort: {{ .Values.master.port }}
+    {{- if $nodePorts.master }}
+    nodePort: {{ $nodePorts.master }}
+    {{- end }}
     protocol: TCP
   - name: "swfs-master-grpc"
     port: {{ .Values.master.grpcPort }}
     targetPort: {{ .Values.master.grpcPort }}
+    {{- if $nodePorts.masterGrpc }}
+    nodePort: {{ $nodePorts.masterGrpc }}
+    {{- end }}
     protocol: TCP
-  
+
   # Volume ports
   - name: "swfs-volume"
     port: {{ .Values.volume.port }}
     targetPort: {{ .Values.volume.port }}
+    {{- if $nodePorts.volume }}
+    nodePort: {{ $nodePorts.volume }}
+    {{- end }}
     protocol: TCP
   - name: "swfs-volume-grpc"
     port: {{ .Values.volume.grpcPort }}
     targetPort: {{ .Values.volume.grpcPort }}
+    {{- if $nodePorts.volumeGrpc }}
+    nodePort: {{ $nodePorts.volumeGrpc }}
+    {{- end }}
     protocol: TCP
-  
+
   # Filer ports
   - name: "swfs-filer"
     port: {{ .Values.filer.port }}
     targetPort: {{ .Values.filer.port }}
+    {{- if $nodePorts.filer }}
+    nodePort: {{ $nodePorts.filer }}
+    {{- end }}
     protocol: TCP
   - name: "swfs-filer-grpc"
     port: {{ .Values.filer.grpcPort }}
     targetPort: {{ .Values.filer.grpcPort }}
+    {{- if $nodePorts.filerGrpc }}
+    nodePort: {{ $nodePorts.filerGrpc }}
+    {{- end }}
     protocol: TCP
   
   # S3 ports (if enabled)
@@ -56,21 +80,30 @@ spec:
   - name: "swfs-s3"
     port: {{ .Values.allInOne.s3.port | default .Values.s3.port }}
     targetPort: {{ .Values.allInOne.s3.port | default .Values.s3.port }}
+    {{- if $nodePorts.s3 }}
+    nodePort: {{ $nodePorts.s3 }}
+    {{- end }}
     protocol: TCP
   {{- $httpsPort := .Values.allInOne.s3.httpsPort | default .Values.s3.httpsPort }}
   {{- if $httpsPort }}
   - name: "swfs-s3-tls"
     port: {{ $httpsPort }}
     targetPort: {{ $httpsPort }}
+    {{- if $nodePorts.s3Https }}
+    nodePort: {{ $nodePorts.s3Https }}
+    {{- end }}
     protocol: TCP
   {{- end }}
   {{- end }}
-  
+
   # SFTP ports (if enabled)
   {{- if .Values.allInOne.sftp.enabled }}
   - name: "swfs-sftp"
     port: {{ .Values.allInOne.sftp.port | default .Values.sftp.port }}
     targetPort: {{ .Values.allInOne.sftp.port | default .Values.sftp.port }}
+    {{- if $nodePorts.sftp }}
+    nodePort: {{ $nodePorts.sftp }}
+    {{- end }}
     protocol: TCP
   {{- end }}
 
@@ -79,6 +112,9 @@ spec:
   - name: "server-metrics"
     port: {{ .Values.allInOne.metricsPort }}
     targetPort: {{ .Values.allInOne.metricsPort }}
+    {{- if $nodePorts.metrics }}
+    nodePort: {{ $nodePorts.metrics }}
+    {{- end }}
     protocol: TCP
   {{- end }}
   

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cert/admin-cert.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cert/admin-cert.yaml
@@ -29,6 +29,11 @@ spec:
     - '*.{{ include "seaweedfs.fullname" . }}-admin.{{ .Release.Namespace }}'
     - '*.{{ include "seaweedfs.fullname" . }}-admin.{{ .Release.Namespace }}.svc'
     - '*.{{ include "seaweedfs.fullname" . }}-admin.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.dnsNames }}
+{{- range .Values.certificates.dnsNames }}
+    - {{ . | quote }}
+{{- end }}
+{{- end }}
 {{- if .Values.certificates.ipAddresses }}
   ipAddresses:
     {{- range .Values.certificates.ipAddresses }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cert/client-cert.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cert/client-cert.yaml
@@ -23,6 +23,11 @@ spec:
     - '*.{{ .Release.Namespace }}'
     - '*.{{ .Release.Namespace }}.svc'
     - '*.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.dnsNames }}
+{{- range .Values.certificates.dnsNames }}
+    - {{ . | quote }}
+{{- end }}
+{{- end }}
     - '*.{{ include "seaweedfs.fullname" . }}-master'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc'

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cert/filer-cert.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cert/filer-cert.yaml
@@ -28,6 +28,11 @@ spec:
     - '*.{{ .Release.Namespace }}'
     - '*.{{ .Release.Namespace }}.svc'
     - '*.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.dnsNames }}
+{{- range .Values.certificates.dnsNames }}
+    - {{ . | quote }}
+{{- end }}
+{{- end }}
     - '*.{{ include "seaweedfs.fullname" . }}-master'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc'

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cert/master-cert.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cert/master-cert.yaml
@@ -28,6 +28,11 @@ spec:
     - '*.{{ .Release.Namespace }}'
     - '*.{{ .Release.Namespace }}.svc'
     - '*.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.dnsNames }}
+{{- range .Values.certificates.dnsNames }}
+    - {{ . | quote }}
+{{- end }}
+{{- end }}
     - '*.{{ include "seaweedfs.fullname" . }}-master'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc'

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cert/volume-cert.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cert/volume-cert.yaml
@@ -28,6 +28,11 @@ spec:
     - '*.{{ .Release.Namespace }}'
     - '*.{{ .Release.Namespace }}.svc'
     - '*.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.dnsNames }}
+{{- range .Values.certificates.dnsNames }}
+    - {{ . | quote }}
+{{- end }}
+{{- end }}
     - '*.{{ include "seaweedfs.fullname" . }}-master'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}'
     - '*.{{ include "seaweedfs.fullname" . }}-master.{{ .Release.Namespace }}.svc'

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cert/worker-cert.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cert/worker-cert.yaml
@@ -29,6 +29,11 @@ spec:
     - '*.{{ include "seaweedfs.fullname" . }}-worker.{{ .Release.Namespace }}'
     - '*.{{ include "seaweedfs.fullname" . }}-worker.{{ .Release.Namespace }}.svc'
     - '*.{{ include "seaweedfs.fullname" . }}-worker.{{ .Release.Namespace }}.svc.cluster.local'
+{{- if .Values.certificates.dnsNames }}
+{{- range .Values.certificates.dnsNames }}
+    - {{ . | quote }}
+{{- end }}
+{{- end }}
 {{- if .Values.certificates.ipAddresses }}
   ipAddresses:
     {{- range .Values.certificates.ipAddresses }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/cosi/cosi-deployment.yaml
@@ -57,6 +57,9 @@ spec:
       {{- if .Values.cosi.priorityClassName }}
       priorityClassName: {{ .Values.cosi.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.cosi.schedulerName }}
+      schedulerName: {{ .Values.cosi.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       serviceAccountName: {{ .Values.global.seaweedfs.serviceAccountName }}-objectstorage-provisioner
       {{- if .Values.cosi.initContainers }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-grpc-ingressroutetcp.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-grpc-ingressroutetcp.yaml
@@ -1,0 +1,47 @@
+{{- /* Traefik IngressRouteTCP for the filer gRPC port. Rendered instead of the
+       standard Ingress when the gRPC ingress className starts with "traefik",
+       since a Kubernetes Ingress can't do raw TCP/gRPC passthrough.
+
+       global.seaweedfs.enableSecurity controls the mode:
+         false: plain TCP, Traefik forwards h2c to the pod. A non-TLS TCP
+                router can only match HostSNI(`*`) (SNI needs TLS).
+         true:  TLS passthrough, matched by SNI so it can route on the host. */}}
+
+{{- $filerEnabled := or .Values.filer.enabled .Values.allInOne.enabled }}
+{{- $isTraefik := hasPrefix "traefik" (default "" .Values.filer.ingresses.grpc.className) }}
+{{- $securityEnabled := .Values.global.seaweedfs.enableSecurity }}
+
+{{- if and $filerEnabled .Values.filer.ingresses.grpc.enabled $isTraefik }}
+{{- $serviceName := ternary (include "seaweedfs.componentName" (list . "all-in-one")) (include "seaweedfs.componentName" (list . "filer")) .Values.allInOne.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-filer-grpc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: filer
+spec:
+  {{- if $securityEnabled }}
+  tls:
+    passthrough: true
+  {{- end }}
+  entryPoints:
+    {{- with .Values.filer.ingresses.grpc.entryPoint }}
+    - {{ . | quote }}
+    {{- else }}
+    - filer-grpc
+    {{- end }}
+  routes:
+    {{- if $securityEnabled }}
+    - match: HostSNI(`{{ .Values.filer.ingresses.grpc.host }}`)
+    {{- else }}
+    - match: HostSNI(`*`)
+    {{- end }}
+      services:
+        - name: {{ $serviceName }}
+          port: {{ .Values.filer.grpcPort }}
+{{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-ingress.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-ingress.yaml
@@ -1,6 +1,8 @@
-{{- /* Filer ingress works for both normal mode (filer.enabled) and all-in-one mode (allInOne.enabled) */}}
+{{- /* Filer ingresses work for both normal mode (filer.enabled) and all-in-one mode (allInOne.enabled) */}}
 {{- $filerEnabled := or .Values.filer.enabled .Values.allInOne.enabled }}
-{{- if and $filerEnabled .Values.filer.ingress.enabled }}
+
+{{- /* HTTP Ingress */}}
+{{- if and $filerEnabled .Values.filer.ingresses.http.enabled }}
 {{- /* Determine service name based on deployment mode */}}
 {{- $serviceName := ternary (include "seaweedfs.componentName" (list . "all-in-one")) (include "seaweedfs.componentName" (list . "filer")) .Values.allInOne.enabled }}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
@@ -12,10 +14,13 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: ingress-{{ include "seaweedfs.fullname" . }}-filer
+  name: ingress-{{ include "seaweedfs.fullname" . }}-filer-http
   namespace: {{ .Release.Namespace }}
-  {{- with .Values.filer.ingress.annotations }}
   annotations:
+  {{- if and (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) .Values.filer.ingresses.http.className }}
+    kubernetes.io/ingress.class: {{ .Values.filer.ingresses.http.className }}
+  {{- end }}
+  {{- with .Values.filer.ingresses.http.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
@@ -25,14 +30,21 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
 spec:
-  ingressClassName: {{ .Values.filer.ingress.className | quote }}
+  {{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) .Values.filer.ingresses.http.className }}
+  ingressClassName: {{ .Values.filer.ingresses.http.className | quote }}
+  {{- end }}
   tls:
-    {{ .Values.filer.ingress.tls | default list | toYaml | nindent 6}}
+    {{ .Values.filer.ingresses.http.tls | default list | toYaml | nindent 6}}
   rules:
-  - http:
+  - {{- if .Values.filer.ingresses.http.host }}
+    host: {{ .Values.filer.ingresses.http.host | quote }}
+    {{- end }}
+    http:
       paths:
-      - path: {{ .Values.filer.ingress.path | quote }}
-        pathType: {{ .Values.filer.ingress.pathType | quote }}
+      - path: {{ .Values.filer.ingresses.http.path | quote }}
+        {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+        pathType: {{ .Values.filer.ingresses.http.pathType | quote }}
+        {{- end }}
         backend:
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
           service:
@@ -43,7 +55,62 @@ spec:
           serviceName: {{ $serviceName }}
           servicePort: {{ .Values.filer.port }}
 {{- end }}
-{{- if .Values.filer.ingress.host }}
-    host: {{ .Values.filer.ingress.host }}
+{{- end }}
+
+---
+
+{{- /* gRPC Ingress (standard Kubernetes Ingress, NOT for Traefik) */}}
+{{- if and $filerEnabled .Values.filer.ingresses.grpc.enabled (not (hasPrefix "traefik" (default "" .Values.filer.ingresses.grpc.className))) }}
+{{- /* Determine service name based on deployment mode */}}
+{{- $serviceName := ternary (include "seaweedfs.componentName" (list . "all-in-one")) (include "seaweedfs.componentName" (list . "filer")) .Values.allInOne.enabled }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: ingress-{{ include "seaweedfs.fullname" . }}-filer-grpc
+  namespace: {{ .Release.Namespace }}
+  annotations:
+  {{- if and (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) .Values.filer.ingresses.grpc.className }}
+    kubernetes.io/ingress.class: {{ .Values.filer.ingresses.grpc.className }}
+  {{- end }}
+  {{- with .Values.filer.ingresses.grpc.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: filer
+spec:
+  {{- if and (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) .Values.filer.ingresses.grpc.className }}
+  ingressClassName: {{ .Values.filer.ingresses.grpc.className | quote }}
+  {{- end }}
+  tls:
+    {{ .Values.filer.ingresses.grpc.tls | default list | toYaml | nindent 6}}
+  rules:
+  - {{- if .Values.filer.ingresses.grpc.host }}
+    host: {{ .Values.filer.ingresses.grpc.host | quote }}
+    {{- end }}
+    http:
+      paths:
+      - path: {{ .Values.filer.ingresses.grpc.path | quote }}
+        {{- if semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion }}
+        pathType: {{ .Values.filer.ingresses.grpc.pathType | quote }}
+        {{- end }}
+        backend:
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: {{ $serviceName }}
+            port:
+              number: {{ .Values.filer.grpcPort }}
+{{- else }}
+          serviceName: {{ $serviceName }}
+          servicePort: {{ .Values.filer.grpcPort }}
 {{- end }}
 {{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-service-client.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-service-client.yaml
@@ -10,9 +10,6 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
-{{- if .Values.filer.metricsPort }}
-    monitoring: "true"
-{{- end }}
 {{- if .Values.filer.annotations }}
   annotations:
     {{- toYaml .Values.filer.annotations | nindent 4 }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-service.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-service.yaml
@@ -2,8 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
   name: {{ include "seaweedfs.componentName" (list . "filer") }}
   namespace: {{ .Release.Namespace }}
   labels:
@@ -12,8 +10,12 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: filer
-{{- if .Values.filer.annotations }}
+{{- if .Values.filer.metricsPort }}
+    monitoring: "true"
+{{- end }}
   annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+{{- if .Values.filer.annotations }}
     {{- toYaml .Values.filer.annotations | nindent 4 }}
 {{- end }}
 spec:

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-servicemonitor.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-servicemonitor.yaml
@@ -30,6 +30,7 @@ spec:
       app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
       app.kubernetes.io/component: filer
+      monitoring: "true"
 {{- end }}
 {{- end }}
 {{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-statefulset.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/filer/filer-statefulset.yaml
@@ -76,6 +76,9 @@ spec:
       {{- if .Values.filer.priorityClassName }}
       priorityClassName: {{ .Values.filer.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.filer.schedulerName }}
+      schedulerName: {{ .Values.filer.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       {{- if .Values.filer.initContainers }}
       initContainers:
@@ -89,6 +92,7 @@ spec:
           image: {{ template "seaweedfs.filer.image" . }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
           env:
+            {{- $mysqlEnabled := include "seaweedfs.filer.mysqlEnabled" . }}
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -101,6 +105,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            {{- if $mysqlEnabled }}
             - name: WEED_MYSQL_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -113,10 +118,21 @@ spec:
                   name: {{ include "seaweedfs.fullname" . }}-db-secret
                   key: password
                   optional: true
+            {{- end }}
             - name: SEAWEEDFS_FULLNAME
               value: "{{ include "seaweedfs.fullname" . }}"
+            {{- if and .Values.filer.s3.enabled .Values.filer.s3.enableAuth }}
+            {{- include "seaweedfs.s3.credentialEnv" . | nindent 12 }}
+            {{- end }}
             {{- $mergedExtraEnvironmentVars := dict }}
             {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.filer "target" $mergedExtraEnvironmentVars) }}
+            {{- if not $mysqlEnabled }}
+            {{- range $key := keys $mergedExtraEnvironmentVars }}
+            {{- if hasPrefix "WEED_MYSQL_" $key }}
+            {{- $_ := unset $mergedExtraEnvironmentVars $key }}
+            {{- end }}
+            {{- end }}
+            {{- end }}
             {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
             {{- $value := index $mergedExtraEnvironmentVars $key }}
             - name: {{ $key }}
@@ -129,8 +145,10 @@ spec:
             {{- end }}
             {{- if .Values.filer.secretExtraEnvironmentVars }}
             {{- range $key, $value := .Values.filer.secretExtraEnvironmentVars }}
+            {{- if or $mysqlEnabled (not (hasPrefix "WEED_MYSQL_" $key)) }}
             - name: {{ $key }}
               valueFrom: {{ toYaml $value | nindent 16 }}
+            {{- end }}
             {{- end }}
             {{- end }}
           command:
@@ -356,6 +374,7 @@ spec:
         - name: db-schema-config-volume
           configMap:
             name: {{ default (printf "%s-db-init-config" (include "seaweedfs.fullname" .)) .Values.filer.dbInitConfigName }}
+            optional: true
         {{- if and .Values.filer.s3.enabled .Values.filer.s3.enableAuth }}
         - name: config-users
           secret:

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/master/master-statefulset.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/master/master-statefulset.yaml
@@ -69,6 +69,9 @@ spec:
       {{- if .Values.master.priorityClassName }}
       priorityClassName: {{ .Values.master.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.master.schedulerName }}
+      schedulerName: {{ .Values.master.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       serviceAccountName: {{ .Values.master.serviceAccountName | default (include "seaweedfs.serviceAccountName" .) | quote }} # for deleting statefulset pods after migration
       {{- if .Values.master.initContainers }}
@@ -83,6 +86,7 @@ spec:
           image: {{ template "seaweedfs.master.image" . }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
           env:
+            {{- include "seaweedfs.licenseEnv" . | nindent 12 }}
             - name: POD_IP
               valueFrom:
                 fieldRef:
@@ -211,6 +215,7 @@ spec:
               readOnly: true
               mountPath: /usr/local/share/ca-certificates/client/
             {{- end }}
+            {{- include "seaweedfs.licenseVolumeMount" . | nindent 12 }}
             {{ tpl .Values.master.extraVolumeMounts . | nindent 12 | trim }}
           ports:
             - containerPort: {{ .Values.master.port }}
@@ -256,6 +261,7 @@ spec:
         {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.master.sidecars "context" $) | nindent 8 }}
         {{- end }}
       volumes:
+        {{- include "seaweedfs.licenseVolume" . | nindent 8 }}
         {{- if eq .Values.master.logs.type "hostPath" }}
         - name: seaweedfs-master-log-volume
           hostPath:

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
@@ -61,6 +61,9 @@ spec:
       {{- if .Values.s3.priorityClassName }}
       priorityClassName: {{ .Values.s3.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.s3.schedulerName }}
+      schedulerName: {{ .Values.s3.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       {{- if .Values.s3.serviceAccountName }}
       serviceAccountName: {{ .Values.s3.serviceAccountName | quote }}
@@ -91,6 +94,9 @@ spec:
                   fieldPath: metadata.namespace
             - name: SEAWEEDFS_FULLNAME
               value: "{{ include "seaweedfs.fullname" . }}"
+            {{- if .Values.s3.enableAuth }}
+            {{- include "seaweedfs.s3.credentialEnv" . | nindent 12 }}
+            {{- end }}
             {{- $mergedExtraEnvironmentVars := dict }}
             {{- include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.s3 "target" $mergedExtraEnvironmentVars) }}
             {{- range $key := keys $mergedExtraEnvironmentVars | sortAlpha }}
@@ -143,6 +149,8 @@ spec:
               {{- if .Values.s3.icebergPort }}
               -port.iceberg={{ .Values.s3.icebergPort }} \
               {{- end }}
+              {{- /* rendered even when 0: an if would drop the flag and weed would serve its default */}}
+              -port.lance={{ .Values.s3.lancePort | default 0 }} \
               {{- range .Values.s3.extraArgs }}
               {{ . }} \
               {{- end }}
@@ -191,6 +199,10 @@ spec:
             {{- if .Values.s3.icebergPort }}
             - containerPort: {{ .Values.s3.icebergPort }}
               name: swfs-iceberg
+            {{- end }}
+            {{- if .Values.s3.lancePort }}
+            - containerPort: {{ .Values.s3.lancePort }}
+              name: swfs-lance
             {{- end }}
             {{- if .Values.s3.metricsPort }}
             - containerPort: {{ .Values.s3.metricsPort }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
@@ -146,9 +146,8 @@ spec:
               -auditLogConfig=/etc/sw/s3_auditLogConfig.json \
               {{- end }}
               -filer={{ include "seaweedfs.componentName" (list . "filer-client") }}.{{ .Release.Namespace }}:{{ .Values.filer.port }} \
-              {{- if .Values.s3.icebergPort }}
-              -port.iceberg={{ .Values.s3.icebergPort }} \
-              {{- end }}
+              {{- /* rendered even when 0: an if would drop the flag and weed would serve its 8181 default */}}
+              -port.iceberg={{ .Values.s3.icebergPort | default 0 }} \
               {{- /* rendered even when 0: an if would drop the flag and weed would serve its default */}}
               -port.lance={{ .Values.s3.lancePort | default 0 }} \
               {{- range .Values.s3.extraArgs }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-lance-ingress.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-lance-ingress.yaml
@@ -1,0 +1,61 @@
+{{- define "seaweedfs.s3.lance.ingress.paths" -}}
+paths:
+- path: {{ .Values.s3.lanceIngress.path | quote }}
+  pathType: {{ .Values.s3.lanceIngress.pathType | quote }}
+  backend:
+    {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+    service:
+      name: {{ include "seaweedfs.componentName" (list . "s3") }}
+      port:
+        number: {{ .Values.s3.lancePort }}
+    {{- else }}
+    serviceName: {{ include "seaweedfs.componentName" (list . "s3") }}
+    servicePort: {{ .Values.s3.lancePort }}
+    {{- end }}
+{{- end -}}
+{{- if and .Values.s3.enabled .Values.s3.lancePort .Values.s3.lanceIngress.enabled }}
+{{- $hosts := list }}
+{{- if kindIs "slice" .Values.s3.lanceIngress.host }}
+  {{- $hosts = .Values.s3.lanceIngress.host }}
+{{- else if .Values.s3.lanceIngress.host }}
+  {{- $hosts = list .Values.s3.lanceIngress.host }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: ingress-{{ include "seaweedfs.fullname" . }}-s3-lance
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.s3.lanceIngress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: s3-lance
+spec:
+  {{- if .Values.s3.lanceIngress.className }}
+  ingressClassName: {{ .Values.s3.lanceIngress.className | quote }}
+  {{- end }}
+  tls:
+    {{ .Values.s3.lanceIngress.tls | default list | toYaml | nindent 6}}
+  rules:
+{{- if $hosts }}
+{{- range $host := $hosts }}
+  - host: {{ $host | quote }}
+    http:
+      {{- include "seaweedfs.s3.lance.ingress.paths" $ | nindent 6 }}
+{{- end }}
+{{- else }}
+  - http:
+      {{- include "seaweedfs.s3.lance.ingress.paths" . | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-secret.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-secret.yaml
@@ -1,4 +1,7 @@
-{{- if or (and (or .Values.s3.enabled .Values.allInOne.enabled) .Values.s3.enableAuth (not .Values.s3.existingConfigSecret)) (and .Values.filer.s3.enabled .Values.filer.s3.enableAuth (not .Values.filer.s3.existingConfigSecret)) }}
+{{- /* Mirrors the condition the all-in-one deployment mounts this secret under,
+       so the flags that make it mount are exactly the flags that create it. */}}
+{{- $allInOneAuth := and .Values.allInOne.enabled .Values.allInOne.s3.enabled (or .Values.allInOne.s3.enableAuth .Values.s3.enableAuth .Values.filer.s3.enableAuth) (not (or .Values.allInOne.s3.existingConfigSecret .Values.s3.existingConfigSecret .Values.filer.s3.existingConfigSecret)) }}
+{{- if or (and (or .Values.s3.enabled .Values.allInOne.enabled) .Values.s3.enableAuth (not .Values.s3.existingConfigSecret)) (and .Values.filer.s3.enabled .Values.filer.s3.enableAuth (not .Values.filer.s3.existingConfigSecret)) $allInOneAuth }}
 {{- $secretName := printf "%s-s3-secret" (include "seaweedfs.fullname" .) }}
 {{- $legacySecretName := "seaweedfs-s3-secret" }}
 {{- $lookupName := $secretName }}
@@ -14,14 +17,20 @@
 {{- $adminCreds := $creds.admin | default dict -}}
 {{- $access_key_admin := $adminCreds.accessKey -}}
 {{- $secret_key_admin := $adminCreds.secretKey -}}
-{{- if not (and $access_key_admin $secret_key_admin) -}}
+{{- if $adminCreds.existingSecret -}}
+  {{- $access_key_admin = printf "${%s}" (include "seaweedfs.s3.credentialEnvName" (list "admin" "accessKey")) -}}
+  {{- $secret_key_admin = printf "${%s}" (include "seaweedfs.s3.credentialEnvName" (list "admin" "secretKey")) -}}
+{{- else if not (and $access_key_admin $secret_key_admin) -}}
   {{- $access_key_admin = include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_access_key_id" "length" 20 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
   {{- $secret_key_admin = include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_secret_access_key" "length" 40 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
 {{- end -}}
 {{- $readCreds := $creds.read | default dict -}}
 {{- $access_key_read := $readCreds.accessKey -}}
 {{- $secret_key_read := $readCreds.secretKey -}}
-{{- if not (and $access_key_read $secret_key_read) -}}
+{{- if $readCreds.existingSecret -}}
+  {{- $access_key_read = printf "${%s}" (include "seaweedfs.s3.credentialEnvName" (list "read" "accessKey")) -}}
+  {{- $secret_key_read = printf "${%s}" (include "seaweedfs.s3.credentialEnvName" (list "read" "secretKey")) -}}
+{{- else if not (and $access_key_read $secret_key_read) -}}
   {{- $access_key_read = include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "read_access_key_id" "length" 20 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
   {{- $secret_key_read = include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "read_secret_access_key" "length" 40 "existingSecret" (ternary $existingSecret nil $reuse)) -}}
 {{- end -}}
@@ -41,10 +50,16 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: s3
 stringData:
+  {{- /* An identity read from an existing Secret keeps its keys there; the
+         config below names the environment variables carrying them. */}}
+  {{- if not $adminCreds.existingSecret }}
   admin_access_key_id: {{ $access_key_admin }}
   admin_secret_access_key: {{ $secret_key_admin }}
+  {{- end }}
+  {{- if not $readCreds.existingSecret }}
   read_access_key_id: {{ $access_key_read }}
   read_secret_access_key: {{ $secret_key_read }}
+  {{- end }}
   seaweedfs_s3_config: '{"identities":[{"name":"anvAdmin","credentials":[{"accessKey":"{{ $access_key_admin }}","secretKey":"{{ $secret_key_admin }}"}],"actions":["Admin","Read","Write"]},{"name":"anvReadOnly","credentials":[{"accessKey":"{{ $access_key_read }}","secretKey":"{{ $secret_key_read }}"}],"actions":["Read"]}]}'
   {{- if .Values.filer.s3.auditLogConfig }}
   filer_s3_auditLogConfig.json: |

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-service.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-service.yaml
@@ -15,7 +15,13 @@ metadata:
     {{- toYaml .Values.s3.annotations | nindent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.s3.service.type }}
+  {{- $serviceType := .Values.s3.service.type }}
+  {{- $nodePorts := dict }}
+  {{- if or (eq $serviceType "NodePort") (eq $serviceType "LoadBalancer") }}
+  {{- $nodePorts = .Values.s3.service.nodePorts | default dict }}
+  {{- end }}
+  type: {{ $serviceType }}
+  {{- include "seaweedfs.service.loadBalancerFields" .Values.s3.service }}
   internalTrafficPolicy: {{ .Values.s3.internalTrafficPolicy | default "Cluster" }}
   {{- $td := .Values.s3.trafficDistribution | default .Values.filer.s3.trafficDistribution }}
   {{- if and (semverCompare ">=1.31-0" .Capabilities.KubeVersion.GitVersion) $td }}
@@ -25,23 +31,44 @@ spec:
   - name: "swfs-s3"
     port: {{ if .Values.s3.enabled }}{{ .Values.s3.port }}{{ else }}{{ .Values.filer.s3.port }}{{ end }}
     targetPort: {{ if .Values.s3.enabled }}{{ .Values.s3.port }}{{ else }}{{ .Values.filer.s3.port }}{{ end }}
+{{- if $nodePorts.http }}
+    nodePort: {{ $nodePorts.http }}
+{{- end }}
     protocol: TCP
 {{- if and .Values.s3.enabled .Values.s3.icebergPort }}
   - name: "swfs-iceberg"
     port: {{ .Values.s3.icebergPort }}
     targetPort: {{ .Values.s3.icebergPort }}
+{{- if $nodePorts.iceberg }}
+    nodePort: {{ $nodePorts.iceberg }}
+{{- end }}
+    protocol: TCP
+{{- end }}
+{{- if and .Values.s3.enabled .Values.s3.lancePort }}
+  - name: "swfs-lance"
+    port: {{ .Values.s3.lancePort }}
+    targetPort: {{ .Values.s3.lancePort }}
+{{- if $nodePorts.lance }}
+    nodePort: {{ $nodePorts.lance }}
+{{- end }}
     protocol: TCP
 {{- end }}
 {{- if and .Values.s3.enabled .Values.s3.httpsPort }}
   - name: "swfs-s3-tls"
     port: {{ .Values.s3.httpsPort }}
     targetPort: {{ .Values.s3.httpsPort }}
+{{- if $nodePorts.https }}
+    nodePort: {{ $nodePorts.https }}
+{{- end }}
     protocol: TCP
 {{- end }}
 {{- if and .Values.s3.enabled .Values.s3.metricsPort }}
   - name: "metrics"
     port: {{ .Values.s3.metricsPort }}
     targetPort: {{ .Values.s3.metricsPort }}
+{{- if $nodePorts.metrics }}
+    nodePort: {{ $nodePorts.metrics }}
+{{- end }}
     protocol: TCP
 {{- end }}
   selector:

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-ca-secret.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-ca-secret.yaml
@@ -1,0 +1,40 @@
+{{- include "seaweedfs.compat" . -}}
+{{- /*
+Render a chart-managed Secret carrying the SSH user CA public key(s) for
+certificate-based SFTP authentication, but only when:
+  - SFTP (standalone or all-in-one) is enabled,
+  - "certificate" is in the relevant authMethods list,
+  - the user provided inline CA keys via sftp.trustedUserCAKeys, and
+  - no existingCAKeysSecret is set (which would supersede this Secret).
+*/}}
+{{- $sftpEnabled := or .Values.sftp.enabled (and .Values.allInOne.enabled .Values.allInOne.sftp.enabled) -}}
+{{- $authMethods := .Values.sftp.authMethods -}}
+{{- if and .Values.allInOne.enabled .Values.allInOne.sftp.authMethods -}}
+{{- $authMethods = .Values.allInOne.sftp.authMethods -}}
+{{- end -}}
+{{- $certInMethods := and $authMethods (contains "certificate" $authMethods) -}}
+{{- $inlineCAKeys := .Values.sftp.trustedUserCAKeys -}}
+{{- if and .Values.allInOne.enabled .Values.allInOne.sftp.trustedUserCAKeys -}}
+{{- $inlineCAKeys = .Values.allInOne.sftp.trustedUserCAKeys -}}
+{{- end -}}
+{{- $existingSecret := .Values.sftp.existingCAKeysSecret -}}
+{{- if and .Values.allInOne.enabled .Values.allInOne.sftp.existingCAKeysSecret -}}
+{{- $existingSecret = .Values.allInOne.sftp.existingCAKeysSecret -}}
+{{- end -}}
+{{- if and $sftpEnabled $certInMethods $inlineCAKeys (not $existingSecret) }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "seaweedfs.fullname" . }}-sftp-ca-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: sftp
+stringData:
+  ca_user.pub: |
+{{ $inlineCAKeys | indent 4 }}
+{{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-deployment.yaml
@@ -61,6 +61,9 @@ spec:
       {{- if .Values.sftp.priorityClassName }}
       priorityClassName: {{ .Values.sftp.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.sftp.schedulerName }}
+      schedulerName: {{ .Values.sftp.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       {{- if .Values.sftp.serviceAccountName }}
       serviceAccountName: {{ .Values.sftp.serviceAccountName | quote }}
@@ -135,6 +138,9 @@ spec:
               {{- end }}
               {{- if .Values.sftp.authMethods }}
               -authMethods={{ .Values.sftp.authMethods }} \
+              {{- if contains "certificate" .Values.sftp.authMethods }}
+              -trustedUserCAKeysFile=/etc/sw/sftp_ca/ca_user.pub \
+              {{- end }}
               {{- end }}
               {{- if .Values.sftp.maxAuthTries }}
               -maxAuthTries={{ .Values.sftp.maxAuthTries }} \
@@ -173,9 +179,14 @@ spec:
               name: config-users
               readOnly: true
             {{- end }}
-            - mountPath: /etc/sw/ssh
+            - mountPath: {{ .Values.sftp.hostKeysFolder | default "/etc/sw/ssh" }}
               name: config-ssh
               readOnly: true
+            {{- if and .Values.sftp.authMethods (contains "certificate" .Values.sftp.authMethods) }}
+            - mountPath: /etc/sw/sftp_ca
+              name: config-sftp-ca
+              readOnly: true
+            {{- end }}
             {{- if include "seaweedfs.securityConfigEnabled" . }}
             - name: security-config
               readOnly: true
@@ -256,6 +267,19 @@ spec:
             {{- else }}
             secretName: {{ include "seaweedfs.fullname" . }}-sftp-ssh-secret
             {{- end }}
+        {{- if and .Values.sftp.authMethods (contains "certificate" .Values.sftp.authMethods) }}
+        {{- if and (not .Values.sftp.existingCAKeysSecret) (not .Values.sftp.trustedUserCAKeys) }}
+        {{- fail "sftp.authMethods includes \"certificate\" but neither sftp.trustedUserCAKeys nor sftp.existingCAKeysSecret is set" }}
+        {{- end }}
+        - name: config-sftp-ca
+          secret:
+            defaultMode: 420
+            {{- if .Values.sftp.existingCAKeysSecret }}
+            secretName: {{ .Values.sftp.existingCAKeysSecret }}
+            {{- else }}
+            secretName: {{ include "seaweedfs.fullname" . }}-sftp-ca-secret
+            {{- end }}
+        {{- end }}
         {{- if eq .Values.sftp.logs.type "hostPath" }}
         - name: logs
           hostPath:

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-secret.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-secret.yaml
@@ -3,6 +3,15 @@
 {{- $admin_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "admin_password" "length" 20) -}}
 {{- $read_user_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "readonly_password" "length" 20) -}}
 {{- $public_user_pwd := include "seaweedfs.getOrGeneratePassword" (dict "namespace" .Release.Namespace "secretName" $secretName "key" "public_user_password" "length" 20) -}}
+{{- $ssh_private_key := "" -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- if and $existingSecret (index $existingSecret.data "seaweedfs_sftp_ssh_private_key") -}}
+{{- $ssh_private_key = index $existingSecret.data "seaweedfs_sftp_ssh_private_key" | b64dec | trim -}}
+{{- end -}}
+{{/* generate a fresh host key; also replace the key earlier chart versions bundled */}}
+{{- if or (not $ssh_private_key) (contains "H4McwcDphteXVullu6q7ephEN1N60z" $ssh_private_key) -}}
+{{- $ssh_private_key = genPrivateKey "ed25519" -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -24,11 +33,5 @@ stringData:
   public_user_password: {{ $public_user_pwd }}
   seaweedfs_sftp_config: '[{"Username":"admin","Password":"{{ $admin_pwd }}","PublicKeys":[],"HomeDir":"/","Permissions":{"/":["read","write","list"]},"Uid":0,"Gid":0},{"Username":"readonly_user","Password":"{{ $read_user_pwd }}","PublicKeys":[],"HomeDir":"/","Permissions":{"/":["read","list"]},"Uid":1112,"Gid":1112},{"Username":"public_user","Password":"{{ $public_user_pwd }}","PublicKeys":[],"HomeDir":"/public","Permissions":{"/public":["write","read","list"]},"Uid":1113,"Gid":1113}]'
   seaweedfs_sftp_ssh_private_key: |
-    -----BEGIN OPENSSH PRIVATE KEY-----
-    b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
-    QyNTUxOQAAACDH4McwcDphteXVullu6q7ephEN1N60z+w0qZw0UVW8OwAAAJDjxkmk48ZJ
-    pAAAAAtzc2gtZWQyNTUxOQAAACDH4McwcDphteXVullu6q7ephEN1N60z+w0qZw0UVW8Ow
-    AAAEAeVy/4+gf6rjj2jla/AHqJpC1LcS5hn04IUs4q+iVq/MfgxzBwOmG15dW6WW7qrt6m
-    EQ3U3rTP7DSpnDRRVbw7AAAADHNla291ckAwMDY2NwE=
-    -----END OPENSSH PRIVATE KEY-----
+{{ $ssh_private_key | trim | indent 4 }}
 {{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-service.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-service.yaml
@@ -15,17 +15,29 @@ metadata:
     {{- toYaml .Values.sftp.annotations | nindent 4 }}
 {{- end }}
 spec:
-  type: {{ .Values.sftp.service.type }}
+  {{- $serviceType := .Values.sftp.service.type }}
+  {{- $nodePorts := dict }}
+  {{- if or (eq $serviceType "NodePort") (eq $serviceType "LoadBalancer") }}
+  {{- $nodePorts = .Values.sftp.service.nodePorts | default dict }}
+  {{- end }}
+  type: {{ $serviceType }}
+  {{- include "seaweedfs.service.loadBalancerFields" .Values.sftp.service }}
   internalTrafficPolicy: {{ .Values.sftp.internalTrafficPolicy | default "Cluster" }}
   ports:
   - name: "swfs-sftp"
     port: {{ .Values.sftp.port }}
     targetPort: {{ .Values.sftp.port }}
+{{- if $nodePorts.sftp }}
+    nodePort: {{ $nodePorts.sftp }}
+{{- end }}
     protocol: TCP
 {{- if .Values.sftp.metricsPort }}
   - name: "metrics"
     port: {{ .Values.sftp.metricsPort }}
     targetPort: {{ .Values.sftp.metricsPort }}
+{{- if $nodePorts.metrics }}
+    nodePort: {{ $nodePorts.metrics }}
+{{- end }}
     protocol: TCP
 {{- end }}
   selector:

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-ssh-secret.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/sftp/sftp-ssh-secret.yaml
@@ -1,0 +1,35 @@
+{{- if or (and .Values.sftp.enabled (not .Values.sftp.existingSshConfigSecret)) (and .Values.allInOne.enabled .Values.allInOne.sftp.enabled (not (or .Values.allInOne.sftp.existingSshConfigSecret .Values.sftp.existingSshConfigSecret))) }}
+{{/* Host keys mounted at sftp.hostKeysFolder; existing keys are kept across upgrades, except the key earlier chart versions bundled. */}}
+{{- $secretName := printf "%s-sftp-ssh-secret" (include "seaweedfs.fullname" .) }}
+{{- $hostKeys := dict }}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- if $existingSecret }}
+{{- range $name, $value := $existingSecret.data }}
+{{- if not (contains "H4McwcDphteXVullu6q7ephEN1N60z" (b64dec $value)) }}
+{{- $_ := set $hostKeys $name $value }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if eq (len $hostKeys) 0 }}
+{{- $_ := set $hostKeys "ssh_host_ed25519_key" (genPrivateKey "ed25519" | b64enc) }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
+    "helm.sh/hook": "pre-install,pre-upgrade"
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: sftp
+data:
+{{- range $name, $value := $hostKeys }}
+  {{ $name }}: {{ $value }}
+{{- end }}
+{{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -415,7 +415,11 @@ true
 {{-           if eq .type "persistentVolumeClaim" }}
 {{-             $desiredSize := .size }}
 {{-             range $statefulset.spec.volumeClaimTemplates }}
-{{-               if and (eq .metadata.name $dir.name) (ne .spec.resources.requests.storage $desiredSize) }}
+{{- /* normalise both sides: the API server re-emits a quantity in its canonical
+       form, so values saying 10240Mi come back from the cluster as 10Gi and a raw
+       string compare deletes the statefulset on EVERY upgrade for a size that
+       never changed. */}}
+{{-               if and (eq .metadata.name $dir.name) (ne (include "seaweedfs.resource-quantity" .spec.resources.requests.storage) (include "seaweedfs.resource-quantity" $desiredSize)) }}
 {{-                 $commands = append $commands (printf "kubectl delete statefulset %s --cascade=orphan" $statefulsetName) }}
 {{-               end }}
 {{-             end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -69,6 +69,23 @@ Inject extra environment vars in the format key:value, if populated
 {{- range $key, $value := $component }}
 {{- $_ := set $target $key $value }}
 {{- end }}
+{{/* the license block owns SEAWEED_LICENSE; letting one through here too would
+     render the key twice in one container */}}
+{{- if ((.global | default dict).license | default dict).existingSecret }}
+{{- $_ := unset $target "SEAWEED_LICENSE" }}
+{{- end }}
+{{- end -}}
+
+{{/* Whether the mysql filer store is selected; a flag the chart cannot read counts as selected. */}}
+{{- define "seaweedfs.filer.mysqlEnabled" -}}
+{{- $merged := dict -}}
+{{- $_ := include "seaweedfs.mergeExtraEnvironmentVars" (dict "global" .Values.global.seaweedfs "component" .Values.filer "target" $merged) -}}
+{{- $enabled := index $merged "WEED_MYSQL_ENABLED" -}}
+{{- if or (kindIs "map" $enabled) (hasKey (.Values.filer.secretExtraEnvironmentVars | default dict) "WEED_MYSQL_ENABLED") -}}
+true
+{{- else if and $enabled (eq (lower (toString $enabled)) "true") -}}
+true
+{{- end -}}
 {{- end -}}
 
 {{/* Return the proper filer image */}}
@@ -128,6 +145,15 @@ Inject extra environment vars in the format key:value, if populated
 {{- printf "%s" $imageOverride -}}
 {{- else -}}
 {{- include "seaweedfs.image" . }}
+{{- end -}}
+{{- end -}}
+
+{{/* Lance namespace URL the worker's Lance container maintains; empty when unreachable */}}
+{{- define "seaweedfs.worker.lanceNamespaceUrl" -}}
+{{- if .Values.worker.namespaceUrl -}}
+{{- .Values.worker.namespaceUrl -}}
+{{- else if and .Values.s3.enabled .Values.s3.lancePort -}}
+{{- printf "http://%s.%s:%d" (include "seaweedfs.componentName" (list . "s3")) .Release.Namespace (int .Values.s3.lancePort) -}}
 {{- end -}}
 {{- end -}}
 
@@ -333,13 +359,90 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/* True when security.toml should be rendered and mounted. volumeWrite is
-     excluded since it defaults to true. */}}
+     excluded unless its non-default expiration is configured. */}}
 {{- define "seaweedfs.securityConfigEnabled" -}}
 {{- $sec := (.Values.global.seaweedfs).securityConfig | default dict -}}
 {{- $jwt := $sec.jwtSigning | default dict -}}
-{{- if or .Values.global.seaweedfs.enableSecurity $jwt.volumeRead $jwt.filerWrite $jwt.filerRead -}}
+{{- $expiresAfterSeconds := $jwt.expiresAfterSeconds | default dict -}}
+{{- $volumeWriteExpirationConfigured := and $jwt.volumeWrite (gt (int $expiresAfterSeconds.volumeWrite) 0) -}}
+{{- if or .Values.global.seaweedfs.enableSecurity $volumeWriteExpirationConfigured $jwt.volumeRead $jwt.filerWrite $jwt.filerRead -}}
 true
 {{- end -}}
+{{- end -}}
+
+{{/* True when the post-install bucket hook Job renders: an S3 endpoint, plus
+     buckets to create on it. Read by the Job itself and by its NetworkPolicy,
+     which has to appear exactly when the Job does - a Job without its policy
+     hangs in a default-deny namespace. */}}
+{{- define "seaweedfs.bucketHookEnabled" -}}
+{{- if .Values.allInOne.enabled -}}
+{{-   if and .Values.allInOne.s3.enabled .Values.allInOne.s3.createBuckets -}}
+true
+{{-   end -}}
+{{- else if .Values.master.enabled -}}
+{{-   if and (or .Values.filer.s3.enabled .Values.s3.enabled) (or .Values.s3.createBuckets .Values.filer.s3.createBuckets) -}}
+true
+{{-   end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* The kubectl commands the volume resize hook has to run, one per line: a
+     cascade-orphan delete for every StatefulSet whose volumeClaimTemplates no
+     longer match the values, and a patch for every PVC the values grew.
+
+     Empty when there is nothing to resize, which is what gates the Job. Read by
+     its NetworkPolicy too, which has to appear exactly when the Job does - a Job
+     without its policy hangs in a default-deny namespace, and a policy without
+     its Job is an orphaned hook resource on every install.
+
+     Built on lookup, so it is always empty under helm template and on a fresh
+     install, where there is no StatefulSet to compare against yet. */}}
+{{- define "seaweedfs.volumeResizeHookCommands" -}}
+{{- $seaweedfsName := include "seaweedfs.fullname" $ }}
+{{- $volumes := deepCopy .Values.volumes | mergeOverwrite (dict "" .Values.volume) }}
+{{- $commands := list }}
+{{- if .Values.volume.resizeHook.enabled }}
+{{-   range $vname, $volume := $volumes }}
+{{-     $volumeName := trimSuffix "-" (printf "volume-%s" $vname) }}
+{{-     $volume := mergeOverwrite (deepCopy $.Values.volume) (dict "enabled" true) $volume }}
+{{-     if $volume.enabled }}
+{{-       $replicas := int $volume.replicas }}
+{{-       $statefulsetName := printf "%s-%s" $seaweedfsName $volumeName }}
+{{-       $statefulset := (lookup "apps/v1" "StatefulSet" $.Release.Namespace $statefulsetName) }}
+{{- /* Check for changes in volumeClaimTemplates */}}
+{{-       if $statefulset }}
+{{-         range $dir := $volume.dataDirs }}
+{{-           if eq .type "persistentVolumeClaim" }}
+{{-             $desiredSize := .size }}
+{{-             range $statefulset.spec.volumeClaimTemplates }}
+{{-               if and (eq .metadata.name $dir.name) (ne .spec.resources.requests.storage $desiredSize) }}
+{{-                 $commands = append $commands (printf "kubectl delete statefulset %s --cascade=orphan" $statefulsetName) }}
+{{-               end }}
+{{-             end }}
+{{-           end }}
+{{-         end }}
+{{-       end }}
+{{- /* Check for the need for patching existing PVCs */}}
+{{-       range $dir := $volume.dataDirs }}
+{{-         if eq .type "persistentVolumeClaim" }}
+{{-           $desiredSize := .size }}
+{{-           range $i, $e := until $replicas }}
+{{-             $pvcName := printf "%s-%s-%s-%d" $dir.name $seaweedfsName $volumeName $e }}
+{{-             $currentPVC := (lookup "v1" "PersistentVolumeClaim" $.Release.Namespace $pvcName) }}
+{{-             if $currentPVC }}
+{{-               $oldSize := include "seaweedfs.resource-quantity" $currentPVC.spec.resources.requests.storage }}
+{{-               $newSize := include "seaweedfs.resource-quantity" $desiredSize }}
+{{-               if gt $newSize $oldSize }}
+{{-                 $commands = append $commands (printf "kubectl patch pvc %s-%s-%s-%d -p '{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"%s\"}}}}'" $dir.name $seaweedfsName $volumeName $e $desiredSize) }}
+{{-               end }}
+{{-             end }}
+{{-           end }}
+{{-         end }}
+{{-       end }}
+{{-     end }}
+{{-   end }}
+{{- end }}
+{{- join "\n" $commands }}
 {{- end -}}
 
 {{/* S3 TLS cert/key arguments, using custom secret if s3.tlsSecret is set */}}
@@ -373,10 +476,104 @@ true
 {{- end }}
 {{- end -}}
 
+{{/* True when an enterprise license Secret is configured. */}}
+{{- define "seaweedfs.licenseEnabled" -}}
+{{- if ((.Values.global.seaweedfs).license).existingSecret -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/* Enterprise license volume. Projects just the license key. */}}
+{{- define "seaweedfs.licenseVolume" -}}
+{{- if include "seaweedfs.licenseEnabled" . -}}
+- name: seaweedfs-license
+  secret:
+    secretName: {{ .Values.global.seaweedfs.license.existingSecret }}
+    defaultMode: 0444
+    items:
+      - key: {{ .Values.global.seaweedfs.license.secretKey | default "seaweed-license.json" | quote }}
+        path: {{ .Values.global.seaweedfs.license.secretKey | default "seaweed-license.json" | quote }}
+{{- end }}
+{{- end -}}
+
+{{/* Enterprise license volume mount. Never a subPath: that is resolved once at
+     container start, so a renewed Secret would not reach a running master. */}}
+{{- define "seaweedfs.licenseVolumeMount" -}}
+{{- if include "seaweedfs.licenseEnabled" . -}}
+- name: seaweedfs-license
+  readOnly: true
+  mountPath: {{ .Values.global.seaweedfs.license.mountPath | default "/etc/seaweedfs/license" | quote }}
+{{- end }}
+{{- end -}}
+
+{{/* SEAWEED_LICENSE, set explicitly rather than relying on the binary's search
+     paths, which depend on the working directory. */}}
+{{- define "seaweedfs.licenseEnv" -}}
+{{- if include "seaweedfs.licenseEnabled" . -}}
+- name: SEAWEED_LICENSE
+  value: {{ printf "%s/%s"
+      (.Values.global.seaweedfs.license.mountPath | default "/etc/seaweedfs/license")
+      (.Values.global.seaweedfs.license.secretKey | default "seaweed-license.json") | quote }}
+{{- end }}
+{{- end -}}
+
+{{/* Name of the environment variable carrying one generated S3 credential
+     field, e.g. SEAWEEDFS_S3_ADMIN_ACCESS_KEY_ID. The generated identities file
+     names it in place of the key when the key lives in an existing Secret.
+     Usage: include "seaweedfs.s3.credentialEnvName" (list "admin" "accessKey") */}}
+{{- define "seaweedfs.s3.credentialEnvName" -}}
+{{- $identity := index . 0 -}}
+{{- $field := index . 1 -}}
+{{- printf "SEAWEEDFS_S3_%s_%s" (upper $identity) (ternary "ACCESS_KEY_ID" "SECRET_ACCESS_KEY" (eq $field "accessKey")) -}}
+{{- end -}}
+
+{{/* Environment for the S3 identities the chart generates from an existing
+     Secret. The gateway resolves the ${VAR} references the identities file
+     carries, so the keys never enter the rendered manifests and a dry run
+     renders the same as an install. */}}
+{{- define "seaweedfs.s3.credentialEnv" -}}
+{{- $creds := $.Values.s3.credentials | default dict -}}
+{{- range $identity := list "admin" "read" -}}
+{{- $identityCreds := index $creds $identity | default dict -}}
+{{- if $identityCreds.existingSecret }}
+- name: {{ include "seaweedfs.s3.credentialEnvName" (list $identity "accessKey") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $identityCreds.existingSecret | quote }}
+      key: {{ default (printf "%s_access_key_id" $identity) $identityCreds.accessKeyKey | quote }}
+- name: {{ include "seaweedfs.s3.credentialEnvName" (list $identity "secretKey") }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $identityCreds.existingSecret | quote }}
+      key: {{ default (printf "%s_secret_access_key" $identity) $identityCreds.secretKeyKey | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Generate a compatible trafficDistribution value due to "PreferClose" fast deprecation in k8s v1.35.
      Accepts a dict with "value" (the trafficDistribution string) and "Capabilities". */}}
 {{- define "seaweedfs.trafficDistribution" -}}
 {{- if .value -}}
 {{- and (eq .value "PreferClose") (semverCompare ">=1.35-0" .Capabilities.KubeVersion.GitVersion) | ternary "PreferSameZone" .value -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Render LoadBalancer-specific service fields (loadBalancerClass, loadBalancerIP,
+loadBalancerSourceRanges), only when the service type is LoadBalancer.
+Usage: {{ include "seaweedfs.service.loadBalancerFields" .Values.s3.service }}
+*/}}
+{{- define "seaweedfs.service.loadBalancerFields" -}}
+{{- if eq (.type | default "ClusterIP") "LoadBalancer" }}
+{{- with .loadBalancerClass }}
+  loadBalancerClass: {{ . }}
+{{- end }}
+{{- with .loadBalancerIP }}
+  loadBalancerIP: {{ . }}
+{{- end }}
+{{- with .loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
@@ -432,7 +432,11 @@ true
 {{-             if $currentPVC }}
 {{-               $oldSize := include "seaweedfs.resource-quantity" $currentPVC.spec.resources.requests.storage }}
 {{-               $newSize := include "seaweedfs.resource-quantity" $desiredSize }}
-{{-               if gt $newSize $oldSize }}
+{{- /* both sides come from an include, so they are STRINGS: gt would compare
+       them lexicographically and read 1.073741824e+10 (10Gi) as smaller than
+       5.36870912e+09 (5Gi), skipping the patch while the statefulset delete
+       above still runs. Compare as numbers. */}}
+{{-               if gt (float64 $newSize) (float64 $oldSize) }}
 {{-                 $commands = append $commands (printf "kubectl patch pvc %s-%s-%s-%d -p '{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"%s\"}}}}'" $dir.name $seaweedfsName $volumeName $e $desiredSize) }}
 {{-               end }}
 {{-             end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/networkpolicy.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/networkpolicy.yaml
@@ -1,0 +1,267 @@
+{{- include "seaweedfs.compat" . -}}
+{{- if .Values.networkPolicy.enabled }}
+{{- $np := .Values.networkPolicy }}
+{{- $egressCfg := $np.egress | default dict }}
+{{- $overrides := $np.components | default dict }}
+
+{{- /* One entry per rendered workload, keyed by its app.kubernetes.io/component
+       label. "ports" is everything the workload listens on, taken from the same
+       values the containerPorts are taken from, so a changed port cannot drift
+       out of the policy. "apiserver" marks the workloads that talk to the
+       Kubernetes API. "name" overrides the object name where the component
+       label already reads as a full name. */}}
+{{- $targets := list }}
+
+{{- /* allInOne.enabled does not turn the individual components off - their
+       templates only look at their own enabled flag - so the all-in-one pod is
+       an addition here, not an alternative. */}}
+{{- if .Values.allInOne.enabled }}
+{{-   $ports := list .Values.master.port .Values.master.grpcPort .Values.volume.port .Values.volume.grpcPort .Values.filer.port .Values.filer.grpcPort }}
+{{-   if .Values.allInOne.metricsPort }}
+{{-     $ports = append $ports .Values.allInOne.metricsPort }}
+{{-   end }}
+{{-   if .Values.allInOne.s3.enabled }}
+{{-     $ports = append $ports (.Values.allInOne.s3.port | default .Values.s3.port) }}
+{{-     $https := .Values.allInOne.s3.httpsPort | default .Values.s3.httpsPort }}
+{{-     if and $https (gt (int $https) 0) }}
+{{-       $ports = append $ports $https }}
+{{-     end }}
+{{-   end }}
+{{-   if .Values.allInOne.sftp.enabled }}
+{{-     $ports = append $ports (.Values.allInOne.sftp.port | default .Values.sftp.port) }}
+{{-   end }}
+{{-   $targets = append $targets (dict "component" "seaweedfs-all-in-one" "name" "all-in-one" "ports" $ports) }}
+{{- end }}
+{{- if .Values.master.enabled }}
+{{-   $ports := list .Values.master.port .Values.master.grpcPort }}
+{{-   if .Values.master.metricsPort }}
+{{-     $ports = append $ports .Values.master.metricsPort }}
+{{-   end }}
+{{-   $targets = append $targets (dict "component" "master" "ports" $ports) }}
+{{- end }}
+{{- /* Every volume group carries its own component label and its own ports. */}}
+{{- $volumes := deepCopy .Values.volumes | mergeOverwrite (dict "" .Values.volume) }}
+{{- range $vname, $volume := $volumes }}
+{{-   $volumeName := trimSuffix "-" (printf "volume-%s" $vname) }}
+{{-   $volume := mergeOverwrite (deepCopy $.Values.volume) (dict "enabled" true) $volume }}
+{{-   if $volume.enabled }}
+{{-     $ports := list $volume.port $volume.grpcPort }}
+{{-     if $volume.metricsPort }}
+{{-       $ports = append $ports $volume.metricsPort }}
+{{-     end }}
+{{-     $targets = append $targets (dict "component" $volumeName "ports" $ports) }}
+{{-   end }}
+{{- end }}
+{{- if .Values.filer.enabled }}
+{{-   $ports := list .Values.filer.port .Values.filer.grpcPort }}
+{{-   if .Values.filer.metricsPort }}
+{{-     $ports = append $ports .Values.filer.metricsPort }}
+{{-   end }}
+{{-   if .Values.filer.s3.enabled }}
+{{-     $ports = append $ports .Values.filer.s3.port }}
+{{-     if and .Values.filer.s3.httpsPort (gt (int .Values.filer.s3.httpsPort) 0) }}
+{{-       $ports = append $ports .Values.filer.s3.httpsPort }}
+{{-     end }}
+{{-   end }}
+{{-   $targets = append $targets (dict "component" "filer" "ports" $ports) }}
+{{- end }}
+{{- if .Values.s3.enabled }}
+{{-   $ports := list .Values.s3.port }}
+{{-   if and .Values.s3.httpsPort (gt (int .Values.s3.httpsPort) 0) }}
+{{-     $ports = append $ports .Values.s3.httpsPort }}
+{{-   end }}
+{{-   if .Values.s3.icebergPort }}
+{{-     $ports = append $ports .Values.s3.icebergPort }}
+{{-   end }}
+{{-   if .Values.s3.lancePort }}
+{{-     $ports = append $ports .Values.s3.lancePort }}
+{{-   end }}
+{{-   if .Values.s3.metricsPort }}
+{{-     $ports = append $ports .Values.s3.metricsPort }}
+{{-   end }}
+{{-   $targets = append $targets (dict "component" "s3" "ports" $ports) }}
+{{- end }}
+{{- if .Values.sftp.enabled }}
+{{-   $ports := list .Values.sftp.port }}
+{{-   if .Values.sftp.metricsPort }}
+{{-     $ports = append $ports .Values.sftp.metricsPort }}
+{{-   end }}
+{{-   $targets = append $targets (dict "component" "sftp" "ports" $ports) }}
+{{- end }}
+{{- /* No seaweedfs binary speaks to the Kubernetes API - the repository has no
+       client-go dependency - so admin gets no apiserver rule. The pod-RW
+       ClusterRole under global.seaweedfs.createClusterRole is a leftover from a
+       migration and is not exercised by any component. */}}
+{{- if .Values.admin.enabled }}
+{{-   $targets = append $targets (dict "component" "admin" "ports" (list .Values.admin.port .Values.admin.grpcPort)) }}
+{{- end }}
+{{- if .Values.worker.enabled }}
+{{-   $ports := list }}
+{{-   if .Values.worker.metricsPort }}
+{{-     $ports = append $ports .Values.worker.metricsPort }}
+{{-   end }}
+{{-   if and .Values.worker.lanceMetricsPort (include "seaweedfs.worker.lanceNamespaceUrl" .) }}
+{{-     $ports = append $ports .Values.worker.lanceMetricsPort }}
+{{-   end }}
+{{-   $targets = append $targets (dict "component" "worker" "ports" $ports) }}
+{{- end }}
+
+{{- if .Values.cosi.enabled }}
+{{- /* The provisioner sidecar watches the COSI CRs, so it needs the API
+       server; nothing needs to reach the driver itself. */}}
+{{-   $targets = append $targets (dict "component" "objectstorage-provisioner" "ports" (list) "apiserver" true) }}
+{{- end }}
+
+{{- /* The hook Jobs. Nothing connects to either, but under a default-deny
+       namespace they need egress or they hang: the bucket hook waits on the
+       master and filer, the resize hook shells out to kubectl.
+
+       The bucket hook is post-install, and Helm applies the release manifest
+       before post-install hooks run, so a plain policy is already in place by
+       then. The resize hook is pre-install weight 0, which runs before the
+       manifest is applied at all, so its policy has to be a pre-install hook
+       itself, at a weight below the Job's. */}}
+{{- if include "seaweedfs.bucketHookEnabled" . }}
+{{-   $targets = append $targets (dict "component" "bucket-hook" "ports" (list)) }}
+{{- end }}
+{{- /* Same cluster lookup the Job is gated on, so the policy appears on exactly
+       the upgrades that grow a PVC and never on the ones that do not. Helm does
+       not garbage-collect hook resources, so a policy rendered unconditionally
+       would be left in the namespace by every install that uninstalls again -
+       and would make egress.kubeApiServer.cidrs mandatory for every release,
+       for a Job most of them never run. */}}
+{{- if include "seaweedfs.volumeResizeHookCommands" . | trim }}
+{{-   $targets = append $targets (dict "component" "volume-resize-hook" "ports" (list) "apiserver" true "hook" "pre-install,pre-upgrade" "hookWeight" "-10") }}
+{{- end }}
+
+{{- /* A key under networkPolicy.components that names no component would be
+       read as "these rules are applied" and silently do nothing. Check against
+       every component the chart can produce rather than the ones enabled here,
+       so one values file can still carry overrides for a component this release
+       leaves off. */}}
+{{- $known := list "master" "filer" "s3" "sftp" "admin" "worker" "volume" "bucket-hook" "volume-resize-hook" "objectstorage-provisioner" "seaweedfs-all-in-one" }}
+{{- range $vname, $_ := (.Values.volumes | default dict) }}
+{{-   $known = append $known (trimSuffix "-" (printf "volume-%s" $vname)) }}
+{{- end }}
+{{- range $name, $_ := $overrides }}
+{{-   if not (has $name $known) }}
+{{-     fail (printf "networkPolicy.components: %q is not a component of this chart, so its rules would never be applied. Known components: %s." $name (join ", " (sortAlpha $known))) }}
+{{-   end }}
+{{- end }}
+
+{{- range $target := $targets }}
+{{- $component := $target.component }}
+{{- $override := get $overrides $component | default dict }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "seaweedfs.componentName" (list $ ($target.name | default $component)) }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "seaweedfs.name" $ | quote }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service | quote }}
+    app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+    app.kubernetes.io/component: {{ $component | quote }}
+{{- if $target.hook }}
+  annotations:
+    {{- /* Only before-hook-creation: the policy has to outlive the Job it
+           covers, so it must not be deleted when the Job succeeds. That does
+           leave it behind on uninstall, the usual trade-off for Helm hook
+           resources. */}}
+    "helm.sh/hook": {{ $target.hook }}
+    "helm.sh/hook-weight": {{ $target.hookWeight | quote }}
+    "helm.sh/hook-delete-policy": before-hook-creation
+{{- end }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "seaweedfs.name" $ | quote }}
+      app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+      app.kubernetes.io/component: {{ $component | quote }}
+  policyTypes:
+    - Ingress
+{{- if $egressCfg.enabled }}
+    - Egress
+{{- end }}
+  ingress:
+{{- $extraIngress := concat ($np.extraIngress | default list) ($override.extraIngress | default list) }}
+{{- if and (not $target.ports) (not $extraIngress) }}
+    []
+{{- end }}
+{{- if $target.ports }}
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ include "seaweedfs.name" $ | quote }}
+              app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+      ports:
+{{- range $port := $target.ports }}
+        - protocol: TCP
+          port: {{ $port }}
+{{- end }}
+{{- end }}
+{{- with $extraIngress }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- if $egressCfg.enabled }}
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ include "seaweedfs.name" $ | quote }}
+              app.kubernetes.io/instance: {{ $.Release.Name | quote }}
+{{- if $egressCfg.allowDNS }}
+{{- /* Emit only the selectors that are set. An empty one has to be left out
+       rather than rendered as null: a missing podSelector means every pod in
+       the namespace, and a missing namespaceSelector means this namespace
+       instead of the one DNS runs in. */}}
+{{- if not (or $egressCfg.dnsNamespaceSelector $egressCfg.dnsPodSelector) }}
+{{- fail "networkPolicy: egress.allowDNS is on but both egress.dnsNamespaceSelector and egress.dnsPodSelector are empty, which would open port 53 to every pod in the release namespace. Set at least one of them, or turn allowDNS off and name the resolver in egress.extraEgress." }}
+{{- end }}
+    - to:
+{{- if and $egressCfg.dnsNamespaceSelector $egressCfg.dnsPodSelector }}
+        - namespaceSelector:
+            {{- toYaml $egressCfg.dnsNamespaceSelector | nindent 12 }}
+          podSelector:
+            {{- toYaml $egressCfg.dnsPodSelector | nindent 12 }}
+{{- else if $egressCfg.dnsNamespaceSelector }}
+        - namespaceSelector:
+            {{- toYaml $egressCfg.dnsNamespaceSelector | nindent 12 }}
+{{- else }}
+        - podSelector:
+            {{- toYaml $egressCfg.dnsPodSelector | nindent 12 }}
+{{- end }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}
+{{- if and $target.apiserver ($egressCfg.kubeApiServer).enabled }}
+{{- if not $egressCfg.kubeApiServer.cidrs }}
+{{- fail (printf "networkPolicy: %s needs the Kubernetes API server, but networkPolicy.egress.kubeApiServer.cidrs is empty. Set it to your API server address(es), or disable networkPolicy.egress.kubeApiServer and allow it through networkPolicy.egress.extraEgress." $component) }}
+{{- end }}
+{{- /* An empty port list is not "no ports" in a NetworkPolicy, it is every
+       port, so refuse it rather than quietly opening the CIDR up. */}}
+{{- if not $egressCfg.kubeApiServer.ports }}
+{{- fail "networkPolicy: egress.kubeApiServer.ports is empty, which allows every port on the API server CIDR(s) rather than none. Set it (the default is [443, 6443]), or turn egress.kubeApiServer off and describe the access in egress.extraEgress." }}
+{{- end }}
+{{- range $cidr := $egressCfg.kubeApiServer.cidrs }}
+    - to:
+        - ipBlock:
+            cidr: {{ $cidr }}
+      ports:
+{{- range $port := $egressCfg.kubeApiServer.ports }}
+        - protocol: TCP
+          port: {{ $port }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- with concat ($egressCfg.extraEgress | default list) ($override.extraEgress | default list) }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/post-install-bucket-hook.yaml
@@ -1,7 +1,6 @@
 {{- include "seaweedfs.compat" . -}}
 {{- /* Support bucket creation for both standalone filer.s3 and allInOne modes */}}
 {{- $createBuckets := list }}
-{{- $s3Enabled := false }}
 {{- $enableAuth := false }}
 {{- $existingConfigSecret := "" }}
 {{- $bucketsFolder := "/buckets" }}
@@ -13,11 +12,14 @@
 {{- end }}
 {{- $bucketsFolder = default $bucketsFolder (get $bucketEnvVars "WEED_FILER_BUCKETS_FOLDER") }}
 {{- $bucketsFolder = trimSuffix "/" $bucketsFolder }}
+{{- $clusterAlias := default "sw" (get $bucketEnvVars "WEED_CLUSTER_DEFAULT") }}
+{{- $clusterUpper := upper $clusterAlias }}
+{{- $clusterMasterKey := printf "WEED_CLUSTER_%s_MASTER" $clusterUpper }}
+{{- $clusterFilerKey := printf "WEED_CLUSTER_%s_FILER" $clusterUpper }}
 
 {{- /* Check allInOne mode first */}}
 {{- if .Values.allInOne.enabled }}
   {{- if .Values.allInOne.s3.enabled }}
-    {{- $s3Enabled = true }}
     {{- if .Values.allInOne.s3.createBuckets }}
       {{- $createBuckets = .Values.allInOne.s3.createBuckets }}
     {{- end }}
@@ -27,7 +29,6 @@
 {{- else if .Values.master.enabled }}
   {{- /* Check if embedded (in filer) or standalone S3 gateway is enabled */}}
   {{- if or .Values.filer.s3.enabled .Values.s3.enabled }}
-    {{- $s3Enabled = true }}
     {{- if .Values.s3.createBuckets }}
       {{- $createBuckets = .Values.s3.createBuckets }}
       {{- $enableAuth = .Values.s3.enableAuth }}
@@ -40,15 +41,20 @@
   {{- end }}
 {{- end }}
 
-{{- if and $s3Enabled $createBuckets }}
+{{- /* Shared with networkpolicy.yaml, which renders this Job's policy exactly
+       when the Job itself renders. */}}
+{{- if include "seaweedfs.bucketHookEnabled" . }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ $.Release.Name }}-bucket-hook"
   labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/component: bucket-hook
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
@@ -58,8 +64,11 @@ spec:
     metadata:
       name: "{{ .Release.Name }}"
       labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/component: bucket-hook
     spec:
       restartPolicy: Never
       {{- if .Values.filer.podSecurityContext.enabled }}
@@ -71,12 +80,6 @@ spec:
         image: {{ template "seaweedfs.master.image" . }}
         imagePullPolicy: {{ $.Values.global.seaweedfs.imagePullPolicy | default "IfNotPresent" }}
         env:
-          - name: WEED_CLUSTER_DEFAULT
-            value: "sw"
-          - name: WEED_CLUSTER_SW_MASTER
-            value: {{ include "seaweedfs.cluster.masterAddress" . | quote }}
-          - name: WEED_CLUSTER_SW_FILER
-            value: {{ include "seaweedfs.cluster.filerAddress" . | quote }}
           - name: POD_IP
             valueFrom:
               fieldRef:
@@ -91,6 +94,28 @@ spec:
                 fieldPath: metadata.namespace
           - name: SEAWEEDFS_FULLNAME
             value: "{{ include "seaweedfs.fullname" . }}"
+          {{- /* Carries the JWT signing keys when they are set as environment
+                 overrides rather than in security.toml. */}}
+          {{- range $key := keys $bucketEnvVars | sortAlpha }}
+          {{- $value := index $bucketEnvVars $key }}
+          {{- if not (has $key (list "WEED_CLUSTER_DEFAULT" $clusterMasterKey $clusterFilerKey)) }}
+          - name: {{ $key }}
+          {{- if kindIs "string" $value }}
+            value: {{ tpl $value $ | quote }}
+          {{- else }}
+            valueFrom:
+              {{ toYaml $value | nindent 14 | trim }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- /* Computed, as in all-in-one: the values pick the cluster alias,
+                 the chart still owns the endpoints the script waits on. */}}
+          - name: WEED_CLUSTER_DEFAULT
+            value: {{ $clusterAlias | quote }}
+          - name: {{ $clusterMasterKey }}
+            value: {{ include "seaweedfs.cluster.masterAddress" . | quote }}
+          - name: {{ $clusterFilerKey }}
+            value: {{ include "seaweedfs.cluster.filerAddress" . | quote }}
         command:
           - "/bin/sh"
           - "-ec"
@@ -103,7 +128,7 @@ spec:
               
               echo "Waiting for service at $url..."
               while [ $attempt -le $max_attempts ]; do
-                if wget -q --spider "$url" >/dev/null 2>&1; then
+                if curl -sS -o /dev/null --max-time 5 "$url" >/dev/null 2>&1; then
                   echo "Service at $url is up!"
                   return 0
                 fi
@@ -115,11 +140,11 @@ spec:
               exit 1
             }
             {{- if .Values.allInOne.enabled }}
-            wait_for_service "http://$WEED_CLUSTER_SW_MASTER{{ .Values.allInOne.readinessProbe.httpGet.path }}"
-            wait_for_service "http://$WEED_CLUSTER_SW_FILER{{ .Values.filer.readinessProbe.httpGet.path }}"
+            wait_for_service "http://${{ $clusterMasterKey }}{{ .Values.allInOne.readinessProbe.httpGet.path }}"
+            wait_for_service "http://${{ $clusterFilerKey }}{{ .Values.filer.readinessProbe.httpGet.path }}"
             {{- else }}
-            wait_for_service "http://$WEED_CLUSTER_SW_MASTER{{ .Values.master.readinessProbe.httpGet.path }}"
-            wait_for_service "http://$WEED_CLUSTER_SW_FILER{{ .Values.filer.readinessProbe.httpGet.path }}"
+            wait_for_service "http://${{ $clusterMasterKey }}{{ .Values.master.readinessProbe.httpGet.path }}"
+            wait_for_service "http://${{ $clusterFilerKey }}{{ .Values.filer.readinessProbe.httpGet.path }}"
             {{- end }}
             {{- range $createBuckets }}
             {{- $bucketName := .name }}
@@ -143,6 +168,8 @@ spec:
           {{- if kindIs "bool" .versioning }}
             {{- if .versioning }}
               {{- $bucketVersioning = "Enabled" }}
+            {{- else }}
+              {{- $bucketVersioning = "Suspended" }}
             {{- end }}
           {{- else if kindIs "string" .versioning }}
             {{- $versioningLower := lower .versioning }}
@@ -175,11 +202,19 @@ spec:
                 /usr/bin/weed shell
           {{- end }}  
           {{- end }}
-        {{- if $enableAuth }}
+        {{- if or $enableAuth (include "seaweedfs.securityConfigEnabled" .) }}
         volumeMounts:
+          {{- if $enableAuth }}
           - name: config-users
             mountPath: /etc/sw
             readOnly: true
+          {{- end }}
+          {{- if include "seaweedfs.securityConfigEnabled" . }}
+          - name: security-config
+            readOnly: true
+            mountPath: /etc/seaweedfs/security.toml
+            subPath: security.toml
+          {{- end }}
         {{- end }}
         ports:
           - containerPort: {{ .Values.master.port }}
@@ -197,8 +232,9 @@ spec:
         {{- if .Values.filer.containerSecurityContext.enabled }}
         securityContext: {{- omit .Values.filer.containerSecurityContext "enabled" | toYaml | nindent 12 }}
         {{- end }}
-    {{- if $enableAuth }}
+    {{- if or $enableAuth (include "seaweedfs.securityConfigEnabled" .) }}
       volumes:
+        {{- if $enableAuth }}
         - name: config-users
           secret:
             defaultMode: 420
@@ -207,5 +243,11 @@ spec:
             {{- else }}
             secretName: {{ include "seaweedfs.fullname" . }}-s3-secret
             {{- end }}
+        {{- end }}
+        {{- if include "seaweedfs.securityConfigEnabled" . }}
+        - name: security-config
+          configMap:
+            name: {{ include "seaweedfs.fullname" . }}-security-config
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/secret-seaweedfs-db.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/secret-seaweedfs-db.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.filer.enabled }}
+{{- if and .Values.filer.enabled (include "seaweedfs.filer.mysqlEnabled" .) }}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/security-configmap.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/security-configmap.yaml
@@ -19,40 +19,56 @@ data:
   {{- $existing = lookup "v1" "ConfigMap" .Release.Namespace $legacyName }}
   {{- end }}
   {{- $securityConfig := fromToml (dig "data" "security.toml" "" $existing) }}
+  {{- $securityConfigValues := .Values.global.seaweedfs.securityConfig | default dict }}
+  {{- $jwtSigning := $securityConfigValues.jwtSigning | default dict }}
+  {{- $expiresAfterSeconds := $jwtSigning.expiresAfterSeconds | default dict }}
   security.toml: |-
     # this file is read by master, volume server, and filer
 
-    {{- if .Values.global.seaweedfs.securityConfig.jwtSigning.volumeWrite }}
+    {{- if $jwtSigning.volumeWrite }}
     # the jwt signing key is read by master and volume server
-    # a jwt expires in 10 seconds
+    # the jwt defaults to expire after 10 seconds
     [jwt.signing]
     key = "{{ dig "jwt" "signing" "key" (randAlphaNum 10 | b64enc) $securityConfig }}"
+    {{- if gt (int $expiresAfterSeconds.volumeWrite) 0 }}
+    expires_after_seconds = {{ int $expiresAfterSeconds.volumeWrite }}
+    {{- end }}
     {{- end }}
 
-    {{- if .Values.global.seaweedfs.securityConfig.jwtSigning.volumeRead }}
+    {{- if $jwtSigning.volumeRead }}
     # this jwt signing key is read by master and volume server, and it is used for read operations:
     # - the Master server generates the JWT, which can be used to read a certain file on a volume server
     # - the Volume server validates the JWT on reading
+    # the jwt defaults to expire after 60 seconds
     [jwt.signing.read]
     key = "{{ dig "jwt" "signing" "read" "key" (randAlphaNum 10 | b64enc) $securityConfig }}"
+    {{- if gt (int $expiresAfterSeconds.volumeRead) 0 }}
+    expires_after_seconds = {{ int $expiresAfterSeconds.volumeRead }}
+    {{- end }}
     {{- end }}
 
-    {{- if .Values.global.seaweedfs.securityConfig.jwtSigning.filerWrite }}
+    {{- if $jwtSigning.filerWrite }}
     # If this JWT key is configured, Filer only accepts writes over HTTP if they are signed with this JWT:
     # - f.e. the S3 API Shim generates the JWT
     # - the Filer server validates the JWT on writing
-    # the jwt defaults to expire after 10 seconds.
+    # the jwt defaults to expire after 10 seconds
     [jwt.filer_signing]
     key = "{{ dig "jwt" "filer_signing" "key" (randAlphaNum 10 | b64enc) $securityConfig }}"
+    {{- if gt (int $expiresAfterSeconds.filerWrite) 0 }}
+    expires_after_seconds = {{ int $expiresAfterSeconds.filerWrite }}
+    {{- end }}
     {{- end }}
 
-    {{- if .Values.global.seaweedfs.securityConfig.jwtSigning.filerRead }}
+    {{- if $jwtSigning.filerRead }}
     # If this JWT key is configured, Filer only accepts reads over HTTP if they are signed with this JWT:
     # - f.e. the S3 API Shim generates the JWT
     # - the Filer server validates the JWT on reading
-    # the jwt defaults to expire after 10 seconds.
+    # the jwt defaults to expire after 60 seconds
     [jwt.filer_signing.read]
     key = "{{ dig "jwt" "filer_signing" "read" "key" (randAlphaNum 10 | b64enc) $securityConfig }}"
+    {{- if gt (int $expiresAfterSeconds.filerRead) 0 }}
+    expires_after_seconds = {{ int $expiresAfterSeconds.filerRead }}
+    {{- end }}
     {{- end }}
 
     {{- if .Values.global.seaweedfs.enableSecurity }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
@@ -1,58 +1,20 @@
 {{- $seaweedfsName := include "seaweedfs.fullname" $ }}
-{{- $volumes := deepCopy .Values.volumes | mergeOverwrite (dict "" .Values.volume)  }}
+{{- /* Shared with networkpolicy.yaml, which renders this Job's policy exactly
+       when the Job itself renders. */}}
+{{- /* trim: include returns a string, and a whitespace-only one is truthy. */}}
+{{- $commands := include "seaweedfs.volumeResizeHookCommands" . | trim }}
 
-
-{{- if .Values.volume.resizeHook.enabled }}
-{{-   $commands := list }}
-{{-   range $vname, $volume := $volumes }}
-{{-     $volumeName := trimSuffix "-" (printf "volume-%s" $vname) }}
-{{-     $volume := mergeOverwrite (deepCopy $.Values.volume) (dict "enabled" true) $volume }}
-
-{{-     if $volume.enabled }}
-{{-       $replicas := int $volume.replicas -}}
-{{-       $statefulsetName := printf "%s-%s" $seaweedfsName $volumeName -}}
-{{-       $statefulset := (lookup "apps/v1" "StatefulSet" $.Release.Namespace $statefulsetName) -}}
-
-{{/*      Check for changes in volumeClaimTemplates */}}
-{{-       if $statefulset }}
-{{-         range $dir := $volume.dataDirs }}
-{{-           if eq .type "persistentVolumeClaim" }}
-{{-             $desiredSize := .size }}
-{{-             range $statefulset.spec.volumeClaimTemplates }}
-{{-               if and (eq .metadata.name $dir.name) (ne .spec.resources.requests.storage $desiredSize) }}
-{{-                 $commands = append $commands (printf "kubectl delete statefulset %s --cascade=orphan" $statefulsetName) }}
-{{-               end }}
-{{-             end }}
-{{-           end }}
-{{-         end }}
-{{-       end }}
-
-{{/*      Check for the need for patching existing PVCs */}}
-{{-       range $dir := $volume.dataDirs }}
-{{-         if eq .type "persistentVolumeClaim" }}
-{{-           $desiredSize := .size }}
-{{-           range $i, $e := until $replicas }}
-{{-             $pvcName := printf "%s-%s-%s-%d" $dir.name $seaweedfsName $volumeName $e }}
-{{-             $currentPVC := (lookup "v1" "PersistentVolumeClaim" $.Release.Namespace $pvcName) }}
-{{-             if and $currentPVC }}
-{{-             $oldSize := include "seaweedfs.resource-quantity" $currentPVC.spec.resources.requests.storage }}
-{{-             $newSize := include "seaweedfs.resource-quantity" $desiredSize }}
-{{-               if gt $newSize $oldSize }}
-{{-               $commands = append $commands (printf "kubectl patch pvc %s-%s-%s-%d -p '{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"%s\"}}}}'" $dir.name $seaweedfsName $volumeName $e $desiredSize) }}
-{{-               end }}
-{{-             end }}
-{{-           end }}
-{{-         end }}
-{{-       end }}
-
-{{-     end }}
-{{-   end }}
-
-{{-   if $commands }}
+{{- if $commands }}
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ $seaweedfsName }}-volume-resize-hook"
+  labels:
+    app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/component: volume-resize-hook
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "0"
@@ -62,6 +24,11 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/name: {{ template "seaweedfs.name" . }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/component: volume-resize-hook
         policy.cozystack.io/allow-to-apiserver: "true"
     spec:
       serviceAccountName: {{ $seaweedfsName }}-volume-resize-hook
@@ -72,9 +39,7 @@ spec:
           command: ["sh", "-xec"]
           args:
             - |
-              {{- range $commands }}
-              {{ . }}
-              {{- end }}
+{{ $commands | indent 14 }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -116,5 +81,4 @@ roleRef:
   kind: Role
   name: {{ $seaweedfsName }}-volume-resize-hook
   apiGroup: rbac.authorization.k8s.io
-{{-   end }}
 {{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-statefulset.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-statefulset.yaml
@@ -4,6 +4,10 @@
 {{- $volumeName := trimSuffix "-" (printf "volume-%s" $vname) }}
 {{- $volume := mergeOverwrite (deepCopy $.Values.volume) (dict "enabled" true) $volume }}
 
+{{- if and $volume.idx (eq ($volume.idx.type | toString) "emptyDir") }}
+{{- fail (printf "%s: idx.type \"emptyDir\" is not supported. An ephemeral index is wiped on every pod restart while the data persists, forcing a full index rebuild from the .dat on each start (a fatal crash on older versions). Use the default (idx: {}, kept next to the data) or a persistentVolumeClaim/hostPath/existingClaim for a separate persistent index." $volumeName) }}
+{{- end }}
+
 {{- if $volume.enabled }}
 ---
 apiVersion: apps/v1
@@ -69,6 +73,9 @@ spec:
       {{- if $volume.priorityClassName }}
       priorityClassName: {{ $volume.priorityClassName | quote }}
       {{- end }}
+      {{- if $volume.schedulerName }}
+      schedulerName: {{ $volume.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       serviceAccountName: {{ $volume.serviceAccountName | default (include "seaweedfs.serviceAccountName" $) | quote }} # for deleting statefulset pods after migration
       {{- $initContainers_exists := include "seaweedfs.volume.initContainers_exists" $ -}}
@@ -79,7 +86,23 @@ spec:
           image: {{ template "seaweedfs.volume.image" $ }}
           imagePullPolicy: {{ $.Values.global.seaweedfs.imagePullPolicy | default "IfNotPresent" }}
           command: [ '/bin/sh', '-c' ]
-          args: [ '{{range $dir :=  $volume.dataDirs }}if ls /{{$dir.name}}/*.idx  >/dev/null 2>&1; then mv /{{$dir.name}}/*.idx /idx/ ; fi; {{end}}' ]
+          args:
+            - |
+              for dir in {{ range $index, $dir := $volume.dataDirs }}{{ if ne $index 0 }} {{ end }}/{{ $dir.name }}{{ end }}; do
+                # Rebuild a .idx missing from both dirs (e.g. an index volume that lost files) from the .dat, else the server fatally exits on its idx check.
+                for dat in "$dir"/*.dat; do
+                  [ -e "$dat" ] || continue
+                  base=${dat##*/}; base=${base%.dat}
+                  if [ ! -e "$dir/$base.idx" ] && [ ! -e "/idx/$base.idx" ]; then
+                    echo "rebuilding missing idx in $dir (trigger: volume $base)"
+                    weed fix "$dir"
+                    break
+                  fi
+                done
+                if ls "$dir"/*.idx >/dev/null 2>&1; then
+                  mv "$dir"/*.idx /idx/
+                fi
+              done
           volumeMounts:
             - name: idx
               mountPath: /idx

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/worker/worker-deployment.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/worker/worker-deployment.yaml
@@ -64,6 +64,9 @@ spec:
       {{- if .Values.worker.priorityClassName }}
       priorityClassName: {{ .Values.worker.priorityClassName | quote }}
       {{- end }}
+      {{- if .Values.worker.schedulerName }}
+      schedulerName: {{ .Values.worker.schedulerName | quote }}
+      {{- end }}
       enableServiceLinks: false
       {{- if .Values.worker.serviceAccountName }}
       serviceAccountName: {{ .Values.worker.serviceAccountName | quote }}
@@ -220,6 +223,81 @@ spec:
           {{- if .Values.worker.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.worker.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
+        {{- if include "seaweedfs.worker.lanceNamespaceUrl" . }}
+        - name: worker-lance
+          image: {{ template "seaweedfs.worker.image" . }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.global.seaweedfs.imagePullPolicy }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- /* the URL crosses a shell line; metacharacters must arrive as data, not syntax */}}
+            - name: LANCE_NAMESPACE_URL
+              value: {{ include "seaweedfs.worker.lanceNamespaceUrl" . | quote }}
+          command:
+            - "/bin/sh"
+            - "-ec"
+            - |
+              {{- /* the armv7/386 placeholder is empty; exec of it becomes the shell and exits 0 */}}
+              if [ ! -s /usr/bin/weed-worker ]; then
+                echo "the Rust worker is not available on this platform ($(uname -m)); it ships for amd64 and arm64" >&2
+                exit 1
+              fi
+              exec /usr/bin/weed-worker \
+              --id="$POD_NAME" \
+              {{- if .Values.worker.adminServer }}
+              --admin={{ .Values.worker.adminServer }} \
+              {{- else }}
+              --admin={{ template "seaweedfs.fullname" . }}-admin.{{ .Release.Namespace }}:{{ .Values.admin.port }}{{ if .Values.admin.grpcPort }}.{{ .Values.admin.grpcPort }}{{ end }} \
+              {{- end }}
+              --namespace="$LANCE_NAMESPACE_URL" \
+              {{- if .Values.global.seaweedfs.enableSecurity }}
+              --tls-ca=/usr/local/share/ca-certificates/ca/tls.crt \
+              --tls-cert=/usr/local/share/ca-certificates/worker/tls.crt \
+              --tls-key=/usr/local/share/ca-certificates/worker/tls.key \
+              {{- end }}
+              {{- if .Values.worker.lanceMetricsPort }}
+              --metrics-port={{ .Values.worker.lanceMetricsPort }} \
+              --metrics-ip=0.0.0.0 \
+              {{- end }}
+              --max-concurrency={{ .Values.worker.maxExecute }}
+          {{- if .Values.global.seaweedfs.enableSecurity }}
+          volumeMounts:
+            - name: ca-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/ca/
+            - name: worker-cert
+              readOnly: true
+              mountPath: /usr/local/share/ca-certificates/worker/
+          {{- end }}
+          {{- if .Values.worker.lanceMetricsPort }}
+          ports:
+            - containerPort: {{ .Values.worker.lanceMetricsPort }}
+              name: lance-metrics
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: lance-metrics
+            initialDelaySeconds: 30
+            periodSeconds: 60
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: lance-metrics
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            successThreshold: 1
+            failureThreshold: 3
+            timeoutSeconds: 10
+          {{- end }}
+          {{- if .Values.worker.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.worker.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+        {{- end }}
       {{- if .Values.worker.sidecars }}
       {{- include "seaweedfs.tplvalues.render" (dict "value" .Values.worker.sidecars "context" $) | nindent 8 }}
       {{- end }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/worker/worker-service.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/worker/worker-service.yaml
@@ -12,12 +12,21 @@ metadata:
     app.kubernetes.io/component: worker
 spec:
   clusterIP: None  # Headless service
-  {{- if .Values.worker.metricsPort }}
+  {{- $lanceMetrics := and .Values.worker.lanceMetricsPort (include "seaweedfs.worker.lanceNamespaceUrl" .) }}
+  {{- if or .Values.worker.metricsPort $lanceMetrics }}
   ports:
+  {{- if .Values.worker.metricsPort }}
   - name: "metrics"
     port: {{ .Values.worker.metricsPort }}
     targetPort: {{ .Values.worker.metricsPort }}
     protocol: TCP
+  {{- end }}
+  {{- if $lanceMetrics }}
+  - name: "lance-metrics"
+    port: {{ .Values.worker.lanceMetricsPort }}
+    targetPort: {{ .Values.worker.lanceMetricsPort }}
+    protocol: TCP
+  {{- end }}
   {{- end }}
   selector:
     app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/packages/system/seaweedfs/charts/seaweedfs/templates/worker/worker-servicemonitor.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/templates/worker/worker-servicemonitor.yaml
@@ -1,6 +1,7 @@
 {{- include "seaweedfs.compat" . -}}
 {{- if .Values.worker.enabled }}
-{{- if .Values.worker.metricsPort }}
+{{- $lanceMetrics := and .Values.worker.lanceMetricsPort (include "seaweedfs.worker.lanceNamespaceUrl" .) }}
+{{- if or .Values.worker.metricsPort $lanceMetrics }}
 {{- if .Values.global.seaweedfs.monitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -22,9 +23,16 @@ metadata:
 {{- end }}
 spec:
   endpoints:
+    {{- if .Values.worker.metricsPort }}
     - interval: 30s
       port: metrics
       scrapeTimeout: 5s
+    {{- end }}
+    {{- if $lanceMetrics }}
+    - interval: 30s
+      port: lance-metrics
+      scrapeTimeout: 5s
+    {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "seaweedfs.name" . }}

--- a/packages/system/seaweedfs/charts/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/charts/seaweedfs/values.yaml
@@ -12,7 +12,16 @@ global:
     image:
       # if repository is set, it overrides the namespace part of image.name
       repository: ""
+      # chrislusf/seaweedfs-enterprise for the enterprise edition
       name: chrislusf/seaweedfs
+    # Enterprise license file, held in a Secret in the release namespace and
+    # mounted read-only on the components that run a master. A renewed Secret
+    # reaches the running master without a restart. SEAWEED_LICENSE is reserved
+    # while this is set: an extraEnvironmentVars entry of that name is dropped.
+    license:
+      existingSecret: ""
+      secretKey: seaweed-license.json
+      mountPath: /etc/seaweedfs/license
     imagePullPolicy: IfNotPresent
     restartPolicy: Always
     loggingLevel: 1
@@ -26,6 +35,13 @@ global:
         volumeRead: false
         filerWrite: false
         filerRead: false
+        # Positive values override SeaweedFS token lifetime defaults.
+        # Zero keeps the runtime defaults: 10s for writes and 60s for reads.
+        expiresAfterSeconds:
+          volumeWrite: 0
+          volumeRead: 0
+          filerWrite: 0
+          filerRead: 0
     # we will use this serviceAccountName for all ClusterRoles/ClusterRoleBindings
     serviceAccountName: "seaweedfs"
     serviceAccountAnnotations: {}
@@ -118,7 +134,7 @@ master:
   #    annotations:
   #      "key": "value"
   #
-  # You may also spacify an existing claim:
+  # You may also specify an existing claim:
   #  data:
   #    type: "existingClaim"
   #    claimName: "my-pvc"
@@ -126,8 +142,13 @@ master:
   # You can also use emptyDir storage:
   #  data:
   #    type: "emptyDir"
+  # -mdir holds the Raft log and snapshots, and with them the cluster's
+  # identity (its topology UUID). A hostPath does not follow a rescheduled pod,
+  # so prefer type "persistentVolumeClaim" for new installs. The default stays
+  # hostPath so existing releases keep upgrading; see the README to switch one.
   data:
     type: "hostPath"
+    size: "1Gi"
     storageClass: ""
     hostPathPrefix: /ssd
 
@@ -220,6 +241,10 @@ master:
   # used to assign priority to master pods
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
+
+  # used to specify a custom scheduler for master pods
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
 
   # used to assign a service account.
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -344,7 +369,7 @@ volume:
   #      "key": "value"
   #     maxVolumes: 0  # If set to zero on non-windows OS, the limit will be auto configured. (default "7")
   #
-  # You may also spacify an existing claim:
+  # You may also specify an existing claim:
   #   - name: data
   #     type: "existingClaim"
   #     claimName: "my-pvc"
@@ -378,7 +403,7 @@ volume:
     enabled: true
     image: alpine/k8s:1.28.4
 
-  # idx can be defined by:
+  # idx (the volume index) may use a separate PERSISTENT volume:
   #
   # idx:
   #  type: "hostPath"
@@ -397,13 +422,14 @@ volume:
   #   type: "existingClaim"
   #   claimName: "myClaim"
   #
-  # or
+  # "emptyDir" is rejected for idx (the chart fails to render): an ephemeral
+  # index is wiped on every restart while the data persists, forcing a full
+  # rebuild each start (a fatal crash on older versions). "logs" may still use
+  # any of the above or emptyDir.
   #
-  # idx:
-  #  type: "emptyDir"
-
-  # same applies to "logs"
-
+  # Default {} keeps the index next to the data, so it persists with the data and
+  # needs no separate volume. Recommended unless you must split the index onto
+  # its own persistent storage.
   idx: {}
 
   # Resource requests, limits, etc. for the vol-move-idx initContainer. This
@@ -512,6 +538,10 @@ volume:
   # used to assign priority to server pods
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
+
+  # used to specify a custom scheduler for volume pods
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
 
   # used to assign a service account.
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -793,6 +823,10 @@ filer:
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
 
+  # used to specify a custom scheduler for filer pods
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/kube-scheduler/
+  schedulerName: ""
+
   # used to assign a service account.
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   serviceAccountName: ""
@@ -816,33 +850,54 @@ filer:
   #   allowPrivilegeEscalation: false
   containerSecurityContext: {}
 
-  ingress:
-    enabled: false
-    className: ""
-    # host: false for "*" hostname
-    host: "seaweedfs.cluster.local"
-    path: "/sw-filer/?(.*)"
-    pathType: ImplementationSpecific
-    annotations: {}
-      # nginx.ingress.kubernetes.io/backend-protocol: GRPC
-      # nginx.ingress.kubernetes.io/auth-type: "basic"
-      # nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
-      # nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Filer'
-      # nginx.ingress.kubernetes.io/service-upstream: "true"
-      # nginx.ingress.kubernetes.io/rewrite-target: /$1
-      # nginx.ingress.kubernetes.io/use-regex: "true"
-      # nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
-      # nginx.ingress.kubernetes.io/ssl-redirect: "false"
-      # nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-      # nginx.ingress.kubernetes.io/configuration-snippet: |
-      #   sub_filter '<head>' '<head> <base href="/sw-filer/">'; #add base url
-      #   sub_filter '="/' '="./';                               #make absolute paths to relative
-      #   sub_filter '=/' '=./';
-      #   sub_filter '/seaweedfsstatic' './seaweedfsstatic';
-      #   sub_filter_once off;
+  ingresses:
+    http:
+      enabled: false
+      className: ""
+      # host: false for "*" hostname
+      host: "seaweedfs.cluster.local"
+      path: "/sw-filer/?(.*)"
+      pathType: ImplementationSpecific
+      annotations: {}
+        # nginx.ingress.kubernetes.io/backend-protocol: GRPC
+        # nginx.ingress.kubernetes.io/auth-type: "basic"
+        # nginx.ingress.kubernetes.io/auth-secret: "default/ingress-basic-auth-secret"
+        # nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - SW-Filer'
+        # nginx.ingress.kubernetes.io/service-upstream: "true"
+        # nginx.ingress.kubernetes.io/rewrite-target: /$1
+        # nginx.ingress.kubernetes.io/use-regex: "true"
+        # nginx.ingress.kubernetes.io/enable-rewrite-log: "true"
+        # nginx.ingress.kubernetes.io/ssl-redirect: "false"
+        # nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+        # nginx.ingress.kubernetes.io/configuration-snippet: |
+        #   sub_filter '<head>' '<head> <base href="/sw-filer/">'; #add base url
+        #   sub_filter '="/' '="./';                               #make absolute paths to relative
+        #   sub_filter '=/' '=./';
+        #   sub_filter '/seaweedfsstatic' './seaweedfsstatic';
+        #   sub_filter_once off;
+      tls: []
+    grpc:
+      enabled: false
+      className: ""
+      host: "seaweedfs.cluster.local"
+      # gRPC methods are called at /<package>.<Service>/<Method>, so route the
+      # whole host, not the HTTP UI's regex path.
+      path: "/"
+      pathType: Prefix
+      annotations:
+        # Ingress terminates TLS and re-originates gRPC (HTTP/2) to the filer.
+        nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+        # For end-to-end mTLS (the filer's own TLS reaches the client, not
+        # terminated at the edge), drop backend-protocol above and use TLS
+        # passthrough instead:
+        #   nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+        # Passthrough routes by SNI (set `host` above), ignores `path`, and
+        # requires ingress-nginx to run with --enable-ssl-passthrough.
+      tls: []
 
   # extraEnvVars is a list of extra environment variables to set with the stateful set.
   extraEnvironmentVars:
+    # the WEED_MYSQL_* keys and the db credential secret only render while this is "true"
     WEED_MYSQL_ENABLED: "false"
     WEED_MYSQL_HOSTNAME: "mysql-db-host"
     WEED_MYSQL_PORT: "3306"
@@ -919,7 +974,7 @@ filer:
     # Buckets may be exposed publicly by setting `anonymousRead` to `true`
     # ttl format: [1-255][m|h|d|w|M|y] (e.g., 7d)
     # objectLock enables S3 Object Lock (irreversible, forces versioning)
-    # versioning: Enabled or Suspended (or true to enable)
+    # versioning: Enabled or Suspended (or bool true/false)
     # createBuckets:
     #   - name: bucket-a
     #     anonymousRead: true
@@ -951,6 +1006,9 @@ s3:
   # Iceberg catalog REST port (Apache Iceberg REST Catalog API)
   # Set to a port number to enable, or 0/null to disable
   icebergPort: null
+  # Lance Namespace port; weed serves 9101 by default, 0 disables it
+  # (and, unless worker.namespaceUrl points elsewhere, the worker's Lance container)
+  lancePort: 9101
   loggingOverrideLevel: null
   # enable user & permission to s3 (need to inject to all services)
   enableAuth: false
@@ -960,19 +1018,30 @@ s3:
   # Optionally provide explicit credentials for the S3 gateway.
   # When set, these are used in the generated s3 secret instead of
   # auto-generating random credentials.
+  # An identity may instead name an existing Secret to read its keys from. The
+  # generated config then references the keys through environment variables, so
+  # nothing is looked up at render time and a dry run renders what an install
+  # applies. Note the COSI driver parses the config itself and does not resolve
+  # those references.
   # credentials:
   #   admin:
   #     accessKey: ""
   #     secretKey: ""
+  #     existingSecret: ""
+  #     accessKeyKey: admin_access_key_id
+  #     secretKeyKey: admin_secret_access_key
   #   read:
   #     accessKey: ""
   #     secretKey: ""
+  #     existingSecret: ""
+  #     accessKeyKey: read_access_key_id
+  #     secretKeyKey: read_secret_access_key
   auditLogConfig: {}
   # You may specify buckets to be created during the install or upgrade process.
   # Buckets may be exposed publicly by setting `anonymousRead` to `true`
   # ttl format: [1-255][m|h|d|w|M|y] (e.g., 7d)
   # objectLock enables S3 Object Lock (irreversible, forces versioning)
-  # versioning: Enabled or Suspended (or true to enable)
+  # versioning: Enabled or Suspended (or bool true/false)
   # createBuckets:
   #   - name: bucket-a
   #     anonymousRead: true
@@ -1031,6 +1100,10 @@ s3:
   # used to assign priority to server pods
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
+
+  # used to assign a custom scheduler to server pods
+  # ref: https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/
+  schedulerName: ""
 
   # used to assign a service account.
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
@@ -1114,11 +1187,31 @@ s3:
   # Service settings
   service:
     type: ClusterIP
+    # used only when type is LoadBalancer
+    loadBalancerClass: ""
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    # fixed nodePorts, used only when type is NodePort or LoadBalancer
+    nodePorts:
+      http: null
+      https: null
+      iceberg: null
+      lance: null
+      metrics: null
 
   icebergIngress:
     enabled: false
     className: ""
     host: "seaweedfs-iceberg.cluster.local"
+    path: "/"
+    pathType: Prefix
+    annotations: {}
+    tls: []
+
+  lanceIngress:
+    enabled: false
+    className: ""
+    host: "seaweedfs-lance.cluster.local"
     path: "/"
     pathType: Prefix
     annotations: {}
@@ -1136,9 +1229,9 @@ sftp:
   loggingOverrideLevel: null
 
   # SSH server configuration
-  sshPrivateKey: "/etc/sw/seaweedfs_sftp_ssh_private_key"  # Path to the SSH private key file for host authentication
+  sshPrivateKey: ""  # Optional path to a single SSH host key file; the server fails to start if set but missing. Host keys come from hostKeysFolder by default.
   hostKeysFolder: "/etc/sw/ssh"  # path to folder containing SSH private key files for host authentication
-  authMethods: "password,publickey"  # Comma-separated list of allowed auth methods: password, publickey, keyboard-interactive
+  authMethods: "password,publickey"  # Comma-separated list of allowed auth methods: password, publickey, certificate
   maxAuthTries: 6  # Maximum number of authentication attempts per connection
   bannerMessage: "SeaweedFS SFTP Server"  # Message displayed before authentication
   loginGraceTime: "2m"  # Timeout for authentication
@@ -1155,6 +1248,18 @@ sftp:
   # Set to the name of an existing kubernetes Secret with the list of ssh private keys for sftp
   existingSshConfigSecret: null
 
+  # SSH user-certificate authentication (CA-signed user certs). Mirrors
+  # OpenSSH `TrustedUserCAKeys` and MinIO `--sftp=trusted-user-ca-key`.
+  # Add "certificate" to `authMethods` to activate; when active, plain
+  # public keys are rejected on the public-key channel.
+  #
+  # Inline CA public keys in OpenSSH authorized_keys format (one per
+  # line). Ignored when `existingCAKeysSecret` is set.
+  trustedUserCAKeys: ""
+  # Set to the name of an existing kubernetes Secret carrying the CA
+  # public keys under data key `ca_user.pub`.
+  existingCAKeysSecret: null
+
   # Additional resources
   sidecars: []
   initContainers: ""
@@ -1167,6 +1272,7 @@ sftp:
   tolerations: ""
   nodeSelector: ""
   priorityClassName: ""
+  schedulerName: ""
   serviceAccountName: ""
   podSecurityContext: {}
   containerSecurityContext: {}
@@ -1199,6 +1305,14 @@ sftp:
   # Service settings
   service:
     type: ClusterIP
+    # used only when type is LoadBalancer
+    loadBalancerClass: ""
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    # fixed nodePorts, used only when type is NodePort or LoadBalancer
+    nodePorts:
+      sftp: null
+      metrics: null
 
 admin:
   enabled: false
@@ -1287,6 +1401,7 @@ admin:
   tolerations: ""
   nodeSelector: ""
   priorityClassName: ""
+  schedulerName: ""
   serviceAccountName: ""
   podSecurityContext: {}
   containerSecurityContext: {}
@@ -1336,6 +1451,14 @@ admin:
   service:
     type: ClusterIP
     annotations: {}
+    # used only when type is LoadBalancer
+    loadBalancerClass: ""
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    # fixed nodePorts, used only when type is NodePort or LoadBalancer
+    nodePorts:
+      http: null
+      grpc: null
 
   # ServiceMonitor annotations (separate from pod/deployment annotations)
   serviceMonitor:
@@ -1349,6 +1472,15 @@ worker:
   loggingOverrideLevel: null
   metricsPort: 9327
   metricsIp: ""  # If empty, defaults to 0.0.0.0
+
+  # The lance_* jobs run in their own container, /usr/bin/weed-worker.
+  # amd64/arm64 only; pin mixed clusters with worker.affinity/nodeSelector.
+
+  # Lance namespace URL override; empty derives it from s3.lancePort.
+  namespaceUrl: ""
+
+  # Metrics port for the Lance worker container; the Go worker keeps metricsPort
+  lanceMetricsPort: 9328
 
   # Admin server to connect to
   adminServer: ""
@@ -1425,6 +1557,7 @@ worker:
   tolerations: ""
   nodeSelector: ""
   priorityClassName: ""
+  schedulerName: ""
   serviceAccountName: ""
   podSecurityContext: {}
   containerSecurityContext: {}
@@ -1514,7 +1647,7 @@ allInOne:
     # Buckets may be exposed publicly by setting `anonymousRead` to `true`
     # ttl format: [1-255][m|h|d|w|M|y] (e.g., 7d)
     # objectLock enables S3 Object Lock (irreversible, forces versioning)
-    # versioning: Enabled or Suspended (or true to enable)
+    # versioning: Enabled or Suspended (or bool true/false)
     # createBuckets:
     #   - name: bucket-a
     #     anonymousRead: true
@@ -1545,12 +1678,32 @@ allInOne:
     existingConfigSecret: null
     # Set to the name of an existing kubernetes Secret with the SSH keys
     existingSshConfigSecret: null
+    # SSH user-certificate authentication. See sftp.trustedUserCAKeys above.
+    # (null on either field inherits from the top-level sftp.* setting.)
+    trustedUserCAKeys: null
+    existingCAKeysSecret: null
 
   # Service settings
   service:
     annotations: {}  # Annotations for the service
     type: ClusterIP  # Service type (ClusterIP, NodePort, LoadBalancer)
     internalTrafficPolicy: Cluster  # Internal traffic policy
+    # used only when type is LoadBalancer
+    loadBalancerClass: ""
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    # fixed nodePorts, used only when type is NodePort or LoadBalancer
+    nodePorts:
+      master: null
+      masterGrpc: null
+      volume: null
+      volumeGrpc: null
+      filer: null
+      filerGrpc: null
+      s3: null
+      s3Https: null
+      sftp: null
+      metrics: null
 
   # Note: For ingress in all-in-one mode, use the standard s3.ingress and
   # filer.ingress settings. The templates automatically detect all-in-one mode
@@ -1648,6 +1801,10 @@ allInOne:
   # ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
   priorityClassName: ""
 
+  # Used to assign a custom scheduler to pods
+  # ref: https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/
+  schedulerName: ""
+
   # Used to assign a service account.
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
   serviceAccountName: ""
@@ -1710,6 +1867,10 @@ cosi:
   podSecurityContext: {}
   containerSecurityContext: {}
 
+  # used to assign a custom scheduler to cosi pods
+  # ref: https://kubernetes.io/docs/tasks/extend-kubernetes/configure-multiple-schedulers/
+  schedulerName: ""
+
   extraVolumes: ""
   extraVolumeMounts: ""
 
@@ -1721,6 +1882,7 @@ cosi:
 
 certificates:
   commonName: "SeaweedFS CA"
+  dnsNames: []
   ipAddresses: []
   keyAlgorithm: RSA
   keySize: 2048
@@ -1739,3 +1901,140 @@ certificates:
 podLabels: {}
 # Annotations to be added to all the created pods
 podAnnotations: {}
+
+networkPolicy:
+  # Opt-in. While false the chart renders no NetworkPolicy objects at all and
+  # the cluster default (usually allow-all) applies. Turn this on for a
+  # namespace with a default-deny policy, where the components otherwise
+  # cannot reach each other and the install hangs.
+  #
+  # This alone covers a default-deny that only restricts ingress. If yours has
+  # Egress in its policyTypes as well - the usual baseline - the components
+  # still cannot resolve DNS or reach each other, and you need egress.enabled
+  # below too, together with an extraEgress entry for the filer store.
+  enabled: false
+
+  # One policy is rendered per component, selecting its pods by the standard
+  # app.kubernetes.io/{name,instance,component} labels. Each policy admits
+  # traffic from any pod of this release, on the ports that component listens
+  # on - the same values the containerPorts are taken from, so changing a port
+  # does not leave the policy behind. Everything else is denied.
+  #
+  # Traffic from outside the release has to be added here. Rules are plain
+  # NetworkPolicyIngressRule entries, appended to every component's policy.
+  #
+  # The metrics ports are covered by the same rule as everything else, so with
+  # global.seaweedfs.monitoring.enabled the ServiceMonitors keep pointing at
+  # ports a Prometheus outside the release can no longer reach. Nothing reports
+  # that - the targets just go down - so add the scraper here:
+  #
+  #   extraIngress:
+  #     # an ingress controller reaching filer/s3/admin
+  #     - from:
+  #         - namespaceSelector:
+  #             matchLabels:
+  #               kubernetes.io/metadata.name: ingress-nginx
+  #       ports:
+  #         - protocol: TCP
+  #           port: 8888
+  #         - protocol: TCP
+  #           port: 8333
+  #     # Prometheus scraping the metrics ports
+  #     - from:
+  #         - namespaceSelector:
+  #             matchLabels:
+  #               kubernetes.io/metadata.name: monitoring
+  #       ports:
+  #         - protocol: TCP
+  #           port: 9327
+  #
+  # An ingress controller running on the host network is not a pod as far as
+  # the policy is concerned; select it with an ipBlock of the node addresses
+  # instead of a namespaceSelector.
+  #
+  # Kubelet probes are not covered by these rules. Node-to-pod traffic is
+  # outside NetworkPolicy in the CNIs that come up without host endpoints
+  # (Calico, Cilium); if yours polices it, allow the node addresses here.
+  extraIngress: []
+
+  egress:
+    # Egress is a separate opt-in: the chart knows the addresses of its own
+    # components, but not where your filer store (MySQL, Postgres, Redis,
+    # ...), notification sink or remote tier lives. Enabling this without
+    # listing those under extraEgress will cut the filer off from its store.
+    #
+    # It cannot be on by default either. In a namespace with no default-deny,
+    # egress rules would take the components from "may reach anything" down to
+    # "may reach the peers listed here", which is the same breakage from the
+    # other direction. Required if your default-deny covers egress.
+    enabled: false
+
+    # Every component resolves its peers by DNS name, so this is required
+    # for the release to function at all.
+    #
+    # The defaults below are CoreDNS as kubeadm, kind and the managed offerings
+    # from AWS, Google and Azure install it. OpenShift runs its resolver
+    # elsewhere and needs both overridden:
+    #   dnsNamespaceSelector:
+    #     matchLabels:
+    #       kubernetes.io/metadata.name: openshift-dns
+    #   dnsPodSelector:
+    #     matchLabels:
+    #       dns.operator.openshift.io/daemonset-dns: default
+    # A node-local DNS cache is not a pod peer at all - the resolver address is
+    # a link-local IP - so name it with an ipBlock in extraEgress instead.
+    allowDNS: true
+    dnsNamespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: kube-system
+    dnsPodSelector:
+      matchLabels:
+        k8s-app: kube-dns
+
+    # The COSI sidecar watches the COSI custom resources and the volume resize
+    # hook shells out to kubectl. Only those two get this rule - no seaweedfs
+    # component itself speaks to the Kubernetes API. The resize hook's policy,
+    # and with it this requirement, only appears on an upgrade that actually
+    # grows a volume PVC.
+    kubeApiServer:
+      enabled: true
+      # The API server cannot be selected by label, so its address has to be
+      # given here - there is no sane default, and 0.0.0.0/0 would defeat the
+      # point. Rendering fails with a pointer to this value if a component
+      # needs the API server and this is empty.
+      #
+      # Use the endpoint behind the kubernetes service, not its ClusterIP:
+      # kube-proxy rewrites the destination before the packet is matched.
+      #   kubectl get endpointslice kubernetes -o jsonpath='{.endpoints[*].addresses[*]}'
+      cidrs: []
+      ports: [443, 6443]
+
+    # Plain NetworkPolicyEgressRule entries, appended to every component's
+    # policy. This is where the filer store and the notification sinks go:
+    #
+    #   extraEgress:
+    #     - to:
+    #         - podSelector:
+    #             matchLabels:
+    #               app.kubernetes.io/name: mysql
+    #       ports:
+    #         - protocol: TCP
+    #           port: 3306
+    extraEgress: []
+
+  # Per-component additions, keyed by the component's app.kubernetes.io/component
+  # label value, for rules that should not apply to the whole release. The keys
+  # are master, filer, s3, sftp, admin, worker, bucket-hook,
+  # volume-resize-hook, objectstorage-provisioner, seaweedfs-all-in-one, and
+  # volume (plus volume-<name> for every entry under `volumes`):
+  #
+  #   components:
+  #     filer:
+  #       extraEgress:
+  #         - to:
+  #             - ipBlock:
+  #                 cidr: 10.0.0.5/32
+  #           ports:
+  #             - protocol: TCP
+  #               port: 5432
+  components: {}

--- a/packages/system/seaweedfs/patches/resize-api-server-annotation.diff
+++ b/packages/system/seaweedfs/patches/resize-api-server-annotation.diff
@@ -1,13 +1,10 @@
 diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-resize-hook.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
-index 436a785..9f186ea 100644
 --- a/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
 +++ b/packages/system/seaweedfs/charts/seaweedfs/templates/volume/volume-resize-hook.yaml
-@@ -45,6 +45,9 @@ metadata:
-     helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
- spec:
-   template:
-+    metadata:
-+      labels:
+@@ -29,6 +29,7 @@
+         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+         app.kubernetes.io/instance: {{ .Release.Name | quote }}
+         app.kubernetes.io/component: volume-resize-hook
 +        policy.cozystack.io/allow-to-apiserver: "true"
      spec:
        serviceAccountName: {{ $seaweedfsName }}-volume-resize-hook

--- a/packages/system/seaweedfs/patches/s3-iceberg-port-explicit.patch
+++ b/packages/system/seaweedfs/patches/s3-iceberg-port-explicit.patch
@@ -1,0 +1,16 @@
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+index 0849f8a28..cf5710ba0 100644
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/s3/s3-deployment.yaml
+@@ -146,9 +146,8 @@ spec:
+               -auditLogConfig=/etc/sw/s3_auditLogConfig.json \
+               {{- end }}
+               -filer={{ include "seaweedfs.componentName" (list . "filer-client") }}.{{ .Release.Namespace }}:{{ .Values.filer.port }} \
+-              {{- if .Values.s3.icebergPort }}
+-              -port.iceberg={{ .Values.s3.icebergPort }} \
+-              {{- end }}
++              {{- /* rendered even when 0: an if would drop the flag and weed would serve its 8181 default */}}
++              -port.iceberg={{ .Values.s3.icebergPort | default 0 }} \
+               {{- /* rendered even when 0: an if would drop the flag and weed would serve its default */}}
+               -port.lance={{ .Values.s3.lancePort | default 0 }} \
+               {{- range .Values.s3.extraArgs }}

--- a/packages/system/seaweedfs/patches/volume-resize-quantity.diff
+++ b/packages/system/seaweedfs/patches/volume-resize-quantity.diff
@@ -1,0 +1,17 @@
+diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
+index 3ac343075..911f7d71d 100644
+--- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
++++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
+@@ -432,7 +432,11 @@ true
+ {{-             if $currentPVC }}
+ {{-               $oldSize := include "seaweedfs.resource-quantity" $currentPVC.spec.resources.requests.storage }}
+ {{-               $newSize := include "seaweedfs.resource-quantity" $desiredSize }}
+-{{-               if gt $newSize $oldSize }}
++{{- /* both sides come from an include, so they are STRINGS: gt would compare
++       them lexicographically and read 1.073741824e+10 (10Gi) as smaller than
++       5.36870912e+09 (5Gi), skipping the patch while the statefulset delete
++       above still runs. Compare as numbers. */}}
++{{-               if gt (float64 $newSize) (float64 $oldSize) }}
+ {{-                 $commands = append $commands (printf "kubectl patch pvc %s-%s-%s-%d -p '{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"%s\"}}}}'" $dir.name $seaweedfsName $volumeName $e $desiredSize) }}
+ {{-               end }}
+ {{-             end }}

--- a/packages/system/seaweedfs/patches/volume-resize-quantity.diff
+++ b/packages/system/seaweedfs/patches/volume-resize-quantity.diff
@@ -1,8 +1,20 @@
 diff --git a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
-index 3ac343075..911f7d71d 100644
 --- a/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
 +++ b/packages/system/seaweedfs/charts/seaweedfs/templates/shared/_helpers.tpl
-@@ -432,7 +432,11 @@ true
+@@ -415,7 +415,11 @@
+ {{-           if eq .type "persistentVolumeClaim" }}
+ {{-             $desiredSize := .size }}
+ {{-             range $statefulset.spec.volumeClaimTemplates }}
+-{{-               if and (eq .metadata.name $dir.name) (ne .spec.resources.requests.storage $desiredSize) }}
++{{- /* normalise both sides: the API server re-emits a quantity in its canonical
++       form, so values saying 10240Mi come back from the cluster as 10Gi and a raw
++       string compare deletes the statefulset on EVERY upgrade for a size that
++       never changed. */}}
++{{-               if and (eq .metadata.name $dir.name) (ne (include "seaweedfs.resource-quantity" .spec.resources.requests.storage) (include "seaweedfs.resource-quantity" $desiredSize)) }}
+ {{-                 $commands = append $commands (printf "kubectl delete statefulset %s --cascade=orphan" $statefulsetName) }}
+ {{-               end }}
+ {{-             end }}
+@@ -432,7 +436,11 @@
  {{-             if $currentPVC }}
  {{-               $oldSize := include "seaweedfs.resource-quantity" $currentPVC.spec.resources.requests.storage }}
  {{-               $newSize := include "seaweedfs.resource-quantity" $desiredSize }}

--- a/packages/system/seaweedfs/tests/s3_catalog_ports_test.yaml
+++ b/packages/system/seaweedfs/tests/s3_catalog_ports_test.yaml
@@ -1,0 +1,65 @@
+suite: seaweedfs s3 catalog listener ports
+
+# The 4.45 bump brought upstream's Lance Namespace catalog, which defaults to
+# lancePort 9101 and is published on the s3 Service. weed serves that catalog
+# over plain HTTP with no certificate option (weed/command/s3.go: newHttpServer
+# with a nil TLS config) while every other port on this gateway is TLS by way of
+# patches/s3-tls-main-port.patch, and its namespace and table routes are
+# writable. Nothing in Cozystack consumes the catalog, so values.yaml pins the
+# port off. These cases fail if that pin is dropped or if a future bump
+# reintroduces the listener under a different default.
+
+templates:
+  - charts/seaweedfs/templates/s3/s3-service.yaml
+  - charts/seaweedfs/templates/s3/s3-deployment.yaml
+
+release:
+  name: seaweedfs
+  namespace: cozy-seaweedfs
+
+tests:
+  - it: does not publish a Lance port on the s3 Service
+    template: charts/seaweedfs/templates/s3/s3-service.yaml
+    asserts:
+      - isKind:
+          of: Service
+      - notContains:
+          path: spec.ports
+          content:
+            name: swfs-lance
+          any: true
+
+  - it: keeps the s3 Service on the pre-4.45 port set
+    template: charts/seaweedfs/templates/s3/s3-service.yaml
+    asserts:
+      - contains:
+          path: spec.ports
+          content:
+            name: swfs-s3
+          any: true
+      - contains:
+          path: spec.ports
+          content:
+            name: metrics
+          any: true
+      - lengthEqual:
+          path: spec.ports
+          count: 2
+
+  - it: tells weed to skip the Lance server
+    template: charts/seaweedfs/templates/s3/s3-deployment.yaml
+    asserts:
+      - isKind:
+          of: Deployment
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: -port\.lance=0
+
+  - it: does not expose a Lance container port
+    template: charts/seaweedfs/templates/s3/s3-deployment.yaml
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            name: swfs-lance
+          any: true

--- a/packages/system/seaweedfs/tests/s3_catalog_ports_test.yaml
+++ b/packages/system/seaweedfs/tests/s3_catalog_ports_test.yaml
@@ -1,13 +1,15 @@
 suite: seaweedfs s3 catalog listener ports
 
-# The 4.45 bump brought upstream's Lance Namespace catalog, which defaults to
-# lancePort 9101 and is published on the s3 Service. weed serves that catalog
-# over plain HTTP with no certificate option (weed/command/s3.go: newHttpServer
-# with a nil TLS config) while every other port on this gateway is TLS by way of
-# patches/s3-tls-main-port.patch, and its namespace and table routes are
-# writable. Nothing in Cozystack consumes the catalog, so values.yaml pins the
-# port off. These cases fail if that pin is dropped or if a future bump
-# reintroduces the listener under a different default.
+# weed s3 ships two table-catalog listeners that default to on: Lance on 9101
+# and Iceberg on 8181. Both are served over plain HTTP with no certificate
+# option (weed/command/s3.go: newHttpServer with a nil TLS config) while every
+# other port on this gateway is TLS by way of patches/s3-tls-main-port.patch,
+# and both expose writable routes. Nothing in Cozystack consumes either, so
+# values.yaml pins lancePort off and s3-iceberg-port-explicit.patch renders
+# -port.iceberg unconditionally so the chart's null default reaches weed as 0
+# rather than being dropped into weed's own 8181. These cases fail if either
+# control is lost, and the last two pin that an operator who does want a
+# catalog can still turn one on.
 
 templates:
   - charts/seaweedfs/templates/s3/s3-service.yaml
@@ -60,6 +62,33 @@ tests:
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].ports
+          content:
+            name: swfs-lance
+          any: true
+
+  - it: tells weed to skip the Iceberg catalog too
+    template: charts/seaweedfs/templates/s3/s3-deployment.yaml
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: -port\.iceberg=0
+
+  - it: still honours an explicitly configured Iceberg port
+    template: charts/seaweedfs/templates/s3/s3-deployment.yaml
+    set:
+      seaweedfs.s3.icebergPort: 8334
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: -port\.iceberg=8334
+
+  - it: still honours an explicitly configured Lance port
+    template: charts/seaweedfs/templates/s3/s3-service.yaml
+    set:
+      seaweedfs.s3.lancePort: 9101
+    asserts:
+      - contains:
+          path: spec.ports
           content:
             name: swfs-lance
           any: true

--- a/packages/system/seaweedfs/tests/volume_resize_hook_test.yaml
+++ b/packages/system/seaweedfs/tests/volume_resize_hook_test.yaml
@@ -1,0 +1,169 @@
+suite: seaweedfs volume resize hook
+
+# The pre-upgrade hook deletes the volume StatefulSet with --cascade=orphan and
+# then patches each PVC to the new size. Both sizes reach the comparison through
+# an include, which returns a STRING, so the original `gt $newSize $oldSize`
+# compared them lexicographically: growing across a decimal exponent that lowers
+# the leading digit (5Gi -> 10Gi, 8Gi -> 16Gi, 20Gi -> 100Gi) read as "smaller",
+# the patches were skipped, and the tenant was left with its StatefulSet
+# recreated and its claims still at the old size, hook exit 0 and no signal.
+# patches/volume-resize-quantity.diff compares as numbers instead. The first
+# case is the one that was silently broken; the second is a size pair that
+# worked before the fix and must keep working.
+
+templates:
+  - charts/seaweedfs/templates/volume/volume-resize-hook.yaml
+
+release:
+  name: seaweedfs
+  namespace: tenant-test
+
+tests:
+  - it: patches the PVCs when the grow crosses a decimal exponent (5Gi to 10Gi)
+    kubernetesProvider:
+      scheme: &scheme
+        "apps/v1/StatefulSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "statefulsets"
+          namespaced: true
+        "v1/PersistentVolumeClaim":
+          gvr:
+            group: ""
+            version: "v1"
+            resource: "persistentvolumeclaims"
+          namespaced: true
+      objects:
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-volume
+            namespace: tenant-test
+          spec:
+            volumeClaimTemplates:
+              - metadata:
+                  name: data1
+                spec:
+                  resources:
+                    requests:
+                      storage: 5Gi
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-test
+          spec:
+            resources:
+              requests:
+                storage: 5Gi
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-1
+            namespace: tenant-test
+          spec:
+            resources:
+              requests:
+                storage: 5Gi
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Job
+      - documentIndex: 0
+        matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: kubectl delete statefulset seaweedfs-volume --cascade=orphan
+      - documentIndex: 0
+        matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: kubectl patch pvc data1-seaweedfs-volume-0 .*"storage":"10Gi"
+      - documentIndex: 0
+        matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: kubectl patch pvc data1-seaweedfs-volume-1 .*"storage":"10Gi"
+
+  - it: still patches a grow that stays inside one exponent (10Gi to 20Gi)
+    set:
+      seaweedfs.volume.dataDirs:
+        - name: data1
+          type: persistentVolumeClaim
+          size: 20Gi
+          maxVolumes: 0
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-volume
+            namespace: tenant-test
+          spec:
+            volumeClaimTemplates:
+              - metadata:
+                  name: data1
+                spec:
+                  resources:
+                    requests:
+                      storage: 10Gi
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-test
+          spec:
+            resources:
+              requests:
+                storage: 10Gi
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-1
+            namespace: tenant-test
+          spec:
+            resources:
+              requests:
+                storage: 10Gi
+    asserts:
+      - documentIndex: 0
+        matchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: kubectl patch pvc data1-seaweedfs-volume-0 .*"storage":"20Gi"
+
+  - it: does not shrink a PVC when the desired size is smaller
+    set:
+      seaweedfs.volume.dataDirs:
+        - name: data1
+          type: persistentVolumeClaim
+          size: 5Gi
+          maxVolumes: 0
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-volume
+            namespace: tenant-test
+          spec:
+            volumeClaimTemplates:
+              - metadata:
+                  name: data1
+                spec:
+                  resources:
+                    requests:
+                      storage: 10Gi
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-test
+          spec:
+            resources:
+              requests:
+                storage: 10Gi
+    asserts:
+      - documentIndex: 0
+        notMatchRegex:
+          path: spec.template.spec.containers[0].args[0]
+          pattern: kubectl patch pvc

--- a/packages/system/seaweedfs/tests/volume_resize_hook_test.yaml
+++ b/packages/system/seaweedfs/tests/volume_resize_hook_test.yaml
@@ -7,9 +7,16 @@ suite: seaweedfs volume resize hook
 # the leading digit (5Gi -> 10Gi, 8Gi -> 16Gi, 20Gi -> 100Gi) read as "smaller",
 # the patches were skipped, and the tenant was left with its StatefulSet
 # recreated and its claims still at the old size, hook exit 0 and no signal.
-# patches/volume-resize-quantity.diff compares as numbers instead. The first
-# case is the one that was silently broken; the second is a size pair that
-# worked before the fix and must keep working.
+# The gate that emits the delete had the same defect in the other direction: it
+# compared the two size strings raw, and the API server re-emits a quantity in
+# its canonical form, so values spelling 10Gi as 10240Mi come back from the
+# cluster as 10Gi and the statefulset was deleted on every upgrade for a size
+# that never changed.
+#
+# patches/volume-resize-quantity.diff normalises both gates through
+# seaweedfs.resource-quantity. The cases below cover a grow that was silently
+# skipped, a grow that always worked, a shrink that must stay a no-op, and a
+# respelling that must not touch anything.
 
 templates:
   - charts/seaweedfs/templates/volume/volume-resize-hook.yaml
@@ -167,3 +174,39 @@ tests:
         notMatchRegex:
           path: spec.template.spec.containers[0].args[0]
           pattern: kubectl patch pvc
+
+  - it: does nothing when the size is respelled but unchanged (10Gi as 10240Mi)
+    set:
+      seaweedfs.volume.dataDirs:
+        - name: data1
+          type: persistentVolumeClaim
+          size: 10240Mi
+          maxVolumes: 0
+    kubernetesProvider:
+      scheme: *scheme
+      objects:
+        - kind: StatefulSet
+          apiVersion: apps/v1
+          metadata:
+            name: seaweedfs-volume
+            namespace: tenant-test
+          spec:
+            volumeClaimTemplates:
+              - metadata:
+                  name: data1
+                spec:
+                  resources:
+                    requests:
+                      storage: 10Gi
+        - kind: PersistentVolumeClaim
+          apiVersion: v1
+          metadata:
+            name: data1-seaweedfs-volume-0
+            namespace: tenant-test
+          spec:
+            resources:
+              requests:
+                storage: 10Gi
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/packages/system/seaweedfs/values.yaml
+++ b/packages/system/seaweedfs/values.yaml
@@ -156,6 +156,15 @@ seaweedfs:
     enabled: true
     replicas: 2
     port: 8333
+    # Upstream 4.45 turns the Lance Namespace catalog on by default
+    # (charts/seaweedfs/values.yaml: lancePort: 9101) and the s3 Service
+    # publishes it. weed serves that catalog over plain HTTP and accepts no
+    # certificate for it, which is the posture patches/s3-tls-main-port.patch
+    # exists to avoid, and its namespace and table routes are writable. Nothing
+    # in Cozystack consumes the catalog, so keep the pre-4.45 surface: 0 makes
+    # weed skip startLanceServer and drops the container port and Service port
+    # with it.
+    lancePort: 0
     # Keep S3 traffic on same-zone endpoints. Native chart support landed in 4.12
     # (replaces the former s3-traffic-distribution.patch); the chart gates the
     # field on Kubernetes >=1.31 and auto-converts to PreferSameZone on >=1.35.


### PR DESCRIPTION
## What this PR does

Refreshes the vendored SeaweedFS chart from 4.31 to 4.45 through `make update`. This supersedes #2918, which stopped at 4.34: both things that bump was after (SIGHUP hot-reload of the JWT signing keys, and native `expires_after_seconds` under `global.seaweedfs.securityConfig.jwtSigning`) are in 4.45 too, along with three months of chart fixes.

What changes in a rendered cozystack install:

- The mysql Secret and the `WEED_MYSQL_*` env block now render only for the mysql filer store, so the dummy `seaweedfs-db-secret` and its env vars drop out of a postgres2 install. The object carries `helm.sh/resource-policy: keep`, so an existing one stays behind unused rather than being deleted.
- The filer ServiceMonitor selects on a `monitoring: "true"` label that upstream moved from the filer-client Service onto the filer Service, so metrics come from one Service instead of two. See the upgrade note below.
- The filer db-init ConfigMap volume is marked optional.
- S3 gained a Lance catalog port (9101), rendered on the deployment and published on the Service. This package pins it off, see below.
- The new per-component NetworkPolicy templates are opt-in and off by default.

The rendered s3 port set is therefore unchanged from 4.31: `swfs-s3` and `metrics`, same as before the bump.

## Catalog listeners

`weed s3` ships two table-catalog listeners that default to on: Lance on 9101, new in this bump and published on the s3 Service, and Iceberg on 8181, which predates it and stays on the pod IP. Both are served over plain HTTP with no way to supply a certificate, while every other port on this gateway is TLS by way of `s3-tls-main-port.patch`, and both expose writable namespace and table routes. Nothing in cozystack consumes either.

- Lance is pinned off in `values.yaml`, which drops the container port and the Service port with it.
- Iceberg could not be pinned off at all: the chart wraps `-port.iceberg` in an `if` and the value defaults to null, so the flag was dropped and weed served its own 8181. A new carried patch renders the flag the way 4.45 already renders `-port.lance`, so null reaches weed as 0. An explicitly configured port still wins in both cases.

## Volume resize hook

The hook decides twice: one gate emits the `--cascade=orphan` delete of the volume StatefulSet, the other emits the PVC patches. Both were comparing sizes as strings, in different ways, and the two disagreed about what a size change is.

The PVC gate reached its operands through an `include`, which returns a string, so byte counts were compared lexicographically. A grow that crossed a decimal exponent and lowered the leading digit (5Gi to 10Gi, 8Gi to 16Gi, 20Gi to 100Gi) read as a shrink: the patches were skipped while the delete above them still ran, leaving the StatefulSet recreated and the claims at the old size, hook exit 0 and nothing logged. The same comparison read a real shrink across an exponent as a grow and emitted a patch the API server rejects, failing the pre-upgrade hook after the delete had landed.

The delete gate compared the live `volumeClaimTemplates` size against the desired one raw. Since the API server re-emits a quantity in canonical form, that never converges for a non-canonical spelling: values saying `10240Mi` come back from the cluster as `10Gi`, so the volume StatefulSet is deleted and recreated on every upgrade for a size that never moved, and no patch follows because the numeric gate correctly sees no growth.

Carried as one patch normalising both gates through `seaweedfs.resource-quantity`, with unit tests on the exponent-crossing grow, a grow that always worked, a shrink, and a respelling.

## Upgrade notes

Two things to know before upgrading.

`filer.ingress` is gone from the chart's values. Upstream replaced it with `filer.ingresses.http.*` and added `filer.ingresses.grpc.*`; those five removed keys are the only contract break in the whole values file across the bump. Nothing in tree sets the old key and the tenant-facing SeaweedFS resource has no filer-ingress field, so a default install is unaffected. An operator who set `filer.ingress.enabled: true` through a platform-level `spec.components.seaweedfs-system.values` override is not: Helm accepts the unknown key without complaint and the Ingress simply stops rendering, with nothing in an event or a log to read.

Filer metrics stop being double-counted. Before this bump both `seaweedfs-filer` and `seaweedfs-filer-client` matched the filer ServiceMonitor, so Prometheus scraped two targets per filer pod and every filer series was duplicated. One target is the correct number, but panels built on `rate(SeaweedFS_filer_request_total{...})` and `rate(SeaweedFS_filerStore_request_total{...})` in the shipped dashboard step down by half at upgrade time. That step is the duplicate going away, not a throughput loss. Quantile panels are ratios and are unaffected.

## Patches

Ten carried patches, all applying cleanly from a fresh download. `resize-api-server-annotation.diff` needed a rebase: upstream now renders pod-template labels on the resize hook, so the patch appends the cozystack apiserver label to them instead of creating the block. Two are new and are described above: `s3-iceberg-port-explicit.patch` and `volume-resize-quantity.diff`. Both belong upstream and are carried only until they land there.

## Verification

Checked locally: a fresh download of 4.45 with all ten patches applied in Makefile order reproduces the committed tree byte for byte; `helm unittest` passes 66 in `packages/system/seaweedfs` and 24 in `packages/extra/seaweedfs`; the naming-guard canary still refuses a blind upgrade; and a rendered diff against 4.31 comes back identical for object names, StatefulSet selectors, `serviceName` and `volumeClaimTemplates`, so a running install keeps its workloads and volumes across the upgrade. Each fix above has a unit test that is red without it.

Not checked locally, worth an eye in review or e2e: the live upgrade path, since `helm template` cannot exercise the `lookup` that preserves the security.toml JWT keys, and server-side apply convergence when the `monitoring` label moves between the two filer Services.

### Screenshots

N/A, no UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
chore(seaweedfs): bump the vendored SeaweedFS chart to 4.45, with the Lance and Iceberg table catalogs kept off and both gates of the volume resize hook comparing sizes numerically. Two operator-visible notes: filer metrics stop being double-counted, so filer rate panels step down by half at upgrade time, and the chart's `filer.ingress` values key is replaced by `filer.ingresses.http`, so an override still using the old key is silently inert.
```
