### PR TITLE
test(rabbitmq): add default render helm unit tests

### DIFF
--- a/packages/apps/rabbitmq/Makefile
+++ b/packages/apps/rabbitmq/Makefile
@@ -7,3 +7,7 @@ generate:
 update:
 	hack/update-versions.sh
 	make generate
+
+.PHONY: test
+test:
+	helm unittest .

--- a/packages/apps/rabbitmq/tests/rabbitmq_test.yaml
+++ b/packages/apps/rabbitmq/tests/rabbitmq_test.yaml
@@ -1,0 +1,61 @@
+suite: rabbitmq default render
+templates:
+  - templates/rabbitmq.yaml
+
+release:
+  name: rabbitmq-test
+  namespace: tenant-test
+
+tests:
+  - it: renders a RabbitmqCluster with the default version, replicas and storage size
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: RabbitmqCluster
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.image
+          value: "rabbitmq:4.2.4-management"
+      - equal:
+          path: spec.persistence.storage
+          value: 10Gi
+
+  - it: renders a User and credentials Secret for a configured user with an explicit password
+    set:
+      users:
+        alice:
+          password: s3cr3t
+    asserts:
+      - hasDocuments:
+          count: 3
+      - equal:
+          path: kind
+          value: RabbitmqCluster
+        documentIndex: 0
+      - equal:
+          path: kind
+          value: User
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: rabbitmq-test-alice
+        documentIndex: 1
+      - equal:
+          path: kind
+          value: Secret
+        documentIndex: 2
+      - equal:
+          path: metadata.name
+          value: rabbitmq-test-alice-credentials
+        documentIndex: 2
+      - equal:
+          path: stringData.username
+          value: alice
+        documentIndex: 2
+      - equal:
+          path: stringData.password
+          value: s3cr3t
+        documentIndex: 2


### PR DESCRIPTION
## What this PR does

Adds Helm unit test coverage for the rabbitmq application chart, per #3631, one of the remaining user-facing apps that shipped with no test target. Adds a `tests/` suite and the standard `test: helm unittest .` target to the Makefile, matching the pattern already used by http-cache and tested sibling charts.

The suite covers the default render (RabbitmqCluster kind, replicas, pinned version image, storage size) and the per-user resource rendering (User and credentials Secret with an explicit password), the two behaviors a tenant actually relies on.

Ran `helm unittest .` locally against the chart; both tests pass, verified with the actual `make test` target as well.

### Screenshots

Not applicable, test-only change.

### Downstream repositories

- [x] No downstream repository is affected by this change

Walked the trigger map in docs/agents/contributing.md against the diff: this only adds test files and a Makefile target inside an existing package, it does not add, rename or remove a package, and it does not touch `values.yaml`, `values.schema.json`, `Chart.yaml` or `README.md`, so none of the listed triggers apply.

### Release note

```release-note
test(rabbitmq): add Helm unit test coverage for the default render
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Helm chart tests covering RabbitMQ cluster replicas, container image, and persistent storage settings.
  * Added coverage for user configuration, including generated user and credentials resources.

* **Chores**
  * Added a Make target for running the RabbitMQ Helm chart test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->