### PR TITLE
fix(monitoring): scope tenant VMAlert to its own rule namespaces

### DIFF
--- a/packages/system/monitoring/templates/vm/vmalert.yaml
+++ b/packages/system/monitoring/templates/vm/vmalert.yaml
@@ -22,6 +22,34 @@ spec:
   remoteWrite:
     url: http://vminsert-{{ .name }}.{{ $.Release.Namespace }}.svc:8480/insert/0/prometheus/api/v1/write
   resources: {}
+  {{- if eq $.Release.Namespace "tenant-root" }}
+  {{- /*
+    Root monitoring is the platform-wide view: it must keep seeing the
+    infrastructure VMRules, which live outside any tenant namespace
+    (cozy-monitoring, cozy-kubevirt-cdi, cozy-linstor, ...). Those namespaces
+    carry no namespace.cozystack.io/monitoring label, so any selector would
+    cut them off.
+  */}}
   selectAllByDefault: true
+  {{- else }}
+  {{- /*
+    A tenant VMAlert evaluates rules against its own vmselect, which only holds
+    that tenant's metrics. With selectAllByDefault and no selector it picks up
+    every VMRule in the cluster, so infrastructure alerts written as
+    absent(up{job="kubelet"} == 1) fire in the tenant precisely because the
+    series is absent there (issue #2775).
+
+    Scope rules the same way vmagent.yaml scopes scrapes: by the
+    namespace.cozystack.io/monitoring label, whose value names the tenant whose
+    monitoring stack covers that namespace (apps/tenant/templates/namespace.yaml).
+    That selects this tenant's own namespace plus any child tenant inheriting
+    this monitoring stack -- exactly the namespaces whose metrics reach this
+    vmselect. ruleSelector stays unset, so all VMRules in those namespaces match.
+  */}}
+  selectAllByDefault: false
+  ruleNamespaceSelector:
+    matchLabels:
+      namespace.cozystack.io/monitoring: {{ $.Release.Namespace }}
+  {{- end }}
 {{- break }}
 {{- end }}

--- a/packages/system/monitoring/tests/vmalert_rule_scope_test.yaml
+++ b/packages/system/monitoring/tests/vmalert_rule_scope_test.yaml
@@ -1,0 +1,46 @@
+suite: VMAlert selects VMRules only from namespaces its own metrics come from
+
+# A tenant VMAlert queries the tenant's own vmselect. Left with
+# selectAllByDefault and no selector it also picks up infrastructure VMRules
+# from cozy-monitoring, cozy-kubevirt-cdi and friends, and those are written as
+# absent(up{job="..."} == 1) -- so they fire in the tenant precisely because the
+# series is absent there (issue #2775). Scoping by the
+# namespace.cozystack.io/monitoring label mirrors how vmagent.yaml scopes
+# scrapes. Root keeps selectAllByDefault, because the infrastructure namespaces
+# carry no such label and a selector would silence the platform's own alerts.
+
+set:
+  _namespace:
+    host: example.org
+    ingress: tenant-root
+  _cluster:
+    expose-ingress: ingress
+    host: example.org
+
+tests:
+  - it: keeps the cluster-wide selection for root monitoring
+    release:
+      name: monitoring-system
+      namespace: tenant-root
+    templates:
+      - templates/vm/vmalert.yaml
+    asserts:
+      - equal:
+          path: spec.selectAllByDefault
+          value: true
+      - notExists:
+          path: spec.ruleNamespaceSelector
+
+  - it: scopes a tenant to the namespaces its monitoring stack covers
+    release:
+      name: monitoring-system
+      namespace: tenant-foo
+    templates:
+      - templates/vm/vmalert.yaml
+    asserts:
+      - equal:
+          path: spec.selectAllByDefault
+          value: false
+      - equal:
+          path: spec.ruleNamespaceSelector.matchLabels["namespace.cozystack.io/monitoring"]
+          value: tenant-foo


### PR DESCRIPTION
Tenant vmalert was rendered with `selectAllByDefault` and no rule selector, which for vm-operator means select every VMRule in cluster. It then evaluates them against tenant own vmselect that holds only tenant metrics. Infra alerts are written as `absent(up{job="kubelet"} == 1)`, so they fire in tenant exactly because series is absent there.

This PR scopes tenant vmalert by `namespace.cozystack.io/monitoring` label, same way `vmagent.yaml` already scopes scrapes. Label value is the tenant whose monitoring stack covers that namespace, so selector matches tenant own namespace plus child tenants inheriting this stack. `ruleSelector` stays unset, so all VMRules in those namespaces still match, tenant written ones included.

Root keeps `selectAllByDefault`. Infra rules live in `cozy-monitoring`, `cozy-kubevirt-cdi`, `cozy-linstor` and those namespaces carry no such label, so any selector there would silence platform own alerts. Root behaviour is unchanged.

Note that rendering infra alerts conditionally (like dashboards do) does not fix this, because the rules must exist for root anyway and one of the five alerts comes from `cozy-kubevirt-cdi`, not from monitoring-agents at all. Too wide selection is the problem, not the place rules are rendered.

Checked on a live cluster with two vmalerts in one namespace, one scoped and one not:

```
configmap/vm-probe-scoped-rulefiles-0     1
configmap/vm-probe-unscoped-rulefiles-0   46
```

All five alerts from the issue (CDIOperatorDown, KubeAPIDown, KubeControllerManagerDown, KubeletDown, KubeSchedulerDown) are in unscoped set and absent in scoped one, tenant own rule survives.

Closes #2775

```release-note
Stop infrastructure alerts from firing in tenant monitoring
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant monitoring by limiting alert evaluation to the tenant’s namespace and its child tenants.
  * Prevented tenant alerts from firing for unavailable infrastructure metrics.
  * Preserved platform-wide infrastructure alert visibility for root monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->