### PR TITLE
test(tcp-balancer): add default render helm unit tests

### DIFF
--- a/packages/apps/tcp-balancer/Makefile
+++ b/packages/apps/tcp-balancer/Makefile
@@ -3,3 +3,7 @@ include ../../../hack/package.mk
 generate:
 	cozyvalues-gen -m 'tcpbalancer' -v values.yaml -s values.schema.json -r README.md -g ../../../api/apps/v1alpha1/tcpbalancer/types.go
 	../../../hack/update-crd.sh
+
+.PHONY: test
+test:
+	helm unittest .

--- a/packages/apps/tcp-balancer/tests/tcp-balancer_test.yaml
+++ b/packages/apps/tcp-balancer/tests/tcp-balancer_test.yaml
@@ -1,0 +1,21 @@
+suite: tcp-balancer default render
+templates:
+  - templates/deployment.yaml
+  - templates/configmap.yaml
+
+release:
+  name: tcp-balancer-test
+  namespace: tenant-test
+
+tests:
+  - it: renders a Deployment with the default replica count and haproxy image
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "haproxy:latest"


### PR DESCRIPTION
## What this PR does

tcp-balancer was one of the eight user-facing apps in `packages/apps/` called out in #3631 as shipping with zero helm-unittest coverage. This adds a `tests/` suite pinning the default Deployment render (replica count, haproxy image) and wires the standard `test: helm unittest .` target the sibling charts already use, following the same pattern as #4081 and #4074.

Ran `helm unittest .` locally against the chart, it passes, and also ran the repo's full `hack/helm-unit-tests.sh` sweep across every package to confirm nothing else broke.

### Screenshots

Not applicable, test-only change.

### Downstream repositories

- [x] No downstream repository is affected by this change

Walked the trigger map in docs/agents/contributing.md against the diff: this only adds a test file and a Makefile target inside an existing package, it does not add, rename or remove a package, and it does not touch `values.yaml`, `values.schema.json`, `Chart.yaml` or `README.md`, so none of the listed triggers apply.

### Release note

```release-note
test(tcp-balancer): add Helm unit test coverage for the default render
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added Helm chart tests for the TCP balancer’s default configuration.
  - Verified that the default deployment uses two replicas and the expected container image.
  - Added a command to run the chart test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->