### PR TITLE
fix(harbor): give the nginx proxy explicit resources so it survives the tenant LimitRange

### DIFF
--- a/packages/apps/harbor/templates/harbor.yaml
+++ b/packages/apps/harbor/templates/harbor.yaml
@@ -191,8 +191,10 @@ spec:
             {{- end }}
           {{- end }}
         {{- end }}
+      nginx:
+        resources: {{- include "cozy-lib.resources.defaultingSanitize" (list "t1.small" (dict) $) | nindent 10 }}
       portal:
-        resources: {{- include "cozy-lib.resources.defaultingSanitize" (list "t1.nano" (dict) $) | nindent 10 }}
+        resources: {{- include "cozy-lib.resources.defaultingSanitize" (list "t1.micro" (dict) $) | nindent 10 }}
       core:
         {{- if and $tokenKey $tokenCert }}
         tokenKey: {{ $tokenKey | quote }}


### PR DESCRIPTION
## What this PR does

With `expose.type: clusterIP` the goharbor chart deploys an nginx proxy pod, but the `harbor` chart set no resources for it. In a tenant namespace the `tenant-quota` LimitRange defaults any container without resources to a 128Mi memory limit, so the proxy is OOMKilled (exit 137) and Harbor never becomes ready.

This gives the nginx proxy `t1.small` (512Mi), and bumps the portal (also an nginx container) from `t1.nano` (128Mi) to `t1.micro` (256Mi), which sat at the same limit.

Reported from a tenant where the Harbor nginx pod was OOMKilled at a 128Mi limit.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map against the diff. The change is limited to `packages/apps/harbor/templates/harbor.yaml` and only sets container resource presets already used elsewhere in the same file. No `values.schema.json`, `values.yaml` default, `ApplicationDefinition`, version enum, or `release.prefix` is touched, so nothing downstream (provider schemas, website reference pages, ansible role) is affected.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
fix(harbor): set resources for the nginx proxy and raise the portal preset so neither is OOMKilled by the tenant LimitRange default (128Mi)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added default nginx resources using the `t1.small` preset.
* **Updates**
  * Increased the portal resource preset from `t1.nano` to `t1.micro`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->