### PR TITLE
docs(gpu): drop two stale references in the vGPU page

### DIFF
--- a/docs/gpu-vgpu.md
+++ b/docs/gpu-vgpu.md
@@ -2,7 +2,7 @@
 
 This document describes how to configure the GPU Operator package with NVIDIA vGPU support so that a single physical GPU can be sliced and shared across multiple virtual machines.
 
-**Last verified:** 2026-04-29 against KubeVirt `main` (`virt-handler` nightly `20260429_74d7c52588`) + this PR's `vgpu` variant + NVIDIA vGPU 20.0 host driver `595.58.02` + GRID guest driver `595.58.03`.
+**Last verified:** 2026-04-29 against KubeVirt `main` (`virt-handler` nightly `20260429_74d7c52588`) + the `vgpu` variant + NVIDIA vGPU 20.0 host driver `595.58.02` + GRID guest driver `595.58.03`.
 
 ## Two driver models
 
@@ -41,7 +41,7 @@ The `default` (passthrough) variant assumes the GPU is **owned by the host kerne
 
 **Current mitigation.** The only mitigation that keeps VM passthrough working is to remove the host NVIDIA stack before enabling the variant (the "Clean-host workaround" section below).
 
-**Alternatives and scope.** The `container` variant of `cozystack.gpu-operator` is the no-purge path: it keeps the host driver and exposes GPUs to pods rather than VMs, so it does not replace passthrough for anyone who actually needs a GPU inside a VM. Talos is unaffected because the Talos image ships only the `vfio-pci` extension; this section applies to Linux distributions where you installed the host driver yourself (typically Ubuntu / Debian / RHEL with `apt install nvidia-driver-*` or equivalent). See also [`packages/system/gpu-operator/examples/README.md`](../packages/system/gpu-operator/examples/README.md) for the native-pod-workload reference flow that predates the `container` variant.
+**Alternatives and scope.** The `container` variant of `cozystack.gpu-operator` is the no-purge path: it keeps the host driver and exposes GPUs to pods rather than VMs, so it does not replace passthrough for anyone who actually needs a GPU inside a VM. Talos is unaffected because the Talos image ships only the `vfio-pci` extension; this section applies to Linux distributions where you installed the host driver yourself (typically Ubuntu / Debian / RHEL with `apt install nvidia-driver-*` or equivalent). See also [`packages/system/gpu-operator/examples/README.md`](../packages/system/gpu-operator/examples/README.md) for the Talos native-pod-workload reference flow.
 
 ### Symptom
 


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `kind/backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

## What this PR does

Two stale references in `docs/gpu-vgpu.md`.

The `Last verified` line says "this PR's `vgpu` variant". The variant ships, so there is no PR left for a reader to resolve that against.

The link to `packages/system/gpu-operator/examples/README.md` calls it the flow "that predates the `container` variant". That README now opens with the container variant and sends non-Talos hosts to it. The link is there because it is the Talos path.

The rest is gone. #4101 rewrote the same three passages in main, and got right the one thing this PR had wrong: `bundles.iaas.gpuOperatorVariant` takes `container` now, so the `disabledPackages` plus hand-written `Package` route described here is not the way in. The rebase takes main's text for all three and keeps only the two references #4101 did not touch.

### Screenshots

Docs only, no UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

Checked cozystack/website: neither line exists in `content/en/docs/next/virtualization/gpu.md` or `vgpu.md`. The `v1.2` snapshot carries its own PR-relative `Last verified` line, pointing at cozystack/cozystack#2323, but that is a released version's record and out of scope here.

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated GPU/vGPU verification details to reference the released vGPU variant.
  - Documented the available container variant, including deployment guidance and its scope compared with passthrough.
  - Updated known limitations to reflect that the container variant is shipped and does not configure host-device wiring through KubeVirt.
  - Clarified when KubeVirt GPU device wiring is applied based on GPU configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->