### PR TITLE
fix(kubevirt): verify the vendored operator manifest and add a test target

### DIFF
--- a/packages/system/kubevirt-operator/.gitignore
+++ b/packages/system/kubevirt-operator/.gitignore
@@ -1,0 +1,3 @@
+# `update` fetches and transforms here before moving the result into
+# templates/. A run that dies between those steps leaves the file behind.
+kubevirt-operator.yaml.download

--- a/packages/system/kubevirt-operator/Makefile
+++ b/packages/system/kubevirt-operator/Makefile
@@ -1,14 +1,47 @@
 export NAME=kubevirt-operator
 export NAMESPACE=cozy-kubevirt
 
+# The KubeVirt release whose operator manifest is vendored under templates/.
+#
+# A live migration onto the new virt-launcher can fail on virtio feature bits
+# whenever its QEMU build moves at all, major or not (kubevirt/kubevirt#16386
+# broke on qemu-kvm 9.1.0-19 to 9.1.0-20): test one before moving RELEASE.
+RELEASE = v1.9.0
+
+# sha256 of the kubevirt-operator.yaml release asset as published, measured
+# before the two transforms below run over it. Upstream signs the source
+# tarball and publishes no checksum for this generated manifest, so the pin is
+# taken from a download rather than fetched alongside one. It therefore detects
+# an asset that moved under its tag; it is not authenticity verification.
+MANIFEST_SHA256 = f11307caafc3c23ffedf9887d8beb5a4419e2694da242fa68f63d1ec820de2e0
+
+# sha256sum is not everywhere: current macOS carries a native one in /sbin,
+# older releases carry only shasum(1). Both print "<digest>  <path>", so field
+# 1 is the digest whichever gets picked. The rest of `update` needs GNU sed and
+# gawk regardless, so this alone does not make the recipe portable.
+SHA256SUM := $(shell command -v sha256sum >/dev/null 2>&1 && echo sha256sum || echo 'shasum -a 256')
+
 include ../../../hack/package.mk
 
 update:
 	mkdir -p templates
-	@# A live migration onto the new virt-launcher can fail on virtio feature bits
-	@# whenever its QEMU build moves at all, major or not (kubevirt/kubevirt#16386
-	@# broke on qemu-kvm 9.1.0-19 to 9.1.0-20): test one before moving RELEASE.
-	export RELEASE=v1.9.0 && \
-	wget https://github.com/kubevirt/kubevirt/releases/download/$${RELEASE}/kubevirt-operator.yaml -O templates/kubevirt-operator.yaml && \
-	sed -i 's/namespace: kubevirt/namespace: $(NAMESPACE)/g' templates/kubevirt-operator.yaml
-	awk -i inplace -v RS="---" '!/kind: Namespace/{printf "%s", $$0 RS}' templates/kubevirt-operator.yaml
+	@# Helm renders every file under templates/, and that directory also holds
+	@# prometheusrule.yaml, which is ours rather than upstream's. So the
+	@# download is verified and transformed where Helm cannot see it and moved
+	@# in once, finished: a refresh that fails at any step leaves the vendored
+	@# copy as it was rather than half-replaced.
+	wget https://github.com/kubevirt/kubevirt/releases/download/$(RELEASE)/kubevirt-operator.yaml -O kubevirt-operator.yaml.download || { rm -f kubevirt-operator.yaml.download; exit 1; }
+	@actual=$$($(SHA256SUM) kubevirt-operator.yaml.download | awk '{print $$1}'); \
+	if [ "$$actual" != "$(MANIFEST_SHA256)" ]; then \
+	  rm -f kubevirt-operator.yaml.download; \
+	  echo "ERROR: kubevirt-operator.yaml for $(RELEASE) hashed $$actual," >&2; \
+	  echo "       expected $(MANIFEST_SHA256). Nothing was written." >&2; \
+	  echo "       Moving to a new release starts from RELEASE, MANIFEST_SHA256 and" >&2; \
+	  echo "       the version expectations under tests/. If RELEASE did not" >&2; \
+	  echo "       change, the asset moved under a tag that should be immutable:" >&2; \
+	  echo "       find out why before pasting the new digest." >&2; \
+	  exit 1; \
+	fi
+	sed -i 's/namespace: kubevirt/namespace: $(NAMESPACE)/g' kubevirt-operator.yaml.download
+	awk -i inplace -v RS="---" '!/kind: Namespace/{printf "%s", $$0 RS}' kubevirt-operator.yaml.download
+	mv kubevirt-operator.yaml.download templates/kubevirt-operator.yaml

--- a/packages/system/kubevirt-operator/Makefile
+++ b/packages/system/kubevirt-operator/Makefile
@@ -23,6 +23,22 @@ SHA256SUM := $(shell command -v sha256sum >/dev/null 2>&1 && echo sha256sum || e
 
 include ../../../hack/package.mk
 
+# Phony because hack/package.mk's .PHONY line lists only the targets that file
+# defines, and hack/package-mk-phony.bats pins the omission of `test`: without
+# this, a path named `test` next to this Makefile would make the target up to
+# date and skip the recipe.
+.PHONY: test
+test:
+	helm unittest .
+	@# Nothing else ties RELEASE to the tree, because helm-unittest reads the
+	@# vendored file and cannot see this variable. Without this check a pin
+	@# bumped without re-running `update` leaves every assertion green against
+	@# the old release.
+	@if ! grep -q 'image: quay.io/kubevirt/virt-operator:$(RELEASE)$$' templates/kubevirt-operator.yaml; then \
+	  echo "ERROR: templates/kubevirt-operator.yaml carries no virt-operator image at $(RELEASE). Re-run 'make update'." >&2; \
+	  exit 1; \
+	fi
+
 update:
 	mkdir -p templates
 	@# Helm renders every file under templates/, and that directory also holds

--- a/packages/system/kubevirt-operator/tests/vendored_manifest_test.yaml
+++ b/packages/system/kubevirt-operator/tests/vendored_manifest_test.yaml
@@ -1,0 +1,70 @@
+suite: cozy-kubevirt-operator vendored manifest
+release:
+  name: kubevirt-operator
+  namespace: cozy-kubevirt
+tests:
+  # prometheusrule.yaml is ours rather than upstream's and sits in the
+  # directory `make update` writes into, so a refresh is what is most likely to
+  # take it. Addressed as a `template:` because helm-unittest fails outright on
+  # one it cannot find, which is what makes the absence loud rather than a
+  # quietly smaller render.
+  - it: keeps the local PrometheusRule beside the vendored manifest
+    template: prometheusrule.yaml
+    asserts:
+      - containsDocument:
+          apiVersion: monitoring.coreos.com/v1
+          kind: PrometheusRule
+          name: vm-not-running-alert
+      - equal:
+          path: spec.groups[0].name
+          value: kubevirt-alerts
+
+  # Addressed by name rather than by index: the vendored file is one long
+  # document stream and an upstream reorder would slide any index off the
+  # Deployment silently.
+  - it: runs the virt-operator image from the pinned release
+    template: kubevirt-operator.yaml
+    documentSelector:
+      path: metadata.name
+      value: virt-operator
+    asserts:
+      - equal:
+          path: kind
+          value: Deployment
+      # The Makefile's grep ties this tag back to RELEASE. This one says the
+      # tag is on the operator Deployment rather than somewhere in the stream.
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: quay.io/kubevirt/virt-operator:v1.9.0
+      # KUBEVIRT_VERSION is what virt-operator reads to pick the tags for
+      # virt-controller, virt-handler and virt-launcher, so a manifest whose
+      # operator image moved while this did not deploys a split control plane.
+      # Matched against the env list by content rather than by position: the
+      # order upstream emits these in is not ours to rely on.
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBEVIRT_VERSION
+            value: v1.9.0
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: VIRT_OPERATOR_IMAGE
+            value: quay.io/kubevirt/virt-operator:v1.9.0
+      # First of the two transforms `update` applies: upstream ships
+      # `namespace: kubevirt` throughout and the recipe rewrites it.
+      - equal:
+          path: metadata.namespace
+          value: cozy-kubevirt
+
+  # Second transform. `any: true` is load-bearing on a negated containsDocument:
+  # without it the assertion reads "not every document is a Namespace", which is
+  # true of any multi-document template and would pin nothing.
+  - it: drops the Namespace object upstream ships
+    template: kubevirt-operator.yaml
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Namespace
+          any: true
+        not: true


### PR DESCRIPTION
## What this PR does

`packages/system/kubevirt-operator` had only an `update:` target, so `hack/helm-unit-tests.sh` skipped it: that script decides what to run by probing `make -C <dir> -n test`. Nothing rendered the chart after a refresh. The same recipe pulled the upstream manifest with `wget` and ran two transforms over whatever came back, with no check on the download.

`update` now fetches outside `templates/`, checks the download against a pinned sha256, transforms it there, and moves it in last. The vendored file gets written once per refresh with finished content, and a failure at any step leaves it alone. It has to stay out of `templates/` because Helm renders every file in there, and that directory also holds `prometheusrule.yaml`, which is ours and not upstream's.

Upstream ships no checksum for `kubevirt-operator.yaml`. `v1.9.0.tar.gz.asc` signs the source tarball, not the generated manifest. So I measured the pin: downloaded the v1.9.0 asset, hashed it, got `f11307caafc3c23ffedf9887d8beb5a4419e2694da242fa68f63d1ec820de2e0`, and confirmed the recipe's two transforms turn that download into the committed `templates/kubevirt-operator.yaml` byte for byte. It catches an asset that moved under its tag. It is not authenticity verification, and the comment says that.

The digest command is resolved at parse time: `sha256sum` when it is on PATH, `shasum -a 256` otherwise. Worth saying which one actually ran, because the usual claim about macOS is out of date: this machine picked `sha256sum`, and it is not GNU coreutils but `/sbin/sha256sum`, a native Darwin binary hardlinked to `/sbin/md5` that reports `sha256sum (Darwin) 1.0` and prints the same `<digest>  <path>` format. I checked the fallback separately with `make update SHA256SUM='shasum -a 256'`, which finished and left the tree clean. The fallback still earns its place for older macOS, but it does not make `update` portable on its own: `sed -i` and `awk -i inplace` in the same recipe need GNU sed and gawk, and the comment now says so.

`test:` runs `helm unittest`, then greps the vendored manifest for `RELEASE`, same shape as `packages/system/reloader`. helm-unittest cannot see `RELEASE`, so without the grep a pin bumped without re-running `update` leaves every assertion green against the old release. The suite pins that the `PrometheusRule` still renders, and that the `virt-operator` Deployment carries the pinned release in its image, `VIRT_OPERATOR_IMAGE` and `KUBEVIRT_VERSION`, plus both transforms.

Every assertion is mutation-tested: removing `prometheusrule.yaml`, drifting each of the three version strings, reverting the namespace rewrite, adding a `Namespace` document back, renaming the Deployment, and bumping `RELEASE` without re-vendoring all go red. `any: true` on the negated `containsDocument` is doing real work, drop it and the suite stays green with a `Namespace` document present. The sweep now runs 84 package suites, one of them new, all green.

Closes #4031.

### Screenshots

No UI changes.

### Downstream repositories

Walked the trigger map against the diff. Two entries look close and neither fires. The website triggers on developer tooling and package Makefiles, but `content/en/docs/next/development.md` documents `make update` only as "Update Helm chart and versions from the upstream source", which still holds, and its `make test` line refers to the e2e sandbox in `packages/core/testing`, not per-package unit tests. `ccp` triggers on `hack/` layout and what a make target does, and its skills anchor on `hack/package.mk` and `hack/common-envs.mk`; nothing under `hack/` is touched and its `package-bump` skill handles vendored charts, in-repo image builds and version enums, none of which is this package's raw manifest download. Everything else in the map needs an app, a schema, an installer value, a variant or a release asset, and this PR changes none of them.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
fix(kubevirt): kubevirt-operator now verifies the upstream manifest against a pinned sha256 before vendoring it, and the package has a unit-test target so hack/helm-unit-tests.sh no longer skips it.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved manifest updates so incomplete downloads or integrity-check failures no longer overwrite the existing working manifest.
  - Temporary download files are cleaned up after failed updates.

- **Tests**
  - Added validation for the bundled KubeVirt operator manifest, including the expected version, image configuration, namespace, monitoring alert, and removal of an unwanted namespace resource.

- **Chores**
  - Pinned the KubeVirt operator release and verified downloaded manifests against their expected checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->