### PR TITLE
fix(platform): declare the injected _cluster values in system charts

### DIFF
--- a/packages/system/bucket/tests/standalone_render_test.yaml
+++ b/packages/system/bucket/tests/standalone_render_test.yaml
@@ -1,0 +1,21 @@
+suite: bucket renders with no platform values injected
+release:
+  name: bucket
+  namespace: cozy-bucket
+
+# The platform injects _cluster and _namespace through the cozystack-values
+# Secret, so every case that sets them itself renders fine whether or not
+# values.yaml declares the keys. This case supplies neither. Drop the
+# _cluster declaration and the render dies on "index of untyped nil"; drop
+# the _namespace one and it dies on "nil pointer evaluating interface
+# {}.host". Both are what keep the chart renderable outside a cluster. No
+# suite-level `templates:` list here on purpose: it would narrow the render
+# to the listed files and let a later template reintroduce the same
+# breakage unseen.
+
+tests:
+  - it: still renders the ingress when _cluster and _namespace are absent
+    asserts:
+      - template: templates/ingress.yaml
+        hasDocuments:
+          count: 1

--- a/packages/system/bucket/values.yaml
+++ b/packages/system/bucket/values.yaml
@@ -1,2 +1,7 @@
+# Injected by the platform from the cozystack-values Secret. The empty
+# defaults keep the chart renderable on its own, outside a cluster.
+_cluster: {}
+_namespace: {}
+
 bucketName: "cozystack"
 users: {}

--- a/packages/system/cert-manager-issuers/tests/standalone_render_test.yaml
+++ b/packages/system/cert-manager-issuers/tests/standalone_render_test.yaml
@@ -1,0 +1,20 @@
+suite: cert-manager-issuers renders with no platform values injected
+release:
+  name: cert-manager-issuers
+  namespace: cozy-cert-manager
+
+# The platform injects _cluster through the cozystack-values Secret, so every
+# case that sets it itself renders fine whether or not values.yaml declares
+# the key. This case supplies nothing. Drop the declaration from values.yaml
+# and the render dies on "index of untyped nil" before a single assert runs;
+# the declaration is the only thing keeping the chart renderable outside a
+# cluster. No suite-level `templates:` list here on purpose: it would narrow
+# the render to the listed files and let a later template reintroduce the
+# same breakage unseen.
+
+tests:
+  - it: still renders the cluster issuers when _cluster is absent
+    asserts:
+      - template: templates/cluster-issuers.yaml
+        hasDocuments:
+          count: 3

--- a/packages/system/cert-manager-issuers/values.yaml
+++ b/packages/system/cert-manager-issuers/values.yaml
@@ -1,2 +1,6 @@
+# Injected by the platform from the cozystack-values Secret. The empty
+# default keeps the chart renderable on its own, outside a cluster.
+_cluster: {}
+
 cert-manager:
   installCRDs: true

--- a/packages/system/cozystack-api/tests/standalone_render_test.yaml
+++ b/packages/system/cozystack-api/tests/standalone_render_test.yaml
@@ -1,0 +1,23 @@
+suite: cozystack-api renders with no platform values injected
+release:
+  name: cozystack-api
+  namespace: cozy-system
+
+# The platform injects _cluster through the cozystack-values Secret, so every
+# case that sets it itself renders fine whether or not values.yaml declares
+# the key. This case supplies nothing. Drop the declaration from values.yaml
+# and the render dies on "index of untyped nil" before a single assert runs;
+# the declaration is the only thing keeping the chart renderable outside a
+# cluster. No suite-level `templates:` list here on purpose: it would narrow
+# the render to the listed files and let a later template reintroduce the
+# same breakage unseen.
+
+tests:
+  - it: exposes nothing when _cluster is absent
+    asserts:
+      - template: templates/api-ingress.yaml
+        hasDocuments:
+          count: 0
+      - template: templates/api-tlsroute.yaml
+        hasDocuments:
+          count: 0

--- a/packages/system/cozystack-api/values.yaml
+++ b/packages/system/cozystack-api/values.yaml
@@ -1,3 +1,7 @@
+# Injected by the platform from the cozystack-values Secret. The empty
+# default keeps the chart renderable on its own, outside a cluster.
+_cluster: {}
+
 cozystackAPI:
   image: ghcr.io/cozystack/cozystack/cozystack-api:v1.6.0@sha256:c4d374a9bc5e6f6e66d24b29396f1eae9d7f06fd268ff767d05c45ca35e84e2e
   replicas: 2

--- a/packages/system/dashboard/tests/standalone_render_test.yaml
+++ b/packages/system/dashboard/tests/standalone_render_test.yaml
@@ -1,0 +1,23 @@
+suite: dashboard renders with no platform values injected
+release:
+  name: dashboard
+  namespace: cozy-dashboard
+
+# The platform injects _cluster through the cozystack-values Secret, so every
+# case that sets it itself renders fine whether or not values.yaml declares
+# the key. This case supplies nothing. Drop the declaration from values.yaml
+# and the render dies on "index of untyped nil" before a single assert runs;
+# the declaration is the only thing keeping the chart renderable outside a
+# cluster. No suite-level `templates:` list here on purpose: it would narrow
+# the render to the listed files and let a later template reintroduce the
+# same breakage unseen.
+
+tests:
+  - it: exposes nothing when _cluster is absent
+    asserts:
+      - template: templates/ingress.yaml
+        hasDocuments:
+          count: 0
+      - template: templates/httproute.yaml
+        hasDocuments:
+          count: 0

--- a/packages/system/dashboard/values.yaml
+++ b/packages/system/dashboard/values.yaml
@@ -1,3 +1,7 @@
+# Injected by the platform from the cozystack-values Secret. The empty
+# default keeps the chart renderable on its own, outside a cluster.
+_cluster: {}
+
 console:
   image: ghcr.io/cozystack/cozystack/cozystack-ui:v1.6.0@sha256:ad0e132ce506bbc9e0f6a5dfb94311c9bbc08da3d8eca84eb0e527ba6c1a8897
 tokenProxy:

--- a/packages/system/keycloak-configure/tests/standalone_render_test.yaml
+++ b/packages/system/keycloak-configure/tests/standalone_render_test.yaml
@@ -1,0 +1,20 @@
+suite: keycloak-configure renders with no platform values injected
+release:
+  name: keycloak-configure
+  namespace: cozy-keycloak
+
+# The platform injects _cluster through the cozystack-values Secret, so every
+# case that sets it itself renders fine whether or not values.yaml declares
+# the key. This case supplies nothing. Drop the declaration from values.yaml
+# and the render dies on "index of untyped nil" before a single assert runs;
+# the declaration is the only thing keeping the chart renderable outside a
+# cluster. No suite-level `templates:` list here on purpose: it would narrow
+# the render to the listed files and let a later template reintroduce the
+# same breakage unseen.
+
+tests:
+  - it: still renders the realm objects when _cluster is absent
+    asserts:
+      - template: templates/configure-kk.yaml
+        hasDocuments:
+          count: 6

--- a/packages/system/keycloak-configure/values.yaml
+++ b/packages/system/keycloak-configure/values.yaml
@@ -1,3 +1,7 @@
+# Injected by the platform from the cozystack-values Secret. The empty
+# default keeps the chart renderable on its own, outside a cluster.
+_cluster: {}
+
 # Keycloak image used by the one-shot admin-API job that enables the
 # UPDATE_EMAIL required action. Only kcadm.sh is used, so it just needs
 # to track the Keycloak server major version (packages/system/keycloak).

--- a/packages/system/keycloak/tests/standalone_render_test.yaml
+++ b/packages/system/keycloak/tests/standalone_render_test.yaml
@@ -1,0 +1,20 @@
+suite: keycloak renders with no platform values injected
+release:
+  name: keycloak
+  namespace: cozy-keycloak
+
+# The platform injects _cluster through the cozystack-values Secret, so every
+# case that sets it itself renders fine whether or not values.yaml declares
+# the key. This case supplies nothing. Drop the declaration from values.yaml
+# and the render dies on "index of untyped nil" before a single assert runs;
+# the declaration is the only thing keeping the chart renderable outside a
+# cluster. No suite-level `templates:` list here on purpose: it would narrow
+# the render to the listed files and let a later template reintroduce the
+# same breakage unseen.
+
+tests:
+  - it: still renders the statefulset and its secret when _cluster is absent
+    asserts:
+      - template: templates/sts.yaml
+        hasDocuments:
+          count: 2

--- a/packages/system/keycloak/values.yaml
+++ b/packages/system/keycloak/values.yaml
@@ -1,3 +1,7 @@
+# Injected by the platform from the cozystack-values Secret. The empty
+# default keeps the chart renderable on its own, outside a cluster.
+_cluster: {}
+
 image: quay.io/keycloak/keycloak:26.6.3
 
 ingress:

--- a/packages/system/kubevirt-cdi/Makefile
+++ b/packages/system/kubevirt-cdi/Makefile
@@ -8,3 +8,6 @@ update:
 	mkdir templates
 	export VERSION=$$(basename $$(curl -s -w %{redirect_url} https://github.com/kubevirt/containerized-data-importer/releases/latest)) && \
 	wget https://github.com/kubevirt/containerized-data-importer/releases/download/$$VERSION/cdi-cr.yaml -O templates/cdi-cr.yaml
+
+test:
+	helm unittest .

--- a/packages/system/kubevirt-cdi/tests/standalone_render_test.yaml
+++ b/packages/system/kubevirt-cdi/tests/standalone_render_test.yaml
@@ -1,0 +1,57 @@
+suite: kubevirt-cdi renders with no platform values injected
+release:
+  name: kubevirt-cdi
+  namespace: cozy-kubevirt-cdi
+
+# The platform injects _cluster through the cozystack-values Secret, so every
+# case that sets it itself renders fine whether or not values.yaml declares
+# the key. This case supplies nothing. Drop the declaration from values.yaml
+# and the render dies on "index of untyped nil" before a single assert runs;
+# the declaration is the only thing keeping the chart renderable outside a
+# cluster. No suite-level `templates:` list here on purpose: it would narrow
+# the render to the listed files and let a later template reintroduce the
+# same breakage unseen.
+
+tests:
+  - it: exposes no cdi-uploadproxy route when _cluster is absent
+    asserts:
+      - template: templates/cdi-uploadproxy-ingress.yaml
+        hasDocuments:
+          count: 0
+      - template: templates/cdi-uploadproxy-tlsroute.yaml
+        hasDocuments:
+          count: 0
+
+  # Counterpart to the case above: with _cluster populated the way the
+  # platform populates it, both routes have to appear. Without this the
+  # suite only ever asserts absence, and a template that stopped rendering
+  # under every input would still satisfy it.
+  - it: exposes the uploadproxy ingress once _cluster selects the service
+    set:
+      _cluster:
+        root-host: example.com
+        expose-services: cdi-uploadproxy
+        gateway-enabled: "false"
+    asserts:
+      - template: templates/cdi-uploadproxy-ingress.yaml
+        equal:
+          path: spec.rules[0].host
+          value: cdi-uploadproxy.example.com
+      - template: templates/cdi-uploadproxy-tlsroute.yaml
+        hasDocuments:
+          count: 0
+
+  - it: swaps the ingress for a TLSRoute when the gateway is enabled
+    set:
+      _cluster:
+        root-host: example.com
+        expose-services: cdi-uploadproxy
+        gateway-enabled: "true"
+    asserts:
+      - template: templates/cdi-uploadproxy-tlsroute.yaml
+        equal:
+          path: spec.hostnames[0]
+          value: cdi-uploadproxy.example.com
+      - template: templates/cdi-uploadproxy-ingress.yaml
+        hasDocuments:
+          count: 0

--- a/packages/system/kubevirt-cdi/values.yaml
+++ b/packages/system/kubevirt-cdi/values.yaml
@@ -1,3 +1,7 @@
+# Injected by the platform from the cozystack-values Secret. The empty
+# default keeps the chart renderable on its own, outside a cluster.
+_cluster: {}
+
 uploadProxyURL: ""
 
 ## @param cloneStrategyOverride Strategy CDI uses to clone DataVolumes (golden image -> VM disk).

--- a/packages/system/kubevirt/tests/standalone_render_test.yaml
+++ b/packages/system/kubevirt/tests/standalone_render_test.yaml
@@ -1,0 +1,23 @@
+suite: kubevirt renders with no platform values injected
+release:
+  name: kubevirt
+  namespace: cozy-kubevirt
+
+# The platform injects _cluster through the cozystack-values Secret, so every
+# case that sets it itself renders fine whether or not values.yaml declares
+# the key. This case supplies nothing. Drop the declaration from values.yaml
+# and the render dies on "index of untyped nil" before a single assert runs;
+# the declaration is the only thing keeping the chart renderable outside a
+# cluster. No suite-level `templates:` list here on purpose: it would narrow
+# the render to the listed files and let a later template reintroduce the
+# same breakage unseen.
+
+tests:
+  - it: exposes no vm-exportproxy route when _cluster is absent
+    asserts:
+      - template: templates/vm-exportproxy-ingress.yaml
+        hasDocuments:
+          count: 0
+      - template: templates/vm-exportproxy-tlsroute.yaml
+        hasDocuments:
+          count: 0

--- a/packages/system/kubevirt/values.yaml
+++ b/packages/system/kubevirt/values.yaml
@@ -1,3 +1,7 @@
+# Injected by the platform from the cozystack-values Secret. The empty
+# default keeps the chart renderable on its own, outside a cluster.
+_cluster: {}
+
 # CPU oversubscription ratio. When set, propagates to
 # spec.configuration.developerConfiguration.cpuAllocationRatio on the
 # KubeVirt CR. Driven by .Values.resources.cpuAllocationRatio at the

--- a/packages/system/linstor-gui/tests/standalone_render_test.yaml
+++ b/packages/system/linstor-gui/tests/standalone_render_test.yaml
@@ -1,0 +1,20 @@
+suite: linstor-gui renders with no platform values injected
+release:
+  name: linstor-gui
+  namespace: cozy-linstor
+
+# The platform injects _cluster through the cozystack-values Secret, so every
+# case that sets it itself renders fine whether or not values.yaml declares
+# the key. This case supplies nothing. Drop the declaration from values.yaml
+# and the render dies on "index of untyped nil" before a single assert runs;
+# the declaration is the only thing keeping the chart renderable outside a
+# cluster. No suite-level `templates:` list here on purpose: it would narrow
+# the render to the listed files and let a later template reintroduce the
+# same breakage unseen.
+
+tests:
+  - it: exposes nothing when _cluster is absent
+    asserts:
+      - template: templates/ingress.yaml
+        hasDocuments:
+          count: 0

--- a/packages/system/linstor-gui/values.yaml
+++ b/packages/system/linstor-gui/values.yaml
@@ -1,3 +1,7 @@
+# Injected by the platform from the cozystack-values Secret. The empty
+# default keeps the chart renderable on its own, outside a cluster.
+_cluster: {}
+
 ## @section Image
 ## @param image.repository LINSTOR GUI container image repository
 ## @param image.tag LINSTOR GUI container image tag (digest recommended)

--- a/packages/system/monitoring/tests/standalone_render_test.yaml
+++ b/packages/system/monitoring/tests/standalone_render_test.yaml
@@ -1,0 +1,24 @@
+suite: monitoring renders with no platform values injected
+release:
+  name: monitoring
+  namespace: cozy-monitoring
+
+# The platform injects _cluster and _namespace through the cozystack-values
+# Secret, so every case that sets them itself renders fine whether or not
+# values.yaml declares the keys. This case supplies neither. Drop the
+# _cluster declaration and the render dies on "index of untyped nil"; drop
+# the _namespace one and it dies on "nil pointer evaluating interface
+# {}.host". Both are what keep the chart renderable outside a cluster. No
+# suite-level `templates:` list here on purpose: it would narrow the render
+# to the listed files and let a later template reintroduce the same
+# breakage unseen.
+
+tests:
+  - it: still renders grafana and no route when _cluster and _namespace are absent
+    asserts:
+      - template: templates/grafana/grafana.yaml
+        hasDocuments:
+          count: 1
+      - template: templates/grafana/httproute.yaml
+        hasDocuments:
+          count: 0

--- a/packages/system/monitoring/values.yaml
+++ b/packages/system/monitoring/values.yaml
@@ -1,3 +1,8 @@
+# Injected by the platform from the cozystack-values Secret. The empty
+# defaults keep the chart renderable on its own, outside a cluster.
+_cluster: {}
+_namespace: {}
+
 host: ""
 
 metricsStorages:


### PR DESCRIPTION
## What this PR does

Ten charts under `packages/system` read `_cluster`, and `bucket` and `monitoring` also read `_namespace`. The platform injects both through the `cozystack-values` Secret, so installs never notice. Rendering a chart on its own does: `helm template packages/system/kubevirt` dies on `index of untyped nil` before it emits anything, and the `_namespace` readers die on `nil pointer evaluating interface {}.host`.

Each of the ten now declares the keys it reads, with an empty default. Injected values merge over chart defaults, so an installed release renders exactly what it rendered before. Checked per chart against a realistic injected `_cluster`/`_namespace`: six came out byte-identical, and the other four differ only in `randAlphaNum` secrets, which also differ between two renders of the same tree.

The declaration on its own is not worth much, so every chart also gets a suite that renders with nothing injected. The existing suites all set `_cluster` themselves and cannot see whether `values.yaml` still declares it. Drop a declaration and exactly that chart's suite goes red, with the error its comment quotes; I ran that for all twelve. None of the new suites carries a suite-level `templates:` list, on purpose: that list narrows what helm-unittest renders, and would hide the same breakage in a template added later.

`kubevirt-cdi` had no `tests/` and no `test:` target, so it gets both. `etcd-operator` reads `_cluster` too and stays as it is, since its one call site already guards with `| default dict`. `cozystack-basics` already declared the key.

Closes #4030.

### Not in this PR

No CI job runs `helm lint` or a standalone `helm template`, which is why none of this was red. A gate is worth proposing separately. Its value is narrow though: `_cluster` is always populated on a real install, and eight of these ten already had a suite rendering the affected template with `_cluster` supplied. The two with nothing were `kubevirt`, whose `vm-exportproxy-*` templates no test touched, and `kubevirt-cdi`, which had no tests at all.

`helm lint` still exits 1 on `keycloak` and `monitoring` with `chart metadata is missing these dependencies: cozy-lib`. Both carry a `charts/cozy-lib` symlink that `Chart.yaml` never declares. That one is not a two-chart item: 82 charts across `packages/{system,apps,extra,core}` fail lint the same way, which is invisible because no job runs `helm lint`. Separate defect, untouched here.

Fifteen charts outside `packages/system` break the same way: `apps/{bucket,foundationdb,harbor,kubernetes,mongodb,nats,opensearch,postgres,vpn}` and `extra/{bootbox,etcd,gateway,info,ingress,seaweedfs}`. `cozy-lib`'s own helpers already guard every access with `| default dict`, so routing those reads through the library would close the class instead of patching fifteen more values files.

`kubevirt`'s suite only pins that the routes stay absent with nothing injected. Nothing pins that they show up once `_cluster` selects the service.

### Screenshots

No UI change: the diff is ten `values.yaml` files, ten helm-unittest suites, and one package `Makefile`.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` file by file against this diff. No package is added, renamed or removed under `packages/apps` or `packages/extra`; `packages/core/platform/values.yaml` is untouched; no variant, bundle, component, release asset, namespace or `ApplicationDefinition` semantic changes; no `values.schema.json` and no version enum moves, so the provider's hand-written schemas and defaults are unaffected; nothing under `hack/` moves and no existing make target changes behaviour. The one `Makefile` edit adds a `test:` target to `packages/system/kubevirt-cdi`, matching the target the other nine already have, so `make generate` and the ccp skills that drive it see nothing new.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
fix(platform): declare the platform-injected `_cluster` and `_namespace` values in the ten system charts that read them, so each chart renders with `helm template` outside a cluster instead of failing on a nil map. No change to what an installed release renders.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved standalone Helm chart rendering when platform-provided values are unavailable.
  - Prevented rendering failures across system charts, including bucket, dashboard, Keycloak, monitoring, KubeVirt, and related components.

- **Tests**
  - Added comprehensive standalone rendering coverage for system charts.
  - Added validation for expected ingress, gateway, TLS route, and resource output under different configuration scenarios.
  - Added a chart test command for KubeVirt CDI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->