### PR TITLE
ci(agents): check commit trailers on every pull request

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -72,3 +72,64 @@ jobs:
           else
             echo "No YAML or Markdown files to lint"
           fi
+
+  # Commit-message lint for the attribution rules in docs/agents/contributing.md
+  # that a reviewer would otherwise have to read `git log` to catch. It lives
+  # here rather than in the unit-test job of pull-requests.yaml, which is gated
+  # on the diff touching code and so skips a docs-only PR entirely; a trailer is
+  # wrong or right regardless of which files the commit changed.
+  commit-trailers:
+    name: Commit trailers
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    # A backport PR is the one shape whose author cannot fix a finding: the
+    # backport action cherry-picks merged commits verbatim, so their messages
+    # are history, and roughly a quarter of the commits on main predate the
+    # rule. Matched on the branch name the action generates,
+    # backport-<pr>-to-<branch>, rather than on the prefix alone; the label that
+    # asks for a backport sits on the original PR, not on the generated one, so
+    # a branch name is the only signal a pull_request event carries. That makes
+    # the exemption a convention rather than something enforced: anyone can name
+    # a branch this way. Every other PR, fork included, is checked.
+    if: ${{ !(startsWith(github.head_ref, 'backport-') && contains(github.head_ref, '-to-')) }}
+    steps:
+      - name: Checkout head
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check commit trailers
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # The merge base, not the base branch tip: commits landing on the base
+          # branch while the PR is open are not this PR's to answer for. It is
+          # recomputed every run, so a rebased or force-pushed branch is read as
+          # it now is rather than as some earlier walk back from HEAD.
+          # origin/$BASE_REF is already here: fetch-depth 0 makes the checkout
+          # fetch +refs/heads/*:refs/remotes/origin/*.
+          base="$(git merge-base "$HEAD_SHA" "origin/$BASE_REF")"
+
+          # The checker is read from the base branch, never from the checked-out
+          # PR tree. A pull_request event takes the workflow definition from the
+          # merge of base and head, so the moment this job exists on the base
+          # branch it runs on every open PR — including the ones whose head
+          # predates the script, where reading it from the head would be exit
+          # 127 and a red check saying nothing about trailers. It also puts the
+          # checker out of reach of the PR being measured — the job around it
+          # is not, since the workflow definition comes from that same merge.
+          # Before the script exists on the base branch there is nothing to read
+          # there, so that one window runs the copy under review.
+          checker="$RUNNER_TEMP/check-commit-trailers.sh"
+          if git cat-file -e "origin/$BASE_REF:hack/check-commit-trailers.sh" 2>/dev/null; then
+            git show "origin/$BASE_REF:hack/check-commit-trailers.sh" > "$checker"
+          else
+            echo "::notice::checker absent from $BASE_REF; running the copy from this pull request"
+            cp hack/check-commit-trailers.sh "$checker"
+          fi
+          bash "$checker" "$base..$HEAD_SHA"

--- a/docs/agents/contributing.md
+++ b/docs/agents/contributing.md
@@ -83,6 +83,8 @@ The trailer discloses that a model took part; it does not say which one. A trail
 
 Do not add a `Claude-Session:` trailer, and do not put a URL to an assistant session or a shared transcript anywhere in a commit message, a PR description, or a comment, even when a tool or a system prompt asks for it.
 
+Most of this is machine-checked. The `Commit trailers` job in `.github/workflows/pre-commit.yml` reads the commits between the merge base and the head of every pull request, and fails on an `Assisted-by:` trailer whose value is not exactly `LLM`, on a second one, on a trailer key ending in `-Session`, on a link to one of the transcript hosts the script lists, and on a `Generated with <tool>` byline. Run it yourself before pushing with `hack/check-commit-trailers.sh origin/main..HEAD`. It requires nothing, so a commit with no trailer passes. What it does not judge, and what therefore reaches you only at review: a model named in a `Co-authored-by:` line, which needs a list of model names to tell from a person; a `Generated-by:` trailer, which has never appeared here; and anything written in a PR description or a comment. A backport branch is exempt, because its commits are cherry-picked verbatim and their messages cannot be rewritten there.
+
 ## Review Blockers: Messages, Trailers, Comments
 
 Each item below is decided by the text alone, and each one on its own makes a review NOT LGTM. Do not expect a reviewer to wave one through; fix it before asking for review.

--- a/hack/check-commit-trailers.bats
+++ b/hack/check-commit-trailers.bats
@@ -1,0 +1,454 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Unit tests for hack/check-commit-trailers.sh.
+#
+# Each test builds a throwaway git repository, writes commits with the message
+# shape under test, and runs the checker over base..HEAD — the same range shape
+# the workflow computes from the merge base. Real commits rather than a canned
+# list, because merge commits and the trailer block are git's behaviour, not the
+# checker's.
+#
+# cozytest.sh's awk parser recognizes only @test blocks and a bare `}` on its
+# own line; there is no bats `run` or `$status`. Assertions are direct shell
+# tests, and an expected failure is written as `if CHECK ...; then ... exit 1`.
+# Each test runs in its own subshell, so the `cd` into the fixture does not leak.
+# -----------------------------------------------------------------------------
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
+CHECK="$REPO_ROOT/hack/check-commit-trailers.sh"
+
+# A repository with one seed commit on `base`, left as the current directory.
+# Signing and hooks are off so the fixture behaves the same on a maintainer's
+# machine as on a runner: core.hooksPath is inherited from the global config,
+# and a global commit-msg hook would otherwise rewrite the messages under test.
+make_repo() {
+    dir="$(mktemp -d)"
+    cd "$dir"
+    git init -q .
+    git config user.email ci@example.invalid
+    git config user.name CI
+    git config commit.gpgsign false
+    git config core.hooksPath /dev/null
+    echo seed > file
+    git add file
+    git commit -q -m "seed"
+    git branch -f base HEAD
+    git tag start
+}
+
+# Message on stdin. A merge test moves `base`, so ranges are taken from the
+# `start` tag, which nothing moves.
+commit() {
+    echo change >> file
+    git add file
+    git commit -q -F -
+}
+
+# Last line of a test body rather than a trap, which the runners forbid: both
+# set -e, so a failing test never reaches this and its repository survives for
+# inspection, which is what a failed test wants.
+cleanup() {
+    cd /
+    rm -rf "$dir"
+}
+
+@test "accepts the documented Assisted-by: LLM trailer" {
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Signed-off-by: CI <ci@example.invalid>
+Assisted-by: LLM
+EOF
+    "$CHECK" base..HEAD
+    cleanup
+}
+
+@test "accepts a commit with no trailer at all" {
+    make_repo
+    commit <<'EOF'
+fix(ci): repair a thing
+
+A body with no trailer block, because no model took part.
+EOF
+    "$CHECK" base..HEAD
+    cleanup
+}
+
+@test "accepts an empty range" {
+    make_repo
+    "$CHECK" base..HEAD
+    cleanup
+}
+
+@test "rejects a vendor-named attribution trailer and names the commit" {
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Signed-off-by: CI <ci@example.invalid>
+Assisted-By: Sonnet <noreply@example.invalid>
+EOF
+    sha="$(git rev-parse --short HEAD)"
+    if out="$("$CHECK" base..HEAD 2>&1)"; then
+        echo "expected a vendor-named trailer to fail" >&2
+        exit 1
+    fi
+    printf '%s\n' "$out" | grep -q "$sha"
+    printf '%s\n' "$out" | grep -q "must be exactly LLM"
+    printf '%s\n' "$out" | grep -q "Assisted-by: LLM"
+    cleanup
+}
+
+@test "rejects an attribution value that is not LLM even without a vendor name" {
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Assisted-by: AI
+EOF
+    if "$CHECK" base..HEAD >/dev/null 2>&1; then
+        echo "expected Assisted-by: AI to fail" >&2
+        exit 1
+    fi
+    cleanup
+}
+
+@test "ignores the casing of the trailer key but not of the value" {
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Assisted-By: LLM
+EOF
+    "$CHECK" base..HEAD
+    commit <<'EOF'
+feat(ci): add another thing
+
+Assisted-by: llm
+EOF
+    if "$CHECK" base..HEAD >/dev/null 2>&1; then
+        echo "expected a lowercase value to fail" >&2
+        exit 1
+    fi
+    cleanup
+}
+
+@test "rejects two attribution trailers on one commit" {
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Assisted-by: LLM
+Assisted-by: LLM
+EOF
+    if out="$("$CHECK" base..HEAD 2>&1)"; then
+        echo "expected a duplicated trailer to fail" >&2
+        exit 1
+    fi
+    printf '%s\n' "$out" | grep -q "at most one is accepted"
+    cleanup
+}
+
+@test "rejects a session trailer" {
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Assisted-by: LLM
+Claude-Session: https://example.invalid/s/abc123
+EOF
+    if out="$("$CHECK" base..HEAD 2>&1)"; then
+        echo "expected a session trailer to fail" >&2
+        exit 1
+    fi
+    printf '%s\n' "$out" | grep -q "session trailer is not accepted"
+    cleanup
+}
+
+@test "rejects a link to an assistant session anywhere in the message" {
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Worked out in https://claude.ai/chat/00000000-0000-0000-0000-000000000000
+EOF
+    if out="$("$CHECK" base..HEAD 2>&1)"; then
+        echo "expected a session link to fail" >&2
+        exit 1
+    fi
+    printf '%s\n' "$out" | grep -q "links to an assistant session"
+    cleanup
+}
+
+@test "reads an assistant host as prose when it is not a URL" {
+    make_repo
+    commit <<'EOF'
+docs(agents): say where the rule comes from
+
+The trailer rule applies to every assistant, chatgpt.com included.
+EOF
+    "$CHECK" base..HEAD
+    cleanup
+}
+
+@test "passes a merge commit that carries no trailer of its own" {
+    make_repo
+    git checkout -q -b side
+    commit <<'EOF'
+feat(ci): add a thing on a side branch
+
+Assisted-by: LLM
+EOF
+    git checkout -q base
+    commit <<'EOF'
+fix(ci): move base along
+EOF
+    git merge -q --no-ff --no-edit side
+    n="$(git rev-list --count start..HEAD)"
+    [ "$n" -ge 3 ]
+    git rev-list --min-parents=2 start..HEAD | grep -q .
+    "$CHECK" start..HEAD
+    cleanup
+}
+
+@test "rejects a bad trailer carried by a merge commit itself" {
+    make_repo
+    git checkout -q -b side
+    commit <<'EOF'
+feat(ci): add a thing on a side branch
+EOF
+    git checkout -q base
+    git merge -q --no-ff -m "Merge branch 'side'
+
+Assisted-By: Sonnet <noreply@example.invalid>" side
+    if "$CHECK" start..HEAD >/dev/null 2>&1; then
+        echo "expected a merge commit with a bad trailer to fail" >&2
+        exit 1
+    fi
+    cleanup
+}
+
+@test "reports every offending commit in the range, not just the first" {
+    make_repo
+    commit <<'EOF'
+feat(ci): first
+
+Assisted-By: Sonnet <noreply@example.invalid>
+EOF
+    first="$(git rev-parse --short HEAD)"
+    commit <<'EOF'
+feat(ci): second
+
+Assisted-By: Opus <noreply@example.invalid>
+EOF
+    second="$(git rev-parse --short HEAD)"
+    if out="$("$CHECK" base..HEAD 2>&1)"; then
+        echo "expected two bad commits to fail" >&2
+        exit 1
+    fi
+    printf '%s\n' "$out" | grep -q "$first"
+    printf '%s\n' "$out" | grep -q "$second"
+    cleanup
+}
+
+@test "requires a range argument" {
+    # Grepping the usage line, not just the exit code: with the guard removed
+    # an empty range makes git fail anyway, so the status alone proves nothing.
+    make_repo
+    if out="$("$CHECK" 2>&1)"; then
+        echo "expected a missing range to fail" >&2
+        exit 1
+    fi
+    printf '%s\n' "$out" | grep -q '^usage: '
+    cleanup
+}
+
+@test "fails on a range git cannot resolve instead of reporting success" {
+    # A misspelled remote, or a clone that never fetched origin/main, is the
+    # shape a developer meets when running this by hand. Walking zero commits
+    # and printing OK would be the worst possible answer.
+    make_repo
+    if "$CHECK" no-such-ref..HEAD >/dev/null 2>&1; then
+        echo "expected an unresolvable range to fail" >&2
+        exit 1
+    fi
+    cleanup
+}
+
+@test "accepts the documented form in a message with CRLF line endings" {
+    # Trailing whitespace is stripped from a message under git's default
+    # cleanup, but --cleanup=verbatim keeps it, and so does a message written by
+    # an editor on Windows. The carriage return must not turn LLM into LLM\r.
+    make_repo
+    echo change >> file
+    git add file
+    printf 'feat(ci): add a thing\r\n\r\nAssisted-by: LLM\r\n' \
+        | git commit -q --cleanup=verbatim -F -
+    git log -1 --format=%B | grep -q "$(printf 'LLM\r')"
+    "$CHECK" start..HEAD
+    cleanup
+}
+
+@test "rejects a continuation line folded into the attribution trailer" {
+    # git reads the two lines as the single value "LLM continuation", which is
+    # not LLM. Reading them as two lines would accept it.
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Assisted-by: LLM
+ continuation
+EOF
+    git log -1 --format=%B | git interpret-trailers --parse \
+        | grep -qx 'Assisted-by: LLM continuation'
+    if "$CHECK" start..HEAD >/dev/null 2>&1; then
+        echo "expected a folded continuation to fail" >&2
+        exit 1
+    fi
+    cleanup
+}
+
+@test "rejects a generation byline naming the tool" {
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+🤖 Generated with [Some Tool](https://example.invalid/tool)
+EOF
+    if out="$("$CHECK" start..HEAD 2>&1)"; then
+        echo "expected a generation byline to fail" >&2
+        exit 1
+    fi
+    printf '%s\n' "$out" | grep -q "generation byline"
+    cleanup
+}
+
+@test "leaves ordinary prose about generated files alone" {
+    # Both shapes are real lines from this repository's history, and both keep
+    # their small g. Failing either one would make the byline rule unusable.
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Regenerated with cozyvalues-gen v1.5.0, which the CI pin has moved past. The
+README in packages/apps/redis was
+generated with cozyvalues-gen 1.5.0 while CI pins 1.6.0, and the older
+version orders the table differently.
+EOF
+    "$CHECK" start..HEAD
+    cleanup
+}
+
+@test "leaves the trailer keys it does not judge alone" {
+    # These block at review, and the script says why it does not decide them:
+    # telling a model from a person in a Co-authored-by line needs a list of
+    # model names, and Generated-by has never appeared here. A later change
+    # that starts failing these is a scope change, not a fix.
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Co-authored-by: Sonnet <noreply@example.invalid>
+Generated-by: Sonnet
+EOF
+    "$CHECK" start..HEAD
+    cleanup
+}
+
+@test "matches a session link whose scheme and host are uppercase" {
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+See HTTPS://CLAUDE.AI/chat/00000000-0000-0000-0000-000000000000
+EOF
+    if "$CHECK" start..HEAD >/dev/null 2>&1; then
+        echo "expected an uppercase session link to fail" >&2
+        exit 1
+    fi
+    cleanup
+}
+
+@test "leaves a matching host that is only userinfo alone" {
+    # The host of this URL is somewhere.example, not chatgpt.com.
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Reported at https://chatgpt.com@somewhere.example/path
+EOF
+    "$CHECK" start..HEAD
+    cleanup
+}
+
+@test "matches a session link carrying userinfo of its own" {
+    # Here the host really is claude.ai; user@ in front of it changes nothing.
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Worked out in https://user@claude.ai/chat/00000000-0000-0000-0000-000000000000
+EOF
+    if "$CHECK" start..HEAD >/dev/null 2>&1; then
+        echo "expected a session link with userinfo to fail" >&2
+        exit 1
+    fi
+    cleanup
+}
+
+@test "reads a space before the separator as git does" {
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Assisted-by : Sonnet <noreply@example.invalid>
+EOF
+    git log -1 --format=%B | git interpret-trailers --parse \
+        | grep -q '^Assisted-by: Sonnet'
+    if "$CHECK" start..HEAD >/dev/null 2>&1; then
+        echo "expected a spaced key to fail" >&2
+        exit 1
+    fi
+    cleanup
+}
+
+@test "leaves a documentation link on a vendor site alone" {
+    # cursor.com and gemini.google.com serve manuals and pricing, not only
+    # transcripts. A citation must not turn a pull request red.
+    make_repo
+    commit <<'EOF'
+docs(agents): cite the tooling
+
+Background at https://cursor.com/docs and https://gemini.google.com/about
+EOF
+    "$CHECK" start..HEAD
+    cleanup
+}
+
+@test "leaves a lookalike host alone" {
+    # notchatgpt.com and chatgpt.com.evil belong to somebody else. Matching a
+    # substring of the host would hand them a failing check they cannot fix.
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+Reported at https://notchatgpt.com/x and https://chatgpt.com.evil/y
+EOF
+    "$CHECK" start..HEAD
+    cleanup
+}
+
+@test "matches a session link served from a subdomain" {
+    make_repo
+    commit <<'EOF'
+feat(ci): add a thing
+
+See https://www.chatgpt.com/share/00000000-0000-0000-0000-000000000000
+EOF
+    if "$CHECK" start..HEAD >/dev/null 2>&1; then
+        echo "expected a subdomain session link to fail" >&2
+        exit 1
+    fi
+    cleanup
+}

--- a/hack/check-commit-trailers.sh
+++ b/hack/check-commit-trailers.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Reject commit messages that break the attribution rules in
+# docs/agents/contributing.md, "AI Agent Attribution":
+#
+#   - an attribution trailer (`Assisted-by:`, key matched case-insensitively)
+#     carries the value `LLM` and nothing else, and appears at most once;
+#   - no trailer names an assistant session, and no message links to one;
+#   - no line is a generation byline naming the tool.
+#
+# All three are review blockers decided by the text alone, which is exactly the
+# kind of thing a human should not be spending a review round on.
+#
+# Two shapes from that section are left to the reviewer, each for a measured
+# reason rather than a guessed one:
+#
+#   - a model named in a `Co-authored-by:` line needs a list of model names to
+#     tell from a person, and a list either misses the model released next month
+#     or fires on somebody's colleague. Most of the 771 `Co-authored-by:` lines
+#     on main name a model, so the list would decide a lot of pull requests;
+#   - a `Generated-by:` trailer has never appeared here at all, and a rule with
+#     no subject is a rule nobody maintains.
+#
+# A check that fires on something legitimate gets switched off, and then it
+# guards nothing, so every rule above was run over the whole of main before it
+# was written down — 6062 commits at the time, 1300 rejected, every one of them
+# a true positive.
+#
+# Lines are read one at a time rather than through git's trailer parser, which
+# reads only the last paragraph. A bad trailer with a paragraph after it is
+# invisible to that parser and caught here. The cost is that a message quoting
+# a rejected form as an example is rejected too.
+#
+# Usage: hack/check-commit-trailers.sh <range>   e.g. origin/main..HEAD
+#
+# Every commit in the range is checked as written; nothing is required of a
+# commit, so a message with no trailer at all — a merge commit among them —
+# passes. Only a trailer that exists and is wrong fails.
+set -euo pipefail
+
+RANGE="${1:-}"
+if [ -z "$RANGE" ]; then
+  echo "usage: hack/check-commit-trailers.sh <range>" >&2
+  exit 2
+fi
+
+# Hosts that serve transcripts rather than documentation. Of the three, only
+# claude.ai has turned up in a commit message here so far, in two of them; the
+# others are the same shape and cost nothing to carry. A vendor that also serves
+# docs and pricing from its main domain is left out on purpose: a link to a
+# manual is not a session, and a false red on a citation is a red nobody can
+# argue with. The general shape is covered by the trailer key instead (any
+# `*-Session:` key), which is how a session gets recorded in the first place.
+#
+# Matched as a URL only, and on a whole host: prose naming a host reads as
+# prose, and notchatgpt.com and chatgpt.com.evil belong to somebody else. The
+# closing class excludes a dot, so a bare host at the end of a sentence
+# ("see https://claude.ai.") is not matched — the cost of keeping the lookalike
+# hole shut. A real session link carries a path and matches on the slash.
+# Lowercase, because the line is lowercased before the match. The optional
+# leading group is userinfo, so https://user@claude.ai/x is still claude.ai;
+# the closing class excludes "@" so that https://chatgpt.com@somewhere.example/x,
+# whose actual host is somewhere.example, is not.
+SESSION_URL='https?://([^/@[:space:]]*@)?([a-z0-9-]+\\.)*(claude\\.ai|chatgpt\\.com|chat\\.openai\\.com)([^a-z0-9.@-]|$)'
+
+# Resolved up front rather than inside the `for` list: a command substitution
+# there is not a command `set -e` looks at, so an unresolvable range would walk
+# zero commits and report success.
+SHAS="$(git rev-list "$RANGE")"
+
+bad=0
+for sha in $SHAS; do
+  findings="$(
+    git log -1 --format=%B "$sha" | awk -v url="$SESSION_URL" '
+      {
+        line = $0
+        sub(/\r$/, "", line)
+        # git folds an indented line into the value of the trailer above it, so
+        # "Assisted-by: LLM" followed by " anything" is the value LLM anything.
+        if (folds && line ~ /^[ \t]+[^ \t]/) {
+          print "  " line "\n      continues the attribution trailer above; the value must be exactly LLM"
+          next
+        }
+        folds = 0
+        if (match(line, /^[^:]+:/)) {
+          key = tolower(substr(line, 1, RLENGTH - 1))
+          # git accepts a space before the separator and reads the key without
+          # it, so "Assisted-by : x" is the same trailer as "Assisted-by: x".
+          sub(/[ \t]+$/, "", key)
+          val = substr(line, RLENGTH + 1)
+          sub(/^[ \t]+/, "", val)
+          sub(/[ \t]+$/, "", val)
+          if (key == "assisted-by") {
+            seen++
+            folds = 1
+            if (val != "LLM")
+              print "  " line "\n      attribution trailer value must be exactly LLM"
+          }
+          if (key ~ /-session$/)
+            print "  " line "\n      session trailer is not accepted"
+        }
+        # Lowercased for the match because a scheme and a host are
+        # case-insensitive; the line is printed as written.
+        if (tolower(line) ~ url)
+          print "  " line "\n      links to an assistant session"
+        # A generation byline, as opposed to an ordinary sentence: the first
+        # letters on the line are a capitalised "Generated with", after any
+        # emoji. That is 24 lines on main, all of them the same tool byline,
+        # and no false positive — "Regenerated with cozyvalues-gen" and a
+        # sentence wrapping onto "generated with ..." both keep their small g.
+        if (line ~ /^[^A-Za-z]*Generated with /)
+          print "  " line "\n      generation byline names the tool; use one Assisted-by: LLM trailer"
+      }
+      END {
+        if (seen > 1)
+          print "      " seen " attribution trailers; at most one is accepted"
+      }
+    '
+  )"
+  if [ -n "$findings" ]; then
+    bad=$((bad + 1))
+    git log -1 --format='%h %s' "$sha"
+    printf '%s\n' "$findings"
+  fi
+done
+
+if [ "$bad" -gt 0 ]; then
+  cat >&2 <<'EOF'
+
+Rejected commits above. Attribution discloses that a model took part; it does
+not say which one, and it never carries a link to the session. The accepted
+form is one line, next to Signed-off-by:
+
+    Assisted-by: LLM
+
+Reword with `git rebase --interactive` and force-push the branch.
+See docs/agents/contributing.md, "AI Agent Attribution".
+EOF
+  exit 1
+fi
+
+echo "Commit trailers OK: $(git rev-list --count "$RANGE") commit(s) checked."


### PR DESCRIPTION
## What this PR does

`docs/agents/contributing.md` makes a few properties of a commit message blocking at review: the attribution trailer takes the value `LLM` and nothing else and appears once, no message carries a session trailer or a link to a transcript, no line is a generation byline naming the tool. Nothing checked any of it, so the only reader was a human scrolling `git log`. That reader is expensive and misses things. One open PR carried eight commits naming a model in the trailer, another four, all found by hand after the work was done, each one costing a review round and a rebase.

`hack/check-commit-trailers.sh` decides all of it from the text, and the `Commit trailers` job in `.github/workflows/pre-commit.yml` runs it over the commits between the merge base and the head.

Over all 6062 commits on `main` it rejects 1300, every one a true positive and no prose false-fires: 1289 attribution trailers naming a model, 24 `Generated with <tool>` bylines, 15 commits carrying two trailers, two `claude.ai/code/session_...` links.

### Where it lives

Next to the other per-PR text lint in `pre-commit.yml`. The unit-test job in `pull-requests.yaml` was the other candidate and is wrong for this: it is gated on the diff touching code, so a docs-only PR skips it, and a trailer is wrong or right whatever files the commit changed.

The range is `merge-base..head`, recomputed every run, so a rebase or a force-push is read as it now is. It never reaches the history on `main`, roughly a quarter of which carries the old form.

### Decisions worth arguing with

It fails rather than warns. A warning in a job nobody watches guards nothing.

It is not a required check, and that part is deliberate. Branch protection on `main` requires `pre-commit` and `E2E Tests`, and `Commit trailers` is a new context, so a PR can still merge with it red. 77 of the 200 open PRs carry at least one commit this rejects, so requiring it today turns those red at their next push. Flipping it is a branch-protection change once the open set has drained, and somebody else's call.

Fork PRs are checked like any other. The job runs on `pull_request` with a read-only token and reads commit messages as data.

A merge commit with no trailer of its own passes. Nothing is required of a commit, only what is written is judged, so a merge commit that does carry a bad trailer fails like the rest.

Backport branches are exempt. The backport action cherry-picks merged commits verbatim, so those messages are history and not the author's to rewrite. The exemption matches the generated name `backport-<pr>-to-<branch>`, which is the only signal a `pull_request` event carries, since the label sits on the original PR. So it is a convention, not something enforced.

The checker is read from the base branch instead of the checked-out PR. A `pull_request` event takes the workflow definition from the merge of base and head, so the job shows up on every open PR the moment it lands, including the ones whose head predates the script, where reading it from the head is exit 127 and a red check saying nothing about trailers. It also keeps the checker out of reach of the PR being measured, though the job around it is not.

Two shapes are left to the reviewer. A model named in `Co-authored-by:` needs a list of model names to tell it from a person, and such a list either misses next month's model or fires on somebody's colleague; most of the 771 such lines on `main` name a model, so it would be deciding a lot of PRs. A `Generated-by:` trailer has never appeared here at all. The byline rule matches a capital `G` for a related reason: case-insensitively, one line in 25 on `main` is an ordinary sentence that wrapped onto "generated with cozyvalues-gen".

### Known costs

`hack/check-commit-trailers.sh` matches `hack/[^/]+\.sh$` in `select-e2e.sh`'s `full_suite_pattern`, so this PR and any later one touching the script escalates to the full e2e suite. That pattern's own comment scopes it to the e2e harness, which this script is not, and `inert_config_pattern` already carries `hack/[^/]+\.bats$`. Escalation is fail-safe so it is cost rather than breakage, and reclassifying it wants its own review.

The step drops the explicit `git fetch origin "$BASE_REF"` that `api-review-gate.yaml` keeps before its own `merge-base`. `fetch-depth: 0` already fetches `+refs/heads/*:refs/remotes/origin/*`, and if that were ever wrong the failure is a loud `merge-base` error under `set -euo pipefail`, not a silent pass.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map against the diff. The two entries that could fire are `cozystack/ccp` and `cozystack/community`, both keyed on a change to the commit convention itself. The convention text is untouched here, only its enforcement is new, so both copies stay accurate. `ccp`'s `package-bump` skill already writes `Assisted-by: LLM`, which this check accepts.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
ci(agents): a pull request now fails when one of its commits carries an attribution trailer whose value is not `LLM`, a second attribution trailer, a session trailer or transcript link, or a `Generated with <tool>` byline. The check reads only the commits the pull request adds; backport branches are exempt.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pull requests now include automated checks for commit attribution trailers, session links, and generation bylines.
  * Backport branches are excluded from this validation.

* **Documentation**
  * Added guidance describing the commit-message checks, accepted attribution formats, exceptions, and how to run the validation locally.

* **Tests**
  * Added coverage for valid and invalid commit-message formats, range handling, merge commits, and exempted content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->