### PR TITLE
fix(cdi): pin the CDI release kubevirt-cdi is reconciled against and stop update overwriting it

### DIFF
--- a/hack/package-update-templates.bats
+++ b/hack/package-update-templates.bats
@@ -4,19 +4,18 @@
 #
 # `update` refetches a package's vendored upstream manifests, and several
 # recipes open by deleting templates/ to guarantee a clean slate. That is safe
-# only while every file under templates/ comes back from the recipe. templates/
-# is an ordinary chart directory, so a package can also keep first-party
-# manifests there -- kubevirt-cdi keeps the CDI upload-proxy Ingress and
-# TLSRoute -- and the recipe knows nothing about those. The wipe takes them and
-# `make update` exits 0, so the deletion lands in the diff with nothing marking
-# it. Whether anything downstream notices depends on the package carrying a
-# helm-unittest suite that names the file, and where none does the loss is
-# silent all the way to a cluster. That is a property of the package, not of
-# the tree, so it is worth re-deriving rather than reading: at the time of
-# writing kubevirt-cdi has such a suite and a deletion there fails `make test`
-# as well, while three of the packages that clear their own templates/ declare
-# no `test` target at all. Adding one to any of them changes that sentence and
-# not this one.
+# only while every file under templates/ comes back from the recipe.
+# templates/ is an ordinary chart directory, so a package can also keep
+# first-party manifests there, and the recipe knows nothing about them. The
+# wipe takes them and `make update` exits 0, so the deletion lands in the diff
+# with nothing marking it. Whether anything downstream notices depends on the
+# package carrying a helm-unittest suite that names the file, and where none
+# does the loss is silent all the way to a cluster. That is a property of the
+# package, not of the tree, so it is worth re-deriving rather than reading: at
+# the time of writing kubevirt-cdi has such a suite and a deletion there fails
+# `make test` as well, while three of the packages that clear their own
+# templates/ declare no `test` target at all. Adding one to any of them
+# changes that sentence and not this one.
 #
 # The invariant: a recipe that clears templates/ must NAME every file tracked
 # under it. Both halves are approximations of the shell the recipe would run,
@@ -258,8 +257,7 @@ unnamed_templates() {
     # A tab-indented comment inside the recipe is not shell. A recipe that
     # stopped clearing templates/ tends to acquire a line saying so, and
     # searching that line would fail the package the removal protected. Both
-    # spellings are pinned because make accepts both and the tree writes both:
-    # `@#` in kubevirt-operator's own update recipe, bare `#` everywhere else.
+    # spellings are pinned because make accepts both and the tree writes both.
     for lead in '#' '@#'; do
         printf 'update:\n\tmkdir -p templates\n\t%s deliberately no rm -rf templates here: the upload-proxy files are ours\n' \
             "$lead" > "$tmp/pkg/Makefile"
@@ -330,10 +328,10 @@ unnamed_templates() {
         exit 1
     fi
 
-    # The other order, and the one this tree actually writes: kubevirt-cdi puts
-    # `test:` below its `update:` recipe. Above, `r` is still 0 and the gate
-    # does the work; here the recipe has already started and only the
-    # terminator can stop it, so without this case that half is unpinned.
+    # The other order, and one the tree writes: a `test:` below the `update:`
+    # recipe. Above, `r` is still 0 and the gate does the work; here the recipe
+    # has already started and only the terminator can stop it, so without this
+    # case that half is unpinned.
     printf 'update:\n\tmkdir -p templates\nclean:\n\trm -rf templates\n' \
         > "$tmp/pkg/Makefile"
     if [ -n "$(wipe_command "$tmp/pkg/Makefile")" ]; then
@@ -373,8 +371,8 @@ unnamed_templates() {
         exit 1
     fi
 
-    # And the shape kubevirt-cdi moved to switches the check off, so the scan
-    # is measuring the removal rather than the package.
+    # And a recipe that only creates the directory switches the check off, so
+    # the scan is measuring the removal rather than the package.
     printf 'update:\n\tmkdir -p templates\n\twget -O templates/fetched.yaml https://example.invalid/f.yaml\n' \
         > "$tmp/pkg/Makefile"
     if [ -n "$(wipe_command "$tmp/pkg/Makefile")" ]; then

--- a/packages/system/kubevirt-cdi/.gitignore
+++ b/packages/system/kubevirt-cdi/.gitignore
@@ -1,0 +1,3 @@
+# `update` fetches here to check the pin, and keeps the file on a mismatch.
+# The recipe's error text says why.
+/cdi-cr.yaml.download

--- a/packages/system/kubevirt-cdi/Makefile
+++ b/packages/system/kubevirt-cdi/Makefile
@@ -1,27 +1,71 @@
 export NAME=kubevirt-cdi
 export NAMESPACE=cozy-$(NAME)
 
+# The CDI release templates/cdi-cr.yaml is reconciled against. Moving to a
+# newer CDI is an edit to this line. What the platform actually deploys is set
+# by ../kubevirt-cdi-operator, which pins nothing: its recipe vendors whatever
+# GitHub's releases/latest resolved to when someone last ran it. So this line
+# does not track that one, it has to be pointed at it by hand, and nothing in
+# either file reports the two having drifted apart. Deriving this from the
+# sibling manifest would end the pin: the point is that a human chooses which
+# release this object is reconciled against, and a computed value hides that
+# choice from the diff.
+RELEASE = v1.66.1
+
+# sha256 of the cdi-cr.yaml release asset as published. Upstream publishes no
+# checksum for it, so the pin is taken from a download rather than fetched
+# alongside one: it detects an asset that moved under its tag, and it is not
+# authenticity verification.
+CR_SHA256 = a497f90de608c1df26f9ee4095289373f17132d74a2042ca03e00c17c964f8a7
+
+# sha256sum is not everywhere: current macOS carries a native one in /sbin,
+# older releases carry only shasum(1). Both print "<digest>  <path>", so field
+# 1 is the digest whichever gets picked.
+SHA256SUM = $(shell command -v sha256sum >/dev/null 2>&1 && echo sha256sum || echo 'shasum -a 256')
+
 include ../../../hack/package.mk
 
-# hack/package.mk defines no `test` target and hack/helm-unit-tests.sh only runs
-# a package whose `make -n test` resolves, so a tests/ directory without this
-# line is collected by nothing and the suite is skipped in silence.
+# Phony because hack/package.mk's .PHONY line lists only the targets that file
+# defines: with neither name declared, a path named `test` or `update` next to
+# this Makefile would make that target up to date and skip the recipe.
+.PHONY: test update
+
+# hack/package.mk defines no `test` target and hack/helm-unit-tests.sh only
+# runs a package whose `make -n test` resolves, so a tests/ directory with no
+# `test:` target is collected by nothing and the suite is skipped in silence.
 test:
 	helm unittest .
 
-# Nothing under templates/ here is purely vendored. The upload-proxy Ingress
-# and TLSRoute are ours and no fetch recreates them, so clearing the directory
-# loses them outright, which is why the removal is gone: wget -O truncates the
-# one file it writes and leaves the rest.
+# templates/cdi-cr.yaml is ours, not upstream's: it adds to upstream's bare CDI
+# object, and what it adds is pinned under tests/ rather than restated here.
+# The delta is a fact about one release and not a standing property of CDI:
+# upstream carried WebhookPvcRendering from v1.63.0 through v1.65.0 and dropped
+# it by v1.66.0, and this object never carried it at all, so the difference ran
+# both ways for three releases and one way after. Re-derive it at each bump
+# instead of inheriting it.
 #
-# cdi-cr.yaml is ours too, despite being named after an upstream asset: it
-# carries Helm templating and RBAC that no fetch reproduces. The fetch below
-# still overwrites it, so a CDI bump means diffing it against the upstream
-# asset and re-applying whatever is local by hand.
+# So nothing here writes under templates/: fetching the release the object is
+# derived from confirms the bytes still hash to the pin, and stops there. What
+# that catches is an edit to RELEASE without a matching digest, and an asset
+# that moved under a tag that should be immutable. Moving RELEASE is therefore
+# the step that forces someone to reconcile this object by hand, which is the
+# point. It does not catch ../kubevirt-cdi-operator vendoring a new release,
+# because nothing here reads that package. RELEASE is checked by `update`
+# rather than by `test`, because helm-unittest reads rendered output and this
+# object renders no version string.
 update:
-	mkdir -p templates
-	export VERSION=$$(basename $$(curl -s -w %{redirect_url} https://github.com/kubevirt/containerized-data-importer/releases/latest)) && \
-	wget https://github.com/kubevirt/containerized-data-importer/releases/download/$$VERSION/cdi-cr.yaml -O templates/cdi-cr.yaml
-
-test:
-	helm unittest .
+	wget https://github.com/kubevirt/containerized-data-importer/releases/download/$(RELEASE)/cdi-cr.yaml -O cdi-cr.yaml.download || { rm -f cdi-cr.yaml.download; exit 1; }
+	@# Kept on a mismatch rather than deleted; the error below says why.
+	@actual=$$($(SHA256SUM) cdi-cr.yaml.download | awk '{print $$1}'); \
+	if [ "$$actual" != "$(CR_SHA256)" ]; then \
+	  echo "ERROR: cdi-cr.yaml for $(RELEASE) hashed $$actual," >&2; \
+	  echo "       expected $(CR_SHA256). The download is kept as" >&2; \
+	  echo "       cdi-cr.yaml.download." >&2; \
+	  echo "       If RELEASE just moved, diff it against templates/cdi-cr.yaml," >&2; \
+	  echo "       carry over what belongs there and update CR_SHA256. If RELEASE" >&2; \
+	  echo "       did not change, the asset moved under a tag that should be" >&2; \
+	  echo "       immutable: find out why first." >&2; \
+	  exit 1; \
+	fi; \
+	rm -f cdi-cr.yaml.download
+	@echo "upstream cdi-cr.yaml for $(RELEASE) matches the pin; templates/cdi-cr.yaml is maintained by hand and was left alone."

--- a/packages/system/kubevirt-cdi/tests/local_templates_test.yaml
+++ b/packages/system/kubevirt-cdi/tests/local_templates_test.yaml
@@ -1,0 +1,148 @@
+suite: cozy-kubevirt-cdi local templates
+release:
+  name: kubevirt-cdi
+  namespace: cozy-kubevirt-cdi
+# Both route cases run against this block; the TLSRoute case overrides the
+# gate alone. Emission is gated on expose-services and gateway-enabled, so
+# without a matching expose-services entry neither route renders and both
+# fail on "no manifest found" rather than on the assertion they are about.
+# root-host is not part of that gate and no assertion reads it: it is set
+# because the hostname is built from it, and without it the TLSRoute renders
+# "cdi-uploadproxy.%!s(<nil>)". tests/standalone_render_test.yaml covers the
+# opposite case, that the chart renders with nothing injected at all.
+set:
+  _cluster:
+    root-host: example.com
+    expose-services: cdi-uploadproxy
+    gateway-enabled: "false"
+tests:
+  # Each list and map is pinned whole rather than by membership or by leaf:
+  # `contains` answers "is ours still here" and cannot answer "has anything
+  # been added beside it", and an assert per leaf cannot answer "has a key
+  # appeared". Both directions matter for a file whose whole maintenance model
+  # is a hand reconciliation at each bump. Pinning featureGates whole also
+  # pins HonorWaitForFirstConsumer, which is upstream's rather than ours; that
+  # is a side effect of the shape, not a claim that the upstream half is
+  # covered.
+  - it: keeps the local additions to the CDI object
+    template: cdi-cr.yaml
+    documentSelector:
+      path: kind
+      value: CDI
+      matchMany: false
+    asserts:
+      - equal:
+          path: spec.config.featureGates
+          value:
+            - HonorWaitForFirstConsumer
+            - ExpandDisks
+      - equal:
+          path: spec.infra.tolerations
+          value:
+            - key: CriticalAddonsOnly
+              operator: Exists
+      - equal:
+          path: spec.config.podResourceRequirements
+          value:
+            limits:
+              cpu: 750m
+              memory: 600M
+            requests:
+              cpu: 100m
+              memory: 60M
+
+  # The default is the empty string, so the block renders nothing and an
+  # assertion on the default value would pass against a template that had
+  # stopped rendering the block. Setting it is what makes this able to fail.
+  - it: renders the upload-proxy URL override when one is set
+    template: cdi-cr.yaml
+    documentSelector:
+      path: kind
+      value: CDI
+      matchMany: false
+    set:
+      uploadProxyURL: https://cdi-uploadproxy.example.com
+    asserts:
+      - equal:
+          path: spec.config.uploadProxyURLOverride
+          value: https://cdi-uploadproxy.example.com
+
+  # What lets a tenant service account clone from the golden-image namespace.
+  # `any: true` on both: a bare containsDocument holds every document in the
+  # template to the match, and this template renders three.
+  - it: keeps the golden-image clone RBAC
+    template: cdi-cr.yaml
+    asserts:
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          name: cdi-copy-dv
+          any: true
+      - containsDocument:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          name: cdi-clone-dv
+          namespace: cozy-public
+          any: true
+
+  # containsDocument reaches this document's identity and nothing inside it,
+  # so what the role grants was pinned by nothing. Widening verbs to ["*"]
+  # hands every service account in the cluster whatever the binding reaches.
+  - it: grants create on datavolumes/source and nothing else
+    template: cdi-cr.yaml
+    documentSelector:
+      path: metadata.name
+      value: cdi-copy-dv
+    asserts:
+      - equal:
+          path: rules
+          value:
+            - apiGroups:
+                - cdi.kubevirt.io
+              resources:
+                - datavolumes/source
+              verbs:
+                - create
+
+  # roleRef and subjects decide who may clone out of cozy-public, so each is
+  # pinned whole rather than field by field. An assert on subjects[0] answers
+  # "was the Group replaced by something narrower" and cannot answer "was a
+  # second subject appended", and appending is the direction that widens
+  # access: pinning the list is what makes both reachable.
+  - it: binds exactly the service-account Group to the copy role
+    template: cdi-cr.yaml
+    documentSelector:
+      path: metadata.name
+      value: cdi-clone-dv
+    asserts:
+      - equal:
+          path: roleRef
+          value:
+            kind: ClusterRole
+            name: cdi-copy-dv
+            apiGroup: rbac.authorization.k8s.io
+      - equal:
+          path: subjects
+          value:
+            - kind: Group
+              name: system:serviceaccounts
+              apiGroup: rbac.authorization.k8s.io
+
+  # Addressed as a `template:` because helm-unittest fails outright on one it
+  # cannot find, which makes a deleted file loud rather than a smaller render.
+  - it: renders the upload-proxy Ingress when the gateway is off
+    template: cdi-uploadproxy-ingress.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations["nginx.ingress.kubernetes.io/ssl-passthrough"]
+          value: "true"
+
+  - it: renders the upload-proxy TLSRoute when the gateway is on
+    template: cdi-uploadproxy-tlsroute.yaml
+    set:
+      _cluster:
+        gateway-enabled: "true"
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: tls-cdi-uploadproxy


### PR DESCRIPTION
## What this PR does

`packages/system/kubevirt-cdi` resolved its CDI version at run time from GitHub's `releases/latest` redirect and wrote the result straight over `templates/cdi-cr.yaml`. That file is not vendored. Upstream ships a bare CDI object; ours adds Helm templating for `cloneStrategyOverride`, `uploadProxyURL` and the worker-pod `podResourceRequirements`, the `ExpandDisks` feature gate, a `CriticalAddonsOnly` toleration, and the two RBAC documents that let a tenant clone from the golden-image namespace. I diffed the two at v1.66.1 to write that list, so it is complete as of that release rather than only hedged: upstream ships 283 bytes with one feature gate, two nodeSelectors and an `imagePullPolicy`, and we are a strict superset of it. Every entry arrived by hand, so `wget -O templates/cdi-cr.yaml` was not refreshing a vendored file, it was overwriting a first-party one. Same loss as the `rm -rf templates` that #4097 removes, arriving through the fetch instead of the wipe.

`update` now pins the release the object is reconciled against, and fetches it only to confirm the bytes still hash to a digest I measured. Nothing is written under `templates/`. At the next CDI bump that check fails, which is the point: upstream moving its own defaults is when the local copy needs a human to reconcile it, not an overwrite. The download is kept on a mismatch, since reconciling one starts by reading it.

`RELEASE` is `v1.66.1`, which is the release `kubevirt-cdi-operator` vendors, so the pin and the deployed version agree. What the platform deploys is decided by that package, which pins nothing at all: its recipe takes whatever `releases/latest` resolved to the last time someone ran it. So this line cannot track that one, it is pointed at it by hand, and neither file reports the two having drifted.

Upstream publishes no checksum for the asset, so the pin comes from a download rather than from a published file: `a497f90de608c1df26f9ee4095289373f17132d74a2042ca03e00c17c964f8a7`. It catches an asset that moved under a tag that should be immutable. It is not authenticity verification, and the comment beside it says so.

The digest command is resolved at parse time, `sha256sum` when it is on PATH and `shasum -a 256` otherwise. Which one ran here is worth stating, because the usual claim about macOS is out of date: this machine picked `sha256sum`, and that binary is `/sbin/sha256sum`, a native Darwin one rather than GNU coreutils. It reports `sha256sum (Darwin) 1.0` and prints the same `<digest>  <path>` format.

The package already had a `test:` target, from `0418577f5`, so what it gains here is the `.PHONY` line that commit did not add. `hack/package.mk` declares only the nine targets it defines itself, so without it a file or directory named `test` or `update` beside the Makefile makes make consider that target up to date and skip the recipe in silence. The suite pins the clone-strategy override, the `ExpandDisks` gate, the toleration and the clone RBAC, and renders the upload-proxy Ingress and TLSRoute, each under the `gateway-enabled` value that selects it.

One consequence of the pin move is a claim rather than a number, so it gets its own line. Upstream carried `WebhookPvcRendering` from v1.63.0 through v1.65.0 and dropped it by v1.66.0; the local object never carried it, so the divergence ran both ways across those three releases and one way since. The comment says to re-derive the delta at each bump instead of trusting it, because that was a fact about a span of releases and not about CDI.

`packages/system/kubevirt-cdi/Makefile` carried two identical `test:` targets, one from `0418577f5` and one appended by a later merge, so make printed `overriding commands for target 'test'` on every invocation in the package. The second sat inside the span this recipe rewrites, so it goes with the rewrite rather than being re-authored into it. The comment kept above it is the reason a reader should not add another. Closes #4157.

### Scope

An earlier revision also pinned and tested `kubevirt-cdi-operator`. #3920 has since landed the two real bugs in that recipe, the patch strip level and `patches/tolerations.diff`, so that half is dropped here rather than merged twice. Pinning and testing the operator package is #4190.

Named improvements left alone, so they read as choices. The two upload-proxy tests each render their route under the `gateway-enabled` value that selects it and neither asserts the other is absent; the templates already settle that with `ne "true"` and `eq "true"` on the same variable, and `tests/standalone_render_test.yaml` already asserts each route absent under the values that select the other. So the package does cover it; these two cases just do not, and a third copy would not add anything. The CDI object carries no version string for a rendered-output assertion, so `RELEASE` is checked by `make update` rather than by `make test`. `RELEASE` does not track `kubevirt-cdi-operator`. They agree at v1.66.1 today and nothing fails if they drift. Neither route case pins the backend service port, 443 in both templates; that is outside what the suite claims. The template-loss guard still counts `cdi-cr.yaml` as named, because the download line in `update` mentions the stem, so re-adding a wipe here would have it report two files instead of three; the guard's header already says a mention is not proof of a write, and the fix would edit the failure-path message, which is where most of the wrong sentences in this branch have come from. The suite pins the local additions by design, and most of the upstream-derived half is pinned by nothing: `imagePullPolicy` and the two `nodeSelector` blocks have no assertion anywhere under `tests/`. `HonorWaitForFirstConsumer` is the exception and only as a side effect: `featureGates` is pinned whole, so that gate rides along with `ExpandDisks`. The rest are maintained by the same hand reconciliation the pin forces at each bump, so a carry-over that drops one of them is green. Three asserts would close what is left. One more, remote enough to name rather than code around: if the digest tool is missing entirely, `$$actual` comes out empty, the comparison against `CR_SHA256` fails, and the error text diagnoses a moved asset when the real cause is a machine with neither `sha256sum` nor `shasum`. Busybox ships the first and macOS ships the second, so nobody has hit it. Closing it means an executable line, which would then owe mutation coverage of its own, and that is disproportionate to a case with no known instance. The mechanism is written here so the next reader does not have to re-derive it from an error message that points the wrong way. Separately, the per-package `.PHONY` gap this Makefile's own line argues against is filed as #4214: at `origin/main`, 106 of the 126 package Makefiles that define `test:` or `update:` declare neither phony. A key that does not exist yet is not held either: every item in the delta is pinned whole, but a NEW key appearing at `spec` or `spec.config` level passes unnoticed, and such a key can change behaviour rather than sit inert. I confirmed it on a copy extracted from this commit, appending `spec.config.filesystemOverhead.global: "0.99"` and getting a green suite. That is the shape to recognise at the next bump: not a changed value, which is caught, but a new sibling key beside the ones we pin. `SHA256SUM` is assigned with `:=`, so its `$(shell ...)` runs when the Makefile is parsed rather than when `update` reads it, which forks a shell on every `make apply`, `show` and `diff` in the package; I confirmed it by making the shell touch a marker file and running `make -n show`, where `:=` fires it and `=` does not. One character fixes it and it is queued rather than done here, because reopening a settled commit for one character is the thing that has cost this branch five amends. And `spec.config.podResourceRequirements` is now pinned whole here and by four leaves in `tests/importer-resources_test.yaml`: the whole-map form is the stronger one and the leaves are a subset of it, so changing the default takes two edits and the second failure reads as a surprise until you know why both exist. Nothing in the branch claims otherwise, which is why it is named here rather than fixed: the commit message, the Makefile comment and the case title are all scoped to the local half. Deriving `RELEASE` with `$(shell ...)` from the sibling manifest was suggested and declined on merits: a derived value is not a pin, the point is that a human chooses which CDI release this object is reconciled against, and computing it from whatever the neighbour last vendored hides that choice from the diff.

One suggestion I declined rather than deferred. `RELEASE` could be tied to the tree by grepping `../kubevirt-cdi-operator/templates/cdi-operator.yaml` from this package's `test:` target, which is what the merged `kubevirt-operator` does for its own manifest. That grep does match today, I checked. The Makefile already declares the gap twice though, in the `RELEASE` header and again above `update:`, where it says outright that nothing here catches the operator vendoring a new release.

Worth knowing when reading the mismatch path: `kubevirt-operator` deletes its download on a hash mismatch and this package keeps it. That is deliberate here, since reconciling a moved asset starts by reading it, but the two packages do read oppositely and neither file says so.

### Base and ordering

This stacks on #4097 and should land after it. Both edit `packages/system/kubevirt-cdi/Makefile`, and this change builds directly on that one's edit to the same recipe, so it is based on the head of `fix/cdi-update-keeps-local-templates` rather than on `main`. GitHub computes mergeability against the PR's base branch, which here is that stack branch and not `main`. There is no conflict with `main` either: it has not touched these paths since the merge-base, so a merge of this head into `main` resolves clean today.


### Screenshots

No UI changes.

### Downstream repositories

Walked the trigger map against the diff. Two entries come close and neither fires.

The website triggers on developer tooling and package Makefiles, but `content/en/docs/next/development.md` documents `make update` only as "Update Helm chart and versions from the upstream source", which still holds, and its worked example is cilium, which this does not touch. Its `make test` line refers to the e2e sandbox in `packages/core/testing`, not per-package unit tests.

`ccp` triggers on `hack/` layout and on what a make target does, and nothing under `hack/` is touched. Its `package-bump` skill already assumes a package's `update` recipe hardcodes the upstream version instead of resolving it at run time, and names cilium, kafka-operator, opensearch-operator and postgres-operator as examples. `kubevirt-cdi` was one of those counterexamples and now is not. `kubevirt-cdi-operator` still resolves `releases/latest` at run time and still wipes its `templates/`, which is #4190 and out of scope here, so the assumption gets more accurate for one of the two rather than both. The skill handles vendored Helm charts, in-repo image builds and version enums, and a raw manifest download is none of those. Everything else in the map needs an app, a schema, an installer value, a variant or a release asset.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
fix(cdi): `make update` in kubevirt-cdi no longer overwrites the hand-maintained CDI object. It pins the CDI release that object is reconciled against instead of resolving GitHub's releases/latest at run time, and verifies the fetched asset against a pinned sha256 without writing under templates/.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Updates now use verified, pinned CDI releases to prevent unintended manifest changes.
  * Failed or checksum-mismatched downloads no longer overwrite existing configuration.

* **Bug Fixes**
  * Preserved local CDI customizations during release updates.
  * Added validation for CDI resources, access controls, upload-proxy routing, and TLS configuration.

* **Tests**
  * Added automated checks for incomplete template refreshes and generated Kubernetes resources.
  * Added chart tests covering CDI behavior, clone permissions, and upload-proxy networking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->















