### PR TITLE
test(tests): wire the gpu-operator suite into the unit sweep

### DIFF
--- a/hack/package-test-target-coverage.bats
+++ b/hack/package-test-target-coverage.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Coverage invariant for the helm-unittest sweep: every package that ships a
+# suite must answer the probe the sweep opens with.
+#
+# hack/helm-unit-tests.sh decides whether to enter a package directory by asking
+# `make -C "$dir" -n test`, and a package that answers "No rule to make target"
+# is skipped without a word. Every other guard in that script — the shadowed
+# target check, the zero-suite check, the positive-evidence check — runs inside
+# a directory the sweep already reached, so a package missing the target escapes
+# all of them at once and the sweep still reports success. The suites under
+# tests/ then read as coverage to anyone opening the directory while nothing
+# executes them, which is worse than having no suite at all: a suite that has
+# never run is where a stale assertion hides. packages/system/gpu-operator sat
+# in exactly that state, with three passing test cases nothing ever ran.
+#
+# hack/helm-unit-tests.bats covers the script's own reactions against synthetic
+# trees. This file makes the complementary claim, about the real tree: every
+# package that ships a suite answers the probe the sweep opens with.
+#
+# That is narrower than "the sweep reaches every suite", and deliberately so.
+# Reach also depends on the hardcoded root list the sweep loops over, so
+# dropping packages/system from it would take every package under that root out
+# of the run while each one keeps its target and this file stays green. That is
+# the same shape as the packages/tests incident recorded in the sweep's own
+# header, and it wants its own guard rather than a looser predicate here.
+#
+# The predicate is "holds at least one tests/*_test.yaml", not "has a tests/
+# directory". That glob is helm-unittest's own default, so a package outside it
+# has nothing of its own for a `test:` target to run and the sweep would reject
+# it for reporting zero suites. packages/system/nfs-driver is the live case:
+# its tests/ holds a PersistentVolumeClaim and a StorageClass to apply by hand,
+# not a suite.
+#
+# "Of its own" is the load-bearing part. `--with-subchart` defaults to true, so
+# a package carrying no suite of its own would still run any that came down
+# with a vendored chart under charts/, and this predicate would not look for it.
+# Only ingress-nginx and reloader vendor such suites today and both ship their
+# own as well, so nothing is out of reach; a package that vendored suites and
+# wrote none itself would need this predicate widened.
+#
+# Probed with `make -n` rather than by grepping the Makefile for `test:`, so the
+# question asked here is the same one the sweep asks — a target reached through
+# an include counts, and so would a rule this file cannot parse. The sweep's
+# other precondition, that `$dir/Makefile` exists, is mirrored rather than left
+# to make, which is looser about the name and about there being a makefile at
+# all.
+#
+# The verdict comes from the sweep's command unchanged. Reading the diagnostic
+# needs `LC_ALL=C` and `--no-print-directory`, and both are visible to a
+# Makefile through `LC_ALL` and `MAKEFLAGS`, so a Makefile branching on either
+# would answer this file and the sweep differently. That is why the failing
+# package is probed a second time to explain rather than once to do both.
+#
+# Answering the probe is not the same as declaring a recipe: a path named `test`
+# beside the Makefile, or an implicit rule that can build one, satisfies it too,
+# and this file would report that package as covered. That is deliberate rather
+# than overlooked. It is the sweep's own gate, so a package passing here is a
+# package the sweep enters once it walks that package's root, which is the
+# whole claim and no more than it: the root list is the caveat above. From
+# inside, the sweep's positive-evidence check refuses whatever does not print
+# the line a helm-unittest run emits. A pattern rule written to run
+# helm-unittest would satisfy that check on its merits, which is the right
+# outcome rather than a hole: the suites would be running.
+#
+# Not the "is up to date" check, which is the near miss worth naming. A path
+# named `test` with no rule behind it makes make print "Nothing to be done for
+# 'test'." and exit 0, which that grep does not match; measured on 3.81 and
+# 4.4.1. "is up to date" is what make prints for the third case, a real recipe
+# shadowed by a file of that name -- the one `.PHONY: test` prevents.
+#
+# Runs under hack/cozytest.sh, which is POSIX /bin/sh: no arrays, no bats `run`,
+# no `$status`.
+# -----------------------------------------------------------------------------
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
+
+@test "every package shipping a helm-unittest suite answers the sweep probe" {
+    # An empty violation list means "no violations" only if the scan reached
+    # some packages. A renamed directory or a wrong root yields the same empty
+    # string, and the test would pass having read nothing.
+    scanned=0
+    # cozytest.sh injects `set -u`, so every variable the loop reads is seeded
+    # here rather than on first append.
+    seen=""
+    diagnostics=""
+
+    for suite in "$REPO_ROOT"/packages/*/*/tests/*_test.yaml; do
+        [ -f "$suite" ] || continue
+        pkg=$(dirname "$(dirname "$suite")")
+        # One package may ship several suites; count and probe it once.
+        case " $seen " in
+            *" $pkg "*) continue ;;
+        esac
+        seen="$seen $pkg"
+        scanned=$((scanned + 1))
+
+        # The sweep opens with `[ -f "$dir/Makefile" ]` and returns before it
+        # probes anything, so mirror that first. make would not: it also accepts
+        # GNUmakefile and makefile, and with no makefile at all it still answers
+        # 0 for a target a path of that name satisfies. Either shape would pass
+        # the probe below while the sweep skipped the package, which is the one
+        # thing this file claims cannot happen.
+        if [ ! -f "$pkg/Makefile" ]; then
+            diagnostics="$diagnostics
+  ${pkg#"$REPO_ROOT"/}: no Makefile, so the sweep returns before probing"
+            continue
+        fi
+
+        # The verdict is taken from the sweep's own command, byte for byte, so
+        # that no flag of this file's can separate the two answers. Deciding and
+        # explaining are split for that reason: anything added here to make the
+        # output readable is a variable a Makefile could branch on.
+        if ! make -C "$pkg" -n test >/dev/null 2>&1; then
+            # Only now, and only to explain. LC_ALL=C keeps make's wording in
+            # the language the remedy text below is written against.
+            #
+            # --no-print-directory because on modern GNU make `-C` auto-enables
+            # `-w`, and the fatal path prints the "Leaving directory" line after
+            # the error, so `tail -n 1` would report the directory trace and
+            # drop every diagnostic this block exists to surface: a missing rule
+            # and a broken include collapse to the same trace line. Measured on
+            # 4.4.1, where it happens, and on 3.81 -- still the /usr/bin/make on
+            # macOS -- where `-C` prints no trace at all, so a local run cannot
+            # see the difference. The version that draws the line was not
+            # measured.
+            #
+            # `|| true` because this re-run is expected to fail and cozytest.sh
+            # injects `set -e`; the verdict is already decided above.
+            probe=$(LC_ALL=C make --no-print-directory -C "$pkg" -n test 2>&1 || true)
+
+            # A missing rule is the expected cause, but an unparseable Makefile
+            # and a broken include fail the same probe and have a different
+            # remedy. Report what make said rather than asserting the cause.
+            diagnostics="$diagnostics
+  ${pkg#"$REPO_ROOT"/}: $(printf '%s' "$probe" | tail -n 1)"
+        fi
+    done
+
+    if [ "$scanned" -eq 0 ]; then
+        echo "no tests/*_test.yaml found under $REPO_ROOT/packages -- guard is blind." >&2
+        return 1
+    fi
+
+    if [ -n "$diagnostics" ]; then
+        echo "Packages shipping a helm-unittest suite the sweep cannot reach:" >&2
+        # Each entry is appended with a leading newline, so the accumulator
+        # opens with an empty one; drop it rather than the reader parsing a
+        # blank first line under pressure.
+        printf '%s\n' "$diagnostics" | sed '/^$/d' >&2
+        echo "hack/helm-unit-tests.sh probes 'make -C <pkg> -n test' to decide whether" >&2
+        echo "to enter a package, so these suites never run and the sweep stays green." >&2
+        echo "Where the reason is a missing rule, add to that Makefile:" >&2
+        echo "    .PHONY: test" >&2
+        echo "    test:" >&2
+        echo "    	helm unittest ." >&2
+        return 1
+    fi
+}

--- a/packages/system/gpu-operator/Makefile
+++ b/packages/system/gpu-operator/Makefile
@@ -4,6 +4,15 @@ export NAMESPACE=cozy-$(NAME)
 include ../../../hack/common-envs.mk
 include ../../../hack/package.mk
 
+# hack/helm-unit-tests.sh discovers work by probing for this target, so a
+# package without one is skipped in silence however many suites sit under
+# tests/. Phony because hack/package.mk's .PHONY line lists only the targets
+# that file defines, so a path named `test` here would make the target up to
+# date and skip the recipe.
+.PHONY: test
+test:
+	helm unittest .
+
 update:
 	rm -rf charts
 	helm repo add nvidia https://helm.ngc.nvidia.com/nvidia


### PR DESCRIPTION
<!-- Thank you for making a contribution! Here are some tips for you:
- Use Conventional Commits for the PR title: `type(scope): description`
  - Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore
  - Scopes are not an exhaustive list — pick the most specific scope for the change and extend the list when a genuinely new area appears. Examples:
    - System components: dashboard, platform, operator, cilium, kube-ovn, linstor, fluxcd, cluster-api
    - Managed apps: postgres, mariadb, redis, kafka, clickhouse, virtual-machine, kubernetes
    - Development and maintenance: api, hack, tests, ci, docs, maintenance
  - Breaking changes: append `!` after type/scope (`feat(api)!: ...`) or add a `BREAKING CHANGE:` footer
- If it's a work in progress, consider creating this PR as a draft.
- Don't hesistate to ask for opinion and review in the community chats, even if it's still a draft.
- Add the label `kind/backport` if it's a bugfix that needs to be backported to a previous version.
-->

## What this PR does

`hack/helm-unit-tests.sh` decides whether to enter a package by asking `make -C <pkg> -n test`. `packages/system/gpu-operator` declared only `update:`, so the sweep skipped it silently and the three test cases in `tests/kernel_module_config_test.yaml` had never run. They pass, so nothing was hiding behind them. Still worth fixing: the directory reads as coverage to whoever opens it, and a suite nothing runs is where a stale assertion sits.

The target is phony. `hack/package.mk`'s `.PHONY` line lists only the targets that file defines, so a path named `test` next to the Makefile would make the target up to date and skip the recipe.

Rather than fix the one package I enumerated the rest of the tree. 84 packages hold a `tests/` directory, 83 ship at least one `tests/*_test.yaml`, and gpu-operator was the only one of those without the target. The 84th is `packages/system/nfs-driver`, whose `tests/` holds a PersistentVolumeClaim and a StorageClass to apply by hand. No suite there, so a `test:` target would only make the sweep fail it for reporting zero suites. Left alone.

`hack/package-test-target-coverage.bats` pins the class. Every other guard in the sweep runs inside a directory it already reached, so a package with no target escapes all of them at once and the run still reports success. The new case probes with `make -n` instead of grepping for `test:`, which is the question the sweep asks, and it mirrors the sweep's other precondition too: the sweep requires `$dir/Makefile` and returns before probing, where make would also accept `GNUmakefile` or no makefile at all. The verdict comes from the sweep's command unchanged, and a failing package is probed a second time with `LC_ALL=C --no-print-directory` purely to read the diagnostic, since both of those are visible to a Makefile through `LC_ALL` and `MAKEFLAGS`.

Mutations, because a guard that has never been red proves nothing:

```text
target removed from gpu-operator  -> red, names packages/system/gpu-operator, quotes make's error
Makefile renamed to GNUmakefile   -> red; make still answers 0 here, so this leg is load-bearing
glob pointed at a missing dir     -> red via the blindness leg, instead of passing on an empty set
unmodified tree                   -> green, 83 packages scanned
```

The full `hack/helm-unit-tests.sh` sweep now enters gpu-operator and finishes green.

One detail that is invisible on a Mac: the probe runs under `--no-print-directory`. On modern GNU make `-C` turns on `-w`, and the fatal path prints `Leaving directory` after the error, so `tail -n 1` picks up the directory trace and drops the diagnostic. Measured on 4.4.1 where that happens, and on 3.81 (still `/usr/bin/make` on macOS) where `-C` prints no trace at all.

### Screenshots

No UI changes.

### Downstream repositories

<!--
Cozystack is upstream for repositories that are NOT kept in sync with it automatically, and nothing in CI compares the two sides, so a change here can break them silently.

Which change forces what, and which file to touch, is the trigger map in docs/agents/contributing.md under "Downstream Repositories". Walk it before you tick anything.

IF YOU ARE AN AI AGENT OR AN LLM, THIS IS PART OF THE TASK, NOT A FORM TO FILL IN:

1. Walk the trigger map against the actual diff of this PR, file by file. Do not decide from the PR title or from your memory of what you changed.
2. For every repository you tick, open the follow-up PR there and link it on the same line. A ticked box with no link claims work that does not exist, which is worse than an empty box. Search that repository for an open PR or issue covering it first, and link that instead of filing a duplicate.
3. When the follow-up is out of scope, or needs a decision that is not yours to make, open an issue in that repository instead, link that, and say so in the PR body.
4. Do not tick "No downstream repository is affected" to make the checklist go away. If you are unsure, leave every box empty and say so in the PR body, so a human decides.
-->

Walked the trigger map against both changed files. Two entries come close and both miss. `ccp` gates on `hack/package.mk`, `hack/common-envs.mk` and the `packages/{apps,system,extra,core}` layout; nothing here is moved or renamed and no existing target changes what it does, so a new `test:` target sitting beside 80 identical ones is not something its skills read. The `website` entry for developer tooling points at `content/en/docs/next/development.md`, whose Testing section covers the e2e sandbox under `packages/core/testing` and says nothing about the per-package helm-unittest sweep.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
test(tests): run the gpu-operator helm-unittest suite, which the sweep had been skipping because the package declared no `test:` target
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage checks to verify that all Helm test suites are included in the package test sweep.
  - Added diagnostics for packages missing a runnable test target.

- **Bug Fixes**
  - Added a test target to the GPU operator package, enabling its Helm tests to run through the standard package test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->