### PR TITLE
fix(ci): map the recurring app scopes to their area labels

### DIFF
--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -71,6 +71,10 @@ jobs:
               'kafka':               'area/database',
               'clickhouse':          'area/database',
               'mongodb':             'area/database',
+              'rabbitmq':            'area/database',
+              'nats':                'area/database',
+              'qdrant':              'area/database',
+              'foundationdb':        'area/database',
 
               // area/extra
               'extra':               'area/extra',
@@ -84,6 +88,7 @@ jobs:
               // area/kubernetes
               'kubernetes':          'area/kubernetes',
               'apps/kubernetes':     'area/kubernetes',
+              'kubernetes-nodes':    'area/kubernetes',
 
               // area/monitoring
               'monitoring':          'area/monitoring',
@@ -98,6 +103,7 @@ jobs:
               'ingress-nginx':       'area/networking',
               'gateway':             'area/networking',
               'vpn':                 'area/networking',
+              'vpc':                 'area/networking',
               'metallb':             'area/networking',
               'kube-ovn':            'area/networking',
               'kubeovn-webhook':     'area/networking',
@@ -150,6 +156,8 @@ jobs:
               'vmi':                 'area/virtualization',
               'vm-import':           'area/virtualization',
               'migration':           'area/virtualization',
+              'vm-instance':         'area/virtualization',
+              'vm-disk':             'area/virtualization',
               'virtual-machine':     'area/virtualization',
               'hami':                'area/virtualization',
               'gpu-operator':        'area/virtualization',


### PR DESCRIPTION
## What this PR does

The auto-labeler maps a Conventional Commits scope to an `area/*` label. Scopes that PR titles use for apps under `packages/apps` were missing from that map, so a PR whose title carries only such a scope gets `area/uncategorized` and the area has to be set by hand afterwards.

Each scope added here clears the bar the map's own comment sets for a new entry, three or more occurrences over the whole PR history in both title forms the labeler parses: `vm-instance` 14, `nats` 10, `rabbitmq` 8, `vpc` 8, `foundationdb` 5, `qdrant` 4, `kubernetes-nodes` 3, `vm-disk` 3. Each also has an unambiguous home among the labels that already exist. `area/virtualization` names `cdi`, and `vm-disk` renders a `DataVolume` while `vm-instance` renders a `VirtualMachine`. `area/kubernetes` is the tenant Kubernetes app and `kubernetes-nodes` is the worker half split out of it. `area/database` is described as managed databases and already lists `kafka`, so `rabbitmq`, `nats`, `qdrant` and `foundationdb` sit there without stretching it. `vpc` renders `Vpc` and `Subnet`, and `area/networking` already names `kube-ovn`.

Replayed the map before and after this change over the whole PR title history: 53 titles come out with a different label set. Each of them gains one `area/*` and loses nothing. 48 stop falling back to `area/uncategorized`; the other 5 already had an area from a second scope in the title and now carry both.

A scope that clears the bar but has no unambiguous home is left out rather than pushed into the nearest label. AGENTS.md asks for a new `area/*` in that case, which is a separate decision. Those, and the scopes still below the bar, are collected in #4122 along with the measurement and two bits of drift found on the way. `opensearch` is not that case: its home was never in question, it was below the bar when this PR opened and crossed it while the PR waited. It stays in #4122 rather than being folded in here.

### Screenshots

No UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff. The diff touches `.github/workflows/pr-labeler.yaml` only. The nearest triggers are the ccp and community entries on the commit convention in `docs/agents/contributing.md`, and that file is not touched here: the scope table there is a summary that already lags the workflow, and the workflow is named as the full mapping.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
fix(ci): more of the app scopes used in PR titles now map to an `area/*` label instead of falling back to `area/uncategorized`
```
