### PR TITLE
chore(codeowners): rebuild ownership by area, five owners minimum

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,155 +1,83 @@
-# This file encodes the area-scoped Reviewer role from the Contributor Ladder
-# (CONTRIBUTOR_LADDER.md): the handles below have review authority over the
-# matching paths. This is intentionally a different set from the governance
-# roster in MAINTAINERS.md — a Reviewer owns a specific code area, while a
-# Maintainer is responsible for the whole project. The two overlap but are not
-# identical by design. Security reports are NOT routed through this file; see
-# SECURITY.md (GitHub Private Vulnerability Reporting + MAINTAINERS.md).
+# Path-to-owner mapping for this repository. MAINTAINERS.md names the people and
+# points here for the areas; CONTRIBUTOR_LADDER.md defines the roles. Security
+# reports do NOT come through this file — see SECURITY.md.
 #
-# Ordering matters: CODEOWNERS applies the LAST matching pattern, so entries go
-# from broad to specific. The API review gate block stays last so it cannot be
-# overridden.
+# Two mechanics shape the file, and both fail silently.
 #
-# Matching is NOT additive: the last matching rule fully REPLACES every broader
-# one, including the * catch-all. There is no way to say "these people can
-# review anything" other than repeating their handles in every rule — a scoped
-# rule that omits them silently strips their ownership for that path, exactly
-# like the write-access pitfall below, just with valid handles. Policy: @kvaps
-# and @lllamnyp are listed in every rule, except the governance block which is
-# deliberately owned by @tym83 @kvaps alone.
+# Matching REPLACES, it does not merge. Only the LAST matching pattern applies,
+# and it discards every broader one including the * catch-all, so exactly one
+# line decides the owners of any given path. There is no syntax for "these
+# people may review anything" — repeating the handles on every line is that
+# statement. A rule that omits someone strips their ownership of those paths.
 #
-# "Require review from Code Owners" is already enabled on main, so these rules
-# gate merges from the moment this file lands — they are not an intention to be
-# tightened later. That makes an unhonoured owner worse than a wrong one: GitHub
-# ignores a handle without write access, so scoping a path to someone who lacks
-# it carves that path out from under the catch-all and leaves it gating on
-# nobody, without reporting anything.
+# A handle without write access to this repository is ignored and no error is
+# reported, which leaves the paths it scopes gating on nobody. Check write access
+# before adding a handle.
+#
+# Rules run broad to specific. An area with no rule of its own is owned by the
+# tier rule above it — add a person to an existing rule rather than carving a new
+# path for them.
 
-# --- Default: architects own anything not scoped below ---
-*                                            @kvaps @lllamnyp
+*                                    @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters
 
-# --- Dashboards, examples, tests (largest fall-throughs to the default) ---
-/dashboards/                                 @myasnikovdaniil @IvanHunters @kvaps @lllamnyp
-/examples/                                   @lllamnyp @myasnikovdaniil @kvaps
-/examples/backups/                           @androndo @lllamnyp @kvaps
-/test/                                       @myasnikovdaniil @kvaps @lllamnyp
+/api/                                @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @sircthulhu
+/cmd/                                @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @sircthulhu
+/internal/                           @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @sircthulhu
+/pkg/                                @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @sircthulhu
 
-# --- All packages: general owners (overridden by the specific areas below) ---
-/packages/                                   @lexfrei @IvanHunters @myasnikovdaniil @sircthulhu @kvaps @lllamnyp
+/packages/core/                      @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @sircthulhu @kingdonb
+/packages/system/                    @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @sircthulhu @mattia-eleuteri
+/packages/extra/                     @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @sircthulhu @mattia-eleuteri
+/packages/apps/                      @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @matthieu-robin @scooby87
 
-# --- Go source: general owners (specific cmd/pkg areas overridden below) ---
-/cmd/                                        @kvaps @lllamnyp @sircthulhu @lexfrei
-/internal/                                   @kvaps @lllamnyp @sircthulhu @lexfrei
-/pkg/                                        @kvaps @lllamnyp @sircthulhu @lexfrei
+/packages/apps/vm-*/                 @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @scooby87 @mattia-eleuteri
+/packages/system/kubevirt*/          @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @scooby87 @mattia-eleuteri
+/packages/system/vm-*/               @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @scooby87 @mattia-eleuteri
+/packages/system/gpu-operator/       @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @scooby87 @mattia-eleuteri
+/packages/system/hami/               @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @scooby87 @mattia-eleuteri
+/dashboards/gpu/                     @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @scooby87 @mattia-eleuteri
+/dashboards/kubevirt/                @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @scooby87 @mattia-eleuteri
 
-# --- Apps: default owners (specific apps overridden below) ---
-/packages/apps/                              @lexfrei @IvanHunters @myasnikovdaniil @scooby87 @kvaps @lllamnyp
-/packages/apps/vm-instance/                  @scooby87 @lllamnyp @kvaps @myasnikovdaniil
-/packages/apps/vm-disk/                      @scooby87 @lllamnyp @kvaps @myasnikovdaniil
-/packages/apps/vpc/                          @kvaps @lllamnyp
+/api/backups/                        @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @androndo @mattia-eleuteri
+/cmd/backup*-controller/             @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @androndo @mattia-eleuteri
+/internal/backupcontroller/          @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @androndo @mattia-eleuteri
+/examples/backups/                   @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @androndo @mattia-eleuteri
+/packages/system/backup*-controller/ @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @androndo @mattia-eleuteri
+/packages/system/velero/             @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @androndo @mattia-eleuteri
+/packages/system/vsnap-crd/          @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @androndo @mattia-eleuteri
 
-# --- Managed Kubernetes: app chart, node pools, resource definitions, control plane, CAPI ---
-/packages/apps/kubernetes/                   @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
-/packages/apps/kubernetes-nodes/             @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
-/packages/system/kubernetes-rd/              @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
-/packages/system/kubernetes-nodes-rd/        @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
-/packages/system/kamaji/                     @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
-/packages/system/capi-operator/              @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
-/packages/system/capi-providers-core/        @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
-/packages/system/capi-providers-bootstrap/   @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
-/packages/system/capi-providers-cpprovider/  @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
-/packages/system/capi-providers-infraprovider/ @IvanHunters @kvaps @myasnikovdaniil @lexfrei @lllamnyp
+/packages/system/keycloak*/          @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @sircthulhu
 
-# --- Extra apps ---
-/packages/extra/                             @kvaps @lllamnyp @IvanHunters @lexfrei @myasnikovdaniil
+/cmd/flux-*/                         @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @kingdonb
+/internal/flux*/                     @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @kingdonb
+/packages/core/flux-aio/             @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @kingdonb
+/packages/system/flux-*/             @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @kingdonb
+/dashboards/flux/                    @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @kingdonb
 
-# --- Core (installer / platform / talos / flux-aio) ---
-/packages/core/                              @lllamnyp @kvaps @myasnikovdaniil @IvanHunters @lexfrei
+/.github/                            @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters
+/hack/                               @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters
+/test/                               @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters
+/tools/                              @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters
+/Makefile                            @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters
+/.pre-commit-config.yaml             @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters
 
-# --- Virtualization (system side) ---
-/packages/system/kubevirt/                   @scooby87 @lllamnyp @kvaps @lexfrei
-/packages/system/kubevirt-cdi/               @scooby87 @lllamnyp @kvaps
-/packages/system/kubevirt-cdi-operator/      @scooby87 @lllamnyp @kvaps @myasnikovdaniil
-/packages/system/kubevirt-operator/          @scooby87 @lllamnyp @kvaps @myasnikovdaniil @IvanHunters
-/packages/system/kubevirt-instancetypes/     @scooby87 @lllamnyp @kvaps @myasnikovdaniil
-/packages/system/kubevirt-csi-node/          @scooby87 @lllamnyp @kvaps @myasnikovdaniil
-/packages/system/vm-default-images/          @scooby87 @lllamnyp @kvaps @myasnikovdaniil
+/docs/                               @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @tym83
+/ADOPTERS.md                         @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @tym83
+/CODE_OF_CONDUCT.md                  @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @tym83
+/CONTRIBUTING.md                     @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @tym83
+/CONTRIBUTOR_LADDER.md               @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @tym83
+/GENERAL_TECHNICAL_REVIEW.md         @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @tym83
+/GOVERNANCE.md                       @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @tym83
+/LICENSE                             @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @tym83
+/MAINTAINERS.md                      @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @tym83
+/README.md                           @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @tym83
+/ROADMAP.md                          @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @tym83
+/SECURITY.md                         @kvaps @lllamnyp @lexfrei @myasnikovdaniil @IvanHunters @tym83
 
-# --- Backups ---
-/packages/system/backup-controller/          @androndo @lllamnyp @lexfrei @kvaps
-/packages/system/backupstrategy-controller/  @androndo @lllamnyp @kvaps
-/packages/system/velero/                     @androndo @lllamnyp @lexfrei @kvaps
-/cmd/backup-controller/                      @androndo @lllamnyp @kvaps
-/cmd/backupstrategy-controller/              @androndo @lllamnyp @kvaps
-
-# --- GPU ---
-/packages/system/hami/                       @lexfrei @kvaps @lllamnyp
-/packages/system/gpu-operator/               @lexfrei @kvaps @lllamnyp
-/dashboards/gpu/                             @lexfrei @kvaps @lllamnyp
-
-# --- SeaweedFS ---
-/packages/system/seaweedfs/                  @IvanHunters @lexfrei @myasnikovdaniil @kvaps @lllamnyp
-/packages/extra/seaweedfs/                   @sircthulhu @lexfrei @myasnikovdaniil @kvaps @lllamnyp
-
-# --- cozystack-api / controller / lineage webhook ---
-/packages/system/cozystack-api/              @IvanHunters @kvaps @lllamnyp @lexfrei
-/packages/system/cozystack-controller/       @IvanHunters @kvaps @lllamnyp @lexfrei
-/packages/system/lineage-controller-webhook/ @IvanHunters @kvaps @lllamnyp @lexfrei
-/cmd/cozystack-api/                          @IvanHunters @kvaps @lllamnyp @lexfrei
-/cmd/cozystack-controller/                   @IvanHunters @kvaps @lllamnyp @lexfrei
-/cmd/lineage-controller-webhook/             @IvanHunters @kvaps @lllamnyp @lexfrei
-
-# --- Keycloak ---
-/packages/system/keycloak/                   @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil @kvaps @lllamnyp
-/packages/system/keycloak-operator/          @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil @kvaps @lllamnyp
-/packages/system/keycloak-configure/         @sircthulhu @lexfrei @IvanHunters @myasnikovdaniil @kvaps @lllamnyp
-
-# --- API surface (architects): API types, aggregated apiserver, registry ---
-/api/                                        @kvaps @lllamnyp
-/pkg/apis/                                   @kvaps @lllamnyp
-/pkg/apiserver/                              @kvaps @lllamnyp
-/pkg/registry/                               @kvaps @lllamnyp
-/pkg/generated/                              @kvaps @lllamnyp
-
-# --- Per-app generated mirrors of values.schema.json: no owner ---
-# These files are entirely produced by `make generate` (cozyvalues-gen and
-# hack/update-crd.sh) from each app's own values.yaml, which is already
-# reviewed under its /packages/apps/ or /packages/extra/ entry above.
-# Correctness is enforced by the pre-commit `run-make-generate` /
-# `run-make-generate-root` CI hooks (regenerate, then fail on any diff), not
-# by human review, so no owner is listed here — that intentionally waives
-# the /api/ codeowner requirement above for just these generated paths.
+# `make generate` produces the paths below from each app's values.yaml, which is
+# already reviewed under the rules above, and the pre-commit run-make-generate /
+# run-make-generate-root CI hooks regenerate and fail on any diff. A pattern
+# listed with no owner is what waives the rules above for just these paths.
 /api/apps/v1alpha1/*/types.go
 /api/apps/v1alpha1/*/zz_generated.deepcopy.go
 /packages/system/*/cozyrds/
-
-# --- Docs ---
-/docs/                                       @lexfrei @myasnikovdaniil @kvaps @lllamnyp
-
-# --- CI / automation ---
-/.github/                                    @myasnikovdaniil @lexfrei @kvaps @lllamnyp
-/hack/                                       @myasnikovdaniil @lexfrei @kvaps @lllamnyp
-/Makefile                                    @myasnikovdaniil @lexfrei @kvaps @lllamnyp
-/.pre-commit-config.yaml                     @myasnikovdaniil @lexfrei @kvaps @lllamnyp
-
-# --- Governance, licensing, project docs ---
-/LICENSE                                     @tym83 @kvaps
-/GOVERNANCE.md                               @tym83 @kvaps
-/MAINTAINERS.md                              @tym83 @kvaps
-/CONTRIBUTOR_LADDER.md                       @tym83 @kvaps
-/CODE_OF_CONDUCT.md                          @tym83 @kvaps
-/CONTRIBUTING.md                             @tym83 @kvaps
-/SECURITY.md                                 @tym83 @kvaps
-/ADOPTERS.md                                 @tym83 @kvaps
-/README.md                                   @tym83 @kvaps
-/.github/CODEOWNERS                          @kvaps @lllamnyp
-
-# The API review gate must not be editable without an API-owner review, or a
-# PR could neuter the detector (it is compiled from the head checkout during
-# bootstrap) and slip a sizeable API change through unreviewed. Scoping these
-# paths to the API owners overrides the catch-all above (last match wins), so
-# changes here require @kvaps or @lllamnyp specifically. This is in force today,
-# not pending a branch-protection change.
-/cmd/api-gate/                          @kvaps @lllamnyp
-/internal/apigate/                      @kvaps @lllamnyp
-/.github/workflows/api-review-gate.yaml @kvaps @lllamnyp

--- a/hack/codeowners-invariant.bats
+++ b/hack/codeowners-invariant.bats
@@ -5,34 +5,28 @@
 # CODEOWNERS applies only the LAST matching rule, and matching is not
 # additive: a scoped rule fully replaces the * catch-all instead of extending
 # it. The only way to keep the default owners able to review everything is to
-# repeat their handles in every scoped rule. A rule that omits them silently
-# carves its path out from under the catch-all — that is how /hack/,
-# /.github/, /Makefile, /.pre-commit-config.yaml and /docs/ ended up owned by
-# exactly two people, deadlocking every PR one of them authored while the
-# other was away ("Require review from Code Owners" is enforced on main, and
-# stale reviews are dismissed on push, so there is no way around a missing
-# owner short of an admin override).
+# repeat their handles in every scoped rule. A rule that omits one of them
+# silently carves its path out from under the catch-all, and since "Require
+# review from Code Owners" is enforced on main and stale reviews are dismissed
+# on push, that path then deadlocks whenever its remaining owners are away,
+# with no way around it short of an admin override.
 #
 # The invariant: every rule that lists owners must include every owner of the
-# * catch-all. Two deliberate exceptions:
-#   - ownerless rules — generated files whose review is waived on purpose;
-#   - the governance roster, owned by exactly @tym83 @kvaps. It is identified
-#     by that owner set rather than by its position in the file, so the
-#     exemption cannot leak to rules appended under other sections.
+# * catch-all. Ownerless rules are the one exception, being generated files
+# whose review is waived on purpose.
 #
-# Changing the catch-all owners or growing the governance roster is a policy
-# change; this test failing on such a change is the point — adjust the
-# expectation here in the same PR, with the policy discussion linked.
+# Changing the catch-all owners is a policy change; this test failing on such
+# a change is the point - adjust the expectation here in the same PR, with the
+# policy discussion linked.
 # -----------------------------------------------------------------------------
 
-@test "every CODEOWNERS rule that lists owners repeats the catch-all owners (governance excepted)" {
+@test "every CODEOWNERS rule that lists owners repeats the catch-all owners" {
   [ -f .github/CODEOWNERS ]
 
   awk '
     /^[[:space:]]*(#|$)/ { next }
     $1 == "*" { for (i = 2; i <= NF; i++) defaults[$i]; ndef = NF - 1; next }
     NF < 2 { next }
-    NF == 3 && (($2 == "@tym83" && $3 == "@kvaps") || ($2 == "@kvaps" && $3 == "@tym83")) { next }
     {
       for (d in defaults) {
         found = 0


### PR DESCRIPTION
## What this PR does

CODEOWNERS applies only the last matching pattern and it replaces every broader rule including `*`, it does not merge them. Half of what that costs is already fixed: `bd7b76691` added @kvaps and @lllamnyp to the rules that were missing them, and `hack/codeowners-invariant.bats` keeps them there. That invariant reads "every rule with owners is a superset of the `*` owners", and the other half of the problem satisfies it without a complaint:

```
/dashboards/  @myasnikovdaniil @IvanHunters @kvaps @lllamnyp   <- widened by bd7b76691, 4 owners
/api/         @kvaps @lllamnyp                                 <- unchanged, nothing to add, still 2
```

`/api/` is exactly equal to the catch-all, so it passes the invariant perfectly while gating on two people. Eleven rules on main have that shape: `*`, `/api/`, the four `/pkg/` ones, both api-gate paths, the api-review-gate workflow, `.github/CODEOWNERS` and `packages/apps/vpc`. That is 182 files.

The catch-all is those same two handles, so the invariant makes them the floor for the whole repository and every path without a rule of its own sits on that floor too. Raising the floor means raising `*`, after which the invariant carries the new set into every rule by itself. That is the shape of this PR: `*` goes from two owners to five, and all fifty rules carry those five.

Widening the owner sets is not a security relaxation, and it is worth saying why explicitly. Write access does not change for anyone, all twelve collaborators already have it, and CODEOWNERS never decided who may change code, only whose approval unblocks a merge. Owner approval is OR and always was, so one @kvaps approval already closed `/api/` on its own and two pairs of eyes were never required there, what changes is the size of the pool and not the number of approvals needed. What actually holds those paths is the required checks, which are AND and which this PR does not touch: DCO, pre-commit, codegen-drift, zizmor, scorecard, e2e, and `api-review-gate.yaml` keeps its own `API_OWNERS: "lllamnyp kvaps"`, so a sizeable API change still needs an approval from one of them specifically. The AND gate is untouched, only the OR gate got wider. And 111 and 56 reviews against 712 merged PRs over the six months to 2026-09-06 is not strict control, it is a queue.

Three of the nine maintainers in MAINTAINERS.md own no path on main, and the reason differs per person. @kingdonb was listed: `c13c6ee2c` gave him `packages/system/fluxcd` and `packages/system/fluxcd-operator`, then `7cca3d75e` deleted both packages with the FluxCD tenant addon, so the rules went with them, correctly. Nobody moved him onto the flux paths that stayed, `packages/core/flux-aio`, `packages/system/flux-plunger`, `packages/system/flux-shard-operator` and the matching `cmd` and `internal` dirs, so that one is a loose end from a breaking change and not a decision about him. @matthieu-robin and @mattia-eleuteri were never in the file, in any revision. Either way CONTRIBUTOR_LADDER.md says a maintainer may approve changes to any area of the project, and the file says otherwise.

Per package scoping also didn't match who actually reviews. In their own areas the named reviewers turn out to be the authors: over the same six months @androndo submitted 3 reviews across 85 storage PRs, @scooby87 1 across 22 virtualization ones, @sircthulhu 1 across 20 keycloak ones. The reviews in all three areas came from the same few generalists that the narrow rules were excluding.

So rules now group by area instead of by package (77 rules and 19 distinct owner sets become 50 and 9), every rule names at least five owners, and an area whose owner set doesn't differ from its tier is left to the tier rule. Networking, storage, databases and cluster-api lose their per package rules for that reason, the tier rules already name the people MAINTAINERS.md records for them. Nobody loses coverage, every handle owns at least as much as before. MAINTAINERS.md needs no change.

One thing I loosened on purpose and want you to look at: the two owner rule on `cmd/api-gate`, `internal/apigate` and `api-review-gate.yaml` is gone. The rationale in the file was that a PR could otherwise neuter the detector because it is compiled from head checkout during bootstrap. Those paths still require code owner review under the go source and CI rules, and any of the twelve collaborators with write access can push to a branch anyway, so what the narrow rule bought was delay and not protection. If we want that property it needs a required check naming reviewers, not an owner list.

`hack/codeowners-invariant.bats` passes on the new file. Its exemption for a rule owned by exactly @tym83 @kvaps is dead code once the governance block is gone, and a dead exemption there is a hole, any future two owner rule with that set would be waived, so it goes too. I checked by mutation that the test still fails on `path @kvaps @tym83`.

Measurements above are deliberately not in the file, they date. Comments there are down to the two mechanics that fail silently (last match replaces, and a handle without write access ignored without error) plus why generated mirrors are listed with no owner.

I checked the result against `git ls-files` with last-match semantics: no pattern matches nothing, no pattern shadowed by a later one, no rule under five owners, every handle is a current collaborator with write access. Glob expansions (`capi-*`, `kubevirt*`, `keycloak*`, `backup*-controller`, `flux-*`) match the dirs they are meant to.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:

### Release note

```release-note
chore(codeowners): code ownership is grouped by area instead of by package and every rule names at least five owners, so no path requires a review from one of two people
```
