### PR TITLE
fix(clickhouse): keep the Keeper name inside the StatefulSet volume-name limit

### DIFF
--- a/packages/apps/clickhouse/templates/_keeper.tpl
+++ b/packages/apps/clickhouse/templates/_keeper.tpl
@@ -1,0 +1,10 @@
+{{- define "clickhouse.keeperName" -}}
+{{- $lastReplica := sub (int .Values.clickhouseKeeper.replicas) 1 -}}
+{{- $name := printf "%s-keeper" .Release.Name -}}
+{{- if gt (len (printf "chk-%s-deploy-confd-cluster1-0-%d" $name $lastReplica)) 63 -}}
+{{- $suffix := printf "-%s-keeper" (trunc 6 (sha256sum .Release.Name)) -}}
+{{- $room := sub 63 (len (printf "chk-%s-deploy-confd-cluster1-0-%d" $suffix $lastReplica)) -}}
+{{- $name = printf "%s%s" (trimSuffix "-" (trunc (int $room) .Release.Name)) $suffix -}}
+{{- end -}}
+{{- $name -}}
+{{- end -}}

--- a/packages/apps/clickhouse/templates/chkeeper.yaml
+++ b/packages/apps/clickhouse/templates/chkeeper.yaml
@@ -4,7 +4,7 @@
 apiVersion: "clickhouse-keeper.altinity.com/v1"
 kind: "ClickHouseKeeperInstallation"
 metadata:
-  name: "{{ .Release.Name }}-keeper"
+  name: {{ include "clickhouse.keeperName" $ | quote }}
   annotations:
     prometheus.io/port: "7000"
     prometheus.io/scrape: "true"

--- a/packages/apps/clickhouse/templates/clickhouse.yaml
+++ b/packages/apps/clickhouse/templates/clickhouse.yaml
@@ -94,11 +94,11 @@ spec:
     zookeeper:
       nodes:
         {{- $replicas := int .Values.clickhouseKeeper.replicas }}
-        {{- $release := .Release.Name }}
+        {{- $keeper := include "clickhouse.keeperName" $ }}
         {{- $namespace := .Release.Namespace }}
         {{- $clusterDomain := .Values.clusterDomain }}
         {{- range $i := until $replicas }}
-        - host: "chk-{{ $release }}-keeper-cluster1-0-{{ $i }}.{{ $namespace }}.svc.{{ $clusterDomain }}"
+        - host: "chk-{{ $keeper }}-cluster1-0-{{ $i }}.{{ $namespace }}.svc.{{ $clusterDomain }}"
           port: 2181
         {{- end }}
     {{- end }}

--- a/packages/apps/clickhouse/tests/keeper_name_test.yaml
+++ b/packages/apps/clickhouse/tests/keeper_name_test.yaml
@@ -1,0 +1,153 @@
+suite: keeper name budget
+
+set:
+  _cluster:
+    cluster-domain: cluster.local
+  clusterDomain: cluster.local
+
+tests:
+  - it: "keeps <release>-keeper for a short release name"
+    release:
+      name: ch-test
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: metadata.name
+          value: ch-test-keeper
+        template: templates/chkeeper.yaml
+        documentSelector:
+          path: kind
+          value: ClickHouseKeeperInstallation
+      - equal:
+          path: spec.configuration.zookeeper.nodes[0].host
+          value: chk-ch-test-keeper-cluster1-0-0.tenant-test.svc.cluster.local
+        template: templates/clickhouse.yaml
+        documentSelector:
+          path: kind
+          value: ClickHouseInstallation
+
+  - it: "keeps <release>-keeper when the confd volume name lands exactly on 63 characters"
+    release:
+      name: clickhouse-abcdefghijklmno
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: metadata.name
+          value: clickhouse-abcdefghijklmno-keeper
+        template: templates/chkeeper.yaml
+        documentSelector:
+          path: kind
+          value: ClickHouseKeeperInstallation
+      - equal:
+          path: spec.configuration.zookeeper.nodes[2].host
+          value: chk-clickhouse-abcdefghijklmno-keeper-cluster1-0-2.tenant-test.svc.cluster.local
+        template: templates/clickhouse.yaml
+        documentSelector:
+          path: kind
+          value: ClickHouseInstallation
+
+  - it: "shortens the name one character past the budget and keeps the ClickHouse side in step"
+    release:
+      name: clickhouse-abcdefghijklmnop
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: metadata.name
+          value: clickhouse-abcdefgh-be3a98-keeper
+        template: templates/chkeeper.yaml
+        documentSelector:
+          path: kind
+          value: ClickHouseKeeperInstallation
+      - matchRegex:
+          path: metadata.name
+          pattern: ^[a-z0-9-]{1,33}$
+        template: templates/chkeeper.yaml
+        documentSelector:
+          path: kind
+          value: ClickHouseKeeperInstallation
+      - equal:
+          path: spec.configuration.zookeeper.nodes[0].host
+          value: chk-clickhouse-abcdefgh-be3a98-keeper-cluster1-0-0.tenant-test.svc.cluster.local
+        template: templates/clickhouse.yaml
+        documentSelector:
+          path: kind
+          value: ClickHouseInstallation
+      - equal:
+          path: spec.configuration.zookeeper.nodes[2].host
+          value: chk-clickhouse-abcdefgh-be3a98-keeper-cluster1-0-2.tenant-test.svc.cluster.local
+        template: templates/clickhouse.yaml
+        documentSelector:
+          path: kind
+          value: ClickHouseInstallation
+
+  - it: "leaves the pod label, the scrape and the monitor on <release>-keeper when the name is shortened"
+    release:
+      name: clickhouse-abcdefghijklmnop
+      namespace: tenant-test
+    asserts:
+      - equal:
+          path: spec.templates.podTemplates[0].metadata.labels.app
+          value: clickhouse-abcdefghijklmnop-keeper
+        template: templates/chkeeper.yaml
+        documentSelector:
+          path: kind
+          value: ClickHouseKeeperInstallation
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: clickhouse-abcdefghijklmnop-keeper
+        template: templates/chkeeper.yaml
+        documentSelector:
+          path: kind
+          value: VMPodScrape
+      - equal:
+          path: spec.selector.app
+          value: clickhouse-abcdefghijklmnop-keeper
+        template: templates/workloadmonitor.yaml
+        documentSelector:
+          path: metadata.name
+          value: clickhouse-abcdefghijklmnop-keeper
+
+  - it: "does not end the truncated prefix with a dash"
+    release:
+      name: clickhouse-abcdefg-hijklmnop
+      namespace: tenant-test
+    templates:
+      - templates/chkeeper.yaml
+    documentSelector:
+      path: kind
+      value: ClickHouseKeeperInstallation
+    asserts:
+      - equal:
+          path: metadata.name
+          value: clickhouse-abcdefg-0c8860-keeper
+
+  - it: "fits a very long release name into the same budget"
+    release:
+      name: clickhouse-very-long-application-name-here
+      namespace: tenant-test
+    templates:
+      - templates/chkeeper.yaml
+    documentSelector:
+      path: kind
+      value: ClickHouseKeeperInstallation
+    asserts:
+      - equal:
+          path: metadata.name
+          value: clickhouse-very-lon-94e5b4-keeper
+
+  - it: "gives a two-digit replica index one more character of room"
+    release:
+      name: clickhouse-abcdefghijklmno
+      namespace: tenant-test
+    set:
+      clickhouseKeeper:
+        replicas: 11
+    templates:
+      - templates/chkeeper.yaml
+    documentSelector:
+      path: kind
+      value: ClickHouseKeeperInstallation
+    asserts:
+      - equal:
+          path: metadata.name
+          value: clickhouse-abcdefg-8d42f8-keeper


### PR DESCRIPTION
## What this PR does

Fixes #4083.

clickhouse-operator names the Keeper config volume `chk-<chk>-deploy-confd-<cluster>-<shard>-<replica>`. With the CHK called `<release>-keeper` and `Release.Name` already prefixed with `clickhouse-`, an application name longer than 15 characters pushes that volume name past 63 characters. The StatefulSet is rejected on every reconcile, no Keeper pod appears, and the CHK still reports `Completed`; the only visible signal is the Keeper `WorkloadMonitor` staying at `operational: false`.

`templates/_keeper.tpl` now computes the CHK name: `<release>-keeper` as before when it fits, otherwise the release name is truncated and a six-character hash of the release name is appended so two long names cannot collide. The budget accounts for the width of the replica index. `chkeeper.yaml` and the zookeeper `nodes` list in `clickhouse.yaml` both use the helper, so the hosts ClickHouse connects to always match the CHK the operator creates. The pod label, the `VMPodScrape` selector and the `WorkloadMonitor` stay on `<release>-keeper`.

Names up to 15 characters render byte-for-byte as before. A release with a longer name never had a Keeper pod; on upgrade its pod-less CHK is replaced by the shortened one and the Keeper comes up.

`helm unittest`: 30/30 in the chart, including the new `tests/keeper_name_test.yaml` (short name unchanged, the exact 63-character boundary, one character past it, a very long name, a two-digit replica index, no trailing dash after truncation).

### Downstream repositories

Templates and tests only: no values, schema, README, defaults, `ApplicationDefinition` or tenant-facing Secret/Service names change.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
fix(clickhouse): shorten the Keeper name for application names longer than 15 characters so the Keeper StatefulSet can be created
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed ClickHouse Keeper resource naming for long release names so generated names remain within Kubernetes’ 63-character limit.
  - Updated ClickHouse Keeper hostnames to consistently match the generated resource name, including when names are shortened.
  - Preserved identifying labels and monitoring selectors while applying the corrected Keeper naming behavior.

- **Tests**
  - Added coverage for standard, boundary-length, and truncated Keeper names, including replica-specific naming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->