### PR TITLE
docs(rabbitmq): say that deleting the application leaves the TLS Secrets behind

### DIFF
--- a/packages/apps/rabbitmq/README.md
+++ b/packages/apps/rabbitmq/README.md
@@ -115,6 +115,12 @@ Verification runs one way only. The server presents a certificate that a client 
 
 Disabling TLS on a release that had it needs one manual step. Helm removes the `TenantProjection` sentinel along with the `Certificate` objects, and Kubernetes garbage-collects `rabbitmq-<name>.tenant-ca` with it, so the trust anchor stops being projected as soon as TLS goes off — no stale anchor is left for an endpoint that has gone back to plaintext. What Helm cannot clean up is the raw CA material: cert-manager does not delete the Secrets it produced (`enableCertificateOwnerRef` is off), so `rabbitmq-<name>-ca` and `rabbitmq-<name>-tls` stick around, unused, holding private keys nobody references any more. Delete them by hand after disabling TLS.
 
+Deleting the application leaves the same two Secrets behind. The chart renders the `Certificate` and `Issuer` objects and never the Secrets, and cert-manager does not own what it issued, so a Helm uninstall removes neither `rabbitmq-<name>-ca`, which holds the CA private key, nor `rabbitmq-<name>-tls`. After removing a RabbitMQ that had TLS on, delete both from the tenant namespace by hand:
+
+```bash
+kubectl delete secret rabbitmq-<name>-ca rabbitmq-<name>-tls --namespace <tenant-namespace>
+```
+
 > **Warning:** the CA is issued with a 5-year duration and cert-manager renews the certificate as it approaches expiry, so a bundle copied once will eventually stop verifying. Re-read `<release>.tenant-ca` on a schedule, or mount it and let the kubelet refresh it, instead of baking `ca.crt` into a client image or a truststore built at release time.
 
 ## Parameter examples and reference


### PR DESCRIPTION
## What this PR does

`packages/apps/rabbitmq/README.md` documented the key material that survives turning TLS off, but not the same outcome on deleting the application. The chart renders `Certificate` and `Issuer` objects and never the Secrets, and cert-manager runs with `enableCertificateOwnerRef: false`, so a Helm uninstall leaves `rabbitmq-<name>-ca` (the CA private key) and `rabbitmq-<name>-tls` in the tenant namespace with nothing referencing them. One paragraph names the two Secrets and the cleanup command. Documentation only.

### Screenshots

Not a UI change.

### Downstream repositories

A README paragraph in one chart; the generated reference page is built from `values.yaml` and does not move.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added uninstall guidance for TLS-enabled RabbitMQ applications.
  - Clarified that generated certificate Secrets must be manually removed from the tenant namespace after application deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->