### PR TITLE
fix(opensearch-operator): raise vm.max_map_count on every node from a DaemonSet

### DIFF
--- a/packages/core/platform/sources/opensearch-operator.yaml
+++ b/packages/core/platform/sources/opensearch-operator.yaml
@@ -18,5 +18,6 @@ spec:
     - name: opensearch-operator
       path: system/opensearch-operator
       install:
+        privileged: true
         namespace: cozy-opensearch-operator
         releaseName: opensearch-operator

--- a/packages/core/platform/tests/sources_opensearch_operator_privileged_test.yaml
+++ b/packages/core/platform/tests/sources_opensearch_operator_privileged_test.yaml
@@ -1,0 +1,25 @@
+suite: opensearch-operator installs as a privileged component
+# The package ships a DaemonSet whose init container raises vm.max_map_count, and
+# that container has to be privileged: the kernel does not namespace vm.*, so no
+# pod can set the value for itself. cozystack-operator labels a namespace
+# enforce=privileged only when some component declares install.privileged, so
+# dropping this field does not fail rendering anywhere; it leaves the DaemonSet
+# inadmissible on any cluster whose PodSecurity default is baseline or stricter.
+# Pin it so the namespace cannot silently lose the level the DaemonSet needs.
+templates:
+  - templates/sources.yaml
+release:
+  name: cozystack
+  namespace: cozy-system
+tests:
+  - it: opensearch-operator PackageSource declares its component privileged
+    documentSelector:
+      path: metadata.name
+      value: cozystack.opensearch-operator
+    asserts:
+      - equal:
+          path: spec.variants[0].components[0].install.privileged
+          value: true
+      - equal:
+          path: spec.variants[0].components[0].install.namespace
+          value: cozy-opensearch-operator

--- a/packages/system/opensearch-operator/templates/sysctl-daemonset.yaml
+++ b/packages/system/opensearch-operator/templates/sysctl-daemonset.yaml
@@ -1,0 +1,96 @@
+{{- /*
+OpenSearch refuses to start when vm.max_map_count is below 262144 and the store
+may use mmap; the kernel default is 65530 and nothing in the platform's node
+configuration raises it.
+
+It cannot be raised from the OpenSearch pod itself. The kernel does not
+namespace vm.*, so kubelet rejects it both in a pod's securityContext.sysctls
+and in --allowed-unsafe-sysctls, which admits namespaced sysctls only. The
+operator's own answer, spec.general.setVMMaxMapCount, appends a privileged
+init container to every OpenSearch pod. Tenant namespaces carry no PodSecurity
+label of their own, so they take the cluster default, which Talos ships as
+baseline through the apiserver's PodSecurityConfiguration; that default rejects
+the container outright (cozystack/cozystack#4131).
+
+This DaemonSet carries the value instead, from a namespace the platform labels
+enforce=privileged. It removes the reason for an OpenSearch pod to ask the
+operator for the sysctl. The app chart still asks, and dropping that request is
+a separate change.
+
+system-node-critical buys scheduling priority, not start ordering: on a freshly
+joined node an OpenSearch pod can still start before this one has written the
+value, fail its own bootstrap check, and retry until the value is in.
+
+The write goes to /proc/sys and nowhere else. The pod restarts with the node
+and reapplies the value, so persisting it into the host's own configuration
+would buy nothing and would mutate a node this chart does not own.
+*/}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Release.Name }}-sysctl
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Release.Name }}-sysctl
+    app.kubernetes.io/component: sysctl
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Release.Name }}-sysctl
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Release.Name }}-sysctl
+    spec:
+      priorityClassName: system-node-critical
+      automountServiceAccountToken: false
+      initContainers:
+      - name: init-sysctl
+        image: {{ .Values.sysctl.image | quote }}
+        # A floor, not an assignment. vm.max_map_count is node-global, so a node
+        # already tuned above 262144 for some other mmap-heavy workload must keep
+        # its value; writing it unconditionally would lower the limit for
+        # everything on that node, on every boot.
+        command:
+        - sh
+        - -c
+        - 'set -e; current=$(sysctl -n vm.max_map_count); if [ "$current" -lt 262144 ]; then sysctl -w vm.max_map_count=262144; fi'
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1m
+            memory: 4Mi
+          limits:
+            memory: 16Mi
+      containers:
+      # Carries no work: it exists so the pod stays scheduled, because a
+      # DaemonSet pod that ran only an init container would complete and be
+      # restarted continuously.
+      #
+      # Do not simplify this back to a bare sleep. The kernel delivers a signal
+      # to PID 1 of a namespace only when PID 1 installed a handler for it, and
+      # busybox sleep installs none, so a bare sleep ignores SIGTERM and every
+      # pod is SIGKILLed after the full grace period on each rollout and drain.
+      # The shell installs the handler, and wait returns when it fires.
+      - name: idle
+        image: {{ .Values.sysctl.image | quote }}
+        command: ["sh", "-c", "trap 'exit 0' TERM INT; sleep infinity & wait"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65534
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: 1m
+            memory: 4Mi
+          limits:
+            memory: 16Mi
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      - operator: Exists
+        effect: NoExecute

--- a/packages/system/opensearch-operator/tests/sysctl_daemonset_test.yaml
+++ b/packages/system/opensearch-operator/tests/sysctl_daemonset_test.yaml
@@ -1,0 +1,102 @@
+suite: opensearch-operator raises vm.max_map_count per node
+
+# OpenSearch will not start below vm.max_map_count=262144 and the sysctl is not
+# namespaced, so no pod can set it for itself. This DaemonSet is the platform's
+# carrier for it, which is why its shape is the contract: privileged init, that
+# exact sysctl, and nothing mounted from the host.
+release:
+  name: opensearch-operator
+  namespace: cozy-opensearch-operator
+tests:
+  # The command is pinned whole because both halves of it are the contract: the
+  # threshold OpenSearch needs, and the comparison that makes it a floor. Writing
+  # the value unconditionally would lower vm.max_map_count on any node already
+  # tuned above it, node-wide, on every boot.
+  - it: raises the sysctl to a floor from a privileged init container
+    template: templates/sysctl-daemonset.yaml
+    asserts:
+      - equal:
+          path: kind
+          value: DaemonSet
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: init-sysctl
+      - equal:
+          path: spec.template.spec.initContainers[0].command
+          value:
+            - sh
+            - -c
+            - 'set -e; current=$(sysctl -n vm.max_map_count); if [ "$current" -lt 262144 ]; then sysctl -w vm.max_map_count=262144; fi'
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext.privileged
+          value: true
+
+  - it: keeps the privilege in the init container only
+    template: templates/sysctl-daemonset.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: idle
+      # The trap is the contract, not decoration. PID 1 of a namespace receives
+      # only the signals it installed a handler for, so a bare sleep here ignores
+      # SIGTERM and every pod is SIGKILLed after the full grace period on each
+      # rollout and node drain.
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value: ["sh", "-c", "trap 'exit 0' TERM INT; sleep infinity & wait"]
+      - notExists:
+          path: spec.template.spec.containers[0].securityContext.privileged
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop
+          value: ["ALL"]
+
+  # Nothing may reach the host filesystem: the write belongs in /proc/sys and
+  # the pod reapplies it on every node restart.
+  - it: touches no host path
+    template: templates/sysctl-daemonset.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.volumes
+      - notExists:
+          path: spec.template.spec.initContainers[0].volumeMounts
+      - notExists:
+          path: spec.template.spec.containers[0].volumeMounts
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: false
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: system-node-critical
+
+  - it: lands on tainted nodes and pins the image by digest
+    template: templates/sysctl-daemonset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            operator: Exists
+            effect: NoSchedule
+      - contains:
+          path: spec.template.spec.tolerations
+          content:
+            operator: Exists
+            effect: NoExecute
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].image
+          pattern: '^docker\.io/library/busybox:[^@]+@sha256:[0-9a-f]{64}$'
+
+  - it: takes the image override for an air-gapped registry
+    template: templates/sysctl-daemonset.yaml
+    set:
+      sysctl:
+        image: registry.example.test/library/busybox:1.37.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: registry.example.test/library/busybox:1.37.0@sha256:0000000000000000000000000000000000000000000000000000000000000000
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: registry.example.test/library/busybox:1.37.0@sha256:0000000000000000000000000000000000000000000000000000000000000000

--- a/packages/system/opensearch-operator/values.yaml
+++ b/packages/system/opensearch-operator/values.yaml
@@ -12,3 +12,10 @@ opensearch-operator:
     image:
       # gcr.io/kubebuilder/kube-rbac-proxy was sunset; use the original upstream
       repository: "quay.io/brancz/kube-rbac-proxy"
+
+sysctl:
+  # busybox carries the sysctl applet and doubles as the idle main container.
+  # Third-party pass-through pinned by digest, the same reference the kubernetes
+  # package vendors; docs/agents/image-refs.md covers why such a ref is neither
+  # retagged nor mirrored.
+  image: docker.io/library/busybox:1.37.0@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e


### PR DESCRIPTION
## What this PR does

OpenSearch will not start below `vm.max_map_count=262144` when the store may use mmap, and nothing in the platform sets it. The Talos profiles declare no sysctls and no documented node-preparation path sets one, so nodes sit at the kernel default of 65530. The app chart asks the operator to cover that with `spec.general.setVMMaxMapCount`, which appends a privileged init container to every OpenSearch pod. Tenant namespaces carry no PodSecurity label of their own, so they take the cluster default, which Talos ships as baseline through the apiserver's `PodSecurityConfiguration`. That default refuses the container and the StatefulSet never produces a pod. On vanilla kubeadm, kind or k3s the default is `privileged` and the same release comes up, which is why this only bites on a Talos install.

The value cannot come from the pod at all. The kernel does not namespace `vm.*`, so kubelet rejects it in `securityContext.sysctls`, and refuses to start if it appears in `--allowed-unsafe-sysctls`. That leaves node configuration or a privileged pod, and a privileged pod belongs in a system namespace rather than in every tenant.

This adds a DaemonSet to the `opensearch-operator` package that sets the value once per node from a privileged init container, and marks the component privileged so the platform labels `cozy-opensearch-operator` with `enforce=privileged`. The init container writes to `/proc/sys` and nothing else, with no hostPath. The pod restarts with the node and reapplies the value, so there is nothing to persist.

It raises the limit to a floor rather than assigning it, which matters more than it looks. `vm.max_map_count` is node-global, and a stock Ubuntu 24.04 node already reads 1048576 from a `sysctl.d` drop-in. An unconditional write would drop that to 262144 for every workload on the node, on every boot, and undo whatever the operator set it for. So the init container reads the current value first and writes only when it is below the threshold.

The idle main container runs its sleep under a shell that traps SIGTERM, so a pod exits on its own when the DaemonSet rolls or a node drains, instead of ignoring the signal and being killed after the full grace period.

This does not fix OpenSearch on its own. The app chart still requests the operator's init container through `setVMMaxMapCount: true`, so a release stays blocked until the flip to `false` lands with #2682, after this merges. The DaemonSet has to be in place first: flipping it without one would trade the admission failure for a failed bootstrap check. Carrying the sysctl in the node contract instead, across the Talos profiles and the downstream node-prep paths, is tracked in #4144; that is what would let this DaemonSet be retired.

Two things change on upgrade, and neither is visible from the diff. One small DaemonSet pod appears per node in `cozy-opensearch-operator`, and that namespace gains `pod-security.kubernetes.io/enforce=privileged`. That label has no finer granularity than the namespace, so the operator Deployment sitting there leaves the cluster default too, not just the DaemonSet. Keeping the manager at baseline would mean a namespace of its own and another component entry, which did not look worth it, but it is a real cost rather than an accident. The operator is in the `paas` bundle's always-on list, so this lands on every node of every paas installation and raises a node-global kernel tunable there, whether or not anyone ever creates an OpenSearchCluster. That is the price of a node-level sysctl having no cheaper carrier, and it is worth an explicit decision rather than being noticed later.

The second is `cozypkg add`, which gates privileged components behind a confirmation or `--allow-privileged`. The gate runs over the resolved dependency closure, and `opensearch-application` dependsOn the operator, so installing the app that way now asks one more question. This is not a new break for scripts: `add` already prompts for a variant on every package it resolves and fails on EOF, so it was never usable non-interactively in the first place. Platform-bundle installs go through the reconciler and are unaffected.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff. It adds a template, a test and a values key under `packages/system/opensearch-operator/`, plus one field in `packages/core/platform/sources/opensearch-operator.yaml`. No new app package, no app schema or version enum, no `ApplicationDefinition`, no installer value, no namespace rename, no variant or bundle, no `hack/` path or make target, and no node prerequisite in `hack/e2e-prepare-cluster.bats`. Nothing in the map matches.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
fix(opensearch-operator): set `vm.max_map_count` on every node from a DaemonSet in the operator's namespace, so OpenSearch no longer depends on a privileged init container that PodSecurity baseline refuses in a tenant namespace. Upgrading adds one small DaemonSet pod per node and labels `cozy-opensearch-operator` with `pod-security.kubernetes.io/enforce=privileged`; installing the package with `cozypkg add` now requires confirmation or `--allow-privileged`. Existing OpenSearch releases are unchanged until a follow-up stops the app chart requesting the operator's own init container.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - OpenSearch Operator installation now runs with the required privileged configuration.
  - OpenSearch deployments automatically ensure nodes meet the required `vm.max_map_count` setting, improving startup reliability.
  - Existing higher kernel values are preserved.
  - Added support for configuring the sysctl image, including use with air-gapped registries.

- **Tests**
  - Added coverage to verify privileged installation, node configuration, security settings, scheduling behavior, and image customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->