### PR TITLE
ci(tests): pin helm-unittest and keep its download off the critical path

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,14 @@
   "customManagers": [
     {
       "customType": "regex",
+      "description": "Track the helm-unittest plugin version the unit-test job installs. The pin is a plain workflow env var rather than a `uses:` reference, so the github-actions manager cannot see it, and the alternative is what this replaced: `helm plugin install` with no constraint takes whatever upstream released last, so a publish there re-pointed the unit-test runner for every pull request with no diff here. Pinning without this manager trades that for the same problem with the sign flipped, a pin that ages silently.",
+      "managerFilePatterns": ["/^\\.github/workflows/pull-requests\\.yaml$/"],
+      "matchStrings": ["HELM_UNITTEST_VERSION:\\s+(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"],
+      "depNameTemplate": "helm-unittest/helm-unittest",
+      "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
       "description": "Track the etcd image pinned in the extra/etcd EtcdCluster podTemplate. etcd-operator v0.4.5 bakes etcd 3.5.12 into its binary, and the chart overrides it with a hardcoded image string that the gomod/dockerfile managers cannot see. Without this manager the security-relevant pin (etcd 3.5.x releases are overwhelmingly security fixes) would silently age.",
       "managerFilePatterns": ["/^packages/extra/etcd/templates/etcd-cluster\\.yaml$/"],
       "matchStrings": ["image:\\s+(?<depName>quay\\.io/coreos/etcd):(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"],

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -294,6 +294,15 @@ jobs:
     name: Unit & controller tests
     runs-on: oracle-vm-4cpu-16gb-x86-64
     timeout-minutes: 30
+    env:
+      # Pinned, because `helm plugin install` without a constraint installs
+      # whatever the newest release is -- the flag's own help says so, and the
+      # install hook logs `No version found` on the way there. So an upstream
+      # release re-pointed the unit-test runner for every pull request in this
+      # repository, with no commit here and nothing in any log to say it had
+      # happened. Renovate keeps this line current, which makes such a change a
+      # reviewable diff instead of a surprise.
+      HELM_UNITTEST_VERSION: v1.1.2
     permissions:
       contents: read
     needs: ["plan"]
@@ -309,11 +318,57 @@ jobs:
         with:
           fetch-depth: 0
       # Ephemeral runners don't carry the helm-unittest plugin the persistent
-      # self-hosted runner accreted. Install if absent (idempotent).
+      # self-hosted runner accreted, so this job used to fetch it from GitHub
+      # releases, unauthenticated, on every run, on the critical path of a
+      # required check. Those downloads are rate limited per egress IP and the
+      # runner fleet shares one: a throttled response arrives as a short error
+      # body, the install hook's checksum validation correctly rejects it, and
+      # the step dies under `bash -e` before a single test has run. Measured on
+      # run 34131816440: 92 bytes in 11 seconds, then `Failed to install
+      # helm-unittest`. Nothing about the tree was wrong and a plain re-run went
+      # green. The failure class was created in #2939, which moved CI to
+      # ephemeral runners; before that the plugin was simply already there.
+      #
+      # Three parts, because there are three distinct failures and no one part
+      # covers another. The cache keeps the steady state off the network
+      # altogether. The pin (above) stops an upstream release from moving the
+      # toolchain under us. The retry covers the cold path, where a cache miss
+      # still has to fetch and can still be throttled.
+      #
+      # The cache is scoped to the version, so a bump is a miss and a fresh
+      # fetch rather than a stale binary. A miss degrades to exactly the old
+      # behaviour plus the retry, so a cache service outage cannot make this
+      # job worse than it was.
+      - name: Restore the helm-unittest plugin
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: ~/.local/share/helm/plugins
+          key: helm-unittest-${{ runner.os }}-${{ runner.arch }}-${{ env.HELM_UNITTEST_VERSION }}
       - name: Set up test toolchain
         run: |
-          helm plugin list 2>/dev/null | grep -q unittest \
-            || helm plugin install https://github.com/helm-unittest/helm-unittest
+          # Deliberately NOT under `pipefail`. `grep -q` exits on its first
+          # match and closes the pipe, so the writer can take EPIPE and return
+          # non-zero after the match was already found; under pipefail that
+          # reads as "absent" and reinstalls a plugin that is present. The same
+          # shape under pipefail is what makes hack/check-rd-presets.sh report a
+          # preset as missing at random, so it is worth not repeating here.
+          if helm plugin list 2>/dev/null | grep -q unittest; then
+            echo "helm-unittest already present, no download needed"
+            exit 0
+          fi
+          for attempt in 1 2 3; do
+            if helm plugin install https://github.com/helm-unittest/helm-unittest \
+                 --version "${HELM_UNITTEST_VERSION}"; then
+              exit 0
+            fi
+            # A half-installed plugin directory would make the next attempt fail
+            # as "plugin already exists" rather than retrying the download.
+            helm plugin uninstall unittest 2>/dev/null || true
+            echo "::warning title=helm-unittest install failed::attempt ${attempt} of 3, retrying"
+            sleep $(( attempt * 10 ))
+          done
+          echo "::error title=helm-unittest install failed::three attempts against ${HELM_UNITTEST_VERSION}; see the log above" >&2
+          exit 1
       # One make process owns all four runner CPUs. Each BATS file is a separate
       # prerequisite, so the long tail no longer runs as one nine-minute shell
       # loop; Helm and Go targets share the same bounded pool. Output stays

--- a/hack/unit-test-toolchain.bats
+++ b/hack/unit-test-toolchain.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# Contract for how the unit-test job gets `helm unittest`.
+#
+# The plugin is not on the runner image, so the job has to obtain it, and the
+# two ways of getting that wrong are opposites. Fetch it unpinned and an
+# upstream release silently re-points the unit-test runner for every pull
+# request. Fetch it on every run and a rate-limited GitHub release download
+# fails a required check for a reason that has nothing to do with the tree,
+# which is what run 34131816440 was: 92 bytes in 11 seconds, a checksum
+# rejection, and a dead step before the first test.
+#
+# So the contract has three parts, and none of them substitutes for another: a
+# pin, a cache to keep the steady state off the network, and a retry for the
+# cold path a cache miss leaves. Each is pinned here because each reads like
+# removable boilerplate on its own.
+
+WORKFLOW="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)/.github/workflows/pull-requests.yaml"
+
+@test "the helm-unittest install is version-pinned" {
+    [ -f "$WORKFLOW" ]
+
+    # `helm plugin install` with no constraint installs the newest release --
+    # its own --version help says exactly that, and the install hook logs
+    # `No version found` on the way there.
+    grep -q -- '--version "\${HELM_UNITTEST_VERSION}"' "$WORKFLOW" || {
+        echo "the plugin install carries no --version constraint, so it tracks" >&2
+        echo "whatever upstream released last and the toolchain moves without a" >&2
+        echo "diff in this repository." >&2
+        exit 1
+    }
+}
+
+@test "one pin feeds both the cache key and the install" {
+    [ -f "$WORKFLOW" ]
+
+    # A literal version in the cache key and a variable in the install (or two
+    # literals) can disagree, and the failure is a cache hit that restores the
+    # wrong binary while the log claims the pinned one. Both sides must read the
+    # same name, and it must be declared once.
+    declared="$(grep -c '^      HELM_UNITTEST_VERSION: ' "$WORKFLOW" || true)"
+    [ "${declared:-0}" -eq 1 ] || {
+        echo "expected exactly one HELM_UNITTEST_VERSION declaration, found ${declared:-0}" >&2
+        exit 1
+    }
+
+    grep -q 'key: helm-unittest-.*env\.HELM_UNITTEST_VERSION' "$WORKFLOW" || {
+        echo "the cache key does not derive from HELM_UNITTEST_VERSION, so a" >&2
+        echo "version bump can hit a cache entry built for another version." >&2
+        exit 1
+    }
+}
+
+@test "a throttled download is retried rather than failing the job" {
+    [ -f "$WORKFLOW" ]
+
+    # The cold path still has to fetch, and one throttled response must not
+    # take a required check with it.
+    grep -q 'for attempt in 1 2 3; do' "$WORKFLOW" || {
+        echo "the plugin install is one-shot; a single rate-limited response" >&2
+        echo "fails the whole unit-test job before any test runs." >&2
+        exit 1
+    }
+
+    # A half-written plugin directory makes the next attempt fail as "plugin
+    # already exists" instead of retrying the download, which turns the retry
+    # into two wasted seconds.
+    grep -q 'helm plugin uninstall unittest' "$WORKFLOW" || {
+        echo "the retry does not clear a partial install first, so attempts 2" >&2
+        echo "and 3 cannot succeed." >&2
+        exit 1
+    }
+}


### PR DESCRIPTION
## What this PR does

Unit-test job fetched the helm-unittest plugin from GitHub releases on every run, unauthenticated and unpinned, before any test could start. Both halves of that break, and in opposite directions.

Unpinned means `helm plugin install` installs whatever upstream released last. Its own `--version` help says exactly that, and the install hook logs `No version found` on the way there. So a release in another repository re-pointed the unit-test runner for every PR here, with no diff and nothing in any log to say it had happened.

Fetching on every run means a rate-limited download fails a required check for a reason that has nothing to do with the tree. Release asset downloads are limited per egress IP and the runner fleet shares one, so a throttled response arrives as a short error body, the install hook checksum validation correctly rejects it, and the step dies under `bash -e` before the first test. Measured on [run 34131816440](https://github.com/cozystack/cozystack/actions/runs/34131816440): 92 bytes in 11 seconds, then `Failed to install helm-unittest`, and a plain re-run went green. This class was created by #2939, which moved CI to ephemeral runners. The persistent runner it replaced had accreted the plugin already, so nothing ever downloaded it.

Three parts, and none of them substitutes for another:

1. pin `HELM_UNITTEST_VERSION`, so upstream cannot move the toolchain without a diff here
2. `actions/cache` entry keyed on that pin, so the steady state touches no network at all
3. three attempts with backoff for the cold path a cache miss leaves

A cache miss degrades to the previous behaviour plus the retry, so a cache service outage cannot make this job worse than it was. The retry clears a partial install between attempts, without which attempts 2 and 3 fail as "plugin already exists" instead of retrying the download.

Renovate custom manager tracks the pin, because a plain workflow env var is invisible to the github-actions manager, and a pin nobody updates is the same problem with the sign flipped.

`hack/unit-test-toolchain.bats` pins the three parts separately, since each one reads like removable boilerplate on its own. One pin feeding both the cache key and the install is the part most worth guarding: a literal in one and a variable in the other can disagree, and the failure is a cache hit restoring a version the log does not name.

### One thing worth knowing

The presence check deliberately does not run under `pipefail`. `grep -q` exits on its first match and closes the pipe, so the writer takes EPIPE and returns non-zero after the match was already found. Under pipefail that reads as absent, and reinstalls what is already present.

That same shape, with pipefail set, is what makes `hack/check-rd-presets.sh:39` report a resourcesPreset as missing at random. Measured: piped form gives 20 false misses out of 20 on a long enough list, herestring form gives 0 out of 20. At 47 presets it is a race, which is why it shows up as three same-commit fail-then-pass pairs in the last 60 runs rather than as a hard failure. Separate one-line fix, not in this PR.

### Downstream repositories

- [x] No downstream repository is affected by this change

Walked the trigger map against the diff rather than the title. It touches one CI workflow step, one renovate manager and one new bats file. Nothing under `packages/`, no `hack/` file moved or renamed, no make target behaviour changed (`bats-unit-tests` globs `hack/*.bats`, so the new file is picked up without touching the target), and no commit or PR convention changed.

### Release note

```release-note
ci(tests): the unit-test job installs a pinned helm-unittest from a cache instead of fetching the newest release on every run, so a throttled GitHub download no longer fails the job and an upstream release no longer changes the test toolchain without a diff.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the unit-test workflow by pinning the Helm unittest plugin version.
  * Added caching to reduce repeated plugin downloads.
  * Added retries and cleanup handling when plugin installation fails.

* **Tests**
  * Added automated checks to verify version pinning, caching, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->