### PR TITLE
refactor(gateway): give every Gateway listener its own allowedRoutes

### DIFF
--- a/internal/controller/tenantgateway/reconciler.go
+++ b/internal/controller/tenantgateway/reconciler.go
@@ -869,8 +869,6 @@ func (r *Reconciler) renderGateway(tgw *gatewayv1alpha1.TenantGateway, dynHostna
 		{Group: ptrGroup(gatewayv1.GroupName), Kind: "HTTPRoute"},
 		{Group: ptrGroup(gatewayv1.GroupName), Kind: "TLSRoute"},
 	}
-	httpsAllowedRoutes := allowedRoutes.DeepCopy()
-	httpsAllowedRoutes.Kinds = port443Kinds
 
 	switch tgw.Spec.CertMode {
 	case gatewayv1alpha1.CertModeEdge:
@@ -883,8 +881,7 @@ func (r *Reconciler) renderGateway(tgw *gatewayv1alpha1.TenantGateway, dynHostna
 		// carry it, and GRPCRoute stays out for parity with the HTTPS
 		// listeners. TLS-passthrough listeners are skipped below for
 		// the same reason.
-		edgeAllowedRoutes := allowedRoutes.DeepCopy()
-		edgeAllowedRoutes.Kinds = []gatewayv1.RouteGroupKind{
+		edgeKinds := []gatewayv1.RouteGroupKind{
 			{Group: ptrGroup(gatewayv1.GroupName), Kind: "HTTPRoute"},
 		}
 		wildcardHost := gatewayv1.Hostname("*." + tgw.Spec.Apex)
@@ -895,14 +892,14 @@ func (r *Reconciler) renderGateway(tgw *gatewayv1alpha1.TenantGateway, dynHostna
 				Port:          80,
 				Protocol:      gatewayv1.HTTPProtocolType,
 				Hostname:      &wildcardHost,
-				AllowedRoutes: edgeAllowedRoutes,
+				AllowedRoutes: listenerAllowedRoutes(allowedRoutes, edgeKinds),
 			},
 			gatewayv1.Listener{
 				Name:          "edge-apex",
 				Port:          80,
 				Protocol:      gatewayv1.HTTPProtocolType,
 				Hostname:      &apexHost,
-				AllowedRoutes: edgeAllowedRoutes.DeepCopy(),
+				AllowedRoutes: listenerAllowedRoutes(allowedRoutes, edgeKinds),
 			},
 		)
 		// Same 2+N fan-out as the DNS-01 branch below, and the same
@@ -916,7 +913,7 @@ func (r *Reconciler) renderGateway(tgw *gatewayv1alpha1.TenantGateway, dynHostna
 				Port:          80,
 				Protocol:      gatewayv1.HTTPProtocolType,
 				Hostname:      &childWildcard,
-				AllowedRoutes: edgeAllowedRoutes.DeepCopy(),
+				AllowedRoutes: listenerAllowedRoutes(allowedRoutes, edgeKinds),
 			})
 		}
 	case gatewayv1alpha1.CertModeDNS01, gatewayv1alpha1.CertModeExistingSecret:
@@ -941,7 +938,7 @@ func (r *Reconciler) renderGateway(tgw *gatewayv1alpha1.TenantGateway, dynHostna
 						{Name: gatewayv1.ObjectName(certName)},
 					},
 				},
-				AllowedRoutes: httpsAllowedRoutes,
+				AllowedRoutes: listenerAllowedRoutes(allowedRoutes, port443Kinds),
 			},
 			gatewayv1.Listener{
 				Name:     "https-apex",
@@ -954,7 +951,7 @@ func (r *Reconciler) renderGateway(tgw *gatewayv1alpha1.TenantGateway, dynHostna
 						{Name: gatewayv1.ObjectName(certName)},
 					},
 				},
-				AllowedRoutes: httpsAllowedRoutes,
+				AllowedRoutes: listenerAllowedRoutes(allowedRoutes, port443Kinds),
 			},
 		)
 		// Per-child-apex wildcard listeners — every inheriting
@@ -982,7 +979,7 @@ func (r *Reconciler) renderGateway(tgw *gatewayv1alpha1.TenantGateway, dynHostna
 						{Name: gatewayv1.ObjectName(certName)},
 					},
 				},
-				AllowedRoutes: httpsAllowedRoutes.DeepCopy(),
+				AllowedRoutes: listenerAllowedRoutes(allowedRoutes, port443Kinds),
 			})
 		}
 	default:
@@ -1004,7 +1001,7 @@ func (r *Reconciler) renderGateway(tgw *gatewayv1alpha1.TenantGateway, dynHostna
 						{Name: gatewayv1.ObjectName(certName)},
 					},
 				},
-				AllowedRoutes: httpsAllowedRoutes.DeepCopy(),
+				AllowedRoutes: listenerAllowedRoutes(allowedRoutes, port443Kinds),
 			})
 		}
 	}
@@ -1030,8 +1027,6 @@ func (r *Reconciler) renderGateway(tgw *gatewayv1alpha1.TenantGateway, dynHostna
 	}
 	for _, svc := range passthroughServices {
 		host := gatewayv1.Hostname(svc + "." + tgw.Spec.Apex)
-		passthroughAllowed := *allowedRoutes
-		passthroughAllowed.Kinds = port443Kinds
 		listeners = append(listeners, gatewayv1.Listener{
 			Name:     gatewayv1.SectionName("tls-" + svc),
 			Port:     443,
@@ -1040,7 +1035,7 @@ func (r *Reconciler) renderGateway(tgw *gatewayv1alpha1.TenantGateway, dynHostna
 			TLS: &gatewayv1.ListenerTLSConfig{
 				Mode: ptrTLSMode(gatewayv1.TLSModePassthrough),
 			},
-			AllowedRoutes: &passthroughAllowed,
+			AllowedRoutes: listenerAllowedRoutes(allowedRoutes, port443Kinds),
 		})
 	}
 

--- a/internal/controller/tenantgateway/reconciler_test.go
+++ b/internal/controller/tenantgateway/reconciler_test.go
@@ -4105,7 +4105,8 @@ func TestReconcile_ExistingSecretModeKeepsHTTPRedirectAndPassthrough(t *testing.
 //     appear in any port-443 listener's kinds set. cilium#45559 governs
 //     only that the sets match each other, so this is least privilege:
 //     nothing the platform ships needs gRPC, TCP or UDP routing on port
-//     443. TCPRoute and UDPRoute also carry no hostname and no admission
+//
+//  443. TCPRoute and UDPRoute also carry no hostname and no admission
 //     rule gates them, so admitting them would let a tenant serve
 //     arbitrary traffic under the apex cert without admission control.
 //     GRPCRoute hostnames are gated by the cozystack-route-hostname-policy
@@ -5107,5 +5108,77 @@ func TestReconcile_SwitchingBackFromEdgeRestoresTheACMEShape(t *testing.T) {
 	}
 	if err := c.Get(context.TODO(), types.NamespacedName{Name: gatewayIssuerName(tgw), Namespace: "tenant-foo"}, &cmv1.Issuer{}); err != nil {
 		t.Errorf("the ACME Issuer must be minted again on the way back: %v", err)
+	}
+}
+
+// TestRenderGateway_EveryListenerOwnsItsAllowedRoutes pins the
+// ownership rule the listener builders follow: no two listeners share
+// an AllowedRoutes, a RouteNamespaces or a Kinds backing array. A
+// shared value renders identically to an owned one, so the aliasing is
+// invisible until someone narrows a single listener's kinds or
+// selector and the edit silently lands on its neighbours too.
+func TestRenderGateway_EveryListenerOwnsItsAllowedRoutes(t *testing.T) {
+	r := &Reconciler{Scheme: newScheme(t)}
+
+	tgwFor := func(mode gatewayv1alpha1.CertMode) *gatewayv1alpha1.TenantGateway {
+		tgw := &gatewayv1alpha1.TenantGateway{
+			ObjectMeta: metav1.ObjectMeta{Name: "cozystack", Namespace: "tenant-foo"},
+			Spec: gatewayv1alpha1.TenantGatewaySpec{
+				Apex:                   "foo.example.com",
+				CertMode:               mode,
+				GatewayClassName:       "cilium",
+				AttachedNamespaces:     []string{"cozy-harbor", "cozy-dashboard"},
+				TLSPassthroughServices: []string{"api", "vm-exportproxy"},
+			},
+		}
+		if mode == gatewayv1alpha1.CertModeExistingSecret {
+			tgw.Spec.WildcardSecretRef = &corev1.LocalObjectReference{Name: "wildcard-tls"}
+		}
+		return tgw
+	}
+
+	for _, mode := range []gatewayv1alpha1.CertMode{
+		gatewayv1alpha1.CertModeHTTP01,
+		gatewayv1alpha1.CertModeDNS01,
+		gatewayv1alpha1.CertModeExistingSecret,
+		gatewayv1alpha1.CertModeEdge,
+	} {
+		t.Run(string(mode), func(t *testing.T) {
+			gw, err := r.renderGateway(
+				tgwFor(mode),
+				[]string{"harbor.foo.example.com", "keycloak.foo.example.com"},
+				[]string{"alice.example.com", "bob.example.com"},
+			)
+			if err != nil {
+				t.Fatalf("renderGateway: %v", err)
+			}
+			if len(gw.Spec.Listeners) < 3 {
+				t.Fatalf("expected several listeners to compare, got %+v", gw.Spec.Listeners)
+			}
+
+			owner := map[any]string{}
+			claim := func(p any, what, listener string) {
+				if prev, ok := owner[p]; ok {
+					t.Errorf("listener %q shares its %s with listener %q", listener, what, prev)
+					return
+				}
+				owner[p] = listener
+			}
+			for i := range gw.Spec.Listeners {
+				l := &gw.Spec.Listeners[i]
+				name := string(l.Name)
+				if l.AllowedRoutes == nil {
+					t.Errorf("listener %q has no allowedRoutes", name)
+					continue
+				}
+				claim(l.AllowedRoutes, "allowedRoutes", name)
+				if l.AllowedRoutes.Namespaces != nil {
+					claim(l.AllowedRoutes.Namespaces, "allowedRoutes.namespaces", name)
+				}
+				if len(l.AllowedRoutes.Kinds) > 0 {
+					claim(&l.AllowedRoutes.Kinds[0], "allowedRoutes.kinds backing array", name)
+				}
+			}
+		})
 	}
 }

--- a/internal/controller/tenantgateway/renderers.go
+++ b/internal/controller/tenantgateway/renderers.go
@@ -130,6 +130,15 @@ func buildAllowedRoutes(tgw *gatewayv1alpha1.TenantGateway) *gatewayv1.AllowedRo
 	}
 }
 
+// listenerAllowedRoutes returns an AllowedRoutes owned by the one
+// listener it is handed to: base's namespace selector restricted to
+// kinds, deep-copied whole. Listeners built from the same base and the
+// same kinds share nothing, so narrowing one of them later — a kind
+// dropped, a selector tightened — cannot reach its neighbours.
+func listenerAllowedRoutes(base *gatewayv1.AllowedRoutes, kinds []gatewayv1.RouteGroupKind) *gatewayv1.AllowedRoutes {
+	return (&gatewayv1.AllowedRoutes{Namespaces: base.Namespaces, Kinds: kinds}).DeepCopy()
+}
+
 // buildHTTPListenerAllowedRoutes returns a strictly narrower
 // allowedRoutes for the port-80 listener: only the tenant namespace,
 // where both the controller-owned http→https redirect HTTPRoute and


### PR DESCRIPTION
## What this PR does

Fixes #4118, and corrects its premise on the way: the `edge` branch is not where listeners share an `allowedRoutes`. `edge` keeps the local `edgeAllowedRoutes`, while `edge-apex` and every `edge-child-*` listener already get a `DeepCopy()`, so no two edge listeners alias each other — the escape is of the local variable into one listener, which is what the issue's "and nothing else" is about. The listener-to-listener sharing the issue holds up as the pattern to follow is the branch that actually has it: in `dns01` and `existingSecret`, `https` and `https-apex` are both handed the same `httpsAllowedRoutes` pointer, and each `tls-<svc>` passthrough listener gets `passthroughAllowed := *allowedRoutes` — a shallow struct copy, so they all share one `RouteNamespaces` and, via `port443Kinds`, one `Kinds` backing array with each other and with the `https` listeners.

Nothing mutates a rendered listener today, so all of this is invisible in the rendered Gateway; it becomes a bug the first time someone narrows one listener's kinds or its namespace selector and the edit lands on its neighbours too.

Rather than adding a `DeepCopy()` at each site and leaving the next listener free to alias again, `listenerAllowedRoutes(base, kinds)` builds the value per listener, so every listener owning its own is a property of the constructor instead of something to remember at seven call sites. The rendered Gateway is byte-identical — same selector, same kinds, same order.

`TestRenderGateway_EveryListenerOwnsItsAllowedRoutes` pins the rule across all four cert modes: it renders the Gateway and fails if two listeners share an `AllowedRoutes`, a `RouteNamespaces`, or a `Kinds` backing array. It has to call `renderGateway` directly — a round trip through the client deep-copies the object and hides the aliasing. On `main` it fails for `http01`, `dns01` and `existingSecret`, and passes for `edge`, which is the evidence for the paragraph above.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

The diff is confined to `internal/controller/tenantgateway`, and the rendered Gateway does not change, so nothing on the trigger map is reached: no package added or removed, no `values.schema.json` or `values.yaml` field, no CRD, no version enum, no namespace or `release.prefix` rename, no `hack/` layout or make-target change, no node prerequisite, no metric or annotation name, no commit-convention change.

### Release note

```release-note
refactor(gateway): every TenantGateway listener now renders its own allowedRoutes value instead of sharing one with its neighbours; the rendered Gateway is unchanged
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Gateway listener configuration so each listener maintains independent route settings.
  - Prevented changes to one listener’s allowed routes from unintentionally affecting other listeners.
  - Preserved existing listener topology and routing behavior across HTTP-01, DNS-01, existing secret, and edge certificate modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->