### PR TITLE
feat(openbao): central platform instance and per-tenant transit provisioning

### DIFF
--- a/cmd/cozystack-operator/main.go
+++ b/cmd/cozystack-operator/main.go
@@ -341,6 +341,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Setup OpenBAO transit auto-unseal provisioner
+	if err := (&operator.OpenBAOTransitReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "OpenBAOTransit")
+		os.Exit(1)
+	}
+
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/internal/operator/openbao_transit_reconciler.go
+++ b/internal/operator/openbao_transit_reconciler.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2025 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cozystack/cozystack/internal/operator/openbaotransit"
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	// TransitUnsealLabel marks the inner OpenBAO HelmRelease whose instance needs
+	// a transit auto-unseal credential provisioned on the central OpenBAO.
+	TransitUnsealLabel = "apps.cozystack.io/transit-unseal"
+
+	// central OpenBAO coordinates (see packages/system/openbao).
+	centralOpenBAONamespace  = "cozy-openbao"
+	centralOpenBAOKeysSecret = "openbao-system-keys"
+	centralOpenBAOCASecret   = "openbao-system-ca"
+	centralOpenBAOAddr       = "https://openbao-system.cozy-openbao.svc:8200"
+
+	transitTokenPeriod = "72h"
+)
+
+// OpenBAOTransitReconciler provisions, on the central OpenBAO, a per-tenant
+// transit key + scoped policy + Kubernetes-auth role bound to the tenant's
+// server ServiceAccount, and publishes the central CA as a ConfigMap in the
+// tenant namespace. The tenant OpenBAO then obtains a transit-scoped token at
+// startup via Kubernetes auth — no token is ever minted or stored as a Secret.
+type OpenBAOTransitReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+//+kubebuilder:rbac:groups=helm.toolkit.fluxcd.io,resources=helmreleases,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch
+
+// Reconcile ensures the transit credential exists for one inner OpenBAO HelmRelease.
+func (r *OpenBAOTransitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	hr := &helmv2.HelmRelease{}
+	if err := r.Get(ctx, req.NamespacedName, hr); err != nil {
+		// HR gone: the CA ConfigMap is owner-referenced to it and is
+		// garbage-collected automatically. The orphaned central transit key /
+		// policy / role are harmless and reclaimed out of band.
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	if hr.GetLabels()[TransitUnsealLabel] != "true" {
+		return ctrl.Result{}, nil
+	}
+
+	// The inner HelmRelease is named "<instance>-system"; the instance (== the
+	// OpenBAO CR / Helm release name) is what the chart uses for the seal key, the
+	// server ServiceAccount, and the CA ConfigMap.
+	instance := strings.TrimSuffix(hr.Name, "-system")
+	if instance == hr.Name {
+		return ctrl.Result{}, nil
+	}
+	ns := hr.Namespace
+	keyName := fmt.Sprintf("%s-%s", ns, instance) // matches the chart's $sealKey and k8s-auth role
+	policyName := keyName + "-unseal"
+	saName := instance // the upstream chart's server ServiceAccount (fullnameOverride)
+	caConfigMap := instance + "-transit-ca"
+
+	// Authenticate to the central OpenBAO with its root token + CA. (The token
+	// minting happens entirely on the central side via Kubernetes auth — no
+	// token is ever delivered to or stored in the tenant namespace.)
+	rootToken, err := r.readCentralSecretKey(ctx, centralOpenBAOKeysSecret, "root-token")
+	if err != nil {
+		logger.Info("central OpenBAO not ready yet (root token unavailable), requeueing", "error", err.Error())
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+	caPEM, err := r.readCentralSecretKey(ctx, centralOpenBAOCASecret, "ca.crt")
+	if err != nil {
+		logger.Info("central OpenBAO CA not ready yet, requeueing", "error", err.Error())
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	bc, err := openbaotransit.New(centralOpenBAOAddr, string(rootToken), caPEM)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	if err := bc.EnsureTransitKey(ctx, keyName); err != nil {
+		logger.Info("transit key provisioning failed, requeueing", "key", keyName, "error", err.Error())
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+	if err := bc.WriteUnsealPolicy(ctx, policyName, keyName); err != nil {
+		logger.Info("policy write failed, requeueing", "policy", policyName, "error", err.Error())
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+	// Bind the tenant's server ServiceAccount to the policy via Kubernetes auth.
+	// The tenant pod logs in with its projected SA token at startup — nothing is
+	// stored in the tenant namespace.
+	if err := bc.EnsureKubernetesAuthRole(ctx, keyName, saName, ns, policyName, transitTokenPeriod); err != nil {
+		logger.Info("kubernetes auth role write failed, requeueing", "role", keyName, "error", err.Error())
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
+
+	// Publish the central CA as a ConfigMap (public cert, not a Secret) so the
+	// tenant's login init container and transit seal can verify the central TLS.
+	if err := r.ensureCAConfigMap(ctx, hr, caConfigMap, caPEM); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	logger.Info("provisioned transit auto-unseal (kubernetes auth)", "namespace", ns, "instance", instance, "key", keyName)
+	return ctrl.Result{}, nil
+}
+
+func (r *OpenBAOTransitReconciler) readCentralSecretKey(ctx context.Context, name, key string) ([]byte, error) {
+	s := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: centralOpenBAONamespace, Name: name}, s); err != nil {
+		return nil, err
+	}
+	v, ok := s.Data[key]
+	if !ok || len(v) == 0 {
+		return nil, fmt.Errorf("secret %s/%s missing key %q", centralOpenBAONamespace, name, key)
+	}
+	return v, nil
+}
+
+func (r *OpenBAOTransitReconciler) ensureCAConfigMap(ctx context.Context, owner *helmv2.HelmRelease, name string, caPEM []byte) error {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: owner.Namespace, Name: name},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, r.Client, cm, func() error {
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		cm.Data["ca.crt"] = string(caPEM)
+		// GC the CA bundle when the instance's HelmRelease is removed.
+		return controllerutil.SetOwnerReference(owner, cm, r.Scheme)
+	})
+	return err
+}
+
+// SetupWithManager wires the reconciler to watch only transit-labelled HelmReleases.
+func (r *OpenBAOTransitReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	hasLabel := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetLabels()[TransitUnsealLabel] == "true"
+	})
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&helmv2.HelmRelease{}, builder.WithPredicates(hasLabel)).
+		Named("openbao-transit").
+		Complete(r)
+}

--- a/internal/operator/openbaotransit/client.go
+++ b/internal/operator/openbaotransit/client.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2025 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package openbaotransit is a minimal client for the subset of the OpenBAO API
+// needed to provision per-tenant transit auto-unseal: enabling a transit key,
+// writing a scoped ACL policy, and minting/validating a scoped token.
+//
+// It speaks plain HTTP (authenticated with X-Vault-Token) rather than pulling in
+// the full OpenBAO SDK — the operator only needs three idempotent calls.
+package openbaotransit
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Client talks to a single OpenBAO server with a fixed auth token.
+type Client struct {
+	addr  string
+	token string
+	http  *http.Client
+}
+
+// New returns a Client for addr authenticating with token. caPEM, when non-empty,
+// is the CA bundle used to verify the server certificate.
+func New(addr, token string, caPEM []byte) (*Client, error) {
+	tlsCfg := &tls.Config{MinVersion: tls.VersionTLS12}
+	if len(caPEM) > 0 {
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caPEM) {
+			return nil, fmt.Errorf("openbaotransit: failed to parse CA bundle")
+		}
+		tlsCfg.RootCAs = pool
+	}
+	return &Client{
+		addr:  addr,
+		token: token,
+		http: &http.Client{
+			Timeout:   15 * time.Second,
+			Transport: &http.Transport{TLSClientConfig: tlsCfg},
+		},
+	}, nil
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body any) (int, []byte, error) {
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return 0, nil, err
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.addr+path, rdr)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("X-Vault-Token", c.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	return resp.StatusCode, data, nil
+}
+
+// EnsureTransitKey creates the named transit key if it does not already exist.
+// Creating an existing key is a no-op, so this is safe to call repeatedly.
+func (c *Client) EnsureTransitKey(ctx context.Context, keyName string) error {
+	// Creating an existing key is a no-op on the OpenBAO side.
+	code, data, err := c.do(ctx, http.MethodPost, "/v1/transit/keys/"+keyName, map[string]string{"type": "aes256-gcm96"})
+	if err != nil {
+		return err
+	}
+	if code != http.StatusOK && code != http.StatusNoContent {
+		return fmt.Errorf("create transit key %q: status %d: %s", keyName, code, string(data))
+	}
+	return nil
+}
+
+// WriteUnsealPolicy writes an ACL policy granting encrypt+decrypt on keyName.
+func (c *Client) WriteUnsealPolicy(ctx context.Context, policyName, keyName string) error {
+	hcl := fmt.Sprintf(`path "transit/encrypt/%s" { capabilities = ["update"] }
+path "transit/decrypt/%s" { capabilities = ["update"] }
+`, keyName, keyName)
+	code, data, err := c.do(ctx, http.MethodPut, "/v1/sys/policies/acl/"+policyName, map[string]string{"policy": hcl})
+	if err != nil {
+		return err
+	}
+	if code != http.StatusOK && code != http.StatusNoContent {
+		return fmt.Errorf("write policy %q: status %d: %s", policyName, code, string(data))
+	}
+	return nil
+}
+
+// EnsureKubernetesAuthRole binds a tenant ServiceAccount (saName in saNamespace)
+// to policyName via the central Kubernetes auth method, so the tenant OpenBAO can
+// obtain a transit-scoped token at startup using its projected SA token — no
+// static token is ever minted or stored. period sets the issued token's period.
+func (c *Client) EnsureKubernetesAuthRole(ctx context.Context, role, saName, saNamespace, policyName, period string) error {
+	body := map[string]any{
+		"bound_service_account_names":      []string{saName},
+		"bound_service_account_namespaces": []string{saNamespace},
+		"token_policies":                   []string{policyName},
+		"token_period":                     period,
+	}
+	code, data, err := c.do(ctx, http.MethodPost, "/v1/auth/kubernetes/role/"+role, body)
+	if err != nil {
+		return err
+	}
+	if code != http.StatusOK && code != http.StatusNoContent {
+		return fmt.Errorf("write kubernetes auth role %q: status %d: %s", role, code, string(data))
+	}
+	return nil
+}

--- a/internal/operator/openbaotransit/client_test.go
+++ b/internal/operator/openbaotransit/client_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2025 The Cozystack Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openbaotransit
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestClient(t *testing.T, h http.HandlerFunc) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	c, err := New(srv.URL, "root-token", nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return c, srv
+}
+
+func TestEnsureTransitKey(t *testing.T) {
+	var gotPath, gotToken string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotToken = r.Header.Get("X-Vault-Token")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer srv.Close()
+
+	if err := c.EnsureTransitKey(context.Background(), "tenant-test-test"); err != nil {
+		t.Fatalf("EnsureTransitKey: %v", err)
+	}
+	if gotPath != "/v1/transit/keys/tenant-test-test" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotToken != "root-token" {
+		t.Errorf("token header = %q", gotToken)
+	}
+}
+
+func TestEnsureTransitKeyError(t *testing.T) {
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, `{"errors":["permission denied"]}`)
+	})
+	defer srv.Close()
+	if err := c.EnsureTransitKey(context.Background(), "k"); err == nil {
+		t.Fatal("expected error on 403")
+	}
+}
+
+func TestWriteUnsealPolicy(t *testing.T) {
+	var body map[string]string
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("method = %s", r.Method)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer srv.Close()
+
+	if err := c.WriteUnsealPolicy(context.Background(), "tenant-test-test-unseal", "tenant-test-test"); err != nil {
+		t.Fatalf("WriteUnsealPolicy: %v", err)
+	}
+	pol := body["policy"]
+	if !strings.Contains(pol, `transit/encrypt/tenant-test-test`) || !strings.Contains(pol, `transit/decrypt/tenant-test-test`) {
+		t.Errorf("policy missing encrypt/decrypt paths: %q", pol)
+	}
+}
+
+func TestEnsureKubernetesAuthRole(t *testing.T) {
+	var gotPath string
+	var body map[string]any
+	c, srv := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer srv.Close()
+
+	if err := c.EnsureKubernetesAuthRole(context.Background(), "tenant-test-test", "test", "tenant-test", "tenant-test-test-unseal", "72h"); err != nil {
+		t.Fatalf("EnsureKubernetesAuthRole: %v", err)
+	}
+	if gotPath != "/v1/auth/kubernetes/role/tenant-test-test" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if got := body["bound_service_account_names"].([]any); got[0].(string) != "test" {
+		t.Errorf("bound SA names = %v", got)
+	}
+	if got := body["bound_service_account_namespaces"].([]any); got[0].(string) != "tenant-test" {
+		t.Errorf("bound SA namespaces = %v", got)
+	}
+	if got := body["token_policies"].([]any); got[0].(string) != "tenant-test-test-unseal" {
+		t.Errorf("token_policies = %v", got)
+	}
+}

--- a/packages/core/platform/sources/openbao-application.yaml
+++ b/packages/core/platform/sources/openbao-application.yaml
@@ -19,8 +19,24 @@ spec:
         - name: cozy-lib
           path: library/cozy-lib
       components:
+        # Published only, never installed on its own: this is the shared
+        # workload chart that both a tenant OpenBAO instance and the central
+        # platform instance below reference as an ExternalArtifact. A component
+        # without an `install` section gets no HelmRelease
+        # (internal/operator/package_reconciler.go), which is what keeps it from
+        # standing up a server nobody asked for.
         - name: openbao-system
           path: system/openbao
+        # The central platform instance that backs transit auto-unseal for
+        # tenants. Its namespace and the release naming inside it are read back
+        # by internal/operator/openbao_transit_reconciler.go, which expects
+        # https://openbao-system.cozy-openbao.svc:8200 and the
+        # openbao-system-keys / openbao-system-ca Secrets in cozy-openbao.
+        - name: openbao-central
+          path: system/openbao-central
+          install:
+            namespace: cozy-openbao
+            releaseName: openbao-central
         - name: openbao
           path: apps/openbao
           libraries: ["cozy-lib"]

--- a/packages/system/openbao-central/Chart.yaml
+++ b/packages/system/openbao-central/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v2
+name: openbao-central
+version: 0.0.0 # Placeholder, the actual version will be automatically set during the build process

--- a/packages/system/openbao-central/Makefile
+++ b/packages/system/openbao-central/Makefile
@@ -1,0 +1,8 @@
+export NAME=openbao-central
+export NAMESPACE=cozy-openbao
+
+include ../../../hack/package.mk
+
+.PHONY: test
+test:
+	helm unittest .

--- a/packages/system/openbao-central/templates/certmanager.yaml
+++ b/packages/system/openbao-central/templates/certmanager.yaml
@@ -1,0 +1,93 @@
+{{- /*
+Self-signed CA -> leaf certificate for the central OpenBAO server.
+Modeled on packages/apps/qdrant/templates/certmanager.yaml.
+
+A self-signed CA (not letsencrypt) is used deliberately: these listeners are
+internal-only (*.svc.<clusterDomain>) and Raft peers verify each other with the
+CA, so we need both server auth and client auth usages.
+*/}}
+{{- $clusterDomain := "cozy.local" }}
+{{- if .Values._cluster }}
+{{- $clusterDomain = (index .Values._cluster "cluster-domain") | default "cozy.local" }}
+{{- end }}
+{{- $name := "openbao-system" }}
+{{- $headless := printf "%s-internal" $name }}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ $name }}-selfsigned
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $name }}-ca
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ $name }}-ca
+  duration: 43800h
+  commonName: {{ $name }}-ca
+  issuerRef:
+    name: {{ $name }}-selfsigned
+  isCA: true
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+    rotationPolicy: Never
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ $name }}-ca
+  namespace: {{ .Release.Namespace }}
+spec:
+  ca:
+    secretName: {{ $name }}-ca
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ $name }}-tls
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ $name }}-tls
+  duration: 8760h
+  renewBefore: 720h
+  isCA: false
+  issuerRef:
+    name: {{ $name }}-ca
+  commonName: {{ $name }}
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+    rotationPolicy: Always
+  # server auth: the API/cluster listeners (8200/8201).
+  # client auth: Raft peers verify each other with this cert (mTLS on 8201).
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth
+  ipAddresses:
+    # bao CLI/probes inside the pod connect to the local listener on 127.0.0.1.
+    - 127.0.0.1
+  dnsNames:
+    - {{ $name }}
+    - {{ $name }}.{{ .Release.Namespace }}.svc
+    - {{ $name }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}
+    - {{ $name }}-active
+    - {{ $name }}-active.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}
+    - {{ $name }}-standby
+    - {{ $name }}-standby.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}
+    - {{ $headless }}
+    - {{ $headless }}.{{ .Release.Namespace }}.svc
+    - {{ $headless }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}
+    - "*.{{ $headless }}.{{ .Release.Namespace }}.svc.{{ $clusterDomain }}"
+    {{- range $i := until 3 }}
+    - {{ printf "%s-%d.%s" $name $i $headless | quote }}
+    - {{ printf "%s-%d.%s.%s.svc" $name $i $headless $.Release.Namespace | quote }}
+    - {{ printf "%s-%d.%s.%s.svc.%s" $name $i $headless $.Release.Namespace $clusterDomain | quote }}
+    {{- end }}

--- a/packages/system/openbao-central/templates/init-job.yaml
+++ b/packages/system/openbao-central/templates/init-job.yaml
@@ -1,0 +1,107 @@
+{{- /*
+One-time initialization of the central OpenBAO cluster.
+
+Gated on the absence of the openbao-system-keys Secret: once the cluster is
+initialized and the keys are persisted, this manifest is no longer rendered, so
+it can never re-run and re-init (which would destroy the cluster). This is safe
+under Flux's remediation.retries: -1 because the gate is evaluated at every
+render.
+
+The init container (openbao image) waits for pod-0's API, initializes if needed,
+and writes the unseal keys + root token to an emptyDir. The store container
+(kubectl image) persists them into the openbao-system-keys Secret.
+*/}}
+{{- if not (lookup "v1" "Secret" .Release.Namespace "openbao-system-keys") }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: openbao-system-init
+  namespace: {{ .Release.Namespace }}
+spec:
+  backoffLimit: 30
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: openbao-system
+        app.kubernetes.io/component: init
+    spec:
+      serviceAccountName: openbao-system-bootstrap
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100
+      volumes:
+        - name: work
+          emptyDir: {}
+        - name: tls
+          secret:
+            secretName: openbao-system-tls
+            optional: true
+      initContainers:
+        - name: init
+          image: {{ .Values.bootstrap.openbaoImage | quote }}
+          env:
+            - name: BAO_ADDR
+              value: https://openbao-system-0.openbao-system-internal:8200
+            - name: BAO_CACERT
+              value: /openbao/tls/ca.crt
+            - name: KEY_SHARES
+              value: {{ .Values.bootstrap.keyShares | quote }}
+            - name: KEY_THRESHOLD
+              value: {{ .Values.bootstrap.keyThreshold | quote }}
+          volumeMounts:
+            - name: work
+              mountPath: /work
+            - name: tls
+              mountPath: /openbao/tls
+              readOnly: true
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              echo "waiting for openbao-system-0 API ..."
+              until bao status >/dev/null 2>&1 || [ $? -eq 2 ]; do sleep 3; done
+              if bao status 2>/dev/null | grep -qi 'Initialized.*true'; then
+                if [ ! -f /work/done ]; then
+                  echo "ERROR: cluster already initialized but openbao-system-keys is missing — unseal keys are unrecoverable. Manual intervention required." >&2
+                  exit 1
+                fi
+                exit 0
+              fi
+              echo "initializing ..."
+              bao operator init -key-shares="$KEY_SHARES" -key-threshold="$KEY_THRESHOLD" > /work/init.txt
+              grep '^Unseal Key' /work/init.txt | sed 's/.*: //' > /work/keys.txt
+              grep '^Initial Root Token' /work/init.txt | sed 's/.*: //' | tr -d '\n' > /work/root-token
+              i=0
+              while IFS= read -r k; do
+                printf '%s' "$k" > "/work/key-$i"
+                i=$((i+1))
+              done < /work/keys.txt
+              rm -f /work/init.txt /work/keys.txt
+              touch /work/done
+              echo "init complete: wrote $i unseal keys + root token"
+      containers:
+        - name: store
+          image: {{ .Values.bootstrap.kubectlImage | quote }}
+          volumeMounts:
+            - name: work
+              mountPath: /work
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              if [ ! -f /work/root-token ]; then
+                echo "nothing to store"
+                exit 0
+              fi
+              args=""
+              for f in /work/key-*; do
+                args="$args --from-file=$(basename "$f")=$f"
+              done
+              args="$args --from-file=root-token=/work/root-token"
+              # shellcheck disable=SC2086
+              kubectl create secret generic openbao-system-keys \
+                -n {{ .Release.Namespace }} $args \
+                --dry-run=client -o yaml | kubectl apply -f -
+              echo "openbao-system-keys persisted"
+{{- end }}

--- a/packages/system/openbao-central/templates/openbao.yaml
+++ b/packages/system/openbao-central/templates/openbao.yaml
@@ -1,0 +1,69 @@
+{{- /*
+The central instance's server, rendered from the same published chart artifact a
+tenant OpenBAO instance uses (packages/system/openbao, component
+`openbao-system`). Wrapping that artifact rather than vendoring the upstream
+chart a second time keeps one copy of it in the tree, so a `make update` there
+moves both consumers at once and they cannot drift to different upstream
+versions.
+
+Deliberately no `sharding.fluxcd.io/key: tenants` label: this is a platform
+component reconciled by the management Flux, not tenant-scoped work.
+*/ -}}
+{{- $name := "openbao-system" -}}
+{{- $replicas := int .Values.replicas -}}
+{{- if lt $replicas 1 -}}
+{{- fail (printf "openbao-central: replicas must be at least 1, got %d." $replicas) -}}
+{{- end -}}
+
+{{- /*
+  Raft over TLS, at every replica count. retry_join is what an uninitialized pod
+  uses to find the cluster, so it is only meaningful once there is another pod to
+  find: at one replica the whole set is omitted rather than pointed at itself,
+  which would leave a lone node retrying a join it can never complete before the
+  init Job promotes it.
+*/ -}}
+{{- $raftConfig := list -}}
+{{- $raftConfig = append $raftConfig (printf "ui = true\n") -}}
+{{- $raftConfig = append $raftConfig "listener \"tcp\" {\n  address         = \"[::]:8200\"\n  cluster_address = \"[::]:8201\"\n  tls_cert_file   = \"/openbao/tls/tls.crt\"\n  tls_key_file    = \"/openbao/tls/tls.key\"\n}\n" -}}
+{{- $storage := "storage \"raft\" {\n  path = \"/openbao/data\"\n" -}}
+{{- if gt $replicas 1 -}}
+{{-   range $i := until $replicas -}}
+{{-     $storage = printf "%s  retry_join {\n    leader_api_addr     = \"https://%s-%d.%s-internal:8200\"\n    leader_ca_cert_file = \"/openbao/tls/ca.crt\"\n  }\n" $storage $name $i $name -}}
+{{-   end -}}
+{{- end -}}
+{{- $storage = printf "%s}\n" $storage -}}
+{{- $raftConfig = append $raftConfig $storage -}}
+{{- $raftConfig = append $raftConfig "service_registration \"kubernetes\" {}\n" -}}
+
+{{- $vals := deepCopy .Values.openbao -}}
+{{- $_ := set $vals.server.ha "replicas" $replicas -}}
+{{- $_ := set $vals.server.ha.raft "config" (join "\n" $raftConfig) -}}
+{{- /*
+  The upstream chart's server.affinity is a REQUIRED podAntiAffinity on
+  kubernetes.io/hostname. Keep it wherever it can be satisfied, and drop it at
+  one replica so a single-node install schedules instead of sitting Pending.
+  Setting it empty is the escape hatch the upstream chart documents for exactly
+  this case.
+*/ -}}
+{{- if eq $replicas 1 -}}
+{{- $_ := set $vals.server "affinity" "" -}}
+{{- end -}}
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: {{ $name }}
+spec:
+  chartRef:
+    kind: ExternalArtifact
+    name: cozystack-openbao-application-default-openbao-system
+    namespace: cozy-system
+  interval: 5m
+  timeout: 10m
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    remediation:
+      retries: -1
+  values:
+    openbao: {{- toYaml $vals | nindent 6 }}

--- a/packages/system/openbao-central/templates/transit-setup-job.yaml
+++ b/packages/system/openbao-central/templates/transit-setup-job.yaml
@@ -1,0 +1,101 @@
+{{- /*
+Enables the transit secrets engine and the Kubernetes auth method on the central
+OpenBAO, so tenant OpenBAO instances can auto-unseal against it.
+
+Gated on the absence of the openbao-system-transit-ready ConfigMap (the sentinel
+written on success), so it runs once and is render-safe under Flux. Every action
+is idempotent (enable-if-absent), so a re-run after the sentinel is cleared is
+harmless. Per-tenant transit keys + scoped policies are created later by the
+cozystack operator, not here.
+*/}}
+{{- if not (lookup "v1" "ConfigMap" .Release.Namespace "openbao-system-transit-ready") }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: openbao-system-transit-setup
+  namespace: {{ .Release.Namespace }}
+spec:
+  backoffLimit: 30
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: openbao-system
+        app.kubernetes.io/component: transit-setup
+    spec:
+      serviceAccountName: openbao-system-bootstrap
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100
+      volumes:
+        - name: work
+          emptyDir: {}
+        - name: keys
+          secret:
+            secretName: openbao-system-keys
+            optional: true
+        - name: tls
+          secret:
+            secretName: openbao-system-tls
+            optional: true
+      initContainers:
+        - name: setup
+          image: {{ .Values.bootstrap.openbaoImage | quote }}
+          env:
+            - name: BAO_ADDR
+              value: https://openbao-system:8200
+            - name: BAO_CACERT
+              value: /openbao/tls/ca.crt
+          volumeMounts:
+            - name: work
+              mountPath: /work
+            - name: keys
+              mountPath: /keys
+              readOnly: true
+            - name: tls
+              mountPath: /openbao/tls
+              readOnly: true
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              echo "waiting for root token + unsealed cluster ..."
+              until [ -f /keys/root-token ]; do sleep 3; done
+              until bao status >/dev/null 2>&1; do sleep 3; done
+              BAO_TOKEN="$(cat /keys/root-token)"; export BAO_TOKEN
+
+              # transit engine (idempotent)
+              if ! bao secrets list -format=json 2>/dev/null | grep -q '"transit/"'; then
+                bao secrets enable -path=transit transit
+              fi
+
+              # kubernetes auth (idempotent)
+              if ! bao auth list -format=json 2>/dev/null | grep -q '"kubernetes/"'; then
+                bao auth enable kubernetes
+              fi
+              bao write auth/kubernetes/config \
+                kubernetes_host="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" \
+                disable_iss_validation=true
+
+              touch /work/ok
+              echo "transit + kubernetes auth ready"
+      containers:
+        - name: mark
+          image: {{ .Values.bootstrap.kubectlImage | quote }}
+          volumeMounts:
+            - name: work
+              mountPath: /work
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              if [ ! -f /work/ok ]; then
+                echo "setup did not complete"
+                exit 1
+              fi
+              kubectl create configmap openbao-system-transit-ready \
+                -n {{ .Release.Namespace }} \
+                --from-literal=ready=true \
+                --dry-run=client -o yaml | kubectl apply -f -
+              echo "sentinel written"
+{{- end }}

--- a/packages/system/openbao-central/templates/unsealer-deployment.yaml
+++ b/packages/system/openbao-central/templates/unsealer-deployment.yaml
@@ -1,0 +1,93 @@
+{{- /*
+Long-running unsealer for the central OpenBAO.
+
+The Shamir-sealed server re-seals on every restart, so a reconcile loop keeps
+all pods unsealed: it polls each pod's seal status and, when sealed, replays the
+threshold of unseal keys from the openbao-system-keys Secret. Unsealing an
+already-unsealed node is a no-op, so the loop is idempotent and safely handles
+single-pod restarts, rejoining Raft peers, and full-cluster restarts.
+*/}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openbao-system-unsealer
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: openbao-system
+    app.kubernetes.io/component: unsealer
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: openbao-system
+      app.kubernetes.io/component: unsealer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: openbao-system
+        app.kubernetes.io/component: unsealer
+    spec:
+      serviceAccountName: openbao-system-bootstrap
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100
+      volumes:
+        - name: keys
+          secret:
+            secretName: openbao-system-keys
+            optional: true
+        - name: tls
+          secret:
+            secretName: openbao-system-tls
+            optional: true
+      containers:
+        - name: unsealer
+          image: {{ .Values.bootstrap.openbaoImage | quote }}
+          env:
+            - name: BAO_CACERT
+              value: /openbao/tls/ca.crt
+            - name: UNSEAL_INTERVAL
+              value: {{ .Values.bootstrap.unsealInterval | quote }}
+            - name: KEY_THRESHOLD
+              value: {{ .Values.bootstrap.keyThreshold | quote }}
+          volumeMounts:
+            - name: keys
+              mountPath: /keys
+              readOnly: true
+            - name: tls
+              mountPath: /openbao/tls
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          command:
+            - /bin/sh
+            - -ec
+            - |
+              echo "openbao unsealer started (interval=${UNSEAL_INTERVAL}s, threshold=${KEY_THRESHOLD})"
+              while true; do
+                if [ ! -f /keys/key-0 ]; then
+                  echo "openbao-system-keys not present yet; waiting for init ..."
+                  sleep "$UNSEAL_INTERVAL"
+                  continue
+                fi
+                i=0
+                while [ "$i" -lt 3 ]; do
+                  addr="https://openbao-system-$i.openbao-system-internal:8200"
+                  if bao status -address="$addr" 2>/dev/null | grep -qi 'Sealed.*true'; then
+                    n=0
+                    while [ "$n" -lt "$KEY_THRESHOLD" ]; do
+                      if [ -f "/keys/key-$n" ]; then
+                        bao operator unseal -address="$addr" "$(cat "/keys/key-$n")" >/dev/null 2>&1 || true
+                      fi
+                      n=$((n+1))
+                    done
+                    echo "$(date -u +%FT%TZ) attempted unseal of openbao-system-$i"
+                  fi
+                  i=$((i+1))
+                done
+                sleep "$UNSEAL_INTERVAL"
+              done

--- a/packages/system/openbao-central/templates/unsealer-rbac.yaml
+++ b/packages/system/openbao-central/templates/unsealer-rbac.yaml
@@ -1,0 +1,42 @@
+{{- /*
+ServiceAccount + namespace-scoped RBAC shared by the bootstrap workloads:
+  - init-job          (creates the openbao-system-keys Secret)
+  - unsealer-deployment (reads keys, re-unseals pods)
+  - transit-setup-job  (reads root token from the keys Secret)
+Scope is intentionally limited to this namespace (cozy-openbao).
+*/}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openbao-system-bootstrap
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openbao-system-bootstrap
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "create"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openbao-system-bootstrap
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openbao-system-bootstrap
+subjects:
+  - kind: ServiceAccount
+    name: openbao-system-bootstrap
+    namespace: {{ .Release.Namespace }}

--- a/packages/system/openbao-central/tests/central_test.yaml
+++ b/packages/system/openbao-central/tests/central_test.yaml
@@ -1,0 +1,138 @@
+suite: central OpenBAO wiring invariants
+
+# internal/operator/openbao_transit_reconciler.go reaches this instance through
+# hardcoded constants: https://openbao-system.cozy-openbao.svc:8200 and the
+# openbao-system-keys / openbao-system-ca Secrets in cozy-openbao. Nothing in
+# Go fails to compile if a values edit here renames the release or turns TLS
+# off, so the naming and the scheme are pinned as assertions instead. The
+# tenant chart carries the same address as a literal in its seal stanza.
+
+templates:
+  - templates/openbao.yaml
+
+release:
+  name: openbao-central
+  namespace: cozy-openbao
+
+tests:
+  - it: "wraps the shared workload chart rather than vendoring a second copy"
+    asserts:
+      - equal:
+          path: spec.chartRef.kind
+          value: ExternalArtifact
+      - equal:
+          path: spec.chartRef.name
+          value: cozystack-openbao-application-default-openbao-system
+      - equal:
+          path: spec.chartRef.namespace
+          value: cozy-system
+
+  - it: "names the server openbao-system, which the reconciler's address assumes"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: openbao-system
+      - equal:
+          path: spec.values.openbao.fullnameOverride
+          value: openbao-system
+
+  - it: "never serves the central instance in plaintext"
+    asserts:
+      - equal:
+          path: spec.values.openbao.global.tlsDisable
+          value: false
+
+  - it: "labels the server pods for apiserver egress"
+    # service_registration "kubernetes" in the raft config needs this egress;
+    # without the label the pods hang at startup. See issue #2793.
+    asserts:
+      - equal:
+          path: spec.values.openbao.server.extraLabels["policy.cozystack.io/allow-to-apiserver"]
+          value: "true"
+      - matchRegex:
+          path: spec.values.openbao.server.ha.raft.config
+          pattern: 'service_registration "kubernetes"'
+
+  - it: "runs HA raft, not the standalone file backend"
+    asserts:
+      - equal:
+          path: spec.values.openbao.server.ha.enabled
+          value: true
+      - equal:
+          path: spec.values.openbao.server.ha.replicas
+          value: 3
+      - equal:
+          path: spec.values.openbao.server.standalone.enabled
+          value: false
+      - matchRegex:
+          path: spec.values.openbao.server.ha.raft.config
+          pattern: 'storage "raft"'
+      # One retry_join per replica, all over https so peers verify each other.
+      - matchRegex:
+          path: spec.values.openbao.server.ha.raft.config
+          pattern: 'openbao-system-2\.openbao-system-internal:8200'
+      - notMatchRegex:
+          path: spec.values.openbao.server.ha.raft.config
+          pattern: 'leader_api_addr\s+= "http://'
+
+  - it: "keeps raft as the backend at one replica, so scaling up adds voters"
+    # Not a cosmetic choice: the backend a barrier was created under cannot be
+    # changed later, so a single-node install must not land on storage "file".
+    set:
+      replicas: 1
+    asserts:
+      - equal:
+          path: spec.values.openbao.server.ha.replicas
+          value: 1
+      - equal:
+          path: spec.values.openbao.server.ha.enabled
+          value: true
+      - matchRegex:
+          path: spec.values.openbao.server.ha.raft.config
+          pattern: 'storage "raft"'
+      - notMatchRegex:
+          path: spec.values.openbao.server.ha.raft.config
+          pattern: 'storage "file"'
+      # A lone node has no cluster to join, and a self-join it can never
+      # complete would just retry until the init Job promotes it.
+      - notMatchRegex:
+          path: spec.values.openbao.server.ha.raft.config
+          pattern: retry_join
+
+  - it: "drops the hostname anti-affinity at one replica so a single node schedules"
+    # The upstream chart's server.affinity is a REQUIRED podAntiAffinity on
+    # kubernetes.io/hostname; left in place it is satisfiable only across nodes.
+    set:
+      replicas: 1
+    asserts:
+      - equal:
+          path: spec.values.openbao.server.affinity
+          value: ""
+
+  - it: "keeps the anti-affinity wherever it can be satisfied"
+    set:
+      replicas: 3
+    asserts:
+      - notExists:
+          path: spec.values.openbao.server.affinity
+
+  - it: "generates one retry_join per replica"
+    set:
+      replicas: 5
+    asserts:
+      - equal:
+          path: spec.values.openbao.server.ha.replicas
+          value: 5
+      - matchRegex:
+          path: spec.values.openbao.server.ha.raft.config
+          pattern: 'openbao-system-4\.openbao-system-internal:8200'
+      - notMatchRegex:
+          path: spec.values.openbao.server.ha.raft.config
+          pattern: 'openbao-system-5\.'
+
+  - it: "refuses a replica count below one"
+    set:
+      replicas: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: 'replicas must be at least 1'

--- a/packages/system/openbao-central/values.yaml
+++ b/packages/system/openbao-central/values.yaml
@@ -1,0 +1,112 @@
+## Central platform OpenBAO.
+##
+## This is the cluster-wide OpenBAO instance that backs auto-unseal for every
+## tenant-provisioned OpenBAO through its transit secrets engine. It runs in HA
+## mode with Raft integrated storage and end-to-end TLS.
+##
+## Its own seal is Shamir, because no cloud KMS is assumed on bare metal: a
+## one-time init Job stores the unseal keys and root token in the
+## `openbao-system-keys` Secret, and a long-running unsealer Deployment
+## re-unseals every pod after a restart. See
+## templates/{init-job,unsealer-deployment,transit-setup-job}.yaml.
+##
+## The server itself is not rendered here. This chart renders a HelmRelease
+## pointing at the same published `openbao-system` chart artifact that a tenant
+## OpenBAO instance uses, so there is one vendored copy of the upstream chart
+## rather than two, and `openbao` below is the value set handed to it.
+##
+## The release name and namespace are load-bearing, not cosmetic:
+## internal/operator/openbao_transit_reconciler.go reaches this instance at
+## https://openbao-system.cozy-openbao.svc:8200 and reads the
+## `openbao-system-keys` and `openbao-system-ca` Secrets from cozy-openbao.
+## Renaming either without changing those constants breaks tenant provisioning.
+
+## Number of server replicas. Three is the production default; one is supported
+## and is what a single-node install needs.
+##
+## Raft is the storage backend at every count, including one, deliberately: the
+## backend a barrier was created under is not something an instance can change
+## later, so scaling 1 -> 3 has to stay an in-place addition of voters rather
+## than a file-to-raft migration nobody can perform.
+##
+## Two replica-dependent things are therefore computed in templates/openbao.yaml
+## rather than written here: the retry_join set, and the anti-affinity. The
+## upstream chart's server.affinity defaults to a REQUIRED podAntiAffinity on
+## kubernetes.io/hostname, so more than one replica on a single node would sit
+## Pending forever; at replicas 1 that rule is dropped.
+replicas: 3
+
+openbao:
+  fullnameOverride: openbao-system
+
+  global:
+    # End-to-end TLS. Never expose this instance in plaintext.
+    tlsDisable: false
+
+  # The injector and CSI provider are out of scope for the platform instance;
+  # tenants consume transit auto-unseal, not sidecar injection.
+  injector:
+    enabled: false
+  csi:
+    enabled: false
+
+  server:
+    # Every pod comes up at once; init targets pod-0 and any others
+    # retry_join into the Raft cluster behind it.
+    podManagementPolicy: Parallel
+
+    # service_registration "kubernetes" below needs egress to kube-apiserver,
+    # which cozystack's allow-to-apiserver CiliumNetworkPolicy only admits for
+    # pods carrying this label. Without it the pods hang at startup with the
+    # listener open and nothing answering. See issue #2793.
+    extraLabels:
+      policy.cozystack.io/allow-to-apiserver: "true"
+
+    # The chart already sets BAO_ADDR=https://127.0.0.1:8200; it does not set a
+    # CA path, which the local bao CLI needs to verify the TLS listener.
+    extraEnvironmentVars:
+      BAO_CACERT: /openbao/tls/ca.crt
+
+    # cert-manager-issued server certificate (see templates/certmanager.yaml).
+    volumes:
+      - name: tls
+        secret:
+          secretName: openbao-system-tls
+    volumeMounts:
+      - name: tls
+        mountPath: /openbao/tls
+        readOnly: true
+
+    dataStorage:
+      enabled: true
+      size: 10Gi
+
+    # Kubernetes auth (used by tenants to authenticate to the transit engine)
+    # needs the token-reviewer binding.
+    authDelegator:
+      enabled: true
+
+    standalone:
+      enabled: false
+
+    ha:
+      enabled: true
+      raft:
+        enabled: true
+        setNodeId: true
+        # replicas, raft.config and affinity are injected by
+        # templates/openbao.yaml, which is the only place that knows the
+        # replica count.
+
+## Bootstrap workloads (init / unseal / transit setup).
+## `openbaoImage` MUST track the vendored charts/openbao appVersion of the
+## packages/system/openbao chart (the server image is
+## quay.io/openbao/openbao:<appVersion without leading v>).
+bootstrap:
+  openbaoImage: quay.io/openbao/openbao:2.5.0
+  kubectlImage: docker.io/clastix/kubectl:v1.32
+  # How often (seconds) the unsealer reconciles seal status across pods.
+  unsealInterval: 10
+  # Shamir key shares / threshold used at init time.
+  keyShares: 5
+  keyThreshold: 3


### PR DESCRIPTION
## What this PR does

Phases 1 and 2 of #2787, the platform side of tenant OpenBAO auto-unseal. Two commits: the central instance, and the reconciler that provisions per tenant against it. The tenant half is not here, see the bottom.

Worth knowing before reading the diff, because it is why a new package exists at all: `packages/system/openbao` has never been a running instance. Its component carries no `install` section, and `package_reconciler.go` creates a HelmRelease only for components that have one, so nothing ever stood it up. It is the workload chart a tenant OpenBAO renders from, published for that purpose and nothing else, which is why its values are a five line stub. The platform instance therefore gets its own package rather than being loaded into that one.

`packages/system/openbao-central` is HA raft over cert-manager issued TLS, with a Shamir seal because no cloud KMS is assumed on bare metal. A one time init Job persists the unseal keys and root token, a long running unsealer re-unseals pods after a restart, and a setup Job enables the transit engine and kubernetes auth that the per-tenant seals will use. It wraps the same published chart artifact a tenant instance uses instead of vendoring the upstream chart a second time, so one `make update` in `packages/system/openbao` moves both consumers and they cannot drift to different upstream versions.

Naming there is load-bearing and nothing in Go checks it: the reconciler reaches this instance at `https://openbao-system.cozy-openbao.svc:8200` and reads `openbao-system-keys` and `openbao-system-ca` from `cozy-openbao`. `central_test.yaml` pins the naming, the https scheme, the apiserver egress label and the raft topology, so a values edit turns into a red test instead of broken tenant provisioning.

Replicas default to 3 and go down to 1, which a single node install needs. Raft stays the backend at every count, including 1: the backend a barrier was created under cannot be changed afterwards, so scaling 1 to 3 has to be an in-place addition of voters rather than a file to raft migration nobody can perform. At one replica the `retry_join` set is omitted, because a lone node would retry a self join it cannot complete until the init Job promotes it, and the upstream chart's REQUIRED hostname anti-affinity is dropped, which is the other half of why a single node schedules at all. Rendering at 3 replicas is byte identical to the hardcoded config it replaces.

The instance also carries `policy.cozystack.io/allow-to-apiserver`. It runs `service_registration "kubernetes"`, and without that label cozystack's CiliumNetworkPolicy does not admit the egress, so the pods hang at startup with the listener open and nothing answering (#2793).

The reconciler watches inner OpenBAO HelmReleases labelled `apps.cozystack.io/transit-unseal` and ensures, per instance, a transit key, an unseal policy scoped to that key, and a kubernetes-auth role bound to the instance's server ServiceAccount. It then publishes the central CA as the `<name>-transit-ca` ConfigMap, a public certificate rather than a Secret. No token is minted or delivered: the instance exchanges its own projected ServiceAccount token for a transit token at every boot, so there is no long-lived credential in the tenant namespace to store, rotate or leak. Nothing emits that label yet, so the reconciler is inert until the tenant chart grows a transit seal.

One cost to be explicit about rather than discover later: this installs a platform OpenBAO on every paas install, and with the tenant default in the next PR being the transit seal it cannot be made opt-in without breaking that default. Three replicas is the default and one is supported, so a small install can pay less, but it does pay something.

Not in this PR, and deliberately: the tenant seal stanza, the auto-init Job on the tenant side, the migration that pins existing instances, and the e2e. Those are the next PR, which also needs #4168 for the `seal.type` enum it extends with a third value.

Verified: `make unit-tests` green on this branch, `go build ./...` and `go test ./internal/operator/...` clean, the central package renders at 1, 3 and 5 replicas and refuses 0, and the new suite was mutation checked (turning TLS off, keeping the anti-affinity at one replica and allowing a self join each turn a test red).

### Screenshots

No UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff. One hit, left unticked because the follow-up is not filed yet and I would rather a human decide whether it belongs on `next` now or with the tenant half: this adds a platform component, which the map routes to the website's `content/en/docs/next/guides/platform-stack/_index.md` and `operations/configuration/licenses.md`.

Nothing else matches. The package is under `packages/system/`, not `packages/apps/` or `packages/extra/`, so no reference page is generated for it and the website `Makefile` app lists are unaffected. No app `values.schema.json`, no `ApplicationDefinition`, no `release.prefix`, no version enum and no hand-typed CRD changed, so terraform-provider-cozystack has nothing to mirror. `packages/core/installer/values.yaml`, the platform variants and the node prerequisites are untouched, so ansible-cozystack is unaffected. The `packages/{apps,system,extra,core}` split, the `hack/` layout and the `cozy-*` namespace names are unchanged, so ccp keeps its anchors.

- [ ] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
feat(openbao): the platform now runs a central OpenBAO (`packages/system/openbao-central`) in `cozy-openbao`: HA raft over cert-manager TLS, Shamir seal with automatic init and re-unseal, and a transit engine that tenant instances will use for auto-unseal. Replicas default to 3 and are configurable down to 1 for single-node installs. The cozystack operator provisions a transit key, a scoped unseal policy and a kubernetes-auth role per tenant instance, and publishes the central CA as a ConfigMap, so no unseal token is ever stored in a tenant namespace.
```
