### PR TITLE
chore(ci): add area/openbao to the label set and the scope mapping

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -242,6 +242,10 @@
   color: 'bfd4f2'
   description: Issues or PRs related to Keycloak (SSO / identity)
 
+- name: area/openbao
+  color: 'bfd4f2'
+  description: Issues or PRs related to OpenBAO (secrets management, seals, auto-unseal)
+
 - name: area/tenant
   color: 'bfd4f2'
   description: Issues or PRs related to the tenant chart and multi-tenancy

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -108,6 +108,10 @@ jobs:
               // area/cilium
               'cilium':              'area/cilium',
 
+              // area/openbao
+              'openbao':             'area/openbao',
+              'openbao-central':     'area/openbao',
+
               // area/platform
               'platform':            'area/platform',
               'cert-manager':        'area/platform',


### PR DESCRIPTION
## What this PR does

Every openbao PR lands on `area/uncategorized`. The labeler has no scope entry for it, and there would be no label to apply if it did, so both #4168 and #4177 are sitting on the fallback right now.

`labels.yml` puts the bar for a new area at three open issues on the topic, and openbao is at three: #2787, #2483 and #2793. The shape follows what is already there for a single shipped component, next to `area/kamaji`, `area/keycloak` and `area/cilium`. The mapping takes the plain `openbao` scope and `openbao-central` alongside it, because the platform instance lives in its own package and carries its own scope.

Checked that every `area/*` and `kind/*` the labeler references is declared in `labels.yml`: 27 referenced, none missing, before and after this change. zizmor and the pre-commit hooks pass, and the embedded script still parses under github-script semantics.

### Screenshots

No UI change.

### Downstream repositories

Walked the trigger map against the diff. Nothing matches: the change is two entries under `.github/`, and no trigger in the map is keyed on the label set or the labeler. No package added, renamed or removed, no platform component or variant, no `values.schema.json`, no `ApplicationDefinition`, no `hack/` layout change, no namespace rename.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an `area/openbao` label for tracking issues and pull requests related to OpenBAO.
  - Updated automatic pull request labeling to apply this label to changes scoped to OpenBAO and OpenBAO Central.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->