### PR TITLE
test(console): add coverage for enrichSchemaWithEnums

### DIFF
--- a/packages/system/dashboard/images/console/apps/console/src/lib/backup-utils.test.ts
+++ b/packages/system/dashboard/images/console/apps/console/src/lib/backup-utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest"
+import { enrichSchemaWithEnums } from "./backup-utils.ts"
+
+describe("enrichSchemaWithEnums", () => {
+  it("returns non-object schemas unchanged", () => {
+    expect(enrichSchemaWithEnums(null, [], {})).toBeNull()
+    expect(enrichSchemaWithEnums("string", [], {})).toBe("string")
+  })
+
+  it("leaves the schema untouched when no path matches the enum map", () => {
+    const schema = { type: "string" }
+    expect(enrichSchemaWithEnums(schema, ["foo"], { bar: ["a", "b"] })).toEqual({
+      type: "string",
+    })
+  })
+
+  it("attaches enum values at a top-level path", () => {
+    const schema = { type: "string" }
+    expect(enrichSchemaWithEnums(schema, ["mode"], { mode: ["a", "b"] })).toEqual({
+      type: "string",
+      enum: ["a", "b"],
+    })
+  })
+
+  it("attaches enum values at a nested path", () => {
+    const schema = {
+      type: "object",
+      properties: { mode: { type: "string" } },
+    }
+    const result = enrichSchemaWithEnums(schema, ["spec"], {
+      "spec.mode": ["a", "b"],
+    })
+    expect(result.properties.mode).toEqual({ type: "string", enum: ["a", "b"] })
+  })
+
+  it("does not mutate the caller's path array", () => {
+    const path = ["spec"]
+    enrichSchemaWithEnums(
+      { properties: { mode: { type: "string" } } },
+      path,
+      { "spec.mode": ["a", "b"] },
+    )
+    expect(path).toEqual(["spec"])
+  })
+})


### PR DESCRIPTION
## What this PR does

backup-utils.ts (in the in-tree console dashboard) had no test file at all, despite sibling files in the same directory (dynamic-options.test.ts, crd-option-sources.test.ts, immutable-paths.test.ts) establishing that convention. Adds backup-utils.test.ts covering enrichSchemaWithEnums: the non-object passthrough, a path with no match in the enum map, a top-level enum attach, a nested one, and that the caller's path array is not mutated (verified by reading the function, it builds a new array via spread on every recursive call rather than mutating the one it receives).

Test-only change, no production code touched. Verified with vitest run src/lib/backup-utils.test.ts (5 tests pass) and tsc --noEmit (no new errors).

### Screenshots

N/A, test-only change, no UI impact.

### Downstream repositories

Walked the trigger map in docs/agents/contributing.md against the diff. This is a single new test file for a pure function, no production code, schema, API, CRD, annotation, or naming changed.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for schema enum enrichment, including top-level and nested paths.
  - Verified that unrelated schemas remain unchanged.
  - Confirmed unmatched paths and caller-provided path arrays are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->