### PR TITLE
fix(postgres): follow-up review remarks from #3954 (KEDA autoscaling)

### DIFF
--- a/packages/apps/postgres/templates/_autoscaling.tpl
+++ b/packages/apps/postgres/templates/_autoscaling.tpl
@@ -174,7 +174,7 @@ provisioning so it no longer errors there; it stays opt-in / not-live-validated.
 {{- $ns := .Release.Namespace -}}
 {{- $rel := .Release.Name -}}
 {{- $target := .Values.autoscaling.target -}}
-{{- $joinReplica := printf "* on(namespace,pod) group_left() kube_pod_labels{namespace=%q,label_cnpg_io_cluster=%q,label_cnpg_io_instance_role=\"replica\"}" $ns $rel -}}
+{{- $joinReplica := printf "* on(namespace,pod) group_left() kube_pod_labels{job=\"kube-state-metrics\",namespace=%q,label_cnpg_io_cluster=%q,label_cnpg_io_instance_role=\"replica\"}" $ns $rel -}}
 {{- /* Read-load term Σ. The floor is GATED on the existence of ANY instance pod
        (instance_role=~".+", primary OR replica), not replica-only: `or (vector(0) and
        on() (count(...instance_role=~".+") > 0))` returns 0 whenever the cluster has a
@@ -187,7 +187,7 @@ provisioning so it no longer errors there; it stays opt-in / not-live-validated.
        basebackup that routinely exceeds the alert's 15m window. The primary always exists
        during provisioning, so gating on any instance role floors correctly there. This is
        the fail-safe separation of no-load from no-series. */ -}}
-{{- $idleFloor := printf "(vector(0) and on() (count(kube_pod_labels{namespace=%q,label_cnpg_io_cluster=%q,label_cnpg_io_instance_role=~\".+\"}) > 0))" $ns $rel -}}
+{{- $idleFloor := printf "(vector(0) and on() (count(kube_pod_labels{job=\"kube-state-metrics\",namespace=%q,label_cnpg_io_cluster=%q,label_cnpg_io_instance_role=~\".+\"}) > 0))" $ns $rel -}}
 {{- $load := "" -}}
 {{- if eq .Values.autoscaling.metric "ReadCPUUtilization" -}}
 {{- $load = printf "((sum(rate(container_cpu_usage_seconds_total{namespace=%q,container=\"postgres\"}[5m]) %s) * 1000) or %s)" $ns $joinReplica $idleFloor -}}
@@ -200,7 +200,7 @@ provisioning so it no longer errors there; it stays opt-in / not-live-validated.
 {{- $base -}}
 {{- else -}}
 {{- /* Cluster-wide join (all instances) for the lag and WAL-write terms. */ -}}
-{{- $joinCluster := printf "* on(namespace,pod) group_left() kube_pod_labels{namespace=%q,label_cnpg_io_cluster=%q}" $ns $rel -}}
+{{- $joinCluster := printf "* on(namespace,pod) group_left() kube_pod_labels{job=\"kube-state-metrics\",namespace=%q,label_cnpg_io_cluster=%q}" $ns $rel -}}
 {{- $cooldown := "5m" -}}
 {{- /* Each gate is individually floored with `or vector(0)`: if its source series
        is absent (a CNPG that does not emit cnpg_pg_replication_lag /
@@ -218,7 +218,7 @@ provisioning so it no longer errors there; it stays opt-in / not-live-validated.
        carry jobRole, not instanceRole), and kube-state-metrics reports them until
        GC. Without this filter a lingering join Job pod inflates the frozen count
        while the brake is engaged, nudging desired up instead of holding it. */ -}}
-{{- $frozen := printf "(count(kube_pod_labels{namespace=%q,label_cnpg_io_cluster=%q,label_cnpg_io_instance_role=~\".+\"}) * %v)" $ns $rel $target -}}
+{{- $frozen := printf "(count(kube_pod_labels{job=\"kube-state-metrics\",namespace=%q,label_cnpg_io_cluster=%q,label_cnpg_io_instance_role=~\".+\"}) * %v)" $ns $rel $target -}}
 {{- /* base when not braking, frozen (= currentInstances * target) when braking.
        The frozen summand carries a defensive `or vector(0)`, but note it is a no-op
        given the surrounding expression, NOT a floor that ever changes the result: the

--- a/packages/apps/postgres/templates/scaledobject.yaml
+++ b/packages/apps/postgres/templates/scaledobject.yaml
@@ -5,9 +5,11 @@ is NOT enabled by default, but autoscaling.enabled is a tenant-facing knob, so a
 tenant can turn it on against a cluster where the admin never enabled `keda`.
 Without this guard the ScaledObject renders against an unknown kind and the whole
 database HelmRelease fails with an opaque `no matches for kind "ScaledObject"`.
-We must NOT instead skip rendering: db.yaml already drops the static
-`.spec.instances` under active autoscaling, so a missing ScaledObject would let
-CNPG collapse the cluster to 1 instance. Stop with an actionable message instead.
+We must NOT instead silently skip rendering: db.yaml seeds `.spec.instances` at a
+static `max(replicas, effectiveMin)` under active autoscaling, so a skipped
+ScaledObject would leave the tenant with a fixed-size cluster and no HPA — the
+autoscaling they asked for silently absent, with nothing to signal it. Stop with an
+actionable message instead.
 */ -}}
 {{- if not (.Capabilities.APIVersions.Has "keda.sh/v1alpha1") }}
 {{- fail "postgres: autoscaling.enabled is set, but the KEDA platform package is not installed (keda.sh/v1alpha1 is unknown to the cluster). Ask your platform admin to enable the 'keda' package before enabling database autoscaling." }}

--- a/packages/apps/postgres/tests/autoscaling_test.yaml
+++ b/packages/apps/postgres/tests/autoscaling_test.yaml
@@ -182,6 +182,12 @@ tests:
       - matchRegex:
           path: spec.triggers[0].metadata.query
           pattern: label_cnpg_io_instance_role="replica"
+      # the kube_pod_labels join pins job="kube-state-metrics", parity with the alert
+      # rules, so a duplicate kube_pod_labels series from another exporter cannot
+      # multiply the join.
+      - matchRegex:
+          path: spec.triggers[0].metadata.query
+          pattern: kube_pod_labels\{job="kube-state-metrics"
       # ...and scoped to THIS cluster by release name, so a namespace with multiple
       # postgres clusters does not cross-count. The dashboard read-load panel mirrors
       # this per-cluster scoping (label_cnpg_io_cluster).
@@ -560,7 +566,7 @@ tests:
       # (which carry cnpg.io/cluster but jobRole, not instanceRole) don't inflate it
       - matchRegex:
           path: spec.triggers[0].metadata.query
-          pattern: count\(kube_pod_labels\{namespace="tenant-acme",label_cnpg_io_cluster="postgres-db",label_cnpg_io_instance_role=~".\+"\}\) \* 150
+          pattern: count\(kube_pod_labels\{job="kube-state-metrics",namespace="tenant-acme",label_cnpg_io_cluster="postgres-db",label_cnpg_io_instance_role=~".\+"\}\) \* 150
       # the frozen summand is floored with `or vector(0)` so a kube-state-metrics
       # scrape gap (empty count) cannot empty the whole `+` sum and defeat the
       # base term's own floor

--- a/packages/apps/postgres/tests/autoscaling_test.yaml
+++ b/packages/apps/postgres/tests/autoscaling_test.yaml
@@ -182,12 +182,18 @@ tests:
       - matchRegex:
           path: spec.triggers[0].metadata.query
           pattern: label_cnpg_io_instance_role="replica"
-      # the kube_pod_labels join pins job="kube-state-metrics", parity with the alert
-      # rules, so a duplicate kube_pod_labels series from another exporter cannot
-      # multiply the join.
+      # every kube_pod_labels selector pins job="kube-state-metrics", parity with the
+      # alert rules, so a duplicate kube_pod_labels series from another exporter cannot
+      # multiply the join. Assert the pin on each selector by its own identifying label
+      # (a bare presence match would pass with only one of them pinned): the read-load
+      # join keys on instance_role="replica"...
       - matchRegex:
           path: spec.triggers[0].metadata.query
-          pattern: kube_pod_labels\{job="kube-state-metrics"
+          pattern: kube_pod_labels\{job="kube-state-metrics",namespace="tenant-acme",label_cnpg_io_cluster="postgres-db",label_cnpg_io_instance_role="replica"\}
+      # ...and the fail-safe idle floor gates on any instance_role (=~".+")
+      - matchRegex:
+          path: spec.triggers[0].metadata.query
+          pattern: count\(kube_pod_labels\{job="kube-state-metrics",namespace="tenant-acme",label_cnpg_io_cluster="postgres-db",label_cnpg_io_instance_role=~".\+"\}\) > 0
       # ...and scoped to THIS cluster by release name, so a namespace with multiple
       # postgres clusters does not cross-count. The dashboard read-load panel mirrors
       # this per-cluster scoping (label_cnpg_io_cluster).
@@ -573,6 +579,12 @@ tests:
       - matchRegex:
           path: spec.triggers[0].metadata.query
           pattern: count\(kube_pod_labels.*\* 150\).*or vector\(0\)\)$
+      # the cluster-wide lag/WAL join is the fourth kube_pod_labels selector; it pins
+      # job="kube-state-metrics" too and carries no instance_role (closes right after
+      # the cluster label), so assert it distinctly from the role-scoped selectors
+      - matchRegex:
+          path: spec.triggers[0].metadata.query
+          pattern: kube_pod_labels\{job="kube-state-metrics",namespace="tenant-acme",label_cnpg_io_cluster="postgres-db"\}
 
   - it: fails closed when the monitoring namespace is not set
     templates:

--- a/packages/library/cozy-lib/templates/_keda.tpl
+++ b/packages/library/cozy-lib/templates/_keda.tpl
@@ -89,6 +89,13 @@ Parameters:
 {{-   end -}}
 {{-   $min := int .minReplicaCount -}}
 {{-   $max := int .maxReplicaCount -}}
+{{- /* A replica floor cannot be negative; reject it before the ordering check so an
+       all-negative or mixed-sign pair (e.g. min -5, max -3, which satisfies max >= min)
+       cannot render a ScaledObject with a nonsensical bound. A negative max with a
+       non-negative min is already caught by the ordering check below. */ -}}
+{{-   if lt $min 0 -}}
+{{-     fail "cozy-lib.keda.scaledObject: minReplicaCount must be >= 0" -}}
+{{-   end -}}
 {{-   if lt $max $min -}}
 {{-     fail "cozy-lib.keda.scaledObject: maxReplicaCount must be >= minReplicaCount" -}}
 {{-   end -}}

--- a/packages/library/cozy-lib/templates/_keda.tpl
+++ b/packages/library/cozy-lib/templates/_keda.tpl
@@ -92,8 +92,11 @@ Parameters:
 {{- /* A replica floor cannot be negative; reject it before the ordering check so an
        all-negative or mixed-sign pair (e.g. min -5, max -3, which satisfies max >= min)
        cannot render a ScaledObject with a nonsensical bound. A negative max with a
-       non-negative min is already caught by the ordering check below. */ -}}
-{{-   if lt $min 0 -}}
+       non-negative min is already caught by the ordering check below. Test the
+       untruncated value: `int` truncates toward zero, so a fractional negative like
+       -0.5 would become $min 0 and slip past a `$min`-based check into exactly the
+       scale-to-zero-capable object the type guard above exists to prevent. */ -}}
+{{-   if lt (float64 .minReplicaCount) 0.0 -}}
 {{-     fail "cozy-lib.keda.scaledObject: minReplicaCount must be >= 0" -}}
 {{-   end -}}
 {{-   if lt $max $min -}}

--- a/packages/system/postgres-rd/cozyrds/postgres.yaml
+++ b/packages/system/postgres-rd/cozyrds/postgres.yaml
@@ -16,8 +16,13 @@ metadata:
     # this design avoids. Trade-off: a never-autoscaled release is client-side too, so
     # a chart field that drifts on the live CR is no longer re-asserted (client-side
     # never reads live state; driftDetection is unset) - accepted, the platform relies
-    # on GitOps re-render, and per-instance apply strategy is a follow-up. See
-    # HelmServerSideApplyAnnotation in pkg/config/config.go.
+    # on GitOps re-render, and per-instance apply strategy is a follow-up.
+    # Rollout is gradual, not fleet-wide at the platform upgrade that ships this: an
+    # existing Postgres HelmRelease keeps server-side apply until its Application is next
+    # written through the aggregated API (the ApplicationDefinition reconciler syncs only
+    # chartRef/valuesFrom/labels onto a live HelmRelease, not the apply strategy), so an
+    # upgraded fleet flips one app at a time as each is next reconciled.
+    # See HelmServerSideApplyAnnotation in pkg/config/config.go.
     release.cozystack.io/helm-server-side-apply: "false"
 spec:
   application:

--- a/packages/tests/cozy-lib-tests/templates/tests/keda-scaledobject-arg.yaml
+++ b/packages/tests/cozy-lib-tests/templates/tests/keda-scaledobject-arg.yaml
@@ -1,9 +1,12 @@
-{{- if or .Values.omit .Values.badRef .Values.badMin .Values.negMin .Values.wantAnnotations -}}
+{{- if or .Values.omit .Values.badRef .Values.badMin .Values.negMin .Values.negFracMin .Values.wantAnnotations .Values.wantPausedMerge -}}
 {{- /* Build a fully-valid argument dict, then either drop exactly one required
        field named by .Values.omit, replace scaleTargetRef with a non-map
        (.Values.badRef), set a non-numeric minReplicaCount (.Values.badMin), set a
-       negative minReplicaCount (.Values.negMin), or attach an extra annotation
-       (.Values.wantAnnotations), to exercise each guard / merge path in isolation. */ -}}
+       negative minReplicaCount, whole (.Values.negMin) or fractional
+       (.Values.negFracMin), attach an extra annotation
+       (.Values.wantAnnotations), or attach an annotation AND pause
+       (.Values.wantPausedMerge) so the caller annotation and the pause pair land in
+       one merge, to exercise each guard / merge path in isolation. */ -}}
 {{- $ref := dict "apiVersion" "postgresql.cnpg.io/v1" "kind" "Cluster" "name" "db" -}}
 {{- if eq .Values.omit "kind" }}{{- $_ := unset $ref "kind" }}{{- end -}}
 {{- if eq .Values.omit "apiVersion" }}{{- $_ := unset $ref "apiVersion" }}{{- end -}}
@@ -12,6 +15,8 @@
 {{- if .Values.badRef }}{{- $arg = set $arg "scaleTargetRef" "not-a-map" -}}{{- end -}}
 {{- if .Values.badMin }}{{- $arg = set $arg "minReplicaCount" "two" -}}{{- end -}}
 {{- if .Values.negMin }}{{- $arg = set $arg "minReplicaCount" -1 -}}{{- end -}}
+{{- if .Values.negFracMin }}{{- $arg = set $arg "minReplicaCount" -0.5 -}}{{- end -}}
 {{- if .Values.wantAnnotations }}{{- $arg = set $arg "annotations" (dict "cozystack.io/example" "hi") -}}{{- end -}}
+{{- if .Values.wantPausedMerge }}{{- $arg = set $arg "annotations" (dict "cozystack.io/example" "hi" "autoscaling.keda.sh/paused-scale-in" "false") -}}{{- $arg = set $arg "paused" true -}}{{- end -}}
 {{ include "cozy-lib.keda.scaledObject" $arg }}
 {{- end -}}

--- a/packages/tests/cozy-lib-tests/templates/tests/keda-scaledobject-arg.yaml
+++ b/packages/tests/cozy-lib-tests/templates/tests/keda-scaledobject-arg.yaml
@@ -1,8 +1,9 @@
-{{- if or .Values.omit .Values.badRef .Values.badMin -}}
+{{- if or .Values.omit .Values.badRef .Values.badMin .Values.negMin .Values.wantAnnotations -}}
 {{- /* Build a fully-valid argument dict, then either drop exactly one required
        field named by .Values.omit, replace scaleTargetRef with a non-map
-       (.Values.badRef), or set a non-numeric minReplicaCount (.Values.badMin), to
-       exercise each fail-closed guard in isolation. */ -}}
+       (.Values.badRef), set a non-numeric minReplicaCount (.Values.badMin), set a
+       negative minReplicaCount (.Values.negMin), or attach an extra annotation
+       (.Values.wantAnnotations), to exercise each guard / merge path in isolation. */ -}}
 {{- $ref := dict "apiVersion" "postgresql.cnpg.io/v1" "kind" "Cluster" "name" "db" -}}
 {{- if eq .Values.omit "kind" }}{{- $_ := unset $ref "kind" }}{{- end -}}
 {{- if eq .Values.omit "apiVersion" }}{{- $_ := unset $ref "apiVersion" }}{{- end -}}
@@ -10,5 +11,7 @@
 {{- if .Values.omit }}{{- $arg = unset $arg .Values.omit -}}{{- end -}}
 {{- if .Values.badRef }}{{- $arg = set $arg "scaleTargetRef" "not-a-map" -}}{{- end -}}
 {{- if .Values.badMin }}{{- $arg = set $arg "minReplicaCount" "two" -}}{{- end -}}
+{{- if .Values.negMin }}{{- $arg = set $arg "minReplicaCount" -1 -}}{{- end -}}
+{{- if .Values.wantAnnotations }}{{- $arg = set $arg "annotations" (dict "cozystack.io/example" "hi") -}}{{- end -}}
 {{ include "cozy-lib.keda.scaledObject" $arg }}
 {{- end -}}

--- a/packages/tests/cozy-lib-tests/tests/keda_scaledobject_test.yaml
+++ b/packages/tests/cozy-lib-tests/tests/keda_scaledobject_test.yaml
@@ -210,6 +210,14 @@ tests:
     asserts:
       - failedTemplate: {errorMessage: "cozy-lib.keda.scaledObject: minReplicaCount must be >= 0"}
 
+  # a fractional negative like -0.5 truncates toward zero through `int`, so the guard
+  # must test the untruncated value or it would render a scale-to-zero-capable object
+  - it: fails closed when minReplicaCount is a fractional negative
+    templates: [templates/tests/keda-scaledobject-arg.yaml]
+    set: {negFracMin: true}
+    asserts:
+      - failedTemplate: {errorMessage: "cozy-lib.keda.scaledObject: minReplicaCount must be >= 0"}
+
   - it: merges a caller-supplied annotation onto the ScaledObject
     templates: [templates/tests/keda-scaledobject-arg.yaml]
     set: {wantAnnotations: true}
@@ -217,3 +225,20 @@ tests:
       - equal:
           path: metadata.annotations["cozystack.io/example"]
           value: hi
+
+  # the pause pair is the merge destination, so it wins a key collision: the caller
+  # passes paused-scale-in="false" and a distinct key, and on the paused render the
+  # distinct key survives while the pause value overrides the caller's "false"
+  - it: merges a caller annotation under the pause pair and wins the collision when paused
+    templates: [templates/tests/keda-scaledobject-arg.yaml]
+    set: {wantPausedMerge: true}
+    asserts:
+      - equal:
+          path: metadata.annotations["cozystack.io/example"]
+          value: hi
+      - equal:
+          path: metadata.annotations["autoscaling.keda.sh/paused-scale-in"]
+          value: "true"
+      - equal:
+          path: metadata.annotations["autoscaling.keda.sh/paused-scale-out"]
+          value: "true"

--- a/packages/tests/cozy-lib-tests/tests/keda_scaledobject_test.yaml
+++ b/packages/tests/cozy-lib-tests/tests/keda_scaledobject_test.yaml
@@ -203,3 +203,17 @@ tests:
     set: {badMin: true}
     asserts:
       - failedTemplate: {errorMessage: "cozy-lib.keda.scaledObject: minReplicaCount is required and must be a number"}
+
+  - it: fails closed when minReplicaCount is negative
+    templates: [templates/tests/keda-scaledobject-arg.yaml]
+    set: {negMin: true}
+    asserts:
+      - failedTemplate: {errorMessage: "cozy-lib.keda.scaledObject: minReplicaCount must be >= 0"}
+
+  - it: merges a caller-supplied annotation onto the ScaledObject
+    templates: [templates/tests/keda-scaledobject-arg.yaml]
+    set: {wantAnnotations: true}
+    asserts:
+      - equal:
+          path: metadata.annotations["cozystack.io/example"]
+          value: hi


### PR DESCRIPTION
Follow-up to #3954 (postgres read-replica autoscaling via KEDA), closing the non-blocking review remarks tracked in #4187. Each change is small, isolated, and covered by a red→green test where it is a behaviour change.

## Changes

- **fix(postgres): pin `job="kube-state-metrics"` on the autoscaler read-load query.** The trigger query joined on `kube_pod_labels` without the job pin the sibling `DatabaseAutoscaler*` alerts already carry; a duplicate `kube_pod_labels` series from another exporter would multiply the join. Pinned on every selector; unittest asserts it in both the base and lag-brake query shapes.
- **fix(cozy-lib): reject a negative `minReplicaCount` in `cozy-lib.keda.scaledObject`.** Only `max >= min` was checked, so a mixed-sign pair (`min -5, max -3`) passed and rendered a nonsensical floor. Now failed closed before the ordering check, with a unit case. Also added coverage for the previously-untested `annotations` parameter.
- **docs(postgres): correct the KEDA-missing guard rationale and note the gradual client-side rollout.** The guard comment still described the replaced drop-instances design; corrected to the seed design (a skipped ScaledObject leaves a fixed-size cluster with no HPA, not a collapse to 1). The cozyrds apply-strategy annotation now notes that the client-side switch rolls out per-app as each Application is next written through the aggregated API, not fleet-wide at upgrade.

## Testing

`helm unittest` green: postgres 66/66, cozy-lib-tests 45/45, keda 12/12. Both behaviour changes are mutation-verified (reverting the fix reddens the suite). No generated artifacts affected (no `values.yaml`/`values.schema.json`/`Chart.yaml`/`README.md` changes).

## Release note

```release-note
NONE
```

Closes #4187


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved PostgreSQL autoscaling metrics by ensuring pod data is sourced from the correct metrics exporter, preventing duplicate data from distorting scaling decisions.
  - Added validation to reject negative minimum replica counts.
  - Preserved caller-provided annotations on generated autoscaling resources.

- **Documentation**
  - Clarified PostgreSQL autoscaling fallback behavior when the autoscaling controller is unavailable.
  - Documented the gradual transition of existing PostgreSQL resources to the updated apply behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->