### PR TITLE
fix(tests): stop the RD preset check reporting presets that are present

### DIFF
--- a/hack/check-rd-presets.sh
+++ b/hack/check-rd-presets.sh
@@ -16,6 +16,8 @@ EXPECTED=(
 )
 
 fail=0
+jq_err=$(mktemp)
+trap 'rm -f "$jq_err"' EXIT
 for f in packages/system/*-rd/cozyrds/*.yaml; do
   schema=$(yq -r '.spec.application.openAPISchema // ""' "$f")
   if [ -z "$schema" ]; then
@@ -24,12 +26,30 @@ for f in packages/system/*-rd/cozyrds/*.yaml; do
   # Pull every resourcesPreset enum out of the schema. Key on the JSON
   # path ending in "resourcesPreset" rather than a description heuristic,
   # so an unrelated field with "preset" in its description does not match.
-  enums=$(printf '%s' "$schema" | jq -r '
+  #
+  # Fed by here-string rather than `printf | jq`, and its status is read rather
+  # than discarded, because the two together produced a FALSE FAILURE naming a
+  # preset that is present in the file. On a 4-CPU/16 GiB runner under `make
+  # -j4`, jq processing the largest schema here would exit early; `printf` then
+  # died of EPIPE ("write error: Broken pipe"), `2>/dev/null || true` hid the
+  # status, and $enums held the PARTIAL output -- non-empty, so the guard below
+  # passed it through, and every expected value past the truncation point was
+  # reported missing. Seen on two PRs the same day naming different files and
+  # different presets, which is the tell: a real drift names the same pair every
+  # time. A here-string cannot raise EPIPE, and a non-zero jq is now named as an
+  # unreadable schema instead of being converted into a data defect.
+  if ! enums=$(jq -r '
     [paths(type == "object" and has("enum")) as $p
      | select($p[-1] == "resourcesPreset")
      | getpath($p).enum[]]
     | .[]
-  ' 2>/dev/null || true)
+  ' <<<"$schema" 2>"$jq_err"); then
+    echo "FAIL: $f openAPISchema could not be read, so its presets were not checked: $(tr '\n' ' ' <"$jq_err")" >&2
+    fail=1
+    continue
+  fi
+  # Empty stays a skip, not a failure: most RDs define no resourcesPreset at all,
+  # and only a read that ERRORED is evidence of anything.
   if [ -z "$enums" ]; then
     continue
   fi
@@ -47,8 +67,10 @@ for f in packages/system/*-rd/cozyrds/*.yaml; do
 done
 
 if [ "$fail" -ne 0 ]; then
-  echo "Some RD schemas are out of sync with the canonical preset set." >&2
-  echo "Run 'make generate' inside the affected chart directory." >&2
+  echo "One or more RD schemas did not pass the preset check above." >&2
+  echo "A missing preset is drift: run 'make generate' inside the affected chart" >&2
+  echo "directory. A schema that could not be read is not drift and carries its" >&2
+  echo "own reason on the line that names it." >&2
   exit 1
 fi
 echo "All RD schemas carry the full 47-preset enum."

--- a/hack/check-rd-presets.sh
+++ b/hack/check-rd-presets.sh
@@ -27,17 +27,14 @@ for f in packages/system/*-rd/cozyrds/*.yaml; do
   # path ending in "resourcesPreset" rather than a description heuristic,
   # so an unrelated field with "preset" in its description does not match.
   #
-  # Fed by here-string rather than `printf | jq`, and its status is read rather
-  # than discarded, because the two together produced a FALSE FAILURE naming a
-  # preset that is present in the file. On a 4-CPU/16 GiB runner under `make
-  # -j4`, jq processing the largest schema here would exit early; `printf` then
-  # died of EPIPE ("write error: Broken pipe"), `2>/dev/null || true` hid the
-  # status, and $enums held the PARTIAL output -- non-empty, so the guard below
-  # passed it through, and every expected value past the truncation point was
-  # reported missing. Seen on two PRs the same day naming different files and
-  # different presets, which is the tell: a real drift names the same pair every
-  # time. A here-string cannot raise EPIPE, and a non-zero jq is now named as an
-  # unreadable schema instead of being converted into a data defect.
+  # jq's status is read rather than discarded. `2>/dev/null || true` left a
+  # read that failed indistinguishable from one that found nothing, and it goes
+  # two ways: with no output the emptiness guard below turned it into a clean
+  # skip, so a schema nobody could parse silently passed the check whose whole
+  # job is to parse it, and with output already written before jq died $enums
+  # held a truncated list that every preset past the cut was then judged
+  # against. An errored read is now named as one and carries jq's own reason.
+  # Fed by here-string for the same reason as the membership test below.
   if ! enums=$(jq -r '
     [paths(type == "object" and has("enum")) as $p
      | select($p[-1] == "resourcesPreset")

--- a/hack/check-rd-presets.sh
+++ b/hack/check-rd-presets.sh
@@ -56,7 +56,13 @@ for f in packages/system/*-rd/cozyrds/*.yaml; do
   missing=()
   for want in "${EXPECTED[@]}"; do
     # -F: literal match so the `.` in t1.nano does not match any character.
-    if ! printf '%s\n' "$enums" | grep -Fqx -- "$want"; then
+    # A here-string, not a pipe: `grep -q` exits on its first match, so a pipe
+    # leaves the writer with unwritten output and kills it with SIGPIPE. Under
+    # `set -o pipefail` that becomes exit 141 for the whole pipeline, which
+    # reads exactly like "not found" — so a preset that IS present is reported
+    # missing, on a different file and a different preset each run. Measured at
+    # roughly one spurious failure per run of this script.
+    if ! grep -Fqx -- "$want" <<<"$enums"; then
       missing+=("$want")
     fi
   done

--- a/hack/check-rd-presets_test.bats
+++ b/hack/check-rd-presets_test.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+# -----------------------------------------------------------------------------
+# Regression guard for hack/check-rd-presets.sh: a schema it could not read must
+# be reported as unreadable, never as a chart whose presets drifted.
+#
+# The distinction is not academic. The script used to feed jq through a pipe and
+# discard its status (`printf '%s' "$schema" | jq ... 2>/dev/null || true`). When
+# jq exited early -- seen on the 4-CPU/16 GiB unit runner under `make -j4` --
+# printf died of EPIPE and the variable held PARTIAL output. Non-empty, so the
+# emptiness guard passed it through, and every expected preset past the
+# truncation point was reported missing from a file that contained all of them.
+# Two PRs the same day were reddened that way, naming different files and
+# different presets, which is the tell: real drift names the same pair every run.
+#
+# The stub reproduces exactly that shape -- some values on stdout, an error on
+# stderr, a non-zero exit -- because that is the case the old code turned into a
+# false verdict, and a stub that merely fails with no output would pass against
+# the old code too.
+#
+# Compatible with the in-repo cozytest.sh runner, which runs each @test in a
+# fresh subshell under `set -u` and provides no bats `run`/`$status`.
+# -----------------------------------------------------------------------------
+
+@test "a schema that cannot be read is named as unreadable, not as a missing preset" {
+    work=$(mktemp -d)
+    cat > "$work/jq" <<'STUB'
+#!/bin/sh
+printf '%s\n' t1.nano t1.micro
+echo "jq: error (at <stdin>:0): simulated early exit" >&2
+exit 2
+STUB
+    chmod +x "$work/jq"
+
+    rc=0
+    out=$(PATH="$work:$PATH" hack/check-rd-presets.sh 2>&1) || rc=$?
+    rm -rf "$work"
+
+    if [ "$rc" -eq 0 ]; then
+        echo "the check passed while every schema read was failing" >&2
+        printf '%s\n' "$out" >&2
+        exit 1
+    fi
+    case "$out" in
+        *"could not be read"*) ;;
+        *)
+            echo "a failed read was not named as one" >&2
+            printf '%s\n' "$out" >&2
+            exit 1 ;;
+    esac
+    case "$out" in
+        *"resourcesPreset enum missing"*)
+            echo "a failed read was reported as drift, which is the regression this guards" >&2
+            printf '%s\n' "$out" >&2
+            exit 1 ;;
+    esac
+    # The reason travels with the verdict, so a reader does not have to reproduce
+    # the failure to learn what jq objected to.
+    case "$out" in
+        *"simulated early exit"*) ;;
+        *)
+            echo "the message dropped jq's own reason" >&2
+            printf '%s\n' "$out" >&2
+            exit 1 ;;
+    esac
+}

--- a/hack/check-rd-presets_test.bats
+++ b/hack/check-rd-presets_test.bats
@@ -1,25 +1,72 @@
 #!/usr/bin/env bats
 # -----------------------------------------------------------------------------
-# Regression guard for hack/check-rd-presets.sh: a schema it could not read must
-# be reported as unreadable, never as a chart whose presets drifted.
+# Regression guards for hack/check-rd-presets.sh, covering the two ways it used
+# to reach a verdict the files do not support, plus the matching contract the
+# fix rests on.
 #
-# The distinction is not academic. The script used to feed jq through a pipe and
-# discard its status (`printf '%s' "$schema" | jq ... 2>/dev/null || true`). When
-# jq exited early -- seen on the 4-CPU/16 GiB unit runner under `make -j4` --
-# printf died of EPIPE and the variable held PARTIAL output. Non-empty, so the
-# emptiness guard passed it through, and every expected preset past the
-# truncation point was reported missing from a file that contained all of them.
-# Two PRs the same day were reddened that way, naming different files and
-# different presets, which is the tell: real drift names the same pair every run.
+# The first is a read it could not complete. `printf '%s' "$schema" | jq ...
+# 2>/dev/null || true` discarded jq's status, so a read that failed was skipped
+# in silence, or worse, passed on whatever jq had already written before it
+# died: the check that exists to parse a schema was free not to parse it.
 #
-# The stub reproduces exactly that shape -- some values on stdout, an error on
-# stderr, a non-zero exit -- because that is the case the old code turned into a
-# false verdict, and a stub that merely fails with no output would pass against
-# the old code too.
+# The second is the one that reddened pull requests. Membership was decided by
+# `printf '%s\n' "$enums" | grep -Fqx -- "$want"`, and `grep -q` exits at its
+# first match. Once the list is longer than the pipe buffer the writer is still
+# writing when the reader leaves, the write fails, and `set -o pipefail` reports
+# the pipeline as failed even though grep matched -- a verdict indistinguishable
+# from "not found", so a preset that is present is named as missing. Below the
+# buffer size the writer usually wins, which is why it stayed hidden while
+# `make unit-tests` ran serially and started firing on the 4-CPU runner under
+# `make -j4`: 32 of the 48 unit-lane failures over 2026-09-04..09-10, each
+# naming a different preset in a different file, each carrying one
+# "printf: write error: Broken pipe" per preset it accused.
+#
+# Cases that need control over which files are walked build a package tree with
+# a single ApplicationDefinition in it, because the checker globs
+# packages/system/*-rd/cozyrds/*.yaml relative to the working directory. That
+# is what keeps the large-payload case to 47 greps rather than 1504.
 #
 # Compatible with the in-repo cozytest.sh runner, which runs each @test in a
 # fresh subshell under `set -u` and provides no bats `run`/`$status`.
 # -----------------------------------------------------------------------------
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
+CHECK="$REPO_ROOT/hack/check-rd-presets.sh"
+
+# The presets the checker expects, one per line. Read from its own source of
+# truth so a fixture cannot disagree with it by accident; the last case below is
+# what stops that array from being whatever the schemas happen to carry.
+expected_presets() {
+    sed -n '/^EXPECTED=(/,/^)/p' "$CHECK" | sed '1d;$d' | tr -s '[:space:]' '\n' | sed '/^$/d'
+}
+
+# A package tree holding one ApplicationDefinition, left as the current
+# directory. The schema body is a placeholder: every case that uses this drives
+# the enum through the jq stub instead.
+make_tree() {
+    dir=$(mktemp -d)
+    cd "$dir"
+    mkdir -p packages/system/foo-rd/cozyrds packages/apps packages/extra
+    printf 'spec:\n  application:\n    openAPISchema: |-\n      {"type":"object"}\n' \
+        > packages/system/foo-rd/cozyrds/foo.yaml
+}
+
+# A jq stub in $1/jq that prints the file $2 and exits 0.
+install_jq_stub() {
+    cat > "$1/jq" <<STUB
+#!/bin/sh
+cat "$2"
+STUB
+    chmod +x "$1/jq"
+}
+
+# Last line of a test body rather than a trap, which the runners forbid: both
+# set -e, so a failing test never reaches this and its tree survives for
+# inspection, which is what a failed test wants.
+cleanup() {
+    cd /
+    rm -rf "$dir"
+}
 
 @test "a schema that cannot be read is named as unreadable, not as a missing preset" {
     work=$(mktemp -d)
@@ -32,7 +79,7 @@ STUB
     chmod +x "$work/jq"
 
     rc=0
-    out=$(PATH="$work:$PATH" hack/check-rd-presets.sh 2>&1) || rc=$?
+    out=$(PATH="$work:$PATH" "$CHECK" 2>&1) || rc=$?
     rm -rf "$work"
 
     if [ "$rc" -eq 0 ]; then
@@ -62,4 +109,109 @@ STUB
             printf '%s\n' "$out" >&2
             exit 1 ;;
     esac
+}
+
+@test "a preset list far past any pipe capacity is read whole, not reported missing" {
+    # A schema that repeats the set per component is ordinary: seaweedfs-rd
+    # carries 329 entries today. Doubled to 4 MiB it is past what a process can
+    # even ask for -- fs/pipe-max-size is 1 MiB on the runners -- so the old
+    # pipeline cannot finish its write before grep leaves, on any host, rather
+    # than losing a race the writer often wins at the sizes seen in CI.
+    make_tree
+    expected_presets > enums
+    while [ "$(wc -c < enums)" -lt 4194304 ]; do
+        cat enums enums > enums.next
+        mv enums.next enums
+    done
+    install_jq_stub "$dir" "$dir/enums"
+
+    rc=0
+    out=$(PATH="$dir:$PATH" "$CHECK" 2>&1) || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "a complete preset list was rejected because of its length" >&2
+        printf '%s\n' "$out" >&2
+        exit 1
+    fi
+    cleanup
+}
+
+@test "a preset genuinely absent from the schema is reported and named" {
+    make_tree
+    expected_presets | sed '/^c1\.medium$/d' > enums
+    install_jq_stub "$dir" "$dir/enums"
+
+    rc=0
+    out=$(PATH="$dir:$PATH" "$CHECK" 2>&1) || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "a schema missing c1.medium passed" >&2
+        printf '%s\n' "$out" >&2
+        exit 1
+    fi
+    case "$out" in
+        *"resourcesPreset enum missing: c1.medium"*) ;;
+        *)
+            echo "the verdict did not name c1.medium as the missing preset" >&2
+            printf '%s\n' "$out" >&2
+            exit 1 ;;
+    esac
+    cleanup
+}
+
+@test "a preset the schema only resembles does not count as carrying it" {
+    # Both flags on the membership grep are load-bearing and neither is visible
+    # from a fixture that simply omits a value. `t1.nanoX` satisfies a match
+    # without -x, and `c1Xsmall` satisfies one without -F because the `.` in the
+    # pattern then matches any character. Either way the checker would pass a
+    # schema that carries neither preset, so the verdict has to name both.
+    make_tree
+    expected_presets | sed 's/^t1\.nano$/t1.nanoX/; s/^c1\.small$/c1Xsmall/' > enums
+    install_jq_stub "$dir" "$dir/enums"
+
+    rc=0
+    out=$(PATH="$dir:$PATH" "$CHECK" 2>&1) || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "a schema carrying t1.nanoX and c1Xsmall passed as carrying t1.nano and c1.small" >&2
+        printf '%s\n' "$out" >&2
+        exit 1
+    fi
+    for want in t1.nano c1.small; do
+        case "$out" in
+            *"$want"*) ;;
+            *)
+                echo "$want was not reported missing, so the match is not literal and whole-line" >&2
+                printf '%s\n' "$out" >&2
+                exit 1 ;;
+        esac
+    done
+    cleanup
+}
+
+@test "EXPECTED is the canonical set, not whatever the schemas happen to carry" {
+    # Built from the contract the script's own header states -- five instance
+    # type families across eight sizes, plus the seven legacy aliases, which
+    # have no 4xlarge -- rather than read out of the array. Every case above
+    # takes its fixture from EXPECTED and therefore cannot see a name being
+    # dropped from it, which is the one thing this check exists to prevent.
+    work=$(mktemp -d)
+    for family in t1 c1 s1 u1 m1; do
+        for size in nano micro small medium large xlarge 2xlarge 4xlarge; do
+            echo "$family.$size"
+        done
+    done > "$work/canonical"
+    printf '%s\n' nano micro small medium large xlarge 2xlarge >> "$work/canonical"
+    sort "$work/canonical" > "$work/canonical.sorted"
+    expected_presets | sort > "$work/actual.sorted"
+
+    n=$(wc -l < "$work/canonical.sorted")
+    if [ "$n" -ne 47 ]; then
+        echo "the canonical set built here is $n names, not the documented 47" >&2
+        rm -rf "$work"
+        exit 1
+    fi
+    if ! diff -u "$work/canonical.sorted" "$work/actual.sorted"; then
+        echo "EXPECTED no longer matches the canonical 40 instance types plus 7 aliases" >&2
+        rm -rf "$work"
+        exit 1
+    fi
+    rm -rf "$work"
 }


### PR DESCRIPTION
## What this PR does

`rd-presets-check` could reach two verdicts that files do not support, and neither of them is drift.

### The one that reddened other PRs

Membership was `printf '%s\n' "$enums" | grep -Fqx -- "$want"`. `grep -q` exits on first match and closes the pipe, writer is still writing, write fails, and `set -o pipefail` then reports whole pipeline as failed even though grep matched. Caller reads that exactly like "not found", so a preset that is present gets named as missing.

I went over every unit-lane failure on a PR between 2026-09-04 and 2026-09-10. 48 of 269 jobs failed, 32 of those were this, on 21 different branches. Three things from the logs:

- all 41 `printf: write error: Broken pipe` lines name line 39, which is the membership pipeline (jq one ends on line 32, and bash names last line of a multiline pipeline)
- count of accused presets equals count of broken pipes in the same run, every time, one and one, two and two
- accused preset is a single value anywhere in the set, 24 distinct ones across those runs, and the file differs run to run

Past the pipe buffer it stops being a race and fails on every preset, and that is what the new guard uses. Below that size the writer usually wins, so this sat here since May: while `make unit-tests` ran serially the check had the runner to itself. e49633208 put the lane on `make -j4` on a 4-CPU runner, and now it samples that race about a thousand times per run (21 of 32 RD files carry a `resourcesPreset` enum, 47 presets each).

Fix is @kvaps's, from #4142, cherry-picked with his authorship so it can land without waiting on the reserved addresses work.

### The one that passed in silence

`enums=$(printf '%s' "$schema" | jq -r '...' 2>/dev/null || true)` discarded jq status, so a read that failed was indistinguishable from a read that found nothing. That goes two ways. With no output the emptiness guard below made it a clean skip, so a schema nobody could parse passed the check whose whole job is to parse it. With output already written before jq died, `$enums` held a truncated list and every preset past the cut was judged against it. Errored read is now named as one and carries jq own reason. Empty output stays a skip, because most RDs define no `resourcesPreset` at all.

### Correction

First version of this PR read those false failures as a truncated jq read. That mechanism is real, but it is not what these runs were. Line numbers point at the membership pipeline, and a truncated read would accuse the contiguous tail of the list rather than one preset from the middle. jq change stays because that path is a fail-open on its own, not because it caused those runs.

## Testing

`hack/check-rd-presets_test.bats`, five cases, driven through a jq stub so only the schema the checker reads is under test control. Membership one feeds a list doubled past 4 MiB: `fs/pipe-max-size` is 1 MiB, so no pipe can hold it and the old pipeline fails on every preset instead of losing a race the writer often won at the sizes CI actually saw. That case uses a one-file fixture tree, which keeps it at 47 greps rather than 1504.

Each guard was checked by mutation, and each is caught by the case that names its contract:

| mutation | caught by |
| --- | --- |
| restore the old `printf \| grep -Fqx` pipe | list past any pipe capacity |
| drop `-x` from the membership grep | a preset the schema only resembles |
| drop `-F` from the membership grep | a preset the schema only resembles |
| drop a name from `EXPECTED` | EXPECTED is the canonical set |
| swallow jq's status again | a schema that cannot be read |

`make unit-tests test-controllers -j4 --output-sync=target` on this branch: exit 0, 1589 bats cases, 314 helm suites. shellcheck clean, and the suite runs green under `dash hack/cozytest.sh`, not just parses.

Branch is 59 commits behind main and needs a rebase before merge.

## Why it matters beyond the noise

`finalize` needs `checks` and `e2e` needs `finalize`, so a red unit lane skips the hour-long install. False red does not just redden a PR, it leaves it with no e2e verdict at all. #4171 sat on that for two attempts, both with `e2e` skipped.

### Screenshots

Not applicable, no UI change.

### Downstream repositories

- [x] No downstream repository is affected by this change

Both files are under `hack/`, nothing moved or renamed, and `make rd-presets-check` keeps its contract. cozystack/ccp gates on `hack/package.mk`, `hack/common-envs.mk` and failure modes of `make generate`, none of which this touches.

### Release note

```release-note
fix(tests): RD preset check no longer reports a resourcesPreset that is present in the schema as missing, and a schema it cannot parse is reported as unreadable instead of being skipped in silence.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preset validation to correctly detect unreadable schemas and preserve underlying error details.
  * Prevented partial schema output and long preset lists from causing incorrect missing-preset reports.
  * Ensured similarly named presets are not treated as valid matches.
  * Updated failure messages to distinguish schema read errors from preset mismatches.

* **Tests**
  * Added regression coverage for unreadable schemas, large preset lists, exact preset matching, missing presets, and the canonical preset set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->