### PR TITLE
fix(ci): stop check-rd-presets reporting present presets as missing

### DIFF
--- a/hack/check-rd-presets.bats
+++ b/hack/check-rd-presets.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+# Guards the membership check in hack/check-rd-presets.sh against reporting a
+# preset that is present as missing.
+#
+# That is what it used to do. The check was
+# `printf '%s\n' "$enums" | grep -Fqx -- "$want"` in a script running under
+# `set -o pipefail`: grep -q exits on its first match and can close the pipe
+# while printf is still writing, printf fails with EPIPE, pipefail makes the
+# pipeline non-zero, and the `!` reads that as "not found". See #4193 for the
+# CI log. These tests do not try to win that race, since a test that only
+# reddens when the scheduler cooperates is the flaky kind this repo does not
+# add. They pin the two outcomes the check owes: a complete enum passes, an
+# incomplete one fails and says which value is gone.
+#
+# hack/cozytest.sh knows @test and plain bash: no setup/teardown, no `run`.
+# The fixture is written with jq alone so the test does not depend on which
+# yq dialect is installed.
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)"
+SCRIPT="$REPO_ROOT/hack/check-rd-presets.sh"
+
+# Writes a probe ApplicationDefinition under $TMP. $1 is a canonical preset to
+# leave out of the enum, or "" to keep all 47.
+write_probe_rd() {
+  mkdir -p "$TMP/packages/system/probe-rd/cozyrds"
+  jq -rn --arg drop "$1" '
+    def canonical:
+      ["t1","c1","s1","u1","m1"] as $fam
+      | ["nano","micro","small","medium","large","xlarge","2xlarge","4xlarge"] as $sz
+      | [$fam[] as $f | $sz[] | "\($f).\(.)"]
+        + ["nano","micro","small","medium","large","xlarge","2xlarge"];
+    {properties:{resources:{properties:{resourcesPreset:{
+      enum: (canonical | map(select($drop == "" or . != $drop)))
+    }}}}} | tojson
+  ' > "$TMP/schema.json"
+  # A JSON document carries no single quotes, so a single-quoted YAML scalar
+  # needs no escaping, and writing the fixture without yq keeps the test off
+  # the mikefarah/python dialect split.
+  {
+    printf 'spec:\n  application:\n    openAPISchema: '"'"
+    cat "$TMP/schema.json"
+    printf "'\n"
+  } > "$TMP/packages/system/probe-rd/cozyrds/probe.yaml"
+}
+
+@test "an enum carrying every canonical preset passes" {
+  command -v jq >/dev/null || skip "jq not installed"
+  command -v yq >/dev/null || skip "yq not installed"
+  TMP=$(mktemp -d)
+  write_probe_rd ""
+  if ! out=$(cd "$TMP" && bash "$SCRIPT" 2>&1); then
+    echo "expected the check to pass, it failed:" >&2
+    echo "$out" >&2
+    exit 1
+  fi
+  case "$out" in
+    *"All RD schemas carry the full 47-preset enum."*) ;;
+    *) echo "unexpected output: $out" >&2; exit 1 ;;
+  esac
+  rm -rf "$TMP"
+}
+
+@test "a missing preset fails the check and is named in the output" {
+  command -v jq >/dev/null || skip "jq not installed"
+  command -v yq >/dev/null || skip "yq not installed"
+  TMP=$(mktemp -d)
+  write_probe_rd c1.small
+  if out=$(cd "$TMP" && bash "$SCRIPT" 2>&1); then
+    echo "expected the check to fail on a missing preset, it passed:" >&2
+    echo "$out" >&2
+    exit 1
+  fi
+  case "$out" in
+    *c1.small*) ;;
+    *) echo "expected c1.small in output, got: $out" >&2; exit 1 ;;
+  esac
+  rm -rf "$TMP"
+}

--- a/hack/check-rd-presets.sh
+++ b/hack/check-rd-presets.sh
@@ -36,7 +36,13 @@ for f in packages/system/*-rd/cozyrds/*.yaml; do
   missing=()
   for want in "${EXPECTED[@]}"; do
     # -F: literal match so the `.` in t1.nano does not match any character.
-    if ! printf '%s\n' "$enums" | grep -Fqx -- "$want"; then
+    # Fed by here-string rather than by a pipe on purpose. `grep -q` exits on
+    # its first match, which can close a pipe while the writer is still in its
+    # write(2); the writer then fails with EPIPE, `set -o pipefail` makes the
+    # whole pipeline non-zero, and the `!` reads that as "not found" — so a
+    # value that matched FIRST gets reported missing. It is a scheduling race,
+    # so it fires under CI load and not on an idle machine.
+    if ! grep -Fqx -- "$want" <<<"$enums"; then
       missing+=("$want")
     fi
   done


### PR DESCRIPTION
## What this PR does

`hack/check-rd-presets.sh` sometimes reports a preset as missing when it is in the file. Seen on #4185:

```
hack/check-rd-presets.sh: line 39: printf: write error: Broken pipe
FAIL: packages/system/mariadb-rd/cozyrds/mariadb.yaml resourcesPreset enum missing: c1.small
```

`c1.small` is in that file, and the script passes when I run it on the same head.

The check was `printf '%s\n' "$enums" | grep -Fqx -- "$want"` in a script with `set -o pipefail`. `grep -q` exits on the first match and closes the pipe while printf is still writing, printf fails with EPIPE, pipefail makes the pipeline non-zero, and `!` reads that as not found. So a preset gets reported missing because it matched first. It is a race, so it hits under `make -j4` in CI and not on a laptop.

It costs more than a red tick. `Unit & controller tests` is in `needs` for `finalize`, `finalize` gates `e2e`, so the false failure skips e2e and `e2e-report` posts the required `E2E Tests` context as failed. #4185, #4138 and #3539 are red this way right now. #4109, #4097, #3802 and #3594 are not.

Fix is a here-string instead of the pipe. This is the only script under `hack/` with `pipefail` and `| grep -q`.

`hack/check-rd-presets.bats` covers it, picked up by the `hack/*.bats` glob in `Makefile:161`. It pins the two outcomes the check owes, a complete enum passing and an incomplete one failing with the missing value named. It does not try to win the race: a test that only reddens when the scheduler cooperates is the flaky kind this repo does not add, and the CI log in #4178 is the evidence for the bug. The fixture is written with jq alone so it does not depend on which yq dialect is installed, and it makes its temp dir in the test body because `hack/cozytest.sh` knows `@test` and nothing else.

shellcheck is clean and the check still passes on the tree.

Refs #4178

### Screenshots

Not a UI change.

### Downstream repositories

Nothing under `packages/`, no API type, no values schema, no release asset, no Talos version. One CI check script edited in place and one test file added next to it. Nothing moved or renamed, and `bats-unit-tests` already globbed `hack/*.bats`.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
NONE
```
