### PR TITLE
feat(monitoring): scrape KubeVirt VMI metrics from virt-handler

### DIFF
--- a/packages/system/monitoring/templates/vm/kubevirt-scrape.yaml
+++ b/packages/system/monitoring/templates/vm/kubevirt-scrape.yaml
@@ -1,0 +1,45 @@
+{{- /*
+  KubeVirt exports the resource usage of every VirtualMachineInstance
+  (kubevirt_vmi_*) from virt-handler in cozy-kubevirt, not from the VMI's
+  own pod, so no per-application scrape object can collect it and no
+  Monitoring application saw VM metrics at all: virt-operator creates its
+  ServiceMonitor only when the monitorAccount ServiceAccount exists in the
+  monitorNamespace, which Cozystack never creates.
+
+  Every Monitoring scrapes virt-handler itself. The tenant chart already
+  opens that path (<tenant>-egress-virt-handler lets the tenant vmagent
+  reach virt-handler:8443). A tenant Monitoring keeps only the series of
+  the namespaces it collects: its own namespace and the sub-tenants below
+  it (tenant-a collects tenant-a-b), which is how the
+  namespace.cozystack.io/monitoring label resolves for a sub-tenant with
+  no Monitoring of its own. The root Monitoring keeps everything, as the
+  cluster-wide vmagent in cozy-monitoring does for every other target.
+*/ -}}
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMPodScrape
+metadata:
+  name: kubevirt-virt-handler
+spec:
+  namespaceSelector:
+    matchNames:
+    - cozy-kubevirt
+  selector:
+    matchLabels:
+      kubevirt.io: virt-handler
+  podMetricsEndpoints:
+  - port: metrics
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+    # kubevirt_vmi_* carry the VMI's namespace, name and node; without
+    # honorLabels the scrape would overwrite namespace with cozy-kubevirt.
+    honorLabels: true
+    relabelConfigs:
+    - sourceLabels: [__meta_kubernetes_pod_node_name]
+      targetLabel: node
+    {{- if ne .Release.Namespace "tenant-root" }}
+    metricRelabelConfigs:
+    - action: keep
+      sourceLabels: [namespace]
+      regex: {{ printf "%s(-.*)?" .Release.Namespace | quote }}
+    {{- end }}

--- a/packages/system/monitoring/tests/kubevirt_scrape_test.yaml
+++ b/packages/system/monitoring/tests/kubevirt_scrape_test.yaml
@@ -1,0 +1,40 @@
+suite: kubevirt virt-handler scrape
+templates:
+  - templates/vm/kubevirt-scrape.yaml
+
+tests:
+  - it: a tenant Monitoring keeps only the VMI series of its own subtree
+    release:
+      name: monitoring
+      namespace: tenant-acme
+    asserts:
+      - isKind:
+          of: VMPodScrape
+      - equal:
+          path: spec.namespaceSelector.matchNames
+          value: [cozy-kubevirt]
+      - equal:
+          path: spec.selector.matchLabels["kubevirt.io"]
+          value: virt-handler
+      - equal:
+          path: spec.podMetricsEndpoints[0].honorLabels
+          value: true
+      - equal:
+          path: spec.podMetricsEndpoints[0].scheme
+          value: https
+      - equal:
+          path: spec.podMetricsEndpoints[0].metricRelabelConfigs
+          value:
+            - action: keep
+              sourceLabels: [namespace]
+              regex: "tenant-acme(-.*)?"
+
+  - it: the root Monitoring keeps every VMI series
+    release:
+      name: monitoring
+      namespace: tenant-root
+    asserts:
+      - isKind:
+          of: VMPodScrape
+      - notExists:
+          path: spec.podMetricsEndpoints[0].metricRelabelConfigs


### PR DESCRIPTION
## What this PR does

Makes every Monitoring application collect the resource usage of the VirtualMachineInstances it is responsible for.

KubeVirt exports `kubevirt_vmi_*` (CPU, memory, storage and network usage of every VMI) from virt-handler in `cozy-kubevirt`, not from the VMI's own pod, so no per-application scrape object can collect it. virt-operator would create a ServiceMonitor for virt-handler, but only when the `monitorAccount` ServiceAccount (`prometheus-k8s` by default) exists in the `monitorNamespace` (`tenant-root`), and Cozystack never creates that account. As a result no Monitoring application received VM metrics at all: the cluster-wide vmagent in `cozy-monitoring` has no virt-handler target, and a tenant Monitoring has nothing to select.

The `monitoring` chart now renders a `VMPodScrape` for virt-handler in every Monitoring release:

- a tenant Monitoring keeps only the series whose `namespace` is its own namespace or a sub-tenant below it (`tenant-a` keeps `tenant-a` and `tenant-a-*`), which is what the `namespace.cozystack.io/monitoring` label already promises for a sub-tenant without a Monitoring of its own;
- the root Monitoring keeps everything, as the cluster-wide vmagent does for every other target.

The tenant chart already opens the network path for this: the `<tenant>-egress-virt-handler` policy (#2199) lets the tenant vmagent reach virt-handler on 8443 whenever monitoring is enabled, but nothing used it until now.

Verified on a v1.6.3 cluster in the root mode: with the rendered VMPodScrape applied in `tenant-root`, the cluster-wide vmagent reports the three virt-handler endpoints as `up`, and `kubevirt_vmi_*` series of VMs from two tenants appear in `vmselect-shortterm` with the VMI's `namespace`, `name` and `node` labels intact. The tenant mode was run on the same cluster with the chart's rendered VMAgent and this VMPodScrape applied in a child tenant (with one-replica VMClusters in place of the application's own, which does not fit that cluster): the tenant vmagent reaches all three virt-handlers through the `egress-virt-handler` policy, its vmselect holds only the VMI series of that tenant, and nothing without a `namespace` label gets past the `keep` filter. The chart unit test covers both render modes.

### Screenshots

Not applicable.

### Downstream repositories

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

Walked the trigger map against the diff: the change is a new template plus its unit test in `packages/system/monitoring`, with no values key, schema, package list or version pin touched, so nothing on the website, provider or installer side is affected.

### Release note

```release-note
feat(monitoring): Monitoring applications now collect KubeVirt VMI metrics (kubevirt_vmi_*) from virt-handler; a tenant Monitoring keeps the series of its own namespace and sub-tenants, the root Monitoring keeps all of them
```
