### PR TITLE
docs(readme): stop the logo filling the page and thin the badge wall

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you have a **concrete feature request**, [open an issue](https://github.com/c
 
 ## Community
 
-You are welcome to join us in [#cozystack on CNCF Slack](https://cloud-native.slack.com/archives/C08BQJD95J7) or [#cozystack on Kubernetes Slack](https://kubernetes.slack.com/archives/C06L3CPRVN1), join our [Telegram group](https://t.me/cozystack), and come to our community meetings.
+You are welcome to join us in **#cozystack**, on either [CNCF Slack](https://cloud-native.slack.com/archives/C08BQJD95J7) ([get an invite](https://cncf-slack.netlify.app/)) or [Kubernetes Slack](https://kubernetes.slack.com/archives/C06L3CPRVN1) ([get an invite](https://slack.kubernetes.io/)), in our [Telegram group](https://t.me/cozystack), and at our community meetings.
 Add them to your [Google Calendar](https://calendar.google.com/calendar?cid=ZTQzZDIxZTVjOWI0NWE5NWYyOGM1ZDY0OWMyY2IxZTFmNDMzZTJlNjUzYjU2ZGJiZGE3NGNhMzA2ZjBkMGY2OEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) or [iCal](https://calendar.google.com/calendar/ical/e43d21e5c9b45a95f28c5d649c2cb1e1f433e2e653b56dbbda74ca306f0d0f68%40group.calendar.google.com/public/basic.ics) for convenience.
 
 ## Project documents

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-![Cozystack](img/cozystack-logo-black.svg#gh-light-mode-only)
-![Cozystack](img/cozystack-logo-white.svg#gh-dark-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="img/cozystack-logo-white.svg">
+  <img src="img/cozystack-logo-black.svg" alt="Cozystack" width="340">
+</picture>
 
-[![Open Source](https://img.shields.io/badge/Open-Source-brightgreen)](https://opensource.org/)
-[![Apache-2.0 License](https://img.shields.io/github/license/cozystack/cozystack)](https://opensource.org/licenses/)
-[![Support](https://img.shields.io/badge/$-support-12a0df.svg?style=flat)](https://cozystack.io/support/)
-[![Active](http://img.shields.io/badge/Status-Active-green.svg)](https://github.com/cozystack/cozystack)
 [![GitHub Release](https://img.shields.io/github/release/cozystack/cozystack.svg?style=flat)](https://github.com/cozystack/cozystack/releases/latest)
-[![GitHub Commit](https://img.shields.io/github/commit-activity/y/cozystack/cozystack)](https://github.com/cozystack/cozystack/graphs/contributors)
+[![Apache-2.0 License](https://img.shields.io/github/license/cozystack/cozystack)](https://github.com/cozystack/cozystack/blob/main/LICENSE)
+[![Commit activity](https://img.shields.io/github/commit-activity/y/cozystack/cozystack)](https://github.com/cozystack/cozystack/graphs/contributors)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10177/badge)](https://www.bestpractices.dev/projects/10177)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/cozystack/cozystack/badge)](https://securityscorecards.dev/viewer/?uri=github.com/cozystack/cozystack)
+[![Support](https://img.shields.io/badge/$-support-12a0df.svg?style=flat)](https://cozystack.io/support/)
 
 # Cozystack
 
@@ -19,7 +19,7 @@ Cozystack is a [CNCF Sandbox Level Project](https://www.cncf.io/sandbox-projects
 With Cozystack, you can transform a bunch of servers into an intelligent system with a simple REST API for spawning Kubernetes clusters,
 Database-as-a-Service, virtual machines, load balancers, HTTP caching services, and other services with ease.
 
-Use Cozystack to build your own cloud or provide a cost-effective development environment.  
+Use Cozystack to build your own cloud or provide a cost-effective development environment.
 
 ![Cozystack user interface](https://cozystack.io/img/screenshot-dark.png)
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ If you encounter any difficulties, start with the [troubleshooting guide](https:
 Versioning adheres to the [Semantic Versioning](https://semver.org/) principles.  
 A full list of the available releases is available in the GitHub repository's [Release](https://github.com/cozystack/cozystack/releases) section.
 
-- [Roadmap](ROADMAP.md)
-
 ## Contributions
 
 Contributions are highly appreciated and very welcomed!
@@ -55,7 +53,7 @@ Contributions are highly appreciated and very welcomed!
 In case of bugs, please check if the issue has already been opened by checking the [GitHub Issues](https://github.com/cozystack/cozystack/issues) section.
 If it isn't, you can open a new one. A detailed report will help us replicate it, assess it, and work on a fix.
 
-You are welcome to take the fix on yourself.
+You are welcome to take on the fix yourself.
 Commits are used to generate the changelog, and their author will be referenced in it.
 
 If you have a **concrete feature request**, [open an issue](https://github.com/cozystack/cozystack/issues/new/choose). For a **cross-cutting or architectural change**, open a [design proposal](https://github.com/cozystack/community/tree/main/design-proposals) in the [community](https://github.com/cozystack/community) repo. For **questions or early ideas**, use [GitHub Discussions](https://github.com/cozystack/cozystack/discussions). See [CONTRIBUTING.md](CONTRIBUTING.md#where-do-i-file) for the full routing.
@@ -67,7 +65,7 @@ Add them to your [Google Calendar](https://calendar.google.com/calendar?cid=ZTQz
 
 ## Project documents
 
-| | |
+| Document | What it covers |
 |---|---|
 | [Governance](GOVERNANCE.md) | How decisions are made and who makes them |
 | [Contributor Ladder](CONTRIBUTOR_LADDER.md) | How to grow from contributor to maintainer |

--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="img/cozystack-logo-white.svg">
-  <img src="img/cozystack-logo-black.svg" alt="Cozystack" width="340">
-</picture>
+<img src="img/cozystack-logo-black.svg#gh-light-mode-only" alt="Cozystack" width="340">
+<img src="img/cozystack-logo-white.svg#gh-dark-mode-only" alt="Cozystack" width="340">
 
 [![GitHub Release](https://img.shields.io/github/release/cozystack/cozystack.svg?style=flat)](https://github.com/cozystack/cozystack/releases/latest)
 [![Apache-2.0 License](https://img.shields.io/github/license/cozystack/cozystack)](https://github.com/cozystack/cozystack/blob/main/LICENSE)
-[![Commit activity](https://img.shields.io/github/commit-activity/y/cozystack/cozystack)](https://github.com/cozystack/cozystack/graphs/contributors)
+[![Commit activity](https://img.shields.io/github/commit-activity/y/cozystack/cozystack)](https://github.com/cozystack/cozystack/graphs/commit-activity)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10177/badge)](https://www.bestpractices.dev/projects/10177)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/cozystack/cozystack/badge)](https://securityscorecards.dev/viewer/?uri=github.com/cozystack/cozystack)
+[![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/cozystack/badge)](https://clomonitor.io/projects/cncf/cozystack)
 [![Support](https://img.shields.io/badge/$-support-12a0df.svg?style=flat)](https://cozystack.io/support/)
 
 # Cozystack
 
-**Cozystack** is a free platform and framework for building clouds.
+**Cozystack** is a free and open-source platform and framework for building clouds.
 
-Cozystack is a [CNCF Sandbox Level Project](https://www.cncf.io/sandbox-projects/) that was originally built and sponsored by [Ænix](https://aenix.io/).
+Cozystack is a [CNCF Sandbox project](https://www.cncf.io/sandbox-projects/) that was originally built and sponsored by [Ænix](https://aenix.io/).
 
 With Cozystack, you can transform a bunch of servers into an intelligent system with a simple REST API for spawning Kubernetes clusters,
 Database-as-a-Service, virtual machines, load balancers, HTTP caching services, and other services with ease.
@@ -34,7 +33,6 @@ You can use Cozystack as a platform to build a private cloud powered by Infrastr
 * [**Using Cozystack as a Kubernetes distribution**](https://cozystack.io/docs/guides/use-cases/kubernetes-distribution/)  
 You can use Cozystack as a Kubernetes distribution for Bare Metal
 
-
 ## Documentation
 
 The documentation is located on the [cozystack.io](https://cozystack.io) website.
@@ -45,10 +43,10 @@ If you encounter any difficulties, start with the [troubleshooting guide](https:
 
 ## Versioning
 
-Versioning adheres to the [Semantic Versioning](http://semver.org/) principles.  
+Versioning adheres to the [Semantic Versioning](https://semver.org/) principles.  
 A full list of the available releases is available in the GitHub repository's [Release](https://github.com/cozystack/cozystack/releases) section.
 
-- [Roadmap](https://cozystack.io/docs/roadmap/)
+- [Roadmap](ROADMAP.md)
 
 ## Contributions
 
@@ -57,15 +55,27 @@ Contributions are highly appreciated and very welcomed!
 In case of bugs, please check if the issue has already been opened by checking the [GitHub Issues](https://github.com/cozystack/cozystack/issues) section.
 If it isn't, you can open a new one. A detailed report will help us replicate it, assess it, and work on a fix.
 
-You can express your intention to on the fix on your own.
+You are welcome to take the fix on yourself.
 Commits are used to generate the changelog, and their author will be referenced in it.
 
 If you have a **concrete feature request**, [open an issue](https://github.com/cozystack/cozystack/issues/new/choose). For a **cross-cutting or architectural change**, open a [design proposal](https://github.com/cozystack/community/tree/main/design-proposals) in the [community](https://github.com/cozystack/community) repo. For **questions or early ideas**, use [GitHub Discussions](https://github.com/cozystack/cozystack/discussions). See [CONTRIBUTING.md](CONTRIBUTING.md#where-do-i-file) for the full routing.
 
 ## Community
 
-You are welcome to join our [Telegram group](https://t.me/cozystack) and come to our weekly community meetings.
+You are welcome to join us in [#cozystack on CNCF Slack](https://cloud-native.slack.com/archives/C08BQJD95J7) or [#cozystack on Kubernetes Slack](https://kubernetes.slack.com/archives/C06L3CPRVN1), join our [Telegram group](https://t.me/cozystack), and come to our community meetings.
 Add them to your [Google Calendar](https://calendar.google.com/calendar?cid=ZTQzZDIxZTVjOWI0NWE5NWYyOGM1ZDY0OWMyY2IxZTFmNDMzZTJlNjUzYjU2ZGJiZGE3NGNhMzA2ZjBkMGY2OEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) or [iCal](https://calendar.google.com/calendar/ical/e43d21e5c9b45a95f28c5d649c2cb1e1f433e2e653b56dbbda74ca306f0d0f68%40group.calendar.google.com/public/basic.ics) for convenience.
+
+## Project documents
+
+| | |
+|---|---|
+| [Governance](GOVERNANCE.md) | How decisions are made and who makes them |
+| [Contributor Ladder](CONTRIBUTOR_LADDER.md) | How to grow from contributor to maintainer |
+| [Maintainers](MAINTAINERS.md) | Who maintains the project |
+| [Code of Conduct](CODE_OF_CONDUCT.md) | What we expect of each other |
+| [Security Policy](SECURITY.md) | Reporting a vulnerability, and which releases get fixes |
+| [Adopters](ADOPTERS.md) | Who runs Cozystack in production |
+| [Roadmap](ROADMAP.md) | Where the project is going |
 
 ## License
 


### PR DESCRIPTION
## What it looks like now

The README opens with the logo rendered at **734×246** on a desktop viewport — a wall of logo before a single word of text — followed by eight badges of ragged widths.

The logo is an SVG with no intrinsic width, so GitHub stretches it to the full width of the README column. It also uses the `#gh-light-mode-only` / `#gh-dark-mode-only` fragment hack, which GitHub has since superseded with `<picture>` and `prefers-color-scheme`.

## Changes

**Logo** → a `<picture>` element at a fixed `width="340"`. Bounds the logo (now 340×114, measured on the branch) and drops the hack in the same move. Light and dark variants still switch.

**Badges** → eight down to six. Two carried no information:

- `Open Source` links to opensource.org and says what the Apache-2.0 badge directly beside it already says.
- `Status: Active` is a hand-set claim rather than a measurement — the commit-activity badge next to it is the real thing, and this one was also served over plain `http://`.

The remaining six are ordered identity → health → support: release, licence, commit activity, OpenSSF Best Practices, OpenSSF Scorecard, commercial support. The licence badge now points at `LICENSE` in this repository rather than at opensource.org.

Also removed trailing whitespace on lines where it did nothing. The deliberate two-space line breaks in the use-case list are untouched.

## Verification

Rendered on the branch and measured in the browser: logo 340×114, six badges, light and dark variants both resolving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the README logo for light and dark modes.
  - Reorganized project badges, updated LICENSE and commit activity links, and added a CLOMonitor badge.
  - Removed the Open Source and Active badges.
  - Revised introductory, contribution, and community information.
  - Updated the Semantic Versioning link and removed the Roadmap link.
  - Added a project documents table and CNCF/Kubernetes community channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->