### PR TITLE
docs(security): publish CVE-scanning pipeline policy and scripts

### DIFF
--- a/docs/security/pipeline/README.md
+++ b/docs/security/pipeline/README.md
@@ -1,0 +1,27 @@
+# Cozystack security-scanning pipeline — published policy and scripts
+
+These are published copies of the Cozystack CVE-scanning pipeline's policy documents and
+scripts, so that its method is auditable independently of the finding data it produces.
+The **source of truth is the private `cozystack/security-scanner` repository**, which also
+holds the per-finding reports and triage state that are **not** published here.
+
+## Contents
+
+- `SECURITY_PIPELINE_POLICY.md` — what the pipeline scans, on what schedule, and what is
+  public vs private.
+- `SECURITY_TRIAGE_MATRIX.md` — severity levels, triage clocks and fix targets.
+- `SECURITY_FINDING_STATUS_MODEL.md` — the finding lifecycle and status model. The example
+  identifiers in it are illustrative placeholders; real triage decisions live in the
+  private state.
+- `scripts/` — the discovery, scanning and reporting scripts (`discover.sh`, `scan.sh`,
+  `report.py`, `monthly.py`, `sync_issues.py`, `backfill_issues.py`), published so the
+  method can be audited. These are reference copies; the runnable versions live in the
+  private repository against organization-scoped credentials.
+
+## Disclosure rule
+
+Severity-level aggregate counts are published (see [`../reports/`](../reports/)); individual
+not-yet-fixed findings are not named, because a CVE ID plus an affected package plus this
+project's public, version-pinned component list is enough to locate unpatched exposure in a
+running deployment. That is why the per-finding reports and triage state in the private
+repository are not mirrored here.

--- a/docs/security/pipeline/SECURITY_FINDING_STATUS_MODEL.md
+++ b/docs/security/pipeline/SECURITY_FINDING_STATUS_MODEL.md
@@ -1,0 +1,76 @@
+# Security Finding Status Model
+
+## Statuses
+
+| Status | Meaning | Who sets it | Next action |
+|--------|---------|-------------|-------------|
+| `new` | Scanner found this CVE, no human has reviewed it yet | Automated (default) | Triage needed |
+| `confirmed` | Maintainer verified this is a real, applicable vulnerability | Maintainer | Assign owner, plan fix |
+| `in-progress` | Fix is being worked on | Maintainer / owner | Track to completion |
+| `fixed` | Fix has been released | Maintainer | Close, update advisory if needed |
+| `false-positive` | Scanner finding does not apply to our context | Maintainer | Document reason, no further action |
+| `accepted-risk` | Real vulnerability, but we consciously accept the risk | Maintainer | Document reason, review periodically |
+
+## Lifecycle
+
+```
+new → confirmed → in-progress → fixed
+new → false-positive
+new → accepted-risk
+confirmed → accepted-risk  (if fix becomes impractical)
+accepted-risk → confirmed  (if circumstances change)
+```
+
+## Recording Triage Decisions
+
+Triage decisions are stored in `state/triage-overrides.json`:
+
+```json
+{
+  "CVE-YYYY-NNNN1": {
+    "status": "false-positive",
+    "reason": "example: library CVE in a base image; the distribution has backported the fix",
+    "decided_by": "maintainer-handle",
+    "decided_at": "YYYY-MM-DD",
+    "review_after": null
+  },
+  "CVE-YYYY-NNNN2": {
+    "status": "accepted-risk",
+    "reason": "example: CVE in a component or code path not exercised by Cozystack's usage",
+    "decided_by": "maintainer-handle",
+    "decided_at": "YYYY-MM-DD",
+    "review_after": "YYYY-MM-DD"
+  },
+  "CVE-YYYY-NNNN3": {
+    "status": "in-progress",
+    "reason": "example: vulnerability with an upstream fix available; component bump in progress",
+    "decided_by": "maintainer-handle",
+    "decided_at": "YYYY-MM-DD",
+    "fix_version": "x.y.z",
+    "fix_pr": "https://github.com/cozystack/cozystack/pull/NNNN",
+    "review_after": null
+  }
+}
+```
+
+> The identifiers above are illustrative placeholders showing the record shape only.
+> Live triage decisions are kept in the security pipeline's private state, since a real
+> CVE crossed with this project's public component list can locate unpatched exposure.
+
+## Required Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `status` | Yes | One of: `confirmed`, `in-progress`, `fixed`, `false-positive`, `accepted-risk` |
+| `reason` | Yes | Human-readable explanation of the decision |
+| `decided_by` | Yes | GitHub handle of the maintainer |
+| `decided_at` | Yes | Date of the decision (YYYY-MM-DD) |
+| `review_after` | For `accepted-risk` | Date to re-evaluate (quarterly recommended) |
+| `fix_version` | For `fixed` | Version where the fix is included |
+| `fix_pr` | For `in-progress` / `fixed` | Link to the fix PR |
+
+## Periodic Review
+
+- `accepted-risk` findings must be reviewed every 90 days
+- If `review_after` date has passed, the finding is flagged in the weekly digest
+- `false-positive` findings are re-checked automatically when Trivy DB updates (if the CVE reappears with different metadata, it becomes `new` again)

--- a/docs/security/pipeline/SECURITY_PIPELINE_POLICY.md
+++ b/docs/security/pipeline/SECURITY_PIPELINE_POLICY.md
@@ -1,0 +1,102 @@
+# Security Pipeline Policy
+
+## Purpose
+
+This document defines how the Cozystack project handles vulnerability findings from automated scanners, from initial detection through triage, remediation, and disclosure.
+
+## Scope
+
+This policy applies to:
+- All non-fork repositories in the `cozystack` GitHub organization
+- All container images shipped as part of Cozystack releases
+- All third-party dependencies (Go modules, base images, Helm chart components)
+
+## Ownership
+
+The security pipeline is maintained by the Cozystack security team (subset of project maintainers with write access to this repository).
+
+Security contact: **cncf-cozystack-security@lists.cncf.io**
+
+## Pipeline Overview
+
+```
+Discovery → Scan → Normalize/Deduplicate → Triage → Route → Track → Fix → Disclose → Close
+```
+
+### 1. Discovery (automated, every 6 hours)
+
+The pipeline automatically discovers components across all organization repositories:
+- Go dependencies (`go.mod`)
+- Dockerfile base images (`FROM` directives)
+- Helm chart images (`values.yaml`, templates)
+- Packages from `packages/apps/*`, `packages/system/*`, `packages/core/*`
+
+### 2. Scan (automated)
+
+Trivy scans all discovered components against known vulnerability databases (NVD, vendor advisories, GitHub Advisory Database).
+
+### 3. Normalize / Deduplicate (automated)
+
+- Same CVE across multiple images → single finding with all affected components listed
+- Already-reported CVEs → skipped (tracked in `state/reported-cves.json`)
+- Triage overrides → applied from `state/triage-overrides.json`
+
+### 4. Triage (manual, by maintainers)
+
+Every new finding must be triaged by a maintainer. See [SECURITY_FINDING_STATUS_MODEL.md](SECURITY_FINDING_STATUS_MODEL.md) for available statuses.
+
+Triage questions:
+1. Is this CVE in a **shipped artifact** or only in dev/build tooling?
+2. Is the vulnerable **code path actually reachable** in our usage?
+3. Has the OS distro already **backported** the fix?
+4. Is a **fix available** upstream?
+5. What is the **realistic impact** on a Cozystack deployment?
+
+### 5. Routing (severity-based)
+
+| Severity | Channel | Timing |
+|----------|---------|--------|
+| **Critical** | Individual report in `reports/critical/` + private notification to security team | Immediate (within 6 hours of detection) |
+| **High** | Included in weekly maintainer digest | Weekly (Tuesday 06:00 CET) |
+| **Medium** | Included in weekly maintainer digest | Weekly |
+| **Low** | Included in weekly maintainer digest | Weekly |
+| **Informational** | Monthly summary only | Monthly |
+
+### 6. Fix Tracking
+
+- CRITICAL: maintainer assigns owner within 1 business day
+- Fixes are tracked in `state/triage-overrides.json` with status `in-progress`
+- When fixed, status changes to `fixed` with the fix version noted
+
+### 7. Disclosure
+
+- **CRITICAL/HIGH (confirmed):** GitHub Security Advisory (draft, then published after fix)
+- **MEDIUM/LOW:** Mentioned in monthly public security summary
+- **Raw scanner output** is never published
+- **False positives and accepted risks** are documented internally but not published
+
+## What Is Private
+
+- Raw scan results
+- Unconfirmed CRITICAL/HIGH findings
+- Exploit details before fix is available
+- `state/` directory contents
+- Triage discussions
+
+## What Is Public (after triage and remediation)
+
+- GitHub Security Advisories (post-fix)
+- Monthly security summaries
+- Release notes mentioning security fixes
+- The existence of this security pipeline (not its internal reports)
+
+## Maintainer Responsibilities
+
+See [SECURITY_TRIAGE_MATRIX.md](SECURITY_TRIAGE_MATRIX.md) for detailed SLAs.
+
+Maintainers must:
+1. Review the weekly digest within 3 business days
+2. Triage new CRITICAL findings within 1 business day
+3. Assign an owner for confirmed CRITICAL/HIGH findings
+4. Document triage decisions in `state/triage-overrides.json`
+5. Not disclose CRITICAL/HIGH details publicly before a fix is available

--- a/docs/security/pipeline/SECURITY_TRIAGE_MATRIX.md
+++ b/docs/security/pipeline/SECURITY_TRIAGE_MATRIX.md
@@ -1,0 +1,54 @@
+# Security Triage Matrix
+
+## Severity → Action → SLA
+
+| | Critical | High | Medium | Low | Informational |
+|---|---|---|---|---|---|
+| **Acknowledgment** | 4 hours | 1 business day | 3 business days | Weekly digest | Monthly summary |
+| **Triage** | 1 business day | 3 business days | 10 business days | 30 days | No action required |
+| **Owner assigned** | 1 business day | 5 business days | Best effort | Best effort | N/A |
+| **Remediation plan** | 2 business days | 10 business days | Next release | Best effort | N/A |
+| **Fix target** | 7 days | 30 days | 90 days | No hard deadline | N/A |
+| **Disclosure** | After fix + 7 days | After fix + 14 days | Monthly report | Monthly report | Monthly report |
+
+## Routing
+
+| Severity | Immediate action | Report location | Notification |
+|---|---|---|---|
+| **Critical** | Individual report saved to `reports/critical/` | `reports/critical/YYYY-MM-DD-CVE-XXXX.md` | Security team notified directly |
+| **High** | Added to weekly digest | `reports/weekly/YYYY-MM-DD-security-report.md` | Weekly maintainer digest |
+| **Medium** | Added to weekly digest | `reports/weekly/YYYY-MM-DD-security-report.md` | Weekly maintainer digest |
+| **Low** | Added to weekly digest | `reports/weekly/YYYY-MM-DD-security-report.md` | Weekly maintainer digest |
+| **Informational** | Logged only | Monthly summary | No direct notification |
+
+## Triage Decision Tree
+
+```
+New CVE found by scanner
+  │
+  ├─ Is it in a shipped artifact (not dev/test only)?
+  │   ├─ No → status: false-positive (reason: "dev dependency only")
+  │   └─ Yes ↓
+  │
+  ├─ Is the vulnerable code path reachable in our usage?
+  │   ├─ No → status: accepted-risk (reason: "code path not reachable")
+  │   └─ Yes / Uncertain ↓
+  │
+  ├─ Has the distro already backported the fix?
+  │   ├─ Yes → status: false-positive (reason: "distro backport applied")
+  │   └─ No ↓
+  │
+  ├─ Is a fix available upstream?
+  │   ├─ Yes → status: confirmed, assign owner, schedule update
+  │   └─ No ↓
+  │
+  └─ Is the CVE older than 365 days with no fix?
+      ├─ Yes → status: accepted-risk (reason: "unfixed upstream, monitoring")
+      └─ No → status: confirmed, monitor upstream for fix
+```
+
+## Escalation
+
+- If a CRITICAL finding is not triaged within 1 business day → escalate to all maintainers
+- If a confirmed CRITICAL has no fix plan within 2 business days → discuss workaround/mitigation
+- If a HIGH finding is not triaged within 5 business days → auto-escalate in next digest

--- a/docs/security/pipeline/scripts/backfill_issues.py
+++ b/docs/security/pipeline/scripts/backfill_issues.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+backfill_issues.py — One-time script to create GitHub Issues for CVEs
+that were reported before the Issue integration was added.
+
+Reads state/reported-cves.json, finds entries without issue_url,
+applies the same filters as report.py, and creates Issues.
+
+Usage:
+  python3 scripts/backfill_issues.py                    # dry run
+  python3 scripts/backfill_issues.py --execute          # create issues
+  python3 scripts/backfill_issues.py --execute --limit 50  # create max 50
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import time
+from datetime import datetime, timezone
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+STATE_DIR = os.path.join(REPO_ROOT, "state")
+REPORTED_FILE = os.path.join(STATE_DIR, "reported-cves.json")
+TRIAGE_FILE = os.path.join(STATE_DIR, "triage-overrides.json")
+ISSUES_REPO = os.environ.get("ISSUES_REPO", "cozystack/security-scanner")
+
+SEVERITY_LABELS = {
+    "CRITICAL": "security/critical",
+    "HIGH": "security/high",
+    "MEDIUM": "security/medium",
+    "LOW": "security/low",
+}
+
+UNFIXED_AGE_THRESHOLD_DAYS = 365
+
+
+def load_json(path, default):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return default
+
+
+def save_json(path, data):
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def cve_age_days(cve_id):
+    match = re.match(r"CVE-(\d{4})-", cve_id)
+    if not match:
+        return 0
+    cve_year = int(match.group(1))
+    now = datetime.now(timezone.utc)
+    return max((now - datetime(cve_year, 1, 1, tzinfo=timezone.utc)).days, 0)
+
+
+def should_skip(cve_id, data, triage):
+    """Apply same filters as report.py."""
+    # Already triaged
+    if cve_id in triage:
+        status = triage[cve_id].get("status", "")
+        if status in ("false-positive", "accepted-risk", "fixed"):
+            return True, f"triaged as {status}"
+
+    # Unfixed > 365 days
+    if not data.get("fixed_version"):
+        age = cve_age_days(cve_id)
+        if age > UNFIXED_AGE_THRESHOLD_DAYS:
+            return True, f"unfixed {age}d"
+
+    return False, None
+
+
+def create_issue(cve_id, data):
+    severity = data.get("severity", "UNKNOWN")
+    package = data.get("package", "unknown")
+    fixed = data.get("fixed_version", "")
+    repos = data.get("repos", [])
+
+    title = f"security_{severity.lower()}: {cve_id} in {package}"
+
+    repos_md = "\n".join(f"- `{r}`" for r in repos) if repos else "- Unknown"
+    fix_line = f"`{fixed}`" if fixed else "No fix available yet"
+    report_file = data.get("report_file", "")
+    report_link = f"\n**Report:** [{report_file}]({report_file})" if report_file else ""
+
+    body = f"""## {cve_id}
+
+| Field | Value |
+|-------|-------|
+| **CVE** | [{cve_id}](https://nvd.nist.gov/vuln/detail/{cve_id}) |
+| **Severity** | {severity} |
+| **Package** | `{package}` |
+| **Fixed in** | {fix_line} |
+{report_link}
+
+### Affected Components
+
+{repos_md}
+
+### Triage Checklist
+
+- [ ] Is this in a shipped artifact (not dev/test only)?
+- [ ] Is the vulnerable code path reachable in our usage?
+- [ ] Has the distro already backported the fix?
+- [ ] Is a fix available upstream?
+"""
+
+    labels = ["security/triage-needed"]
+    sev_label = SEVERITY_LABELS.get(severity)
+    if sev_label:
+        labels.append(sev_label)
+
+    label_args = []
+    for l in labels:
+        label_args.extend(["-l", l])
+
+    cmd = ["gh", "issue", "create",
+           "--repo", ISSUES_REPO,
+           "--title", title,
+           "--body", body] + label_args
+
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode == 0:
+        return result.stdout.strip()
+    else:
+        print(f"    ERROR: {result.stderr[:200]}")
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--execute", action="store_true", help="Actually create issues (default: dry run)")
+    parser.add_argument("--limit", type=int, default=0, help="Max issues to create (0 = unlimited)")
+    args = parser.parse_args()
+
+    reported = load_json(REPORTED_FILE, {})
+    triage = load_json(TRIAGE_FILE, {})
+
+    # Find CVEs without issues
+    needs_issue = {}
+    skipped = 0
+    for cve_id, data in reported.items():
+        if data.get("issue_url"):
+            continue
+        skip, reason = should_skip(cve_id, data, triage)
+        if skip:
+            skipped += 1
+            continue
+        needs_issue[cve_id] = data
+
+    # Sort: CRITICAL first, then HIGH, etc.
+    sev_order = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3}
+    sorted_cves = sorted(needs_issue.items(), key=lambda x: (sev_order.get(x[1].get("severity", ""), 9), x[0]))
+
+    from collections import Counter
+    sevs = Counter(d["severity"] for _, d in sorted_cves)
+
+    print(f"Total reported CVEs: {len(reported)}")
+    print(f"Already have issues: {sum(1 for d in reported.values() if d.get('issue_url'))}")
+    print(f"Filtered out: {skipped}")
+    print(f"Need issues: {len(sorted_cves)}")
+    print(f"  By severity: {dict(sevs)}")
+    print()
+
+    if not args.execute:
+        print("DRY RUN — pass --execute to create issues")
+        print()
+        for cve_id, data in sorted_cves[:20]:
+            print(f"  {data['severity']:8s} {cve_id:25s} {data.get('package',''):20s} repos={len(data.get('repos',[]))}")
+        if len(sorted_cves) > 20:
+            print(f"  ... and {len(sorted_cves) - 20} more")
+        return
+
+    # Create issues
+    limit = args.limit if args.limit > 0 else len(sorted_cves)
+    created = 0
+
+    for cve_id, data in sorted_cves[:limit]:
+        print(f"  [{created+1}/{min(limit, len(sorted_cves))}] {data['severity']} {cve_id} ({data.get('package','')})")
+        url = create_issue(cve_id, data)
+        if url:
+            reported[cve_id]["issue_url"] = url
+            created += 1
+            # Rate limit: GitHub allows 100 requests/min for authenticated users
+            time.sleep(1)
+        else:
+            print(f"    Failed, stopping to avoid rate limit issues")
+            break
+
+    save_json(REPORTED_FILE, reported)
+    print(f"\nCreated {created} issues. State saved.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/security/pipeline/scripts/discover.sh
+++ b/docs/security/pipeline/scripts/discover.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# discover.sh — Discover all components across cozystack org.
+# Outputs: workspace/discovery.json with repos, deps, images.
+set -euo pipefail
+
+ORG="cozystack"
+WORKSPACE="${1:-workspace}"
+OUTFILE="$WORKSPACE/discovery.json"
+CLONE_DIR="$WORKSPACE/repos"
+TMP_DIR="$WORKSPACE/tmp-discover"
+
+mkdir -p "$CLONE_DIR" "$TMP_DIR"
+
+echo "==> Discovering repos in $ORG..."
+
+# Get all non-fork, non-archived repos
+gh api --paginate "/orgs/$ORG/repos?per_page=100" \
+  --jq '.[] | select(.fork == false and .archived == false) | .full_name' \
+  > "$TMP_DIR/repos.txt" 2>/dev/null
+
+REPO_COUNT=$(wc -l < "$TMP_DIR/repos.txt")
+echo "   Found $REPO_COUNT repos"
+
+# --- Process each repo ---
+
+REPO_INDEX=0
+while IFS= read -r repo; do
+  repo_name=$(basename "$repo")
+  repo_dir="$CLONE_DIR/$repo_name"
+  repo_tmp="$TMP_DIR/$repo_name"
+  mkdir -p "$repo_tmp"
+
+  REPO_INDEX=$((REPO_INDEX + 1))
+  echo "==> [$REPO_INDEX/$REPO_COUNT] Processing $repo..."
+
+  # Shallow clone if not exists
+  if [ ! -d "$repo_dir" ]; then
+    git clone --depth 1 --quiet "https://github.com/$repo.git" "$repo_dir" 2>/dev/null || {
+      echo "   WARN: cannot clone $repo, skipping"
+      echo "$repo" > "$repo_tmp/repo.txt"
+      touch "$repo_tmp/go_deps.txt" "$repo_tmp/dockerfile_images.txt" "$repo_tmp/helm_images.txt" "$repo_tmp/packages.txt"
+      continue
+    }
+  fi
+
+  echo "$repo" > "$repo_tmp/repo.txt"
+
+  # Go deps (direct only)
+  if [ -f "$repo_dir/go.mod" ]; then
+    grep -E '^\t[a-zA-Z]' "$repo_dir/go.mod" 2>/dev/null \
+      | grep -v '// indirect' \
+      | awk '{print $1 " " $2}' \
+      > "$repo_tmp/go_deps.txt" 2>/dev/null || true
+  else
+    touch "$repo_tmp/go_deps.txt"
+  fi
+
+  # Dockerfile base images
+  find "$repo_dir" -name 'Dockerfile*' -type f 2>/dev/null \
+    | xargs grep -hi '^FROM' 2>/dev/null \
+    | sed 's/^FROM\s*//i; s/\s*[Aa][Ss]\s.*$//' \
+    | grep -v '^\$' \
+    | grep -v '^scratch$' \
+    | sort -u \
+    > "$repo_tmp/dockerfile_images.txt" 2>/dev/null || touch "$repo_tmp/dockerfile_images.txt"
+
+  # Helm images from values.yaml (using Python for reliable YAML parsing)
+  find "$repo_dir" -name 'values.yaml' -type f 2>/dev/null \
+    | xargs -I{} python3 -c "
+import yaml, sys
+try:
+    with open('{}') as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        sys.exit(0)
+    def find_images(d):
+        if not isinstance(d, dict):
+            return
+        # Check image: string field
+        img = d.get('image', '')
+        if isinstance(img, str) and '/' in img and '{{' not in img and img.strip():
+            print(img.strip())
+        # Check image: {repository:, tag:} pattern
+        if isinstance(img, dict):
+            repo = img.get('repository', '')
+            tag = img.get('tag', '')
+            if repo and '{{' not in str(repo):
+                if tag and '{{' not in str(tag):
+                    print(f'{repo}:{tag}')
+                elif ':' in str(repo):
+                    print(repo)
+        # Check repository: + tag: at current level
+        repo = d.get('repository', '')
+        tag = d.get('tag', '')
+        if isinstance(repo, str) and repo and '{{' not in repo and '/' in repo:
+            if isinstance(tag, str) and tag and '{{' not in tag:
+                print(f'{repo}:{tag}')
+            elif ':' in repo:
+                print(repo)
+        for v in d.values():
+            if isinstance(v, dict):
+                find_images(v)
+            elif isinstance(v, list):
+                for item in v:
+                    if isinstance(item, dict):
+                        find_images(item)
+    find_images(data)
+except Exception:
+    pass
+" 2>/dev/null | sort -u > "$repo_tmp/helm_images_raw.txt" 2>/dev/null || true
+
+  # Also grep for hardcoded image: lines in templates (non-templated)
+  grep -rh 'image:' "$repo_dir" --include='*.yaml' --include='*.yml' 2>/dev/null \
+    | grep -v '#' \
+    | grep -v '{{' \
+    | sed 's/.*image:\s*["'"'"']*//; s/["'"'"']*\s*$//' \
+    | grep -E '^[a-zA-Z0-9].*/' \
+    | sort -u \
+    >> "$repo_tmp/helm_images_raw.txt" 2>/dev/null || true
+
+  sort -u "$repo_tmp/helm_images_raw.txt" > "$repo_tmp/helm_images.txt" 2>/dev/null || touch "$repo_tmp/helm_images.txt"
+
+  # Packages (for cozystack main repo)
+  if [ "$repo_name" = "cozystack" ]; then
+    for pkg_dir in "$repo_dir"/packages/*/; do
+      [ -d "$pkg_dir" ] || continue
+      pkg_type=$(basename "$pkg_dir")
+      for app_dir in "$pkg_dir"/*/; do
+        [ -d "$app_dir" ] || continue
+        app_name=$(basename "$app_dir")
+
+        # Dockerfile images in this package
+        find "$app_dir" -name 'Dockerfile*' -type f 2>/dev/null \
+          | xargs grep -hi '^FROM' 2>/dev/null \
+          | sed 's/^FROM\s*//i; s/\s*[Aa][Ss]\s.*$//' \
+          | grep -v '^\$' \
+          | grep -v '^scratch$' \
+          | sort -u \
+          | while read -r img; do
+              echo "$pkg_type/$app_name|dockerfile|$img"
+            done >> "$repo_tmp/packages.txt" 2>/dev/null || true
+
+        # Helm images from values.yaml in this package
+        find "$app_dir" -name 'values.yaml' -type f 2>/dev/null \
+          | xargs -I{} python3 -c "
+import yaml, sys
+try:
+    with open('{}') as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, dict):
+        sys.exit(0)
+    def find_images(d):
+        if not isinstance(d, dict):
+            return
+        img = d.get('image', '')
+        if isinstance(img, str) and '/' in img and '{{' not in img and img.strip():
+            print(img.strip())
+        if isinstance(img, dict):
+            repo = img.get('repository', '')
+            tag = img.get('tag', '')
+            if repo and '{{' not in str(repo):
+                if tag and '{{' not in str(tag):
+                    print(f'{repo}:{tag}')
+        repo = d.get('repository', '')
+        tag = d.get('tag', '')
+        if isinstance(repo, str) and repo and '{{' not in repo and '/' in repo:
+            if isinstance(tag, str) and tag and '{{' not in tag:
+                print(f'{repo}:{tag}')
+        for v in d.values():
+            if isinstance(v, dict):
+                find_images(v)
+            elif isinstance(v, list):
+                for item in v:
+                    if isinstance(item, dict):
+                        find_images(item)
+    find_images(data)
+except Exception:
+    pass
+" 2>/dev/null | sort -u | while read -r img; do
+            echo "$pkg_type/$app_name|helm|$img"
+          done >> "$repo_tmp/packages.txt" 2>/dev/null || true
+      done
+    done
+  fi
+  [ -f "$repo_tmp/packages.txt" ] || touch "$repo_tmp/packages.txt"
+
+done < "$TMP_DIR/repos.txt"
+
+# --- Assemble JSON ---
+
+echo "==> Assembling discovery.json..."
+
+python3 << 'PYEOF'
+import json, os
+
+tmp_dir = os.environ.get("TMP_DIR", "workspace/tmp-discover")
+outfile = os.environ.get("OUTFILE", "workspace/discovery.json")
+workspace = os.environ.get("WORKSPACE", "workspace")
+
+repos = []
+for entry in sorted(os.listdir(tmp_dir)):
+    entry_dir = os.path.join(tmp_dir, entry)
+    if not os.path.isdir(entry_dir) or entry == ".":
+        continue
+    repo_file = os.path.join(entry_dir, "repo.txt")
+    if not os.path.exists(repo_file):
+        continue
+
+    with open(repo_file) as f:
+        repo_name = f.read().strip()
+
+    def read_lines(filename):
+        path = os.path.join(entry_dir, filename)
+        if not os.path.exists(path):
+            return []
+        with open(path) as f:
+            return [l.strip() for l in f if l.strip()]
+
+    go_deps = []
+    for line in read_lines("go_deps.txt"):
+        parts = line.split()
+        if len(parts) >= 2:
+            go_deps.append({"module": parts[0], "version": parts[1]})
+
+    repo_data = {
+        "repo": repo_name,
+        "go_deps": go_deps,
+        "dockerfile_images": read_lines("dockerfile_images.txt"),
+        "helm_images": read_lines("helm_images.txt"),
+    }
+
+    packages = []
+    for line in read_lines("packages.txt"):
+        parts = line.split("|")
+        if len(parts) == 3:
+            packages.append({"component": parts[0], "source": parts[1], "image": parts[2]})
+    if packages:
+        repo_data["packages"] = packages
+
+    repos.append(repo_data)
+
+output = {"repos": repos}
+with open(outfile, "w") as f:
+    json.dump(output, f, indent=2)
+
+# Collect unique images, filtering out unresolvable entries
+import re
+
+def is_valid_image(img):
+    """Filter out images that can't be pulled/scanned."""
+    if '$' in img or '${' in img:
+        return False
+    if img.startswith('--'):
+        return False
+    if '{{' in img or '}}' in img:
+        return False
+    if '/' not in img and ':' not in img:
+        return False
+    if '/' not in img and ':' in img:
+        name = img.split(':')[0]
+        if name in ('alpine', 'redis', 'nginx', 'postgres', 'ubuntu', 'debian', 'busybox', 'node', 'golang', 'python'):
+            return True
+        return False
+    return True
+
+images = set()
+skipped = 0
+for repo in repos:
+    for img in repo.get("dockerfile_images", []):
+        if is_valid_image(img):
+            images.add(img)
+        else:
+            skipped += 1
+    for img in repo.get("helm_images", []):
+        if is_valid_image(img):
+            images.add(img)
+        else:
+            skipped += 1
+    for pkg in repo.get("packages", []):
+        if is_valid_image(pkg["image"]):
+            images.add(pkg["image"])
+        else:
+            skipped += 1
+
+images_file = os.path.join(workspace, "images-to-scan.txt")
+with open(images_file, "w") as f:
+    for img in sorted(images):
+        f.write(img + "\n")
+
+print(f"Total repos: {len(repos)}")
+print(f"Total Go dependencies: {sum(len(r.get('go_deps', [])) for r in repos)}")
+print(f"Total unique images to scan: {len(images)} ({skipped} invalid entries filtered)")
+PYEOF
+
+echo "==> Discovery complete: $OUTFILE"

--- a/docs/security/pipeline/scripts/monthly.py
+++ b/docs/security/pipeline/scripts/monthly.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+monthly.py — Generate a public monthly security summary.
+
+This report contains only triaged, post-review findings — not raw scanner output.
+It is suitable for publishing on the Cozystack website or in the main repository.
+
+Reads state/reported-cves.json and state/triage-overrides.json to produce
+a summary of what was fixed, what is confirmed/in-progress, and what was
+accepted as risk during the past month.
+"""
+
+import json
+import os
+from collections import Counter
+from datetime import datetime, timezone, timedelta
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+STATE_DIR = os.path.join(REPO_ROOT, "state")
+REPORTS_DIR = os.path.join(REPO_ROOT, "reports")
+REPORTED_FILE = os.path.join(STATE_DIR, "reported-cves.json")
+TRIAGE_FILE = os.path.join(STATE_DIR, "triage-overrides.json")
+
+
+def load_json(path, default):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return default
+
+
+def save_report(content, filename):
+    dirpath = os.path.join(REPORTS_DIR, "monthly")
+    os.makedirs(dirpath, exist_ok=True)
+    filepath = os.path.join(dirpath, filename)
+    with open(filepath, "w") as f:
+        f.write(content)
+    print(f"Saved: reports/monthly/{filename}")
+    return filepath
+
+
+def main():
+    now = datetime.now(timezone.utc)
+    # Report covers the previous month
+    first_of_this_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    last_month_end = first_of_this_month - timedelta(seconds=1)
+    first_of_last_month = last_month_end.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    month_label = first_of_last_month.strftime("%B %Y")
+    month_start = first_of_last_month.isoformat()
+    month_end = first_of_this_month.isoformat()
+
+    print(f"Generating monthly report for: {month_label}")
+    print(f"  Period: {month_start} to {month_end}")
+
+    reported = load_json(REPORTED_FILE, {})
+    triage = load_json(TRIAGE_FILE, {})
+
+    # Categorize all CVEs by their triage status
+    fixed_this_month = []
+    confirmed_open = []
+    in_progress = []
+    accepted_risk = []
+    false_positives_count = 0
+    new_this_month = []
+
+    for cve_id, data in reported.items():
+        severity = data.get("severity", "UNKNOWN")
+        triage_entry = triage.get(cve_id, {})
+        status = triage_entry.get("status", "new")
+
+        # Check if reported this month
+        reported_at = data.get("reported_at", "")
+        is_this_month = month_start <= reported_at < month_end if reported_at else False
+
+        if status == "fixed":
+            decided_at = triage_entry.get("decided_at", "")
+            # Check if fixed this month
+            if decided_at and first_of_last_month.strftime("%Y-%m") <= decided_at[:7] <= last_month_end.strftime("%Y-%m"):
+                fixed_this_month.append({
+                    "cve_id": cve_id,
+                    "severity": severity,
+                    "package": data.get("package", ""),
+                    "fixed_version": data.get("fixed_version", triage_entry.get("fix_version", "")),
+                    "repos": data.get("repos", []),
+                })
+        elif status == "confirmed":
+            confirmed_open.append({
+                "cve_id": cve_id, "severity": severity,
+                "package": data.get("package", ""),
+            })
+        elif status == "in-progress":
+            in_progress.append({
+                "cve_id": cve_id, "severity": severity,
+                "package": data.get("package", ""),
+                "fix_pr": triage_entry.get("fix_pr", ""),
+            })
+        elif status == "accepted-risk":
+            accepted_risk.append({
+                "cve_id": cve_id, "severity": severity,
+                "package": data.get("package", ""),
+                "reason": triage_entry.get("reason", ""),
+            })
+        elif status == "false-positive":
+            false_positives_count += 1
+
+        if is_this_month:
+            new_this_month.append({
+                "cve_id": cve_id, "severity": severity,
+                "package": data.get("package", ""),
+            })
+
+    # Count new by severity
+    new_by_sev = Counter(v["severity"] for v in new_this_month)
+    total_tracked = len(reported)
+    total_triaged = len(triage)
+
+    # Build report
+    new_summary_parts = []
+    for sev in ["CRITICAL", "HIGH", "MEDIUM", "LOW"]:
+        if new_by_sev.get(sev):
+            new_summary_parts.append(f"{new_by_sev[sev]} {sev}")
+    new_summary = ", ".join(new_summary_parts) if new_summary_parts else "none"
+
+    # Fixed table
+    if fixed_this_month:
+        fixed_rows = []
+        for v in sorted(fixed_this_month, key=lambda x: x["severity"]):
+            repos = ", ".join(f"`{r}`" for r in v["repos"][:3]) if v["repos"] else "—"
+            fixed_rows.append(
+                f"| [{v['cve_id']}](https://nvd.nist.gov/vuln/detail/{v['cve_id']}) "
+                f"| {v['severity']} | `{v['package']}` | `{v.get('fixed_version', 'N/A')}` | {repos} |"
+            )
+        fixed_table = "\n".join(fixed_rows)
+    else:
+        fixed_table = "| — | — | — | — | — |"
+
+    # In-progress table
+    if in_progress:
+        ip_rows = []
+        for v in sorted(in_progress, key=lambda x: {"CRITICAL": 0, "HIGH": 1}.get(x["severity"], 2)):
+            pr_link = f"[PR]({v['fix_pr']})" if v.get("fix_pr") else "—"
+            ip_rows.append(
+                f"| [{v['cve_id']}](https://nvd.nist.gov/vuln/detail/{v['cve_id']}) "
+                f"| {v['severity']} | `{v['package']}` | {pr_link} |"
+            )
+        ip_table = "\n".join(ip_rows)
+    else:
+        ip_table = "| — | — | — | — |"
+
+    # Accepted risk table
+    if accepted_risk:
+        ar_rows = []
+        for v in sorted(accepted_risk, key=lambda x: x["cve_id"]):
+            reason = v.get("reason", "")[:80]
+            ar_rows.append(
+                f"| [{v['cve_id']}](https://nvd.nist.gov/vuln/detail/{v['cve_id']}) "
+                f"| {v['severity']} | `{v['package']}` | {reason} |"
+            )
+        ar_table = "\n".join(ar_rows)
+    else:
+        ar_table = "| — | — | — | — |"
+
+    content = f"""# Cozystack Security Summary — {month_label}
+
+> This is a public monthly summary of security activities in the Cozystack project.
+> It covers triaged findings only — not raw scanner output.
+
+## Overview
+
+| Metric | Count |
+|--------|-------|
+| New vulnerabilities detected | {len(new_this_month)} ({new_summary}) |
+| Fixed this month | {len(fixed_this_month)} |
+| In progress | {len(in_progress)} |
+| Confirmed (awaiting fix) | {len(confirmed_open)} |
+| Accepted risk | {len(accepted_risk)} |
+| False positives dismissed | {false_positives_count} |
+| Total tracked | {total_tracked} |
+| Total triaged | {total_triaged} |
+
+## Security Updates Released
+
+| CVE | Severity | Package | Fixed Version | Components |
+|-----|----------|---------|---------------|------------|
+{fixed_table}
+
+## In Progress
+
+| CVE | Severity | Package | Fix PR |
+|-----|----------|---------|--------|
+{ip_table}
+
+## Accepted Risks
+
+| CVE | Severity | Package | Reason |
+|-----|----------|---------|--------|
+{ar_table}
+
+## How to Report
+
+If you discover a security vulnerability in Cozystack:
+
+1. Use [GitHub Private Vulnerability Reporting](https://github.com/cozystack/cozystack/security/advisories/new)
+2. Or email **cncf-cozystack-security@lists.cncf.io**
+
+See [SECURITY.md](https://github.com/cozystack/cozystack/blob/main/SECURITY.md) for full details.
+
+---
+*Generated on {now.strftime("%Y-%m-%d")} by the Cozystack security pipeline.*
+"""
+
+    filename = f"{first_of_last_month.strftime('%Y-%m')}-security-summary.md"
+    save_report(content, filename)
+
+    # Also output JSON for the website
+    website_json = {
+        "month": month_label,
+        "generated_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "new_count": len(new_this_month),
+        "fixed": [{"cve_id": v["cve_id"], "severity": v["severity"], "package": v["package"], "fixed_version": v.get("fixed_version", "")} for v in fixed_this_month],
+        "in_progress": [{"cve_id": v["cve_id"], "severity": v["severity"], "package": v["package"]} for v in in_progress],
+        "accepted_risk": [{"cve_id": v["cve_id"], "severity": v["severity"], "package": v["package"], "reason": v.get("reason", "")[:100]} for v in accepted_risk],
+        "stats": {
+            "total_tracked": total_tracked,
+            "total_triaged": total_triaged,
+            "false_positives": false_positives_count,
+        },
+    }
+
+    json_path = os.path.join(REPORTS_DIR, "monthly", "latest.json")
+    with open(json_path, "w") as f:
+        json.dump(website_json, f, indent=2)
+    print(f"Saved: reports/monthly/latest.json")
+
+    print(f"\nSummary for {month_label}:")
+    print(f"  New: {len(new_this_month)}, Fixed: {len(fixed_this_month)}, In-progress: {len(in_progress)}")
+    print(f"  Confirmed: {len(confirmed_open)}, Accepted risk: {len(accepted_risk)}, False positives: {false_positives_count}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/security/pipeline/scripts/report.py
+++ b/docs/security/pipeline/scripts/report.py
@@ -1,0 +1,623 @@
+#!/usr/bin/env python3
+"""
+report.py — Generate security reports as markdown files in reports/.
+
+- CRITICAL: immediately saved to reports/critical/YYYY-MM-DD-<CVE>.md
+- HIGH/MEDIUM/LOW: accumulated, then saved as weekly report
+  reports/weekly/YYYY-MM-DD-security-report.md
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
+
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+STATE_DIR = os.path.join(REPO_ROOT, "state")
+REPORTS_DIR = os.path.join(REPO_ROOT, "reports")
+REPORTED_FILE = os.path.join(STATE_DIR, "reported-cves.json")
+PENDING_FILE = os.path.join(STATE_DIR, "pending-weekly.json")
+TRIAGE_FILE = os.path.join(STATE_DIR, "triage-overrides.json")
+
+# Statuses that mean "already handled, skip in new reports"
+RESOLVED_STATUSES = {"false-positive", "accepted-risk", "fixed"}
+
+# Build/dev image patterns — CVEs in these are informational only
+DEV_IMAGE_PATTERNS = [
+    r"^golang:",
+    r"^docker\.io/library/golang:",
+    r"^docker\.io/golang:",
+    r"^node:",
+    r"^python:",
+    r"^rust:",
+    r"^maven:",
+    r"^gradle:",
+    r"^--platform=",  # build stage artifacts
+]
+
+# Component paths that are dev/test only
+DEV_COMPONENT_PATTERNS = [
+    "core/testing",
+    "hack/",
+    "test/",
+    "e2e/",
+]
+
+# How old an unfixed CVE must be (days) before we auto-demote it
+UNFIXED_AGE_THRESHOLD_DAYS = 365
+
+# Repository where issues are created (this repo)
+ISSUES_REPO = os.environ.get("ISSUES_REPO", "cozystack/security-scanner")
+
+# Severity → GitHub label mapping
+SEVERITY_LABELS = {
+    "CRITICAL": "security/critical",
+    "HIGH": "security/high",
+    "MEDIUM": "security/medium",
+    "LOW": "security/low",
+}
+
+# Slack webhook URL (from env, set via GitHub Actions secret)
+SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL", "")
+
+
+def notify_slack(vulns):
+    """Send a Slack notification for new CRITICAL CVEs."""
+    if not SLACK_WEBHOOK_URL or not vulns:
+        return
+
+    count = len(vulns)
+    cve_lines = []
+    for v in vulns[:10]:
+        cve_id = v["cve_id"]
+        pkg = v.get("package", "unknown")
+        fixed = v.get("fixed_version", "")
+        fix_text = f" → fix in `{fixed}`" if fixed else " — no fix yet"
+        cve_lines.append(f"• <https://nvd.nist.gov/vuln/detail/{cve_id}|{cve_id}> in `{pkg}`{fix_text}")
+
+    if count > 10:
+        cve_lines.append(f"_...and {count - 10} more_")
+
+    text = "\n".join(cve_lines)
+    payload = {
+        "blocks": [
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": f"🚨 {count} new CRITICAL CVE{'s' if count != 1 else ''} detected"}
+            },
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": text}
+            },
+            {
+                "type": "context",
+                "elements": [
+                    {"type": "mrkdwn", "text": f"<https://github.com/{ISSUES_REPO}/issues?q=is%3Aissue+label%3Asecurity%2Fcritical+is%3Aopen|View open CRITICAL issues>"}
+                ]
+            }
+        ]
+    }
+
+    try:
+        import urllib.request
+        req = urllib.request.Request(
+            SLACK_WEBHOOK_URL,
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        resp = urllib.request.urlopen(req, timeout=10)
+        print(f"  Slack notification sent ({resp.status})")
+    except Exception as e:
+        print(f"  WARN: Slack notification failed: {e}")
+
+
+def load_json(path, default):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return default
+
+
+def save_json(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def cve_age_days(cve_id):
+    """Estimate CVE age from its ID (CVE-YYYY-NNNNN)."""
+    match = re.match(r"CVE-(\d{4})-", cve_id)
+    if not match:
+        return 0
+    cve_year = int(match.group(1))
+    now = datetime.now(timezone.utc)
+    # Approximate: assume CVE was published Jan 1 of its year
+    age = (now - datetime(cve_year, 1, 1, tzinfo=timezone.utc)).days
+    return max(age, 0)
+
+
+def is_dev_only(vuln):
+    """Check if a CVE only affects dev/build images or test components."""
+    # Fast path: scan.sh already tagged this
+    if vuln.get("dev_only", False):
+        return True
+
+    repos = vuln.get("affected_repos", [])
+    if not repos:
+        return False
+
+    for repo in repos:
+        # Check component paths (e.g. "cozystack/cozystack:core/testing")
+        if ":" in repo:
+            component = repo.split(":", 1)[1]
+            if any(pat in component for pat in DEV_COMPONENT_PATTERNS):
+                continue  # this one is dev, check the rest
+            return False  # at least one non-dev component
+        else:
+            return False  # whole-repo reference, not dev-only
+
+    # All affected repos/components are dev-only
+    return True
+
+
+def classify_filter(vuln, triage_overrides):
+    """Classify a CVE for filtering. Returns (skip, reason) or (False, None).
+
+    skip=True means the CVE should not appear in critical/weekly reports.
+    reason is a human-readable explanation for logging.
+    """
+    cve_id = vuln["cve_id"]
+    severity = vuln.get("severity", "")
+
+    # UNKNOWN severity — not in any known vulnerability DB
+    if severity == "UNKNOWN":
+        return True, "unknown severity"
+
+    # Already triaged as resolved
+    if cve_id in triage_overrides:
+        status = triage_overrides[cve_id].get("status", "")
+        if status in RESOLVED_STATUSES:
+            return True, f"triaged as {status}"
+
+    # Dev/build-only image or test component
+    if is_dev_only(vuln):
+        return True, "dev/build dependency only"
+
+    # Unfixed upstream older than threshold
+    if not vuln.get("fixed_version"):
+        age = cve_age_days(cve_id)
+        if age > UNFIXED_AGE_THRESHOLD_DAYS:
+            return True, f"unfixed upstream ({age} days old)"
+
+    return False, None
+
+
+def save_report(subdir, filename, content):
+    """Write a markdown report to reports/<subdir>/<filename>."""
+    dirpath = os.path.join(REPORTS_DIR, subdir)
+    os.makedirs(dirpath, exist_ok=True)
+    filepath = os.path.join(dirpath, filename)
+    with open(filepath, "w") as f:
+        f.write(content)
+    print(f"  Saved: reports/{subdir}/{filename}")
+    return filepath
+
+
+def create_ghsa_draft(vuln):
+    """Create a draft GitHub Security Advisory for a CRITICAL CVE."""
+    cve_id = vuln["cve_id"]
+    package = vuln.get("package", "unknown")
+    severity = vuln.get("severity", "CRITICAL").lower()
+    description = vuln.get("description", "No description available.")[:1000]
+    fixed = vuln.get("fixed_version", "")
+
+    # Map severity to GHSA format
+    ghsa_severity = severity if severity in ("critical", "high", "medium", "low") else "high"
+
+    summary = f"{cve_id}: {vuln.get('title', f'Vulnerability in {package}')}"[:240]
+
+    body = {
+        "summary": summary,
+        "description": f"""## Description
+
+{description}
+
+## Affected Component
+
+Package: `{package}`
+Installed version: `{vuln.get('installed_version', 'N/A')}`
+{"Fixed in: `" + fixed + "`" if fixed else "No fix available yet."}
+
+## References
+
+- https://nvd.nist.gov/vuln/detail/{cve_id}
+
+---
+*Draft created automatically by the Cozystack security pipeline.*""",
+        "severity": ghsa_severity,
+        "cve_id": cve_id if cve_id.startswith("CVE-") else None,
+    }
+
+    # Remove None values
+    body = {k: v for k, v in body.items() if v is not None}
+
+    # Determine target repo — use the first affected non-component repo, or main
+    affected = vuln.get("affected_repos", [])
+    target_repos = sorted(set(r.split(":")[0] for r in affected))
+    target_repo = target_repos[0] if target_repos else "cozystack/cozystack"
+
+    cmd = ["gh", "api", f"/repos/{target_repo}/security-advisories",
+           "--method", "POST",
+           "-f", f"summary={body['summary']}",
+           "-f", f"description={body['description']}",
+           "-f", f"severity={body['severity']}"]
+
+    if body.get("cve_id"):
+        cmd.extend(["-f", f"cve_id={body['cve_id']}"])
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if result.returncode == 0:
+            data = json.loads(result.stdout)
+            url = data.get("html_url", "")
+            print(f"  GHSA draft created: {url}")
+            return url
+        else:
+            # 422 often means CVE ID already has an advisory, or permissions issue
+            print(f"  WARN: GHSA draft failed for {cve_id}: {result.stderr[:200]}")
+            return None
+    except Exception as e:
+        print(f"  WARN: GHSA error for {cve_id}: {e}")
+        return None
+
+
+def create_issue(vuln, report_path=None):
+    """Create a GitHub Issue for a CVE in the security-scanner repo."""
+    cve_id = vuln["cve_id"]
+    severity = vuln.get("severity", "UNKNOWN")
+    package = vuln.get("package", "unknown")
+    fixed = vuln.get("fixed_version", "")
+    title = vuln.get("title", "")
+
+    issue_title = f"security_{severity.lower()}: {cve_id} — {title[:80]}" if title else f"security_{severity.lower()}: {cve_id} in {package}"
+
+    refs = "\n".join(f"- {r}" for r in vuln.get("references", [])[:5])
+    repos = "\n".join(f"- `{r}`" for r in vuln.get("affected_repos", []))
+    fix_line = f"`{fixed}`" if fixed else "No fix available yet"
+    report_link = f"\n**Report:** [{report_path}]({report_path})" if report_path else ""
+
+    issue_body = f"""## {cve_id}
+
+| Field | Value |
+|-------|-------|
+| **CVE** | [{cve_id}](https://nvd.nist.gov/vuln/detail/{cve_id}) |
+| **Severity** | {severity} (CVSS {vuln.get('cvss_score', 'N/A')}) |
+| **Package** | `{package}` |
+| **Installed** | `{vuln.get('installed_version', 'N/A')}` |
+| **Fixed in** | {fix_line} |
+{report_link}
+
+### Description
+
+{vuln.get('description', 'No description available.')[:500]}
+
+### Affected Components
+
+{repos if repos else '- Unknown'}
+
+### References
+
+{refs if refs else '- None'}
+
+### Triage Checklist
+
+- [ ] Is this in a shipped artifact (not dev/test only)?
+- [ ] Is the vulnerable code path reachable in our usage?
+- [ ] Has the distro already backported the fix?
+- [ ] Is a fix available upstream?
+
+### Decision
+
+<!-- Set a label and close when done:
+  security/confirmed — real issue, needs fix
+  security/false-positive — not applicable
+  security/accepted-risk — accepted with justification
+  security/in-progress — fix being worked on
+  security/fixed — done
+-->
+"""
+
+    labels = ["security/triage-needed"]
+    sev_label = SEVERITY_LABELS.get(severity)
+    if sev_label:
+        labels.append(sev_label)
+
+    label_args = []
+    for l in labels:
+        label_args.extend(["-l", l])
+
+    cmd = ["gh", "issue", "create",
+           "--repo", ISSUES_REPO,
+           "--title", issue_title,
+           "--body", issue_body] + label_args
+
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if result.returncode == 0:
+            url = result.stdout.strip()
+            print(f"  Issue created: {url}")
+            return url
+        else:
+            print(f"  WARN: failed to create issue for {cve_id}: {result.stderr[:200]}")
+            return None
+    except Exception as e:
+        print(f"  WARN: issue creation error for {cve_id}: {e}")
+        return None
+
+
+def build_critical_report(vuln, today):
+    """Build markdown for a single critical CVE report."""
+    refs = "\n".join(f"- {r}" for r in vuln.get("references", []))
+    repos = "\n".join(f"- `{r}`" for r in vuln.get("affected_repos", []))
+    fixed = vuln.get("fixed_version", "")
+    fix_line = f"`{fixed}`" if fixed else "No fix available yet"
+    cve_id = vuln["cve_id"]
+    title = vuln.get("title", "No title")
+
+    return f"""# security_critical: {cve_id}
+
+**Date:** {today}
+**Severity:** {vuln['severity']} (CVSS {vuln.get('cvss_score', 'N/A')})
+
+## Vulnerability Details
+
+| Field | Value |
+|-------|-------|
+| **CVE** | [{cve_id}](https://nvd.nist.gov/vuln/detail/{cve_id}) |
+| **Severity** | {vuln['severity']} (CVSS {vuln.get('cvss_score', 'N/A')}) |
+| **Package** | `{vuln.get('package', 'N/A')}` |
+| **Installed version** | `{vuln.get('installed_version', 'N/A')}` |
+| **Fixed in** | {fix_line} |
+
+## Description
+
+{vuln.get('description', 'No description available.')}
+
+## Affected Components
+
+{repos if repos else '- Unknown'}
+
+## References
+
+{refs if refs else '- None'}
+
+## Recommended Action
+
+{"Update `" + vuln.get('package', '') + "` to version `" + fixed + "` in the affected components listed above." if fixed else "Monitor for an upstream fix and update as soon as a patched version is available."}
+"""
+
+
+def build_weekly_report(vulns, today):
+    """Build markdown for the weekly summary report."""
+    by_severity = {}
+    for v in vulns:
+        sev = v["severity"]
+        by_severity.setdefault(sev, []).append(v)
+
+    summary_parts = []
+    for sev in ["HIGH", "MEDIUM", "LOW"]:
+        count = len(by_severity.get(sev, []))
+        if count:
+            summary_parts.append(f"{count} {sev}")
+    summary = ", ".join(summary_parts) if summary_parts else "No new vulnerabilities"
+
+    table_rows = []
+    for v in sorted(vulns, key=lambda x: {"HIGH": 0, "MEDIUM": 1, "LOW": 2}.get(x["severity"], 9)):
+        fixed = f"`{v['fixed_version']}`" if v.get("fixed_version") else "N/A"
+        repos = ", ".join(f"`{r}`" for r in v.get("affected_repos", [])[:3])
+        if len(v.get("affected_repos", [])) > 3:
+            repos += f" +{len(v['affected_repos']) - 3} more"
+        table_rows.append(
+            f"| [{v['cve_id']}](https://nvd.nist.gov/vuln/detail/{v['cve_id']}) "
+            f"| {v['severity']} "
+            f"| `{v.get('package', '')}` "
+            f"| {repos} "
+            f"| {fixed} |"
+        )
+
+    table = "\n".join(table_rows) if table_rows else "| — | — | — | — | — |"
+
+    return f"""# security_report: Weekly vulnerability summary ({today})
+
+**Date:** {today}
+**Total new vulnerabilities:** {len(vulns)}
+**Breakdown:** {summary}
+
+## New Vulnerabilities
+
+| CVE | Severity | Package | Affected Repos | Fixed Version |
+|-----|----------|---------|----------------|---------------|
+{table}
+
+## What to do
+
+- Review each CVE and assess impact on your deployment
+- Prioritize HIGH severity items and packages where a fixed version is available
+- Monitor upstream for fixes where none are available yet
+"""
+
+
+def process_critical(scan_results, reported, triage_overrides):
+    """Process CRITICAL CVEs — save individual reports immediately."""
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    new_critical = []
+    filtered_count = 0
+
+    for vuln in scan_results.get("vulnerabilities", []):
+        cve_id = vuln["cve_id"]
+        if vuln["severity"] != "CRITICAL":
+            continue
+        if cve_id in reported:
+            continue
+        skip, reason = classify_filter(vuln, triage_overrides)
+        if skip:
+            filtered_count += 1
+            continue
+        new_critical.append(vuln)
+
+    if filtered_count:
+        print(f"Filtered out {filtered_count} CRITICAL CVEs (triage/dev/unfixed)")
+
+    if not new_critical:
+        print("No new CRITICAL CVEs found.")
+        return reported
+
+    print(f"Found {len(new_critical)} new CRITICAL CVEs")
+
+    for vuln in new_critical:
+        cve_id = vuln["cve_id"]
+        component = vuln.get("package", "unknown")
+        content = build_critical_report(vuln, today)
+        filename = f"{today}-{cve_id}.md"
+        report_path = f"reports/critical/{filename}"
+
+        print(f"\n  CRITICAL: {cve_id} ({component})")
+        save_report("critical", filename, content)
+
+        issue_url = create_issue(vuln, report_path)
+        ghsa_url = create_ghsa_draft(vuln)
+
+        affected = vuln.get("affected_repos", [])
+        target_repos = sorted(set(r.split(":")[0] for r in affected))
+
+        reported[cve_id] = {
+            "severity": vuln["severity"],
+            "reported_at": datetime.now(timezone.utc).isoformat(),
+            "report_file": report_path,
+            "issue_url": issue_url or "",
+            "ghsa_url": ghsa_url or "",
+            "repos": target_repos,
+            "package": vuln.get("package", ""),
+            "fixed_version": vuln.get("fixed_version", ""),
+        }
+
+    # Send Slack alert for all new CRITICAL CVEs in one message
+    notify_slack(new_critical)
+
+    return reported
+
+
+def process_weekly(scan_results, reported, pending, triage_overrides):
+    """Accumulate HIGH/MEDIUM/LOW CVEs into pending list."""
+    new_count = 0
+    filtered_count = 0
+
+    for vuln in scan_results.get("vulnerabilities", []):
+        cve_id = vuln["cve_id"]
+        severity = vuln["severity"]
+
+        if severity == "CRITICAL":
+            continue
+        if cve_id in reported:
+            continue
+        skip, reason = classify_filter(vuln, triage_overrides)
+        if skip:
+            filtered_count += 1
+            continue
+        if any(p["cve_id"] == cve_id for p in pending):
+            continue
+
+        pending.append(vuln)
+        new_count += 1
+
+    if filtered_count:
+        print(f"Filtered out {filtered_count} HIGH/MEDIUM/LOW CVEs (triage/dev/unfixed)")
+    print(f"Added {new_count} new HIGH/MEDIUM/LOW CVEs to pending weekly report (total pending: {len(pending)})")
+    return pending
+
+
+def send_weekly_report(reported, pending):
+    """Save weekly summary report and create issues for each CVE."""
+    if not pending:
+        print("No pending CVEs for weekly report.")
+        return reported, []
+
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    content = build_weekly_report(pending, today)
+    filename = f"{today}-security-report.md"
+    report_path = f"reports/weekly/{filename}"
+
+    print(f"\nCreating weekly report with {len(pending)} CVEs...")
+    save_report("weekly", filename, content)
+
+    # Create individual Issues only for HIGH CVEs (CRITICAL already handled separately)
+    high_vulns = [v for v in pending if v["severity"] == "HIGH"]
+    other_vulns = [v for v in pending if v["severity"] != "HIGH"]
+
+    if high_vulns:
+        print(f"Creating issues for {len(high_vulns)} HIGH CVEs...")
+    for vuln in high_vulns:
+        issue_url = create_issue(vuln, report_path)
+        reported[vuln["cve_id"]] = {
+            "severity": vuln["severity"],
+            "reported_at": datetime.now(timezone.utc).isoformat(),
+            "report_file": report_path,
+            "issue_url": issue_url or "",
+            "repos": vuln.get("affected_repos", []),
+            "package": vuln.get("package", ""),
+            "fixed_version": vuln.get("fixed_version", ""),
+        }
+
+    # MEDIUM/LOW — report only, no individual Issues
+    for vuln in other_vulns:
+        reported[vuln["cve_id"]] = {
+            "severity": vuln["severity"],
+            "reported_at": datetime.now(timezone.utc).isoformat(),
+            "report_file": report_path,
+            "repos": vuln.get("affected_repos", []),
+            "package": vuln.get("package", ""),
+            "fixed_version": vuln.get("fixed_version", ""),
+        }
+
+    return reported, []
+
+
+def main():
+    parser = argparse.ArgumentParser(description="CVE report generator")
+    parser.add_argument("scan_results", help="Path to scan-results.json")
+    parser.add_argument("--weekly", action="store_true", help="Generate weekly report from pending CVEs")
+    args = parser.parse_args()
+
+    reported = load_json(REPORTED_FILE, {})
+    pending = load_json(PENDING_FILE, [])
+    triage_overrides = load_json(TRIAGE_FILE, {})
+
+    with open(args.scan_results) as f:
+        scan_results = json.load(f)
+
+    triaged_count = len([v for v in triage_overrides.values() if v.get("status") in RESOLVED_STATUSES])
+    print(f"Scan date: {scan_results.get('scan_date', 'unknown')}")
+    print(f"Total CVEs in scan: {scan_results.get('total_vulnerabilities', 0)}")
+    print(f"Already reported: {len(reported)}")
+    print(f"Triage overrides: {len(triage_overrides)} ({triaged_count} resolved)")
+    print()
+
+    reported = process_critical(scan_results, reported, triage_overrides)
+    pending = process_weekly(scan_results, reported, pending, triage_overrides)
+
+    if args.weekly:
+        print()
+        reported, pending = send_weekly_report(reported, pending)
+
+    save_json(REPORTED_FILE, reported)
+    save_json(PENDING_FILE, pending)
+    print(f"\nState saved. Reported: {len(reported)}, Pending: {len(pending)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/security/pipeline/scripts/scan.sh
+++ b/docs/security/pipeline/scripts/scan.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# scan.sh — Run Trivy scans on discovered repos and images.
+# Reads discovery output, produces workspace/scan-results.json
+set -euo pipefail
+
+WORKSPACE="${1:-workspace}"
+DISCOVERY="$WORKSPACE/discovery.json"
+IMAGES_FILE="$WORKSPACE/images-to-scan.txt"
+CLONE_DIR="$WORKSPACE/repos"
+RESULTS_DIR="$WORKSPACE/scan-results"
+OUTFILE="$WORKSPACE/scan-results.json"
+
+mkdir -p "$RESULTS_DIR"
+
+if [ ! -f "$DISCOVERY" ]; then
+  echo "ERROR: $DISCOVERY not found. Run discover.sh first." >&2
+  exit 1
+fi
+
+# Check trivy is available
+if ! command -v trivy &>/dev/null; then
+  echo "ERROR: trivy not found. Install it: https://aquasecurity.github.io/trivy/" >&2
+  exit 1
+fi
+
+echo "==> Starting vulnerability scans..."
+
+# --- Phase 1: Scan repos (go.mod, Dockerfiles, lock files) ---
+
+REPO_NAMES=$(python3 -c "
+import json
+with open('$DISCOVERY') as f:
+    data = json.load(f)
+for r in data['repos']:
+    name = r['repo'].split('/')[-1]
+    # Only scan repos that have dependency files
+    if r.get('go_deps') or r.get('dockerfile_images'):
+        print(name)
+")
+
+for repo_name in $REPO_NAMES; do
+  repo_dir="$CLONE_DIR/$repo_name"
+  result_file="$RESULTS_DIR/repo-$repo_name.json"
+
+  if [ ! -d "$repo_dir" ]; then
+    echo "   WARN: $repo_dir not found, skipping"
+    continue
+  fi
+
+  echo "   Scanning repo: $repo_name..."
+  trivy fs "$repo_dir" \
+    --format json \
+    --severity CRITICAL,HIGH,MEDIUM,LOW \
+    --scanners vuln \
+    --quiet \
+    > "$result_file" 2>/dev/null || {
+      echo "   WARN: trivy fs failed for $repo_name"
+      echo '{"Results": []}' > "$result_file"
+    }
+done
+
+# --- Phase 2: Scan Docker images ---
+
+if [ -f "$IMAGES_FILE" ]; then
+  total_images=$(wc -l < "$IMAGES_FILE" | tr -d ' ')
+  echo "==> Scanning $total_images Docker images..."
+  current=0
+
+  while IFS= read -r image; do
+    [ -z "$image" ] && continue
+    current=$((current + 1))
+
+    # Sanitize image name for filename
+    safe_name=$(echo "$image" | sed 's|[/:]|_|g')
+    result_file="$RESULTS_DIR/image-$safe_name.json"
+
+    echo "   [$current/$total_images] Scanning image: $image..."
+    trivy image "$image" \
+      --format json \
+      --severity CRITICAL,HIGH,MEDIUM,LOW \
+      --scanners vuln \
+      --quiet \
+      --timeout 5m \
+      > "$result_file" 2>/dev/null || {
+        echo "   WARN: trivy image failed for $image"
+        echo '{"Results": []}' > "$result_file"
+      }
+  done < "$IMAGES_FILE"
+fi
+
+# --- Phase 3: Merge all results into one file ---
+
+echo "==> Merging scan results..."
+
+python3 << 'PYEOF'
+import json, os, sys, re
+
+results_dir = os.environ.get("RESULTS_DIR", "workspace/scan-results")
+discovery_file = os.environ.get("DISCOVERY", "workspace/discovery.json")
+outfile = os.environ.get("OUTFILE", "workspace/scan-results.json")
+
+# Load discovery data to map images -> repos
+with open(discovery_file) as f:
+    discovery = json.load(f)
+
+# Build image -> repos mapping
+image_to_repos = {}
+# Track which images are build/dev only (golang, node, etc. in Dockerfiles)
+import re
+DEV_IMAGE_RE = re.compile(r'^(--platform=\S+\s+)?(docker\.io/)?(library/)?(golang|node|python|rust|maven|gradle)[:/]', re.I)
+
+dev_only_images = set()
+for repo in discovery["repos"]:
+    repo_name = repo["repo"]
+    for img in repo.get("dockerfile_images", []):
+        image_to_repos.setdefault(img, set()).add(repo_name)
+        if DEV_IMAGE_RE.match(img):
+            dev_only_images.add(img)
+    for img in repo.get("helm_images", []):
+        image_to_repos.setdefault(img, set()).add(repo_name)
+    for pkg in repo.get("packages", []):
+        image_to_repos.setdefault(pkg["image"], set()).add(repo_name)
+        # Also track the specific component path
+        image_to_repos.setdefault(pkg["image"], set()).add(
+            f'{repo_name}:{pkg["component"]}'
+        )
+        # Mark testing components as dev
+        if any(p in pkg["component"] for p in ("testing", "hack/", "test/", "e2e/")):
+            dev_only_images.add(pkg["image"])
+
+all_vulns = {}  # CVE-ID -> details
+
+for filename in sorted(os.listdir(results_dir)):
+    if not filename.endswith(".json"):
+        continue
+
+    filepath = os.path.join(results_dir, filename)
+    try:
+        with open(filepath) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, FileNotFoundError):
+        continue
+
+    # Determine source (repo name or image name)
+    source = filename.replace(".json", "")
+    if source.startswith("repo-"):
+        source_type = "repo"
+        source_name = source[5:]  # strip "repo-"
+    elif source.startswith("image-"):
+        source_type = "image"
+        source_name = source[6:]  # strip "image-"
+    else:
+        continue
+
+    results = data.get("Results", [])
+    for result in results:
+        target = result.get("Target", "")
+        vuln_type = result.get("Type", "")
+        for vuln in result.get("Vulnerabilities", []):
+            cve_id = vuln.get("VulnerabilityID", "")
+            if not cve_id:
+                continue
+
+            severity = vuln.get("Severity", "UNKNOWN")
+            pkg_name = vuln.get("PkgName", "")
+            installed_ver = vuln.get("InstalledVersion", "")
+            fixed_ver = vuln.get("FixedVersion", "")
+            title = vuln.get("Title", "")
+            description = vuln.get("Description", "")[:500]
+            refs = vuln.get("References", [])[:5]
+            cvss_score = ""
+            if vuln.get("CVSS"):
+                for provider, scores in vuln["CVSS"].items():
+                    if "V3Score" in scores:
+                        cvss_score = str(scores["V3Score"])
+                        break
+
+            # Determine affected repos and whether this source is dev-only
+            affected_repos = set()
+            source_is_dev = False
+            if source_type == "repo":
+                affected_repos.add(f"cozystack/{source_name}")
+            else:
+                # Map image back to repos
+                for img, repos in image_to_repos.items():
+                    img_safe = re.sub(r'[/:]', '_', img)
+                    if img_safe == source_name:
+                        affected_repos.update(repos)
+                        if img in dev_only_images:
+                            source_is_dev = True
+
+            if cve_id not in all_vulns:
+                all_vulns[cve_id] = {
+                    "cve_id": cve_id,
+                    "severity": severity,
+                    "cvss_score": cvss_score,
+                    "package": pkg_name,
+                    "installed_version": installed_ver,
+                    "fixed_version": fixed_ver,
+                    "title": title,
+                    "description": description,
+                    "references": refs,
+                    "affected_repos": sorted(affected_repos),
+                    "source_type": source_type,
+                    "dev_only": source_is_dev,
+                }
+            else:
+                # Merge affected repos
+                existing = all_vulns[cve_id]
+                existing["affected_repos"] = sorted(
+                    set(existing["affected_repos"]) | affected_repos
+                )
+                # If any non-dev source contributes, mark as not dev-only
+                if not source_is_dev:
+                    existing["dev_only"] = False
+                # Prefer higher severity
+                sev_order = {"CRITICAL": 4, "HIGH": 3, "MEDIUM": 2, "LOW": 1, "UNKNOWN": 0}
+                if sev_order.get(severity, 0) > sev_order.get(existing["severity"], 0):
+                    existing["severity"] = severity
+
+# Sort by severity
+sev_order = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "UNKNOWN": 4}
+vulns_list = sorted(all_vulns.values(), key=lambda v: (sev_order.get(v["severity"], 9), v["cve_id"]))
+
+output = {
+    "scan_date": __import__("datetime").datetime.utcnow().isoformat() + "Z",
+    "total_vulnerabilities": len(vulns_list),
+    "by_severity": {},
+    "vulnerabilities": vulns_list,
+}
+for v in vulns_list:
+    sev = v["severity"]
+    output["by_severity"][sev] = output["by_severity"].get(sev, 0) + 1
+
+with open(outfile, "w") as f:
+    json.dump(output, f, indent=2)
+
+print(f"Total unique CVEs: {len(vulns_list)}")
+for sev in ["CRITICAL", "HIGH", "MEDIUM", "LOW"]:
+    count = output["by_severity"].get(sev, 0)
+    if count:
+        print(f"  {sev}: {count}")
+PYEOF
+
+echo "==> Scan complete: $OUTFILE"

--- a/docs/security/pipeline/scripts/sync_issues.py
+++ b/docs/security/pipeline/scripts/sync_issues.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""
+sync_issues.py — Sync closed GitHub Issues back to triage-overrides.json.
+
+When a maintainer closes an issue with a triage label (security/confirmed,
+security/false-positive, security/accepted-risk, security/fixed), this script
+reads that decision and writes it into state/triage-overrides.json so the
+next scan skips already-triaged CVEs.
+"""
+
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+STATE_DIR = os.path.join(REPO_ROOT, "state")
+TRIAGE_FILE = os.path.join(STATE_DIR, "triage-overrides.json")
+ISSUES_REPO = os.environ.get("ISSUES_REPO", "cozystack/security-scanner")
+
+# Map GitHub labels to triage statuses
+LABEL_TO_STATUS = {
+    "security/confirmed": "confirmed",
+    "security/false-positive": "false-positive",
+    "security/accepted-risk": "accepted-risk",
+    "security/in-progress": "in-progress",
+    "security/fixed": "fixed",
+}
+
+
+def load_json(path, default):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return default
+
+
+def save_json(path, data):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def extract_cve_from_title(title):
+    """Extract CVE ID from issue title like 'security_critical: CVE-2025-15467 — ...'"""
+    match = re.search(r"(CVE-\d{4}-\d+)", title)
+    return match.group(1) if match else None
+
+
+def get_closed_issues():
+    """Fetch all closed issues with security triage labels."""
+    # Get closed issues with any security label
+    cmd = [
+        "gh", "issue", "list",
+        "--repo", ISSUES_REPO,
+        "--state", "closed",
+        "--label", "security/triage-needed",
+        "--json", "number,title,labels,closedAt,author,assignees",
+        "--limit", "500",
+    ]
+    # Also get issues with triage decision labels (not just triage-needed)
+    all_issues = []
+    for label in list(LABEL_TO_STATUS.keys()) + ["security/triage-needed"]:
+        cmd = [
+            "gh", "issue", "list",
+            "--repo", ISSUES_REPO,
+            "--state", "closed",
+            "--label", label,
+            "--json", "number,title,labels,closedAt,assignees",
+            "--limit", "500",
+        ]
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+            if result.returncode == 0:
+                issues = json.loads(result.stdout)
+                all_issues.extend(issues)
+        except Exception as e:
+            print(f"WARN: error fetching issues with label {label}: {e}")
+
+    # Deduplicate by issue number
+    seen = set()
+    unique = []
+    for issue in all_issues:
+        if issue["number"] not in seen:
+            seen.add(issue["number"])
+            unique.append(issue)
+
+    return unique
+
+
+def determine_status(labels):
+    """Determine triage status from issue labels. Most specific wins."""
+    label_names = {l["name"] for l in labels}
+
+    # Priority order: fixed > in-progress > confirmed > accepted-risk > false-positive
+    for label, status in [
+        ("security/fixed", "fixed"),
+        ("security/in-progress", "in-progress"),
+        ("security/confirmed", "confirmed"),
+        ("security/accepted-risk", "accepted-risk"),
+        ("security/false-positive", "false-positive"),
+    ]:
+        if label in label_names:
+            return status
+
+    return None
+
+
+def main():
+    triage = load_json(TRIAGE_FILE, {})
+    issues = get_closed_issues()
+
+    if not issues:
+        print("No closed issues with security labels found.")
+        return
+
+    updated = 0
+    for issue in issues:
+        cve_id = extract_cve_from_title(issue["title"])
+        if not cve_id:
+            continue
+
+        status = determine_status(issue["labels"])
+        if not status:
+            continue
+
+        # Check if already in triage with same status
+        existing = triage.get(cve_id, {})
+        if existing.get("status") == status:
+            continue
+
+        assignees = [a["login"] for a in issue.get("assignees", [])]
+        decided_by = assignees[0] if assignees else "unknown"
+
+        triage[cve_id] = {
+            "status": status,
+            "reason": f"Triaged via issue #{issue['number']}",
+            "decided_by": decided_by,
+            "decided_at": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            "issue_number": issue["number"],
+            "issue_url": f"https://github.com/{ISSUES_REPO}/issues/{issue['number']}",
+        }
+        updated += 1
+        print(f"  {cve_id}: {status} (issue #{issue['number']}, by {decided_by})")
+
+    if updated:
+        save_json(TRIAGE_FILE, triage)
+        print(f"\nUpdated {updated} triage entries in {TRIAGE_FILE}")
+    else:
+        print("No new triage decisions to sync.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this PR does

Publishes the CVE-scanning pipeline's policy documents and scripts under `docs/security/pipeline/`, so the method is auditable independently of the finding data it produces. Requested by the General Technical Review (Incubation DD, cncf/toc#1916).

- `SECURITY_PIPELINE_POLICY.md`, `SECURITY_TRIAGE_MATRIX.md`, `SECURITY_FINDING_STATUS_MODEL.md` — the pipeline's policy.
- `scripts/` — discovery, scanning and reporting scripts, for method auditability.

The **source of truth remains the private `cozystack/security-scanner` repository**, which holds the per-finding reports and triage state that are **not** published, per the disclosure rule: aggregate counts are public (see `docs/security/reports/`), individual not-yet-fixed findings are not named. Example identifiers in the status model are illustrative placeholders.

### Downstream repositories

- [x] No downstream repository is affected by this change

### Release note

```release-note
docs(security): publish the CVE-scanning pipeline policy documents and scripts for auditability
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated scanning of repositories and container images with deduplicated vulnerability reporting.
  * Added severity-based triage, review scheduling, remediation tracking, and fix details.
  * Added tooling to discover scan targets and create or synchronize security issue records.
  * Added public monthly summaries listing released fixes and aggregating unresolved findings.
  * Added safeguards to identify incomplete or failed scans before reporting completion.

* **Documentation**
  * Documented security policies, privacy boundaries, triage timelines, disclosure rules, and finding status transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->