### PR TITLE
fix(registry): preserve dry-run in tap storage

### DIFF
--- a/pkg/registry/core/tap/rest.go
+++ b/pkg/registry/core/tap/rest.go
@@ -179,7 +179,26 @@ func (r *REST) pendingTapByName(ctx context.Context, name string) (*corev1alpha1
 // materialization is pending.
 // -----------------------------------------------------------------------------
 
-func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, _ *metav1.CreateOptions) (runtime.Object, error) {
+// createDryRun and deleteDryRun carry the caller's dry-run directive down to
+// the backing write. The dynamic client takes the directive by value, so a
+// request that reaches it without one performs the write for real: a
+// --dry-run=server connect would create the Flux source and a dry-run
+// disconnect would delete the PackageSource.
+func createDryRun(opts *metav1.CreateOptions) []string {
+	if opts == nil {
+		return nil
+	}
+	return opts.DryRun
+}
+
+func deleteDryRun(opts *metav1.DeleteOptions) []string {
+	if opts == nil {
+		return nil
+	}
+	return opts.DryRun
+}
+
+func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation rest.ValidateObjectFunc, opts *metav1.CreateOptions) (runtime.Object, error) {
 	in, ok := obj.(*corev1alpha1.Tap)
 	if !ok {
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected a Tap object, got %T", obj))
@@ -219,7 +238,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 	// Create the Flux source, idempotently: a repeat connect updates the
 	// existing source (new tag/secret) rather than erroring.
 	src := r.dyn.Resource(gvrOCIRepos).Namespace("cozy-system")
-	if _, err := src.Create(ctx, repo, metav1.CreateOptions{FieldManager: "cozystack-api"}); err != nil {
+	if _, err := src.Create(ctx, repo, metav1.CreateOptions{FieldManager: "cozystack-api", DryRun: createDryRun(opts)}); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			return nil, apierrors.NewInternalError(fmt.Errorf("create Flux source for tap %s: %w", target.FluxSourceName, err))
 		}
@@ -251,7 +270,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 		}
 		ann[tapconst.NameAnnotation] = target.FluxSourceName
 		cur.SetAnnotations(ann)
-		if _, err := src.Update(ctx, cur, metav1.UpdateOptions{FieldManager: "cozystack-api"}); err != nil {
+		if _, err := src.Update(ctx, cur, metav1.UpdateOptions{FieldManager: "cozystack-api", DryRun: createDryRun(opts)}); err != nil {
 			return nil, apierrors.NewInternalError(fmt.Errorf("update Flux source for tap %s: %w", target.FluxSourceName, err))
 		}
 	}
@@ -273,7 +292,7 @@ func (r *REST) Create(ctx context.Context, obj runtime.Object, createValidation 
 // GracefulDeleter — disconnect a community tap (mirrors `cozypkg untap`)
 // -----------------------------------------------------------------------------
 
-func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, _ *metav1.DeleteOptions) (runtime.Object, bool, error) {
+func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, opts *metav1.DeleteOptions) (runtime.Object, bool, error) {
 	u, err := r.dyn.Resource(gvrPackageSources).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -282,7 +301,7 @@ func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.Va
 			// name). Fall back to removing that source so a pending or
 			// collision-blocked connect is still recoverable from the dashboard
 			// rather than orphaning a finalized OCIRepository.
-			return r.deleteOrphanTapSource(ctx, name)
+			return r.deleteOrphanTapSource(ctx, name, deleteDryRun(opts))
 		}
 		return nil, false, apierrors.NewInternalError(fmt.Errorf("get PackageSource %q: %w", name, err))
 	}
@@ -304,7 +323,7 @@ func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.Va
 		}
 	}
 
-	if err := r.dyn.Resource(gvrPackageSources).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+	if err := r.dyn.Resource(gvrPackageSources).Delete(ctx, name, metav1.DeleteOptions{DryRun: deleteDryRun(opts)}); err != nil {
 		return nil, false, apierrors.NewInternalError(fmt.Errorf("delete PackageSource %q: %w", name, err))
 	}
 
@@ -317,7 +336,7 @@ func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.Va
 			if ns == "" {
 				ns = "cozy-system"
 			}
-			if err := r.dyn.Resource(gvrOCIRepos).Namespace(ns).Delete(ctx, ref.Name, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			if err := r.dyn.Resource(gvrOCIRepos).Namespace(ns).Delete(ctx, ref.Name, metav1.DeleteOptions{DryRun: deleteDryRun(opts)}); err != nil && !apierrors.IsNotFound(err) {
 				klog.V(2).InfoS("tap disconnected but its OCIRepository could not be deleted", "source", ref.Name, "err", err)
 			}
 		}
@@ -329,7 +348,7 @@ func (r *REST) Delete(ctx context.Context, name string, deleteValidation rest.Va
 // deleteOrphanTapSource removes a tap whose OCIRepository exists but whose
 // PackageSource has not been materialized. It matches the labeled OCIRepository
 // carrying the tap-name annotation and deletes it.
-func (r *REST) deleteOrphanTapSource(ctx context.Context, name string) (runtime.Object, bool, error) {
+func (r *REST) deleteOrphanTapSource(ctx context.Context, name string, dryRun []string) (runtime.Object, bool, error) {
 	list, err := r.dyn.Resource(gvrOCIRepos).Namespace("cozy-system").List(ctx, metav1.ListOptions{
 		LabelSelector: tapconst.Label + "=true",
 	})
@@ -341,7 +360,7 @@ func (r *REST) deleteOrphanTapSource(ctx context.Context, name string) (runtime.
 		if item.GetAnnotations()[tapconst.NameAnnotation] != name {
 			continue
 		}
-		if err := r.dyn.Resource(gvrOCIRepos).Namespace("cozy-system").Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		if err := r.dyn.Resource(gvrOCIRepos).Namespace("cozy-system").Delete(ctx, item.GetName(), metav1.DeleteOptions{DryRun: dryRun}); err != nil && !apierrors.IsNotFound(err) {
 			return nil, false, apierrors.NewInternalError(fmt.Errorf("delete tap source %q: %w", item.GetName(), err))
 		}
 		tap := &corev1alpha1.Tap{

--- a/pkg/registry/core/tap/rest_write_options_test.go
+++ b/pkg/registry/core/tap/rest_write_options_test.go
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025 The Cozystack Authors.
+
+package tap
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/cozystack/cozystack/internal/marketplace/tapconst"
+	corev1alpha1 "github.com/cozystack/cozystack/pkg/apis/core/v1alpha1"
+)
+
+// The fake dynamic client's tracker ignores DryRun and persists regardless, so
+// asserting that an object is absent afterwards would pass with or without the
+// fix. What distinguishes them is the options the storage hands to the backing
+// client, which the fake records on the action.
+
+func recordedActions(t *testing.T, r *REST) []k8stesting.Action {
+	t.Helper()
+	f, ok := r.dyn.(*dynamicfake.FakeDynamicClient)
+	if !ok {
+		t.Fatalf("expected a fake dynamic client, got %T", r.dyn)
+	}
+	return f.Actions()
+}
+
+func createDryRunFor(t *testing.T, r *REST, gvr schema.GroupVersionResource) []string {
+	t.Helper()
+	for _, a := range recordedActions(t, r) {
+		c, ok := a.(k8stesting.CreateActionImpl)
+		if ok && a.GetVerb() == "create" && a.GetResource() == gvr {
+			return c.CreateOptions.DryRun
+		}
+	}
+	t.Fatalf("no create action recorded for %q", gvr.Resource)
+	return nil
+}
+
+func updateDryRunFor(t *testing.T, r *REST, gvr schema.GroupVersionResource) []string {
+	t.Helper()
+	for _, a := range recordedActions(t, r) {
+		u, ok := a.(k8stesting.UpdateActionImpl)
+		if ok && a.GetVerb() == "update" && a.GetResource() == gvr {
+			return u.UpdateOptions.DryRun
+		}
+	}
+	t.Fatalf("no update action recorded for %q", gvr.Resource)
+	return nil
+}
+
+func deleteDryRunFor(t *testing.T, r *REST, gvr schema.GroupVersionResource) []string {
+	t.Helper()
+	for _, a := range recordedActions(t, r) {
+		d, ok := a.(k8stesting.DeleteActionImpl)
+		if ok && a.GetVerb() == "delete" && a.GetResource() == gvr {
+			return d.DeleteOptions.DryRun
+		}
+	}
+	t.Fatalf("no delete action recorded for %q", gvr.Resource)
+	return nil
+}
+
+func wantDryRunAll(t *testing.T, what string, got []string) {
+	t.Helper()
+	if len(got) != 1 || got[0] != metav1.DryRunAll {
+		t.Errorf("%s dropped the caller's dry-run: got %v, want [%s]", what, got, metav1.DryRunAll)
+	}
+}
+
+func connectTap() *corev1alpha1.Tap {
+	return &corev1alpha1.Tap{
+		ObjectMeta: metav1.ObjectMeta{Name: "a.b"},
+		Spec:       corev1alpha1.TapSpec{URL: "oci://ghcr.io/a/b", Tag: "v1"},
+	}
+}
+
+// orphanOciRepoObj is a tap whose OCIRepository exists but whose PackageSource
+// was never materialized, which is the fallback branch of Delete.
+func orphanOciRepoObj(srcName, tapName string) *unstructured.Unstructured {
+	u := ociRepoObj(srcName)
+	u.SetLabels(map[string]string{tapconst.Label: "true"})
+	u.SetAnnotations(map[string]string{tapconst.NameAnnotation: tapName})
+	return u
+}
+
+func TestCreateForwardsDryRunToBackingSource(t *testing.T) {
+	r := fakeREST()
+	opts := &metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}
+	if _, err := r.Create(context.Background(), connectTap(), nil, opts); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	wantDryRunAll(t, "the backing OCIRepository create", createDryRunFor(t, r, gvrOCIRepos))
+}
+
+func TestCreateForwardsDryRunWhenSourceAlreadyExists(t *testing.T) {
+	// A repeat connect at the same URL takes the update branch.
+	r := fakeREST(ociRepoObj("tap-a-b"))
+	opts := &metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}}
+	if _, err := r.Create(context.Background(), connectTap(), nil, opts); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	wantDryRunAll(t, "the backing OCIRepository update", updateDryRunFor(t, r, gvrOCIRepos))
+}
+
+func TestDeleteForwardsDryRunToBackingDeletes(t *testing.T) {
+	r := fakeREST(tapPsObj("a.b", "tap-a-b"), ociRepoObj("tap-a-b"))
+	opts := &metav1.DeleteOptions{DryRun: []string{metav1.DryRunAll}}
+	if _, _, err := r.Delete(context.Background(), "a.b", nil, opts); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	wantDryRunAll(t, "the backing PackageSource delete", deleteDryRunFor(t, r, gvrPackageSources))
+	wantDryRunAll(t, "the backing OCIRepository delete", deleteDryRunFor(t, r, gvrOCIRepos))
+}
+
+func TestDeleteOrphanTapSourceForwardsDryRun(t *testing.T) {
+	r := fakeREST(orphanOciRepoObj("tap-a-b", "a.b"))
+	opts := &metav1.DeleteOptions{DryRun: []string{metav1.DryRunAll}}
+	if _, _, err := r.Delete(context.Background(), "a.b", nil, opts); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	wantDryRunAll(t, "the orphan OCIRepository delete", deleteDryRunFor(t, r, gvrOCIRepos))
+}
+
+func TestWritesWithoutOptionsDoNotSynthesiseDryRun(t *testing.T) {
+	// Callers that pass no options at all must keep writing for real.
+	r := fakeREST(tapPsObj("a.b", "tap-a-b"), ociRepoObj("tap-a-b"))
+	if _, _, err := r.Delete(context.Background(), "a.b", nil, nil); err != nil {
+		t.Fatalf("delete with nil options: %v", err)
+	}
+	if got := deleteDryRunFor(t, r, gvrPackageSources); len(got) != 0 {
+		t.Errorf("nil options must not produce a dry-run: got %v", got)
+	}
+}


### PR DESCRIPTION
## What this PR does

Tap `Create` and `Delete` bound the options parameter to `_` and built their own `metav1.CreateOptions` and `DeleteOptions` for the dynamic client, so the caller's dry-run directive never reached the backing write. `kubectl create --dry-run=server` on a tap created the Flux `OCIRepository` for real, and `kubectl delete tap <name> --dry-run=server` removed the `PackageSource` and its source for real. That is the opposite of what a server-side dry-run promises, and it is reachable from the dashboard and from any client that previews a change before applying it.

The directive now reaches all five backing writes: the source create, the update taken on a repeat connect, the `PackageSource` delete, the delete of an unreferenced `OCIRepository`, and the orphan-source fallback, which had no access to the options at all and needed them threaded in.

Field manager stays as the storage sets it. Tap synthesizes the backing objects rather than storing what the caller sent, so who owns their fields is a separate question from whether the write happens, and only the second one is a correctness bug.

`taps` was the last write-capable storage in the aggregated apiserver still discarding its write options. #3937 covers application, tenant-secret and security-group, and excludes this one on the grounds that it uses a different client; the client is not what stood in the way, since `dynamic.Interface` takes the options by value, dry-run included.

### Tests

The fake dynamic client's tracker ignores `DryRun` and persists regardless, so asserting that an object is absent after a dry-run would pass with or without the fix. The tests assert the options recorded on the backing action instead. Reverting any one of the five forwards, one at a time, turns the suite red.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff. It touches only the write plumbing of the `taps` aggregated storage: no package added, renamed or removed, no `values.schema.json`, no version enum, no changed default, no `kind` or `plural`, no `release.prefix`, no renamed output Secret or Service, no hand-typed CRD, and nothing under `hack/`.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
fix(registry): honor server-side dry-run when connecting or disconnecting a tap, which previously performed the write for real
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server-side dry-run requests for TAP connect and disconnect operations now prevent changes from being written to backing resources.
  * Dry-run settings are consistently applied when creating, updating, or deleting associated sources, including orphaned sources.

* **Tests**
  * Added coverage confirming dry-run behavior across create and delete workflows, including requests without write options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->