### PR TITLE
fix(registry): run validating admission on TenantSecret writes

### DIFF
--- a/pkg/registry/core/tenantsecret/rest.go
+++ b/pkg/registry/core/tenantsecret/rest.go
@@ -250,12 +250,18 @@ func buildTenantSelector(opts *metainternal.ListOptions) (labels.Selector, bool)
 func (r *REST) Create(
 	ctx context.Context,
 	obj runtime.Object,
-	_ rest.ValidateObjectFunc,
+	createValidation rest.ValidateObjectFunc,
 	opts *metav1.CreateOptions,
 ) (runtime.Object, error) {
 	in, ok := obj.(*corev1alpha1.TenantSecret)
 	if !ok {
 		return nil, fmt.Errorf("expected TenantSecret, got %T", obj)
+	}
+
+	if createValidation != nil {
+		if err := createValidation(ctx, obj); err != nil {
+			return nil, err
+		}
 	}
 
 	sec := tenantToSecret(in, nil)
@@ -366,8 +372,8 @@ func (r *REST) Update(
 	ctx context.Context,
 	name string,
 	objInfo rest.UpdatedObjectInfo,
-	_ rest.ValidateObjectFunc,
-	_ rest.ValidateObjectUpdateFunc,
+	createValidation rest.ValidateObjectFunc,
+	updateValidation rest.ValidateObjectUpdateFunc,
 	forceCreate bool,
 	opts *metav1.UpdateOptions,
 ) (runtime.Object, bool, error) {
@@ -401,8 +407,19 @@ func (r *REST) Update(
 		if !forceCreate {
 			return nil, false, apierrors.NewNotFound(r.gvr.GroupResource(), name)
 		}
+		if createValidation != nil {
+			if err := createValidation(ctx, newObj); err != nil {
+				return nil, false, err
+			}
+		}
 		err := r.c.Create(ctx, newSec, &client.CreateOptions{Raw: &metav1.CreateOptions{}})
 		return secretToTenant(newSec), true, err
+	}
+
+	if updateValidation != nil {
+		if err := updateValidation(ctx, newObj, secretToTenant(cur)); err != nil {
+			return nil, false, err
+		}
 	}
 
 	newSec.ResourceVersion = cur.ResourceVersion
@@ -413,7 +430,7 @@ func (r *REST) Update(
 func (r *REST) Delete(
 	ctx context.Context,
 	name string,
-	_ rest.ValidateObjectFunc,
+	deleteValidation rest.ValidateObjectFunc,
 	opts *metav1.DeleteOptions,
 ) (runtime.Object, bool, error) {
 	ns, err := nsFrom(ctx)
@@ -427,6 +444,12 @@ func (r *REST) Delete(
 	if current.Labels == nil || current.Labels[tsLabelKey] != tsLabelValue {
 		return nil, false, apierrors.NewNotFound(r.gvr.GroupResource(), name)
 	}
+	if deleteValidation != nil {
+		if err := deleteValidation(ctx, secretToTenant(current)); err != nil {
+			return nil, false, err
+		}
+	}
+
 	err = r.c.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name}}, &client.DeleteOptions{Raw: opts})
 	return nil, err == nil, err
 }

--- a/pkg/registry/core/tenantsecret/rest_admission_test.go
+++ b/pkg/registry/core/tenantsecret/rest_admission_test.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package tenantsecret
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1alpha1 "github.com/cozystack/cozystack/pkg/apis/core/v1alpha1"
+)
+
+// The apiserver delivers validating admission to a storage as the
+// ValidateObjectFunc it passes into Create, Update and Delete: mutating
+// admission runs in the handler, but validating webhooks and
+// ValidatingAdmissionPolicies run only when the storage calls that callback.
+// A storage that drops it answers every write as if no policy existed.
+
+var errDenied = errors.New("denied by test admission")
+
+func denyCreate(called *bool) rest.ValidateObjectFunc {
+	return func(_ context.Context, _ runtime.Object) error {
+		*called = true
+		return errDenied
+	}
+}
+
+func denyUpdate(called *bool) rest.ValidateObjectUpdateFunc {
+	return func(_ context.Context, _, _ runtime.Object) error {
+		*called = true
+		return errDenied
+	}
+}
+
+func tenantSecretIn(name string) *corev1alpha1.TenantSecret {
+	return &corev1alpha1.TenantSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Type:       string(corev1.SecretTypeOpaque),
+	}
+}
+
+func secretExists(t *testing.T, r *REST, name string) bool {
+	t.Helper()
+	err := r.c.Get(testCtx(), types.NamespacedName{Namespace: testNamespace, Name: name}, &corev1.Secret{}, &client.GetOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		t.Fatalf("get backing Secret %q: %v", name, err)
+	}
+	return err == nil
+}
+
+func TestCreateRunsValidatingAdmission(t *testing.T) {
+	r := newTestREST(t)
+	called := false
+
+	_, err := r.Create(testCtx(), tenantSecretIn("creds"), denyCreate(&called), &metav1.CreateOptions{})
+	if !called {
+		t.Fatal("Create never invoked validating admission")
+	}
+	if !errors.Is(err, errDenied) {
+		t.Fatalf("Create swallowed the admission denial: got %v", err)
+	}
+	if secretExists(t, r, "creds") {
+		t.Error("Create wrote the backing Secret despite the denial")
+	}
+}
+
+func TestUpdateRunsValidatingAdmission(t *testing.T) {
+	r := newTestREST(t, makeTenantSecret("creds", nil))
+	called := false
+
+	in := tenantSecretIn("creds")
+	in.Data = map[string][]byte{"k": []byte("v")}
+	_, _, err := r.Update(testCtx(), "creds", rest.DefaultUpdatedObjectInfo(in), nil, denyUpdate(&called), false, &metav1.UpdateOptions{})
+	if !called {
+		t.Fatal("Update never invoked validating admission")
+	}
+	if !errors.Is(err, errDenied) {
+		t.Fatalf("Update swallowed the admission denial: got %v", err)
+	}
+	if got := backingSecret(t, r, "creds").Data["k"]; got != nil {
+		t.Errorf("Update wrote the backing Secret despite the denial: got %q", got)
+	}
+}
+
+func TestUpdateForceCreateRunsValidatingAdmission(t *testing.T) {
+	// The create-on-update path is a create, so it is createValidation that
+	// carries admission for it.
+	r := newTestREST(t)
+	called := false
+
+	_, _, err := r.Update(testCtx(), "creds", rest.DefaultUpdatedObjectInfo(tenantSecretIn("creds")), denyCreate(&called), nil, true, &metav1.UpdateOptions{})
+	if !called {
+		t.Fatal("force-create Update never invoked validating admission")
+	}
+	if !errors.Is(err, errDenied) {
+		t.Fatalf("force-create Update swallowed the admission denial: got %v", err)
+	}
+	if secretExists(t, r, "creds") {
+		t.Error("force-create Update wrote the backing Secret despite the denial")
+	}
+}
+
+func TestDeleteRunsValidatingAdmission(t *testing.T) {
+	// This is the path the cluster-wide no-delete guardrail runs on.
+	r := newTestREST(t, makeTenantSecret("creds", nil))
+	called := false
+
+	_, deleted, err := r.Delete(testCtx(), "creds", denyCreate(&called), &metav1.DeleteOptions{})
+	if !called {
+		t.Fatal("Delete never invoked validating admission")
+	}
+	if !errors.Is(err, errDenied) {
+		t.Fatalf("Delete swallowed the admission denial: got %v", err)
+	}
+	if deleted {
+		t.Error("Delete reported the object as deleted despite the denial")
+	}
+	if !secretExists(t, r, "creds") {
+		t.Error("Delete removed the backing Secret despite the denial")
+	}
+}
+
+func TestWritesAcceptNilValidation(t *testing.T) {
+	// The apiserver passes a nil callback when no admission plugin handles the
+	// operation, so every write path must stay usable without one.
+	r := newTestREST(t)
+	if _, err := r.Create(testCtx(), tenantSecretIn("creds"), nil, &metav1.CreateOptions{}); err != nil {
+		t.Fatalf("Create with nil validation: %v", err)
+	}
+	if _, _, err := r.Update(testCtx(), "creds", rest.DefaultUpdatedObjectInfo(tenantSecretIn("creds")), nil, nil, false, &metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Update with nil validation: %v", err)
+	}
+	if _, _, err := r.Delete(testCtx(), "creds", nil, &metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("Delete with nil validation: %v", err)
+	}
+}


### PR DESCRIPTION
## What this PR does

The apiserver hands validating admission to a storage as the `ValidateObjectFunc` it passes into `Create`, `Update` and `Delete`. Mutating admission runs in the handler, but validating webhooks and `ValidatingAdmissionPolicy` execute only when the storage calls that callback, as `rest.AdmissionToValidateObjectFunc` in `k8s.io/apiserver` builds it for exactly that purpose. TenantSecret bound all three callbacks to `_`, so every write answered as if no policy existed.

The practical effect is that the cluster-wide `cozystack-no-delete-guardrail` policy, and any webhook an operator writes for `tenantsecrets`, are inert on this resource. `application` and `securitygroup` call all three callbacks; TenantSecret was the only write-capable storage in the tree that did not.

The callbacks are now called on all four write paths, including the create-on-update branch, which is a create and so carries `createValidation` rather than `updateValidation`. What goes to admission is the aggregated TenantSecret the caller submitted, or the stored one it replaces, not the backing Secret, so a policy sees the resource it was written against.

This is a behaviour change for anyone who has a policy matching `tenantsecrets` today: writes that silently passed will start being evaluated, and may now be denied. That is the point of the fix, but it is worth saying out loud before it ships.

### Tests

Each write path is covered by a denying admission callback, asserting both that the callback runs and that the backing Secret is left alone when it denies. A nil callback keeps every path working, which is what the apiserver passes when no plugin handles the operation. Removing any one of the four calls, one at a time, turns the suite red.

### Screenshots

Not a UI change.

### Downstream repositories

Walked the trigger map in `docs/agents/contributing.md` against the diff. It touches one aggregated storage's write paths: no package added, renamed or removed, no `values.schema.json`, no version enum, no changed default, no `kind` or `plural`, no `release.prefix`, no renamed output Secret or Service, no hand-typed CRD, and nothing under `hack/`.

- [x] No downstream repository is affected by this change
- [ ] [cozystack/website](https://github.com/cozystack/website) - follow-up:
- [ ] [cozystack/terraform-provider-cozystack](https://github.com/cozystack/terraform-provider-cozystack) - follow-up:
- [ ] [cozystack/ansible-cozystack](https://github.com/cozystack/ansible-cozystack) - follow-up:
- [ ] [cozystack/ccp](https://github.com/cozystack/ccp) - follow-up:
- [ ] [cozystack/talm](https://github.com/cozystack/talm) - follow-up:
- [ ] [cozystack/cozyhr](https://github.com/cozystack/cozyhr) - follow-up:
- [ ] [cozystack/cozy-proxy](https://github.com/cozystack/cozy-proxy) - follow-up:
- [ ] [cozystack/cozystack-telemetry-server](https://github.com/cozystack/cozystack-telemetry-server) - follow-up:
- [ ] [cozystack/external-apps-example](https://github.com/cozystack/external-apps-example) - follow-up:
- [ ] [cozystack/examples](https://github.com/cozystack/examples) - follow-up:
- [ ] [cozystack/community](https://github.com/cozystack/community) - follow-up:

### Release note

```release-note
fix(registry): run validating admission on TenantSecret writes, so ValidatingAdmissionPolicies and webhooks matching tenantsecrets are no longer bypassed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - TenantSecret create, update, force-create, and delete operations now apply validation checks before completing changes.
  - Denied create or update requests are stopped before data is saved.
  - Delete validation runs after the current secret is retrieved and before removal.
  - TenantSecret write operations remain available when no validation callback is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->